### PR TITLE
[cli] add csl info in single child info

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -693,7 +693,7 @@ Child ID: 1
 Rloc: 9c01
 Ext Addr: e2b3540590b0fd87
 Mode: rn
-Csl Synchronized: 1
+CSL Synchronized: 1
 Net Data: 184
 Timeout: 100
 Age: 0

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -693,6 +693,7 @@ Child ID: 1
 Rloc: 9c01
 Ext Addr: e2b3540590b0fd87
 Mode: rn
+Csl Synchronized: 1
 Net Data: 184
 Timeout: 100
 Age: 0

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2151,6 +2151,7 @@ template <> otError Interpreter::Process<Cmd("child")>(Arg aArgs[])
      * Rloc: 9c01
      * Ext Addr: e2b3540590b0fd87
      * Mode: rn
+     * CSL Synchronized: 1
      * Net Data: 184
      * Timeout: 100
      * Age: 0
@@ -2170,6 +2171,7 @@ template <> otError Interpreter::Process<Cmd("child")>(Arg aArgs[])
     linkMode.mDeviceType   = childInfo.mFullThreadDevice;
     linkMode.mNetworkData  = childInfo.mFullThreadDevice;
     OutputLine("Mode: %s", LinkModeToString(linkMode, linkModeString));
+    OutputLine("CSL Synchronized: %d ", childInfo.mIsCslSynced);
     OutputLine("Net Data: %u", childInfo.mNetworkDataVersion);
     OutputLine("Timeout: %lu", ToUlong(childInfo.mTimeout));
     OutputLine("Age: %lu", ToUlong(childInfo.mAge));


### PR DESCRIPTION
There's a use case to check the CSL state of one certain child from the parent. For now this can only be done by showing the full child table. This PR adds the CSL state in the display of single child info (cli command `child <id>`).