### PR TITLE
[test] replace `sprintf` with `snprintf` in `otPlatDiagProcess()`

### DIFF
--- a/src/ncp/ncp_hdlc.cpp
+++ b/src/ncp/ncp_hdlc.cpp
@@ -274,8 +274,6 @@ void NcpHdlc::HandleError(otError aError, uint8_t *aBuf, uint16_t aBufLength)
 
     super_t::IncrementFrameErrorCounter();
 
-    // We can get away with sprintf because we know
-    // `hexbuf` is large enough.
     snprintf(hexbuf, sizeof(hexbuf), "Framing error %d: [", aError);
 
     // Write out the first part of our log message.
@@ -285,9 +283,6 @@ void NcpHdlc::HandleError(otError aError, uint8_t *aBuf, uint16_t aBufLength)
     // The second '3' comes from the length of two hex digits and a space.
     for (i = 0; (i < aBufLength) && (i < (sizeof(hexbuf) - 3) / 3); i++)
     {
-        // We can get away with sprintf because we know
-        // `hexbuf` is large enough, based on our calculations
-        // above.
         snprintf(&hexbuf[i * 3], sizeof(hexbuf) - i * 3, " %02X", static_cast<uint8_t>(aBuf[i]));
     }
 

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -193,9 +193,9 @@ exit:
     return error;
 }
 
-OT_TOOL_WEAK void otPlatDiagProcess(otInstance *, uint8_t, char *aArgs[], char *aOutput, size_t)
+OT_TOOL_WEAK void otPlatDiagProcess(otInstance *, uint8_t, char *aArgs[], char *aOutput, size_t aOutputMaxLen)
 {
-    sprintf(aOutput, "diag feature '%s' is not supported\r\n", aArgs[0]);
+    snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", aArgs[0]);
 }
 
 OT_TOOL_WEAK void otPlatDiagModeSet(bool aMode) { sDiagMode = aMode; }


### PR DESCRIPTION
It also removes stale comments in `ncp_hdlc.cp` about use of `sprintf`.

---

This is to avoid getting warning/errors below:
```
[6/57] Building CXX object tests/unit/CMakeFiles/ot-test-platform.dir/test_platform.cpp.o
/Users/abtink/github/openthread/tests/unit/test_platform.cpp:198:5: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
    sprintf(aOutput, "diag feature '%s' is not supported\r\n", aArgs[0]);
    ^
```