### PR TITLE
[docs] SRP Service Clarification

### DIFF
--- a/src/cli/README_SRP_SERVER.md
+++ b/src/cli/README_SRP_SERVER.md
@@ -168,7 +168,7 @@ Done
 
 Usage: `srp server service`
 
-Print information of all registered services. 
+Print information of all registered services.
 
 The TXT record is displayed as an array of entries. If an entry has a key, the key will be printed in ASCII format. The value portion will always be printed as hex bytes.
 

--- a/src/cli/README_SRP_SERVER.md
+++ b/src/cli/README_SRP_SERVER.md
@@ -168,7 +168,9 @@ Done
 
 Usage: `srp server service`
 
-Print information of all registered services.
+Print information of all registered services. 
+
+The TXT record is displayed as an array of entries. If an entry has a key, the key will be printed in ASCII format. The value portion will always be printed as hex bytes.
 
 ```bash
 > srp server service
@@ -181,7 +183,7 @@ srp-api-test-1._ipps._tcp.default.service.arpa.
     ttl: 7200
     lease: 7200
     key-lease: 1209600
-    TXT: 0130
+    TXT: [616263, xyz=585960]
     host: srp-api-test-1.default.service.arpa.
     addresses: [fdde:ad00:beef:0:0:ff:fe00:fc10]
 srp-api-test-0._ipps._tcp.default.service.arpa.
@@ -193,7 +195,7 @@ srp-api-test-0._ipps._tcp.default.service.arpa.
     ttl: 3600
     lease: 3600
     key-lease: 1209600
-    TXT: 0130
+    TXT: [616263, xyz=585960]
     host: srp-api-test-0.default.service.arpa.
     addresses: [fdde:ad00:beef:0:0:ff:fe00:fc10]
 Done


### PR DESCRIPTION
Adding some clarification around the display of TXT records in `srp server service` based on the discussion in #8459