### PR TITLE
[router-table] signal if router is removed from `UpdateRouterIdSet()`

### DIFF
--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -101,6 +101,11 @@ void RouterTable::RemoveRouter(Router &aRouter)
     // Remove an existing `aRouter` entry from `mRouters` and update the
     // `mRouterIdMap`.
 
+    if (aRouter.IsStateValid())
+    {
+        Get<NeighborTable>().Signal(NeighborTable::kRouterRemoved, aRouter);
+    }
+
     mRouterIdMap.Release(aRouter.GetRouterId());
     mRouters.Remove(aRouter);
 
@@ -185,11 +190,6 @@ Error RouterTable::Release(uint8_t aRouterId)
 
     router = FindRouterById(aRouterId);
     VerifyOrExit(router != nullptr, error = kErrorNotFound);
-
-    if (router->IsStateValid())
-    {
-        Get<NeighborTable>().Signal(NeighborTable::kRouterRemoved, *router);
-    }
 
     RemoveRouter(*router);
 


### PR DESCRIPTION
This commit updates the `RouterTable::RemoveRouter()` to check if `Router` being removed is a neighbor and signal its removal. This ensures that we correctly signal neighboring router removal from a call to either `UpdateRouterIdSet()` or `Release(aRouterId)`.

----

_Related note on this:_
- Method `RouterTable::RemoteRouterLink()` does not actually change the `State` of the neighboring router.
   - It just changes the the Link Quality to zero (making the link unusable). 
   - So even after `RemoveRouterLink()` the `Router` is still technically present in the `NeighborTable` (seen as a neighbor though we would never send any data frame to it directly due to its link quality being zero). 
   - Such a Router will be removed later once it ages (when/if we fail to get MLE Adv from it and fail to re-establish link with it using Link Req exchange) at that point, we signal its removal as a neighbor.
- Alternate option is to change `State` from `RemoteRouterLink()` (so to detect removal earlier?). 
- @jwhui any thoughts/suggestions?