### PR TITLE
[net-diag] define `AppendDiagTlv()`

### DIFF
--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -140,10 +140,11 @@ private:
                       Coap::ResponseHandler aHandler = nullptr,
                       void                 *aContext = nullptr);
 
+    Error AppendDiagTlv(uint8_t aTlvType, Message &aMessage);
     Error AppendIp6AddressList(Message &aMessage);
+    Error AppendMacCounters(Message &aMessage);
     Error AppendChildTable(Message &aMessage);
-    void  FillMacCountersTlv(MacCountersTlv &aTlv);
-    Error AppendRequestedTlvs(const Message &aRequest, Message &aResponse, Tlv &aTlv);
+    Error AppendRequestedTlvs(const Message &aRequest, Message &aResponse);
     void  PrepareMessageInfoForDest(const Ip6::Address &aDestination, Tmf::MessageInfo &aMessageInfo) const;
 
     static void HandleGetResponse(void                *aContext,


### PR DESCRIPTION
This commit adds `AppendDiagTlv()` to append a dig TLV with a given type to a `Message`. It also simplifies the `AppendRequestedTlvs()` to directly parse the "Type List TLV".