### PR TITLE
[dataset] add `otDatasetConvertToTlvs()` API

### DIFF
--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -583,7 +583,7 @@ otError otDatasetGeneratePskc(const char            *aPassPhrase,
 otError otNetworkNameFromString(otNetworkName *aNetworkName, const char *aNameString);
 
 /**
- * This function parses an Operational Dataset from a `otOperationalDatasetTlvs`.
+ * Parses an Operational Dataset from a given `otOperationalDatasetTlvs`.
  *
  * @param[in]  aDatasetTlvs  A pointer to dataset TLVs.
  * @param[out] aDataset      A pointer to where the dataset will be placed.
@@ -593,6 +593,18 @@ otError otNetworkNameFromString(otNetworkName *aNetworkName, const char *aNameSt
  *
  */
 otError otDatasetParseTlvs(const otOperationalDatasetTlvs *aDatasetTlvs, otOperationalDataset *aDataset);
+
+/**
+ * Converts a given Operational Dataset to `otOperationalDatasetTlvs`.
+ *
+ * @param[in]  aDataset      An Operational dataset to convert to TLVs.
+ * @param[out] aDatasetTlvs  A pointer to dataset TLVs to return the result.
+ *
+ * @retval OT_ERROR_NONE          Successfully converted @p aDataset and updated @p aDatasetTlvs.
+ * @retval OT_ERROR_INVALID_ARGS  @p aDataset is invalid, does not contain active or pending timestamps.
+ *
+ */
+otError otDatasetConvertToTlvs(const otOperationalDataset *aDataset, otOperationalDatasetTlvs *aDatasetTlvs);
 
 /**
  * @}

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (297)
+#define OPENTHREAD_API_VERSION (298)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README_DATASET.md
+++ b/src/cli/README_DATASET.md
@@ -129,6 +129,7 @@ After the device successfully attaches to a Thread network, the device will retr
 - [pendingtimestamp](#pendingtimestamp)
 - [pskc](#pskc)
 - [securitypolicy](#securitypolicy)
+- [tlvs](#tlvs)
 
 ## Command Details
 
@@ -160,6 +161,8 @@ pending
 pendingtimestamp
 pskc
 securitypolicy
+set
+tlvs
 Done
 ```
 
@@ -530,13 +533,38 @@ Usage: `dataset set <active|pending> <dataset>`
 Set the Active Operational Dataset using hex-encoded TLVs.
 
 ```bash
-dataset set active 0e080000000000010000000300000f35060004001fffe0020839758ec8144b07fb0708fdf1f1add0797dc00510f366cec7a446bab978d90d27abe38f23030f4f70656e5468726561642d353933380102593804103ca67c969efb0d0c74a4d8ee923b576c0c0402a0f7f8
+> dataset set active 0e080000000000010000000300000f35060004001fffe0020839758ec8144b07fb0708fdf1f1add0797dc00510f366cec7a446bab978d90d27abe38f23030f4f70656e5468726561642d353933380102593804103ca67c969efb0d0c74a4d8ee923b576c0c0402a0f7f8
 Done
 ```
 
 Set the Pending Operational Dataset using hex-encoded TLVs.
 
 ```bash
-dataset set pending 0e0800000000000100003308000000000002000034040000b512000300001a35060004001fffe00208a74182f4d3f4de410708fd46c1b9e15955740510ed916e454d96fd00184f10a6f5c9e1d3030f4f70656e5468726561642d626666380102bff80410264f78414adc683191863d968f72d1b70c0402a0f7f8
+> dataset set pending 0e0800000000000100003308000000000002000034040000b512000300001a35060004001fffe00208a74182f4d3f4de410708fd46c1b9e15955740510ed916e454d96fd00184f10a6f5c9e1d3030f4f70656e5468726561642d626666380102bff80410264f78414adc683191863d968f72d1b70c0402a0f7f8
+Done
+```
+
+### tlvs
+
+Usage: `dataset tlvs`
+
+Convert the Operational Dataset to hex-encoded TLVs.
+
+```bash
+> dataset
+Active Timestamp: 1
+Channel: 22
+Channel Mask: 0x07fff800
+Ext PAN ID: d196fa2040e973b6
+Mesh Local Prefix: fdbb:c310:c48f:3a39::/64
+Network Key: 9929154dbc363218bcd22f907caf5c15
+Network Name: OpenThread-de2b
+PAN ID: 0xde2b
+PSKc: 15b2c16f7ba92ed4bc7b1ee054f1553f
+Security Policy: 672 onrc
+Done
+
+> dataset tlvs
+0e080000000000010000000300001635060004001fffe00208d196fa2040e973b60708fdbbc310c48f3a3905109929154dbc363218bcd22f907caf5c15030f4f70656e5468726561642d646532620102de2b041015b2c16f7ba92ed4bc7b1ee054f1553f0c0402a0f7f8
 Done
 ```

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -1252,6 +1252,29 @@ exit:
     return error;
 }
 
+/**
+ * @cli dataset tlvs
+ * @code
+ * dataset tlvs
+ * 0e080000000000010000000300001635060004001fffe0020...f7f8
+ * Done
+ * @endcode
+ * @par api_copy
+ * #otDatasetConvertToTlvs
+ */
+template <> otError Dataset::Process<Cmd("tlvs")>(Arg aArgs[])
+{
+    otError                  error;
+    otOperationalDatasetTlvs datasetTlvs;
+
+    VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+    SuccessOrExit(error = otDatasetConvertToTlvs(&sDataset, &datasetTlvs));
+    OutputBytesLine(datasetTlvs.mTlvs, datasetTlvs.mLength);
+
+exit:
+    return error;
+}
+
 #if OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE && OPENTHREAD_FTD
 
 template <> otError Dataset::Process<Cmd("updater")>(Arg aArgs[])
@@ -1318,6 +1341,7 @@ otError Dataset::Process(Arg aArgs[])
         CmdEntry("pskc"),
         CmdEntry("securitypolicy"),
         CmdEntry("set"),
+        CmdEntry("tlvs"),
 #if OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE && OPENTHREAD_FTD
         CmdEntry("updater"),
 #endif
@@ -1359,6 +1383,8 @@ otError Dataset::Process(Arg aArgs[])
      * pendingtimestamp
      * pskc
      * securitypolicy
+     * set
+     * tlvs
      * Done
      * @endcode
      * @par

--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -168,3 +168,17 @@ otError otDatasetParseTlvs(const otOperationalDatasetTlvs *aDatasetTlvs, otOpera
 exit:
     return error;
 }
+
+otError otDatasetConvertToTlvs(const otOperationalDataset *aDataset, otOperationalDatasetTlvs *aDatasetTlvs)
+{
+    Error            error = kErrorNone;
+    MeshCoP::Dataset dataset;
+
+    AssertPointerIsNotNull(aDatasetTlvs);
+
+    SuccessOrExit(error = dataset.SetFrom(AsCoreType(aDataset)));
+    dataset.ConvertTo(*aDatasetTlvs);
+
+exit:
+    return error;
+}


### PR DESCRIPTION
This commit adds `otDatasetConvertToTlvs()` to covert a given Operational Dataset `otOperationalDataset` to TLVs. It also adds a related CLI command `dataset tlvs`.