### PR TITLE
[data-poll-sender] faster rtx polling for CSL

### DIFF
--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -513,6 +513,13 @@ uint32_t DataPollSender::CalculatePollPeriod(void) const
     if (mRetxMode)
     {
         period = Min(period, kRetxPollPeriod);
+
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+        if (Get<Mac::Mac>().GetCslPeriodMs() > 0)
+        {
+            period = Min(period, Get<Mac::Mac>().GetCslPeriodMs());
+        }
+#endif
     }
 
     if (mRemainingFastPolls != 0)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -618,6 +618,14 @@ public:
     uint16_t GetCslPeriod(void) const { return mCslPeriod; }
 
     /**
+     * This method gets the CSL period.
+     *
+     * @returns CSL period in milliseconds.
+     *
+     */
+    uint32_t GetCslPeriodMs(void) const { return mCslPeriod * kUsPerTenSymbols / 1000; }
+
+    /**
      * This method sets the CSL period.
      *
      * @param[in]  aPeriod  The CSL period in 10 symbols.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1900,8 +1900,7 @@ void Mle::ScheduleMessageTransmissionTimer(void)
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
         if (Get<Mac::Mac>().IsCslEnabled())
         {
-            ExitNow(interval = Get<Mac::Mac>().GetCslPeriod() * kUsPerTenSymbols / 1000 +
-                               static_cast<uint32_t>(kUnicastRetransmissionDelay));
+            ExitNow(interval = Get<Mac::Mac>().GetCslPeriodMs() + static_cast<uint32_t>(kUnicastRetransmissionDelay));
         }
         else
 #endif


### PR DESCRIPTION
Make sure that retransmission of data polls happens at least at the CSL period rate, when this is lower than OPENTHREAD_CONFIG_MAC_RETX_POLL_PERIOD.

This greatly improves latency under situations of heavy traffic, where CSL synchronization might be lost ocassionaly due to the mix of CSL and indirect transmissions.