### PR TITLE
[posix] add posix config file configuration

### DIFF
--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -31,6 +31,10 @@
 
 #include "openthread-core-config.h"
 
+#ifdef OPENTHREAD_POSIX_CONFIG_FILE
+#include OPENTHREAD_POSIX_CONFIG_FILE
+#endif
+
 /**
  * @file
  * @brief


### PR DESCRIPTION
The ot-br-posix uses the posix platform's config file as its config file. So the ot-br-posix can't set different configurations with posix platform via the config file. This commit adds a config macro `OPENTHREAD_POSIX_CONFIG_FILE` for ot-br-posix to specify a config file to overwrite the posix platform's configurations.