### PR TITLE
[mle] update `GetPathCost()` calculation to handle child dest

### DIFF
--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -428,44 +428,12 @@ exit:
 
 void MeshForwarder::EvaluateRoutingCost(uint16_t aDest, uint8_t &aBestCost, uint16_t &aBestDest) const
 {
-    const Neighbor *neighbor;
-    uint8_t         curCost = 0x00;
+    uint8_t cost = Get<Mle::MleRouter>().GetPathCost(aDest);
 
-    // Path cost
-    curCost = Get<Mle::MleRouter>().GetCost(aDest);
-
-    if (!Mle::IsActiveRouter(aDest))
-    {
-        // Assume best link between remote child server and its parent.
-        curCost += kCostForLinkQuality3;
-    }
-
-    // Cost if the server is direct neighbor.
-    neighbor = Get<NeighborTable>().FindNeighbor(aDest);
-
-    if (neighbor != nullptr && neighbor->IsStateValid())
-    {
-        uint8_t cost;
-
-        if (!Mle::IsActiveRouter(aDest))
-        {
-            // Cost calculated only from Link Quality In as the parent only maintains
-            // one-direction link info.
-            cost = CostForLinkQuality(neighbor->GetLinkQualityIn());
-        }
-        else
-        {
-            cost = Get<Mle::MleRouter>().GetLinkCost(Mle::RouterIdFromRloc16(aDest));
-        }
-
-        // Choose the minimum cost
-        curCost = Min(curCost, cost);
-    }
-
-    if ((aBestDest == Mac::kShortAddrInvalid) || (curCost < aBestCost))
+    if ((aBestDest == Mac::kShortAddrInvalid) || (cost < aBestCost))
     {
         aBestDest = aDest;
-        aBestCost = curCost;
+        aBestCost = cost;
     }
 }
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -419,6 +419,14 @@ public:
     Parent &GetParent(void) { return mParent; }
 
     /**
+     * This method gets the parent when operating in End Device mode.
+     *
+     * @returns A reference to the parent.
+     *
+     */
+    const Parent &GetParent(void) const { return mParent; }
+
+    /**
      * The method retrieves information about the parent.
      *
      * @param[out] aParentInfo     Reference to a parent information structure.

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -258,17 +258,17 @@ public:
      * @returns The link cost to the Router.
      *
      */
-    uint8_t GetLinkCost(uint8_t aRouterId);
+    uint8_t GetLinkCost(uint8_t aRouterId) const;
 
     /**
-     * This method returns the minimum cost to the given router.
+     * This method returns the minimum mesh path cost to the given RLOC16
      *
-     * @param[in]  aRloc16  The short address of the given router.
+     * @param[in]  aDestRloc16  The RLOC16 of destination
      *
-     * @returns The minimum cost to the given router (via direct link or forwarding).
+     * @returns The minimum mesh path cost to @p aDestRloc16 (via direct link or forwarding).
      *
      */
-    uint8_t GetCost(uint16_t aRloc16);
+    uint8_t GetPathCost(uint16_t aDestRloc16) const;
 
     /**
      * This method returns the ROUTER_SELECTION_JITTER value.
@@ -708,7 +708,7 @@ public:
 
     uint16_t GetNextHop(uint16_t aDestination) const { return Mle::GetNextHop(aDestination); }
 
-    uint8_t GetCost(uint16_t) { return 0; }
+    uint8_t GetPathCost(uint16_t) { return 0; }
 
     Error RemoveNeighbor(Neighbor &) { return BecomeDetached(); }
     void  RemoveRouterLink(Router &) { IgnoreError(BecomeDetached()); }

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -273,19 +273,11 @@ int LeaderBase::CompareRouteEntries(int8_t   aFirstPreference,
 {
     // Performs three-way comparison between two BR entries.
 
-    int      result;
-    uint16_t deviceRloc;
+    int result;
 
     // Prefer the entry with higher preference.
 
     result = ThreeWayCompare(aFirstPreference, aSecondPreference);
-    VerifyOrExit(result == 0);
-
-    deviceRloc = Get<Mle::Mle>().GetRloc16();
-
-    // If same preference, prefer the BR that is this device itself.
-
-    result = ThreeWayCompare((aFirstRloc == deviceRloc), (aSecondRloc == deviceRloc));
     VerifyOrExit(result == 0);
 
     // If all the same, prefer the one with lower mesh path cost.
@@ -294,7 +286,8 @@ int LeaderBase::CompareRouteEntries(int8_t   aFirstPreference,
     // if the second entry's cost is larger, we return 1 indicating
     // that the first entry is preferred over the second one.
 
-    result = ThreeWayCompare(Get<Mle::MleRouter>().GetCost(aSecondRloc), Get<Mle::MleRouter>().GetCost(aFirstRloc));
+    result =
+        ThreeWayCompare(Get<Mle::MleRouter>().GetPathCost(aSecondRloc), Get<Mle::MleRouter>().GetPathCost(aFirstRloc));
 
 exit:
     return result;


### PR DESCRIPTION
This commit updates `GetPathCost()` method to handle the cases where the destination RLOC16 is the device itself or if it is the child of the device. It also handles when the device itself is acting as a child (cost is calculated if destination is the parent).

This change addresses situation where `GetPathCost()` is used in `NetworkData::CompareRouteEntries()` to select between BRs (e.g., multiple BRs providing the same off-mesh route prefix) ensuring a direct child BR is preferred over other routers that are multiple hops away.

----

Background
Detected this situation when updating a test-case:
```
# Network Topology
#
#     r1---- r2 ---- r3 ---- r4
#     |             
#     |             
#    fed1        
#
#  Both `fed1` and `r4` provide the same off-mesh route `fd00:3::/64` at `med` preference.
#
```
When we send from `r1` (to an address matching the off-mesh prefix)  noticed `r4` was being selected over `fed1` as the destination BR. Digging deeper figured out the issue with how we were calculating the cost.
