### PR TITLE
[notifier] update to use `Callback<HandlerType>`

### DIFF
--- a/src/core/common/callback.hpp
+++ b/src/core/common/callback.hpp
@@ -105,6 +105,21 @@ public:
      */
     void *GetContext(void) const { return mContext; }
 
+    /**
+     * This method indicates whether the callback matches a given handler function pointer and context.
+     *
+     * @param[in] aHandler   The handler function pointer to compare with.
+     * @param[in] aContext   The context associated with handler.
+     *
+     * @retval TRUE   The callback matches @p aHandler and @p aContext.
+     * @retval FALSE  The callback does not match @p aHandler and @p aContext.
+     *
+     */
+    bool Matches(HandlerType aHandler, void *aContext) const
+    {
+        return (mHandler == aHandler) && (mContext == aContext);
+    }
+
 protected:
     CallbackBase(void)
         : mHandler(nullptr)

--- a/src/core/common/notifier.hpp
+++ b/src/core/common/notifier.hpp
@@ -42,6 +42,7 @@
 #include <openthread/instance.h>
 #include <openthread/platform/toolchain.h>
 
+#include "common/callback.hpp"
 #include "common/error.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
@@ -308,11 +309,7 @@ private:
 
     static constexpr uint16_t kFlagsStringBufferSize = kFlagsStringLineLimit + kMaxFlagNameLength;
 
-    struct ExternalCallback
-    {
-        otStateChangedCallback mHandler;
-        void                  *mContext;
-    };
+    typedef Callback<otStateChangedCallback> ExternalCallback;
 
     void EmitEvents(void);
 


### PR DESCRIPTION
This commit updates `Notifier` class to use the recently added `Callback<HandlerType>` for the external callbacks.