### PR TITLE
[ip6] remove default constructor for `Ip6::Option`

### DIFF
--- a/src/core/net/ip6_headers.cpp
+++ b/src/core/net/ip6_headers.cpp
@@ -38,6 +38,9 @@
 namespace ot {
 namespace Ip6 {
 
+//---------------------------------------------------------------------------------------------------------------------
+// Header
+
 Error Header::ParseFrom(const Message &aMessage)
 {
     Error error = kErrorParse;
@@ -61,6 +64,16 @@ bool Header::IsValid(void) const
 #endif
 
     return IsVersion6() && ((sizeof(Header) + GetPayloadLength()) <= kMaxLength);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+// PadNOption
+
+void PadNOption::Init(uint8_t aPadLength)
+{
+    SetType(kType);
+    SetLength(aPadLength - sizeof(Option));
+    memset(mPad, kData, aPadLength - sizeof(Option));
 }
 
 } // namespace Ip6

--- a/src/core/net/ip6_headers.hpp
+++ b/src/core/net/ip6_headers.hpp
@@ -451,16 +451,6 @@ class Option
 {
 public:
     /**
-     * Default constructor.
-     *
-     */
-    Option(void)
-        : mType(0)
-        , mLength(0)
-    {
-    }
-
-    /**
      * This method returns the IPv6 Option Type value.
      *
      * @returns The IPv6 Option Type value.
@@ -545,12 +535,7 @@ public:
      * @param[in]  aPadLength  The length of needed padding. Allowed value from range 2-7.
      *
      */
-    void Init(uint8_t aPadLength)
-    {
-        SetType(kType);
-        SetLength(aPadLength - sizeof(Option));
-        memset(mPad, kData, aPadLength - sizeof(Option));
-    }
+    void Init(uint8_t aPadLength);
 
 private:
     uint8_t mPad[kMaxLength];


### PR DESCRIPTION
All sub-classes of `Option` provide `Init()` method to initialize the Option.

This commit also updates `Lowpan::CompressExtensionHeader()` to check that we did read an option from message before checking if it can be compressed.