### PR TITLE
[code-utils] use `num_utils` `Min`/`Max` to simplify code

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -7277,7 +7277,7 @@ void Interpreter::HandleDiagnosticGetResponse(otError                 aError,
 
     while (length > 0)
     {
-        bytesToPrint = (length < sizeof(buf)) ? length : sizeof(buf);
+        bytesToPrint = Min(length, static_cast<uint16_t>(sizeof(buf)));
         otMessageRead(aMessage, otMessageGetOffset(aMessage) + bytesPrinted, buf, bytesToPrint);
 
         OutputBytes(buf, static_cast<uint8_t>(bytesToPrint));

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -128,7 +128,7 @@ void Coap::PrintPayload(otMessage *aMessage)
 
         while (length > 0)
         {
-            bytesToPrint = (length < sizeof(buf)) ? length : sizeof(buf);
+            bytesToPrint = Min(length, static_cast<uint16_t>(sizeof(buf)));
             otMessageRead(aMessage, otMessageGetOffset(aMessage) + bytesPrinted, buf, bytesToPrint);
 
             OutputBytes(buf, static_cast<uint8_t>(bytesToPrint));

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -77,7 +77,7 @@ void CoapSecure::PrintPayload(otMessage *aMessage)
 
         while (length > 0)
         {
-            bytesToPrint = (length < sizeof(buf)) ? length : sizeof(buf);
+            bytesToPrint = Min(length, static_cast<uint16_t>(sizeof(buf)));
             otMessageRead(aMessage, otMessageGetOffset(aMessage) + bytesPrinted, buf, bytesToPrint);
 
             OutputBytes(buf, static_cast<uint8_t>(bytesToPrint));

--- a/src/core/api/backbone_router_ftd_api.cpp
+++ b/src/core/api/backbone_router_ftd_api.cpp
@@ -166,8 +166,7 @@ otError otBackboneRouterMulticastListenerAdd(otInstance *aInstance, const otIp6A
         aTimeout = config.mMlrTimeout;
     }
 
-    aTimeout =
-        aTimeout > static_cast<uint32_t>(Mle::kMlrTimeoutMax) ? static_cast<uint32_t>(Mle::kMlrTimeoutMax) : aTimeout;
+    aTimeout = Min(aTimeout, Mle::kMlrTimeoutMax);
     aTimeout = Time::SecToMsec(aTimeout);
 
     return AsCoreType(aInstance).Get<BackboneRouter::MulticastListenersTable>().Add(AsCoreType(aAddress),

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -766,7 +766,7 @@ Message *Message::Clone(uint16_t aLength) const
     SuccessOrExit(error = messageCopy->AppendBytesFromMessage(*this, 0, aLength));
 
     // Copy selected message information.
-    offset = GetOffset() < aLength ? GetOffset() : aLength;
+    offset = Min(GetOffset(), aLength);
     messageCopy->SetOffset(offset);
 
     messageCopy->SetSubType(GetSubType());

--- a/src/core/crypto/crypto_platform.cpp
+++ b/src/core/crypto/crypto_platform.cpp
@@ -294,7 +294,7 @@ OT_TOOL_WEAK otError otPlatCryptoHkdfExpand(otCryptoContext *aContext,
         hmac.Update(iter);
         hmac.Finish(hash);
 
-        copyLength = (aOutputKeyLength > sizeof(hash)) ? sizeof(hash) : aOutputKeyLength;
+        copyLength = Min(aOutputKeyLength, static_cast<uint16_t>(sizeof(hash)));
 
         memcpy(aOutputKey, hash.GetBytes(), copyLength);
         aOutputKey += copyLength;
@@ -733,7 +733,7 @@ OT_TOOL_WEAK void otPlatCryptoPbkdf2GenerateKey(const uint8_t *aPassword,
             }
         }
 
-        useLen = (keyLen < kBlockSize) ? keyLen : kBlockSize;
+        useLen = Min(keyLen, static_cast<uint16_t>(kBlockSize));
         memcpy(key, keyBlock, useLen);
         key += useLen;
         keyLen -= useLen;

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -136,8 +136,7 @@ Error Diags::ProcessEcho(uint8_t aArgsLength, char *aArgs[], char *aOutput, size
         uint32_t      number;
 
         SuccessOrExit(error = ParseLong(aArgs[1], value));
-        number = static_cast<uint32_t>(value);
-        number = (number < outputMaxLen) ? number : outputMaxLen;
+        number = Min(static_cast<uint32_t>(value), outputMaxLen);
 
         for (i = 0; i < number; i++)
         {

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -648,8 +648,7 @@ void MlrManager::UpdateReregistrationDelay(bool aRereg)
         {
             // Calculate renewing period according to Thread Spec. 5.24.2.3.2
             // The random time t SHOULD be chosen such that (0.5* MLR-Timeout) < t < (MLR-Timeout – 9 seconds).
-            effectiveMlrTimeout = config.mMlrTimeout > Mle::kMlrTimeoutMin ? config.mMlrTimeout
-                                                                           : static_cast<uint32_t>(Mle::kMlrTimeoutMin);
+            effectiveMlrTimeout = Max(config.mMlrTimeout, Mle::kMlrTimeoutMin);
             reregDelay = Random::NonCrypto::GetUint32InRange((effectiveMlrTimeout >> 1u) + 1, effectiveMlrTimeout - 9);
         }
 

--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -2588,7 +2588,7 @@ uint32_t RadioSpinel<InterfaceType, ProcessContextType>::Snprintf(char *aDest, u
     len = vsnprintf(aDest, static_cast<size_t>(aSize), aFormat, args);
     va_end(args);
 
-    return (len < 0) ? 0 : (static_cast<uint32_t>(len) > aSize - 1 ? aSize - 1 : static_cast<uint32_t>(len));
+    return (len < 0) ? 0 : Min(static_cast<uint32_t>(len), aSize - 1);
 }
 
 template <typename InterfaceType, typename ProcessContextType>


### PR DESCRIPTION
This PR uses `Min` and `Max` from num_utils to replace Ternary operators.