### PR TITLE
[mle] add `IncrementLinkQuality()` to `ConnectivityTlv`

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3719,23 +3719,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
 
     if (IsChild())
     {
-        switch (mParent.GetLinkQualityIn())
-        {
-        case kLinkQuality0:
-            break;
-
-        case kLinkQuality1:
-            aTlv.SetLinkQuality1(aTlv.GetLinkQuality1() + 1);
-            break;
-
-        case kLinkQuality2:
-            aTlv.SetLinkQuality2(aTlv.GetLinkQuality2() + 1);
-            break;
-
-        case kLinkQuality3:
-            aTlv.SetLinkQuality3(aTlv.GetLinkQuality3() + 1);
-            break;
-        }
+        aTlv.IncrementLinkQuality(mParent.GetLinkQualityIn());
     }
 
     for (const Router &router : Get<RouterTable>())
@@ -3752,23 +3736,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
             continue;
         }
 
-        switch (router.GetTwoWayLinkQuality())
-        {
-        case kLinkQuality0:
-            break;
-
-        case kLinkQuality1:
-            aTlv.SetLinkQuality1(aTlv.GetLinkQuality1() + 1);
-            break;
-
-        case kLinkQuality2:
-            aTlv.SetLinkQuality2(aTlv.GetLinkQuality2() + 1);
-            break;
-
-        case kLinkQuality3:
-            aTlv.SetLinkQuality3(aTlv.GetLinkQuality3() + 1);
-            break;
-        }
+        aTlv.IncrementLinkQuality(router.GetTwoWayLinkQuality());
     }
 
     aTlv.SetActiveRouters(mRouterTable.GetActiveRouterCount());

--- a/src/core/thread/mle_tlvs.cpp
+++ b/src/core/thread/mle_tlvs.cpp
@@ -66,5 +66,23 @@ exit:
 
 #endif // #if !OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
 
+void ConnectivityTlv::IncrementLinkQuality(LinkQuality aLinkQuality)
+{
+    switch (aLinkQuality)
+    {
+    case kLinkQuality0:
+        break;
+    case kLinkQuality1:
+        mLinkQuality1++;
+        break;
+    case kLinkQuality2:
+        mLinkQuality2++;
+        break;
+    case kLinkQuality3:
+        mLinkQuality3++;
+        break;
+    }
+}
+
 } // namespace Mle
 } // namespace ot

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -841,6 +841,17 @@ public:
     void SetLinkQuality1(uint8_t aLinkQuality) { mLinkQuality1 = aLinkQuality; }
 
     /**
+     * This method increments the Link Quality N field in TLV for a given Link Quality N (1,2,3).
+     *
+     * The Link Quality N field specifies the number of neighboring router devices with which the sender shares a link
+     * of quality N.
+     *
+     * @param[in] aLinkQuality  The Link Quality N (1,2,3) field to update.
+     *
+     */
+    void IncrementLinkQuality(LinkQuality aLinkQuality);
+
+    /**
      * This method sets the Active Routers value.
      *
      * @returns The Active Routers value.


### PR DESCRIPTION
This method helps when preparing the `ConnectivityTlv` and counting the neighbors with which device shares a link at different Link Quality values (1,2,3).