### PR TITLE
[test] allow TREL disabled by default

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_trel_connectivity.py
+++ b/tests/scripts/thread-cert/border_router/test_trel_connectivity.py
@@ -104,13 +104,13 @@ class TestTrelConnectivity(thread_cert.TestCase):
         br2 = self.nodes[BR2]
         router2 = self.nodes[ROUTER2]
 
-        if br1.get_trel_state() is None:
-            self.skipTest("TREL is not enabled")
+        if br1.is_trel_enabled() is None:
+            self.skipTest("TREL is not supported")
 
-        if br1.get_trel_state() == False:
+        if br1.is_trel_enabled() == False:
             br1.enable_trel()
 
-        if br2.get_trel_state() == False:
+        if br2.is_trel_enabled() == False:
             br2.enable_trel()
 
         br1.start()

--- a/tests/scripts/thread-cert/border_router/test_trel_connectivity.py
+++ b/tests/scripts/thread-cert/border_router/test_trel_connectivity.py
@@ -107,6 +107,12 @@ class TestTrelConnectivity(thread_cert.TestCase):
         if br1.get_trel_state() is None:
             self.skipTest("TREL is not enabled")
 
+        if br1.get_trel_state() == False:
+            br1.enable_trel()
+
+        if br2.get_trel_state() == False:
+            br2.enable_trel()
+
         br1.start()
         self.wait_node_state(br1, 'leader', 10)
 

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1355,7 +1355,7 @@ class NodeImpl:
         self.send_command(cmd)
         self._expect_done()
 
-    def get_trel_state(self) -> Union[None, bool]:
+    def is_trel_enabled(self) -> Union[None, bool]:
         states = [r'Disabled', r'Enabled']
         self.send_command('trel')
         try:

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1350,6 +1350,11 @@ class NodeImpl:
     # TREL utilities
     #
 
+    def enable_trel(self):
+        cmd = 'trel enable'
+        self.send_command(cmd)
+        self._expect_done()
+
     def get_trel_state(self) -> Union[None, bool]:
         states = [r'Disabled', r'Enabled']
         self.send_command('trel')


### PR DESCRIPTION
There is work planned in ot-br-posix to set trel to disabled at start if feature flags are used. 

This PR updates the test_trel_connectivity to set trel to enabled if it's disabled by default.