### PR TITLE
[ip6-mpl] check the length when reading MPL Option

### DIFF
--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -64,8 +64,8 @@ OT_TOOL_PACKED_BEGIN
 class OptionMpl : public OptionHeader
 {
 public:
-    static constexpr uint8_t kType      = 0x6d; // 01 1 01101
-    static constexpr uint8_t kMinLength = 2;
+    static constexpr uint8_t kType    = 0x6d;                       ///< MPL option type - 01 1 01101
+    static constexpr uint8_t kMinSize = (2 + sizeof(OptionHeader)); ///< Minimum size (num of bytes) of `OptionMpl`
 
     /**
      * This method initializes the MPL header.


### PR DESCRIPTION
This commit enhances/fixes how we validate an `OptionMpl` we read from a received message. In `Mpl::ProcessOption()`, we first ensure that we can read the minimum expected size of an MPL Option and then check based on the read Control field, the Seed ID length and ensure we can read the full `OptionMpl` under `kSeedIdLength2`.