### PR TITLE
[posix] add missing dependencies to "openthread-posix" target

### DIFF
--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -135,6 +135,10 @@ target_link_libraries(openthread-posix
     PUBLIC
         openthread-platform
     PRIVATE
+        openthread-cli-ftd
+        openthread-ftd
+        openthread-hdlc
+        openthread-spinel-rcp
         openthread-url
         ot-config-ftd
         ot-config

--- a/src/posix/platform/memory.cpp
+++ b/src/posix/platform/memory.cpp
@@ -34,7 +34,9 @@
 #include <openthread/platform/memory.h>
 
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+extern "C" {
 void *otPlatCAlloc(size_t aNum, size_t aSize) { return calloc(aNum, aSize); }
 
 void otPlatFree(void *aPtr) { free(aPtr); }
+} // extern "C"
 #endif


### PR DESCRIPTION
The `openthread-posix` library calls OT public APIs and library APIs (e.g. radio_spinel, HDLC), but it doesn't link against the library targets.

------
This commit also adds `extern "C"` for posix impl of `otPlatFree` and `otPlatCAlloc`.