### PR TITLE
[posix] update the config file path

### DIFF
--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -100,6 +100,10 @@ set(OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE "vendor_interface_example.cpp"
 
 set(CMAKE_EXE_LINKER_FLAGS "-rdynamic ${CMAKE_EXE_LINKER_FLAGS}" PARENT_SCOPE)
 
+if(EXISTS /tmp)
+    configure_file(openthread.conf.example /tmp/openthread.conf.example @COPYONLY)
+endif()
+
 add_library(openthread-posix
     alarm.cpp
     backbone.cpp

--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -345,7 +345,7 @@
  *
  */
 #ifndef OPENTHREAD_POSIX_CONFIG_FACTORY_CONFIG_FILE
-#define OPENTHREAD_POSIX_CONFIG_FACTORY_CONFIG_FILE "src/posix/platform/openthread.conf.example"
+#define OPENTHREAD_POSIX_CONFIG_FACTORY_CONFIG_FILE "/tmp/openthread.conf.example"
 #endif
 
 /**
@@ -355,7 +355,7 @@
  *
  */
 #ifndef OPENTHREAD_POSIX_CONFIG_PRODUCT_CONFIG_FILE
-#define OPENTHREAD_POSIX_CONFIG_PRODUCT_CONFIG_FILE "src/posix/platform/openthread.conf.example"
+#define OPENTHREAD_POSIX_CONFIG_PRODUCT_CONFIG_FILE "/tmp/openthread.conf.example"
 #endif
 
 #endif // OPENTHREAD_PLATFORM_CONFIG_H_


### PR DESCRIPTION
The current config file path is a relative path, which makes otbr-agent unable to access the config file correctly. This commit moves the config file to a fixed directory to avoid the config file access failure.