### PR TITLE
[mesh-diag] update `kMaxTlvsToRequest` constant

### DIFF
--- a/src/core/utils/mesh_diag.cpp
+++ b/src/core/utils/mesh_diag.cpp
@@ -90,6 +90,8 @@ void MeshDiag::Cancel(void)
 
 Error MeshDiag::SendDiagGetTo(uint16_t aRloc16, const DiscoverConfig &aConfig)
 {
+    static constexpr uint8_t kMaxTlvsToRequest = 6;
+
     Error            error   = kErrorNone;
     Coap::Message   *message = nullptr;
     Tmf::MessageInfo messageInfo(GetInstance());

--- a/src/core/utils/mesh_diag.hpp
+++ b/src/core/utils/mesh_diag.hpp
@@ -182,8 +182,7 @@ public:
 private:
     typedef ot::NetworkDiagnostic::Tlv Tlv;
 
-    static constexpr uint32_t kResponseTimeout  = OPENTHREAD_CONFIG_MESH_DIAG_RESPONSE_TIMEOUT;
-    static constexpr uint8_t  kMaxTlvsToRequest = 5;
+    static constexpr uint32_t kResponseTimeout = OPENTHREAD_CONFIG_MESH_DIAG_RESPONSE_TIMEOUT;
 
     Error SendDiagGetTo(uint16_t aRloc16, const DiscoverConfig &aConfig);
     void  HandleTimer(void);


### PR DESCRIPTION
This commit updates `kMaxTlvsToRequest` constant to account for the recently added `VersionTlv`. It also moves its definition from header file to cpp file in `SendDiagGetTo()` method so to make it easier to track and update it when/if new TLV types are added.