### PR TITLE
[ip6] rename `Option` sub-classes

### DIFF
--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -945,7 +945,7 @@ private:
         Message *operator->(void) { return static_cast<Message *>(ot::Message::Iterator::operator->()); }
     };
 
-    static_assert(sizeof(HelpData) <= sizeof(Ip6::Header) + sizeof(Ip6::HopByHopHeader) + sizeof(Ip6::OptionMpl) +
+    static_assert(sizeof(HelpData) <= sizeof(Ip6::Header) + sizeof(Ip6::HopByHopHeader) + sizeof(Ip6::MplOption) +
                                           sizeof(Ip6::Udp::Header),
                   "HelpData size exceeds the size of the reserved region in the message");
 

--- a/src/core/net/ip6_headers.hpp
+++ b/src/core/net/ip6_headers.hpp
@@ -447,14 +447,14 @@ class HopByHopHeader : public ExtensionHeader
  *
  */
 OT_TOOL_PACKED_BEGIN
-class OptionHeader
+class Option
 {
 public:
     /**
      * Default constructor.
      *
      */
-    OptionHeader(void)
+    Option(void)
         : mType(0)
         , mLength(0)
     {
@@ -518,7 +518,7 @@ public:
      * @returns The size of the Option.
      *
      */
-    uint16_t GetSize(void) const { return static_cast<uint16_t>(mLength) + sizeof(OptionHeader); }
+    uint16_t GetSize(void) const { return static_cast<uint16_t>(mLength) + sizeof(Option); }
 
 private:
     static constexpr uint8_t kActionMask = 0xc0;
@@ -532,7 +532,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class OptionPadN : public OptionHeader
+class PadNOption : public Option
 {
 public:
     static constexpr uint8_t kType      = 0x01; ///< PadN type
@@ -548,8 +548,8 @@ public:
     void Init(uint8_t aPadLength)
     {
         SetType(kType);
-        SetLength(aPadLength - sizeof(OptionHeader));
-        memset(mPad, kData, aPadLength - sizeof(OptionHeader));
+        SetLength(aPadLength - sizeof(Option));
+        memset(mPad, kData, aPadLength - sizeof(Option));
     }
 
 private:
@@ -561,7 +561,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class OptionPad1
+class Pad1Option
 {
 public:
     static constexpr uint8_t kType = 0x00;

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -54,7 +54,7 @@ Mpl::Mpl(Instance &aInstance)
     memset(mSeedSet, 0, sizeof(mSeedSet));
 }
 
-void Mpl::InitOption(OptionMpl &aOption, const Address &aAddress)
+void Mpl::InitOption(MplOption &aOption, const Address &aAddress)
 {
     aOption.Init();
     aOption.SetSequence(mSequence++);
@@ -62,14 +62,14 @@ void Mpl::InitOption(OptionMpl &aOption, const Address &aAddress)
     // Seed ID can be elided when `aAddress` is RLOC.
     if (aAddress == Get<Mle::Mle>().GetMeshLocal16())
     {
-        aOption.SetSeedIdLength(OptionMpl::kSeedIdLength0);
+        aOption.SetSeedIdLength(MplOption::kSeedIdLength0);
 
         // Decrease default option length.
         aOption.SetLength(aOption.GetLength() - sizeof(uint16_t));
     }
     else
     {
-        aOption.SetSeedIdLength(OptionMpl::kSeedIdLength2);
+        aOption.SetSeedIdLength(MplOption::kSeedIdLength2);
         aOption.SetSeedId(Get<Mle::Mle>().GetRloc16());
     }
 }
@@ -77,26 +77,26 @@ void Mpl::InitOption(OptionMpl &aOption, const Address &aAddress)
 Error Mpl::ProcessOption(Message &aMessage, const Address &aAddress, bool aIsOutbound, bool &aReceive)
 {
     Error     error;
-    OptionMpl option;
+    MplOption option;
 
     // Read the min size bytes first, then check the expected
-    // `SeedIdLength` and read the full `OptionMpl` if needed.
-    SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), &option, OptionMpl::kMinSize));
+    // `SeedIdLength` and read the full `MplOption` if needed.
+    SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), &option, MplOption::kMinSize));
 
     switch (option.GetSeedIdLength())
     {
-    case OptionMpl::kSeedIdLength0:
+    case MplOption::kSeedIdLength0:
         // Retrieve Seed ID from the IPv6 Source Address RLOC.
         VerifyOrExit(aAddress.GetIid().IsLocator(), error = kErrorDrop);
         option.SetSeedId(aAddress.GetIid().GetLocator());
         break;
 
-    case OptionMpl::kSeedIdLength2:
+    case MplOption::kSeedIdLength2:
         SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), option));
         break;
 
-    case OptionMpl::kSeedIdLength8:
-    case OptionMpl::kSeedIdLength16:
+    case MplOption::kSeedIdLength8:
+    case MplOption::kSeedIdLength16:
         ExitNow(error = kErrorParse);
     }
 

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -61,11 +61,11 @@ namespace Ip6 {
  *
  */
 OT_TOOL_PACKED_BEGIN
-class OptionMpl : public OptionHeader
+class MplOption : public Option
 {
 public:
-    static constexpr uint8_t kType    = 0x6d;                       ///< MPL option type - 01 1 01101
-    static constexpr uint8_t kMinSize = (2 + sizeof(OptionHeader)); ///< Minimum size (num of bytes) of `OptionMpl`
+    static constexpr uint8_t kType    = 0x6d;                 ///< MPL option type - 01 1 01101
+    static constexpr uint8_t kMinSize = (2 + sizeof(Option)); ///< Minimum size (num of bytes) of `MplOption`
 
     /**
      * This method initializes the MPL header.
@@ -74,7 +74,7 @@ public:
     void Init(void)
     {
         SetType(kType);
-        SetLength(sizeof(*this) - sizeof(OptionHeader));
+        SetLength(sizeof(*this) - sizeof(Option));
         mControl = 0;
     }
 
@@ -195,7 +195,7 @@ public:
      * @param[in]  aAddress  A reference to the IPv6 Source Address.
      *
      */
-    void InitOption(OptionMpl &aOption, const Address &aAddress);
+    void InitOption(MplOption &aOption, const Address &aAddress);
 
     /**
      * This method processes an MPL option. When the MPL module acts as an MPL Forwarder

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -472,31 +472,31 @@ Error Lowpan::CompressExtensionHeader(Message &aMessage, FrameBuilder &aFrameBui
     // Pad1 or PadN option MAY be elided by the compressor."
     if (aNextHeader == Ip6::kProtoHopOpts || aNextHeader == Ip6::kProtoDstOpts)
     {
-        uint16_t          offset = aMessage.GetOffset();
-        Ip6::OptionHeader optionHeader;
+        uint16_t    offset = aMessage.GetOffset();
+        Ip6::Option option;
 
         while ((offset - aMessage.GetOffset()) < len)
         {
-            SuccessOrExit(error = aMessage.Read(offset, optionHeader));
+            SuccessOrExit(error = aMessage.Read(offset, option));
 
-            if (optionHeader.GetType() == Ip6::OptionPad1::kType)
+            if (option.GetType() == Ip6::Pad1Option::kType)
             {
-                offset += sizeof(Ip6::OptionPad1);
+                offset += sizeof(Ip6::Pad1Option);
             }
             else
             {
-                offset += optionHeader.GetSize();
+                offset += option.GetSize();
             }
         }
 
         // Check if the last option can be compressed.
-        if (optionHeader.GetType() == Ip6::OptionPad1::kType)
+        if (option.GetType() == Ip6::Pad1Option::kType)
         {
-            padLength = sizeof(Ip6::OptionPad1);
+            padLength = sizeof(Ip6::Pad1Option);
         }
-        else if (optionHeader.GetType() == Ip6::OptionPadN::kType)
+        else if (option.GetType() == Ip6::PadNOption::kType)
         {
-            padLength = optionHeader.GetSize();
+            padLength = option.GetSize();
         }
 
         len -= padLength;
@@ -888,17 +888,17 @@ Error Lowpan::DecompressExtensionHeader(Message &aMessage, FrameData &aFrameData
     {
         if (padLength == 1)
         {
-            Ip6::OptionPad1 optionPad1;
+            Ip6::Pad1Option pad1;
 
-            optionPad1.Init();
-            SuccessOrExit(aMessage.AppendBytes(&optionPad1, padLength));
+            pad1.Init();
+            SuccessOrExit(aMessage.AppendBytes(&pad1, padLength));
         }
         else
         {
-            Ip6::OptionPadN optionPadN;
+            Ip6::PadNOption padn;
 
-            optionPadN.Init(padLength);
-            SuccessOrExit(aMessage.AppendBytes(&optionPadN, padLength));
+            padn.Init(padLength);
+            SuccessOrExit(aMessage.AppendBytes(&padn, padLength));
         }
 
         aMessage.MoveOffset(padLength);


### PR DESCRIPTION
This commit renames the `Ip6::Option` and its sub-classes, e.g., we use `MplOption` instead of `OptionMpl` to follow similar naming pattern as `Tlv`s.

----

This commit contains no logic/code change,  just a rename of types and variables.