### PR TITLE
[routing-manager] new APIs to get state and new CLI commands

### DIFF
--- a/include/openthread/border_routing.h
+++ b/include/openthread/border_routing.h
@@ -107,6 +107,18 @@ typedef struct otBorderRoutingPrefixTableEntry
 } otBorderRoutingPrefixTableEntry;
 
 /**
+ * This enumeration represents the state of Border Routing Manager.
+ *
+ */
+typedef enum
+{
+    OT_BORDER_ROUTING_STATE_UNINITIALIZED, ///< Routing Manager is uninitialized.
+    OT_BORDER_ROUTING_STATE_DISABLED,      ///< Routing Manager is initialized but disabled.
+    OT_BORDER_ROUTING_STATE_STOPPED,       ///< Routing Manager in initialized and enabled but currently stopped.
+    OT_BORDER_ROUTING_STATE_RUNNING,       ///< Routing Manager is initialized, enabled, and running.
+} otBorderRoutingState;
+
+/**
  * This method initializes the Border Routing Manager on given infrastructure interface.
  *
  * @note  This method MUST be called before any other otBorderRouting* APIs.
@@ -139,6 +151,16 @@ otError otBorderRoutingInit(otInstance *aInstance, uint32_t aInfraIfIndex, bool 
  *
  */
 otError otBorderRoutingSetEnabled(otInstance *aInstance, bool aEnabled);
+
+/**
+ * Gets the current state of Border Routing Manager.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ *
+ * @returns The current state of Border Routing Manager.
+ *
+ */
+otBorderRoutingState otBorderRoutingGetState(otInstance *aInstance);
 
 /**
  * This function gets the current preference used when advertising Route Info Options (RIO) in Router Advertisement
@@ -212,19 +234,33 @@ otError otBorderRoutingGetOmrPrefix(otInstance *aInstance, otIp6Prefix *aPrefix)
 otError otBorderRoutingGetFavoredOmrPrefix(otInstance *aInstance, otIp6Prefix *aPrefix, otRoutePreference *aPreference);
 
 /**
- * Gets the On-Link Prefix for the adjacent infrastructure link, for example `fd41:2650:a6f5:0::/64`.
+ * Gets the local On-Link Prefix for the adjacent infrastructure link.
  *
- * An On-Link Prefix is a 64-bit prefix that's advertised on the infrastructure link if there isn't already a usable
- * on-link prefix being advertised on the link.
+ * The local On-Link Prefix is a 64-bit prefix that's advertised on the infrastructure link if there isn't already a
+ * usable on-link prefix being advertised on the link.
  *
  * @param[in]   aInstance  A pointer to an OpenThread instance.
  * @param[out]  aPrefix    A pointer to where the prefix will be output to.
  *
  * @retval  OT_ERROR_INVALID_STATE  The Border Routing Manager is not initialized yet.
- * @retval  OT_ERROR_NONE           Successfully retrieved the on-link prefix.
+ * @retval  OT_ERROR_NONE           Successfully retrieved the local on-link prefix.
  *
  */
 otError otBorderRoutingGetOnLinkPrefix(otInstance *aInstance, otIp6Prefix *aPrefix);
+
+/**
+ * Gets the currently favored On-Link Prefix.
+ *
+ * The favored prefix is either a discovered on-link prefix on the infrastructure link or the local on-link prefix.
+ *
+ * @param[in]   aInstance  A pointer to an OpenThread instance.
+ * @param[out]  aPrefix    A pointer to where the prefix will be output to.
+ *
+ * @retval  OT_ERROR_INVALID_STATE  The Border Routing Manager is not initialized yet.
+ * @retval  OT_ERROR_NONE           Successfully retrieved the favored on-link prefix.
+ *
+ */
+otError otBorderRoutingGetFavoredOnLinkPrefix(otInstance *aInstance, otIp6Prefix *aPrefix);
 
 /**
  * Gets the local NAT64 Prefix of the Border Router.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (289)
+#define OPENTHREAD_API_VERSION (290)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/BUILD.gn
+++ b/src/cli/BUILD.gn
@@ -30,6 +30,8 @@ import("../../etc/gn/openthread.gni")
 openthread_cli_sources = [
   "cli.cpp",
   "cli.hpp",
+  "cli_br.cpp",
+  "cli_br.hpp",
   "cli_coap.cpp",
   "cli_coap.hpp",
   "cli_coap_secure.cpp",

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -33,6 +33,7 @@ set(COMMON_INCLUDES
 
 set(COMMON_SOURCES
     cli.cpp
+    cli_br.cpp
     cli_coap.cpp
     cli_coap_secure.cpp
     cli_commissioner.cpp

--- a/src/cli/Makefile.am
+++ b/src/cli/Makefile.am
@@ -153,6 +153,7 @@ libopenthread_cli_radio_a_CPPFLAGS =  \
 
 SOURCES_COMMON =                      \
     cli.cpp                           \
+    cli_br.cpp                        \
     cli_coap.cpp                      \
     cli_coap_secure.cpp               \
     cli_commissioner.cpp              \
@@ -182,6 +183,7 @@ libopenthread_cli_radio_a_SOURCES =   \
 
 noinst_HEADERS                      = \
     cli.hpp                           \
+    cli_br.hpp                        \
     cli_coap.hpp                      \
     cli_coap_secure.hpp               \
     cli_commissioner.hpp              \

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -23,7 +23,7 @@ Done
 
 - [ba](#ba)
 - [bbr](#bbr)
-- [br](#br)
+- [br](README_BR.md)
 - [bufferinfo](#bufferinfo)
 - [ccathreshold](#ccathreshold)
 - [channel](#channel)
@@ -350,71 +350,6 @@ Print border agent state.
 ```bash
 > ba state
 Started
-Done
-```
-
-### br
-
-Enbale/disable the Border Routing functionality.
-
-```bash
-> br enable
-Done
-```
-
-```bash
-> br disable
-Done
-```
-
-### br omrprefix
-
-Get the randomly generated off-mesh-routable prefix of the Border Router.
-
-```bash
-> br omrprefix
-fdfc:1ff5:1512:5622::/64
-Done
-```
-
-### br onlinkprefix
-
-Get the randomly generated on-link prefix of the Border Router.
-
-```bash
-> br onlinkprefix
-fd41:2650:a6f5:0::/64
-Done
-```
-
-### br nat64prefix
-
-Get the local NAT64 prefix of the Border Router.
-
-`OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE` is required.
-
-```bash
-> br nat64prefix
-fd14:1078:b3d5:b0b0:0:0::/96
-Done
-```
-
-### br rioprf
-
-Get the preference used when advertising Route Info Options (e.g., for discovered OMR prefixes) in emitted Router Advertisement message.
-
-```bash
-> br rioprf
-med
-Done
-```
-
-### br rioprf \<prf\>
-
-Set the preference (which may be 'high', 'med', or 'low') to use when advertising Route Info Options (e.g., for discovered OMR prefixes) in emitted Router Advertisement message.
-
-```bash
-> br rioprf low
 Done
 ```
 

--- a/src/cli/README_BR.md
+++ b/src/cli/README_BR.md
@@ -1,0 +1,208 @@
+# OpenThread CLI - Border Router (BR)
+
+## Command List
+
+Usage : `br [command] ...`
+
+- [counters](#counters)
+- [disable](#disable)
+- [enable](#enable)
+- [help](#help)
+- [nat64prefix](#nat64prefix)
+- [omrprefix](#omrprefix)
+- [onlinkprefix](#onlinkprefix)
+- [prefixtable](#prefixtable)
+- [rioprf](#rioprf)
+- [state](#state)
+
+## Command Details
+
+### help
+
+Usage: `br help`
+
+Print BR command help menu.
+
+```bash
+> br help
+counters
+disable
+enable
+omrprefix
+onlinkprefix
+prefixtable
+rioprf
+state
+Done
+```
+
+### enable
+
+Usage: `br enable`
+
+Enable the Border Routing functionality.
+
+```bash
+> br enable
+Done
+```
+
+### disable
+
+Usage: `br disable`
+
+Disable the Border Routing functionality.
+
+```bash
+> br disable
+Done
+```
+
+### state
+
+Usage: `br state`
+
+Get the Border Routing state:
+
+- `uninitialized`: Routing Manager is uninitialized.
+- `disabled`: Routing Manager is initialized but disabled.
+- `stopped`: Routing Manager in initialized and enabled but currently stopped.
+- `running`: Routing Manager is initialized, enabled, and running.
+
+```bash
+> br state
+running
+```
+
+### counters
+
+Usage : `br counters`
+
+Get the Border Router counter.
+
+```bash
+> br counters
+Inbound Unicast: Packets 4 Bytes 320
+Inbound Multicast: Packets 0 Bytes 0
+Outbound Unicast: Packets 2 Bytes 160
+Outbound Multicast: Packets 0 Bytes 0
+RA Rx: 4
+RA TxSuccess: 2
+RA TxFailed: 0
+RS Rx: 0
+RS TxSuccess: 2
+RS TxFailed: 0
+Done
+```
+
+### omrprefix
+
+Usage: `br omrprefix [local|favored]`
+
+Get local or favored or both off-mesh-routable prefixes of the Border Router.
+
+```bash
+> br omrprefix
+Local: fdfc:1ff5:1512:5622::/64
+Favored: fdfc:1ff5:1512:5622::/64 prf:low
+Done
+
+> br omrprefix favored
+fdfc:1ff5:1512:5622::/64 prf:low
+Done
+
+> br omrprefix local
+fdfc:1ff5:1512:5622::/64
+Done
+```
+
+### onlinkprefix
+
+Usage: `br onlinkprefix [local|favored]`
+
+Get local or favored or both on-link prefixes of the Border Router.
+
+```bash
+> br onlinkprefix
+Local: fd41:2650:a6f5:0::/64
+Favored: 2600::0:1234:da12::/64
+Done
+
+> br onlinkprefix favored
+2600::0:1234:da12::/64
+Done
+
+> br onlinkprefix local
+fd41:2650:a6f5:0::/64
+Done
+```
+
+### nat64prefix
+
+Usage: `br nat64prefix [local|favored]`
+
+Get local or favored or both NAT64 prefixes of the Border Router.
+
+`OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE` is required.
+
+```bash
+> br nat64prefix
+Local: fd14:1078:b3d5:b0b0:0:0::/96
+Favored: fd14:1078:b3d5:b0b0:0:0::/96 prf:low
+Done
+
+> br nat64prefix favored
+fd14:1078:b3d5:b0b0:0:0::/96 prf:low
+Done
+
+> br nat64prefix
+fd14:1078:b3d5:b0b0:0:0::/96
+Done
+```
+
+### prefixtable
+
+Usage: `br prefixtable`
+
+Get the discovered prefixes by Border Routing Manager on the infrastructure link.
+
+```bash
+> br prefixtable
+prefix:fd00:1234:5678:0::/64, on-link:no, ms-since-rx:29526, lifetime:1800, route-prf:med, router:ff02:0:0:0:0:0:0:1
+prefix:1200:abba:baba:0::/64, on-link:yes, ms-since-rx:29527, lifetime:1800, preferred:1800, router:ff02:0:0:0:0:0:0:1
+Done
+```
+
+### rioprf
+
+Usage: `br rioprf`
+
+Get the preference used when advertising Route Info Options (e.g., for discovered OMR prefixes) in emitted Router Advertisement message.
+
+```bash
+> br rioprf
+med
+Done
+```
+
+### rioprf \<prf\>
+
+Usage: `br rioprf high|med|low`
+
+Set the preference (which may be 'high', 'med', or 'low') to use when advertising Route Info Options (e.g., for discovered OMR prefixes) in emitted Router Advertisement message.
+
+```bash
+> br rioprf low
+Done
+```
+
+### rioprf clear
+
+Usage: `br rioprf clear`
+
+Clear a previously set preference value for advertising Route Info Options (e.g., for discovered OMR prefixes) in emitted Router Advertisement message. When cleared BR will use device's role to determine the RIO preference: Medium preference when in router/leader role and low preference when in child role.
+
+```bash
+> br rioprf clear
+Done
+```

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -57,6 +57,7 @@
 #include <openthread/thread_ftd.h>
 #include <openthread/udp.h>
 
+#include "cli/cli_br.hpp"
 #include "cli/cli_commissioner.hpp"
 #include "cli/cli_dataset.hpp"
 #include "cli/cli_history.hpp"
@@ -102,6 +103,7 @@ extern "C" void otCliOutputFormat(const char *aFmt, ...);
 class Interpreter : public OutputImplementer, public Output
 {
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
+    friend class Br;
     friend class Commissioner;
     friend class Joiner;
     friend class NetworkData;
@@ -363,6 +365,9 @@ private:
     static otError ParsePrefix(Arg aArgs[], otBorderRouterConfig &aConfig);
     static otError ParseRoute(Arg aArgs[], otExternalRouteConfig &aConfig);
 #endif
+#if OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
+    void OutputBorderRouterCounters(void);
+#endif
 
     otError ProcessCommand(Arg aArgs[]);
 
@@ -534,6 +539,10 @@ private:
     Dataset     mDataset;
     NetworkData mNetworkData;
     UdpExample  mUdp;
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    Br mBr;
+#endif
 
 #if OPENTHREAD_CONFIG_TCP_ENABLE && OPENTHREAD_CONFIG_CLI_TCP_ENABLE
     TcpExample mTcp;

--- a/src/cli/cli_br.cpp
+++ b/src/cli/cli_br.cpp
@@ -1,0 +1,542 @@
+/*
+ *  Copyright (c) 2023, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements CLI for Border Router.
+ */
+
+#include "cli_br.hpp"
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+
+#include <string.h>
+
+#include <openthread/border_routing.h>
+
+#include "cli/cli.hpp"
+
+namespace ot {
+namespace Cli {
+
+/**
+ * @cli br enable
+ * @code
+ * br enable
+ * Done
+ * @endcode
+ * @par
+ * Enables the Border Routing Manager.
+ * @sa otBorderRoutingSetEnabled
+ */
+template <> otError Br::Process<Cmd("enable")>(Arg aArgs[])
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+    error = otBorderRoutingSetEnabled(GetInstancePtr(), true);
+
+exit:
+    return error;
+}
+
+/**
+ * @cli br disable
+ * @code
+ * br disable
+ * Done
+ * @endcode
+ * @par
+ * Disables the Border Routing Manager.
+ * @sa otBorderRoutingSetEnabled
+ */
+template <> otError Br::Process<Cmd("disable")>(Arg aArgs[])
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+    error = otBorderRoutingSetEnabled(GetInstancePtr(), false);
+
+exit:
+    return error;
+}
+
+/**
+ * @cli br state
+ * @code
+ * br state
+ * running
+ * @endcode
+ * @par api_copy
+ * #otBorderRoutingGetState
+ */
+template <> otError Br::Process<Cmd("state")>(Arg aArgs[])
+{
+    static const char *const kStateStrings[] = {
+
+        "uninitialized", // (0) OT_BORDER_ROUTING_STATE_UNINITIALIZED
+        "disabled",      // (1) OT_BORDER_ROUTING_STATE_DISABLED
+        "stopped",       // (2) OT_BORDER_ROUTING_STATE_STOPPED
+        "running",       // (3) OT_BORDER_ROUTING_STATE_RUNNING
+    };
+
+    otError error = OT_ERROR_NONE;
+
+    static_assert(0 == OT_BORDER_ROUTING_STATE_UNINITIALIZED, "STATE_UNINITIALIZED value is incorrect");
+    static_assert(1 == OT_BORDER_ROUTING_STATE_DISABLED, "STATE_DISABLED value is incorrect");
+    static_assert(2 == OT_BORDER_ROUTING_STATE_STOPPED, "STATE_STOPPED value is incorrect");
+    static_assert(3 == OT_BORDER_ROUTING_STATE_RUNNING, "STATE_RUNNING value is incorrect");
+
+    VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+    OutputLine("%s", Stringify(otBorderRoutingGetState(GetInstancePtr()), kStateStrings));
+
+exit:
+    return error;
+}
+
+otError Br::ParsePrefixTypeArgs(Arg aArgs[], bool &aOutputLocal, bool &aOutputFavored)
+{
+    otError error = OT_ERROR_NONE;
+
+    aOutputLocal   = false;
+    aOutputFavored = false;
+
+    if (aArgs[0].IsEmpty())
+    {
+        aOutputLocal   = true;
+        aOutputFavored = true;
+        ExitNow();
+    }
+
+    if (aArgs[0] == "local")
+    {
+        aOutputLocal = true;
+    }
+    else if (aArgs[0] == "favored")
+    {
+        aOutputFavored = true;
+    }
+    else
+    {
+        ExitNow(error = OT_ERROR_INVALID_ARGS);
+    }
+
+    VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+
+exit:
+    return error;
+}
+
+/**
+ * @cli br omrprefix
+ * @code
+ * br omrprefix
+ * Local: fdfc:1ff5:1512:5622::/64
+ * Favored: fdfc:1ff5:1512:5622::/64 prf:low
+ * Done
+ * @endcode
+ * @par
+ * Outputs both local and favored OMR prefix.
+ * @sa otBorderRoutingGetOmrPrefix
+ * @sa otBorderRoutingGetFavoredOmrPrefix
+ */
+template <> otError Br::Process<Cmd("omrprefix")>(Arg aArgs[])
+{
+    otError error = OT_ERROR_NONE;
+    bool    outputLocal;
+    bool    outputFavored;
+
+    SuccessOrExit(error = ParsePrefixTypeArgs(aArgs, outputLocal, outputFavored));
+
+    /**
+     * @cli br omrprefix local
+     * @code
+     * br omrprefix local
+     * fdfc:1ff5:1512:5622::/64
+     * Done
+     * @endcode
+     * @par api_copy
+     * #otBorderRoutingGetOmrPrefix
+     */
+    if (outputLocal)
+    {
+        otIp6Prefix local;
+
+        SuccessOrExit(error = otBorderRoutingGetOmrPrefix(GetInstancePtr(), &local));
+
+        OutputFormat("%s", outputFavored ? "Local: " : "");
+        OutputIp6PrefixLine(local);
+    }
+
+    /**
+     * @cli br omrprefix favored
+     * @code
+     * br omrprefix favored
+     * fdfc:1ff5:1512:5622::/64 prf:low
+     * Done
+     * @endcode
+     * @par api_copy
+     * #otBorderRoutingGetFavoredOmrPrefix
+     */
+    if (outputFavored)
+    {
+        otIp6Prefix       favored;
+        otRoutePreference preference;
+
+        SuccessOrExit(error = otBorderRoutingGetFavoredOmrPrefix(GetInstancePtr(), &favored, &preference));
+
+        OutputFormat("%s", outputLocal ? "Favored: " : "");
+        OutputIp6Prefix(favored);
+        OutputLine(" prf:%s", Interpreter::PreferenceToString(preference));
+    }
+
+exit:
+    return error;
+}
+
+/**
+ * @cli br onlinkprefix
+ * @code
+ * br onlinkprefix
+ * Local: fd41:2650:a6f5:0::/64
+ * Favored: 2600::0:1234:da12::/64
+ * Done
+ * @endcode
+ * @par
+ * Outputs both local and favored on-link prefixes.
+ * @sa otBorderRoutingGetOnLinkPrefix
+ * @sa otBorderRoutingGetFavoredOnLinkPrefix
+ */
+template <> otError Br::Process<Cmd("onlinkprefix")>(Arg aArgs[])
+{
+    otError error = OT_ERROR_NONE;
+    bool    outputLocal;
+    bool    outputFavored;
+
+    SuccessOrExit(error = ParsePrefixTypeArgs(aArgs, outputLocal, outputFavored));
+
+    /**
+     * @cli br onlinkprefix local
+     * @code
+     * br onlinkprefix local
+     * fd41:2650:a6f5:0::/64
+     * Done
+     * @endcode
+     * @par api_copy
+     * #otBorderRoutingGetOnLinkPrefix
+     */
+    if (outputLocal)
+    {
+        otIp6Prefix local;
+
+        SuccessOrExit(error = otBorderRoutingGetOnLinkPrefix(GetInstancePtr(), &local));
+
+        OutputFormat("%s", outputFavored ? "Local: " : "");
+        OutputIp6PrefixLine(local);
+    }
+
+    /**
+     * @cli br onlinkprefix favored
+     * @code
+     * br onlinkprefix favored
+     * 2600::0:1234:da12::/64
+     * Done
+     * @endcode
+     * @par api_copy
+     * #otBorderRoutingGetFavoredOnLinkPrefix
+     */
+    if (outputFavored)
+    {
+        otIp6Prefix favored;
+
+        SuccessOrExit(error = otBorderRoutingGetFavoredOnLinkPrefix(GetInstancePtr(), &favored));
+
+        OutputFormat("%s", outputLocal ? "Favored: " : "");
+        OutputIp6PrefixLine(favored);
+    }
+
+exit:
+    return error;
+}
+
+#if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
+
+/**
+ * @cli br nat64prefix
+ * @code
+ * br nat64prefix
+ * Local: fd14:1078:b3d5:b0b0:0:0::/96
+ * Favored: fd14:1078:b3d5:b0b0:0:0::/96 prf:low
+ * Done
+ * @endcode
+ * @par
+ * Outputs both local and favored NAT64 prefixes.
+ * @sa otBorderRoutingGetNat64Prefix
+ * @sa otBorderRoutingGetFavoredNat64Prefix
+ */
+template <> otError Br::Process<Cmd("nat64prefix")>(Arg aArgs[])
+{
+    otError error = OT_ERROR_NONE;
+    bool    outputLocal;
+    bool    outputFavored;
+
+    SuccessOrExit(error = ParsePrefixTypeArgs(aArgs, outputLocal, outputFavored));
+
+    /**
+     * @cli br nat64prefix local
+     * @code
+     * br nat64prefix local
+     * fd14:1078:b3d5:b0b0:0:0::/96
+     * Done
+     * @endcode
+     * @par api_copy
+     * #otBorderRoutingGetNat64Prefix
+     */
+    if (outputLocal)
+    {
+        otIp6Prefix local;
+
+        SuccessOrExit(error = otBorderRoutingGetNat64Prefix(GetInstancePtr(), &local));
+
+        OutputFormat("%s", outputFavored ? "Local: " : "");
+        OutputIp6PrefixLine(local);
+    }
+
+    /**
+     * @cli br nat64prefix favored
+     * @code
+     * br nat64prefix favored
+     * fd14:1078:b3d5:b0b0:0:0::/96 prf:low
+     * Done
+     * @endcode
+     * @par api_copy
+     * #otBorderRoutingGetFavoredNat64Prefix
+     */
+    if (outputFavored)
+    {
+        otIp6Prefix       favored;
+        otRoutePreference preference;
+
+        SuccessOrExit(error = otBorderRoutingGetFavoredNat64Prefix(GetInstancePtr(), &favored, &preference));
+
+        OutputFormat("%s", outputLocal ? "Favored: " : "");
+        OutputIp6Prefix(favored);
+        OutputLine(" prf:%s", Interpreter::PreferenceToString(preference));
+    }
+
+exit:
+    return error;
+}
+
+#endif // OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
+
+/**
+ * @cli br prefixtable
+ * @code
+ * br prefixtable
+ * prefix:fd00:1234:5678:0::/64, on-link:no, ms-since-rx:29526, lifetime:1800, route-prf:med,
+ * router:ff02:0:0:0:0:0:0:1
+ * prefix:1200:abba:baba:0::/64, on-link:yes, ms-since-rx:29527, lifetime:1800, preferred:1800,
+ * router:ff02:0:0:0:0:0:0:1
+ * Done
+ * @endcode
+ * @par api_copy
+ * #otBorderRoutingGetNextPrefixTableEntry
+ */
+template <> otError Br::Process<Cmd("prefixtable")>(Arg aArgs[])
+{
+    otError                            error = OT_ERROR_NONE;
+    otBorderRoutingPrefixTableIterator iterator;
+    otBorderRoutingPrefixTableEntry    entry;
+
+    VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+
+    otBorderRoutingPrefixTableInitIterator(GetInstancePtr(), &iterator);
+
+    while (otBorderRoutingGetNextPrefixTableEntry(GetInstancePtr(), &iterator, &entry) == OT_ERROR_NONE)
+    {
+        char string[OT_IP6_PREFIX_STRING_SIZE];
+
+        otIp6PrefixToString(&entry.mPrefix, string, sizeof(string));
+        OutputFormat("prefix:%s, on-link:%s, ms-since-rx:%lu, lifetime:%lu, ", string, entry.mIsOnLink ? "yes" : "no",
+                     ToUlong(entry.mMsecSinceLastUpdate), ToUlong(entry.mValidLifetime));
+
+        if (entry.mIsOnLink)
+        {
+            OutputFormat("preferred:%lu, ", ToUlong(entry.mPreferredLifetime));
+        }
+        else
+        {
+            OutputFormat("route-prf:%s, ", Interpreter::PreferenceToString(entry.mRoutePreference));
+        }
+
+        otIp6AddressToString(&entry.mRouterAddress, string, sizeof(string));
+        OutputLine("router:%s", string);
+    }
+
+exit:
+    return error;
+}
+
+template <> otError Br::Process<Cmd("rioprf")>(Arg aArgs[])
+{
+    otError error = OT_ERROR_NONE;
+
+    /**
+     * @cli br rioprf
+     * @code
+     * br rioprf
+     * med
+     * Done
+     * @endcode
+     * @par api_copy
+     * #otBorderRoutingGetRouteInfoOptionPreference
+     */
+    if (aArgs[0].IsEmpty())
+    {
+        OutputLine("%s",
+                   Interpreter::PreferenceToString(otBorderRoutingGetRouteInfoOptionPreference(GetInstancePtr())));
+    }
+    /**
+     * @cli br rioprf clear
+     * @code
+     * br rioprf clear
+     * Done
+     * @endcode
+     * @par api_copy
+     * #otBorderRoutingClearRouteInfoOptionPreference
+     */
+    else if (aArgs[0] == "clear")
+    {
+        otBorderRoutingClearRouteInfoOptionPreference(GetInstancePtr());
+    }
+    /**
+     * @cli br rioprf (high,med,low)
+     * @code
+     * br rioprf low
+     * Done
+     * @endcode
+     * @cparam br rioprf [@ca{high}|@ca{med}|@ca{low}]
+     * @par api_copy
+     * #otBorderRoutingSetRouteInfoOptionPreference
+     */
+    else
+    {
+        otRoutePreference preference;
+
+        SuccessOrExit(error = Interpreter::ParsePreference(aArgs[0], preference));
+        otBorderRoutingSetRouteInfoOptionPreference(GetInstancePtr(), preference);
+    }
+
+exit:
+    return error;
+}
+
+#if OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
+
+/**
+ * @cli br counters
+ * @code
+ * br counters
+ * Inbound Unicast: Packets 4 Bytes 320
+ * Inbound Multicast: Packets 0 Bytes 0
+ * Outbound Unicast: Packets 2 Bytes 160
+ * Outbound Multicast: Packets 0 Bytes 0
+ * RA Rx: 4
+ * RA TxSuccess: 2
+ * RA TxFailed: 0
+ * RS Rx: 0
+ * RS TxSuccess: 2
+ * RS TxFailed: 0
+ * Done
+ * @endcode
+ * @par api_copy
+ * #otIp6GetBorderRoutingCounters
+ */
+template <> otError Br::Process<Cmd("counters")>(Arg aArgs[])
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+    Interpreter::GetInterpreter().OutputBorderRouterCounters();
+
+exit:
+    return error;
+}
+
+#endif // OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
+
+otError Br::Process(Arg aArgs[])
+{
+#define CmdEntry(aCommandString)                          \
+    {                                                     \
+        aCommandString, &Br::Process<Cmd(aCommandString)> \
+    }
+
+    static constexpr Command kCommands[] = {
+#if OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
+        CmdEntry("counters"),
+#endif
+        CmdEntry("disable"),
+        CmdEntry("enable"),
+#if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
+        CmdEntry("nat64prefix"),
+#endif
+        CmdEntry("omrprefix"),
+        CmdEntry("onlinkprefix"),
+        CmdEntry("prefixtable"),
+        CmdEntry("rioprf"),
+        CmdEntry("state"),
+    };
+
+#undef CmdEntry
+
+    static_assert(BinarySearch::IsSorted(kCommands), "kCommands is not sorted");
+
+    otError        error = OT_ERROR_INVALID_COMMAND;
+    const Command *command;
+
+    if (aArgs[0].IsEmpty() || (aArgs[0] == "help"))
+    {
+        OutputCommandTable(kCommands);
+        ExitNow(error = aArgs[0].IsEmpty() ? error : OT_ERROR_NONE);
+    }
+
+    command = BinarySearch::Find(aArgs[0].GetCString(), kCommands);
+    VerifyOrExit(command != nullptr);
+
+    error = (this->*command->mHandler)(aArgs + 1);
+
+exit:
+    return error;
+}
+
+} // namespace Cli
+} // namespace ot
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE

--- a/src/cli/cli_br.hpp
+++ b/src/cli/cli_br.hpp
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2023, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file contains definitions for CLI to Border Router.
+ */
+
+#ifndef CLI_BR_HPP_
+#define CLI_BR_HPP_
+
+#include "openthread-core-config.h"
+
+#include "cli/cli_config.h"
+#include "cli/cli_output.hpp"
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+
+namespace ot {
+namespace Cli {
+
+/**
+ * This class implements the Border Router CLI interpreter.
+ *
+ */
+class Br : private Output
+{
+public:
+    typedef Utils::CmdLineParser::Arg Arg;
+
+    /**
+     * Constructor
+     *
+     * @param[in]  aInstance            The OpenThread Instance.
+     * @param[in]  aOutputImplementer   An `OutputImplementer`.
+     *
+     */
+    Br(otInstance *aInstance, OutputImplementer &aOutputImplementer)
+        : Output(aInstance, aOutputImplementer)
+    {
+    }
+
+    /**
+     * This method interprets a list of CLI arguments.
+     *
+     * @param[in]  aArgs        A pointer an array of command line arguments.
+     *
+     */
+    otError Process(Arg aArgs[]);
+
+private:
+    using Command = CommandEntry<Br>;
+
+    template <CommandId kCommandId> otError Process(Arg aArgs[]);
+
+    otError ParsePrefixTypeArgs(Arg aArgs[], bool &aOutputLocal, bool &aOutputFavored);
+};
+
+} // namespace Cli
+} // namespace ot
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+
+#endif // CLI_BR_HPP_

--- a/src/core/api/border_routing_api.cpp
+++ b/src/core/api/border_routing_api.cpp
@@ -52,6 +52,11 @@ otError otBorderRoutingSetEnabled(otInstance *aInstance, bool aEnabled)
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().SetEnabled(aEnabled);
 }
 
+otBorderRoutingState otBorderRoutingGetState(otInstance *aInstance)
+{
+    return MapEnum(AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetState());
+}
+
 otRoutePreference otBorderRoutingGetRouteInfoOptionPreference(otInstance *aInstance)
 {
     return static_cast<otRoutePreference>(
@@ -92,6 +97,11 @@ exit:
 otError otBorderRoutingGetOnLinkPrefix(otInstance *aInstance, otIp6Prefix *aPrefix)
 {
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetOnLinkPrefix(AsCoreType(aPrefix));
+}
+
+otError otBorderRoutingGetFavoredOnLinkPrefix(otInstance *aInstance, otIp6Prefix *aPrefix)
+{
+    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetFavoredOnLinkPrefix(AsCoreType(aPrefix));
 }
 
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -121,6 +121,19 @@ exit:
     return error;
 }
 
+RoutingManager::State RoutingManager::GetState(void) const
+{
+    State state = kStateUninitialized;
+
+    VerifyOrExit(IsInitialized());
+    VerifyOrExit(IsEnabled(), state = kStateDisabled);
+
+    state = IsRunning() ? kStateRunning : kStateStopped;
+
+exit:
+    return state;
+}
+
 void RoutingManager::SetRouteInfoOptionPreference(RoutePreference aPreference)
 {
     LogInfo("User explicitly set RIO Preference to %s", RoutePreferenceToString(aPreference));
@@ -161,7 +174,7 @@ exit:
     return;
 }
 
-Error RoutingManager::GetOmrPrefix(Ip6::Prefix &aPrefix)
+Error RoutingManager::GetOmrPrefix(Ip6::Prefix &aPrefix) const
 {
     Error error = kErrorNone;
 
@@ -172,7 +185,7 @@ exit:
     return error;
 }
 
-Error RoutingManager::GetFavoredOmrPrefix(Ip6::Prefix &aPrefix, RoutePreference &aPreference)
+Error RoutingManager::GetFavoredOmrPrefix(Ip6::Prefix &aPrefix, RoutePreference &aPreference) const
 {
     Error error = kErrorNone;
 
@@ -184,12 +197,28 @@ exit:
     return error;
 }
 
-Error RoutingManager::GetOnLinkPrefix(Ip6::Prefix &aPrefix)
+Error RoutingManager::GetOnLinkPrefix(Ip6::Prefix &aPrefix) const
 {
     Error error = kErrorNone;
 
     VerifyOrExit(IsInitialized(), error = kErrorInvalidState);
     aPrefix = mOnLinkPrefixManager.GetLocalPrefix();
+
+exit:
+    return error;
+}
+
+Error RoutingManager::GetFavoredOnLinkPrefix(Ip6::Prefix &aPrefix) const
+{
+    Error error = kErrorNone;
+
+    VerifyOrExit(IsInitialized(), error = kErrorInvalidState);
+    aPrefix = mOnLinkPrefixManager.GetFavoredDiscoveredPrefix();
+
+    if (aPrefix.GetLength() == 0)
+    {
+        aPrefix = mOnLinkPrefixManager.GetLocalPrefix();
+    }
 
 exit:
     return error;

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -2110,7 +2110,7 @@ class NodeImpl:
         self._expect_done()
 
     def get_br_omr_prefix(self):
-        cmd = 'br omrprefix'
+        cmd = 'br omrprefix local'
         self.send_command(cmd)
         return self._expect_command_output()[0]
 
@@ -2124,7 +2124,7 @@ class NodeImpl:
         return omr_prefixes
 
     def get_br_on_link_prefix(self):
-        cmd = 'br onlinkprefix'
+        cmd = 'br onlinkprefix local'
         self.send_command(cmd)
         return self._expect_command_output()[0]
 
@@ -2137,12 +2137,12 @@ class NodeImpl:
         return prefixes
 
     def get_br_nat64_prefix(self):
-        cmd = 'br nat64prefix'
+        cmd = 'br nat64prefix local'
         self.send_command(cmd)
         return self._expect_command_output()[0]
 
     def get_br_favored_nat64_prefix(self):
-        cmd = 'br favorednat64prefix'
+        cmd = 'br nat64prefix favored'
         self.send_command(cmd)
         return self._expect_command_output()[0].split(' ')[0]
 

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -3214,7 +3214,7 @@ class OpenThreadTHCI(object):
     @watched
     def isBorderRoutingEnabled(self):
         try:
-            self.__executeCommand('br omrprefix')
+            self.__executeCommand('br omrprefix local')
             return True
         except CommandError:
             return False


### PR DESCRIPTION
This commit adds new public OT APIs in `border_routing.h` to get the
current state of `RoutingManager` and to get the current favored
on-link prefix.

This commit also updates CLI `br` commands:
- It moves the CLI `br` implementation into own `cli_br` module.
- It adds `br state` to get the current state
- It changes `br omrprefix`, `br onlinkprefix`, and `br nat64prefix`
  to output both local and favored prefixes when no additional arg
  is provided and allow the use of `local` or `favored` extra arg to
  specify the type.
- It updates the documentation of `br` related commands in the source
  code and in `cli/README_BR.md`.
