### PR TITLE
[netif] add helper to signal fixed multicast address changes

### DIFF
--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -644,6 +644,10 @@ protected:
     void UnsubscribeAllNodesMulticast(void);
 
 private:
+    void SignalMulticastAddressChange(AddressEvent            aAddressEvent,
+                                      const MulticastAddress *aStart,
+                                      const MulticastAddress *aEnd);
+
     LinkedList<UnicastAddress>   mUnicastAddresses;
     LinkedList<MulticastAddress> mMulticastAddresses;
     bool                         mMulticastPromiscuous;


### PR DESCRIPTION
This commit adds a private method `SignalMulticastAddressChange()`
which signals changes to fixes multicast addresses.