### PR TITLE
[cli] new command to enable/disable discovery request callback

### DIFF
--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -503,11 +503,10 @@ private:
     static void HandleDetachGracefullyResult(void *aContext);
     void        HandleDetachGracefullyResult(void);
 
-    static void HandleDiscoveryRequest(const otThreadDiscoveryRequestInfo *aInfo, void *aContext)
-    {
-        static_cast<Interpreter *>(aContext)->HandleDiscoveryRequest(*aInfo);
-    }
-    void HandleDiscoveryRequest(const otThreadDiscoveryRequestInfo &aInfo);
+#if OPENTHREAD_FTD
+    static void HandleDiscoveryRequest(const otThreadDiscoveryRequestInfo *aInfo, void *aContext);
+    void        HandleDiscoveryRequest(const otThreadDiscoveryRequestInfo &aInfo);
+#endif
 
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD
 

--- a/tests/scripts/expect/cli-scan-discover.exp
+++ b/tests/scripts/expect/cli-scan-discover.exp
@@ -57,6 +57,8 @@ expect "channel"
 expect -re {(\d+)}
 set channel $expect_out(1,string)
 expect_line "Done"
+send "discover reqcallback enable\n"
+expect_line "Done"
 
 switch_node 3
 send "scan $channel\n"


### PR DESCRIPTION
This commit add `discover reqcallback {enable/disable}` CLI command
which registers callback to output whenever device gets a "MLE
Discovery Request". This command allows the callback to be explicitly
set when needed and avoid having it be enabled by default (since the
extra output from this callback can be treated as unexpected result by
tests that parse the CLI output).

---
(old text) 

~This commit removes the CLI code which generates an output whenever device gets a "MLE Discovery Request". These outputs can be treated as unexpected result by tests which parse the CLI output.~

---

This was added from https://github.com/openthread/openthread/pull/5131. I am not sure if this is helpful so opted to remove it from CLI. If we need this output, we should consider adding it under `CONFIG` or enable/disable it through a CLI comand.
