### PR TITLE
[routing-manager] add feature to skip NS probe with router on same device

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1752,6 +1752,18 @@ void RoutingManager::DiscoveredPrefixTable::HandleRouterTimer(void)
             continue;
         }
 
+        // If the `router` emitting RA has an address belonging to
+        // infra interface, it indicates that the RAs are from
+        // same device. In this case we skip performing NS probes.
+        // This addresses situation where platform may not be
+        // be able to receive and pass the NA message response
+        // from device itself.
+
+        if (Get<RoutingManager>().mInfraIf.HasAddress(router.mAddress))
+        {
+            continue;
+        }
+
         if (router.mTimeout <= now)
         {
             router.mNsProbeCount++;


### PR DESCRIPTION
This commit adds a new behavior in `RoutingManager` to skip performing NS probe with a router with an address belonging to device infra interface itself. This addresses the situation where platform may not be be able to receive and pass the NA message responses from device itself.