### PR TITLE
[tcplp] TCP support on 15.4 (#8590)

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1048,6 +1048,15 @@ Error Ip6::ProcessReceiveCallback(Message           &aMessage,
             break;
         }
 
+#if OPENTHREAD_CONFIG_TCP_ENABLE
+        // Do not pass TCP message to avoid dual processing from both openthread and POSIX tcp stacks
+        case kProtoTcp:
+        {
+            error = kErrorNoRoute;
+            goto exit;
+        }
+#endif
+
         default:
             break;
         }


### PR DESCRIPTION
This commit is fix to avoid dual processing on single TCP packet, added fix which restricts TCP packet to pass from opentghread stack. These changes are applicable only when openthread TCP stack is used and it is implemented under feature flag - OPENTHREAD_CONFIG_TCP_ENABLE