### PR TITLE
[continuous-integration][don't review] change `MAX_JOBS` to 2 in `otbr.yml`

### DIFF
--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -175,7 +175,7 @@ jobs:
       VERBOSE: 1
       BORDER_ROUTING: 1
       NAT64: ${{ matrix.nat64 }}
-      MAX_JOBS: 3
+      MAX_JOBS: 2
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0


### PR DESCRIPTION
There are hanging Border Router CI executions like https://github.com/openthread/openthread/actions/runs/3683598290/jobs/6248043121.

This PR tries  to solve the issue by reducing the number of concurrent test jobs.