### PR TITLE
[dua] avoid unnecessary time ticker processing

### DIFF
--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -345,7 +345,12 @@ void DuaManager::HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State
 
     if (aState == BackboneRouter::Leader::kStateAdded || aState == BackboneRouter::Leader::kStateToTriggerRereg)
     {
-        UpdateReregistrationDelay();
+#if OPENTHREAD_CONFIG_DUA_ENABLE
+        if (Get<Mle::Mle>().IsFullThreadDevice() || Get<Mle::Mle>().GetParent().IsThreadVersion1p1())
+#endif
+        {
+            UpdateReregistrationDelay();
+        }
     }
 }
 


### PR DESCRIPTION
If there is no DUA request sent/scheduled to be sent, then there is no need to trigger the periodic one second ticker timer.

This helps SEDs to be more power efficient and to avoid unnecessary wakeups.