### PR TITLE
[commissioner] add joiner session timeout

### DIFF
--- a/src/core/config/commissioner.h
+++ b/src/core/config/commissioner.h
@@ -55,4 +55,15 @@
 #define OPENTHREAD_CONFIG_COMMISSIONER_MAX_JOINER_ENTRIES 2
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_COMMISSIONER_JOINER_SESSION_TIMEOUT
+ *
+ * The timeout for the Joiner's session, in seconds. After this timeout,
+ * the Commissioner tears down the session.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_COMMISSIONER_JOINER_SESSION_TIMEOUT
+#define OPENTHREAD_CONFIG_COMMISSIONER_JOINER_SESSION_TIMEOUT 30
+#endif
+
 #endif // CONFIG_COMMISSIONER_H_

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -499,6 +499,9 @@ private:
     static constexpr uint32_t kKeepAliveTimeout     = 50; // TIMEOUT_COMM_PET (seconds)
     static constexpr uint32_t kRemoveJoinerDelay    = 20; // Delay to remove successfully joined joiner
 
+    static constexpr uint32_t kJoinerSessionTimeoutMillis =
+        1000 * OPENTHREAD_CONFIG_COMMISSIONER_JOINER_SESSION_TIMEOUT; // Expiration time for active Joiner session
+
     enum ResignMode : uint8_t
     {
         kSendKeepAliveToResign,
@@ -580,6 +583,8 @@ private:
 
     void HandleRelayReceive(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
+    void HandleJoinerSessionTimer(void);
+
     void SendJoinFinalizeResponse(const Coap::Message &aRequest, StateTlv::State aState);
 
     static Error SendRelayTransmit(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
@@ -599,6 +604,7 @@ private:
 
     using JoinerExpirationTimer = TimerMilliIn<Commissioner, &Commissioner::HandleJoinerExpirationTimer>;
     using CommissionerTimer     = TimerMilliIn<Commissioner, &Commissioner::HandleTimer>;
+    using JoinerSessionTimer    = TimerMilliIn<Commissioner, &Commissioner::HandleJoinerSessionTimer>;
 
     Joiner mJoiners[OPENTHREAD_CONFIG_COMMISSIONER_MAX_JOINER_ENTRIES];
 
@@ -610,6 +616,7 @@ private:
     uint8_t                  mTransmitAttempts;
     JoinerExpirationTimer    mJoinerExpirationTimer;
     CommissionerTimer        mTimer;
+    JoinerSessionTimer       mJoinerSessionTimer;
 
     AnnounceBeginClient mAnnounceBegin;
     EnergyScanClient    mEnergyScan;


### PR DESCRIPTION
This PR adds a session timeout for the integrated Commissioner.

When the Joiner and Commissioner have a weak link, and the session doesn't time out after a communication failure, the Joiner may fail to join in subsequent attempts if the Commissioner is not stopped and restarted. With the proposed modification, the Commissioner times out the session after a configurable time, so the Joiner may be able to join in a future attempt.

Please see https://github.com/openthread/openthread/discussions/8763 for context.