### PR TITLE
[cli] fix bad CLI command tag

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1419,7 +1419,7 @@ template <> otError Interpreter::Process<Cmd("bufferinfo")>(Arg aArgs[])
      * @code
      * bufferinfo reset
      * Done
-     * @enccode
+     * @endcode
      * @par api_copy
      * #otMessageResetBufferInfo
      */


### PR DESCRIPTION
Invalid Doxygen tag from #8796 breaks the reference import into openthread.io (all commands documented before it are being dropped).

@kylorene for viz