### PR TITLE
[srp] add support for short (4-bytes) lease option variant

### DIFF
--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -766,6 +766,28 @@ public:
      *
      */
     bool IsServiceKeyRecordEnabled(void) const { return mServiceKeyRecordEnabled; }
+
+    /**
+     * This method enables/disables "use short Update Lease Option" behavior.
+     *
+     * When enabled, the SRP client will use the short variant format of Update Lease Option in its message. The short
+     * format only includes the lease interval.
+     *
+     * This method is added under `REFERENCE_DEVICE` config and is intended to override the default behavior for
+     * testing only.
+     *
+     * @param[in] aUseShort    TRUE to enable, FALSE to disable the "use short Update Lease Option" mode.
+     *
+     */
+    void SetUseShortLeaseOption(bool aUseShort) { mUseShortLeaseOption = aUseShort; }
+
+    /**
+     * This method gets the current "use short Update Lease Option" mode.
+     *
+     * @returns TRUE if "use short Update Lease Option" mode is enabled, FALSE otherwise.
+     *
+     */
+    bool GetUseShortLeaseOption(void) const { return mUseShortLeaseOption; }
 #endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 
 private:
@@ -990,7 +1012,7 @@ private:
     Error        AppendDeleteAllRrsets(Message &aMessage) const;
     Error        AppendHostName(Message &aMessage, Info &aInfo, bool aDoNotCompress = false) const;
     Error        AppendAaaaRecord(const Ip6::Address &aAddress, Message &aMessage, Info &aInfo) const;
-    Error        AppendUpdateLeaseOptRecord(Message &aMessage) const;
+    Error        AppendUpdateLeaseOptRecord(Message &aMessage);
     Error        AppendSignature(Message &aMessage, Info &aInfo);
     void         UpdateRecordLengthInMessage(Dns::ResourceRecord &aRecord, uint16_t aOffset, Message &aMessage) const;
     static void  HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
@@ -1035,6 +1057,7 @@ private:
     bool    mSingleServiceMode : 1;
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     bool mServiceKeyRecordEnabled : 1;
+    bool mUseShortLeaseOption : 1;
 #endif
 
     uint16_t mUpdateMessageId;

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -593,6 +593,8 @@ public:
         void  SetTtl(uint32_t aTtl) { mTtl = aTtl; }
         void  SetLease(uint32_t aLease) { mLease = aLease; }
         void  SetKeyLease(uint32_t aKeyLease) { mKeyLease = aKeyLease; }
+        void  SetUseShortLeaseOption(bool aUse) { mUseShortLeaseOption = aUse; }
+        bool  ShouldUseShortLeaseOption(void) const { return mUseShortLeaseOption; }
         Error ProcessTtl(uint32_t aTtl);
 
         LinkedList<Service> &GetServices(void) { return mServices; }
@@ -626,6 +628,7 @@ public:
         uint32_t               mKeyLease; // The KEY-LEASE time in seconds.
         TimeMilli              mUpdateTime;
         LinkedList<Service>    mServices;
+        bool                   mUseShortLeaseOption; // Use short lease option (lease only - 4 byte) when responding.
     };
 
     /**
@@ -1044,6 +1047,7 @@ private:
     void        SendResponse(const Dns::UpdateHeader &aHeader,
                              uint32_t                 aLease,
                              uint32_t                 aKeyLease,
+                             bool                     mUseShortLeaseOption,
                              const Ip6::MessageInfo  &aMessageInfo);
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);

--- a/tests/unit/test_srp_server.cpp
+++ b/tests/unit/test_srp_server.cpp
@@ -225,8 +225,10 @@ enum UpdateHandlerMode
     kIgnore  // Ignore all updates (do not call `otSrpServerHandleServiceUpdateResult()`).
 };
 
-static UpdateHandlerMode sUpdateHandlerMode       = kAccept;
-static bool              sProcessedUpdateCallback = false;
+static UpdateHandlerMode    sUpdateHandlerMode       = kAccept;
+static bool                 sProcessedUpdateCallback = false;
+static otSrpServerLeaseInfo sUpdateHostLeaseInfo;
+static uint32_t             sUpdateHostKeyLease;
 
 void HandleSrpServerUpdate(otSrpServerServiceUpdateId aId,
                            const otSrpServerHost     *aHost,
@@ -239,6 +241,8 @@ void HandleSrpServerUpdate(otSrpServerServiceUpdateId aId,
     VerifyOrQuit(aContext == sInstance);
 
     sProcessedUpdateCallback = true;
+
+    otSrpServerHostGetLeaseInfo(aHost, &sUpdateHostLeaseInfo);
 
     switch (sUpdateHandlerMode)
     {
@@ -699,6 +703,202 @@ void TestSrpServerIgnore(void)
     Log("End of TestSrpServerIgnore");
 }
 
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+void TestUpdateLeaseShortVariant(void)
+{
+    // Test behavior of SRP client and server when short variant of
+    // Update Lease Option is used (which only include lease interval).
+    // This test uses `SetUseShortLeaseOption()` method of `Srp::Client`
+    // which changes the default behavior and is available under the
+    // `REFERENCE_DEVICE` config.
+
+    Srp::Server                *srpServer;
+    Srp::Server::LeaseConfig    leaseConfig;
+    const Srp::Server::Service *service;
+    Srp::Client                *srpClient;
+    Srp::Client::Service        service1;
+    uint16_t                    heapAllocations;
+
+    Log("--------------------------------------------------------------------------------------------");
+    Log("TestUpdateLeaseShortVariant");
+
+    InitTest();
+
+    srpServer = &sInstance->Get<Srp::Server>();
+    srpClient = &sInstance->Get<Srp::Client>();
+
+    heapAllocations = sHeapAllocatedPtrs.GetLength();
+
+    PrepareService1(service1);
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Start SRP server.
+
+    SuccessOrQuit(srpServer->SetAddressMode(Srp::Server::kAddressModeUnicast));
+    VerifyOrQuit(srpServer->GetState() == Srp::Server::kStateDisabled);
+
+    srpServer->SetServiceHandler(HandleSrpServerUpdate, sInstance);
+
+    srpServer->SetEnabled(true);
+    VerifyOrQuit(srpServer->GetState() != Srp::Server::kStateDisabled);
+
+    AdvanceTime(10000);
+    VerifyOrQuit(srpServer->GetState() == Srp::Server::kStateRunning);
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Check the default Lease Config on SRP server.
+    // Server to accept lease in [30 sec, 27 hours] and
+    // key-lease in [30 sec, 189 hours].
+
+    srpServer->GetLeaseConfig(leaseConfig);
+
+    VerifyOrQuit(leaseConfig.mMinLease == 30);             // 30 seconds
+    VerifyOrQuit(leaseConfig.mMaxLease == 27u * 3600);     // 27 hours
+    VerifyOrQuit(leaseConfig.mMinKeyLease == 30);          // 30 seconds
+    VerifyOrQuit(leaseConfig.mMaxKeyLease == 189u * 3600); // 189 hours
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Start SRP client.
+
+    srpClient->SetCallback(HandleSrpClientCallback, sInstance);
+
+    srpClient->EnableAutoStartMode(nullptr, nullptr);
+    VerifyOrQuit(srpClient->IsAutoStartModeEnabled());
+
+    AdvanceTime(2000);
+    VerifyOrQuit(srpClient->IsRunning());
+
+    SuccessOrQuit(srpClient->SetHostName(kHostName));
+    SuccessOrQuit(srpClient->EnableAutoHostAddress());
+
+    sUpdateHandlerMode = kAccept;
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Change default lease intervals on SRP client and enable
+    // "use short Update Lease Option" mode.
+
+    srpClient->SetLeaseInterval(15u * 3600);
+    srpClient->SetKeyLeaseInterval(40u * 3600);
+
+    srpClient->SetUseShortLeaseOption(true);
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Register a service, validate that update handler is called
+    // and service is successfully registered.
+
+    SuccessOrQuit(srpClient->AddService(service1));
+
+    sProcessedUpdateCallback = false;
+    sProcessedClientCallback = false;
+
+    AdvanceTime(2 * 1000);
+
+    VerifyOrQuit(sProcessedUpdateCallback);
+    VerifyOrQuit(sProcessedClientCallback);
+    VerifyOrQuit(sLastClientCallbackError == kErrorNone);
+
+    VerifyOrQuit(service1.GetState() == Srp::Client::kRegistered);
+
+    ValidateHost(*srpServer, kHostName);
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Validate the lease info for service on SRP server. The client
+    // is set up to use "short Update Lease Option format, so it only
+    // include the lease interval as 15 hours in its request
+    // message. Server should then see 15 hours for both lease and
+    // key lease
+
+    VerifyOrQuit(sUpdateHostLeaseInfo.mLease == 15u * 3600 * 1000);
+    VerifyOrQuit(sUpdateHostLeaseInfo.mKeyLease == 15u * 3600 * 1000);
+
+    // Check that SRP server granted 15 hours for both lease and
+    // key lease.
+
+    service = srpServer->GetNextHost(nullptr)->GetServices().GetHead();
+    VerifyOrQuit(service != nullptr);
+    VerifyOrQuit(service->GetLease() == 15u * 3600);
+    VerifyOrQuit(service->GetKeyLease() == 15u * 3600);
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Remove the service.
+
+    SuccessOrQuit(srpClient->RemoveService(service1));
+
+    sProcessedUpdateCallback = false;
+    sProcessedClientCallback = false;
+
+    AdvanceTime(2 * 1000);
+
+    VerifyOrQuit(sProcessedUpdateCallback);
+    VerifyOrQuit(sProcessedClientCallback);
+    VerifyOrQuit(sLastClientCallbackError == kErrorNone);
+
+    VerifyOrQuit(service1.GetState() == Srp::Client::kRemoved);
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Register the service again, but this time change it to request
+    // a lease time that is larger than the `LeaseConfig.mMinLease` of
+    // 27 hours. This ensures that server needs to include the Lease
+    // Option in its response (since it need to grant a different
+    // lease interval).
+
+    service1.mLease    = 100u * 3600; // 100 hours >= 27 hours.
+    service1.mKeyLease = 110u * 3600;
+
+    SuccessOrQuit(srpClient->AddService(service1));
+
+    sProcessedUpdateCallback = false;
+    sProcessedClientCallback = false;
+
+    AdvanceTime(2 * 1000);
+
+    VerifyOrQuit(sProcessedUpdateCallback);
+    VerifyOrQuit(sProcessedClientCallback);
+    VerifyOrQuit(sLastClientCallbackError == kErrorNone);
+
+    VerifyOrQuit(service1.GetState() == Srp::Client::kRegistered);
+
+    ValidateHost(*srpServer, kHostName);
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Validate the lease info for service on SRP server.
+
+    // We should see the 100 hours in request from client
+    VerifyOrQuit(sUpdateHostLeaseInfo.mLease == 100u * 3600 * 1000);
+    VerifyOrQuit(sUpdateHostLeaseInfo.mKeyLease == 100u * 3600 * 1000);
+
+    // Check that SRP server granted  27 hours for both lease and
+    // key lease.
+
+    service = srpServer->GetNextHost(nullptr)->GetServices().GetHead();
+    VerifyOrQuit(service != nullptr);
+    VerifyOrQuit(service->GetLease() == 27u * 3600);
+    VerifyOrQuit(service->GetKeyLease() == 27u * 3600);
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Disable SRP server, verify that all heap allocations by SRP server
+    // are freed.
+
+    Log("Disabling SRP server");
+
+    srpServer->SetEnabled(false);
+    AdvanceTime(100);
+
+    VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Finalize OT instance and validate all heap allocations are freed.
+
+    Log("Finalizing OT instance");
+    FinalizeTest();
+
+    VerifyOrQuit(sHeapAllocatedPtrs.IsEmpty());
+
+    Log("End of TestUpdateLeaseShortVariant");
+}
+
+#endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+
 #endif // ENABLE_SRP_TEST
 
 int main(void)
@@ -707,6 +907,9 @@ int main(void)
     TestSrpServerBase();
     TestSrpServerReject();
     TestSrpServerIgnore();
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+    TestUpdateLeaseShortVariant();
+#endif
     printf("All tests passed\n");
 #else
     printf("SRP_SERVER or SRP_CLIENT feature is not enabled\n");


### PR DESCRIPTION
This commit updates SRP client and server to support short variant format for Update Lease Option. The short variant includes the lease interval only (4 bytes) vs the long variant which includes both lease and key lease intervals (8 bytes). Client and server can parse and process both formats in received messages. Client by default uses the long variant. Server will also use the long variant in its response unless the request message uses the short variant format, i.e., if the client uses the short variant, the server will also respond using the short variant. This behavior is required by the latest Update Lease draft.

This commit also updates `test_srp_server` unit test, adding a new test-case to validate the behavior of client and server when short Update Lease Option is used. A new method (intended for testing and and only available under `REFERENCE_DEVCIE` config) is added which configures the client to use the short variant format changing the default behavior.