### PR TITLE
[mle] add `otDeviceProperties` to calculate local leader weight

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -157,6 +157,23 @@ if(OT_FULL_LOGS)
     target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_LOG_PREPEND_LEVEL=1")
 endif()
 
+set(OT_POWER_SUPPLY "" CACHE STRING "set the device power supply config")
+set(OT_POWER_SUPPLY_VALUES
+    ""
+    "BATTERY"
+    "EXTERNAL"
+    "EXTERNAL_STABLE"
+    "EXTERNAL_UNSTABLE"
+)
+set_property(CACHE OT_POWER_SUPPLY PROPERTY STRINGS ${OT_POWER_SUPPLY_VALUES})
+string(COMPARE EQUAL "${OT_POWER_SUPPLY}" "" is_empty)
+if (is_empty)
+    message(STATUS "OT_POWER_SUPPLY=\"\"")
+else()
+    message(STATUS "OT_POWER_SUPPLY=${OT_POWER_SUPPLY} --> OPENTHREAD_CONFIG_DEVICE_POWER_SUPPLY=OT_POWER_SUPPLY_${OT_POWER_SUPPLY}")
+    target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_DEVICE_POWER_SUPPLY=OT_POWER_SUPPLY_${OT_POWER_SUPPLY}")
+endif()
+
 set(OT_MLE_MAX_CHILDREN "" CACHE STRING "set maximum number of children")
 if(OT_MLE_MAX_CHILDREN MATCHES "^[0-9]+$")
     message(STATUS "OT_MLE_MAX_CHILDREN=${OT_MLE_MAX_CHILDREN}")

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (302)
+#define OPENTHREAD_API_VERSION (303)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -41,6 +41,7 @@ Done
 - [csl](#csl)
 - [dataset](README_DATASET.md)
 - [delaytimermin](#delaytimermin)
+- [deviceprops](#deviceprops)
 - [diag](#diag)
 - [discover](#discover-channel)
 - [dns](#dns-config)
@@ -1053,6 +1054,44 @@ Set the minimal delay timer (in seconds).
 
 ```bash
 > delaytimermin 60
+Done
+```
+
+### deviceprops
+
+Get the current device properties.
+
+```bash
+> deviceprops
+PowerSupply      : external
+IsBorderRouter   : yes
+SupportsCcm      : no
+IsUnstable       : no
+WeightAdjustment : 0
+Done
+```
+
+### deviceprops \<power-supply\> \<is-br\> \<supports-ccm\> \<is-unstable\> \<weight-adjustment\>
+
+Set the device properties which are then used to determine and set the Leader Weight.
+
+- power-supply: `battery`, `external`, `external-stable`, or `external-unstable`.
+- weight-adjustment: Valid range is from -16 to +16. Clamped if not within the range.
+
+```bash
+> deviceprops battery 0 0 0 -5
+Done
+
+> deviceprops
+PowerSupply      : battery
+IsBorderRouter   : no
+SupportsCcm      : no
+IsUnstable       : no
+WeightAdjustment : -5
+Done
+
+> leaderweight
+51
 Done
 ```
 

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -79,6 +79,16 @@ otError otThreadSetPreferredRouterId(otInstance *aInstance, uint8_t aRouterId)
     return AsCoreType(aInstance).Get<Mle::MleRouter>().SetPreferredRouterId(aRouterId);
 }
 
+const otDeviceProperties *otThreadGetDeviceProperties(otInstance *aInstance)
+{
+    return &AsCoreType(aInstance).Get<Mle::MleRouter>().GetDeviceProperties();
+}
+
+void otThreadSetDeviceProperties(otInstance *aInstance, const otDeviceProperties *aDeviceProperties)
+{
+    AsCoreType(aInstance).Get<Mle::MleRouter>().SetDeviceProperties(AsCoreType(aDeviceProperties));
+}
+
 uint8_t otThreadGetLocalLeaderWeight(otInstance *aInstance)
 {
     return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderWeight();

--- a/src/core/config/misc.h
+++ b/src/core/config/misc.h
@@ -78,6 +78,19 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_DEVICE_POWER_SUPPLY
+ *
+ * Specifies the default device power supply config. This config MUST use values from `otPowerSupply` enumeration.
+ *
+ * Device manufacturer can use this config to set the power supply config used by the device. This is then used as part
+ * of default `otDeviceProperties` to determine the Leader Weight used by the device.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_DEVICE_POWER_SUPPLY
+#define OPENTHREAD_CONFIG_DEVICE_POWER_SUPPLY OT_POWER_SUPPLY_EXTERNAL
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_ECDSA_ENABLE
  *
  * Define to 1 to enable ECDSA support.

--- a/src/core/config/mle.h
+++ b/src/core/config/mle.h
@@ -89,6 +89,18 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MLE_DEFAULT_LEADER_WEIGHT_ADJUSTMENT
+ *
+ * Specifies the default value for `mLeaderWeightAdjustment` in `otDeviceProperties`. MUST be from -16 up to +16.
+ *
+ * This value is used to adjust the calculated Leader Weight from `otDeviceProperties`.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MLE_DEFAULT_LEADER_WEIGHT_ADJUSTMENT
+#define OPENTHREAD_CONFIG_MLE_DEFAULT_LEADER_WEIGHT_ADJUSTMENT 0
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE
  *
  * Enable setting steering data out of band.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -70,7 +70,6 @@ MleRouter::MleRouter(Instance &aInstance)
     , mNetworkIdTimeout(kNetworkIdTimeout)
     , mRouterUpgradeThreshold(kRouterUpgradeThreshold)
     , mRouterDowngradeThreshold(kRouterDowngradeThreshold)
-    , mLeaderWeight(kLeaderWeight)
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     , mPreferredLeaderPartitionId(0)
     , mCcmEnabled(false)
@@ -95,6 +94,7 @@ MleRouter::MleRouter(Instance &aInstance)
 #endif
 {
     mDeviceMode.Set(mDeviceMode.Get() | DeviceMode::kModeFullThreadDevice | DeviceMode::kModeFullNetworkData);
+    mLeaderWeight = mDeviceProperties.CalculateLeaderWeight();
 
     SetRouterId(kInvalidRouterId);
 
@@ -181,6 +181,13 @@ Error MleRouter::SetRouterEligible(bool aEligible)
 
 exit:
     return error;
+}
+
+void MleRouter::SetDeviceProperties(const DeviceProperties &aDeviceProperties)
+{
+    mDeviceProperties = aDeviceProperties;
+    mDeviceProperties.ClampWeightAdjustment();
+    SetLeaderWeight(mDeviceProperties.CalculateLeaderWeight());
 }
 
 Error MleRouter::BecomeRouter(ThreadStatusTlv::Status aStatus)

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -144,6 +144,22 @@ public:
     Error BecomeLeader(void);
 
     /**
+     * This method gets the device properties which are used to determine the Leader Weight.
+     *
+     * @returns The current device properties.
+     *
+     */
+    const DeviceProperties &GetDeviceProperties(void) const { return mDeviceProperties; }
+
+    /**
+     * This method sets the device properties which are then used to determine and set the Leader Weight.
+     *
+     * @param[in]  aDeviceProperties    The device properties.
+     *
+     */
+    void SetDeviceProperties(const DeviceProperties &aDeviceProperties);
+
+    /**
      * This method returns the Leader Weighting value for this Thread interface.
      *
      * @returns The Leader Weighting value for this Thread interface.
@@ -153,6 +169,9 @@ public:
 
     /**
      * This method sets the Leader Weighting value for this Thread interface.
+     *
+     * This method directly sets the Leader Weight to the new value replacing its previous value (which may have been
+     * determined from a previous call to `SetDeviceProperties()`).
      *
      * @param[in]  aWeight  The Leader Weighting value.
      *
@@ -635,6 +654,8 @@ private:
     void        HandleTimeTick(void);
 
     TrickleTimer mAdvertiseTrickleTimer;
+
+    DeviceProperties mDeviceProperties;
 
     ChildTable  mChildTable;
     RouterTable mRouterTable;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -665,6 +665,27 @@ target_link_libraries(ot-test-message-queue
 
 add_test(NAME ot-test-message-queue COMMAND ot-test-message-queue)
 
+add_executable(ot-test-mle
+    test_mle.cpp
+)
+
+target_include_directories(ot-test-mle
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_options(ot-test-mle
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
+target_link_libraries(ot-test-mle
+    PRIVATE
+        ${COMMON_LIBS}
+)
+
+add_test(NAME ot-test-mle COMMAND ot-test-mle)
+
 add_executable(ot-test-multicast-listeners-table
     test_multicast_listeners_table.cpp
 )

--- a/tests/unit/test_mle.cpp
+++ b/tests/unit/test_mle.cpp
@@ -1,0 +1,185 @@
+/*
+ *  Copyright (c) 2023, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <openthread/config.h>
+
+#include "test_platform.h"
+#include "test_util.hpp"
+
+#include "common/num_utils.hpp"
+#include "thread/mle_types.hpp"
+
+namespace ot {
+
+#if OPENTHREAD_FTD
+void TestDefaultDeviceProperties(void)
+{
+    Instance                 *instance;
+    const otDeviceProperties *props;
+    uint8_t                   weight;
+
+    instance = static_cast<Instance *>(testInitInstance());
+    VerifyOrQuit(instance != nullptr);
+
+    props = otThreadGetDeviceProperties(instance);
+
+    VerifyOrQuit(props->mPowerSupply == OPENTHREAD_CONFIG_DEVICE_POWER_SUPPLY);
+    VerifyOrQuit(!props->mSupportsCcm);
+    VerifyOrQuit(!props->mIsUnstable);
+    VerifyOrQuit(props->mLeaderWeightAdjustment == OPENTHREAD_CONFIG_MLE_DEFAULT_LEADER_WEIGHT_ADJUSTMENT);
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    VerifyOrQuit(props->mIsBorderRouter);
+#else
+    VerifyOrQuit(!props->mIsBorderRouter);
+#endif
+
+    weight = 64;
+
+    switch (props->mPowerSupply)
+    {
+    case OT_POWER_SUPPLY_BATTERY:
+        weight -= 8;
+        break;
+    case OT_POWER_SUPPLY_EXTERNAL:
+        break;
+    case OT_POWER_SUPPLY_EXTERNAL_STABLE:
+        weight += 4;
+        break;
+    case OT_POWER_SUPPLY_EXTERNAL_UNSTABLE:
+        weight -= 4;
+        break;
+    }
+
+    weight += props->mIsBorderRouter ? 1 : 0;
+
+    VerifyOrQuit(otThreadGetLocalLeaderWeight(instance) == weight);
+
+    printf("TestDefaultDeviceProperties passed\n");
+}
+
+void CompareDevicePropertiess(const otDeviceProperties &aFirst, const otDeviceProperties &aSecond)
+{
+    static constexpr int8_t kMinAdjustment = -16;
+    static constexpr int8_t kMaxAdjustment = +16;
+
+    VerifyOrQuit(aFirst.mPowerSupply == aSecond.mPowerSupply);
+    VerifyOrQuit(aFirst.mIsBorderRouter == aSecond.mIsBorderRouter);
+    VerifyOrQuit(aFirst.mSupportsCcm == aSecond.mSupportsCcm);
+    VerifyOrQuit(aFirst.mIsUnstable == aSecond.mIsUnstable);
+    VerifyOrQuit(Clamp(aFirst.mLeaderWeightAdjustment, kMinAdjustment, kMaxAdjustment) ==
+                 Clamp(aSecond.mLeaderWeightAdjustment, kMinAdjustment, kMaxAdjustment));
+}
+
+void TestLeaderWeightCalculation(void)
+{
+    struct TestCase
+    {
+        otDeviceProperties mDeviceProperties;
+        uint8_t            mExpectedLeaderWeight;
+    };
+
+    static const TestCase kTestCases[] = {
+        {{OT_POWER_SUPPLY_BATTERY, false, false, false, 0}, 56},
+        {{OT_POWER_SUPPLY_EXTERNAL, false, false, false, 0}, 64},
+        {{OT_POWER_SUPPLY_EXTERNAL_STABLE, false, false, false, 0}, 68},
+        {{OT_POWER_SUPPLY_EXTERNAL_UNSTABLE, false, false, false, 0}, 60},
+
+        {{OT_POWER_SUPPLY_BATTERY, true, false, false, 0}, 57},
+        {{OT_POWER_SUPPLY_EXTERNAL, true, false, false, 0}, 65},
+        {{OT_POWER_SUPPLY_EXTERNAL_STABLE, true, false, false, 0}, 69},
+        {{OT_POWER_SUPPLY_EXTERNAL_UNSTABLE, true, false, false, 0}, 61},
+
+        {{OT_POWER_SUPPLY_BATTERY, true, true, false, 0}, 64},
+        {{OT_POWER_SUPPLY_EXTERNAL, true, true, false, 0}, 72},
+        {{OT_POWER_SUPPLY_EXTERNAL_STABLE, true, true, false, 0}, 76},
+        {{OT_POWER_SUPPLY_EXTERNAL_UNSTABLE, true, true, false, 0}, 68},
+
+        // Check when `mIsUnstable` is set.
+        {{OT_POWER_SUPPLY_BATTERY, false, false, true, 0}, 56},
+        {{OT_POWER_SUPPLY_EXTERNAL, false, false, true, 0}, 60},
+        {{OT_POWER_SUPPLY_EXTERNAL_STABLE, false, false, true, 0}, 64},
+        {{OT_POWER_SUPPLY_EXTERNAL_UNSTABLE, false, false, true, 0}, 60},
+
+        {{OT_POWER_SUPPLY_BATTERY, true, false, true, 0}, 57},
+        {{OT_POWER_SUPPLY_EXTERNAL, true, false, true, 0}, 61},
+        {{OT_POWER_SUPPLY_EXTERNAL_STABLE, true, false, true, 0}, 65},
+        {{OT_POWER_SUPPLY_EXTERNAL_UNSTABLE, true, false, true, 0}, 61},
+
+        // Include non-zero `mLeaderWeightAdjustment`.
+        {{OT_POWER_SUPPLY_BATTERY, true, false, false, 10}, 67},
+        {{OT_POWER_SUPPLY_EXTERNAL, true, false, false, 10}, 75},
+        {{OT_POWER_SUPPLY_EXTERNAL_STABLE, true, false, false, 10}, 79},
+        {{OT_POWER_SUPPLY_EXTERNAL_UNSTABLE, true, false, false, 10}, 71},
+
+        {{OT_POWER_SUPPLY_BATTERY, false, false, false, -10}, 46},
+        {{OT_POWER_SUPPLY_EXTERNAL, false, false, false, -10}, 54},
+        {{OT_POWER_SUPPLY_EXTERNAL_STABLE, false, false, false, -10}, 58},
+        {{OT_POWER_SUPPLY_EXTERNAL_UNSTABLE, false, false, false, -10}, 50},
+
+        // Use `mLeaderWeightAdjustment` larger than valid range
+        // Make sure it clamps to -16 and +16.
+        {{OT_POWER_SUPPLY_BATTERY, false, false, false, 20}, 72},
+        {{OT_POWER_SUPPLY_EXTERNAL, false, false, false, 20}, 80},
+        {{OT_POWER_SUPPLY_EXTERNAL_STABLE, false, false, false, 20}, 84},
+        {{OT_POWER_SUPPLY_EXTERNAL_UNSTABLE, false, false, false, 20}, 76},
+
+        {{OT_POWER_SUPPLY_BATTERY, true, false, false, -20}, 41},
+        {{OT_POWER_SUPPLY_EXTERNAL, true, false, false, -20}, 49},
+        {{OT_POWER_SUPPLY_EXTERNAL_STABLE, true, false, false, -20}, 53},
+        {{OT_POWER_SUPPLY_EXTERNAL_UNSTABLE, true, false, false, -20}, 45},
+    };
+
+    Instance *instance;
+
+    instance = static_cast<Instance *>(testInitInstance());
+    VerifyOrQuit(instance != nullptr);
+
+    for (const TestCase &testCase : kTestCases)
+    {
+        otThreadSetDeviceProperties(instance, &testCase.mDeviceProperties);
+        CompareDevicePropertiess(testCase.mDeviceProperties, *otThreadGetDeviceProperties(instance));
+        VerifyOrQuit(otThreadGetLocalLeaderWeight(instance) == testCase.mExpectedLeaderWeight);
+    }
+
+    printf("TestLeaderWeightCalculation passed\n");
+}
+
+#endif // OPENTHREAD_FTD
+
+} // namespace ot
+
+int main(void)
+{
+#if OPENTHREAD_FTD
+    ot::TestDefaultDeviceProperties();
+    ot::TestLeaderWeightCalculation();
+#endif
+
+    printf("All tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
This commit adds `otDeviceProperties` which represents a set of device
configurations which are used to calculate and set the local Leader
Weight on the device.

The device config contains a `otPowerSupplyConfig` enum value
specifying the device power supply:
- Battery powered.
- Externally powered (mains-powered).
- Stable external power with a battery backup or UPS.
- Unstable external power (e.g., a light bulb powered via a switch).

It also indicates whether or not device is a border router, supports
CCM, and specifies a Leader Weight adjustment value.

The `otDeviceProperties` can be set through the newly added OT public API
`otThreadSetDeviceProperties()`. Its default value (upon OT stack start)
can also be configured using OT configs:
- Newly added `OPENTHREAD_CONFIG_DEVICE_POWER_SUPPLY` specifies the
  default power supply config to use. This config can also be set
  using the newly added CMake option `OT_POWER_SUPPLY`.
- Existing `OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE` will indicate
  if device is acting as a BR.

This commit also adds CLI command `deviceprops` for getting/setting
the device config. It also adds a unit test to validate the Leader
Weight calculation algorithm from a given device config.

----

This is related to [SPEC-983](https://threadgroup.atlassian.net/browse/SPEC-983).