### PR TITLE
[netdata] update `CompareRouteEntries()` on MTD to prefer self

### DIFF
--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -428,7 +428,7 @@ exit:
 
 void MeshForwarder::EvaluateRoutingCost(uint16_t aDest, uint8_t &aBestCost, uint16_t &aBestDest) const
 {
-    uint8_t cost = Get<Mle::MleRouter>().GetPathCost(aDest);
+    uint8_t cost = Get<RouterTable>().GetPathCost(aDest);
 
     if ((aBestDest == Mac::kShortAddrInvalid) || (cost < aBestCost))
     {

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -241,16 +241,6 @@ public:
     void SetNetworkIdTimeout(uint8_t aTimeout) { mNetworkIdTimeout = aTimeout; }
 
     /**
-     * This method returns the minimum mesh path cost to the given RLOC16
-     *
-     * @param[in]  aDestRloc16  The RLOC16 of destination
-     *
-     * @returns The minimum mesh path cost to @p aDestRloc16 (via direct link or forwarding).
-     *
-     */
-    uint8_t GetPathCost(uint16_t aDestRloc16) const { return mRouterTable.GetPathCost(aDestRloc16); }
-
-    /**
      * This method returns the ROUTER_SELECTION_JITTER value.
      *
      * @returns The ROUTER_SELECTION_JITTER value.
@@ -690,8 +680,6 @@ public:
     bool IsSingleton(void) const { return false; }
 
     uint16_t GetNextHop(uint16_t aDestination) const { return Mle::GetNextHop(aDestination); }
-
-    uint8_t GetPathCost(uint16_t) { return 0; }
 
     Error RemoveNeighbor(Neighbor &) { return BecomeDetached(); }
     void  RemoveRouterLink(Router &) { IgnoreError(BecomeDetached()); }

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -281,14 +281,22 @@ int LeaderBase::CompareRouteEntries(int8_t   aFirstPreference,
     result = ThreeWayCompare(aFirstPreference, aSecondPreference);
     VerifyOrExit(result == 0);
 
+#if OPENTHREAD_MTD
+    // On MTD, prefer the BR that is this device itself. This handles
+    // the uncommon case where an MTD itself may be acting as BR.
+
+    result = ThreeWayCompare((aFirstRloc == Get<Mle::Mle>().GetRloc16()), (aSecondRloc == Get<Mle::Mle>().GetRloc16()));
+#endif
+
+#if OPENTHREAD_FTD
     // If all the same, prefer the one with lower mesh path cost.
     // Lower cost is preferred so we pass the second entry's cost as
     // the first argument in the call to `ThreeWayCompare()`, i.e.,
     // if the second entry's cost is larger, we return 1 indicating
     // that the first entry is preferred over the second one.
 
-    result =
-        ThreeWayCompare(Get<Mle::MleRouter>().GetPathCost(aSecondRloc), Get<Mle::MleRouter>().GetPathCost(aFirstRloc));
+    result = ThreeWayCompare(Get<RouterTable>().GetPathCost(aSecondRloc), Get<RouterTable>().GetPathCost(aFirstRloc));
+#endif
 
 exit:
     return result;


### PR DESCRIPTION
This commit updates `CompareRouteEntries()` so that on MTD we replace the `PathCost()` check with a check to see if entry's RLOC matches the device itself. This handles the uncommon case where an MTD itself may be acting as a BR. This then allows us to remove the `MleRouter` `PathCost()` method (which on MTD was returning zero).