### PR TITLE
[link-quality] move `CostForLinkQuality()` to `link_quality.hpp`

### DIFF
--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -219,6 +219,29 @@ int8_t GetTypicalRssForLinkQuality(int8_t aNoiseFloor, LinkQuality aLinkQuality)
     return linkMargin + aNoiseFloor;
 }
 
+uint8_t CostForLinkQuality(LinkQuality aLinkQuality)
+{
+    static const uint8_t kCostsForLinkQuality[] = {
+        kCostForLinkQuality0, // Link cost for `kLinkQuality0` (0).
+        kCostForLinkQuality1, // Link cost for `kLinkQuality1` (1).
+        kCostForLinkQuality2, // Link cost for `kLinkQuality2` (2).
+        kCostForLinkQuality3, // Link cost for `kLinkQuality3` (3).
+    };
+
+    static_assert(kLinkQuality0 == 0, "kLinkQuality0 is invalid");
+    static_assert(kLinkQuality1 == 1, "kLinkQuality1 is invalid");
+    static_assert(kLinkQuality2 == 2, "kLinkQuality2 is invalid");
+    static_assert(kLinkQuality3 == 3, "kLinkQuality3 is invalid");
+
+    uint8_t cost = Mle::kMaxRouteCost;
+
+    VerifyOrExit(aLinkQuality <= kLinkQuality3);
+    cost = kCostsForLinkQuality[aLinkQuality];
+
+exit:
+    return cost;
+}
+
 LinkQuality LinkQualityInfo::CalculateLinkQuality(uint8_t aLinkMargin, uint8_t aLastLinkQuality)
 {
     // Static private method to calculate the link quality from a given

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -41,6 +41,7 @@
 #include "common/clearable.hpp"
 #include "common/locator.hpp"
 #include "common/string.hpp"
+#include "thread/mle_types.hpp"
 
 namespace ot {
 
@@ -240,6 +241,21 @@ enum LinkQuality : uint8_t
     kLinkQuality2 = 2, ///< Link quality 2
     kLinkQuality3 = 3, ///< Link quality 3
 };
+
+constexpr uint8_t kCostForLinkQuality0 = Mle::kMaxRouteCost; ///< Link Cost for Link Quality 0.
+constexpr uint8_t kCostForLinkQuality1 = 4;                  ///< Link Cost for Link Quality 1.
+constexpr uint8_t kCostForLinkQuality2 = 2;                  ///< Link Cost for Link Quality 2.
+constexpr uint8_t kCostForLinkQuality3 = 1;                  ///< Link Cost for Link Quality 3.
+
+/**
+ * This function converts link quality to route cost.
+ *
+ * @param[in]  aLinkQuality  The link quality to covert.
+ *
+ * @returns The route cost corresponding to @p aLinkQuality.
+ *
+ */
+uint8_t CostForLinkQuality(LinkQuality aLinkQuality);
 
 /**
  * This function computes the link margin from a given noise floor and received signal strength.

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -437,7 +437,7 @@ void MeshForwarder::EvaluateRoutingCost(uint16_t aDest, uint8_t &aBestCost, uint
     if (!Mle::IsActiveRouter(aDest))
     {
         // Assume best link between remote child server and its parent.
-        curCost += 1;
+        curCost += kCostForLinkQuality3;
     }
 
     // Cost if the server is direct neighbor.
@@ -451,7 +451,7 @@ void MeshForwarder::EvaluateRoutingCost(uint16_t aDest, uint8_t &aBestCost, uint
         {
             // Cost calculated only from Link Quality In as the parent only maintains
             // one-direction link info.
-            cost = Mle::MleRouter::LinkQualityToCost(neighbor->GetLinkQualityIn());
+            cost = CostForLinkQuality(neighbor->GetLinkQualityIn());
         }
         else
         {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1038,32 +1038,6 @@ exit:
     return error;
 }
 
-uint8_t MleRouter::LinkQualityToCost(uint8_t aLinkQuality)
-{
-    uint8_t rval;
-
-    switch (aLinkQuality)
-    {
-    case 1:
-        rval = kLinkQuality1LinkCost;
-        break;
-
-    case 2:
-        rval = kLinkQuality2LinkCost;
-        break;
-
-    case 3:
-        rval = kLinkQuality3LinkCost;
-        break;
-
-    default:
-        rval = kLinkQuality0LinkCost;
-        break;
-    }
-
-    return rval;
-}
-
 uint8_t MleRouter::GetLinkCost(uint8_t aRouterId)
 {
     uint8_t rval = kMaxRouteCost;
@@ -4031,7 +4005,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
             break;
         }
 
-        cost += LinkQualityToCost(mParent.GetLinkQualityIn());
+        cost += CostForLinkQuality(mParent.GetLinkQualityIn());
         break;
 
     case kRoleRouter:

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -493,16 +493,6 @@ public:
      */
     void ResetAdvertiseInterval(void);
 
-    /**
-     * This static method converts link quality to route cost.
-     *
-     * @param[in]  aLinkQuality  The link quality.
-     *
-     * @returns The link cost corresponding to @p aLinkQuality.
-     *
-     */
-    static uint8_t LinkQualityToCost(uint8_t aLinkQuality);
-
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     /**
      * This method generates an MLE Time Synchronization message.

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -183,11 +183,6 @@ constexpr int8_t kParentPriorityMedium      = 0;  ///< Parent Priority Medium (d
 constexpr int8_t kParentPriorityLow         = -1; ///< Parent Priority Low
 constexpr int8_t kParentPriorityUnspecified = -2; ///< Parent Priority Unspecified
 
-constexpr uint8_t kLinkQuality3LinkCost = 1;             ///< Link Cost for Link Quality 3
-constexpr uint8_t kLinkQuality2LinkCost = 2;             ///< Link Cost for Link Quality 2
-constexpr uint8_t kLinkQuality1LinkCost = 4;             ///< Link Cost for Link Quality 1
-constexpr uint8_t kLinkQuality0LinkCost = kMaxRouteCost; ///< Link Cost for Link Quality 0
-
 /**
  * This type represents a Thread device role.
  *

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -352,7 +352,7 @@ uint8_t RouterTable::GetLinkCost(const Router &aRouter) const
 
     VerifyOrExit(aRouter.GetRloc16() != Get<Mle::MleRouter>().GetRloc16() && aRouter.IsStateValid());
 
-    rval = Mle::MleRouter::LinkQualityToCost(aRouter.GetTwoWayLinkQuality());
+    rval = CostForLinkQuality(aRouter.GetTwoWayLinkQuality());
 
 exit:
     return rval;


### PR DESCRIPTION
This commit renames and moves the function which coverts a given `LinkQuality` value to a link cost to `link_quality` source files.