### PR TITLE
[net-diag] simplify `NetworkDiagnostic`

### DIFF
--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -46,6 +46,7 @@
 #include "net/udp6.hpp"
 #include "thread/network_diagnostic_tlvs.hpp"
 #include "thread/tmf.hpp"
+#include "thread/uri_paths.hpp"
 
 namespace ot {
 
@@ -69,25 +70,12 @@ class NetworkDiagnostic : public InstanceLocator, private NonCopyable
     friend class Tmf::Agent;
 
 public:
-    /**
-     * This type represents an iterator used to iterate through Network Diagnostic TLVs from `GetNextDiagTlv()`.
-     *
-     */
-    typedef otNetworkDiagIterator Iterator;
+    typedef otNetworkDiagIterator          Iterator;    ///< Iterator to go through TLVs in `GetNextDiagTlv()`.
+    typedef otNetworkDiagTlv               TlvInfo;     ///< Parse info from a Network Diagnostic TLV.
+    typedef otNetworkDiagChildEntry        ChildInfo;   ///< Parsed info for child table entry.
+    typedef otReceiveDiagnosticGetCallback GetCallback; ///< Diagnostic Get callback function pointer type.
 
     static constexpr Iterator kIteratorInit = OT_NETWORK_DIAGNOSTIC_ITERATOR_INIT; ///< Initializer for Iterator.
-
-    /**
-     * This type represents parsed information from a Network Diagnostic TLV.
-     *
-     */
-    typedef otNetworkDiagTlv TlvInfo;
-
-    /**
-     * This structure represents parsed information from Network Diagnostic Child Table entry.
-     *
-     */
-    typedef otNetworkDiagChildEntry ChildInfo;
 
     /**
      * This constructor initializes the object.
@@ -99,24 +87,23 @@ public:
      * This method sends Diagnostic Get request. If the @p aDestination is of multicast type, the DIAG_GET.qry
      * message is sent or the DIAG_GET.req otherwise.
      *
-     * @param[in]  aDestination      A reference to the destination address.
+     * @param[in]  aDestination      The destination address.
      * @param[in]  aTlvTypes         An array of Network Diagnostic TLV types.
-     * @param[in]  aCount            Number of types in aTlvTypes.
-     * @param[in]  aCallback         A pointer to a function that is called when Network Diagnostic Get response
-     *                               is received or NULL to disable the callback.
-     * @param[in]  aCallbackContext  A pointer to application-specific context.
+     * @param[in]  aCount            Number of types in @p aTlvTypes.
+     * @param[in]  aCallback         Callback when Network Diagnostic Get response is received (can be NULL).
+     * @param[in]  Context           Application-specific context used with @p aCallback.
      *
      */
-    Error SendDiagnosticGet(const Ip6::Address            &aDestination,
-                            const uint8_t                  aTlvTypes[],
-                            uint8_t                        aCount,
-                            otReceiveDiagnosticGetCallback aCallback,
-                            void                          *aCallbackContext);
+    Error SendDiagnosticGet(const Ip6::Address &aDestination,
+                            const uint8_t       aTlvTypes[],
+                            uint8_t             aCount,
+                            GetCallback         aCallback,
+                            void               *Context);
 
     /**
      * This method sends Diagnostic Reset request.
      *
-     * @param[in] aDestination  A reference to the destination address.
+     * @param[in] aDestination  The destination address.
      * @param[in] aTlvTypes     An array of Network Diagnostic TLV types.
      * @param[in] aCount        Number of types in aTlvTypes
      *
@@ -126,10 +113,9 @@ public:
     /**
      * This static method gets the next Network Diagnostic TLV in a given message.
      *
-     * @param[in]      aMessage         A message.
-     * @param[in,out]  aIterator        The Network Diagnostic iterator. To get the first TLV set it to
-     *                                  `kIteratorInit`.
-     * @param[out]     aTlvInfo         A reference to a `TlvInfo` to output the next TLV data.
+     * @param[in]      aMessage    Message to read TLVs from.
+     * @param[in,out]  aIterator   The Network Diagnostic iterator. To get the first TLV set it to `kIteratorInit`.
+     * @param[out]     aTlvInfo    A reference to a `TlvInfo` to output the next TLV data.
      *
      * @retval kErrorNone       Successfully found the next Network Diagnostic TLV.
      * @retval kErrorNotFound   No subsequent Network Diagnostic TLV exists in the message.
@@ -141,30 +127,41 @@ public:
 private:
     static constexpr uint16_t kMaxChildEntries = 398;
 
-    enum CommandType : uint8_t
+    enum Action : uint8_t
     {
-        kDiagnosticGet,
-        kDiagnosticReset,
+        kMessageSend,
+        kMessageReceive,
     };
 
-    Error SendDiagnosticCommand(CommandType         aCommandType,
-                                const Ip6::Address &aDestination,
-                                const uint8_t       aTlvTypes[],
-                                uint8_t             aCount);
+    Error SendCommand(Uri                   aUri,
+                      const Ip6::Address   &aDestination,
+                      const uint8_t         aTlvTypes[],
+                      uint8_t               aCount,
+                      Coap::ResponseHandler aHandler = nullptr,
+                      void                 *aContext = nullptr);
+
     Error AppendIp6AddressList(Message &aMessage);
     Error AppendChildTable(Message &aMessage);
-    void  FillMacCountersTlv(MacCountersTlv &aMacCountersTlv);
-    Error FillRequestedTlvs(const Message &aRequest, Message &aResponse, NetworkDiagnosticTlv &aNetworkDiagnosticTlv);
+    void  FillMacCountersTlv(MacCountersTlv &aTlv);
+    Error AppendRequestedTlvs(const Message &aRequest, Message &aResponse, Tlv &aTlv);
+    void  PrepareMessageInfoForDest(const Ip6::Address &aDestination, Tmf::MessageInfo &aMessageInfo) const;
 
-    static void HandleDiagnosticGetResponse(void                *aContext,
-                                            otMessage           *aMessage,
-                                            const otMessageInfo *aMessageInfo,
-                                            Error                aResult);
-    void HandleDiagnosticGetResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
+    static void HandleGetResponse(void                *aContext,
+                                  otMessage           *aMessage,
+                                  const otMessageInfo *aMessageInfo,
+                                  Error                aResult);
+    void        HandleGetResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    Callback<otReceiveDiagnosticGetCallback> mReceiveDiagnosticGetCallback;
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
+    static const char *UriToString(Uri aUri);
+    void               Log(Action aAction, Uri aUri, const Ip6::Address &aIp6Address) const;
+#else
+    void Log(Action, Uri, const Ip6::Address &) const {}
+#endif
+
+    Callback<GetCallback> mGetCallback;
 };
 
 DeclareTmfHandler(NetworkDiagnostic, kUriDiagnosticGetRequest);

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -60,7 +60,7 @@ using ot::Encoding::BigEndian::HostSwap32;
  *
  */
 OT_TOOL_PACKED_BEGIN
-class NetworkDiagnosticTlv : public ot::Tlv
+class Tlv : public ot::Tlv
 {
 public:
     /**
@@ -109,61 +109,61 @@ public:
  * This class defines Extended MAC Address TLV constants and types.
  *
  */
-typedef SimpleTlvInfo<NetworkDiagnosticTlv::kExtMacAddress, Mac::ExtAddress> ExtMacAddressTlv;
+typedef SimpleTlvInfo<Tlv::kExtMacAddress, Mac::ExtAddress> ExtMacAddressTlv;
 
 /**
  * This class defines Address16 TLV constants and types.
  *
  */
-typedef UintTlvInfo<NetworkDiagnosticTlv::kAddress16, uint16_t> Address16Tlv;
+typedef UintTlvInfo<Tlv::kAddress16, uint16_t> Address16Tlv;
 
 /**
  * This class defines Mode TLV constants and types.
  *
  */
-typedef UintTlvInfo<NetworkDiagnosticTlv::kMode, uint8_t> ModeTlv;
+typedef UintTlvInfo<Tlv::kMode, uint8_t> ModeTlv;
 
 /**
  * This class defines Timeout TLV constants and types.
  *
  */
-typedef UintTlvInfo<NetworkDiagnosticTlv::kTimeout, uint32_t> TimeoutTlv;
+typedef UintTlvInfo<Tlv::kTimeout, uint32_t> TimeoutTlv;
 
 /**
  * This class defines Network Data TLV constants and types.
  *
  */
-typedef TlvInfo<NetworkDiagnosticTlv::kNetworkData> NetworkDataTlv;
+typedef TlvInfo<Tlv::kNetworkData> NetworkDataTlv;
 
 /**
  * This class defines IPv6 Address List TLV constants and types.
  *
  */
-typedef TlvInfo<NetworkDiagnosticTlv::kIp6AddressList> Ip6AddressListTlv;
+typedef TlvInfo<Tlv::kIp6AddressList> Ip6AddressListTlv;
 
 /**
  * This class defines Battery Level TLV constants and types.
  *
  */
-typedef UintTlvInfo<NetworkDiagnosticTlv::kBatteryLevel, uint8_t> BatteryLevelTlv;
+typedef UintTlvInfo<Tlv::kBatteryLevel, uint8_t> BatteryLevelTlv;
 
 /**
  * This class defines Supply Voltage TLV constants and types.
  *
  */
-typedef UintTlvInfo<NetworkDiagnosticTlv::kSupplyVoltage, uint16_t> SupplyVoltageTlv;
+typedef UintTlvInfo<Tlv::kSupplyVoltage, uint16_t> SupplyVoltageTlv;
 
 /**
  * This class defines Child Table TLV constants and types.
  *
  */
-typedef TlvInfo<NetworkDiagnosticTlv::kChildTable> ChildTableTlv;
+typedef TlvInfo<Tlv::kChildTable> ChildTableTlv;
 
 /**
  * This class defines Max Child Timeout TLV constants and types.
  *
  */
-typedef UintTlvInfo<NetworkDiagnosticTlv::kMaxChildTimeout, uint32_t> MaxChildTimeoutTlv;
+typedef UintTlvInfo<Tlv::kMaxChildTimeout, uint32_t> MaxChildTimeoutTlv;
 
 typedef otNetworkDiagConnectivity Connectivity; ///< Network Diagnostic Connectivity value.
 
@@ -175,7 +175,7 @@ OT_TOOL_PACKED_BEGIN
 class ConnectivityTlv : public Mle::ConnectivityTlv
 {
 public:
-    static constexpr uint8_t kType = NetworkDiagnosticTlv::kConnectivity; ///< The TLV Type value.
+    static constexpr uint8_t kType = ot::NetworkDiagnostic::Tlv::kConnectivity; ///< The TLV Type value.
 
     /**
      * This method initializes the TLV.
@@ -216,7 +216,7 @@ OT_TOOL_PACKED_BEGIN
 class RouteTlv : public Mle::RouteTlv
 {
 public:
-    static constexpr uint8_t kType = NetworkDiagnosticTlv::kRoute; ///< The TLV Type value.
+    static constexpr uint8_t kType = ot::NetworkDiagnostic::Tlv::kRoute; ///< The TLV Type value.
 
     /**
      * This method initializes the TLV.
@@ -237,7 +237,7 @@ OT_TOOL_PACKED_BEGIN
 class LeaderDataTlv : public Mle::LeaderDataTlv
 {
 public:
-    static constexpr uint8_t kType = NetworkDiagnosticTlv::kLeaderData; ///< The TLV Type value.
+    static constexpr uint8_t kType = ot::NetworkDiagnostic::Tlv::kLeaderData; ///< The TLV Type value.
 
     /**
      * This method initializes the TLV.
@@ -255,7 +255,7 @@ public:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class MacCountersTlv : public NetworkDiagnosticTlv, public TlvInfo<NetworkDiagnosticTlv::kMacCounters>
+class MacCountersTlv : public Tlv, public TlvInfo<Tlv::kMacCounters>
 {
 public:
     /**
@@ -265,7 +265,7 @@ public:
     void Init(void)
     {
         SetType(kMacCounters);
-        SetLength(sizeof(*this) - sizeof(NetworkDiagnosticTlv));
+        SetLength(sizeof(*this) - sizeof(Tlv));
     }
 
     /**
@@ -275,7 +275,7 @@ public:
      * @retval FALSE  If the TLV does not appear to be well-formed.
      *
      */
-    bool IsValid(void) const { return GetLength() >= sizeof(*this) - sizeof(NetworkDiagnosticTlv); }
+    bool IsValid(void) const { return GetLength() >= sizeof(*this) - sizeof(Tlv); }
 
     /**
      * This method returns the IfInUnknownProtos counter.
@@ -551,7 +551,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ChannelPagesTlv : public NetworkDiagnosticTlv, public TlvInfo<NetworkDiagnosticTlv::kChannelPages>
+class ChannelPagesTlv : public Tlv, public TlvInfo<Tlv::kChannelPages>
 {
 public:
     /**
@@ -561,7 +561,7 @@ public:
     void Init(void)
     {
         SetType(kChannelPages);
-        SetLength(sizeof(*this) - sizeof(NetworkDiagnosticTlv));
+        SetLength(sizeof(*this) - sizeof(Tlv));
     }
 
     /**
@@ -594,7 +594,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class TypeListTlv : public NetworkDiagnosticTlv, public TlvInfo<NetworkDiagnosticTlv::kTypeList>
+class TypeListTlv : public Tlv, public TlvInfo<Tlv::kTypeList>
 {
 public:
     /**
@@ -604,7 +604,7 @@ public:
     void Init(void)
     {
         SetType(kTypeList);
-        SetLength(sizeof(*this) - sizeof(NetworkDiagnosticTlv));
+        SetLength(sizeof(*this) - sizeof(Tlv));
     }
 } OT_TOOL_PACKED_END;
 


### PR DESCRIPTION
This commit contains smaller enactments in `NetworkDiagnostic` class:

- `SendCommand()` method is updated to accept a `Uri` for the intended diag command.
- `PrepareMessageInfoForDest()` method is added which prepares a `Tmf::MessageInfo` for sending diag commands to a destination deciding which source address to use.
- The TLV class is renamed to `Tlv` from `NetworkDiagnosticTlv` (since it is under the namespace `NetworkDiagnostic` already). This makes it similar to TLVs from other modules, `Mle::Tlv`, `MeshCoP::Tlv`, etc).
- Logging in `NetworkDiagnostic` is updated and simplified, now using `Log(Action, Uri)` method. The logs provide more info like the IP6 address of sender/receiver of a message.