### PR TITLE
[ip6] check role to allow forwarding back to Thread

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -67,7 +67,6 @@ RegisterLogModule("Ip6");
 
 Ip6::Ip6(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mForwardingEnabled(false)
     , mIsReceiveIp6FilterEnabled(false)
     , mSendQueueTask(aInstance)
     , mIcmp(aInstance)
@@ -1282,7 +1281,7 @@ start:
 
         if (aOrigin == kFromThreadNetif)
         {
-            VerifyOrExit(mForwardingEnabled);
+            VerifyOrExit(Get<Mle::Mle>().IsRouterOrLeader());
             header.SetHopLimit(header.GetHopLimit() - 1);
         }
 

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -294,22 +294,6 @@ public:
     void SetReceiveIp6FilterEnabled(bool aEnabled) { mIsReceiveIp6FilterEnabled = aEnabled; }
 
     /**
-     * This method indicates whether or not IPv6 forwarding is enabled.
-     *
-     * @returns TRUE if IPv6 forwarding is enabled, FALSE otherwise.
-     *
-     */
-    bool IsForwardingEnabled(void) const { return mForwardingEnabled; }
-
-    /**
-     * This method enables/disables IPv6 forwarding.
-     *
-     * @param[in]  aEnable  TRUE to enable IPv6 forwarding, FALSE otherwise.
-     *
-     */
-    void SetForwardingEnabled(bool aEnable) { mForwardingEnabled = aEnable; }
-
-    /**
      * This method performs default source address selection.
      *
      * @param[in,out]  aMessageInfo  A reference to the message information.
@@ -432,7 +416,6 @@ private:
 
     using SendQueueTask = TaskletIn<Ip6, &Ip6::HandleSendQueue>;
 
-    bool mForwardingEnabled;
     bool mIsReceiveIp6FilterEnabled;
 
     Callback<otIp6ReceiveCallback> mReceiveIp6DatagramCallback;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -697,7 +697,6 @@ void Mle::SetStateDetached(void)
 #if OPENTHREAD_FTD
     Get<MleRouter>().HandleDetachStart();
 #endif
-    Get<Ip6::Ip6>().SetForwardingEnabled(false);
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     Get<Mac::Mac>().UpdateCsl();
 #endif
@@ -726,8 +725,6 @@ void Mle::SetStateChild(uint16_t aRloc16)
         Get<MleRouter>().HandleChildStart(mAttachMode);
     }
 #endif
-
-    Get<Ip6::Ip6>().SetForwardingEnabled(false);
 
     // send announce after attached if needed
     InformPreviousChannel();

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -378,7 +378,6 @@ void MleRouter::SetStateRouter(uint16_t aRloc16)
 
     Get<ThreadNetif>().SubscribeAllRoutersMulticast();
     mPreviousPartitionIdRouter = mLeaderData.GetPartitionId();
-    Get<Ip6::Ip6>().SetForwardingEnabled(true);
     Get<Mac::Mac>().SetBeaconEnabled(true);
 
     // remove children that do not have matching RLOC16
@@ -418,7 +417,6 @@ void MleRouter::SetStateLeader(uint16_t aRloc16, LeaderStartMode aStartMode)
     Get<NetworkData::Leader>().Start(aStartMode);
     Get<MeshCoP::ActiveDatasetManager>().StartLeader();
     Get<MeshCoP::PendingDatasetManager>().StartLeader();
-    Get<Ip6::Ip6>().SetForwardingEnabled(true);
     Get<Mac::Mac>().SetBeaconEnabled(true);
     Get<AddressResolver>().Clear();
 


### PR DESCRIPTION
This commit updates `Ip6::HandleDatagram()` to check the device role to determine whether to allow messages received from the Thread mesh to be forwarded back to the Thread mesh. This is allowed only when device is acting as router or leader. This then lets us remove `SetForwardingEnabled()` method.