### PR TITLE
[api] include `mLinkMargin` in `otNeighborInfo`

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (280)
+#define OPENTHREAD_API_VERSION (281)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -97,6 +97,7 @@ typedef struct
     uint8_t      mLinkQualityIn;        ///< Link Quality In
     int8_t       mAverageRssi;          ///< Average RSSI
     int8_t       mLastRssi;             ///< Last observed RSSI
+    uint8_t      mLinkMargin;           ///< Link Margin
     uint16_t     mFrameErrorRate;       ///< Frame error rate (0xffff->100%). Requires error tracking feature.
     uint16_t     mMessageErrorRate;     ///< (IPv6) msg error rate (0xffff->100%). Requires error tracking feature.
     uint16_t     mVersion;              ///< Thread version of the neighbor

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -76,6 +76,7 @@ void Neighbor::Info::SetFrom(const Neighbor &aNeighbor)
     mLinkQualityIn    = aNeighbor.GetLinkQualityIn();
     mAverageRssi      = aNeighbor.GetLinkInfo().GetAverageRss();
     mLastRssi         = aNeighbor.GetLinkInfo().GetLastRss();
+    mLinkMargin       = aNeighbor.GetLinkInfo().GetLinkMargin();
     mFrameErrorRate   = aNeighbor.GetLinkInfo().GetFrameErrorRate();
     mMessageErrorRate = aNeighbor.GetLinkInfo().GetMessageErrorRate();
     mRxOnWhenIdle     = aNeighbor.IsRxOnWhenIdle();


### PR DESCRIPTION
Included mLinkMargin in the otNeighborInfo struct to retrieve Link margin via otThreadGetNextNeighborInfo