### PR TITLE
[mesh-diag] add Net Diag Version TLV

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (296)
+#define OPENTHREAD_API_VERSION (297)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/mesh_diag.h
+++ b/include/openthread/mesh_diag.h
@@ -82,6 +82,15 @@ typedef struct otMeshDiagIp6AddrIterator otMeshDiagIp6AddrIterator;
 typedef struct otMeshDiagChildIterator otMeshDiagChildIterator;
 
 /**
+ * This constant indicates that Thread Version is unknown.
+ *
+ * This is used in `otMeshDiagRouterInfo` for `mVersion` property when device does not provide its version. This
+ * indicates that device is likely running 1.3.0 (version value 4) or earlier.
+ *
+ */
+#define OT_MESH_DIAG_VERSION_UNKNOWN 0xffff
+
+/**
  * This type represents information about a router in Thread mesh.
  *
  */
@@ -90,6 +99,7 @@ typedef struct otMeshDiagRouterInfo
     otExtAddress mExtAddress;             ///< Extended MAC address.
     uint16_t     mRloc16;                 ///< RLOC16.
     uint8_t      mRouterId;               ///< Router ID.
+    uint16_t     mVersion;                ///< Thread Version. `OT_MESH_DIAG_VERSION_UNKNOWN` if unknown.
     bool         mIsThisDevice : 1;       ///< Whether router is this device itself.
     bool         mIsThisDeviceParent : 1; ///< Whether router is parent of this device (when device is a child).
     bool         mIsLeader : 1;           ///< Whether router is leader.

--- a/include/openthread/netdiag.h
+++ b/include/openthread/netdiag.h
@@ -82,6 +82,7 @@ enum
     OT_NETWORK_DIAGNOSTIC_TLV_CHANNEL_PAGES     = 17, ///< Channel Pages TLV
     OT_NETWORK_DIAGNOSTIC_TLV_TYPE_LIST         = 18, ///< Type List TLV
     OT_NETWORK_DIAGNOSTIC_TLV_MAX_CHILD_TIMEOUT = 19, ///< Max Child Timeout TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_VERSION           = 24, ///< Version TLV
 };
 
 typedef uint16_t otNetworkDiagIterator; ///< Used to iterate through Network Diagnostic TLV.
@@ -245,6 +246,7 @@ typedef struct otNetworkDiagTlv
         uint8_t                   mBatteryLevel;
         uint16_t                  mSupplyVoltage;
         uint32_t                  mMaxChildTimeout;
+        uint16_t                  mVersion;
         struct
         {
             uint8_t mCount;

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1848,6 +1848,7 @@ Output lists all discovered routers. Information per router:
 - Router ID
 - RLOC16
 - Extended MAC address
+- Thread Version (if known).
 - Whether the router is this device is itself (`me`)
 - Whether the router is the parent of this device when device is a child (`parent`)
 - Whether the router is `leader`
@@ -1869,16 +1870,16 @@ Discover network topology:
 
 ```bash
 > meshdiag topology
-id:02 rloc16:0x0800 ext-addr:8aa57d2c603fe16c - me - leader
+id:02 rloc16:0x0800 ext-addr:8aa57d2c603fe16c ver:4 - me - leader
    3-links:{ 46 }
-id:46 rloc16:0xb800 ext-addr:fe109d277e0175cc
+id:46 rloc16:0xb800 ext-addr:fe109d277e0175cc ver:4
    3-links:{ 02 51 57 }
-id:33 rloc16:0x8400 ext-addr:d2e511a146b9e54d
+id:33 rloc16:0x8400 ext-addr:d2e511a146b9e54d ver:4
    3-links:{ 51 57 }
-id:51 rloc16:0xcc00 ext-addr:9aab43ababf05352
+id:51 rloc16:0xcc00 ext-addr:9aab43ababf05352 ver:4
    3-links:{ 33 57 }
    2-links:{ 46 }
-id:57 rloc16:0xe400 ext-addr:dae9c4c0e9da55ff
+id:57 rloc16:0xe400 ext-addr:dae9c4c0e9da55ff ver:4
    3-links:{ 46 51 }
    1-links:{ 33 }
 Done
@@ -1888,14 +1889,14 @@ Discover network topology with router's IPv6 addresses and children:
 
 ```bash
 > meshdiag topology children ip6-addrs
-id:62 rloc16:0xf800 ext-addr:ce349873897233a5 - me - br
+id:62 rloc16:0xf800 ext-addr:ce349873897233a5 ver:4 - me - br
    3-links:{ 46 }
    ip6-addrs:
        fdde:ad00:beef:0:0:ff:fe00:f800
        fdde:ad00:beef:0:211d:39e9:6b2e:4ad1
        fe80:0:0:0:cc34:9873:8972:33a5
    children: none
-id:02 rloc16:0x0800 ext-addr:8aa57d2c603fe16c - leader - br
+id:02 rloc16:0x0800 ext-addr:8aa57d2c603fe16c ver:4 - leader - br
    3-links:{ 46 51 }
    ip6-addrs:
        fdde:ad00:beef:0:0:ff:fe00:fc00
@@ -1905,21 +1906,21 @@ id:02 rloc16:0x0800 ext-addr:8aa57d2c603fe16c - leader - br
    children:
        rloc16:0x0803 lq:3, mode:rn
        rloc16:0x0804 lq:3, mode:rdn
-id:33 rloc16:0x8400 ext-addr:d2e511a146b9e54d
+id:33 rloc16:0x8400 ext-addr:d2e511a146b9e54d ver:4
    3-links:{ 57 }
    ip6-addrs:
        fdde:ad00:beef:0:0:ff:fe00:8400
        fdde:ad00:beef:0:824:a126:cf19:a9f4
        fe80:0:0:0:d0e5:11a1:46b9:e54d
    children: none
-id:51 rloc16:0xcc00 ext-addr:9aab43ababf05352
+id:51 rloc16:0xcc00 ext-addr:9aab43ababf05352 ver:4
    3-links:{ 02 46 57 }
    ip6-addrs:
        fdde:ad00:beef:0:0:ff:fe00:cc00
        fdde:ad00:beef:0:2986:bba3:12d0:1dd2
        fe80:0:0:0:98ab:43ab:abf0:5352
    children: none
-id:57 rloc16:0xe400 ext-addr:dae9c4c0e9da55ff
+id:57 rloc16:0xe400 ext-addr:dae9c4c0e9da55ff ver:4
    3-links:{ 33 51 }
    ip6-addrs:
        fdde:ad00:beef:0:0:ff:fe00:e400
@@ -1928,7 +1929,7 @@ id:57 rloc16:0xe400 ext-addr:dae9c4c0e9da55ff
    children:
        rloc16:0xe402 lq:3, mode:rn - br
        rloc16:0xe403 lq:3, mode:rn
-id:46 rloc16:0xb800 ext-addr:fe109d277e0175cc
+id:46 rloc16:0xb800 ext-addr:fe109d277e0175cc ver:4
    3-links:{ 02 51 62 }
    ip6-addrs:
        fdde:ad00:beef:0:0:ff:fe00:b800
@@ -1942,26 +1943,26 @@ Discover network topology with children:
 
 ```bash
 > meshdiag topology children
-id:02 rloc16:0x0800 ext-addr:8aa57d2c603fe16c - parent - leader - br
+id:02 rloc16:0x0800 ext-addr:8aa57d2c603fe16c ver:4 - parent - leader - br
    3-links:{ 46 51 }
    children:
        rloc16:0x0803 lq:0, mode:rn
        rloc16:0x0804 lq:0, mode:rdn - me
-id:46 rloc16:0xb800 ext-addr:fe109d277e0175cc
+id:46 rloc16:0xb800 ext-addr:fe109d277e0175cc ver:4
    3-links:{ 02 51 62 }
    children: none
-id:33 rloc16:0x8400 ext-addr:d2e511a146b9e54d
+id:33 rloc16:0x8400 ext-addr:d2e511a146b9e54d ver:4
    3-links:{ 57 }
    children: none
-id:51 rloc16:0xcc00 ext-addr:9aab43ababf05352
+id:51 rloc16:0xcc00 ext-addr:9aab43ababf05352 ver:4
    3-links:{ 02 46 57 }
    children: none
-id:57 rloc16:0xe400 ext-addr:dae9c4c0e9da55ff
+id:57 rloc16:0xe400 ext-addr:dae9c4c0e9da55ff ver:4
    3-links:{ 33 51 }
    children:
        rloc16:0xe402 lq:3, mode:rn - br
        rloc16:0xe403 lq:3, mode:rn
-id:62 rloc16:0xf800 ext-addr:ce349873897233a5 - br
+id:62 rloc16:0xf800 ext-addr:ce349873897233a5 ver:4 - br
    3-links:{ 46 }
    children: none
 ```

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -5445,16 +5445,16 @@ template <> otError Interpreter::Process<Cmd("meshdiag")>(Arg aArgs[])
      * @cli meshdiag topology
      * @code
      * meshdiag topology
-     * id:02 rloc16:0x0800 ext-addr:8aa57d2c603fe16c - me - leader
+     * id:02 rloc16:0x0800 ext-addr:8aa57d2c603fe16c ver:4 - me - leader
      *    3-links:{ 46 }
-     * id:46 rloc16:0xb800 ext-addr:fe109d277e0175cc
+     * id:46 rloc16:0xb800 ext-addr:fe109d277e0175cc ver:4
      *    3-links:{ 02 51 57 }
-     * id:33 rloc16:0x8400 ext-addr:d2e511a146b9e54d
+     * id:33 rloc16:0x8400 ext-addr:d2e511a146b9e54d ver:4
      *    3-links:{ 51 57 }
-     * id:51 rloc16:0xcc00 ext-addr:9aab43ababf05352
+     * id:51 rloc16:0xcc00 ext-addr:9aab43ababf05352 ver:4
      *    3-links:{ 33 57 }
      *    2-links:{ 46 }
-     * id:57 rloc16:0xe400 ext-addr:dae9c4c0e9da55ff
+     * id:57 rloc16:0xe400 ext-addr:dae9c4c0e9da55ff ver:4
      *    3-links:{ 46 51 }
      *    1-links:{ 33 }
      * Done
@@ -5469,6 +5469,7 @@ template <> otError Interpreter::Process<Cmd("meshdiag")>(Arg aArgs[])
      * * Router ID
      * * RLOC16
      * * Extended MAC address
+     * * Thread Version (if known)
      * * Whether the router is this device is itself (`me`)
      * * Whether the router is the parent of this device when device is a child (`parent`)
      * * Whether the router is `leader`
@@ -5536,6 +5537,11 @@ void Interpreter::HandleMeshDiagDiscoverDone(otError aError, otMeshDiagRouterInf
 
     OutputFormat("id:%02u rloc16:0x%04x ext-addr:", aRouterInfo->mRouterId, aRouterInfo->mRloc16);
     OutputExtAddress(aRouterInfo->mExtAddress);
+
+    if (aRouterInfo->mVersion != OT_MESH_DIAG_VERSION_UNKNOWN)
+    {
+        OutputFormat(" ver:%u", aRouterInfo->mVersion);
+    }
 
     if (aRouterInfo->mIsThisDevice)
     {

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -50,6 +50,7 @@
 #include "thread/mle_router.hpp"
 #include "thread/thread_netif.hpp"
 #include "thread/thread_tlvs.hpp"
+#include "thread/version.hpp"
 
 namespace ot {
 
@@ -335,6 +336,10 @@ Error NetworkDiagnostic::AppendDiagTlv(uint8_t aTlvType, Message &aMessage)
 
     case Tlv::kMode:
         error = Tlv::Append<ModeTlv>(aMessage, Get<Mle::MleRouter>().GetDeviceMode().Get());
+        break;
+
+    case Tlv::kVersion:
+        error = Tlv::Append<VersionTlv>(aMessage, kThreadVersion);
         break;
 
     case Tlv::kTimeout:
@@ -741,6 +746,10 @@ Error NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage, Iterator 
 
         case Tlv::kMaxChildTimeout:
             SuccessOrExit(error = Tlv::Read<MaxChildTimeoutTlv>(aMessage, offset, aTlvInfo.mData.mMaxChildTimeout));
+            break;
+
+        case Tlv::kVersion:
+            SuccessOrExit(error = Tlv::Read<VersionTlv>(aMessage, offset, aTlvInfo.mData.mVersion));
             break;
 
         default:

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -85,6 +85,7 @@ public:
         kChannelPages    = OT_NETWORK_DIAGNOSTIC_TLV_CHANNEL_PAGES,
         kTypeList        = OT_NETWORK_DIAGNOSTIC_TLV_TYPE_LIST,
         kMaxChildTimeout = OT_NETWORK_DIAGNOSTIC_TLV_MAX_CHILD_TIMEOUT,
+        kVersion         = OT_NETWORK_DIAGNOSTIC_TLV_VERSION,
     };
 
     /**
@@ -164,6 +165,12 @@ typedef TlvInfo<Tlv::kChildTable> ChildTableTlv;
  *
  */
 typedef UintTlvInfo<Tlv::kMaxChildTimeout, uint32_t> MaxChildTimeoutTlv;
+
+/**
+ * This class defines Version TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kVersion, uint16_t> VersionTlv;
 
 typedef otNetworkDiagConnectivity Connectivity; ///< Network Diagnostic Connectivity value.
 

--- a/src/core/utils/mesh_diag.hpp
+++ b/src/core/utils/mesh_diag.hpp
@@ -66,6 +66,8 @@ namespace Utils {
 class MeshDiag : public InstanceLocator
 {
 public:
+    static constexpr uint16_t kVersionUnknown = OT_MESH_DIAG_VERSION_UNKNOWN; ///< Unknown version.
+
     typedef otMeshDiagDiscoverConfig   DiscoverConfig;   ///< The discovery configuration.
     typedef otMeshDiagDiscoverCallback DiscoverCallback; ///< The discovery callback function pointer type.
 


### PR DESCRIPTION
This commit adds support for Net Diag Version TLV (TLV number 24) which returns the Thread version of device (as `uint16_t`). It also updated the `MeshDiag` to query for the Version TLV and provide it in `otMeshDiagRouterInfo`. The related CLI commands are also updated.

----

This is related to [SPEC-1146](https://threadgroup.atlassian.net/jira/core/projects/SPEC/issues/SPEC-1146).