### PR TITLE
[mle] always check for stale parent in `HandleAdv()`

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1158,6 +1158,9 @@ Error MleRouter::HandleAdvertisement(RxInfo &aRxInfo, uint16_t aSourceAddress, c
         routeTlv.SetLength(0); // Mark that a Route TLV was not included
     }
 
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Handle Partition ID mismatch
+
     if (aLeaderData.GetPartitionId() != mLeaderData.GetPartitionId())
     {
         LogNote("Different partition (peer:%lu, local:%lu)", ToUlong(aLeaderData.GetPartitionId()),
@@ -1189,7 +1192,11 @@ Error MleRouter::HandleAdvertisement(RxInfo &aRxInfo, uint16_t aSourceAddress, c
 
         ExitNow(error = kErrorDrop);
     }
-    else if (aLeaderData.GetLeaderRouterId() != GetLeaderId())
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Handle Leader Router ID mismatch
+
+    if (aLeaderData.GetLeaderRouterId() != GetLeaderId())
     {
         VerifyOrExit(aRxInfo.IsNeighborStateValid());
 
@@ -1209,6 +1216,9 @@ Error MleRouter::HandleAdvertisement(RxInfo &aRxInfo, uint16_t aSourceAddress, c
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     Get<TimeSync>().HandleTimeSyncMessage(aRxInfo.mMessage);
 #endif
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Process `RouteTlv`
 
     if (aRxInfo.IsNeighborStateValid() &&
         ((mRouterTable.GetActiveRouterCount() == 0) ||
@@ -1242,6 +1252,9 @@ Error MleRouter::HandleAdvertisement(RxInfo &aRxInfo, uint16_t aSourceAddress, c
             SuccessOrExit(error = ProcessRouteTlv(aRxInfo));
         }
     }
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Update routers as a child
 
     if (IsChild())
     {
@@ -1288,6 +1301,9 @@ Error MleRouter::HandleAdvertisement(RxInfo &aRxInfo, uint16_t aSourceAddress, c
 
         ExitNow();
     }
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Update routers as a router or leader.
 
     if (IsRouter())
     {


### PR DESCRIPTION
This commit contains smaller fixes and enhancements in `Mle` method `Mle::HandleAdvertisement()`
- We add `VerifyOrExit(IsAttached())` at the top of the method.
- We always perform the check for stale parent i.e., check if we got an MLE Advertisement from parent but with a different RLOC16. The `MleRouter` method also does the same check, however in certain cases (e.g., when there is Partition ID or leader ID mismatch) the `MleRouter` method will exit early and expect the `Mle` method to handle these cases.
- When on `Mle` method we handle Partition ID or leader ID mismatch and then process `RouteTlv` we now also call `UpdateRoutesOnFed()`.