### PR TITLE
[netdata] avoid reset context id reuse timer on every network data registration at the leader

### DIFF
--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -1138,8 +1138,11 @@ void Leader::RemoveRlocInPrefix(PrefixTlv       &aPrefix,
     {
         if (aPrefix.GetSubTlvsLength() == sizeof(ContextTlv))
         {
-            context->ClearCompress();
-            StartContextReuseTimer(context->GetContextId());
+	    if (context->IsCompress())
+	    {
+            	context->ClearCompress();
+            	StartContextReuseTimer(context->GetContextId());
+	    }
         }
         else
         {


### PR DESCRIPTION
 [netdata] context reuse timer is restarted whenever any network data registration (containing prefix TLV) comes to the leader. This would cause stale contexts to never expire (even after CONTEXT_ID_REUSE_DELAY)
