### PR TITLE
[github-actions] update `toranj-ncp` to trigger on pull request only

### DIFF
--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -55,6 +55,8 @@ jobs:
     env:
       COVERAGE: 1
       TORANJ_RADIO : ${{ matrix.TORANJ_RADIO }}
+      TORANJ_NCP : 1
+      TORANJ_EVENT_NAME: ${{ github.event_name }}
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
@@ -69,35 +71,10 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
-        sudo apt-get --no-install-recommends install -y dbus libdbus-1-dev
-        sudo apt-get --no-install-recommends install -y autoconf-archive
-        sudo apt-get --no-install-recommends install -y libarchive-tools
-        sudo apt-get --no-install-recommends install -y libtool
-        sudo apt-get --no-install-recommends install -y libglib2.0-dev
-        sudo apt-get --no-install-recommends install -y lcov
-
-        sudo add-apt-repository universe
-        sudo apt-get update
-        sudo apt-get --no-install-recommends install -y libboost-all-dev python2
-
-        script/git-tool clone --depth=1 --branch=master https://github.com/openthread/wpantund.git
-        cd wpantund
-        ./bootstrap.sh
-        ./configure
-        sudo make -j2
-        sudo make install
     - name: Build & Run
       run: |
         top_builddir=$(pwd)/build/toranj ./tests/toranj/start.sh
-    - name: Generate Coverage
-      if: "matrix.TORANJ_RADIO != 'multi'"
-      run: |
-        ./script/test generate_coverage gcc
-    - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
-      if: "matrix.TORANJ_RADIO != 'multi'"
-      with:
-        name: cov-toranj-ncp-${{ matrix.TORANJ_RADIO }}
-        path: tmp/coverage.info
+
 
   toranj-cli:
     name: toranj-cli-${{ matrix.TORANJ_RADIO }}
@@ -166,7 +143,6 @@ jobs:
 
   upload-coverage:
     needs:
-    - toranj-ncp
     - toranj-cli
     runs-on: ubuntu-20.04
     steps:

--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -75,7 +75,51 @@ run()
     done
 }
 
+install_wpantund()
+{
+    echo "Installing wpantund"
+    sudo apt-get --no-install-recommends install -y dbus libdbus-1-dev
+    sudo apt-get --no-install-recommends install -y autoconf-archive
+    sudo apt-get --no-install-recommends install -y libarchive-tools
+    sudo apt-get --no-install-recommends install -y libtool
+    sudo apt-get --no-install-recommends install -y libglib2.0-dev
+    sudo apt-get --no-install-recommends install -y lcov
+
+    sudo add-apt-repository universe
+    sudo apt-get update
+    sudo apt-get --no-install-recommends install -y libboost-all-dev python2
+
+    git clone --depth=1 --branch=master https://github.com/openthread/wpantund.git || die "wpandtund clone"
+    cd wpantund || die "cd wpantund failed"
+    ./bootstrap.sh
+    ./configure
+    sudo make -j2 || die "wpantund make failed"
+    sudo make install || die "wpantund make install failed"
+    cd .. || die "cd .. failed"
+}
+
 cd "$(dirname "$0")" || die "cd failed"
+
+if [ "$TORANJ_NCP" = 1 ]; then
+    echo "========================================================================"
+    echo "Running toranj-ncp triggered by event ${TORANJ_EVENT_NAME}"
+
+    if [ "$TORANJ_EVENT_NAME" = "pull_request" ]; then
+        cd ../..
+        OT_SHA_OLD="$(git cat-file -p HEAD | grep 'parent ' | head -n1 | cut -d' ' -f2)"
+        git fetch --depth 1 --no-recurse-submodules origin "${OT_SHA_OLD}"
+        if git diff --name-only --exit-code "${OT_SHA_OLD}" -- src/ncp; then
+            echo "No changes to any of src/ncp files - skip running tests."
+            echo "========================================================================"
+            exit 0
+        fi
+        cd tests/toranj || die "cd tests/toranj failed"
+        echo "There are change in src/ncp files, running toranj-ncp tests"
+    fi
+
+    echo "========================================================================"
+    install_wpantund
+fi
 
 if [ -z "${top_builddir}" ]; then
     top_builddir=.


### PR DESCRIPTION
This commit updates the github actions `toranj` workflow and the toranj `start.sh` script to trigger `toranj-ncp` tests on a Pull Request only if there are changes in any of the `src/ncp` files.

----

Follow-up from #8599 where all the main tests are re-implemented to use `toranj-cli` so we can limit the run of `toranj-ncp` only if there is any change in `ncp` source files.
This was tested in runs from https://github.com/openthread/openthread/pull/8647 -> [link to runs](https://github.com/openthread/openthread/actions?query=branch%3Agh%2Fconditional-toranj).