### PR TITLE
[mle-router] add common `SetStateRouterOrLeader()`

### DIFF
--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -604,6 +604,7 @@ private:
     Error SendDiscoveryResponse(const Ip6::Address &aDestination, const Message &aDiscoverRequestMessage);
     void  SetStateRouter(uint16_t aRloc16);
     void  SetStateLeader(uint16_t aRloc16, LeaderStartMode aStartMode);
+    void  SetStateRouterOrLeader(DeviceRole aRole, uint16_t aRloc16, LeaderStartMode aStartMode);
     void  StopLeader(void);
     void  SynchronizeChildNetworkData(void);
     Error UpdateChildAddresses(const Message &aMessage, uint16_t aOffset, uint16_t aLength, Child &aChild);


### PR DESCRIPTION
`SetStateRouter()` and `SetStateLeader()` share a bunch of common code (things that need to be updated on transition to either router or leader role). This commit adds `SetStateRouterOrLeader()` method for this.