### PR TITLE
[netif] simplify `ThreadNetif`

### DIFF
--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -409,6 +409,7 @@ private:
                         uint8_t            aIpProto,
                         Message::Ownership aMessageOwnership);
     bool  IsOnLink(const Address &aAddress) const;
+    Error RouteLookup(const Address &aSource, const Address &aDestination) const;
 #if OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
     void UpdateBorderRoutingCounters(const Header &aHeader, uint16_t aMessageLength, bool aIsInbound);
 #endif

--- a/src/core/thread/child_supervision.cpp
+++ b/src/core/thread/child_supervision.cpp
@@ -83,7 +83,7 @@ void ChildSupervisor::SendMessage(Child &aChild)
     childIndex = Get<ChildTable>().GetChildIndex(aChild);
     SuccessOrExit(message->Append(childIndex));
 
-    SuccessOrExit(Get<ThreadNetif>().SendMessage(*message));
+    SuccessOrExit(Get<MeshForwarder>().SendMessage(*message));
     message = nullptr;
 
     LogInfo("Sending supervision message to child 0x%04x", aChild.GetRloc16());

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -118,24 +118,4 @@ exit:
     return;
 }
 
-Error ThreadNetif::SendMessage(Message &aMessage) { return Get<MeshForwarder>().SendMessage(aMessage); }
-
-Error ThreadNetif::RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination)
-{
-    Error    error;
-    uint16_t rloc;
-
-    SuccessOrExit(error = Get<NetworkData::Leader>().RouteLookup(aSource, aDestination, rloc));
-
-    if (rloc == Get<Mle::MleRouter>().GetRloc16())
-    {
-        error = kErrorNoRoute;
-    }
-
-exit:
-    return error;
-}
-
-bool ThreadNetif::IsOnMesh(const Ip6::Address &aAddress) const { return Get<NetworkData::Leader>().IsOnMesh(aAddress); }
-
 } // namespace ot

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -82,39 +82,6 @@ public:
      */
     bool IsUp(void) const { return mIsUp; }
 
-    /**
-     * This method submits a message to the network interface.
-     *
-     * @param[in]  aMessage  A reference to the message.
-     *
-     * @retval kErrorNone  Successfully submitted the message to the interface.
-     *
-     */
-    Error SendMessage(Message &aMessage);
-
-    /**
-     * This method performs a route lookup.
-     *
-     * @param[in]   aSource       A reference to the IPv6 source address.
-     * @param[in]   aDestination  A reference to the IPv6 destination address.
-     *
-     * @retval kErrorNone      Successfully found a route.
-     * @retval kErrorNoRoute   Could not find a valid route.
-     *
-     */
-    Error RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination);
-
-    /**
-     * This method indicates whether @p aAddress matches an on-mesh prefix.
-     *
-     * @param[in]  aAddress  The IPv6 address.
-     *
-     * @retval TRUE   If @p aAddress matches an on-mesh prefix.
-     * @retval FALSE  If @p aAddress does not match an on-mesh prefix.
-     *
-     */
-    bool IsOnMesh(const Ip6::Address &aAddress) const;
-
 private:
     bool mIsUp;
 };


### PR DESCRIPTION
This commit simplifies `ThreadNetif` class by removing methods like `IsOnMesh()` and `SendMessage()` which just call the same method on other modules (`NetworkData::Leader` and `MeshForwarder`). It also moves the `RouteLookup()` method to `Ip6` class.