### PR TITLE
[trel] use same constant for noise-floor under TREL radio link only

### DIFF
--- a/src/core/mac/mac_links.hpp
+++ b/src/core/mac/mac_links.hpp
@@ -41,6 +41,7 @@
 #include "mac/mac_frame.hpp"
 #include "mac/mac_types.hpp"
 #include "mac/sub_mac.hpp"
+#include "radio/radio.hpp"
 #include "radio/trel_link.hpp"
 
 namespace ot {
@@ -680,7 +681,7 @@ public:
 #endif
 
 private:
-    static constexpr int8_t kDefaultNoiseFloor = -100;
+    static constexpr int8_t kDefaultNoiseFloor = Radio::kDefaultReceiveSensitivity;
 
     SubMac mSubMac;
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -105,6 +105,8 @@ public:
 
     static constexpr int8_t kInvalidRssi = OT_RADIO_RSSI_INVALID; ///< Invalid RSSI value.
 
+    static constexpr int8_t kDefaultReceiveSensitivity = -110; ///< Default receive sensitivity (in dBm).
+
     static_assert((OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT || OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT ||
                    OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_SUPPORT),
                   "OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT "
@@ -806,7 +808,7 @@ inline otRadioCaps Radio::GetCaps(void)
     return OT_RADIO_CAPS_ACK_TIMEOUT | OT_RADIO_CAPS_CSMA_BACKOFF | OT_RADIO_CAPS_TRANSMIT_RETRIES;
 }
 
-inline int8_t Radio::GetReceiveSensitivity(void) const { return -110; }
+inline int8_t Radio::GetReceiveSensitivity(void) const { return kDefaultReceiveSensitivity; }
 
 inline void Radio::SetPanId(Mac::PanId) {}
 


### PR DESCRIPTION
This commit applies to edge-case where OT is built with only TREL radio link and no 15.4 radio link.

We define `Radio::kDefaultReceiveSensitivity` as the default rx sensitivity value returned from `GetReceiveSensitivity()` and use the same constant for noise floor returned from `SubMac::GetNoiseFloor()`.

This ensures that fixed RSS value applied through `macfilter add-lqi` CLI command uses the same value for noise floor when calculating the typical RSS for a given Link Quality value.