### PR TITLE
[github-actions] disable `harden-runner` in OTBR workflow

### DIFF
--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -62,11 +62,6 @@ jobs:
       # of OMR prefix and Domain prefix is not deterministic.
       BORDER_ROUTING: 0
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
-      with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       with:
         submodules: true
@@ -177,11 +172,6 @@ jobs:
       NAT64: ${{ matrix.nat64 }}
       MAX_JOBS: 3
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
-      with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
     - name: Build OTBR Docker
       env:
@@ -233,11 +223,6 @@ jobs:
     - thread-border-router
     runs-on: ubuntu-20.04
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
-      with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       with:
         submodules: true
@@ -262,11 +247,6 @@ jobs:
     needs: upload-coverage
     runs-on: ubuntu-20.04
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
-      with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
     - uses: geekyeggo/delete-artifact@54ab544f12cdb7b71613a16a2b5a37a9ade990af # v2.0.0
       with:
         name: cov-*


### PR DESCRIPTION
The `harden-runner` action causes the OTBR workflow jobs to hang for some reason. Disable until we are able to resolve the issue.

Thanks to @superwhd for identifying this in #8566.