### PR TITLE
[mle] fix `NeighborHasComparableConnectivity()`

### DIFF
--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -642,7 +642,7 @@ private:
     bool HasChildren(void);
     void RemoveChildren(void);
     bool HasMinDowngradeNeighborRouters(void);
-    bool HasOneNeighborWithComparableConnectivity(const RouteTlv &aRouteTlv, uint8_t aRouterId);
+    bool NeighborHasComparableConnectivity(const RouteTlv &aRouteTlv, uint8_t aNeighborId) const;
     bool HasSmallNumberOfChildren(void);
 
     static void HandleAdvertiseTrickleTimer(TrickleTimer &aTimer);


### PR DESCRIPTION
This commit updates `NeighborHasComparableConnectivity()` method which is used as one of conditions to decide whether the router needs to downgrade to REED. This method check whether a given neighboring router has as good or better-quality links to all our neighboring routers with two-way link quality of two or better.

The previous implementation assumed that routers in `RouterTable` would match the same set of routers and their order as in the received `RouteTlv` from the peer router. This may not necessarily be the case (particularly after #8483). This commit changes the implementation so that we iterate over all Router IDs and directly track the index of each allocated router ID in the received `RouteTlv`.