### PR TITLE
[heap_string.cpp] Add sanity check for NULL buffers passed to HeapString::Set API

### DIFF
--- a/src/core/common/heap_string.cpp
+++ b/src/core/common/heap_string.cpp
@@ -56,7 +56,11 @@ Error String::Set(const char *aCString)
 
         VerifyOrExit(newBuffer != nullptr, error = kErrorNoBufs);
 
-        Heap::Free(mStringBuffer);
+        if (mStringBuffer != nullptr)
+        {
+            Heap::Free(mStringBuffer);
+        }
+
         mStringBuffer = newBuffer;
     }
 


### PR DESCRIPTION
When running an application which calls Heap::String::Set() without first setting the member buffer mStringBuffer to a known value, the application should continue to run.

Issue Reference: https://github.com/openthread/openthread/issues/8798