### PR TITLE
[test] ensure NAT64 is enabled when running NAT64 tests

### DIFF
--- a/tests/scripts/thread-cert/border_router/nat64/test_multi_border_routers.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_multi_border_routers.py
@@ -108,7 +108,8 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         self.simulator.go(5)
 
         br1.start()
-        # Ensure NAT64 is enabled on BR2.
+        # When feature flag is enabled, NAT64 might be disabled by default. So
+        # ensure NAT64 is enabled here.
         br1.nat64_set_enabled(True)
         self.simulator.go(config.LEADER_STARTUP_DELAY)
         br1.bash("service bind9 stop")
@@ -124,7 +125,8 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         #         it will add the infrastructure nat64 prefix to Network Data.
         #
         br2.start()
-        # Ensure NAT64 is enabled on BR2.
+        # When feature flag is enabled, NAT64 might be disabled by default. So
+        # ensure NAT64 is enabled here.
         br2.nat64_set_enabled(True)
         self.simulator.go(config.BORDER_ROUTER_STARTUP_DELAY)
         self.assertEqual('router', br2.get_state())

--- a/tests/scripts/thread-cert/border_router/nat64/test_multi_border_routers.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_multi_border_routers.py
@@ -107,8 +107,9 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         host.start(start_radvd=False)
         self.simulator.go(5)
 
-        # NAT64 is enabled by default when starting BR1.
         br1.start()
+        # Ensure NAT64 is enabled on BR2.
+        br1.nat64_set_enabled(True)
         self.simulator.go(config.LEADER_STARTUP_DELAY)
         br1.bash("service bind9 stop")
         self.simulator.go(NAT64_PREFIX_REFRESH_DELAY)
@@ -122,8 +123,9 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         # Case 1. BR2 with an infrastructure prefix joins the network later and
         #         it will add the infrastructure nat64 prefix to Network Data.
         #
-        # NAT64 is enabled by default when starting BR2.
         br2.start()
+        # Ensure NAT64 is enabled on BR2.
+        br2.nat64_set_enabled(True)
         self.simulator.go(config.BORDER_ROUTER_STARTUP_DELAY)
         self.assertEqual('router', br2.get_state())
 

--- a/tests/scripts/thread-cert/border_router/nat64/test_single_border_router.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_single_border_router.py
@@ -115,8 +115,9 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         host.start(start_radvd=False)
         self.simulator.go(5)
 
-        # NAT64 is enabled by default when starting BR.
         br.start()
+        # Ensure NAT64 is enabled on BR.
+        br.nat64_set_enabled(True)
         self.simulator.go(config.LEADER_STARTUP_DELAY)
         br.bash("service bind9 stop")
         self.simulator.go(330)

--- a/tests/scripts/thread-cert/border_router/nat64/test_single_border_router.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_single_border_router.py
@@ -116,7 +116,8 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         self.simulator.go(5)
 
         br.start()
-        # Ensure NAT64 is enabled on BR.
+        # When feature flag is enabled, NAT64 might be disabled by default. So
+        # ensure NAT64 is enabled here.
         br.nat64_set_enabled(True)
         self.simulator.go(config.LEADER_STARTUP_DELAY)
         br.bash("service bind9 stop")

--- a/tests/scripts/thread-cert/border_router/nat64/test_with_infrastructure_prefix.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_with_infrastructure_prefix.py
@@ -74,8 +74,9 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         br = self.nodes[BR]
         router = self.nodes[ROUTER]
 
-        # NAT64 is enabled by default when starting BR.
         br.start()
+        # Ensure NAT64 is enabled on BR.
+        br.nat64_set_enabled(True)
         self.simulator.go(config.LEADER_STARTUP_DELAY)
         self.assertEqual('leader', br.get_state())
 

--- a/tests/scripts/thread-cert/border_router/nat64/test_with_infrastructure_prefix.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_with_infrastructure_prefix.py
@@ -75,7 +75,8 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         router = self.nodes[ROUTER]
 
         br.start()
-        # Ensure NAT64 is enabled on BR.
+        # When feature flag is enabled, NAT64 might be disabled by default. So
+        # ensure NAT64 is enabled here.
         br.nat64_set_enabled(True)
         self.simulator.go(config.LEADER_STARTUP_DELAY)
         self.assertEqual('leader', br.get_state())


### PR DESCRIPTION
We cannot ensure NAT64 is enabled when running tests, and calling an extra nat64_set_enabled has no side-effects.