### PR TITLE
[ip6] ensure to make room for new header at correct offset

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -268,7 +268,7 @@ Error Ip6::InsertMplOption(Message &aMessage, Header &aHeader)
             aMessage.Write(0, hbh);
 
             // make space for MPL Option + padding by shifting hop-by-hop option header
-            SuccessOrExit(error = aMessage.InsertHeader(hbh.GetSize(), 8));
+            SuccessOrExit(error = aMessage.InsertHeader(hbhSize, 8));
 
             // insert MPL Option
             mMpl.InitOption(mplOption, aHeader.GetSource());


### PR DESCRIPTION
In `InsertMplOption()` we need to insert the Option at the original end of Hop-by-hop Extension header which we track in `hbhSize`. Note that he read `hbh` is updated (we increment the `Length` field which increases the `hbh.GetSize()` by 8 bytes).

The code before this commit which inserted the header at the new `hbh.GetSize()` offset still works correctly since we copy all the bytes before the insertion offset back. It just copies more bytes than necessary.