### PR TITLE
[cli] add config for log level for emitting cli input/output to logs

### DIFF
--- a/src/cli/cli_config.h
+++ b/src/cli/cli_config.h
@@ -102,6 +102,18 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LEVEL
+ *
+ * Defines the log level to use when CLI emits its command input/output to the logs.
+ *
+ * This is used only when `OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE` is enabled.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LEVEL
+#define OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LEVEL OT_LOG_LEVEL_DEBG
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LOG_STRING_SIZE
  *
  * The log string buffer size (in bytes).

--- a/src/cli/cli_output.cpp
+++ b/src/cli/cli_output.cpp
@@ -307,7 +307,7 @@ void OutputImplementer::OutputV(const char *aFormat, va_list aArguments)
 
         if (lineEnd > mOutputString)
         {
-            otLogCli(OT_LOG_LEVEL_DEBG, "Output: %s", mOutputString);
+            otLogCli(OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LEVEL, "Output: %s", mOutputString);
         }
 
         lineEnd++;
@@ -348,7 +348,7 @@ void OutputImplementer::OutputV(const char *aFormat, va_list aArguments)
 
     if (truncated)
     {
-        otLogCli(OT_LOG_LEVEL_DEBG, "Output: %s ...", mOutputString);
+        otLogCli(OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LEVEL, "Output: %s ...", mOutputString);
         mOutputLength = 0;
     }
 
@@ -367,7 +367,7 @@ void Output::LogInput(const Arg *aArgs)
         inputString.Append(isFirst ? "%s" : " %s", aArgs->GetCString());
     }
 
-    otLogCli(OT_LOG_LEVEL_DEBG, "Input: %s", inputString.AsCString());
+    otLogCli(OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LEVEL, "Input: %s", inputString.AsCString());
 }
 #endif
 


### PR DESCRIPTION
This commit adds `OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LEVEL` to specify the log level to use when CLI input/output is emitted to logs (`OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE` is enabled).

---

This is currently hardcoded as `OT_LOG_LEVEL_DEBG`. This PR allows us to configure it on a specific build which would be helpful to collect logs during CI tests.