### PR TITLE
[backbone-router] define C++ enum/types mirroring public definitions

### DIFF
--- a/src/core/api/backbone_router_ftd_api.cpp
+++ b/src/core/api/backbone_router_ftd_api.cpp
@@ -50,7 +50,7 @@ void otBackboneRouterSetEnabled(otInstance *aInstance, bool aEnabled)
 
 otBackboneRouterState otBackboneRouterGetState(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<BackboneRouter::Local>().GetState();
+    return MapEnum(AsCoreType(aInstance).Get<BackboneRouter::Local>().GetState());
 }
 
 void otBackboneRouterGetConfig(otInstance *aInstance, otBackboneRouterConfig *aConfig)
@@ -161,7 +161,7 @@ otError otBackboneRouterMulticastListenerAdd(otInstance *aInstance, const otIp6A
 {
     if (aTimeout == 0)
     {
-        BackboneRouter::BackboneRouterConfig config;
+        BackboneRouter::Config config;
         AsCoreType(aInstance).Get<BackboneRouter::Local>().GetConfig(config);
         aTimeout = config.mMlrTimeout;
     }

--- a/src/core/backbone_router/bbr_leader.cpp
+++ b/src/core/backbone_router/bbr_leader.cpp
@@ -58,7 +58,7 @@ void Leader::Reset(void)
     mDomainPrefix.SetLength(0);
 }
 
-Error Leader::GetConfig(BackboneRouterConfig &aConfig) const
+Error Leader::GetConfig(Config &aConfig) const
 {
     Error error = kErrorNone;
 
@@ -84,7 +84,7 @@ exit:
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
-void Leader::LogBackboneRouterPrimary(State aState, const BackboneRouterConfig &aConfig) const
+void Leader::LogBackboneRouterPrimary(State aState, const Config &aConfig) const
 {
     OT_UNUSED_VARIABLE(aConfig);
 
@@ -152,9 +152,9 @@ void Leader::Update(void)
 
 void Leader::UpdateBackboneRouterPrimary(void)
 {
-    BackboneRouterConfig config;
-    State                state;
-    uint32_t             origMlrTimeout;
+    Config   config;
+    State    state;
+    uint32_t origMlrTimeout;
 
     Get<NetworkData::Service::Manager>().GetBackboneRouterPrimary(config);
 

--- a/src/core/backbone_router/bbr_leader.hpp
+++ b/src/core/backbone_router/bbr_leader.hpp
@@ -52,7 +52,7 @@ namespace ot {
 
 namespace BackboneRouter {
 
-typedef otBackboneRouterConfig BackboneRouterConfig;
+typedef otBackboneRouterConfig Config;
 
 /**
  * This class implements the basic Primary Backbone Router service operations.
@@ -112,7 +112,7 @@ public:
      * @retval kErrorNotFound      No Backbone Router in the Thread Network.
      *
      */
-    Error GetConfig(BackboneRouterConfig &aConfig) const;
+    Error GetConfig(Config &aConfig) const;
 
     /**
      * This method gets the Backbone Router Service ID.
@@ -177,17 +177,17 @@ private:
     void UpdateBackboneRouterPrimary(void);
     void UpdateDomainPrefixConfig(void);
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
-    void               LogBackboneRouterPrimary(State aState, const BackboneRouterConfig &aConfig) const;
+    void               LogBackboneRouterPrimary(State aState, const Config &aConfig) const;
     void               LogDomainPrefix(DomainPrefixState aState, const Ip6::Prefix &aPrefix) const;
     static const char *StateToString(State aState);
     static const char *DomainPrefixStateToString(DomainPrefixState aState);
 #else
-    void LogBackboneRouterPrimary(State, const BackboneRouterConfig &) const {}
+    void LogBackboneRouterPrimary(State, const Config &) const {}
     void LogDomainPrefix(DomainPrefixState, const Ip6::Prefix &) const {}
 #endif
 
-    BackboneRouterConfig mConfig;       ///< Primary Backbone Router information.
-    Ip6::Prefix          mDomainPrefix; ///< Domain Prefix in the Thread network.
+    Config      mConfig;       ///< Primary Backbone Router information.
+    Ip6::Prefix mDomainPrefix; ///< Domain Prefix in the Thread network.
 };
 
 } // namespace BackboneRouter

--- a/src/core/backbone_router/bbr_local.hpp
+++ b/src/core/backbone_router/bbr_local.hpp
@@ -54,6 +54,7 @@
 #include <openthread/backbone_router_ftd.h>
 
 #include "backbone_router/bbr_leader.hpp"
+#include "common/as_core_type.hpp"
 #include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/log.hpp"
@@ -72,7 +73,16 @@ namespace BackboneRouter {
 class Local : public InstanceLocator, private NonCopyable
 {
 public:
-    typedef otBackboneRouterState BackboneRouterState;
+    /**
+     * This enumeration represents Backbone Router state.
+     *
+     */
+    enum State : uint8_t
+    {
+        kStateDisabled  = OT_BACKBONE_ROUTER_STATE_DISABLED,  ///< Backbone function is disabled.
+        kStateSecondary = OT_BACKBONE_ROUTER_STATE_SECONDARY, ///< Secondary Backbone Router.
+        kStatePrimary   = OT_BACKBONE_ROUTER_STATE_PRIMARY,   ///< The Primary Backbone Router.
+    };
 
     /**
      * This constructor initializes the local Backbone Router.
@@ -94,12 +104,10 @@ public:
      * This method retrieves the Backbone Router state.
      *
      *
-     * @retval OT_BACKBONE_ROUTER_STATE_DISABLED   Backbone function is disabled.
-     * @retval OT_BACKBONE_ROUTER_STATE_SECONDARY  Secondary Backbone Router.
-     * @retval OT_BACKBONE_ROUTER_STATE_PRIMARY    Primary Backbone Router.
+     * @returns The current state of Backbone Router.
      *
      */
-    BackboneRouterState GetState(void) const { return mState; }
+    State GetState(void) const { return mState; }
 
     /**
      * This method resets the local Thread Network Data.
@@ -113,7 +121,7 @@ public:
      * @param[out]  aConfig  The local Backbone Router configuration.
      *
      */
-    void GetConfig(BackboneRouterConfig &aConfig) const;
+    void GetConfig(Config &aConfig) const;
 
     /**
      * This method sets local Backbone Router configuration.
@@ -124,13 +132,13 @@ public:
      * @retval kErrorInvalidArgs  The configuration in @p aConfig is invalid.
      *
      */
-    Error SetConfig(const BackboneRouterConfig &aConfig);
+    Error SetConfig(const Config &aConfig);
 
     /**
      * This method registers Backbone Router Dataset to Leader.
      *
-     * @param[in]  aForce True to force registration regardless of current BackboneRouterState.
-     *                    False to decide based on current BackboneRouterState.
+     * @param[in]  aForce True to force registration regardless of current state.
+     *                    False to decide based on current state.
      *
      *
      * @retval kErrorNone            Successfully added the Service entry.
@@ -147,7 +155,7 @@ public:
      * @retval  False if the Backbone Router is not Primary.
      *
      */
-    bool IsPrimary(void) const { return mState == OT_BACKBONE_ROUTER_STATE_PRIMARY; }
+    bool IsPrimary(void) const { return mState == kStatePrimary; }
 
     /**
      * This method indicates whether or not the Backbone Router is enabled.
@@ -156,7 +164,7 @@ public:
      * @retval  False if the Backbone Router is not enabled.
      *
      */
-    bool IsEnabled(void) const { return mState != OT_BACKBONE_ROUTER_STATE_DISABLED; }
+    bool IsEnabled(void) const { return mState != kStateDisabled; }
 
     /**
      * This method sets the Backbone Router registration jitter value.
@@ -181,7 +189,7 @@ public:
      * @param[in]  aConfig  The Primary Backbone Router service.
      *
      */
-    void HandleBackboneRouterPrimaryUpdate(Leader::State aState, const BackboneRouterConfig &aConfig);
+    void HandleBackboneRouterPrimaryUpdate(Leader::State aState, const Config &aConfig);
 
     /**
      * This method gets the Domain Prefix configuration.
@@ -260,7 +268,7 @@ public:
     }
 
 private:
-    void SetState(BackboneRouterState aState);
+    void SetState(State aState);
     void RemoveService(void);
     void AddDomainPrefixToNetworkData(void);
     void RemoveDomainPrefixFromNetworkData(void);
@@ -273,11 +281,11 @@ private:
     void LogDomainPrefix(const char *, Error) {}
 #endif
 
-    BackboneRouterState mState;
-    uint32_t            mMlrTimeout;
-    uint16_t            mReregistrationDelay;
-    uint8_t             mSequenceNumber;
-    uint8_t             mRegistrationJitter;
+    State    mState;
+    uint32_t mMlrTimeout;
+    uint16_t mReregistrationDelay;
+    uint8_t  mSequenceNumber;
+    uint8_t  mRegistrationJitter;
 
     // Indicates whether or not already add Backbone Router Service to local server data.
     // Used to check whether or not in restore stage after reset or whether to remove
@@ -293,6 +301,8 @@ private:
 };
 
 } // namespace BackboneRouter
+
+DefineMapEnum(otBackboneRouterState, BackboneRouter::Local::State);
 
 /**
  * @}

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -86,7 +86,7 @@ void Manager::HandleNotifierEvents(Events aEvents)
 
     if (aEvents.Contains(kEventThreadBackboneRouterStateChanged))
     {
-        if (Get<Local>().GetState() == OT_BACKBONE_ROUTER_STATE_DISABLED)
+        if (!Get<Local>().IsEnabled())
         {
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
             mMulticastListenersTable.Clear();
@@ -134,7 +134,7 @@ void Manager::HandleTimer(void)
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
 template <> void Manager::HandleTmf<kUriMlr>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    VerifyOrExit(Get<Local>().GetState() != OT_BACKBONE_ROUTER_STATE_DISABLED);
+    VerifyOrExit(Get<Local>().IsEnabled());
     HandleMulticastListenerRegistration(aMessage, aMessageInfo);
 
 exit:
@@ -146,7 +146,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Message &aMessage,
     Error                      error     = kErrorNone;
     bool                       isPrimary = Get<Local>().IsPrimary();
     ThreadStatusTlv::MlrStatus status    = ThreadStatusTlv::kMlrSuccess;
-    BackboneRouterConfig       config;
+    Config                     config;
 
     uint16_t     addressesOffset, addressesLength;
     Ip6::Address address;
@@ -357,7 +357,7 @@ exit:
 template <>
 void Manager::HandleTmf<kUriDuaRegistrationRequest>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    VerifyOrExit(Get<Local>().GetState() != OT_BACKBONE_ROUTER_STATE_DISABLED);
+    VerifyOrExit(Get<Local>().IsEnabled());
     HandleDuaRegistration(aMessage, aMessageInfo);
 
 exit:

--- a/src/core/backbone_router/multicast_listeners_table.cpp
+++ b/src/core/backbone_router/multicast_listeners_table.cpp
@@ -77,10 +77,10 @@ Error MulticastListenersTable::Add(const Ip6::Address &aAddress, Time aExpireTim
 
     FixHeap(mNumValidListeners - 1);
 
-    mCallback.InvokeIfSet(OT_BACKBONE_ROUTER_MULTICAST_LISTENER_ADDED, &aAddress);
+    mCallback.InvokeIfSet(MapEnum(Listener::kEventAdded), &aAddress);
 
 exit:
-    LogMulticastListenersTable("Add", aAddress, aExpireTime, error);
+    Log(kAdd, aAddress, aExpireTime, error);
     CheckInvariants();
     return error;
 }
@@ -103,14 +103,14 @@ void MulticastListenersTable::Remove(const Ip6::Address &aAddress)
                 FixHeap(i);
             }
 
-            mCallback.InvokeIfSet(OT_BACKBONE_ROUTER_MULTICAST_LISTENER_REMOVED, &aAddress);
+            mCallback.InvokeIfSet(MapEnum(Listener::kEventRemoved), &aAddress);
 
             ExitNow(error = kErrorNone);
         }
     }
 
 exit:
-    LogMulticastListenersTable("Remove", aAddress, TimeMilli(0), error);
+    Log(kRemove, aAddress, TimeMilli(0), error);
     CheckInvariants();
 }
 
@@ -121,7 +121,7 @@ void MulticastListenersTable::Expire(void)
 
     while (mNumValidListeners > 0 && now >= mListeners[0].GetExpireTime())
     {
-        LogMulticastListenersTable("Expire", mListeners[0].GetAddress(), mListeners[0].GetExpireTime(), kErrorNone);
+        Log(kExpire, mListeners[0].GetAddress(), mListeners[0].GetExpireTime(), kErrorNone);
         address = mListeners[0].GetAddress();
 
         mNumValidListeners--;
@@ -132,25 +132,34 @@ void MulticastListenersTable::Expire(void)
             FixHeap(0);
         }
 
-        mCallback.InvokeIfSet(OT_BACKBONE_ROUTER_MULTICAST_LISTENER_REMOVED, &address);
+        mCallback.InvokeIfSet(MapEnum(Listener::kEventRemoved), &address);
     }
 
     CheckInvariants();
 }
 
-void MulticastListenersTable::LogMulticastListenersTable(const char         *aAction,
-                                                         const Ip6::Address &aAddress,
-                                                         TimeMilli           aExpireTime,
-                                                         Error               aError)
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)
+void MulticastListenersTable::Log(Action              aAction,
+                                  const Ip6::Address &aAddress,
+                                  TimeMilli           aExpireTime,
+                                  Error               aError) const
 {
-    OT_UNUSED_VARIABLE(aAction);
-    OT_UNUSED_VARIABLE(aAddress);
-    OT_UNUSED_VARIABLE(aExpireTime);
-    OT_UNUSED_VARIABLE(aError);
+    static const char *const kActionStrings[] = {
+        "Add",    // (0) kAdd
+        "Remove", // (1) kRemove
+        "Expire", // (2) kExpire
+    };
 
-    LogDebg("%s %s expire %lu: %s", aAction, aAddress.ToString().AsCString(), ToUlong(aExpireTime.GetValue()),
-            ErrorToString(aError));
+    static_assert(0 == kAdd, "kAdd value is incorrect");
+    static_assert(1 == kRemove, "kRemove value is incorrect");
+    static_assert(2 == kExpire, "kExpire value is incorrect");
+
+    LogDebg("%s %s expire %lu: %s", kActionStrings[aAction], aAddress.ToString().AsCString(),
+            ToUlong(aExpireTime.GetValue()), ErrorToString(aError));
 }
+#else
+void MulticastListenersTable::Log(Action, const Ip6::Address &, TimeMilli, Error) const {}
+#endif
 
 void MulticastListenersTable::FixHeap(uint16_t aIndex)
 {
@@ -258,7 +267,7 @@ void MulticastListenersTable::Clear(void)
     {
         for (uint16_t i = 0; i < mNumValidListeners; i++)
         {
-            mCallback.Invoke(OT_BACKBONE_ROUTER_MULTICAST_LISTENER_REMOVED, &mListeners[i].GetAddress());
+            mCallback.Invoke(MapEnum(Listener::kEventRemoved), &mListeners[i].GetAddress());
         }
     }
 
@@ -267,7 +276,7 @@ void MulticastListenersTable::Clear(void)
     CheckInvariants();
 }
 
-void MulticastListenersTable::SetCallback(otBackboneRouterMulticastListenerCallback aCallback, void *aContext)
+void MulticastListenersTable::SetCallback(Listener::Callback aCallback, void *aContext)
 {
     mCallback.Set(aCallback, aContext);
 
@@ -275,13 +284,12 @@ void MulticastListenersTable::SetCallback(otBackboneRouterMulticastListenerCallb
     {
         for (uint16_t i = 0; i < mNumValidListeners; i++)
         {
-            mCallback.Invoke(OT_BACKBONE_ROUTER_MULTICAST_LISTENER_ADDED, &mListeners[i].GetAddress());
+            mCallback.Invoke(MapEnum(Listener::kEventAdded), &mListeners[i].GetAddress());
         }
     }
 }
 
-Error MulticastListenersTable::GetNext(otBackboneRouterMulticastListenerIterator &aIterator,
-                                       otBackboneRouterMulticastListenerInfo     &aListenerInfo)
+Error MulticastListenersTable::GetNext(Listener::Iterator &aIterator, Listener::Info &aInfo)
 {
     Error     error = kErrorNone;
     TimeMilli now;
@@ -290,8 +298,8 @@ Error MulticastListenersTable::GetNext(otBackboneRouterMulticastListenerIterator
 
     now = TimerMilli::GetNow();
 
-    aListenerInfo.mAddress = mListeners[aIterator].mAddress;
-    aListenerInfo.mTimeout =
+    aInfo.mAddress = mListeners[aIterator].mAddress;
+    aInfo.mTimeout =
         Time::MsecToSec(mListeners[aIterator].mExpireTime > now ? mListeners[aIterator].mExpireTime - now : 0);
 
     aIterator++;

--- a/src/core/backbone_router/ndproxy_table.cpp
+++ b/src/core/backbone_router/ndproxy_table.cpp
@@ -141,7 +141,7 @@ void NdProxyTable::Clear(void)
         proxy.Clear();
     }
 
-    mCallback.InvokeIfSet(OT_BACKBONE_ROUTER_NDPROXY_CLEARED, nullptr);
+    mCallback.InvokeIfSet(MapEnum(NdProxy::kCleared), nullptr);
 
     LogInfo("NdProxyTable::Clear!");
 }
@@ -167,7 +167,7 @@ Error NdProxyTable::Register(const Ip6::InterfaceIdentifier &aAddressIid,
     proxy = FindByMeshLocalIid(aMeshLocalIid);
     if (proxy != nullptr)
     {
-        TriggerCallback(OT_BACKBONE_ROUTER_NDPROXY_REMOVED, proxy->mAddressIid);
+        TriggerCallback(NdProxy::kRemoved, proxy->mAddressIid);
         Erase(*proxy);
     }
     else
@@ -265,8 +265,7 @@ exit:
     return;
 }
 
-void NdProxyTable::TriggerCallback(otBackboneRouterNdProxyEvent    aEvent,
-                                   const Ip6::InterfaceIdentifier &aAddressIid) const
+void NdProxyTable::TriggerCallback(NdProxy::Event aEvent, const Ip6::InterfaceIdentifier &aAddressIid) const
 {
     Ip6::Address       dua;
     const Ip6::Prefix *prefix = Get<BackboneRouter::Leader>().GetDomainPrefix();
@@ -278,7 +277,7 @@ void NdProxyTable::TriggerCallback(otBackboneRouterNdProxyEvent    aEvent,
     dua.SetPrefix(*prefix);
     dua.SetIid(aAddressIid);
 
-    mCallback.Invoke(aEvent, &dua);
+    mCallback.Invoke(MapEnum(aEvent), &dua);
 
 exit:
     return;
@@ -318,8 +317,7 @@ void NdProxyTable::NotifyDuaRegistrationOnBackboneLink(NdProxyTable::NdProxy &aN
 {
     if (!aNdProxy.mDadFlag)
     {
-        TriggerCallback(aIsRenew ? OT_BACKBONE_ROUTER_NDPROXY_RENEWED : OT_BACKBONE_ROUTER_NDPROXY_ADDED,
-                        aNdProxy.mAddressIid);
+        TriggerCallback(aIsRenew ? NdProxy::kRenewed : NdProxy::kAdded, aNdProxy.mAddressIid);
 
         IgnoreError(Get<BackboneRouter::Manager>().SendProactiveBackboneNotification(
             GetDua(aNdProxy), aNdProxy.GetMeshLocalIid(), aNdProxy.GetTimeSinceLastTransaction()));

--- a/src/core/backbone_router/ndproxy_table.hpp
+++ b/src/core/backbone_router/ndproxy_table.hpp
@@ -40,6 +40,7 @@
 #include <openthread/backbone_router_ftd.h>
 
 #include "backbone_router/bbr_leader.hpp"
+#include "common/as_core_type.hpp"
 #include "common/callback.hpp"
 #include "common/iterator_utils.hpp"
 #include "common/locator.hpp"
@@ -69,6 +70,20 @@ public:
         friend class Clearable<NdProxy>;
 
     public:
+        typedef otBackboneRouterNdProxyCallback Callback; ///< ND Proxy callback.
+
+        /**
+         * This type represents the ND Proxy events.
+         *
+         */
+        enum Event
+        {
+            kAdded   = OT_BACKBONE_ROUTER_NDPROXY_ADDED,   ///< ND Proxy was added.
+            kRemoved = OT_BACKBONE_ROUTER_NDPROXY_REMOVED, ///< ND Proxy was removed.
+            kRenewed = OT_BACKBONE_ROUTER_NDPROXY_RENEWED, ///< ND Proxy was renewed.
+            kCleared = OT_BACKBONE_ROUTER_NDPROXY_CLEARED, ///< All ND Proxies were cleared.
+        };
+
         /**
          * This method gets the Mesh-Local IID of the ND Proxy.
          *
@@ -216,7 +231,7 @@ public:
      * @param[in] aContext   A user context pointer.
      *
      */
-    void SetCallback(otBackboneRouterNdProxyCallback aCallback, void *aContext) { mCallback.Set(aCallback, aContext); }
+    void SetCallback(NdProxy::Callback aCallback, void *aContext) { mCallback.Set(aCallback, aContext); }
 
     /**
      * This method retrieves the ND Proxy info of the Domain Unicast Address.
@@ -289,14 +304,16 @@ private:
     NdProxy        *FindInvalid(void);
     Ip6::Address    GetDua(NdProxy &aNdProxy);
     void            NotifyDuaRegistrationOnBackboneLink(NdProxy &aNdProxy, bool aIsRenew);
-    void TriggerCallback(otBackboneRouterNdProxyEvent aEvent, const Ip6::InterfaceIdentifier &aAddressIid) const;
+    void            TriggerCallback(NdProxy::Event aEvent, const Ip6::InterfaceIdentifier &aAddressIid) const;
 
-    NdProxy                                   mProxies[kMaxNdProxyNum];
-    Callback<otBackboneRouterNdProxyCallback> mCallback;
-    bool                                      mIsAnyDadInProcess : 1;
+    NdProxy                     mProxies[kMaxNdProxyNum];
+    Callback<NdProxy::Callback> mCallback;
+    bool                        mIsAnyDadInProcess : 1;
 };
 
 } // namespace BackboneRouter
+
+DefineMapEnum(otBackboneRouterNdProxyEvent, BackboneRouter::NdProxyTable::NdProxy::Event);
 
 } // namespace ot
 

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -273,7 +273,7 @@ void DuaManager::NotifyDuplicateDomainUnicastAddress(void)
 void DuaManager::UpdateReregistrationDelay(void)
 {
     uint16_t               delay = 0;
-    otBackboneRouterConfig config;
+    BackboneRouter::Config config;
 
     VerifyOrExit(Get<BackboneRouter::Leader>().GetConfig(config) == kErrorNone);
 
@@ -338,8 +338,8 @@ exit:
     return;
 }
 
-void DuaManager::HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State               aState,
-                                                   const BackboneRouter::BackboneRouterConfig &aConfig)
+void DuaManager::HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState,
+                                                   const BackboneRouter::Config &aConfig)
 {
     OT_UNUSED_VARIABLE(aConfig);
 

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -110,8 +110,7 @@ public:
      * @param[in]  aConfig  The Primary Backbone Router service.
      *
      */
-    void HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State               aState,
-                                           const BackboneRouter::BackboneRouterConfig &aConfig);
+    void HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState, const BackboneRouter::Config &aConfig);
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
 

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -76,8 +76,8 @@ void MlrManager::HandleNotifierEvents(Events aEvents)
     }
 }
 
-void MlrManager::HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State               aState,
-                                                   const BackboneRouter::BackboneRouterConfig &aConfig)
+void MlrManager::HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState,
+                                                   const BackboneRouter::Config &aConfig)
 {
     OT_UNUSED_VARIABLE(aConfig);
 
@@ -474,7 +474,7 @@ void MlrManager::HandleMulticastListenerRegistrationResponse(Coap::Message      
     }
     else
     {
-        otBackboneRouterConfig config;
+        BackboneRouter::Config config;
         uint16_t               reregDelay;
 
         // The Device has just attempted a Multicast Listener Registration which failed, and it retries the same
@@ -632,9 +632,9 @@ void MlrManager::UpdateReregistrationDelay(bool aRereg)
     }
     else
     {
-        BackboneRouter::BackboneRouterConfig config;
-        uint32_t                             reregDelay;
-        uint32_t                             effectiveMlrTimeout;
+        BackboneRouter::Config config;
+        uint32_t               reregDelay;
+        uint32_t               effectiveMlrTimeout;
 
         IgnoreError(Get<BackboneRouter::Leader>().GetConfig(config));
 

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -95,8 +95,7 @@ public:
      * @param[in]  aConfig  The Primary Backbone Router service.
      *
      */
-    void HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State               aState,
-                                           const BackboneRouter::BackboneRouterConfig &aConfig);
+    void HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState, const BackboneRouter::Config &aConfig);
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     /**

--- a/src/core/thread/network_data_service.cpp
+++ b/src/core/thread/network_data_service.cpp
@@ -94,7 +94,7 @@ Error Manager::GetServiceId(const void *aServiceData,
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 
-void Manager::GetBackboneRouterPrimary(ot::BackboneRouter::BackboneRouterConfig &aConfig) const
+void Manager::GetBackboneRouterPrimary(ot::BackboneRouter::Config &aConfig) const
 {
     const ServerTlv                  *rvalServerTlv  = nullptr;
     const BackboneRouter::ServerData *rvalServerData = nullptr;

--- a/src/core/thread/network_data_service.hpp
+++ b/src/core/thread/network_data_service.hpp
@@ -544,7 +544,7 @@ public:
      * @param[out]  aConfig      The Primary Backbone Router configuration.
      *
      */
-    void GetBackboneRouterPrimary(ot::BackboneRouter::BackboneRouterConfig &aConfig) const;
+    void GetBackboneRouterPrimary(ot::BackboneRouter::Config &aConfig) const;
 #endif
 
     /**


### PR DESCRIPTION
This commit defines C++ style types for use in core module mirroring the public OT C definitions. It also contains renames and smaller enhancements in BackBone Router modules.