### PR TITLE
[cmake] add `OT_15_4` option for `RADIO_LINK_IEEE_802_15_4_ENABLE` and update toranj builds

### DIFF
--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -123,7 +123,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
-        sudo apt-get --no-install-recommends install -y lcov
+        sudo apt-get --no-install-recommends install -y ninja-build lcov
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build & Run
       run: |

--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -34,6 +34,13 @@ option(OT_FTD "enable FTD" ON)
 option(OT_MTD "enable MTD" ON)
 option(OT_RCP "enable RCP" ON)
 
+message(STATUS OT_APP_CLI=${OT_APP_CLI})
+message(STATUS OT_APP_NCP=${OT_APP_NCP})
+message(STATUS OT_APP_RCP=${OT_APP_RCP})
+message(STATUS OT_FTD=${OT_FTD})
+message(STATUS OT_MTD=${OT_MTD})
+message(STATUS OT_RCP=${OT_RCP})
+
 set(OT_CONFIG_VALUES
     ""
     "ON"
@@ -69,6 +76,7 @@ macro(ot_option name ot_config description)
     endif()
 endmacro()
 
+ot_option(OT_15_4 OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE "802.15.4 radio link")
 ot_option(OT_ANYCAST_LOCATOR OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_ENABLE "anycast locator")
 ot_option(OT_ASSERT OPENTHREAD_CONFIG_ASSERT_ENABLE "assert function OT_ASSERT()")
 ot_option(OT_BACKBONE_ROUTER OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE "backbone router functionality")

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,7 @@ This page lists the available common switches with description. Unless stated ot
 
 | Makefile switch | CMake switch | Description |
 | --- | --- | --- |
+|  | OT_15_4 | Enables 802.15.4 radio link. |
 | ANYCAST_LOCATOR | OT_ANYCAST_LOCATOR | Enables anycast locator functionality. |
 | BACKBONE_ROUTER | OT_BACKBONE_ROUTER | Enables Backbone Router functionality for Thread 1.2. |
 | BIG_ENDIAN | OT_BIG_ENDIAN | Allows the host platform to use big-endian byte order. |

--- a/tests/toranj/build.sh
+++ b/tests/toranj/build.sh
@@ -68,10 +68,13 @@ cd ../.. || die "cd failed"
 coverage=no
 tests=no
 
+ot_coverage=OFF
+
 while [ $# -ge 2 ]; do
     case $1 in
         -c | --enable-coverage)
             coverage=yes
+            ot_coverage=ON
             shift
             ;;
         -t | --enable-tests)
@@ -102,14 +105,6 @@ ncp_configure_options=(
     "--enable-coverage=$coverage"
     "--enable-ftd"
     "--enable-ncp"
-)
-
-cli_configure_options=(
-    "--disable-docs"
-    "--enable-tests=$tests"
-    "--enable-coverage=$coverage"
-    "--enable-ftd"
-    "--enable-cli"
 )
 
 posix_configure_options=(
@@ -198,30 +193,25 @@ case ${build_config} in
         echo "==================================================================================================="
         echo "Building OpenThread CLI FTD mode with simulation platform (radios determined by config)"
         echo "==================================================================================================="
-        ./bootstrap || die "bootstrap failed"
         cd "${top_builddir}" || die "cd failed"
-        cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config-simulation.h\"'
-        ${top_srcdir}/configure \
-            CPPFLAGS="$cppflags_config" \
-            --with-examples=simulation \
-            "${cli_configure_options[@]}" || die
-        make -j 8 || die
+        cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=ON -DOT_COVERAGE=${ot_coverage} \
+            -DOT_APP_CLI=ON -DOT_APP_NCP=OFF -DOT_APP_RCP=OFF \
+            -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
+            "${top_srcdir}" || die
+        ninja || die
         ;;
 
     cli-15.4)
         echo "==================================================================================================="
         echo "Building OpenThread CLI FTD mode with simulation platform - 15.4 radio"
         echo "==================================================================================================="
-        cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config-simulation.h\"'
-        cppflags_config="${cppflags_config} -DOPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE=1"
-        cppflags_config="${cppflags_config} -DOPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE=0"
-        ./bootstrap || die "bootstrap failed"
         cd "${top_builddir}" || die "cd failed"
-        ${top_srcdir}/configure \
-            CPPFLAGS="$cppflags_config" \
-            --with-examples=simulation \
-            "${cli_configure_options[@]}" || die
-        make -j 8 || die
+        cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=ON -DOT_COVERAGE=${ot_coverage} \
+            -DOT_APP_CLI=ON -DOT_APP_NCP=OFF -DOT_APP_RCP=OFF \
+            -DOT_15_4=ON -DOT_TREL=OFF \
+            -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
+            "${top_srcdir}" || die
+        ninja || die
         cp -p ${top_builddir}/examples/apps/cli/ot-cli-ftd ${top_builddir}/examples/apps/cli/ot-cli-ftd-15.4
         ;;
 
@@ -229,16 +219,13 @@ case ${build_config} in
         echo "==================================================================================================="
         echo "Building OpenThread CLI FTD mode with simulation platform - TREL radio"
         echo "==================================================================================================="
-        cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config-simulation.h\"'
-        cppflags_config="${cppflags_config} -DOPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE=0"
-        cppflags_config="${cppflags_config} -DOPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE=1"
-        ./bootstrap || die "bootstrap failed"
         cd "${top_builddir}" || die "cd failed"
-        ${top_srcdir}/configure \
-            CPPFLAGS="$cppflags_config" \
-            --with-examples=simulation \
-            "${cli_configure_options[@]}" || die
-        make -j 8 || die
+        cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=ON -DOT_COVERAGE=${ot_coverage} \
+            -DOT_APP_CLI=ON -DOT_APP_NCP=OFF -DOT_APP_RCP=OFF \
+            -DOT_15_4=OFF -DOT_TREL=ON \
+            -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
+            "${top_srcdir}" || die
+        ninja || die
         cp -p ${top_builddir}/examples/apps/cli/ot-cli-ftd ${top_builddir}/examples/apps/cli/ot-cli-ftd-trel
         ;;
 
@@ -246,16 +233,13 @@ case ${build_config} in
         echo "==================================================================================================="
         echo "Building OpenThread NCP FTD mode with simulation platform - multi radio (15.4 + TREL)"
         echo "==================================================================================================="
-        cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config-simulation.h\"'
-        cppflags_config="${cppflags_config} -DOPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE=1"
-        cppflags_config="${cppflags_config} -DOPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE=1"
-        ./bootstrap || die "bootstrap failed"
         cd "${top_builddir}" || die "cd failed"
-        ${top_srcdir}/configure \
-            CPPFLAGS="$cppflags_config" \
-            --with-examples=simulation \
-            "${cli_configure_options[@]}" || die
-        make -j 8 || die
+        cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=ON -DOT_COVERAGE=${ot_coverage} \
+            -DOT_APP_CLI=ON -DOT_APP_NCP=OFF -DOT_APP_RCP=OFF \
+            -DOT_15_4=ON -DOT_TREL=ON \
+            -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
+            "${top_srcdir}" || die
+        ninja || die
         cp -p ${top_builddir}/examples/apps/cli/ot-cli-ftd ${top_builddir}/examples/apps/cli/ot-cli-ftd-15.4-trel
         ;;
 
@@ -344,7 +328,8 @@ case ${build_config} in
         echo "Building OpenThread (NCP/CLI for FTD/MTD/RCP mode) with simulation platform using cmake"
         echo "===================================================================================================="
         cd "${top_builddir}" || die "cd failed"
-        cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=on -DOT_APP_CLI=on \
+        cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=ON -DOT_COVERAGE=${ot_coverage} \
+            -DOT_APP_CLI=ON -DOT_APP_NCP=ON -DOT_APP_RCP=ON \
             -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
             "${top_srcdir}" || die
         ninja || die
@@ -355,7 +340,7 @@ case ${build_config} in
         echo "Building OpenThread POSIX using cmake"
         echo "===================================================================================================="
         cd "${top_builddir}" || die "cd failed"
-        cmake -GNinja -DOT_PLATFORM=posix -DOT_COMPILE_WARNING_AS_ERROR=on -DOT_APP_CLI=off \
+        cmake -GNinja -DOT_PLATFORM=posix -DOT_COMPILE_WARNING_AS_ERROR=ON -DOT_APP_CLI=OFF \
             -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-posix.h \
             "${top_srcdir}" || die
         ninja || die


### PR DESCRIPTION
This PR contains two related commits:

**[cmake] add `OT_15_4` option for `RADIO_LINK_IEEE_802_15_4_ENABLE`**
    
This commit adds new cmake option `OT_15_4` to enable 802.15. radio
link. It also adds additional `message(STATUS)` to output the common
`OT_APP_CLI/NCP/RCP` and `OT_FTD/MTD/RCP` options.


**[toranj update `build.sh` to use `cmake` for CLI builds**


