### PR TITLE
[clang-format] use `AllowShortFunctionsOnASingleLine: All`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,7 @@ AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortFunctionsOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None

--- a/examples/apps/cli/cli_uart.cpp
+++ b/examples/apps/cli/cli_uart.cpp
@@ -368,15 +368,9 @@ exit:
     return rval;
 }
 
-void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength)
-{
-    ReceiveTask(aBuf, aBufLength);
-}
+void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength) { ReceiveTask(aBuf, aBufLength); }
 
-void otPlatUartSendDone(void)
-{
-    SendDoneTask();
-}
+void otPlatUartSendDone(void) { SendDoneTask(); }
 
 extern "C" void otAppCliInit(otInstance *aInstance)
 {

--- a/examples/apps/cli/main.c
+++ b/examples/apps/cli/main.c
@@ -50,21 +50,12 @@
 extern void otAppCliInit(otInstance *aInstance);
 
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-OT_TOOL_WEAK void *otPlatCAlloc(size_t aNum, size_t aSize)
-{
-    return calloc(aNum, aSize);
-}
+OT_TOOL_WEAK void *otPlatCAlloc(size_t aNum, size_t aSize) { return calloc(aNum, aSize); }
 
-OT_TOOL_WEAK void otPlatFree(void *aPtr)
-{
-    free(aPtr);
-}
+OT_TOOL_WEAK void otPlatFree(void *aPtr) { free(aPtr); }
 #endif
 
-void otTaskletsSignalPending(otInstance *aInstance)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-}
+void otTaskletsSignalPending(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
 
 #if OPENTHREAD_POSIX && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 static otError ProcessExit(void *aContext, uint8_t aArgsLength, char *aArgs[])

--- a/examples/apps/ncp/main.c
+++ b/examples/apps/ncp/main.c
@@ -46,21 +46,12 @@
 extern void otAppNcpInit(otInstance *aInstance);
 
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-OT_TOOL_WEAK void *otPlatCAlloc(size_t aNum, size_t aSize)
-{
-    return calloc(aNum, aSize);
-}
+OT_TOOL_WEAK void *otPlatCAlloc(size_t aNum, size_t aSize) { return calloc(aNum, aSize); }
 
-OT_TOOL_WEAK void otPlatFree(void *aPtr)
-{
-    free(aPtr);
-}
+OT_TOOL_WEAK void otPlatFree(void *aPtr) { free(aPtr); }
 #endif
 
-void otTaskletsSignalPending(otInstance *aInstance)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-}
+void otTaskletsSignalPending(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
 
 int main(int argc, char *argv[])
 {

--- a/examples/apps/ncp/ncp.c
+++ b/examples/apps/ncp/ncp.c
@@ -37,15 +37,9 @@
 #if !OPENTHREAD_CONFIG_NCP_SPI_ENABLE
 #include "utils/uart.h"
 
-void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength)
-{
-    otNcpHdlcReceive(aBuf, aBufLength);
-}
+void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength) { otNcpHdlcReceive(aBuf, aBufLength); }
 
-void otPlatUartSendDone(void)
-{
-    otNcpHdlcSendDone();
-}
+void otPlatUartSendDone(void) { otNcpHdlcSendDone(); }
 #endif
 
 #if !OPENTHREAD_ENABLE_NCP_VENDOR_HOOK

--- a/examples/platforms/simulation/alarm.c
+++ b/examples/platforms/simulation/alarm.c
@@ -162,10 +162,7 @@ uint64_t platformGetNow(void)
 }
 #endif // defined(CLOCK_MONOTONIC_RAW) || defined(CLOCK_MONOTONIC)
 
-uint32_t otPlatAlarmMilliGetNow(void)
-{
-    return (uint32_t)(platformGetNow() / US_PER_MS);
-}
+uint32_t otPlatAlarmMilliGetNow(void) { return (uint32_t)(platformGetNow() / US_PER_MS); }
 
 void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
@@ -182,10 +179,7 @@ void otPlatAlarmMilliStop(otInstance *aInstance)
     sIsMsRunning = false;
 }
 
-uint32_t otPlatAlarmMicroGetNow(void)
-{
-    return (uint32_t)platformGetNow();
-}
+uint32_t otPlatAlarmMicroGetNow(void) { return (uint32_t)platformGetNow(); }
 
 void otPlatAlarmMicroStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
@@ -303,14 +297,8 @@ void platformAlarmProcess(otInstance *aInstance)
 #endif
 }
 
-uint64_t otPlatTimeGet(void)
-{
-    return platformGetNow();
-}
+uint64_t otPlatTimeGet(void) { return platformGetNow(); }
 
-uint16_t otPlatTimeGetXtalAccuracy(void)
-{
-    return 0;
-}
+uint16_t otPlatTimeGetXtalAccuracy(void) { return 0; }
 
 #endif // OPENTHREAD_SIMULATION_VIRTUAL_TIME == 0

--- a/examples/platforms/simulation/diag.c
+++ b/examples/platforms/simulation/diag.c
@@ -56,25 +56,13 @@ enum
 static otGpioMode sGpioMode  = OT_GPIO_MODE_INPUT;
 static bool       sGpioValue = false;
 
-void otPlatDiagModeSet(bool aMode)
-{
-    sDiagMode = aMode;
-}
+void otPlatDiagModeSet(bool aMode) { sDiagMode = aMode; }
 
-bool otPlatDiagModeGet()
-{
-    return sDiagMode;
-}
+bool otPlatDiagModeGet() { return sDiagMode; }
 
-void otPlatDiagChannelSet(uint8_t aChannel)
-{
-    OT_UNUSED_VARIABLE(aChannel);
-}
+void otPlatDiagChannelSet(uint8_t aChannel) { OT_UNUSED_VARIABLE(aChannel); }
 
-void otPlatDiagTxPowerSet(int8_t aTxPower)
-{
-    OT_UNUSED_VARIABLE(aTxPower);
-}
+void otPlatDiagTxPowerSet(int8_t aTxPower) { OT_UNUSED_VARIABLE(aTxPower); }
 
 void otPlatDiagRadioReceived(otInstance *aInstance, otRadioFrame *aFrame, otError aError)
 {
@@ -83,10 +71,7 @@ void otPlatDiagRadioReceived(otInstance *aInstance, otRadioFrame *aFrame, otErro
     OT_UNUSED_VARIABLE(aError);
 }
 
-void otPlatDiagAlarmCallback(otInstance *aInstance)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-}
+void otPlatDiagAlarmCallback(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
 
 otError otPlatDiagGpioSet(uint32_t aGpio, bool aValue)
 {

--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -185,10 +185,7 @@ static void NodeIdFilterDeny(uint16_t aNodeId)
     sDeniedNodeIdsBitVector[index / 8] |= 0x80 >> (index % 8);
 }
 
-static void NodeIdFilterClear(void)
-{
-    memset(sDeniedNodeIdsBitVector, 0, sizeof(sDeniedNodeIdsBitVector));
-}
+static void NodeIdFilterClear(void) { memset(sDeniedNodeIdsBitVector, 0, sizeof(sDeniedNodeIdsBitVector)); }
 
 otError ProcessNodeIdFilter(void *aContext, uint8_t aArgsLength, char *aArgs[])
 {
@@ -237,10 +234,7 @@ otError ProcessNodeIdFilter(void *aContext, uint8_t aArgsLength, char *aArgs[])
 }
 #endif // OPENTHREAD_SIMULATION_VIRTUAL_TIME == 0
 
-static bool IsTimeAfterOrEqual(uint32_t aTimeA, uint32_t aTimeB)
-{
-    return (aTimeA - aTimeB) < (1U << 31);
-}
+static bool IsTimeAfterOrEqual(uint32_t aTimeA, uint32_t aTimeB) { return (aTimeA - aTimeB) < (1U << 31); }
 
 static void ReverseExtAddress(otExtAddress *aReversed, const otExtAddress *aOrigin)
 {
@@ -794,10 +788,7 @@ exit:
     return;
 }
 
-bool platformRadioIsTransmitPending(void)
-{
-    return sState == OT_RADIO_STATE_TRANSMIT && !sTxWait;
-}
+bool platformRadioIsTransmitPending(void) { return sState == OT_RADIO_STATE_TRANSMIT && !sTxWait; }
 
 #if OPENTHREAD_SIMULATION_VIRTUAL_TIME
 void platformRadioReceive(otInstance *aInstance, uint8_t *aBuf, uint16_t aBufLength)

--- a/examples/platforms/simulation/spi-stubs.c
+++ b/examples/platforms/simulation/spi-stubs.c
@@ -52,9 +52,7 @@ otError otPlatSpiSlaveEnable(otPlatSpiSlaveTransactionCompleteCallback aComplete
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-void otPlatSpiSlaveDisable(void)
-{
-}
+void otPlatSpiSlaveDisable(void) {}
 
 otError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf,
                                          uint16_t aOutputBufLen,
@@ -73,9 +71,7 @@ otError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf,
 
 // Uart
 
-void otPlatUartSendDone(void)
-{
-}
+void otPlatUartSendDone(void) {}
 
 void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength)
 {

--- a/examples/platforms/simulation/system.c
+++ b/examples/platforms/simulation/system.c
@@ -176,10 +176,7 @@ void otSysInit(int aArgCount, char *aArgVector[])
     platformRandomInit();
 }
 
-bool otSysPseudoResetWasRequested(void)
-{
-    return gPlatformPseudoResetWasRequested;
-}
+bool otSysPseudoResetWasRequested(void) { return gPlatformPseudoResetWasRequested; }
 
 void otSysDeinit(void)
 {

--- a/examples/platforms/simulation/trel.c
+++ b/examples/platforms/simulation/trel.c
@@ -419,10 +419,7 @@ void platformTrelInit(uint32_t aSpeedUpFactor)
     OT_UNUSED_VARIABLE(aSpeedUpFactor);
 }
 
-void platformTrelDeinit(void)
-{
-    deinitFds();
-}
+void platformTrelDeinit(void) { deinitFds(); }
 
 void platformTrelUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, struct timeval *aTimeout, int *aMaxFd)
 {

--- a/examples/platforms/simulation/uart.c
+++ b/examples/platforms/simulation/uart.c
@@ -54,15 +54,9 @@ static int            s_out_fd;
 static struct termios original_stdin_termios;
 static struct termios original_stdout_termios;
 
-static void restore_stdin_termios(void)
-{
-    tcsetattr(s_in_fd, TCSAFLUSH, &original_stdin_termios);
-}
+static void restore_stdin_termios(void) { tcsetattr(s_in_fd, TCSAFLUSH, &original_stdin_termios); }
 
-static void restore_stdout_termios(void)
-{
-    tcsetattr(s_out_fd, TCSAFLUSH, &original_stdout_termios);
-}
+static void restore_stdout_termios(void) { tcsetattr(s_out_fd, TCSAFLUSH, &original_stdout_termios); }
 
 void platformUartRestore(void)
 {

--- a/examples/platforms/simulation/virtual_time/alarm-sim.c
+++ b/examples/platforms/simulation/virtual_time/alarm-sim.c
@@ -55,20 +55,11 @@ void platformAlarmInit(uint32_t aSpeedUpFactor)
     sNow = 0;
 }
 
-uint64_t platformAlarmGetNow(void)
-{
-    return sNow;
-}
+uint64_t platformAlarmGetNow(void) { return sNow; }
 
-void platformAlarmAdvanceNow(uint64_t aDelta)
-{
-    sNow += aDelta;
-}
+void platformAlarmAdvanceNow(uint64_t aDelta) { sNow += aDelta; }
 
-uint32_t otPlatAlarmMilliGetNow(void)
-{
-    return (uint32_t)(sNow / US_PER_MS);
-}
+uint32_t otPlatAlarmMilliGetNow(void) { return (uint32_t)(sNow / US_PER_MS); }
 
 void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
@@ -85,10 +76,7 @@ void otPlatAlarmMilliStop(otInstance *aInstance)
     sIsMsRunning = false;
 }
 
-uint32_t otPlatAlarmMicroGetNow(void)
-{
-    return (uint32_t)sNow;
-}
+uint32_t otPlatAlarmMicroGetNow(void) { return (uint32_t)sNow; }
 
 void otPlatAlarmMicroStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
@@ -186,16 +174,10 @@ void platformAlarmProcess(otInstance *aInstance)
 #endif // OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 }
 
-uint64_t otPlatTimeGet(void)
-{
-    return platformAlarmGetNow();
-}
+uint64_t otPlatTimeGet(void) { return platformAlarmGetNow(); }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-uint16_t otPlatTimeGetXtalAccuracy(void)
-{
-    return 0;
-}
+uint16_t otPlatTimeGetXtalAccuracy(void) { return 0; }
 #endif
 
 #endif // OPENTHREAD_SIMULATION_VIRTUAL_TIME

--- a/examples/platforms/simulation/virtual_time/platform-sim.c
+++ b/examples/platforms/simulation/virtual_time/platform-sim.c
@@ -136,19 +136,11 @@ static void platformSendSleepEvent(void)
 }
 
 #if OPENTHREAD_SIMULATION_VIRTUAL_TIME_UART
-void platformUartRestore(void)
-{
-}
+void platformUartRestore(void) {}
 
-otError otPlatUartEnable(void)
-{
-    return OT_ERROR_NONE;
-}
+otError otPlatUartEnable(void) { return OT_ERROR_NONE; }
 
-otError otPlatUartDisable(void)
-{
-    return OT_ERROR_NONE;
-}
+otError otPlatUartDisable(void) { return OT_ERROR_NONE; }
 
 otError otPlatUartSend(const uint8_t *aData, uint16_t aLength)
 {
@@ -168,10 +160,7 @@ otError otPlatUartSend(const uint8_t *aData, uint16_t aLength)
     return error;
 }
 
-otError otPlatUartFlush(void)
-{
-    return OT_ERROR_NONE;
-}
+otError otPlatUartFlush(void) { return OT_ERROR_NONE; }
 #endif // OPENTHREAD_SIMULATION_VIRTUAL_TIME_UART
 
 static void socket_init(void)
@@ -242,15 +231,9 @@ void otSysInit(int argc, char *argv[])
     signal(SIGHUP, &handleSignal);
 }
 
-bool otSysPseudoResetWasRequested(void)
-{
-    return gPlatformPseudoResetWasRequested;
-}
+bool otSysPseudoResetWasRequested(void) { return gPlatformPseudoResetWasRequested; }
 
-void otSysDeinit(void)
-{
-    close(sSockFd);
-}
+void otSysDeinit(void) { close(sSockFd); }
 
 void otSysProcessDrivers(otInstance *aInstance)
 {

--- a/examples/platforms/utils/debug_uart.c
+++ b/examples/platforms/utils/debug_uart.c
@@ -103,22 +103,13 @@ void otPlatDebugUart_putchar(int c)
 
 /* provide WEAK stubs for platforms that do not implement all functions */
 OT_TOOL_WEAK
-void otPlatDebugUart_putchar_raw(int c)
-{
-    OT_UNUSED_VARIABLE(c);
-}
+void otPlatDebugUart_putchar_raw(int c) { OT_UNUSED_VARIABLE(c); }
 
 OT_TOOL_WEAK
-int otPlatDebugUart_kbhit(void)
-{
-    return 0; /* nothing */
-}
+int otPlatDebugUart_kbhit(void) { return 0; /* nothing */ }
 
 OT_TOOL_WEAK
-int otPlatDebugUart_getc(void)
-{
-    return -1; /* nothing */
-}
+int otPlatDebugUart_getc(void) { return -1; /* nothing */ }
 
 OT_TOOL_WEAK
 otError otPlatDebugUart_logfile(const char *filename)

--- a/examples/platforms/utils/link_metrics.cpp
+++ b/examples/platforms/utils/link_metrics.cpp
@@ -177,10 +177,7 @@ static inline bool IsLinkMetricsClear(otLinkMetrics aLinkMetrics)
     return !aLinkMetrics.mPduCount && !aLinkMetrics.mLqi && !aLinkMetrics.mLinkMargin && !aLinkMetrics.mRssi;
 }
 
-void otLinkMetricsInit(int8_t aNoiseFloor)
-{
-    sNoiseFloor = aNoiseFloor;
-}
+void otLinkMetricsInit(int8_t aNoiseFloor) { sNoiseFloor = aNoiseFloor; }
 
 otError otLinkMetricsConfigureEnhAckProbing(otShortAddress      aShortAddress,
                                             const otExtAddress *aExtAddress,

--- a/examples/platforms/utils/logging_rtt.c
+++ b/examples/platforms/utils/logging_rtt.c
@@ -136,10 +136,7 @@ exit:
     return;
 }
 
-void utilsLogRttDeinit(void)
-{
-    sLogInitialized = false;
-}
+void utilsLogRttDeinit(void) { sLogInitialized = false; }
 
 void utilsLogRttOutput(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list ap)
 {

--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -206,10 +206,7 @@ uint8_t otMacFrameGetKeyId(otRadioFrame *aFrame)
     return keyId;
 }
 
-void otMacFrameSetKeyId(otRadioFrame *aFrame, uint8_t aKeyId)
-{
-    static_cast<Mac::Frame *>(aFrame)->SetKeyId(aKeyId);
-}
+void otMacFrameSetKeyId(otRadioFrame *aFrame, uint8_t aKeyId) { static_cast<Mac::Frame *>(aFrame)->SetKeyId(aKeyId); }
 
 uint32_t otMacFrameGetFrameCounter(otRadioFrame *aFrame)
 {

--- a/examples/platforms/utils/otns_utils.cpp
+++ b/examples/platforms/utils/otns_utils.cpp
@@ -43,9 +43,6 @@ using namespace ot;
 #if OPENTHREAD_CONFIG_OTNS_ENABLE
 
 OT_TOOL_WEAK
-void otPlatOtnsStatus(const char *aStatus)
-{
-    LogAlways("[OTNS] %s", aStatus);
-}
+void otPlatOtnsStatus(const char *aStatus) { LogAlways("[OTNS] %s", aStatus); }
 
 #endif // OPENTHREAD_CONFIG_OTNS_ENABLE

--- a/examples/platforms/utils/settings_ram.c
+++ b/examples/platforms/utils/settings_ram.c
@@ -66,10 +66,7 @@ void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aSensitiveKeys, u
     sSettingsBufLength = 0;
 }
 
-void otPlatSettingsDeinit(otInstance *aInstance)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-}
+void otPlatSettingsDeinit(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
 
 otError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength)
 {
@@ -229,9 +226,6 @@ otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
     return error;
 }
 
-void otPlatSettingsWipe(otInstance *aInstance)
-{
-    otPlatSettingsInit(aInstance, NULL, 0);
-}
+void otPlatSettingsWipe(otInstance *aInstance) { otPlatSettingsInit(aInstance, NULL, 0); }
 
 #endif // OPENTHREAD_SETTINGS_RAM

--- a/examples/platforms/utils/soft_source_match_table.c
+++ b/examples/platforms/utils/soft_source_match_table.c
@@ -46,10 +46,7 @@
 #if RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM || RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM
 static uint16_t sPanId = 0;
 
-void utilsSoftSrcMatchSetPanId(uint16_t aPanId)
-{
-    sPanId = aPanId;
-}
+void utilsSoftSrcMatchSetPanId(uint16_t aPanId) { sPanId = aPanId; }
 #endif // RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM || RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM
 
 #if RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -483,10 +483,7 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-template <> otError Interpreter::Process<Cmd("history")>(Arg aArgs[])
-{
-    return mHistory.Process(aArgs);
-}
+template <> otError Interpreter::Process<Cmd("history")>(Arg aArgs[]) { return mHistory.Process(aArgs); }
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
@@ -2352,17 +2349,11 @@ template <> otError Interpreter::Process<Cmd("childtimeout")>(Arg aArgs[])
 }
 
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
-template <> otError Interpreter::Process<Cmd("coap")>(Arg aArgs[])
-{
-    return mCoap.Process(aArgs);
-}
+template <> otError Interpreter::Process<Cmd("coap")>(Arg aArgs[]) { return mCoap.Process(aArgs); }
 #endif
 
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-template <> otError Interpreter::Process<Cmd("coaps")>(Arg aArgs[])
-{
-    return mCoapSecure.Process(aArgs);
-}
+template <> otError Interpreter::Process<Cmd("coaps")>(Arg aArgs[]) { return mCoapSecure.Process(aArgs); }
 #endif
 
 #if OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
@@ -5079,10 +5070,7 @@ exit:
 }
 #endif // OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
-template <> otError Interpreter::Process<Cmd("netdata")>(Arg aArgs[])
-{
-    return mNetworkData.Process(aArgs);
-}
+template <> otError Interpreter::Process<Cmd("netdata")>(Arg aArgs[]) { return mNetworkData.Process(aArgs); }
 
 #if OPENTHREAD_FTD
 template <> otError Interpreter::Process<Cmd("networkidtimeout")>(Arg aArgs[])
@@ -6358,10 +6346,7 @@ template <> otError Interpreter::Process<Cmd("thread")>(Arg aArgs[])
     return error;
 }
 
-template <> otError Interpreter::Process<Cmd("dataset")>(Arg aArgs[])
-{
-    return mDataset.Process(aArgs);
-}
+template <> otError Interpreter::Process<Cmd("dataset")>(Arg aArgs[]) { return mDataset.Process(aArgs); }
 
 template <> otError Interpreter::Process<Cmd("txpower")>(Arg aArgs[])
 {
@@ -6384,16 +6369,10 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_TCP_ENABLE && OPENTHREAD_CONFIG_CLI_TCP_ENABLE
-template <> otError Interpreter::Process<Cmd("tcp")>(Arg aArgs[])
-{
-    return mTcp.Process(aArgs);
-}
+template <> otError Interpreter::Process<Cmd("tcp")>(Arg aArgs[]) { return mTcp.Process(aArgs); }
 #endif
 
-template <> otError Interpreter::Process<Cmd("udp")>(Arg aArgs[])
-{
-    return mUdp.Process(aArgs);
-}
+template <> otError Interpreter::Process<Cmd("udp")>(Arg aArgs[]) { return mUdp.Process(aArgs); }
 
 template <> otError Interpreter::Process<Cmd("unsecureport")>(Arg aArgs[])
 {
@@ -6465,17 +6444,11 @@ template <> otError Interpreter::Process<Cmd("uptime")>(Arg aArgs[])
 #endif
 
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-template <> otError Interpreter::Process<Cmd("commissioner")>(Arg aArgs[])
-{
-    return mCommissioner.Process(aArgs);
-}
+template <> otError Interpreter::Process<Cmd("commissioner")>(Arg aArgs[]) { return mCommissioner.Process(aArgs); }
 #endif
 
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
-template <> otError Interpreter::Process<Cmd("joiner")>(Arg aArgs[])
-{
-    return mJoiner.Process(aArgs);
-}
+template <> otError Interpreter::Process<Cmd("joiner")>(Arg aArgs[]) { return mJoiner.Process(aArgs); }
 #endif
 
 #if OPENTHREAD_FTD
@@ -7449,10 +7422,7 @@ extern "C" void otCliInit(otInstance *aInstance, otCliOutputCallback aCallback, 
     Interpreter::Initialize(aInstance, aCallback, aContext);
 }
 
-extern "C" void otCliInputLine(char *aBuf)
-{
-    Interpreter::GetInterpreter().ProcessLine(aBuf);
-}
+extern "C" void otCliInputLine(char *aBuf) { Interpreter::GetInterpreter().ProcessLine(aBuf); }
 
 extern "C" void otCliSetUserCommands(const otCliCommand *aUserCommands, uint8_t aLength, void *aContext)
 {
@@ -7472,10 +7442,7 @@ extern "C" void otCliOutputFormat(const char *aFmt, ...)
     va_end(aAp);
 }
 
-extern "C" void otCliAppendResult(otError aError)
-{
-    Interpreter::GetInterpreter().OutputResult(aError);
-}
+extern "C" void otCliAppendResult(otError aError) { Interpreter::GetInterpreter().OutputResult(aError); }
 
 extern "C" void otCliPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list aArgs)
 {
@@ -7499,18 +7466,9 @@ exit:
 } // namespace ot
 
 #if OPENTHREAD_CONFIG_LEGACY_ENABLE
-OT_TOOL_WEAK void otNcpRegisterLegacyHandlers(const otNcpLegacyHandlers *aHandlers)
-{
-    OT_UNUSED_VARIABLE(aHandlers);
-}
+OT_TOOL_WEAK void otNcpRegisterLegacyHandlers(const otNcpLegacyHandlers *aHandlers) { OT_UNUSED_VARIABLE(aHandlers); }
 
-OT_TOOL_WEAK void otNcpHandleDidReceiveNewLegacyUlaPrefix(const uint8_t *aUlaPrefix)
-{
-    OT_UNUSED_VARIABLE(aUlaPrefix);
-}
+OT_TOOL_WEAK void otNcpHandleDidReceiveNewLegacyUlaPrefix(const uint8_t *aUlaPrefix) { OT_UNUSED_VARIABLE(aUlaPrefix); }
 
-OT_TOOL_WEAK void otNcpHandleLegacyNodeDidJoin(const otExtAddress *aExtAddr)
-{
-    OT_UNUSED_VARIABLE(aExtAddr);
-}
+OT_TOOL_WEAK void otNcpHandleLegacyNodeDidJoin(const otExtAddress *aExtAddr) { OT_UNUSED_VARIABLE(aExtAddr); }
 #endif

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -153,10 +153,7 @@ public:
      * @returns  Whether the interpreter is initialized.
      *
      */
-    static bool IsInitialized(void)
-    {
-        return sInterpreter != nullptr;
-    }
+    static bool IsInitialized(void) { return sInterpreter != nullptr; }
 
     /**
      * This method interprets a CLI command.
@@ -582,35 +579,17 @@ private:
 
 // Specializations of `FormatStringFor<ValueType>()`
 
-template <> inline constexpr const char *Interpreter::FormatStringFor<uint8_t>(void)
-{
-    return "%u";
-}
+template <> inline constexpr const char *Interpreter::FormatStringFor<uint8_t>(void) { return "%u"; }
 
-template <> inline constexpr const char *Interpreter::FormatStringFor<uint16_t>(void)
-{
-    return "%u";
-}
+template <> inline constexpr const char *Interpreter::FormatStringFor<uint16_t>(void) { return "%u"; }
 
-template <> inline constexpr const char *Interpreter::FormatStringFor<uint32_t>(void)
-{
-    return "%lu";
-}
+template <> inline constexpr const char *Interpreter::FormatStringFor<uint32_t>(void) { return "%lu"; }
 
-template <> inline constexpr const char *Interpreter::FormatStringFor<int8_t>(void)
-{
-    return "%d";
-}
+template <> inline constexpr const char *Interpreter::FormatStringFor<int8_t>(void) { return "%d"; }
 
-template <> inline constexpr const char *Interpreter::FormatStringFor<int16_t>(void)
-{
-    return "%d";
-}
+template <> inline constexpr const char *Interpreter::FormatStringFor<int16_t>(void) { return "%d"; }
 
-template <> inline constexpr const char *Interpreter::FormatStringFor<int32_t>(void)
-{
-    return "%ld";
-}
+template <> inline constexpr const char *Interpreter::FormatStringFor<int32_t>(void) { return "%ld"; }
 
 // Specialization of ProcessGet<> for `uint32_t` and `int32_t`
 

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -328,25 +328,13 @@ exit:
     return error;
 }
 
-template <> otError Coap::Process<Cmd("get")>(Arg aArgs[])
-{
-    return ProcessRequest(aArgs, OT_COAP_CODE_GET);
-}
+template <> otError Coap::Process<Cmd("get")>(Arg aArgs[]) { return ProcessRequest(aArgs, OT_COAP_CODE_GET); }
 
-template <> otError Coap::Process<Cmd("post")>(Arg aArgs[])
-{
-    return ProcessRequest(aArgs, OT_COAP_CODE_POST);
-}
+template <> otError Coap::Process<Cmd("post")>(Arg aArgs[]) { return ProcessRequest(aArgs, OT_COAP_CODE_POST); }
 
-template <> otError Coap::Process<Cmd("put")>(Arg aArgs[])
-{
-    return ProcessRequest(aArgs, OT_COAP_CODE_PUT);
-}
+template <> otError Coap::Process<Cmd("put")>(Arg aArgs[]) { return ProcessRequest(aArgs, OT_COAP_CODE_PUT); }
 
-template <> otError Coap::Process<Cmd("delete")>(Arg aArgs[])
-{
-    return ProcessRequest(aArgs, OT_COAP_CODE_DELETE);
-}
+template <> otError Coap::Process<Cmd("delete")>(Arg aArgs[]) { return ProcessRequest(aArgs, OT_COAP_CODE_DELETE); }
 
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
 template <> otError Coap::Process<Cmd("observe")>(Arg aArgs[])

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -200,20 +200,11 @@ template <> otError CoapSecure::Process<Cmd("stop")>(Arg aArgs[])
     return OT_ERROR_NONE;
 }
 
-template <> otError CoapSecure::Process<Cmd("get")>(Arg aArgs[])
-{
-    return ProcessRequest(aArgs, OT_COAP_CODE_GET);
-}
+template <> otError CoapSecure::Process<Cmd("get")>(Arg aArgs[]) { return ProcessRequest(aArgs, OT_COAP_CODE_GET); }
 
-template <> otError CoapSecure::Process<Cmd("post")>(Arg aArgs[])
-{
-    return ProcessRequest(aArgs, OT_COAP_CODE_POST);
-}
+template <> otError CoapSecure::Process<Cmd("post")>(Arg aArgs[]) { return ProcessRequest(aArgs, OT_COAP_CODE_POST); }
 
-template <> otError CoapSecure::Process<Cmd("put")>(Arg aArgs[])
-{
-    return ProcessRequest(aArgs, OT_COAP_CODE_PUT);
-}
+template <> otError CoapSecure::Process<Cmd("put")>(Arg aArgs[]) { return ProcessRequest(aArgs, OT_COAP_CODE_PUT); }
 
 template <> otError CoapSecure::Process<Cmd("delete")>(Arg aArgs[])
 {

--- a/src/cli/cli_history.cpp
+++ b/src/cli/cli_history.cpp
@@ -299,20 +299,11 @@ exit:
     return error;
 }
 
-template <> otError History::Process<Cmd("rx")>(Arg aArgs[])
-{
-    return ProcessRxTxHistory(kRx, aArgs);
-}
+template <> otError History::Process<Cmd("rx")>(Arg aArgs[]) { return ProcessRxTxHistory(kRx, aArgs); }
 
-template <> otError History::Process<Cmd("rxtx")>(Arg aArgs[])
-{
-    return ProcessRxTxHistory(kRxTx, aArgs);
-}
+template <> otError History::Process<Cmd("rxtx")>(Arg aArgs[]) { return ProcessRxTxHistory(kRxTx, aArgs); }
 
-template <> otError History::Process<Cmd("tx")>(Arg aArgs[])
-{
-    return ProcessRxTxHistory(kTx, aArgs);
-}
+template <> otError History::Process<Cmd("tx")>(Arg aArgs[]) { return ProcessRxTxHistory(kTx, aArgs); }
 
 const char *History::MessagePriorityToString(uint8_t aPriority)
 {

--- a/src/cli/cli_joiner.cpp
+++ b/src/cli/cli_joiner.cpp
@@ -261,10 +261,7 @@ exit:
     return error;
 }
 
-void Joiner::HandleCallback(otError aError, void *aContext)
-{
-    static_cast<Joiner *>(aContext)->HandleCallback(aError);
-}
+void Joiner::HandleCallback(otError aError, void *aContext) { static_cast<Joiner *>(aContext)->HandleCallback(aError); }
 
 void Joiner::HandleCallback(otError aError)
 {

--- a/src/cli/cli_output.cpp
+++ b/src/cli/cli_output.cpp
@@ -104,15 +104,9 @@ void Output::OutputLine(uint8_t aIndentSize, const char *aFormat, ...)
     OutputNewLine();
 }
 
-void Output::OutputNewLine(void)
-{
-    OutputFormat("\r\n");
-}
+void Output::OutputNewLine(void) { OutputFormat("\r\n"); }
 
-void Output::OutputSpaces(uint8_t aCount)
-{
-    OutputFormat("%*s", aCount, "");
-}
+void Output::OutputSpaces(uint8_t aCount) { OutputFormat("%*s", aCount, ""); }
 
 void Output::OutputBytes(const uint8_t *aBytes, uint16_t aLength)
 {
@@ -162,10 +156,7 @@ void Output::OutputUint64Line(uint64_t aUint64)
     OutputNewLine();
 }
 
-void Output::OutputEnabledDisabledStatus(bool aEnabled)
-{
-    OutputLine(aEnabled ? "Enabled" : "Disabled");
-}
+void Output::OutputEnabledDisabledStatus(bool aEnabled) { OutputLine(aEnabled ? "Enabled" : "Disabled"); }
 
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
 
@@ -272,10 +263,7 @@ void Output::OutputDnsTxtData(const uint8_t *aTxtData, uint16_t aTxtDataLength)
 }
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD
 
-void Output::OutputFormatV(const char *aFormat, va_list aArguments)
-{
-    mImplementer.OutputV(aFormat, aArguments);
-}
+void Output::OutputFormatV(const char *aFormat, va_list aArguments) { mImplementer.OutputV(aFormat, aArguments); }
 
 void OutputImplementer::OutputV(const char *aFormat, va_list aArguments)
 {

--- a/src/cli/cli_output.hpp
+++ b/src/cli/cli_output.hpp
@@ -90,14 +90,9 @@ public:
     OutputImplementer(otCliOutputCallback aCallback, void *aCallbackContext);
 
 #if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
-    void SetEmittingCommandOutput(bool aEmittingOutput)
-    {
-        mEmittingCommandOutput = aEmittingOutput;
-    }
+    void SetEmittingCommandOutput(bool aEmittingOutput) { mEmittingCommandOutput = aEmittingOutput; }
 #else
-    void SetEmittingCommandOutput(bool)
-    {
-    }
+    void SetEmittingCommandOutput(bool) {}
 #endif
 
 private:
@@ -512,9 +507,7 @@ protected:
 #if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
     void LogInput(const Arg *aArgs);
 #else
-    void LogInput(const Arg *)
-    {
-    }
+    void LogInput(const Arg *) {}
 #endif
 
 private:

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -129,10 +129,7 @@ otError otCoapMessageAppendUriQueryOption(otMessage *aMessage, const char *aUriQ
     return AsCoapMessage(aMessage).AppendUriQueryOption(aUriQuery);
 }
 
-otError otCoapMessageSetPayloadMarker(otMessage *aMessage)
-{
-    return AsCoapMessage(aMessage).SetPayloadMarker();
-}
+otError otCoapMessageSetPayloadMarker(otMessage *aMessage) { return AsCoapMessage(aMessage).SetPayloadMarker(); }
 
 otCoapType otCoapMessageGetType(const otMessage *aMessage)
 {
@@ -144,30 +141,15 @@ otCoapCode otCoapMessageGetCode(const otMessage *aMessage)
     return static_cast<otCoapCode>(AsCoapMessage(aMessage).GetCode());
 }
 
-void otCoapMessageSetCode(otMessage *aMessage, otCoapCode aCode)
-{
-    AsCoapMessage(aMessage).SetCode(MapEnum(aCode));
-}
+void otCoapMessageSetCode(otMessage *aMessage, otCoapCode aCode) { AsCoapMessage(aMessage).SetCode(MapEnum(aCode)); }
 
-const char *otCoapMessageCodeToString(const otMessage *aMessage)
-{
-    return AsCoapMessage(aMessage).CodeToString();
-}
+const char *otCoapMessageCodeToString(const otMessage *aMessage) { return AsCoapMessage(aMessage).CodeToString(); }
 
-uint16_t otCoapMessageGetMessageId(const otMessage *aMessage)
-{
-    return AsCoapMessage(aMessage).GetMessageId();
-}
+uint16_t otCoapMessageGetMessageId(const otMessage *aMessage) { return AsCoapMessage(aMessage).GetMessageId(); }
 
-uint8_t otCoapMessageGetTokenLength(const otMessage *aMessage)
-{
-    return AsCoapMessage(aMessage).GetTokenLength();
-}
+uint8_t otCoapMessageGetTokenLength(const otMessage *aMessage) { return AsCoapMessage(aMessage).GetTokenLength(); }
 
-const uint8_t *otCoapMessageGetToken(const otMessage *aMessage)
-{
-    return AsCoapMessage(aMessage).GetToken();
-}
+const uint8_t *otCoapMessageGetToken(const otMessage *aMessage) { return AsCoapMessage(aMessage).GetToken(); }
 
 otError otCoapOptionIteratorInit(otCoapOptionIterator *aIterator, const otMessage *aMessage)
 {
@@ -271,10 +253,7 @@ otError otCoapStart(otInstance *aInstance, uint16_t aPort)
     return AsCoreType(aInstance).GetApplicationCoap().Start(aPort);
 }
 
-otError otCoapStop(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).GetApplicationCoap().Stop();
-}
+otError otCoapStop(otInstance *aInstance) { return AsCoreType(aInstance).GetApplicationCoap().Stop(); }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
 void otCoapAddBlockWiseResource(otInstance *aInstance, otCoapBlockwiseResource *aResource)

--- a/src/core/api/coap_secure_api.cpp
+++ b/src/core/api/coap_secure_api.cpp
@@ -110,10 +110,7 @@ otError otCoapSecureConnect(otInstance                     *aInstance,
     return AsCoreType(aInstance).GetApplicationCoapSecure().Connect(AsCoreType(aSockAddr), aHandler, aContext);
 }
 
-void otCoapSecureDisconnect(otInstance *aInstance)
-{
-    AsCoreType(aInstance).GetApplicationCoapSecure().Disconnect();
-}
+void otCoapSecureDisconnect(otInstance *aInstance) { AsCoreType(aInstance).GetApplicationCoapSecure().Disconnect(); }
 
 bool otCoapSecureIsConnected(otInstance *aInstance)
 {
@@ -125,10 +122,7 @@ bool otCoapSecureIsConnectionActive(otInstance *aInstance)
     return AsCoreType(aInstance).GetApplicationCoapSecure().IsConnectionActive();
 }
 
-void otCoapSecureStop(otInstance *aInstance)
-{
-    AsCoreType(aInstance).GetApplicationCoapSecure().Stop();
-}
+void otCoapSecureStop(otInstance *aInstance) { AsCoreType(aInstance).GetApplicationCoapSecure().Stop(); }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
 otError otCoapSecureSendRequestBlockWise(otInstance                 *aInstance,

--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -60,10 +60,7 @@ otError otCommissionerSetId(otInstance *aInstance, const char *aId)
     return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().SetId(aId);
 }
 
-otError otCommissionerStop(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().Stop();
-}
+otError otCommissionerStop(otInstance *aInstance) { return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().Stop(); }
 
 otError otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aEui64, const char *aPskd, uint32_t aTimeout)
 {

--- a/src/core/api/diags_api.cpp
+++ b/src/core/api/diags_api.cpp
@@ -54,9 +54,6 @@ otError otDiagProcessCmd(otInstance *aInstance, uint8_t aArgsLength, char *aArgs
     return AsCoreType(aInstance).Get<FactoryDiags::Diags>().ProcessCmd(aArgsLength, aArgs, aOutput, aOutputMaxLen);
 }
 
-bool otDiagIsEnabled(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<FactoryDiags::Diags>().IsEnabled();
-}
+bool otDiagIsEnabled(otInstance *aInstance) { return AsCoreType(aInstance).Get<FactoryDiags::Diags>().IsEnabled(); }
 
 #endif // OPENTHREAD_CONFIG_DIAG_ENABLE

--- a/src/core/api/dns_api.cpp
+++ b/src/core/api/dns_api.cpp
@@ -51,15 +51,9 @@ otError otDnsGetNextTxtEntry(otDnsTxtEntryIterator *aIterator, otDnsTxtEntry *aE
 }
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-void otDnsSetNameCompressionEnabled(bool aEnabled)
-{
-    Instance::SetDnsNameCompressionEnabled(aEnabled);
-}
+void otDnsSetNameCompressionEnabled(bool aEnabled) { Instance::SetDnsNameCompressionEnabled(aEnabled); }
 
-bool otDnsIsNameCompressionEnabled(void)
-{
-    return Instance::IsDnsNameCompressionEnabled();
-}
+bool otDnsIsNameCompressionEnabled(void) { return Instance::IsDnsNameCompressionEnabled(); }
 #endif
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE

--- a/src/core/api/error_api.cpp
+++ b/src/core/api/error_api.cpp
@@ -37,7 +37,4 @@
 
 using namespace ot;
 
-const char *otThreadErrorToString(otError aError)
-{
-    return ErrorToString(aError);
-}
+const char *otThreadErrorToString(otError aError) { return ErrorToString(aError); }

--- a/src/core/api/heap_api.cpp
+++ b/src/core/api/heap_api.cpp
@@ -60,13 +60,7 @@ void otHeapFree(void *aPointer)
 }
 
 #else  // OPENTHREAD_RADIO
-void *otHeapCAlloc(size_t aCount, size_t aSize)
-{
-    return ot::Heap::CAlloc(aCount, aSize);
-}
+void *otHeapCAlloc(size_t aCount, size_t aSize) { return ot::Heap::CAlloc(aCount, aSize); }
 
-void otHeapFree(void *aPointer)
-{
-    ot::Heap::Free(aPointer);
-}
+void otHeapFree(void *aPointer) { ot::Heap::Free(aPointer); }
 #endif // OPENTHREAD_RADIO

--- a/src/core/api/history_tracker_api.cpp
+++ b/src/core/api/history_tracker_api.cpp
@@ -43,10 +43,7 @@
 
 using namespace ot;
 
-void otHistoryTrackerInitIterator(otHistoryTrackerIterator *aIterator)
-{
-    AsCoreType(aIterator).Init();
-}
+void otHistoryTrackerInitIterator(otHistoryTrackerIterator *aIterator) { AsCoreType(aIterator).Init(); }
 
 const otHistoryTrackerNetworkInfo *otHistoryTrackerIterateNetInfoHistory(otInstance               *aInstance,
                                                                          otHistoryTrackerIterator *aIterator,

--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -67,10 +67,7 @@ otInstance *otInstanceInit(void *aInstanceBuffer, size_t *aInstanceBufferSize)
     return instance;
 }
 #else
-otInstance *otInstanceInitSingle(void)
-{
-    return &Instance::InitSingle();
-}
+otInstance *otInstanceInitSingle(void) { return &Instance::InitSingle(); }
 #endif // #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
 
 bool otInstanceIsInitialized(otInstance *aInstance)
@@ -83,21 +80,12 @@ bool otInstanceIsInitialized(otInstance *aInstance)
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 }
 
-void otInstanceFinalize(otInstance *aInstance)
-{
-    AsCoreType(aInstance).Finalize();
-}
+void otInstanceFinalize(otInstance *aInstance) { AsCoreType(aInstance).Finalize(); }
 
-void otInstanceReset(otInstance *aInstance)
-{
-    AsCoreType(aInstance).Reset();
-}
+void otInstanceReset(otInstance *aInstance) { AsCoreType(aInstance).Reset(); }
 
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
-uint64_t otInstanceGetUptime(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Uptime>().GetUptime();
-}
+uint64_t otInstanceGetUptime(otInstance *aInstance) { return AsCoreType(aInstance).Get<Uptime>().GetUptime(); }
 
 void otInstanceGetUptimeAsString(otInstance *aInstance, char *aBuffer, uint16_t aSize)
 {
@@ -118,22 +106,13 @@ void otRemoveStateChangeCallback(otInstance *aInstance, otStateChangedCallback a
     AsCoreType(aInstance).Get<Notifier>().RemoveCallback(aCallback, aContext);
 }
 
-void otInstanceFactoryReset(otInstance *aInstance)
-{
-    AsCoreType(aInstance).FactoryReset();
-}
+void otInstanceFactoryReset(otInstance *aInstance) { AsCoreType(aInstance).FactoryReset(); }
 
-otError otInstanceErasePersistentInfo(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).ErasePersistentInfo();
-}
+otError otInstanceErasePersistentInfo(otInstance *aInstance) { return AsCoreType(aInstance).ErasePersistentInfo(); }
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 
 #if OPENTHREAD_RADIO
-void otInstanceResetRadioStack(otInstance *aInstance)
-{
-    AsCoreType(aInstance).ResetRadioStack();
-}
+void otInstanceResetRadioStack(otInstance *aInstance) { AsCoreType(aInstance).ResetRadioStack(); }
 #endif
 
 const char *otGetVersionString(void)

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -68,10 +68,7 @@ exit:
     return error;
 }
 
-bool otIp6IsEnabled(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<ThreadNetif>().IsUp();
-}
+bool otIp6IsEnabled(otInstance *aInstance) { return AsCoreType(aInstance).Get<ThreadNetif>().IsUp(); }
 
 const otNetifAddress *otIp6GetUnicastAddresses(otInstance *aInstance)
 {
@@ -222,10 +219,7 @@ void otIp6GetPrefix(const otIp6Address *aAddress, uint8_t aLength, otIp6Prefix *
     AsCoreType(aAddress).GetPrefix(aLength, AsCoreType(aPrefix));
 }
 
-bool otIp6IsAddressUnspecified(const otIp6Address *aAddress)
-{
-    return AsCoreType(aAddress).IsUnspecified();
-}
+bool otIp6IsAddressUnspecified(const otIp6Address *aAddress) { return AsCoreType(aAddress).IsUnspecified(); }
 
 otError otIp6SelectSourceAddress(otInstance *aInstance, otMessageInfo *aMessageInfo)
 {
@@ -255,10 +249,7 @@ otError otIp6RegisterMulticastListeners(otInstance                             *
 
 #if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
 
-bool otIp6IsSlaacEnabled(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Utils::Slaac>().IsEnabled();
-}
+bool otIp6IsSlaacEnabled(otInstance *aInstance) { return AsCoreType(aInstance).Get<Utils::Slaac>().IsEnabled(); }
 
 void otIp6SetSlaacEnabled(otInstance *aInstance, bool aEnabled)
 {
@@ -290,10 +281,7 @@ otError otIp6SetMeshLocalIid(otInstance *aInstance, const otIp6InterfaceIdentifi
 
 #endif
 
-const char *otIp6ProtoToString(uint8_t aIpProto)
-{
-    return Ip6::Ip6::IpProtoToString(aIpProto);
-}
+const char *otIp6ProtoToString(uint8_t aIpProto) { return Ip6::Ip6::IpProtoToString(aIpProto); }
 
 #if OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
 const otBorderRoutingCounters *otIp6GetBorderRoutingCounters(otInstance *aInstance)

--- a/src/core/api/jam_detection_api.cpp
+++ b/src/core/api/jam_detection_api.cpp
@@ -79,10 +79,7 @@ otError otJamDetectionStart(otInstance *aInstance, otJamDetectionCallback aCallb
     return AsCoreType(aInstance).Get<Utils::JamDetector>().Start(aCallback, aContext);
 }
 
-otError otJamDetectionStop(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Utils::JamDetector>().Stop();
-}
+otError otJamDetectionStop(otInstance *aInstance) { return AsCoreType(aInstance).Get<Utils::JamDetector>().Stop(); }
 
 bool otJamDetectionIsEnabled(otInstance *aInstance)
 {

--- a/src/core/api/joiner_api.cpp
+++ b/src/core/api/joiner_api.cpp
@@ -57,10 +57,7 @@ otError otJoinerStart(otInstance      *aInstance,
                                                               aVendorSwVersion, aVendorData, aCallback, aContext);
 }
 
-void otJoinerStop(otInstance *aInstance)
-{
-    AsCoreType(aInstance).Get<MeshCoP::Joiner>().Stop();
-}
+void otJoinerStop(otInstance *aInstance) { AsCoreType(aInstance).Get<MeshCoP::Joiner>().Stop(); }
 
 otJoinerState otJoinerGetState(otInstance *aInstance)
 {

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -127,10 +127,7 @@ void otLinkGetFactoryAssignedIeeeEui64(otInstance *aInstance, otExtAddress *aEui
     AsCoreType(aInstance).Get<Radio>().GetIeeeEui64(AsCoreType(aEui64));
 }
 
-otPanId otLinkGetPanId(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Mac::Mac>().GetPanId();
-}
+otPanId otLinkGetPanId(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mac::Mac>().GetPanId(); }
 
 otError otLinkSetPanId(otInstance *aInstance, otPanId aPanId)
 {
@@ -246,10 +243,7 @@ void otLinkFilterClearDefaultRssIn(otInstance *aInstance)
     AsCoreType(aInstance).Get<Mac::Filter>().ClearDefaultRssIn();
 }
 
-void otLinkFilterClearAllRssIn(otInstance *aInstance)
-{
-    AsCoreType(aInstance).Get<Mac::Filter>().ClearAllRssIn();
-}
+void otLinkFilterClearAllRssIn(otInstance *aInstance) { AsCoreType(aInstance).Get<Mac::Filter>().ClearAllRssIn(); }
 
 otError otLinkFilterGetNextRssIn(otInstance *aInstance, otMacFilterIterator *aIterator, otMacFilterEntry *aEntry)
 {
@@ -319,10 +313,7 @@ void otLinkSetPcapCallback(otInstance *aInstance, otLinkPcapCallback aPcapCallba
     AsCoreType(aInstance).Get<Mac::Mac>().SetPcapCallback(aPcapCallback, aCallbackContext);
 }
 
-bool otLinkIsPromiscuous(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Mac::Mac>().IsPromiscuous();
-}
+bool otLinkIsPromiscuous(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mac::Mac>().IsPromiscuous(); }
 
 otError otLinkSetPromiscuous(otInstance *aInstance, bool aPromiscuous)
 {
@@ -352,20 +343,14 @@ exit:
     return error;
 }
 
-bool otLinkIsEnabled(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Mac::Mac>().IsEnabled();
-}
+bool otLinkIsEnabled(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mac::Mac>().IsEnabled(); }
 
 const otMacCounters *otLinkGetCounters(otInstance *aInstance)
 {
     return &AsCoreType(aInstance).Get<Mac::Mac>().GetCounters();
 }
 
-void otLinkResetCounters(otInstance *aInstance)
-{
-    AsCoreType(aInstance).Get<Mac::Mac>().ResetCounters();
-}
+void otLinkResetCounters(otInstance *aInstance) { AsCoreType(aInstance).Get<Mac::Mac>().ResetCounters(); }
 
 otError otLinkActiveScan(otInstance              *aInstance,
                          uint32_t                 aScanChannels,
@@ -406,10 +391,7 @@ uint16_t otLinkGetCcaFailureRate(otInstance *aInstance)
 }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-uint8_t otLinkCslGetChannel(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Mac::Mac>().GetCslChannel();
-}
+uint8_t otLinkCslGetChannel(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mac::Mac>().GetCslChannel(); }
 
 otError otLinkCslSetChannel(otInstance *aInstance, uint8_t aChannel)
 {
@@ -423,10 +405,7 @@ exit:
     return error;
 }
 
-uint16_t otLinkCslGetPeriod(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Mac::Mac>().GetCslPeriod();
-}
+uint16_t otLinkCslGetPeriod(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mac::Mac>().GetCslPeriod(); }
 
 otError otLinkCslSetPeriod(otInstance *aInstance, uint16_t aPeriod)
 {

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -54,20 +54,14 @@ otError otLinkRawSetReceiveDone(otInstance *aInstance, otLinkRawReceiveDone aCal
     return AsCoreType(aInstance).Get<Mac::LinkRaw>().SetReceiveDone(aCallback);
 }
 
-bool otLinkRawIsEnabled(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Mac::LinkRaw>().IsEnabled();
-}
+bool otLinkRawIsEnabled(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mac::LinkRaw>().IsEnabled(); }
 
 otError otLinkRawSetShortAddress(otInstance *aInstance, uint16_t aShortAddress)
 {
     return AsCoreType(aInstance).Get<Mac::LinkRaw>().SetShortAddress(aShortAddress);
 }
 
-bool otLinkRawGetPromiscuous(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Radio>().GetPromiscuous();
-}
+bool otLinkRawGetPromiscuous(otInstance *aInstance) { return AsCoreType(aInstance).Get<Radio>().GetPromiscuous(); }
 
 otError otLinkRawSetPromiscuous(otInstance *aInstance, bool aEnable)
 {
@@ -94,10 +88,7 @@ exit:
     return error;
 }
 
-otError otLinkRawReceive(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Mac::LinkRaw>().Receive();
-}
+otError otLinkRawReceive(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mac::LinkRaw>().Receive(); }
 
 otRadioFrame *otLinkRawGetTransmitBuffer(otInstance *aInstance)
 {
@@ -109,15 +100,9 @@ otError otLinkRawTransmit(otInstance *aInstance, otLinkRawTransmitDone aCallback
     return AsCoreType(aInstance).Get<Mac::LinkRaw>().Transmit(aCallback);
 }
 
-int8_t otLinkRawGetRssi(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Radio>().GetRssi();
-}
+int8_t otLinkRawGetRssi(otInstance *aInstance) { return AsCoreType(aInstance).Get<Radio>().GetRssi(); }
 
-otRadioCaps otLinkRawGetCaps(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Mac::LinkRaw>().GetCaps();
-}
+otRadioCaps otLinkRawGetCaps(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mac::LinkRaw>().GetCaps(); }
 
 otError otLinkRawEnergyScan(otInstance             *aInstance,
                             uint8_t                 aScanChannel,
@@ -255,20 +240,14 @@ otDeviceRole otThreadGetDeviceRole(otInstance *aInstance)
     return OT_DEVICE_ROLE_DISABLED;
 }
 
-uint8_t otLinkGetChannel(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Mac::LinkRaw>().GetChannel();
-}
+uint8_t otLinkGetChannel(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mac::LinkRaw>().GetChannel(); }
 
 otError otLinkSetChannel(otInstance *aInstance, uint8_t aChannel)
 {
     return AsCoreType(aInstance).Get<Mac::LinkRaw>().SetChannel(aChannel);
 }
 
-otPanId otLinkGetPanId(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Mac::LinkRaw>().GetPanId();
-}
+otPanId otLinkGetPanId(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mac::LinkRaw>().GetPanId(); }
 
 otError otLinkSetPanId(otInstance *aInstance, uint16_t aPanId)
 {

--- a/src/core/api/logging_api.cpp
+++ b/src/core/api/logging_api.cpp
@@ -41,10 +41,7 @@
 
 using namespace ot;
 
-otLogLevel otLoggingGetLevel(void)
-{
-    return static_cast<otLogLevel>(Instance::GetLogLevel());
-}
+otLogLevel otLoggingGetLevel(void) { return static_cast<otLogLevel>(Instance::GetLogLevel()); }
 
 #if OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE
 otError otLoggingSetLevel(otLogLevel aLogLevel)

--- a/src/core/api/message_api.cpp
+++ b/src/core/api/message_api.cpp
@@ -40,35 +40,17 @@
 
 using namespace ot;
 
-void otMessageFree(otMessage *aMessage)
-{
-    AsCoreType(aMessage).Free();
-}
+void otMessageFree(otMessage *aMessage) { AsCoreType(aMessage).Free(); }
 
-uint16_t otMessageGetLength(const otMessage *aMessage)
-{
-    return AsCoreType(aMessage).GetLength();
-}
+uint16_t otMessageGetLength(const otMessage *aMessage) { return AsCoreType(aMessage).GetLength(); }
 
-otError otMessageSetLength(otMessage *aMessage, uint16_t aLength)
-{
-    return AsCoreType(aMessage).SetLength(aLength);
-}
+otError otMessageSetLength(otMessage *aMessage, uint16_t aLength) { return AsCoreType(aMessage).SetLength(aLength); }
 
-uint16_t otMessageGetOffset(const otMessage *aMessage)
-{
-    return AsCoreType(aMessage).GetOffset();
-}
+uint16_t otMessageGetOffset(const otMessage *aMessage) { return AsCoreType(aMessage).GetOffset(); }
 
-void otMessageSetOffset(otMessage *aMessage, uint16_t aOffset)
-{
-    AsCoreType(aMessage).SetOffset(aOffset);
-}
+void otMessageSetOffset(otMessage *aMessage, uint16_t aOffset) { AsCoreType(aMessage).SetOffset(aOffset); }
 
-bool otMessageIsLinkSecurityEnabled(const otMessage *aMessage)
-{
-    return AsCoreType(aMessage).IsLinkSecurityEnabled();
-}
+bool otMessageIsLinkSecurityEnabled(const otMessage *aMessage) { return AsCoreType(aMessage).IsLinkSecurityEnabled(); }
 
 void otMessageSetDirectTransmission(otMessage *aMessage, bool aEnabled)
 {
@@ -82,10 +64,7 @@ void otMessageSetDirectTransmission(otMessage *aMessage, bool aEnabled)
     }
 }
 
-int8_t otMessageGetRss(const otMessage *aMessage)
-{
-    return AsCoreType(aMessage).GetAverageRss();
-}
+int8_t otMessageGetRss(const otMessage *aMessage) { return AsCoreType(aMessage).GetAverageRss(); }
 
 otError otMessageAppend(otMessage *aMessage, const void *aBuf, uint16_t aLength)
 {
@@ -132,10 +111,7 @@ void otMessageQueueDequeue(otMessageQueue *aQueue, otMessage *aMessage)
     AsCoreType(aQueue).Dequeue(AsCoreType(aMessage));
 }
 
-otMessage *otMessageQueueGetHead(otMessageQueue *aQueue)
-{
-    return AsCoreType(aQueue).GetHead();
-}
+otMessage *otMessageQueueGetHead(otMessageQueue *aQueue) { return AsCoreType(aQueue).GetHead(); }
 
 otMessage *otMessageQueueGetNext(otMessageQueue *aQueue, const otMessage *aMessage)
 {

--- a/src/core/api/ping_sender_api.cpp
+++ b/src/core/api/ping_sender_api.cpp
@@ -47,9 +47,6 @@ otError otPingSenderPing(otInstance *aInstance, const otPingSenderConfig *aConfi
     return AsCoreType(aInstance).Get<Utils::PingSender>().Ping(AsCoreType(aConfig));
 }
 
-void otPingSenderStop(otInstance *aInstance)
-{
-    AsCoreType(aInstance).Get<Utils::PingSender>().Stop();
-}
+void otPingSenderStop(otInstance *aInstance) { AsCoreType(aInstance).Get<Utils::PingSender>().Stop(); }
 
 #endif // OPENTHREAD_CONFIG_PING_SENDER_ENABLE

--- a/src/core/api/random_noncrypto_api.cpp
+++ b/src/core/api/random_noncrypto_api.cpp
@@ -37,20 +37,11 @@
 
 using namespace ot;
 
-uint32_t otRandomNonCryptoGetUint32(void)
-{
-    return Random::NonCrypto::GetUint32();
-}
+uint32_t otRandomNonCryptoGetUint32(void) { return Random::NonCrypto::GetUint32(); }
 
-uint8_t otRandomNonCryptoGetUint8(void)
-{
-    return Random::NonCrypto::GetUint8();
-}
+uint8_t otRandomNonCryptoGetUint8(void) { return Random::NonCrypto::GetUint8(); }
 
-uint16_t otRandomNonCryptoGetUint16(void)
-{
-    return Random::NonCrypto::GetUint16();
-}
+uint16_t otRandomNonCryptoGetUint16(void) { return Random::NonCrypto::GetUint16(); }
 
 uint8_t otRandomNonCryptoGetUint8InRange(uint8_t aMin, uint8_t aMax)
 {
@@ -67,10 +58,7 @@ uint32_t otRandomNonCryptoGetUint32InRange(uint32_t aMin, uint32_t aMax)
     return Random::NonCrypto::GetUint32InRange(aMin, aMax);
 }
 
-void otRandomNonCryptoFillBuffer(uint8_t *aBuffer, uint16_t aSize)
-{
-    Random::NonCrypto::FillBuffer(aBuffer, aSize);
-}
+void otRandomNonCryptoFillBuffer(uint8_t *aBuffer, uint16_t aSize) { Random::NonCrypto::FillBuffer(aBuffer, aSize); }
 
 uint32_t otRandomNonCryptoAddJitter(uint32_t aValue, uint16_t aJitter)
 {

--- a/src/core/api/srp_client_api.cpp
+++ b/src/core/api/srp_client_api.cpp
@@ -47,15 +47,9 @@ otError otSrpClientStart(otInstance *aInstance, const otSockAddr *aServerSockAdd
     return AsCoreType(aInstance).Get<Srp::Client>().Start(AsCoreType(aServerSockAddr));
 }
 
-void otSrpClientStop(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Srp::Client>().Stop();
-}
+void otSrpClientStop(otInstance *aInstance) { return AsCoreType(aInstance).Get<Srp::Client>().Stop(); }
 
-bool otSrpClientIsRunning(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Srp::Client>().IsRunning();
-}
+bool otSrpClientIsRunning(otInstance *aInstance) { return AsCoreType(aInstance).Get<Srp::Client>().IsRunning(); }
 
 const otSockAddr *otSrpClientGetServerAddress(otInstance *aInstance)
 {
@@ -84,10 +78,7 @@ bool otSrpClientIsAutoStartModeEnabled(otInstance *aInstance)
 }
 #endif // OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
 
-uint32_t otSrpClientGetTtl(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Srp::Client>().GetTtl();
-}
+uint32_t otSrpClientGetTtl(otInstance *aInstance) { return AsCoreType(aInstance).Get<Srp::Client>().GetTtl(); }
 
 void otSrpClientSetTtl(otInstance *aInstance, uint32_t aTtl)
 {

--- a/src/core/api/srp_server_api.cpp
+++ b/src/core/api/srp_server_api.cpp
@@ -42,10 +42,7 @@
 
 using namespace ot;
 
-const char *otSrpServerGetDomain(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Srp::Server>().GetDomain();
-}
+const char *otSrpServerGetDomain(otInstance *aInstance) { return AsCoreType(aInstance).Get<Srp::Server>().GetDomain(); }
 
 otError otSrpServerSetDomain(otInstance *aInstance, const char *aDomain)
 {
@@ -57,10 +54,7 @@ otSrpServerState otSrpServerGetState(otInstance *aInstance)
     return MapEnum(AsCoreType(aInstance).Get<Srp::Server>().GetState());
 }
 
-uint16_t otSrpServerGetPort(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Srp::Server>().GetPort();
-}
+uint16_t otSrpServerGetPort(otInstance *aInstance) { return AsCoreType(aInstance).Get<Srp::Server>().GetPort(); }
 
 otSrpServerAddressMode otSrpServerGetAddressMode(otInstance *aInstance)
 {
@@ -141,15 +135,9 @@ const otSrpServerResponseCounters *otSrpServerGetResponseCounters(otInstance *aI
     return AsCoreType(aInstance).Get<Srp::Server>().GetResponseCounters();
 }
 
-bool otSrpServerHostIsDeleted(const otSrpServerHost *aHost)
-{
-    return AsCoreType(aHost).IsDeleted();
-}
+bool otSrpServerHostIsDeleted(const otSrpServerHost *aHost) { return AsCoreType(aHost).IsDeleted(); }
 
-const char *otSrpServerHostGetFullName(const otSrpServerHost *aHost)
-{
-    return AsCoreType(aHost).GetFullName();
-}
+const char *otSrpServerHostGetFullName(const otSrpServerHost *aHost) { return AsCoreType(aHost).GetFullName(); }
 
 const otIp6Address *otSrpServerHostGetAddresses(const otSrpServerHost *aHost, uint8_t *aAddressesNum)
 {
@@ -161,10 +149,7 @@ void otSrpServerHostGetLeaseInfo(const otSrpServerHost *aHost, otSrpServerLeaseI
     AsCoreType(aHost).GetLeaseInfo(*aLeaseInfo);
 }
 
-uint32_t otSrpServerHostGetKeyLease(const otSrpServerHost *aHost)
-{
-    return AsCoreType(aHost).GetKeyLease();
-}
+uint32_t otSrpServerHostGetKeyLease(const otSrpServerHost *aHost) { return AsCoreType(aHost).GetKeyLease(); }
 
 const otSrpServerService *otSrpServerHostGetNextService(const otSrpServerHost    *aHost,
                                                         const otSrpServerService *aService)
@@ -181,15 +166,9 @@ const otSrpServerService *otSrpServerHostFindNextService(const otSrpServerHost  
     return AsCoreType(aHost).FindNextService(AsCoreTypePtr(aPrevService), aFlags, aServiceName, aInstanceName);
 }
 
-bool otSrpServerServiceIsDeleted(const otSrpServerService *aService)
-{
-    return AsCoreType(aService).IsDeleted();
-}
+bool otSrpServerServiceIsDeleted(const otSrpServerService *aService) { return AsCoreType(aService).IsDeleted(); }
 
-bool otSrpServerServiceIsSubType(const otSrpServerService *aService)
-{
-    return AsCoreType(aService).IsSubType();
-}
+bool otSrpServerServiceIsSubType(const otSrpServerService *aService) { return AsCoreType(aService).IsSubType(); }
 
 const char *otSrpServerServiceGetFullName(const otSrpServerService *aService)
 {
@@ -211,25 +190,16 @@ otError otSrpServerServiceGetServiceSubTypeLabel(const otSrpServerService *aServ
     return AsCoreType(aService).GetServiceSubTypeLabel(aLabel, aMaxSize);
 }
 
-uint16_t otSrpServerServiceGetPort(const otSrpServerService *aService)
-{
-    return AsCoreType(aService).GetPort();
-}
+uint16_t otSrpServerServiceGetPort(const otSrpServerService *aService) { return AsCoreType(aService).GetPort(); }
 
-uint16_t otSrpServerServiceGetWeight(const otSrpServerService *aService)
-{
-    return AsCoreType(aService).GetWeight();
-}
+uint16_t otSrpServerServiceGetWeight(const otSrpServerService *aService) { return AsCoreType(aService).GetWeight(); }
 
 uint16_t otSrpServerServiceGetPriority(const otSrpServerService *aService)
 {
     return AsCoreType(aService).GetPriority();
 }
 
-uint32_t otSrpServerServiceGetTtl(const otSrpServerService *aService)
-{
-    return AsCoreType(aService).GetTtl();
-}
+uint32_t otSrpServerServiceGetTtl(const otSrpServerService *aService) { return AsCoreType(aService).GetTtl(); }
 
 const uint8_t *otSrpServerServiceGetTxtData(const otSrpServerService *aService, uint16_t *aDataLength)
 {

--- a/src/core/api/tasklet_api.cpp
+++ b/src/core/api/tasklet_api.cpp
@@ -60,6 +60,4 @@ exit:
     return retval;
 }
 
-OT_TOOL_WEAK void otTaskletsSignalPending(otInstance *)
-{
-}
+OT_TOOL_WEAK void otTaskletsSignalPending(otInstance *) {}

--- a/src/core/api/tcp_api.cpp
+++ b/src/core/api/tcp_api.cpp
@@ -49,15 +49,9 @@ otError otTcpEndpointInitialize(otInstance                        *aInstance,
     return AsCoreType(aEndpoint).Initialize(AsCoreType(aInstance), *aArgs);
 }
 
-otInstance *otTcpEndpointGetInstance(otTcpEndpoint *aEndpoint)
-{
-    return &AsCoreType(aEndpoint).GetInstance();
-}
+otInstance *otTcpEndpointGetInstance(otTcpEndpoint *aEndpoint) { return &AsCoreType(aEndpoint).GetInstance(); }
 
-void *otTcpEndpointGetContext(otTcpEndpoint *aEndpoint)
-{
-    return AsCoreType(aEndpoint).GetContext();
-}
+void *otTcpEndpointGetContext(otTcpEndpoint *aEndpoint) { return AsCoreType(aEndpoint).GetContext(); }
 
 const otSockAddr *otTcpGetLocalAddress(const otTcpEndpoint *aEndpoint)
 {
@@ -94,30 +88,18 @@ otError otTcpReceiveByReference(otTcpEndpoint *aEndpoint, const otLinkedBuffer *
     return AsCoreType(aEndpoint).ReceiveByReference(*aBuffer);
 }
 
-otError otTcpReceiveContiguify(otTcpEndpoint *aEndpoint)
-{
-    return AsCoreType(aEndpoint).ReceiveContiguify();
-}
+otError otTcpReceiveContiguify(otTcpEndpoint *aEndpoint) { return AsCoreType(aEndpoint).ReceiveContiguify(); }
 
 otError otTcpCommitReceive(otTcpEndpoint *aEndpoint, size_t aNumBytes, uint32_t aFlags)
 {
     return AsCoreType(aEndpoint).CommitReceive(aNumBytes, aFlags);
 }
 
-otError otTcpSendEndOfStream(otTcpEndpoint *aEndpoint)
-{
-    return AsCoreType(aEndpoint).SendEndOfStream();
-}
+otError otTcpSendEndOfStream(otTcpEndpoint *aEndpoint) { return AsCoreType(aEndpoint).SendEndOfStream(); }
 
-otError otTcpAbort(otTcpEndpoint *aEndpoint)
-{
-    return AsCoreType(aEndpoint).Abort();
-}
+otError otTcpAbort(otTcpEndpoint *aEndpoint) { return AsCoreType(aEndpoint).Abort(); }
 
-otError otTcpEndpointDeinitialize(otTcpEndpoint *aEndpoint)
-{
-    return AsCoreType(aEndpoint).Deinitialize();
-}
+otError otTcpEndpointDeinitialize(otTcpEndpoint *aEndpoint) { return AsCoreType(aEndpoint).Deinitialize(); }
 
 otError otTcpListenerInitialize(otInstance                        *aInstance,
                                 otTcpListener                     *aListener,
@@ -126,29 +108,17 @@ otError otTcpListenerInitialize(otInstance                        *aInstance,
     return AsCoreType(aListener).Initialize(AsCoreType(aInstance), *aArgs);
 }
 
-otInstance *otTcpListenerGetInstance(otTcpListener *aListener)
-{
-    return &AsCoreType(aListener).GetInstance();
-}
+otInstance *otTcpListenerGetInstance(otTcpListener *aListener) { return &AsCoreType(aListener).GetInstance(); }
 
-void *otTcpListenerGetContext(otTcpListener *aListener)
-{
-    return AsCoreType(aListener).GetContext();
-}
+void *otTcpListenerGetContext(otTcpListener *aListener) { return AsCoreType(aListener).GetContext(); }
 
 otError otTcpListen(otTcpListener *aListener, const otSockAddr *aSockName)
 {
     return AsCoreType(aListener).Listen(AsCoreType(aSockName));
 }
 
-otError otTcpStopListening(otTcpListener *aListener)
-{
-    return AsCoreType(aListener).StopListening();
-}
+otError otTcpStopListening(otTcpListener *aListener) { return AsCoreType(aListener).StopListening(); }
 
-otError otTcpListenerDeinitialize(otTcpListener *aListener)
-{
-    return AsCoreType(aListener).Deinitialize();
-}
+otError otTcpListenerDeinitialize(otTcpListener *aListener) { return AsCoreType(aListener).Deinitialize(); }
 
 #endif // OPENTHREAD_CONFIG_TCP_ENABLE

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -292,10 +292,7 @@ otError otThreadBecomeDetached(otInstance *aInstance)
     return AsCoreType(aInstance).Get<Mle::MleRouter>().BecomeDetached();
 }
 
-otError otThreadBecomeChild(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Mle::MleRouter>().BecomeChild();
-}
+otError otThreadBecomeChild(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mle::MleRouter>().BecomeChild(); }
 
 otError otThreadGetNextNeighborInfo(otInstance *aInstance, otNeighborInfoIterator *aIterator, otNeighborInfo *aInfo)
 {
@@ -309,10 +306,7 @@ otDeviceRole otThreadGetDeviceRole(otInstance *aInstance)
     return MapEnum(AsCoreType(aInstance).Get<Mle::MleRouter>().GetRole());
 }
 
-const char *otThreadDeviceRoleToString(otDeviceRole aRole)
-{
-    return Mle::RoleToString(MapEnum(aRole));
-}
+const char *otThreadDeviceRoleToString(otDeviceRole aRole) { return Mle::RoleToString(MapEnum(aRole)); }
 
 otError otThreadGetLeaderData(otInstance *aInstance, otLeaderData *aLeaderData)
 {
@@ -342,10 +336,7 @@ uint32_t otThreadGetPartitionId(otInstance *aInstance)
     return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderData().GetPartitionId();
 }
 
-uint16_t otThreadGetRloc16(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetRloc16();
-}
+uint16_t otThreadGetRloc16(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mle::MleRouter>().GetRloc16(); }
 
 otError otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo)
 {
@@ -401,15 +392,9 @@ otError otThreadSetEnabled(otInstance *aInstance, bool aEnabled)
     return error;
 }
 
-uint16_t otThreadGetVersion(void)
-{
-    return kThreadVersion;
-}
+uint16_t otThreadGetVersion(void) { return kThreadVersion; }
 
-bool otThreadIsSingleton(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Mle::MleRouter>().IsSingleton();
-}
+bool otThreadIsSingleton(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mle::MleRouter>().IsSingleton(); }
 
 otError otThreadDiscover(otInstance              *aInstance,
                          uint32_t                 aScanChannels,
@@ -442,20 +427,14 @@ const otIpCounters *otThreadGetIp6Counters(otInstance *aInstance)
     return &AsCoreType(aInstance).Get<MeshForwarder>().GetCounters();
 }
 
-void otThreadResetIp6Counters(otInstance *aInstance)
-{
-    AsCoreType(aInstance).Get<MeshForwarder>().ResetCounters();
-}
+void otThreadResetIp6Counters(otInstance *aInstance) { AsCoreType(aInstance).Get<MeshForwarder>().ResetCounters(); }
 
 const otMleCounters *otThreadGetMleCounters(otInstance *aInstance)
 {
     return &AsCoreType(aInstance).Get<Mle::MleRouter>().GetCounters();
 }
 
-void otThreadResetMleCounters(otInstance *aInstance)
-{
-    AsCoreType(aInstance).Get<Mle::MleRouter>().ResetCounters();
-}
+void otThreadResetMleCounters(otInstance *aInstance) { AsCoreType(aInstance).Get<Mle::MleRouter>().ResetCounters(); }
 
 void otThreadRegisterParentResponseCallback(otInstance                    *aInstance,
                                             otThreadParentResponseCallback aCallback,

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -277,10 +277,7 @@ void otThreadGetPskc(otInstance *aInstance, otPskc *aPskc)
 }
 
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
-otPskcRef otThreadGetPskcRef(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<KeyManager>().GetPskcRef();
-}
+otPskcRef otThreadGetPskcRef(otInstance *aInstance) { return AsCoreType(aInstance).Get<KeyManager>().GetPskcRef(); }
 #endif
 
 otError otThreadSetPskc(otInstance *aInstance, const otPskc *aPskc)

--- a/src/core/api/trel_api.cpp
+++ b/src/core/api/trel_api.cpp
@@ -43,20 +43,11 @@
 
 using namespace ot;
 
-void otTrelEnable(otInstance *aInstance)
-{
-    AsCoreType(aInstance).Get<Trel::Interface>().Enable();
-}
+void otTrelEnable(otInstance *aInstance) { AsCoreType(aInstance).Get<Trel::Interface>().Enable(); }
 
-void otTrelDisable(otInstance *aInstance)
-{
-    AsCoreType(aInstance).Get<Trel::Interface>().Disable();
-}
+void otTrelDisable(otInstance *aInstance) { AsCoreType(aInstance).Get<Trel::Interface>().Disable(); }
 
-bool otTrelIsEnabled(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Trel::Interface>().IsEnabled();
-}
+bool otTrelIsEnabled(otInstance *aInstance) { return AsCoreType(aInstance).Get<Trel::Interface>().IsEnabled(); }
 
 void otTrelInitPeerIterator(otInstance *aInstance, otTrelPeerIterator *aIterator)
 {

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -76,10 +76,7 @@ otError otUdpSend(otInstance *aInstance, otUdpSocket *aSocket, otMessage *aMessa
                                                         AsCoreType(aMessageInfo));
 }
 
-otUdpSocket *otUdpGetSockets(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<Ip6::Udp>().GetUdpSockets();
-}
+otUdpSocket *otUdpGetSockets(otInstance *aInstance) { return AsCoreType(aInstance).Get<Ip6::Udp>().GetUdpSockets(); }
 
 #if OPENTHREAD_CONFIG_UDP_FORWARD_ENABLE
 void otUdpForwardSetForwarder(otInstance *aInstance, otUdpForwarder aForwarder, void *aContext)

--- a/src/core/backbone_router/bbr_leader.hpp
+++ b/src/core/backbone_router/bbr_leader.hpp
@@ -182,12 +182,8 @@ private:
     static const char *StateToString(State aState);
     static const char *DomainPrefixStateToString(DomainPrefixState aState);
 #else
-    void LogBackboneRouterPrimary(State, const BackboneRouterConfig &) const
-    {
-    }
-    void LogDomainPrefix(DomainPrefixState, const Ip6::Prefix &) const
-    {
-    }
+    void LogBackboneRouterPrimary(State, const BackboneRouterConfig &) const {}
+    void LogDomainPrefix(DomainPrefixState, const Ip6::Prefix &) const {}
 #endif
 
     BackboneRouterConfig mConfig;       ///< Primary Backbone Router information.

--- a/src/core/backbone_router/bbr_local.hpp
+++ b/src/core/backbone_router/bbr_local.hpp
@@ -265,12 +265,8 @@ private:
     void LogBackboneRouterService(const char *aAction, Error aError);
     void LogDomainPrefix(const char *aAction, Error aError);
 #else
-    void LogBackboneRouterService(const char *, Error)
-    {
-    }
-    void LogDomainPrefix(const char *, Error)
-    {
-    }
+    void LogBackboneRouterService(const char *, Error) {}
+    void LogDomainPrefix(const char *, Error) {}
 #endif
 
     BackboneRouterState mState;

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -492,10 +492,7 @@ void Manager::ConfigNextMulticastListenerRegistrationResponse(ThreadStatusTlv::M
 #endif
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
-NdProxyTable &Manager::GetNdProxyTable(void)
-{
-    return mNdProxyTable;
-}
+NdProxyTable &Manager::GetNdProxyTable(void) { return mNdProxyTable; }
 
 bool Manager::ShouldForwardDuaToBackbone(const Ip6::Address &aAddress)
 {

--- a/src/core/backbone_router/bbr_manager.hpp
+++ b/src/core/backbone_router/bbr_manager.hpp
@@ -119,10 +119,7 @@ public:
      * @returns The Multicast Listeners Table.
      *
      */
-    MulticastListenersTable &GetMulticastListenersTable(void)
-    {
-        return mMulticastListenersTable;
-    }
+    MulticastListenersTable &GetMulticastListenersTable(void) { return mMulticastListenersTable; }
 #endif
 
     /**
@@ -143,10 +140,7 @@ public:
      * @returns A reference to the Backbone TMF agent.
      *
      */
-    BackboneTmfAgent &GetBackboneTmfAgent(void)
-    {
-        return mBackboneTmfAgent;
-    }
+    BackboneTmfAgent &GetBackboneTmfAgent(void) { return mBackboneTmfAgent; }
 
     /**
      * This method sends BB.qry on the Backbone link.

--- a/src/core/backbone_router/ndproxy_table.cpp
+++ b/src/core/backbone_router/ndproxy_table.cpp
@@ -123,10 +123,7 @@ void NdProxyTable::Iterator::Advance(void)
     } while (mItem < GetArrayEnd(table.mProxies) && !MatchesFilter(*mItem, mFilter));
 }
 
-void NdProxyTable::Erase(NdProxy &aNdProxy)
-{
-    aNdProxy.mValid = false;
-}
+void NdProxyTable::Erase(NdProxy &aNdProxy) { aNdProxy.mValid = false; }
 
 void NdProxyTable::HandleDomainPrefixUpdate(Leader::DomainPrefixState aState)
 {

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1633,10 +1633,7 @@ exit:
     return shouldPublish;
 }
 
-void RoutingManager::DiscoveredPrefixTable::HandleEntryTimer(void)
-{
-    RemoveExpiredEntries();
-}
+void RoutingManager::DiscoveredPrefixTable::HandleEntryTimer(void) { RemoveExpiredEntries(); }
 
 void RoutingManager::DiscoveredPrefixTable::RemoveExpiredEntries(void)
 {
@@ -1682,10 +1679,7 @@ void RoutingManager::DiscoveredPrefixTable::RemoveExpiredEntries(void)
     }
 }
 
-void RoutingManager::DiscoveredPrefixTable::SignalTableChanged(void)
-{
-    mSignalTask.Post();
-}
+void RoutingManager::DiscoveredPrefixTable::SignalTableChanged(void) { mSignalTask.Post(); }
 
 void RoutingManager::DiscoveredPrefixTable::ProcessNeighborAdvertMessage(
     const Ip6::Nd::NeighborAdvertMessage &aNaMessage,
@@ -2890,10 +2884,7 @@ exit:
     return;
 }
 
-void RoutingManager::RsSender::Stop(void)
-{
-    mTimer.Stop();
-}
+void RoutingManager::RsSender::Stop(void) { mTimer.Stop(); }
 
 Error RoutingManager::RsSender::SendRs(void)
 {

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -230,10 +230,7 @@ public:
      * @retval  kStateActive     The Border router is publishing a NAT64 prefix.
      *
      */
-    Nat64::State GetNat64PrefixManagerState(void) const
-    {
-        return mNat64PrefixManager.GetState();
-    }
+    Nat64::State GetNat64PrefixManagerState(void) const { return mNat64PrefixManager.GetState(); }
 
     /**
      * Enable or disable NAT64 orefix publishing.
@@ -275,10 +272,7 @@ public:
      * @param[in]  aPrefix  The discovered NAT64 prefix on `InfraIf`.
      *
      */
-    void HandleDiscoverNat64PrefixDone(const Ip6::Prefix &aPrefix)
-    {
-        mNat64PrefixManager.HandleDiscoverDone(aPrefix);
-    }
+    void HandleDiscoverNat64PrefixDone(const Ip6::Prefix &aPrefix) { mNat64PrefixManager.HandleDiscoverDone(aPrefix); }
 
 #endif // OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
 
@@ -297,10 +291,7 @@ public:
      * This method handles infrastructure interface state changes.
      *
      */
-    void HandleInfraIfStateChanged(void)
-    {
-        EvaluateState();
-    }
+    void HandleInfraIfStateChanged(void) { EvaluateState(); }
 
     /**
      * This method checks whether the on-mesh prefix configuration is a valid OMR prefix.
@@ -372,10 +363,7 @@ public:
      * @retval FALSE The RoutingManager is not running.
      *
      */
-    bool IsRunning(void) const
-    {
-        return mIsRunning;
-    }
+    bool IsRunning(void) const { return mIsRunning; }
 
 private:
     static constexpr uint8_t kMaxOnMeshPrefixes = OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_ON_MESH_PREFIXES;
@@ -433,14 +421,8 @@ private:
     };
 
     void HandleDiscoveredPrefixTableChanged(void); // Declare early so we can use in `mSignalTask`
-    void HandleDiscoveredPrefixTableEntryTimer(void)
-    {
-        mDiscoveredPrefixTable.HandleEntryTimer();
-    }
-    void HandleDiscoveredPrefixTableRouterTimer(void)
-    {
-        mDiscoveredPrefixTable.HandleRouterTimer();
-    }
+    void HandleDiscoveredPrefixTableEntryTimer(void) { mDiscoveredPrefixTable.HandleEntryTimer(); }
+    void HandleDiscoveredPrefixTableRouterTimer(void) { mDiscoveredPrefixTable.HandleRouterTimer(); }
 
     class DiscoveredPrefixTable : public InstanceLocator
     {
@@ -674,10 +656,7 @@ private:
         bool        mIsAddedInNetData;
     };
 
-    void HandleOnLinkPrefixManagerTimer(void)
-    {
-        mOnLinkPrefixManager.HandleTimer();
-    }
+    void HandleOnLinkPrefixManagerTimer(void) { mOnLinkPrefixManager.HandleTimer(); }
 
     class OnLinkPrefixManager : public InstanceLocator
     {
@@ -748,10 +727,7 @@ private:
     };
 
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
-    void HandleNat64PrefixManagerTimer(void)
-    {
-        mNat64PrefixManager.HandleTimer();
-    }
+    void HandleNat64PrefixManagerTimer(void) { mNat64PrefixManager.HandleTimer(); }
 
     class Nat64PrefixManager : public InstanceLocator
     {
@@ -820,10 +796,7 @@ private:
         TimeMilli                            mLastTxTime;
     };
 
-    void HandleRsSenderTimer(void)
-    {
-        mRsSender.HandleTimer();
-    }
+    void HandleRsSenderTimer(void) { mRsSender.HandleTimer(); }
 
     class RsSender : public InstanceLocator
     {
@@ -859,18 +832,12 @@ private:
         TimeMilli mStartTime;
     };
 
-    void EvaluateState(void);
-    void Start(void);
-    void Stop(void);
-    void HandleNotifierEvents(Events aEvents);
-    bool IsInitialized(void) const
-    {
-        return mInfraIf.IsInitialized();
-    }
-    bool IsEnabled(void) const
-    {
-        return mIsEnabled;
-    }
+    void  EvaluateState(void);
+    void  Start(void);
+    void  Stop(void);
+    void  HandleNotifierEvents(Events aEvents);
+    bool  IsInitialized(void) const { return mInfraIf.IsInitialized(); }
+    bool  IsEnabled(void) const { return mIsEnabled; }
     Error LoadOrGenerateRandomBrUlaPrefix(void);
 
     void EvaluateRoutingPolicy(void);

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -73,10 +73,7 @@ void CoapBase::ClearRequestsAndResponses(void)
     mResponsesQueue.DequeueAllResponses();
 }
 
-void CoapBase::ClearRequests(const Ip6::Address &aAddress)
-{
-    ClearRequests(&aAddress);
-}
+void CoapBase::ClearRequests(const Ip6::Address &aAddress) { ClearRequests(&aAddress); }
 
 void CoapBase::ClearRequests(const Ip6::Address *aAddress)
 {
@@ -94,10 +91,7 @@ void CoapBase::ClearRequests(const Ip6::Address *aAddress)
 }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
-void CoapBase::AddBlockWiseResource(ResourceBlockWise &aResource)
-{
-    IgnoreError(mBlockWiseResources.Add(aResource));
-}
+void CoapBase::AddBlockWiseResource(ResourceBlockWise &aResource) { IgnoreError(mBlockWiseResources.Add(aResource)); }
 
 void CoapBase::RemoveBlockWiseResource(ResourceBlockWise &aResource)
 {
@@ -106,10 +100,7 @@ void CoapBase::RemoveBlockWiseResource(ResourceBlockWise &aResource)
 }
 #endif
 
-void CoapBase::AddResource(Resource &aResource)
-{
-    IgnoreError(mResources.Add(aResource));
-}
+void CoapBase::AddResource(Resource &aResource) { IgnoreError(mResources.Add(aResource)); }
 
 void CoapBase::RemoveResource(Resource &aResource)
 {
@@ -145,10 +136,7 @@ Message *CoapBase::NewPriorityConfirmablePostMessage(Uri aUri)
     return InitMessage(NewPriorityMessage(), kTypeConfirmable, aUri);
 }
 
-Message *CoapBase::NewConfirmablePostMessage(Uri aUri)
-{
-    return InitMessage(NewMessage(), kTypeConfirmable, aUri);
-}
+Message *CoapBase::NewConfirmablePostMessage(Uri aUri) { return InitMessage(NewMessage(), kTypeConfirmable, aUri); }
 
 Message *CoapBase::NewPriorityNonConfirmablePostMessage(Uri aUri)
 {
@@ -165,10 +153,7 @@ Message *CoapBase::NewPriorityResponseMessage(const Message &aRequest)
     return InitResponse(NewPriorityMessage(), aRequest);
 }
 
-Message *CoapBase::NewResponseMessage(const Message &aRequest)
-{
-    return InitResponse(NewMessage(), aRequest);
-}
+Message *CoapBase::NewResponseMessage(const Message &aRequest) { return InitResponse(NewMessage(), aRequest); }
 
 Message *CoapBase::InitMessage(Message *aMessage, Type aType, Uri aUri)
 {
@@ -1589,15 +1574,9 @@ void ResponsesQueue::UpdateQueue(void)
     }
 }
 
-void ResponsesQueue::DequeueResponse(Message &aMessage)
-{
-    mQueue.DequeueAndFree(aMessage);
-}
+void ResponsesQueue::DequeueResponse(Message &aMessage) { mQueue.DequeueAndFree(aMessage); }
 
-void ResponsesQueue::DequeueAllResponses(void)
-{
-    mQueue.DequeueAndFreeAll();
-}
+void ResponsesQueue::DequeueAllResponses(void) { mQueue.DequeueAndFreeAll(); }
 
 void ResponsesQueue::HandleTimer(Timer &aTimer)
 {
@@ -1686,10 +1665,7 @@ uint32_t TxParameters::CalculateExchangeLifetime(void) const
     return CalculateSpan(mMaxRetransmit) + 2 * kDefaultMaxLatency + mAckTimeout;
 }
 
-uint32_t TxParameters::CalculateMaxTransmitWait(void) const
-{
-    return CalculateSpan(mMaxRetransmit + 1);
-}
+uint32_t TxParameters::CalculateMaxTransmitWait(void) const { return CalculateSpan(mMaxRetransmit + 1); }
 
 uint32_t TxParameters::CalculateSpan(uint8_t aMaxRetx) const
 {

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -737,10 +737,7 @@ public:
      * @returns A reference to the request message list.
      *
      */
-    const MessageQueue &GetRequestMessages(void) const
-    {
-        return mPendingRequests;
-    }
+    const MessageQueue &GetRequestMessages(void) const { return mPendingRequests; }
 
     /**
      * This method returns a reference to the cached response list.
@@ -748,10 +745,7 @@ public:
      * @returns A reference to the cached response list.
      *
      */
-    const MessageQueue &GetCachedResponses(void) const
-    {
-        return mResponsesQueue.GetResponses();
-    }
+    const MessageQueue &GetCachedResponses(void) const { return mResponsesQueue.GetResponses(); }
 
 protected:
     /**
@@ -812,10 +806,7 @@ protected:
      * @param[in] aResourceHandler   The resource handler function pointer.
      *
      */
-    void SetResourceHandler(ResourceHandler aHandler)
-    {
-        mResourceHandler = aHandler;
-    }
+    void SetResourceHandler(ResourceHandler aHandler) { mResourceHandler = aHandler; }
 
 private:
     struct Metadata

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -84,15 +84,9 @@ Error Message::InitAsPost(const Ip6::Address &aDestination, Uri aUri)
     return Init(aDestination.IsMulticast() ? kTypeNonConfirmable : kTypeConfirmable, kCodePost, aUri);
 }
 
-bool Message::IsConfirmablePostRequest(void) const
-{
-    return IsConfirmable() && IsPostRequest();
-}
+bool Message::IsConfirmablePostRequest(void) const { return IsConfirmable() && IsPostRequest(); }
 
-bool Message::IsNonConfirmablePostRequest(void) const
-{
-    return IsNonConfirmable() && IsPostRequest();
-}
+bool Message::IsNonConfirmablePostRequest(void) const { return IsNonConfirmable() && IsPostRequest(); }
 
 void Message::Finish(void)
 {
@@ -456,15 +450,9 @@ const char *Message::CodeToString(void) const
 }
 #endif // OPENTHREAD_CONFIG_COAP_API_ENABLE
 
-Message::Iterator MessageQueue::begin(void)
-{
-    return Message::Iterator(GetHead());
-}
+Message::Iterator MessageQueue::begin(void) { return Message::Iterator(GetHead()); }
 
-Message::ConstIterator MessageQueue::begin(void) const
-{
-    return Message::ConstIterator(GetHead());
-}
+Message::ConstIterator MessageQueue::begin(void) const { return Message::ConstIterator(GetHead()); }
 
 Error Option::Iterator::Init(const Message &aMessage)
 {

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -315,10 +315,7 @@ public:
      * @returns The Message ID value.
      *
      */
-    uint16_t GetMessageId(void) const
-    {
-        return HostSwap16(GetHelpData().mHeader.mMessageId);
-    }
+    uint16_t GetMessageId(void) const { return HostSwap16(GetHelpData().mHeader.mMessageId); }
 
     /**
      * This method sets the Message ID value.
@@ -326,10 +323,7 @@ public:
      * @param[in]  aMessageId  The Message ID value.
      *
      */
-    void SetMessageId(uint16_t aMessageId)
-    {
-        GetHelpData().mHeader.mMessageId = HostSwap16(aMessageId);
-    }
+    void SetMessageId(uint16_t aMessageId) { GetHelpData().mHeader.mMessageId = HostSwap16(aMessageId); }
 
     /**
      * This method returns the Token length.
@@ -348,10 +342,7 @@ public:
      * @returns A pointer to the Token value.
      *
      */
-    const uint8_t *GetToken(void) const
-    {
-        return GetHelpData().mHeader.mToken;
-    }
+    const uint8_t *GetToken(void) const { return GetHelpData().mHeader.mToken; }
 
     /**
      * This method sets the Token value and length.
@@ -447,10 +438,7 @@ public:
      * @retval kErrorInvalidArgs  The option type is not equal or greater than the last option type.
      * @retval kErrorNoBufs       The option length exceeds the buffer size.
      */
-    Error AppendObserveOption(uint32_t aObserve)
-    {
-        return AppendUintOption(kOptionObserve, aObserve & kObserveMask);
-    }
+    Error AppendObserveOption(uint32_t aObserve) { return AppendUintOption(kOptionObserve, aObserve & kObserveMask); }
 
     /**
      * This method appends a Uri-Path option.
@@ -501,10 +489,7 @@ public:
      * @retval kErrorNoBufs       The option length exceeds the buffer size.
      *
      */
-    Error AppendProxyUriOption(const char *aProxyUri)
-    {
-        return AppendStringOption(kOptionProxyUri, aProxyUri);
-    }
+    Error AppendProxyUriOption(const char *aProxyUri) { return AppendStringOption(kOptionProxyUri, aProxyUri); }
 
     /**
      * This method appends a Content-Format option.
@@ -530,10 +515,7 @@ public:
      * @retval kErrorInvalidArgs  The option type is not equal or greater than the last option type.
      * @retval kErrorNoBufs       The option length exceeds the buffer size.
      */
-    Error AppendMaxAgeOption(uint32_t aMaxAge)
-    {
-        return AppendUintOption(kOptionMaxAge, aMaxAge);
-    }
+    Error AppendMaxAgeOption(uint32_t aMaxAge) { return AppendUintOption(kOptionMaxAge, aMaxAge); }
 
     /**
      * This method appends a single Uri-Query option.
@@ -544,10 +526,7 @@ public:
      * @retval kErrorInvalidArgs  The option type is not equal or greater than the last option type.
      * @retval kErrorNoBufs       The option length exceeds the buffer size.
      */
-    Error AppendUriQueryOption(const char *aUriQuery)
-    {
-        return AppendStringOption(kOptionUriQuery, aUriQuery);
-    }
+    Error AppendUriQueryOption(const char *aUriQuery) { return AppendStringOption(kOptionUriQuery, aUriQuery); }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
     /**
@@ -568,10 +547,7 @@ public:
      * @returns The length of the message header.
      *
      */
-    uint16_t GetHeaderLength(void) const
-    {
-        return GetHelpData().mHeaderLength;
-    }
+    uint16_t GetHeaderLength(void) const { return GetHelpData().mHeaderLength; }
 
     /**
      * This method returns the block number of a CoAP block-wise transfer message.
@@ -579,10 +555,7 @@ public:
      * @returns The block number.
      *
      */
-    uint32_t GetBlockWiseBlockNumber(void) const
-    {
-        return GetHelpData().mBlockWiseData.mBlockNumber;
-    }
+    uint32_t GetBlockWiseBlockNumber(void) const { return GetHelpData().mBlockWiseData.mBlockNumber; }
 
     /**
      * This method checks if the More Blocks flag is set.
@@ -591,10 +564,7 @@ public:
      * @retval FALSE  More Blocks flag is not set.
      *
      */
-    bool IsMoreBlocksFlagSet(void) const
-    {
-        return GetHelpData().mBlockWiseData.mMoreBlocks;
-    }
+    bool IsMoreBlocksFlagSet(void) const { return GetHelpData().mBlockWiseData.mMoreBlocks; }
 
     /**
      * This method returns the block size of a CoAP block-wise transfer message.
@@ -602,10 +572,7 @@ public:
      * @returns The block size.
      *
      */
-    otCoapBlockSzx GetBlockWiseBlockSize(void) const
-    {
-        return GetHelpData().mBlockWiseData.mBlockSize;
-    }
+    otCoapBlockSzx GetBlockWiseBlockSize(void) const { return GetHelpData().mBlockWiseData.mBlockSize; }
 #endif // OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
 
     /**
@@ -634,10 +601,7 @@ public:
      * @returns The offset of the first CoAP option.
      *
      */
-    uint16_t GetOptionStart(void) const
-    {
-        return kMinHeaderLength + GetTokenLength();
-    }
+    uint16_t GetOptionStart(void) const { return kMinHeaderLength + GetTokenLength(); }
 
     /**
      * This method parses CoAP header and moves offset end of CoAP header.
@@ -667,10 +631,7 @@ public:
      * @param[in]   aBlockNumber    Block number value to set.
      *
      */
-    void SetBlockWiseBlockNumber(uint32_t aBlockNumber)
-    {
-        GetHelpData().mBlockWiseData.mBlockNumber = aBlockNumber;
-    }
+    void SetBlockWiseBlockNumber(uint32_t aBlockNumber) { GetHelpData().mBlockWiseData.mBlockNumber = aBlockNumber; }
 
     /**
      * This method sets the More Blocks falg in the message HelpData.
@@ -678,10 +639,7 @@ public:
      * @param[in]   aMoreBlocks    TRUE or FALSE.
      *
      */
-    void SetMoreBlocksFlag(bool aMoreBlocks)
-    {
-        GetHelpData().mBlockWiseData.mMoreBlocks = aMoreBlocks;
-    }
+    void SetMoreBlocksFlag(bool aMoreBlocks) { GetHelpData().mBlockWiseData.mMoreBlocks = aMoreBlocks; }
 
     /**
      * This method sets the block size value in the message HelpData.
@@ -689,10 +647,7 @@ public:
      * @param[in]   aBlockSize    Block size value to set.
      *
      */
-    void SetBlockWiseBlockSize(otCoapBlockSzx aBlockSize)
-    {
-        GetHelpData().mBlockWiseData.mBlockSize = aBlockSize;
-    }
+    void SetBlockWiseBlockSize(otCoapBlockSzx aBlockSize) { GetHelpData().mBlockWiseData.mBlockSize = aBlockSize; }
 #endif // OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
 
     /**
@@ -702,10 +657,7 @@ public:
      * @retval FALSE  Message is not an empty message header.
      *
      */
-    bool IsEmpty(void) const
-    {
-        return (GetCode() == kCodeEmpty);
-    }
+    bool IsEmpty(void) const { return (GetCode() == kCodeEmpty); }
 
     /**
      * This method checks if a header is a request header.
@@ -714,10 +666,7 @@ public:
      * @retval FALSE  Message is not a request header.
      *
      */
-    bool IsRequest(void) const
-    {
-        return (GetCode() >= kCodeGet) && (GetCode() <= kCodeDelete);
-    }
+    bool IsRequest(void) const { return (GetCode() >= kCodeGet) && (GetCode() <= kCodeDelete); }
 
     /**
      * This method indicates whether or not the CoAP code in header is "Get" request.
@@ -726,10 +675,7 @@ public:
      * @retval FALSE  Message is not a Get request.
      *
      */
-    bool IsGetRequest(void) const
-    {
-        return GetCode() == kCodeGet;
-    }
+    bool IsGetRequest(void) const { return GetCode() == kCodeGet; }
 
     /**
      * This method indicates whether or not the CoAP code in header is "Post" request.
@@ -738,10 +684,7 @@ public:
      * @retval FALSE  Message is not a Post request.
      *
      */
-    bool IsPostRequest(void) const
-    {
-        return GetCode() == kCodePost;
-    }
+    bool IsPostRequest(void) const { return GetCode() == kCodePost; }
 
     /**
      * This method indicates whether or not the CoAP code in header is "Put" request.
@@ -750,10 +693,7 @@ public:
      * @retval FALSE  Message is not a Put request.
      *
      */
-    bool IsPutRequest(void) const
-    {
-        return GetCode() == kCodePut;
-    }
+    bool IsPutRequest(void) const { return GetCode() == kCodePut; }
 
     /**
      * This method indicates whether or not the CoAP code in header is "Delete" request.
@@ -762,10 +702,7 @@ public:
      * @retval FALSE  Message is not a Delete request.
      *
      */
-    bool IsDeleteRequest(void) const
-    {
-        return GetCode() == kCodeDelete;
-    }
+    bool IsDeleteRequest(void) const { return GetCode() == kCodeDelete; }
 
     /**
      * This method checks if a header is a response header.
@@ -774,10 +711,7 @@ public:
      * @retval FALSE  Message is not a response header.
      *
      */
-    bool IsResponse(void) const
-    {
-        return GetCode() >= OT_COAP_CODE_RESPONSE_MIN;
-    }
+    bool IsResponse(void) const { return GetCode() >= OT_COAP_CODE_RESPONSE_MIN; }
 
     /**
      * This method checks if a header is a CON message header.
@@ -786,10 +720,7 @@ public:
      * @retval FALSE  Message is not is a CON message header.
      *
      */
-    bool IsConfirmable(void) const
-    {
-        return (GetType() == kTypeConfirmable);
-    }
+    bool IsConfirmable(void) const { return (GetType() == kTypeConfirmable); }
 
     /**
      * This method checks if a header is a NON message header.
@@ -798,10 +729,7 @@ public:
      * @retval FALSE  Message is not is a NON message header.
      *
      */
-    bool IsNonConfirmable(void) const
-    {
-        return (GetType() == kTypeNonConfirmable);
-    }
+    bool IsNonConfirmable(void) const { return (GetType() == kTypeNonConfirmable); }
 
     /**
      * This method checks if a header is a ACK message header.
@@ -810,10 +738,7 @@ public:
      * @retval FALSE  Message is not is a ACK message header.
      *
      */
-    bool IsAck(void) const
-    {
-        return (GetType() == kTypeAck);
-    }
+    bool IsAck(void) const { return (GetType() == kTypeAck); }
 
     /**
      * This method checks if a header is a RST message header.
@@ -822,10 +747,7 @@ public:
      * @retval FALSE  Message is not is a RST message header.
      *
      */
-    bool IsReset(void) const
-    {
-        return (GetType() == kTypeReset);
-    }
+    bool IsReset(void) const { return (GetType() == kTypeReset); }
 
     /**
      * This method indicates whether or not the header is a confirmable Put request (i.e, `kTypeConfirmable` with
@@ -871,19 +793,13 @@ public:
      * @returns A pointer to the message or `nullptr` if insufficient message buffers are available.
      *
      */
-    Message *Clone(void) const
-    {
-        return Clone(GetLength());
-    }
+    Message *Clone(void) const { return Clone(GetLength()); }
 
     /**
      * This method returns the minimal reserved bytes required for CoAP message.
      *
      */
-    static uint16_t GetHelpDataReserved(void)
-    {
-        return sizeof(HelpData) + kHelpDataAlignment;
-    }
+    static uint16_t GetHelpDataReserved(void) { return sizeof(HelpData) + kHelpDataAlignment; }
 
     /**
      * This method returns a pointer to the next message after this as a `Coap::Message`.
@@ -894,10 +810,7 @@ public:
      * @returns A pointer to the next message in the queue or `nullptr` if at the end of the queue.
      *
      */
-    Message *GetNextCoapMessage(void)
-    {
-        return static_cast<Message *>(GetNext());
-    }
+    Message *GetNextCoapMessage(void) { return static_cast<Message *>(GetNext()); }
 
     /**
      * This method returns a pointer to the next message after this as a `Coap::Message`.
@@ -908,10 +821,7 @@ public:
      * @returns A pointer to the next message in the queue or `nullptr` if at the end of the queue.
      *
      */
-    const Message *GetNextCoapMessage(void) const
-    {
-        return static_cast<const Message *>(GetNext());
-    }
+    const Message *GetNextCoapMessage(void) const { return static_cast<const Message *>(GetNext()); }
 
 private:
     /*
@@ -1047,15 +957,9 @@ private:
         return *static_cast<const HelpData *>(OT_ALIGN(GetFirstData(), kHelpDataAlignment));
     }
 
-    HelpData &GetHelpData(void)
-    {
-        return AsNonConst(AsConst(this)->GetHelpData());
-    }
+    HelpData &GetHelpData(void) { return AsNonConst(AsConst(this)->GetHelpData()); }
 
-    uint8_t *GetToken(void)
-    {
-        return GetHelpData().mHeader.mToken;
-    }
+    uint8_t *GetToken(void) { return GetHelpData().mHeader.mToken; }
 
     void SetTokenLength(uint8_t aTokenLength)
     {
@@ -1337,10 +1241,7 @@ DefineMapEnum(otCoapCode, Coap::Code);
  * @returns A reference to `Coap::Message` matching @p aMessage.
  *
  */
-inline Coap::Message &AsCoapMessage(otMessage *aMessage)
-{
-    return *static_cast<Coap::Message *>(aMessage);
-}
+inline Coap::Message &AsCoapMessage(otMessage *aMessage) { return *static_cast<Coap::Message *>(aMessage); }
 
 /**
  * This method casts an `otMessage` pointer to a `Coap::Message` reference.
@@ -1350,10 +1251,7 @@ inline Coap::Message &AsCoapMessage(otMessage *aMessage)
  * @returns A reference to `Coap::Message` matching @p aMessage.
  *
  */
-inline Coap::Message *AsCoapMessagePtr(otMessage *aMessage)
-{
-    return static_cast<Coap::Message *>(aMessage);
-}
+inline Coap::Message *AsCoapMessagePtr(otMessage *aMessage) { return static_cast<Coap::Message *>(aMessage); }
 
 /**
  * This method casts an `otMessage` pointer to a `Coap::Message` pointer.

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -278,10 +278,7 @@ public:
      * @param[in]  aVerifyPeerCertificate  true, if the peer certificate should be verified
      *
      */
-    void SetSslAuthMode(bool aVerifyPeerCertificate)
-    {
-        mDtls.SetSslAuthMode(aVerifyPeerCertificate);
-    }
+    void SetSslAuthMode(bool aVerifyPeerCertificate) { mDtls.SetSslAuthMode(aVerifyPeerCertificate); }
 
 #endif // OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
 
@@ -395,10 +392,7 @@ public:
      * @return DTLS session's message info.
      *
      */
-    const Ip6::MessageInfo &GetMessageInfo(void) const
-    {
-        return mDtls.GetMessageInfo();
-    }
+    const Ip6::MessageInfo &GetMessageInfo(void) const { return mDtls.GetMessageInfo(); }
 
 private:
     static Error Send(CoapBase &aCoapBase, ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/common/code_utils.hpp
+++ b/src/core/common/code_utils.hpp
@@ -170,9 +170,6 @@
  * @param[in]  aError  The error to be ignored.
  *
  */
-static inline void IgnoreError(otError aError)
-{
-    OT_UNUSED_VARIABLE(aError);
-}
+static inline void IgnoreError(otError aError) { OT_UNUSED_VARIABLE(aError); }
 
 #endif // CODE_UTILS_HPP_

--- a/src/core/common/const_cast.hpp
+++ b/src/core/common/const_cast.hpp
@@ -48,10 +48,7 @@ namespace ot {
  * @returns A const reference to @p aObject reference.
  *
  */
-template <typename Type> const Type &AsConst(Type &aObject)
-{
-    return const_cast<const Type &>(aObject);
-}
+template <typename Type> const Type &AsConst(Type &aObject) { return const_cast<const Type &>(aObject); }
 
 /**
  * This template method casts a given non-const pointer to a const pointer.
@@ -63,10 +60,7 @@ template <typename Type> const Type &AsConst(Type &aObject)
  * @returns A const pointer to @p aPointer pointer.
  *
  */
-template <typename Type> const Type *AsConst(Type *aPointer)
-{
-    return const_cast<const Type *>(aPointer);
-}
+template <typename Type> const Type *AsConst(Type *aPointer) { return const_cast<const Type *>(aPointer); }
 
 /**
  * This template method casts a given const reference to a non-const reference.
@@ -78,10 +72,7 @@ template <typename Type> const Type *AsConst(Type *aPointer)
  * @returns A non-const reference to @p aObject reference.
  *
  */
-template <typename Type> Type &AsNonConst(const Type &aObject)
-{
-    return const_cast<Type &>(aObject);
-}
+template <typename Type> Type &AsNonConst(const Type &aObject) { return const_cast<Type &>(aObject); }
 
 /**
  * This template method casts a given const pointer to a non-const pointer.
@@ -93,10 +84,7 @@ template <typename Type> Type &AsNonConst(const Type &aObject)
  * @returns A non-const pointer to @p aPointer pointer.
  *
  */
-template <typename Type> Type *AsNonConst(const Type *aPointer)
-{
-    return const_cast<Type *>(aPointer);
-}
+template <typename Type> Type *AsNonConst(const Type *aPointer) { return const_cast<Type *>(aPointer); }
 
 } // namespace ot
 

--- a/src/core/common/encoding.hpp
+++ b/src/core/common/encoding.hpp
@@ -51,10 +51,7 @@
 namespace ot {
 namespace Encoding {
 
-inline uint16_t Swap16(uint16_t v)
-{
-    return (((v & 0x00ffU) << 8) & 0xff00) | (((v & 0xff00U) >> 8) & 0x00ff);
-}
+inline uint16_t Swap16(uint16_t v) { return (((v & 0x00ffU) << 8) & 0xff00) | (((v & 0xff00U) >> 8) & 0x00ff); }
 
 inline uint32_t Swap32(uint32_t v)
 {
@@ -91,33 +88,15 @@ namespace BigEndian {
 
 #if BYTE_ORDER_BIG_ENDIAN
 
-inline uint16_t HostSwap16(uint16_t v)
-{
-    return v;
-}
-inline uint32_t HostSwap32(uint32_t v)
-{
-    return v;
-}
-inline uint64_t HostSwap64(uint64_t v)
-{
-    return v;
-}
+inline uint16_t HostSwap16(uint16_t v) { return v; }
+inline uint32_t HostSwap32(uint32_t v) { return v; }
+inline uint64_t HostSwap64(uint64_t v) { return v; }
 
 #else /* BYTE_ORDER_LITTLE_ENDIAN */
 
-inline uint16_t HostSwap16(uint16_t v)
-{
-    return Swap16(v);
-}
-inline uint32_t HostSwap32(uint32_t v)
-{
-    return Swap32(v);
-}
-inline uint64_t HostSwap64(uint64_t v)
-{
-    return Swap64(v);
-}
+inline uint16_t HostSwap16(uint16_t v) { return Swap16(v); }
+inline uint32_t HostSwap32(uint32_t v) { return Swap32(v); }
+inline uint64_t HostSwap64(uint64_t v) { return Swap64(v); }
 
 #endif // LITTLE_ENDIAN
 
@@ -133,22 +112,10 @@ inline uint64_t HostSwap64(uint64_t v)
  */
 template <typename UintType> UintType HostSwap(UintType aValue);
 
-template <> inline uint8_t HostSwap(uint8_t aValue)
-{
-    return aValue;
-}
-template <> inline uint16_t HostSwap(uint16_t aValue)
-{
-    return HostSwap16(aValue);
-}
-template <> inline uint32_t HostSwap(uint32_t aValue)
-{
-    return HostSwap32(aValue);
-}
-template <> inline uint64_t HostSwap(uint64_t aValue)
-{
-    return HostSwap64(aValue);
-}
+template <> inline uint8_t  HostSwap(uint8_t aValue) { return aValue; }
+template <> inline uint16_t HostSwap(uint16_t aValue) { return HostSwap16(aValue); }
+template <> inline uint32_t HostSwap(uint32_t aValue) { return HostSwap32(aValue); }
+template <> inline uint64_t HostSwap(uint64_t aValue) { return HostSwap64(aValue); }
 
 /**
  * This function reads a `uint16_t` value from a given buffer assuming big-endian encoding.
@@ -158,10 +125,7 @@ template <> inline uint64_t HostSwap(uint64_t aValue)
  * @returns The `uint16_t` value read from buffer.
  *
  */
-inline uint16_t ReadUint16(const uint8_t *aBuffer)
-{
-    return static_cast<uint16_t>((aBuffer[0] << 8) | aBuffer[1]);
-}
+inline uint16_t ReadUint16(const uint8_t *aBuffer) { return static_cast<uint16_t>((aBuffer[0] << 8) | aBuffer[1]); }
 
 /**
  * This function reads a `uint32_t` value from a given buffer assuming big-endian encoding.
@@ -274,33 +238,15 @@ namespace LittleEndian {
 
 #if BYTE_ORDER_BIG_ENDIAN
 
-inline uint16_t HostSwap16(uint16_t v)
-{
-    return Swap16(v);
-}
-inline uint32_t HostSwap32(uint32_t v)
-{
-    return Swap32(v);
-}
-inline uint64_t HostSwap64(uint64_t v)
-{
-    return Swap64(v);
-}
+inline uint16_t HostSwap16(uint16_t v) { return Swap16(v); }
+inline uint32_t HostSwap32(uint32_t v) { return Swap32(v); }
+inline uint64_t HostSwap64(uint64_t v) { return Swap64(v); }
 
 #else /* BYTE_ORDER_LITTLE_ENDIAN */
 
-inline uint16_t HostSwap16(uint16_t v)
-{
-    return v;
-}
-inline uint32_t HostSwap32(uint32_t v)
-{
-    return v;
-}
-inline uint64_t HostSwap64(uint64_t v)
-{
-    return v;
-}
+inline uint16_t HostSwap16(uint16_t v) { return v; }
+inline uint32_t HostSwap32(uint32_t v) { return v; }
+inline uint64_t HostSwap64(uint64_t v) { return v; }
 
 #endif
 
@@ -316,22 +262,10 @@ inline uint64_t HostSwap64(uint64_t v)
  */
 template <typename UintType> UintType HostSwap(UintType aValue);
 
-template <> inline uint8_t HostSwap(uint8_t aValue)
-{
-    return aValue;
-}
-template <> inline uint16_t HostSwap(uint16_t aValue)
-{
-    return HostSwap16(aValue);
-}
-template <> inline uint32_t HostSwap(uint32_t aValue)
-{
-    return HostSwap32(aValue);
-}
-template <> inline uint64_t HostSwap(uint64_t aValue)
-{
-    return HostSwap64(aValue);
-}
+template <> inline uint8_t  HostSwap(uint8_t aValue) { return aValue; }
+template <> inline uint16_t HostSwap(uint16_t aValue) { return HostSwap16(aValue); }
+template <> inline uint32_t HostSwap(uint32_t aValue) { return HostSwap32(aValue); }
+template <> inline uint64_t HostSwap(uint64_t aValue) { return HostSwap64(aValue); }
 
 /**
  * This function reads a `uint16_t` value from a given buffer assuming little-endian encoding.
@@ -341,10 +275,7 @@ template <> inline uint64_t HostSwap(uint64_t aValue)
  * @returns The `uint16_t` value read from buffer.
  *
  */
-inline uint16_t ReadUint16(const uint8_t *aBuffer)
-{
-    return static_cast<uint16_t>(aBuffer[0] | (aBuffer[1] << 8));
-}
+inline uint16_t ReadUint16(const uint8_t *aBuffer) { return static_cast<uint16_t>(aBuffer[0] | (aBuffer[1] << 8)); }
 
 /**
  * This function reads a 24-bit integer value from a given buffer assuming little-endian encoding.

--- a/src/core/common/frame_builder.cpp
+++ b/src/core/common/frame_builder.cpp
@@ -42,10 +42,7 @@ void FrameBuilder::Init(void *aBuffer, uint16_t aLength)
     mMaxLength = aLength;
 }
 
-Error FrameBuilder::AppendUint8(uint8_t aUint8)
-{
-    return Append<uint8_t>(aUint8);
-}
+Error FrameBuilder::AppendUint8(uint8_t aUint8) { return Append<uint8_t>(aUint8); }
 
 Error FrameBuilder::AppendBigEndianUint16(uint16_t aUint16)
 {

--- a/src/core/common/frame_data.cpp
+++ b/src/core/common/frame_data.cpp
@@ -38,10 +38,7 @@
 
 namespace ot {
 
-Error FrameData::ReadUint8(uint8_t &aUint8)
-{
-    return ReadBytes(&aUint8, sizeof(uint8_t));
-}
+Error FrameData::ReadUint8(uint8_t &aUint8) { return ReadBytes(&aUint8, sizeof(uint8_t)); }
 
 Error FrameData::ReadBigEndianUint16(uint16_t &aUint16)
 {
@@ -99,9 +96,6 @@ exit:
     return error;
 }
 
-void FrameData::SkipOver(uint16_t aLength)
-{
-    Init(GetBytes() + aLength, GetLength() - aLength);
-}
+void FrameData::SkipOver(uint16_t aLength) { Init(GetBytes() + aLength, GetLength() - aLength); }
 
 } // namespace ot

--- a/src/core/common/heap.cpp
+++ b/src/core/common/heap.cpp
@@ -40,27 +40,15 @@ namespace Heap {
 
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 
-void *CAlloc(size_t aCount, size_t aSize)
-{
-    return otPlatCAlloc(aCount, aSize);
-}
+void *CAlloc(size_t aCount, size_t aSize) { return otPlatCAlloc(aCount, aSize); }
 
-void Free(void *aPointer)
-{
-    otPlatFree(aPointer);
-}
+void Free(void *aPointer) { otPlatFree(aPointer); }
 
 #else
 
-void *CAlloc(size_t aCount, size_t aSize)
-{
-    return Instance::GetHeap().CAlloc(aCount, aSize);
-}
+void *CAlloc(size_t aCount, size_t aSize) { return Instance::GetHeap().CAlloc(aCount, aSize); }
 
-void Free(void *aPointer)
-{
-    Instance::GetHeap().Free(aPointer);
-}
+void Free(void *aPointer) { Instance::GetHeap().Free(aPointer); }
 
 #endif // OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -299,10 +299,7 @@ exit:
 
 #endif // OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
 
-void Instance::Reset(void)
-{
-    otPlatReset(this);
-}
+void Instance::Reset(void) { otPlatReset(this); }
 
 #if OPENTHREAD_RADIO
 void Instance::ResetRadioStack(void)
@@ -426,10 +423,7 @@ void Instance::SetLogLevel(LogLevel aLogLevel)
     }
 }
 
-extern "C" OT_TOOL_WEAK void otPlatLogHandleLevelChanged(otLogLevel aLogLevel)
-{
-    OT_UNUSED_VARIABLE(aLogLevel);
-}
+extern "C" OT_TOOL_WEAK void otPlatLogHandleLevelChanged(otLogLevel aLogLevel) { OT_UNUSED_VARIABLE(aLogLevel); }
 
 #endif
 

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -211,10 +211,7 @@ public:
      * @returns TRUE if the instance is valid/initialized, FALSE otherwise.
      *
      */
-    bool IsInitialized(void) const
-    {
-        return mIsInitialized;
-    }
+    bool IsInitialized(void) const { return mIsInitialized; }
 
     /**
      * This method triggers a platform reset.
@@ -303,10 +300,7 @@ public:
      * @returns A reference to the application COAP object.
      *
      */
-    Coap::Coap &GetApplicationCoap(void)
-    {
-        return mApplicationCoap;
-    }
+    Coap::Coap &GetApplicationCoap(void) { return mApplicationCoap; }
 #endif
 
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
@@ -316,10 +310,7 @@ public:
      * @returns A reference to the application COAP Secure object.
      *
      */
-    Coap::CoapSecure &GetApplicationCoapSecure(void)
-    {
-        return mApplicationCoapSecure;
-    }
+    Coap::CoapSecure &GetApplicationCoapSecure(void) { return mApplicationCoapSecure; }
 #endif
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
@@ -334,10 +325,7 @@ public:
      * @param[in] aEnabled   TRUE to enable the "DNS name compression" mode, FALSE to disable.
      *
      */
-    static void SetDnsNameCompressionEnabled(bool aEnabled)
-    {
-        sDnsNameCompressionEnabled = aEnabled;
-    }
+    static void SetDnsNameCompressionEnabled(bool aEnabled) { sDnsNameCompressionEnabled = aEnabled; }
 
     /**
      * This method indicates whether the "DNS name compression" mode is enabled or not.
@@ -345,10 +333,7 @@ public:
      * @returns TRUE if the "DNS name compressions" mode is enabled, FALSE otherwise.
      *
      */
-    static bool IsDnsNameCompressionEnabled(void)
-    {
-        return sDnsNameCompressionEnabled;
-    }
+    static bool IsDnsNameCompressionEnabled(void) { return sDnsNameCompressionEnabled; }
 #endif
 
     /**
@@ -646,507 +631,255 @@ DefineCoreType(otBufferInfo, Instance::BufferInfo);
 
 // Specializations of the `Get<Type>()` method.
 
-template <> inline Instance &Instance::Get(void)
-{
-    return *this;
-}
+template <> inline Instance &Instance::Get(void) { return *this; }
 
-template <> inline Radio &Instance::Get(void)
-{
-    return mRadio;
-}
+template <> inline Radio &Instance::Get(void) { return mRadio; }
 
-template <> inline Radio::Callbacks &Instance::Get(void)
-{
-    return mRadio.mCallbacks;
-}
+template <> inline Radio::Callbacks &Instance::Get(void) { return mRadio.mCallbacks; }
 
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
-template <> inline Uptime &Instance::Get(void)
-{
-    return mUptime;
-}
+template <> inline Uptime &Instance::Get(void) { return mUptime; }
 #endif
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
-template <> inline Notifier &Instance::Get(void)
-{
-    return mNotifier;
-}
+template <> inline Notifier &Instance::Get(void) { return mNotifier; }
 
-template <> inline TimeTicker &Instance::Get(void)
-{
-    return mTimeTicker;
-}
+template <> inline TimeTicker &Instance::Get(void) { return mTimeTicker; }
 
-template <> inline Settings &Instance::Get(void)
-{
-    return mSettings;
-}
+template <> inline Settings &Instance::Get(void) { return mSettings; }
 
-template <> inline SettingsDriver &Instance::Get(void)
-{
-    return mSettingsDriver;
-}
+template <> inline SettingsDriver &Instance::Get(void) { return mSettingsDriver; }
 
-template <> inline MeshForwarder &Instance::Get(void)
-{
-    return mMeshForwarder;
-}
+template <> inline MeshForwarder &Instance::Get(void) { return mMeshForwarder; }
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-template <> inline RadioSelector &Instance::Get(void)
-{
-    return mRadioSelector;
-}
+template <> inline RadioSelector &Instance::Get(void) { return mRadioSelector; }
 #endif
 
-template <> inline Mle::Mle &Instance::Get(void)
-{
-    return mMleRouter;
-}
+template <> inline Mle::Mle &Instance::Get(void) { return mMleRouter; }
 
-template <> inline Mle::MleRouter &Instance::Get(void)
-{
-    return mMleRouter;
-}
+template <> inline Mle::MleRouter &Instance::Get(void) { return mMleRouter; }
 
-template <> inline Mle::DiscoverScanner &Instance::Get(void)
-{
-    return mDiscoverScanner;
-}
+template <> inline Mle::DiscoverScanner &Instance::Get(void) { return mDiscoverScanner; }
 
-template <> inline NeighborTable &Instance::Get(void)
-{
-    return mMleRouter.mNeighborTable;
-}
+template <> inline NeighborTable &Instance::Get(void) { return mMleRouter.mNeighborTable; }
 
 #if OPENTHREAD_FTD
-template <> inline ChildTable &Instance::Get(void)
-{
-    return mMleRouter.mChildTable;
-}
+template <> inline ChildTable &Instance::Get(void) { return mMleRouter.mChildTable; }
 
-template <> inline RouterTable &Instance::Get(void)
-{
-    return mMleRouter.mRouterTable;
-}
+template <> inline RouterTable &Instance::Get(void) { return mMleRouter.mRouterTable; }
 #endif
 
-template <> inline Ip6::Netif &Instance::Get(void)
-{
-    return mThreadNetif;
-}
+template <> inline Ip6::Netif &Instance::Get(void) { return mThreadNetif; }
 
-template <> inline ThreadNetif &Instance::Get(void)
-{
-    return mThreadNetif;
-}
+template <> inline ThreadNetif &Instance::Get(void) { return mThreadNetif; }
 
-template <> inline Ip6::Ip6 &Instance::Get(void)
-{
-    return mIp6;
-}
+template <> inline Ip6::Ip6 &Instance::Get(void) { return mIp6; }
 
-template <> inline Mac::Mac &Instance::Get(void)
-{
-    return mMac;
-}
+template <> inline Mac::Mac &Instance::Get(void) { return mMac; }
 
-template <> inline Mac::SubMac &Instance::Get(void)
-{
-    return mMac.mLinks.mSubMac;
-}
+template <> inline Mac::SubMac &Instance::Get(void) { return mMac.mLinks.mSubMac; }
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-template <> inline Trel::Link &Instance::Get(void)
-{
-    return mMac.mLinks.mTrel;
-}
+template <> inline Trel::Link &Instance::Get(void) { return mMac.mLinks.mTrel; }
 
-template <> inline Trel::Interface &Instance::Get(void)
-{
-    return mMac.mLinks.mTrel.mInterface;
-}
+template <> inline Trel::Interface &Instance::Get(void) { return mMac.mLinks.mTrel.mInterface; }
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
-template <> inline Mac::Filter &Instance::Get(void)
-{
-    return mMac.mFilter;
-}
+template <> inline Mac::Filter &Instance::Get(void) { return mMac.mFilter; }
 #endif
 
-template <> inline Lowpan::Lowpan &Instance::Get(void)
-{
-    return mLowpan;
-}
+template <> inline Lowpan::Lowpan &Instance::Get(void) { return mLowpan; }
 
-template <> inline KeyManager &Instance::Get(void)
-{
-    return mKeyManager;
-}
+template <> inline KeyManager &Instance::Get(void) { return mKeyManager; }
 
-template <> inline Ip6::Filter &Instance::Get(void)
-{
-    return mIp6Filter;
-}
+template <> inline Ip6::Filter &Instance::Get(void) { return mIp6Filter; }
 
-template <> inline AddressResolver &Instance::Get(void)
-{
-    return mAddressResolver;
-}
+template <> inline AddressResolver &Instance::Get(void) { return mAddressResolver; }
 
 #if OPENTHREAD_FTD
 
-template <> inline IndirectSender &Instance::Get(void)
-{
-    return mMeshForwarder.mIndirectSender;
-}
+template <> inline IndirectSender &Instance::Get(void) { return mMeshForwarder.mIndirectSender; }
 
 template <> inline SourceMatchController &Instance::Get(void)
 {
     return mMeshForwarder.mIndirectSender.mSourceMatchController;
 }
 
-template <> inline DataPollHandler &Instance::Get(void)
-{
-    return mMeshForwarder.mIndirectSender.mDataPollHandler;
-}
+template <> inline DataPollHandler &Instance::Get(void) { return mMeshForwarder.mIndirectSender.mDataPollHandler; }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-template <> inline CslTxScheduler &Instance::Get(void)
-{
-    return mMeshForwarder.mIndirectSender.mCslTxScheduler;
-}
+template <> inline CslTxScheduler &Instance::Get(void) { return mMeshForwarder.mIndirectSender.mCslTxScheduler; }
 #endif
 
-template <> inline MeshCoP::Leader &Instance::Get(void)
-{
-    return mLeader;
-}
+template <> inline MeshCoP::Leader &Instance::Get(void) { return mLeader; }
 
-template <> inline MeshCoP::JoinerRouter &Instance::Get(void)
-{
-    return mJoinerRouter;
-}
+template <> inline MeshCoP::JoinerRouter &Instance::Get(void) { return mJoinerRouter; }
 #endif // OPENTHREAD_FTD
 
-template <> inline AnnounceBeginServer &Instance::Get(void)
-{
-    return mAnnounceBegin;
-}
+template <> inline AnnounceBeginServer &Instance::Get(void) { return mAnnounceBegin; }
 
-template <> inline DataPollSender &Instance::Get(void)
-{
-    return mMeshForwarder.mDataPollSender;
-}
+template <> inline DataPollSender &Instance::Get(void) { return mMeshForwarder.mDataPollSender; }
 
-template <> inline EnergyScanServer &Instance::Get(void)
-{
-    return mEnergyScan;
-}
+template <> inline EnergyScanServer &Instance::Get(void) { return mEnergyScan; }
 
-template <> inline PanIdQueryServer &Instance::Get(void)
-{
-    return mPanIdQuery;
-}
+template <> inline PanIdQueryServer &Instance::Get(void) { return mPanIdQuery; }
 
 #if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_ENABLE
-template <> inline AnycastLocator &Instance::Get(void)
-{
-    return mAnycastLocator;
-}
+template <> inline AnycastLocator &Instance::Get(void) { return mAnycastLocator; }
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-template <> inline NetworkData::Local &Instance::Get(void)
-{
-    return mNetworkDataLocal;
-}
+template <> inline NetworkData::Local &Instance::Get(void) { return mNetworkDataLocal; }
 #endif
 
-template <> inline NetworkData::Leader &Instance::Get(void)
-{
-    return mNetworkDataLeader;
-}
+template <> inline NetworkData::Leader &Instance::Get(void) { return mNetworkDataLeader; }
 
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-template <> inline NetworkData::Notifier &Instance::Get(void)
-{
-    return mNetworkDataNotifier;
-}
+template <> inline NetworkData::Notifier &Instance::Get(void) { return mNetworkDataNotifier; }
 #endif
 
 #if OPENTHREAD_CONFIG_NETDATA_PUBLISHER_ENABLE
-template <> inline NetworkData::Publisher &Instance::Get(void)
-{
-    return mNetworkDataPublisher;
-}
+template <> inline NetworkData::Publisher &Instance::Get(void) { return mNetworkDataPublisher; }
 #endif
 
-template <> inline NetworkData::Service::Manager &Instance::Get(void)
-{
-    return mNetworkDataServiceManager;
-}
+template <> inline NetworkData::Service::Manager &Instance::Get(void) { return mNetworkDataServiceManager; }
 
 #if OPENTHREAD_CONFIG_TCP_ENABLE
-template <> inline Ip6::Tcp &Instance::Get(void)
-{
-    return mIp6.mTcp;
-}
+template <> inline Ip6::Tcp &Instance::Get(void) { return mIp6.mTcp; }
 #endif
 
-template <> inline Ip6::Udp &Instance::Get(void)
-{
-    return mIp6.mUdp;
-}
+template <> inline Ip6::Udp &Instance::Get(void) { return mIp6.mUdp; }
 
-template <> inline Ip6::Icmp &Instance::Get(void)
-{
-    return mIp6.mIcmp;
-}
+template <> inline Ip6::Icmp &Instance::Get(void) { return mIp6.mIcmp; }
 
-template <> inline Ip6::Mpl &Instance::Get(void)
-{
-    return mIp6.mMpl;
-}
+template <> inline Ip6::Mpl &Instance::Get(void) { return mIp6.mMpl; }
 
-template <> inline Tmf::Agent &Instance::Get(void)
-{
-    return mTmfAgent;
-}
+template <> inline Tmf::Agent &Instance::Get(void) { return mTmfAgent; }
 
 #if OPENTHREAD_CONFIG_DTLS_ENABLE
-template <> inline Tmf::SecureAgent &Instance::Get(void)
-{
-    return mTmfSecureAgent;
-}
+template <> inline Tmf::SecureAgent &Instance::Get(void) { return mTmfSecureAgent; }
 #endif
 
-template <> inline MeshCoP::ExtendedPanIdManager &Instance::Get(void)
-{
-    return mExtendedPanIdManager;
-}
+template <> inline MeshCoP::ExtendedPanIdManager &Instance::Get(void) { return mExtendedPanIdManager; }
 
-template <> inline MeshCoP::NetworkNameManager &Instance::Get(void)
-{
-    return mNetworkNameManager;
-}
+template <> inline MeshCoP::NetworkNameManager &Instance::Get(void) { return mNetworkNameManager; }
 
-template <> inline MeshCoP::ActiveDatasetManager &Instance::Get(void)
-{
-    return mActiveDataset;
-}
+template <> inline MeshCoP::ActiveDatasetManager &Instance::Get(void) { return mActiveDataset; }
 
-template <> inline MeshCoP::PendingDatasetManager &Instance::Get(void)
-{
-    return mPendingDataset;
-}
+template <> inline MeshCoP::PendingDatasetManager &Instance::Get(void) { return mPendingDataset; }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-template <> inline TimeSync &Instance::Get(void)
-{
-    return mTimeSync;
-}
+template <> inline TimeSync &Instance::Get(void) { return mTimeSync; }
 #endif
 
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-template <> inline MeshCoP::Commissioner &Instance::Get(void)
-{
-    return mCommissioner;
-}
+template <> inline MeshCoP::Commissioner &Instance::Get(void) { return mCommissioner; }
 
-template <> inline AnnounceBeginClient &Instance::Get(void)
-{
-    return mCommissioner.GetAnnounceBeginClient();
-}
+template <> inline AnnounceBeginClient &Instance::Get(void) { return mCommissioner.GetAnnounceBeginClient(); }
 
-template <> inline EnergyScanClient &Instance::Get(void)
-{
-    return mCommissioner.GetEnergyScanClient();
-}
+template <> inline EnergyScanClient &Instance::Get(void) { return mCommissioner.GetEnergyScanClient(); }
 
-template <> inline PanIdQueryClient &Instance::Get(void)
-{
-    return mCommissioner.GetPanIdQueryClient();
-}
+template <> inline PanIdQueryClient &Instance::Get(void) { return mCommissioner.GetPanIdQueryClient(); }
 #endif
 
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
-template <> inline MeshCoP::Joiner &Instance::Get(void)
-{
-    return mJoiner;
-}
+template <> inline MeshCoP::Joiner &Instance::Get(void) { return mJoiner; }
 #endif
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
-template <> inline Dns::Client &Instance::Get(void)
-{
-    return mDnsClient;
-}
+template <> inline Dns::Client &Instance::Get(void) { return mDnsClient; }
 #endif
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
-template <> inline Srp::Client &Instance::Get(void)
-{
-    return mSrpClient;
-}
+template <> inline Srp::Client &Instance::Get(void) { return mSrpClient; }
 #endif
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
-template <> inline Utils::SrpClientBuffers &Instance::Get(void)
-{
-    return mSrpClientBuffers;
-}
+template <> inline Utils::SrpClientBuffers &Instance::Get(void) { return mSrpClientBuffers; }
 #endif
 
 #if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
-template <> inline Dns::ServiceDiscovery::Server &Instance::Get(void)
-{
-    return mDnssdServer;
-}
+template <> inline Dns::ServiceDiscovery::Server &Instance::Get(void) { return mDnssdServer; }
 #endif
 
 #if OPENTHREAD_CONFIG_DNS_DSO_ENABLE
-template <> inline Dns::Dso &Instance::Get(void)
-{
-    return mDnsDso;
-}
+template <> inline Dns::Dso &Instance::Get(void) { return mDnsDso; }
 #endif
 
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
-template <> inline NetworkDiagnostic::NetworkDiagnostic &Instance::Get(void)
-{
-    return mNetworkDiagnostic;
-}
+template <> inline NetworkDiagnostic::NetworkDiagnostic &Instance::Get(void) { return mNetworkDiagnostic; }
 #endif
 
 #if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
-template <> inline Dhcp6::Client &Instance::Get(void)
-{
-    return mDhcp6Client;
-}
+template <> inline Dhcp6::Client &Instance::Get(void) { return mDhcp6Client; }
 #endif
 
 #if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
-template <> inline Dhcp6::Server &Instance::Get(void)
-{
-    return mDhcp6Server;
-}
+template <> inline Dhcp6::Server &Instance::Get(void) { return mDhcp6Server; }
 #endif
 
 #if OPENTHREAD_CONFIG_NEIGHBOR_DISCOVERY_AGENT_ENABLE
-template <> inline NeighborDiscovery::Agent &Instance::Get(void)
-{
-    return mNeighborDiscoveryAgent;
-}
+template <> inline NeighborDiscovery::Agent &Instance::Get(void) { return mNeighborDiscoveryAgent; }
 #endif
 
 #if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
-template <> inline Utils::Slaac &Instance::Get(void)
-{
-    return mSlaac;
-}
+template <> inline Utils::Slaac &Instance::Get(void) { return mSlaac; }
 #endif
 
 #if OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
-template <> inline Utils::JamDetector &Instance::Get(void)
-{
-    return mJamDetector;
-}
+template <> inline Utils::JamDetector &Instance::Get(void) { return mJamDetector; }
 #endif
 
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
-template <> inline Sntp::Client &Instance::Get(void)
-{
-    return mSntpClient;
-}
+template <> inline Sntp::Client &Instance::Get(void) { return mSntpClient; }
 #endif
 
 #if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
 #if OPENTHREAD_FTD
-template <> inline Utils::ChildSupervisor &Instance::Get(void)
-{
-    return mChildSupervisor;
-}
+template <> inline Utils::ChildSupervisor &Instance::Get(void) { return mChildSupervisor; }
 #endif
-template <> inline Utils::SupervisionListener &Instance::Get(void)
-{
-    return mSupervisionListener;
-}
+template <> inline Utils::SupervisionListener &Instance::Get(void) { return mSupervisionListener; }
 #endif
 
 #if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
-template <> inline Utils::PingSender &Instance::Get(void)
-{
-    return mPingSender;
-}
+template <> inline Utils::PingSender &Instance::Get(void) { return mPingSender; }
 #endif
 
 #if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
-template <> inline Utils::ChannelMonitor &Instance::Get(void)
-{
-    return mChannelMonitor;
-}
+template <> inline Utils::ChannelMonitor &Instance::Get(void) { return mChannelMonitor; }
 #endif
 
 #if OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
-template <> inline Utils::ChannelManager &Instance::Get(void)
-{
-    return mChannelManager;
-}
+template <> inline Utils::ChannelManager &Instance::Get(void) { return mChannelManager; }
 #endif
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-template <> inline Utils::HistoryTracker &Instance::Get(void)
-{
-    return mHistoryTracker;
-}
+template <> inline Utils::HistoryTracker &Instance::Get(void) { return mHistoryTracker; }
 #endif
 
 #if (OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE || OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE) && OPENTHREAD_FTD
-template <> inline MeshCoP::DatasetUpdater &Instance::Get(void)
-{
-    return mDatasetUpdater;
-}
+template <> inline MeshCoP::DatasetUpdater &Instance::Get(void) { return mDatasetUpdater; }
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-template <> inline MeshCoP::BorderAgent &Instance::Get(void)
-{
-    return mBorderAgent;
-}
+template <> inline MeshCoP::BorderAgent &Instance::Get(void) { return mBorderAgent; }
 #endif
 
 #if OPENTHREAD_CONFIG_ANNOUNCE_SENDER_ENABLE
-template <> inline AnnounceSender &Instance::Get(void)
-{
-    return mAnnounceSender;
-}
+template <> inline AnnounceSender &Instance::Get(void) { return mAnnounceSender; }
 #endif
 
-template <> inline MessagePool &Instance::Get(void)
-{
-    return mMessagePool;
-}
+template <> inline MessagePool &Instance::Get(void) { return mMessagePool; }
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 
-template <> inline BackboneRouter::Leader &Instance::Get(void)
-{
-    return mBackboneRouterLeader;
-}
+template <> inline BackboneRouter::Leader &Instance::Get(void) { return mBackboneRouterLeader; }
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-template <> inline BackboneRouter::Local &Instance::Get(void)
-{
-    return mBackboneRouterLocal;
-}
-template <> inline BackboneRouter::Manager &Instance::Get(void)
-{
-    return mBackboneRouterManager;
-}
+template <> inline BackboneRouter::Local   &Instance::Get(void) { return mBackboneRouterLocal; }
+template <> inline BackboneRouter::Manager &Instance::Get(void) { return mBackboneRouterManager; }
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
 template <> inline BackboneRouter::MulticastListenersTable &Instance::Get(void)
@@ -1169,107 +902,62 @@ template <> inline BackboneRouter::BackboneTmfAgent &Instance::Get(void)
 #endif
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
-template <> inline MlrManager &Instance::Get(void)
-{
-    return mMlrManager;
-}
+template <> inline MlrManager &Instance::Get(void) { return mMlrManager; }
 #endif
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE)
-template <> inline DuaManager &Instance::Get(void)
-{
-    return mDuaManager;
-}
+template <> inline DuaManager &Instance::Get(void) { return mDuaManager; }
 #endif
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
-template <> inline LinkMetrics::LinkMetrics &Instance::Get(void)
-{
-    return mLinkMetrics;
-}
+template <> inline LinkMetrics::LinkMetrics &Instance::Get(void) { return mLinkMetrics; }
 #endif
 
 #endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 
 #if OPENTHREAD_CONFIG_OTNS_ENABLE
-template <> inline Utils::Otns &Instance::Get(void)
-{
-    return mOtns;
-}
+template <> inline Utils::Otns &Instance::Get(void) { return mOtns; }
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-template <> inline BorderRouter::RoutingManager &Instance::Get(void)
-{
-    return mRoutingManager;
-}
+template <> inline BorderRouter::RoutingManager &Instance::Get(void) { return mRoutingManager; }
 
-template <> inline BorderRouter::InfraIf &Instance::Get(void)
-{
-    return mRoutingManager.mInfraIf;
-}
+template <> inline BorderRouter::InfraIf &Instance::Get(void) { return mRoutingManager.mInfraIf; }
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 
 #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
-template <> inline Nat64::Translator &Instance::Get(void)
-{
-    return mNat64Translator;
-}
+template <> inline Nat64::Translator &Instance::Get(void) { return mNat64Translator; }
 #endif
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
-template <> inline Srp::Server &Instance::Get(void)
-{
-    return mSrpServer;
-}
+template <> inline Srp::Server &Instance::Get(void) { return mSrpServer; }
 #endif
 
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 
 #if OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
-template <> inline Mac::LinkRaw &Instance::Get(void)
-{
-    return mLinkRaw;
-}
+template <> inline Mac::LinkRaw &Instance::Get(void) { return mLinkRaw; }
 
 #if OPENTHREAD_RADIO
-template <> inline Mac::SubMac &Instance::Get(void)
-{
-    return mLinkRaw.mSubMac;
-}
+template <> inline Mac::SubMac &Instance::Get(void) { return mLinkRaw.mSubMac; }
 #endif
 
 #endif // OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
 
-template <> inline Tasklet::Scheduler &Instance::Get(void)
-{
-    return mTaskletScheduler;
-}
+template <> inline Tasklet::Scheduler &Instance::Get(void) { return mTaskletScheduler; }
 
-template <> inline TimerMilli::Scheduler &Instance::Get(void)
-{
-    return mTimerMilliScheduler;
-}
+template <> inline TimerMilli::Scheduler &Instance::Get(void) { return mTimerMilliScheduler; }
 
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
-template <> inline TimerMicro::Scheduler &Instance::Get(void)
-{
-    return mTimerMicroScheduler;
-}
+template <> inline TimerMicro::Scheduler &Instance::Get(void) { return mTimerMicroScheduler; }
 #endif
 
 #if OPENTHREAD_ENABLE_VENDOR_EXTENSION
-template <> inline Extension::ExtensionBase &Instance::Get(void)
-{
-    return mExtension;
-}
+template <> inline Extension::ExtensionBase &Instance::Get(void) { return mExtension; }
 #endif
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-template <> inline FactoryDiags::Diags &Instance::Get(void)
-{
-    return mDiags;
-}
+template <> inline FactoryDiags::Diags &Instance::Get(void) { return mDiags; }
 #endif
 
 /**

--- a/src/core/common/locator.hpp
+++ b/src/core/common/locator.hpp
@@ -113,15 +113,9 @@ public:
      *
      */
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
-    Instance &GetInstance(void) const
-    {
-        return *mInstance;
-    }
+    Instance &GetInstance(void) const { return *mInstance; }
 #else
-    Instance &GetInstance(void) const
-    {
-        return *reinterpret_cast<Instance *>(&gInstanceRaw);
-    }
+    Instance &GetInstance(void) const { return *reinterpret_cast<Instance *>(&gInstanceRaw); }
 #endif
 
 protected:

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -154,10 +154,7 @@ void MessagePool::FreeBuffers(Buffer *aBuffer)
     }
 }
 
-Error MessagePool::ReclaimBuffers(Message::Priority aPriority)
-{
-    return Get<MeshForwarder>().EvictMessage(aPriority);
-}
+Error MessagePool::ReclaimBuffers(Message::Priority aPriority) { return Get<MeshForwarder>().EvictMessage(aPriority); }
 
 uint16_t MessagePool::GetFreeBufferCount(void) const
 {
@@ -255,10 +252,7 @@ exit:
     return error;
 }
 
-void Message::Free(void)
-{
-    GetMessagePool()->Free(this);
-}
+void Message::Free(void) { GetMessagePool()->Free(this); }
 
 Message *Message::GetNext(void) const
 {
@@ -703,25 +697,13 @@ exit:
     return messageCopy;
 }
 
-bool Message::GetChildMask(uint16_t aChildIndex) const
-{
-    return GetMetadata().mChildMask.Get(aChildIndex);
-}
+bool Message::GetChildMask(uint16_t aChildIndex) const { return GetMetadata().mChildMask.Get(aChildIndex); }
 
-void Message::ClearChildMask(uint16_t aChildIndex)
-{
-    GetMetadata().mChildMask.Set(aChildIndex, false);
-}
+void Message::ClearChildMask(uint16_t aChildIndex) { GetMetadata().mChildMask.Set(aChildIndex, false); }
 
-void Message::SetChildMask(uint16_t aChildIndex)
-{
-    GetMetadata().mChildMask.Set(aChildIndex, true);
-}
+void Message::SetChildMask(uint16_t aChildIndex) { GetMetadata().mChildMask.Set(aChildIndex, true); }
 
-bool Message::IsChildPending(void) const
-{
-    return GetMetadata().mChildMask.HasAny();
-}
+bool Message::IsChildPending(void) const { return GetMetadata().mChildMask.HasAny(); }
 
 void Message::SetLinkInfo(const ThreadLinkInfo &aLinkInfo)
 {
@@ -835,15 +817,9 @@ void MessageQueue::DequeueAndFreeAll(void)
     }
 }
 
-Message::Iterator MessageQueue::begin(void)
-{
-    return Message::Iterator(GetHead());
-}
+Message::Iterator MessageQueue::begin(void) { return Message::Iterator(GetHead()); }
 
-Message::ConstIterator MessageQueue::begin(void) const
-{
-    return Message::ConstIterator(GetHead());
-}
+Message::ConstIterator MessageQueue::begin(void) const { return Message::ConstIterator(GetHead()); }
 
 void MessageQueue::GetInfo(Info &aInfo) const
 {
@@ -909,10 +885,7 @@ const Message *PriorityQueue::GetHeadForPriority(Message::Priority aPriority) co
     return head;
 }
 
-const Message *PriorityQueue::GetTail(void) const
-{
-    return FindFirstNonNullTail(Message::kPriorityLow);
-}
+const Message *PriorityQueue::GetTail(void) const { return FindFirstNonNullTail(Message::kPriorityLow); }
 
 void PriorityQueue::Enqueue(Message &aMessage)
 {
@@ -993,15 +966,9 @@ void PriorityQueue::DequeueAndFreeAll(void)
     }
 }
 
-Message::Iterator PriorityQueue::begin(void)
-{
-    return Message::Iterator(GetHead());
-}
+Message::Iterator PriorityQueue::begin(void) { return Message::Iterator(GetHead()); }
 
-Message::ConstIterator PriorityQueue::begin(void) const
-{
-    return Message::ConstIterator(GetHead());
-}
+Message::ConstIterator PriorityQueue::begin(void) const { return Message::ConstIterator(GetHead()); }
 
 void PriorityQueue::GetInfo(Info &aInfo) const
 {

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -232,32 +232,14 @@ protected:
     static constexpr uint16_t kBufferDataSize     = kBufferSize - sizeof(otMessageBuffer);
     static constexpr uint16_t kHeadBufferDataSize = kBufferDataSize - sizeof(Metadata);
 
-    Metadata &GetMetadata(void)
-    {
-        return mBuffer.mHead.mMetadata;
-    }
-    const Metadata &GetMetadata(void) const
-    {
-        return mBuffer.mHead.mMetadata;
-    }
+    Metadata       &GetMetadata(void) { return mBuffer.mHead.mMetadata; }
+    const Metadata &GetMetadata(void) const { return mBuffer.mHead.mMetadata; }
 
-    uint8_t *GetFirstData(void)
-    {
-        return mBuffer.mHead.mData;
-    }
-    const uint8_t *GetFirstData(void) const
-    {
-        return mBuffer.mHead.mData;
-    }
+    uint8_t       *GetFirstData(void) { return mBuffer.mHead.mData; }
+    const uint8_t *GetFirstData(void) const { return mBuffer.mHead.mData; }
 
-    uint8_t *GetData(void)
-    {
-        return mBuffer.mData;
-    }
-    const uint8_t *GetData(void) const
-    {
-        return mBuffer.mData;
-    }
+    uint8_t       *GetData(void) { return mBuffer.mData; }
+    const uint8_t *GetData(void) const { return mBuffer.mData; }
 
 private:
     union
@@ -1167,10 +1149,7 @@ public:
      * @param[in] aLqi A new LQI value (has no unit) to be added to average.
      *
      */
-    void AddLqi(uint8_t aLqi)
-    {
-        GetMetadata().mLqiAverager.Add(aLqi);
-    }
+    void AddLqi(uint8_t aLqi) { GetMetadata().mLqiAverager.Add(aLqi); }
 
     /**
      * This method returns the average LQI (Link Quality Indicator) associated with the message.
@@ -1178,10 +1157,7 @@ public:
      * @returns The current average LQI value (in dBm) or OT_RADIO_LQI_NONE if no average is available.
      *
      */
-    uint8_t GetAverageLqi(void) const
-    {
-        return GetMetadata().mLqiAverager.GetAverage();
-    }
+    uint8_t GetAverageLqi(void) const { return GetMetadata().mLqiAverager.GetAverage(); }
 
     /**
      * This method returns the count of frames counted so far.
@@ -1189,10 +1165,7 @@ public:
      * @returns The count of frames that have been counted.
      *
      */
-    uint8_t GetPsduCount(void) const
-    {
-        return GetMetadata().mLqiAverager.GetCount();
-    }
+    uint8_t GetPsduCount(void) const { return GetMetadata().mLqiAverager.GetCount(); }
 #endif
 
     /**
@@ -1243,10 +1216,7 @@ public:
      * @param[in]  aEnabled  TRUE if the message is also used for time sync purpose, FALSE otherwise.
      *
      */
-    void SetTimeSync(bool aEnabled)
-    {
-        GetMetadata().mTimeSync = aEnabled;
-    }
+    void SetTimeSync(bool aEnabled) { GetMetadata().mTimeSync = aEnabled; }
 
     /**
      * This method sets the offset to network time.
@@ -1254,10 +1224,7 @@ public:
      * @param[in]  aNetworkTimeOffset  The offset to network time.
      *
      */
-    void SetNetworkTimeOffset(int64_t aNetworkTimeOffset)
-    {
-        GetMetadata().mNetworkTimeOffset = aNetworkTimeOffset;
-    }
+    void SetNetworkTimeOffset(int64_t aNetworkTimeOffset) { GetMetadata().mNetworkTimeOffset = aNetworkTimeOffset; }
 
     /**
      * This method gets the offset to network time.
@@ -1265,10 +1232,7 @@ public:
      * @returns  The offset to network time.
      *
      */
-    int64_t GetNetworkTimeOffset(void) const
-    {
-        return GetMetadata().mNetworkTimeOffset;
-    }
+    int64_t GetNetworkTimeOffset(void) const { return GetMetadata().mNetworkTimeOffset; }
 
     /**
      * This method sets the time sync sequence.
@@ -1276,10 +1240,7 @@ public:
      * @param[in]  aTimeSyncSeq  The time sync sequence.
      *
      */
-    void SetTimeSyncSeq(uint8_t aTimeSyncSeq)
-    {
-        GetMetadata().mTimeSyncSeq = aTimeSyncSeq;
-    }
+    void SetTimeSyncSeq(uint8_t aTimeSyncSeq) { GetMetadata().mTimeSyncSeq = aTimeSyncSeq; }
 
     /**
      * This method gets the time sync sequence.
@@ -1287,10 +1248,7 @@ public:
      * @returns  The time sync sequence.
      *
      */
-    uint8_t GetTimeSyncSeq(void) const
-    {
-        return GetMetadata().mTimeSyncSeq;
-    }
+    uint8_t GetTimeSyncSeq(void) const { return GetMetadata().mTimeSyncSeq; }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
@@ -1301,10 +1259,7 @@ public:
      * @retval FALSE  If the radio type is not set.
      *
      */
-    bool IsRadioTypeSet(void) const
-    {
-        return GetMetadata().mIsRadioTypeSet;
-    }
+    bool IsRadioTypeSet(void) const { return GetMetadata().mIsRadioTypeSet; }
 
     /**
      * This method gets the radio link type the message was received on, or should be sent on.
@@ -1314,10 +1269,7 @@ public:
      * @returns The radio link type of the message.
      *
      */
-    Mac::RadioType GetRadioType(void) const
-    {
-        return static_cast<Mac::RadioType>(GetMetadata().mRadioType);
-    }
+    Mac::RadioType GetRadioType(void) const { return static_cast<Mac::RadioType>(GetMetadata().mRadioType); }
 
     /**
      * This method sets the radio link type the message was received on, or should be sent on.
@@ -1337,10 +1289,7 @@ public:
      * After calling this method, `IsRadioTypeSet()` returns false until radio type is set (`SetRadioType()`).
      *
      */
-    void ClearRadioType(void)
-    {
-        GetMetadata().mIsRadioTypeSet = false;
-    }
+    void ClearRadioType(void) { GetMetadata().mIsRadioTypeSet = false; }
 
 #endif // #if OPENTHREAD_CONFIG_MULTI_RADIO
 
@@ -1384,14 +1333,8 @@ protected:
         Message *mNext;
     };
 
-    uint16_t GetReserved(void) const
-    {
-        return GetMetadata().mReserved;
-    }
-    void SetReserved(uint16_t aReservedHeader)
-    {
-        GetMetadata().mReserved = aReservedHeader;
-    }
+    uint16_t GetReserved(void) const { return GetMetadata().mReserved; }
+    void     SetReserved(uint16_t aReservedHeader) { GetMetadata().mReserved = aReservedHeader; }
 
 private:
     class Chunk : public Data<kWithUint16Length>
@@ -1423,43 +1366,19 @@ private:
         AsConst(this)->GetNextChunk(aLength, static_cast<Chunk &>(aChunk));
     }
 
-    MessagePool *GetMessagePool(void) const
-    {
-        return GetMetadata().mMessagePool;
-    }
-    void SetMessagePool(MessagePool *aMessagePool)
-    {
-        GetMetadata().mMessagePool = aMessagePool;
-    }
+    MessagePool *GetMessagePool(void) const { return GetMetadata().mMessagePool; }
+    void         SetMessagePool(MessagePool *aMessagePool) { GetMetadata().mMessagePool = aMessagePool; }
 
-    bool IsInAQueue(void) const
-    {
-        return (GetMetadata().mQueue != nullptr);
-    }
+    bool IsInAQueue(void) const { return (GetMetadata().mQueue != nullptr); }
     void SetMessageQueue(MessageQueue *aMessageQueue);
     void SetPriorityQueue(PriorityQueue *aPriorityQueue);
 
-    Message *&Next(void)
-    {
-        return GetMetadata().mNext;
-    }
-    Message *const &Next(void) const
-    {
-        return GetMetadata().mNext;
-    }
-    Message *&Prev(void)
-    {
-        return GetMetadata().mPrev;
-    }
+    Message       *&Next(void) { return GetMetadata().mNext; }
+    Message *const &Next(void) const { return GetMetadata().mNext; }
+    Message       *&Prev(void) { return GetMetadata().mPrev; }
 
-    static Message *NextOf(Message *aMessage)
-    {
-        return (aMessage != nullptr) ? aMessage->Next() : nullptr;
-    }
-    static const Message *NextOf(const Message *aMessage)
-    {
-        return (aMessage != nullptr) ? aMessage->Next() : nullptr;
-    }
+    static Message       *NextOf(Message *aMessage) { return (aMessage != nullptr) ? aMessage->Next() : nullptr; }
+    static const Message *NextOf(const Message *aMessage) { return (aMessage != nullptr) ? aMessage->Next() : nullptr; }
 
     Error ResizeMessage(uint16_t aLength);
 };
@@ -1791,10 +1710,7 @@ private:
 #endif
 };
 
-inline Instance &Message::GetInstance(void) const
-{
-    return GetMessagePool()->GetInstance();
-}
+inline Instance &Message::GetInstance(void) const { return GetMessagePool()->GetInstance(); }
 
 /**
  * @}

--- a/src/core/common/new.hpp
+++ b/src/core/common/new.hpp
@@ -40,9 +40,6 @@
 
 #include <openthread/platform/toolchain.h>
 
-inline void *operator new(size_t, void *p) throw()
-{
-    return p;
-}
+inline void *operator new(size_t, void *p) throw() { return p; }
 
 #endif // NEW_HPP_

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -300,14 +300,9 @@ const char *Notifier::EventToString(Event aEvent) const
 
 #else // #if OT_SHOULD_LOG_AT( OT_LOG_LEVEL_INFO)
 
-void Notifier::LogEvents(Events) const
-{
-}
+void Notifier::LogEvents(Events) const {}
 
-const char *Notifier::EventToString(Event) const
-{
-    return "";
-}
+const char *Notifier::EventToString(Event) const { return ""; }
 
 #endif // #if OT_SHOULD_LOG_AT( OT_LOG_LEVEL_INFO)
 

--- a/src/core/common/num_utils.hpp
+++ b/src/core/common/num_utils.hpp
@@ -52,10 +52,7 @@ namespace ot {
  * @returns The minimum of @p aFirst and @p aSecond.
  *
  */
-template <typename Type> Type Min(Type aFirst, Type aSecond)
-{
-    return (aFirst < aSecond) ? aFirst : aSecond;
-}
+template <typename Type> Type Min(Type aFirst, Type aSecond) { return (aFirst < aSecond) ? aFirst : aSecond; }
 
 /**
  * This template function returns the maximum of two given values.
@@ -70,10 +67,7 @@ template <typename Type> Type Min(Type aFirst, Type aSecond)
  * @returns The maximum of @p aFirst and @p aSecond.
  *
  */
-template <typename Type> Type Max(Type aFirst, Type aSecond)
-{
-    return (aFirst < aSecond) ? aSecond : aFirst;
-}
+template <typename Type> Type Max(Type aFirst, Type aSecond) { return (aFirst < aSecond) ? aSecond : aFirst; }
 
 /**
  * This template function returns clamped version of a given value to a given closed range [min, max].
@@ -195,10 +189,7 @@ template <typename IntType> inline IntType DivideAndRoundToClosest(IntType aDivi
  * @returns The @p aUint32 value as `unsigned long`.
  *
  */
-inline unsigned long ToUlong(uint32_t aUint32)
-{
-    return static_cast<unsigned long>(aUint32);
-}
+inline unsigned long ToUlong(uint32_t aUint32) { return static_cast<unsigned long>(aUint32); }
 
 /**
  * This function counts the number of `1` bits in the binary representation of a given unsigned int bit-mask value.

--- a/src/core/common/random.hpp
+++ b/src/core/common/random.hpp
@@ -84,10 +84,7 @@ public:
      * @retval kErrorNone    Successfully filled buffer with random values.
      *
      */
-    static Error CryptoFillBuffer(uint8_t *aBuffer, uint16_t aSize)
-    {
-        return otPlatCryptoRandomGet(aBuffer, aSize);
-    }
+    static Error CryptoFillBuffer(uint8_t *aBuffer, uint16_t aSize) { return otPlatCryptoRandomGet(aBuffer, aSize); }
 #endif
 
 private:
@@ -113,10 +110,7 @@ namespace NonCrypto {
  * @returns    A random `uint32_t` value.
  *
  */
-inline uint32_t GetUint32(void)
-{
-    return Manager::NonCryptoGetUint32();
-}
+inline uint32_t GetUint32(void) { return Manager::NonCryptoGetUint32(); }
 
 /**
  * This function generates and returns a random byte.
@@ -124,10 +118,7 @@ inline uint32_t GetUint32(void)
  * @returns A random `uint8_t` value.
  *
  */
-inline uint8_t GetUint8(void)
-{
-    return static_cast<uint8_t>(GetUint32() & 0xff);
-}
+inline uint8_t GetUint8(void) { return static_cast<uint8_t>(GetUint32() & 0xff); }
 
 /**
  * This function generates and returns a random `uint16_t` value.
@@ -135,10 +126,7 @@ inline uint8_t GetUint8(void)
  * @returns A random `uint16_t` value.
  *
  */
-inline uint16_t GetUint16(void)
-{
-    return static_cast<uint16_t>(GetUint32() & 0xffff);
-}
+inline uint16_t GetUint16(void) { return static_cast<uint16_t>(GetUint32() & 0xffff); }
 
 /**
  * This function generates and returns a random `uint8_t` value within a given range `[aMin, aMax)`.
@@ -212,10 +200,7 @@ namespace Crypto {
  * @retval kErrorNone    Successfully filled buffer with random values.
  *
  */
-inline Error FillBuffer(uint8_t *aBuffer, uint16_t aSize)
-{
-    return Manager::CryptoFillBuffer(aBuffer, aSize);
-}
+inline Error FillBuffer(uint8_t *aBuffer, uint16_t aSize) { return Manager::CryptoFillBuffer(aBuffer, aSize); }
 
 } // namespace Crypto
 

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -193,15 +193,9 @@ const uint16_t Settings::kSensitiveKeys[] = {
     SettingsBase::kKeySrpEcdsaKey,
 };
 
-void Settings::Init(void)
-{
-    Get<SettingsDriver>().Init(kSensitiveKeys, GetArrayLength(kSensitiveKeys));
-}
+void Settings::Init(void) { Get<SettingsDriver>().Init(kSensitiveKeys, GetArrayLength(kSensitiveKeys)); }
 
-void Settings::Deinit(void)
-{
-    Get<SettingsDriver>().Deinit();
-}
+void Settings::Deinit(void) { Get<SettingsDriver>().Deinit(); }
 
 void Settings::Wipe(void)
 {
@@ -364,10 +358,7 @@ exit:
     return error;
 }
 
-Error Settings::DeleteAllBrOnLinkPrefixes(void)
-{
-    return Get<SettingsDriver>().Delete(kKeyBrOnLinkPrefixes);
-}
+Error Settings::DeleteAllBrOnLinkPrefixes(void) { return Get<SettingsDriver>().Delete(kKeyBrOnLinkPrefixes); }
 
 Error Settings::ReadBrOnLinkPrefix(int aIndex, BrOnLinkPrefix &aBrOnLinkPrefix)
 {

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -1015,10 +1015,7 @@ public:
      * @returns A ChildInfoIteratorBuilder instance.
      *
      */
-    ChildInfoIteratorBuilder IterateChildInfo(void)
-    {
-        return ChildInfoIteratorBuilder(GetInstance());
-    }
+    ChildInfoIteratorBuilder IterateChildInfo(void) { return ChildInfoIteratorBuilder(GetInstance()); }
 
     /**
      * This class defines an iterator to access all Child Info entries in the settings.

--- a/src/core/common/settings_driver.hpp
+++ b/src/core/common/settings_driver.hpp
@@ -187,10 +187,7 @@ public:
      * @retval kErrorNotFound    The key was not found.
      *
      */
-    Error Get(uint16_t aKey, void *aValue, uint16_t *aValueLength) const
-    {
-        return Get(aKey, 0, aValue, aValueLength);
-    }
+    Error Get(uint16_t aKey, void *aValue, uint16_t *aValueLength) const { return Get(aKey, 0, aValue, aValueLength); }
 
     /**
      * This method sets or replaces the value identified by @p aKey.
@@ -234,10 +231,7 @@ public:
     }
 
 private:
-    otInstance *GetInstancePtr(void) const
-    {
-        return reinterpret_cast<otInstance *>(&InstanceLocator::GetInstance());
-    }
+    otInstance *GetInstancePtr(void) const { return reinterpret_cast<otInstance *>(&InstanceLocator::GetInstance()); }
 
 #if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
     Flash mFlash;

--- a/src/core/common/string.cpp
+++ b/src/core/common/string.cpp
@@ -255,10 +255,7 @@ StringWriter &StringWriter::AppendHexBytes(const uint8_t *aBytes, uint16_t aLeng
     return *this;
 }
 
-bool IsValidUtf8String(const char *aString)
-{
-    return IsValidUtf8String(aString, strlen(aString));
-}
+bool IsValidUtf8String(const char *aString) { return IsValidUtf8String(aString, strlen(aString)); }
 
 bool IsValidUtf8String(const char *aString, size_t aLength)
 {

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -77,10 +77,7 @@ bool Timer::DoesFireBefore(const Timer &aSecondTimer, Time aNow) const
     return retval;
 }
 
-void TimerMilli::Start(uint32_t aDelay)
-{
-    StartAt(GetNow(), aDelay);
-}
+void TimerMilli::Start(uint32_t aDelay) { StartAt(GetNow(), aDelay); }
 
 void TimerMilli::StartAt(TimeMilli aStartTime, uint32_t aDelay)
 {
@@ -102,15 +99,9 @@ void TimerMilli::FireAtIfEarlier(TimeMilli aFireTime)
     }
 }
 
-void TimerMilli::Stop(void)
-{
-    Get<Scheduler>().Remove(*this);
-}
+void TimerMilli::Stop(void) { Get<Scheduler>().Remove(*this); }
 
-void TimerMilli::RemoveAll(Instance &aInstance)
-{
-    aInstance.Get<Scheduler>().RemoveAll();
-}
+void TimerMilli::RemoveAll(Instance &aInstance) { aInstance.Get<Scheduler>().RemoveAll(); }
 
 void Timer::Scheduler::Add(Timer &aTimer, const AlarmApi &aAlarmApi)
 {
@@ -228,10 +219,7 @@ const Timer::Scheduler::AlarmApi TimerMicro::Scheduler::sAlarmMicroApi = {
     &otPlatAlarmMicroGetNow,
 };
 
-void TimerMicro::Start(uint32_t aDelay)
-{
-    StartAt(GetNow(), aDelay);
-}
+void TimerMicro::Start(uint32_t aDelay) { StartAt(GetNow(), aDelay); }
 
 void TimerMicro::StartAt(TimeMicro aStartTime, uint32_t aDelay)
 {
@@ -245,15 +233,9 @@ void TimerMicro::FireAt(TimeMicro aFireTime)
     Get<Scheduler>().Add(*this);
 }
 
-void TimerMicro::Stop(void)
-{
-    Get<Scheduler>().Remove(*this);
-}
+void TimerMicro::Stop(void) { Get<Scheduler>().Remove(*this); }
 
-void TimerMicro::RemoveAll(Instance &aInstance)
-{
-    aInstance.Get<Scheduler>().RemoveAll();
-}
+void TimerMicro::RemoveAll(Instance &aInstance) { aInstance.Get<Scheduler>().RemoveAll(); }
 
 extern "C" void otPlatAlarmMicroFired(otInstance *aInstance)
 {

--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -54,10 +54,7 @@ const uint8_t *Tlv::GetValue(void) const
     return reinterpret_cast<const uint8_t *>(this) + (IsExtended() ? sizeof(ExtendedTlv) : sizeof(Tlv));
 }
 
-Error Tlv::AppendTo(Message &aMessage) const
-{
-    return aMessage.AppendBytes(this, static_cast<uint16_t>(GetSize()));
-}
+Error Tlv::AppendTo(Message &aMessage) const { return aMessage.AppendBytes(this, static_cast<uint16_t>(GetSize())); }
 
 Error Tlv::FindTlv(const Message &aMessage, uint8_t aType, uint16_t aMaxSize, Tlv &aTlv)
 {

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -562,10 +562,7 @@ private:
  * @returns A `TlvType` pointer to `aTlv`.
  *
  */
-template <class TlvType> TlvType *As(Tlv *aTlv)
-{
-    return static_cast<TlvType *>(aTlv);
-}
+template <class TlvType> TlvType *As(Tlv *aTlv) { return static_cast<TlvType *>(aTlv); }
 
 /**
  * This template method casts a `Tlv` pointer to a given subclass `TlvType` pointer.
@@ -577,10 +574,7 @@ template <class TlvType> TlvType *As(Tlv *aTlv)
  * @returns A `TlvType` pointer to `aTlv`.
  *
  */
-template <class TlvType> const TlvType *As(const Tlv *aTlv)
-{
-    return static_cast<const TlvType *>(aTlv);
-}
+template <class TlvType> const TlvType *As(const Tlv *aTlv) { return static_cast<const TlvType *>(aTlv); }
 
 /**
  * This template method casts a `Tlv` reference to a given subclass `TlvType` reference.
@@ -592,10 +586,7 @@ template <class TlvType> const TlvType *As(const Tlv *aTlv)
  * @returns A `TlvType` reference to `aTlv`.
  *
  */
-template <class TlvType> TlvType &As(Tlv &aTlv)
-{
-    return static_cast<TlvType &>(aTlv);
-}
+template <class TlvType> TlvType &As(Tlv &aTlv) { return static_cast<TlvType &>(aTlv); }
 
 /**
  * This template method casts a `Tlv` reference to a given subclass `TlvType` reference.
@@ -607,10 +598,7 @@ template <class TlvType> TlvType &As(Tlv &aTlv)
  * @returns A `TlvType` reference to `aTlv`.
  *
  */
-template <class TlvType> const TlvType &As(const Tlv &aTlv)
-{
-    return static_cast<const TlvType &>(aTlv);
-}
+template <class TlvType> const TlvType &As(const Tlv &aTlv) { return static_cast<const TlvType &>(aTlv); }
 
 /**
  * This class defines constants for a TLV.

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -115,10 +115,7 @@ void TrickleTimer::StartNewInterval(void)
     TimerMilli::Start(mTimeInInterval);
 }
 
-void TrickleTimer::HandleTimer(Timer &aTimer)
-{
-    static_cast<TrickleTimer *>(&aTimer)->HandleTimer();
-}
+void TrickleTimer::HandleTimer(Timer &aTimer) { static_cast<TrickleTimer *>(&aTimer)->HandleTimer(); }
 
 void TrickleTimer::HandleTimer(void)
 {

--- a/src/core/crypto/aes_ccm.hpp
+++ b/src/core/crypto/aes_ccm.hpp
@@ -174,10 +174,7 @@ public:
      * @returns The tag length in bytes.
      *
      */
-    uint8_t GetTagLength(void) const
-    {
-        return mTagLength;
-    }
+    uint8_t GetTagLength(void) const { return mTagLength; }
 
     /**
      * This method generates the tag.

--- a/src/core/crypto/aes_ecb.cpp
+++ b/src/core/crypto/aes_ecb.cpp
@@ -45,20 +45,14 @@ AesEcb::AesEcb(void)
     SuccessOrAssert(otPlatCryptoAesInit(&mContext));
 }
 
-void AesEcb::SetKey(const Key &aKey)
-{
-    SuccessOrAssert(otPlatCryptoAesSetKey(&mContext, &aKey));
-}
+void AesEcb::SetKey(const Key &aKey) { SuccessOrAssert(otPlatCryptoAesSetKey(&mContext, &aKey)); }
 
 void AesEcb::Encrypt(const uint8_t aInput[kBlockSize], uint8_t aOutput[kBlockSize])
 {
     SuccessOrAssert(otPlatCryptoAesEncrypt(&mContext, aInput, aOutput));
 }
 
-AesEcb::~AesEcb(void)
-{
-    SuccessOrAssert(otPlatCryptoAesFree(&mContext));
-}
+AesEcb::~AesEcb(void) { SuccessOrAssert(otPlatCryptoAesFree(&mContext)); }
 
 } // namespace Crypto
 } // namespace ot

--- a/src/core/crypto/hkdf_sha256.cpp
+++ b/src/core/crypto/hkdf_sha256.cpp
@@ -50,10 +50,7 @@ HkdfSha256::HkdfSha256(void)
     SuccessOrAssert(otPlatCryptoHkdfInit(&mContext));
 }
 
-HkdfSha256::~HkdfSha256(void)
-{
-    SuccessOrAssert(otPlatCryptoHkdfDeinit(&mContext));
-}
+HkdfSha256::~HkdfSha256(void) { SuccessOrAssert(otPlatCryptoHkdfDeinit(&mContext)); }
 
 void HkdfSha256::Extract(const uint8_t *aSalt, uint16_t aSaltLength, const Key &aInputKey)
 {

--- a/src/core/crypto/hmac_sha256.cpp
+++ b/src/core/crypto/hmac_sha256.cpp
@@ -47,15 +47,9 @@ HmacSha256::HmacSha256(void)
     SuccessOrAssert(otPlatCryptoHmacSha256Init(&mContext));
 }
 
-HmacSha256::~HmacSha256(void)
-{
-    SuccessOrAssert(otPlatCryptoHmacSha256Deinit(&mContext));
-}
+HmacSha256::~HmacSha256(void) { SuccessOrAssert(otPlatCryptoHmacSha256Deinit(&mContext)); }
 
-void HmacSha256::Start(const Key &aKey)
-{
-    SuccessOrAssert(otPlatCryptoHmacSha256Start(&mContext, &aKey));
-}
+void HmacSha256::Start(const Key &aKey) { SuccessOrAssert(otPlatCryptoHmacSha256Start(&mContext, &aKey)); }
 
 void HmacSha256::Update(const void *aBuf, uint16_t aBufLength)
 {

--- a/src/core/crypto/sha256.cpp
+++ b/src/core/crypto/sha256.cpp
@@ -47,15 +47,9 @@ Sha256::Sha256(void)
     SuccessOrAssert(otPlatCryptoSha256Init(&mContext));
 }
 
-Sha256::~Sha256(void)
-{
-    SuccessOrAssert(otPlatCryptoSha256Deinit(&mContext));
-}
+Sha256::~Sha256(void) { SuccessOrAssert(otPlatCryptoSha256Deinit(&mContext)); }
 
-void Sha256::Start(void)
-{
-    SuccessOrAssert(otPlatCryptoSha256Start(&mContext));
-}
+void Sha256::Start(void) { SuccessOrAssert(otPlatCryptoSha256Start(&mContext)); }
 
 void Sha256::Update(const void *aBuf, uint16_t aBufLength)
 {
@@ -75,10 +69,7 @@ void Sha256::Update(const Message &aMessage, uint16_t aOffset, uint16_t aLength)
     }
 }
 
-void Sha256::Finish(Hash &aHash)
-{
-    SuccessOrAssert(otPlatCryptoSha256Finish(&mContext, aHash.m8, Hash::kSize));
-}
+void Sha256::Finish(Hash &aHash) { SuccessOrAssert(otPlatCryptoSha256Finish(&mContext, aHash.m8, Hash::kSize)); }
 
 } // namespace Crypto
 } // namespace ot

--- a/src/core/crypto/storage.hpp
+++ b/src/core/crypto/storage.hpp
@@ -112,10 +112,7 @@ constexpr KeyRef kPendingDatasetPskcRef       = OPENTHREAD_CONFIG_PSA_ITS_NVM_OF
  * @retval FALSE  If @p aKeyRef is not valid.
  *
  */
-inline bool IsKeyRefValid(KeyRef aKeyRef)
-{
-    return (aKeyRef < kInvalidKeyRef);
-}
+inline bool IsKeyRefValid(KeyRef aKeyRef) { return (aKeyRef < kInvalidKeyRef); }
 
 /**
  * Import a key into PSA ITS.
@@ -187,10 +184,7 @@ inline void DestroyKey(KeyRef aKeyRef)
  * @retval false                Key Ref passed is invalid and has no key associated in PSA.
  *
  */
-inline bool HasKey(KeyRef aKeyRef)
-{
-    return otPlatCryptoHasKey(aKeyRef);
-}
+inline bool HasKey(KeyRef aKeyRef) { return otPlatCryptoHasKey(aKeyRef); }
 
 } // namespace Storage
 
@@ -250,10 +244,7 @@ public:
      * @retval FALSE The `Key` represents a literal key.
      *
      */
-    bool IsKeyRef(void) const
-    {
-        return (mKey == nullptr);
-    }
+    bool IsKeyRef(void) const { return (mKey == nullptr); }
 
     /**
      * This method gets the `KeyRef`.
@@ -263,10 +254,7 @@ public:
      * @returns The `KeyRef` associated with `Key`.
      *
      */
-    Storage::KeyRef GetKeyRef(void) const
-    {
-        return mKeyRef;
-    }
+    Storage::KeyRef GetKeyRef(void) const { return mKeyRef; }
 
     /**
      * This method sets the `Key` as a `KeyRef`.

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -173,10 +173,7 @@ Error Diags::ProcessStop(uint8_t aArgsLength, char *aArgs[], char *aOutput, size
     return kErrorNone;
 }
 
-extern "C" void otPlatDiagAlarmFired(otInstance *aInstance)
-{
-    otPlatDiagAlarmCallback(aInstance);
-}
+extern "C" void otPlatDiagAlarmFired(otInstance *aInstance) { otPlatDiagAlarmCallback(aInstance); }
 
 #else // OPENTHREAD_RADIO && !OPENTHREAD_RADIO_CLI
 // For OPENTHREAD_FTD, OPENTHREAD_MTD, OPENTHREAD_RADIO_CLI
@@ -475,10 +472,7 @@ exit:
     return error;
 }
 
-extern "C" void otPlatDiagAlarmFired(otInstance *aInstance)
-{
-    AsCoreType(aInstance).Get<Diags>().AlarmFired();
-}
+extern "C" void otPlatDiagAlarmFired(otInstance *aInstance) { AsCoreType(aInstance).Get<Diags>().AlarmFired(); }
 
 void Diags::AlarmFired(void)
 {
@@ -724,10 +718,7 @@ exit:
     return error;
 }
 
-bool Diags::IsEnabled(void)
-{
-    return otPlatDiagModeGet();
-}
+bool Diags::IsEnabled(void) { return otPlatDiagModeGet(); }
 
 } // namespace FactoryDiags
 } // namespace ot

--- a/src/core/mac/data_poll_handler.hpp
+++ b/src/core/mac/data_poll_handler.hpp
@@ -94,82 +94,31 @@ public:
 #endif
 
     private:
-        bool IsDataPollPending(void) const
-        {
-            return mDataPollPending;
-        }
-        void SetDataPollPending(bool aPending)
-        {
-            mDataPollPending = aPending;
-        }
+        bool IsDataPollPending(void) const { return mDataPollPending; }
+        void SetDataPollPending(bool aPending) { mDataPollPending = aPending; }
 
-        uint32_t GetIndirectFrameCounter(void) const
-        {
-            return mIndirectFrameCounter;
-        }
-        void SetIndirectFrameCounter(uint32_t aFrameCounter)
-        {
-            mIndirectFrameCounter = aFrameCounter;
-        }
+        uint32_t GetIndirectFrameCounter(void) const { return mIndirectFrameCounter; }
+        void     SetIndirectFrameCounter(uint32_t aFrameCounter) { mIndirectFrameCounter = aFrameCounter; }
 
-        uint8_t GetIndirectKeyId(void) const
-        {
-            return mIndirectKeyId;
-        }
-        void SetIndirectKeyId(uint8_t aKeyId)
-        {
-            mIndirectKeyId = aKeyId;
-        }
+        uint8_t GetIndirectKeyId(void) const { return mIndirectKeyId; }
+        void    SetIndirectKeyId(uint8_t aKeyId) { mIndirectKeyId = aKeyId; }
 
-        uint8_t GetIndirectTxAttempts(void) const
-        {
-            return mIndirectTxAttempts;
-        }
-        void ResetIndirectTxAttempts(void)
-        {
-            mIndirectTxAttempts = 0;
-        }
-        void IncrementIndirectTxAttempts(void)
-        {
-            mIndirectTxAttempts++;
-        }
+        uint8_t GetIndirectTxAttempts(void) const { return mIndirectTxAttempts; }
+        void    ResetIndirectTxAttempts(void) { mIndirectTxAttempts = 0; }
+        void    IncrementIndirectTxAttempts(void) { mIndirectTxAttempts++; }
 
-        uint8_t GetIndirectDataSequenceNumber(void) const
-        {
-            return mIndirectDsn;
-        }
-        void SetIndirectDataSequenceNumber(uint8_t aDsn)
-        {
-            mIndirectDsn = aDsn;
-        }
+        uint8_t GetIndirectDataSequenceNumber(void) const { return mIndirectDsn; }
+        void    SetIndirectDataSequenceNumber(uint8_t aDsn) { mIndirectDsn = aDsn; }
 
-        bool IsFramePurgePending(void) const
-        {
-            return mFramePurgePending;
-        }
-        void SetFramePurgePending(bool aPurgePending)
-        {
-            mFramePurgePending = aPurgePending;
-        }
+        bool IsFramePurgePending(void) const { return mFramePurgePending; }
+        void SetFramePurgePending(bool aPurgePending) { mFramePurgePending = aPurgePending; }
 
-        bool IsFrameReplacePending(void) const
-        {
-            return mFrameReplacePending;
-        }
-        void SetFrameReplacePending(bool aReplacePending)
-        {
-            mFrameReplacePending = aReplacePending;
-        }
+        bool IsFrameReplacePending(void) const { return mFrameReplacePending; }
+        void SetFrameReplacePending(bool aReplacePending) { mFrameReplacePending = aReplacePending; }
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-        Mac::RadioType GetLastPollRadioType(void) const
-        {
-            return mLastPollRadioType;
-        }
-        void SetLastPollRadioType(Mac::RadioType aRadioType)
-        {
-            mLastPollRadioType = aRadioType;
-        }
+        Mac::RadioType GetLastPollRadioType(void) const { return mLastPollRadioType; }
+        void           SetLastPollRadioType(Mac::RadioType aRadioType) { mLastPollRadioType = aRadioType; }
 #endif
 
         uint32_t mIndirectFrameCounter;    // Frame counter for current indirect frame (used for retx).

--- a/src/core/mac/data_poll_sender.hpp
+++ b/src/core/mac/data_poll_sender.hpp
@@ -276,10 +276,7 @@ private:
     void            ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector);
     uint32_t        CalculatePollPeriod(void) const;
     const Neighbor &GetParent(void) const;
-    void            HandlePollTimer(void)
-    {
-        IgnoreError(SendDataPoll());
-    }
+    void            HandlePollTimer(void) { IgnoreError(SendDataPoll()); }
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     Error GetPollDestinationAddress(Mac::Address &aDest, Mac::RadioType &aRadioType) const;
 #else

--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -303,9 +303,7 @@ public:
                                    uint8_t        aRetryCount,
                                    bool           aWillRetx);
 #else
-    void RecordFrameTransmitStatus(const TxFrame &, const RxFrame *, Error, uint8_t, bool)
-    {
-    }
+    void    RecordFrameTransmitStatus(const TxFrame &, const RxFrame *, Error, uint8_t, bool) {}
 #endif
 
 private:

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -578,10 +578,7 @@ exit:
     return;
 }
 
-bool Mac::IsActiveOrPending(Operation aOperation) const
-{
-    return (mOperation == aOperation) || IsPending(aOperation);
-}
+bool Mac::IsActiveOrPending(Operation aOperation) const { return (mOperation == aOperation) || IsPending(aOperation); }
 
 void Mac::StartOperation(Operation aOperation)
 {
@@ -2114,16 +2111,10 @@ const uint32_t *Mac::GetIndirectRetrySuccessHistogram(uint8_t &aNumberOfEntries)
 }
 #endif
 
-void Mac::ResetRetrySuccessHistogram()
-{
-    memset(&mRetryHistogram, 0, sizeof(mRetryHistogram));
-}
+void Mac::ResetRetrySuccessHistogram() { memset(&mRetryHistogram, 0, sizeof(mRetryHistogram)); }
 #endif // OPENTHREAD_CONFIG_MAC_RETRY_SUCCESS_HISTOGRAM_ENABLE
 
-uint8_t Mac::ComputeLinkMargin(int8_t aRss) const
-{
-    return ot::ComputeLinkMargin(GetNoiseFloor(), aRss);
-}
+uint8_t Mac::ComputeLinkMargin(int8_t aRss) const { return ot::ComputeLinkMargin(GetNoiseFloor(), aRss); }
 
 // LCOV_EXCL_START
 
@@ -2214,24 +2205,15 @@ void Mac::LogFrameTxFailure(const TxFrame &aFrame, Error aError, uint8_t aRetryC
     }
 }
 
-void Mac::LogBeacon(const char *aActionText) const
-{
-    LogInfo("%s Beacon", aActionText);
-}
+void Mac::LogBeacon(const char *aActionText) const { LogInfo("%s Beacon", aActionText); }
 
 #else // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
-void Mac::LogFrameRxFailure(const RxFrame *, Error) const
-{
-}
+void Mac::LogFrameRxFailure(const RxFrame *, Error) const {}
 
-void Mac::LogBeacon(const char *) const
-{
-}
+void Mac::LogBeacon(const char *) const {}
 
-void Mac::LogFrameTxFailure(const TxFrame &, Error, uint8_t, bool) const
-{
-}
+void Mac::LogFrameTxFailure(const TxFrame &, Error, uint8_t, bool) const {}
 
 #endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
@@ -2290,15 +2272,9 @@ void Mac::SetCslPeriod(uint16_t aPeriod)
     UpdateCsl();
 }
 
-bool Mac::IsCslEnabled(void) const
-{
-    return !Get<Mle::Mle>().IsRxOnWhenIdle() && IsCslCapable();
-}
+bool Mac::IsCslEnabled(void) const { return !Get<Mle::Mle>().IsRxOnWhenIdle() && IsCslCapable(); }
 
-bool Mac::IsCslCapable(void) const
-{
-    return (GetCslPeriod() > 0) && IsCslSupported();
-}
+bool Mac::IsCslCapable(void) const { return (GetCslPeriod() > 0) && IsCslSupported(); }
 
 bool Mac::IsCslSupported(void) const
 {

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -239,10 +239,7 @@ public:
      * @returns A pointer to the IEEE 802.15.4 Extended Address.
      *
      */
-    const ExtAddress &GetExtAddress(void) const
-    {
-        return mLinks.GetExtAddress();
-    }
+    const ExtAddress &GetExtAddress(void) const { return mLinks.GetExtAddress(); }
 
     /**
      * This method sets the IEEE 802.15.4 Extended Address.
@@ -250,10 +247,7 @@ public:
      * @param[in]  aExtAddress  A reference to the IEEE 802.15.4 Extended Address.
      *
      */
-    void SetExtAddress(const ExtAddress &aExtAddress)
-    {
-        mLinks.SetExtAddress(aExtAddress);
-    }
+    void SetExtAddress(const ExtAddress &aExtAddress) { mLinks.SetExtAddress(aExtAddress); }
 
     /**
      * This method returns the IEEE 802.15.4 Short Address.
@@ -261,10 +255,7 @@ public:
      * @returns The IEEE 802.15.4 Short Address.
      *
      */
-    ShortAddress GetShortAddress(void) const
-    {
-        return mLinks.GetShortAddress();
-    }
+    ShortAddress GetShortAddress(void) const { return mLinks.GetShortAddress(); }
 
     /**
      * This method sets the IEEE 802.15.4 Short Address.
@@ -272,10 +263,7 @@ public:
      * @param[in]  aShortAddress  The IEEE 802.15.4 Short Address.
      *
      */
-    void SetShortAddress(ShortAddress aShortAddress)
-    {
-        mLinks.SetShortAddress(aShortAddress);
-    }
+    void SetShortAddress(ShortAddress aShortAddress) { mLinks.SetShortAddress(aShortAddress); }
 
     /**
      * This method returns the IEEE 802.15.4 PAN Channel.
@@ -283,10 +271,7 @@ public:
      * @returns The IEEE 802.15.4 PAN Channel.
      *
      */
-    uint8_t GetPanChannel(void) const
-    {
-        return mPanChannel;
-    }
+    uint8_t GetPanChannel(void) const { return mPanChannel; }
 
     /**
      * This method sets the IEEE 802.15.4 PAN Channel.
@@ -327,10 +312,7 @@ public:
      * @returns The supported channel mask.
      *
      */
-    const ChannelMask &GetSupportedChannelMask(void) const
-    {
-        return mSupportedChannelMask;
-    }
+    const ChannelMask &GetSupportedChannelMask(void) const { return mSupportedChannelMask; }
 
     /**
      * This method sets the supported channel mask
@@ -346,10 +328,7 @@ public:
      * @returns The IEEE 802.15.4 PAN ID.
      *
      */
-    PanId GetPanId(void) const
-    {
-        return mPanId;
-    }
+    PanId GetPanId(void) const { return mPanId; }
 
     /**
      * This method sets the IEEE 802.15.4 PAN ID.
@@ -365,10 +344,7 @@ public:
      * @returns The maximum number of retries during direct transmission.
      *
      */
-    uint8_t GetMaxFrameRetriesDirect(void) const
-    {
-        return mMaxFrameRetriesDirect;
-    }
+    uint8_t GetMaxFrameRetriesDirect(void) const { return mMaxFrameRetriesDirect; }
 
     /**
      * This method sets the maximum number of frame retries during direct transmission.
@@ -376,10 +352,7 @@ public:
      * @param[in]  aMaxFrameRetriesDirect  The maximum number of retries during direct transmission.
      *
      */
-    void SetMaxFrameRetriesDirect(uint8_t aMaxFrameRetriesDirect)
-    {
-        mMaxFrameRetriesDirect = aMaxFrameRetriesDirect;
-    }
+    void SetMaxFrameRetriesDirect(uint8_t aMaxFrameRetriesDirect) { mMaxFrameRetriesDirect = aMaxFrameRetriesDirect; }
 
 #if OPENTHREAD_FTD
     /**
@@ -388,10 +361,7 @@ public:
      * @returns The maximum number of retries during indirect transmission.
      *
      */
-    uint8_t GetMaxFrameRetriesIndirect(void) const
-    {
-        return mMaxFrameRetriesIndirect;
-    }
+    uint8_t GetMaxFrameRetriesIndirect(void) const { return mMaxFrameRetriesIndirect; }
 
     /**
      * This method sets the maximum number of frame retries during indirect transmission.
@@ -464,19 +434,13 @@ public:
      * This method returns if an active scan is in progress.
      *
      */
-    bool IsActiveScanInProgress(void) const
-    {
-        return IsActiveOrPending(kOperationActiveScan);
-    }
+    bool IsActiveScanInProgress(void) const { return IsActiveOrPending(kOperationActiveScan); }
 
     /**
      * This method returns if an energy scan is in progress.
      *
      */
-    bool IsEnergyScanInProgress(void) const
-    {
-        return IsActiveOrPending(kOperationEnergyScan);
-    }
+    bool IsEnergyScanInProgress(void) const { return IsActiveOrPending(kOperationEnergyScan); }
 
 #if OPENTHREAD_FTD
     /**
@@ -485,10 +449,7 @@ public:
      * @returns TRUE if in middle of an indirect transmission, FALSE otherwise.
      *
      */
-    bool IsPerformingIndirectTransmit(void) const
-    {
-        return (mOperation == kOperationTransmitDataIndirect);
-    }
+    bool IsPerformingIndirectTransmit(void) const { return (mOperation == kOperationTransmitDataIndirect); }
 #endif
 
     /**
@@ -521,10 +482,7 @@ public:
      * @retval false  Promiscuous mode is not enabled.
      *
      */
-    bool IsPromiscuous(void) const
-    {
-        return mPromiscuous;
-    }
+    bool IsPromiscuous(void) const { return mPromiscuous; }
 
     /**
      * This method enables or disables the link layer promiscuous mode.
@@ -540,10 +498,7 @@ public:
      * This method resets mac counters
      *
      */
-    void ResetCounters(void)
-    {
-        memset(&mCounters, 0, sizeof(mCounters));
-    }
+    void ResetCounters(void) { memset(&mCounters, 0, sizeof(mCounters)); }
 
     /**
      * This method returns the MAC counter.
@@ -551,10 +506,7 @@ public:
      * @returns A reference to the MAC counter.
      *
      */
-    otMacCounters &GetCounters(void)
-    {
-        return mCounters;
-    }
+    otMacCounters &GetCounters(void) { return mCounters; }
 
 #if OPENTHREAD_CONFIG_MAC_RETRY_SUCCESS_HISTOGRAM_ENABLE
     /**
@@ -594,10 +546,7 @@ public:
      * @returns The noise floor value in dBm.
      *
      */
-    int8_t GetNoiseFloor(void) const
-    {
-        return mLinks.GetNoiseFloor();
-    }
+    int8_t GetNoiseFloor(void) const { return mLinks.GetNoiseFloor(); }
 
     /**
      * This method computes the link margin for a given a received signal strength value using noise floor.
@@ -618,10 +567,7 @@ public:
      * @returns The CCA failure rate with maximum value `0xffff` corresponding to 100% failure rate.
      *
      */
-    uint16_t GetCcaFailureRate(void) const
-    {
-        return mCcaSuccessRateTracker.GetFailureRate();
-    }
+    uint16_t GetCcaFailureRate(void) const { return mCcaSuccessRateTracker.GetFailureRate(); }
 
     /**
      * This method Starts/Stops the Link layer. It may only be used when the Netif Interface is down.
@@ -629,10 +575,7 @@ public:
      * @param[in]  aEnable The requested State for the MAC layer. true - Start, false - Stop.
      *
      */
-    void SetEnabled(bool aEnable)
-    {
-        mEnabled = aEnable;
-    }
+    void SetEnabled(bool aEnable) { mEnabled = aEnable; }
 
     /**
      * This method indicates whether or not the link layer is enabled.
@@ -641,10 +584,7 @@ public:
      * @retval false  Link layer is not enabled.
      *
      */
-    bool IsEnabled(void) const
-    {
-        return mEnabled;
-    }
+    bool IsEnabled(void) const { return mEnabled; }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     /**
@@ -653,10 +593,7 @@ public:
      * @returns CSL channel.
      *
      */
-    uint8_t GetCslChannel(void) const
-    {
-        return mCslChannel;
-    }
+    uint8_t GetCslChannel(void) const { return mCslChannel; }
 
     /**
      * This method sets the CSL channel.
@@ -678,10 +615,7 @@ public:
      * @returns CSL period in units of 10 symbols.
      *
      */
-    uint16_t GetCslPeriod(void) const
-    {
-        return mCslPeriod;
-    }
+    uint16_t GetCslPeriod(void) const { return mCslPeriod; }
 
     /**
      * This method sets the CSL period.
@@ -724,10 +658,7 @@ public:
      * @returns The parent CSL accuracy.
      *
      */
-    const CslAccuracy &GetCslParentAccuracy(void) const
-    {
-        return mLinks.GetSubMac().GetCslParentAccuracy();
-    }
+    const CslAccuracy &GetCslParentAccuracy(void) const { return mLinks.GetSubMac().GetCslParentAccuracy(); }
 
     /**
      * This method sets parent CSL accuracy.
@@ -762,10 +693,7 @@ public:
      * @retval FALSE  If the radio filter is disabled.
      *
      */
-    bool IsRadioFilterEnabled(void) const
-    {
-        return mLinks.GetSubMac().IsRadioFilterEnabled();
-    }
+    bool IsRadioFilterEnabled(void) const { return mLinks.GetSubMac().IsRadioFilterEnabled(); }
 #endif
 
 private:
@@ -817,20 +745,11 @@ private:
     Error ProcessEnhAckSecurity(TxFrame &aTxFrame, RxFrame &aAckFrame);
 #endif
 
-    void UpdateIdleMode(void);
-    bool IsPending(Operation aOperation) const
-    {
-        return mPendingOperations & (1U << aOperation);
-    }
-    bool IsActiveOrPending(Operation aOperation) const;
-    void SetPending(Operation aOperation)
-    {
-        mPendingOperations |= (1U << aOperation);
-    }
-    void ClearPending(Operation aOperation)
-    {
-        mPendingOperations &= ~(1U << aOperation);
-    }
+    void     UpdateIdleMode(void);
+    bool     IsPending(Operation aOperation) const { return mPendingOperations & (1U << aOperation); }
+    bool     IsActiveOrPending(Operation aOperation) const;
+    void     SetPending(Operation aOperation) { mPendingOperations |= (1U << aOperation); }
+    void     ClearPending(Operation aOperation) { mPendingOperations &= ~(1U << aOperation); }
     void     StartOperation(Operation aOperation);
     void     FinishOperation(void);
     void     PerformNextOperation(void);

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -82,10 +82,7 @@ void Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)
     mLength += GetFcsSize();
 }
 
-uint16_t Frame::GetFrameControlField(void) const
-{
-    return ReadUint16(mPsdu);
-}
+uint16_t Frame::GetFrameControlField(void) const { return ReadUint16(mPsdu); }
 
 Error Frame::ValidatePsdu(void) const
 {
@@ -187,10 +184,7 @@ void Frame::SetDstPanId(PanId aPanId)
     WriteUint16(aPanId, &mPsdu[index]);
 }
 
-uint8_t Frame::FindDstAddrIndex(void) const
-{
-    return kFcfSize + kDsnSize + (IsDstPanIdPresent() ? sizeof(PanId) : 0);
-}
+uint8_t Frame::FindDstAddrIndex(void) const { return kFcfSize + kDsnSize + (IsDstPanIdPresent() ? sizeof(PanId) : 0); }
 
 Error Frame::GetDstAddr(Address &aAddress) const
 {
@@ -633,10 +627,7 @@ exit:
     return isDataRequest;
 }
 
-uint8_t Frame::GetHeaderLength(void) const
-{
-    return static_cast<uint8_t>(GetPayload() - mPsdu);
-}
+uint8_t Frame::GetHeaderLength(void) const { return static_cast<uint8_t>(GetPayload() - mPsdu); }
 
 uint8_t Frame::GetFooterLength(void) const
 {
@@ -680,20 +671,11 @@ uint8_t Frame::CalculateMicSize(uint8_t aSecurityControl)
     return micSize;
 }
 
-uint16_t Frame::GetMaxPayloadLength(void) const
-{
-    return GetMtu() - (GetHeaderLength() + GetFooterLength());
-}
+uint16_t Frame::GetMaxPayloadLength(void) const { return GetMtu() - (GetHeaderLength() + GetFooterLength()); }
 
-uint16_t Frame::GetPayloadLength(void) const
-{
-    return mLength - (GetHeaderLength() + GetFooterLength());
-}
+uint16_t Frame::GetPayloadLength(void) const { return mLength - (GetHeaderLength() + GetFooterLength()); }
 
-void Frame::SetPayloadLength(uint16_t aLength)
-{
-    mLength = GetHeaderLength() + GetFooterLength() + aLength;
-}
+void Frame::SetPayloadLength(uint16_t aLength) { mLength = GetHeaderLength() + GetFooterLength() + aLength; }
 
 uint8_t Frame::SkipSecurityHeaderIndex(void) const
 {
@@ -884,10 +866,7 @@ exit:
     return payload;
 }
 
-const uint8_t *Frame::GetFooter(void) const
-{
-    return mPsdu + mLength - GetFooterLength();
-}
+const uint8_t *Frame::GetFooter(void) const { return mPsdu + mLength - GetFooterLength(); }
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
 uint8_t Frame::FindHeaderIeIndex(void) const
@@ -943,16 +922,10 @@ template <> void Frame::InitIeContentAt<TimeIe>(uint8_t &aIndex)
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-template <> void Frame::InitIeContentAt<CslIe>(uint8_t &aIndex)
-{
-    aIndex += sizeof(CslIe);
-}
+template <> void Frame::InitIeContentAt<CslIe>(uint8_t &aIndex) { aIndex += sizeof(CslIe); }
 #endif
 
-template <> void Frame::InitIeContentAt<Termination2Ie>(uint8_t &aIndex)
-{
-    OT_UNUSED_VARIABLE(aIndex);
-}
+template <> void Frame::InitIeContentAt<Termination2Ie>(uint8_t &aIndex) { OT_UNUSED_VARIABLE(aIndex); }
 #endif // OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
 
 const uint8_t *Frame::GetHeaderIe(uint8_t aIeId) const
@@ -1112,15 +1085,9 @@ uint8_t Frame::GetFcsSize(void) const
 }
 
 #elif OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-uint16_t Frame::GetMtu(void) const
-{
-    return Trel::Link::kMtuSize;
-}
+uint16_t Frame::GetMtu(void) const { return Trel::Link::kMtuSize; }
 
-uint8_t Frame::GetFcsSize(void) const
-{
-    return Trel::Link::kFcsSize;
-}
+uint8_t Frame::GetFcsSize(void) const { return Trel::Link::kFcsSize; }
 #endif
 
 // Explicit instantiation

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -903,10 +903,7 @@ public:
      * @returns A pointer to the Time IE, `nullptr` if not found.
      *
      */
-    TimeIe *GetTimeIe(void)
-    {
-        return AsNonConst(AsConst(this)->GetTimeIe());
-    }
+    TimeIe *GetTimeIe(void) { return AsNonConst(AsConst(this)->GetTimeIe()); }
 
     /**
      * This method returns a pointer to the vendor specific Time IE.
@@ -944,10 +941,7 @@ public:
      * @returns A pointer to the Header IE, `nullptr` if not found.
      *
      */
-    uint8_t *GetHeaderIe(uint8_t aIeId)
-    {
-        return AsNonConst(AsConst(this)->GetHeaderIe(aIeId));
-    }
+    uint8_t *GetHeaderIe(uint8_t aIeId) { return AsNonConst(AsConst(this)->GetHeaderIe(aIeId)); }
 
     /**
      * This method returns a pointer to the Header IE.
@@ -969,10 +963,7 @@ public:
      * @returns A pointer to the Thread IE, `nullptr` if not found.
      *
      */
-    uint8_t *GetThreadIe(uint8_t aSubType)
-    {
-        return AsNonConst(AsConst(this)->GetThreadIe(aSubType));
-    }
+    uint8_t *GetThreadIe(uint8_t aSubType) { return AsNonConst(AsConst(this)->GetThreadIe(aSubType)); }
 
     /**
      * This method returns a pointer to a specific Thread IE.
@@ -1017,10 +1008,7 @@ public:
      * @returns Frame's radio link type.
      *
      */
-    RadioType GetRadioType(void) const
-    {
-        return static_cast<RadioType>(mRadioType);
-    }
+    RadioType GetRadioType(void) const { return static_cast<RadioType>(mRadioType); }
 
     /**
      * This method sets the radio link type of the frame.
@@ -1028,10 +1016,7 @@ public:
      * @param[in] aRadioType  A radio link type.
      *
      */
-    void SetRadioType(RadioType aRadioType)
-    {
-        mRadioType = static_cast<uint8_t>(aRadioType);
-    }
+    void SetRadioType(RadioType aRadioType) { mRadioType = static_cast<uint8_t>(aRadioType); }
 #endif
 
     /**
@@ -1103,20 +1088,11 @@ protected:
 
     static uint8_t GetKeySourceLength(uint8_t aKeyIdMode);
 
-    static bool IsDstAddrPresent(uint16_t aFcf)
-    {
-        return (aFcf & kFcfDstAddrMask) != kFcfDstAddrNone;
-    }
+    static bool IsDstAddrPresent(uint16_t aFcf) { return (aFcf & kFcfDstAddrMask) != kFcfDstAddrNone; }
     static bool IsDstPanIdPresent(uint16_t aFcf);
-    static bool IsSrcAddrPresent(uint16_t aFcf)
-    {
-        return (aFcf & kFcfSrcAddrMask) != kFcfSrcAddrNone;
-    }
+    static bool IsSrcAddrPresent(uint16_t aFcf) { return (aFcf & kFcfSrcAddrMask) != kFcfSrcAddrNone; }
     static bool IsSrcPanIdPresent(uint16_t aFcf);
-    static bool IsVersion2015(uint16_t aFcf)
-    {
-        return (aFcf & kFcfFrameVersionMask) == kFcfFrameVersion2015;
-    }
+    static bool IsVersion2015(uint16_t aFcf) { return (aFcf & kFcfFrameVersionMask) == kFcfFrameVersion2015; }
 
     static uint8_t CalculateAddrFieldSize(uint16_t aFcf);
     static uint8_t CalculateSecurityHeaderSize(uint8_t aSecurityControl);
@@ -1212,10 +1188,7 @@ public:
      * @returns  The time sync sequence.
      *
      */
-    uint8_t ReadTimeSyncSeq(void) const
-    {
-        return GetTimeIe()->GetSequence();
-    }
+    uint8_t ReadTimeSyncSeq(void) const { return GetTimeIe()->GetSequence(); }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 };
 
@@ -1387,10 +1360,7 @@ public:
      * @param[in]  aOffset  The Time IE offset, 0 means no Time IE.
      *
      */
-    void SetTimeIeOffset(uint8_t aOffset)
-    {
-        mInfo.mTxInfo.mIeInfo->mTimeIeOffset = aOffset;
-    }
+    void SetTimeIeOffset(uint8_t aOffset) { mInfo.mTxInfo.mIeInfo->mTimeIeOffset = aOffset; }
 
     /**
      * This method gets the Time IE offset.
@@ -1398,10 +1368,7 @@ public:
      * @returns The Time IE offset, 0 means no Time IE.
      *
      */
-    uint8_t GetTimeIeOffset(void) const
-    {
-        return mInfo.mTxInfo.mIeInfo->mTimeIeOffset;
-    }
+    uint8_t GetTimeIeOffset(void) const { return mInfo.mTxInfo.mIeInfo->mTimeIeOffset; }
 
     /**
      * This method sets the offset to network time.
@@ -1420,10 +1387,7 @@ public:
      * @param[in]  aTimeSyncSeq  The time sync sequence.
      *
      */
-    void SetTimeSyncSeq(uint8_t aTimeSyncSeq)
-    {
-        mInfo.mTxInfo.mIeInfo->mTimeSyncSeq = aTimeSyncSeq;
-    }
+    void SetTimeSyncSeq(uint8_t aTimeSyncSeq) { mInfo.mTxInfo.mIeInfo->mTimeSyncSeq = aTimeSyncSeq; }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
     /**
@@ -1456,10 +1420,7 @@ public:
      * @param[in]    aTxDelay    The delay time for the TX frame.
      *
      */
-    void SetTxDelay(uint32_t aTxDelay)
-    {
-        mInfo.mTxInfo.mTxDelay = aTxDelay;
-    }
+    void SetTxDelay(uint32_t aTxDelay) { mInfo.mTxInfo.mTxDelay = aTxDelay; }
 
     /**
      * Set TX delay base time field for the frame.
@@ -1467,10 +1428,7 @@ public:
      * @param[in]    aTxDelayBaseTime    The delay base time for the TX frame.
      *
      */
-    void SetTxDelayBaseTime(uint32_t aTxDelayBaseTime)
-    {
-        mInfo.mTxInfo.mTxDelayBaseTime = aTxDelayBaseTime;
-    }
+    void SetTxDelayBaseTime(uint32_t aTxDelayBaseTime) { mInfo.mTxInfo.mTxDelayBaseTime = aTxDelayBaseTime; }
 #endif
 };
 
@@ -1631,10 +1589,7 @@ public:
      * @returns The Network Name field as `NameData`.
      *
      */
-    MeshCoP::NameData GetNetworkName(void) const
-    {
-        return MeshCoP::NameData(mNetworkName, sizeof(mNetworkName));
-    }
+    MeshCoP::NameData GetNetworkName(void) const { return MeshCoP::NameData(mNetworkName, sizeof(mNetworkName)); }
 
     /**
      * This method sets the Network Name field.
@@ -1642,10 +1597,7 @@ public:
      * @param[in]  aNameData  The Network Name (as a `NameData`).
      *
      */
-    void SetNetworkName(const MeshCoP::NameData &aNameData)
-    {
-        aNameData.CopyTo(mNetworkName, sizeof(mNetworkName));
-    }
+    void SetNetworkName(const MeshCoP::NameData &aNameData) { aNameData.CopyTo(mNetworkName, sizeof(mNetworkName)); }
 
     /**
      * This method returns the Extended PAN ID field.
@@ -1653,10 +1605,7 @@ public:
      * @returns The Extended PAN ID field.
      *
      */
-    const otExtendedPanId &GetExtendedPanId(void) const
-    {
-        return mExtendedPanId;
-    }
+    const otExtendedPanId &GetExtendedPanId(void) const { return mExtendedPanId; }
 
     /**
      * This method sets the Extended PAN ID field.
@@ -1664,10 +1613,7 @@ public:
      * @param[in]  aExtPanId  An Extended PAN ID.
      *
      */
-    void SetExtendedPanId(const otExtendedPanId &aExtPanId)
-    {
-        mExtendedPanId = aExtPanId;
-    }
+    void SetExtendedPanId(const otExtendedPanId &aExtPanId) { mExtendedPanId = aExtPanId; }
 
 private:
     uint8_t         mProtocolId;

--- a/src/core/mac/mac_links.hpp
+++ b/src/core/mac/mac_links.hpp
@@ -114,10 +114,7 @@ public:
      * @returns The selected radio types.
      *
      */
-    RadioTypes GetSelectedRadioTypes(void) const
-    {
-        return mSelectedRadioTypes;
-    }
+    RadioTypes GetSelectedRadioTypes(void) const { return mSelectedRadioTypes; }
 
     /**
      * This method gets the required radio types.
@@ -131,10 +128,7 @@ public:
      * @returns The required radio types.
      *
      */
-    RadioTypes GetRequiredRadioTypes(void) const
-    {
-        return mRequiredRadioTypes;
-    }
+    RadioTypes GetRequiredRadioTypes(void) const { return mRequiredRadioTypes; }
 
     /**
      * This method sets the required types.
@@ -144,10 +138,7 @@ public:
      * @param[in] aRadioTypes   A set of radio link types.
      *
      */
-    void SetRequiredRadioTypes(RadioTypes aRadioTypes)
-    {
-        mRequiredRadioTypes = aRadioTypes;
-    }
+    void SetRequiredRadioTypes(RadioTypes aRadioTypes) { mRequiredRadioTypes = aRadioTypes; }
 
 #else // #if OPENTHREAD_CONFIG_MULTI_RADIO
 
@@ -158,10 +149,7 @@ public:
      * @returns A reference to `TxFrame`.
      *
      */
-    TxFrame &GetTxFrame(void)
-    {
-        return mTxFrame802154;
-    }
+    TxFrame &GetTxFrame(void) { return mTxFrame802154; }
 #elif OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
     /**
      * This method gets the tx frame.
@@ -169,10 +157,7 @@ public:
      * @returns A reference to `TxFrame`.
      *
      */
-    TxFrame &GetTxFrame(void)
-    {
-        return mTxFrameTrel;
-    }
+    TxFrame &GetTxFrame(void) { return mTxFrameTrel; }
 #endif
     /**
      * This method gets a tx frame for sending a broadcast frame.
@@ -180,10 +165,7 @@ public:
      * @returns A reference to a `TxFrame` for broadcast.
      *
      */
-    TxFrame &GetBroadcastTxFrame(void)
-    {
-        return GetTxFrame();
-    }
+    TxFrame &GetBroadcastTxFrame(void) { return GetTxFrame(); }
 
 #endif // #if OPENTHREAD_CONFIG_MULTI_RADIO
 
@@ -538,10 +520,7 @@ public:
      * @returns The transmit frames.
      *
      */
-    TxFrames &GetTxFrames(void)
-    {
-        return mTxFrames;
-    }
+    TxFrames &GetTxFrames(void) { return mTxFrames; }
 
 #if !OPENTHREAD_CONFIG_MULTI_RADIO
 
@@ -655,10 +634,7 @@ public:
      * @returns A reference to the `SubMac` instance.
      *
      */
-    SubMac &GetSubMac(void)
-    {
-        return mSubMac;
-    }
+    SubMac &GetSubMac(void) { return mSubMac; }
 
     /**
      * This methods gets a reference to the `SubMac` instance.
@@ -666,10 +642,7 @@ public:
      * @returns A reference to the `SubMac` instance.
      *
      */
-    const SubMac &GetSubMac(void) const
-    {
-        return mSubMac;
-    }
+    const SubMac &GetSubMac(void) const { return mSubMac; }
 
     /**
      * This method returns a reference to the current MAC key (for Key Mode 1) for a given Frame.

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -499,10 +499,7 @@ public:
      * @returns The literal `Key`
      *
      */
-    const Key &GetKey(void) const
-    {
-        return static_cast<const Key &>(mKeyMaterial.mKey);
-    }
+    const Key &GetKey(void) const { return static_cast<const Key &>(mKeyMaterial.mKey); }
 
 #else
     /**
@@ -511,10 +508,7 @@ public:
      * @returns The `KeyRef`
      *
      */
-    KeyRef GetKeyRef(void) const
-    {
-        return mKeyMaterial.mKeyRef;
-    }
+    KeyRef GetKeyRef(void) const { return mKeyMaterial.mKeyRef; }
 #endif
 
     /**
@@ -562,19 +556,10 @@ private:
     static constexpr KeyRef kInvalidKeyRef = Crypto::Storage::kInvalidKeyRef;
 
     void DestroyKey(void);
-    void SetKeyRef(KeyRef aKeyRef)
-    {
-        mKeyMaterial.mKeyRef = aKeyRef;
-    }
+    void SetKeyRef(KeyRef aKeyRef) { mKeyMaterial.mKeyRef = aKeyRef; }
 #endif
-    Key &GetKey(void)
-    {
-        return static_cast<Key &>(mKeyMaterial.mKey);
-    }
-    void SetKey(const Key &aKey)
-    {
-        mKeyMaterial.mKey = aKey;
-    }
+    Key &GetKey(void) { return static_cast<Key &>(mKeyMaterial.mKey); }
+    void SetKey(const Key &aKey) { mKeyMaterial.mKey = aKey; }
 };
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
@@ -829,10 +814,7 @@ public:
      * @returns The Link Frame Counter for 802.15.4 radio link.
      *
      */
-    uint32_t Get154(void) const
-    {
-        return m154Counter;
-    }
+    uint32_t Get154(void) const { return m154Counter; }
 
     /**
      * This method sets the Link Frame Counter for 802.15.4 radio link.
@@ -840,10 +822,7 @@ public:
      * @param[in] aCounter   The new counter value.
      *
      */
-    void Set154(uint32_t aCounter)
-    {
-        m154Counter = aCounter;
-    }
+    void Set154(uint32_t aCounter) { m154Counter = aCounter; }
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
@@ -853,19 +832,13 @@ public:
      * @returns The Link Frame Counter for TREL radio link.
      *
      */
-    uint32_t GetTrel(void) const
-    {
-        return mTrelCounter;
-    }
+    uint32_t GetTrel(void) const { return mTrelCounter; }
 
     /**
      * This method increments the Link Frame Counter for TREL radio link.
      *
      */
-    void IncrementTrel(void)
-    {
-        mTrelCounter++;
-    }
+    void IncrementTrel(void) { mTrelCounter++; }
 #endif
 
     /**

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -683,10 +683,7 @@ int8_t SubMac::GetRssi(void) const
     return rssi;
 }
 
-int8_t SubMac::GetNoiseFloor(void) const
-{
-    return Get<Radio>().GetReceiveSensitivity();
-}
+int8_t SubMac::GetNoiseFloor(void) const { return Get<Radio>().GetReceiveSensitivity(); }
 
 Error SubMac::EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration)
 {
@@ -1073,10 +1070,7 @@ exit:
     return retval;
 }
 
-void SubMac::HandleCslTimer(Timer &aTimer)
-{
-    aTimer.Get<SubMac>().HandleCslTimer();
-}
+void SubMac::HandleCslTimer(Timer &aTimer) { aTimer.Get<SubMac>().HandleCslTimer(); }
 
 void SubMac::HandleCslTimer(void)
 {

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -421,10 +421,7 @@ public:
      * @returns The parent CSL accuracy.
      *
      */
-    const CslAccuracy &GetCslParentAccuracy(void) const
-    {
-        return mCslParentAccuracy;
-    }
+    const CslAccuracy &GetCslParentAccuracy(void) const { return mCslParentAccuracy; }
 
     /**
      * This method sets parent CSL accuracy.
@@ -432,10 +429,7 @@ public:
      * @param[in] aCslAccuracy  The parent CSL accuracy.
      *
      */
-    void SetCslParentAccuracy(const CslAccuracy &aCslAccuracy)
-    {
-        mCslParentAccuracy = aCslAccuracy;
-    }
+    void SetCslParentAccuracy(const CslAccuracy &aCslAccuracy) { mCslParentAccuracy = aCslAccuracy; }
 
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
@@ -461,10 +455,7 @@ public:
      * @returns A reference to the current MAC key.
      *
      */
-    const KeyMaterial &GetCurrentMacKey(void) const
-    {
-        return mCurrKey;
-    }
+    const KeyMaterial &GetCurrentMacKey(void) const { return mCurrKey; }
 
     /**
      * This method returns a reference to the previous MAC key.
@@ -472,10 +463,7 @@ public:
      * @returns A reference to the previous MAC key.
      *
      */
-    const KeyMaterial &GetPreviousMacKey(void) const
-    {
-        return mPrevKey;
-    }
+    const KeyMaterial &GetPreviousMacKey(void) const { return mPrevKey; }
 
     /**
      * This method returns a reference to the next MAC key.
@@ -483,10 +471,7 @@ public:
      * @returns A reference to the next MAC key.
      *
      */
-    const KeyMaterial &GetNextMacKey(void) const
-    {
-        return mNextKey;
-    }
+    const KeyMaterial &GetNextMacKey(void) const { return mNextKey; }
 
     /**
      * This method returns the current MAC frame counter value.
@@ -494,10 +479,7 @@ public:
      * @returns The current MAC frame counter value.
      *
      */
-    uint32_t GetFrameCounter(void) const
-    {
-        return mFrameCounter;
-    }
+    uint32_t GetFrameCounter(void) const { return mFrameCounter; }
 
     /**
      * This method sets the current MAC Frame Counter value.
@@ -518,10 +500,7 @@ public:
      * @param[in] aFilterEnabled    TRUE to enable radio filter, FALSE to disable.
      *
      */
-    void SetRadioFilterEnabled(bool aFilterEnabled)
-    {
-        mRadioFilterEnabled = aFilterEnabled;
-    }
+    void SetRadioFilterEnabled(bool aFilterEnabled) { mRadioFilterEnabled = aFilterEnabled; }
 
     /**
      * This method indicates whether the radio filter is enabled or not.
@@ -530,10 +509,7 @@ public:
      * @retval FALSE  If the radio filter is disabled.
      *
      */
-    bool IsRadioFilterEnabled(void) const
-    {
-        return mRadioFilterEnabled;
-    }
+    bool IsRadioFilterEnabled(void) const { return mRadioFilterEnabled; }
 #endif
 
 private:
@@ -600,30 +576,12 @@ private:
         return ((mRadioCaps & (OT_RADIO_CAPS_CSMA_BACKOFF | OT_RADIO_CAPS_TRANSMIT_RETRIES)) != 0);
     }
 
-    bool RadioSupportsTransmitSecurity(void) const
-    {
-        return ((mRadioCaps & OT_RADIO_CAPS_TRANSMIT_SEC) != 0);
-    }
-    bool RadioSupportsRetries(void) const
-    {
-        return ((mRadioCaps & OT_RADIO_CAPS_TRANSMIT_RETRIES) != 0);
-    }
-    bool RadioSupportsAckTimeout(void) const
-    {
-        return ((mRadioCaps & OT_RADIO_CAPS_ACK_TIMEOUT) != 0);
-    }
-    bool RadioSupportsEnergyScan(void) const
-    {
-        return ((mRadioCaps & OT_RADIO_CAPS_ENERGY_SCAN) != 0);
-    }
-    bool RadioSupportsTransmitTiming(void) const
-    {
-        return ((mRadioCaps & OT_RADIO_CAPS_TRANSMIT_TIMING) != 0);
-    }
-    bool RadioSupportsReceiveTiming(void) const
-    {
-        return ((mRadioCaps & OT_RADIO_CAPS_RECEIVE_TIMING) != 0);
-    }
+    bool RadioSupportsTransmitSecurity(void) const { return ((mRadioCaps & OT_RADIO_CAPS_TRANSMIT_SEC) != 0); }
+    bool RadioSupportsRetries(void) const { return ((mRadioCaps & OT_RADIO_CAPS_TRANSMIT_RETRIES) != 0); }
+    bool RadioSupportsAckTimeout(void) const { return ((mRadioCaps & OT_RADIO_CAPS_ACK_TIMEOUT) != 0); }
+    bool RadioSupportsEnergyScan(void) const { return ((mRadioCaps & OT_RADIO_CAPS_ENERGY_SCAN) != 0); }
+    bool RadioSupportsTransmitTiming(void) const { return ((mRadioCaps & OT_RADIO_CAPS_TRANSMIT_TIMING) != 0); }
+    bool RadioSupportsReceiveTiming(void) const { return ((mRadioCaps & OT_RADIO_CAPS_RECEIVE_TIMING) != 0); }
 
     bool ShouldHandleTransmitSecurity(void) const;
     bool ShouldHandleCsmaBackOff(void) const;

--- a/src/core/mac/sub_mac_callbacks.cpp
+++ b/src/core/mac/sub_mac_callbacks.cpp
@@ -114,14 +114,9 @@ void SubMac::Callbacks::FrameCounterUsed(uint32_t aFrameCounter)
 
 #elif OPENTHREAD_RADIO
 
-void SubMac::Callbacks::ReceiveDone(RxFrame *aFrame, Error aError)
-{
-    Get<LinkRaw>().InvokeReceiveDone(aFrame, aError);
-}
+void SubMac::Callbacks::ReceiveDone(RxFrame *aFrame, Error aError) { Get<LinkRaw>().InvokeReceiveDone(aFrame, aError); }
 
-void SubMac::Callbacks::RecordCcaStatus(bool, uint8_t)
-{
-}
+void SubMac::Callbacks::RecordCcaStatus(bool, uint8_t) {}
 
 void SubMac::Callbacks::RecordFrameTransmitStatus(const TxFrame &aFrame,
                                                   const RxFrame *aAckFrame,
@@ -137,15 +132,9 @@ void SubMac::Callbacks::TransmitDone(TxFrame &aFrame, RxFrame *aAckFrame, Error 
     Get<LinkRaw>().InvokeTransmitDone(aFrame, aAckFrame, aError);
 }
 
-void SubMac::Callbacks::EnergyScanDone(int8_t aMaxRssi)
-{
-    Get<LinkRaw>().InvokeEnergyScanDone(aMaxRssi);
-}
+void SubMac::Callbacks::EnergyScanDone(int8_t aMaxRssi) { Get<LinkRaw>().InvokeEnergyScanDone(aMaxRssi); }
 
-void SubMac::Callbacks::FrameCounterUsed(uint32_t aFrameCounter)
-{
-    OT_UNUSED_VARIABLE(aFrameCounter);
-}
+void SubMac::Callbacks::FrameCounterUsed(uint32_t aFrameCounter) { OT_UNUSED_VARIABLE(aFrameCounter); }
 
 #endif // OPENTHREAD_RADIO
 

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -562,10 +562,7 @@ void BorderAgent::HandleConnected(bool aConnected)
     }
 }
 
-uint16_t BorderAgent::GetUdpPort(void) const
-{
-    return Get<Tmf::SecureAgent>().GetUdpPort();
-}
+uint16_t BorderAgent::GetUdpPort(void) const { return Get<Tmf::SecureAgent>().GetUdpPort(); }
 
 void BorderAgent::Start(void)
 {

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -887,10 +887,7 @@ exit:
     }
 }
 
-void Commissioner::SendKeepAlive(void)
-{
-    SendKeepAlive(mSessionId);
-}
+void Commissioner::SendKeepAlive(void) { SendKeepAlive(mSessionId); }
 
 void Commissioner::SendKeepAlive(uint16_t aSessionId)
 {
@@ -1218,9 +1215,7 @@ void Commissioner::LogJoinerEntry(const char *aAction, const Joiner &aJoiner) co
 
 #else
 
-void Commissioner::LogJoinerEntry(const char *, const Joiner &) const
-{
-}
+void Commissioner::LogJoinerEntry(const char *, const Joiner &) const {}
 
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -162,10 +162,7 @@ Dataset::Dataset(void)
     memset(mTlvs, 0, sizeof(mTlvs));
 }
 
-void Dataset::Clear(void)
-{
-    mLength = 0;
-}
+void Dataset::Clear(void) { mLength = 0; }
 
 bool Dataset::IsValid(void) const
 {
@@ -182,10 +179,7 @@ exit:
     return rval;
 }
 
-const Tlv *Dataset::GetTlv(Tlv::Type aType) const
-{
-    return Tlv::FindTlv(mTlvs, mLength, aType);
-}
+const Tlv *Dataset::GetTlv(Tlv::Type aType) const { return Tlv::FindTlv(mTlvs, mLength, aType); }
 
 void Dataset::ConvertTo(Info &aDatasetInfo) const
 {
@@ -431,10 +425,7 @@ exit:
     return error;
 }
 
-Error Dataset::SetTlv(const Tlv &aTlv)
-{
-    return SetTlv(aTlv.GetType(), aTlv.GetValue(), aTlv.GetLength());
-}
+Error Dataset::SetTlv(const Tlv &aTlv) { return SetTlv(aTlv.GetType(), aTlv.GetValue(), aTlv.GetLength()); }
 
 Error Dataset::ReadFromMessage(const Message &aMessage, uint16_t aOffset, uint16_t aLength)
 {
@@ -612,10 +603,7 @@ void Dataset::ConvertToActive(void)
     RemoveTlv(Tlv::kDelayTimer);
 }
 
-const char *Dataset::TypeToString(Type aType)
-{
-    return (aType == kActive) ? "Active" : "Pending";
-}
+const char *Dataset::TypeToString(Type aType) { return (aType == kActive) ? "Active" : "Pending"; }
 
 } // namespace MeshCoP
 } // namespace ot

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -65,10 +65,7 @@ DatasetManager::DatasetManager(Instance &aInstance, Dataset::Type aType, Timer::
     mTimestamp.Clear();
 }
 
-const Timestamp *DatasetManager::GetTimestamp(void) const
-{
-    return mTimestampValid ? &mTimestamp : nullptr;
-}
+const Timestamp *DatasetManager::GetTimestamp(void) const { return mTimestampValid ? &mTimestamp : nullptr; }
 
 Error DatasetManager::Restore(void)
 {
@@ -115,10 +112,7 @@ void DatasetManager::Clear(void)
     SignalDatasetChange();
 }
 
-void DatasetManager::HandleDetach(void)
-{
-    IgnoreError(Restore());
-}
+void DatasetManager::HandleDetach(void) { IgnoreError(Restore()); }
 
 Error DatasetManager::Save(const Dataset &aDataset)
 {
@@ -246,10 +240,7 @@ exit:
     return error;
 }
 
-void DatasetManager::HandleTimer(void)
-{
-    SendSet();
-}
+void DatasetManager::HandleTimer(void) { SendSet(); }
 
 void DatasetManager::SendSet(void)
 {
@@ -646,10 +637,7 @@ ActiveDatasetManager::ActiveDatasetManager(Instance &aInstance)
 {
 }
 
-bool ActiveDatasetManager::IsPartiallyComplete(void) const
-{
-    return mLocal.IsSaved() && !mTimestampValid;
-}
+bool ActiveDatasetManager::IsPartiallyComplete(void) const { return mLocal.IsSaved() && !mTimestampValid; }
 
 bool ActiveDatasetManager::IsCommissioned(void) const
 {
@@ -687,10 +675,7 @@ void ActiveDatasetManager::HandleTmf<kUriActiveGet>(Coap::Message &aMessage, con
     DatasetManager::HandleGet(aMessage, aMessageInfo);
 }
 
-void ActiveDatasetManager::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<ActiveDatasetManager>().HandleTimer();
-}
+void ActiveDatasetManager::HandleTimer(Timer &aTimer) { aTimer.Get<ActiveDatasetManager>().HandleTimer(); }
 
 PendingDatasetManager::PendingDatasetManager(Instance &aInstance)
     : DatasetManager(aInstance, Dataset::kPending, PendingDatasetManager::HandleTimer)
@@ -826,10 +811,7 @@ void PendingDatasetManager::HandleTmf<kUriPendingGet>(Coap::Message &aMessage, c
     DatasetManager::HandleGet(aMessage, aMessageInfo);
 }
 
-void PendingDatasetManager::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<PendingDatasetManager>().HandleTimer();
-}
+void PendingDatasetManager::HandleTimer(Timer &aTimer) { aTimer.Get<PendingDatasetManager>().HandleTimer(); }
 
 } // namespace MeshCoP
 } // namespace ot

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -221,10 +221,7 @@ protected:
      * @returns The Operational Dataset type.
      *
      */
-    Dataset::Type GetType(void) const
-    {
-        return mLocal.GetType();
-    }
+    Dataset::Type GetType(void) const { return mLocal.GetType(); }
 
     /**
      * This method clears the Operational Dataset.
@@ -341,14 +338,8 @@ private:
                                       Error                aError);
     void        HandleMgmtSetResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aError);
 
-    bool IsActiveDataset(void) const
-    {
-        return GetType() == Dataset::kActive;
-    }
-    bool IsPendingDataset(void) const
-    {
-        return GetType() == Dataset::kPending;
-    }
+    bool  IsActiveDataset(void) const { return GetType() == Dataset::kActive; }
+    bool  IsPendingDataset(void) const { return GetType() == Dataset::kPending; }
     void  SignalDatasetChange(void) const;
     void  HandleDatasetUpdated(void);
     Error AppendDatasetToMessage(const Dataset::Info &aDatasetInfo, Message &aMessage) const;
@@ -472,10 +463,7 @@ public:
      * @retval kErrorFailed  Failed to generate random values for new parameters.
      *
      */
-    Error CreateNewNetwork(Dataset::Info &aDatasetInfo)
-    {
-        return aDatasetInfo.GenerateRandom(GetInstance());
-    }
+    Error CreateNewNetwork(Dataset::Info &aDatasetInfo) { return aDatasetInfo.GenerateRandom(GetInstance()); }
 
     /**
      * This method starts the Leader functions for maintaining the Active Operational Dataset.
@@ -498,10 +486,7 @@ private:
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void)
-    {
-        DatasetManager::HandleTimer();
-    }
+    void        HandleTimer(void) { DatasetManager::HandleTimer(); }
 };
 
 DeclareTmfHandler(ActiveDatasetManager, kUriActiveGet);
@@ -611,10 +596,7 @@ private:
     void StartDelayTimer(void);
 
     static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void)
-    {
-        DatasetManager::HandleTimer();
-    }
+    void        HandleTimer(void) { DatasetManager::HandleTimer(); }
 
     void                     HandleDelayTimer(void);
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -394,10 +394,7 @@ exit:
     return error;
 }
 
-void ActiveDatasetManager::StartLeader(void)
-{
-    IgnoreError(GenerateLocal());
-}
+void ActiveDatasetManager::StartLeader(void) { IgnoreError(GenerateLocal()); }
 
 template <>
 void ActiveDatasetManager::HandleTmf<kUriActiveSet>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -410,10 +407,7 @@ exit:
     return;
 }
 
-void PendingDatasetManager::StartLeader(void)
-{
-    StartDelayTimer();
-}
+void PendingDatasetManager::StartLeader(void) { StartDelayTimer(); }
 
 template <>
 void PendingDatasetManager::HandleTmf<kUriPendingSet>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/meshcop/dataset_updater.cpp
+++ b/src/core/meshcop/dataset_updater.cpp
@@ -94,10 +94,7 @@ exit:
     return;
 }
 
-void DatasetUpdater::HandleTimer(void)
-{
-    PreparePendingDataset();
-}
+void DatasetUpdater::HandleTimer(void) { PreparePendingDataset(); }
 
 void DatasetUpdater::PreparePendingDataset(void)
 {

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -214,10 +214,7 @@ exit:
     return;
 }
 
-uint16_t Dtls::GetUdpPort(void) const
-{
-    return mSocket.GetSockName().GetPort();
-}
+uint16_t Dtls::GetUdpPort(void) const { return mSocket.GetSockName().GetPort(); }
 
 Error Dtls::Bind(uint16_t aPort)
 {
@@ -683,10 +680,7 @@ exit:
     return rval;
 }
 
-int Dtls::HandleMbedtlsGetTimer(void *aContext)
-{
-    return static_cast<Dtls *>(aContext)->HandleMbedtlsGetTimer();
-}
+int Dtls::HandleMbedtlsGetTimer(void *aContext) { return static_cast<Dtls *>(aContext)->HandleMbedtlsGetTimer(); }
 
 int Dtls::HandleMbedtlsGetTimer(void)
 {

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -286,10 +286,7 @@ public:
      * @param[in]  aVerifyPeerCertificate  true, if the peer certificate should verify.
      *
      */
-    void SetSslAuthMode(bool aVerifyPeerCertificate)
-    {
-        mVerifyPeerCertificate = aVerifyPeerCertificate;
-    }
+    void SetSslAuthMode(bool aVerifyPeerCertificate) { mVerifyPeerCertificate = aVerifyPeerCertificate; }
 #endif // OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
 
 #ifdef MBEDTLS_SSL_SRV_C
@@ -332,10 +329,7 @@ public:
      * @param[in]  aMessageSubType  The default message sub-type.
      *
      */
-    void SetDefaultMessageSubType(Message::SubType aMessageSubType)
-    {
-        mMessageDefaultSubType = aMessageSubType;
-    }
+    void SetDefaultMessageSubType(Message::SubType aMessageSubType) { mMessageDefaultSubType = aMessageSubType; }
 
     /**
      * This method returns the DTLS session's peer address.
@@ -343,10 +337,7 @@ public:
      * @return DTLS session's message info.
      *
      */
-    const Ip6::MessageInfo &GetMessageInfo(void) const
-    {
-        return mMessageInfo;
-    }
+    const Ip6::MessageInfo &GetMessageInfo(void) const { return mMessageInfo; }
 
     void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -81,10 +81,7 @@ void Joiner::SetIdFromIeeeEui64(void)
     ComputeJoinerId(eui64, mId);
 }
 
-const JoinerDiscerner *Joiner::GetDiscerner(void) const
-{
-    return mDiscerner.IsEmpty() ? nullptr : &mDiscerner;
-}
+const JoinerDiscerner *Joiner::GetDiscerner(void) const { return mDiscerner.IsEmpty() ? nullptr : &mDiscerner; }
 
 Error Joiner::SetDiscerner(const JoinerDiscerner &aDiscerner)
 {

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -235,10 +235,7 @@ exit:
     LogError("schedule joiner entrust", error);
 }
 
-void JoinerRouter::HandleTimer(void)
-{
-    SendDelayedJoinerEntrust();
-}
+void JoinerRouter::HandleTimer(void) { SendDelayedJoinerEntrust(); }
 
 void JoinerRouter::SendDelayedJoinerEntrust(void)
 {

--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -459,9 +459,7 @@ Error GetBorderAgentRloc(ThreadNetif &aNetIf, uint16_t &aRloc);
  */
 void LogError(const char *aActionText, Error aError);
 #else
-inline void LogError(const char *, Error)
-{
-}
+inline void LogError(const char *, Error) {}
 #endif
 
 } // namespace MeshCoP

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -239,10 +239,7 @@ exit:
     return error;
 }
 
-uint32_t Leader::GetDelayTimerMinimal(void) const
-{
-    return mDelayTimerMinimal;
-}
+uint32_t Leader::GetDelayTimerMinimal(void) const { return mDelayTimerMinimal; }
 
 void Leader::HandleTimer(void)
 {

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -136,10 +136,7 @@ void NetworkNameTlv::SetNetworkName(const NameData &aNameData)
     SetLength(len);
 }
 
-bool NetworkNameTlv::IsValid(void) const
-{
-    return IsValidUtf8String(mNetworkName, GetLength());
-}
+bool NetworkNameTlv::IsValid(void) const { return IsValidUtf8String(mNetworkName, GetLength()); }
 
 void SteeringDataTlv::CopyTo(SteeringData &aSteeringData) const
 {
@@ -261,10 +258,7 @@ exit:
     return entry;
 }
 
-ChannelMaskEntryBase *ChannelMaskBaseTlv::GetFirstEntry(void)
-{
-    return AsNonConst(AsConst(this)->GetFirstEntry());
-}
+ChannelMaskEntryBase *ChannelMaskBaseTlv::GetFirstEntry(void) { return AsNonConst(AsConst(this)->GetFirstEntry()); }
 
 void ChannelMaskTlv::SetChannelMask(uint32_t aChannelMask)
 {

--- a/src/core/meshcop/network_name.cpp
+++ b/src/core/meshcop/network_name.cpp
@@ -109,10 +109,7 @@ exit:
     return error;
 }
 
-bool NetworkName::operator==(const NetworkName &aOther) const
-{
-    return GetAsData() == aOther.GetAsData();
-}
+bool NetworkName::operator==(const NetworkName &aOther) const { return GetAsData() == aOther.GetAsData(); }
 
 NetworkNameManager::NetworkNameManager(Instance &aInstance)
     : InstanceLocator(aInstance)

--- a/src/core/meshcop/network_name.hpp
+++ b/src/core/meshcop/network_name.hpp
@@ -234,10 +234,7 @@ public:
      * @returns The Thread Domain Name.
      *
      */
-    const DomainName &GetDomainName(void) const
-    {
-        return mDomainName;
-    }
+    const DomainName &GetDomainName(void) const { return mDomainName; }
 
     /**
      * This method sets the Thread Domain Name.

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -218,10 +218,7 @@ exit:
     return rval;
 }
 
-void Client::HandleTrickleTimer(TrickleTimer &aTrickleTimer)
-{
-    aTrickleTimer.Get<Client>().HandleTrickleTimer();
-}
+void Client::HandleTrickleTimer(TrickleTimer &aTrickleTimer) { aTrickleTimer.Get<Client>().HandleTrickleTimer(); }
 
 void Client::HandleTrickleTimer(void)
 {

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -145,10 +145,7 @@ exit:
     return;
 }
 
-void Server::Stop(void)
-{
-    IgnoreError(mSocket.Close());
-}
+void Server::Stop(void) { IgnoreError(mSocket.Close()); }
 
 void Server::AddPrefixAgent(const Ip6::Prefix &aIp6Prefix, const Lowpan::Context &aContext)
 {

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -759,10 +759,7 @@ exit:
     return error;
 }
 
-void Client::FreeQuery(Query &aQuery)
-{
-    mQueries.DequeueAndFree(aQuery);
-}
+void Client::FreeQuery(Query &aQuery) { mQueries.DequeueAndFree(aQuery); }
 
 void Client::SendQuery(Query &aQuery, QueryInfo &aInfo, bool aUpdateTimer)
 {

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -164,10 +164,7 @@ public:
          * @returns The timeout interval in msec.
          *
          */
-        uint32_t GetResponseTimeout(void) const
-        {
-            return mResponseTimeout;
-        }
+        uint32_t GetResponseTimeout(void) const { return mResponseTimeout; }
 
         /**
          * This method gets the maximum number of query transmit attempts before reporting failure.
@@ -175,10 +172,7 @@ public:
          * @returns The maximum number of query transmit attempts.
          *
          */
-        uint8_t GetMaxTxAttempts(void) const
-        {
-            return mMaxTxAttempts;
-        }
+        uint8_t GetMaxTxAttempts(void) const { return mMaxTxAttempts; }
 
         /**
          * This method gets the recursion flag indicating whether the server can resolve the query recursively or not.
@@ -186,10 +180,7 @@ public:
          * @returns The recursion flag.
          *
          */
-        RecursionFlag GetRecursionFlag(void) const
-        {
-            return static_cast<RecursionFlag>(mRecursionFlag);
-        }
+        RecursionFlag GetRecursionFlag(void) const { return static_cast<RecursionFlag>(mRecursionFlag); }
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_NAT64_ENABLE
         /**
@@ -198,10 +189,7 @@ public:
          * @returns The NAT64 mode.
          *
          */
-        Nat64Mode GetNat64Mode(void) const
-        {
-            return static_cast<Nat64Mode>(mNat64Mode);
-        }
+        Nat64Mode GetNat64Mode(void) const { return static_cast<Nat64Mode>(mNat64Mode); }
 #endif
 
     private:
@@ -223,28 +211,13 @@ public:
 
         explicit QueryConfig(InitMode aMode);
 
-        Ip6::SockAddr &GetServerSockAddr(void)
-        {
-            return AsCoreType(&mServerSockAddr);
-        }
+        Ip6::SockAddr &GetServerSockAddr(void) { return AsCoreType(&mServerSockAddr); }
 
-        void SetResponseTimeout(uint32_t aResponseTimeout)
-        {
-            mResponseTimeout = aResponseTimeout;
-        }
-        void SetMaxTxAttempts(uint8_t aMaxTxAttempts)
-        {
-            mMaxTxAttempts = aMaxTxAttempts;
-        }
-        void SetRecursionFlag(RecursionFlag aFlag)
-        {
-            mRecursionFlag = static_cast<otDnsRecursionFlag>(aFlag);
-        }
+        void SetResponseTimeout(uint32_t aResponseTimeout) { mResponseTimeout = aResponseTimeout; }
+        void SetMaxTxAttempts(uint8_t aMaxTxAttempts) { mMaxTxAttempts = aMaxTxAttempts; }
+        void SetRecursionFlag(RecursionFlag aFlag) { mRecursionFlag = static_cast<otDnsRecursionFlag>(aFlag); }
 #if OPENTHREAD_CONFIG_DNS_CLIENT_NAT64_ENABLE
-        void SetNat64Mode(Nat64Mode aMode)
-        {
-            mNat64Mode = static_cast<otDnsNat64Mode>(aMode);
-        }
+        void SetNat64Mode(Nat64Mode aMode) { mNat64Mode = static_cast<otDnsNat64Mode>(aMode); }
 #endif
 
         void SetFrom(const QueryConfig &aConfig, const QueryConfig &aDefaultConfig);
@@ -593,10 +566,7 @@ public:
      * @returns The current default query config.
      *
      */
-    const QueryConfig &GetDefaultConfig(void) const
-    {
-        return mDefaultConfig;
-    }
+    const QueryConfig &GetDefaultConfig(void) const { return mDefaultConfig; }
 
     /**
      * This method sets the default query config.
@@ -756,17 +726,14 @@ private:
 
     static constexpr uint16_t kNameOffsetInQuery = sizeof(QueryInfo);
 
-    Error StartQuery(QueryInfo         &aInfo,
-                     const QueryConfig *aConfig,
-                     const char        *aLabel,
-                     const char        *aName,
-                     void              *aContext);
-    Error AllocateQuery(const QueryInfo &aInfo, const char *aLabel, const char *aName, Query *&aQuery);
-    void  FreeQuery(Query &aQuery);
-    void  UpdateQuery(Query &aQuery, const QueryInfo &aInfo)
-    {
-        aQuery.Write(0, aInfo);
-    }
+    Error       StartQuery(QueryInfo         &aInfo,
+                           const QueryConfig *aConfig,
+                           const char        *aLabel,
+                           const char        *aName,
+                           void              *aContext);
+    Error       AllocateQuery(const QueryInfo &aInfo, const char *aLabel, const char *aName, Query *&aQuery);
+    void        FreeQuery(Query &aQuery);
+    void        UpdateQuery(Query &aQuery, const QueryInfo &aInfo) { aQuery.Write(0, aInfo); }
     void        SendQuery(Query &aQuery, QueryInfo &aInfo, bool aUpdateTimer);
     void        FinalizeQuery(Query &aQuery, Error aError);
     void        FinalizeQuery(Response &Response, QueryType aType, Error aError);

--- a/src/core/net/dns_dso.cpp
+++ b/src/core/net/dns_dso.cpp
@@ -1408,10 +1408,7 @@ exit:
     return error;
 }
 
-void Dso::Connection::PendingRequests::Remove(MessageId aMessageId)
-{
-    mRequests.RemoveMatching(aMessageId);
-}
+void Dso::Connection::PendingRequests::Remove(MessageId aMessageId) { mRequests.RemoveMatching(aMessageId); }
 
 bool Dso::Connection::PendingRequests::HasAnyTimedOut(TimeMilli aNow) const
 {
@@ -1459,10 +1456,7 @@ void Dso::StartListening(AcceptHandler aAcceptHandler)
     otPlatDsoEnableListening(&GetInstance(), true);
 }
 
-void Dso::StopListening(void)
-{
-    otPlatDsoEnableListening(&GetInstance(), false);
-}
+void Dso::StopListening(void) { otPlatDsoEnableListening(&GetInstance(), false); }
 
 Dso::Connection *Dso::FindClientConnection(const Ip6::SockAddr &aPeerSockAddr)
 {

--- a/src/core/net/dns_types.cpp
+++ b/src/core/net/dns_types.cpp
@@ -1074,10 +1074,7 @@ bool AaaaRecord::IsValid(void) const
     return GetType() == Dns::ResourceRecord::kTypeAaaa && GetSize() == sizeof(*this);
 }
 
-bool KeyRecord::IsValid(void) const
-{
-    return GetType() == Dns::ResourceRecord::kTypeKey;
-}
+bool KeyRecord::IsValid(void) const { return GetType() == Dns::ResourceRecord::kTypeKey; }
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
 void Ecdsa256KeyRecord::Init(void)
@@ -1098,10 +1095,7 @@ bool SigRecord::IsValid(void) const
     return GetType() == Dns::ResourceRecord::kTypeSig && GetLength() >= sizeof(*this) - sizeof(ResourceRecord);
 }
 
-bool LeaseOption::IsValid(void) const
-{
-    return GetLeaseInterval() <= GetKeyLeaseInterval();
-}
+bool LeaseOption::IsValid(void) const { return GetLeaseInterval() <= GetKeyLeaseInterval(); }
 
 Error PtrRecord::ReadPtrName(const Message &aMessage,
                              uint16_t      &aOffset,

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -54,15 +54,9 @@ Icmp::Icmp(Instance &aInstance)
 {
 }
 
-Message *Icmp::NewMessage(uint16_t aReserved)
-{
-    return Get<Ip6>().NewMessage(sizeof(Header) + aReserved);
-}
+Message *Icmp::NewMessage(uint16_t aReserved) { return Get<Ip6>().NewMessage(sizeof(Header) + aReserved); }
 
-Error Icmp::RegisterHandler(Handler &aHandler)
-{
-    return mHandlers.Add(aHandler);
-}
+Error Icmp::RegisterHandler(Handler &aHandler) { return mHandlers.Add(aHandler); }
 
 Error Icmp::SendEchoRequest(Message &aMessage, const MessageInfo &aMessageInfo, uint16_t aIdentifier)
 {

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -812,10 +812,7 @@ exit:
     return error;
 }
 
-void Ip6::CleanupFragmentationBuffer(void)
-{
-    mReassemblyList.DequeueAndFreeAll();
-}
+void Ip6::CleanupFragmentationBuffer(void) { mReassemblyList.DequeueAndFreeAll(); }
 
 void Ip6::HandleTimeTick(void)
 {

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -272,10 +272,7 @@ public:
      * @sa SetReceiveIp6FilterEnabled
      *
      */
-    bool IsReceiveIp6FilterEnabled(void) const
-    {
-        return mIsReceiveIp6FilterEnabled;
-    }
+    bool IsReceiveIp6FilterEnabled(void) const { return mIsReceiveIp6FilterEnabled; }
 
     /**
      * This method sets whether or not Thread control traffic is filtered out when delivering IPv6 datagrams
@@ -287,10 +284,7 @@ public:
      * @sa IsReceiveIp6FilterEnabled
      *
      */
-    void SetReceiveIp6FilterEnabled(bool aEnabled)
-    {
-        mIsReceiveIp6FilterEnabled = aEnabled;
-    }
+    void SetReceiveIp6FilterEnabled(bool aEnabled) { mIsReceiveIp6FilterEnabled = aEnabled; }
 
     /**
      * This method indicates whether or not IPv6 forwarding is enabled.
@@ -298,10 +292,7 @@ public:
      * @returns TRUE if IPv6 forwarding is enabled, FALSE otherwise.
      *
      */
-    bool IsForwardingEnabled(void) const
-    {
-        return mForwardingEnabled;
-    }
+    bool IsForwardingEnabled(void) const { return mForwardingEnabled; }
 
     /**
      * This method enables/disables IPv6 forwarding.
@@ -309,10 +300,7 @@ public:
      * @param[in]  aEnable  TRUE to enable IPv6 forwarding, FALSE otherwise.
      *
      */
-    void SetForwardingEnabled(bool aEnable)
-    {
-        mForwardingEnabled = aEnable;
-    }
+    void SetForwardingEnabled(bool aEnable) { mForwardingEnabled = aEnable; }
 
     /**
      * This method perform default source address selection.
@@ -330,10 +318,7 @@ public:
      * @returns A reference to the send queue.
      *
      */
-    const PriorityQueue &GetSendQueue(void) const
-    {
-        return mSendQueue;
-    }
+    const PriorityQueue &GetSendQueue(void) const { return mSendQueue; }
 
     /**
      * This static method converts an IP protocol number to a string.
@@ -362,10 +347,7 @@ public:
      * @returns A reference to the Border Routing counters.
      *
      */
-    const otBorderRoutingCounters &GetBorderRoutingCounters(void) const
-    {
-        return mBorderRoutingCounters;
-    }
+    const otBorderRoutingCounters &GetBorderRoutingCounters(void) const { return mBorderRoutingCounters; }
 
     /**
      * This method returns a reference to the Border Routing counters.
@@ -373,19 +355,13 @@ public:
      * @returns A reference to the Border Routing counters.
      *
      */
-    otBorderRoutingCounters &GetBorderRoutingCounters(void)
-    {
-        return mBorderRoutingCounters;
-    }
+    otBorderRoutingCounters &GetBorderRoutingCounters(void) { return mBorderRoutingCounters; }
 
     /**
      * This method resets the Border Routing counters.
      *
      */
-    void ResetBorderRoutingCounters(void)
-    {
-        memset(&mBorderRoutingCounters, 0, sizeof(mBorderRoutingCounters));
-    }
+    void ResetBorderRoutingCounters(void) { memset(&mBorderRoutingCounters, 0, sizeof(mBorderRoutingCounters)); }
 #endif
 
 private:

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -75,15 +75,9 @@ bool Prefix::IsLinkLocal(void) const
     return (mLength >= 10) && ((mPrefix.mFields.m16[0] & HostSwap16(0xffc0)) == HostSwap16(0xfe80));
 }
 
-bool Prefix::IsMulticast(void) const
-{
-    return (mLength >= 8) && (mPrefix.mFields.m8[0] == 0xff);
-}
+bool Prefix::IsMulticast(void) const { return (mLength >= 8) && (mPrefix.mFields.m8[0] == 0xff); }
 
-bool Prefix::IsUniqueLocal(void) const
-{
-    return (mLength >= 7) && ((mPrefix.mFields.m8[0] & 0xfe) == 0xfc);
-}
+bool Prefix::IsUniqueLocal(void) const { return (mLength >= 7) && ((mPrefix.mFields.m8[0] & 0xfe) == 0xfc); }
 
 bool Prefix::IsEqual(const uint8_t *aPrefixBytes, uint8_t aPrefixLength) const
 {
@@ -196,20 +190,14 @@ void Prefix::ToString(StringWriter &aWriter) const
 //---------------------------------------------------------------------------------------------------------------------
 // InterfaceIdentifier methods
 
-bool InterfaceIdentifier::IsUnspecified(void) const
-{
-    return (mFields.m32[0] == 0) && (mFields.m32[1] == 0);
-}
+bool InterfaceIdentifier::IsUnspecified(void) const { return (mFields.m32[0] == 0) && (mFields.m32[1] == 0); }
 
 bool InterfaceIdentifier::IsReserved(void) const
 {
     return IsSubnetRouterAnycast() || IsReservedSubnetAnycast() || IsAnycastLocator();
 }
 
-bool InterfaceIdentifier::IsSubnetRouterAnycast(void) const
-{
-    return (mFields.m32[0] == 0) && (mFields.m32[1] == 0);
-}
+bool InterfaceIdentifier::IsSubnetRouterAnycast(void) const { return (mFields.m32[0] == 0) && (mFields.m32[1] == 0); }
 
 bool InterfaceIdentifier::IsReservedSubnetAnycast(void) const
 {
@@ -224,15 +212,9 @@ bool InterfaceIdentifier::IsReservedSubnetAnycast(void) const
             mFields.m8[7] >= 0x80);
 }
 
-void InterfaceIdentifier::GenerateRandom(void)
-{
-    SuccessOrAssert(Random::Crypto::FillBuffer(mFields.m8, kSize));
-}
+void InterfaceIdentifier::GenerateRandom(void) { SuccessOrAssert(Random::Crypto::FillBuffer(mFields.m8, kSize)); }
 
-void InterfaceIdentifier::SetBytes(const uint8_t *aBuffer)
-{
-    memcpy(mFields.m8, aBuffer, kSize);
-}
+void InterfaceIdentifier::SetBytes(const uint8_t *aBuffer) { memcpy(mFields.m8, aBuffer, kSize); }
 
 void InterfaceIdentifier::SetFromExtAddress(const Mac::ExtAddress &aExtAddress)
 {
@@ -318,10 +300,7 @@ bool Address::IsLoopback(void) const
     return (mFields.m32[0] == 0 && mFields.m32[1] == 0 && mFields.m32[2] == 0 && mFields.m32[3] == HostSwap32(1));
 }
 
-bool Address::IsLinkLocal(void) const
-{
-    return (mFields.m16[0] & HostSwap16(0xffc0)) == HostSwap16(0xfe80);
-}
+bool Address::IsLinkLocal(void) const { return (mFields.m16[0] & HostSwap16(0xffc0)) == HostSwap16(0xfe80); }
 
 void Address::SetToLinkLocalAddress(const Mac::ExtAddress &aExtAddress)
 {
@@ -337,70 +316,31 @@ void Address::SetToLinkLocalAddress(const InterfaceIdentifier &aIid)
     SetIid(aIid);
 }
 
-bool Address::IsLinkLocalMulticast(void) const
-{
-    return IsMulticast() && (GetScope() == kLinkLocalScope);
-}
+bool Address::IsLinkLocalMulticast(void) const { return IsMulticast() && (GetScope() == kLinkLocalScope); }
 
-bool Address::IsLinkLocalAllNodesMulticast(void) const
-{
-    return (*this == GetLinkLocalAllNodesMulticast());
-}
+bool Address::IsLinkLocalAllNodesMulticast(void) const { return (*this == GetLinkLocalAllNodesMulticast()); }
 
-void Address::SetToLinkLocalAllNodesMulticast(void)
-{
-    *this = GetLinkLocalAllNodesMulticast();
-}
+void Address::SetToLinkLocalAllNodesMulticast(void) { *this = GetLinkLocalAllNodesMulticast(); }
 
-bool Address::IsLinkLocalAllRoutersMulticast(void) const
-{
-    return (*this == GetLinkLocalAllRoutersMulticast());
-}
+bool Address::IsLinkLocalAllRoutersMulticast(void) const { return (*this == GetLinkLocalAllRoutersMulticast()); }
 
-void Address::SetToLinkLocalAllRoutersMulticast(void)
-{
-    *this = GetLinkLocalAllRoutersMulticast();
-}
+void Address::SetToLinkLocalAllRoutersMulticast(void) { *this = GetLinkLocalAllRoutersMulticast(); }
 
-bool Address::IsRealmLocalMulticast(void) const
-{
-    return IsMulticast() && (GetScope() == kRealmLocalScope);
-}
+bool Address::IsRealmLocalMulticast(void) const { return IsMulticast() && (GetScope() == kRealmLocalScope); }
 
-bool Address::IsMulticastLargerThanRealmLocal(void) const
-{
-    return IsMulticast() && (GetScope() > kRealmLocalScope);
-}
+bool Address::IsMulticastLargerThanRealmLocal(void) const { return IsMulticast() && (GetScope() > kRealmLocalScope); }
 
-bool Address::IsRealmLocalAllNodesMulticast(void) const
-{
-    return (*this == GetRealmLocalAllNodesMulticast());
-}
+bool Address::IsRealmLocalAllNodesMulticast(void) const { return (*this == GetRealmLocalAllNodesMulticast()); }
 
-void Address::SetToRealmLocalAllNodesMulticast(void)
-{
-    *this = GetRealmLocalAllNodesMulticast();
-}
+void Address::SetToRealmLocalAllNodesMulticast(void) { *this = GetRealmLocalAllNodesMulticast(); }
 
-bool Address::IsRealmLocalAllRoutersMulticast(void) const
-{
-    return (*this == GetRealmLocalAllRoutersMulticast());
-}
+bool Address::IsRealmLocalAllRoutersMulticast(void) const { return (*this == GetRealmLocalAllRoutersMulticast()); }
 
-void Address::SetToRealmLocalAllRoutersMulticast(void)
-{
-    *this = GetRealmLocalAllRoutersMulticast();
-}
+void Address::SetToRealmLocalAllRoutersMulticast(void) { *this = GetRealmLocalAllRoutersMulticast(); }
 
-bool Address::IsRealmLocalAllMplForwarders(void) const
-{
-    return (*this == GetRealmLocalAllMplForwarders());
-}
+bool Address::IsRealmLocalAllMplForwarders(void) const { return (*this == GetRealmLocalAllMplForwarders()); }
 
-void Address::SetToRealmLocalAllMplForwarders(void)
-{
-    *this = GetRealmLocalAllMplForwarders();
-}
+void Address::SetToRealmLocalAllMplForwarders(void) { *this = GetRealmLocalAllMplForwarders(); }
 
 bool Address::MatchesPrefix(const Prefix &aPrefix) const
 {
@@ -412,15 +352,9 @@ bool Address::MatchesPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength) const
     return Prefix::MatchLength(mFields.m8, aPrefix, Prefix::SizeForLength(aPrefixLength)) >= aPrefixLength;
 }
 
-void Address::SetPrefix(const NetworkPrefix &aNetworkPrefix)
-{
-    mFields.mComponents.mNetworkPrefix = aNetworkPrefix;
-}
+void Address::SetPrefix(const NetworkPrefix &aNetworkPrefix) { mFields.mComponents.mNetworkPrefix = aNetworkPrefix; }
 
-void Address::SetPrefix(const Prefix &aPrefix)
-{
-    CopyBits(mFields.m8, aPrefix.GetBytes(), aPrefix.GetLength());
-}
+void Address::SetPrefix(const Prefix &aPrefix) { CopyBits(mFields.m8, aPrefix.GetBytes(), aPrefix.GetLength()); }
 
 void Address::CopyBits(uint8_t *aDst, const uint8_t *aSrc, uint8_t aNumBits)
 {

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -430,10 +430,7 @@ void Mpl::Metadata::RemoveFrom(Message &aMessage) const
     SuccessOrAssert(aMessage.SetLength(aMessage.GetLength() - sizeof(*this)));
 }
 
-void Mpl::Metadata::UpdateIn(Message &aMessage) const
-{
-    aMessage.Write(aMessage.GetLength() - sizeof(*this), *this);
-}
+void Mpl::Metadata::UpdateIn(Message &aMessage) const { aMessage.Write(aMessage.GetLength() - sizeof(*this), *this); }
 
 void Mpl::Metadata::GenerateNextTransmissionTime(TimeMilli aCurrentTime, uint8_t aInterval)
 {

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -231,10 +231,7 @@ public:
      * @returns A reference to the buffered message set.
      *
      */
-    const MessageQueue &GetBufferedMessageSet(void) const
-    {
-        return mBufferedMessageSet;
-    }
+    const MessageQueue &GetBufferedMessageSet(void) const { return mBufferedMessageSet; }
 #endif
 
 private:

--- a/src/core/net/nd6.cpp
+++ b/src/core/net/nd6.cpp
@@ -66,10 +66,7 @@ const Option *Option::Iterator::Next(const Option *aOption)
     return reinterpret_cast<const Option *>(reinterpret_cast<const uint8_t *>(aOption) + aOption->GetSize());
 }
 
-void Option::Iterator::Advance(void)
-{
-    mOption = (mOption != nullptr) ? Validate(Next(mOption)) : nullptr;
-}
+void Option::Iterator::Advance(void) { mOption = (mOption != nullptr) ? Validate(Next(mOption)) : nullptr; }
 
 const Option *Option::Iterator::Validate(const Option *aOption) const
 {
@@ -99,10 +96,7 @@ void PrefixInfoOption::SetPrefix(const Prefix &aPrefix)
     mPrefix       = AsCoreType(&aPrefix.mPrefix);
 }
 
-void PrefixInfoOption::GetPrefix(Prefix &aPrefix) const
-{
-    aPrefix.Set(mPrefix.GetBytes(), mPrefixLength);
-}
+void PrefixInfoOption::GetPrefix(Prefix &aPrefix) const { aPrefix.Set(mPrefix.GetBytes(), mPrefixLength); }
 
 bool PrefixInfoOption::IsValid(void) const
 {
@@ -137,10 +131,7 @@ void RouteInfoOption::SetPrefix(const Prefix &aPrefix)
     memcpy(GetPrefixBytes(), aPrefix.GetBytes(), aPrefix.GetBytesSize());
 }
 
-void RouteInfoOption::GetPrefix(Prefix &aPrefix) const
-{
-    aPrefix.Set(GetPrefixBytes(), mPrefixLength);
-}
+void RouteInfoOption::GetPrefix(Prefix &aPrefix) const { aPrefix.Set(GetPrefixBytes(), mPrefixLength); }
 
 bool RouteInfoOption::IsValid(void) const
 {

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -586,10 +586,7 @@ void Netif::RemoveAllExternalUnicastAddresses(void)
     }
 }
 
-bool Netif::HasUnicastAddress(const Address &aAddress) const
-{
-    return mUnicastAddresses.ContainsMatching(aAddress);
-}
+bool Netif::HasUnicastAddress(const Address &aAddress) const { return mUnicastAddresses.ContainsMatching(aAddress); }
 
 bool Netif::IsUnicastAddressExternal(const UnicastAddress &aAddress) const
 {

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -333,10 +333,7 @@ public:
          * @returns The current Multicast Listener Registration state.
          *
          */
-        MlrState GetMlrState(void) const
-        {
-            return mMlrState;
-        }
+        MlrState GetMlrState(void) const { return mMlrState; }
 
         /**
          * This method sets the Multicast Listener Registration (MLR) state.
@@ -344,17 +341,11 @@ public:
          * @param[in] aState  The new Multicast Listener Registration state.
          *
          */
-        void SetMlrState(MlrState aState)
-        {
-            mMlrState = aState;
-        }
+        void SetMlrState(MlrState aState) { mMlrState = aState; }
 #endif
 
     private:
-        ExternalMulticastAddress *GetNext(void)
-        {
-            return static_cast<ExternalMulticastAddress *>(AsNonConst(mNext));
-        }
+        ExternalMulticastAddress *GetNext(void) { return static_cast<ExternalMulticastAddress *>(AsNonConst(mNext)); }
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
         MlrState mMlrState;
@@ -384,10 +375,7 @@ public:
      * @returns The linked list of unicast addresses.
      *
      */
-    const LinkedList<UnicastAddress> &GetUnicastAddresses(void) const
-    {
-        return mUnicastAddresses;
-    }
+    const LinkedList<UnicastAddress> &GetUnicastAddresses(void) const { return mUnicastAddresses; }
 
     /**
      * This method adds a unicast address to the network interface.
@@ -435,10 +423,7 @@ public:
      * @retval FALSE  If @p aAddress is not assigned to the network interface.
      *
      */
-    bool HasUnicastAddress(const UnicastAddress &aAddress) const
-    {
-        return mUnicastAddresses.Contains(aAddress);
-    }
+    bool HasUnicastAddress(const UnicastAddress &aAddress) const { return mUnicastAddresses.Contains(aAddress); }
 
     /**
      * This method indicates whether a unicast address is an external or internal address.
@@ -517,10 +502,7 @@ public:
      * @returns The linked list of multicast addresses.
      *
      */
-    const LinkedList<MulticastAddress> &GetMulticastAddresses(void) const
-    {
-        return mMulticastAddresses;
-    }
+    const LinkedList<MulticastAddress> &GetMulticastAddresses(void) const { return mMulticastAddresses; }
 
     /**
      * This method indicates whether a multicast address is an external or internal address.
@@ -599,10 +581,7 @@ public:
      * @retval FALSE  If the multicast promiscuous mode is disabled.
      *
      */
-    bool IsMulticastPromiscuousEnabled(void) const
-    {
-        return mMulticastPromiscuous;
-    }
+    bool IsMulticastPromiscuousEnabled(void) const { return mMulticastPromiscuous; }
 
     /**
      * This method enables multicast promiscuous mode on the network interface.
@@ -610,10 +589,7 @@ public:
      * @param[in]  aEnabled  TRUE if Multicast Promiscuous mode is enabled, FALSE otherwise.
      *
      */
-    void SetMulticastPromiscuous(bool aEnabled)
-    {
-        mMulticastPromiscuous = aEnabled;
-    }
+    void SetMulticastPromiscuous(bool aEnabled) { mMulticastPromiscuous = aEnabled; }
 
     /**
      * This method enables range-based `for` loop iteration over external multicast addresses on the Netif that matches
@@ -648,10 +624,7 @@ public:
      * @retval FALSE The network interface is not subscribed to any external multicast address.
      *
      */
-    bool HasAnyExternalMulticastAddress(void) const
-    {
-        return !ExternalMulticastAddress::Iterator(*this).IsDone();
-    }
+    bool HasAnyExternalMulticastAddress(void) const { return !ExternalMulticastAddress::Iterator(*this).IsDone(); }
 
 protected:
     /**

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -739,10 +739,7 @@ void Client::ChangeHostAndServiceStates(const ItemState *aNewStates, ServiceStat
 #endif // OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE && OPENTHREAD_CONFIG_SRP_CLIENT_SAVE_SELECTED_SERVER_ENABLE
 }
 
-void Client::InvokeCallback(Error aError) const
-{
-    InvokeCallback(aError, mHostInfo, nullptr);
-}
+void Client::InvokeCallback(Error aError) const { InvokeCallback(aError, mHostInfo, nullptr); }
 
 void Client::InvokeCallback(Error aError, const HostInfo &aHostInfo, const Service *aRemovedServices) const
 {

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -413,10 +413,7 @@ public:
      * Note that a call to `Stop()` will also disable the auto-start mode.
      *
      */
-    void DisableAutoStartMode(void)
-    {
-        mAutoStart.SetState(AutoStart::kDisabled);
-    }
+    void DisableAutoStartMode(void) { mAutoStart.SetState(AutoStart::kDisabled); }
 
     /**
      * This method indicates the current state of auto-start mode (enabled or disabled).
@@ -424,10 +421,7 @@ public:
      * @returns TRUE if the auto-start mode is enabled, FALSE otherwise.
      *
      */
-    bool IsAutoStartModeEnabled(void) const
-    {
-        return mAutoStart.GetState() != AutoStart::kDisabled;
-    }
+    bool IsAutoStartModeEnabled(void) const { return mAutoStart.GetState() != AutoStart::kDisabled; }
 
     /**
      * This method indicates whether or not the current SRP server's address is selected by auto-start.
@@ -435,10 +429,7 @@ public:
      * @returns TRUE if the SRP server's address is selected by auto-start, FALSE otherwise.
      *
      */
-    bool IsServerSelectedByAutoStart(void) const
-    {
-        return mAutoStart.HasSelectedServer();
-    }
+    bool IsServerSelectedByAutoStart(void) const { return mAutoStart.HasSelectedServer(); }
 #endif // OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
 
     /**
@@ -447,10 +438,7 @@ public:
      * @returns TRUE if the SRP client is running, FALSE otherwise.
      *
      */
-    bool IsRunning(void) const
-    {
-        return (mState != kStateStopped);
-    }
+    bool IsRunning(void) const { return (mState != kStateStopped); }
 
     /**
      * This method gets the socket address (IPv6 address and port number) of the SRP server which is being used by SRP
@@ -461,10 +449,7 @@ public:
      * @returns The SRP server's socket address.
      *
      */
-    const Ip6::SockAddr &GetServerAddress(void) const
-    {
-        return mSocket.GetPeerName();
-    }
+    const Ip6::SockAddr &GetServerAddress(void) const { return mSocket.GetPeerName(); }
 
     /**
      * This method sets the callback used to notify caller of events/changes.
@@ -489,10 +474,7 @@ public:
      * @returns The TTL (in seconds).
      *
      */
-    uint32_t GetTtl(void) const
-    {
-        return mTtl;
-    }
+    uint32_t GetTtl(void) const { return mTtl; }
 
     /**
      * This method sets the TTL used in SRP update requests.
@@ -504,10 +486,7 @@ public:
      *                  lease interval.
      *
      */
-    void SetTtl(uint32_t aTtl)
-    {
-        mTtl = aTtl;
-    }
+    void SetTtl(uint32_t aTtl) { mTtl = aTtl; }
 
     /**
      * This method gets the lease interval used in SRP update requests.
@@ -518,10 +497,7 @@ public:
      * @returns The lease interval (in seconds).
      *
      */
-    uint32_t GetLeaseInterval(void) const
-    {
-        return mDefaultLease;
-    }
+    uint32_t GetLeaseInterval(void) const { return mDefaultLease; }
 
     /**
      * This method sets the lease interval used in SRP update requests.
@@ -532,10 +508,7 @@ public:
      * @param[in] aInterval  The lease interval (in seconds). If zero, the default value `kDefaultLease` would be used.
      *
      */
-    void SetLeaseInterval(uint32_t aInterval)
-    {
-        mDefaultLease = DetermineLeaseInterval(aInterval, kDefaultLease);
-    }
+    void SetLeaseInterval(uint32_t aInterval) { mDefaultLease = DetermineLeaseInterval(aInterval, kDefaultLease); }
 
     /**
      * This method gets the key lease interval used in SRP update requests.
@@ -543,10 +516,7 @@ public:
      * @returns The key lease interval (in seconds).
      *
      */
-    uint32_t GetKeyLeaseInterval(void) const
-    {
-        return mDefaultKeyLease;
-    }
+    uint32_t GetKeyLeaseInterval(void) const { return mDefaultKeyLease; }
 
     /**
      * This method sets the key lease interval used in SRP update requests.
@@ -569,10 +539,7 @@ public:
      * @returns A reference to host info structure.
      *
      */
-    const HostInfo &GetHostInfo(void) const
-    {
-        return mHostInfo;
-    }
+    const HostInfo &GetHostInfo(void) const { return mHostInfo; }
 
     /**
      * This method sets the host name label.
@@ -692,10 +659,7 @@ public:
      * @returns The list of services.
      *
      */
-    const LinkedList<Service> &GetServices(void) const
-    {
-        return mServices;
-    }
+    const LinkedList<Service> &GetServices(void) const { return mServices; }
 
     /**
      * This method starts the remove process of the host info and all services.
@@ -749,10 +713,7 @@ public:
      * @returns The domain name string.
      *
      */
-    const char *GetDomainName(void) const
-    {
-        return mDomainName;
-    }
+    const char *GetDomainName(void) const { return mDomainName; }
 
     /**
      * This method sets the domain name to be used by SRP client.
@@ -795,10 +756,7 @@ public:
      * @param[in] aEnabled   TRUE to enable, FALSE to disable the "service key record inclusion" mode.
      *
      */
-    void SetServiceKeyRecordEnabled(bool aEnabled)
-    {
-        mServiceKeyRecordEnabled = aEnabled;
-    }
+    void SetServiceKeyRecordEnabled(bool aEnabled) { mServiceKeyRecordEnabled = aEnabled; }
 
     /**
      * This method indicates whether the "service key record inclusion" mode is enabled or disabled.
@@ -806,10 +764,7 @@ public:
      * @returns TRUE if "service key record inclusion" mode is enabled, FALSE otherwise.
      *
      */
-    bool IsServiceKeyRecordEnabled(void) const
-    {
-        return mServiceKeyRecordEnabled;
-    }
+    bool IsServiceKeyRecordEnabled(void) const { return mServiceKeyRecordEnabled; }
 #endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 
 private:
@@ -974,15 +929,9 @@ private:
         void    InvokeCallback(const Ip6::SockAddr *aServerSockAddr) const;
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_SWITCH_SERVER_ON_FAILURE
-        uint8_t GetTimoutFailureCount(void) const
-        {
-            return mTimoutFailureCount;
-        }
-        void ResetTimoutFailureCount(void)
-        {
-            mTimoutFailureCount = 0;
-        }
-        void IncrementTimoutFailureCount(void)
+        uint8_t GetTimoutFailureCount(void) const { return mTimoutFailureCount; }
+        void    ResetTimoutFailureCount(void) { mTimoutFailureCount = 0; }
+        void    IncrementTimoutFailureCount(void)
         {
             if (mTimoutFailureCount < NumericLimits<uint8_t>::kMax)
             {
@@ -1016,18 +965,15 @@ private:
         Crypto::Ecdsa::P256::KeyPair mKeyPair;          // The ECDSA key pair.
     };
 
-    Error Start(const Ip6::SockAddr &aServerSockAddr, Requester aRequester);
-    void  Stop(Requester aRequester, StopMode aMode);
-    void  Resume(void);
-    void  Pause(void);
-    void  HandleNotifierEvents(Events aEvents);
-    void  HandleRoleChanged(void);
-    Error UpdateHostInfoStateOnAddressChange(void);
-    void  UpdateServiceStateToRemove(Service &aService);
-    State GetState(void) const
-    {
-        return mState;
-    }
+    Error        Start(const Ip6::SockAddr &aServerSockAddr, Requester aRequester);
+    void         Stop(Requester aRequester, StopMode aMode);
+    void         Resume(void);
+    void         Pause(void);
+    void         HandleNotifierEvents(Events aEvents);
+    void         HandleRoleChanged(void);
+    Error        UpdateHostInfoStateOnAddressChange(void);
+    void         UpdateServiceStateToRemove(Service &aService);
+    State        GetState(void) const { return mState; }
     void         SetState(State aState);
     void         ChangeHostAndServiceStates(const ItemState *aNewStates, ServiceStateChangeMode aMode);
     void         InvokeCallback(Error aError) const;
@@ -1054,19 +1000,13 @@ private:
     static Error ReadResourceRecord(const Message &aMessage, uint16_t &aOffset, Dns::ResourceRecord &aRecord);
     Error        ProcessOptRecord(const Message &aMessage, uint16_t aOffset, const Dns::OptRecord &aOptRecord);
     void         UpdateState(void);
-    uint32_t     GetRetryWaitInterval(void) const
-    {
-        return mRetryWaitInterval;
-    }
-    void ResetRetryWaitInterval(void)
-    {
-        mRetryWaitInterval = kMinRetryWaitInterval;
-    }
-    void     GrowRetryWaitInterval(void);
-    uint32_t DetermineLeaseInterval(uint32_t aInterval, uint32_t aDefaultInterval) const;
-    uint32_t DetermineTtl(void) const;
-    bool     ShouldRenewEarly(const Service &aService) const;
-    void     HandleTimer(void);
+    uint32_t     GetRetryWaitInterval(void) const { return mRetryWaitInterval; }
+    void         ResetRetryWaitInterval(void) { mRetryWaitInterval = kMinRetryWaitInterval; }
+    void         GrowRetryWaitInterval(void);
+    uint32_t     DetermineLeaseInterval(uint32_t aInterval, uint32_t aDefaultInterval) const;
+    uint32_t     DetermineTtl(void) const;
+    bool         ShouldRenewEarly(const Service &aService) const;
+    void         HandleTimer(void);
 #if OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
     void  ProcessAutoStart(void);
     Error SelectUnicastEntry(DnsSrpUnicast::Origin aOrigin, DnsSrpUnicast::Info &aInfo) const;
@@ -1079,9 +1019,7 @@ private:
     static const char *StateToString(State aState);
     void               LogRetryWaitInterval(void) const;
 #else
-    void LogRetryWaitInterval(void) const
-    {
-    }
+    void LogRetryWaitInterval(void) const {}
 #endif
 
     static const char kDefaultDomainName[];

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -1843,9 +1843,7 @@ void Server::Service::Log(Action aAction) const
     }
 }
 #else
-void Server::Service::Log(Action) const
-{
-}
+void Server::Service::Log(Action) const {}
 #endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1923,10 +1921,7 @@ Server::Host::Host(Instance &aInstance, TimeMilli aUpdateTime)
     mKeyRecord.Clear();
 }
 
-Server::Host::~Host(void)
-{
-    FreeAllServices();
-}
+Server::Host::~Host(void) { FreeAllServices(); }
 
 Error Server::Host::SetFullName(const char *aFullName)
 {
@@ -1967,10 +1962,7 @@ TimeMilli Server::Host::GetExpireTime(void) const
     return mUpdateTime + Time::SecToMsec(mLease);
 }
 
-TimeMilli Server::Host::GetKeyExpireTime(void) const
-{
-    return mUpdateTime + Time::SecToMsec(mKeyLease);
-}
+TimeMilli Server::Host::GetKeyExpireTime(void) const { return mUpdateTime + Time::SecToMsec(mKeyLease); }
 
 void Server::Host::GetLeaseInfo(LeaseInfo &aLeaseInfo) const
 {
@@ -2126,10 +2118,7 @@ void Server::Host::FreeAllServices(void)
     }
 }
 
-void Server::Host::ClearResources(void)
-{
-    mAddresses.Free();
-}
+void Server::Host::ClearResources(void) { mAddresses.Free(); }
 
 Error Server::Host::MergeServicesAndResourcesFrom(Host &aHost)
 {

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -729,10 +729,7 @@ public:
      * @returns A pointer to the dot-joined domain string.
      *
      */
-    const char *GetDomain(void) const
-    {
-        return mDomain.AsCString();
-    }
+    const char *GetDomain(void) const { return mDomain.AsCString(); }
 
     /**
      * This method sets the domain on the SRP server.
@@ -756,10 +753,7 @@ public:
      * @returns The SRP server's address mode.
      *
      */
-    AddressMode GetAddressMode(void) const
-    {
-        return mAddressMode;
-    }
+    AddressMode GetAddressMode(void) const { return mAddressMode; }
 
     /**
      * This method sets the address mode to be used by the SRP server.
@@ -780,10 +774,7 @@ public:
      * @returns The anycast sequence number.
      *
      */
-    uint8_t GetAnycastModeSequenceNumber(void) const
-    {
-        return mAnycastSequenceNumber;
-    }
+    uint8_t GetAnycastModeSequenceNumber(void) const { return mAnycastSequenceNumber; }
 
     /**
      * This method sets the sequence number used with anycast address mode.
@@ -802,10 +793,7 @@ public:
      * @returns  The state of the server.
      *
      */
-    State GetState(void) const
-    {
-        return mState;
-    }
+    State GetState(void) const { return mState; }
 
     /**
      * This method tells the port the SRP server is listening to.
@@ -813,10 +801,7 @@ public:
      * @returns  The port of the server or 0 if the SRP server is not running.
      *
      */
-    uint16_t GetPort(void) const
-    {
-        return (mState == kStateRunning) ? mPort : 0;
-    }
+    uint16_t GetPort(void) const { return (mState == kStateRunning) ? mPort : 0; }
 
     /**
      * This method enables/disables the SRP server.
@@ -852,10 +837,7 @@ public:
      * @retval FALSE  The auto-enable mode is disabled.
      *
      */
-    bool IsAutoEnableMode(void) const
-    {
-        return mAutoEnable;
-    }
+    bool IsAutoEnableMode(void) const { return mAutoEnable; }
 #endif
 
     /**
@@ -864,10 +846,7 @@ public:
      * @param[out]  aTtlConfig  A reference to the `TtlConfig` instance.
      *
      */
-    void GetTtlConfig(TtlConfig &aTtlConfig) const
-    {
-        aTtlConfig = mTtlConfig;
-    }
+    void GetTtlConfig(TtlConfig &aTtlConfig) const { aTtlConfig = mTtlConfig; }
 
     /**
      * This method sets the TTL configuration.
@@ -886,10 +865,7 @@ public:
      * @param[out]  aLeaseConfig  A reference to the `LeaseConfig` instance.
      *
      */
-    void GetLeaseConfig(LeaseConfig &aLeaseConfig) const
-    {
-        aLeaseConfig = mLeaseConfig;
-    }
+    void GetLeaseConfig(LeaseConfig &aLeaseConfig) const { aLeaseConfig = mLeaseConfig; }
 
     /**
      * This method sets the LEASE and KEY-LEASE configurations.
@@ -922,10 +898,7 @@ public:
      * @returns  A pointer to the response counters of the SRP server.
      *
      */
-    const otSrpServerResponseCounters *GetResponseCounters(void) const
-    {
-        return &mResponseCounters;
-    }
+    const otSrpServerResponseCounters *GetResponseCounters(void) const { return &mResponseCounters; }
 
     /**
      * This method receives the service update result from service handler set by
@@ -1018,10 +991,7 @@ private:
 
     void HandleNetDataPublisherEvent(NetworkData::Publisher::Event aEvent);
 
-    ServiceUpdateId AllocateId(void)
-    {
-        return mServiceUpdateId++;
-    }
+    ServiceUpdateId AllocateId(void) { return mServiceUpdateId++; }
 
     void  InformUpdateHandlerOrCommit(Error aError, Host &aHost, const MessageMetadata &aMetadata);
     void  CommitSrpUpdate(Error aError, Host &aHost, const MessageMetadata &aMessageMetadata);

--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -124,10 +124,7 @@ exit:
     return error;
 }
 
-Instance &Tcp::Endpoint::GetInstance(void) const
-{
-    return AsNonConst(AsCoreType(GetTcb().instance));
-}
+Instance &Tcp::Endpoint::GetInstance(void) const { return AsNonConst(AsCoreType(GetTcb().instance)); }
 
 const SockAddr &Tcp::Endpoint::GetLocalAddress(void) const
 {
@@ -287,10 +284,7 @@ exit:
     return error;
 }
 
-bool Tcp::Endpoint::IsClosed(void) const
-{
-    return GetTcb().t_state == TCP6S_CLOSED;
-}
+bool Tcp::Endpoint::IsClosed(void) const { return GetTcb().t_state == TCP6S_CLOSED; }
 
 uint8_t Tcp::Endpoint::TimerFlagToIndex(uint8_t aTimerFlag)
 {
@@ -483,25 +477,16 @@ size_t Tcp::Endpoint::GetInFlightBytes(void) const
     return tp.snd_max - tp.snd_una;
 }
 
-size_t Tcp::Endpoint::GetBacklogBytes(void) const
-{
-    return GetSendBufferBytes() - GetInFlightBytes();
-}
+size_t Tcp::Endpoint::GetBacklogBytes(void) const { return GetSendBufferBytes() - GetInFlightBytes(); }
 
-Address &Tcp::Endpoint::GetLocalIp6Address(void)
-{
-    return *reinterpret_cast<Address *>(&GetTcb().laddr);
-}
+Address &Tcp::Endpoint::GetLocalIp6Address(void) { return *reinterpret_cast<Address *>(&GetTcb().laddr); }
 
 const Address &Tcp::Endpoint::GetLocalIp6Address(void) const
 {
     return *reinterpret_cast<const Address *>(&GetTcb().laddr);
 }
 
-Address &Tcp::Endpoint::GetForeignIp6Address(void)
-{
-    return *reinterpret_cast<Address *>(&GetTcb().faddr);
-}
+Address &Tcp::Endpoint::GetForeignIp6Address(void) { return *reinterpret_cast<Address *>(&GetTcb().faddr); }
 
 const Address &Tcp::Endpoint::GetForeignIp6Address(void) const
 {
@@ -543,10 +528,7 @@ exit:
     return error;
 }
 
-Instance &Tcp::Listener::GetInstance(void) const
-{
-    return AsNonConst(AsCoreType(GetTcbListen().instance));
-}
+Instance &Tcp::Listener::GetInstance(void) const { return AsNonConst(AsCoreType(GetTcbListen().instance)); }
 
 Error Tcp::Listener::Listen(const SockAddr &aSockName)
 {
@@ -586,15 +568,9 @@ exit:
     return error;
 }
 
-bool Tcp::Listener::IsClosed(void) const
-{
-    return GetTcbListen().t_state == TCP6S_CLOSED;
-}
+bool Tcp::Listener::IsClosed(void) const { return GetTcbListen().t_state == TCP6S_CLOSED; }
 
-Address &Tcp::Listener::GetLocalIp6Address(void)
-{
-    return *reinterpret_cast<Address *>(&GetTcbListen().laddr);
-}
+Address &Tcp::Listener::GetLocalIp6Address(void) { return *reinterpret_cast<Address *>(&GetTcbListen().laddr); }
 
 const Address &Tcp::Listener::GetLocalIp6Address(void) const
 {
@@ -972,15 +948,9 @@ void tcplp_sys_send_message(otInstance *aInstance, otMessage *aMessage, otMessag
     IgnoreError(instance.Get<ot::Ip6::Ip6>().SendDatagram(message, info, kProtoTcp));
 }
 
-uint32_t tcplp_sys_get_ticks(void)
-{
-    return TimerMilli::GetNow().GetValue();
-}
+uint32_t tcplp_sys_get_ticks(void) { return TimerMilli::GetNow().GetValue(); }
 
-uint32_t tcplp_sys_get_millis(void)
-{
-    return TimerMilli::GetNow().GetValue();
-}
+uint32_t tcplp_sys_get_millis(void) { return TimerMilli::GetNow().GetValue(); }
 
 void tcplp_sys_set_timer(struct tcpcb *aTcb, uint8_t aTimerFlag, uint32_t aDelay)
 {
@@ -1151,15 +1121,9 @@ uint32_t tcplp_sys_generate_isn()
     return isn;
 }
 
-uint16_t tcplp_sys_hostswap16(uint16_t aHostPort)
-{
-    return HostSwap16(aHostPort);
-}
+uint16_t tcplp_sys_hostswap16(uint16_t aHostPort) { return HostSwap16(aHostPort); }
 
-uint32_t tcplp_sys_hostswap32(uint32_t aHostPort)
-{
-    return HostSwap32(aHostPort);
-}
+uint32_t tcplp_sys_hostswap32(uint32_t aHostPort) { return HostSwap32(aHostPort); }
 }
 
 #endif // OPENTHREAD_CONFIG_TCP_ENABLE

--- a/src/core/net/tcp6_ext.cpp
+++ b/src/core/net/tcp6_ext.cpp
@@ -189,10 +189,7 @@ void TcpCircularSendBuffer::HandleForwardProgress(size_t aInSendBuffer)
     mCapacityUsed = aInSendBuffer;
 }
 
-size_t TcpCircularSendBuffer::GetFreeSpace(void) const
-{
-    return mCapacity - mCapacityUsed;
-}
+size_t TcpCircularSendBuffer::GetFreeSpace(void) const { return mCapacity - mCapacityUsed; }
 
 void TcpCircularSendBuffer::ForceDiscardAll(void)
 {
@@ -201,10 +198,7 @@ void TcpCircularSendBuffer::ForceDiscardAll(void)
     mFirstSendLinkIndex = 0;
 }
 
-Error TcpCircularSendBuffer::Deinitialize(void)
-{
-    return (mCapacityUsed != 0) ? kErrorBusy : kErrorNone;
-}
+Error TcpCircularSendBuffer::Deinitialize(void) { return (mCapacityUsed != 0) ? kErrorBusy : kErrorNone; }
 
 size_t TcpCircularSendBuffer::GetIndex(size_t aStart, size_t aOffsetFromStart) const
 {

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -82,15 +82,9 @@ Message *Udp::Socket::NewMessage(uint16_t aReserved, const Message::Settings &aS
     return Get<Udp>().NewMessage(aReserved, aSettings);
 }
 
-Error Udp::Socket::Open(otUdpReceive aHandler, void *aContext)
-{
-    return Get<Udp>().Open(*this, aHandler, aContext);
-}
+Error Udp::Socket::Open(otUdpReceive aHandler, void *aContext) { return Get<Udp>().Open(*this, aHandler, aContext); }
 
-bool Udp::Socket::IsOpen(void) const
-{
-    return Get<Udp>().IsOpen(*this);
-}
+bool Udp::Socket::IsOpen(void) const { return Get<Udp>().IsOpen(*this); }
 
 Error Udp::Socket::Bind(const SockAddr &aSockAddr, NetifIdentifier aNetifIdentifier)
 {
@@ -102,20 +96,11 @@ Error Udp::Socket::Bind(uint16_t aPort, NetifIdentifier aNetifIdentifier)
     return Bind(SockAddr(aPort), aNetifIdentifier);
 }
 
-Error Udp::Socket::Connect(const SockAddr &aSockAddr)
-{
-    return Get<Udp>().Connect(*this, aSockAddr);
-}
+Error Udp::Socket::Connect(const SockAddr &aSockAddr) { return Get<Udp>().Connect(*this, aSockAddr); }
 
-Error Udp::Socket::Connect(uint16_t aPort)
-{
-    return Connect(SockAddr(aPort));
-}
+Error Udp::Socket::Connect(uint16_t aPort) { return Connect(SockAddr(aPort)); }
 
-Error Udp::Socket::Close(void)
-{
-    return Get<Udp>().Close(*this);
-}
+Error Udp::Socket::Close(void) { return Get<Udp>().Close(*this); }
 
 Error Udp::Socket::SendTo(Message &aMessage, const MessageInfo &aMessageInfo)
 {
@@ -171,10 +156,7 @@ Udp::Udp(Instance &aInstance)
 {
 }
 
-Error Udp::AddReceiver(Receiver &aReceiver)
-{
-    return mReceivers.Add(aReceiver);
-}
+Error Udp::AddReceiver(Receiver &aReceiver) { return mReceivers.Add(aReceiver); }
 
 Error Udp::RemoveReceiver(Receiver &aReceiver)
 {

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -471,10 +471,7 @@ public:
      * @returns If the UDP socket is open.
      *
      */
-    bool IsOpen(const SocketHandle &aSocket) const
-    {
-        return mSockets.Contains(aSocket);
-    }
+    bool IsOpen(const SocketHandle &aSocket) const { return mSockets.Contains(aSocket); }
 
     /**
      * This method binds a UDP socket.
@@ -586,10 +583,7 @@ public:
      * @returns A pointer to the head of UDP Socket linked list.
      *
      */
-    SocketHandle *GetUdpSockets(void)
-    {
-        return mSockets.GetHead();
-    }
+    SocketHandle *GetUdpSockets(void) { return mSockets.GetHead(); }
 
 #if OPENTHREAD_CONFIG_UDP_FORWARD_ENABLE
     /**

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -658,10 +658,7 @@ public:
     }
 
 private:
-    otInstance *GetInstancePtr(void) const
-    {
-        return reinterpret_cast<otInstance *>(&InstanceLocator::GetInstance());
-    }
+    otInstance *GetInstancePtr(void) const { return reinterpret_cast<otInstance *>(&InstanceLocator::GetInstance()); }
 
     Callbacks mCallbacks;
 };
@@ -669,25 +666,16 @@ private:
 //---------------------------------------------------------------------------------------------------------------------
 // Radio APIs that are always mapped to the same `otPlatRadio` function (independent of the link type)
 
-inline const char *Radio::GetVersionString(void)
-{
-    return otPlatRadioGetVersionString(GetInstancePtr());
-}
+inline const char *Radio::GetVersionString(void) { return otPlatRadioGetVersionString(GetInstancePtr()); }
 
 inline void Radio::GetIeeeEui64(Mac::ExtAddress &aIeeeEui64)
 {
     otPlatRadioGetIeeeEui64(GetInstancePtr(), aIeeeEui64.m8);
 }
 
-inline uint32_t Radio::GetSupportedChannelMask(void)
-{
-    return otPlatRadioGetSupportedChannelMask(GetInstancePtr());
-}
+inline uint32_t Radio::GetSupportedChannelMask(void) { return otPlatRadioGetSupportedChannelMask(GetInstancePtr()); }
 
-inline uint32_t Radio::GetPreferredChannelMask(void)
-{
-    return otPlatRadioGetPreferredChannelMask(GetInstancePtr());
-}
+inline uint32_t Radio::GetPreferredChannelMask(void) { return otPlatRadioGetPreferredChannelMask(GetInstancePtr()); }
 
 //---------------------------------------------------------------------------------------------------------------------
 // If IEEE 802.15.4 is among supported radio links, provide inline
@@ -695,20 +683,11 @@ inline uint32_t Radio::GetPreferredChannelMask(void)
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 
-inline otRadioCaps Radio::GetCaps(void)
-{
-    return otPlatRadioGetCaps(GetInstancePtr());
-}
+inline otRadioCaps Radio::GetCaps(void) { return otPlatRadioGetCaps(GetInstancePtr()); }
 
-inline int8_t Radio::GetReceiveSensitivity(void) const
-{
-    return otPlatRadioGetReceiveSensitivity(GetInstancePtr());
-}
+inline int8_t Radio::GetReceiveSensitivity(void) const { return otPlatRadioGetReceiveSensitivity(GetInstancePtr()); }
 
-inline void Radio::SetPanId(Mac::PanId aPanId)
-{
-    otPlatRadioSetPanId(GetInstancePtr(), aPanId);
-}
+inline void Radio::SetPanId(Mac::PanId aPanId) { otPlatRadioSetPanId(GetInstancePtr(), aPanId); }
 
 inline void Radio::SetMacKey(uint8_t                 aKeyIdMode,
                              uint8_t                 aKeyId,
@@ -727,15 +706,9 @@ inline void Radio::SetMacKey(uint8_t                 aKeyIdMode,
     otPlatRadioSetMacKey(GetInstancePtr(), aKeyIdMode, aKeyId, &aPrevKey, &aCurrKey, &aNextKey, aKeyType);
 }
 
-inline Error Radio::GetTransmitPower(int8_t &aPower)
-{
-    return otPlatRadioGetTransmitPower(GetInstancePtr(), &aPower);
-}
+inline Error Radio::GetTransmitPower(int8_t &aPower) { return otPlatRadioGetTransmitPower(GetInstancePtr(), &aPower); }
 
-inline Error Radio::SetTransmitPower(int8_t aPower)
-{
-    return otPlatRadioSetTransmitPower(GetInstancePtr(), aPower);
-}
+inline Error Radio::SetTransmitPower(int8_t aPower) { return otPlatRadioSetTransmitPower(GetInstancePtr(), aPower); }
 
 inline Error Radio::GetCcaEnergyDetectThreshold(int8_t &aThreshold)
 {
@@ -747,45 +720,21 @@ inline Error Radio::SetCcaEnergyDetectThreshold(int8_t aThreshold)
     return otPlatRadioSetCcaEnergyDetectThreshold(GetInstancePtr(), aThreshold);
 }
 
-inline bool Radio::GetPromiscuous(void)
-{
-    return otPlatRadioGetPromiscuous(GetInstancePtr());
-}
+inline bool Radio::GetPromiscuous(void) { return otPlatRadioGetPromiscuous(GetInstancePtr()); }
 
-inline void Radio::SetPromiscuous(bool aEnable)
-{
-    otPlatRadioSetPromiscuous(GetInstancePtr(), aEnable);
-}
+inline void Radio::SetPromiscuous(bool aEnable) { otPlatRadioSetPromiscuous(GetInstancePtr(), aEnable); }
 
-inline otRadioState Radio::GetState(void)
-{
-    return otPlatRadioGetState(GetInstancePtr());
-}
+inline otRadioState Radio::GetState(void) { return otPlatRadioGetState(GetInstancePtr()); }
 
-inline Error Radio::Enable(void)
-{
-    return otPlatRadioEnable(GetInstancePtr());
-}
+inline Error Radio::Enable(void) { return otPlatRadioEnable(GetInstancePtr()); }
 
-inline Error Radio::Disable(void)
-{
-    return otPlatRadioDisable(GetInstancePtr());
-}
+inline Error Radio::Disable(void) { return otPlatRadioDisable(GetInstancePtr()); }
 
-inline bool Radio::IsEnabled(void)
-{
-    return otPlatRadioIsEnabled(GetInstancePtr());
-}
+inline bool Radio::IsEnabled(void) { return otPlatRadioIsEnabled(GetInstancePtr()); }
 
-inline Error Radio::Sleep(void)
-{
-    return otPlatRadioSleep(GetInstancePtr());
-}
+inline Error Radio::Sleep(void) { return otPlatRadioSleep(GetInstancePtr()); }
 
-inline Error Radio::Receive(uint8_t aChannel)
-{
-    return otPlatRadioReceive(GetInstancePtr(), aChannel);
-}
+inline Error Radio::Receive(uint8_t aChannel) { return otPlatRadioReceive(GetInstancePtr(), aChannel); }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 inline void Radio::UpdateCslSampleTime(uint32_t aCslSampleTime)
@@ -805,17 +754,11 @@ inline Error Radio::EnableCsl(uint32_t aCslPeriod, otShortAddress aShortAddr, co
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-inline uint8_t Radio::GetCslAccuracy(void)
-{
-    return otPlatRadioGetCslAccuracy(GetInstancePtr());
-}
+inline uint8_t Radio::GetCslAccuracy(void) { return otPlatRadioGetCslAccuracy(GetInstancePtr()); }
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-inline uint8_t Radio::GetCslUncertainty(void)
-{
-    return otPlatRadioGetCslUncertainty(GetInstancePtr());
-}
+inline uint8_t Radio::GetCslUncertainty(void) { return otPlatRadioGetCslUncertainty(GetInstancePtr()); }
 #endif
 
 inline Mac::TxFrame &Radio::GetTransmitBuffer(void)
@@ -823,20 +766,14 @@ inline Mac::TxFrame &Radio::GetTransmitBuffer(void)
     return *static_cast<Mac::TxFrame *>(otPlatRadioGetTransmitBuffer(GetInstancePtr()));
 }
 
-inline int8_t Radio::GetRssi(void)
-{
-    return otPlatRadioGetRssi(GetInstancePtr());
-}
+inline int8_t Radio::GetRssi(void) { return otPlatRadioGetRssi(GetInstancePtr()); }
 
 inline Error Radio::EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration)
 {
     return otPlatRadioEnergyScan(GetInstancePtr(), aScanChannel, aScanDuration);
 }
 
-inline void Radio::EnableSrcMatch(bool aEnable)
-{
-    otPlatRadioEnableSrcMatch(GetInstancePtr(), aEnable);
-}
+inline void Radio::EnableSrcMatch(bool aEnable) { otPlatRadioEnableSrcMatch(GetInstancePtr(), aEnable); }
 
 inline Error Radio::AddSrcMatchShortEntry(Mac::ShortAddress aShortAddress)
 {
@@ -858,15 +795,9 @@ inline Error Radio::ClearSrcMatchExtEntry(const Mac::ExtAddress &aExtAddress)
     return otPlatRadioClearSrcMatchExtEntry(GetInstancePtr(), &aExtAddress);
 }
 
-inline void Radio::ClearSrcMatchShortEntries(void)
-{
-    otPlatRadioClearSrcMatchShortEntries(GetInstancePtr());
-}
+inline void Radio::ClearSrcMatchShortEntries(void) { otPlatRadioClearSrcMatchShortEntries(GetInstancePtr()); }
 
-inline void Radio::ClearSrcMatchExtEntries(void)
-{
-    otPlatRadioClearSrcMatchExtEntries(GetInstancePtr());
-}
+inline void Radio::ClearSrcMatchExtEntries(void) { otPlatRadioClearSrcMatchExtEntries(GetInstancePtr()); }
 
 #else //----------------------------------------------------------------------------------------------------------------
 
@@ -875,22 +806,13 @@ inline otRadioCaps Radio::GetCaps(void)
     return OT_RADIO_CAPS_ACK_TIMEOUT | OT_RADIO_CAPS_CSMA_BACKOFF | OT_RADIO_CAPS_TRANSMIT_RETRIES;
 }
 
-inline int8_t Radio::GetReceiveSensitivity(void) const
-{
-    return -110;
-}
+inline int8_t Radio::GetReceiveSensitivity(void) const { return -110; }
 
-inline void Radio::SetPanId(Mac::PanId)
-{
-}
+inline void Radio::SetPanId(Mac::PanId) {}
 
-inline void Radio::SetExtendedAddress(const Mac::ExtAddress &)
-{
-}
+inline void Radio::SetExtendedAddress(const Mac::ExtAddress &) {}
 
-inline void Radio::SetShortAddress(Mac::ShortAddress)
-{
-}
+inline void Radio::SetShortAddress(Mac::ShortAddress) {}
 
 inline void Radio::SetMacKey(uint8_t,
                              uint8_t,
@@ -900,74 +822,34 @@ inline void Radio::SetMacKey(uint8_t,
 {
 }
 
-inline Error Radio::GetTransmitPower(int8_t &)
-{
-    return kErrorNotImplemented;
-}
+inline Error Radio::GetTransmitPower(int8_t &) { return kErrorNotImplemented; }
 
-inline Error Radio::SetTransmitPower(int8_t)
-{
-    return kErrorNotImplemented;
-}
+inline Error Radio::SetTransmitPower(int8_t) { return kErrorNotImplemented; }
 
-inline Error Radio::GetCcaEnergyDetectThreshold(int8_t &)
-{
-    return kErrorNotImplemented;
-}
+inline Error Radio::GetCcaEnergyDetectThreshold(int8_t &) { return kErrorNotImplemented; }
 
-inline Error Radio::SetCcaEnergyDetectThreshold(int8_t)
-{
-    return kErrorNotImplemented;
-}
+inline Error Radio::SetCcaEnergyDetectThreshold(int8_t) { return kErrorNotImplemented; }
 
-inline bool Radio::GetPromiscuous(void)
-{
-    return false;
-}
+inline bool Radio::GetPromiscuous(void) { return false; }
 
-inline void Radio::SetPromiscuous(bool)
-{
-}
+inline void Radio::SetPromiscuous(bool) {}
 
-inline otRadioState Radio::GetState(void)
-{
-    return OT_RADIO_STATE_DISABLED;
-}
+inline otRadioState Radio::GetState(void) { return OT_RADIO_STATE_DISABLED; }
 
-inline Error Radio::Enable(void)
-{
-    return kErrorNone;
-}
+inline Error Radio::Enable(void) { return kErrorNone; }
 
-inline Error Radio::Disable(void)
-{
-    return kErrorInvalidState;
-}
+inline Error Radio::Disable(void) { return kErrorInvalidState; }
 
-inline bool Radio::IsEnabled(void)
-{
-    return true;
-}
+inline bool Radio::IsEnabled(void) { return true; }
 
-inline Error Radio::Sleep(void)
-{
-    return kErrorNone;
-}
+inline Error Radio::Sleep(void) { return kErrorNone; }
 
-inline Error Radio::Receive(uint8_t)
-{
-    return kErrorNone;
-}
+inline Error Radio::Receive(uint8_t) { return kErrorNone; }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-inline void Radio::UpdateCslSampleTime(uint32_t)
-{
-}
+inline void Radio::UpdateCslSampleTime(uint32_t) {}
 
-inline Error Radio::ReceiveAt(uint8_t, uint32_t, uint32_t)
-{
-    return kErrorNone;
-}
+inline Error Radio::ReceiveAt(uint8_t, uint32_t, uint32_t) { return kErrorNone; }
 
 inline Error Radio::EnableCsl(uint32_t, otShortAddress aShortAddr, const otExtAddress *)
 {
@@ -976,15 +858,9 @@ inline Error Radio::EnableCsl(uint32_t, otShortAddress aShortAddr, const otExtAd
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-inline uint8_t Radio::GetCslAccuracy(void)
-{
-    return UINT8_MAX;
-}
+inline uint8_t Radio::GetCslAccuracy(void) { return UINT8_MAX; }
 
-inline uint8_t Radio::GetCslUncertainty(void)
-{
-    return UINT8_MAX;
-}
+inline uint8_t Radio::GetCslUncertainty(void) { return UINT8_MAX; }
 #endif
 
 inline Mac::TxFrame &Radio::GetTransmitBuffer(void)
@@ -992,52 +868,25 @@ inline Mac::TxFrame &Radio::GetTransmitBuffer(void)
     return *static_cast<Mac::TxFrame *>(otPlatRadioGetTransmitBuffer(GetInstancePtr()));
 }
 
-inline Error Radio::Transmit(Mac::TxFrame &)
-{
-    return kErrorAbort;
-}
+inline Error Radio::Transmit(Mac::TxFrame &) { return kErrorAbort; }
 
-inline int8_t Radio::GetRssi(void)
-{
-    return kInvalidRssi;
-}
+inline int8_t Radio::GetRssi(void) { return kInvalidRssi; }
 
-inline Error Radio::EnergyScan(uint8_t, uint16_t)
-{
-    return kErrorNotImplemented;
-}
+inline Error Radio::EnergyScan(uint8_t, uint16_t) { return kErrorNotImplemented; }
 
-inline void Radio::EnableSrcMatch(bool)
-{
-}
+inline void Radio::EnableSrcMatch(bool) {}
 
-inline Error Radio::AddSrcMatchShortEntry(Mac::ShortAddress)
-{
-    return kErrorNone;
-}
+inline Error Radio::AddSrcMatchShortEntry(Mac::ShortAddress) { return kErrorNone; }
 
-inline Error Radio::AddSrcMatchExtEntry(const Mac::ExtAddress &)
-{
-    return kErrorNone;
-}
+inline Error Radio::AddSrcMatchExtEntry(const Mac::ExtAddress &) { return kErrorNone; }
 
-inline Error Radio::ClearSrcMatchShortEntry(Mac::ShortAddress)
-{
-    return kErrorNone;
-}
+inline Error Radio::ClearSrcMatchShortEntry(Mac::ShortAddress) { return kErrorNone; }
 
-inline Error Radio::ClearSrcMatchExtEntry(const Mac::ExtAddress &)
-{
-    return kErrorNone;
-}
+inline Error Radio::ClearSrcMatchExtEntry(const Mac::ExtAddress &) { return kErrorNone; }
 
-inline void Radio::ClearSrcMatchShortEntries(void)
-{
-}
+inline void Radio::ClearSrcMatchShortEntries(void) {}
 
-inline void Radio::ClearSrcMatchExtEntries(void)
-{
-}
+inline void Radio::ClearSrcMatchExtEntries(void) {}
 
 #endif // #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 

--- a/src/core/radio/radio_callbacks.cpp
+++ b/src/core/radio/radio_callbacks.cpp
@@ -43,20 +43,14 @@ void Radio::Callbacks::HandleReceiveDone(Mac::RxFrame *aFrame, Error aError)
     Get<Mac::SubMac>().HandleReceiveDone(aFrame, aError);
 }
 
-void Radio::Callbacks::HandleTransmitStarted(Mac::TxFrame &aFrame)
-{
-    Get<Mac::SubMac>().HandleTransmitStarted(aFrame);
-}
+void Radio::Callbacks::HandleTransmitStarted(Mac::TxFrame &aFrame) { Get<Mac::SubMac>().HandleTransmitStarted(aFrame); }
 
 void Radio::Callbacks::HandleTransmitDone(Mac::TxFrame &aFrame, Mac::RxFrame *aAckFrame, Error aError)
 {
     Get<Mac::SubMac>().HandleTransmitDone(aFrame, aAckFrame, aError);
 }
 
-void Radio::Callbacks::HandleEnergyScanDone(int8_t aMaxRssi)
-{
-    Get<Mac::SubMac>().HandleEnergyScanDone(aMaxRssi);
-}
+void Radio::Callbacks::HandleEnergyScanDone(int8_t aMaxRssi) { Get<Mac::SubMac>().HandleEnergyScanDone(aMaxRssi); }
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
 void Radio::Callbacks::HandleDiagsReceiveDone(Mac::RxFrame *aFrame, Error aError)

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -145,30 +145,18 @@ extern "C" void otPlatDiagRadioTransmitDone(otInstance *aInstance, otRadioFrame 
 
 #else // #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 
-extern "C" void otPlatRadioReceiveDone(otInstance *, otRadioFrame *, otError)
-{
-}
+extern "C" void otPlatRadioReceiveDone(otInstance *, otRadioFrame *, otError) {}
 
-extern "C" void otPlatRadioTxStarted(otInstance *, otRadioFrame *)
-{
-}
+extern "C" void otPlatRadioTxStarted(otInstance *, otRadioFrame *) {}
 
-extern "C" void otPlatRadioTxDone(otInstance *, otRadioFrame *, otRadioFrame *, otError)
-{
-}
+extern "C" void otPlatRadioTxDone(otInstance *, otRadioFrame *, otRadioFrame *, otError) {}
 
-extern "C" void otPlatRadioEnergyScanDone(otInstance *, int8_t)
-{
-}
+extern "C" void otPlatRadioEnergyScanDone(otInstance *, int8_t) {}
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-extern "C" void otPlatDiagRadioReceiveDone(otInstance *, otRadioFrame *, otError)
-{
-}
+extern "C" void otPlatDiagRadioReceiveDone(otInstance *, otRadioFrame *, otError) {}
 
-extern "C" void otPlatDiagRadioTransmitDone(otInstance *, otRadioFrame *, otError)
-{
-}
+extern "C" void otPlatDiagRadioTransmitDone(otInstance *, otRadioFrame *, otError) {}
 #endif
 
 #endif // // #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
@@ -224,10 +212,7 @@ OT_TOOL_WEAK void otPlatRadioSetMacFrameCounter(otInstance *aInstance, uint32_t 
     OT_UNUSED_VARIABLE(aMacFrameCounter);
 }
 
-OT_TOOL_WEAK uint64_t otPlatTimeGet(void)
-{
-    return UINT64_MAX;
-}
+OT_TOOL_WEAK uint64_t otPlatTimeGet(void) { return UINT64_MAX; }
 
 OT_TOOL_WEAK uint64_t otPlatRadioGetNow(otInstance *aInstance)
 {

--- a/src/core/radio/trel_link.cpp
+++ b/src/core/radio/trel_link.cpp
@@ -70,10 +70,7 @@ Link::Link(Instance &aInstance)
     mTimer.Start(kAckWaitWindow);
 }
 
-void Link::AfterInit(void)
-{
-    mInterface.Init();
-}
+void Link::AfterInit(void) { mInterface.Init(); }
 
 void Link::Enable(void)
 {
@@ -116,10 +113,7 @@ void Link::Send(void)
     mTxTasklet.Post();
 }
 
-void Link::HandleTxTasklet(void)
-{
-    BeginTransmit();
-}
+void Link::HandleTxTasklet(void) { BeginTransmit(); }
 
 void Link::BeginTransmit(void)
 {

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -168,10 +168,7 @@ void AddressResolver::Remove(uint8_t aRouterId)
     Remove(Mle::Rloc16FromRouterId(aRouterId), /* aMatchRouterId */ true);
 }
 
-void AddressResolver::Remove(uint16_t aRloc16)
-{
-    Remove(aRloc16, /* aMatchRouterId */ false);
-}
+void AddressResolver::Remove(uint16_t aRloc16) { Remove(aRloc16, /* aMatchRouterId */ false); }
 
 AddressResolver::CacheEntry *AddressResolver::GetEntryAfter(CacheEntry *aPrev, CacheEntryList &aList)
 {
@@ -224,10 +221,7 @@ exit:
     return entry;
 }
 
-void AddressResolver::Remove(const Ip6::Address &aEid)
-{
-    Remove(aEid, kReasonRemovingEid);
-}
+void AddressResolver::Remove(const Ip6::Address &aEid) { Remove(aEid, kReasonRemovingEid); }
 
 void AddressResolver::Remove(const Ip6::Address &aEid, Reason aReason)
 {
@@ -1069,9 +1063,7 @@ exit:
 
 #else // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
-void AddressResolver::LogCacheEntryChange(EntryChange, Reason, const CacheEntry &, CacheEntryList *)
-{
-}
+void AddressResolver::LogCacheEntryChange(EntryChange, Reason, const CacheEntry &, CacheEntryList *) {}
 
 #endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
 

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -329,10 +329,7 @@ private:
         kReasonRemovingEid,
     };
 
-    CacheEntryPool &GetCacheEntryPool(void)
-    {
-        return mCacheEntryPool;
-    }
+    CacheEntryPool &GetCacheEntryPool(void) { return mCacheEntryPool; }
 
     Error       Resolve(const Ip6::Address &aEid, Mac::ShortAddress &aRloc16, bool aAllowAddressQuery);
     void        Remove(Mac::ShortAddress aRloc16, bool aMatchRouterId);

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -161,10 +161,7 @@ AnnounceSender::AnnounceSender(Instance &aInstance)
     SetJitter(kMaxJitter);
 }
 
-void AnnounceSender::UpdateOnReceivedAnnounce(void)
-{
-    mTrickleTimer.IndicateConsistent();
-}
+void AnnounceSender::UpdateOnReceivedAnnounce(void) { mTrickleTimer.IndicateConsistent(); }
 
 void AnnounceSender::Stop(void)
 {
@@ -173,15 +170,9 @@ void AnnounceSender::Stop(void)
     LogInfo("Stopped");
 }
 
-void AnnounceSender::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<AnnounceSender>().AnnounceSenderBase::HandleTimer();
-}
+void AnnounceSender::HandleTimer(Timer &aTimer) { aTimer.Get<AnnounceSender>().AnnounceSenderBase::HandleTimer(); }
 
-void AnnounceSender::HandleTrickleTimer(TrickleTimer &aTimer)
-{
-    aTimer.Get<AnnounceSender>().HandleTrickleTimer();
-}
+void AnnounceSender::HandleTrickleTimer(TrickleTimer &aTimer) { aTimer.Get<AnnounceSender>().HandleTrickleTimer(); }
 
 void AnnounceSender::HandleTrickleTimer(void)
 {

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -243,10 +243,7 @@ exit:
 
 #else // OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 
-Mac::TxFrame *CslTxScheduler::HandleFrameRequest(Mac::TxFrames &)
-{
-    return nullptr;
-}
+Mac::TxFrame *CslTxScheduler::HandleFrameRequest(Mac::TxFrames &) { return nullptr; }
 
 #endif // OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -121,10 +121,7 @@ public:
      * @returns A reference to the Domain Unicast Address.
      *
      */
-    const Ip6::Address &GetDomainUnicastAddress(void) const
-    {
-        return mDomainUnicastAddress.GetAddress();
-    }
+    const Ip6::Address &GetDomainUnicastAddress(void) const { return mDomainUnicastAddress.GetAddress(); }
 
     /**
      * This method sets the Interface Identifier manually specified for the Thread Domain Unicast Address.
@@ -151,10 +148,7 @@ public:
      * @retval false If there is no Interface Identifier manually specified.
      *
      */
-    bool IsFixedDuaInterfaceIdentifierSet(void)
-    {
-        return !mFixedDuaInterfaceIdentifier.IsUnspecified();
-    }
+    bool IsFixedDuaInterfaceIdentifierSet(void) { return !mFixedDuaInterfaceIdentifier.IsUnspecified(); }
 
     /**
      * This method gets the Interface Identifier for the Thread Domain Unicast Address if manually specified.
@@ -162,10 +156,7 @@ public:
      * @returns A reference to the Interface Identifier.
      *
      */
-    const Ip6::InterfaceIdentifier &GetFixedDuaInterfaceIdentifier(void) const
-    {
-        return mFixedDuaInterfaceIdentifier;
-    }
+    const Ip6::InterfaceIdentifier &GetFixedDuaInterfaceIdentifier(void) const { return mFixedDuaInterfaceIdentifier; }
 
     /*
      * This method restores duplicate address detection information from non-volatile memory.

--- a/src/core/thread/indirect_sender.hpp
+++ b/src/core/thread/indirect_sender.hpp
@@ -145,10 +145,7 @@ public:
      * This method enables indirect transmissions.
      *
      */
-    void Start(void)
-    {
-        mEnabled = true;
-    }
+    void Start(void) { mEnabled = true; }
 
     /**
      * This method disables indirect transmission.

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -202,10 +202,7 @@ void KeyManager::Start(void)
     StartKeyRotationTimer();
 }
 
-void KeyManager::Stop(void)
-{
-    mKeyRotationTimer.Stop();
-}
+void KeyManager::Stop(void) { mKeyRotationTimer.Stop(); }
 
 void KeyManager::SetPskc(const Pskc &aPskc)
 {
@@ -444,9 +441,7 @@ exit:
     return;
 }
 #else
-void KeyManager::MacFrameCounterUsed(uint32_t)
-{
-}
+void KeyManager::MacFrameCounterUsed(uint32_t) {}
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -148,10 +148,7 @@ public:
      * @retval kErrorFailed   Failed to generate random sequence.
      *
      */
-    Error GenerateRandom(void)
-    {
-        return Random::Crypto::FillBuffer(m8, sizeof(m8));
-    }
+    Error GenerateRandom(void) { return Random::Crypto::FillBuffer(m8, sizeof(m8)); }
 #endif
 
 } OT_TOOL_PACKED_END;
@@ -181,10 +178,7 @@ public:
      * @retval kErrorNone  Successfully generated a random Thread PSKc.
      *
      */
-    Error GenerateRandom(void)
-    {
-        return Random::Crypto::FillBuffer(m8, sizeof(m8));
-    }
+    Error GenerateRandom(void) { return Random::Crypto::FillBuffer(m8, sizeof(m8)); }
 #endif
 } OT_TOOL_PACKED_END;
 
@@ -260,10 +254,7 @@ public:
      * @returns A key reference to the Thread Network Key.
      *
      */
-    NetworkKeyRef GetNetworkKeyRef(void)
-    {
-        return mNetworkKeyRef;
-    }
+    NetworkKeyRef GetNetworkKeyRef(void) { return mNetworkKeyRef; }
 
     /**
      * This method sets the Thread Network Key using Key Reference.
@@ -283,10 +274,7 @@ public:
      * @retval FALSE if the PSKc is not not configured.
      *
      */
-    bool IsPskcSet(void) const
-    {
-        return mIsPskcSet;
-    }
+    bool IsPskcSet(void) const { return mIsPskcSet; }
 
     /**
      * This method gets the PKSc.
@@ -311,10 +299,7 @@ public:
      * @returns A key reference to the PSKc.
      *
      */
-    const PskcRef &GetPskcRef(void)
-    {
-        return mPskcRef;
-    }
+    const PskcRef &GetPskcRef(void) { return mPskcRef; }
 
     /**
      * This method sets the PSKc as a Key reference.
@@ -331,10 +316,7 @@ public:
      * @returns The current key sequence value.
      *
      */
-    uint32_t GetCurrentKeySequence(void) const
-    {
-        return mKeySequence;
-    }
+    uint32_t GetCurrentKeySequence(void) const { return mKeySequence; }
 
     /**
      * This method sets the current key sequence value.
@@ -351,10 +333,7 @@ public:
      * @returns The current TREL MAC key.
      *
      */
-    const Mac::KeyMaterial &GetCurrentTrelMacKey(void) const
-    {
-        return mTrelKey;
-    }
+    const Mac::KeyMaterial &GetCurrentTrelMacKey(void) const { return mTrelKey; }
 
     /**
      * This method returns a temporary MAC key for TREL radio link computed from the given key sequence.
@@ -373,10 +352,7 @@ public:
      * @returns The current MLE key.
      *
      */
-    const Mle::KeyMaterial &GetCurrentMleKey(void) const
-    {
-        return mMleKey;
-    }
+    const Mle::KeyMaterial &GetCurrentMleKey(void) const { return mMleKey; }
 
     /**
      * This method returns a temporary MLE key Material computed from the given key sequence.
@@ -395,10 +371,7 @@ public:
      * @returns The current MAC Frame Counter value.
      *
      */
-    uint32_t Get154MacFrameCounter(void) const
-    {
-        return mMacFrameCounters.Get154();
-    }
+    uint32_t Get154MacFrameCounter(void) const { return mMacFrameCounters.Get154(); }
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
@@ -408,10 +381,7 @@ public:
      * @returns The current MAC Frame Counter value for TREL radio link.
      *
      */
-    uint32_t GetTrelMacFrameCounter(void) const
-    {
-        return mMacFrameCounters.GetTrel();
-    }
+    uint32_t GetTrelMacFrameCounter(void) const { return mMacFrameCounters.GetTrel(); }
 
     /**
      * This method increments the current MAC Frame Counter value for TREL radio link.
@@ -426,10 +396,7 @@ public:
      * @return The maximum MAC frame Counter among all supported radio links.
      *
      */
-    uint32_t GetMaximumMacFrameCounter(void) const
-    {
-        return mMacFrameCounters.GetMaximum();
-    }
+    uint32_t GetMaximumMacFrameCounter(void) const { return mMacFrameCounters.GetMaximum(); }
 
     /**
      * This method sets the current MAC Frame Counter value for all radio links.
@@ -445,10 +412,7 @@ public:
      * @param[in]  aStoredMacFrameCounter  The stored MAC Frame Counter value.
      *
      */
-    void SetStoredMacFrameCounter(uint32_t aStoredMacFrameCounter)
-    {
-        mStoredMacFrameCounter = aStoredMacFrameCounter;
-    }
+    void SetStoredMacFrameCounter(uint32_t aStoredMacFrameCounter) { mStoredMacFrameCounter = aStoredMacFrameCounter; }
 
     /**
      * This method returns the current MLE Frame Counter value.
@@ -456,10 +420,7 @@ public:
      * @returns The current MLE Frame Counter value.
      *
      */
-    uint32_t GetMleFrameCounter(void) const
-    {
-        return mMleFrameCounter;
-    }
+    uint32_t GetMleFrameCounter(void) const { return mMleFrameCounter; }
 
     /**
      * This method sets the current MLE Frame Counter value.
@@ -467,10 +428,7 @@ public:
      * @param[in]  aMleFrameCounter  The MLE Frame Counter value.
      *
      */
-    void SetMleFrameCounter(uint32_t aMleFrameCounter)
-    {
-        mMleFrameCounter = aMleFrameCounter;
-    }
+    void SetMleFrameCounter(uint32_t aMleFrameCounter) { mMleFrameCounter = aMleFrameCounter; }
 
     /**
      * This method sets the MLE Frame Counter value which is stored in non-volatile memory.
@@ -478,10 +436,7 @@ public:
      * @param[in]  aStoredMleFrameCounter  The stored MLE Frame Counter value.
      *
      */
-    void SetStoredMleFrameCounter(uint32_t aStoredMleFrameCounter)
-    {
-        mStoredMleFrameCounter = aStoredMleFrameCounter;
-    }
+    void SetStoredMleFrameCounter(uint32_t aStoredMleFrameCounter) { mStoredMleFrameCounter = aStoredMleFrameCounter; }
 
     /**
      * This method increments the current MLE Frame Counter value.
@@ -495,10 +450,7 @@ public:
      * @returns The KEK as `KekKeyMaterial`.
      *
      */
-    const KekKeyMaterial &GetKek(void) const
-    {
-        return mKek;
-    }
+    const KekKeyMaterial &GetKek(void) const { return mKek; }
 
     /**
      * This method retrieves the KEK as literal `Kek` key.
@@ -506,10 +458,7 @@ public:
      * @param[out] aKek  A reference to a `Kek` to output the retrieved KEK.
      *
      */
-    void ExtractKek(Kek &aKek)
-    {
-        mKek.ExtractKey(aKek);
-    }
+    void ExtractKek(Kek &aKek) { mKek.ExtractKey(aKek); }
 
     /**
      * This method sets the KEK.
@@ -525,10 +474,7 @@ public:
      * @param[in]  aKekBytes  A pointer to the KEK bytes.
      *
      */
-    void SetKek(const uint8_t *aKekBytes)
-    {
-        SetKek(*reinterpret_cast<const Kek *>(aKekBytes));
-    }
+    void SetKek(const uint8_t *aKekBytes) { SetKek(*reinterpret_cast<const Kek *>(aKekBytes)); }
 
     /**
      * This method returns the current KEK Frame Counter value.
@@ -536,19 +482,13 @@ public:
      * @returns The current KEK Frame Counter value.
      *
      */
-    uint32_t GetKekFrameCounter(void) const
-    {
-        return mKekFrameCounter;
-    }
+    uint32_t GetKekFrameCounter(void) const { return mKekFrameCounter; }
 
     /**
      * This method increments the current KEK Frame Counter value.
      *
      */
-    void IncrementKekFrameCounter(void)
-    {
-        mKekFrameCounter++;
-    }
+    void IncrementKekFrameCounter(void) { mKekFrameCounter++; }
 
     /**
      * This method returns the KeySwitchGuardTime.
@@ -558,10 +498,7 @@ public:
      * @returns The KeySwitchGuardTime value in hours.
      *
      */
-    uint32_t GetKeySwitchGuardTime(void) const
-    {
-        return mKeySwitchGuardTime;
-    }
+    uint32_t GetKeySwitchGuardTime(void) const { return mKeySwitchGuardTime; }
 
     /**
      * This method sets the KeySwitchGuardTime.
@@ -571,10 +508,7 @@ public:
      * @param[in]  aKeySwitchGuardTime  The KeySwitchGuardTime value in hours.
      *
      */
-    void SetKeySwitchGuardTime(uint32_t aKeySwitchGuardTime)
-    {
-        mKeySwitchGuardTime = aKeySwitchGuardTime;
-    }
+    void SetKeySwitchGuardTime(uint32_t aKeySwitchGuardTime) { mKeySwitchGuardTime = aKeySwitchGuardTime; }
 
     /**
      * This method returns the Security Policy.
@@ -585,10 +519,7 @@ public:
      * @returns The SecurityPolicy.
      *
      */
-    const SecurityPolicy &GetSecurityPolicy(void) const
-    {
-        return mSecurityPolicy;
-    }
+    const SecurityPolicy &GetSecurityPolicy(void) const { return mSecurityPolicy; }
 
     /**
      * This method sets the Security Policy.

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -681,10 +681,7 @@ exit:
     return error;
 }
 
-bool MeshForwarder::GetRxOnWhenIdle(void) const
-{
-    return Get<Mac::Mac>().GetRxOnWhenIdle();
-}
+bool MeshForwarder::GetRxOnWhenIdle(void) const { return Get<Mac::Mac>().GetRxOnWhenIdle(); }
 
 void MeshForwarder::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 {
@@ -1925,9 +1922,7 @@ void MeshForwarder::LogIp6SourceDestAddresses(const Ip6::Headers &aHeaders, LogL
     }
 }
 #else
-void MeshForwarder::LogIp6SourceDestAddresses(const Ip6::Headers &, LogLevel)
-{
-}
+void MeshForwarder::LogIp6SourceDestAddresses(const Ip6::Headers &, LogLevel) {}
 #endif
 
 void MeshForwarder::LogIp6Message(MessageAction       aAction,
@@ -2060,21 +2055,15 @@ void MeshForwarder::LogLowpanHcFrameDrop(Error                 aError,
 
 #else // #if OT_SHOULD_LOG_AT( OT_LOG_LEVEL_NOTE)
 
-void MeshForwarder::LogMessage(MessageAction, const Message &, Error, const Mac::Address *)
-{
-}
+void MeshForwarder::LogMessage(MessageAction, const Message &, Error, const Mac::Address *) {}
 
-void MeshForwarder::LogFrame(const char *, const Mac::Frame &, Error)
-{
-}
+void MeshForwarder::LogFrame(const char *, const Mac::Frame &, Error) {}
 
 void MeshForwarder::LogFragmentFrameDrop(Error, uint16_t, const Mac::Addresses &, const Lowpan::FragmentHeader &, bool)
 {
 }
 
-void MeshForwarder::LogLowpanHcFrameDrop(Error, uint16_t, const Mac::Addresses &, bool)
-{
-}
+void MeshForwarder::LogLowpanHcFrameDrop(Error, uint16_t, const Mac::Addresses &, bool) {}
 
 #endif // #if OT_SHOULD_LOG_AT( OT_LOG_LEVEL_NOTE)
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -138,10 +138,7 @@ public:
      * @returns The Time Sync Sequence.
      *
      */
-    uint8_t GetTimeSyncSeq(void) const
-    {
-        return mTimeSyncSeq;
-    }
+    uint8_t GetTimeSyncSeq(void) const { return mTimeSyncSeq; }
 
     /**
      * This method returns the time offset to the Thread network time (in microseconds).
@@ -149,10 +146,7 @@ public:
      * @returns The time offset to the Thread network time (in microseconds).
      *
      */
-    int64_t GetNetworkTimeOffset(void) const
-    {
-        return mNetworkTimeOffset;
-    }
+    int64_t GetNetworkTimeOffset(void) const { return mNetworkTimeOffset; }
 #endif
 
     /**
@@ -293,10 +287,7 @@ public:
      * @returns  A reference to the send queue.
      *
      */
-    const PriorityQueue &GetSendQueue(void) const
-    {
-        return mSendQueue;
-    }
+    const PriorityQueue &GetSendQueue(void) const { return mSendQueue; }
 
     /**
      * This method returns a reference to the reassembly queue.
@@ -304,10 +295,7 @@ public:
      * @returns  A reference to the reassembly queue.
      *
      */
-    const MessageQueue &GetReassemblyQueue(void) const
-    {
-        return mReassemblyList;
-    }
+    const MessageQueue &GetReassemblyQueue(void) const { return mReassemblyList; }
 
     /**
      * This method returns a reference to the IP level counters.
@@ -315,19 +303,13 @@ public:
      * @returns A reference to the IP level counters.
      *
      */
-    const otIpCounters &GetCounters(void) const
-    {
-        return mIpCounters;
-    }
+    const otIpCounters &GetCounters(void) const { return mIpCounters; }
 
     /**
      * This method resets the IP level counters.
      *
      */
-    void ResetCounters(void)
-    {
-        memset(&mIpCounters, 0, sizeof(mIpCounters));
-    }
+    void ResetCounters(void) { memset(&mIpCounters, 0, sizeof(mIpCounters)); }
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
     /**
@@ -400,22 +382,10 @@ private:
                 kReassemblyTimeout;
 #endif
 
-            Message::Priority GetPriority(void) const
-            {
-                return static_cast<Message::Priority>(mPriority);
-            }
-            bool IsExpired(void) const
-            {
-                return (mLifetime == 0);
-            }
-            void DecrementLifetime(void)
-            {
-                mLifetime--;
-            }
-            void ResetLifetime(void)
-            {
-                mLifetime = kLifetime;
-            }
+            Message::Priority GetPriority(void) const { return static_cast<Message::Priority>(mPriority); }
+            bool              IsExpired(void) const { return (mLifetime == 0); }
+            void              DecrementLifetime(void) { mLifetime--; }
+            void              ResetLifetime(void) { mLifetime = kLifetime; }
 
             bool Matches(uint16_t aSrcRloc16, uint16_t aTag) const
             {
@@ -423,14 +393,8 @@ private:
             }
 
 #if OPENTHREAD_CONFIG_DELAY_AWARE_QUEUE_MANAGEMENT_ENABLE
-            bool ShouldDrop(void) const
-            {
-                return mShouldDrop;
-            }
-            void MarkToDrop(void)
-            {
-                mShouldDrop = true;
-            }
+            bool ShouldDrop(void) const { return mShouldDrop; }
+            void MarkToDrop(void) { mShouldDrop = true; }
 #endif
 
         private:
@@ -540,10 +504,7 @@ private:
     void AppendHeaderIe(const Message *aMessage, Mac::TxFrame &aFrame);
 #endif
 
-    void PauseMessageTransmissions(void)
-    {
-        mTxPaused = true;
-    }
+    void PauseMessageTransmissions(void) { mTxPaused = true; }
     void ResumeMessageTransmissions(void);
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_COLLISION_AVOIDANCE_DELAY_ENABLE

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -660,15 +660,9 @@ exit:
     return delay;
 }
 
-bool Mle::IsAttached(void) const
-{
-    return (IsChild() || IsRouter() || IsLeader());
-}
+bool Mle::IsAttached(void) const { return (IsChild() || IsRouter() || IsLeader()); }
 
-bool Mle::IsRouterOrLeader(void) const
-{
-    return (IsRouter() || IsLeader());
-}
+bool Mle::IsRouterOrLeader(void) const { return (IsRouter() || IsLeader()); }
 
 void Mle::SetStateDetached(void)
 {
@@ -958,10 +952,7 @@ exit:
     Get<Notifier>().Signal(kEventThreadMeshLocalAddrChanged);
 }
 
-uint16_t Mle::GetRloc16(void) const
-{
-    return Get<Mac::Mac>().GetShortAddress();
-}
+uint16_t Mle::GetRloc16(void) const { return Get<Mac::Mac>().GetShortAddress(); }
 
 void Mle::SetRloc16(uint16_t aRloc16)
 {
@@ -1983,10 +1974,7 @@ exit:
     return;
 }
 
-Error Mle::SendChildUpdateRequest(bool aAppendChallenge)
-{
-    return SendChildUpdateRequest(aAppendChallenge, mTimeout);
-}
+Error Mle::SendChildUpdateRequest(bool aAppendChallenge) { return SendChildUpdateRequest(aAppendChallenge, mTimeout); }
 
 Error Mle::SendChildUpdateRequest(bool aAppendChallenge, uint32_t aTimeout)
 {
@@ -4012,15 +4000,9 @@ void Mle::Log(MessageAction aAction, MessageType aType, const Ip6::Address &aAdd
 #endif
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
-void Mle::LogProcessError(MessageType aType, Error aError)
-{
-    LogError(kMessageReceive, aType, aError);
-}
+void Mle::LogProcessError(MessageType aType, Error aError) { LogError(kMessageReceive, aType, aError); }
 
-void Mle::LogSendError(MessageType aType, Error aError)
-{
-    LogError(kMessageSend, aType, aError);
-}
+void Mle::LogSendError(MessageType aType, Error aError) { LogError(kMessageSend, aType, aError); }
 
 void Mle::LogError(MessageAction aAction, MessageType aType, Error aError)
 {
@@ -4350,10 +4332,7 @@ exit:
     return error;
 }
 
-void Mle::HandleDetachGracefullyTimer(void)
-{
-    Stop();
-}
+void Mle::HandleDetachGracefullyTimer(void) { Stop(); }
 
 //---------------------------------------------------------------------------------------------------------------------
 // TlvList
@@ -4489,20 +4468,11 @@ Error Mle::TxMessage::AppendSourceAddressTlv(void)
     return Tlv::Append<SourceAddressTlv>(*this, Get<Mle>().GetRloc16());
 }
 
-Error Mle::TxMessage::AppendStatusTlv(StatusTlv::Status aStatus)
-{
-    return Tlv::Append<StatusTlv>(*this, aStatus);
-}
+Error Mle::TxMessage::AppendStatusTlv(StatusTlv::Status aStatus) { return Tlv::Append<StatusTlv>(*this, aStatus); }
 
-Error Mle::TxMessage::AppendModeTlv(DeviceMode aMode)
-{
-    return Tlv::Append<ModeTlv>(*this, aMode.Get());
-}
+Error Mle::TxMessage::AppendModeTlv(DeviceMode aMode) { return Tlv::Append<ModeTlv>(*this, aMode.Get()); }
 
-Error Mle::TxMessage::AppendTimeoutTlv(uint32_t aTimeout)
-{
-    return Tlv::Append<TimeoutTlv>(*this, aTimeout);
-}
+Error Mle::TxMessage::AppendTimeoutTlv(uint32_t aTimeout) { return Tlv::Append<TimeoutTlv>(*this, aTimeout); }
 
 Error Mle::TxMessage::AppendChallengeTlv(const Challenge &aChallenge)
 {
@@ -4542,10 +4512,7 @@ Error Mle::TxMessage::AppendMleFrameCounterTlv(void)
     return Tlv::Append<MleFrameCounterTlv>(*this, Get<KeyManager>().GetMleFrameCounter());
 }
 
-Error Mle::TxMessage::AppendAddress16Tlv(uint16_t aRloc16)
-{
-    return Tlv::Append<Address16Tlv>(*this, aRloc16);
-}
+Error Mle::TxMessage::AppendAddress16Tlv(uint16_t aRloc16) { return Tlv::Append<Address16Tlv>(*this, aRloc16); }
 
 Error Mle::TxMessage::AppendLeaderDataTlv(void)
 {
@@ -4582,20 +4549,14 @@ Error Mle::TxMessage::AppendTlvRequestTlv(const uint8_t *aTlvs, uint8_t aTlvsLen
     return Tlv::Append<TlvRequestTlv>(*this, aTlvs, aTlvsLength);
 }
 
-Error Mle::TxMessage::AppendScanMaskTlv(uint8_t aScanMask)
-{
-    return Tlv::Append<ScanMaskTlv>(*this, aScanMask);
-}
+Error Mle::TxMessage::AppendScanMaskTlv(uint8_t aScanMask) { return Tlv::Append<ScanMaskTlv>(*this, aScanMask); }
 
 Error Mle::TxMessage::AppendLinkMarginTlv(uint8_t aLinkMargin)
 {
     return Tlv::Append<LinkMarginTlv>(*this, aLinkMargin);
 }
 
-Error Mle::TxMessage::AppendVersionTlv(void)
-{
-    return Tlv::Append<VersionTlv>(*this, kThreadVersion);
-}
+Error Mle::TxMessage::AppendVersionTlv(void) { return Tlv::Append<VersionTlv>(*this, kThreadVersion); }
 
 Error Mle::TxMessage::AppendAddressRegistrationTlv(AddressRegistrationMode aMode)
 {

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -136,19 +136,13 @@ public:
      * @retval kErrorInvalidState   IPv6 interface is down or device is in raw-link mode.
      *
      */
-    Error Start(void)
-    {
-        return Start(kNormalAttach);
-    }
+    Error Start(void) { return Start(kNormalAttach); }
 
     /**
      * This method stops the MLE protocol operation.
      *
      */
-    void Stop(void)
-    {
-        Stop(kUpdateNetworkDatasets);
-    }
+    void Stop(void) { Stop(kUpdateNetworkDatasets); }
 
     /**
      * This method restores network information from non-volatile memory (if any).
@@ -171,10 +165,7 @@ public:
      * @param[in]  aChannel        The channel to use when transmitting.
      *
      */
-    void SendAnnounce(uint8_t aChannel)
-    {
-        SendAnnounce(aChannel, kNormalAnnounce);
-    }
+    void SendAnnounce(uint8_t aChannel) { SendAnnounce(aChannel, kNormalAnnounce); }
 
     /**
      * This method causes the Thread interface to detach from the Thread network.
@@ -229,10 +220,7 @@ public:
      * @retval FALSE  Device is not in middle of attach process.
      *
      */
-    bool IsAttaching(void) const
-    {
-        return (mAttachState != kAttachStateIdle);
-    }
+    bool IsAttaching(void) const { return (mAttachState != kAttachStateIdle); }
 
     /**
      * This method returns the current Thread device role.
@@ -240,10 +228,7 @@ public:
      * @returns The current Thread device role.
      *
      */
-    DeviceRole GetRole(void) const
-    {
-        return mRole;
-    }
+    DeviceRole GetRole(void) const { return mRole; }
 
     /**
      * This method indicates whether device role is disabled.
@@ -252,10 +237,7 @@ public:
      * @retval FALSE  Device role is not disabled.
      *
      */
-    bool IsDisabled(void) const
-    {
-        return (mRole == kRoleDisabled);
-    }
+    bool IsDisabled(void) const { return (mRole == kRoleDisabled); }
 
     /**
      * This method indicates whether device role is detached.
@@ -264,10 +246,7 @@ public:
      * @retval FALSE  Device role is not detached.
      *
      */
-    bool IsDetached(void) const
-    {
-        return (mRole == kRoleDetached);
-    }
+    bool IsDetached(void) const { return (mRole == kRoleDetached); }
 
     /**
      * This method indicates whether device role is child.
@@ -276,10 +255,7 @@ public:
      * @retval FALSE  Device role is not child.
      *
      */
-    bool IsChild(void) const
-    {
-        return (mRole == kRoleChild);
-    }
+    bool IsChild(void) const { return (mRole == kRoleChild); }
 
     /**
      * This method indicates whether device role is router.
@@ -288,10 +264,7 @@ public:
      * @retval FALSE  Device role is not router.
      *
      */
-    bool IsRouter(void) const
-    {
-        return (mRole == kRoleRouter);
-    }
+    bool IsRouter(void) const { return (mRole == kRoleRouter); }
 
     /**
      * This method indicates whether device role is leader.
@@ -300,10 +273,7 @@ public:
      * @retval FALSE  Device role is not leader.
      *
      */
-    bool IsLeader(void) const
-    {
-        return (mRole == kRoleLeader);
-    }
+    bool IsLeader(void) const { return (mRole == kRoleLeader); }
 
     /**
      * This method indicates whether device role is either router or leader.
@@ -320,10 +290,7 @@ public:
      * @returns The Device Mode as reported in the Mode TLV.
      *
      */
-    DeviceMode GetDeviceMode(void) const
-    {
-        return mDeviceMode;
-    }
+    DeviceMode GetDeviceMode(void) const { return mDeviceMode; }
 
     /**
      * This method sets the Device Mode as reported in the Mode TLV.
@@ -342,10 +309,7 @@ public:
      * @returns TRUE if rx-on-when-idle, FALSE otherwise.
      *
      */
-    bool IsRxOnWhenIdle(void) const
-    {
-        return mDeviceMode.IsRxOnWhenIdle();
-    }
+    bool IsRxOnWhenIdle(void) const { return mDeviceMode.IsRxOnWhenIdle(); }
 
     /**
      * This method indicates whether or not the device is a Full Thread Device.
@@ -353,10 +317,7 @@ public:
      * @returns TRUE if a Full Thread Device, FALSE otherwise.
      *
      */
-    bool IsFullThreadDevice(void) const
-    {
-        return mDeviceMode.IsFullThreadDevice();
-    }
+    bool IsFullThreadDevice(void) const { return mDeviceMode.IsFullThreadDevice(); }
 
     /**
      * This method indicates whether or not the device is a Minimal End Device.
@@ -364,10 +325,7 @@ public:
      * @returns TRUE if the device is a Minimal End Device, FALSE otherwise.
      *
      */
-    bool IsMinimalEndDevice(void) const
-    {
-        return mDeviceMode.IsMinimalEndDevice();
-    }
+    bool IsMinimalEndDevice(void) const { return mDeviceMode.IsMinimalEndDevice(); }
 
     /**
      * This method gets the Network Data type (full set or stable subset) that this device requests.
@@ -375,10 +333,7 @@ public:
      * @returns The Network Data type requested by this device.
      *
      */
-    NetworkData::Type GetNetworkDataType(void) const
-    {
-        return mDeviceMode.GetNetworkDataType();
-    }
+    NetworkData::Type GetNetworkDataType(void) const { return mDeviceMode.GetNetworkDataType(); }
 
     /**
      * This method returns a pointer to the Mesh Local Prefix.
@@ -386,10 +341,7 @@ public:
      * @returns A reference to the Mesh Local Prefix.
      *
      */
-    const Ip6::NetworkPrefix &GetMeshLocalPrefix(void) const
-    {
-        return mMeshLocal16.GetAddress().GetPrefix();
-    }
+    const Ip6::NetworkPrefix &GetMeshLocalPrefix(void) const { return mMeshLocal16.GetAddress().GetPrefix(); }
 
     /**
      * This method sets the Mesh Local Prefix.
@@ -428,10 +380,7 @@ public:
      * @returns A reference to the Thread link local address.
      *
      */
-    const Ip6::Address &GetLinkLocalAddress(void) const
-    {
-        return mLinkLocal64.GetAddress();
-    }
+    const Ip6::Address &GetLinkLocalAddress(void) const { return mLinkLocal64.GetAddress(); }
 
     /**
      * This method updates the link local address.
@@ -447,10 +396,7 @@ public:
      * @returns A reference to the link-local all Thread nodes multicast address.
      *
      */
-    const Ip6::Address &GetLinkLocalAllThreadNodesAddress(void) const
-    {
-        return mLinkLocalAllThreadNodes.GetAddress();
-    }
+    const Ip6::Address &GetLinkLocalAllThreadNodesAddress(void) const { return mLinkLocalAllThreadNodes.GetAddress(); }
 
     /**
      * This method returns a reference to the realm-local all Thread nodes multicast address.
@@ -469,10 +415,7 @@ public:
      * @returns A reference to the parent.
      *
      */
-    Parent &GetParent(void)
-    {
-        return mParent;
-    }
+    Parent &GetParent(void) { return mParent; }
 
     /**
      * The method retrieves information about the parent.
@@ -491,10 +434,7 @@ public:
      * The parent candidate is valid when attempting to attach to a new parent.
      *
      */
-    Parent &GetParentCandidate(void)
-    {
-        return mParentCandidate;
-    }
+    Parent &GetParentCandidate(void) { return mParentCandidate; }
 
     /**
      * This method starts the process for child to search for a better parent while staying attached to its current
@@ -539,10 +479,7 @@ public:
      * @returns The MLE Timeout value in seconds.
      *
      */
-    uint32_t GetTimeout(void) const
-    {
-        return mTimeout;
-    }
+    uint32_t GetTimeout(void) const { return mTimeout; }
 
     /**
      * This method sets the MLE Timeout value.
@@ -566,10 +503,7 @@ public:
      * @returns A reference to the RLOC assigned to the Thread interface.
      *
      */
-    const Ip6::Address &GetMeshLocal16(void) const
-    {
-        return mMeshLocal16.GetAddress();
-    }
+    const Ip6::Address &GetMeshLocal16(void) const { return mMeshLocal16.GetAddress(); }
 
     /**
      * This method returns a reference to the ML-EID assigned to the Thread interface.
@@ -577,10 +511,7 @@ public:
      * @returns A reference to the ML-EID assigned to the Thread interface.
      *
      */
-    const Ip6::Address &GetMeshLocal64(void) const
-    {
-        return mMeshLocal64.GetAddress();
-    }
+    const Ip6::Address &GetMeshLocal64(void) const { return mMeshLocal64.GetAddress(); }
 
     /**
      * This method returns the Router ID of the Leader.
@@ -588,10 +519,7 @@ public:
      * @returns The Router ID of the Leader.
      *
      */
-    uint8_t GetLeaderId(void) const
-    {
-        return mLeaderData.GetLeaderRouterId();
-    }
+    uint8_t GetLeaderId(void) const { return mLeaderData.GetLeaderRouterId(); }
 
     /**
      * This method retrieves the Leader's RLOC.
@@ -613,10 +541,7 @@ public:
      * @retval kErrorDetached  The Thread interface is not currently attached to a Thread Partition.
      *
      */
-    Error GetLeaderAloc(Ip6::Address &aAddress) const
-    {
-        return GetLocatorAddress(aAddress, kAloc16Leader);
-    }
+    Error GetLeaderAloc(Ip6::Address &aAddress) const { return GetLocatorAddress(aAddress, kAloc16Leader); }
 
     /**
      * This method computes the Commissioner's ALOC.
@@ -659,10 +584,7 @@ public:
      * @returns A reference to the send queue.
      *
      */
-    const MessageQueue &GetMessageQueue(void) const
-    {
-        return mDelayedResponses;
-    }
+    const MessageQueue &GetMessageQueue(void) const { return mDelayedResponses; }
 
     /**
      * This method frees multicast MLE Data Response from Delayed Message Queue if any.
@@ -688,10 +610,7 @@ public:
      * This method resets the MLE counters.
      *
      */
-    void ResetCounters(void)
-    {
-        memset(&mCounters, 0, sizeof(mCounters));
-    }
+    void ResetCounters(void) { memset(&mCounters, 0, sizeof(mCounters)); }
 
     /**
      * This function registers the client callback that is called when processing an MLE Parent Response message.
@@ -738,10 +657,7 @@ public:
      * @retval false No valid network information was found.
      *
      */
-    bool HasRestored(void) const
-    {
-        return mHasRestored;
-    }
+    bool HasRestored(void) const { return mHasRestored; }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     /**
@@ -750,10 +666,7 @@ public:
      * @returns CSL timeout
      *
      */
-    uint32_t GetCslTimeout(void) const
-    {
-        return mCslTimeout;
-    }
+    uint32_t GetCslTimeout(void) const { return mCslTimeout; }
 
     /**
      * This method sets the CSL timeout.
@@ -1516,10 +1429,7 @@ protected:
      * This method clears the parent candidate.
      *
      */
-    void ClearParentCandidate(void)
-    {
-        mParentCandidate.Clear();
-    }
+    void ClearParentCandidate(void) { mParentCandidate.Clear(); }
 
     /**
      * This method checks if the destination is reachable.
@@ -1661,12 +1571,8 @@ protected:
      */
     static void Log(MessageAction aAction, MessageType aType, const Ip6::Address &aAddress, uint16_t aRloc);
 #else
-    static void Log(MessageAction, MessageType, const Ip6::Address &)
-    {
-    }
-    static void Log(MessageAction, MessageType, const Ip6::Address &, uint16_t)
-    {
-    }
+    static void Log(MessageAction, MessageType, const Ip6::Address &) {}
+    static void Log(MessageAction, MessageType, const Ip6::Address &, uint16_t) {}
 #endif // #if OT_SHOULD_LOG_AT( OT_LOG_LEVEL_INFO)
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
@@ -1694,12 +1600,8 @@ protected:
      */
     static void LogSendError(MessageType aType, Error aError);
 #else
-    static void LogProcessError(MessageType, Error)
-    {
-    }
-    static void LogSendError(MessageType, Error)
-    {
-    }
+    static void LogProcessError(MessageType, Error) {}
+    static void LogSendError(MessageType, Error) {}
 #endif // #if OT_SHOULD_LOG_AT( OT_LOG_LEVEL_WARN)
 
     /**
@@ -1718,10 +1620,7 @@ protected:
      * @retval true if attaching/attached on the announced parameters, false otherwise.
      *
      */
-    bool IsAnnounceAttach(void) const
-    {
-        return mAlternatePanId != Mac::kPanIdBroadcast;
-    }
+    bool IsAnnounceAttach(void) const { return mAlternatePanId != Mac::kPanIdBroadcast; }
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
     /**
@@ -1955,10 +1854,7 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE
-    void HandleParentSearchTimer(void)
-    {
-        mParentSearch.HandleTimer();
-    }
+    void HandleParentSearchTimer(void) { mParentSearch.HandleTimer(); }
 
     class ParentSearch : public InstanceLocator
     {
@@ -2005,11 +1901,8 @@ private:
     void        ReestablishLinkWithNeighbor(Neighbor &aNeighbor);
     static void HandleDetachGracefullyTimer(Timer &aTimer);
     void        HandleDetachGracefullyTimer(void);
-    bool        IsDetachingGracefully(void)
-    {
-        return mDetachGracefullyTimer.IsRunning();
-    }
-    Error SendChildUpdateRequest(bool aAppendChallenge, uint32_t aTimeout);
+    bool        IsDetachingGracefully(void) { return mDetachGracefullyTimer.IsRunning(); }
+    Error       SendChildUpdateRequest(bool aAppendChallenge, uint32_t aTimeout);
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
     Error SendDataRequest(const Ip6::Address                        &aDestination,

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -455,10 +455,7 @@ exit:
     return;
 }
 
-void MleRouter::StopAdvertiseTrickleTimer(void)
-{
-    mAdvertiseTrickleTimer.Stop();
-}
+void MleRouter::StopAdvertiseTrickleTimer(void) { mAdvertiseTrickleTimer.Stop(); }
 
 void MleRouter::ResetAdvertiseInterval(void)
 {
@@ -4234,10 +4231,7 @@ exit:
     return;
 }
 
-bool MleRouter::HasChildren(void)
-{
-    return mChildTable.HasChildren(Child::kInStateValidOrAttaching);
-}
+bool MleRouter::HasChildren(void) { return mChildTable.HasChildren(Child::kInStateValidOrAttaching); }
 
 void MleRouter::RemoveChildren(void)
 {

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -166,10 +166,7 @@ public:
      * @returns The preferred Partition Id value.
      *
      */
-    uint32_t GetPreferredLeaderPartitionId(void) const
-    {
-        return mPreferredLeaderPartitionId;
-    }
+    uint32_t GetPreferredLeaderPartitionId(void) const { return mPreferredLeaderPartitionId; }
 
     /**
      * This method sets the preferred Partition Id when operating in the Leader role for certification testing.
@@ -177,10 +174,7 @@ public:
      * @param[in]  aPartitionId  The preferred Leader Partition Id.
      *
      */
-    void SetPreferredLeaderPartitionId(uint32_t aPartitionId)
-    {
-        mPreferredLeaderPartitionId = aPartitionId;
-    }
+    void SetPreferredLeaderPartitionId(uint32_t aPartitionId) { mPreferredLeaderPartitionId = aPartitionId; }
 #endif
 
     /**
@@ -201,10 +195,7 @@ public:
      * This method gets the Partition Id which the device joined successfully once.
      *
      */
-    uint32_t GetPreviousPartitionId(void) const
-    {
-        return mPreviousPartitionId;
-    }
+    uint32_t GetPreviousPartitionId(void) const { return mPreviousPartitionId; }
 
     /**
      * This method sets the Partition Id which the device joins successfully.
@@ -212,10 +203,7 @@ public:
      * @param[in]  aPartitionId   The Partition Id.
      *
      */
-    void SetPreviousPartitionId(uint32_t aPartitionId)
-    {
-        mPreviousPartitionId = aPartitionId;
-    }
+    void SetPreviousPartitionId(uint32_t aPartitionId) { mPreviousPartitionId = aPartitionId; }
 
     /**
      * This method sets the Router Id.
@@ -241,10 +229,7 @@ public:
      * @returns The NETWORK_ID_TIMEOUT value.
      *
      */
-    uint8_t GetNetworkIdTimeout(void) const
-    {
-        return mNetworkIdTimeout;
-    }
+    uint8_t GetNetworkIdTimeout(void) const { return mNetworkIdTimeout; }
 
     /**
      * This method sets the NETWORK_ID_TIMEOUT value.
@@ -252,10 +237,7 @@ public:
      * @param[in]  aTimeout  The NETWORK_ID_TIMEOUT value.
      *
      */
-    void SetNetworkIdTimeout(uint8_t aTimeout)
-    {
-        mNetworkIdTimeout = aTimeout;
-    }
+    void SetNetworkIdTimeout(uint8_t aTimeout) { mNetworkIdTimeout = aTimeout; }
 
     /**
      * This method returns the route cost to a RLOC16.
@@ -293,10 +275,7 @@ public:
      * @returns The ROUTER_SELECTION_JITTER value.
      *
      */
-    uint8_t GetRouterSelectionJitter(void) const
-    {
-        return mRouterSelectionJitter;
-    }
+    uint8_t GetRouterSelectionJitter(void) const { return mRouterSelectionJitter; }
 
     /**
      * This method sets the ROUTER_SELECTION_JITTER value.
@@ -312,10 +291,7 @@ public:
      * @returns The current router selection jitter timeout value.
      *
      */
-    uint8_t GetRouterSelectionJitterTimeout(void) const
-    {
-        return mRouterSelectionJitterTimeout;
-    }
+    uint8_t GetRouterSelectionJitterTimeout(void) const { return mRouterSelectionJitterTimeout; }
 
     /**
      * This method returns the ROUTER_UPGRADE_THRESHOLD value.
@@ -323,10 +299,7 @@ public:
      * @returns The ROUTER_UPGRADE_THRESHOLD value.
      *
      */
-    uint8_t GetRouterUpgradeThreshold(void) const
-    {
-        return mRouterUpgradeThreshold;
-    }
+    uint8_t GetRouterUpgradeThreshold(void) const { return mRouterUpgradeThreshold; }
 
     /**
      * This method sets the ROUTER_UPGRADE_THRESHOLD value.
@@ -334,10 +307,7 @@ public:
      * @param[in]  aThreshold  The ROUTER_UPGRADE_THRESHOLD value.
      *
      */
-    void SetRouterUpgradeThreshold(uint8_t aThreshold)
-    {
-        mRouterUpgradeThreshold = aThreshold;
-    }
+    void SetRouterUpgradeThreshold(uint8_t aThreshold) { mRouterUpgradeThreshold = aThreshold; }
 
     /**
      * This method returns the ROUTER_DOWNGRADE_THRESHOLD value.
@@ -345,10 +315,7 @@ public:
      * @returns The ROUTER_DOWNGRADE_THRESHOLD value.
      *
      */
-    uint8_t GetRouterDowngradeThreshold(void) const
-    {
-        return mRouterDowngradeThreshold;
-    }
+    uint8_t GetRouterDowngradeThreshold(void) const { return mRouterDowngradeThreshold; }
 
     /**
      * This method sets the ROUTER_DOWNGRADE_THRESHOLD value.
@@ -356,10 +323,7 @@ public:
      * @param[in]  aThreshold  The ROUTER_DOWNGRADE_THRESHOLD value.
      *
      */
-    void SetRouterDowngradeThreshold(uint8_t aThreshold)
-    {
-        mRouterDowngradeThreshold = aThreshold;
-    }
+    void SetRouterDowngradeThreshold(uint8_t aThreshold) { mRouterDowngradeThreshold = aThreshold; }
 
     /**
      * This method returns if the REED is expected to become Router soon.
@@ -445,10 +409,7 @@ public:
      * @retval FALSE  If @p aRouterId is not a valid Router ID.
      *
      */
-    static bool IsRouterIdValid(uint8_t aRouterId)
-    {
-        return aRouterId <= kMaxRouterId;
-    }
+    static bool IsRouterIdValid(uint8_t aRouterId) { return aRouterId <= kMaxRouterId; }
 
     /**
      * This method fills an ConnectivityTlv.
@@ -465,10 +426,7 @@ public:
      * @retval kErrorNoBufs   Insufficient buffers to generate the MLE Child Update Request message.
      *
      */
-    Error SendChildUpdateRequest(void)
-    {
-        return Mle::SendChildUpdateRequest();
-    }
+    Error SendChildUpdateRequest(void) { return Mle::SendChildUpdateRequest(); }
 
     Error SendLinkRequest(Neighbor *aNeighbor);
 
@@ -491,10 +449,7 @@ public:
      * @returns The assigned parent priority value, -2 means not assigned.
      *
      */
-    int8_t GetAssignParentPriority(void) const
-    {
-        return mParentPriority;
-    }
+    int8_t GetAssignParentPriority(void) const { return mParentPriority; }
 
     /**
      * This method sets the parent priority.
@@ -566,10 +521,7 @@ public:
      * @param[in]  aDelay  The delay before registering Backbone Router service.
      *
      */
-    void SetBackboneRouterRegistrationDelay(uint8_t aDelay)
-    {
-        mBackboneRouterRegistrationDelay = aDelay;
-    }
+    void SetBackboneRouterRegistrationDelay(uint8_t aDelay) { mBackboneRouterRegistrationDelay = aDelay; }
 #endif
 
     /**
@@ -600,10 +552,7 @@ public:
      * @param[in]  aEnabled  TRUE if the device was commissioned using CCM, FALSE otherwise.
      *
      */
-    void SetCcmEnabled(bool aEnabled)
-    {
-        mCcmEnabled = aEnabled;
-    }
+    void SetCcmEnabled(bool aEnabled) { mCcmEnabled = aEnabled; }
 
     /**
      * This function sets whether the Security Policy TLV version-threshold for routing (VR field) is enabled.
@@ -611,10 +560,7 @@ public:
      * @param[in]  aEnabled  TRUE to enable Security Policy TLV version-threshold for routing, FALSE otherwise.
      *
      */
-    void SetThreadVersionCheckEnabled(bool aEnabled)
-    {
-        mThreadVersionCheckEnabled = aEnabled;
-    }
+    void SetThreadVersionCheckEnabled(bool aEnabled) { mThreadVersionCheckEnabled = aEnabled; }
 #endif
 
 private:

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -589,10 +589,7 @@ typedef Mac::Key Key;
  * @returns The Child ID portion of an RLOC16.
  *
  */
-inline uint16_t ChildIdFromRloc16(uint16_t aRloc16)
-{
-    return aRloc16 & kMaxChildId;
-}
+inline uint16_t ChildIdFromRloc16(uint16_t aRloc16) { return aRloc16 & kMaxChildId; }
 
 /**
  * This function derives the Router ID portion from a given RLOC16.
@@ -602,10 +599,7 @@ inline uint16_t ChildIdFromRloc16(uint16_t aRloc16)
  * @returns The Router ID portion of an RLOC16.
  *
  */
-inline uint8_t RouterIdFromRloc16(uint16_t aRloc16)
-{
-    return aRloc16 >> kRouterIdOffset;
-}
+inline uint8_t RouterIdFromRloc16(uint16_t aRloc16) { return aRloc16 >> kRouterIdOffset; }
 
 /**
  * This function returns whether the two RLOC16 have the same Router ID.
@@ -629,10 +623,7 @@ inline bool RouterIdMatch(uint16_t aRloc16A, uint16_t aRloc16B)
  * @returns The Service ID corresponding to given ALOC16.
  *
  */
-inline uint8_t ServiceIdFromAloc(uint16_t aAloc16)
-{
-    return static_cast<uint8_t>(aAloc16 - kAloc16ServiceStart);
-}
+inline uint8_t ServiceIdFromAloc(uint16_t aAloc16) { return static_cast<uint8_t>(aAloc16 - kAloc16ServiceStart); }
 
 /**
  * This function returns the Service ALOC16 corresponding to a Service ID.
@@ -668,10 +659,7 @@ inline uint16_t CommissionerAloc16FromId(uint16_t aSessionId)
  * @returns The RLOC16 corresponding to the given Router ID.
  *
  */
-inline uint16_t Rloc16FromRouterId(uint8_t aRouterId)
-{
-    return static_cast<uint16_t>(aRouterId << kRouterIdOffset);
-}
+inline uint16_t Rloc16FromRouterId(uint8_t aRouterId) { return static_cast<uint16_t>(aRouterId << kRouterIdOffset); }
 
 /**
  * This function indicates whether or not @p aRloc16 refers to an active router.
@@ -682,10 +670,7 @@ inline uint16_t Rloc16FromRouterId(uint8_t aRouterId)
  * @retval FALSE  If @p aRloc16 does not refer to an active router.
  *
  */
-inline bool IsActiveRouter(uint16_t aRloc16)
-{
-    return ChildIdFromRloc16(aRloc16) == 0;
-}
+inline bool IsActiveRouter(uint16_t aRloc16) { return ChildIdFromRloc16(aRloc16) == 0; }
 
 /**
  * This function converts a device role into a human-readable string.

--- a/src/core/thread/neighbor_table.hpp
+++ b/src/core/thread/neighbor_table.hpp
@@ -213,10 +213,7 @@ public:
      * @param[in] aCallback    A pointer to callback handler function.
      *
      */
-    void RegisterCallback(Callback aCallback)
-    {
-        mCallback = aCallback;
-    }
+    void RegisterCallback(Callback aCallback) { mCallback = aCallback; }
 
     /**
      * This method signals a "neighbor table changed" event.

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -630,10 +630,7 @@ void MutableNetworkData::Remove(void *aRemoveStart, uint8_t aRemoveLength)
     mLength -= aRemoveLength;
 }
 
-void MutableNetworkData::RemoveTlv(NetworkDataTlv *aTlv)
-{
-    Remove(aTlv, aTlv->GetSize());
-}
+void MutableNetworkData::RemoveTlv(NetworkDataTlv *aTlv) { Remove(aTlv, aTlv->GetSize()); }
 
 Error NetworkData::GetNextServer(Iterator &aIterator, uint16_t &aRloc16) const
 {

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -641,15 +641,9 @@ bool Leader::ContainsMatchingServer(const ServiceTlv *aService, const ServerTlv 
     return contains;
 }
 
-Leader::UpdateStatus Leader::UpdatePrefix(PrefixTlv &aPrefix)
-{
-    return UpdateTlv(aPrefix, aPrefix.GetSubTlvs());
-}
+Leader::UpdateStatus Leader::UpdatePrefix(PrefixTlv &aPrefix) { return UpdateTlv(aPrefix, aPrefix.GetSubTlvs()); }
 
-Leader::UpdateStatus Leader::UpdateService(ServiceTlv &aService)
-{
-    return UpdateTlv(aService, aService.GetSubTlvs());
-}
+Leader::UpdateStatus Leader::UpdateService(ServiceTlv &aService) { return UpdateTlv(aService, aService.GetSubTlvs()); }
 
 Leader::UpdateStatus Leader::UpdateTlv(NetworkDataTlv &aTlv, const NetworkDataTlv *aSubTlvs)
 {
@@ -1019,10 +1013,7 @@ void Leader::StartContextReuseTimer(uint8_t aContextId)
     mTimer.Start(kStateUpdatePeriod);
 }
 
-void Leader::StopContextReuseTimer(uint8_t aContextId)
-{
-    mContextLastUsed[aContextId - kMinContextId].SetValue(0);
-}
+void Leader::StopContextReuseTimer(uint8_t aContextId) { mContextLastUsed[aContextId - kMinContextId].SetValue(0); }
 
 void Leader::RemoveRloc(uint16_t aRloc16, MatchMode aMatchMode, ChangedFlags &aChangedFlags)
 {

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -98,10 +98,7 @@ public:
      * @retval kErrorNotFound   Could not find the Border Router entry.
      *
      */
-    Error RemoveOnMeshPrefix(const Ip6::Prefix &aPrefix)
-    {
-        return RemovePrefix(aPrefix);
-    }
+    Error RemoveOnMeshPrefix(const Ip6::Prefix &aPrefix) { return RemovePrefix(aPrefix); }
 
     /**
      * This method indicates whether or not the Thread Network Data contains a given on mesh prefix.
@@ -135,10 +132,7 @@ public:
      * @retval kErrorNotFound   Could not find the Border Router entry.
      *
      */
-    Error RemoveHasRoutePrefix(const Ip6::Prefix &aPrefix)
-    {
-        return RemovePrefix(aPrefix);
-    }
+    Error RemoveHasRoutePrefix(const Ip6::Prefix &aPrefix) { return RemovePrefix(aPrefix); }
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -243,10 +243,7 @@ void Notifier::HandleNotifierEvents(Events aEvents)
     }
 }
 
-void Notifier::HandleTimer(void)
-{
-    SynchronizeServerData();
-}
+void Notifier::HandleTimer(void) { SynchronizeServerData(); }
 
 void Notifier::HandleCoapResponse(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo, Error aResult)
 {

--- a/src/core/thread/network_data_publisher.hpp
+++ b/src/core/thread/network_data_publisher.hpp
@@ -137,10 +137,7 @@ public:
      * @param[in] aSequenceNumber  The sequence number of DNS/SRP Anycast Service.
      *
      */
-    void PublishDnsSrpServiceAnycast(uint8_t aSequenceNumber)
-    {
-        mDnsSrpServiceEntry.PublishAnycast(aSequenceNumber);
-    }
+    void PublishDnsSrpServiceAnycast(uint8_t aSequenceNumber) { mDnsSrpServiceEntry.PublishAnycast(aSequenceNumber); }
 
     /**
      * This method requests "DNS/SRP Service Unicast Address" to be published in the Thread Network Data.
@@ -173,10 +170,7 @@ public:
      * @param[in] aPort      The SRP server port number to publish.
      *
      */
-    void PublishDnsSrpServiceUnicast(uint16_t aPort)
-    {
-        mDnsSrpServiceEntry.PublishUnicast(aPort);
-    }
+    void PublishDnsSrpServiceUnicast(uint16_t aPort) { mDnsSrpServiceEntry.PublishUnicast(aPort); }
 
     /**
      * This method indicates whether or not currently the "DNS/SRP Service" entry is added to the Thread Network Data.
@@ -185,20 +179,14 @@ public:
      * @retval FALSE   The entry is not added to Thread Network Data or there is no entry to publish.
      *
      */
-    bool IsDnsSrpServiceAdded(void) const
-    {
-        return mDnsSrpServiceEntry.IsAdded();
-    }
+    bool IsDnsSrpServiceAdded(void) const { return mDnsSrpServiceEntry.IsAdded(); }
 
     /**
      * This method unpublishes any previously added "DNS/SRP (Anycast or Unicast) Service" entry from the Thread
      * Network Data.
      *
      */
-    void UnpublishDnsSrpService(void)
-    {
-        mDnsSrpServiceEntry.Unpublish();
-    }
+    void UnpublishDnsSrpService(void) { mDnsSrpServiceEntry.Unpublish(); }
 
 #endif // OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
@@ -475,10 +463,7 @@ private:
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    bool IsADnsSrpServiceEntry(const Entry &aEntry) const
-    {
-        return (&aEntry == &mDnsSrpServiceEntry);
-    }
+    bool IsADnsSrpServiceEntry(const Entry &aEntry) const { return (&aEntry == &mDnsSrpServiceEntry); }
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
@@ -489,12 +474,9 @@ private:
     void               NotifyPrefixEntryChange(Event aEvent, const Ip6::Prefix &aPrefix) const;
 #endif
 
-    TimerMilli &GetTimer(void)
-    {
-        return mTimer;
-    }
-    void HandleNotifierEvents(Events aEvents);
-    void HandleTimer(void);
+    TimerMilli &GetTimer(void) { return mTimer; }
+    void        HandleNotifierEvents(Events aEvents);
+    void        HandleTimer(void);
 
     using PublisherTimer = TimerMilliIn<Publisher, &Publisher::HandleTimer>;
 

--- a/src/core/thread/network_data_tlvs.cpp
+++ b/src/core/thread/network_data_tlvs.cpp
@@ -81,10 +81,7 @@ exit:
 //---------------------------------------------------------------------------------------------------------------------
 // PrefixTlv
 
-const NetworkDataTlv *PrefixTlv::FindSubTlv(Type aType) const
-{
-    return Find(GetSubTlvs(), GetNext(), aType);
-}
+const NetworkDataTlv *PrefixTlv::FindSubTlv(Type aType) const { return Find(GetSubTlvs(), GetNext(), aType); }
 
 const NetworkDataTlv *PrefixTlv::FindSubTlv(Type aType, bool aStable) const
 {

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -73,10 +73,7 @@ class NetworkDataTlv;
  * @returns A `TlvType` pointer to `aTlv`.
  *
  */
-template <class TlvType> TlvType *As(NetworkDataTlv *aTlv)
-{
-    return static_cast<TlvType *>(aTlv);
-}
+template <class TlvType> TlvType *As(NetworkDataTlv *aTlv) { return static_cast<TlvType *>(aTlv); }
 
 /**
  * This template method casts a `NetworkDataTlv` pointer to a given subclass `TlvType` pointer.
@@ -88,10 +85,7 @@ template <class TlvType> TlvType *As(NetworkDataTlv *aTlv)
  * @returns A `TlvType` pointer to `aTlv`.
  *
  */
-template <class TlvType> const TlvType *As(const NetworkDataTlv *aTlv)
-{
-    return static_cast<const TlvType *>(aTlv);
-}
+template <class TlvType> const TlvType *As(const NetworkDataTlv *aTlv) { return static_cast<const TlvType *>(aTlv); }
 
 /**
  * This template method casts a `NetworkDataTlv` reference to a given subclass `TlvType` reference.
@@ -103,10 +97,7 @@ template <class TlvType> const TlvType *As(const NetworkDataTlv *aTlv)
  * @returns A `TlvType` reference to `aTlv`.
  *
  */
-template <class TlvType> TlvType &As(NetworkDataTlv &aTlv)
-{
-    return static_cast<TlvType &>(aTlv);
-}
+template <class TlvType> TlvType &As(NetworkDataTlv &aTlv) { return static_cast<TlvType &>(aTlv); }
 
 /**
  * This template method casts a `NetworkDataTlv` reference to a given subclass `TlvType` reference.
@@ -118,10 +109,7 @@ template <class TlvType> TlvType &As(NetworkDataTlv &aTlv)
  * @returns A `TlvType` reference to `aTlv`.
  *
  */
-template <class TlvType> const TlvType &As(const NetworkDataTlv &aTlv)
-{
-    return static_cast<const TlvType &>(aTlv);
-}
+template <class TlvType> const TlvType &As(const NetworkDataTlv &aTlv) { return static_cast<const TlvType &>(aTlv); }
 
 /**
  * This class implements Thread Network Data TLV generation and parsing.

--- a/src/core/thread/radio_selector.cpp
+++ b/src/core/thread/radio_selector.cpp
@@ -387,9 +387,7 @@ exit:
 
 #else // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
-void RadioSelector::Log(LogLevel, const char *, Mac::RadioType, const Neighbor &)
-{
-}
+void RadioSelector::Log(LogLevel, const char *, Mac::RadioType, const Neighbor &) {}
 
 #endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -50,10 +50,7 @@ RouterTable::Iterator::Iterator(Instance &aInstance)
 {
 }
 
-void RouterTable::Iterator::Advance(void)
-{
-    mItem = Get<RouterTable>().GetNextEntry(mItem);
-}
+void RouterTable::Iterator::Advance(void) { mItem = Get<RouterTable>().GetNextEntry(mItem); }
 
 RouterTable::RouterTable(Instance &aInstance)
     : InstanceLocator(aInstance)
@@ -114,10 +111,7 @@ void RouterTable::ClearNeighbors(void)
     }
 }
 
-bool RouterTable::IsAllocated(uint8_t aRouterId) const
-{
-    return mAllocatedRouterIds.Contains(aRouterId);
-}
+bool RouterTable::IsAllocated(uint8_t aRouterId) const { return mAllocatedRouterIds.Contains(aRouterId); }
 
 void RouterTable::UpdateAllocation(void)
 {
@@ -398,10 +392,7 @@ const Router *RouterTable::FindRouterByRloc16(uint16_t aRloc16) const
     return FindRouterById(Mle::RouterIdFromRloc16(aRloc16));
 }
 
-const Router *RouterTable::FindNextHopOf(const Router &aRouter) const
-{
-    return FindRouterById(aRouter.GetNextHop());
-}
+const Router *RouterTable::FindNextHopOf(const Router &aRouter) const { return FindRouterById(aRouter.GetNextHop()); }
 
 Router *RouterTable::FindRouter(const Mac::ExtAddress &aExtAddress)
 {
@@ -434,10 +425,7 @@ exit:
     return error;
 }
 
-Router *RouterTable::GetLeader(void)
-{
-    return FindRouterById(Get<Mle::MleRouter>().GetLeaderId());
-}
+Router *RouterTable::GetLeader(void) { return FindRouterById(Get<Mle::MleRouter>().GetLeaderId()); }
 
 uint32_t RouterTable::GetLeaderAge(void) const
 {

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -371,9 +371,7 @@ public:
      */
     void LogRouteTable(void);
 #else
-    void LogRouteTable(void)
-    {
-    }
+    void LogRouteTable(void) {}
 #endif
 
 private:
@@ -392,14 +390,8 @@ private:
     void          UpdateAllocation(void);
     const Router *GetFirstEntry(void) const;
     const Router *GetNextEntry(const Router *aRouter) const;
-    Router       *GetFirstEntry(void)
-    {
-        return AsNonConst(AsConst(this)->GetFirstEntry());
-    }
-    Router *GetNextEntry(Router *aRouter)
-    {
-        return AsNonConst(AsConst(this)->GetNextEntry(aRouter));
-    }
+    Router       *GetFirstEntry(void) { return AsNonConst(AsConst(this)->GetFirstEntry()); }
+    Router       *GetNextEntry(Router *aRouter) { return AsNonConst(AsConst(this)->GetNextEntry(aRouter)); }
 
     Router       *FindNeighbor(uint16_t aRloc16);
     Router       *FindNeighbor(const Mac::ExtAddress &aExtAddress);

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -118,10 +118,7 @@ exit:
     return;
 }
 
-Error ThreadNetif::SendMessage(Message &aMessage)
-{
-    return Get<MeshForwarder>().SendMessage(aMessage);
-}
+Error ThreadNetif::SendMessage(Message &aMessage) { return Get<MeshForwarder>().SendMessage(aMessage); }
 
 Error ThreadNetif::RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination)
 {
@@ -139,9 +136,6 @@ exit:
     return error;
 }
 
-bool ThreadNetif::IsOnMesh(const Ip6::Address &aAddress) const
-{
-    return Get<NetworkData::Leader>().IsOnMesh(aAddress);
-}
+bool ThreadNetif::IsOnMesh(const Ip6::Address &aAddress) const { return Get<NetworkData::Leader>().IsOnMesh(aAddress); }
 
 } // namespace ot

--- a/src/core/thread/time_sync_service.cpp
+++ b/src/core/thread/time_sync_service.cpp
@@ -204,10 +204,7 @@ void TimeSync::HandleNotifierEvents(Events aEvents)
     }
 }
 
-void TimeSync::HandleTimeout(void)
-{
-    CheckAndHandleChanges(false);
-}
+void TimeSync::HandleTimeout(void) { CheckAndHandleChanges(false); }
 
 void TimeSync::CheckAndHandleChanges(bool aTimeUpdated)
 {

--- a/src/core/thread/time_sync_service.hpp
+++ b/src/core/thread/time_sync_service.hpp
@@ -100,10 +100,7 @@ public:
      * @returns The time synchronization sequence.
      *
      */
-    uint8_t GetTimeSyncSeq(void) const
-    {
-        return mTimeSyncSeq;
-    }
+    uint8_t GetTimeSyncSeq(void) const { return mTimeSyncSeq; }
 
     /**
      * This method gets the time offset to the Thread network time.
@@ -111,10 +108,7 @@ public:
      * @returns The time offset to the Thread network time, in microseconds.
      *
      */
-    int64_t GetNetworkTimeOffset(void) const
-    {
-        return mNetworkTimeOffset;
-    }
+    int64_t GetNetworkTimeOffset(void) const { return mNetworkTimeOffset; }
 
     /**
      * Set the time synchronization period.
@@ -122,10 +116,7 @@ public:
      * @param[in] aTimeSyncPeriod   The time synchronization period, in seconds.
      *
      */
-    void SetTimeSyncPeriod(uint16_t aTimeSyncPeriod)
-    {
-        mTimeSyncPeriod = aTimeSyncPeriod;
-    }
+    void SetTimeSyncPeriod(uint16_t aTimeSyncPeriod) { mTimeSyncPeriod = aTimeSyncPeriod; }
 
     /**
      * Get the time synchronization period.
@@ -133,10 +124,7 @@ public:
      * @returns The time synchronization period, in seconds.
      *
      */
-    uint16_t GetTimeSyncPeriod(void) const
-    {
-        return mTimeSyncPeriod;
-    }
+    uint16_t GetTimeSyncPeriod(void) const { return mTimeSyncPeriod; }
 
     /**
      * Set the time synchronization XTAL accuracy threshold for Router.
@@ -144,10 +132,7 @@ public:
      * @param[in] aXtalThreshold   The XTAL accuracy threshold for Router, in PPM.
      *
      */
-    void SetXtalThreshold(uint16_t aXtalThreshold)
-    {
-        mXtalThreshold = aXtalThreshold;
-    }
+    void SetXtalThreshold(uint16_t aXtalThreshold) { mXtalThreshold = aXtalThreshold; }
 
     /**
      * Get the time synchronization XTAL accuracy threshold for Router.
@@ -155,10 +140,7 @@ public:
      * @returns The XTAL accuracy threshold for Router, in PPM.
      *
      */
-    uint16_t GetXtalThreshold(void) const
-    {
-        return mXtalThreshold;
-    }
+    uint16_t GetXtalThreshold(void) const { return mXtalThreshold; }
 
     /**
      * Set the time sync callback to be notified of a network time update.

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -41,10 +41,7 @@ namespace Tmf {
 //----------------------------------------------------------------------------------------------------------------------
 // MessageInfo
 
-void MessageInfo::SetSockAddrToRloc(void)
-{
-    SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
-}
+void MessageInfo::SetSockAddrToRloc(void) { SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16()); }
 
 Error MessageInfo::SetSockAddrToRlocPeerAddrToLeaderAloc(void)
 {
@@ -87,10 +84,7 @@ Agent::Agent(Instance &aInstance)
     SetResourceHandler(&HandleResource);
 }
 
-Error Agent::Start(void)
-{
-    return Coap::Start(kUdpPort, Ip6::kNetifThread);
-}
+Error Agent::Start(void) { return Coap::Start(kUdpPort, Ip6::kNetifThread); }
 
 template <> void Agent::HandleTmf<kUriRelayRx>(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -546,10 +546,7 @@ void Router::Clear(void)
     Init(instance);
 }
 
-LinkQuality Router::GetTwoWayLinkQuality(void) const
-{
-    return Min(GetLinkQualityIn(), GetLinkQualityOut());
-}
+LinkQuality Router::GetTwoWayLinkQuality(void) const { return Min(GetLinkQualityIn(), GetLinkQualityOut()); }
 
 void Router::SetFrom(const Parent &aParent)
 {

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -440,10 +440,7 @@ public:
      * @returns The link ACK frame counter value.
      *
      */
-    uint32_t GetLinkAckFrameCounter(void) const
-    {
-        return mValidPending.mValid.mLinkAckFrameCounter;
-    }
+    uint32_t GetLinkAckFrameCounter(void) const { return mValidPending.mValid.mLinkAckFrameCounter; }
 #endif
 
     /**
@@ -467,10 +464,7 @@ public:
      * @returns The MLE frame counter value.
      *
      */
-    uint32_t GetMleFrameCounter(void) const
-    {
-        return mValidPending.mValid.mMleFrameCounter;
-    }
+    uint32_t GetMleFrameCounter(void) const { return mValidPending.mValid.mMleFrameCounter; }
 
     /**
      * This method sets the MLE frame counter value.
@@ -478,10 +472,7 @@ public:
      * @param[in]  aFrameCounter  The MLE frame counter value.
      *
      */
-    void SetMleFrameCounter(uint32_t aFrameCounter)
-    {
-        mValidPending.mValid.mMleFrameCounter = aFrameCounter;
-    }
+    void SetMleFrameCounter(uint32_t aFrameCounter) { mValidPending.mValid.mMleFrameCounter = aFrameCounter; }
 
     /**
      * This method gets the RLOC16 value.
@@ -489,10 +480,7 @@ public:
      * @returns The RLOC16 value.
      *
      */
-    uint16_t GetRloc16(void) const
-    {
-        return mRloc16;
-    }
+    uint16_t GetRloc16(void) const { return mRloc16; }
 
     /**
      * This method gets the Router ID value.
@@ -500,10 +488,7 @@ public:
      * @returns The Router ID value.
      *
      */
-    uint8_t GetRouterId(void) const
-    {
-        return mRloc16 >> Mle::kRouterIdOffset;
-    }
+    uint8_t GetRouterId(void) const { return mRloc16 >> Mle::kRouterIdOffset; }
 
     /**
      * This method sets the RLOC16 value.
@@ -511,10 +496,7 @@ public:
      * @param[in]  aRloc16  The RLOC16 value.
      *
      */
-    void SetRloc16(uint16_t aRloc16)
-    {
-        mRloc16 = aRloc16;
-    }
+    void SetRloc16(uint16_t aRloc16) { mRloc16 = aRloc16; }
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     /**
@@ -524,10 +506,7 @@ public:
      * multi-radio feature is enabled.
      *
      */
-    void ClearLastRxFragmentTag(void)
-    {
-        mLastRxFragmentTag = 0;
-    }
+    void ClearLastRxFragmentTag(void) { mLastRxFragmentTag = 0; }
 
     /**
      * This method gets the last received fragment tag.
@@ -537,10 +516,7 @@ public:
      * @returns The last received fragment tag.
      *
      */
-    uint16_t GetLastRxFragmentTag(void) const
-    {
-        return mLastRxFragmentTag;
-    }
+    uint16_t GetLastRxFragmentTag(void) const { return mLastRxFragmentTag; }
 
     /**
      * This method set the last received fragment tag.
@@ -572,10 +548,7 @@ public:
      * before @p aTag.
      *
      */
-    bool IsLastRxFragmentTagAfter(uint16_t aTag) const
-    {
-        return SerialNumber::IsGreater(mLastRxFragmentTag, aTag);
-    }
+    bool IsLastRxFragmentTagAfter(uint16_t aTag) const { return SerialNumber::IsGreater(mLastRxFragmentTag, aTag); }
 
 #endif // OPENTHREAD_CONFIG_MULTI_RADIO
 
@@ -585,10 +558,7 @@ public:
      * @returns TRUE if neighbors is Thread 1.1, FALSE otherwise.
      *
      */
-    bool IsThreadVersion1p1(void) const
-    {
-        return mState != kStateInvalid && mVersion == kThreadVersion1p1;
-    }
+    bool IsThreadVersion1p1(void) const { return mState != kStateInvalid && mVersion == kThreadVersion1p1; }
 
     /**
      * This method indicates whether or not neighbor is Thread 1.2 or higher..
@@ -596,10 +566,7 @@ public:
      * @returns TRUE if neighbor is Thread 1.2 or higher, FALSE otherwise.
      *
      */
-    bool IsThreadVersion1p2OrHigher(void) const
-    {
-        return mState != kStateInvalid && mVersion >= kThreadVersion1p2;
-    }
+    bool IsThreadVersion1p2OrHigher(void) const { return mState != kStateInvalid && mVersion >= kThreadVersion1p2; }
 
     /**
      * This method indicates whether Thread version supports CSL.
@@ -607,10 +574,7 @@ public:
      * @returns TRUE if CSL is supported, FALSE otherwise.
      *
      */
-    bool IsThreadVersionCslCapable(void) const
-    {
-        return IsThreadVersion1p2OrHigher() && !IsRxOnWhenIdle();
-    }
+    bool IsThreadVersionCslCapable(void) const { return IsThreadVersion1p2OrHigher() && !IsRxOnWhenIdle(); }
 
     /**
      * This method indicates whether Enhanced Keep-Alive is supported or not.
@@ -627,10 +591,7 @@ public:
      * This method gets the device MLE version.
      *
      */
-    uint16_t GetVersion(void) const
-    {
-        return mVersion;
-    }
+    uint16_t GetVersion(void) const { return mVersion; }
 
     /**
      * This method sets the device MLE version.
@@ -638,10 +599,7 @@ public:
      * @param[in]  aVersion  The device MLE version.
      *
      */
-    void SetVersion(uint16_t aVersion)
-    {
-        mVersion = aVersion;
-    }
+    void SetVersion(uint16_t aVersion) { mVersion = aVersion; }
 
     /**
      * This method gets the number of consecutive link failures.
@@ -649,28 +607,19 @@ public:
      * @returns The number of consecutive link failures.
      *
      */
-    uint8_t GetLinkFailures(void) const
-    {
-        return mLinkFailures;
-    }
+    uint8_t GetLinkFailures(void) const { return mLinkFailures; }
 
     /**
      * This method increments the number of consecutive link failures.
      *
      */
-    void IncrementLinkFailures(void)
-    {
-        mLinkFailures++;
-    }
+    void IncrementLinkFailures(void) { mLinkFailures++; }
 
     /**
      * This method resets the number of consecutive link failures to zero.
      *
      */
-    void ResetLinkFailures(void)
-    {
-        mLinkFailures = 0;
-    }
+    void ResetLinkFailures(void) { mLinkFailures = 0; }
 
     /**
      * This method returns the LinkQualityInfo object.
@@ -678,10 +627,7 @@ public:
      * @returns The LinkQualityInfo object.
      *
      */
-    LinkQualityInfo &GetLinkInfo(void)
-    {
-        return mLinkInfo;
-    }
+    LinkQualityInfo &GetLinkInfo(void) { return mLinkInfo; }
 
     /**
      * This method returns the LinkQualityInfo object.
@@ -689,10 +635,7 @@ public:
      * @returns The LinkQualityInfo object.
      *
      */
-    const LinkQualityInfo &GetLinkInfo(void) const
-    {
-        return mLinkInfo;
-    }
+    const LinkQualityInfo &GetLinkInfo(void) const { return mLinkInfo; }
 
     /**
      * This method gets the link quality in value.
@@ -700,10 +643,7 @@ public:
      * @returns The link quality in value.
      *
      */
-    LinkQuality GetLinkQualityIn(void) const
-    {
-        return GetLinkInfo().GetLinkQuality();
-    }
+    LinkQuality GetLinkQualityIn(void) const { return GetLinkInfo().GetLinkQuality(); }
 
     /**
      * This method generates a new challenge value for MLE Link Request/Response exchanges.
@@ -717,10 +657,7 @@ public:
      * @returns The current challenge value.
      *
      */
-    const uint8_t *GetChallenge(void) const
-    {
-        return mValidPending.mPending.mChallenge;
-    }
+    const uint8_t *GetChallenge(void) const { return mValidPending.mPending.mChallenge; }
 
     /**
      * This method returns the size (bytes) of the challenge value for MLE Link Request/Response exchanges.
@@ -728,10 +665,7 @@ public:
      * @returns The size (bytes) of the challenge value for MLE Link Request/Response exchanges.
      *
      */
-    uint8_t GetChallengeSize(void) const
-    {
-        return sizeof(mValidPending.mPending.mChallenge);
-    }
+    uint8_t GetChallengeSize(void) const { return sizeof(mValidPending.mPending.mChallenge); }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     /**
@@ -740,10 +674,7 @@ public:
      * @returns TRUE if time sync feature is enabled, FALSE otherwise.
      *
      */
-    bool IsTimeSyncEnabled(void) const
-    {
-        return mTimeSyncEnabled;
-    }
+    bool IsTimeSyncEnabled(void) const { return mTimeSyncEnabled; }
 
     /**
      * This method sets whether or not time sync feature is enabled.
@@ -751,10 +682,7 @@ public:
      * @param[in]  aEnable    TRUE if time sync feature is enabled, FALSE otherwise.
      *
      */
-    void SetTimeSyncEnabled(bool aEnabled)
-    {
-        mTimeSyncEnabled = aEnabled;
-    }
+    void SetTimeSyncEnabled(bool aEnabled) { mTimeSyncEnabled = aEnabled; }
 #endif
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
@@ -812,10 +740,7 @@ public:
      * @returns Enh-ACK Probing metrics configured.
      *
      */
-    const LinkMetrics::Metrics &GetEnhAckProbingMetrics(void) const
-    {
-        return mEnhAckProbingMetrics;
-    }
+    const LinkMetrics::Metrics &GetEnhAckProbingMetrics(void) const { return mEnhAckProbingMetrics; }
 
     /**
      * This method sets the Enh-ACK Probing metrics (this `Neighbor` object is the Probing Subject).
@@ -1212,10 +1137,7 @@ public:
      * @returns The child timeout.
      *
      */
-    uint32_t GetTimeout(void) const
-    {
-        return mTimeout;
-    }
+    uint32_t GetTimeout(void) const { return mTimeout; }
 
     /**
      * This method sets the child timeout.
@@ -1223,10 +1145,7 @@ public:
      * @param[in]  aTimeout  The child timeout.
      *
      */
-    void SetTimeout(uint32_t aTimeout)
-    {
-        mTimeout = aTimeout;
-    }
+    void SetTimeout(uint32_t aTimeout) { mTimeout = aTimeout; }
 
     /**
      * This method gets the network data version.
@@ -1234,10 +1153,7 @@ public:
      * @returns The network data version.
      *
      */
-    uint8_t GetNetworkDataVersion(void) const
-    {
-        return mNetworkDataVersion;
-    }
+    uint8_t GetNetworkDataVersion(void) const { return mNetworkDataVersion; }
 
     /**
      * This method sets the network data version.
@@ -1245,10 +1161,7 @@ public:
      * @param[in]  aVersion  The network data version.
      *
      */
-    void SetNetworkDataVersion(uint8_t aVersion)
-    {
-        mNetworkDataVersion = aVersion;
-    }
+    void SetNetworkDataVersion(uint8_t aVersion) { mNetworkDataVersion = aVersion; }
 
     /**
      * This method generates a new challenge value to use during a child attach.
@@ -1262,10 +1175,7 @@ public:
      * @returns The current challenge value.
      *
      */
-    const uint8_t *GetChallenge(void) const
-    {
-        return mAttachChallenge;
-    }
+    const uint8_t *GetChallenge(void) const { return mAttachChallenge; }
 
     /**
      * This method gets the challenge size (bytes) used during attach.
@@ -1273,19 +1183,13 @@ public:
      * @returns The challenge size (bytes).
      *
      */
-    uint8_t GetChallengeSize(void) const
-    {
-        return sizeof(mAttachChallenge);
-    }
+    uint8_t GetChallengeSize(void) const { return sizeof(mAttachChallenge); }
 
     /**
      * This method clears the requested TLV list.
      *
      */
-    void ClearRequestTlvs(void)
-    {
-        memset(mRequestTlvs, Mle::Tlv::kInvalid, sizeof(mRequestTlvs));
-    }
+    void ClearRequestTlvs(void) { memset(mRequestTlvs, Mle::Tlv::kInvalid, sizeof(mRequestTlvs)); }
 
     /**
      * This method returns the requested TLV at index @p aIndex.
@@ -1295,10 +1199,7 @@ public:
      * @returns The requested TLV at index @p aIndex.
      *
      */
-    uint8_t GetRequestTlv(uint8_t aIndex) const
-    {
-        return mRequestTlvs[aIndex];
-    }
+    uint8_t GetRequestTlv(uint8_t aIndex) const { return mRequestTlvs[aIndex]; }
 
     /**
      * This method sets the requested TLV at index @p aIndex.
@@ -1307,10 +1208,7 @@ public:
      * @param[in]  aType   The TLV type.
      *
      */
-    void SetRequestTlv(uint8_t aIndex, uint8_t aType)
-    {
-        mRequestTlvs[aIndex] = aType;
-    }
+    void SetRequestTlv(uint8_t aIndex, uint8_t aType) { mRequestTlvs[aIndex] = aType; }
 
 #if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
 
@@ -1318,10 +1216,7 @@ public:
      * This method increments the number of seconds since last supervision of the child.
      *
      */
-    void IncrementSecondsSinceLastSupervision(void)
-    {
-        mSecondsSinceSupervision++;
-    }
+    void IncrementSecondsSinceLastSupervision(void) { mSecondsSinceSupervision++; }
 
     /**
      * This method returns the number of seconds since last supervision of the child (last message to the child)
@@ -1329,19 +1224,13 @@ public:
      * @returns Number of seconds since last supervision of the child.
      *
      */
-    uint16_t GetSecondsSinceLastSupervision(void) const
-    {
-        return mSecondsSinceSupervision;
-    }
+    uint16_t GetSecondsSinceLastSupervision(void) const { return mSecondsSinceSupervision; }
 
     /**
      * This method resets the number of seconds since last supervision of the child to zero.
      *
      */
-    void ResetSecondsSinceLastSupervision(void)
-    {
-        mSecondsSinceSupervision = 0;
-    }
+    void ResetSecondsSinceLastSupervision(void) { mSecondsSinceSupervision = 0; }
 
 #endif // #if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
 
@@ -1387,10 +1276,7 @@ public:
      * @retval false  If the Child does not have any IPv6 address of MLR state `kMlrStateRegistered`.
      *
      */
-    bool HasAnyMlrRegisteredAddress(void) const
-    {
-        return mMlrRegisteredMask.HasAny();
-    }
+    bool HasAnyMlrRegisteredAddress(void) const { return mMlrRegisteredMask.HasAny(); }
 
     /**
      * This method returns if the Child has any IPv6 address of MLR state `kMlrStateToRegister`.
@@ -1399,10 +1285,7 @@ public:
      * @retval false  If the Child does not have any IPv6 address of MLR state `kMlrStateToRegister`.
      *
      */
-    bool HasAnyMlrToRegisterAddress(void) const
-    {
-        return mMlrToRegisterMask.HasAny();
-    }
+    bool HasAnyMlrToRegisterAddress(void) const { return mMlrToRegisterMask.HasAny(); }
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 
 private:
@@ -1610,10 +1493,7 @@ public:
      * @returns The route cost from parent to leader
      *
      */
-    uint8_t GetLeaderCost(void) const
-    {
-        return mLeaderCost;
-    }
+    uint8_t GetLeaderCost(void) const { return mLeaderCost; }
 
     /**
      * This method sets route cost from parent to leader.
@@ -1621,10 +1501,7 @@ public:
      * @param[in] aLaderConst  The route cost.
      *
      */
-    void SetLeaderCost(uint8_t aLeaderCost)
-    {
-        mLeaderCost = aLeaderCost;
-    }
+    void SetLeaderCost(uint8_t aLeaderCost) { mLeaderCost = aLeaderCost; }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     /**
@@ -1633,10 +1510,7 @@ public:
      * @returns The CSL accuracy.
      *
      */
-    const Mac::CslAccuracy &GetCslAccuracy(void) const
-    {
-        return mCslAccuracy;
-    }
+    const Mac::CslAccuracy &GetCslAccuracy(void) const { return mCslAccuracy; }
 
     /**
      * This method sets CSL accuracy.
@@ -1644,10 +1518,7 @@ public:
      * @param[in] aCslAccuracy  The CSL accuracy.
      *
      */
-    void SetCslAccuracy(const Mac::CslAccuracy &aCslAccuracy)
-    {
-        mCslAccuracy = aCslAccuracy;
-    }
+    void SetCslAccuracy(const Mac::CslAccuracy &aCslAccuracy) { mCslAccuracy = aCslAccuracy; }
 #endif
 
 private:

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -102,10 +102,7 @@ exit:
     FreeMessage(message);
 }
 
-void ChildSupervisor::UpdateOnSend(Child &aChild)
-{
-    aChild.ResetSecondsSinceLastSupervision();
-}
+void ChildSupervisor::UpdateOnSend(Child &aChild) { aChild.ResetSecondsSinceLastSupervision(); }
 
 void ChildSupervisor::HandleTimeTick(void)
 {
@@ -162,15 +159,9 @@ SupervisionListener::SupervisionListener(Instance &aInstance)
     SetTimeout(kDefaultTimeout);
 }
 
-void SupervisionListener::Start(void)
-{
-    RestartTimer();
-}
+void SupervisionListener::Start(void) { RestartTimer(); }
 
-void SupervisionListener::Stop(void)
-{
-    mTimer.Stop();
-}
+void SupervisionListener::Stop(void) { mTimer.Stop(); }
 
 void SupervisionListener::SetTimeout(uint16_t aTimeout)
 {

--- a/src/core/utils/heap.hpp
+++ b/src/core/utils/heap.hpp
@@ -250,10 +250,7 @@ private:
      * @returns A reference to the block.
      *
      */
-    Block &BlockAt(uint16_t aOffset)
-    {
-        return *reinterpret_cast<Block *>(&mMemory.m16[aOffset / 2]);
-    }
+    Block &BlockAt(uint16_t aOffset) { return *reinterpret_cast<Block *>(&mMemory.m16[aOffset / 2]); }
 
     /**
      * This method returns the block of @p aPointer.
@@ -276,10 +273,7 @@ private:
      * @returns Reference to the super block.
      *
      */
-    Block &BlockSuper(void)
-    {
-        return BlockAt(kSuperBlockOffset);
-    }
+    Block &BlockSuper(void) { return BlockAt(kSuperBlockOffset); }
 
     /**
      * This method returns the free block after @p aBlock in the free block list.
@@ -289,10 +283,7 @@ private:
      * @returns Reference to the free block after this block.
      *
      */
-    Block &BlockNext(const Block &aBlock)
-    {
-        return BlockAt(aBlock.GetNext());
-    }
+    Block &BlockNext(const Block &aBlock) { return BlockAt(aBlock.GetNext()); }
 
     /**
      * This method returns the block on the right side of @p aBlock.
@@ -302,10 +293,7 @@ private:
      * @returns Reference to the block on the right side.
      *
      */
-    Block &BlockRight(const Block &aBlock)
-    {
-        return BlockAt(BlockOffset(aBlock) + sizeof(Block) + aBlock.GetSize());
-    }
+    Block &BlockRight(const Block &aBlock) { return BlockAt(BlockOffset(aBlock) + sizeof(Block) + aBlock.GetSize()); }
 
     /**
      * This method returns the free block before @p aBlock in the free block list.
@@ -321,10 +309,7 @@ private:
      * @param[in]   aBlock  A reference to the block.
      *
      */
-    bool IsLeftFree(const Block &aBlock)
-    {
-        return (BlockOffset(aBlock) != kFirstBlockOffset && aBlock.IsLeftFree());
-    }
+    bool IsLeftFree(const Block &aBlock) { return (BlockOffset(aBlock) != kFirstBlockOffset && aBlock.IsLeftFree()); }
 
     /**
      * This method returns the offset of @p aBlock.

--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -47,10 +47,7 @@ RegisterLogModule("Otns");
 
 const int kMaxStatusStringLength = 128;
 
-void Otns::EmitShortAddress(uint16_t aShortAddress)
-{
-    EmitStatus("rloc16=%d", aShortAddress);
-}
+void Otns::EmitShortAddress(uint16_t aShortAddress) { EmitStatus("rloc16=%d", aShortAddress); }
 
 void Otns::EmitExtendedAddress(const Mac::ExtAddress &aExtAddress)
 {

--- a/src/core/utils/parse_cmdline.cpp
+++ b/src/core/utils/parse_cmdline.cpp
@@ -44,15 +44,9 @@ namespace ot {
 namespace Utils {
 namespace CmdLineParser {
 
-static bool IsSeparator(char aChar)
-{
-    return (aChar == ' ') || (aChar == '\t') || (aChar == '\r') || (aChar == '\n');
-}
+static bool IsSeparator(char aChar) { return (aChar == ' ') || (aChar == '\t') || (aChar == '\r') || (aChar == '\n'); }
 
-static bool IsEscapable(char aChar)
-{
-    return IsSeparator(aChar) || (aChar == '\\');
-}
+static bool IsEscapable(char aChar) { return IsSeparator(aChar) || (aChar == '\\'); }
 
 static Error ParseDigit(char aDigitChar, uint8_t &aValue)
 {
@@ -137,20 +131,11 @@ exit:
     return error;
 }
 
-Error ParseAsUint8(const char *aString, uint8_t &aUint8)
-{
-    return ParseUint<uint8_t>(aString, aUint8);
-}
+Error ParseAsUint8(const char *aString, uint8_t &aUint8) { return ParseUint<uint8_t>(aString, aUint8); }
 
-Error ParseAsUint16(const char *aString, uint16_t &aUint16)
-{
-    return ParseUint<uint16_t>(aString, aUint16);
-}
+Error ParseAsUint16(const char *aString, uint16_t &aUint16) { return ParseUint<uint16_t>(aString, aUint16); }
 
-Error ParseAsUint32(const char *aString, uint32_t &aUint32)
-{
-    return ParseUint<uint32_t>(aString, aUint32);
-}
+Error ParseAsUint32(const char *aString, uint32_t &aUint32) { return ParseUint<uint32_t>(aString, aUint32); }
 
 Error ParseAsUint64(const char *aString, uint64_t &aUint64)
 {
@@ -208,15 +193,9 @@ exit:
     return error;
 }
 
-Error ParseAsInt8(const char *aString, int8_t &aInt8)
-{
-    return ParseInt<int8_t>(aString, aInt8);
-}
+Error ParseAsInt8(const char *aString, int8_t &aInt8) { return ParseInt<int8_t>(aString, aInt8); }
 
-Error ParseAsInt16(const char *aString, int16_t &aInt16)
-{
-    return ParseInt<int16_t>(aString, aInt16);
-}
+Error ParseAsInt16(const char *aString, int16_t &aInt16) { return ParseInt<int16_t>(aString, aInt16); }
 
 Error ParseAsInt32(const char *aString, int32_t &aInt32)
 {
@@ -390,15 +369,9 @@ Error ParseAsHexStringSegment(const char *&aString, uint16_t &aSize, uint8_t *aB
 //---------------------------------------------------------------------------------------------------------------------
 // Arg class
 
-uint16_t Arg::GetLength(void) const
-{
-    return IsEmpty() ? 0 : static_cast<uint16_t>(strlen(mString));
-}
+uint16_t Arg::GetLength(void) const { return IsEmpty() ? 0 : static_cast<uint16_t>(strlen(mString)); }
 
-bool Arg::operator==(const char *aString) const
-{
-    return !IsEmpty() && (strcmp(mString, aString) == 0);
-}
+bool Arg::operator==(const char *aString) const { return !IsEmpty() && (strcmp(mString, aString) == 0); }
 
 void Arg::CopyArgsToStringArray(Arg aArgs[], char *aStrings[])
 {

--- a/src/core/utils/parse_cmdline.hpp
+++ b/src/core/utils/parse_cmdline.hpp
@@ -524,10 +524,7 @@ public:
      * @retval kErrorInvalidArgs  The argument is empty or does not contain a valid IPv6 prefix.
      *
      */
-    otError ParseAsIp6Prefix(otIp6Prefix &aPrefix) const
-    {
-        return CmdLineParser::ParseAsIp6Prefix(mString, aPrefix);
-    }
+    otError ParseAsIp6Prefix(otIp6Prefix &aPrefix) const { return CmdLineParser::ParseAsIp6Prefix(mString, aPrefix); }
 
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD
 
@@ -660,57 +657,27 @@ template <uint8_t kLength> inline otError ParseCmd(char *aCommandString, Arg (&a
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Specializations of `Arg::ParseAs<Type>()` method.
 
-template <> inline otError Arg::ParseAs(uint8_t &aValue) const
-{
-    return ParseAsUint8(aValue);
-}
+template <> inline otError Arg::ParseAs(uint8_t &aValue) const { return ParseAsUint8(aValue); }
 
-template <> inline otError Arg::ParseAs(uint16_t &aValue) const
-{
-    return ParseAsUint16(aValue);
-}
+template <> inline otError Arg::ParseAs(uint16_t &aValue) const { return ParseAsUint16(aValue); }
 
-template <> inline otError Arg::ParseAs(uint32_t &aValue) const
-{
-    return ParseAsUint32(aValue);
-}
+template <> inline otError Arg::ParseAs(uint32_t &aValue) const { return ParseAsUint32(aValue); }
 
-template <> inline otError Arg::ParseAs(uint64_t &aValue) const
-{
-    return ParseAsUint64(aValue);
-}
+template <> inline otError Arg::ParseAs(uint64_t &aValue) const { return ParseAsUint64(aValue); }
 
-template <> inline otError Arg::ParseAs(bool &aValue) const
-{
-    return ParseAsBool(aValue);
-}
+template <> inline otError Arg::ParseAs(bool &aValue) const { return ParseAsBool(aValue); }
 
-template <> inline otError Arg::ParseAs(int8_t &aValue) const
-{
-    return ParseAsInt8(aValue);
-}
+template <> inline otError Arg::ParseAs(int8_t &aValue) const { return ParseAsInt8(aValue); }
 
-template <> inline otError Arg::ParseAs(int16_t &aValue) const
-{
-    return ParseAsInt16(aValue);
-}
+template <> inline otError Arg::ParseAs(int16_t &aValue) const { return ParseAsInt16(aValue); }
 
-template <> inline otError Arg::ParseAs(int32_t &aValue) const
-{
-    return ParseAsInt32(aValue);
-}
+template <> inline otError Arg::ParseAs(int32_t &aValue) const { return ParseAsInt32(aValue); }
 
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
 
-template <> inline otError Arg::ParseAs(otIp6Address &aValue) const
-{
-    return ParseAsIp6Address(aValue);
-}
+template <> inline otError Arg::ParseAs(otIp6Address &aValue) const { return ParseAsIp6Address(aValue); }
 
-template <> inline otError Arg::ParseAs(otIp6Prefix &aValue) const
-{
-    return ParseAsIp6Prefix(aValue);
-}
+template <> inline otError Arg::ParseAs(otIp6Prefix &aValue) const { return ParseAsIp6Prefix(aValue); }
 
 #endif
 

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -365,10 +365,7 @@ public:
      * @returns A reference to the transmit buffer.
      *
      */
-    otRadioFrame &GetTransmitFrame(void)
-    {
-        return mTxRadioFrame;
-    }
+    otRadioFrame &GetTransmitFrame(void) { return mTxRadioFrame; }
 
     /**
      * This method enables or disables source address match feature.
@@ -531,10 +528,7 @@ public:
      * @returns TRUE if the radio is enabled, FALSE otherwise.
      *
      */
-    bool IsEnabled(void) const
-    {
-        return mState != kStateDisabled;
-    }
+    bool IsEnabled(void) const { return mState != kStateDisabled; }
 
     /**
      * This method indicates whether there is a pending transmission.
@@ -543,10 +537,7 @@ public:
      * @retval FALSE There is no pending transmission.
      *
      */
-    bool IsTransmitting(void) const
-    {
-        return mState == kStateTransmitting;
-    }
+    bool IsTransmitting(void) const { return mState == kStateTransmitting; }
 
     /**
      * This method indicates whether a transmit has just finished.
@@ -555,10 +546,7 @@ public:
      * @retval FALSE The transmission is not done.
      *
      */
-    bool IsTransmitDone(void) const
-    {
-        return mState == kStateTransmitDone;
-    }
+    bool IsTransmitDone(void) const { return mState == kStateTransmitDone; }
 
     /**
      * This method returns the timeout timepoint for the pending transmission.
@@ -566,10 +554,7 @@ public:
      * @returns The timeout timepoint for the pending transmission.
      *
      */
-    uint64_t GetTxRadioEndUs(void) const
-    {
-        return mTxRadioEndUs;
-    }
+    uint64_t GetTxRadioEndUs(void) const { return mTxRadioEndUs; }
 
     /**
      * This method processes any pending the I/O data.
@@ -585,10 +570,7 @@ public:
      * @returns The underlying spinel interface.
      *
      */
-    InterfaceType &GetSpinelInterface(void)
-    {
-        return mSpinelInterface;
-    }
+    InterfaceType &GetSpinelInterface(void) { return mSpinelInterface; }
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
     /**
@@ -597,10 +579,7 @@ public:
      * @param[in]  aMode  TRUE to enable diagnostics mode, FALSE otherwise.
      *
      */
-    void SetDiagEnabled(bool aMode)
-    {
-        mDiagMode = aMode;
-    }
+    void SetDiagEnabled(bool aMode) { mDiagMode = aMode; }
 
     /**
      * This method indicates whether or not factory diagnostics mode is enabled.
@@ -608,10 +587,7 @@ public:
      * @returns TRUE if factory diagnostics mode is enabled, FALSE otherwise.
      *
      */
-    bool IsDiagEnabled(void) const
-    {
-        return mDiagMode;
-    }
+    bool IsDiagEnabled(void) const { return mDiagMode; }
 
     /**
      * This method processes platform diagnostics commands.
@@ -766,10 +742,7 @@ public:
      * @returns Whether there is pending frame in the buffer.
      *
      */
-    bool HasPendingFrame(void) const
-    {
-        return mRxFrameBuffer.HasSavedFrame();
-    }
+    bool HasPendingFrame(void) const { return mRxFrameBuffer.HasSavedFrame(); }
 
     /**
      * This method gets dataset from NCP radio and saves it.
@@ -788,10 +761,7 @@ public:
      * @returns The timepoint to start the recalculation of RCP time offset.
      *
      */
-    uint64_t GetNextRadioTimeRecalcStart(void) const
-    {
-        return mRadioTimeRecalcStart;
-    }
+    uint64_t GetNextRadioTimeRecalcStart(void) const { return mRadioTimeRecalcStart; }
 
     /**
      * This method gets the current estimated time on RCP.
@@ -914,10 +884,7 @@ public:
      * @returns The radio Spinel metrics.
      *
      */
-    const otRadioSpinelMetrics *GetRadioSpinelMetrics(void) const
-    {
-        return &mRadioSpinelMetrics;
-    }
+    const otRadioSpinelMetrics *GetRadioSpinelMetrics(void) const { return &mRadioSpinelMetrics; }
 
 private:
     enum
@@ -959,10 +926,7 @@ private:
     void ProcessFrameQueue(void);
 
     spinel_tid_t GetNextTid(void);
-    void         FreeTid(spinel_tid_t tid)
-    {
-        mCmdTidsInUse &= ~(1 << tid);
-    }
+    void         FreeTid(spinel_tid_t tid) { mCmdTidsInUse &= ~(1 << tid); }
 
     otError RequestV(uint32_t aCommand, spinel_prop_key_t aKey, const char *aFormat, va_list aArgs);
     otError Request(uint32_t aCommand, spinel_prop_key_t aKey, const char *aFormat, ...);

--- a/src/lib/spinel/spinel_buffer.cpp
+++ b/src/lib/spinel/spinel_buffer.cpp
@@ -536,20 +536,11 @@ exit:
     return error;
 }
 
-Buffer::FrameTag Buffer::InFrameGetLastTag(void) const
-{
-    return mWriteFrameTag;
-}
+Buffer::FrameTag Buffer::InFrameGetLastTag(void) const { return mWriteFrameTag; }
 
-bool Buffer::HasFrame(Priority aPriority) const
-{
-    return mReadFrameStart[aPriority] != mWriteFrameStart[aPriority];
-}
+bool Buffer::HasFrame(Priority aPriority) const { return mReadFrameStart[aPriority] != mWriteFrameStart[aPriority]; }
 
-bool Buffer::IsEmpty(void) const
-{
-    return !HasFrame(kPriorityHigh) && !HasFrame(kPriorityLow);
-}
+bool Buffer::IsEmpty(void) const { return !HasFrame(kPriorityHigh) && !HasFrame(kPriorityLow); }
 
 void Buffer::OutFrameSelectReadDirection(void)
 {
@@ -704,10 +695,7 @@ exit:
     return error;
 }
 
-bool Buffer::OutFrameHasEnded(void)
-{
-    return (mReadState == kReadStateDone) || (mReadState == kReadStateNotActive);
-}
+bool Buffer::OutFrameHasEnded(void) { return (mReadState == kReadStateDone) || (mReadState == kReadStateNotActive); }
 
 uint8_t Buffer::OutFrameReadByte(void)
 {

--- a/src/lib/spinel/spinel_encoder.hpp
+++ b/src/lib/spinel/spinel_encoder.hpp
@@ -563,10 +563,7 @@ public:
      * @retval OT_ERROR_INVALID_ARGS    If @p aMessage is nullptr.
      *
      */
-    otError WriteMessage(otMessage *aMessage)
-    {
-        return mNcpBuffer.InFrameFeedMessage(aMessage);
-    }
+    otError WriteMessage(otMessage *aMessage) { return mNcpBuffer.InFrameFeedMessage(aMessage); }
 #endif
 
     /**

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -56,10 +56,7 @@ namespace Ncp {
 // ----------------------------------------------------------------------------
 
 #if OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
-static bool HasOnly1BitSet(uint32_t aValue)
-{
-    return aValue != 0 && ((aValue & (aValue - 1)) == 0);
-}
+static bool HasOnly1BitSet(uint32_t aValue) { return aValue != 0 && ((aValue & (aValue - 1)) == 0); }
 
 static uint8_t IndexOfMSB(uint32_t aValue)
 {
@@ -308,10 +305,7 @@ NcpBase::NcpBase(Instance *aInstance)
 #endif
 }
 
-NcpBase *NcpBase::GetNcpInstance(void)
-{
-    return sNcpInstance;
-}
+NcpBase *NcpBase::GetNcpInstance(void) { return sNcpInstance; }
 
 void NcpBase::ResetCounters(void)
 {
@@ -334,10 +328,7 @@ void NcpBase::ResetCounters(void)
 // MARK: Serial Traffic Glue
 // ----------------------------------------------------------------------------
 
-Spinel::Buffer::FrameTag NcpBase::GetLastOutboundFrameTag(void)
-{
-    return mTxFrameBuffer.InFrameGetLastTag();
-}
+Spinel::Buffer::FrameTag NcpBase::GetLastOutboundFrameTag(void) { return mTxFrameBuffer.InFrameGetLastTag(); }
 
 void NcpBase::HandleReceive(const uint8_t *aBuf, uint16_t aBufLength)
 {
@@ -477,10 +468,7 @@ bool NcpBase::ShouldDeferHostSend(void)
     return (mHostPowerState == SPINEL_HOST_POWER_STATE_DEEP_SLEEP && !mHostPowerStateInProgress);
 }
 
-void NcpBase::IncrementFrameErrorCounter(void)
-{
-    mFramingErrorCounter++;
-}
+void NcpBase::IncrementFrameErrorCounter(void) { mFramingErrorCounter++; }
 
 otError NcpBase::StreamWrite(int aStreamId, const uint8_t *aDataPtr, int aDataLen)
 {
@@ -1198,10 +1186,7 @@ exit:
 // MARK: Individual Command Handlers
 // ----------------------------------------------------------------------------
 
-otError NcpBase::CommandHandler_NOOP(uint8_t aHeader)
-{
-    return PrepareLastStatusResponse(aHeader, SPINEL_STATUS_OK);
-}
+otError NcpBase::CommandHandler_NOOP(uint8_t aHeader) { return PrepareLastStatusResponse(aHeader, SPINEL_STATUS_OK); }
 
 otError NcpBase::CommandHandler_RESET(uint8_t aHeader)
 {
@@ -2090,10 +2075,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_POWER_STATE>(void)
     return mEncoder.WriteUint8(SPINEL_POWER_STATE_ONLINE);
 }
 
-template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_POWER_STATE>(void)
-{
-    return OT_ERROR_NOT_IMPLEMENTED;
-}
+template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_POWER_STATE>(void) { return OT_ERROR_NOT_IMPLEMENTED; }
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_HWADDR>(void)
 {

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -241,10 +241,7 @@ protected:
                                                    uint16_t          aValueLen);
 
     otError SendQueuedResponses(void);
-    bool    IsResponseQueueEmpty(void) const
-    {
-        return (mResponseQueueHead == mResponseQueueTail);
-    }
+    bool    IsResponseQueueEmpty(void) const { return (mResponseQueueHead == mResponseQueueTail); }
     otError EnqueueResponse(uint8_t aHeader, ResponseType aType, unsigned int aPropKeyOrStatus);
 
     otError PrepareGetResponse(uint8_t aHeader, spinel_prop_key_t aPropKey)
@@ -492,12 +489,8 @@ protected:
     void StartLegacy(void);
     void StopLegacy(void);
 #else
-    void StartLegacy(void)
-    {
-    }
-    void StopLegacy(void)
-    {
-    }
+    void StartLegacy(void) {}
+    void StopLegacy(void) {}
 #endif
 
     static uint8_t      ConvertLogLevel(otLogLevel aLogLevel);

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -4206,10 +4206,7 @@ exit:
     return error;
 }
 
-void NcpBase::HandleTimeSyncUpdate(void *aContext)
-{
-    static_cast<NcpBase *>(aContext)->HandleTimeSyncUpdate();
-}
+void NcpBase::HandleTimeSyncUpdate(void *aContext) { static_cast<NcpBase *>(aContext)->HandleTimeSyncUpdate(); }
 
 void NcpBase::HandleTimeSyncUpdate(void)
 {

--- a/src/ncp/ncp_hdlc.cpp
+++ b/src/ncp/ncp_hdlc.cpp
@@ -240,10 +240,7 @@ void NcpHdlc::HandleHdlcReceiveDone(const uint8_t *aBuf, uint16_t aBufLength)
     mFrameDecoder.Decode(aBuf, aBufLength);
 }
 
-void NcpHdlc::HandleFrame(void *aContext, otError aError)
-{
-    static_cast<NcpHdlc *>(aContext)->HandleFrame(aError);
-}
+void NcpHdlc::HandleFrame(void *aContext, otError aError) { static_cast<NcpHdlc *>(aContext)->HandleFrame(aError); }
 
 void NcpHdlc::HandleFrame(otError aError)
 {
@@ -312,10 +309,7 @@ NcpHdlc::BufferEncrypterReader::BufferEncrypterReader(Spinel::Buffer &aTxFrameBu
 {
 }
 
-bool NcpHdlc::BufferEncrypterReader::IsEmpty(void) const
-{
-    return mTxFrameBuffer.IsEmpty() && !mOutputDataLength;
-}
+bool NcpHdlc::BufferEncrypterReader::IsEmpty(void) const { return mTxFrameBuffer.IsEmpty() && !mOutputDataLength; }
 
 otError NcpHdlc::BufferEncrypterReader::OutFrameBegin(void)
 {
@@ -347,20 +341,11 @@ otError NcpHdlc::BufferEncrypterReader::OutFrameBegin(void)
     return status;
 }
 
-bool NcpHdlc::BufferEncrypterReader::OutFrameHasEnded(void)
-{
-    return (mDataBufferReadIndex >= mOutputDataLength);
-}
+bool NcpHdlc::BufferEncrypterReader::OutFrameHasEnded(void) { return (mDataBufferReadIndex >= mOutputDataLength); }
 
-uint8_t NcpHdlc::BufferEncrypterReader::OutFrameReadByte(void)
-{
-    return mDataBuffer[mDataBufferReadIndex++];
-}
+uint8_t NcpHdlc::BufferEncrypterReader::OutFrameReadByte(void) { return mDataBuffer[mDataBufferReadIndex++]; }
 
-otError NcpHdlc::BufferEncrypterReader::OutFrameRemove(void)
-{
-    return mTxFrameBuffer.OutFrameRemove();
-}
+otError NcpHdlc::BufferEncrypterReader::OutFrameRemove(void) { return mTxFrameBuffer.OutFrameRemove(); }
 
 void NcpHdlc::BufferEncrypterReader::Reset(void)
 {

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -224,10 +224,7 @@ exit:
     return shouldProcess;
 }
 
-void NcpSpi::SpiTransactionProcess(void *aContext)
-{
-    reinterpret_cast<NcpSpi *>(aContext)->SpiTransactionProcess();
-}
+void NcpSpi::SpiTransactionProcess(void *aContext) { reinterpret_cast<NcpSpi *>(aContext)->SpiTransactionProcess(); }
 
 void NcpSpi::SpiTransactionProcess(void)
 {

--- a/src/posix/cli_readline.cpp
+++ b/src/posix/cli_readline.cpp
@@ -94,10 +94,7 @@ extern "C" void otAppCliInit(otInstance *aInstance)
     otCliInit(aInstance, OutputCallback, nullptr);
 }
 
-extern "C" void otAppCliDeinit(void)
-{
-    rl_callback_handler_remove();
-}
+extern "C" void otAppCliDeinit(void) { rl_callback_handler_remove(); }
 
 extern "C" void otAppCliUpdate(otSysMainloopContext *aMainloop)
 {

--- a/src/posix/cli_stdio.cpp
+++ b/src/posix/cli_stdio.cpp
@@ -58,14 +58,9 @@ int OutputCallback(void *aContext, const char *aFormat, va_list aArguments)
 }
 } // namespace
 
-extern "C" void otAppCliInit(otInstance *aInstance)
-{
-    otCliInit(aInstance, OutputCallback, nullptr);
-}
+extern "C" void otAppCliInit(otInstance *aInstance) { otCliInit(aInstance, OutputCallback, nullptr); }
 
-extern "C" void otAppCliDeinit(void)
-{
-}
+extern "C" void otAppCliDeinit(void) {}
 
 extern "C" void otAppCliUpdate(otSysMainloopContext *aMainloop)
 {

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -315,10 +315,7 @@ static otInstance *InitInstance(PosixConfig *aConfig)
     return instance;
 }
 
-void otTaskletsSignalPending(otInstance *aInstance)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-}
+void otTaskletsSignalPending(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
 
 void otPlatReset(otInstance *aInstance)
 {

--- a/src/posix/platform/alarm.cpp
+++ b/src/posix/platform/alarm.cpp
@@ -87,10 +87,7 @@ uint64_t otPlatTimeGet(void)
 }
 #endif // !OPENTHREAD_POSIX_VIRTUAL_TIME
 
-static uint64_t platformAlarmGetNow(void)
-{
-    return otPlatTimeGet() * sSpeedUpFactor;
-}
+static uint64_t platformAlarmGetNow(void) { return otPlatTimeGet() * sSpeedUpFactor; }
 
 void platformAlarmInit(uint32_t aSpeedUpFactor, int aRealTimeSignal)
 {
@@ -131,10 +128,7 @@ void platformAlarmInit(uint32_t aSpeedUpFactor, int aRealTimeSignal)
     }
 }
 
-uint32_t otPlatAlarmMilliGetNow(void)
-{
-    return (uint32_t)(platformAlarmGetNow() / US_PER_MS);
-}
+uint32_t otPlatAlarmMilliGetNow(void) { return (uint32_t)(platformAlarmGetNow() / US_PER_MS); }
 
 void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
@@ -152,10 +146,7 @@ void otPlatAlarmMilliStop(otInstance *aInstance)
 }
 
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
-uint32_t otPlatAlarmMicroGetNow(void)
-{
-    return static_cast<uint32_t>(platformAlarmGetNow());
-}
+uint32_t otPlatAlarmMicroGetNow(void) { return static_cast<uint32_t>(platformAlarmGetNow()); }
 
 void otPlatAlarmMicroStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {

--- a/src/posix/platform/backtrace.cpp
+++ b/src/posix/platform/backtrace.cpp
@@ -162,8 +162,6 @@ void platformBacktraceInit(void)
     sigaction(SIGFPE, &sigact, (struct sigaction *)nullptr);
 }
 #else  // OPENTHREAD_POSIX_CONFIG_ANDROID_ENABLE || defined(__GLIBC__)
-void platformBacktraceInit(void)
-{
-}
+void platformBacktraceInit(void) {}
 #endif // OPENTHREAD_POSIX_CONFIG_ANDROID_ENABLE || defined(__GLIBC__)
 #endif // OPENTHREAD_POSIX_CONFIG_BACKTRACE_ENABLE

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -139,10 +139,7 @@ HdlcInterface::HdlcInterface(SpinelInterface::ReceiveFrameCallback aCallback,
     mInterfaceMetrics.mRcpInterfaceType = OT_POSIX_RCP_BUS_UART;
 }
 
-void HdlcInterface::OnRcpReset(void)
-{
-    mHdlcDecoder.Reset();
-}
+void HdlcInterface::OnRcpReset(void) { mHdlcDecoder.Reset(); }
 
 otError HdlcInterface::Init(const Url::Url &aRadioUrl)
 {
@@ -177,15 +174,9 @@ exit:
     return error;
 }
 
-HdlcInterface::~HdlcInterface(void)
-{
-    Deinit();
-}
+HdlcInterface::~HdlcInterface(void) { Deinit(); }
 
-void HdlcInterface::Deinit(void)
-{
-    CloseFile();
-}
+void HdlcInterface::Deinit(void) { CloseFile(); }
 
 void HdlcInterface::Read(void)
 {
@@ -204,10 +195,7 @@ void HdlcInterface::Read(void)
     }
 }
 
-void HdlcInterface::Decode(const uint8_t *aBuffer, uint16_t aLength)
-{
-    mHdlcDecoder.Decode(aBuffer, aLength);
-}
+void HdlcInterface::Decode(const uint8_t *aBuffer, uint16_t aLength) { mHdlcDecoder.Decode(aBuffer, aLength); }
 
 otError HdlcInterface::SendFrame(const uint8_t *aFrame, uint16_t aLength)
 {

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -146,10 +146,7 @@ public:
      * @param[in] aEvent   The data event.
      *
      */
-    void Process(const VirtualTimeEvent &aEvent)
-    {
-        Decode(aEvent.mData, aEvent.mDataLength);
-    }
+    void Process(const VirtualTimeEvent &aEvent) { Decode(aEvent.mData, aEvent.mDataLength); }
 #endif
 
     /**
@@ -158,10 +155,7 @@ public:
      * @returns   Bus speed in bits/second.
      *
      */
-    uint32_t GetBusSpeed(void) const
-    {
-        return mBaudRate;
-    }
+    uint32_t GetBusSpeed(void) const { return mBaudRate; }
 
     /**
      * This method is called when RCP failure detected and resets internal states of the interface.
@@ -181,10 +175,7 @@ public:
      * @returns The RCP interface metrics.
      *
      */
-    const otRcpInterfaceMetrics *GetRcpInterfaceMetrics(void) const
-    {
-        return &mInterfaceMetrics;
-    }
+    const otRcpInterfaceMetrics *GetRcpInterfaceMetrics(void) const { return &mInterfaceMetrics; }
 
 private:
     /**

--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -111,15 +111,9 @@ otError otPlatInfraIfDiscoverNat64Prefix(uint32_t aInfraIfIndex)
 #endif
 }
 
-bool platformInfraIfIsRunning(void)
-{
-    return ot::Posix::InfraNetif::Get().IsRunning();
-}
+bool platformInfraIfIsRunning(void) { return ot::Posix::InfraNetif::Get().IsRunning(); }
 
-const char *otSysGetInfraNetifName(void)
-{
-    return ot::Posix::InfraNetif::Get().GetNetifName();
-}
+const char *otSysGetInfraNetifName(void) { return ot::Posix::InfraNetif::Get().GetNetifName(); }
 
 namespace ot {
 namespace Posix {

--- a/src/posix/platform/memory.cpp
+++ b/src/posix/platform/memory.cpp
@@ -34,13 +34,7 @@
 #include <openthread/platform/memory.h>
 
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-void *otPlatCAlloc(size_t aNum, size_t aSize)
-{
-    return calloc(aNum, aSize);
-}
+void *otPlatCAlloc(size_t aNum, size_t aSize) { return calloc(aNum, aSize); }
 
-void otPlatFree(void *aPtr)
-{
-    free(aPtr);
-}
+void otPlatFree(void *aPtr) { free(aPtr); }
 #endif

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -155,15 +155,9 @@ unsigned int gNetifIndex = 0;
 char         gNetifName[IFNAMSIZ];
 otIp4Cidr    gNat64Cidr;
 
-const char *otSysGetThreadNetifName(void)
-{
-    return gNetifName;
-}
+const char *otSysGetThreadNetifName(void) { return gNetifName; }
 
-unsigned int otSysGetThreadNetifIndex(void)
-{
-    return gNetifIndex;
-}
+unsigned int otSysGetThreadNetifIndex(void) { return gNetifIndex; }
 
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
 #if OPENTHREAD_POSIX_CONFIG_FIREWALL_ENABLE
@@ -1818,9 +1812,7 @@ void platformNetifSetUp(void)
 #endif
 }
 
-void platformNetifTearDown(void)
-{
-}
+void platformNetifTearDown(void) {}
 
 void platformNetifDeinit(void)
 {

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -198,10 +198,7 @@ void Radio::Init(void)
 } // namespace Posix
 } // namespace ot
 
-void platformRadioDeinit(void)
-{
-    sRadioSpinel.Deinit();
-}
+void platformRadioDeinit(void) { sRadioSpinel.Deinit(); }
 
 void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
 {
@@ -246,10 +243,7 @@ bool otPlatRadioIsEnabled(otInstance *aInstance)
     return sRadioSpinel.IsEnabled();
 }
 
-otError otPlatRadioEnable(otInstance *aInstance)
-{
-    return sRadioSpinel.Enable(aInstance);
-}
+otError otPlatRadioEnable(otInstance *aInstance) { return sRadioSpinel.Enable(aInstance); }
 
 otError otPlatRadioDisable(otInstance *aInstance)
 {
@@ -532,10 +526,7 @@ exit:
     return;
 }
 
-bool otPlatDiagModeGet(void)
-{
-    return sRadioSpinel.IsDiagEnabled();
-}
+bool otPlatDiagModeGet(void) { return sRadioSpinel.IsDiagEnabled(); }
 
 void otPlatDiagTxPowerSet(int8_t aTxPower)
 {
@@ -634,10 +625,7 @@ void otPlatDiagRadioReceived(otInstance *aInstance, otRadioFrame *aFrame, otErro
     OT_UNUSED_VARIABLE(aError);
 }
 
-void otPlatDiagAlarmCallback(otInstance *aInstance)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-}
+void otPlatDiagAlarmCallback(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
 #endif // OPENTHREAD_CONFIG_DIAG_ENABLE
 
 uint32_t otPlatRadioGetSupportedChannelMask(otInstance *aInstance)
@@ -746,10 +734,7 @@ otError otPlatRadioReceiveAt(otInstance *aInstance, uint8_t aChannel, uint32_t a
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-const otRadioSpinelMetrics *otSysGetRadioSpinelMetrics(void)
-{
-    return sRadioSpinel.GetRadioSpinelMetrics();
-}
+const otRadioSpinelMetrics *otSysGetRadioSpinelMetrics(void) { return sRadioSpinel.GetRadioSpinelMetrics(); }
 
 const otRcpInterfaceMetrics *otSysGetRcpInterfaceMetrics(void)
 {

--- a/src/posix/platform/settings.cpp
+++ b/src/posix/platform/settings.cpp
@@ -525,10 +525,7 @@ void PlatformSettingsGetSensitiveKeys(otInstance *aInstance, const uint16_t **aK
 
 #if SELF_TEST
 
-void otLogCritPlat(const char *aFormat, ...)
-{
-    OT_UNUSED_VARIABLE(aFormat);
-}
+void otLogCritPlat(const char *aFormat, ...) { OT_UNUSED_VARIABLE(aFormat); }
 
 const char *otExitCodeToString(uint8_t aExitCode)
 {
@@ -544,10 +541,7 @@ void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
 }
 
 // Stub implementation for testing
-bool IsSystemDryRun(void)
-{
-    return false;
-}
+bool IsSystemDryRun(void) { return false; }
 
 int main()
 {

--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -191,10 +191,7 @@ otError SpiInterface::Init(const Url::Url &aRadioUrl)
     return OT_ERROR_NONE;
 }
 
-SpiInterface::~SpiInterface(void)
-{
-    Deinit();
-}
+SpiInterface::~SpiInterface(void) { Deinit(); }
 
 void SpiInterface::Deinit(void)
 {
@@ -725,10 +722,7 @@ void SpiInterface::UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, int &aMa
     }
 }
 
-void SpiInterface::Process(const RadioProcessContext &aContext)
-{
-    Process(aContext.mReadFdSet, aContext.mWriteFdSet);
-}
+void SpiInterface::Process(const RadioProcessContext &aContext) { Process(aContext.mReadFdSet, aContext.mWriteFdSet); }
 
 void SpiInterface::Process(const fd_set *aReadFdSet, const fd_set *aWriteFdSet)
 {

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -410,7 +410,4 @@ void otSysMainloopProcess(otInstance *aInstance, const otSysMainloopContext *aMa
 #endif
 }
 
-bool IsSystemDryRun(void)
-{
-    return gDryRun;
-}
+bool IsSystemDryRun(void) { return gDryRun; }

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -65,25 +65,13 @@ namespace {
 
 constexpr size_t kMaxUdpSize = 1280;
 
-void *FdToHandle(int aFd)
-{
-    return reinterpret_cast<void *>(aFd);
-}
+void *FdToHandle(int aFd) { return reinterpret_cast<void *>(aFd); }
 
-int FdFromHandle(void *aHandle)
-{
-    return static_cast<int>(reinterpret_cast<long>(aHandle));
-}
+int FdFromHandle(void *aHandle) { return static_cast<int>(reinterpret_cast<long>(aHandle)); }
 
-bool IsLinkLocal(const struct in6_addr &aAddress)
-{
-    return aAddress.s6_addr[0] == 0xfe && aAddress.s6_addr[1] == 0x80;
-}
+bool IsLinkLocal(const struct in6_addr &aAddress) { return aAddress.s6_addr[0] == 0xfe && aAddress.s6_addr[1] == 0x80; }
 
-bool IsMulticast(const otIp6Address &aAddress)
-{
-    return aAddress.mFields.m8[0] == 0xff;
-}
+bool IsMulticast(const otIp6Address &aAddress) { return aAddress.mFields.m8[0] == 0xff; }
 
 otError transmitPacket(int aFd, uint8_t *aPayload, uint16_t aLength, const otMessageInfo &aMessageInfo)
 {
@@ -591,15 +579,9 @@ void Udp::Init(const char *aIfName)
     assert(gNetifIndex != 0);
 }
 
-void Udp::SetUp(void)
-{
-    Mainloop::Manager::Get().Add(*this);
-}
+void Udp::SetUp(void) { Mainloop::Manager::Get().Add(*this); }
 
-void Udp::TearDown(void)
-{
-    Mainloop::Manager::Get().Remove(*this);
-}
+void Udp::TearDown(void) { Mainloop::Manager::Get().Remove(*this); }
 
 void Udp::Deinit(void)
 {

--- a/src/posix/platform/vendor_interface_example.cpp
+++ b/src/posix/platform/vendor_interface_example.cpp
@@ -83,10 +83,7 @@ VendorInterface::VendorInterface(SpinelInterface::ReceiveFrameCallback aCallback
     OT_UNUSED_VARIABLE(sVendorInterfaceImplRaw);
 }
 
-VendorInterface::~VendorInterface(void)
-{
-    Deinit();
-}
+VendorInterface::~VendorInterface(void) { Deinit(); }
 
 otError VendorInterface::Init(const Url::Url &aRadioUrl)
 {
@@ -102,10 +99,7 @@ void VendorInterface::Deinit(void)
     // TODO: Implement vendor code here.
 }
 
-uint32_t VendorInterface::GetBusSpeed(void) const
-{
-    return 1000000;
-}
+uint32_t VendorInterface::GetBusSpeed(void) const { return 1000000; }
 
 void VendorInterface::OnRcpReset(void)
 {

--- a/src/posix/platform/virtual_time.cpp
+++ b/src/posix/platform/virtual_time.cpp
@@ -197,9 +197,6 @@ void virtualTimeProcess(otInstance   *aInstance,
     virtualTimeRadioSpinelProcess(aInstance, &event);
 }
 
-uint64_t otPlatTimeGet(void)
-{
-    return sNow;
-}
+uint64_t otPlatTimeGet(void) { return sNow; }
 
 #endif // OPENTHREAD_POSIX_VIRTUAL_TIME

--- a/tests/fuzz/fuzzer_platform.cpp
+++ b/tests/fuzz/fuzzer_platform.cpp
@@ -144,15 +144,9 @@ void FuzzerPlatformProcess(otInstance *aInstance)
     }
 }
 
-bool FuzzerPlatformResetWasRequested(void)
-{
-    return sResetWasRequested;
-}
+bool FuzzerPlatformResetWasRequested(void) { return sResetWasRequested; }
 
-uint32_t otPlatAlarmMilliGetNow(void)
-{
-    return sAlarmNow / 1000;
-}
+uint32_t otPlatAlarmMilliGetNow(void) { return sAlarmNow / 1000; }
 
 void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
@@ -169,10 +163,7 @@ void otPlatAlarmMilliStop(otInstance *aInstance)
     sAlarmMilli.isRunning = false;
 }
 
-uint32_t otPlatAlarmMicroGetNow(void)
-{
-    return sAlarmNow;
-}
+uint32_t otPlatAlarmMicroGetNow(void) { return sAlarmNow; }
 
 void otPlatAlarmMicroStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
@@ -237,9 +228,7 @@ OT_TOOL_WEAK void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const 
     OT_UNUSED_VARIABLE(aFormat);
 }
 
-void otPlatWakeHost(void)
-{
-}
+void otPlatWakeHost(void) {}
 
 void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
 {
@@ -388,15 +377,9 @@ otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const otExtAddre
     return OT_ERROR_NONE;
 }
 
-void otPlatRadioClearSrcMatchShortEntries(otInstance *aInstance)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-}
+void otPlatRadioClearSrcMatchShortEntries(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
 
-void otPlatRadioClearSrcMatchExtEntries(otInstance *aInstance)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-}
+void otPlatRadioClearSrcMatchExtEntries(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
 
 otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration)
 {
@@ -450,10 +433,7 @@ void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aSensitiveKeys, u
     OT_UNUSED_VARIABLE(aSensitiveKeysLength);
 }
 
-void otPlatSettingsDeinit(otInstance *aInstance)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-}
+void otPlatSettingsDeinit(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
 
 otError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength)
 {
@@ -491,10 +471,7 @@ otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
     return OT_ERROR_NONE;
 }
 
-void otPlatSettingsWipe(otInstance *aInstance)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-}
+void otPlatSettingsWipe(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
 
 otError otPlatDiagProcess(otInstance *aInstance,
                           uint8_t     aArgsLength,
@@ -511,25 +488,13 @@ otError otPlatDiagProcess(otInstance *aInstance,
     return OT_ERROR_INVALID_COMMAND;
 }
 
-void otPlatDiagModeSet(bool aMode)
-{
-    OT_UNUSED_VARIABLE(aMode);
-}
+void otPlatDiagModeSet(bool aMode) { OT_UNUSED_VARIABLE(aMode); }
 
-bool otPlatDiagModeGet(void)
-{
-    return false;
-}
+bool otPlatDiagModeGet(void) { return false; }
 
-void otPlatDiagChannelSet(uint8_t aChannel)
-{
-    OT_UNUSED_VARIABLE(aChannel);
-}
+void otPlatDiagChannelSet(uint8_t aChannel) { OT_UNUSED_VARIABLE(aChannel); }
 
-void otPlatDiagTxPowerSet(int8_t aTxPower)
-{
-    OT_UNUSED_VARIABLE(aTxPower);
-}
+void otPlatDiagTxPowerSet(int8_t aTxPower) { OT_UNUSED_VARIABLE(aTxPower); }
 
 void otPlatDiagRadioReceived(otInstance *aInstance, otRadioFrame *aFrame, otError aError)
 {
@@ -538,7 +503,4 @@ void otPlatDiagRadioReceived(otInstance *aInstance, otRadioFrame *aFrame, otErro
     OT_UNUSED_VARIABLE(aError);
 }
 
-void otPlatDiagAlarmCallback(otInstance *aInstance)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-}
+void otPlatDiagAlarmCallback(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }

--- a/tests/unit/test_dso.cpp
+++ b/tests/unit/test_dso.cpp
@@ -52,10 +52,7 @@ static otInstance *sInstance;
     printf("%02u:%02u:%02u.%03u " OT_FIRST_ARG(__VA_ARGS__) "\n", (sNow / 36000000), (sNow / 60000) % 60, \
            (sNow / 1000) % 60, sNow % 1000 OT_REST_ARGS(__VA_ARGS__))
 
-void otPlatAlarmMilliStop(otInstance *)
-{
-    sAlarmOn = false;
-}
+void otPlatAlarmMilliStop(otInstance *) { sAlarmOn = false; }
 
 void otPlatAlarmMilliStartAt(otInstance *, uint32_t aT0, uint32_t aDt)
 {
@@ -66,10 +63,7 @@ void otPlatAlarmMilliStartAt(otInstance *, uint32_t aT0, uint32_t aDt)
         (sAlarmTime - sNow) / 1000, (sAlarmTime - sNow) % 1000);
 }
 
-uint32_t otPlatAlarmMilliGetNow(void)
-{
-    return sNow;
-}
+uint32_t otPlatAlarmMilliGetNow(void) { return sNow; }
 
 } // extern "C"
 

--- a/tests/unit/test_hdlc.cpp
+++ b/tests/unit/test_hdlc.cpp
@@ -591,10 +591,7 @@ void TestEncoderDecoder(void)
     printf(" -- PASS\n");
 }
 
-uint32_t GetRandom(uint32_t max)
-{
-    return static_cast<uint32_t>(rand()) % max;
-}
+uint32_t GetRandom(uint32_t max) { return static_cast<uint32_t>(rand()) % max; }
 
 void TestFuzzEncoderDecoder(void)
 {

--- a/tests/unit/test_heap_string.cpp
+++ b/tests/unit/test_heap_string.cpp
@@ -150,10 +150,7 @@ void TestHeapString(void)
     printf("\n -- PASS\n");
 }
 
-void PrintData(const Heap::Data &aData)
-{
-    DumpBuffer("data", aData.GetBytes(), aData.GetLength());
-}
+void PrintData(const Heap::Data &aData) { DumpBuffer("data", aData.GetBytes(), aData.GetLength()); }
 
 static const uint8_t kTestValue = 0x77;
 

--- a/tests/unit/test_link_quality.cpp
+++ b/tests/unit/test_link_quality.cpp
@@ -82,10 +82,7 @@ void VerifyRawRssValue(int8_t aAverage, uint16_t aRawValue)
 }
 
 // This function prints the values in the passed in link info instance. It is invoked as the final step in test-case.
-void PrintOutcome(LinkQualityInfo &aLinkInfo)
-{
-    printf("%s -> PASS \n", aLinkInfo.ToInfoString().AsCString());
-}
+void PrintOutcome(LinkQualityInfo &aLinkInfo) { printf("%s -> PASS \n", aLinkInfo.ToInfoString().AsCString()); }
 
 void TestLinkQualityData(RssTestData aRssData)
 {
@@ -138,10 +135,7 @@ void VerifyRawRssValue(RssAverager &aRssAverager)
 }
 
 // This function prints the values in the passed link info instance. It is invoked as the final step in test-case.
-void PrintOutcome(RssAverager &aRssAverager)
-{
-    printf("%s -> PASS\n", aRssAverager.ToString().AsCString());
-}
+void PrintOutcome(RssAverager &aRssAverager) { printf("%s -> PASS\n", aRssAverager.ToString().AsCString()); }
 
 int8_t GetRandomRss(void)
 {

--- a/tests/unit/test_macros.cpp
+++ b/tests/unit/test_macros.cpp
@@ -30,55 +30,25 @@
 
 #include "common/arg_macros.hpp"
 
-static constexpr uint8_t NumberOfArgs(void)
-{
-    return 0;
-}
+static constexpr uint8_t NumberOfArgs(void) { return 0; }
 
-static constexpr uint8_t NumberOfArgs(uint8_t)
-{
-    return 1;
-}
+static constexpr uint8_t NumberOfArgs(uint8_t) { return 1; }
 
-static constexpr uint8_t NumberOfArgs(uint8_t, uint8_t)
-{
-    return 2;
-}
+static constexpr uint8_t NumberOfArgs(uint8_t, uint8_t) { return 2; }
 
-static constexpr uint8_t NumberOfArgs(uint8_t, uint8_t, uint8_t)
-{
-    return 3;
-}
+static constexpr uint8_t NumberOfArgs(uint8_t, uint8_t, uint8_t) { return 3; }
 
-static constexpr uint8_t NumberOfArgs(uint8_t, uint8_t, uint8_t, uint8_t)
-{
-    return 4;
-}
+static constexpr uint8_t NumberOfArgs(uint8_t, uint8_t, uint8_t, uint8_t) { return 4; }
 
-static constexpr uint8_t NumberOfArgs(uint8_t, uint8_t, uint8_t, uint8_t, uint8_t)
-{
-    return 5;
-}
+static constexpr uint8_t NumberOfArgs(uint8_t, uint8_t, uint8_t, uint8_t, uint8_t) { return 5; }
 
-static constexpr uint8_t NumberOfArgs(uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t)
-{
-    return 6;
-}
+static constexpr uint8_t NumberOfArgs(uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t) { return 6; }
 
-static constexpr uint8_t NumberOfArgs(uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t)
-{
-    return 7;
-}
+static constexpr uint8_t NumberOfArgs(uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t) { return 7; }
 
-int Sum(int aFirst)
-{
-    return aFirst;
-}
+int Sum(int aFirst) { return aFirst; }
 
-template <typename... Args> int Sum(int aFirst, Args... aArgs)
-{
-    return aFirst + Sum(aArgs...);
-}
+template <typename... Args> int Sum(int aFirst, Args... aArgs) { return aFirst + Sum(aArgs...); }
 
 void TestMacros(void)
 {

--- a/tests/unit/test_multicast_listeners_table.cpp
+++ b/tests/unit/test_multicast_listeners_table.cpp
@@ -57,10 +57,7 @@ static const otIp6Address MA501 = {
 
 uint32_t sNow;
 
-extern "C" uint32_t otPlatAlarmMilliGetNow(void)
-{
-    return sNow;
-}
+extern "C" uint32_t otPlatAlarmMilliGetNow(void) { return sNow; }
 
 void testMulticastListenersTableAPIs(Instance *aInstance);
 
@@ -199,8 +196,5 @@ int main(void)
 }
 
 #else
-int main(void)
-{
-    return 0;
-}
+int main(void) { return 0; }
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE

--- a/tests/unit/test_ndproxy_table.cpp
+++ b/tests/unit/test_ndproxy_table.cpp
@@ -111,8 +111,5 @@ int main(void)
 }
 
 #else
-int main(void)
-{
-    return 0;
-}
+int main(void) { return 0; }
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -76,28 +76,16 @@ bool sDiagMode = false;
 extern "C" {
 
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-OT_TOOL_WEAK void *otPlatCAlloc(size_t aNum, size_t aSize)
-{
-    return calloc(aNum, aSize);
-}
+OT_TOOL_WEAK void *otPlatCAlloc(size_t aNum, size_t aSize) { return calloc(aNum, aSize); }
 
-OT_TOOL_WEAK void otPlatFree(void *aPtr)
-{
-    free(aPtr);
-}
+OT_TOOL_WEAK void otPlatFree(void *aPtr) { free(aPtr); }
 #endif
 
-OT_TOOL_WEAK void otTaskletsSignalPending(otInstance *)
-{
-}
+OT_TOOL_WEAK void otTaskletsSignalPending(otInstance *) {}
 
-OT_TOOL_WEAK void otPlatAlarmMilliStop(otInstance *)
-{
-}
+OT_TOOL_WEAK void otPlatAlarmMilliStop(otInstance *) {}
 
-OT_TOOL_WEAK void otPlatAlarmMilliStartAt(otInstance *, uint32_t, uint32_t)
-{
-}
+OT_TOOL_WEAK void otPlatAlarmMilliStartAt(otInstance *, uint32_t, uint32_t) {}
 
 OT_TOOL_WEAK uint32_t otPlatAlarmMilliGetNow(void)
 {
@@ -108,13 +96,9 @@ OT_TOOL_WEAK uint32_t otPlatAlarmMilliGetNow(void)
     return (uint32_t)((tv.tv_sec * 1000) + (tv.tv_usec / 1000) + 123456);
 }
 
-OT_TOOL_WEAK void otPlatAlarmMicroStop(otInstance *)
-{
-}
+OT_TOOL_WEAK void otPlatAlarmMicroStop(otInstance *) {}
 
-OT_TOOL_WEAK void otPlatAlarmMicroStartAt(otInstance *, uint32_t, uint32_t)
-{
-}
+OT_TOOL_WEAK void otPlatAlarmMicroStartAt(otInstance *, uint32_t, uint32_t) {}
 
 OT_TOOL_WEAK uint32_t otPlatAlarmMicroGetNow(void)
 {
@@ -125,122 +109,55 @@ OT_TOOL_WEAK uint32_t otPlatAlarmMicroGetNow(void)
     return (uint32_t)((tv.tv_sec * 1000000) + tv.tv_usec + 123456);
 }
 
-OT_TOOL_WEAK void otPlatRadioGetIeeeEui64(otInstance *, uint8_t *)
-{
-}
+OT_TOOL_WEAK void otPlatRadioGetIeeeEui64(otInstance *, uint8_t *) {}
 
-OT_TOOL_WEAK void otPlatRadioSetPanId(otInstance *, uint16_t)
-{
-}
+OT_TOOL_WEAK void otPlatRadioSetPanId(otInstance *, uint16_t) {}
 
-OT_TOOL_WEAK void otPlatRadioSetExtendedAddress(otInstance *, const otExtAddress *)
-{
-}
+OT_TOOL_WEAK void otPlatRadioSetExtendedAddress(otInstance *, const otExtAddress *) {}
 
-OT_TOOL_WEAK void otPlatRadioSetShortAddress(otInstance *, uint16_t)
-{
-}
+OT_TOOL_WEAK void otPlatRadioSetShortAddress(otInstance *, uint16_t) {}
 
-OT_TOOL_WEAK void otPlatRadioSetPromiscuous(otInstance *, bool)
-{
-}
+OT_TOOL_WEAK void otPlatRadioSetPromiscuous(otInstance *, bool) {}
 
-OT_TOOL_WEAK bool otPlatRadioIsEnabled(otInstance *)
-{
-    return true;
-}
+OT_TOOL_WEAK bool otPlatRadioIsEnabled(otInstance *) { return true; }
 
-OT_TOOL_WEAK otError otPlatRadioEnable(otInstance *)
-{
-    return OT_ERROR_NONE;
-}
+OT_TOOL_WEAK otError otPlatRadioEnable(otInstance *) { return OT_ERROR_NONE; }
 
-OT_TOOL_WEAK otError otPlatRadioDisable(otInstance *)
-{
-    return OT_ERROR_NONE;
-}
+OT_TOOL_WEAK otError otPlatRadioDisable(otInstance *) { return OT_ERROR_NONE; }
 
-OT_TOOL_WEAK otError otPlatRadioSleep(otInstance *)
-{
-    return OT_ERROR_NONE;
-}
+OT_TOOL_WEAK otError otPlatRadioSleep(otInstance *) { return OT_ERROR_NONE; }
 
-OT_TOOL_WEAK otError otPlatRadioReceive(otInstance *, uint8_t)
-{
-    return OT_ERROR_NONE;
-}
+OT_TOOL_WEAK otError otPlatRadioReceive(otInstance *, uint8_t) { return OT_ERROR_NONE; }
 
-OT_TOOL_WEAK otError otPlatRadioTransmit(otInstance *, otRadioFrame *)
-{
-    return OT_ERROR_NONE;
-}
+OT_TOOL_WEAK otError otPlatRadioTransmit(otInstance *, otRadioFrame *) { return OT_ERROR_NONE; }
 
-OT_TOOL_WEAK otRadioFrame *otPlatRadioGetTransmitBuffer(otInstance *)
-{
-    return nullptr;
-}
+OT_TOOL_WEAK otRadioFrame *otPlatRadioGetTransmitBuffer(otInstance *) { return nullptr; }
 
-OT_TOOL_WEAK int8_t otPlatRadioGetRssi(otInstance *)
-{
-    return 0;
-}
+OT_TOOL_WEAK int8_t otPlatRadioGetRssi(otInstance *) { return 0; }
 
-OT_TOOL_WEAK otRadioCaps otPlatRadioGetCaps(otInstance *)
-{
-    return OT_RADIO_CAPS_NONE;
-}
+OT_TOOL_WEAK otRadioCaps otPlatRadioGetCaps(otInstance *) { return OT_RADIO_CAPS_NONE; }
 
-OT_TOOL_WEAK bool otPlatRadioGetPromiscuous(otInstance *)
-{
-    return false;
-}
+OT_TOOL_WEAK bool otPlatRadioGetPromiscuous(otInstance *) { return false; }
 
-OT_TOOL_WEAK void otPlatRadioEnableSrcMatch(otInstance *, bool)
-{
-}
+OT_TOOL_WEAK void otPlatRadioEnableSrcMatch(otInstance *, bool) {}
 
-OT_TOOL_WEAK otError otPlatRadioAddSrcMatchShortEntry(otInstance *, uint16_t)
-{
-    return OT_ERROR_NONE;
-}
+OT_TOOL_WEAK otError otPlatRadioAddSrcMatchShortEntry(otInstance *, uint16_t) { return OT_ERROR_NONE; }
 
-OT_TOOL_WEAK otError otPlatRadioAddSrcMatchExtEntry(otInstance *, const otExtAddress *)
-{
-    return OT_ERROR_NONE;
-}
+OT_TOOL_WEAK otError otPlatRadioAddSrcMatchExtEntry(otInstance *, const otExtAddress *) { return OT_ERROR_NONE; }
 
-OT_TOOL_WEAK otError otPlatRadioClearSrcMatchShortEntry(otInstance *, uint16_t)
-{
-    return OT_ERROR_NONE;
-}
+OT_TOOL_WEAK otError otPlatRadioClearSrcMatchShortEntry(otInstance *, uint16_t) { return OT_ERROR_NONE; }
 
-OT_TOOL_WEAK otError otPlatRadioClearSrcMatchExtEntry(otInstance *, const otExtAddress *)
-{
-    return OT_ERROR_NONE;
-}
+OT_TOOL_WEAK otError otPlatRadioClearSrcMatchExtEntry(otInstance *, const otExtAddress *) { return OT_ERROR_NONE; }
 
-OT_TOOL_WEAK void otPlatRadioClearSrcMatchShortEntries(otInstance *)
-{
-}
+OT_TOOL_WEAK void otPlatRadioClearSrcMatchShortEntries(otInstance *) {}
 
-OT_TOOL_WEAK void otPlatRadioClearSrcMatchExtEntries(otInstance *)
-{
-}
+OT_TOOL_WEAK void otPlatRadioClearSrcMatchExtEntries(otInstance *) {}
 
-OT_TOOL_WEAK otError otPlatRadioEnergyScan(otInstance *, uint8_t, uint16_t)
-{
-    return OT_ERROR_NOT_IMPLEMENTED;
-}
+OT_TOOL_WEAK otError otPlatRadioEnergyScan(otInstance *, uint8_t, uint16_t) { return OT_ERROR_NOT_IMPLEMENTED; }
 
-OT_TOOL_WEAK otError otPlatRadioSetTransmitPower(otInstance *, int8_t)
-{
-    return OT_ERROR_NOT_IMPLEMENTED;
-}
+OT_TOOL_WEAK otError otPlatRadioSetTransmitPower(otInstance *, int8_t) { return OT_ERROR_NOT_IMPLEMENTED; }
 
-OT_TOOL_WEAK int8_t otPlatRadioGetReceiveSensitivity(otInstance *)
-{
-    return -100;
-}
+OT_TOOL_WEAK int8_t otPlatRadioGetReceiveSensitivity(otInstance *) { return -100; }
 
 OT_TOOL_WEAK otError otPlatEntropyGet(uint8_t *aOutput, uint16_t aOutputLength)
 {
@@ -281,84 +198,44 @@ OT_TOOL_WEAK void otPlatDiagProcess(otInstance *, uint8_t, char *aArgs[], char *
     sprintf(aOutput, "diag feature '%s' is not supported\r\n", aArgs[0]);
 }
 
-OT_TOOL_WEAK void otPlatDiagModeSet(bool aMode)
-{
-    sDiagMode = aMode;
-}
+OT_TOOL_WEAK void otPlatDiagModeSet(bool aMode) { sDiagMode = aMode; }
 
-OT_TOOL_WEAK bool otPlatDiagModeGet()
-{
-    return sDiagMode;
-}
+OT_TOOL_WEAK bool otPlatDiagModeGet() { return sDiagMode; }
 
-OT_TOOL_WEAK void otPlatDiagChannelSet(uint8_t)
-{
-}
+OT_TOOL_WEAK void otPlatDiagChannelSet(uint8_t) {}
 
-OT_TOOL_WEAK void otPlatDiagTxPowerSet(int8_t)
-{
-}
+OT_TOOL_WEAK void otPlatDiagTxPowerSet(int8_t) {}
 
-OT_TOOL_WEAK void otPlatDiagRadioReceived(otInstance *, otRadioFrame *, otError)
-{
-}
+OT_TOOL_WEAK void otPlatDiagRadioReceived(otInstance *, otRadioFrame *, otError) {}
 
-OT_TOOL_WEAK void otPlatDiagAlarmCallback(otInstance *)
-{
-}
+OT_TOOL_WEAK void otPlatDiagAlarmCallback(otInstance *) {}
 
-OT_TOOL_WEAK void otPlatUartSendDone(void)
-{
-}
+OT_TOOL_WEAK void otPlatUartSendDone(void) {}
 
-OT_TOOL_WEAK void otPlatUartReceived(const uint8_t *, uint16_t)
-{
-}
+OT_TOOL_WEAK void otPlatUartReceived(const uint8_t *, uint16_t) {}
 
-OT_TOOL_WEAK void otPlatReset(otInstance *)
-{
-}
+OT_TOOL_WEAK void otPlatReset(otInstance *) {}
 
-OT_TOOL_WEAK otPlatResetReason otPlatGetResetReason(otInstance *)
-{
-    return OT_PLAT_RESET_REASON_POWER_ON;
-}
+OT_TOOL_WEAK otPlatResetReason otPlatGetResetReason(otInstance *) { return OT_PLAT_RESET_REASON_POWER_ON; }
 
-OT_TOOL_WEAK void otPlatLog(otLogLevel, otLogRegion, const char *, ...)
-{
-}
+OT_TOOL_WEAK void otPlatLog(otLogLevel, otLogRegion, const char *, ...) {}
 
-OT_TOOL_WEAK void otPlatSettingsInit(otInstance *, const uint16_t *, uint16_t)
-{
-}
+OT_TOOL_WEAK void otPlatSettingsInit(otInstance *, const uint16_t *, uint16_t) {}
 
-OT_TOOL_WEAK void otPlatSettingsDeinit(otInstance *)
-{
-}
+OT_TOOL_WEAK void otPlatSettingsDeinit(otInstance *) {}
 
 OT_TOOL_WEAK otError otPlatSettingsGet(otInstance *, uint16_t, int, uint8_t *, uint16_t *)
 {
     return OT_ERROR_NOT_FOUND;
 }
 
-OT_TOOL_WEAK otError otPlatSettingsSet(otInstance *, uint16_t, const uint8_t *, uint16_t)
-{
-    return OT_ERROR_NONE;
-}
+OT_TOOL_WEAK otError otPlatSettingsSet(otInstance *, uint16_t, const uint8_t *, uint16_t) { return OT_ERROR_NONE; }
 
-OT_TOOL_WEAK otError otPlatSettingsAdd(otInstance *, uint16_t, const uint8_t *, uint16_t)
-{
-    return OT_ERROR_NONE;
-}
+OT_TOOL_WEAK otError otPlatSettingsAdd(otInstance *, uint16_t, const uint8_t *, uint16_t) { return OT_ERROR_NONE; }
 
-OT_TOOL_WEAK otError otPlatSettingsDelete(otInstance *, uint16_t, int)
-{
-    return OT_ERROR_NONE;
-}
+OT_TOOL_WEAK otError otPlatSettingsDelete(otInstance *, uint16_t, int) { return OT_ERROR_NONE; }
 
-OT_TOOL_WEAK void otPlatSettingsWipe(otInstance *)
-{
-}
+OT_TOOL_WEAK void otPlatSettingsWipe(otInstance *) {}
 
 uint8_t *GetFlash(void)
 {
@@ -374,14 +251,9 @@ uint8_t *GetFlash(void)
     return sFlash;
 }
 
-OT_TOOL_WEAK void otPlatFlashInit(otInstance *)
-{
-}
+OT_TOOL_WEAK void otPlatFlashInit(otInstance *) {}
 
-OT_TOOL_WEAK uint32_t otPlatFlashGetSwapSize(otInstance *)
-{
-    return FLASH_SWAP_SIZE;
-}
+OT_TOOL_WEAK uint32_t otPlatFlashGetSwapSize(otInstance *) { return FLASH_SWAP_SIZE; }
 
 OT_TOOL_WEAK void otPlatFlashErase(otInstance *, uint8_t aSwapIndex)
 {
@@ -428,10 +300,7 @@ OT_TOOL_WEAK void otPlatFlashWrite(otInstance *,
 }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE || OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-OT_TOOL_WEAK uint16_t otPlatTimeGetXtalAccuracy(void)
-{
-    return 0;
-}
+OT_TOOL_WEAK uint16_t otPlatTimeGetXtalAccuracy(void) { return 0; }
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
@@ -440,9 +309,7 @@ OT_TOOL_WEAK otError otPlatRadioEnableCsl(otInstance *, uint32_t, otShortAddress
     return OT_ERROR_NONE;
 }
 
-OT_TOOL_WEAK void otPlatRadioUpdateCslSampleTime(otInstance *, uint32_t)
-{
-}
+OT_TOOL_WEAK void otPlatRadioUpdateCslSampleTime(otInstance *, uint32_t) {}
 
 OT_TOOL_WEAK uint8_t otPlatRadioGetCslAccuracy(otInstance *)
 {
@@ -451,27 +318,17 @@ OT_TOOL_WEAK uint8_t otPlatRadioGetCslAccuracy(otInstance *)
 #endif
 
 #if OPENTHREAD_CONFIG_OTNS_ENABLE
-OT_TOOL_WEAK void otPlatOtnsStatus(const char *)
-{
-}
+OT_TOOL_WEAK void otPlatOtnsStatus(const char *) {}
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-OT_TOOL_WEAK void otPlatTrelEnable(otInstance *, uint16_t *)
-{
-}
+OT_TOOL_WEAK void otPlatTrelEnable(otInstance *, uint16_t *) {}
 
-OT_TOOL_WEAK void otPlatTrelDisable(otInstance *)
-{
-}
+OT_TOOL_WEAK void otPlatTrelDisable(otInstance *) {}
 
-OT_TOOL_WEAK void otPlatTrelSend(otInstance *, const uint8_t *, uint16_t, const otSockAddr *)
-{
-}
+OT_TOOL_WEAK void otPlatTrelSend(otInstance *, const uint8_t *, uint16_t, const otSockAddr *) {}
 
-OT_TOOL_WEAK void otPlatTrelRegisterService(otInstance *, uint16_t, const uint8_t *, uint8_t)
-{
-}
+OT_TOOL_WEAK void otPlatTrelRegisterService(otInstance *, uint16_t, const uint8_t *, uint8_t) {}
 #endif
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
@@ -494,20 +351,14 @@ OT_TOOL_WEAK otLinkMetrics otPlatRadioGetEnhAckProbingMetrics(otInstance *, cons
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-OT_TOOL_WEAK bool otPlatInfraIfHasAddress(uint32_t, const otIp6Address *)
-{
-    return false;
-}
+OT_TOOL_WEAK bool otPlatInfraIfHasAddress(uint32_t, const otIp6Address *) { return false; }
 
 OT_TOOL_WEAK otError otPlatInfraIfSendIcmp6Nd(uint32_t, const otIp6Address *, const uint8_t *, uint16_t)
 {
     return OT_ERROR_FAILED;
 }
 
-OT_TOOL_WEAK otError otPlatInfraIfDiscoverNat64Prefix(uint32_t)
-{
-    return OT_ERROR_FAILED;
-}
+OT_TOOL_WEAK otError otPlatInfraIfDiscoverNat64Prefix(uint32_t) { return OT_ERROR_FAILED; }
 #endif
 
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -187,18 +187,12 @@ otError otPlatRadioTransmit(otInstance *, otRadioFrame *)
     return OT_ERROR_NONE;
 }
 
-otRadioFrame *otPlatRadioGetTransmitBuffer(otInstance *)
-{
-    return &sRadioTxFrame;
-}
+otRadioFrame *otPlatRadioGetTransmitBuffer(otInstance *) { return &sRadioTxFrame; }
 
 //----------------------------------------------------------------------------------------------------------------------
 // `otPlatAlaram
 
-void otPlatAlarmMilliStop(otInstance *)
-{
-    sAlarmOn = false;
-}
+void otPlatAlarmMilliStop(otInstance *) { sAlarmOn = false; }
 
 void otPlatAlarmMilliStartAt(otInstance *, uint32_t aT0, uint32_t aDt)
 {
@@ -206,10 +200,7 @@ void otPlatAlarmMilliStartAt(otInstance *, uint32_t aT0, uint32_t aDt)
     sAlarmTime = aT0 + aDt;
 }
 
-uint32_t otPlatAlarmMilliGetNow(void)
-{
-    return sNow;
-}
+uint32_t otPlatAlarmMilliGetNow(void) { return sNow; }
 
 //---------------------------------------------------------------------------------------------------------------------
 // otPlatInfraIf

--- a/tests/unit/test_srp_server.cpp
+++ b/tests/unit/test_srp_server.cpp
@@ -87,18 +87,12 @@ otError otPlatRadioTransmit(otInstance *, otRadioFrame *)
     return OT_ERROR_NONE;
 }
 
-otRadioFrame *otPlatRadioGetTransmitBuffer(otInstance *)
-{
-    return &sRadioTxFrame;
-}
+otRadioFrame *otPlatRadioGetTransmitBuffer(otInstance *) { return &sRadioTxFrame; }
 
 //----------------------------------------------------------------------------------------------------------------------
 // `otPlatAlaram`
 
-void otPlatAlarmMilliStop(otInstance *)
-{
-    sAlarmOn = false;
-}
+void otPlatAlarmMilliStop(otInstance *) { sAlarmOn = false; }
 
 void otPlatAlarmMilliStartAt(otInstance *, uint32_t aT0, uint32_t aDt)
 {
@@ -106,10 +100,7 @@ void otPlatAlarmMilliStartAt(otInstance *, uint32_t aT0, uint32_t aDt)
     sAlarmTime = aT0 + aDt;
 }
 
-uint32_t otPlatAlarmMilliGetNow(void)
-{
-    return sNow;
-}
+uint32_t otPlatAlarmMilliGetNow(void) { return sNow; }
 
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/tests/unit/test_timer.cpp
+++ b/tests/unit/test_timer.cpp
@@ -65,10 +65,7 @@ void otPlatAlarmMilliStartAt(otInstance *, uint32_t aT0, uint32_t aDt)
     sPlatDt = aDt;
 }
 
-uint32_t otPlatAlarmMilliGetNow(void)
-{
-    return sNow;
-}
+uint32_t otPlatAlarmMilliGetNow(void) { return sNow; }
 
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 void otPlatAlarmMicroStop(otInstance *)
@@ -85,18 +82,12 @@ void otPlatAlarmMicroStartAt(otInstance *, uint32_t aT0, uint32_t aDt)
     sPlatDt = aDt;
 }
 
-uint32_t otPlatAlarmMicroGetNow(void)
-{
-    return sNow;
-}
+uint32_t otPlatAlarmMicroGetNow(void) { return sNow; }
 #endif
 
 } // extern "C"
 
-void InitCounters(void)
-{
-    memset(sCallCount, 0, sizeof(sCallCount));
-}
+void InitCounters(void) { memset(sCallCount, 0, sizeof(sCallCount)); }
 
 /**
  * `TestTimer` sub-classes `ot::TimerMilli` and provides a handler and a counter to keep track of number of times timer
@@ -131,16 +122,10 @@ private:
 
 template <typename TimerType> void AlarmFired(otInstance *aInstance);
 
-template <> void AlarmFired<ot::TimerMilli>(otInstance *aInstance)
-{
-    otPlatAlarmMilliFired(aInstance);
-}
+template <> void AlarmFired<ot::TimerMilli>(otInstance *aInstance) { otPlatAlarmMilliFired(aInstance); }
 
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
-template <> void AlarmFired<ot::TimerMicro>(otInstance *aInstance)
-{
-    otPlatAlarmMicroFired(aInstance);
-}
+template <> void AlarmFired<ot::TimerMicro>(otInstance *aInstance) { otPlatAlarmMicroFired(aInstance); }
 #endif
 
 /**

--- a/tests/unit/test_toolchain.cpp
+++ b/tests/unit/test_toolchain.cpp
@@ -109,10 +109,7 @@ void test_addr_sizes(void)
     VerifyOrQuit(sizeof(otNetifAddress) == otNetifAddress_Size_c(), "otNetifAddress should the same in C & C++");
 }
 
-void test_addr_bitfield(void)
-{
-    VerifyOrQuit(CreateNetif_c().mScopeOverrideValid == true, "test_addr_size_cpp");
-}
+void test_addr_bitfield(void) { VerifyOrQuit(CreateNetif_c().mScopeOverrideValid == true, "test_addr_size_cpp"); }
 
 void test_packed_alignment(void)
 {

--- a/tests/unit/test_toolchain_c.c
+++ b/tests/unit/test_toolchain_c.c
@@ -36,15 +36,9 @@
 
 #include "test_util.h"
 
-uint32_t otNetifAddress_Size_c()
-{
-    return sizeof(otNetifAddress);
-}
+uint32_t otNetifAddress_Size_c() { return sizeof(otNetifAddress); }
 
-uint32_t otNetifAddress_offset_mNext_c()
-{
-    return offsetof(otNetifAddress, mNext);
-}
+uint32_t otNetifAddress_offset_mNext_c() { return offsetof(otNetifAddress, mNext); }
 
 otNetifAddress CreateNetif_c()
 {

--- a/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
+++ b/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
@@ -395,10 +395,7 @@ static void log_debug_buffer(const char *desc, const uint8_t *buffer_ptr, int bu
 /* ------------------------------------------------------------------------- */
 /* MARK: SPI Transfer Functions */
 
-static void spi_header_set_flag_byte(uint8_t *header, uint8_t value)
-{
-    header[0] = value;
-}
+static void spi_header_set_flag_byte(uint8_t *header, uint8_t value) { header[0] = value; }
 
 static void spi_header_set_accept_len(uint8_t *header, uint16_t len)
 {
@@ -412,20 +409,11 @@ static void spi_header_set_data_len(uint8_t *header, uint16_t len)
     header[4] = ((len >> 8) & 0xFF);
 }
 
-static uint8_t spi_header_get_flag_byte(const uint8_t *header)
-{
-    return header[0];
-}
+static uint8_t spi_header_get_flag_byte(const uint8_t *header) { return header[0]; }
 
-static uint16_t spi_header_get_accept_len(const uint8_t *header)
-{
-    return (header[1] + (uint16_t)(header[2] << 8));
-}
+static uint16_t spi_header_get_accept_len(const uint8_t *header) { return (header[1] + (uint16_t)(header[2] << 8)); }
 
-static uint16_t spi_header_get_data_len(const uint8_t *header)
-{
-    return (header[3] + (uint16_t)(header[4] << 8));
-}
+static uint16_t spi_header_get_data_len(const uint8_t *header) { return (header[3] + (uint16_t)(header[4] << 8)); }
 
 static uint8_t *get_real_rx_frame_start(void)
 {


### PR DESCRIPTION
This commit updates `AllowShortFunctionsOnASingleLine` to `All` from `InlineOnly`.

----
Background: 
- We recently moved to clang-format v14 (https://github.com/openthread/openthread/pull/8490)
- We use `AllowShortFunctionsOnASingleLine: InlineOnly` which is supposed to apply this to inline methods.
- However, noticed that this is applied to some inline methods and not all.
- For example, in `Mac` class we see both cases:
https://github.com/openthread/openthread/blob/48c0582e4e0abbdfa6470de90cad5a2e07e1a3b5/src/core/mac/mac.hpp#L192-L192
https://github.com/openthread/openthread/blob/48c0582e4e0abbdfa6470de90cad5a2e07e1a3b5/src/core/mac/mac.hpp#L242-L245 
  - This issue seems to happen in all modules (happens after we have an `#if` in class definition).
- Seems like there may be a bug in clang-format v14 which does not realize certain methods are "inline" after an `#if`.
- To harmonize this, we can use `AllowShortFunctionsOnASingleLine: All` which then applies this rule whenever it can  and I think looks good overall.
