### PR TITLE
[ip6] add `GetSize()` to `ExtensionHeader` and `OptionHeader`

### DIFF
--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -73,19 +73,10 @@ public:
      */
     void Init(void)
     {
-        OptionHeader::SetType(kType);
-        OptionHeader::SetLength(sizeof(*this) - sizeof(OptionHeader));
+        SetType(kType);
+        SetLength(sizeof(*this) - sizeof(OptionHeader));
         mControl = 0;
     }
-
-    /**
-     * This method returns the total MPL Option length value including option
-     * header.
-     *
-     * @returns The total IPv6 Option Length.
-     *
-     */
-    uint8_t GetTotalLength(void) const { return OptionHeader::GetLength() + sizeof(OptionHeader); }
 
     /**
      * MPL Seed Id lengths.

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -438,7 +438,7 @@ Error Lowpan::CompressExtensionHeader(Message &aMessage, FrameBuilder &aFrameBui
     uint16_t             startOffset = aMessage.GetOffset();
     Ip6::ExtensionHeader extHeader;
     uint16_t             len;
-    uint8_t              padLength = 0;
+    uint16_t             padLength = 0;
     uint8_t              tmpByte;
 
     SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), extHeader));
@@ -461,7 +461,7 @@ Error Lowpan::CompressExtensionHeader(Message &aMessage, FrameBuilder &aFrameBui
 
     SuccessOrExit(error = aFrameBuilder.AppendUint8(tmpByte));
 
-    len = (extHeader.GetLength() + 1) * 8 - sizeof(extHeader);
+    len = extHeader.GetSize() - sizeof(extHeader);
 
     // RFC 6282 does not support compressing large extension headers
     VerifyOrExit(len <= kExtHdrMaxLength, error = kErrorFailed);
@@ -485,7 +485,7 @@ Error Lowpan::CompressExtensionHeader(Message &aMessage, FrameBuilder &aFrameBui
             }
             else
             {
-                offset += sizeof(optionHeader) + optionHeader.GetLength();
+                offset += optionHeader.GetSize();
             }
         }
 
@@ -496,7 +496,7 @@ Error Lowpan::CompressExtensionHeader(Message &aMessage, FrameBuilder &aFrameBui
         }
         else if (optionHeader.GetType() == Ip6::OptionPadN::kType)
         {
-            padLength = sizeof(optionHeader) + optionHeader.GetLength();
+            padLength = optionHeader.GetSize();
         }
 
         len -= padLength;


### PR DESCRIPTION
This commit adds `GetSize()` to `Ip6::ExtensionHeader` and base class `OptionHeader`. This method returns the size (number of bytes) of the header/option. In case of `ExtensionHeader` the size is derived from "Length" field which is in 8-bye unit and does not count the first 8 bytes.