### PR TITLE
[mesh-forwarder] use constant for `hopsLeft` in lowpan `MeshHeader`

### DIFF
--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -298,12 +298,6 @@ class MeshHeader
 {
 public:
     /**
-     * The additional value that is added to predicted value of the route cost.
-     *
-     */
-    static constexpr uint8_t kAdditionalHopsLeft = 1;
-
-    /**
      * This method initializes the Mesh Header with a given Mesh Source, Mesh Destination and Hops Left value.
      *
      * @param[in]  aSource       The Mesh Source address.

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -965,9 +965,7 @@ start:
     // Initialize Mesh header
     if (aAddMeshHeader)
     {
-        Mle::MleRouter    &mle = Get<Mle::MleRouter>();
         Lowpan::MeshHeader meshHeader;
-        uint8_t            hopsLeft;
         uint16_t           maxPayloadLength;
 
         // Mesh Header frames are forwarded by routers over multiple
@@ -990,35 +988,7 @@ start:
 
         frameBuilder.Init(aFrame.GetPayload(), maxPayloadLength);
 
-        if (mle.IsChild())
-        {
-            // REED sets hopsLeft to max (16) + 1. It does not know the route cost.
-            hopsLeft = Mle::kMaxRouteCost + 1;
-        }
-        else
-        {
-            // Calculate the number of predicted hops.
-            hopsLeft = mle.GetRouteCost(aMeshDest);
-
-            if (hopsLeft != Mle::kMaxRouteCost)
-            {
-                hopsLeft += mle.GetLinkCost(Mle::RouterIdFromRloc16(mle.GetNextHop(aMeshDest)));
-            }
-            else
-            {
-                // In case there is no route to the destination router (only link).
-                hopsLeft = mle.GetLinkCost(Mle::RouterIdFromRloc16(aMeshDest));
-            }
-        }
-
-        // The hopsLft field MUST be incremented by one if the
-        // destination RLOC16 is not that of an active Router.
-        if (!Mle::IsActiveRouter(aMeshDest))
-        {
-            hopsLeft += 1;
-        }
-
-        meshHeader.Init(aMeshSource, aMeshDest, hopsLeft + Lowpan::MeshHeader::kAdditionalHopsLeft);
+        meshHeader.Init(aMeshSource, aMeshDest, kMeshHeaderHopsLeft);
 
         IgnoreError(meshHeader.AppendTo(frameBuilder));
     }

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -334,6 +334,12 @@ private:
     static constexpr uint8_t kMeshHeaderFrameMtu     = OT_RADIO_FRAME_MAX_SIZE; // Max MTU with a Mesh Header frame.
     static constexpr uint8_t kMeshHeaderFrameFcsSize = sizeof(uint16_t);        // Frame FCS size for Mesh Header frame.
 
+    // Hops left to use in lowpan mesh header: We use `kMaxRouteCost` as
+    // max hops between routers within Thread  mesh. We then add two
+    // for possibility of source or destination being a child
+    // (requiring one hop) and one as additional guard increment.
+    static constexpr uint8_t kMeshHeaderHopsLeft = Mle::kMaxRouteCost + 3;
+
     static constexpr uint32_t kTxDelayInterval = OPENTHREAD_CONFIG_MAC_COLLISION_AVOIDANCE_DELAY_INTERVAL; // In msec
 
 #if OPENTHREAD_CONFIG_DELAY_AWARE_QUEUE_MANAGEMENT_ENABLE


### PR DESCRIPTION
This commit updates how we set the `hopsLeft` when preparing a lowpan `MeshHeader` frame so to use a constant max value. The max hops lefts value is determined based on `kMaxRouteCost`(estimate on max hops between routers within Thread mesh) and additional guard increment (e.g., adding for two for source or destination being child and require one more hop).

This change replaces the previous model where number of hops was predicted on source using the routing cost towards the destination. While the cost can be a good estimate for number of hops, it may not necessarily be correct, as the source's view of route cost may be less than what its neighbor and next hops on the path currently have (e.g., sender can have stale information).