### PR TITLE
[csl] reset tx attempt on `mCslTxChild` when msg is replaced/purged

### DIFF
--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -90,6 +90,7 @@ void CslTxScheduler::Update(void)
     {
         // `Mac` has already started the CSL tx, so wait for tx done callback
         // to call `RescheduleCslTx`
+        mCslTxChild->ResetCslTxAttempts();
         mCslTxChild                      = nullptr;
         mFrameContext.mMessageNextOffset = 0;
     }
@@ -260,7 +261,7 @@ void CslTxScheduler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError)
     HandleSentFrame(aFrame, aError, *child);
 
 exit:
-    return;
+    RescheduleCslTx();
 }
 
 void CslTxScheduler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, Child &aChild)
@@ -312,7 +313,6 @@ void CslTxScheduler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, C
             }
         }
 
-        RescheduleCslTx();
         ExitNow();
 
     default:


### PR DESCRIPTION
This commit contains two updates/fixes in `CslTxScheduler`:

In `CslTxScheduler::Update()` method, this commit adds a new call to `ResetCslTxAttempts()` on `mCslTxChild` when the current indirect message associated with the child gets changed (replaced or purged), while MAC is busy with tx of a CSL frame to this child. This ensures that the next CSL tx associated this child will be correctly treated as a new frame (and not a retx) and gets its own frame counter.

This commit also updates `HandleSentFrame()` to ensure that we always call `RescheduleCslTx()` from this method. `Update()` method is called whenever there is a change to the head of indirect message queue of any sleepy child. If we are not in the middle of CSL tx at MAC layer, `RescheduleCslTx()` is called immediately to determine the next CSL tx among all children and schedule it. Otherwise, we wait for MAC to signal that frame TX is done. Current code only called `RescheduleCslTx()` when there was a tx error in `HandleSentFrame()`. This can cause the issue of not scheduling the next CSL in case of tx success and/or if the current message was replaced/purged.

