### PR TITLE
[mle] update `HandleAdv` to not exit when deciding to promote to router

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1259,7 +1259,6 @@ Error MleRouter::HandleAdvertisement(RxInfo &aRxInfo, uint16_t aSourceAddress, c
             if ((mRouterSelectionJitterTimeout == 0) && (mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold))
             {
                 mRouterSelectionJitterTimeout = 1 + Random::NonCrypto::GetUint8InRange(0, mRouterSelectionJitter);
-                ExitNow();
             }
 
             mRouterTable.UpdateRoutesOnFed(routeTlv, routerId);


### PR DESCRIPTION
This commit updates `MleRouter::HandleAdvertisement()` to not call `ExitNow()` and exit early when as a child we decide to try to promote to router role and set `mRouterSelectionJitterTimeout`. This ensures that we continue processing the message and call `UpdateRoutesOnFed()` and `router->SetLastHeard()`.