### PR TITLE
[netdiag] include `netdiag.h` header in `network_diagnostic_tlvs.hpp`

### DIFF
--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -36,6 +36,7 @@
 
 #include "openthread-core-config.h"
 
+#include <openthread/netdiag.h>
 #include <openthread/thread.h>
 
 #include "common/clearable.hpp"


### PR DESCRIPTION
The `network_diagnostic_tlvs.hpp` defines the net diag TLVs and uses the public definitions (constants) from `openthread/netdiag.h` but did not include it directly. This commit ensures we include it directly.