### PR TITLE
[ip6] add `Option::ParseFrom()` and common `PadOption`

### DIFF
--- a/src/core/net/ip6_headers.hpp
+++ b/src/core/net/ip6_headers.hpp
@@ -378,6 +378,14 @@ class ExtensionHeader
 {
 public:
     /**
+     * This constant defines the size of Length unit in bytes.
+     *
+     * The Length field is in 8-bytes unit. The total size of `ExtensionHeader` MUST be a multiple of 8.
+     *
+     */
+    static constexpr uint16_t kLengthUnitSize = 8;
+
+    /**
      * This method returns the IPv6 Next Header value.
      *
      * @returns The IPv6 Next Header value.
@@ -419,11 +427,9 @@ public:
      * @returns The size (number of bytes) of the Extension Header.
      *
      */
-    uint16_t GetSize(void) const { return kLengthUnitInBytes * (mLength + 1); }
+    uint16_t GetSize(void) const { return kLengthUnitSize * (mLength + 1); }
 
 private:
-    static constexpr uint16_t kLengthUnitInBytes = 8;
-
     // |     m8[0]     |     m8[1]     |     m8[2]     |      m8[3]    |
     // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     // | Next Header   | Header Length | . . .                         |
@@ -451,22 +457,6 @@ class Option
 {
 public:
     /**
-     * This method returns the IPv6 Option Type value.
-     *
-     * @returns The IPv6 Option Type value.
-     *
-     */
-    uint8_t GetType(void) const { return mType; }
-
-    /**
-     * This method sets the IPv6 Option Type value.
-     *
-     * @param[in]  aType  The IPv6 Option Type value.
-     *
-     */
-    void SetType(uint8_t aType) { mType = aType; }
-
-    /**
      * IPv6 Option Type actions for unrecognized IPv6 Options.
      *
      */
@@ -477,6 +467,23 @@ public:
         kActionForceIcmp = 0x80, ///< Discard the packet and forcibly send an ICMP Parameter Problem.
         kActionIcmp      = 0xc0, ///< Discard packet and conditionally send an ICMP Parameter Problem.
     };
+
+    /**
+     * This method returns the IPv6 Option Type value.
+     *
+     * @returns The IPv6 Option Type value.
+     *
+     */
+    uint8_t GetType(void) const { return mType; }
+
+    /**
+     * This method indicates whether IPv6 Option is padding (either Pad1 or PadN).
+     *
+     * @retval TRUE   The Option is padding.
+     * @retval FALSE  The Option is not padding.
+     *
+     */
+    bool IsPadding(void) const { return (mType == kTypePad1) || (mType == kTypePadN); }
 
     /**
      * This method returns the IPv6 Option action for unrecognized IPv6 Options.
@@ -495,20 +502,52 @@ public:
     uint8_t GetLength(void) const { return mLength; }
 
     /**
+     * This method returns the size (number of bytes) of the IPv6 Option.
+     *
+     * This method returns the proper size of the Option independent of its type, particularly if Option is Pad1 (which
+     * does not follow the common Option header structure and has only Type field with no Length field). For other
+     * Option types, the returned size includes the Type and Length fields.
+     *
+     * @returns The size of the Option.
+     *
+     */
+    uint16_t GetSize(void) const;
+
+    /**
+     * This method parses and validates the IPv6 Option from a given message.
+     *
+     * The Option is read from @p aOffset in @p aMessage. This method then checks that the entire Option is present
+     * in @p aMessage before the @p aEndOffset.
+     *
+     * @param[in]  aMessage    The IPv6 message.
+     * @param[in]  aOffset     The offset in @p aMessage to read the IPv6 Option.
+     * @param[in]  aEndOffset  The end offset in @p aMessage.
+     *
+     * @retval kErrorNone   Successfully parsed the IPv6 option from @p aMessage.
+     * @retval kErrorParse  Malformed IPv6 Option or Option is not contained within @p aMessage by @p aEndOffset.
+     *
+     */
+    Error ParseFrom(const Message &aMessage, uint16_t aOffset, uint16_t aEndOffset);
+
+protected:
+    static constexpr uint8_t kTypePad1 = 0x00; ///< Pad1 Option Type.
+    static constexpr uint8_t kTypePadN = 0x01; ///< PanN Option Type.
+
+    /**
+     * This method sets the IPv6 Option Type value.
+     *
+     * @param[in]  aType  The IPv6 Option Type value.
+     *
+     */
+    void SetType(uint8_t aType) { mType = aType; }
+
+    /**
      * This method sets the IPv6 Option Length value.
      *
      * @param[in]  aLength  The IPv6 Option Length value.
      *
      */
     void SetLength(uint8_t aLength) { mLength = aLength; }
-
-    /**
-     * This method returns the size (number of bytes) of the IPv6 Option including the Type and Length fields.
-     *
-     * @returns The size of the Option.
-     *
-     */
-    uint16_t GetSize(void) const { return static_cast<uint16_t>(mLength) + sizeof(Option); }
 
 private:
     static constexpr uint8_t kActionMask = 0xc0;
@@ -518,47 +557,45 @@ private:
 } OT_TOOL_PACKED_END;
 
 /**
- * This class implements IPv6 PadN Option generation and parsing.
+ * This class implements IPv6 Pad Options (Pad1 or PadN) generation.
  *
  */
 OT_TOOL_PACKED_BEGIN
-class PadNOption : public Option
+class PadOption : public Option, private Clearable<PadOption>
 {
-public:
-    static constexpr uint8_t kType      = 0x01; ///< PadN type
-    static constexpr uint8_t kData      = 0x00; ///< PadN specific data
-    static constexpr uint8_t kMaxLength = 0x05; ///< Maximum length of PadN option data
+    friend class Clearable<PadOption>;
 
+public:
     /**
-     * This method initializes the PadN header.
+     * This method initializes the Pad Option for a given total Pad size.
      *
-     * @param[in]  aPadLength  The length of needed padding. Allowed value from range 2-7.
+     * The @p aPadSize MUST be from range 1-7. Otherwise the behavior of this method is undefined.
+     *
+     * @param[in]  aPadSize  The total number of needed padding bytes.
      *
      */
-    void Init(uint8_t aPadLength);
-
-private:
-    uint8_t mPad[kMaxLength];
-} OT_TOOL_PACKED_END;
-
-/**
- * This class implements IPv6 Pad1 Option generation and parsing. Pad1 does not follow default option header structure.
- *
- */
-OT_TOOL_PACKED_BEGIN
-class Pad1Option
-{
-public:
-    static constexpr uint8_t kType = 0x00;
+    void InitForPadSize(uint8_t aPadSize);
 
     /**
-     * This method initializes the Pad1 header.
+     * This method initializes the Pad Option for padding an IPv6 Extension header with a given current size.
+     *
+     * The Extension Header Length is in 8-bytes unit, so the total size should be a multiple of 8. This method
+     * determines the Pad Option size needed for appending to Extension Header based on it current size @p aHeaderSize
+     * so to make it a multiple of 8. This method returns `kErrorAlready` when the @p aHeaderSize is already
+     * a multiple of 8 (i.e., no padding is needed).
+     *
+     * @param[in] aHeaderSize  The current IPv6 Extension header size (in bytes).
+     *
+     * @retval kErrorNone     The Pad Option is successfully initialized.
+     * @retval kErrorAlready  The @p aHeaderSize is already a multiple of 8 and no padding is needed.
      *
      */
-    void Init(void) { mType = kType; }
+    Error InitToPadHeaderWithSize(uint16_t aHeaderSize);
 
 private:
-    uint8_t mType;
+    static constexpr uint8_t kMaxLength = 5;
+
+    uint8_t mPads[kMaxLength];
 } OT_TOOL_PACKED_END;
 
 /**

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -68,18 +68,7 @@ public:
     static constexpr uint8_t kMinSize = (2 + sizeof(Option)); ///< Minimum size (num of bytes) of `MplOption`
 
     /**
-     * This method initializes the MPL header.
-     *
-     */
-    void Init(void)
-    {
-        SetType(kType);
-        SetLength(sizeof(*this) - sizeof(Option));
-        mControl = 0;
-    }
-
-    /**
-     * MPL Seed Id lengths.
+     * MPL Seed Id Lengths.
      *
      */
     enum SeedIdLength : uint8_t
@@ -91,23 +80,22 @@ public:
     };
 
     /**
+     * This method initializes the MPL Option.
+     *
+     * The @p aSeedIdLength MUST be either `kSeedIdLength0` or `kSeedIdLength2`. Other values are not supported.
+     *
+     * @param[in] aSeedIdLength   The MPL Seed Id Length.
+     *
+     */
+    void Init(SeedIdLength aSeedIdLength);
+
+    /**
      * This method returns the MPL Seed Id Length value.
      *
      * @returns The MPL Seed Id Length value.
      *
      */
     SeedIdLength GetSeedIdLength(void) const { return static_cast<SeedIdLength>(mControl & kSeedIdLengthMask); }
-
-    /**
-     * This method sets the MPL Seed Id Length value.
-     *
-     * @param[in]  aSeedIdLength  The MPL Seed Length.
-     *
-     */
-    void SetSeedIdLength(SeedIdLength aSeedIdLength)
-    {
-        mControl = static_cast<uint8_t>((mControl & ~kSeedIdLengthMask) | aSeedIdLength);
-    }
 
     /**
      * This method indicates whether or not the MPL M flag is set.
@@ -204,6 +192,7 @@ public:
      * timer expirations for subsequent retransmissions.
      *
      * @param[in]  aMessage    A reference to the message.
+     * @param[in]  aOffset     The offset in @p aMessage to read the MPL option.
      * @param[in]  aAddress    A reference to the IPv6 Source Address.
      * @param[in]  aIsOutbound TRUE if this message was locally generated, FALSE otherwise.
      * @param[out] aReceive    Set to FALSE if the MPL message is a duplicate and must not
@@ -213,7 +202,7 @@ public:
      * @retval kErrorDrop  The MPL message is a duplicate and should be dropped.
      *
      */
-    Error ProcessOption(Message &aMessage, const Address &aAddress, bool aIsOutbound, bool &aReceive);
+    Error ProcessOption(Message &aMessage, uint16_t aOffset, const Address &aAddress, bool aIsOutbound, bool &aReceive);
 
 #if OPENTHREAD_FTD
     /**


### PR DESCRIPTION
This commit contains changes related to handling of IPv6 Options. It adds a new method `Option::ParseFrom()` which parses and validates an IPv6 Option from a given message. This method handles the Pad1 Option as well as other Option Types. This makes it easier (and safer) to iterate through Options in an Extension Header. `Option::GetSize()` is also updated to return the correct size for Pad1 Option since Pad1 Option does not follow the common Option format (has Type field with no Length field).

This commit also adds a common `PadOption` class which based on the desired padding size uses Pad1 or PadN as its type. It also provides `InitToPadHeaderWithSize()` which prepares the option with proper length to pad an Extension Header with a given current size (also determining whether or not padding is needed).

This commit also updates `Ip6` methods to use `kLengthUnitSize` constant.