### PR TITLE
[simul-plat] new option to write logs to a given file

### DIFF
--- a/examples/platforms/simulation/logging.c
+++ b/examples/platforms/simulation/logging.c
@@ -31,6 +31,7 @@
 #include <openthread/config.h>
 
 #include <ctype.h>
+#include <errno.h>
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdint.h>
@@ -44,21 +45,82 @@
 #include "utils/code_utils.h"
 
 #if (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED)
-OT_TOOL_WEAK void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
+
+static FILE *sLogFile = NULL;
+
+void platformLoggingSetFileName(const char *aName)
+{
+    if (sLogFile != NULL)
+    {
+        fclose(sLogFile);
+    }
+
+    sLogFile = fopen(aName, "wt");
+
+    if (sLogFile == NULL)
+    {
+        fprintf(stderr, "Failed to open log file '%s': %s\r\n", aName, strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+}
+
+void platformLoggingInit(const char *aName)
+{
+    if (sLogFile == NULL)
+    {
+        openlog(aName, LOG_PID, LOG_USER);
+        setlogmask(setlogmask(0) & LOG_UPTO(LOG_NOTICE));
+    }
+    else
+    {
+        fprintf(sLogFile, "OpenThread logs\r\n");
+        fprintf(sLogFile, "- Program:  %s\r\n", aName);
+        fprintf(sLogFile, "- Platform: simulation\r\n");
+        fprintf(sLogFile, "- Node ID:  %lu\r\n", (unsigned long)gNodeId);
+        fprintf(sLogFile, "\r\n");
+    }
+}
+
+void platformLoggingDeinit(void)
+{
+    if (sLogFile != NULL)
+    {
+        fclose(sLogFile);
+        sLogFile = NULL;
+    }
+}
+
+void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
 {
     OT_UNUSED_VARIABLE(aLogLevel);
     OT_UNUSED_VARIABLE(aLogRegion);
 
-    char    logString[512];
-    int     offset;
     va_list args;
 
-    offset = snprintf(logString, sizeof(logString), "[%d]", gNodeId);
-
     va_start(args, aFormat);
-    vsnprintf(&logString[offset], sizeof(logString) - (uint16_t)offset, aFormat, args);
-    va_end(args);
 
-    syslog(LOG_CRIT, "%s", logString);
+    if (sLogFile == NULL)
+    {
+        char logString[512];
+        int  offset;
+
+        offset = snprintf(logString, sizeof(logString), "[%lu]", (unsigned long)gNodeId);
+
+        vsnprintf(&logString[offset], sizeof(logString) - (uint16_t)offset, aFormat, args);
+        syslog(LOG_CRIT, "%s", logString);
+    }
+    else
+    {
+        vfprintf(sLogFile, aFormat, args);
+        fprintf(sLogFile, "\r\n");
+    }
+
+    va_end(args);
 }
-#endif
+
+#else
+
+void platformLoggingInit(const char *aName) { OT_UNUSED_VARIABLE(aName); }
+void platformLoggingDeinit(void) {}
+
+#endif // (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED)

--- a/examples/platforms/simulation/platform-simulation.h
+++ b/examples/platforms/simulation/platform-simulation.h
@@ -186,6 +186,28 @@ void platformRadioProcess(otInstance *aInstance, const fd_set *aReadFdSet, const
 void platformRandomInit(void);
 
 /**
+ * This functions set the file name to use for logging.
+ *
+ * @param[in] aName  The file name.
+ *
+ */
+void platformLoggingSetFileName(const char *aName);
+
+/**
+ * This function initializes the platform logging service.
+ *
+ * @param[in] aName    The log module name to set with syslog.
+ *
+ */
+void platformLoggingInit(const char *aName);
+
+/**
+ * This function finalizes the platform logging service.
+ *
+ */
+void platformLoggingDeinit(void);
+
+/**
  * This function updates the file descriptor sets with file descriptors used by the UART driver.
  *
  * @param[in,out]  aReadFdSet   A pointer to the read file descriptors.


### PR DESCRIPTION
This commit adds a new option in simulation platform to allow us to specify a file name to write the logs into. This is applicable when `LOG_OUTPUT` is set to `PLATFORM_DEFINED`. The filename can be specified by `-l <name>` or `--log-file=<name>` options. If no log file is provided then logs are emitted to syslog.