### PR TITLE
[trel] remove deprecated `otTrelEnable`/`otTrelDisable` APIs

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (287)
+#define OPENTHREAD_API_VERSION (288)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/trel.h
+++ b/include/openthread/trel.h
@@ -93,28 +93,12 @@ typedef uint16_t otTrelPeerIterator;
 void otTrelSetEnabled(otInstance *aInstance, bool aEnable);
 
 /**
- * This function enables TREL operation.
- *
- * This function initiates an ongoing DNS-SD browse on the service name "_trel._udp" within the local browsing domain
- * to discover other devices supporting TREL. Device also registers a new service to be advertised using DNS-SD,
- * with the service name is "_trel._udp" indicating its support for TREL. Device is then ready to receive TREL messages
- * from peers.
- *
- * @note By default the OpenThread stack enables the TREL operation on start.
+ * This function indicates whether the TREL operation is enabled.
  *
  * @param[in] aInstance   The OpenThread instance.
  *
- */
-void otTrelEnable(otInstance *aInstance);
-
-/**
- * This function is deprecated.
- *
- */
-void otTrelDisable(otInstance *aInstance);
-
-/**
- * This function is deprecated.
+ * @retval TRUE if the TREL operation is enabled.
+ * @retval FALSE if the TREL operation is disabled.
  *
  */
 bool otTrelIsEnabled(otInstance *aInstance);

--- a/src/core/api/trel_api.cpp
+++ b/src/core/api/trel_api.cpp
@@ -48,10 +48,6 @@ void otTrelSetEnabled(otInstance *aInstance, bool aEnable)
     AsCoreType(aInstance).Get<Trel::Interface>().SetEnabled(aEnable);
 }
 
-void otTrelEnable(otInstance *aInstance) { AsCoreType(aInstance).Get<Trel::Interface>().Enable(); }
-
-void otTrelDisable(otInstance *aInstance) { AsCoreType(aInstance).Get<Trel::Interface>().Disable(); }
-
 bool otTrelIsEnabled(otInstance *aInstance) { return AsCoreType(aInstance).Get<Trel::Interface>().IsEnabled(); }
 
 void otTrelInitPeerIterator(otInstance *aInstance, otTrelPeerIterator *aIterator)


### PR DESCRIPTION
Removed deprecated `otTrelEnable/otTrelDisable` apis

(In a previous PR the comment for `otTrelIsEnabled` was removed by accident, restored the comment.)