### PR TITLE
[common] add `Callback<HandlerType>` class

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -386,6 +386,7 @@ openthread_core_files = [
   "common/binary_search.cpp",
   "common/binary_search.hpp",
   "common/bit_vector.hpp",
+  "common/callback.hpp",
   "common/clearable.hpp",
   "common/code_utils.hpp",
   "common/const_cast.hpp",

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -432,6 +432,7 @@ HEADERS_COMMON                                  = \
     common/as_core_type.hpp                       \
     common/binary_search.hpp                      \
     common/bit_vector.hpp                         \
+    common/callback.hpp                           \
     common/clearable.hpp                          \
     common/code_utils.hpp                         \
     common/const_cast.hpp                         \

--- a/src/core/backbone_router/bbr_local.cpp
+++ b/src/core/backbone_router/bbr_local.cpp
@@ -57,8 +57,6 @@ Local::Local(Instance &aInstance)
     , mSequenceNumber(Random::NonCrypto::GetUint8() % 127)
     , mRegistrationJitter(Mle::kBackboneRouterRegistrationJitter)
     , mIsServiceAdded(false)
-    , mDomainPrefixCallback(nullptr)
-    , mDomainPrefixCallbackContext(nullptr)
 {
     mDomainPrefixConfig.GetPrefix().SetLength(0);
 
@@ -378,21 +376,18 @@ void Local::HandleDomainPrefixUpdate(Leader::DomainPrefixState aState)
         Get<BackboneTmfAgent>().SubscribeMulticast(mAllDomainBackboneRouters);
     }
 
-    if (mDomainPrefixCallback != nullptr)
+    if (mDomainPrefixCallback.IsSet())
     {
         switch (aState)
         {
         case Leader::kDomainPrefixAdded:
-            mDomainPrefixCallback(mDomainPrefixCallbackContext, OT_BACKBONE_ROUTER_DOMAIN_PREFIX_ADDED,
-                                  Get<Leader>().GetDomainPrefix());
+            mDomainPrefixCallback.Invoke(OT_BACKBONE_ROUTER_DOMAIN_PREFIX_ADDED, Get<Leader>().GetDomainPrefix());
             break;
         case Leader::kDomainPrefixRemoved:
-            mDomainPrefixCallback(mDomainPrefixCallbackContext, OT_BACKBONE_ROUTER_DOMAIN_PREFIX_REMOVED,
-                                  Get<Leader>().GetDomainPrefix());
+            mDomainPrefixCallback.Invoke(OT_BACKBONE_ROUTER_DOMAIN_PREFIX_REMOVED, Get<Leader>().GetDomainPrefix());
             break;
         case Leader::kDomainPrefixRefreshed:
-            mDomainPrefixCallback(mDomainPrefixCallbackContext, OT_BACKBONE_ROUTER_DOMAIN_PREFIX_CHANGED,
-                                  Get<Leader>().GetDomainPrefix());
+            mDomainPrefixCallback.Invoke(OT_BACKBONE_ROUTER_DOMAIN_PREFIX_CHANGED, Get<Leader>().GetDomainPrefix());
             break;
         default:
             break;
@@ -458,12 +453,6 @@ void Local::LogBackboneRouterService(const char *aAction, Error aError)
             mReregistrationDelay, ToUlong(mMlrTimeout), ErrorToString(aError));
 }
 #endif
-
-void Local::SetDomainPrefixCallback(otBackboneRouterDomainPrefixCallback aCallback, void *aContext)
-{
-    mDomainPrefixCallback        = aCallback;
-    mDomainPrefixCallbackContext = aContext;
-}
 
 } // namespace BackboneRouter
 

--- a/src/core/backbone_router/bbr_local.hpp
+++ b/src/core/backbone_router/bbr_local.hpp
@@ -54,6 +54,7 @@
 #include <openthread/backbone_router_ftd.h>
 
 #include "backbone_router/bbr_leader.hpp"
+#include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/log.hpp"
 #include "common/non_copyable.hpp"
@@ -253,7 +254,10 @@ public:
      * @param[in] aContext   A user context pointer.
      *
      */
-    void SetDomainPrefixCallback(otBackboneRouterDomainPrefixCallback aCallback, void *aContext);
+    void SetDomainPrefixCallback(otBackboneRouterDomainPrefixCallback aCallback, void *aContext)
+    {
+        mDomainPrefixCallback.Set(aCallback, aContext);
+    }
 
 private:
     void SetState(BackboneRouterState aState);
@@ -282,11 +286,10 @@ private:
 
     NetworkData::OnMeshPrefixConfig mDomainPrefixConfig;
 
-    Ip6::Netif::UnicastAddress           mBackboneRouterPrimaryAloc;
-    Ip6::Address                         mAllNetworkBackboneRouters;
-    Ip6::Address                         mAllDomainBackboneRouters;
-    otBackboneRouterDomainPrefixCallback mDomainPrefixCallback;
-    void                                *mDomainPrefixCallbackContext;
+    Ip6::Netif::UnicastAddress                     mBackboneRouterPrimaryAloc;
+    Ip6::Address                                   mAllNetworkBackboneRouters;
+    Ip6::Address                                   mAllDomainBackboneRouters;
+    Callback<otBackboneRouterDomainPrefixCallback> mDomainPrefixCallback;
 };
 
 } // namespace BackboneRouter

--- a/src/core/backbone_router/multicast_listeners_table.cpp
+++ b/src/core/backbone_router/multicast_listeners_table.cpp
@@ -77,10 +77,7 @@ Error MulticastListenersTable::Add(const Ip6::Address &aAddress, Time aExpireTim
 
     FixHeap(mNumValidListeners - 1);
 
-    if (mCallback != nullptr)
-    {
-        mCallback(mCallbackContext, OT_BACKBONE_ROUTER_MULTICAST_LISTENER_ADDED, &aAddress);
-    }
+    mCallback.InvokeIfSet(OT_BACKBONE_ROUTER_MULTICAST_LISTENER_ADDED, &aAddress);
 
 exit:
     LogMulticastListenersTable("Add", aAddress, aExpireTime, error);
@@ -106,10 +103,7 @@ void MulticastListenersTable::Remove(const Ip6::Address &aAddress)
                 FixHeap(i);
             }
 
-            if (mCallback != nullptr)
-            {
-                mCallback(mCallbackContext, OT_BACKBONE_ROUTER_MULTICAST_LISTENER_REMOVED, &aAddress);
-            }
+            mCallback.InvokeIfSet(OT_BACKBONE_ROUTER_MULTICAST_LISTENER_REMOVED, &aAddress);
 
             ExitNow(error = kErrorNone);
         }
@@ -138,10 +132,7 @@ void MulticastListenersTable::Expire(void)
             FixHeap(0);
         }
 
-        if (mCallback != nullptr)
-        {
-            mCallback(mCallbackContext, OT_BACKBONE_ROUTER_MULTICAST_LISTENER_REMOVED, &address);
-        }
+        mCallback.InvokeIfSet(OT_BACKBONE_ROUTER_MULTICAST_LISTENER_REMOVED, &address);
     }
 
     CheckInvariants();
@@ -263,11 +254,11 @@ MulticastListenersTable::Listener *MulticastListenersTable::IteratorBuilder::end
 
 void MulticastListenersTable::Clear(void)
 {
-    if (mCallback != nullptr)
+    if (mCallback.IsSet())
     {
         for (uint16_t i = 0; i < mNumValidListeners; i++)
         {
-            mCallback(mCallbackContext, OT_BACKBONE_ROUTER_MULTICAST_LISTENER_REMOVED, &mListeners[i].GetAddress());
+            mCallback.Invoke(OT_BACKBONE_ROUTER_MULTICAST_LISTENER_REMOVED, &mListeners[i].GetAddress());
         }
     }
 
@@ -278,14 +269,13 @@ void MulticastListenersTable::Clear(void)
 
 void MulticastListenersTable::SetCallback(otBackboneRouterMulticastListenerCallback aCallback, void *aContext)
 {
-    mCallback        = aCallback;
-    mCallbackContext = aContext;
+    mCallback.Set(aCallback, aContext);
 
-    if (mCallback != nullptr)
+    if (mCallback.IsSet())
     {
         for (uint16_t i = 0; i < mNumValidListeners; i++)
         {
-            mCallback(mCallbackContext, OT_BACKBONE_ROUTER_MULTICAST_LISTENER_ADDED, &mListeners[i].GetAddress());
+            mCallback.Invoke(OT_BACKBONE_ROUTER_MULTICAST_LISTENER_ADDED, &mListeners[i].GetAddress());
         }
     }
 }

--- a/src/core/backbone_router/multicast_listeners_table.hpp
+++ b/src/core/backbone_router/multicast_listeners_table.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/backbone_router_ftd.h>
 
+#include "common/callback.hpp"
 #include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/time.hpp"
@@ -108,8 +109,6 @@ public:
     explicit MulticastListenersTable(Instance &aInstance)
         : InstanceLocator(aInstance)
         , mNumValidListeners(0)
-        , mCallback(nullptr)
-        , mCallbackContext(nullptr)
     {
     }
 
@@ -220,8 +219,7 @@ private:
     Listener mListeners[kMulticastListenersTableSize];
     uint16_t mNumValidListeners;
 
-    otBackboneRouterMulticastListenerCallback mCallback;
-    void                                     *mCallbackContext;
+    Callback<otBackboneRouterMulticastListenerCallback> mCallback;
 };
 
 } // namespace BackboneRouter

--- a/src/core/backbone_router/ndproxy_table.cpp
+++ b/src/core/backbone_router/ndproxy_table.cpp
@@ -141,10 +141,7 @@ void NdProxyTable::Clear(void)
         proxy.Clear();
     }
 
-    if (mCallback != nullptr)
-    {
-        mCallback(mCallbackContext, OT_BACKBONE_ROUTER_NDPROXY_CLEARED, nullptr);
-    }
+    mCallback.InvokeIfSet(OT_BACKBONE_ROUTER_NDPROXY_CLEARED, nullptr);
 
     LogInfo("NdProxyTable::Clear!");
 }
@@ -268,26 +265,20 @@ exit:
     return;
 }
 
-void NdProxyTable::SetCallback(otBackboneRouterNdProxyCallback aCallback, void *aContext)
-{
-    mCallback        = aCallback;
-    mCallbackContext = aContext;
-}
-
 void NdProxyTable::TriggerCallback(otBackboneRouterNdProxyEvent    aEvent,
                                    const Ip6::InterfaceIdentifier &aAddressIid) const
 {
     Ip6::Address       dua;
     const Ip6::Prefix *prefix = Get<BackboneRouter::Leader>().GetDomainPrefix();
 
-    VerifyOrExit(mCallback != nullptr);
+    VerifyOrExit(mCallback.IsSet());
 
     OT_ASSERT(prefix != nullptr);
 
     dua.SetPrefix(*prefix);
     dua.SetIid(aAddressIid);
 
-    mCallback(mCallbackContext, aEvent, &dua);
+    mCallback.Invoke(aEvent, &dua);
 
 exit:
     return;

--- a/src/core/backbone_router/ndproxy_table.hpp
+++ b/src/core/backbone_router/ndproxy_table.hpp
@@ -40,6 +40,7 @@
 #include <openthread/backbone_router_ftd.h>
 
 #include "backbone_router/bbr_leader.hpp"
+#include "common/callback.hpp"
 #include "common/iterator_utils.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
@@ -134,8 +135,6 @@ public:
      */
     explicit NdProxyTable(Instance &aInstance)
         : InstanceLocator(aInstance)
-        , mCallback(nullptr)
-        , mCallbackContext(nullptr)
         , mIsAnyDadInProcess(false)
     {
     }
@@ -217,7 +216,7 @@ public:
      * @param[in] aContext   A user context pointer.
      *
      */
-    void SetCallback(otBackboneRouterNdProxyCallback aCallback, void *aContext);
+    void SetCallback(otBackboneRouterNdProxyCallback aCallback, void *aContext) { mCallback.Set(aCallback, aContext); }
 
     /**
      * This method retrieves the ND Proxy info of the Domain Unicast Address.
@@ -292,10 +291,9 @@ private:
     void            NotifyDuaRegistrationOnBackboneLink(NdProxy &aNdProxy, bool aIsRenew);
     void TriggerCallback(otBackboneRouterNdProxyEvent aEvent, const Ip6::InterfaceIdentifier &aAddressIid) const;
 
-    NdProxy                         mProxies[kMaxNdProxyNum];
-    otBackboneRouterNdProxyCallback mCallback;
-    void                           *mCallbackContext;
-    bool                            mIsAnyDadInProcess : 1;
+    NdProxy                                   mProxies[kMaxNdProxyNum];
+    Callback<otBackboneRouterNdProxyCallback> mCallback;
+    bool                                      mIsAnyDadInProcess : 1;
 };
 
 } // namespace BackboneRouter

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -54,11 +54,7 @@ CoapBase::CoapBase(Instance &aInstance, Sender aSender)
     : InstanceLocator(aInstance)
     , mMessageId(Random::NonCrypto::GetUint16())
     , mRetransmissionTimer(aInstance, Coap::HandleRetransmissionTimer, this)
-    , mContext(nullptr)
-    , mInterceptor(nullptr)
     , mResponsesQueue(aInstance)
-    , mDefaultHandler(nullptr)
-    , mDefaultHandlerContext(nullptr)
     , mResourceHandler(nullptr)
     , mSender(aSender)
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
@@ -106,18 +102,6 @@ void CoapBase::RemoveResource(Resource &aResource)
 {
     IgnoreError(mResources.Remove(aResource));
     aResource.SetNext(nullptr);
-}
-
-void CoapBase::SetDefaultHandler(RequestHandler aHandler, void *aContext)
-{
-    mDefaultHandler        = aHandler;
-    mDefaultHandlerContext = aContext;
-}
-
-void CoapBase::SetInterceptor(Interceptor aInterceptor, void *aContext)
-{
-    mInterceptor = aInterceptor;
-    mContext     = aContext;
 }
 
 Message *CoapBase::NewMessage(const Message::Settings &aSettings)
@@ -1295,9 +1279,9 @@ void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo 
     uint32_t         totalTransfereSize = 0;
 #endif
 
-    if (mInterceptor != nullptr)
+    if (mInterceptor.IsSet())
     {
-        SuccessOrExit(error = mInterceptor(aMessage, aMessageInfo, mContext));
+        SuccessOrExit(error = mInterceptor.Invoke(aMessage, aMessageInfo));
     }
 
     switch (mResponsesQueue.GetMatchedResponseCopy(aMessage, aMessageInfo, &cachedResponse))
@@ -1434,9 +1418,9 @@ void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo 
         }
     }
 
-    if (mDefaultHandler)
+    if (mDefaultHandler.IsSet())
     {
-        mDefaultHandler(mDefaultHandlerContext, &aMessage, &aMessageInfo);
+        mDefaultHandler.Invoke(&aMessage, &aMessageInfo);
         error = kErrorNone;
         ExitNow();
     }

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -35,6 +35,7 @@
 
 #include "coap/coap_message.hpp"
 #include "common/as_core_type.hpp"
+#include "common/callback.hpp"
 #include "common/debug.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
@@ -438,7 +439,7 @@ public:
      * @param[in]  aContext   A pointer to arbitrary context information. May be `nullptr` if not used.
      *
      */
-    void SetDefaultHandler(RequestHandler aHandler, void *aContext);
+    void SetDefaultHandler(RequestHandler aHandler, void *aContext) { mDefaultHandler.Set(aHandler, aContext); }
 
     /**
      * This method allocates a new message with a CoAP header.
@@ -729,7 +730,7 @@ public:
      * @param[in]   aContext        A pointer to arbitrary context information.
      *
      */
-    void SetInterceptor(Interceptor aInterceptor, void *aContext);
+    void SetInterceptor(Interceptor aInterceptor, void *aContext) { mInterceptor.Set(aInterceptor, aContext); }
 
     /**
      * This method returns a reference to the request message list.
@@ -900,12 +901,10 @@ private:
 
     LinkedList<Resource> mResources;
 
-    void          *mContext;
-    Interceptor    mInterceptor;
-    ResponsesQueue mResponsesQueue;
+    Callback<Interceptor> mInterceptor;
+    ResponsesQueue        mResponsesQueue;
 
-    RequestHandler mDefaultHandler;
-    void          *mDefaultHandlerContext;
+    Callback<RequestHandler> mDefaultHandler;
 
     ResourceHandler mResourceHandler;
 

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -34,6 +34,7 @@
 #if OPENTHREAD_CONFIG_DTLS_ENABLE
 
 #include "coap/coap.hpp"
+#include "common/callback.hpp"
 #include "meshcop/dtls.hpp"
 #include "meshcop/meshcop.hpp"
 
@@ -101,8 +102,7 @@ public:
      */
     void SetConnectedCallback(ConnectedCallback aCallback, void *aContext)
     {
-        mConnectedCallback = aCallback;
-        mConnectedContext  = aContext;
+        mConnectedCallback.Set(aCallback, aContext);
     }
 
     /**
@@ -267,8 +267,7 @@ public:
      */
     void SetClientConnectedCallback(ConnectedCallback aCallback, void *aContext)
     {
-        mConnectedCallback = aCallback;
-        mConnectedContext  = aContext;
+        mConnectedCallback.Set(aCallback, aContext);
     }
 
     /**
@@ -410,11 +409,10 @@ private:
     static void HandleTransmit(Tasklet &aTasklet);
     void        HandleTransmit(void);
 
-    MeshCoP::Dtls     mDtls;
-    ConnectedCallback mConnectedCallback;
-    void             *mConnectedContext;
-    ot::MessageQueue  mTransmitQueue;
-    TaskletContext    mTransmitTask;
+    MeshCoP::Dtls               mDtls;
+    Callback<ConnectedCallback> mConnectedCallback;
+    ot::MessageQueue            mTransmitQueue;
+    TaskletContext              mTransmitTask;
 };
 
 } // namespace Coap

--- a/src/core/common/callback.hpp
+++ b/src/core/common/callback.hpp
@@ -1,0 +1,228 @@
+/*
+ *  Copyright (c) 2022, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *  This file defines OpenThread `Callback` class.
+ */
+
+#ifndef CALLBACK_HPP_
+#define CALLBACK_HPP_
+
+#include "openthread-core-config.h"
+
+#include <stdint.h>
+
+#include "common/type_traits.hpp"
+
+namespace ot {
+
+/**
+ * This enumeration specifies the context argument position in a callback function pointer.
+ *
+ */
+enum CallbackContextPosition : uint8_t
+{
+    kContextAsFirstArg, ///< Context is the first argument.
+    kContextAsLastArg,  ///< Context is the last argument.
+};
+
+/**
+ * This class is the base class for `Callback` (a function pointer handler and a `void *` context).
+ *
+ * @tparam HandlerType    The handler function pointer type.
+ *
+ */
+template <typename HandlerType> class CallbackBase
+{
+public:
+    /**
+     * This method clears the `Callback` by setting the handler function pointer to `nullptr`.
+     *
+     */
+    void Clear(void) { mHandler = nullptr; }
+
+    /**
+     * This method sets the callback handler function pointer and its associated context.
+     *
+     * @param[in] aHandler   The handler function pointer.
+     * @param[in] aContext   The context associated with handler.
+     *
+     */
+    void Set(HandlerType aHandler, void *aContext)
+    {
+        mHandler = aHandler;
+        mContext = aContext;
+    }
+
+    /**
+     * This method indicates whether or not the callback is set (not `nullptr`).
+     *
+     * @retval TRUE   The handler is set.
+     * @retval FALSE  The handler is not set.
+     *
+     */
+    bool IsSet(void) const { return (mHandler != nullptr); }
+
+    /**
+     * This method returns the handler function pointer.
+     *
+     * @returns The handler function pointer.
+     *
+     */
+    HandlerType GetHandler(void) const { return mHandler; }
+
+    /**
+     * This method returns the context associated with callback.
+     *
+     * @returns The context.
+     *
+     */
+    void *GetContext(void) const { return mContext; }
+
+protected:
+    CallbackBase(void)
+        : mHandler(nullptr)
+        , mContext(nullptr)
+    {
+    }
+
+    HandlerType mHandler;
+    void       *mContext;
+};
+
+/**
+ * This class represents a `Callback` (a function pointer handler and a `void *` context).
+ *
+ * The context is passed as one of the arguments to the function pointer handler when invoked.
+ *
+ * The `Callback` provides two specializations based on `CallbackContextPosition` in the function pointer, i.e., whether
+ * it is passed as the first argument or as the last argument.
+ *
+ * The `CallbackContextPosition` template parameter is automatically determined at compile-time based on the given
+ * `HandlerType`. So user can simply use `Callback<HandlerType>`. The `Invoke()` method will properly pass the context
+ * to the function handler.
+ *
+ * @tparam  HandlerType                The function pointer handler type.
+ * @tparam  CallbackContextPosition    Context position (first or last). Automatically determined at compile-time.
+ *
+ */
+template <typename HandlerType,
+          CallbackContextPosition =
+              (TypeTraits::IsSame<typename TypeTraits::FirstArgTypeOf<HandlerType>::Type, void *>::kValue
+                   ? kContextAsFirstArg
+                   : kContextAsLastArg)>
+class Callback
+{
+};
+
+// Specialization for `kContextAsLastArg`
+template <typename HandlerType> class Callback<HandlerType, kContextAsLastArg> : public CallbackBase<HandlerType>
+{
+    using CallbackBase<HandlerType>::mHandler;
+    using CallbackBase<HandlerType>::mContext;
+
+public:
+    using ReturnType = typename TypeTraits::ReturnTypeOf<HandlerType>::Type; ///< Return type of `HandlerType`.
+
+    static constexpr CallbackContextPosition kContextPosition = kContextAsLastArg; ///< Context position.
+
+    /**
+     * This constructor initializes `Callback` as empty (`nullptr` handler function pointer).
+     *
+     */
+    Callback(void) = default;
+
+    /**
+     * This method invokes the callback handler.
+     *
+     * The caller MUST ensure that callback is set (`IsSet()` returns `true`) before calling this method.
+     *
+     * @param[in] aArgs   The args to pass to the callback handler.
+     *
+     * @returns The return value from handler.
+     *
+     */
+    template <typename... Args> ReturnType Invoke(Args &&...aArgs) const
+    {
+        return mHandler(static_cast<Args &&>(aArgs)..., mContext);
+    }
+
+    /**
+     * This method invokes the callback handler if it is set.
+     *
+     * The method MUST be used when the handler function returns `void`.
+     *
+     * @param[in] aArgs   The args to pass to the callback handler.
+     *
+     */
+    template <typename... Args> void InvokeIfSet(Args &&...aArgs) const
+    {
+        static_assert(TypeTraits::IsSame<ReturnType, void>::kValue,
+                      "InvokeIfSet() MUST be used with `void` returning handler");
+
+        if (mHandler != nullptr)
+        {
+            Invoke(static_cast<Args &&>(aArgs)...);
+        }
+    }
+};
+
+// Specialization for `kContextAsFirstArg`
+template <typename HandlerType> class Callback<HandlerType, kContextAsFirstArg> : public CallbackBase<HandlerType>
+{
+    using CallbackBase<HandlerType>::mHandler;
+    using CallbackBase<HandlerType>::mContext;
+
+public:
+    using ReturnType = typename TypeTraits::ReturnTypeOf<HandlerType>::Type;
+
+    static constexpr CallbackContextPosition kContextPosition = kContextAsFirstArg;
+
+    Callback(void) = default;
+
+    template <typename... Args> ReturnType Invoke(Args &&...aArgs) const
+    {
+        return mHandler(mContext, static_cast<Args &&>(aArgs)...);
+    }
+
+    template <typename... Args> void InvokeIfSet(Args &&...aArgs) const
+    {
+        static_assert(TypeTraits::IsSame<ReturnType, void>::kValue,
+                      "InvokeIfSet() MUST be used with `void` returning handler");
+
+        if (mHandler != nullptr)
+        {
+            Invoke(static_cast<Args &&>(aArgs)...);
+        }
+    }
+};
+
+} // namespace ot
+
+#endif // CALLBACK_HPP_

--- a/src/core/common/type_traits.hpp
+++ b/src/core/common/type_traits.hpp
@@ -125,6 +125,41 @@ template <typename TypeOnTrue, typename TypeOnFalse> struct Conditional<true, Ty
     typedef TypeOnTrue Type;
 };
 
+/**
+ * This type determines the return type of a given function pointer type.
+ *
+ * It provides member type named `Type` which gives the return type of `HandlerType` function pointer.
+ *
+ * For example, `ReturnTypeOf<Error (*)(void *aContext)>::Type` would be `Error`.
+ *
+ * @tparam HandlerType   The function pointer type.
+ *
+ */
+template <typename HandlerType> struct ReturnTypeOf;
+
+template <typename RetType, typename... Args> struct ReturnTypeOf<RetType (*)(Args...)>
+{
+    typedef RetType Type; ///< The return type.
+};
+
+/**
+ * This type determines the type of the first argument of a given function pointer type.
+ *
+ * It provides member type named `Type` which gives the first argument type of `HandlerType` function pointer.
+ *
+ * For example, `ReturnTypeOf<Error (*)(void *aContext)>::Type` would be `void *`.
+ *
+ * @tparam HandlerType   The function pointer type.
+ *
+ */
+template <typename HandlerType> struct FirstArgTypeOf;
+
+template <typename RetType, typename FirstArgType, typename... Args>
+struct FirstArgTypeOf<RetType (*)(FirstArgType, Args...)>
+{
+    typedef FirstArgType Type; ///< The first argument type.
+};
+
 } // namespace TypeTraits
 } // namespace ot
 

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -57,8 +57,6 @@ SubMac::SubMac(Instance &aInstance)
     , mRadioCaps(Get<Radio>().GetCaps())
     , mTransmitFrame(Get<Radio>().GetTransmitBuffer())
     , mCallbacks(aInstance)
-    , mPcapCallback(nullptr)
-    , mPcapCallbackContext(nullptr)
     , mTimer(aInstance)
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     , mCslTimer(aInstance, SubMac::HandleCslTimer)
@@ -178,12 +176,6 @@ void SubMac::SetExtAddress(const ExtAddress &aExtAddress)
     LogDebg("RadioExtAddress: %s", mExtAddress.ToString().AsCString());
 }
 
-void SubMac::SetPcapCallback(otLinkPcapCallback aPcapCallback, void *aCallbackContext)
-{
-    mPcapCallback        = aPcapCallback;
-    mPcapCallbackContext = aCallbackContext;
-}
-
 Error SubMac::Enable(void)
 {
     Error error = kErrorNone;
@@ -286,9 +278,9 @@ exit:
 
 void SubMac::HandleReceiveDone(RxFrame *aFrame, Error aError)
 {
-    if (mPcapCallback && (aFrame != nullptr) && (aError == kErrorNone))
+    if (mPcapCallback.IsSet() && (aFrame != nullptr) && (aError == kErrorNone))
     {
-        mPcapCallback(aFrame, false, mPcapCallbackContext);
+        mPcapCallback.Invoke(aFrame, false);
     }
 
     if (!ShouldHandleTransmitSecurity() && aFrame != nullptr && aFrame->mInfo.mRxInfo.mAckedWithSecEnhAck)
@@ -507,9 +499,9 @@ void SubMac::BeginTransmit(void)
 
     SetState(kStateTransmit);
 
-    if (mPcapCallback)
+    if (mPcapCallback.IsSet())
     {
-        mPcapCallback(&mTransmitFrame, true, mPcapCallbackContext);
+        mPcapCallback.Invoke(&mTransmitFrame, true);
     }
 
     error = Get<Radio>().Transmit(mTransmitFrame);

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/platform/crypto.h>
 
+#include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/timer.hpp"
@@ -276,7 +277,10 @@ public:
      * @param[in]  aCallbackContext  A pointer to application-specific context.
      *
      */
-    void SetPcapCallback(otLinkPcapCallback aPcapCallback, void *aCallbackContext);
+    void SetPcapCallback(otLinkPcapCallback aPcapCallback, void *aCallbackContext)
+    {
+        mPcapCallback.Set(aPcapCallback, aCallbackContext);
+    }
 
     /**
      * This method indicates whether radio should stay in Receive or Sleep during CSMA backoff.
@@ -624,17 +628,16 @@ private:
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
     bool mRadioFilterEnabled : 1;
 #endif
-    int8_t             mEnergyScanMaxRssi;
-    TimeMilli          mEnergyScanEndTime;
-    TxFrame           &mTransmitFrame;
-    Callbacks          mCallbacks;
-    otLinkPcapCallback mPcapCallback;
-    void              *mPcapCallbackContext;
-    KeyMaterial        mPrevKey;
-    KeyMaterial        mCurrKey;
-    KeyMaterial        mNextKey;
-    uint32_t           mFrameCounter;
-    uint8_t            mKeyId;
+    int8_t                       mEnergyScanMaxRssi;
+    TimeMilli                    mEnergyScanEndTime;
+    TxFrame                     &mTransmitFrame;
+    Callbacks                    mCallbacks;
+    Callback<otLinkPcapCallback> mPcapCallback;
+    KeyMaterial                  mPrevKey;
+    KeyMaterial                  mCurrKey;
+    KeyMaterial                  mNextKey;
+    uint32_t                     mFrameCounter;
+    uint8_t                      mKeyId;
 #if OPENTHREAD_CONFIG_MAC_ADD_DELAY_ON_NO_ACK_ERROR_BEFORE_RETRY
     uint8_t mRetxDelayBackOffExponent;
 #endif

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -42,6 +42,7 @@
 
 #include "coap/coap_secure.hpp"
 #include "common/as_core_type.hpp"
+#include "common/callback.hpp"
 #include "common/clearable.hpp"
 #include "common/locator.hpp"
 #include "common/log.hpp"
@@ -621,9 +622,8 @@ private:
 
     State mState;
 
-    StateCallback  mStateCallback;
-    JoinerCallback mJoinerCallback;
-    void          *mCallbackContext;
+    Callback<StateCallback>  mStateCallback;
+    Callback<JoinerCallback> mJoinerCallback;
 };
 
 DeclareTmfHandler(Commissioner, kUriDatasetChanged);

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -37,6 +37,7 @@
 
 #include "openthread-core-config.h"
 
+#include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/timer.hpp"
@@ -359,8 +360,7 @@ private:
     bool       mMgmtPending : 1;
     TimerMilli mTimer;
 
-    otDatasetMgmtSetCallback mMgmtSetCallback;
-    void                    *mMgmtSetCallbackContext;
+    Callback<otDatasetMgmtSetCallback> mMgmtSetCallback;
 };
 
 class ActiveDatasetManager : public DatasetManager, private NonCopyable

--- a/src/core/meshcop/dataset_updater.cpp
+++ b/src/core/meshcop/dataset_updater.cpp
@@ -48,14 +48,12 @@ namespace MeshCoP {
 
 DatasetUpdater::DatasetUpdater(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mCallback(nullptr)
-    , mCallbackContext(nullptr)
     , mTimer(aInstance)
     , mDataset(nullptr)
 {
 }
 
-Error DatasetUpdater::RequestUpdate(const Dataset::Info &aDataset, Callback aCallback, void *aContext)
+Error DatasetUpdater::RequestUpdate(const Dataset::Info &aDataset, UpdaterCallback aCallback, void *aContext)
 {
     Error    error   = kErrorNone;
     Message *message = nullptr;
@@ -71,9 +69,8 @@ Error DatasetUpdater::RequestUpdate(const Dataset::Info &aDataset, Callback aCal
 
     SuccessOrExit(error = message->Append(aDataset));
 
-    mCallback        = aCallback;
-    mCallbackContext = aContext;
-    mDataset         = message;
+    mCallback.Set(aCallback, aContext);
+    mDataset = message;
 
     mTimer.Start(1);
 
@@ -163,10 +160,7 @@ void DatasetUpdater::Finish(Error aError)
     FreeMessage(mDataset);
     mDataset = nullptr;
 
-    if (mCallback != nullptr)
-    {
-        mCallback(aError, mCallbackContext);
-    }
+    mCallback.InvokeIfSet(aError);
 }
 
 void DatasetUpdater::HandleNotifierEvents(Events aEvents)

--- a/src/core/meshcop/dataset_updater.hpp
+++ b/src/core/meshcop/dataset_updater.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/dataset_updater.h>
 
+#include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/non_copyable.hpp"
@@ -72,10 +73,10 @@ public:
      * This type represents the callback function pointer which is called when a Dataset update request finishes,
      * reporting success or failure status of the request.
      *
-     * The function pointer has the syntax `void (*Callback)(Error aError, void *aContext)`.
+     * The function pointer has the syntax `void (*UpdaterCallback)(Error aError, void *aContext)`.
      *
      */
-    typedef otDatasetUpdaterCallback Callback;
+    typedef otDatasetUpdaterCallback UpdaterCallback;
 
     /**
      * This method requests an update to Operational Dataset.
@@ -94,7 +95,7 @@ public:
      * @retval kErrorNoBufs         Could not allocated buffer to save Dataset.
      *
      */
-    Error RequestUpdate(const Dataset::Info &aDataset, Callback aCallback, void *aContext);
+    Error RequestUpdate(const Dataset::Info &aDataset, UpdaterCallback aCallback, void *aContext);
 
     /**
      * This method cancels an ongoing (if any) Operational Dataset update request.
@@ -125,10 +126,9 @@ private:
 
     using UpdaterTimer = TimerMilliIn<DatasetUpdater, &DatasetUpdater::HandleTimer>;
 
-    Callback     mCallback;
-    void        *mCallbackContext;
-    UpdaterTimer mTimer;
-    Message     *mDataset;
+    Callback<UpdaterCallback> mCallback;
+    UpdaterTimer              mTimer;
+    Message                  *mDataset;
 };
 
 } // namespace MeshCoP

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -83,12 +83,7 @@ Dtls::Dtls(Instance &aInstance, bool aLayerTwoSecurity)
     , mTimerSet(false)
     , mLayerTwoSecurity(aLayerTwoSecurity)
     , mReceiveMessage(nullptr)
-    , mConnectedHandler(nullptr)
-    , mReceiveHandler(nullptr)
-    , mContext(nullptr)
     , mSocket(aInstance)
-    , mTransportCallback(nullptr)
-    , mTransportContext(nullptr)
     , mMessageSubType(Message::kSubTypeNone)
     , mMessageDefaultSubType(Message::kSubTypeNone)
 {
@@ -147,10 +142,9 @@ Error Dtls::Open(ReceiveHandler aReceiveHandler, ConnectedHandler aConnectedHand
 
     SuccessOrExit(error = mSocket.Open(&Dtls::HandleUdpReceive, this));
 
-    mReceiveHandler   = aReceiveHandler;
-    mConnectedHandler = aConnectedHandler;
-    mContext          = aContext;
-    mState            = kStateOpen;
+    mConnectedCallback.Set(aConnectedHandler, aContext);
+    mReceiveCallback.Set(aReceiveHandler, aContext);
+    mState = kStateOpen;
 
 exit:
     return error;
@@ -221,7 +215,7 @@ Error Dtls::Bind(uint16_t aPort)
     Error error;
 
     VerifyOrExit(mState == kStateOpen, error = kErrorInvalidState);
-    VerifyOrExit(mTransportCallback == nullptr, error = kErrorAlready);
+    VerifyOrExit(!mTransportCallback.IsSet(), error = kErrorAlready);
 
     SuccessOrExit(error = mSocket.Bind(aPort, Ip6::kNetifUnspecified));
 
@@ -235,10 +229,9 @@ Error Dtls::Bind(TransportCallback aCallback, void *aContext)
 
     VerifyOrExit(mState == kStateOpen, error = kErrorInvalidState);
     VerifyOrExit(!mSocket.IsBound(), error = kErrorAlready);
-    VerifyOrExit(mTransportCallback == nullptr, error = kErrorAlready);
+    VerifyOrExit(!mTransportCallback.IsSet(), error = kErrorAlready);
 
-    mTransportCallback = aCallback;
-    mTransportContext  = aContext;
+    mTransportCallback.Set(aCallback, aContext);
 
 exit:
     return error;
@@ -439,10 +432,9 @@ void Dtls::Close(void)
 {
     Disconnect();
 
-    mState             = kStateClosed;
-    mTransportCallback = nullptr;
-    mTransportContext  = nullptr;
-    mTimerSet          = false;
+    mState    = kStateClosed;
+    mTimerSet = false;
+    mTransportCallback.Clear();
 
     IgnoreError(mSocket.Close());
     mTimer.Stop();
@@ -851,11 +843,7 @@ void Dtls::HandleTimer(void)
     case kStateCloseNotify:
         mState = kStateOpen;
         mTimer.Stop();
-
-        if (mConnectedHandler != nullptr)
-        {
-            mConnectedHandler(mContext, false);
-        }
+        mConnectedCallback.InvokeIfSet(false);
         break;
 
     default:
@@ -879,11 +867,7 @@ void Dtls::Process(void)
             if (mSsl.MBEDTLS_PRIVATE(state) == MBEDTLS_SSL_HANDSHAKE_OVER)
             {
                 mState = kStateConnected;
-
-                if (mConnectedHandler != nullptr)
-                {
-                    mConnectedHandler(mContext, true);
-                }
+                mConnectedCallback.InvokeIfSet(true);
             }
         }
         else
@@ -893,10 +877,7 @@ void Dtls::Process(void)
 
         if (rval > 0)
         {
-            if (mReceiveHandler != nullptr)
-            {
-                mReceiveHandler(mContext, buf, static_cast<uint16_t>(rval));
-            }
+            mReceiveCallback.InvokeIfSet(buf, static_cast<uint16_t>(rval));
         }
         else if (rval == 0 || rval == MBEDTLS_ERR_SSL_WANT_READ || rval == MBEDTLS_ERR_SSL_WANT_WRITE)
         {
@@ -1006,9 +987,9 @@ Error Dtls::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, Message::SubTy
         message->SetSubType(aMessageSubType);
     }
 
-    if (mTransportCallback)
+    if (mTransportCallback.IsSet())
     {
-        SuccessOrExit(error = mTransportCallback(mTransportContext, *message, mMessageInfo));
+        SuccessOrExit(error = mTransportCallback.Invoke(*message, mMessageInfo));
     }
     else
     {

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -51,6 +51,7 @@
 #endif
 #endif
 
+#include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/random.hpp"
@@ -494,15 +495,13 @@ private:
 
     Message *mReceiveMessage;
 
-    ConnectedHandler mConnectedHandler;
-    ReceiveHandler   mReceiveHandler;
-    void            *mContext;
+    Callback<ConnectedHandler> mConnectedCallback;
+    Callback<ReceiveHandler>   mReceiveCallback;
 
     Ip6::MessageInfo mMessageInfo;
     Ip6::Udp::Socket mSocket;
 
-    TransportCallback mTransportCallback;
-    void             *mTransportContext;
+    Callback<TransportCallback> mTransportCallback;
 
     Message::SubType mMessageSubType;
     Message::SubType mMessageDefaultSubType;

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -55,8 +55,6 @@ RegisterLogModule("EnergyScanClnt");
 
 EnergyScanClient::EnergyScanClient(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mCallback(nullptr)
-    , mContext(nullptr)
 {
 }
 
@@ -95,8 +93,7 @@ Error EnergyScanClient::SendQuery(uint32_t                           aChannelMas
 
     LogInfo("sent query");
 
-    mCallback = aCallback;
-    mContext  = aContext;
+    mCallback.Set(aCallback, aContext);
 
 exit:
     FreeMessageOnError(message, error);
@@ -117,10 +114,7 @@ void EnergyScanClient::HandleTmf<kUriEnergyReport>(Coap::Message &aMessage, cons
 
     SuccessOrExit(MeshCoP::Tlv::FindTlv(aMessage, MeshCoP::Tlv::kEnergyList, sizeof(energyListTlv), energyListTlv));
 
-    if (mCallback != nullptr)
-    {
-        mCallback(mask, energyListTlv.GetEnergyList(), energyListTlv.GetEnergyListLength(), mContext);
-    }
+    mCallback.InvokeIfSet(mask, energyListTlv.GetEnergyList(), energyListTlv.GetEnergyListLength());
 
     SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
 

--- a/src/core/meshcop/energy_scan_client.hpp
+++ b/src/core/meshcop/energy_scan_client.hpp
@@ -41,6 +41,7 @@
 #include <openthread/commissioner.h>
 
 #include "coap/coap.hpp"
+#include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "net/ip6_address.hpp"
 #include "net/udp6.hpp"
@@ -89,8 +90,7 @@ public:
 private:
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    otCommissionerEnergyReportCallback mCallback;
-    void                              *mContext;
+    Callback<otCommissionerEnergyReportCallback> mCallback;
 };
 
 DeclareTmfHandler(EnergyScanClient, kUriEnergyReport);

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -43,6 +43,7 @@
 #include "coap/coap_message.hpp"
 #include "coap/coap_secure.hpp"
 #include "common/as_core_type.hpp"
+#include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/log.hpp"
 #include "common/message.hpp"
@@ -239,8 +240,7 @@ private:
 
     State mState;
 
-    otJoinerCallback mCallback;
-    void            *mContext;
+    Callback<otJoinerCallback> mCallback;
 
     JoinerRouter mJoinerRouters[OPENTHREAD_CONFIG_JOINER_MAX_CANDIDATES];
     uint16_t     mJoinerRouterIndex;

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -53,8 +53,6 @@ RegisterLogModule("PanIdQueryClnt");
 
 PanIdQueryClient::PanIdQueryClient(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mCallback(nullptr)
-    , mContext(nullptr)
 {
 }
 
@@ -89,8 +87,7 @@ Error PanIdQueryClient::SendQuery(uint16_t                            aPanId,
 
     LogInfo("sent panid query");
 
-    mCallback = aCallback;
-    mContext  = aContext;
+    mCallback.Set(aCallback, aContext);
 
 exit:
     FreeMessageOnError(message, error);
@@ -112,10 +109,7 @@ void PanIdQueryClient::HandleTmf<kUriPanIdConflict>(Coap::Message &aMessage, con
 
     VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
 
-    if (mCallback != nullptr)
-    {
-        mCallback(panId, mask, mContext);
-    }
+    mCallback.InvokeIfSet(panId, mask);
 
     SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, responseInfo));
 

--- a/src/core/meshcop/panid_query_client.hpp
+++ b/src/core/meshcop/panid_query_client.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/commissioner.h>
 
+#include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "net/ip6_address.hpp"
 #include "net/udp6.hpp"
@@ -84,8 +85,7 @@ public:
 private:
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    otCommissionerPanIdConflictCallback mCallback;
-    void                               *mContext;
+    Callback<otCommissionerPanIdConflictCallback> mCallback;
 };
 
 DeclareTmfHandler(PanIdQueryClient, kUriPanIdConflict);

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -42,6 +42,7 @@
 #include <openthread/nat64.h>
 #include <openthread/udp.h>
 
+#include "common/callback.hpp"
 #include "common/encoding.hpp"
 #include "common/frame_data.hpp"
 #include "common/locator.hpp"
@@ -246,7 +247,10 @@ public:
      * @sa SetReceiveIp6FilterEnabled
      *
      */
-    void SetReceiveDatagramCallback(otIp6ReceiveCallback aCallback, void *aCallbackContext);
+    void SetReceiveDatagramCallback(otIp6ReceiveCallback aCallback, void *aCallbackContext)
+    {
+        mReceiveIp6DatagramCallback.Set(aCallback, aCallbackContext);
+    }
 
 #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
     /**
@@ -259,7 +263,10 @@ public:
      * @sa SetReceiveDatagramCallback
      *
      */
-    void SetNat64ReceiveIp4DatagramCallback(otNat64ReceiveIp4Callback aCallback, void *aCallbackContext);
+    void SetNat64ReceiveIp4DatagramCallback(otNat64ReceiveIp4Callback aCallback, void *aCallbackContext)
+    {
+        mReceiveIp4DatagramCallback.Set(aCallback, aCallbackContext);
+    }
 #endif
 
     /**
@@ -414,14 +421,13 @@ private:
 
     using SendQueueTask = TaskletIn<Ip6, &Ip6::HandleSendQueue>;
 
-    bool                 mForwardingEnabled;
-    bool                 mIsReceiveIp6FilterEnabled;
-    otIp6ReceiveCallback mReceiveIp6DatagramCallback;
-    void                *mReceiveIp6DatagramCallbackContext;
+    bool mForwardingEnabled;
+    bool mIsReceiveIp6FilterEnabled;
+
+    Callback<otIp6ReceiveCallback> mReceiveIp6DatagramCallback;
 
 #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
-    otNat64ReceiveIp4Callback mReceiveIp4DatagramCallback;
-    void                     *mReceiveIp4DatagramCallbackContext;
+    Callback<otNat64ReceiveIp4Callback> mReceiveIp4DatagramCallback;
 #endif
 
     PriorityQueue mSendQueue;

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include "common/as_core_type.hpp"
+#include "common/callback.hpp"
 #include "common/clearable.hpp"
 #include "common/code_utils.hpp"
 #include "common/const_cast.hpp"
@@ -367,7 +368,10 @@ public:
      * @param[in]  aCallbackContext  A pointer to application-specific context.
      *
      */
-    void SetAddressCallback(otIp6AddressCallback aCallback, void *aCallbackContext);
+    void SetAddressCallback(otIp6AddressCallback aCallback, void *aCallbackContext)
+    {
+        mAddressCallback.Set(aCallback, aCallbackContext);
+    }
 
     /**
      * This method returns the linked list of unicast addresses.
@@ -652,8 +656,7 @@ private:
     LinkedList<MulticastAddress> mMulticastAddresses;
     bool                         mMulticastPromiscuous;
 
-    otIp6AddressCallback mAddressCallback;
-    void                *mAddressCallbackContext;
+    Callback<otIp6AddressCallback> mAddressCallback;
 
     Pool<UnicastAddress, OPENTHREAD_CONFIG_IP6_MAX_EXT_UCAST_ADDRS>           mExtUnicastAddressPool;
     Pool<ExternalMulticastAddress, OPENTHREAD_CONFIG_IP6_MAX_EXT_MCAST_ADDRS> mExtMulticastAddressPool;

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -206,18 +206,9 @@ void Client::AutoStart::SetState(State aState)
     }
 }
 
-void Client::AutoStart::SetCallback(AutoStartCallback aCallback, void *aContext)
-{
-    mCallback = aCallback;
-    mContext  = aContext;
-}
-
 void Client::AutoStart::InvokeCallback(const Ip6::SockAddr *aServerSockAddr) const
 {
-    if (mCallback != nullptr)
-    {
-        mCallback(aServerSockAddr, mContext);
-    }
+    mCallback.InvokeIfSet(aServerSockAddr);
 }
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
@@ -266,8 +257,6 @@ Client::Client(Instance &aInstance)
     , mDefaultLease(kDefaultLease)
     , mDefaultKeyLease(kDefaultKeyLease)
     , mSocket(aInstance)
-    , mCallback(nullptr)
-    , mCallbackContext(nullptr)
     , mDomainName(kDefaultDomainName)
     , mTimer(aInstance)
 {
@@ -380,12 +369,6 @@ exit:
         DisableAutoStartMode();
     }
 #endif
-}
-
-void Client::SetCallback(Callback aCallback, void *aContext)
-{
-    mCallback        = aCallback;
-    mCallbackContext = aContext;
 }
 
 void Client::Resume(void)
@@ -743,11 +726,7 @@ void Client::InvokeCallback(Error aError) const { InvokeCallback(aError, mHostIn
 
 void Client::InvokeCallback(Error aError, const HostInfo &aHostInfo, const Service *aRemovedServices) const
 {
-    VerifyOrExit(mCallback != nullptr);
-    mCallback(aError, &aHostInfo, mServices.GetHead(), aRemovedServices, mCallbackContext);
-
-exit:
-    return;
+    mCallback.InvokeIfSet(aError, &aHostInfo, mServices.GetHead(), aRemovedServices);
 }
 
 void Client::SendUpdate(void)

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -36,6 +36,7 @@
 #include <openthread/srp_client.h>
 
 #include "common/as_core_type.hpp"
+#include "common/callback.hpp"
 #include "common/clearable.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
@@ -97,7 +98,7 @@ public:
      * Please see `otSrpClientCallback` for more details.
      *
      */
-    typedef otSrpClientCallback Callback;
+    typedef otSrpClientCallback ClientCallback;
 
     /**
      * This type represents an SRP client host info.
@@ -461,7 +462,7 @@ public:
      * @param[in] aContext         An arbitrary context used with @p aCallback.
      *
      */
-    void SetCallback(Callback aCallback, void *aContext);
+    void SetCallback(ClientCallback aCallback, void *aContext) { mCallback.Set(aCallback, aContext); }
 
     /**
      * This method gets the TTL used in SRP update requests.
@@ -925,7 +926,7 @@ private:
         void    SetState(State aState);
         uint8_t GetAnycastSeqNum(void) const { return mAnycastSeqNum; }
         void    SetAnycastSeqNum(uint8_t aAnycastSeqNum) { mAnycastSeqNum = aAnycastSeqNum; }
-        void    SetCallback(AutoStartCallback aCallback, void *aContext);
+        void    SetCallback(AutoStartCallback aCallback, void *aContext) { mCallback.Set(aCallback, aContext); }
         void    InvokeCallback(const Ip6::SockAddr *aServerSockAddr) const;
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_SWITCH_SERVER_ON_FAILURE
@@ -945,10 +946,9 @@ private:
 
         static const char *StateToString(State aState);
 
-        AutoStartCallback mCallback;
-        void             *mContext;
-        State             mState;
-        uint8_t           mAnycastSeqNum;
+        Callback<AutoStartCallback> mCallback;
+        State                       mState;
+        uint8_t                     mAnycastSeqNum;
 #if OPENTHREAD_CONFIG_SRP_CLIENT_SWITCH_SERVER_ON_FAILURE
         uint8_t mTimoutFailureCount; // Number of no-response timeout failures with the currently selected server.
 #endif
@@ -1049,12 +1049,11 @@ private:
 
     Ip6::Udp::Socket mSocket;
 
-    Callback            mCallback;
-    void               *mCallbackContext;
-    const char         *mDomainName;
-    HostInfo            mHostInfo;
-    LinkedList<Service> mServices;
-    DelayTimer          mTimer;
+    Callback<ClientCallback> mCallback;
+    const char              *mDomainName;
+    HostInfo                 mHostInfo;
+    LinkedList<Service>      mServices;
+    DelayTimer               mTimer;
 #if OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
     AutoStart mAutoStart;
 #endif

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -86,8 +86,6 @@ static Dns::UpdateHeader::Response ErrorToDnsResponseCode(Error aError)
 Server::Server(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mSocket(aInstance)
-    , mServiceUpdateHandler(nullptr)
-    , mServiceUpdateHandlerContext(nullptr)
     , mLeaseTimer(aInstance)
     , mOutstandingUpdatesTimer(aInstance)
     , mServiceUpdateId(Random::NonCrypto::GetUint32())
@@ -101,12 +99,6 @@ Server::Server(Instance &aInstance)
 #endif
 {
     IgnoreError(SetDomain(kDefaultDomain));
-}
-
-void Server::SetServiceHandler(otSrpServerServiceUpdateHandler aServiceHandler, void *aServiceHandlerContext)
-{
-    mServiceUpdateHandler        = aServiceHandler;
-    mServiceUpdateHandlerContext = aServiceHandlerContext;
 }
 
 Error Server::SetAddressMode(AddressMode aMode)
@@ -342,12 +334,12 @@ void Server::RemoveHost(Host *aHost, RetainName aRetainName, NotifyMode aNotifyS
         LogInfo("Fully remove host %s", aHost->GetFullName());
     }
 
-    if (aNotifyServiceHandler && mServiceUpdateHandler != nullptr)
+    if (aNotifyServiceHandler && mServiceUpdateHandler.IsSet())
     {
         uint32_t updateId = AllocateId();
 
         LogInfo("SRP update handler is notified (updatedId = %lu)", ToUlong(updateId));
-        mServiceUpdateHandler(updateId, aHost, kDefaultEventsHandlerTimeout, mServiceUpdateHandlerContext);
+        mServiceUpdateHandler.Invoke(updateId, aHost, static_cast<uint32_t>(kDefaultEventsHandlerTimeout));
         // We don't wait for the reply from the service update handler,
         // but always remove the host (and its services) regardless of
         // host/service update result. Because removing a host should fail
@@ -1373,7 +1365,7 @@ void Server::InformUpdateHandlerOrCommit(Error aError, Host &aHost, const Messag
     }
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
-    if ((aError == kErrorNone) && (mServiceUpdateHandler != nullptr))
+    if ((aError == kErrorNone) && mServiceUpdateHandler.IsSet())
     {
         UpdateMetadata *update = UpdateMetadata::Allocate(GetInstance(), aHost, aMetadata);
 
@@ -1383,7 +1375,7 @@ void Server::InformUpdateHandlerOrCommit(Error aError, Host &aHost, const Messag
             mOutstandingUpdatesTimer.FireAtIfEarlier(update->GetExpireTime());
 
             LogInfo("SRP update handler is notified (updatedId = %lu)", ToUlong(update->GetId()));
-            mServiceUpdateHandler(update->GetId(), &aHost, kDefaultEventsHandlerTimeout, mServiceUpdateHandlerContext);
+            mServiceUpdateHandler.Invoke(update->GetId(), &aHost, static_cast<uint32_t>(kDefaultEventsHandlerTimeout));
             ExitNow();
         }
 
@@ -2068,12 +2060,12 @@ void Server::Host::RemoveService(Service *aService, RetainName aRetainName, Noti
 
     aService->Log(aRetainName ? Service::kRemoveButRetainName : Service::kFullyRemove);
 
-    if (aNotifyServiceHandler && server.mServiceUpdateHandler != nullptr)
+    if (aNotifyServiceHandler && server.mServiceUpdateHandler.IsSet())
     {
         uint32_t updateId = server.AllocateId();
 
         LogInfo("SRP update handler is notified (updatedId = %lu)", ToUlong(updateId));
-        server.mServiceUpdateHandler(updateId, this, kDefaultEventsHandlerTimeout, server.mServiceUpdateHandlerContext);
+        server.mServiceUpdateHandler.Invoke(updateId, this, static_cast<uint32_t>(kDefaultEventsHandlerTimeout));
         // We don't wait for the reply from the service update handler,
         // but always remove the service regardless of service update result.
         // Because removing a service should fail only when there is system

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -55,6 +55,7 @@
 
 #include "common/array.hpp"
 #include "common/as_core_type.hpp"
+#include "common/callback.hpp"
 #include "common/clearable.hpp"
 #include "common/heap.hpp"
 #include "common/heap_allocatable.hpp"
@@ -718,7 +719,10 @@ public:
      * @sa  HandleServiceUpdateResult
      *
      */
-    void SetServiceHandler(otSrpServerServiceUpdateHandler aServiceHandler, void *aServiceHandlerContext);
+    void SetServiceHandler(otSrpServerServiceUpdateHandler aServiceHandler, void *aServiceHandlerContext)
+    {
+        mServiceUpdateHandler.Set(aServiceHandler, aServiceHandlerContext);
+    }
 
     /**
      * This method returns the domain authorized to the SRP server.
@@ -1056,9 +1060,9 @@ private:
     using LeaseTimer  = TimerMilliIn<Server, &Server::HandleLeaseTimer>;
     using UpdateTimer = TimerMilliIn<Server, &Server::HandleOutstandingUpdatesTimer>;
 
-    Ip6::Udp::Socket                mSocket;
-    otSrpServerServiceUpdateHandler mServiceUpdateHandler;
-    void                           *mServiceUpdateHandlerContext;
+    Ip6::Udp::Socket mSocket;
+
+    Callback<otSrpServerServiceUpdateHandler> mServiceUpdateHandler;
 
     Heap::String mDomain;
 

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -149,10 +149,6 @@ Udp::Udp(Instance &aInstance)
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     , mPrevBackboneSockets(nullptr)
 #endif
-#if OPENTHREAD_CONFIG_UDP_FORWARD_ENABLE
-    , mUdpForwarderContext(nullptr)
-    , mUdpForwarder(nullptr)
-#endif
 {
 }
 
@@ -430,9 +426,8 @@ Error Udp::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aI
 #if OPENTHREAD_CONFIG_UDP_FORWARD_ENABLE
     if (aMessageInfo.IsHostInterface())
     {
-        VerifyOrExit(mUdpForwarder != nullptr, error = kErrorNoRoute);
-        mUdpForwarder(&aMessage, aMessageInfo.mPeerPort, &aMessageInfo.GetPeerAddr(), aMessageInfo.mSockPort,
-                      mUdpForwarderContext);
+        VerifyOrExit(mUdpForwarder.IsSet(), error = kErrorNoRoute);
+        mUdpForwarder.Invoke(&aMessage, aMessageInfo.mPeerPort, &aMessageInfo.GetPeerAddr(), aMessageInfo.mSockPort);
         // message is consumed by the callback
     }
     else

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -40,6 +40,7 @@
 #include <openthread/platform/udp.h>
 
 #include "common/as_core_type.hpp"
+#include "common/callback.hpp"
 #include "common/clearable.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
@@ -593,11 +594,7 @@ public:
      * @param[in]   aContext    A pointer to arbitrary context information.
      *
      */
-    void SetUdpForwarder(otUdpForwarder aForwarder, void *aContext)
-    {
-        mUdpForwarder        = aForwarder;
-        mUdpForwarderContext = aContext;
-    }
+    void SetUdpForwarder(otUdpForwarder aForwarder, void *aContext) { mUdpForwarder.Set(aForwarder, aContext); }
 #endif
 
     /**
@@ -652,8 +649,7 @@ private:
     SocketHandle *mPrevBackboneSockets;
 #endif
 #if OPENTHREAD_CONFIG_UDP_FORWARD_ENABLE
-    void          *mUdpForwarderContext;
-    otUdpForwarder mUdpForwarder;
+    Callback<otUdpForwarder> mUdpForwarder;
 #endif
 };
 

--- a/src/core/thread/anycast_locator.hpp
+++ b/src/core/thread/anycast_locator.hpp
@@ -38,6 +38,7 @@
 
 #if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_ENABLE
 
+#include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "net/ip6_address.hpp"
@@ -61,7 +62,7 @@ public:
      * This function pointer type defines the callback to notify the outcome of a request.
      *
      */
-    typedef otThreadAnycastLocatorCallback Callback;
+    typedef otThreadAnycastLocatorCallback LocatorCallback;
 
     /**
      * This constructor initializes the `AnycastLocator` object.
@@ -86,7 +87,7 @@ public:
      * @retval kErrorInvalidArgs  The @p aAnycastAddress is not a valid anycast address or @p aCallback is `nullptr`.
      *
      */
-    Error Locate(const Ip6::Address &aAnycastAddress, Callback aCallback, void *aContext);
+    Error Locate(const Ip6::Address &aAnycastAddress, LocatorCallback aCallback, void *aContext);
 
     /**
      * This method indicates whether an earlier request is in progress.
@@ -94,7 +95,7 @@ public:
      * @returns TRUE if an earlier request is in progress, FALSE otherwise.
      *
      */
-    bool IsInProgress(void) const { return (mCallback != nullptr); }
+    bool IsInProgress(void) const { return mCallback.IsSet(); }
 
 private:
     static void HandleResponse(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo, Error aError);
@@ -103,8 +104,7 @@ private:
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    Callback mCallback;
-    void    *mContext;
+    Callback<LocatorCallback> mCallback;
 };
 
 #if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_SEND_RESPONSE

--- a/src/core/thread/discover_scanner.hpp
+++ b/src/core/thread/discover_scanner.hpp
@@ -36,6 +36,7 @@
 
 #include "openthread-core-config.h"
 
+#include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/tasklet.hpp"
@@ -177,19 +178,18 @@ private:
     using ScanTimer    = TimerMilliIn<DiscoverScanner, &DiscoverScanner::HandleTimer>;
     using ScanDoneTask = TaskletIn<DiscoverScanner, &DiscoverScanner::HandleScanDoneTask>;
 
-    Handler          mHandler;
-    void            *mHandlerContext;
-    ScanDoneTask     mScanDoneTask;
-    ScanTimer        mTimer;
-    FilterIndexes    mFilterIndexes;
-    Mac::ChannelMask mScanChannels;
-    State            mState;
-    uint32_t         mOui;
-    uint8_t          mScanChannel;
-    uint8_t          mAdvDataLength;
-    uint8_t          mAdvData[MeshCoP::JoinerAdvertisementTlv::kAdvDataMaxLength];
-    bool             mEnableFiltering : 1;
-    bool             mShouldRestorePanId : 1;
+    Callback<Handler> mCallback;
+    ScanDoneTask      mScanDoneTask;
+    ScanTimer         mTimer;
+    FilterIndexes     mFilterIndexes;
+    Mac::ChannelMask  mScanChannels;
+    State             mState;
+    uint32_t          mOui;
+    uint8_t           mScanChannel;
+    uint8_t           mAdvDataLength;
+    uint8_t           mAdvData[MeshCoP::JoinerAdvertisementTlv::kAdvDataMaxLength];
+    bool              mEnableFiltering : 1;
+    bool              mShouldRestorePanId : 1;
 };
 
 } // namespace Mle

--- a/src/core/thread/link_metrics.hpp
+++ b/src/core/thread/link_metrics.hpp
@@ -46,6 +46,7 @@
 #include <openthread/link.h>
 
 #include "common/as_core_type.hpp"
+#include "common/callback.hpp"
 #include "common/clearable.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
@@ -245,7 +246,7 @@ public:
      * @param[in]  aContext   A pointer to application-specific context.
      *
      */
-    void SetReportCallback(ReportCallback aCallback, void *aContext);
+    void SetReportCallback(ReportCallback aCallback, void *aContext) { mReportCallback.Set(aCallback, aContext); }
 
     /**
      * This method registers a callback to handle Link Metrics Management Response received.
@@ -254,7 +255,10 @@ public:
      * @param[in]  aContext  A pointer to application-specific context.
      *
      */
-    void SetMgmtResponseCallback(MgmtResponseCallback aCallback, void *aContext);
+    void SetMgmtResponseCallback(MgmtResponseCallback aCallback, void *aContext)
+    {
+        mMgmtResponseCallback.Set(aCallback, aContext);
+    }
 
     /**
      * This method registers a callback to handle Link Metrics when Enh-ACK Probing IE is received.
@@ -263,7 +267,10 @@ public:
      * @param[in]  aContext  A pointer to application-specific context.
      *
      */
-    void SetEnhAckProbingCallback(EnhAckProbingIeReportCallback aCallback, void *aContext);
+    void SetEnhAckProbingCallback(EnhAckProbingIeReportCallback aCallback, void *aContext)
+    {
+        mEnhAckProbingIeReportCallback.Set(aCallback, aContext);
+    }
 
     /**
      * This method processes received Enh-ACK Probing IE data.
@@ -320,12 +327,9 @@ private:
     static uint8_t ScaleRssiToRawValue(int8_t aRssi);
     static int8_t  ScaleRawValueToRssi(uint8_t aRawValue);
 
-    ReportCallback                mReportCallback;
-    void                         *mReportCallbackContext;
-    MgmtResponseCallback          mMgmtResponseCallback;
-    void                         *mMgmtResponseCallbackContext;
-    EnhAckProbingIeReportCallback mEnhAckProbingIeReportCallback;
-    void                         *mEnhAckProbingIeReportCallbackContext;
+    Callback<ReportCallback>                mReportCallback;
+    Callback<MgmtResponseCallback>          mMgmtResponseCallback;
+    Callback<EnhAckProbingIeReportCallback> mEnhAckProbingIeReportCallback;
 
     Pool<SeriesInfo, kMaxSeriesSupported> mSeriesInfoPool;
 };

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -36,6 +36,7 @@
 
 #include "openthread-core-config.h"
 
+#include "common/callback.hpp"
 #include "common/encoding.hpp"
 #include "common/locator.hpp"
 #include "common/log.hpp"
@@ -619,7 +620,10 @@ public:
      * @param[in]  aContext  A pointer to application-specific context.
      *
      */
-    void RegisterParentResponseStatsCallback(otThreadParentResponseCallback aCallback, void *aContext);
+    void RegisterParentResponseStatsCallback(otThreadParentResponseCallback aCallback, void *aContext)
+    {
+        mParentResponseCallback.Set(aCallback, aContext);
+    }
 
     /**
      * This method requests MLE layer to prepare and send a shorter version of Child ID Request message by only
@@ -2047,12 +2051,10 @@ private:
     Ip6::Netif::MulticastAddress mLinkLocalAllThreadNodes;
     Ip6::Netif::MulticastAddress mRealmLocalAllThreadNodes;
 
-    DetachGracefullyTimer      mDetachGracefullyTimer;
-    otDetachGracefullyCallback mDetachGracefullyCallback;
-    void                      *mDetachGracefullyContext;
+    DetachGracefullyTimer                mDetachGracefullyTimer;
+    Callback<otDetachGracefullyCallback> mDetachGracefullyCallback;
 
-    otThreadParentResponseCallback mParentResponseCb;
-    void                          *mParentResponseCbContext;
+    Callback<otThreadParentResponseCallback> mParentResponseCallback;
 };
 
 } // namespace Mle

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -93,8 +93,6 @@ MleRouter::MleRouter(Instance &aInstance)
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     , mMaxChildIpAddresses(0)
 #endif
-    , mDiscoveryRequestCallback(nullptr)
-    , mDiscoveryRequestCallbackContext(nullptr)
 {
     mDeviceMode.Set(mDeviceMode.Get() | DeviceMode::kModeFullThreadDevice | DeviceMode::kModeFullNetworkData);
 
@@ -2935,7 +2933,7 @@ void MleRouter::HandleDiscoveryRequest(RxInfo &aRxInfo)
 
     if (discoveryRequestTlv.IsValid())
     {
-        if (mDiscoveryRequestCallback != nullptr)
+        if (mDiscoveryRequestCallback.IsSet())
         {
             otThreadDiscoveryRequestInfo info;
 
@@ -2943,7 +2941,7 @@ void MleRouter::HandleDiscoveryRequest(RxInfo &aRxInfo)
             info.mVersion  = discoveryRequestTlv.GetVersion();
             info.mIsJoiner = discoveryRequestTlv.IsJoiner();
 
-            mDiscoveryRequestCallback(&info, mDiscoveryRequestCallbackContext);
+            mDiscoveryRequestCallback.Invoke(&info);
         }
 
         if (discoveryRequestTlv.IsJoiner())

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -39,6 +39,7 @@
 #include <openthread/thread_ftd.h>
 
 #include "coap/coap_message.hpp"
+#include "common/callback.hpp"
 #include "common/time_ticker.hpp"
 #include "common/timer.hpp"
 #include "common/trickle_timer.hpp"
@@ -483,8 +484,7 @@ public:
      */
     void SetDiscoveryRequestCallback(otThreadDiscoveryRequestCallback aCallback, void *aContext)
     {
-        mDiscoveryRequestCallback        = aCallback;
-        mDiscoveryRequestCallbackContext = aContext;
+        mDiscoveryRequestCallback.Set(aCallback, aContext);
     }
 
     /**
@@ -693,8 +693,7 @@ private:
     MeshCoP::SteeringData mSteeringData;
 #endif
 
-    otThreadDiscoveryRequestCallback mDiscoveryRequestCallback;
-    void                            *mDiscoveryRequestCallbackContext;
+    Callback<otThreadDiscoveryRequestCallback> mDiscoveryRequestCallback;
 };
 
 DeclareTmfHandler(MleRouter, kUriAddressSolicit);

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -44,6 +44,7 @@
 
 #include "backbone_router/bbr_leader.hpp"
 #include "coap/coap_message.hpp"
+#include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
@@ -214,8 +215,7 @@ private:
                                uint8_t             aFailedAddressNum);
 
 #if (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE) && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
-    otIp6RegisterMulticastListenersCallback mRegisterMulticastListenersCallback;
-    void                                   *mRegisterMulticastListenersContext;
+    Callback<otIp6RegisterMulticastListenersCallback> mRegisterMulticastListenersCallback;
 #endif
 
     uint32_t mReregistrationDelay;

--- a/src/core/thread/network_data_publisher.hpp
+++ b/src/core/thread/network_data_publisher.hpp
@@ -46,6 +46,7 @@
 #include <openthread/netdata_publisher.h>
 
 #include "border_router/routing_manager.hpp"
+#include "common/callback.hpp"
 #include "common/clearable.hpp"
 #include "common/equatable.hpp"
 #include "common/error.hpp"
@@ -212,7 +213,7 @@ public:
      * @param[in] aContext         A pointer to application-specific context (used when @p aCallback is invoked).
      *
      */
-    void SetPrefixCallback(PrefixCallback aCallback, void *aContext);
+    void SetPrefixCallback(PrefixCallback aCallback, void *aContext) { mPrefixCallback.Set(aCallback, aContext); }
 
     /**
      * This method requests an on-mesh prefix to be published in the Thread Network Data.
@@ -346,7 +347,7 @@ private:
 
     public:
         explicit DnsSrpServiceEntry(Instance &aInstance);
-        void SetCallback(DnsSrpServiceCallback aCallback, void *aContext);
+        void SetCallback(DnsSrpServiceCallback aCallback, void *aContext) { mCallback.Set(aCallback, aContext); }
         void PublishAnycast(uint8_t aSequenceNumber);
         void PublishUnicast(const Ip6::Address &aAddress, uint16_t aPort);
         void PublishUnicast(uint16_t aPort);
@@ -401,9 +402,8 @@ private:
         void CountAnycastEntries(uint8_t &aNumEntries, uint8_t &aNumPreferredEntries) const;
         void CountUnicastEntries(uint8_t &aNumEntries, uint8_t &aNumPreferredEntries) const;
 
-        Info                  mInfo;
-        DnsSrpServiceCallback mCallback;
-        void                 *mCallbackContext;
+        Info                            mInfo;
+        Callback<DnsSrpServiceCallback> mCallback;
     };
 #endif // OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
@@ -485,9 +485,8 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
-    PrefixEntry    mPrefixEntries[kMaxUserPrefixEntries + kMaxRoutingManagerPrefixEntries];
-    PrefixCallback mPrefixCallback;
-    void          *mPrefixCallbackContext;
+    PrefixEntry              mPrefixEntries[kMaxUserPrefixEntries + kMaxRoutingManagerPrefixEntries];
+    Callback<PrefixCallback> mPrefixCallback;
 #endif
 
     PublisherTimer mTimer;

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/netdiag.h>
 
+#include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "net/udp6.hpp"
@@ -163,8 +164,7 @@ private:
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    otReceiveDiagnosticGetCallback mReceiveDiagnosticGetCallback;
-    void                          *mReceiveDiagnosticGetCallbackContext;
+    Callback<otReceiveDiagnosticGetCallback> mReceiveDiagnosticGetCallback;
 };
 
 DeclareTmfHandler(NetworkDiagnostic, kUriDiagnosticGetRequest);

--- a/src/core/thread/time_sync_service.cpp
+++ b/src/core/thread/time_sync_service.cpp
@@ -62,8 +62,6 @@ TimeSync::TimeSync(Instance &aInstance)
 #endif
     , mLastTimeSyncReceived(0)
     , mNetworkTimeOffset(0)
-    , mTimeSyncCallback(nullptr)
-    , mTimeSyncCallbackContext(nullptr)
     , mTimer(aInstance)
     , mCurrentStatus(OT_NETWORK_TIME_UNSYNCHRONIZED)
 {
@@ -140,13 +138,7 @@ void TimeSync::IncrementTimeSyncSeq(void)
     }
 }
 
-void TimeSync::NotifyTimeSyncCallback(void)
-{
-    if (mTimeSyncCallback != nullptr)
-    {
-        mTimeSyncCallback(mTimeSyncCallbackContext);
-    }
-}
+void TimeSync::NotifyTimeSyncCallback(void) { mTimeSyncCallback.InvokeIfSet(); }
 
 #if OPENTHREAD_FTD
 void TimeSync::ProcessTimeSync(void)

--- a/src/core/thread/time_sync_service.hpp
+++ b/src/core/thread/time_sync_service.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/network_time.h>
 
+#include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/non_copyable.hpp"
@@ -151,8 +152,7 @@ public:
      */
     void SetTimeSyncCallback(otNetworkTimeSyncCallbackFn aCallback, void *aCallbackContext)
     {
-        mTimeSyncCallback        = aCallback;
-        mTimeSyncCallbackContext = aCallbackContext;
+        mTimeSyncCallback.Set(aCallback, aCallbackContext);
     }
 
     /**
@@ -202,11 +202,10 @@ private:
 #endif
     TimeMilli mLastTimeSyncReceived; ///< The time when the last time synchronization message was received.
     int64_t   mNetworkTimeOffset;    ///< The time offset to the Thread Network time
-    otNetworkTimeSyncCallbackFn
-                        mTimeSyncCallback; ///< The callback to be called when time sync is handled or status updated.
-    void               *mTimeSyncCallbackContext; ///< The context to be passed to callback.
-    SyncTimer           mTimer;                   ///< Timer for checking if a resync is required.
-    otNetworkTimeStatus mCurrentStatus;           ///< Current network time status.
+
+    Callback<otNetworkTimeSyncCallbackFn> mTimeSyncCallback; ///< Callback when time sync is handled or status updated.
+    SyncTimer                             mTimer;            ///< Timer for checking if a resync is required.
+    otNetworkTimeStatus                   mCurrentStatus;    ///< Current network time status.
 };
 
 /**

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -49,8 +49,6 @@ RegisterLogModule("JamDetector");
 
 JamDetector::JamDetector(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mHandler(nullptr)
-    , mContext(nullptr)
     , mTimer(aInstance)
     , mHistoryBitmap(0)
     , mCurSecondStartTime(0)
@@ -71,8 +69,7 @@ Error JamDetector::Start(Handler aHandler, void *aContext)
     VerifyOrExit(!mEnabled, error = kErrorAlready);
     VerifyOrExit(aHandler != nullptr, error = kErrorInvalidArgs);
 
-    mHandler = aHandler;
-    mContext = aContext;
+    mCallback.Set(aHandler, aContext);
     mEnabled = true;
 
     LogInfo("Started");
@@ -263,7 +260,7 @@ void JamDetector::SetJamState(bool aNewState)
 
     if (shouldInvokeHandler)
     {
-        mHandler(mJamState, mContext);
+        mCallback.Invoke(aNewState);
     }
 }
 

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -40,6 +40,7 @@
 
 #include <stdint.h>
 
+#include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
@@ -194,18 +195,17 @@ private:
 
     using SampleTimer = TimerMilliIn<JamDetector, &JamDetector::HandleTimer>;
 
-    Handler     mHandler;                  // Handler/callback to inform about jamming state
-    void       *mContext;                  // Context for handler/callback
-    SampleTimer mTimer;                    // RSSI sample timer
-    uint64_t    mHistoryBitmap;            // History bitmap, each bit correspond to 1 sec interval
-    TimeMilli   mCurSecondStartTime;       // Start time for current 1 sec interval
-    uint16_t    mSampleInterval;           // Current sample interval
-    uint8_t     mWindow : 6;               // Window (in sec) to monitor jamming
-    uint8_t     mBusyPeriod : 6;           // BusyPeriod (in sec) with mWindow to alert jamming
-    bool        mEnabled : 1;              // If jam detection is enabled
-    bool        mAlwaysAboveThreshold : 1; // State for current 1 sec interval
-    bool        mJamState : 1;             // Current jam state
-    int8_t      mRssiThreshold;            // RSSI threshold for jam detection
+    Callback<Handler> mCallback;                 // Callback to inform about jamming state
+    SampleTimer       mTimer;                    // RSSI sample timer
+    uint64_t          mHistoryBitmap;            // History bitmap, each bit correspond to 1 sec interval
+    TimeMilli         mCurSecondStartTime;       // Start time for current 1 sec interval
+    uint16_t          mSampleInterval;           // Current sample interval
+    uint8_t           mWindow : 6;               // Window (in sec) to monitor jamming
+    uint8_t           mBusyPeriod : 6;           // BusyPeriod (in sec) with mWindow to alert jamming
+    bool              mEnabled : 1;              // If jam detection is enabled
+    bool              mAlwaysAboveThreshold : 1; // State for current 1 sec interval
+    bool              mJamState : 1;             // Current jam state
+    int8_t            mRssiThreshold;            // RSSI threshold for jam detection
 };
 
 /**


### PR DESCRIPTION
This commit adds a new class `Callback<HandlerType>` which represents a callback as a function pointer handler and a `void *` context pair. The context is passed as one of the arguments to the function pointer handler when the callback is invoked.

The `Callback` provides two specializations based on the position of the context argument in the function pointer, i.e., whether it is passed as the first argument or as the last argument. The `Callback<HandlerType>` class automatically determines this at compile-time based on the given `HandlerType` and passes the context properly from `Invoke()` method.

The `Callback` class is used by OT core modules to simplify how callbacks are defined and used.