### PR TITLE
[ip6] simplify `SelectSourceAddress()`

### DIFF
--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -223,15 +223,7 @@ bool otIp6IsAddressUnspecified(const otIp6Address *aAddress) { return AsCoreType
 
 otError otIp6SelectSourceAddress(otInstance *aInstance, otMessageInfo *aMessageInfo)
 {
-    Error                             error = kErrorNone;
-    const Ip6::Netif::UnicastAddress *netifAddr;
-
-    netifAddr = AsCoreType(aInstance).Get<Ip6::Ip6>().SelectSourceAddress(AsCoreType(aMessageInfo));
-    VerifyOrExit(netifAddr != nullptr, error = kErrorNotFound);
-    aMessageInfo->mSockAddr = netifAddr->GetAddress();
-
-exit:
-    return error;
+    return AsCoreType(aInstance).Get<Ip6::Ip6>().SelectSourceAddress(AsCoreType(aMessageInfo));
 }
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -310,14 +310,25 @@ public:
     void SetForwardingEnabled(bool aEnable) { mForwardingEnabled = aEnable; }
 
     /**
-     * This method perform default source address selection.
+     * This method performs default source address selection.
      *
-     * @param[in]  aMessageInfo  A reference to the message information.
+     * @param[in,out]  aMessageInfo  A reference to the message information.
+     *
+     * @retval  kErrorNone      Found a source address and updated SockAddr of @p aMessageInfo.
+     * @retval  kErrorNotFound  No source address was found and @p aMessageInfo is unchanged.
+     *
+     */
+    Error SelectSourceAddress(MessageInfo &aMessageInfo) const;
+
+    /**
+     * This method performs default source address selection.
+     *
+     * @param[in]  aDestination  The destination address.
      *
      * @returns A pointer to the selected IPv6 source address or `nullptr` if no source address was found.
      *
      */
-    const Netif::UnicastAddress *SelectSourceAddress(MessageInfo &aMessageInfo);
+    const Address *SelectSourceAddress(const Address &aDestination) const;
 
     /**
      * This method returns a reference to the send queue.
@@ -404,8 +415,8 @@ private:
     void SendIcmpError(Message &aMessage, Icmp::Header::Type aIcmpType, Icmp::Header::Code aIcmpCode);
 #endif
     Error AddMplOption(Message &aMessage, Header &aHeader);
-    Error AddTunneledMplOption(Message &aMessage, Header &aHeader, MessageInfo &aMessageInfo);
-    Error InsertMplOption(Message &aMessage, Header &aHeader, MessageInfo &aMessageInfo);
+    Error AddTunneledMplOption(Message &aMessage, Header &aHeader);
+    Error InsertMplOption(Message &aMessage, Header &aHeader);
     Error RemoveMplOption(Message &aMessage);
     Error HandleOptions(Message &aMessage, Header &aHeader, bool aIsOutbound, bool &aReceive);
     Error HandlePayload(Header            &aIp6Header,

--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -780,14 +780,11 @@ bool Tcp::AutoBind(const SockAddr &aPeer, SockAddr &aToBind, bool aBindAddress, 
 
     if (aBindAddress)
     {
-        MessageInfo                  peerInfo;
-        const Netif::UnicastAddress *netifAddress;
+        const Address *source;
 
-        peerInfo.Clear();
-        peerInfo.SetPeerAddr(aPeer.GetAddress());
-        netifAddress = Get<Ip6>().SelectSourceAddress(peerInfo);
-        VerifyOrExit(netifAddress != nullptr, success = false);
-        aToBind.GetAddress() = netifAddress->GetAddress();
+        source = Get<Ip6>().SelectSourceAddress(aPeer.GetAddress());
+        VerifyOrExit(source != nullptr, success = false);
+        aToBind.SetAddress(*source);
     }
 
     if (aBindPort)


### PR DESCRIPTION
This commit updates `Ip6::SelectSourceAddress()`. A new version of is added which as its input gets a destination `Ip6::Address` instead of an `Ip6::MessageInfo`, and returns the selected source address as an `Ip6::Address *`. This helps simplify its use (no need to create or pass `MessageInfo` instances). This commit also moves the implementation of `otIp6SelectSourceAddress()` from `ip6_api.cpp` to `Ip6` class adding a version of `SelectSourceAddress()` which updates a passed-in `MessageInfo`directly.