### PR TITLE
[github-actions] update otns to python 3.10

### DIFF
--- a/.github/workflows/otns.yml
+++ b/.github/workflows/otns.yml
@@ -65,11 +65,11 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: '1.14'
-    - name: Set up Python 3.6
+        go-version: '1.17'
+    - name: Set up Python 3.10
       uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
       with:
-        python-version: 3.6
+        python-version: "3.10"
     - name: Bootstrap
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
@@ -105,11 +105,11 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: '1.14'
-      - name: Set up Python 3.6
+          go-version: '1.17'
+      - name: Set up Python 3.10
         uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
         with:
-          python-version: 3.6
+          python-version: "3.10"
       - name: Bootstrap
         run: |
           sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
@@ -168,11 +168,11 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: '1.14'
-      - name: Set up Python 3.6
+          go-version: '1.17'
+      - name: Set up Python 3.10
         uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
         with:
-          python-version: 3.6
+          python-version: "3.10"
       - name: Bootstrap
         run: |
           sudo rm /etc/apt/sources.list.d/* && sudo apt-get update


### PR DESCRIPTION
In https://github.com/openthread/ot-ns/commit/f8f6bd9299cf2fe844339a61decd4792d3bf66b4, `pylibs/unittests/requirements.txt` was updated to use `wheel==0.38.1`.

Starting in `wheel v0.38.0`, support for Python < 3.7 was dropped. https://github.com/pypa/wheel/blob/814c2efe8e40051039c5a6de6945e04ecdd162ee/docs/news.rst

This is is causing the OTNS workflow to fail
- https://github.com/openthread/openthread/pull/8826
- https://github.com/openthread/openthread/pull/8827

---

This PR updates the OTNS workflow to use Python 3.10 instead.