### PR TITLE
[discovery] allow (S)SED devices to perform MLE Discovery

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (304)
+#define OPENTHREAD_API_VERSION (305)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -264,6 +264,8 @@ bool otThreadIsSingleton(otInstance *aInstance);
 /**
  * This function starts a Thread Discovery scan.
  *
+ * @note A successful call to this function enables the rx-on-when-idle mode for the entire scan procedure.
+ *
  * @param[in]  aInstance              A pointer to an OpenThread instance.
  * @param[in]  aScanChannels          A bit vector indicating which channels to scan (e.g. OT_CHANNEL_11_MASK).
  * @param[in]  aPanId                 The PAN ID filter (set to Broadcast PAN to disable filter).

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -1159,7 +1159,9 @@ void SubMac::HandleCslTimer(void)
 
         Get<Radio>().UpdateCslSampleTime(mCslSampleTime.GetValue());
 
-        if (RadioSupportsReceiveTiming() && (mState != kStateDisabled))
+        // Scedule reception window for any state except RX - so that CSL RX Window has lower priority
+        // than scanning or RX after the data poll.
+        if (RadioSupportsReceiveTiming() && (mState != kStateDisabled) && (mState != kStateReceive))
         {
             IgnoreError(Get<Radio>().ReceiveAt(mCslChannel, mCslSampleTime.GetValue() - periodUs - timeAhead,
                                                timeAhead + timeAfter));

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -733,7 +733,7 @@ Mac::TxFrame *MeshForwarder::HandleFrameRequest(Mac::TxFrames &aTxFrames)
             VerifyOrExit(frame != nullptr);
         }
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-        if (Get<Mac::Mac>().IsCslEnabled() && mSendMessage->IsSubTypeMle())
+        else if (Get<Mac::Mac>().IsCslEnabled() && mSendMessage->IsSubTypeMle())
         {
             mSendMessage->SetLinkSecurityEnabled(true);
         }
@@ -1669,7 +1669,10 @@ bool MeshForwarder::CalcIePresent(const Message *aMessage)
     iePresent |= (aMessage != nullptr && aMessage->IsTimeSync());
 #endif
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    iePresent |= Get<Mac::Mac>().IsCslEnabled();
+    if (!(aMessage != nullptr && aMessage->GetSubType() == Message::kSubTypeMleDiscoverRequest))
+    {
+        iePresent |= Get<Mac::Mac>().IsCslEnabled();
+    }
 #endif
 #endif
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2764,6 +2764,7 @@ Error MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, const M
     uint16_t                      delay;
 
     VerifyOrExit((message = NewMleMessage(kCommandDiscoveryResponse)) != nullptr, error = kErrorNoBufs);
+    message->SetDirectTransmission();
     message->SetPanId(aDiscoverRequestMessage.GetPanId());
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     // Send the MLE Discovery Response message on same radio link

--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -126,6 +126,15 @@ proc switch_node {id} {
     set spawn_id $spawn_ids($id)
 }
 
+proc attach {{role "leader"}} {
+    send "ifconfig up\n"
+    expect_line "Done"
+    send "thread start\n"
+    expect_line "Done"
+    wait_for "state" $role
+    expect_line "Done"
+}
+
 proc setup_leader {} {
     send "dataset init new\n"
     expect_line "Done"
@@ -133,12 +142,7 @@ proc setup_leader {} {
     expect_line "Done"
     send "dataset commit active\n"
     expect_line "Done"
-    send "ifconfig up\n"
-    expect_line "Done"
-    send "thread start\n"
-    expect_line "Done"
-    wait_for "state" "leader"
-    expect_line "Done"
+    attach
 }
 
 proc dispose_node {id} {
@@ -168,6 +172,23 @@ proc get_ipaddr {type} {
 proc get_extaddr {} {
     send "extaddr\n"
     set rval [expect_line {[0-9a-fA-F]{16}}]
+    expect_line "Done"
+
+    return $rval
+}
+
+proc get_extpanid {} {
+    send "extpanid\n"
+    set rval [expect_line {[0-9a-fA-F]{16}}]
+    expect_line "Done"
+
+    return $rval
+}
+
+proc get_panid {} {
+    send "panid\n"
+    expect -re {0x([0-9a-fA-F]{4})}
+    set rval $expect_out(1,string)
     expect_line "Done"
 
     return $rval

--- a/tests/scripts/expect/cli-discover.exp
+++ b/tests/scripts/expect/cli-discover.exp
@@ -1,0 +1,146 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2023, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+source "tests/scripts/expect/_common.exp"
+source "tests/scripts/expect/_multinode.exp"
+
+for {set i 1} {$i <= 5} {incr i} {
+    spawn_node $i
+}
+
+switch_node 1
+
+send "dataset init new\n"
+expect_line "Done"
+send "dataset networkkey 00112233445566778899aabbccddeeff\n"
+expect_line "Done"
+send "dataset channel 12\n"
+expect_line "Done"
+send "dataset networkname OpenThread-ch12\n"
+expect_line "Done"
+send "dataset commit active\n"
+expect_line "Done"
+send "dataset active -x\n"
+expect -re {([0-9a-f]+)[\r\n]+Done}
+set dataset $expect_out(1,string) 
+attach
+
+set extaddr_1 [get_extaddr]
+set extpan_1 [get_extpanid]
+set pan_1 [get_panid]
+
+switch_node 2
+
+send "dataset init new\n"
+expect_line "Done"
+send "dataset channel 23\n"
+expect_line "Done"
+send "dataset networkname OpenThread-ch23\n"
+expect_line "Done"
+send "dataset commit active\n"
+expect_line "Done" 
+attach
+
+set extaddr_2 [get_extaddr]
+set extpan_2 [get_extpanid]
+set pan_2 [get_panid]
+
+switch_node 3
+
+send "dataset set active $dataset\n"
+expect_line "Done"
+send "mode r\n"
+expect_line "Done"
+attach "child"
+
+switch_node 4
+
+send "dataset set active $dataset\n"
+expect_line "Done"
+send "mode -\n"
+expect_line "Done"
+attach "child"
+
+for {set i 3} {$i <= 4} {incr i} {
+    switch_node $i
+
+    send "discover\n"
+    expect "| Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |"
+    expect "+------------------+------------------+------+------------------+----+-----+-----+"
+    wait_for "" "\\| OpenThread-ch12 +\\| $extpan_1 \\| $pan_1 \\| $extaddr_1 \\| 12 \\| +-?\\d+ \\| +\\d \\|"
+    wait_for "" "\\| OpenThread-ch23 +\\| $extpan_2 \\| $pan_2 \\| $extaddr_2 \\| 23 \\| +-?\\d+ \\| +\\d \\|"
+    wait_for "" "Done"
+}
+
+if {$::env(THREAD_VERSION) != "1.1" && $::env(OT_NODE_TYPE) == "cli"} {
+    send "csl channel 12\n"
+    expect_line "Done"
+    send "csl period 3125\n"
+    expect_line "Done"
+
+    sleep 1
+
+    send "discover\n"
+    expect "| Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |"
+    expect "+------------------+------------------+------+------------------+----+-----+-----+"
+    wait_for "" "\\| OpenThread-ch12 +\\| $extpan_1 \\| $pan_1 \\| $extaddr_1 \\| 12 \\| +-?\\d+ \\| +\\d \\|"
+    wait_for "" "\\| OpenThread-ch23 +\\| $extpan_2 \\| $pan_2 \\| $extaddr_2 \\| 23 \\| +-?\\d+ \\| +\\d \\|"
+    wait_for "" "Done"
+}
+
+switch_node 1
+send "discover reqcallback enable\n"
+expect_line "Done"
+
+switch_node 5
+send "discover\n"
+expect "Error 13: InvalidState"
+send "ifconfig up\n"
+expect_line "Done"
+send "discover 12\n"
+
+expect "| Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |"
+expect "+------------------+------------------+------+------------------+----+-----+-----+"
+wait_for "" "\\| OpenThread-ch12 +\\| $extpan_1 \\| $pan_1 \\| $extaddr_1 \\| 12 \\| +-?\\d+ \\| +\\d \\|"
+wait_for "" "Done"
+
+switch_node 1
+expect -re {version=\d,joiner=0}
+
+switch_node 5
+send "ifconfig up\n"
+expect_line "Done"
+send "joiner start 123456\n"
+set timeout 10
+expect "NotFound"
+
+switch_node 1
+expect -re {version=\d,joiner=1}
+
+dispose_all

--- a/tests/scripts/expect/cli-multicast-loop.exp
+++ b/tests/scripts/expect/cli-multicast-loop.exp
@@ -44,14 +44,7 @@ set timeout 1
 send "panid 0xface\n"
 expect_line "Done"
 
-send "ifconfig up\n"
-expect_line "Done"
-
-send "thread start\n"
-expect_line "Done"
-
-wait_for "state" "leader"
-expect_line "Done"
+attach
 
 set extaddr1 [get_extaddr]
 
@@ -63,14 +56,8 @@ setup_default_network
 send "panid 0xface\n"
 expect_line "Done"
 
-send "ifconfig up\n"
-expect_line "Done"
+attach "router"
 
-send "thread start\n"
-expect_line "Done"
-
-wait_for "state" "router"
-expect_line "Done"
 sleep 3
 
 get_rloc16
@@ -87,14 +74,8 @@ expect_line "Done"
 send "macfilter addr denylist\n"
 expect_line "Done"
 
-send "ifconfig up\n"
-expect_line "Done"
+attach "router"
 
-send "thread start\n"
-expect_line "Done"
-
-wait_for "state" "router"
-expect_line "Done"
 sleep 4
 
 set extaddr3 [get_extaddr]
@@ -116,14 +97,7 @@ expect_line "Done"
 send "macfilter addr allowlist\n"
 expect_line "Done"
 
-send "ifconfig up\n"
-expect_line "Done"
-
-send "thread start\n"
-expect_line "Done"
-
-wait_for "state" "child"
-expect_line "Done"
+attach "child"
 
 get_rloc16
 

--- a/tests/scripts/expect/cli-scan.exp
+++ b/tests/scripts/expect/cli-scan.exp
@@ -41,23 +41,11 @@ expect "panid"
 expect -re {([0-9a-f]{4})}
 set pan $expect_out(1,string)
 expect_line "Done"
-send "extpanid\n"
-expect "extpanid"
-expect -re {([0-9a-f]{16})}
-set extpan $expect_out(1,string)
-expect_line "Done"
 expect "> "
-send "networkname\n"
-expect "networkname"
-expect -re {[\r\n]([^\r\n]+?)[\r\n]}
-set network $expect_out(1,string)
-expect_line "Done"
 send "channel\n"
 expect "channel"
 expect -re {(\d+)}
 set channel $expect_out(1,string)
-expect_line "Done"
-send "discover reqcallback enable\n"
 expect_line "Done"
 
 switch_node 3
@@ -78,29 +66,5 @@ expect "| Ch | RSSI |"
 expect "+----+------+"
 expect -re "\\| +$channel \\| +-?\\d+ \\|"
 expect_line "Done"
-
-switch_node 3
-send "discover\n"
-expect "Error 13: InvalidState"
-send "ifconfig up\n"
-expect_line "Done"
-send "discover $channel\n"
-expect "| Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |"
-expect "+------------------+------------------+------+------------------+----+-----+-----+"
-wait_for "" "\\| $network +\\| $extpan \\| $pan \\| $extaddr \\| +$channel \\| +-?\\d+ \\| +\\d \\|"
-wait_for "" "Done"
-send "discover something_invalid\n"
-expect "Error 7: InvalidArgs"
-
-switch_node 1
-expect -re {version=\d,joiner=0}
-
-switch_node 3
-send "joiner start 123456\n"
-set timeout 10
-expect "NotFound"
-
-switch_node 1
-expect -re {version=\d,joiner=1}
 
 dispose_all

--- a/tests/scripts/expect/posix-rcp-restoration.exp
+++ b/tests/scripts/expect/posix-rcp-restoration.exp
@@ -251,12 +251,7 @@ try {
     puts "While energy scanning"
 
     spawn_node 1 "rcp" "spinel+hdlc_uart://$host_pty"
-    send "ifconfig up\n"
-    expect_line "Done"
-    send "thread start\n"
-    expect_line "Done"
-    wait_for "state" "leader"
-    expect_line "Done"
+    attach
 
     send "scan energy 100\n"
     expect "| Ch | RSSI |"

--- a/tests/scripts/expect/posix-scan-tx-to-sleep.exp
+++ b/tests/scripts/expect/posix-scan-tx-to-sleep.exp
@@ -36,12 +36,7 @@ send "dataset panid 0xface\n"
 expect_line "Done"
 send "dataset commit active\n"
 expect_line "Done"
-send "ifconfig up\n"
-expect_line "Done"
-send "thread start\n"
-expect_line "Done"
-wait_for "state" "leader"
-expect_line "Done"
+attach
 
 set extaddr [get_extaddr]
 send "panid\n"

--- a/tests/scripts/expect/tun-realm-local-multicast.exp
+++ b/tests/scripts/expect/tun-realm-local-multicast.exp
@@ -39,27 +39,15 @@ source "tests/scripts/expect/_common.exp"
 spawn_node 1
 setup_default_network
 
-send "ifconfig up\n"
-expect_line "Done"
-
-send "thread start\n"
-expect_line "Done"
-
-wait_for "state" "leader"
-expect_line "Done"
+attach
 
 set extaddr1 [get_extaddr]
 
 spawn_node 2 cli
 setup_default_network
 
-send "ifconfig up\n"
-expect_line "Done"
+attach "router"
 
-send "thread start\n"
-expect_line "Done"
-
-wait_for "state" "router"
 sleep 3
 
 spawn_node 3 cli
@@ -71,13 +59,8 @@ expect_line "Done"
 send "macfilter addr denylist\n"
 expect_line "Done"
 
-send "ifconfig up\n"
-expect_line "Done"
+attach "router"
 
-send "thread start\n"
-expect_line "Done"
-
-wait_for "state" "router"
 sleep 4
 
 set extaddr3 [get_extaddr]
@@ -94,13 +77,7 @@ expect_line "Done"
 send "macfilter addr allowlist\n"
 expect_line "Done"
 
-send "ifconfig up\n"
-expect_line "Done"
-
-send "thread start\n"
-expect_line "Done"
-
-wait_for "state" "child"
+attach "child"
 
 set mleid4 [get_ipaddr "mleid"]
 

--- a/tests/scripts/expect/tun-sntp.exp
+++ b/tests/scripts/expect/tun-sntp.exp
@@ -35,12 +35,7 @@ spawn_node 1
 
 send "panid 0xface\n"
 expect_line "Done"
-send "ifconfig up\n"
-expect_line "Done"
-send "thread start\n"
-expect_line "Done"
-wait_for "state" "leader"
-expect_line "Done"
+attach
 
 send "sntp query ::1 123\n"
 expect -re {SNTP response - Unix time: \d+ \(era: \d+\)}

--- a/tests/scripts/expect/tun-udp.exp
+++ b/tests/scripts/expect/tun-udp.exp
@@ -38,14 +38,7 @@ set timeout 1
 send "panid 0xface\n"
 expect_line "Done"
 
-send "ifconfig up\n"
-expect_line "Done"
-
-send "thread start\n"
-expect_line "Done"
-
-wait_for "state" "leader"
-expect_line "Done"
+attach
 
 send "udp open\n"
 expect_line "Done"


### PR DESCRIPTION
Currently, MLE Discovery does not work for SED or SSED devices (#8614).

This PR is a simple attempt to address the issue by:
 - turning off Data Polling and turning on the receiver for the SED device during discovery (to receive MLE Discovery Response)
 - disabling including CSL IE and Auxilary Security Header in the MLE Discovery Request
 - make sure Routers transmit MLE Discovery Response as a direct unicast message (e.g. currently it is sent as an indirect message to SED children).

So far tested with a simulated platform and CLI.