### PR TITLE
[mle] update and enhance processing of Route TLV

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1360,7 +1360,7 @@ protected:
         /**
          * This method reads CSL Clock Accuracy TLV from a message.
          *
-         * @param[out]      A reference to output the CSL accuracy.
+         * @param[out] aCslAccuracy A reference to output the CSL accuracy.
          *
          * @retval kErrorNone       Successfully read the TLV.
          * @retval kErrorNotFound   TLV was not found in the message.
@@ -1368,6 +1368,20 @@ protected:
          *
          */
         Error ReadCslClockAccuracyTlv(Mac::CslAccuracy &aCslAccuracy) const;
+#endif
+
+#if OPENTHREAD_FTD
+        /**
+         * This method reads and validates Route TLV from a message.
+         *
+         * @param[out] aRouteTlv    A reference to output the read Route TLV.
+         *
+         * @retval kErrorNone       Successfully read and validated the Route TLV.
+         * @retval kErrorNotFound   TLV was not found in the message.
+         * @retval kErrorParse      TLV was found but could not be parsed or is not valid.
+         *
+         */
+        Error ReadRouteTlv(RouteTlv &aRouteTlv) const;
 #endif
 
     private:

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -579,8 +579,9 @@ private:
     void HandleTimeSync(RxInfo &aRxInfo);
 #endif
 
-    Error ProcessRouteTlv(RxInfo &aRxInfo);
-    Error ProcessRouteTlv(RxInfo &aRxInfo, RouteTlv &aRouteTlv);
+    Error ProcessRouteTlv(const RouteTlv &aRouteTlv, RxInfo &aRxInfo);
+    Error ReadAndProcessRouteTlvOnFed(RxInfo &aRxInfo, uint8_t aParentId);
+
     void  StopAdvertiseTrickleTimer(void);
     Error SendAddressSolicit(ThreadStatusTlv::Status aStatus);
     void  SendAddressSolicitResponse(const Coap::Message    &aRequest,

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -66,6 +66,12 @@ void RouterTable::Clear(void)
     SignalTableChanged();
 }
 
+bool RouterTable::IsRouteTlvIdSequenceMoreRecent(const Mle::RouteTlv &aRouteTlv) const
+{
+    return (GetActiveRouterCount() == 0) ||
+           SerialNumber::IsGreater(aRouteTlv.GetRouterIdSequence(), GetRouterIdSequence());
+}
+
 void RouterTable::ClearNeighbors(void)
 {
     for (Router &router : mRouters)

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -39,6 +39,7 @@
 #include "common/iterator_utils.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
+#include "common/serial_number.hpp"
 #include "common/tasklet.hpp"
 #include "mac/mac_types.hpp"
 #include "thread/mle_tlvs.hpp"
@@ -314,6 +315,18 @@ public:
      *
      */
     TimeMilli GetRouterIdSequenceLastUpdated(void) const { return mRouterIdSequenceLastUpdated; }
+
+    /**
+     * This method determines whether the Router ID Sequence in a received Route TLV is more recent than the current
+     * Router ID Sequence being used by `RouterTable`.
+     *
+     * @param[in] aRouteTlv   The Route TLV to compare.
+     *
+     * @retval TRUE    The Router ID Sequence in @p aRouteTlv is more recent.
+     * @retval FALSE   The Router ID Sequence in @p aRouteTlv is not more recent.
+     *
+     */
+    bool IsRouteTlvIdSequenceMoreRecent(const Mle::RouteTlv &aRouteTlv) const;
 
     /**
      * This method returns the number of neighbor links.


### PR DESCRIPTION
This commit updates how we process Route TLV in a received "MLE Link Accept" message when device is already acting as router or leader:

- We ensure that the Router ID Sequence number in the received Route TLV is more recent compared to the current one being used before adopting the Router ID Set. We still update the router table (next hops and costs) based on the received Route TLV even if Sequence number is older.
- We also check that the ID of the router which sent the Link Accept is marked as allocated in the Route TLV that it includes in the message. This protects against an edge-case where the sending router may be misbehaving.

In addition to the above two changes, this commit contains some enhancements and simplifications:

- `RxMessage::ReadRouteTlv()` is added which reads and validates a `RouteTlv` from an `Mle::RxMessage`.
- `MleRouter::ReadAndProcessRouteTlvOnFed()` is added which reads and processes `RouteTlv` on an FED (avoid repeating same code).
- `MleRouter::ProcessRouteTlv()` is simplified.