### PR TITLE
[posix] make `mInfraIfIndex` non-static for `posix::InfraIf`

### DIFF
--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -62,8 +62,6 @@
 #include "lib/platform/exit_code.h"
 #include "posix/platform/infra_if.hpp"
 
-uint32_t ot::Posix::InfraNetif::mInfraIfIndex = 0;
-
 bool otPlatInfraIfHasAddress(uint32_t aInfraIfIndex, const otIp6Address *aAddress)
 {
     bool            ret     = false;
@@ -599,7 +597,7 @@ void InfraNetif::DiscoverNat64PrefixDone(union sigval sv)
         }
     }
 
-    otPlatInfraIfDiscoverNat64PrefixDone(gInstance, mInfraIfIndex, &prefix);
+    otPlatInfraIfDiscoverNat64PrefixDone(gInstance, Get().mInfraIfIndex, &prefix);
 
 exit:
     freeaddrinfo(res);

--- a/src/posix/platform/infra_if.hpp
+++ b/src/posix/platform/infra_if.hpp
@@ -164,10 +164,10 @@ private:
     static const otIp4Address kWellKnownIpv4OnlyAddress2; // 192.0.0.171
     static const uint8_t      kValidNat64PrefixLength[];
 
-    char            mInfraIfName[IFNAMSIZ];
-    static uint32_t mInfraIfIndex;
-    int             mInfraIfIcmp6Socket = -1;
-    int             mNetLinkSocket      = -1;
+    char     mInfraIfName[IFNAMSIZ];
+    uint32_t mInfraIfIndex       = 0;
+    int      mInfraIfIcmp6Socket = -1;
+    int      mNetLinkSocket      = -1;
 
     void        ReceiveNetLinkMessage(void);
     void        ReceiveIcmp6Message(void);


### PR DESCRIPTION
We should not use static member fields given the `posix::InfraIf` is already a singleton.
Instead, let's make it consistent with the rest of the fields which are all non-static. 