### PR TITLE
[cli] update dataset readme with the latest output

### DIFF
--- a/src/cli/README_DATASET.md
+++ b/src/cli/README_DATASET.md
@@ -36,15 +36,15 @@ The Pending Operational Dataset is used to communicate changes to the Active Ope
    Done
    > dataset
    Active Timestamp: 1
-   Channel: 13
+   Channel: 15
    Channel Mask: 0x07fff800
-   Ext PAN ID: d63e8e3e495ebbc3
-   Mesh Local Prefix: fd3d:b50b:f96d:722d::/64
-   Network Key: dfd34f0f05cad978ec4e32b0413038ff
-   Network Name: OpenThread-8f28
-   PAN ID: 0x8f28
-   PSKc: c23a76e98f1a6483639b1ac1271e2e27
-   Security Policy: 0, onrc
+   Ext PAN ID: 39758ec8144b07fb
+   Mesh Local Prefix: fdf1:f1ad:d079:7dc0::/64
+   Network Key: f366cec7a446bab978d90d27abe38f23
+   Network Name: OpenThread-5938
+   PAN ID: 0x5938
+   PSKc: 3ca67c969efb0d0c74a4d8ee923b576c
+   Security Policy: 672 onrc
    Done
    ```
 
@@ -95,15 +95,15 @@ After the device successfully attaches to a Thread network, the device will retr
    ```bash
    > dataset active
    Active Timestamp: 1
-   Channel: 13
+   Channel: 15
    Channel Mask: 0x07fff800
-   Ext PAN ID: d63e8e3e495ebbc3
-   Mesh Local Prefix: fd3d:b50b:f96d:722d::/64
-   Network Key: dfd34f0f05cad978ec4e32b0413038ff
-   Network Name: OpenThread-8f28
-   PAN ID: 0x8f28
-   PSKc: c23a76e98f1a6483639b1ac1271e2e27
-   Security Policy: 0, onrc
+   Ext PAN ID: 39758ec8144b07fb
+   Mesh Local Prefix: fdf1:f1ad:d079:7dc0::/64
+   Network Key: f366cec7a446bab978d90d27abe38f23
+   Network Name: OpenThread-5938
+   PAN ID: 0x5938
+   PSKc: 3ca67c969efb0d0c74a4d8ee923b576c
+   Security Policy: 672 onrc
    Done
    ```
 
@@ -172,15 +172,15 @@ Print Active Operational Dataset in human-readable form.
 ```bash
 > dataset active
 Active Timestamp: 1
-Channel: 13
+Channel: 15
 Channel Mask: 0x07fff800
-Ext PAN ID: d63e8e3e495ebbc3
-Mesh Local Prefix: fd3d:b50b:f96d:722d::/64
-Network Key: dfd34f0f05cad978ec4e32b0413038ff
-Network Name: OpenThread-8f28
-PAN ID: 0x8f28
-PSKc: c23a76e98f1a6483639b1ac1271e2e27
-Security Policy: 0, onrc
+Ext PAN ID: 39758ec8144b07fb
+Mesh Local Prefix: fdf1:f1ad:d079:7dc0::/64
+Network Key: f366cec7a446bab978d90d27abe38f23
+Network Name: OpenThread-5938
+PAN ID: 0x5938
+PSKc: 3ca67c969efb0d0c74a4d8ee923b576c
+Security Policy: 672 onrc
 Done
 ```
 
@@ -188,7 +188,7 @@ Print Active Operational Dataset as hex-encoded TLVs.
 
 ```bash
 > dataset active -x
-0e080000000000010000000300001035060004001fffe002084eb74ab03c56e6d00708fdc7fe165c83a67805108e2104f183e698da87e96efc1e45aa51030f4f70656e5468726561642d383631310102861104108d6273023d82c841eff0e68db86f35740c030000ff
+0e080000000000010000000300000f35060004001fffe0020839758ec8144b07fb0708fdf1f1add0797dc00510f366cec7a446bab978d90d27abe38f23030f4f70656e5468726561642d353933380102593804103ca67c969efb0d0c74a4d8ee923b576c0c0402a0f7f8
 Done
 ```
 
@@ -431,17 +431,17 @@ Print Pending Operational Dataset in human-readable form.
 ```bash
 > dataset pending
 Pending Timestamp: 2
-Active Timestamp: 15
-Channel: 16
+Active Timestamp: 1
+Channel: 26
 Channel Mask: 0x07fff800
 Delay: 58706
-Ext PAN ID: d63e8e3e495ebbc3
-Mesh Local Prefix: fd3d:b50b:f96d:722d::/64
-Network Key: dfd34f0f05cad978ec4e32b0413038ff
-Network Name: OpenThread-8f28
-PAN ID: 0x8f28
-PSKc: c23a76e98f1a6483639b1ac1271e2e27
-Security Policy: 0, onrc
+Ext PAN ID: a74182f4d3f4de41
+Mesh Local Prefix: fd46:c1b9:e159:5574::/64
+Network Key: ed916e454d96fd00184f10a6f5c9e1d3
+Network Name: OpenThread-bff8
+PAN ID: 0xbff8
+PSKc: 264f78414adc683191863d968f72d1b7
+Security Policy: 672 onrc
 Done
 ```
 
@@ -449,7 +449,7 @@ Print Pending Operational Dataset as hex-encoded TLVs.
 
 ```bash
 > dataset pending -x
-0e080000000000010000000300001035060004001fffe002084eb74ab03c56e6d00708fdc7fe165c83a67805108e2104f183e698da87e96efc1e45aa51030f4f70656e5468726561642d383631310102861104108d6273023d82c841eff0e68db86f35740c030000ff
+0e0800000000000100003308000000000002000034040000b512000300001a35060004001fffe00208a74182f4d3f4de410708fd46c1b9e15955740510ed916e454d96fd00184f10a6f5c9e1d3030f4f70656e5468726561642d626666380102bff80410264f78414adc683191863d968f72d1b70c0402a0f7f8
 Done
 ```
 
@@ -530,13 +530,13 @@ Usage: `dataset set <active|pending> <dataset>`
 Set the Active Operational Dataset using hex-encoded TLVs.
 
 ```bash
-dataset set active 0e080000000000010000000300001035060004001fffe002084eb74ab03c56e6d00708fdc7fe165c83a67805108e2104f183e698da87e96efc1e45aa51030f4f70656e5468726561642d383631310102861104108d6273023d82c841eff0e68db86f35740c030000ff
+dataset set active 0e080000000000010000000300000f35060004001fffe0020839758ec8144b07fb0708fdf1f1add0797dc00510f366cec7a446bab978d90d27abe38f23030f4f70656e5468726561642d353933380102593804103ca67c969efb0d0c74a4d8ee923b576c0c0402a0f7f8
 Done
 ```
 
 Set the Pending Operational Dataset using hex-encoded TLVs.
 
 ```bash
-dataset set pending 0e080000000000010000000300001035060004001fffe002084eb74ab03c56e6d00708fdc7fe165c83a67805108e2104f183e698da87e96efc1e45aa51030f4f70656e5468726561642d383631310102861104108d6273023d82c841eff0e68db86f35740c030000ff
+dataset set pending 0e0800000000000100003308000000000002000034040000b512000300001a35060004001fffe00208a74182f4d3f4de410708fd46c1b9e15955740510ed916e454d96fd00184f10a6f5c9e1d3030f4f70656e5468726561642d626666380102bff80410264f78414adc683191863d968f72d1b70c0402a0f7f8
 Done
 ```


### PR DESCRIPTION
The dataset examples are generated by version 1.1 OT stack where the Security Policy value has length of 3 bytes but 1.2 extends it to 4 bytes.

The real problem is that spec requires that **ZERO** Key Rotation **SHALL NOT** be allowed:
```
Key rotation period in hours. The
minimum key rotation period SHALL be
1 hour and a key rotation period of 0
SHALL NOT be allowed.
```

But the example is using ZERO.

This commit fix this by updating the examples to 1.2 version. This commit fix also problems that incomplete TLV HEX string (Pending Timestamp and Delay Timer are missing) are used for setting the Pending Dataset (e.g. `dataset set pending`).