### PR TITLE
[network-data] ensure `ExternalRouteLookup()` picks longest match

### DIFF
--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -334,7 +334,8 @@ Error LeaderBase::ExternalRouteLookup(uint8_t aDomainId, const Ip6::Address &aDe
             for (const HasRouteEntry *entry = hasRoute->GetFirstEntry(); entry <= hasRoute->GetLastEntry();
                  entry                      = entry->GetNext())
             {
-                if (bestRouteEntry == nullptr || CompareRouteEntries(*entry, *bestRouteEntry) > 0)
+                if ((bestRouteEntry == nullptr) || (prefixLength > bestMatchLength) ||
+                    CompareRouteEntries(*entry, *bestRouteEntry) > 0)
                 {
                     bestRouteEntry  = entry;
                     bestMatchLength = prefixLength;


### PR DESCRIPTION
This commit updates the `ExternalRouteLookup()` to ensure we pick the longest match before checking the route preference.

---

While updating some of the test scripts,  noticed that we may in some cases select a higher preference shorter off-mesh route match over a longer match. If I am not mistaken per spec we need to prefer a longer match (independent of preference) first and use the preference only if we have multiple options with same length. Here is the related text from section 5.10.2:
> - Find the External Route Set prefix(es) that have the longest prefix match to the IPv6 destination address.
> - If more than one External Route prefix matches, choose the one with higher preference (R_preference).
> - ...

Here is how this situation may happen in the code:
- In `ExternalRouteLookup()` we iterate over Prefix TLVs and track the best entry found so far.
- We have the check `if ((bestRouteEntry != nullptr) && (prefixLength <= bestMatchLength)) { continue; }` which ensures that we only accept a longer match as we iterate.
- But if in previous iteration we have found a shorter match (with high preference) and then in next loop find a longer match, we call `CompareRouteEntries()` which compares based on the preference and can keep the shorter match high preference entry.

