### PR TITLE
[mac] add build config for timeout for receiving a Data Frame

### DIFF
--- a/src/core/config/mac.h
+++ b/src/core/config/mac.h
@@ -521,4 +521,15 @@
 #define OPENTHREAD_CONFIG_MAC_OUTGOING_BEACON_PAYLOAD_ENABLE 0
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_MAC_DATA_POLL_TIMEOUT
+ *
+ * This setting specifies the timeout for receiving the Data Frame (in msec) - after an ACK with FP bit set was
+ * received.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAC_DATA_POLL_TIMEOUT
+#define OPENTHREAD_CONFIG_MAC_DATA_POLL_TIMEOUT 100
+#endif
+
 #endif // CONFIG_MAC_H_

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -71,8 +71,9 @@ class Neighbor;
 
 namespace Mac {
 
-constexpr uint32_t kDataPollTimeout = 100; ///< Timeout for receiving Data Frame (in msec).
-constexpr uint32_t kSleepDelay      = 300; ///< Max sleep delay when frame is pending (in msec).
+constexpr uint32_t kDataPollTimeout =
+    OPENTHREAD_CONFIG_MAC_DATA_POLL_TIMEOUT; ///< Timeout for receiving Data Frame (in msec).
+constexpr uint32_t kSleepDelay = 300;        ///< Max sleep delay when frame is pending (in msec)
 
 constexpr uint16_t kScanDurationDefault = OPENTHREAD_CONFIG_MAC_SCAN_DURATION; ///< Duration per channel (in msec).
 


### PR DESCRIPTION
This setting is targeted for SEDs which may need to decrease the timeout for receiving a Data Frame (which follows an ACK with FP bit set) for power saving reasons.

IEEE 802.15.4/2015 specification doesn't enforce a specific timeout value for this parameter so the application should be able to configure it.