### PR TITLE
[net-diag] add Net Diag Version TLV

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (286)
+#define OPENTHREAD_API_VERSION (287)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/netdiag.h
+++ b/include/openthread/netdiag.h
@@ -82,6 +82,7 @@ enum
     OT_NETWORK_DIAGNOSTIC_TLV_CHANNEL_PAGES     = 17, ///< Channel Pages TLV
     OT_NETWORK_DIAGNOSTIC_TLV_TYPE_LIST         = 18, ///< Type List TLV
     OT_NETWORK_DIAGNOSTIC_TLV_MAX_CHILD_TIMEOUT = 19, ///< Max Child Timeout TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_VERSION           = 24, ///< Version TLV
 };
 
 typedef uint16_t otNetworkDiagIterator; ///< Used to iterate through Network Diagnostic TLV.
@@ -245,6 +246,7 @@ typedef struct otNetworkDiagTlv
         uint8_t                   mBatteryLevel;
         uint16_t                  mSupplyVoltage;
         uint32_t                  mMaxChildTimeout;
+        uint16_t                  mVersion;
         struct
         {
             uint8_t mCount;

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -50,6 +50,7 @@
 #include "thread/mle_router.hpp"
 #include "thread/thread_netif.hpp"
 #include "thread/thread_tlvs.hpp"
+#include "thread/version.hpp"
 
 namespace ot {
 
@@ -440,6 +441,10 @@ Error NetworkDiagnostic::AppendRequestedTlvs(const Message &aRequest, Message &a
         }
 #endif
 
+        case Tlv::kVersion:
+            SuccessOrExit(error = Tlv::Append<VersionTlv>(aResponse, kThreadVersion));
+            break;
+
         default:
             // Skip unrecognized TLV type.
             break;
@@ -774,6 +779,10 @@ Error NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage, Iterator 
 
         case Tlv::kMaxChildTimeout:
             SuccessOrExit(error = Tlv::Read<MaxChildTimeoutTlv>(aMessage, offset, aTlvInfo.mData.mMaxChildTimeout));
+            break;
+
+        case Tlv::kVersion:
+            SuccessOrExit(error = Tlv::Read<VersionTlv>(aMessage, offset, aTlvInfo.mData.mVersion));
             break;
 
         default:

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -85,6 +85,7 @@ public:
         kChannelPages    = OT_NETWORK_DIAGNOSTIC_TLV_CHANNEL_PAGES,
         kTypeList        = OT_NETWORK_DIAGNOSTIC_TLV_TYPE_LIST,
         kMaxChildTimeout = OT_NETWORK_DIAGNOSTIC_TLV_MAX_CHILD_TIMEOUT,
+        kVersion         = OT_NETWORK_DIAGNOSTIC_TLV_VERSION,
     };
 
     /**
@@ -164,6 +165,12 @@ typedef TlvInfo<Tlv::kChildTable> ChildTableTlv;
  *
  */
 typedef UintTlvInfo<Tlv::kMaxChildTimeout, uint32_t> MaxChildTimeoutTlv;
+
+/**
+ * This class defines Version TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kVersion, uint16_t> VersionTlv;
 
 typedef otNetworkDiagConnectivity Connectivity; ///< Network Diagnostic Connectivity value.
 


### PR DESCRIPTION
This commit adds support for Net Diag Version TLV (TLV number 24) which returns the Thread version of device (as `uint16_t`).

----

This is related to [SPEC-1146](https://threadgroup.atlassian.net/jira/core/projects/SPEC/issues/SPEC-1146).