### PR TITLE
[tcp] update `otTcpConnect()` doc to indicate currently supported behavior

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (298)
+#define OPENTHREAD_API_VERSION (299)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/tcp.h
+++ b/include/openthread/tcp.h
@@ -401,11 +401,11 @@ enum
 /**
  * Records the remote host and port for this connection.
  *
- * By default TCP Fast Open is used. This means that this function merely
- * records the remote host and port, and that the TCP connection establishment
- * handshake only happens on the first call to otTcpSendByReference(). TCP Fast
- * Open can be explicitly disabled using @p aFlags, in which case the TCP
- * connection establishment handshake is initiated immediately.
+ * Caller must wait for `otTcpEstablished` callback indicating that TCP
+ * connection establishment handshake is done before it can start sending data
+ * e.g., calling `otTcpSendByReference()`.
+ *
+ * The TCP Fast Open is not yet supported and @p aFlags is ignored.
  *
  * @param[in]  aEndpoint  A pointer to the TCP endpoint structure to connect.
  * @param[in]  aSockName  The IP address and port of the host to which to connect.


### PR DESCRIPTION
This commit updates the documentation for `otTcpConnect()` indicating that caller need to wait for `otTcpEstablished` callback indicating that TCP connection was established  before it can start sending data (e.g., calling `otTcpSendByReference()`).

It also removes the mention of "TCP Fast Open" which is not yet supported.

----

@samkumar can you please check/verify this?
- I think "fast open" is not yet supported. I see in `Tcp::Endpoint::Connect()` we ignore `aFlags` (we have `OT_UNUSED_VARIABLE(aFlags);`)
- Also `otTcpSendByReference()` cannot be called until connection is established
   - `SendByReference()` calls `tcp_usr_send()` which has this `tp->t_state` check:
   ```c++
    /*
	 * samkumar: This if statement and the next are checks that I added
	 */
	if (tp->t_state < TCPS_ESTABLISHED) {
		error = ENOTCONN;
		goto out;
	}
   ```

If you are aware of other things  in TCP API docs that may be yet be supported, let me know (so we update the docs). It is better to keep docs mirror current behavior (to help  folks using the API). We can update the docs when features are supported (e.g. fast open, etc). 


