### PR TITLE
[posix] add build option for posix infra if implementation

### DIFF
--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -33,7 +33,7 @@
 
 #include "platform-posix.h"
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+#if OPENTHREAD_POSIX_CONFIG_INFRA_IF_ENABLE
 
 #ifdef __APPLE__
 #define __APPLE_USE_RFC_3542
@@ -682,4 +682,4 @@ InfraNetif &InfraNetif::Get(void)
 
 } // namespace Posix
 } // namespace ot
-#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+#endif // OPENTHREAD_POSIX_CONFIG_INFRA_IF_ENABLE

--- a/src/posix/platform/infra_if.hpp
+++ b/src/posix/platform/infra_if.hpp
@@ -39,7 +39,7 @@
 #include "core/common/non_copyable.hpp"
 #include "posix/platform/mainloop.hpp"
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+#if OPENTHREAD_POSIX_CONFIG_INFRA_IF_ENABLE
 
 namespace ot {
 namespace Posix {
@@ -177,4 +177,4 @@ private:
 
 } // namespace Posix
 } // namespace ot
-#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+#endif // OPENTHREAD_POSIX_CONFIG_INFRA_IF_ENABLE

--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -323,4 +323,16 @@
 #ifndef OPENTHREAD_POSIX_CONFIG_ANDROID_ENABLE
 #define OPENTHREAD_POSIX_CONFIG_ANDROID_ENABLE 0
 #endif
+
+/**
+ * @def OPENTHREAD_POSIX_CONFIG_INFRA_IF_ENABLE
+ *
+ * Defines `1` to enable the posix implementation of platform/infra_if.h APIs.
+ * The default value is set to `OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE` if it's
+ * not explicit defined.
+ */
+#ifndef OPENTHREAD_POSIX_CONFIG_INFRA_IF_ENABLE
+#define OPENTHREAD_POSIX_CONFIG_INFRA_IF_ENABLE OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+#endif
+
 #endif // OPENTHREAD_PLATFORM_CONFIG_H_

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -142,7 +142,7 @@ void platformInit(otPlatformConfig *aPlatformConfig)
     platformBackboneInit(aPlatformConfig->mBackboneInterfaceName);
 #endif
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+#if OPENTHREAD_POSIX_CONFIG_INFRA_IF_ENABLE
     ot::Posix::InfraNetif::Get().Init(aPlatformConfig->mBackboneInterfaceName);
 #endif
 
@@ -181,7 +181,7 @@ void platformSetUp(void)
     platformBackboneSetUp();
 #endif
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+#if OPENTHREAD_POSIX_CONFIG_INFRA_IF_ENABLE
     ot::Posix::InfraNetif::Get().SetUp();
 #endif
 
@@ -236,7 +236,7 @@ void platformTearDown(void)
     platformNetifTearDown();
 #endif
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+#if OPENTHREAD_POSIX_CONFIG_INFRA_IF_ENABLE
     ot::Posix::InfraNetif::Get().TearDown();
 #endif
 
@@ -268,7 +268,7 @@ void platformDeinit(void)
     platformTrelDeinit();
 #endif
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+#if OPENTHREAD_POSIX_CONFIG_INFRA_IF_ENABLE
     ot::Posix::InfraNetif::Get().Deinit();
 #endif
 


### PR DESCRIPTION
On some platforms, we need to support the cases that
1. the infrastructure interface can't be determined when the Thread daemon is started
    and we need to enable the Border Router features after the infra interface is available.
3. Some BR devices want to send/recv RAs in a coordinated way to be more efficient
    and consistent. For example, a BR which is also a Wi-Fi router may want to send/recv
    RAs by a single component.

This commit add a new `OPENTHREAD_POSIX_CONFIG_INFRA_IF_ENABLE` for
disabling the default posix infra if implementation so that posix platforms can add their
own version.