### PR TITLE
[netdata] update `StartContextReuseTimer()` to start time if not running

### DIFF
--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -1003,6 +1003,11 @@ void Leader::FreeContextId(uint8_t aContextId)
 
 void Leader::StartContextReuseTimer(uint8_t aContextId)
 {
+    // Start the reuse timer for `aContextId` if it is not already
+    // scheduled.
+
+    VerifyOrExit(mContextLastUsed[aContextId - kMinContextId].GetValue() == 0);
+
     mContextLastUsed[aContextId - kMinContextId] = TimerMilli::GetNow();
 
     if (mContextLastUsed[aContextId - kMinContextId].GetValue() == 0)
@@ -1010,7 +1015,13 @@ void Leader::StartContextReuseTimer(uint8_t aContextId)
         mContextLastUsed[aContextId - kMinContextId].SetValue(1);
     }
 
-    mTimer.Start(kStateUpdatePeriod);
+    if (!mTimer.IsRunning())
+    {
+        mTimer.Start(kStateUpdatePeriod);
+    }
+
+exit:
+    return;
 }
 
 void Leader::StopContextReuseTimer(uint8_t aContextId) { mContextLastUsed[aContextId - kMinContextId].SetValue(0); }


### PR DESCRIPTION
This commit contains two changes to `StartContextReuseTimer()`:
- We now start the context reuse timer only if the timer is not already scheduled (`mContextLastUsed` will be non-zero when reuse timer is already scheduled).
- The `mTimer` (which is used as a periodic timer) is only started if it is not already running.

----

Related to https://github.com/openthread/openthread/pull/8855.

There are some other enhancement ideas (did not add these in this PR to keep it small but we can add in a follow-up PR):
- Instead of tracking `mContextLastUsed` we can track the expire time directly.
- Use `mTimer` to directly schedule the next (earliest) expire time (instead of using it as periodic timer of 60 seconds).
