### PR TITLE
[link-metrics] fix build flags for Link Metrics Initiator

### DIFF
--- a/src/core/api/link_metrics_api.cpp
+++ b/src/core/api/link_metrics_api.cpp
@@ -55,6 +55,7 @@ otError otLinkMetricsQuery(otInstance                 *aInstance,
                                                                        AsCoreTypePtr(aLinkMetricsFlags));
 }
 
+#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
 otError otLinkMetricsConfigForwardTrackingSeries(otInstance                       *aInstance,
                                                  const otIp6Address               *aDestination,
                                                  uint8_t                           aSeriesId,
@@ -71,7 +72,6 @@ otError otLinkMetricsConfigForwardTrackingSeries(otInstance                     
         AsCoreType(aDestination), aSeriesId, AsCoreType(&aSeriesFlags), AsCoreTypePtr(aLinkMetricsFlags));
 }
 
-#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
 otError otLinkMetricsConfigEnhAckProbing(otInstance                                *aInstance,
                                          const otIp6Address                        *aDestination,
                                          otLinkMetricsEnhAckFlags                   aEnhAckFlags,

--- a/src/core/thread/link_metrics.hpp
+++ b/src/core/thread/link_metrics.hpp
@@ -121,6 +121,7 @@ public:
      */
     Error Query(const Ip6::Address &aDestination, uint8_t aSeriesId, const Metrics *aMetrics);
 
+#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
     /**
      * This method sends an MLE Link Metrics Management Request to configure/clear a Forward Tracking Series.
      *
@@ -140,7 +141,6 @@ public:
                                                const SeriesFlags  &aSeriesFlags,
                                                const Metrics      *aMetrics);
 
-#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
     /**
      * This method sends an MLE Link Metrics Management Request to configure/clear a Enhanced-ACK Based Probing.
      *


### PR DESCRIPTION
This commit fixes the placement of the preprocessor directive to avoid linking errors.