### PR TITLE
[srp-server] fix -Werror=maybe-uninitialized

### DIFF
--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -442,12 +442,12 @@ void Server::CommitSrpUpdate(Error                    aError,
                              const LeaseConfig       &aLeaseConfig)
 {
     Host    *existingHost;
-    uint32_t hostLease;
-    uint32_t hostKeyLease;
-    uint32_t grantedLease;
-    uint32_t grantedKeyLease;
     uint32_t grantedTtl;
-    bool     shouldFreeHost = true;
+    uint32_t hostLease       = 0;
+    uint32_t hostKeyLease    = 0;
+    uint32_t grantedLease    = 0;
+    uint32_t grantedKeyLease = 0;
+    bool     shouldFreeHost  = true;
 
     SuccessOrExit(aError);
 
@@ -824,7 +824,7 @@ Error Server::ProcessHostDescriptionInstruction(Host                  &aHost,
                                                 const Message         &aMessage,
                                                 const MessageMetadata &aMetadata) const
 {
-    Error    error;
+    Error    error  = kErrorNone;
     uint16_t offset = aMetadata.mOffset;
 
     OT_ASSERT(aHost.GetFullName() == nullptr);


### PR DESCRIPTION
Build errors are raised by arm-none-eabi-gcc 10 toolchain when building with -Og option and this commit aims to fix them:

```
/ot/openthread/src/core/net/srp_server.cpp:906:12: error: 'error' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  906 |     return error;
      |            ^~~~~
/ot/openthread/src/core/net/srp_server.cpp: In member function 'void ot::Srp::Server::CommitSrpUpdate(ot::Error, ot::Srp::Server::Host&, const ot::Dns::UpdateHeader&, const ot::Ip6::MessageInfo*, const ot::Srp::Server::TtlConfig&, const ot::Srp::Server::LeaseConfig&)':
/ot/openthread/src/core/net/srp_server.cpp:526:25: error: 'grantedKeyLease' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  526 |             SendResponse(aDnsHeader, grantedLease, grantedKeyLease, *aMessageInfo);
      |             ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/ot/openthread/src/core/net/srp_server.cpp:526:25: error: 'grantedLease' may be used uninitialized in this function [-Werror=maybe-uninitialized]
/ot/openthread/src/core/net/srp_server.cpp:524:37: error: 'hostKeyLease' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  524 |         if (aError == kErrorNone && !(grantedLease == hostLease && grantedKeyLease == hostKeyLease))
      |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/ot/openthread/src/core/net/srp_server.cpp:524:34: error: 'hostLease' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  524 |         if (aError == kErrorNone && !(grantedLease == hostLease && grantedKeyLease == hostKeyLease))
      |             ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
[214/938] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/mle.cpp.obj
ninja: build stopped: subcommand failed.
```

