### PR TITLE
[pretty] combine strings in `node.py`

### DIFF
--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -2876,7 +2876,7 @@ class NodeImpl:
         else:
             timeout = 5
 
-        self._expect(r'Received ACK in reply to notification ' r'from ([\da-f:]+)\b', timeout=timeout)
+        self._expect(r'Received ACK in reply to notification from ([\da-f:]+)\b', timeout=timeout)
         (source,) = self.pexpect.match.groups()
         source = source.decode('UTF-8')
 


### PR DESCRIPTION

---
Background:

On Mac OS running `./script/make-pretty python` always creates a `diff` (it tries to put the two strings on different lines):
(which I think is different from outcome under other Linux OSes?).
```bash
$ git diff
diff --git a/tests/scripts/thread-cert/node.py b/tests/scripts/thread-cert/node.py
index 1904c7199..516a53175 100755
--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -2876,7 +2876,8 @@ class NodeImpl:
         else:
             timeout = 5
 
-        self._expect(r'Received ACK in reply to notification ' r'from ([\da-f:]+)\b', timeout=timeout)
+        self._expect(r'Received ACK in reply to notification '
+                     r'from ([\da-f:]+)\b', timeout=timeout)
         (source,) = self.pexpect.match.groups()
         source = source.decode('UTF-8')
```

By combining them into one string, we should get same behavior on all and avoid this.