### PR TITLE
[netdata] ensure to free context ID once

### DIFF
--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -1336,6 +1336,7 @@ void Leader::HandleTimer(void)
 
         if (TimerMilli::GetNow() - mContextLastUsed[i] >= Time::SecToMsec(mContextIdReuseDelay))
         {
+            mContextLastUsed[i].SetValue(0);
             FreeContextId(kMinContextId + i);
         }
         else


### PR DESCRIPTION
This commit updates `NetworkData::Leader::HandleTimer()` such that once the reuse delay time for a previously used Context ID is reached and the ID is freed, the `mContextLastUsed` is also set to zero. This ensures that context ID is freed only once from `HandleTimer()`(which avoids incrementing the version again).

----

This is follow up from https://github.com/openthread/openthread/pull/8859 (reading the related code we noticed this situation).