### PR TITLE
[posix] rename and move the configuration of host-rcp time sync interval

### DIFF
--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -64,16 +64,9 @@
 #ifndef US_PER_S
 #define US_PER_S (MS_PER_S * US_PER_MS)
 #endif
-#ifndef NS_PER_US
-#define NS_PER_US 1000
-#endif
 
 #ifndef TX_WAIT_US
 #define TX_WAIT_US (5 * US_PER_S)
-#endif
-
-#ifndef RCP_TIME_OFFSET_CHECK_INTERVAL
-#define RCP_TIME_OFFSET_CHECK_INTERVAL (60 * US_PER_S)
 #endif
 
 using ot::Spinel::Decoder;
@@ -2234,7 +2227,7 @@ void RadioSpinel<InterfaceType, ProcessContextType>::CalcRcpTimeOffset(void)
 
     mRadioTimeOffset      = (remoteTimestamp - ((localRxTimestamp / 2) + (localTxTimestamp / 2)));
     mIsTimeSynced         = true;
-    mRadioTimeRecalcStart = localRxTimestamp + RCP_TIME_OFFSET_CHECK_INTERVAL;
+    mRadioTimeRecalcStart = localRxTimestamp + OPENTHREAD_POSIX_CONFIG_RCP_TIME_SYNC_INTERVAL;
 
 exit:
     LogIfFail("Error calculating RCP time offset: %s", error);

--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -362,4 +362,15 @@
 #define OPENTHREAD_POSIX_CONFIG_PRODUCT_CONFIG_FILE "src/posix/platform/openthread.conf.example"
 #endif
 
+/**
+ * @def OPENTHREAD_POSIX_CONFIG_RCP_TIME_SYNC_INTERVAL
+ *
+ * This setting configures the interval (in unit of microseconds) for host-rcp
+ * time sync. i.e., the host  will recalculate the time offset b/w host and RCP
+ * every interval.
+ *
+ */
+#ifndef OPENTHREAD_POSIX_CONFIG_RCP_TIME_SYNC_INTERVAL
+#define OPENTHREAD_POSIX_CONFIG_RCP_TIME_SYNC_INTERVAL (60 * 1000 * 1000)
+#endif
 #endif // OPENTHREAD_PLATFORM_CONFIG_H_

--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -365,8 +365,8 @@
 /**
  * @def OPENTHREAD_POSIX_CONFIG_RCP_TIME_SYNC_INTERVAL
  *
- * This setting configures the interval (in unit of microseconds) for host-rcp
- * time sync. i.e., the host  will recalculate the time offset b/w host and RCP
+ * This setting configures the interval (in units of microseconds) for host-rcp
+ * time sync. The host will recalculate the time offset between host and RCP
  * every interval.
  *
  */


### PR DESCRIPTION
This PR renamed the configuration `RCP_TIME_OFFSET_CHECK_INTERVAL`
to `OPENTHREAD_POSIX_CONFIG_RCP_TIME_SYNC_INTERVAL` and moved it to
posix configuration file because this configuration may need to be
configured on different platforms.