### PR TITLE
[log] fix some print format when enable csl debug

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -299,9 +299,10 @@ void SubMac::HandleReceiveDone(RxFrame *aFrame, Error aError)
 
 #if OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
         // Split the log into two lines for RTT to output
-        LogDebg("Received frame in state (SubMac %s, CSL %s), timestamp %u", StateToString(mState),
-                mIsCslSampling ? "CslSample" : "CslSleep", static_cast<uint32_t>(aFrame->mInfo.mRxInfo.mTimestamp));
-        LogDebg("Target sample start time %u, time drift %d", mCslSampleTime.GetValue(),
+        LogDebg("Received frame in state (SubMac %s, CSL %s), timestamp %lu", StateToString(mState),
+                mIsCslSampling ? "CslSample" : "CslSleep",
+                ToUlong(static_cast<uint32_t>(aFrame->mInfo.mRxInfo.mTimestamp)));
+        LogDebg("Target sample start time %lu, time drift %d", ToUlong(mCslSampleTime.GetValue()),
                 static_cast<uint32_t>(aFrame->mInfo.mRxInfo.mTimestamp) - mCslSampleTime.GetValue());
 #endif
     }


### PR DESCRIPTION
Fix some `uint32_t` variables using `%u` format when enable csl debug.

related: [[log] add compile-time check for printf style arg check to log functions](https://github.com/openthread/openthread/pull/8339)