### PR TITLE
[test] update toranj-cli logging to use log to file model

### DIFF
--- a/tests/toranj/cli/cli.py
+++ b/tests/toranj/cli/cli.py
@@ -115,17 +115,18 @@ class Node(object):
         self._index = index
         self._verbose = verbose
 
-        if Node._SAVE_LOGS:
-            self._log_file = open(self._LOG_FNAME + str(index) + '.log', 'wb')
-        else:
-            self._log_file = None
+        cmd = f'{self._OT_CLI_FTD} --time-speed={self._SPEED_UP_FACTOR} '
 
-        cmd = f'{self._OT_CLI_FTD} --time-speed={self._SPEED_UP_FACTOR} {self._index}'
+        if Node._SAVE_LOGS:
+            log_file_name = self._LOG_FNAME + str(index) + '.log'
+            cmd = cmd + f'--log-file={log_file_name} '
+
+        cmd = cmd + f'{self._index}'
 
         if self._verbose:
             _log(f'$ Node{index}.__init__() cmd: `{cmd}`')
 
-        self._cli_process = pexpect.popen_spawn.PopenSpawn(cmd, logfile=self._log_file)
+        self._cli_process = pexpect.popen_spawn.PopenSpawn(cmd)
         Node._all_nodes.add(self)
 
     def __del__(self):

--- a/tests/toranj/openthread-core-toranj-config-simulation.h
+++ b/tests/toranj/openthread-core-toranj-config-simulation.h
@@ -65,7 +65,23 @@
  * Selects if, and where the LOG output goes to.
  *
  */
-#define OPENTHREAD_CONFIG_LOG_OUTPUT OPENTHREAD_CONFIG_LOG_OUTPUT_APP
+#define OPENTHREAD_CONFIG_LOG_OUTPUT OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED
+
+/**
+ * @def OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
+ *
+ * Define as 1 for CLI to emit its command input string and the resulting output to the logs.
+ *
+ */
+#define OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE 1
+
+/**
+ * @def OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LEVEL
+ *
+ * Defines the log level to use when CLI emits its command input/output to the logs.
+ *
+ */
+#define OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LEVEL OT_LOG_LEVEL_INFO
 
 /**
  * @def OPENTHREAD_CONFIG_DNS_DSO_ENABLE


### PR DESCRIPTION
This commit updates `toranj-cli` to use the simulation platforms "log
to file" feature and CLI feature to emit CLI input/output to log. This
helps simplify the log collection during testing and decouple it from
parsing/processing the CLI output while performing the test.

----

~This PR also contains commits from the following PRs:~
- ~https://github.com/openthread/openthread/pull/8545~
- ~https://github.com/openthread/openthread/pull/8516~