### PR TITLE
[build] fix the warning `-Wunused-command-line-argument` on macOS

### DIFF
--- a/src/posix/Makefile-posix
+++ b/src/posix/Makefile-posix
@@ -79,7 +79,6 @@ UPTIME                               ?= 1
 
 COMMONCFLAGS                         := \
     -g                                  \
-    -rdynamic                           \
     $(NULL)
 
 # If the user has asserted COVERAGE, alter the configuration options
@@ -145,6 +144,7 @@ CXXFLAGS                       += \
 
 LDFLAGS                        += \
     $(COMMONCFLAGS)               \
+    -rdynamic                     \
     $(NULL)
 
 TopSourceDir                   := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))../..


### PR DESCRIPTION
Use the command `make -f src/posix/Makefile-posix` to build the POSIX platform on macOS, it generates the warning `-Wunused-command-line-argument` (refer to #8828).

This commit moves the linker option `-rdynamic` from `COMMONCFLAGS` to the `LDFLAGS` to remove the warning.

Fixes #8828 