### PR TITLE
[mac] ensure to apply RSS filter on all rx frame including ack

### DIFF
--- a/src/core/mac/link_raw.cpp
+++ b/src/core/mac/link_raw.cpp
@@ -274,7 +274,7 @@ exit:
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 void LinkRaw::RecordFrameTransmitStatus(const TxFrame &aFrame,
-                                        const RxFrame *aAckFrame,
+                                        RxFrame       *aAckFrame,
                                         Error          aError,
                                         uint8_t        aRetryCount,
                                         bool           aWillRetx)

--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -298,12 +298,12 @@ public:
      *
      */
     void RecordFrameTransmitStatus(const TxFrame &aFrame,
-                                   const RxFrame *aAckFrame,
+                                   RxFrame       *aAckFrame,
                                    Error          aError,
                                    uint8_t        aRetryCount,
                                    bool           aWillRetx);
 #else
-    void    RecordFrameTransmitStatus(const TxFrame &, const RxFrame *, Error, uint8_t, bool) {}
+    void    RecordFrameTransmitStatus(const TxFrame &, RxFrame *, Error, uint8_t, bool) {}
 #endif
 
 private:

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -412,7 +412,7 @@ public:
      *
      */
     void RecordFrameTransmitStatus(const TxFrame &aFrame,
-                                   const RxFrame *aAckFrame,
+                                   RxFrame       *aAckFrame,
                                    Error          aError,
                                    uint8_t        aRetryCount,
                                    bool           aWillRetx);

--- a/src/core/mac/mac_filter.cpp
+++ b/src/core/mac/mac_filter.cpp
@@ -38,6 +38,7 @@
 #include "common/array.hpp"
 #include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
+#include "thread/topology.hpp"
 
 namespace ot {
 namespace Mac {
@@ -53,11 +54,11 @@ Filter::Filter(void)
     }
 }
 
-Filter::FilterEntry *Filter::FindEntry(const ExtAddress &aExtAddress)
+const Filter::FilterEntry *Filter::FindEntry(const ExtAddress &aExtAddress) const
 {
-    FilterEntry *rval = nullptr;
+    const FilterEntry *rval = nullptr;
 
-    for (FilterEntry &entry : mFilterEntries)
+    for (const FilterEntry &entry : mFilterEntries)
     {
         if (entry.IsInUse() && (aExtAddress == entry.mExtAddress))
         {
@@ -182,13 +183,13 @@ void Filter::ClearAllRssIn(void)
     mDefaultRssIn = kFixedRssDisabled;
 }
 
-Error Filter::GetNextRssIn(Iterator &aIterator, Entry &aEntry)
+Error Filter::GetNextRssIn(Iterator &aIterator, Entry &aEntry) const
 {
     Error error = kErrorNotFound;
 
     for (; aIterator < GetArrayLength(mFilterEntries); aIterator++)
     {
-        FilterEntry &entry = mFilterEntries[aIterator];
+        const FilterEntry &entry = mFilterEntries[aIterator];
 
         if (entry.mRssIn != kFixedRssDisabled)
         {
@@ -213,11 +214,11 @@ exit:
     return error;
 }
 
-Error Filter::Apply(const ExtAddress &aExtAddress, int8_t &aRss)
+Error Filter::Apply(const ExtAddress &aExtAddress, int8_t &aRss) const
 {
-    Error        error = kErrorNone;
-    FilterEntry *entry = FindEntry(aExtAddress);
-    bool         isInFilterList;
+    Error              error = kErrorNone;
+    const FilterEntry *entry = FindEntry(aExtAddress);
+    bool               isInFilterList;
 
     // Use the default RssIn setting for all receiving messages first.
     aRss = mDefaultRssIn;
@@ -244,6 +245,28 @@ Error Filter::Apply(const ExtAddress &aExtAddress, int8_t &aRss)
     if ((entry != nullptr) && (entry->mRssIn != kFixedRssDisabled))
     {
         aRss = entry->mRssIn;
+    }
+
+exit:
+    return error;
+}
+
+Error Filter::ApplyToRxFrame(RxFrame &aRxFrame, const ExtAddress &aExtAddress, Neighbor *aNeighbor) const
+{
+    Error  error;
+    int8_t fixedRss;
+
+    SuccessOrExit(error = Apply(aExtAddress, fixedRss));
+
+    VerifyOrExit(fixedRss != kFixedRssDisabled);
+
+    aRxFrame.SetRssi(fixedRss);
+
+    if (aNeighbor != nullptr)
+    {
+        // Clear the previous RSS average to ensure the fixed RSS
+        // value takes effect quickly.
+        aNeighbor->GetLinkInfo().CleaAverageRss();
     }
 
 exit:

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -166,7 +166,7 @@ public:
          *
          */
         void RecordFrameTransmitStatus(const TxFrame &aFrame,
-                                       const RxFrame *aAckFrame,
+                                       RxFrame       *aAckFrame,
                                        Error          aError,
                                        uint8_t        aRetryCount,
                                        bool           aWillRetx);

--- a/src/core/mac/sub_mac_callbacks.cpp
+++ b/src/core/mac/sub_mac_callbacks.cpp
@@ -71,7 +71,7 @@ void SubMac::Callbacks::RecordCcaStatus(bool aCcaSuccess, uint8_t aChannel)
 }
 
 void SubMac::Callbacks::RecordFrameTransmitStatus(const TxFrame &aFrame,
-                                                  const RxFrame *aAckFrame,
+                                                  RxFrame       *aAckFrame,
                                                   Error          aError,
                                                   uint8_t        aRetryCount,
                                                   bool           aWillRetx)
@@ -119,7 +119,7 @@ void SubMac::Callbacks::ReceiveDone(RxFrame *aFrame, Error aError) { Get<LinkRaw
 void SubMac::Callbacks::RecordCcaStatus(bool, uint8_t) {}
 
 void SubMac::Callbacks::RecordFrameTransmitStatus(const TxFrame &aFrame,
-                                                  const RxFrame *aAckFrame,
+                                                  RxFrame       *aAckFrame,
                                                   Error          aError,
                                                   uint8_t        aRetryCount,
                                                   bool           aWillRetx)

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -323,6 +323,12 @@ public:
     void Clear(void);
 
     /**
+     * This method clears the average RSS value.
+     *
+     */
+    void CleaAverageRss(void) { mRssAverager.Clear(); }
+
+    /**
      * This method adds a new received signal strength (RSS) value to the average.
      *
      * @param[in] aRss         A new received signal strength value (in dBm) to be added to the average.


### PR DESCRIPTION
This commit updates how we apply `Mac::Filter` ensuring the fixed RSS filter is applied to all rx frames including received ack frames.

We add a new method `Mac::Filter::ApplyToRxFrame()` which applies the filter rules directly to a rx frame, potentially updating its signal strength to a fixed RSS. This common method is then called from `Mac::HandleReceivedFrame()` replacing the existing code and also from `Mac::RecordFrameTransmitStatus()` to a received `aAckFrame`. This ensures that fixed RSS is correctly tracked on the corresponding neighbor.

This commit also updates `Mac::Filter` methods which do not change the `Filter` to be marked as `const`.