### PR TITLE
[core] use `AppendBytesFromMessage()` to copy bytes between messages

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -40,6 +40,7 @@
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
 #include "common/log.hpp"
+#include "common/num_utils.hpp"
 #include "common/numeric_limits.hpp"
 #include "net/checksum.hpp"
 #include "net/ip6.hpp"
@@ -678,10 +679,10 @@ Message *Message::Clone(uint16_t aLength) const
     Settings settings(IsLinkSecurityEnabled() ? kWithLinkSecurity : kNoLinkSecurity, GetPriority());
     uint16_t offset;
 
+    aLength     = Min(GetLength(), aLength);
     messageCopy = GetMessagePool()->Allocate(GetType(), GetReserved(), settings);
     VerifyOrExit(messageCopy != nullptr, error = kErrorNoBufs);
-    SuccessOrExit(error = messageCopy->SetLength(aLength));
-    CopyTo(0, 0, aLength, *messageCopy);
+    SuccessOrExit(error = messageCopy->AppendBytesFromMessage(*this, 0, aLength));
 
     // Copy selected message information.
     offset = GetOffset() < aLength ? GetOffset() : aLength;

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -1116,7 +1116,6 @@ Error Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::MessageInfo 
     Error            error = kErrorNone;
     ExtendedTlv      tlv;
     Coap::Message   *message;
-    uint16_t         offset;
     Tmf::MessageInfo messageInfo(GetInstance());
     Kek              kek;
 
@@ -1137,9 +1136,7 @@ Error Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::MessageInfo 
     tlv.SetType(Tlv::kJoinerDtlsEncapsulation);
     tlv.SetLength(aMessage.GetLength());
     SuccessOrExit(error = message->Append(tlv));
-    offset = message->GetLength();
-    SuccessOrExit(error = message->SetLength(offset + aMessage.GetLength()));
-    aMessage.CopyTo(0, offset, aMessage.GetLength(), *message);
+    SuccessOrExit(error = message->AppendBytesFromMessage(aMessage, 0, aMessage.GetLength()));
 
     messageInfo.SetSockAddrToRlocPeerAddrTo(mJoinerRloc);
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -134,7 +134,6 @@ void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &a
     Tmf::MessageInfo messageInfo(GetInstance());
     ExtendedTlv      tlv;
     uint16_t         borderAgentRloc;
-    uint16_t         offset;
 
     LogInfo("JoinerRouter::HandleUdpReceive");
 
@@ -150,9 +149,7 @@ void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &a
     tlv.SetType(Tlv::kJoinerDtlsEncapsulation);
     tlv.SetLength(aMessage.GetLength() - aMessage.GetOffset());
     SuccessOrExit(error = message->Append(tlv));
-    offset = message->GetLength();
-    SuccessOrExit(error = message->SetLength(offset + tlv.GetLength()));
-    aMessage.CopyTo(aMessage.GetOffset(), offset, tlv.GetLength(), *message);
+    SuccessOrExit(error = message->AppendBytesFromMessage(aMessage, aMessage.GetOffset(), tlv.GetLength()));
 
     messageInfo.SetSockAddrToRlocPeerAddrTo(borderAgentRloc);
 
@@ -189,8 +186,7 @@ template <> void JoinerRouter::HandleTmf<kUriRelayTx>(Coap::Message &aMessage, c
 
     VerifyOrExit((message = mSocket.NewMessage(0, settings)) != nullptr, error = kErrorNoBufs);
 
-    SuccessOrExit(error = message->SetLength(length));
-    aMessage.CopyTo(offset, 0, length, *message);
+    SuccessOrExit(error = message->AppendBytesFromMessage(aMessage, offset, length));
 
     messageInfo.GetPeerAddr().SetToLinkLocalAddress(joinerIid);
     messageInfo.SetPeerPort(joinerPort);

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -833,24 +833,10 @@ exit:
 
 Error Client::AppendNameFromQuery(const Query &aQuery, Message &aMessage)
 {
-    Error    error = kErrorNone;
-    uint16_t offset;
-    uint16_t length;
+    // The name is encoded and included after the `Info` in `aQuery`
+    // starting at `kNameOffsetInQuery`.
 
-    // The name is encoded and included after the `Info` in `aQuery`. We
-    // first calculate the encoded length of the name, then grow the
-    // message, and finally copy the encoded name bytes from `aQuery`
-    // into `aMessage`.
-
-    length = aQuery.GetLength() - kNameOffsetInQuery;
-
-    offset = aMessage.GetLength();
-    SuccessOrExit(error = aMessage.SetLength(offset + length));
-
-    aQuery.CopyTo(/* aSourceOffset */ kNameOffsetInQuery, /* aDestOffset */ offset, length, aMessage);
-
-exit:
-    return error;
+    return aMessage.AppendBytesFromMessage(aQuery, kNameOffsetInQuery, aQuery.GetLength() - kNameOffsetInQuery);
 }
 
 void Client::FinalizeQuery(Query &aQuery, Error aError)


### PR DESCRIPTION
This commit updates multiple core modules to use the `Message` helper method `AppendBytesFromMessage()` to append bytes read from one message at a given offset and length to the end of another message.

----

This replaces the use `Message::CopyTo()` (which is not as readable).