### PR TITLE
[ip6] refer to correct RFC in comments/docs

### DIFF
--- a/src/core/net/ip4_types.cpp
+++ b/src/core/net/ip4_types.cpp
@@ -85,7 +85,7 @@ void Address::ExtractFromIp6Address(uint8_t aPrefixLength, const Ip6::Address &a
 {
     // The prefix length must be 32, 40, 48, 56, 64, 96. IPv4 bytes are added
     // after the prefix, skipping over the bits 64 to 71 (byte at `kSkipIndex`)
-    // which must be set to zero. The suffix is set to zero (per RFC 6502).
+    // which must be set to zero. The suffix is set to zero (per RFC 6052).
     //
     //    +--+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
     //    |PL| 0-------------32--40--48--56--64--72--80--88--96--104---------|

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -450,7 +450,7 @@ void Address::SynthesizeFromIp4Address(const Prefix &aPrefix, const Ip4::Address
 {
     // The prefix length must be 32, 40, 48, 56, 64, 96. IPv4 bytes are added
     // after the prefix, skipping over the bits 64 to 71 (byte at `kSkipIndex`)
-    // which must be set to zero. The suffix is set to zero (per RFC 6502).
+    // which must be set to zero. The suffix is set to zero (per RFC 6052).
     //
     //    +--+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
     //    |PL| 0-------------32--40--48--56--64--72--80--88--96--104---------|

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -294,7 +294,7 @@ public:
     /**
      * This method indicates whether or not a given prefix length is valid for use as a NAT64 prefix.
      *
-     * A NAT64 prefix must have one of the following lengths: 32, 40, 48, 56, 64, or 96 (per RFC 6502).
+     * A NAT64 prefix must have one of the following lengths: 32, 40, 48, 56, 64, or 96 (per RFC 6052).
      *
      * @param[in] aLength The length of the prefix.
      *
@@ -307,7 +307,7 @@ public:
     /**
      * This method indicates whether or not the prefix has a valid length for use as a NAT64 prefix.
      *
-     * A NAT64 prefix must have one of the following lengths: 32, 40, 48, 56, 64, or 96 (per RFC 6502).
+     * A NAT64 prefix must have one of the following lengths: 32, 40, 48, 56, 64, or 96 (per RFC 6052).
      *
      * @retval TRUE   If the prefix has a valid length for use as a NAT64 prefix.
      * @retval FALSE  If the prefix does not have a valid length for use as a NAT64 prefix.

--- a/tests/unit/test_ip_address.cpp
+++ b/tests/unit/test_ip_address.cpp
@@ -467,7 +467,7 @@ void TestIp4Ip6Translation(void)
         const char *mIp6Address; // Expected IPv6 address (with embedded IPv4 "192.0.2.33").
     };
 
-    // The test cases are from RFC 6502 - section 2.4
+    // The test cases are from RFC 6052 - section 2.4
 
     const TestCase kTestCases[] = {
         {"2001:db8::", 32, "2001:db8:c000:221::"},


### PR DESCRIPTION
This commit updates comments to refer to correct RFC number. RFC 6052 instead of 6502 (typo in some comments).