### PR TITLE
[mle] add `InitNeighbor()` method

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1462,6 +1462,22 @@ protected:
     void SetAttachState(AttachState aState);
 
     /**
+     * This method initializes a given @p aNeighbor with information from @p aRxInfo.
+     *
+     * This method updates the following properties on @p aNeighbor from @p aRxInfo:
+     *
+     * - Sets the Extended MAC address from `MessageInfo` peer IPv6 address IID.
+     * - Clears the `GetLinkInfo()` and adds RSS from the `GetThreadLinkInfo()`.
+     * - Resets the link failure counter (`ResetLinkFailures()`).
+     * - Sets the "last heard" time to now (`SetLastHeard()`).
+     *
+     * @param[in,out] aNeighbor   The `Neighbor` to initialize.
+     * @param[in]     aRxInfo     The `RxtInfo` to use for initialization.
+     *
+     */
+    void InitNeighbor(Neighbor &aNeighbor, const RxInfo &aRxInfo);
+
+    /**
      * This method clears the parent candidate.
      *
      */

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -364,10 +364,12 @@ public:
     NetworkData::Type GetNetworkDataType(void) const { return GetDeviceMode().GetNetworkDataType(); }
 
     /**
-     * This method sets all bytes of the Extended Address to zero.
+     * This method returns the Extended Address.
+     *
+     * @returns A const reference to the Extended Address.
      *
      */
-    void ClearExtAddress(void) { memset(&mMacAddr, 0, sizeof(mMacAddr)); }
+    const Mac::ExtAddress &GetExtAddress(void) const { return mMacAddr; }
 
     /**
      * This method returns the Extended Address.
@@ -375,7 +377,7 @@ public:
      * @returns A reference to the Extended Address.
      *
      */
-    const Mac::ExtAddress &GetExtAddress(void) const { return mMacAddr; }
+    Mac::ExtAddress &GetExtAddress(void) { return mMacAddr; }
 
     /**
      * This method sets the Extended Address.


### PR DESCRIPTION
This commit adds a helper method `MleRouter::InitNeighbor()` which perform common initialization done using `RxInfo` like setting the Extended MAC address from the sender's IPv6 address IID, updating the `LinkInfo`, and setting `LastHeard` time. This method is used from different methods in `MleRouter` where a new neighbor (router or child) is initialized.