### PR TITLE
[dua] remove DUA address if network data no longer contains DUA prefix

### DIFF
--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -305,6 +305,19 @@ void DuaManager::HandleNotifierEvents(Events aEvents)
 {
     Mle::MleRouter &mle = Get<Mle::MleRouter>();
 
+#if OPENTHREAD_CONFIG_DUA_ENABLE
+    if (aEvents.Contains(kEventThreadNetdataChanged))
+    {
+        Lowpan::Context context;
+        // Remove a stale DUA address if any.
+        if (Get<ThreadNetif>().HasUnicastAddress(Get<DuaManager>().GetDomainUnicastAddress()) &&
+            (Get<NetworkData::Leader>().GetContext(Get<DuaManager>().GetDomainUnicastAddress(), context) != kErrorNone))
+        {
+            RemoveDomainUnicastAddress();
+        }
+    }
+#endif
+
     VerifyOrExit(mle.IsAttached(), mDelay.mValue = 0);
 
     if (aEvents.Contains(kEventThreadRoleChanged))

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -4599,10 +4599,9 @@ Error Mle::TxMessage::AppendAddressRegistrationTlv(AddressRegistrationMode aMode
     counter++;
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
-    if (Get<ThreadNetif>().HasUnicastAddress(Get<DuaManager>().GetDomainUnicastAddress()))
+    if (Get<ThreadNetif>().HasUnicastAddress(Get<DuaManager>().GetDomainUnicastAddress()) &&
+        (Get<NetworkData::Leader>().GetContext(Get<DuaManager>().GetDomainUnicastAddress(), context) == kErrorNone))
     {
-        SuccessOrAssert(Get<NetworkData::Leader>().GetContext(Get<DuaManager>().GetDomainUnicastAddress(), context));
-
         // Prioritize DUA, compressed entry
         entry.SetContextId(context.mContextId);
         entry.SetIid(Get<DuaManager>().GetDomainUnicastAddress().GetIid());


### PR DESCRIPTION
Fix for the following bug:

Leader/Parent (OTBR) is reset (taken off the network), leading to its MTD child being detached. When the parent is brought back on the network without configuring the previous DUA prefix, the MTD asserts complaining that its DUA prefix is not valid anymore.

1. We don't assert anymore in this situation, rather the MTD just won't include the DUA address in its address registration TLV.
2. More importantly, we remove a "cached" DUA address if we find that the network leader is no longer configured with a DUA prefix.