### PR TITLE
[radio] refine the definition of SYMBOL_TIME

### DIFF
--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -453,10 +453,10 @@ void platformRadioInit(void)
 static uint16_t getCslPhase(void)
 {
     uint32_t curTime       = otPlatAlarmMicroGetNow();
-    uint32_t cslPeriodInUs = sCslPeriod * OT_RADIO_TEN_SYMBOLS_TIME_US;
+    uint32_t cslPeriodInUs = sCslPeriod * OT_US_PER_TEN_SYMBOLS;
     uint32_t diff = ((sCslSampleTime % cslPeriodInUs) - (curTime % cslPeriodInUs) + cslPeriodInUs) % cslPeriodInUs;
 
-    return (uint16_t)(diff / OT_RADIO_TEN_SYMBOLS_TIME_US);
+    return (uint16_t)(diff / OT_US_PER_TEN_SYMBOLS);
 }
 #endif
 

--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -453,10 +453,10 @@ void platformRadioInit(void)
 static uint16_t getCslPhase(void)
 {
     uint32_t curTime       = otPlatAlarmMicroGetNow();
-    uint32_t cslPeriodInUs = sCslPeriod * OT_US_PER_TEN_SYMBOLS;
+    uint32_t cslPeriodInUs = sCslPeriod * OT_RADIO_TEN_SYMBOLS_TIME_US;
     uint32_t diff = ((sCslSampleTime % cslPeriodInUs) - (curTime % cslPeriodInUs) + cslPeriodInUs) % cslPeriodInUs;
 
-    return (uint16_t)(diff / OT_US_PER_TEN_SYMBOLS);
+    return (uint16_t)(diff / OT_RADIO_TEN_SYMBOLS_TIME_US);
 }
 #endif
 

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (274)
+#define OPENTHREAD_API_VERSION (275)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -52,6 +52,7 @@ extern "C" {
  * @{
  *
  */
+#define OT_US_PER_TEN_SYMBOLS OT_RADIO_TEN_SYMBOLS_TIME ///< Time for 10 symbols in unit of microseconds
 
 /**
  * This structure represents link-specific information for messages received from the Thread radio.

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -52,7 +52,6 @@ extern "C" {
  * @{
  *
  */
-#define OT_US_PER_TEN_SYMBOLS 160 ///< The microseconds per 10 symbols.
 
 /**
  * This structure represents link-specific information for messages received from the Thread radio.

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -52,7 +52,7 @@ extern "C" {
  * @{
  *
  */
-#define OT_US_PER_TEN_SYMBOLS OT_RADIO_TEN_SYMBOLS_TIME ///< Time for 10 symbols in unit of microseconds
+#define OT_US_PER_TEN_SYMBOLS OT_RADIO_TEN_SYMBOLS_TIME ///< Time for 10 symbols in units of microseconds
 
 /**
  * This structure represents link-specific information for messages received from the Thread radio.

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -71,15 +71,20 @@ enum
     OT_RADIO_FRAME_MAX_SIZE = 127, ///< aMaxPHYPacketSize (IEEE 802.15.4-2006)
     OT_RADIO_FRAME_MIN_SIZE = 3,   ///< Minimal size of frame FCS + CONTROL
 
+    OT_RADIO_SYMBOLS_PER_OCTET = 2,      ///< 2.4 GHz IEEE 802.15.4-2006
+    OT_RADIO_BIT_RATE          = 250000, ///< 2.4 GHz IEEE 802.15.4 (bits per second)
+    OT_RADIO_BITS_PER_OCTET    = 8,      ///< Number of bits per octet
+
     // Per IEEE 802.15.4-2015, 12.3.3 Symbol rate:
     // The O-QPSK PHY symbol rate shall be 25 ksymbol/s when operating in the 868 MHz band and 62.5 ksymbol/s when
     // operating in the 780 MHz, 915 MHz, 2380 MHz, or 2450 MHz band
     OT_RADIO_SYMBOL_RATE = 62500, ///< The O-QPSK PHY symbol rate when operating in the 780MHz, 915MHz, 2380MHz, 2450MHz
-    OT_RADIO_SYMBOL_TIME_US      = 1000000 * 1 / OT_RADIO_SYMBOL_RATE, ///< Symbol duration time
-    OT_RADIO_TEN_SYMBOLS_TIME_US = 10 * OT_RADIO_SYMBOL_TIME_US,       ///< Time for 10 symbols
-    OT_RADIO_LQI_NONE            = 0,                                  ///< LQI measurement not supported
-    OT_RADIO_RSSI_INVALID        = 127,                                ///< Invalid or unknown RSSI value
-    OT_RADIO_POWER_INVALID       = 127,                                ///< Invalid or unknown power value
+    OT_RADIO_SYMBOL_TIME = 1000000 * 1 / OT_RADIO_SYMBOL_RATE, ///< Symbol duration time in unit of microseconds
+    OT_RADIO_TEN_SYMBOLS_TIME = 10 * OT_RADIO_SYMBOL_TIME,     ///< Time for 10 symbols in unit of microseconds
+
+    OT_RADIO_LQI_NONE      = 0,   ///< LQI measurement not supported
+    OT_RADIO_RSSI_INVALID  = 127, ///< Invalid or unknown RSSI value
+    OT_RADIO_POWER_INVALID = 127, ///< Invalid or unknown power value
 };
 
 /**

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -68,16 +68,18 @@ extern "C" {
 
 enum
 {
-    OT_RADIO_FRAME_MAX_SIZE    = 127,    ///< aMaxPHYPacketSize (IEEE 802.15.4-2006)
-    OT_RADIO_FRAME_MIN_SIZE    = 3,      ///< Minimal size of frame FCS + CONTROL
-    OT_RADIO_SYMBOLS_PER_OCTET = 2,      ///< 2.4 GHz IEEE 802.15.4-2006
-    OT_RADIO_BIT_RATE          = 250000, ///< 2.4 GHz IEEE 802.15.4 (bits per second)
-    OT_RADIO_BITS_PER_OCTET    = 8,      ///< Number of bits per octet
+    OT_RADIO_FRAME_MAX_SIZE = 127, ///< aMaxPHYPacketSize (IEEE 802.15.4-2006)
+    OT_RADIO_FRAME_MIN_SIZE = 3,   ///< Minimal size of frame FCS + CONTROL
 
-    OT_RADIO_SYMBOL_TIME   = ((OT_RADIO_BITS_PER_OCTET / OT_RADIO_SYMBOLS_PER_OCTET) * 1000000) / OT_RADIO_BIT_RATE,
-    OT_RADIO_LQI_NONE      = 0,   ///< LQI measurement not supported
-    OT_RADIO_RSSI_INVALID  = 127, ///< Invalid or unknown RSSI value
-    OT_RADIO_POWER_INVALID = 127, ///< Invalid or unknown power value
+    // Per IEEE 802.15.4-2015, 12.3.3 Symbol rate:
+    // The O-QPSK PHY symbol rate shall be 25 ksymbol/s when operating in the 868 MHz band and 62.5 ksymbol/s when
+    // operating in the 780 MHz, 915 MHz, 2380 MHz, or 2450 MHz band
+    OT_RADIO_SYMBOL_RATE = 62500, ///< The O-QPSK PHY symbol rate when operating in the 780MHz, 915MHz, 2380MHz, 2450MHz
+    OT_RADIO_SYMBOL_TIME_US      = 1000000 * 1 / OT_RADIO_SYMBOL_RATE, ///< Symbol duration time
+    OT_RADIO_TEN_SYMBOLS_TIME_US = 10 * OT_RADIO_SYMBOL_TIME_US,       ///< Time for 10 symbols
+    OT_RADIO_LQI_NONE            = 0,                                  ///< LQI measurement not supported
+    OT_RADIO_RSSI_INVALID        = 127,                                ///< Invalid or unknown RSSI value
+    OT_RADIO_POWER_INVALID       = 127,                                ///< Invalid or unknown power value
 };
 
 /**

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -45,7 +45,7 @@
 
 namespace ot {
 
-static constexpr uint32_t kUsPerTenSymbols = OT_US_PER_TEN_SYMBOLS; ///< Time for 10 symbols in unit of microseconds
+static constexpr uint32_t kUsPerTenSymbols = OT_US_PER_TEN_SYMBOLS; ///< Time for 10 symbols in units of microseconds
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 /**

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -45,7 +45,7 @@
 
 namespace ot {
 
-static constexpr uint32_t kUsPerTenSymbols = OT_US_PER_TEN_SYMBOLS; ///< The microseconds per 10 symbols.
+static constexpr uint32_t kUsPerTenSymbols = OT_RADIO_TEN_SYMBOLS_TIME_US; ///< The microseconds per 10 symbols.
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 /**
@@ -75,7 +75,7 @@ class Radio : public InstanceLocator, private NonCopyable
     friend class Instance;
 
 public:
-    static constexpr uint32_t kSymbolTime = OT_RADIO_SYMBOL_TIME;
+    static constexpr uint32_t kSymbolTime = OT_RADIO_SYMBOL_TIME_US;
 #if (OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT && OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT)
     static constexpr uint16_t kNumChannelPages = 2;
     static constexpr uint32_t kSupportedChannels =

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -45,7 +45,7 @@
 
 namespace ot {
 
-static constexpr uint32_t kUsPerTenSymbols = OT_RADIO_TEN_SYMBOLS_TIME_US; ///< The microseconds per 10 symbols.
+static constexpr uint32_t kUsPerTenSymbols = OT_US_PER_TEN_SYMBOLS; ///< Time for 10 symbols in unit of microseconds
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 /**
@@ -75,7 +75,7 @@ class Radio : public InstanceLocator, private NonCopyable
     friend class Instance;
 
 public:
-    static constexpr uint32_t kSymbolTime = OT_RADIO_SYMBOL_TIME_US;
+    static constexpr uint32_t kSymbolTime = OT_RADIO_SYMBOL_TIME;
 #if (OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT && OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT)
     static constexpr uint16_t kNumChannelPages = 2;
     static constexpr uint32_t kSupportedChannels =


### PR DESCRIPTION
This PR simplied the definition of `OT_RADIO_SYMBOL_TIME` and
provided the reference of the value from IEEE 802.15.4-2015.