### PR TITLE
[router-table] simplify `UpdateRoutes()` and how to reset Adv interval

### DIFF
--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -336,10 +336,10 @@ public:
      * This method updates the routes based on a received `RouteTlv` from a neighboring router.
      *
      * @param[in]  aRouteTlv    The received `RouteTlv`
-     * @param[in]  aRouterId    The router ID of neighboring router from which @p aRouteTlv is received.
+     * @param[in]  aNeighborId  The router ID of neighboring router from which @p aRouteTlv is received.
      *
      */
-    void UpdateRoutes(const Mle::RouteTlv &aRouteTlv, uint8_t aRouterId);
+    void UpdateRoutes(const Mle::RouteTlv &aRouteTlv, uint8_t aNeighborId);
 
     /**
      * This method updates the routes on an FED based on a received `RouteTlv` from the parent.
@@ -436,8 +436,6 @@ private:
     {
         return AsNonConst(AsConst(this)->FindRouter(aMatcher));
     }
-
-    bool UpdateLinkQualityOut(const Mle::RouteTlv &aRouteTlv, Router &aNeighbor, bool &aResetAdvInterval);
 
     class RouterIdMap
     {


### PR DESCRIPTION
This commit changes `RouterTable::UpdateRoutes()`. Before updating the routes, we track which routers have finite path cost. After the update we check again to see if any path cost changed from finite to infinite or vice versa and use this to decide whether to reset the MLE Advertisement interval. This helps simplify the code and handle some edge-cases related to resetting the Advertisement interval where changing the Link Quality on the neighbor may impact the cost towards routers which used it as next hop.
