### PR TITLE
[debug] rename assert macro to `Assert()`

### DIFF
--- a/examples/apps/cli/cli_uart.cpp
+++ b/examples/apps/cli/cli_uart.cpp
@@ -349,7 +349,7 @@ static int CliUartOutput(void *aContext, const char *aFormat, va_list aArguments
                 }
             }
             rval = vsnprintf(sTxBuffer, kTxBufferSize, aFormat, retryArguments);
-            OT_ASSERT(rval > 0);
+            Assert(rval > 0);
             sTxLength   = static_cast<uint16_t>(rval);
             sTxHead     = 0;
             sSendLength = 0;

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -155,7 +155,7 @@ Interpreter::Interpreter(Instance *aInstance, otCliOutputCallback aCallback, voi
 
 void Interpreter::OutputResult(otError aError)
 {
-    OT_ASSERT(mCommandIsPending);
+    Assert(mCommandIsPending);
 
     VerifyOrExit(aError != OT_ERROR_PENDING);
 
@@ -257,7 +257,7 @@ void Interpreter::ProcessLine(char *aBuf)
     Arg     args[kMaxArgs + 1];
     otError error = OT_ERROR_NONE;
 
-    OT_ASSERT(aBuf != nullptr);
+    Assert(aBuf != nullptr);
 
     // Ignore the command if another command is pending.
     VerifyOrExit(!mCommandIsPending, args[0].Clear());
@@ -7891,7 +7891,7 @@ void Interpreter::HandleTimer(void)
 
 void Interpreter::SetCommandTimeout(uint32_t aTimeoutMilli)
 {
-    OT_ASSERT(mCommandIsPending);
+    Assert(mCommandIsPending);
     mTimer.Start(aTimeoutMilli);
 }
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -135,7 +135,7 @@ public:
      */
     static Interpreter &GetInterpreter(void)
     {
-        OT_ASSERT(sInterpreter != nullptr);
+        Assert(sInterpreter != nullptr);
 
         return *sInterpreter;
     }

--- a/src/cli/cli_tcp.cpp
+++ b/src/cli/cli_tcp.cpp
@@ -590,7 +590,7 @@ void TcpExample::HandleTcpEstablished(otTcpEndpoint *aEndpoint)
 void TcpExample::HandleTcpSendDone(otTcpEndpoint *aEndpoint, otLinkedBuffer *aData)
 {
     OT_UNUSED_VARIABLE(aEndpoint);
-    OT_ASSERT(!mUseCircularSendBuffer); // this callback is not used when using the circular send buffer
+    Assert(!mUseCircularSendBuffer); // this callback is not used when using the circular send buffer
 
     if (mBenchmarkBytesTotal == 0)
     {
@@ -598,14 +598,14 @@ void TcpExample::HandleTcpSendDone(otTcpEndpoint *aEndpoint, otLinkedBuffer *aDa
         // tolerate some benchmark links finishing in this case.
         if (aData == &mSendLink)
         {
-            OT_ASSERT(mSendBusy);
+            Assert(mSendBusy);
             mSendBusy = false;
         }
     }
     else
     {
-        OT_ASSERT(aData != &mSendLink);
-        OT_ASSERT(mBenchmarkBytesUnsent >= aData->mLength);
+        Assert(aData != &mSendLink);
+        Assert(mBenchmarkBytesUnsent >= aData->mLength);
         mBenchmarkBytesUnsent -= aData->mLength; // could be less than sizeof(mSendBufferBytes) for the first link
         if (mBenchmarkBytesUnsent >= OT_ARRAY_LENGTH(mBenchmarkLinks) * sizeof(mSendBufferBytes))
         {
@@ -627,7 +627,7 @@ void TcpExample::HandleTcpForwardProgress(otTcpEndpoint *aEndpoint, size_t aInSe
 {
     OT_UNUSED_VARIABLE(aEndpoint);
     OT_UNUSED_VARIABLE(aBacklog);
-    OT_ASSERT(mUseCircularSendBuffer); // this callback is only used when using the circular send buffer
+    Assert(mUseCircularSendBuffer); // this callback is only used when using the circular send buffer
 
     otTcpCircularSendBufferHandleForwardProgress(&mSendBuffer, aInSendBuffer);
 
@@ -660,7 +660,7 @@ void TcpExample::HandleTcpReceiveAvailable(otTcpEndpoint *aEndpoint,
                                            size_t         aBytesRemaining)
 {
     OT_UNUSED_VARIABLE(aBytesRemaining);
-    OT_ASSERT(aEndpoint == &mEndpoint);
+    Assert(aEndpoint == &mEndpoint);
 
 #if OPENTHREAD_CONFIG_TLS_ENABLE
     if (mUseTls && ContinueTLSHandshake())
@@ -706,7 +706,7 @@ void TcpExample::HandleTcpReceiveAvailable(otTcpEndpoint *aEndpoint,
                            static_cast<unsigned>(data->mLength), reinterpret_cast<const char *>(data->mData));
                 totalReceived += data->mLength;
             }
-            OT_ASSERT(aBytesAvailable == totalReceived);
+            Assert(aBytesAvailable == totalReceived);
             IgnoreReturnValue(otTcpCommitReceive(aEndpoint, totalReceived, 0));
         }
     }
@@ -832,7 +832,7 @@ otError TcpExample::ContinueBenchmarkCircularSend(void)
             if (rv > 0)
             {
                 written = static_cast<size_t>(rv);
-                OT_ASSERT(written <= mBenchmarkBytesUnsent);
+                Assert(written <= mBenchmarkBytesUnsent);
             }
             else if (rv != MBEDTLS_ERR_SSL_WANT_WRITE && rv != MBEDTLS_ERR_SSL_WANT_READ)
             {

--- a/src/core/api/backbone_router_ftd_api.cpp
+++ b/src/core/api/backbone_router_ftd_api.cpp
@@ -146,7 +146,7 @@ void otBackboneRouterConfigNextDuaRegistrationResponse(otInstance               
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
 void otBackboneRouterConfigNextMulticastListenerRegistrationResponse(otInstance *aInstance, uint8_t aStatus)
 {
-    OT_ASSERT(aStatus <= ThreadStatusTlv::kMlrStatusMax);
+    Assert(aStatus <= ThreadStatusTlv::kMlrStatusMax);
 
     AsCoreType(aInstance).Get<BackboneRouter::Manager>().ConfigNextMulticastListenerRegistrationResponse(
         static_cast<ThreadStatusTlv::MlrStatus>(aStatus));

--- a/src/core/api/crypto_api.cpp
+++ b/src/core/api/crypto_api.cpp
@@ -82,7 +82,7 @@ void otCryptoAesCcm(const otCryptoKey *aKey,
 
     if (aHeaderLength != 0)
     {
-        OT_ASSERT(aHeader != nullptr);
+        Assert(aHeader != nullptr);
         aesCcm.Header(aHeader, aHeaderLength);
     }
 

--- a/src/core/api/heap_api.cpp
+++ b/src/core/api/heap_api.cpp
@@ -45,7 +45,7 @@ void *otHeapCAlloc(size_t aCount, size_t aSize)
     OT_UNUSED_VARIABLE(aSize);
 
     // Should never get called!
-    OT_ASSERT(false);
+    Assert(false);
 
     // This function is reachable when asserts are disabled
     OT_UNREACHABLE_CODE(return nullptr;)
@@ -56,7 +56,7 @@ void otHeapFree(void *aPointer)
     OT_UNUSED_VARIABLE(aPointer);
 
     // Should never get called!
-    OT_ASSERT(false);
+    Assert(false);
 }
 
 #else  // OPENTHREAD_RADIO

--- a/src/core/api/joiner_api.cpp
+++ b/src/core/api/joiner_api.cpp
@@ -93,7 +93,7 @@ const otJoinerDiscerner *otJoinerGetDiscerner(otInstance *aInstance)
 
 const char *otJoinerStateToString(otJoinerState aState)
 {
-    OT_ASSERT(aState <= OT_JOINER_STATE_JOINED);
+    Assert(aState <= OT_JOINER_STATE_JOINED);
 
     return MeshCoP::Joiner::StateToString(MapEnum(aState));
 }

--- a/src/core/api/logging_api.cpp
+++ b/src/core/api/logging_api.cpp
@@ -186,7 +186,7 @@ void otLogCli(otLogLevel aLogLevel, const char *aFormat, ...)
 
     va_list args;
 
-    OT_ASSERT(aLogLevel >= kLogLevelNone && aLogLevel <= kLogLevelDebg);
+    Assert(aLogLevel >= kLogLevelNone && aLogLevel <= kLogLevelDebg);
     VerifyOrExit(aLogLevel >= kLogLevelNone && aLogLevel <= kLogLevelDebg);
 
     va_start(args, aFormat);

--- a/src/core/api/srp_client_api.cpp
+++ b/src/core/api/srp_client_api.cpp
@@ -169,7 +169,7 @@ otError otSrpClientSetDomainName(otInstance *aInstance, const char *aDomainName)
 
 const char *otSrpClientItemStateToString(otSrpClientItemState aItemState)
 {
-    OT_ASSERT(aItemState <= OT_SRP_CLIENT_ITEM_STATE_REMOVED);
+    Assert(aItemState <= OT_SRP_CLIENT_ITEM_STATE_REMOVED);
 
     return Srp::Client::ItemStateToString(MapEnum(aItemState));
 }

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -253,7 +253,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Message &aMessage,
                 }
                 break;
             default:
-                OT_ASSERT(false);
+                Assert(false);
             }
 
             if (failed)
@@ -326,7 +326,7 @@ void Manager::SendBackboneMulticastListenerRegistration(const Ip6::Address *aAdd
     Ip6AddressesTlv   addressesTlv;
     BackboneTmfAgent &backboneTmf = Get<BackboneRouter::BackboneTmfAgent>();
 
-    OT_ASSERT(aAddressNum >= Ip6AddressesTlv::kMinAddresses && aAddressNum <= Ip6AddressesTlv::kMaxAddresses);
+    Assert(aAddressNum >= Ip6AddressesTlv::kMinAddresses && aAddressNum <= Ip6AddressesTlv::kMaxAddresses);
 
     message = backboneTmf.NewNonConfirmablePostMessage(kUriBackboneMlr);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);

--- a/src/core/backbone_router/multicast_listeners_table.cpp
+++ b/src/core/backbone_router/multicast_listeners_table.cpp
@@ -176,7 +176,7 @@ void MulticastListenersTable::CheckInvariants(void) const
     {
         uint16_t parent = (child - 1) / 2;
 
-        OT_ASSERT(!(mListeners[child] < mListeners[parent]));
+        Assert(!(mListeners[child] < mListeners[parent]));
     }
 #endif
 }
@@ -186,7 +186,7 @@ bool MulticastListenersTable::SiftHeapElemDown(uint16_t aIndex)
     uint16_t index = aIndex;
     Listener saveElem;
 
-    OT_ASSERT(aIndex < mNumValidListeners);
+    Assert(aIndex < mNumValidListeners);
 
     saveElem = mListeners[aIndex];
 
@@ -227,7 +227,7 @@ void MulticastListenersTable::SiftHeapElemUp(uint16_t aIndex)
     uint16_t index = aIndex;
     Listener saveElem;
 
-    OT_ASSERT(aIndex < mNumValidListeners);
+    Assert(aIndex < mNumValidListeners);
 
     saveElem = mListeners[aIndex];
 

--- a/src/core/backbone_router/ndproxy_table.cpp
+++ b/src/core/backbone_router/ndproxy_table.cpp
@@ -51,7 +51,7 @@ void NdProxyTable::NdProxy::Init(const Ip6::InterfaceIdentifier &aAddressIid,
                                  uint16_t                        aRloc16,
                                  uint32_t                        aTimeSinceLastTransaction)
 {
-    OT_ASSERT(!mValid);
+    Assert(!mValid);
 
     Clear();
 
@@ -65,7 +65,7 @@ void NdProxyTable::NdProxy::Init(const Ip6::InterfaceIdentifier &aAddressIid,
 
 void NdProxyTable::NdProxy::Update(uint16_t aRloc16, uint32_t aTimeSinceLastTransaction)
 {
-    OT_ASSERT(mValid);
+    Assert(mValid);
 
     mRloc16                   = aRloc16;
     aTimeSinceLastTransaction = Min(aTimeSinceLastTransaction, Mle::kTimeSinceLastTransactionMax);
@@ -272,7 +272,7 @@ void NdProxyTable::TriggerCallback(NdProxy::Event aEvent, const Ip6::InterfaceId
 
     VerifyOrExit(mCallback.IsSet());
 
-    OT_ASSERT(prefix != nullptr);
+    Assert(prefix != nullptr);
 
     dua.SetPrefix(*prefix);
     dua.SetIid(aAddressIid);
@@ -300,7 +300,7 @@ Ip6::Address NdProxyTable::GetDua(NdProxy &aNdProxy)
     Ip6::Address       dua;
     const Ip6::Prefix *domainPrefix = Get<BackboneRouter::Leader>().GetDomainPrefix();
 
-    OT_ASSERT(domainPrefix != nullptr);
+    Assert(domainPrefix != nullptr);
 
     dua.SetPrefix(*domainPrefix);
     dua.SetIid(aNdProxy.mAddressIid);

--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -82,14 +82,14 @@ void InfraIf::Deinit(void)
 
 bool InfraIf::HasAddress(const Ip6::Address &aAddress) const
 {
-    OT_ASSERT(mInitialized);
+    Assert(mInitialized);
 
     return otPlatInfraIfHasAddress(mIfIndex, &aAddress);
 }
 
 Error InfraIf::Send(const Icmp6Packet &aPacket, const Ip6::Address &aDestination) const
 {
-    OT_ASSERT(mInitialized);
+    Assert(mInitialized);
 
     return otPlatInfraIfSendIcmp6Nd(mIfIndex, &aDestination, aPacket.GetBytes(), aPacket.GetLength());
 }
@@ -114,7 +114,7 @@ exit:
 
 Error InfraIf::DiscoverNat64Prefix(void) const
 {
-    OT_ASSERT(mInitialized);
+    Assert(mInitialized);
 
     return otPlatInfraIfDiscoverNat64Prefix(mIfIndex);
 }

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -475,7 +475,7 @@ void RoutingManager::EvaluateOmrPrefix(void)
     NetworkData::Iterator           iterator = NetworkData::kIteratorInit;
     NetworkData::OnMeshPrefixConfig onMeshPrefixConfig;
 
-    OT_ASSERT(mIsRunning);
+    Assert(mIsRunning);
 
     mFavoredOmrPrefix.Clear();
 
@@ -589,7 +589,7 @@ exit:
 // OMR and NAT64 prefix in the Thread network.
 void RoutingManager::EvaluateRoutingPolicy(void)
 {
-    OT_ASSERT(mIsRunning);
+    Assert(mIsRunning);
 
     LogInfo("Evaluating routing policy");
 
@@ -989,7 +989,7 @@ void RoutingManager::HandleRouterAdvertisement(const InfraIf::Icmp6Packet &aPack
 {
     Ip6::Nd::RouterAdvertMessage routerAdvMessage(aPacket);
 
-    OT_ASSERT(mIsRunning);
+    Assert(mIsRunning);
 
     VerifyOrExit(routerAdvMessage.IsValid());
 
@@ -1184,7 +1184,7 @@ void RoutingManager::ResetDiscoveredPrefixStaleTimer(void)
     TimeMilli now = TimerMilli::GetNow();
     TimeMilli nextStaleTime;
 
-    OT_ASSERT(mIsRunning);
+    Assert(mIsRunning);
 
     // The stale timer triggers sending RS to check the state of
     // discovered prefixes and host RA messages.
@@ -1856,7 +1856,7 @@ Error RoutingManager::DiscoveredPrefixTable::GetNextEntry(PrefixTableIterator &a
     Iterator &iterator = static_cast<Iterator &>(aIterator);
 
     VerifyOrExit(iterator.GetRouter() != nullptr, error = kErrorNotFound);
-    OT_ASSERT(iterator.GetEntry() != nullptr);
+    Assert(iterator.GetEntry() != nullptr);
 
     aEntry.mRouterAddress       = iterator.GetRouter()->mAddress;
     aEntry.mPrefix              = iterator.GetEntry()->GetPrefix();
@@ -1946,7 +1946,7 @@ TimeMilli RoutingManager::DiscoveredPrefixTable::Entry::GetStaleTime(void) const
 
 bool RoutingManager::DiscoveredPrefixTable::Entry::IsDeprecated(void) const
 {
-    OT_ASSERT(IsOnLinkPrefix());
+    Assert(IsOnLinkPrefix());
 
     return mLastUpdateTime + TimeMilli::SecToMsec(GetPreferredLifetime()) <= TimerMilli::GetNow();
 }
@@ -2029,7 +2029,7 @@ bool RoutingManager::OmrPrefix::IsFavoredOver(const NetworkData::OnMeshPrefixCon
 
     bool isFavored = (mPreference > aOmrPrefixConfig.GetPreference());
 
-    OT_ASSERT(IsValidOmrPrefix(aOmrPrefixConfig));
+    Assert(IsValidOmrPrefix(aOmrPrefixConfig));
 
     if (mPreference == aOmrPrefixConfig.GetPreference())
     {
@@ -2891,7 +2891,7 @@ exit:
 
 void RoutingManager::Nat64PrefixManager::HandleTimer(void)
 {
-    OT_ASSERT(mEnabled);
+    Assert(mEnabled);
 
     Discover();
 

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -233,7 +233,7 @@ Error CoapBase::SendMessage(Message                &aMessage,
         mResponsesQueue.EnqueueResponse(aMessage, aMessageInfo, aTxParameters);
         break;
     case kTypeReset:
-        OT_ASSERT(aMessage.GetCode() == kCodeEmpty);
+        Assert(aMessage.GetCode() == kCodeEmpty);
         break;
     default:
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
@@ -1445,7 +1445,7 @@ void CoapBase::Metadata::ReadFrom(const Message &aMessage)
 {
     uint16_t length = aMessage.GetLength();
 
-    OT_ASSERT(length >= sizeof(*this));
+    Assert(length >= sizeof(*this));
     IgnoreError(aMessage.Read(length - sizeof(*this), *this));
 }
 
@@ -1596,7 +1596,7 @@ void ResponsesQueue::ResponseMetadata::ReadFrom(const Message &aMessage)
 {
     uint16_t length = aMessage.GetLength();
 
-    OT_ASSERT(length >= sizeof(*this));
+    Assert(length >= sizeof(*this));
     IgnoreError(aMessage.Read(length - sizeof(*this), *this));
 }
 

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -331,8 +331,8 @@ Error Message::ParseHeader(void)
     Error            error = kErrorNone;
     Option::Iterator iterator;
 
-    OT_ASSERT(GetReserved() >=
-              sizeof(HelpData) + static_cast<size_t>((reinterpret_cast<uint8_t *>(&GetHelpData()) - GetFirstData())));
+    Assert(GetReserved() >=
+           sizeof(HelpData) + static_cast<size_t>((reinterpret_cast<uint8_t *>(&GetHelpData()) - GetFirstData())));
 
     GetHelpData().Clear();
 
@@ -357,7 +357,7 @@ exit:
 
 Error Message::SetToken(const uint8_t *aToken, uint8_t aTokenLength)
 {
-    OT_ASSERT(aTokenLength <= kMaxTokenLength);
+    Assert(aTokenLength <= kMaxTokenLength);
 
     SetTokenLength(aTokenLength);
     memcpy(GetToken(), aToken, aTokenLength);
@@ -370,7 +370,7 @@ Error Message::GenerateRandomToken(uint8_t aTokenLength)
 {
     uint8_t token[kMaxTokenLength];
 
-    OT_ASSERT(aTokenLength <= sizeof(token));
+    Assert(aTokenLength <= sizeof(token));
 
     IgnoreError(Random::Crypto::FillBuffer(token, aTokenLength));
 

--- a/src/core/common/bit_vector.hpp
+++ b/src/core/common/bit_vector.hpp
@@ -73,7 +73,7 @@ public:
      */
     bool Get(uint16_t aIndex) const
     {
-        OT_ASSERT(aIndex < N);
+        Assert(aIndex < N);
         return (mMask[aIndex / 8] & (0x80 >> (aIndex % 8))) != 0;
     }
 
@@ -86,7 +86,7 @@ public:
      */
     void Set(uint16_t aIndex, bool aValue)
     {
-        OT_ASSERT(aIndex < N);
+        Assert(aIndex < N);
 
         if (aValue)
         {

--- a/src/core/common/debug.hpp
+++ b/src/core/common/debug.hpp
@@ -53,7 +53,7 @@
 #define FILE_NAME __FILE__
 #endif
 
-#define OT_ASSERT(cond)                            \
+#define Assert(cond)                               \
     do                                             \
     {                                              \
         if (!(cond))                               \
@@ -69,32 +69,32 @@
 
 #include <assert.h>
 
-#define OT_ASSERT(cond) assert(cond)
+#define Assert(cond) assert(cond)
 
 #else // OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT
 
-#define OT_ASSERT(cond) \
-    do                  \
-    {                   \
-        if (!(cond))    \
-        {               \
-            while (1)   \
-            {           \
-            }           \
-        }               \
+#define Assert(cond)  \
+    do                \
+    {                 \
+        if (!(cond))  \
+        {             \
+            while (1) \
+            {         \
+            }         \
+        }             \
     } while (0)
 
 #endif // OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT
 
 #else // OPENTHREAD_CONFIG_ASSERT_ENABLE
 
-#define OT_ASSERT(cond)
+#define Assert(cond)
 
 #endif // OPENTHREAD_CONFIG_ASSERT_ENABLE
 
 /**
  * This macro checks a given status (which is expected to be successful) against zero (0) which indicates success,
- * and `OT_ASSERT()` if it is not.
+ * and `Assert()` if it is not.
  *
  * @param[in]  aStatus     A scalar status to be evaluated against zero (0).
  *
@@ -104,7 +104,7 @@
     {                            \
         if ((aStatus) != 0)      \
         {                        \
-            OT_ASSERT(false);    \
+            Assert(false);       \
         }                        \
     } while (false)
 
@@ -118,7 +118,7 @@
  *
  */
 #if OPENTHREAD_CONFIG_ASSERT_CHECK_API_POINTER_PARAM_FOR_NULL
-#define AssertPointerIsNotNull(aPointer) OT_ASSERT((aPointer) != nullptr)
+#define AssertPointerIsNotNull(aPointer) Assert((aPointer) != nullptr)
 #else
 #define AssertPointerIsNotNull(aPointer)
 #endif

--- a/src/core/common/frame_builder.cpp
+++ b/src/core/common/frame_builder.cpp
@@ -133,7 +133,7 @@ Error FrameBuilder::InsertBytes(uint16_t aOffset, const void *aBuffer, uint16_t 
 {
     Error error = kErrorNone;
 
-    OT_ASSERT(aOffset <= mLength);
+    Assert(aOffset <= mLength);
 
     VerifyOrExit(CanAppend(aLength), error = kErrorNoBufs);
 

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -100,7 +100,7 @@ exit:
 
 void MessagePool::Free(Message *aMessage)
 {
-    OT_ASSERT(aMessage->Next() == nullptr && aMessage->Prev() == nullptr);
+    Assert(aMessage->Next() == nullptr && aMessage->Prev() == nullptr);
 
     FreeBuffers(static_cast<Buffer *>(aMessage));
 }
@@ -312,14 +312,14 @@ uint8_t Message::GetBufferCount(void) const
 
 void Message::MoveOffset(int aDelta)
 {
-    OT_ASSERT(GetOffset() + aDelta <= GetLength());
+    Assert(GetOffset() + aDelta <= GetLength());
     GetMetadata().mOffset += static_cast<int16_t>(aDelta);
-    OT_ASSERT(GetMetadata().mOffset <= GetLength());
+    Assert(GetMetadata().mOffset <= GetLength());
 }
 
 void Message::SetOffset(uint16_t aOffset)
 {
-    OT_ASSERT(aOffset <= GetLength());
+    Assert(aOffset <= GetLength());
     GetMetadata().mOffset = aOffset;
 }
 
@@ -466,7 +466,7 @@ exit:
 
 void Message::RemoveHeader(uint16_t aLength)
 {
-    OT_ASSERT(aLength <= GetMetadata().mLength);
+    Assert(aLength <= GetMetadata().mLength);
 
     GetMetadata().mReserved += aLength;
     GetMetadata().mLength -= aLength;
@@ -578,7 +578,7 @@ void Message::GetFirstChunk(uint16_t aOffset, uint16_t &aLength, Chunk &aChunk) 
     {
         aChunk.SetBuffer(aChunk.GetBuffer()->GetNextBuffer());
 
-        OT_ASSERT(aChunk.GetBuffer() != nullptr);
+        Assert(aChunk.GetBuffer() != nullptr);
 
         if (aOffset < kBufferDataSize)
         {
@@ -610,7 +610,7 @@ void Message::GetNextChunk(uint16_t &aLength, Chunk &aChunk) const
 
     aChunk.SetBuffer(aChunk.GetBuffer()->GetNextBuffer());
 
-    OT_ASSERT(aChunk.GetBuffer() != nullptr);
+    Assert(aChunk.GetBuffer() != nullptr);
 
     aChunk.Init(aChunk.GetBuffer()->GetData(), kBufferDataSize);
 
@@ -695,7 +695,7 @@ void Message::WriteBytes(uint16_t aOffset, const void *aBuf, uint16_t aLength)
     const uint8_t *bufPtr = reinterpret_cast<const uint8_t *>(aBuf);
     MutableChunk   chunk;
 
-    OT_ASSERT(aOffset + aLength <= GetLength());
+    Assert(aOffset + aLength <= GetLength());
 
     GetFirstChunk(aOffset, aLength, chunk);
 
@@ -829,8 +829,8 @@ void Message::SetPriorityQueue(PriorityQueue *aPriorityQueue)
 
 void MessageQueue::Enqueue(Message &aMessage, QueuePosition aPosition)
 {
-    OT_ASSERT(!aMessage.IsInAQueue());
-    OT_ASSERT((aMessage.Next() == nullptr) && (aMessage.Prev() == nullptr));
+    Assert(!aMessage.IsInAQueue());
+    Assert((aMessage.Next() == nullptr) && (aMessage.Prev() == nullptr));
 
     aMessage.SetMessageQueue(this);
 
@@ -860,8 +860,8 @@ void MessageQueue::Enqueue(Message &aMessage, QueuePosition aPosition)
 
 void MessageQueue::Dequeue(Message &aMessage)
 {
-    OT_ASSERT(aMessage.GetMessageQueue() == this);
-    OT_ASSERT((aMessage.Next() != nullptr) && (aMessage.Prev() != nullptr));
+    Assert(aMessage.GetMessageQueue() == this);
+    Assert((aMessage.Next() != nullptr) && (aMessage.Prev() != nullptr));
 
     if (&aMessage == GetTail())
     {
@@ -954,7 +954,7 @@ const Message *PriorityQueue::GetHeadForPriority(Message::Priority aPriority) co
     {
         previousTail = FindFirstNonNullTail(static_cast<Message::Priority>(PrevPriority(aPriority)));
 
-        OT_ASSERT(previousTail != nullptr);
+        Assert(previousTail != nullptr);
 
         head = previousTail->Next();
     }
@@ -974,7 +974,7 @@ void PriorityQueue::Enqueue(Message &aMessage)
     Message          *tail;
     Message          *next;
 
-    OT_ASSERT(!aMessage.IsInAQueue());
+    Assert(!aMessage.IsInAQueue());
 
     aMessage.SetPriorityQueue(this);
 
@@ -1005,7 +1005,7 @@ void PriorityQueue::Dequeue(Message &aMessage)
     Message::Priority priority;
     Message          *tail;
 
-    OT_ASSERT(aMessage.GetPriorityQueue() == this);
+    Assert(aMessage.GetPriorityQueue() == this);
 
     priority = aMessage.GetPriority();
 

--- a/src/core/common/random.cpp
+++ b/src/core/common/random.cpp
@@ -48,7 +48,7 @@ Manager::Manager(void)
 {
     uint32_t seed;
 
-    OT_ASSERT(sInitCount < 0xffff);
+    Assert(sInitCount < 0xffff);
 
     VerifyOrExit(sInitCount == 0);
 
@@ -67,7 +67,7 @@ exit:
 
 Manager::~Manager(void)
 {
-    OT_ASSERT(sInitCount > 0);
+    Assert(sInitCount > 0);
 
     sInitCount--;
     VerifyOrExit(sInitCount == 0);
@@ -82,7 +82,7 @@ exit:
 
 uint32_t Manager::NonCryptoGetUint32(void)
 {
-    OT_ASSERT(sInitCount > 0);
+    Assert(sInitCount > 0);
 
     return sPrng.GetNext();
 }
@@ -131,20 +131,20 @@ namespace NonCrypto {
 
 uint8_t GetUint8InRange(uint8_t aMin, uint8_t aMax)
 {
-    OT_ASSERT(aMax > aMin);
+    Assert(aMax > aMin);
 
     return (aMin + (GetUint8() % (aMax - aMin)));
 }
 
 uint16_t GetUint16InRange(uint16_t aMin, uint16_t aMax)
 {
-    OT_ASSERT(aMax > aMin);
+    Assert(aMax > aMin);
     return (aMin + (GetUint16() % (aMax - aMin)));
 }
 
 uint32_t GetUint32InRange(uint32_t aMin, uint32_t aMax)
 {
-    OT_ASSERT(aMax > aMin);
+    Assert(aMax > aMin);
     return (aMin + (GetUint32() % (aMax - aMin)));
 }
 

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -175,7 +175,7 @@ const char *SettingsBase::KeyToString(Key aKey)
 
     static_assert(kLastKey == kKeyBrOnLinkPrefixes, "kLastKey is not valid");
 
-    OT_ASSERT(aKey <= kLastKey);
+    Assert(aKey <= kLastKey);
 
     return kKeyStrings[aKey];
 }

--- a/src/core/common/string.cpp
+++ b/src/core/common/string.cpp
@@ -233,7 +233,7 @@ StringWriter &StringWriter::AppendVarArgs(const char *aFormat, va_list aArgs)
     int len;
 
     len = vsnprintf(mBuffer + mLength, (mSize > mLength ? (mSize - mLength) : 0), aFormat, aArgs);
-    OT_ASSERT(len >= 0);
+    Assert(len >= 0);
 
     mLength += static_cast<uint16_t>(len);
 

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -81,7 +81,7 @@ void TimerMilli::Start(uint32_t aDelay) { StartAt(GetNow(), aDelay); }
 
 void TimerMilli::StartAt(TimeMilli aStartTime, uint32_t aDelay)
 {
-    OT_ASSERT(aDelay <= kMaxDelay);
+    Assert(aDelay <= kMaxDelay);
     FireAt(aStartTime + aDelay);
 }
 
@@ -223,7 +223,7 @@ void TimerMicro::Start(uint32_t aDelay) { StartAt(GetNow(), aDelay); }
 
 void TimerMicro::StartAt(TimeMicro aStartTime, uint32_t aDelay)
 {
-    OT_ASSERT(aDelay <= kMaxDelay);
+    Assert(aDelay <= kMaxDelay);
     FireAt(aStartTime + aDelay);
 }
 

--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -297,7 +297,7 @@ Error Tlv::AppendTlv(Message &aMessage, uint8_t aType, const void *aValue, uint8
     Error error = kErrorNone;
     Tlv   tlv;
 
-    OT_ASSERT(aLength <= Tlv::kBaseTlvMaxLength);
+    Assert(aLength <= Tlv::kBaseTlvMaxLength);
 
     tlv.SetType(aType);
     tlv.SetLength(aLength);

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -55,7 +55,7 @@ TrickleTimer::TrickleTimer(Instance &aInstance, Handler aHandler)
 
 void TrickleTimer::Start(Mode aMode, uint32_t aIntervalMin, uint32_t aIntervalMax, uint16_t aRedundancyConstant)
 {
-    OT_ASSERT((aIntervalMax >= aIntervalMin) && (aIntervalMin > 0));
+    Assert((aIntervalMax >= aIntervalMin) && (aIntervalMin > 0));
 
     mIntervalMin        = aIntervalMin;
     mIntervalMax        = aIntervalMax;

--- a/src/core/config/misc.h
+++ b/src/core/config/misc.h
@@ -339,7 +339,7 @@
 /**
  * @def OPENTHREAD_CONFIG_ASSERT_ENABLE
  *
- * Define as 1 to enable assert function `OT_ASSERT()` within OpenThread code and its libraries.
+ * Define as 1 to enable assert function `Assert()` within OpenThread code and its libraries.
  *
  */
 #ifndef OPENTHREAD_CONFIG_ASSERT_ENABLE

--- a/src/core/crypto/aes_ccm.cpp
+++ b/src/core/crypto/aes_ccm.cpp
@@ -71,7 +71,7 @@ void AesCcm::Init(uint32_t    aHeaderLength,
     uint8_t        i;
 
     // Tag length must be even and within [kMinTagLength, kMaxTagLength]
-    OT_ASSERT(((aTagLength & 0x1) == 0) && (kMinTagLength <= aTagLength) && (aTagLength <= kMaxTagLength));
+    Assert(((aTagLength & 0x1) == 0) && (kMinTagLength <= aTagLength) && (aTagLength <= kMaxTagLength));
 
     L = 0;
 
@@ -162,7 +162,7 @@ void AesCcm::Header(const void *aHeader, uint32_t aHeaderLength)
 {
     const uint8_t *headerBytes = reinterpret_cast<const uint8_t *>(aHeader);
 
-    OT_ASSERT(mHeaderCur + aHeaderLength <= mHeaderLength);
+    Assert(mHeaderCur + aHeaderLength <= mHeaderLength);
 
     // process header
     for (unsigned i = 0; i < aHeaderLength; i++)
@@ -196,7 +196,7 @@ void AesCcm::Payload(void *aPlainText, void *aCipherText, uint32_t aLength, Mode
     uint8_t *ciphertextBytes = reinterpret_cast<uint8_t *>(aCipherText);
     uint8_t  byte;
 
-    OT_ASSERT(mPlainTextCur + aLength <= mPlainTextLength);
+    Assert(mPlainTextCur + aLength <= mPlainTextLength);
 
     for (unsigned i = 0; i < aLength; i++)
     {
@@ -267,7 +267,7 @@ void AesCcm::Finalize(void *aTag)
 {
     uint8_t *tagBytes = reinterpret_cast<uint8_t *>(aTag);
 
-    OT_ASSERT(mPlainTextCur == mPlainTextLength);
+    Assert(mPlainTextCur == mPlainTextLength);
 
     mEcb.Encrypt(mCtr, mCtrPad);
 

--- a/src/core/crypto/crypto_platform.cpp
+++ b/src/core/crypto/crypto_platform.cpp
@@ -475,7 +475,7 @@ OT_TOOL_WEAK void otPlatCryptoRandomInit(void)
     mbedtls_ctr_drbg_init(&sCtrDrbgContext);
 
     int rval = mbedtls_ctr_drbg_seed(&sCtrDrbgContext, mbedtls_entropy_func, &sEntropyContext, nullptr, 0);
-    OT_ASSERT(rval == 0);
+    Assert(rval == 0);
     OT_UNUSED_VARIABLE(rval);
 }
 
@@ -598,7 +598,7 @@ OT_TOOL_WEAK otError otPlatCryptoEcdsaSign(const otPlatCryptoEcdsaKeyPair *aKeyP
 #endif
     VerifyOrExit(ret == 0, error = MbedTls::MapError(ret));
 
-    OT_ASSERT(mbedtls_mpi_size(&r) <= Ecdsa::P256::kMpiSize);
+    Assert(mbedtls_mpi_size(&r) <= Ecdsa::P256::kMpiSize);
 
     ret = mbedtls_mpi_write_binary(&r, aSignature->m8, Ecdsa::P256::kMpiSize);
     VerifyOrExit(ret == 0, error = MbedTls::MapError(ret));
@@ -687,9 +687,9 @@ OT_TOOL_WEAK void otPlatCryptoPbkdf2GenerateKey(const uint8_t *aPassword,
     uint16_t     keyLen       = aKeyLen;
     uint16_t     useLen       = 0;
 
-    OT_ASSERT(aSaltLen <= sizeof(prfInput));
+    Assert(aSaltLen <= sizeof(prfInput));
     memcpy(prfInput, aSalt, aSaltLen);
-    OT_ASSERT(aIterationCounter % 2 == 0);
+    Assert(aIterationCounter % 2 == 0);
     aIterationCounter /= 2;
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION

--- a/src/core/crypto/storage.cpp
+++ b/src/core/crypto/storage.cpp
@@ -44,7 +44,7 @@ Error Key::ExtractKey(uint8_t *aKeyBuffer, uint16_t &aKeyLength) const
     Error  error;
     size_t readKeyLength;
 
-    OT_ASSERT(IsKeyRef());
+    Assert(IsKeyRef());
 
     SuccessOrAssert(Crypto::Storage::ExportKey(GetKeyRef(), aKeyBuffer, aKeyLength, readKeyLength));
 

--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -251,7 +251,7 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, 
         break;
 
     case kErrorNoAck:
-        OT_ASSERT(!aFrame.GetSecurityEnabled() || aFrame.IsHeaderUpdated());
+        Assert(!aFrame.GetSecurityEnabled() || aFrame.IsHeaderUpdated());
 
         aChild.IncrementIndirectTxAttempts();
         LogInfo("Indirect tx to child %04x failed, attempt %d/%d", aChild.GetRloc16(), aChild.GetIndirectTxAttempts(),
@@ -297,7 +297,7 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, 
         break;
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     mCallbacks.HandleSentFrameToChild(aFrame, mFrameContext, aError, aChild);

--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -76,7 +76,7 @@ void DataPollSender::StartPolling(void)
 {
     VerifyOrExit(!mEnabled);
 
-    OT_ASSERT(!Get<Mle::MleRouter>().IsRxOnWhenIdle());
+    Assert(!Get<Mle::MleRouter>().IsRxOnWhenIdle());
 
     mEnabled = true;
     ScheduleNextPoll(kRecalculatePollPeriod);

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -748,7 +748,7 @@ TxFrame *Mac::PrepareBeacon(void)
 #endif
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    OT_ASSERT(!mTxBeaconRadioLinks.IsEmpty());
+    Assert(!mTxBeaconRadioLinks.IsEmpty());
     frame = &mLinks.GetTxFrames().GetTxFrame(mTxBeaconRadioLinks);
     mTxBeaconRadioLinks.Clear();
 #else
@@ -897,7 +897,7 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame)
     }
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
@@ -1007,7 +1007,7 @@ void Mac::BeginTransmit(void)
 #endif // OPENTHREAD_FTD
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
@@ -1365,7 +1365,7 @@ void Mac::HandleTransmitDone(TxFrame &aFrame, RxFrame *aAckFrame, Error aError)
         break;
 
     case kOperationTransmitPoll:
-        OT_ASSERT(aFrame.IsEmpty() || aFrame.GetAckRequest());
+        Assert(aFrame.IsEmpty() || aFrame.GetAckRequest());
 
         if ((aError == kErrorNone) && (aAckFrame != nullptr))
         {
@@ -1442,7 +1442,7 @@ void Mac::HandleTransmitDone(TxFrame &aFrame, RxFrame *aAckFrame, Error aError)
 #endif // OPENTHREAD_FTD
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     ExitNow(); // Added to suppress "unused label exit" warning (in TREL radio only).
@@ -1487,7 +1487,7 @@ void Mac::HandleTimer(void)
         break;
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 }
 

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -262,7 +262,7 @@ void Frame::SetDstPanId(PanId aPanId)
 {
     uint8_t index = FindDstPanIdIndex();
 
-    OT_ASSERT(index != kInvalidIndex);
+    Assert(index != kInvalidIndex);
     WriteUint16(aPanId, &mPsdu[index]);
 }
 
@@ -296,7 +296,7 @@ exit:
 
 void Frame::SetDstAddr(ShortAddress aShortAddress)
 {
-    OT_ASSERT((GetFrameControlField() & kFcfDstAddrMask) == kFcfDstAddrShort);
+    Assert((GetFrameControlField() & kFcfDstAddrMask) == kFcfDstAddrShort);
     WriteUint16(aShortAddress, &mPsdu[FindDstAddrIndex()]);
 }
 
@@ -304,8 +304,8 @@ void Frame::SetDstAddr(const ExtAddress &aExtAddress)
 {
     uint8_t index = FindDstAddrIndex();
 
-    OT_ASSERT((GetFrameControlField() & kFcfDstAddrMask) == kFcfDstAddrExt);
-    OT_ASSERT(index != kInvalidIndex);
+    Assert((GetFrameControlField() & kFcfDstAddrMask) == kFcfDstAddrExt);
+    Assert(index != kInvalidIndex);
 
     aExtAddress.CopyTo(&mPsdu[index], ExtAddress::kReverseByteOrder);
 }
@@ -323,7 +323,7 @@ void Frame::SetDstAddr(const Address &aAddress)
         break;
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
         OT_UNREACHABLE_CODE(break);
     }
 }
@@ -467,8 +467,8 @@ void Frame::SetSrcAddr(ShortAddress aShortAddress)
 {
     uint8_t index = FindSrcAddrIndex();
 
-    OT_ASSERT((GetFrameControlField() & kFcfSrcAddrMask) == kFcfSrcAddrShort);
-    OT_ASSERT(index != kInvalidIndex);
+    Assert((GetFrameControlField() & kFcfSrcAddrMask) == kFcfSrcAddrShort);
+    Assert(index != kInvalidIndex);
 
     WriteUint16(aShortAddress, &mPsdu[index]);
 }
@@ -477,8 +477,8 @@ void Frame::SetSrcAddr(const ExtAddress &aExtAddress)
 {
     uint8_t index = FindSrcAddrIndex();
 
-    OT_ASSERT((GetFrameControlField() & kFcfSrcAddrMask) == kFcfSrcAddrExt);
-    OT_ASSERT(index != kInvalidIndex);
+    Assert((GetFrameControlField() & kFcfSrcAddrMask) == kFcfSrcAddrExt);
+    Assert(index != kInvalidIndex);
 
     aExtAddress.CopyTo(&mPsdu[index], ExtAddress::kReverseByteOrder);
 }
@@ -496,7 +496,7 @@ void Frame::SetSrcAddr(const Address &aAddress)
         break;
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 }
 
@@ -517,7 +517,7 @@ void Frame::SetSecurityControlField(uint8_t aSecurityControlField)
 {
     uint8_t index = FindSecurityHeaderIndex();
 
-    OT_ASSERT(index != kInvalidIndex);
+    Assert(index != kInvalidIndex);
 
     mPsdu[index] = aSecurityControlField;
 }
@@ -580,7 +580,7 @@ void Frame::SetFrameCounter(uint32_t aFrameCounter)
 {
     uint8_t index = FindSecurityHeaderIndex();
 
-    OT_ASSERT(index != kInvalidIndex);
+    Assert(index != kInvalidIndex);
 
     // Security Control
     index += kSecurityControlSize;
@@ -594,7 +594,7 @@ const uint8_t *Frame::GetKeySource(void) const
 {
     uint8_t index = FindSecurityHeaderIndex();
 
-    OT_ASSERT(index != kInvalidIndex);
+    Assert(index != kInvalidIndex);
 
     return &mPsdu[index + kSecurityControlSize + kFrameCounterSize];
 }
@@ -630,7 +630,7 @@ void Frame::SetKeySource(const uint8_t *aKeySource)
     uint8_t keySourceLength;
     uint8_t index = FindSecurityHeaderIndex();
 
-    OT_ASSERT(index != kInvalidIndex);
+    Assert(index != kInvalidIndex);
 
     keySourceLength = GetKeySourceLength(mPsdu[index] & kKeyIdModeMask);
 
@@ -658,7 +658,7 @@ void Frame::SetKeyId(uint8_t aKeyId)
     uint8_t keySourceLength;
     uint8_t index = FindSecurityHeaderIndex();
 
-    OT_ASSERT(index != kInvalidIndex);
+    Assert(index != kInvalidIndex);
 
     keySourceLength = GetKeySourceLength(mPsdu[index] & kKeyIdModeMask);
 
@@ -1092,7 +1092,7 @@ void Frame::SetEnhAckProbingIe(const uint8_t *aValue, uint8_t aLen)
 {
     uint8_t *cur = GetThreadIe(ThreadIe::kEnhAckProbingIe);
 
-    OT_ASSERT(cur != nullptr);
+    Assert(cur != nullptr);
 
     memcpy(cur + sizeof(HeaderIe) + sizeof(VendorIeHeader), aValue, aLen);
 }
@@ -1369,13 +1369,13 @@ Error TxFrame::GenerateEnhAck(const RxFrame &aFrame, bool aIsFramePending, const
     // Set header IE
     if (aIeLength > 0)
     {
-        OT_ASSERT(aIeData != nullptr);
+        Assert(aIeData != nullptr);
         memcpy(&mPsdu[FindHeaderIeIndex()], aIeData, aIeLength);
     }
 
     // Set frame length
     footerLength = GetFooterLength();
-    OT_ASSERT(footerLength != kInvalidIndex);
+    Assert(footerLength != kInvalidIndex);
     mLength = SkipSecurityHeaderIndex() + aIeLength + footerLength;
 
 exit:

--- a/src/core/mac/mac_links.cpp
+++ b/src/core/mac/mac_links.cpp
@@ -227,7 +227,7 @@ const KeyMaterial *Links::GetTemporaryMacKey(const Frame &aFrame, uint32_t aKeyS
         }
         else
         {
-            OT_ASSERT(false);
+            Assert(false);
         }
     }
 #endif

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -574,7 +574,7 @@ void SubMac::HandleTransmitDone(TxFrame &aFrame, RxFrame *aAckFrame, Error aErro
         break;
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
         OT_UNREACHABLE_CODE(ExitNow());
     }
 
@@ -661,10 +661,10 @@ void SubMac::SignalFrameCounterUsedOnTxDone(const TxFrame &aFrame)
     allowError = Get<LinkRaw>().IsEnabled();
 #endif
 
-    VerifyOrExit(aFrame.GetKeyIdMode(keyIdMode) == kErrorNone, OT_ASSERT(allowError));
+    VerifyOrExit(aFrame.GetKeyIdMode(keyIdMode) == kErrorNone, Assert(allowError));
     VerifyOrExit(keyIdMode == Frame::kKeyIdMode1);
 
-    VerifyOrExit(aFrame.GetFrameCounter(frameCounter) == kErrorNone, OT_ASSERT(allowError));
+    VerifyOrExit(aFrame.GetFrameCounter(frameCounter) == kErrorNone, Assert(allowError));
     SignalFrameCounterUsed(frameCounter);
 
 exit:
@@ -746,7 +746,7 @@ exit:
 
 void SubMac::SampleRssi(void)
 {
-    OT_ASSERT(!RadioSupportsEnergyScan());
+    Assert(!RadioSupportsEnergyScan());
 
     int8_t rssi = GetRssi();
 
@@ -948,7 +948,7 @@ void SubMac::SetMacKey(uint8_t            aKeyIdMode,
         break;
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
         break;
     }
 

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -288,7 +288,7 @@ void DatasetLocal::EmplaceSecurelyStoredKeys(Dataset &aDataset) const
         }
         else
         {
-            OT_ASSERT(keyLen == NetworkKey::kSize);
+            Assert(keyLen == NetworkKey::kSize);
             networkKeyTlv->SetNetworkKey(networkKey);
         }
     }
@@ -307,7 +307,7 @@ void DatasetLocal::EmplaceSecurelyStoredKeys(Dataset &aDataset) const
         }
         else
         {
-            OT_ASSERT(keyLen == Pskc::kSize);
+            Assert(keyLen == Pskc::kSize);
             pskcTlv->SetPskc(pskc);
         }
     }

--- a/src/core/meshcop/dataset_updater.cpp
+++ b/src/core/meshcop/dataset_updater.cpp
@@ -155,7 +155,7 @@ exit:
 
 void DatasetUpdater::Finish(Error aError)
 {
-    OT_ASSERT(mDataset != nullptr);
+    Assert(mDataset != nullptr);
 
     FreeMessage(mDataset);
     mDataset = nullptr;

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -285,7 +285,7 @@ Error Dtls::Setup(bool aClient)
     mbedtls_ssl_conf_max_version(&mConf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3);
 #endif
 
-    OT_ASSERT(mCipherSuites[1] == 0);
+    Assert(mCipherSuites[1] == 0);
     mbedtls_ssl_conf_ciphersuites(&mConf, mCipherSuites);
     if (mCipherSuites[0] == MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8)
     {
@@ -480,11 +480,11 @@ void Dtls::SetCertificate(const uint8_t *aX509Certificate,
                           const uint8_t *aPrivateKey,
                           uint32_t       aPrivateKeyLength)
 {
-    OT_ASSERT(aX509CertLength > 0);
-    OT_ASSERT(aX509Certificate != nullptr);
+    Assert(aX509CertLength > 0);
+    Assert(aX509Certificate != nullptr);
 
-    OT_ASSERT(aPrivateKeyLength > 0);
-    OT_ASSERT(aPrivateKey != nullptr);
+    Assert(aPrivateKeyLength > 0);
+    Assert(aPrivateKey != nullptr);
 
     mOwnCertSrc       = aX509Certificate;
     mOwnCertLength    = aX509CertLength;
@@ -497,8 +497,8 @@ void Dtls::SetCertificate(const uint8_t *aX509Certificate,
 
 void Dtls::SetCaCertificateChain(const uint8_t *aX509CaCertificateChain, uint32_t aX509CaCertChainLength)
 {
-    OT_ASSERT(aX509CaCertChainLength > 0);
-    OT_ASSERT(aX509CaCertificateChain != nullptr);
+    Assert(aX509CaCertChainLength > 0);
+    Assert(aX509CaCertificateChain != nullptr);
 
     mCaChainSrc    = aX509CaCertificateChain;
     mCaChainLength = aX509CaCertChainLength;
@@ -509,10 +509,10 @@ void Dtls::SetCaCertificateChain(const uint8_t *aX509CaCertificateChain, uint32_
 #ifdef MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
 void Dtls::SetPreSharedKey(const uint8_t *aPsk, uint16_t aPskLength, const uint8_t *aPskIdentity, uint16_t aPskIdLength)
 {
-    OT_ASSERT(aPsk != nullptr);
-    OT_ASSERT(aPskIdentity != nullptr);
-    OT_ASSERT(aPskLength > 0);
-    OT_ASSERT(aPskIdLength > 0);
+    Assert(aPsk != nullptr);
+    Assert(aPskIdentity != nullptr);
+    Assert(aPskLength > 0);
+    Assert(aPskIdLength > 0);
 
     mPreSharedKey         = aPsk;
     mPreSharedKeyLength   = aPskLength;
@@ -847,7 +847,7 @@ void Dtls::HandleTimer(void)
         break;
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
         OT_UNREACHABLE_CODE(break);
     }
 }

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -477,7 +477,7 @@ exit:
 
 void Joiner::SendJoinerFinalize(void)
 {
-    OT_ASSERT(mFinalizeMessage != nullptr);
+    Assert(mFinalizeMessage != nullptr);
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     LogCertMessage("[THCI] direction=send | type=JOIN_FIN.req |", *mFinalizeMessage);
@@ -508,7 +508,7 @@ void Joiner::HandleJoinerFinalizeResponse(Coap::Message *aMessage, const Ip6::Me
     uint8_t state;
 
     VerifyOrExit(mState == kStateConnected && aResult == kErrorNone);
-    OT_ASSERT(aMessage != nullptr);
+    Assert(aMessage != nullptr);
 
     VerifyOrExit(aMessage->IsAck() && aMessage->GetCode() == Coap::kCodeChanged);
 
@@ -605,7 +605,7 @@ void Joiner::HandleTimer(void)
     case kStateIdle:
     case kStateDiscover:
     case kStateConnect:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     Finish(error);

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -393,7 +393,7 @@ void JoinerRouter::JoinerEntrustMetadata::ReadFrom(const Message &aMessage)
 {
     uint16_t length = aMessage.GetLength();
 
-    OT_ASSERT(length >= sizeof(*this));
+    Assert(length >= sizeof(*this));
     IgnoreError(aMessage.Read(length - sizeof(*this), *this));
 }
 

--- a/src/core/meshcop/meshcop.cpp
+++ b/src/core/meshcop/meshcop.cpp
@@ -114,7 +114,7 @@ bool JoinerDiscerner::Matches(const Mac::ExtAddress &aJoinerId) const
 {
     uint64_t mask;
 
-    OT_ASSERT(IsValid());
+    Assert(IsValid());
 
     mask = GetMask();
 
@@ -132,7 +132,7 @@ void JoinerDiscerner::CopyTo(Mac::ExtAddress &aExtAddress) const
     uint8_t  remaining = mLength;
     uint64_t value     = mValue;
 
-    OT_ASSERT(IsValid());
+    Assert(IsValid());
 
     // Write full bytes
     while (remaining >= CHAR_BIT)
@@ -188,7 +188,7 @@ JoinerDiscerner::InfoString JoinerDiscerner::ToString(void) const
 
 void SteeringData::Init(uint8_t aLength)
 {
-    OT_ASSERT(aLength <= kMaxLength);
+    Assert(aLength <= kMaxLength);
     mLength = aLength;
     memset(m8, 0, sizeof(m8));
 }
@@ -217,7 +217,7 @@ void SteeringData::UpdateBloomFilter(const JoinerDiscerner &aDiscerner)
 
 void SteeringData::UpdateBloomFilter(const HashBitIndexes &aIndexes)
 {
-    OT_ASSERT((mLength > 0) && (mLength <= kMaxLength));
+    Assert((mLength > 0) && (mLength <= kMaxLength));
 
     SetBit(aIndexes.mIndex[0] % GetNumBits());
     SetBit(aIndexes.mIndex[1] % GetNumBits());

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -270,7 +270,7 @@ void ChannelMaskTlv::SetChannelMask(uint32_t aChannelMask)
 #if OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT
     if (aChannelMask & OT_RADIO_915MHZ_OQPSK_CHANNEL_MASK)
     {
-        OT_ASSERT(entry != nullptr);
+        Assert(entry != nullptr);
         entry->Init();
         entry->SetChannelPage(OT_RADIO_CHANNEL_PAGE_2);
         entry->SetMask(aChannelMask & OT_RADIO_915MHZ_OQPSK_CHANNEL_MASK);
@@ -284,7 +284,7 @@ void ChannelMaskTlv::SetChannelMask(uint32_t aChannelMask)
 #if OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT
     if (aChannelMask & OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MASK)
     {
-        OT_ASSERT(entry != nullptr);
+        Assert(entry != nullptr);
         entry->Init();
         entry->SetChannelPage(OT_RADIO_CHANNEL_PAGE_0);
         entry->SetMask(aChannelMask & OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MASK);
@@ -296,7 +296,7 @@ void ChannelMaskTlv::SetChannelMask(uint32_t aChannelMask)
 #if OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_SUPPORT
     if (aChannelMask & OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_MASK)
     {
-        OT_ASSERT(entry != nullptr);
+        Assert(entry != nullptr);
         entry->Init();
         entry->SetChannelPage(OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_PAGE);
         entry->SetMask(aChannelMask & OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_MASK);

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -2054,7 +2054,7 @@ public:
      */
     void SetAdvData(const uint8_t *aAdvData, uint8_t aAdvDataLength)
     {
-        OT_ASSERT((aAdvData != nullptr) && (aAdvDataLength > 0) && (aAdvDataLength <= kAdvDataMaxLength));
+        Assert((aAdvData != nullptr) && (aAdvDataLength > 0) && (aAdvDataLength <= kAdvDataMaxLength));
 
         SetLength(aAdvDataLength + sizeof(mOui));
         memcpy(mAdvData, aAdvData, aAdvDataLength);

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -222,7 +222,7 @@ void Client::HandleTrickleTimer(TrickleTimer &aTrickleTimer) { aTrickleTimer.Get
 
 void Client::HandleTrickleTimer(void)
 {
-    OT_ASSERT(mSocket.IsBound());
+    Assert(mSocket.IsBound());
 
     VerifyOrExit(mIdentityAssociationCurrent != nullptr, mTrickleTimer.Stop());
 

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -1225,7 +1225,7 @@ void Client::HandleTcpSendDone(otTcpEndpoint *aEndpoint, otLinkedBuffer *aData)
 {
     OT_UNUSED_VARIABLE(aEndpoint);
     OT_UNUSED_VARIABLE(aData);
-    OT_ASSERT(mTcpState == kTcpConnectedSending);
+    Assert(mTcpState == kTcpConnectedSending);
 
     mSendLink.mLength = 0;
     mTcpState         = kTcpConnectedIdle;

--- a/src/core/net/dns_dso.cpp
+++ b/src/core/net/dns_dso.cpp
@@ -95,7 +95,7 @@ Dso::Connection::Connection(Instance            &aInstance,
     , mInactivity(aInactivityTimeout)
     , mKeepAlive(aKeepAliveInterval)
 {
-    OT_ASSERT(aKeepAliveInterval >= kMinKeepAliveInterval);
+    Assert(aKeepAliveInterval >= kMinKeepAliveInterval);
     Init(/* aIsServer */ false);
 }
 
@@ -160,7 +160,7 @@ Message *Dso::Connection::NewMessage(void)
 
 void Dso::Connection::Connect(void)
 {
-    OT_ASSERT(mState == kStateDisconnected);
+    Assert(mState == kStateDisconnected);
 
     Init(/* aIsServer */ false);
     Get<Dso>().mClientConnections.Push(*this);
@@ -170,7 +170,7 @@ void Dso::Connection::Connect(void)
 
 void Dso::Connection::Accept(void)
 {
-    OT_ASSERT(mState == kStateDisconnected);
+    Assert(mState == kStateDisconnected);
 
     Init(/* aIsServer */ true);
     Get<Dso>().mServerConnections.Push(*this);
@@ -194,7 +194,7 @@ void Dso::Connection::MarkAsConnecting(void)
 
 void Dso::Connection::HandleConnected(void)
 {
-    OT_ASSERT(mState == kStateConnecting);
+    Assert(mState == kStateConnecting);
 
     SetState(kStateConnectedButSessionless);
     ResetTimeouts(/* aIsKeepAliveMessage */ false);
@@ -271,7 +271,7 @@ void Dso::Connection::MarkSessionEstablished(void)
 
     case kStateDisconnected:
     case kStateConnecting:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     SetState(kStateSessionEstablished);
@@ -329,14 +329,14 @@ Error Dso::Connection::SendRetryDelayMessage(uint32_t aDelay, Dns::Header::Respo
     switch (mState)
     {
     case kStateSessionEstablished:
-        OT_ASSERT(IsServer());
+        Assert(IsServer());
         break;
 
     case kStateConnectedButSessionless:
     case kStateEstablishingSession:
     case kStateDisconnected:
     case kStateConnecting:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     message = NewMessage();
@@ -423,7 +423,7 @@ Error Dso::Connection::SendKeepAliveMessage(MessageType aMessageType, MessageId 
         {
             // While session is being established, server is only allowed
             // to send a Keep Alive response to a request from client.
-            OT_ASSERT(aMessageType == kResponseMessage);
+            Assert(aMessageType == kResponseMessage);
         }
         break;
 
@@ -432,7 +432,7 @@ Error Dso::Connection::SendKeepAliveMessage(MessageType aMessageType, MessageId 
 
     case kStateDisconnected:
     case kStateConnecting:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     // Server can send Keep Alive response (to a request from client)
@@ -443,16 +443,16 @@ Error Dso::Connection::SendKeepAliveMessage(MessageType aMessageType, MessageId 
     {
         if (aMessageType == kResponseMessage)
         {
-            OT_ASSERT(aResponseId != 0);
+            Assert(aResponseId != 0);
         }
         else
         {
-            OT_ASSERT(aMessageType == kUnidirectionalMessage);
+            Assert(aMessageType == kUnidirectionalMessage);
         }
     }
     else
     {
-        OT_ASSERT(aMessageType == kRequestMessage);
+        Assert(aMessageType == kRequestMessage);
     }
 
     message = NewMessage();
@@ -496,8 +496,8 @@ Error Dso::Connection::SendMessage(Message              &aMessage,
         // To establish session, client MUST send a request message.
         // Server is not allowed to send any messages. Unidirectional
         // messages are not allowed before session is established.
-        OT_ASSERT(IsClient());
-        OT_ASSERT(aMessageType == kRequestMessage);
+        Assert(IsClient());
+        Assert(aMessageType == kRequestMessage);
         break;
 
     case kStateEstablishingSession:
@@ -506,11 +506,11 @@ Error Dso::Connection::SendMessage(Message              &aMessage,
         // send response.
         if (IsClient())
         {
-            OT_ASSERT(aMessageType == kRequestMessage);
+            Assert(aMessageType == kRequestMessage);
         }
         else
         {
-            OT_ASSERT(aMessageType == kResponseMessage);
+            Assert(aMessageType == kResponseMessage);
         }
         break;
 
@@ -520,7 +520,7 @@ Error Dso::Connection::SendMessage(Message              &aMessage,
 
     case kStateDisconnected:
     case kStateConnecting:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     // A DSO request or unidirectional message MUST contain at
@@ -539,7 +539,7 @@ Error Dso::Connection::SendMessage(Message              &aMessage,
         break;
     case kRequestMessage:
     case kUnidirectionalMessage:
-        OT_ASSERT(primaryTlvType != Tlv::kReservedType);
+        Assert(primaryTlvType != Tlv::kReservedType);
     }
 
     // `header` is cleared from its constructor call so all fields
@@ -1142,7 +1142,7 @@ uint32_t Dso::Connection::CalculateServerInactivityWaitTime(void) const
     // (`kMinServerInactivityWaitTime`) or twice the inactivity
     // timeout value, whichever is greater [RFC 8490 - 6.4.1].
 
-    OT_ASSERT(mInactivity.IsUsed());
+    Assert(mInactivity.IsUsed());
 
     return Max(mInactivity.GetInterval() * 2, kMinServerInactivityWaitTime);
 }

--- a/src/core/net/dns_types.cpp
+++ b/src/core/net/dns_types.cpp
@@ -247,7 +247,7 @@ Error Name::AppendPointerLabel(uint16_t aOffset, Message &aMessage)
     // restricted to 63 octets or less). The next 14-bits specify
     // an offset value relative to start of DNS header.
 
-    OT_ASSERT(aOffset < kPointerLabelTypeUint16);
+    Assert(aOffset < kPointerLabelTypeUint16);
 
     value = HostSwap16(aOffset | kPointerLabelTypeUint16);
 

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -350,7 +350,7 @@ Error Server::AppendQuestion(const char       *aName,
         SuccessOrExit(error = AppendHostName(aMessage, aName, aCompressInfo));
         break;
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     error = aMessage.Append(aQuestion);
@@ -505,7 +505,7 @@ Error Server::AppendInstanceName(Message &aMessage, const char *aName, NameCompr
         NameComponentsOffsetInfo nameComponentsInfo;
 
         IgnoreError(FindNameComponents(aName, aCompressInfo.GetDomainName(), nameComponentsInfo));
-        OT_ASSERT(nameComponentsInfo.IsServiceInstanceName());
+        Assert(nameComponentsInfo.IsServiceInstanceName());
 
         aCompressInfo.SetInstanceNameOffset(aMessage.GetLength());
 
@@ -1060,8 +1060,8 @@ void Server::AnswerQuery(QueryTransaction                 &aQuery,
             {
                 const Ip6::Address &address = AsCoreType(&aInstanceInfo.mAddresses[i]);
 
-                OT_ASSERT(!address.IsUnspecified() && !address.IsLinkLocal() && !address.IsMulticast() &&
-                          !address.IsLoopback());
+                Assert(!address.IsUnspecified() && !address.IsLinkLocal() && !address.IsMulticast() &&
+                       !address.IsLoopback());
 
                 SuccessOrExit(error = AppendAaaaRecord(responseMessage, aInstanceInfo.mHostName, address,
                                                        aInstanceInfo.mTtl, compressInfo));
@@ -1088,8 +1088,8 @@ void Server::AnswerQuery(QueryTransaction &aQuery, const char *aHostFullName, co
         {
             const Ip6::Address &address = AsCoreType(&aHostInfo.mAddresses[i]);
 
-            OT_ASSERT(!address.IsUnspecified() && !address.IsMulticast() && !address.IsLinkLocal() &&
-                      !address.IsLoopback());
+            Assert(!address.IsUnspecified() && !address.IsMulticast() && !address.IsLinkLocal() &&
+                   !address.IsLoopback());
 
             SuccessOrExit(error =
                               AppendAaaaRecord(responseMessage, aHostFullName, address, aHostInfo.mTtl, compressInfo));
@@ -1106,7 +1106,7 @@ void Server::SetQueryCallbacks(otDnssdQuerySubscribeCallback   aSubscribe,
                                otDnssdQueryUnsubscribeCallback aUnsubscribe,
                                void                           *aContext)
 {
-    OT_ASSERT((aSubscribe == nullptr) == (aUnsubscribe == nullptr));
+    Assert((aSubscribe == nullptr) == (aUnsubscribe == nullptr));
 
     mQuerySubscribe       = aSubscribe;
     mQueryUnsubscribe     = aUnsubscribe;
@@ -1116,9 +1116,9 @@ void Server::SetQueryCallbacks(otDnssdQuerySubscribeCallback   aSubscribe,
 void Server::HandleDiscoveredServiceInstance(const char                       *aServiceFullName,
                                              const otDnssdServiceInstanceInfo &aInstanceInfo)
 {
-    OT_ASSERT(StringEndsWith(aServiceFullName, Name::kLabelSeperatorChar));
-    OT_ASSERT(StringEndsWith(aInstanceInfo.mFullName, Name::kLabelSeperatorChar));
-    OT_ASSERT(StringEndsWith(aInstanceInfo.mHostName, Name::kLabelSeperatorChar));
+    Assert(StringEndsWith(aServiceFullName, Name::kLabelSeperatorChar));
+    Assert(StringEndsWith(aInstanceInfo.mFullName, Name::kLabelSeperatorChar));
+    Assert(StringEndsWith(aInstanceInfo.mHostName, Name::kLabelSeperatorChar));
 
     for (QueryTransaction &query : mQueryTransactions)
     {
@@ -1131,7 +1131,7 @@ void Server::HandleDiscoveredServiceInstance(const char                       *a
 
 void Server::HandleDiscoveredHost(const char *aHostFullName, const otDnssdHostInfo &aHostInfo)
 {
-    OT_ASSERT(StringEndsWith(aHostFullName, Name::kLabelSeperatorChar));
+    Assert(StringEndsWith(aHostFullName, Name::kLabelSeperatorChar));
 
     for (QueryTransaction &query : mQueryTransactions)
     {
@@ -1169,7 +1169,7 @@ Server::DnsQueryType Server::GetQueryTypeAndName(const otDnssdQuery *aQuery, cha
 {
     const QueryTransaction *query = static_cast<const QueryTransaction *>(aQuery);
 
-    OT_ASSERT(query->IsValid());
+    Assert(query->IsValid());
     return GetQueryTypeAndName(query->GetResponseHeader(), query->GetResponseMessage(), aName);
 }
 
@@ -1320,11 +1320,11 @@ void Server::FinalizeQuery(QueryTransaction &aQuery, Header::Response aResponseC
     char         name[Name::kMaxNameSize];
     DnsQueryType sdType;
 
-    OT_ASSERT(mQueryUnsubscribe != nullptr);
+    Assert(mQueryUnsubscribe != nullptr);
 
     sdType = GetQueryTypeAndName(aQuery.GetResponseHeader(), aQuery.GetResponseMessage(), name);
 
-    OT_ASSERT(sdType != kDnsQueryNone);
+    Assert(sdType != kDnsQueryNone);
     OT_UNUSED_VARIABLE(sdType);
 
     mQueryUnsubscribe(mQueryCallbackContext, name);
@@ -1337,7 +1337,7 @@ void Server::QueryTransaction::Init(const Header           &aResponseHeader,
                                     const Ip6::MessageInfo &aMessageInfo,
                                     Instance               &aInstance)
 {
-    OT_ASSERT(mResponseMessage == nullptr);
+    Assert(mResponseMessage == nullptr);
 
     InstanceLocatorInit::Init(aInstance);
     mResponseHeader  = aResponseHeader;
@@ -1349,7 +1349,7 @@ void Server::QueryTransaction::Init(const Header           &aResponseHeader,
 
 void Server::QueryTransaction::Finalize(Header::Response aResponseMessage, Ip6::Udp::Socket &aSocket)
 {
-    OT_ASSERT(mResponseMessage != nullptr);
+    Assert(mResponseMessage != nullptr);
 
     Get<Server>().SendResponse(mResponseHeader, aResponseMessage, *mResponseMessage, mMessageInfo, aSocket);
     mResponseMessage = nullptr;

--- a/src/core/net/ip4_types.cpp
+++ b/src/core/net/ip4_types.cpp
@@ -107,7 +107,7 @@ void Address::ExtractFromIp6Address(uint8_t aPrefixLength, const Ip6::Address &a
 
     uint8_t ip6Index;
 
-    OT_ASSERT(Ip6::Prefix::IsValidNat64PrefixLength(aPrefixLength));
+    Assert(Ip6::Prefix::IsValidNat64PrefixLength(aPrefixLength));
 
     ip6Index = aPrefixLength / CHAR_BIT;
 

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -126,7 +126,7 @@ uint8_t Prefix::MatchLength(const uint8_t *aPrefixA, const uint8_t *aPrefixB, ui
 {
     uint8_t matchedLength = 0;
 
-    OT_ASSERT(aMaxSize <= Address::kSize);
+    Assert(aMaxSize <= Address::kSize);
 
     for (uint8_t i = 0; i < aMaxSize; i++)
     {
@@ -472,7 +472,7 @@ void Address::SynthesizeFromIp4Address(const Prefix &aPrefix, const Ip4::Address
 
     uint8_t ip6Index;
 
-    OT_ASSERT(aPrefix.IsValidNat64());
+    Assert(aPrefix.IsValidNat64());
 
     Clear();
     SetPrefix(aPrefix);

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -68,7 +68,7 @@ void MplOption::Init(SeedIdLength aSeedIdLength)
         SetLength(sizeof(*this) - sizeof(Option));
         break;
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     mControl = aSeedIdLength;
@@ -229,7 +229,7 @@ Error Mpl::UpdateSeedSet(uint16_t aSeedId, uint8_t aSequence)
     if (evict->mLifetime != 0)
     {
         // no free entries available, look to evict an existing entry
-        OT_ASSERT(curCount != 0);
+        Assert(curCount != 0);
 
         if (aSeedId == group->mSeedId && insert == nullptr)
         {
@@ -262,12 +262,12 @@ Error Mpl::UpdateSeedSet(uint16_t aSeedId, uint8_t aSequence)
 
     if (evict > insert)
     {
-        OT_ASSERT(insert >= mSeedSet);
+        Assert(insert >= mSeedSet);
         memmove(insert + 1, insert, static_cast<size_t>(evict - insert) * sizeof(SeedEntry));
     }
     else if (evict < insert)
     {
-        OT_ASSERT(evict >= mSeedSet);
+        Assert(evict >= mSeedSet);
         memmove(evict, evict + 1, static_cast<size_t>(insert - 1 - evict) * sizeof(SeedEntry));
         insert--;
     }
@@ -446,7 +446,7 @@ void Mpl::Metadata::ReadFrom(const Message &aMessage)
 {
     uint16_t length = aMessage.GetLength();
 
-    OT_ASSERT(length >= sizeof(*this));
+    Assert(length >= sizeof(*this));
     IgnoreError(aMessage.Read(length - sizeof(*this), *this));
 }
 

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -168,7 +168,7 @@ void Netif::UnsubscribeAllNodesMulticast(void)
     //    LinkLocalAllRouters -> RealmLocalAllRouters -> LinkLocalAll
     //         -> RealmLocalAll -> RealmLocalAllMpl.
 
-    OT_ASSERT(prev != AsCoreTypePtr(AsNonConst(&kRealmLocalAllRoutersMulticastAddress)));
+    Assert(prev != AsCoreTypePtr(AsNonConst(&kRealmLocalAllRoutersMulticastAddress)));
 
     if (prev == nullptr)
     {

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -948,13 +948,13 @@ Error Client::AppendServiceInstructions(Message &aMessage, Info &aInfo)
         {
         case kAdding:
         case kRefreshing:
-            OT_ASSERT((mLease == kUnspecifiedInterval) || (mLease == lease));
+            Assert((mLease == kUnspecifiedInterval) || (mLease == lease));
             mLease = lease;
 
             OT_FALL_THROUGH;
 
         case kRemoving:
-            OT_ASSERT((mKeyLease == kUnspecifiedInterval) || (mKeyLease == keyLease));
+            Assert((mKeyLease == kUnspecifiedInterval) || (mKeyLease == keyLease));
             mKeyLease = keyLease;
             break;
 

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -213,7 +213,7 @@ exit:
 
 uint32_t Server::TtlConfig::GrantTtl(uint32_t aLease, uint32_t aTtl) const
 {
-    OT_ASSERT(mMinTtl <= mMaxTtl);
+    Assert(mMinTtl <= mMaxTtl);
 
     return Clamp(Min(aTtl, aLease), mMinTtl, mMaxTtl);
 }
@@ -246,14 +246,14 @@ exit:
 
 uint32_t Server::LeaseConfig::GrantLease(uint32_t aLease) const
 {
-    OT_ASSERT(mMinLease <= mMaxLease);
+    Assert(mMinLease <= mMaxLease);
 
     return (aLease == 0) ? 0 : Clamp(aLease, mMinLease, mMaxLease);
 }
 
 uint32_t Server::LeaseConfig::GrantKeyLease(uint32_t aKeyLease) const
 {
-    OT_ASSERT(mMinKeyLease <= mMaxKeyLease);
+    Assert(mMinKeyLease <= mMaxKeyLease);
 
     return (aKeyLease == 0) ? 0 : Clamp(aKeyLease, mMinKeyLease, mMaxKeyLease);
 }
@@ -313,7 +313,7 @@ void Server::AddHost(Host &aHost)
 {
     LogInfo("Add new host %s", aHost.GetFullName());
 
-    OT_ASSERT(mHosts.FindMatching(aHost.GetFullName()) == nullptr);
+    Assert(mHosts.FindMatching(aHost.GetFullName()) == nullptr);
     IgnoreError(mHosts.Add(aHost));
 }
 void Server::RemoveHost(Host *aHost, RetainName aRetainName, NotifyMode aNotifyServiceHandler)
@@ -827,7 +827,7 @@ Error Server::ProcessHostDescriptionInstruction(Host                  &aHost,
     Error    error  = kErrorNone;
     uint16_t offset = aMetadata.mOffset;
 
-    OT_ASSERT(aHost.GetFullName() == nullptr);
+    Assert(aHost.GetFullName() == nullptr);
 
     for (uint16_t numRecords = aMetadata.mDnsHeader.GetUpdateRecordCount(); numRecords > 0; numRecords--)
     {
@@ -1552,7 +1552,7 @@ void Server::HandleLeaseTimer(void)
             {
                 next = service->GetNext();
 
-                OT_ASSERT(service->mIsDeleted);
+                Assert(service->mIsDeleted);
 
                 if (service->GetKeyExpireTime() <= now)
                 {
@@ -1586,7 +1586,7 @@ void Server::HandleLeaseTimer(void)
 
             Service *next;
 
-            OT_ASSERT(!host->IsDeleted());
+            Assert(!host->IsDeleted());
 
             earliestExpireTime = Min(earliestExpireTime, host->GetExpireTime());
 
@@ -1622,7 +1622,7 @@ void Server::HandleLeaseTimer(void)
 
     if (earliestExpireTime != now.GetDistantFuture())
     {
-        OT_ASSERT(earliestExpireTime >= now);
+        Assert(earliestExpireTime >= now);
         if (!mLeaseTimer.IsRunning() || earliestExpireTime <= mLeaseTimer.GetFireTime())
         {
             LogInfo("Lease timer is scheduled for %lu seconds", ToUlong(Time::MsecToSec(earliestExpireTime - now)));
@@ -1710,7 +1710,7 @@ Error Server::Service::GetServiceSubTypeLabel(char *aLabel, uint8_t aMaxSize) co
     VerifyOrExit(IsSubType(), error = kErrorInvalidArgs);
 
     subServiceName = StringFind(serviceName, kServiceSubTypeLabel, kStringCaseInsensitiveMatch);
-    OT_ASSERT(subServiceName != nullptr);
+    Assert(subServiceName != nullptr);
 
     if (subServiceName - serviceName < aMaxSize)
     {
@@ -1730,8 +1730,8 @@ exit:
 
 TimeMilli Server::Service::GetExpireTime(void) const
 {
-    OT_ASSERT(!mIsDeleted);
-    OT_ASSERT(!GetHost().IsDeleted());
+    Assert(!mIsDeleted);
+    Assert(!GetHost().IsDeleted());
 
     return mUpdateTime + Time::SecToMsec(mDescription->mLease);
 }
@@ -1942,14 +1942,14 @@ bool Server::Host::Matches(const char *aFullName) const
 
 void Server::Host::SetKeyRecord(Dns::Ecdsa256KeyRecord &aKeyRecord)
 {
-    OT_ASSERT(aKeyRecord.IsValid());
+    Assert(aKeyRecord.IsValid());
 
     mKeyRecord = aKeyRecord;
 }
 
 TimeMilli Server::Host::GetExpireTime(void) const
 {
-    OT_ASSERT(!IsDeleted());
+    Assert(!IsDeleted());
 
     return mUpdateTime + Time::SecToMsec(mLease);
 }

--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -315,7 +315,7 @@ bool Tcp::Endpoint::IsTimerActive(uint8_t aTimerIndex)
     bool          active = false;
     struct tcpcb *tp     = &GetTcb();
 
-    OT_ASSERT(aTimerIndex < kNumTimers);
+    Assert(aTimerIndex < kNumTimers);
     switch (aTimerIndex)
     {
     case kTimerDelack:
@@ -1096,7 +1096,7 @@ void tcplp_sys_panic(const char *aFormat, ...)
 
     LogCrit("%s", buffer);
 
-    OT_ASSERT(false);
+    Assert(false);
 }
 
 bool tcplp_sys_autobind(otInstance       *aInstance,

--- a/src/core/net/tcp6_ext.cpp
+++ b/src/core/net/tcp6_ext.cpp
@@ -169,7 +169,7 @@ void TcpCircularSendBuffer::HandleForwardProgress(size_t aInSendBuffer)
     size_t bytesRemoved;
     size_t bytesUntilWrap;
 
-    OT_ASSERT(aInSendBuffer <= mCapacityUsed);
+    Assert(aInSendBuffer <= mCapacityUsed);
     LogDebg("Forward progress: %u bytes in send buffer\n", static_cast<unsigned>(aInSendBuffer));
     bytesRemoved   = mCapacityUsed - aInSendBuffer;
     bytesUntilWrap = mCapacity - mStartIndex;
@@ -205,7 +205,7 @@ size_t TcpCircularSendBuffer::GetIndex(size_t aStart, size_t aOffsetFromStart) c
     size_t bytesUntilWrap;
     size_t index;
 
-    OT_ASSERT(aStart < mCapacity);
+    Assert(aStart < mCapacity);
     bytesUntilWrap = mCapacity - aStart;
     if (aOffsetFromStart < bytesUntilWrap)
     {

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -169,7 +169,7 @@ Error Udp::Open(SocketHandle &aSocket, otUdpReceive aHandler, void *aContext)
 {
     Error error = kErrorNone;
 
-    OT_ASSERT(!IsOpen(aSocket));
+    Assert(!IsOpen(aSocket));
 
     aSocket.GetSockName().Clear();
     aSocket.GetPeerName().Clear();
@@ -509,7 +509,7 @@ void Udp::HandlePayload(Message &aMessage, MessageInfo &aMessageInfo)
     VerifyOrExit(socket != nullptr);
 
     aMessage.RemoveHeader(aMessage.GetOffset());
-    OT_ASSERT(aMessage.GetOffset() == 0);
+    Assert(aMessage.GetOffset() == 0);
     socket->HandleUdpReceive(aMessage, aMessageInfo);
 
 exit:

--- a/src/core/radio/trel_interface.cpp
+++ b/src/core/radio/trel_interface.cpp
@@ -65,7 +65,7 @@ Interface::Interface(Instance &aInstance)
 
 void Interface::Init(void)
 {
-    OT_ASSERT(!mInitialized);
+    Assert(!mInitialized);
 
     mInitialized = true;
 

--- a/src/core/radio/trel_link.cpp
+++ b/src/core/radio/trel_link.cpp
@@ -94,20 +94,20 @@ void Link::Disable(void)
 
 void Link::Sleep(void)
 {
-    OT_ASSERT(mState != kStateDisabled);
+    Assert(mState != kStateDisabled);
     SetState(kStateSleep);
 }
 
 void Link::Receive(uint8_t aChannel)
 {
-    OT_ASSERT(mState != kStateDisabled);
+    Assert(mState != kStateDisabled);
     mRxChannel = aChannel;
     SetState(kStateReceive);
 }
 
 void Link::Send(void)
 {
-    OT_ASSERT(mState != kStateDisabled);
+    Assert(mState != kStateDisabled);
 
     SetState(kStateTransmit);
     mTxTasklet.Post();
@@ -206,7 +206,7 @@ void Link::BeginTransmit(void)
 
     if (type == Header::kTypeUnicast)
     {
-        OT_ASSERT(destAddr.IsExtended());
+        Assert(destAddr.IsExtended());
         txPacket.GetHeader().SetDestination(destAddr.GetExtended());
     }
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -930,7 +930,7 @@ void AddressResolver::HandleTimeTick(void)
 
         while ((entry = GetEntryAfter(prev, mQueryList)) != nullptr)
         {
-            OT_ASSERT(!entry->IsTimeoutZero());
+            Assert(!entry->IsTimeoutZero());
 
             continueRxingTicks = true;
             entry->DecrementTimeout();

--- a/src/core/thread/anycast_locator.cpp
+++ b/src/core/thread/anycast_locator.cpp
@@ -96,7 +96,7 @@ void AnycastLocator::HandleResponse(Coap::Message *aMessage, const Ip6::MessageI
     Ip6::Address        meshLocalAddress;
 
     SuccessOrExit(aError);
-    OT_ASSERT(aMessage != nullptr);
+    Assert(aMessage != nullptr);
 
     meshLocalAddress.SetPrefix(Get<Mle::Mle>().GetMeshLocalPrefix());
     SuccessOrExit(Tlv::Find<ThreadMeshLocalEidTlv>(*aMessage, meshLocalAddress.GetIid()));

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -279,7 +279,7 @@ void CslTxScheduler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, C
         break;
 
     case kErrorNoAck:
-        OT_ASSERT(!aFrame.GetSecurityEnabled() || aFrame.IsHeaderUpdated());
+        Assert(!aFrame.GetSecurityEnabled() || aFrame.IsHeaderUpdated());
 
         aChild.IncrementCslTxAttempts();
         LogInfo("CSL tx to child %04x failed, attempt %d/%d", aChild.GetRloc16(), aChild.GetCslTxAttempts(),
@@ -321,7 +321,7 @@ void CslTxScheduler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, C
         ExitNow();
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
         OT_UNREACHABLE_CODE(break);
     }
 

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -114,7 +114,7 @@ void DuaManager::HandleDomainPrefixUpdate(BackboneRouter::Leader::DomainPrefixSt
     case BackboneRouter::Leader::kDomainPrefixAdded:
     {
         const Ip6::Prefix *prefix = Get<BackboneRouter::Leader>().GetDomainPrefix();
-        OT_ASSERT(prefix != nullptr);
+        Assert(prefix != nullptr);
         mDomainUnicastAddress.mPrefixLength = prefix->GetLength();
         mDomainUnicastAddress.GetAddress().Clear();
         mDomainUnicastAddress.GetAddress().SetPrefix(*prefix);
@@ -467,7 +467,7 @@ void DuaManager::PerformNextRegistration(void)
         const Ip6::Address *duaPtr = nullptr;
         Child              *child  = nullptr;
 
-        OT_ASSERT(mChildIndexDuaRegistering == Mle::kMaxChildren);
+        Assert(mChildIndexDuaRegistering == Mle::kMaxChildren);
 
         for (Child &iter : Get<ChildTable>().Iterate(Child::kInStateValid))
         {
@@ -483,7 +483,7 @@ void DuaManager::PerformNextRegistration(void)
         child  = Get<ChildTable>().GetChildAtIndex(mChildIndexDuaRegistering);
         duaPtr = child->GetDomainUnicastAddress();
 
-        OT_ASSERT(duaPtr != nullptr);
+        Assert(duaPtr != nullptr);
 
         dua = *duaPtr;
         SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, dua));
@@ -561,7 +561,7 @@ void DuaManager::HandleDuaResponse(Coap::Message *aMessage, const Ip6::MessageIn
     }
 
     VerifyOrExit(aResult == kErrorNone, error = kErrorParse);
-    OT_ASSERT(aMessage != nullptr);
+    Assert(aMessage != nullptr);
 
     VerifyOrExit(aMessage->GetCode() == Coap::kCodeChanged || aMessage->GetCode() >= Coap::kCodeBadRequest,
                  error = kErrorParse);

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -93,7 +93,7 @@ void IndirectSender::AddMessageForSleepyChild(Message &aMessage, Child &aChild)
 {
     uint16_t childIndex;
 
-    OT_ASSERT(!aChild.IsRxOnWhenIdle());
+    Assert(!aChild.IsRxOnWhenIdle());
 
     childIndex = Get<ChildTable>().GetChildIndex(aChild);
     VerifyOrExit(!aMessage.GetChildMask(childIndex));
@@ -350,7 +350,7 @@ Error IndirectSender::PrepareFrameForChild(Mac::TxFrame &aFrame, FrameContext &a
         break;
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
 exit:
@@ -461,7 +461,7 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
         break;
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     if ((message != nullptr) && (nextOffset < message->GetLength()))

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -82,7 +82,7 @@ void SecurityPolicy::SetToDefaultFlags(void)
 
 void SecurityPolicy::SetFlags(const uint8_t *aFlags, uint8_t aFlagsLength)
 {
-    OT_ASSERT(aFlagsLength > 0);
+    Assert(aFlagsLength > 0);
 
     SetToDefaultFlags();
 
@@ -105,7 +105,7 @@ exit:
 
 void SecurityPolicy::GetFlags(uint8_t *aFlags, uint8_t aFlagsLength) const
 {
-    OT_ASSERT(aFlagsLength > 0);
+    Assert(aFlagsLength > 0);
 
     memset(aFlags, 0, aFlagsLength);
 
@@ -521,7 +521,7 @@ void KeyManager::GetNetworkKey(NetworkKey &aNetworkKey) const
         size_t keyLen;
 
         SuccessOrAssert(Crypto::Storage::ExportKey(mNetworkKeyRef, aNetworkKey.m8, NetworkKey::kSize, keyLen));
-        OT_ASSERT(keyLen == NetworkKey::kSize);
+        Assert(keyLen == NetworkKey::kSize);
     }
     else
     {
@@ -540,7 +540,7 @@ void KeyManager::GetPskc(Pskc &aPskc) const
         size_t keyLen;
 
         SuccessOrAssert(Crypto::Storage::ExportKey(mPskcRef, aPskc.m8, Pskc::kSize, keyLen));
-        OT_ASSERT(keyLen == Pskc::kSize);
+        Assert(keyLen == Pskc::kSize);
     }
     else
     {

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -189,7 +189,7 @@ void MeshForwarder::RemoveMessage(Message &aMessage)
 {
     PriorityQueue *queue = aMessage.GetPriorityQueue();
 
-    OT_ASSERT(queue != nullptr);
+    Assert(queue != nullptr);
 
     if (queue == &mSendQueue)
     {
@@ -646,7 +646,7 @@ Error MeshForwarder::UpdateIp6Route(Message &aMessage)
 #if OPENTHREAD_FTD
         error = UpdateIp6RouteFtd(ip6Header, aMessage);
 #else
-        OT_ASSERT(false);
+        Assert(false);
 #endif
     }
 
@@ -1128,8 +1128,8 @@ void MeshForwarder::HandleSentFrame(Mac::TxFrame &aFrame, Error aError)
     Neighbor    *neighbor = nullptr;
     Mac::Address macDest;
 
-    OT_ASSERT((aError == kErrorNone) || (aError == kErrorChannelAccessFailure) || (aError == kErrorAbort) ||
-              (aError == kErrorNoAck));
+    Assert((aError == kErrorNone) || (aError == kErrorChannelAccessFailure) || (aError == kErrorAbort) ||
+           (aError == kErrorNoAck));
 
     mSendBusy = false;
 
@@ -1165,7 +1165,7 @@ void MeshForwarder::UpdateSendMessage(Error aFrameTxError, Mac::Address &aMacDes
 
     VerifyOrExit(mSendMessage != nullptr);
 
-    OT_ASSERT(mSendMessage->IsDirectTransmission());
+    Assert(mSendMessage->IsDirectTransmission());
 
     if (aFrameTxError != kErrorNone)
     {

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -125,7 +125,7 @@ Error MeshForwarder::SendMessage(Message &aMessage)
     case Message::kTypeSupervision:
     {
         Child *child = Get<ChildSupervisor>().GetDestination(aMessage);
-        OT_ASSERT((child != nullptr) && !child->IsRxOnWhenIdle());
+        Assert((child != nullptr) && !child->IsRxOnWhenIdle());
         mIndirectSender.AddMessageForSleepyChild(aMessage, *child);
         break;
     }
@@ -356,7 +356,7 @@ void MeshForwarder::SendMesh(Message &aMessage, Mac::TxFrame &aFrame)
                       Mac::Frame::kKeyIdMode1, &aMessage);
 
     // write payload
-    OT_ASSERT(aMessage.GetLength() <= aFrame.GetMaxPayloadLength());
+    Assert(aMessage.GetLength() <= aFrame.GetMaxPayloadLength());
     aMessage.ReadBytes(0, aFrame.GetPayload(), aMessage.GetLength());
     aFrame.SetPayloadLength(aMessage.GetLength());
 
@@ -456,7 +456,7 @@ Error MeshForwarder::AnycastRouteLookup(uint8_t aServiceId, AnycastType aType, u
                 }
                 break;
             default:
-                OT_ASSERT(false);
+                Assert(false);
                 break;
             }
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1339,7 +1339,7 @@ Error Mle::DetermineParentRequestType(ParentRequestType &aType) const
 
     Error error = kErrorNone;
 
-    OT_ASSERT(mAttachState == kAttachStateParentRequest);
+    Assert(mAttachState == kAttachStateParentRequest);
 
     aType = kToRoutersAndReeds;
 
@@ -2078,7 +2078,7 @@ Error Mle::SendChildUpdateRequest(bool aAppendChallenge, uint32_t aTimeout)
     case kRoleDisabled:
     case kRoleRouter:
     case kRoleLeader:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     if (!IsFullThreadDevice())
@@ -2487,7 +2487,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
 
             if ((frameCounter + 1) == neighbor->GetMleFrameCounter())
             {
-                OT_ASSERT(aMessage.IsRadioTypeSet());
+                Assert(aMessage.IsRadioTypeSet());
                 Get<RadioSelector>().UpdateOnReceive(*neighbor, aMessage.GetRadioType(), /* IsDuplicate */ true);
 
                 // We intentionally exit without setting the error to
@@ -2515,7 +2515,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     if (neighbor != nullptr)
     {
-        OT_ASSERT(aMessage.IsRadioTypeSet());
+        Assert(aMessage.IsRadioTypeSet());
         Get<RadioSelector>().UpdateOnReceive(*neighbor, aMessage.GetRadioType(), /* IsDuplicate */ false);
     }
 #endif
@@ -3547,7 +3547,7 @@ void Mle::HandleChildUpdateResponse(RxInfo &aRxInfo)
         break;
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     // Status
@@ -3640,7 +3640,7 @@ void Mle::HandleChildUpdateResponse(RxInfo &aRxInfo)
         break;
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     aRxInfo.mClass = (response.mLength == 0) ? RxInfo::kPeerMessage : RxInfo::kAuthoritativeMessage;
@@ -3796,7 +3796,7 @@ void Mle::ProcessAnnounce(void)
     uint8_t  newChannel = mAlternateChannel;
     uint16_t newPanId   = mAlternatePanId;
 
-    OT_ASSERT(mAttachState == kAttachStateProcessAnnounce);
+    Assert(mAttachState == kAttachStateProcessAnnounce);
 
     LogNote("Processing Announce - channel %d, panid 0x%02x", newChannel, newPanId);
 
@@ -4310,7 +4310,7 @@ Error Mle::DetachGracefully(otDetachGracefullyCallback aCallback, void *aContext
 
     VerifyOrExit(!IsDetachingGracefully(), error = kErrorBusy);
 
-    OT_ASSERT(!mDetachGracefullyCallback.IsSet());
+    Assert(!mDetachGracefullyCallback.IsSet());
 
     mDetachGracefullyCallback.Set(aCallback, aContext);
 
@@ -4396,7 +4396,7 @@ void Mle::DelayedResponseMetadata::ReadFrom(const Message &aMessage)
 {
     uint16_t length = aMessage.GetLength();
 
-    OT_ASSERT(length >= sizeof(*this));
+    Assert(length >= sizeof(*this));
     IgnoreError(aMessage.Read(length - sizeof(*this), *this));
 }
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -218,7 +218,7 @@ Error MleRouter::BecomeRouter(ThreadStatusTlv::Status aStatus)
         break;
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
 exit:
@@ -259,7 +259,7 @@ Error MleRouter::BecomeLeader(void)
     SetLeaderData(partitionId, mLeaderWeight, leaderId);
 
     router = mRouterTable.Allocate(leaderId);
-    OT_ASSERT(router != nullptr);
+    Assert(router != nullptr);
 
     SetRouterId(leaderId);
     router->SetExtAddress(Get<Mac::Mac>().GetExtAddress());
@@ -491,7 +491,7 @@ void MleRouter::SendAdvertisement(void)
 
     case kRoleDisabled:
     case kRoleDetached:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     destination.SetToLinkLocalAllNodesMulticast();
@@ -548,7 +548,7 @@ Error MleRouter::SendLinkRequest(Neighbor *aNeighbor)
         break;
 
     case kRoleDisabled:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
@@ -945,7 +945,7 @@ Error MleRouter::HandleLinkAccept(RxInfo &aRxInfo, bool aRequest)
             {
                 SuccessOrExit(error = ProcessRouteTlv(routeTlv, aRxInfo));
                 router = mRouterTable.FindRouterById(routerId);
-                OT_ASSERT(router != nullptr);
+                Assert(router != nullptr);
             }
 
             mRouterTable.UpdateRoutes(routeTlv, routerId);
@@ -966,7 +966,7 @@ Error MleRouter::HandleLinkAccept(RxInfo &aRxInfo, bool aRequest)
         break;
 
     case kRoleDisabled:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     // finish link synchronization
@@ -1577,7 +1577,7 @@ void MleRouter::HandleTimeTick(void)
         break;
 
     case kRoleDisabled:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     // update children state
@@ -1600,7 +1600,7 @@ void MleRouter::HandleTimeTick(void)
 
         case Neighbor::kStateParentResponse:
         case Neighbor::kStateLinkRequest:
-            OT_ASSERT(false);
+            Assert(false);
         }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
@@ -1809,7 +1809,7 @@ Error MleRouter::UpdateChildAddresses(const Message &aMessage, uint16_t aOffset,
     // Retrieve registered multicast addresses of the Child
     if (aChild.HasAnyMlrRegisteredAddress())
     {
-        OT_ASSERT(aChild.IsStateValid());
+        Assert(aChild.IsStateValid());
 
         for (const Ip6::Address &childAddress :
              aChild.IterateIp6Addresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
@@ -2154,7 +2154,7 @@ void MleRouter::HandleChildIdRequest(RxInfo &aRxInfo)
 
     case kRoleDisabled:
     case kRoleDetached:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
 exit:
@@ -3135,7 +3135,7 @@ void MleRouter::SendDataResponse(const Ip6::Address &aDestination,
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
         case Tlv::kLinkMetricsReport:
-            OT_ASSERT(aRequestMessage != nullptr);
+            Assert(aRequestMessage != nullptr);
             neighbor = mNeighborTable.FindNeighbor(aDestination);
             VerifyOrExit(neighbor != nullptr, error = kErrorInvalidState);
             SuccessOrExit(error = Get<LinkMetrics::LinkMetrics>().AppendReport(*message, *aRequestMessage, *neighbor));
@@ -3220,7 +3220,7 @@ void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
     }
     else if (!IsActiveRouter(aNeighbor.GetRloc16()))
     {
-        OT_ASSERT(mChildTable.Contains(aNeighbor));
+        Assert(mChildTable.Contains(aNeighbor));
 
         if (aNeighbor.IsStateValidOrRestoring())
         {
@@ -3239,7 +3239,7 @@ void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
     }
     else if (aNeighbor.IsStateValid())
     {
-        OT_ASSERT(mRouterTable.Contains(aNeighbor));
+        Assert(mRouterTable.Contains(aNeighbor));
 
         mNeighborTable.Signal(NeighborTable::kRouterRemoved, aNeighbor);
         mRouterTable.RemoveRouterLink(static_cast<Router &>(aNeighbor));
@@ -3484,7 +3484,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message          *aMessage,
     {
         Router *leader = mRouterTable.GetLeader();
 
-        OT_ASSERT(leader != nullptr);
+        Assert(leader != nullptr);
         leader->SetNextHopAndCost(RouterIdFromRloc16(mParent.GetRloc16()), mParent.GetLeaderCost());
     }
 

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -110,7 +110,7 @@ bool MlrManager::IsAddressMlrRegisteredByNetif(const Ip6::Address &aAddress) con
 {
     bool ret = false;
 
-    OT_ASSERT(aAddress.IsMulticastLargerThanRealmLocal());
+    Assert(aAddress.IsMulticastLargerThanRealmLocal());
 
     for (const Ip6::Netif::ExternalMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
     {
@@ -132,7 +132,7 @@ bool MlrManager::IsAddressMlrRegisteredByAnyChildExcept(const Ip6::Address &aAdd
 {
     bool ret = false;
 
-    OT_ASSERT(aAddress.IsMulticastLargerThanRealmLocal());
+    Assert(aAddress.IsMulticastLargerThanRealmLocal());
 
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {
@@ -191,7 +191,7 @@ exit:
 
 void MlrManager::ScheduleSend(uint16_t aDelay)
 {
-    OT_ASSERT(!mMlrPending || mSendDelay == 0);
+    Assert(!mMlrPending || mSendDelay == 0);
 
     VerifyOrExit(!mMlrPending);
 
@@ -414,7 +414,7 @@ Error MlrManager::SendMulticastListenerRegistrationMessage(const otIp6Address   
         SuccessOrExit(error = Tlv::Append<ThreadTimeoutTlv>(*message, *aTimeout));
     }
 #else
-    OT_ASSERT(aTimeout == nullptr);
+    Assert(aTimeout == nullptr);
 #endif
 
     if (!mle.IsFullThreadDevice() && mle.GetParent().IsThreadVersion1p1())
@@ -556,7 +556,7 @@ void MlrManager::FinishMulticastListenerRegistration(bool                aSucces
                                                      const Ip6::Address *aFailedAddresses,
                                                      uint8_t             aFailedAddressNum)
 {
-    OT_ASSERT(mMlrPending);
+    Assert(mMlrPending);
 
     mMlrPending = false;
 
@@ -768,7 +768,7 @@ void MlrManager::CheckInvariants(void) const
 #if OPENTHREAD_EXAMPLES_SIMULATION && OPENTHREAD_CONFIG_ASSERT_ENABLE
     uint16_t registeringNum = 0;
 
-    OT_ASSERT(!mMlrPending || mSendDelay == 0);
+    Assert(!mMlrPending || mSendDelay == 0);
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
     for (Ip6::Netif::ExternalMulticastAddress &addr :
@@ -787,7 +787,7 @@ void MlrManager::CheckInvariants(void) const
     }
 #endif
 
-    OT_ASSERT(registeringNum == 0 || mMlrPending);
+    Assert(registeringNum == 0 || mMlrPending);
 #endif // OPENTHREAD_EXAMPLES_SIMULATION
 }
 

--- a/src/core/thread/neighbor_table.cpp
+++ b/src/core/thread/neighbor_table.cpp
@@ -271,7 +271,7 @@ void NeighborTable::Signal(Event aEvent, const Neighbor &aNeighbor)
         case kChildRemoved:
         case kChildModeChanged:
 #if OPENTHREAD_FTD
-            OT_ASSERT(Get<ChildTable>().Contains(aNeighbor));
+            Assert(Get<ChildTable>().Contains(aNeighbor));
             static_cast<Child::Info &>(info.mInfo.mChild).SetFrom(static_cast<const Child &>(aNeighbor));
 #endif
             break;

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -656,7 +656,7 @@ void MutableNetworkData::Insert(void *aStart, uint8_t aLength)
 {
     uint8_t *start = reinterpret_cast<uint8_t *>(aStart);
 
-    OT_ASSERT(CanInsert(aLength) && mTlvs <= start && start <= mTlvs + mLength);
+    Assert(CanInsert(aLength) && mTlvs <= start && start <= mTlvs + mLength);
     memmove(start + aLength, start, mLength - static_cast<size_t>(start - mTlvs));
     mLength += aLength;
 }
@@ -667,7 +667,7 @@ void MutableNetworkData::Remove(void *aRemoveStart, uint8_t aRemoveLength)
     uint8_t *removeStart = reinterpret_cast<uint8_t *>(aRemoveStart);
     uint8_t *removeEnd   = removeStart + aRemoveLength;
 
-    OT_ASSERT((aRemoveLength <= mLength) && (GetBytes() <= removeStart) && (removeEnd <= end));
+    Assert((aRemoveLength <= mLength) && (GetBytes() <= removeStart) && (removeEnd <= end));
 
     memmove(removeStart, removeEnd, static_cast<uint8_t>(end - removeEnd));
     mLength -= aRemoveLength;
@@ -704,7 +704,7 @@ Error NetworkData::GetNextServer(Iterator &aIterator, uint16_t &aRloc16) const
     }
     else
     {
-        OT_ASSERT(false);
+        Assert(false);
     }
 
 exit:

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -785,7 +785,7 @@ Error Leader::AddService(const ServiceTlv &aService, ChangedFlags &aChangedFlags
     }
 
     server = NetworkDataTlv::Find<ServerTlv>(aService.GetSubTlvs(), aService.GetNext());
-    OT_ASSERT(server != nullptr);
+    Assert(server != nullptr);
 
     SuccessOrExit(error = AddServer(*server, *dstService, aChangedFlags));
 

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -167,7 +167,7 @@ void Local::UpdateRloc(PrefixTlv &aPrefixTlv)
             break;
 
         default:
-            OT_ASSERT(false);
+            Assert(false);
         }
     }
 }
@@ -241,7 +241,7 @@ void Local::UpdateRloc(ServiceTlv &aService)
             break;
 
         default:
-            OT_ASSERT(false);
+            Assert(false);
         }
     }
 }
@@ -268,7 +268,7 @@ void Local::UpdateRloc(void)
 #endif
 
         default:
-            OT_ASSERT(false);
+            Assert(false);
         }
     }
 }

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -111,7 +111,7 @@ exit:
     case kErrorNotFound:
         break;
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 }
 
@@ -269,7 +269,7 @@ void Notifier::HandleCoapResponse(Error aResult)
         break;
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 }
 

--- a/src/core/thread/network_data_types.hpp
+++ b/src/core/thread/network_data_types.hpp
@@ -133,7 +133,7 @@ inline uint8_t RoutePreferenceToValue(int8_t aPref)
     constexpr uint8_t kMedium = 0; // 00
     constexpr uint8_t kLow    = 3; // 11
 
-    OT_ASSERT(IsRoutePreferenceValid(aPref));
+    Assert(IsRoutePreferenceValid(aPref));
 
     return (aPref == 0) ? kMedium : ((aPref > 0) ? kHigh : kLow);
 }

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -111,7 +111,7 @@ Error NetworkDiagnostic::SendCommand(Uri                   aUri,
         break;
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -164,7 +164,7 @@ Router *RouterTable::Allocate(void)
     VerifyOrExit(selectedRouterId != Mle::kInvalidRouterId);
 
     router = Allocate(selectedRouterId);
-    OT_ASSERT(router != nullptr);
+    Assert(router != nullptr);
 
 exit:
     return router;
@@ -196,7 +196,7 @@ Error RouterTable::Release(uint8_t aRouterId)
     Error   error = kErrorNone;
     Router *router;
 
-    OT_ASSERT(aRouterId <= Mle::kMaxRouterId);
+    Assert(aRouterId <= Mle::kMaxRouterId);
 
     VerifyOrExit(Get<Mle::MleRouter>().IsLeader(), error = kErrorInvalidState);
 
@@ -532,7 +532,7 @@ void RouterTable::UpdateRouterIdSet(uint8_t aRouterIdSequence, const Mle::Router
         {
             Router *router = FindRouterById(routerId);
 
-            OT_ASSERT(router != nullptr);
+            Assert(router != nullptr);
             router->SetNextHopToInvalid();
             RemoveRouterLink(*router);
             RemoveRouter(*router);
@@ -787,7 +787,7 @@ void RouterTable::FillRouteTlv(Mle::RouteTlv &aRouteTlv, const Neighbor *aNeighb
             const Router *router = FindRouterById(routerId);
             uint8_t       pathCost;
 
-            OT_ASSERT(router != nullptr);
+            Assert(router != nullptr);
 
             pathCost = GetPathCost(routerRloc16);
 

--- a/src/core/thread/time_sync_service.cpp
+++ b/src/core/thread/time_sync_service.cpp
@@ -232,7 +232,7 @@ void TimeSync::CheckAndHandleChanges(bool aTimeUpdated)
         else
         {
             // Schedule a check 1 millisecond after two periods of time
-            OT_ASSERT(resyncNeededThresholdMs >= timeSyncLastSyncMs);
+            Assert(resyncNeededThresholdMs >= timeSyncLastSyncMs);
             mTimer.Start(resyncNeededThresholdMs - timeSyncLastSyncMs + 1);
             LogInfo("Time sync status SYNCHRONIZED");
         }

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -491,7 +491,7 @@ MlrState Child::GetAddressMlrState(const Ip6::Address &aAddress) const
 {
     uint16_t addressIndex;
 
-    OT_ASSERT(&mIp6Address[0] <= &aAddress && &aAddress < GetArrayEnd(mIp6Address));
+    Assert(&mIp6Address[0] <= &aAddress && &aAddress < GetArrayEnd(mIp6Address));
 
     addressIndex = static_cast<uint16_t>(&aAddress - mIp6Address);
 
@@ -504,7 +504,7 @@ void Child::SetAddressMlrState(const Ip6::Address &aAddress, MlrState aState)
 {
     uint16_t addressIndex;
 
-    OT_ASSERT(&mIp6Address[0] <= &aAddress && &aAddress < GetArrayEnd(mIp6Address));
+    Assert(&mIp6Address[0] <= &aAddress && &aAddress < GetArrayEnd(mIp6Address));
 
     addressIndex = static_cast<uint16_t>(&aAddress - mIp6Address);
 

--- a/src/core/thread/uri_paths.cpp
+++ b/src/core/thread/uri_paths.cpp
@@ -144,7 +144,7 @@ static_assert(38 == kUriMlr, "kUriMlr (`n/mr`) is invalid");
 
 const char *PathForUri(Uri aUri)
 {
-    OT_ASSERT(aUri != kUriUnknown);
+    Assert(aUri != kUriUnknown);
 
     return UriList::kEntries[aUri].mPath;
 }

--- a/src/core/utils/channel_monitor.cpp
+++ b/src/core/utils/channel_monitor.cpp
@@ -149,7 +149,7 @@ void ChannelMonitor::HandleEnergyScanResult(Mac::EnergyScanResult *aResult)
         uint32_t newValue     = 0;
         uint32_t weight;
 
-        OT_ASSERT(channelIndex < kNumChannels);
+        Assert(channelIndex < kNumChannels);
 
         LogDebg("channel: %d, rssi:%d", aResult->mChannel, aResult->mMaxRssi);
 

--- a/src/core/utils/flash.cpp
+++ b/src/core/utils/flash.cpp
@@ -185,7 +185,7 @@ Error Flash::Add(uint16_t aKey, bool aFirst, const uint8_t *aValue, uint16_t aVa
     record.Init(aKey, aFirst);
     record.SetData(aValue, aValueLength);
 
-    OT_ASSERT((mSwapSize - record.GetSize()) >= kSwapMarkerSize);
+    Assert((mSwapSize - record.GetSize()) >= kSwapMarkerSize);
 
     if ((mSwapSize - record.GetSize()) < mSwapUsed)
     {

--- a/src/core/utils/flash.hpp
+++ b/src/core/utils/flash.hpp
@@ -202,7 +202,7 @@ private:
         const uint8_t *GetData(void) const { return mData; }
         void           SetData(const uint8_t *aData, uint16_t aDataLength)
         {
-            OT_ASSERT(aDataLength <= kMaxDataSize);
+            Assert(aDataLength <= kMaxDataSize);
             memcpy(mData, aData, aDataLength);
             SetLength(aDataLength);
         }

--- a/src/core/utils/history_tracker.cpp
+++ b/src/core/utils/history_tracker.cpp
@@ -570,7 +570,7 @@ uint16_t HistoryTracker::List::MapEntryNumberToListIndex(uint16_t aEntryNumber, 
 
     uint32_t index;
 
-    OT_ASSERT(aEntryNumber < mSize);
+    Assert(aEntryNumber < mSize);
 
     index = static_cast<uint32_t>(aEntryNumber) + mStartIndex;
     index -= (index >= aMaxSize) ? aMaxSize : 0;

--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -80,7 +80,7 @@ void Otns::EmitStatus(const char *aFmt, ...)
 
     n = vsnprintf(statusStr, sizeof(statusStr), aFmt, ap);
     OT_UNUSED_VARIABLE(n);
-    OT_ASSERT(n >= 0);
+    Assert(n >= 0);
 
     va_end(ap);
 

--- a/src/core/utils/power_calibration.cpp
+++ b/src/core/utils/power_calibration.cpp
@@ -54,7 +54,7 @@ void PowerCalibration::CalibratedPowerEntry::Init(int16_t        aActualPower,
                                                   uint16_t       aRawPowerSettingLength)
 {
     AssertPointerIsNotNull(aRawPowerSetting);
-    OT_ASSERT(aRawPowerSettingLength <= kMaxRawPowerSettingSize);
+    Assert(aRawPowerSettingLength <= kMaxRawPowerSettingSize);
 
     mActualPower = aActualPower;
     mLength      = aRawPowerSettingLength;

--- a/src/lib/hdlc/hdlc.hpp
+++ b/src/lib/hdlc/hdlc.hpp
@@ -367,7 +367,7 @@ public:
     {
         otError error = OT_ERROR_NONE;
 
-        OT_ASSERT(aFrame == nullptr || (mBuffer <= aFrame && aFrame < GetArrayEnd(mBuffer)));
+        Assert(aFrame == nullptr || (mBuffer <= aFrame && aFrame < GetArrayEnd(mBuffer)));
 
         aFrame = (aFrame == nullptr) ? mBuffer : aFrame + aLength;
 

--- a/src/lib/spinel/spinel_buffer.cpp
+++ b/src/lib/spinel/spinel_buffer.cpp
@@ -152,7 +152,7 @@ uint8_t *Buffer::GetUpdatedBufPtr(uint8_t *aBufPtr, uint16_t aOffset, Direction 
         break;
 
     case kUnknown:
-        OT_ASSERT(false);
+        Assert(false);
         OT_UNREACHABLE_CODE(break);
     }
 
@@ -195,7 +195,7 @@ uint16_t Buffer::GetDistance(const uint8_t *aStartPtr, const uint8_t *aEndPtr, D
         break;
 
     case kUnknown:
-        OT_ASSERT(false);
+        Assert(false);
         OT_UNREACHABLE_CODE(break);
     }
 
@@ -226,7 +226,7 @@ otError Buffer::InFrameAppend(uint8_t aByte)
     otError  error = OT_ERROR_NONE;
     uint8_t *newTail;
 
-    OT_ASSERT(mWriteDirection != kUnknown);
+    Assert(mWriteDirection != kUnknown);
 
     newTail = GetUpdatedBufPtr(mWriteSegmentTail, 1, mWriteDirection);
 
@@ -831,7 +831,7 @@ otError Buffer::OutFrameRemove(void)
 
         // If this assert fails, it is a likely indicator that the internal structure of the NCP buffer has been
         // corrupted.
-        OT_ASSERT(numSegments <= kMaxSegments);
+        Assert(numSegments <= kMaxSegments);
     }
 
     mReadFrameStart[mReadDirection] = bufPtr;
@@ -934,7 +934,7 @@ uint16_t Buffer::OutFrameGetLength(void)
 
         // If this assert fails, it is a likely indicator that the internal structure of the NCP buffer has been
         // corrupted.
-        OT_ASSERT(numSegments <= kMaxSegments);
+        Assert(numSegments <= kMaxSegments);
     }
 
     // Remember the calculated frame length for current active frame.

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -260,7 +260,7 @@ NcpBase::NcpBase(Instance *aInstance)
     , mDidInitialUpdates(false)
     , mLogTimestampBase(0)
 {
-    OT_ASSERT(mInstance != nullptr);
+    Assert(mInstance != nullptr);
 
     sNcpInstance = this;
 
@@ -1056,7 +1056,7 @@ otError NcpBase::HandleCommandPropertyInsertRemove(uint8_t aHeader, spinel_prop_
         break;
 
     default:
-        OT_ASSERT(false);
+        Assert(false);
     }
 
     VerifyOrExit(handler != nullptr, error = PrepareLastStatusResponse(aHeader, SPINEL_STATUS_PROP_NOT_FOUND));
@@ -2349,10 +2349,10 @@ exit:
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_DEBUG_TEST_ASSERT>(void)
 {
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    OT_ASSERT(false);
+    Assert(false);
 #endif
 
-    // We only get to this point if `OT_ASSERT(false)`
+    // We only get to this point if `Assert(false)`
     // does not cause an NCP reset on the platform.
     // In such a case we return `false` as the
     // property value to indicate this.

--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -755,7 +755,7 @@ NcpBase::PropertyHandler NcpBase::FindPropertyHandler(const HandlerEntry *aHandl
 {
     size_t l = 0;
 
-    OT_ASSERT(aSize > 0);
+    Assert(aSize > 0);
 
     for (size_t r = aSize - 1; l < r;)
     {

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -2777,7 +2777,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_CNTR_MLE_COUNTERS>(vo
     otError              error    = OT_ERROR_NONE;
     const otMleCounters *counters = otThreadGetMleCounters(mInstance);
 
-    OT_ASSERT(counters != nullptr);
+    Assert(counters != nullptr);
 
     SuccessOrExit(error = mEncoder.WriteUint16(counters->mDisabledRole));
     SuccessOrExit(error = mEncoder.WriteUint16(counters->mDetachedRole));
@@ -2805,7 +2805,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_CNTR_ALL_IP_COUNTERS>
     otError             error    = OT_ERROR_NONE;
     const otIpCounters *counters = otThreadGetIp6Counters(mInstance);
 
-    OT_ASSERT(counters != nullptr);
+    Assert(counters != nullptr);
 
     // Encode Tx related counters
     SuccessOrExit(error = mEncoder.OpenStruct());
@@ -2835,8 +2835,8 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_CNTR_MAC_RETRY_HISTOG
     histogramDirect   = otLinkGetTxDirectRetrySuccessHistogram(mInstance, &histogramDirectEntries);
     histogramIndirect = otLinkGetTxIndirectRetrySuccessHistogram(mInstance, &histogramIndirectEntries);
 
-    OT_ASSERT((histogramDirectEntries == 0) || (histogramDirect != nullptr));
-    OT_ASSERT((histogramIndirectEntries == 0) || (histogramIndirect != nullptr));
+    Assert((histogramDirectEntries == 0) || (histogramDirect != nullptr));
+    Assert((histogramIndirectEntries == 0) || (histogramIndirect != nullptr));
 
     // Encode direct message retries histogram
     SuccessOrExit(error = mEncoder.OpenStruct());
@@ -3777,7 +3777,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_SRP_CLIENT_HOST_ADDRE
     uint8_t       hostAddressArrayLength;
 
     hostAddressArray = otSrpClientBuffersGetHostAddressesArray(mInstance, &hostAddressArrayLength);
-    OT_ASSERT(hostAddressArrayLength <= kSrpClientMaxHostAddresses);
+    Assert(hostAddressArrayLength <= kSrpClientMaxHostAddresses);
 
     while (!mDecoder.IsAllReadInStruct())
     {

--- a/src/ncp/ncp_hdlc.cpp
+++ b/src/ncp/ncp_hdlc.cpp
@@ -73,7 +73,7 @@ extern "C" void otNcpHdlcInit(otInstance *aInstance, otNcpHdlcSendCallback aSend
 
     if (ncpHdlc == nullptr || ncpHdlc != NcpBase::GetNcpInstance())
     {
-        OT_ASSERT(false);
+        Assert(false);
     }
 }
 
@@ -205,7 +205,7 @@ exit:
     {
         int rval = mSendCallback(mHdlcBuffer.GetFrame(), len);
         OT_UNUSED_VARIABLE(rval);
-        OT_ASSERT(rval == static_cast<int>(len));
+        Assert(rval == static_cast<int>(len));
     }
 }
 
@@ -318,7 +318,7 @@ otError NcpHdlc::BufferEncrypterReader::OutFrameBegin(void)
 
         if (mOutputDataLength > 0)
         {
-            OT_ASSERT(mOutputDataLength <= sizeof(mDataBuffer));
+            Assert(mOutputDataLength <= sizeof(mDataBuffer));
             mTxFrameBuffer.OutFrameRead(mOutputDataLength, mDataBuffer);
 
             if (!SpinelEncrypter::EncryptOutbound(mDataBuffer, sizeof(mDataBuffer), &mOutputDataLength))

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -71,7 +71,7 @@ extern "C" void otNcpSpiInit(otInstance *aInstance)
 
     if (ncpSpi == nullptr || ncpSpi != NcpBase::GetNcpInstance())
     {
-        OT_ASSERT(false);
+        Assert(false);
     }
 }
 
@@ -268,14 +268,14 @@ void NcpSpi::PrepareNextSpiSendFrame(void)
     SuccessOrExit(error = mTxFrameBuffer.OutFrameBegin());
 
     frameLength = mTxFrameBuffer.OutFrameGetLength();
-    OT_ASSERT(frameLength <= kSpiBufferSize - kSpiHeaderSize);
+    Assert(frameLength <= kSpiBufferSize - kSpiHeaderSize);
 
     // The "accept length" in `mSendFrame` is already updated based
     // on current state of receive. It is changed either from the
     // `SpiTransactionComplete()` callback or from `HandleRxFrame()`.
 
     readLength = mTxFrameBuffer.OutFrameRead(frameLength, sendFrame.GetData());
-    OT_ASSERT(readLength == frameLength);
+    Assert(readLength == frameLength);
 
     // Suppress the warning when assertions are disabled
     OT_UNUSED_VARIABLE(readLength);

--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -282,7 +282,7 @@ uint32_t InfraNetif::GetFlags(void) const
     int          sock;
     struct ifreq ifReq;
 
-    OT_ASSERT(mInfraIfIndex != 0);
+    Assert(mInfraIfIndex != 0);
 
     sock = SocketWithCloseExec(AF_INET6, SOCK_DGRAM, IPPROTO_IP, kSocketBlock);
     VerifyOrDie(sock != -1, OT_EXIT_ERROR_ERRNO);
@@ -404,7 +404,7 @@ exit:
 
 void InfraNetif::SetUp(void)
 {
-    OT_ASSERT(gInstance != nullptr);
+    Assert(gInstance != nullptr);
     VerifyOrExit(mInfraIfIndex != 0);
 
     SuccessOrDie(otBorderRoutingInit(gInstance, mInfraIfIndex, platformInfraIfIsRunning()));

--- a/src/posix/platform/multicast_routing.cpp
+++ b/src/posix/platform/multicast_routing.cpp
@@ -71,7 +71,7 @@ namespace Posix {
 
 void MulticastRoutingManager::SetUp(void)
 {
-    OT_ASSERT(gInstance != nullptr);
+    Assert(gInstance != nullptr);
 
     otBackboneRouterSetMulticastListenerCallback(gInstance,
                                                  &MulticastRoutingManager::HandleBackboneMulticastListenerEvent, this);
@@ -80,7 +80,7 @@ void MulticastRoutingManager::SetUp(void)
 
 void MulticastRoutingManager::TearDown(void)
 {
-    OT_ASSERT(gInstance != nullptr);
+    Assert(gInstance != nullptr);
 
     otBackboneRouterSetMulticastListenerCallback(gInstance, nullptr, nullptr);
     Mainloop::Manager::Get().Remove(*this);

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -1888,7 +1888,7 @@ void platformNetifInit(otPlatformConfig *aPlatformConfig)
 
 void platformNetifSetUp(void)
 {
-    OT_ASSERT(gInstance != nullptr);
+    Assert(gInstance != nullptr);
 
     otIp6SetReceiveFilterEnabled(gInstance, true);
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -207,13 +207,13 @@ exit:
 
 otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
 {
-    OT_ASSERT(gInstance == nullptr);
+    Assert(gInstance == nullptr);
 
     platformInit(aPlatformConfig);
 
     gDryRun   = aPlatformConfig->mDryRun;
     gInstance = otInstanceInitSingle();
-    OT_ASSERT(gInstance != nullptr);
+    Assert(gInstance != nullptr);
 
     platformSetUp();
 
@@ -282,7 +282,7 @@ exit:
 
 void otSysDeinit(void)
 {
-    OT_ASSERT(gInstance != nullptr);
+    Assert(gInstance != nullptr);
 
     platformTearDown();
     otInstanceFinalize(gInstance);

--- a/tests/unit/test_multicast_listeners_table.cpp
+++ b/tests/unit/test_multicast_listeners_table.cpp
@@ -135,8 +135,8 @@ void TestMulticastListenersTable(void)
 
         for (MulticastListenersTable::Listener &listener : table.Iterate())
         {
-            OT_ASSERT(listener.GetAddress().IsMulticastLargerThanRealmLocal());
-            OT_ASSERT(listener.GetExpireTime() > TimerMilli::GetNow());
+            Assert(listener.GetAddress().IsMulticastLargerThanRealmLocal());
+            Assert(listener.GetExpireTime() > TimerMilli::GetNow());
         }
 
         address = static_cast<const Ip6::Address &>(MA401);


### PR DESCRIPTION
This commit renames assert macro to `Assert()` to follow same style for other macros like `VerifyOrExit()` or `SuccessOrAssert()`.

----

This PR renames `OT_ASSERT()` to `Assert()`. 
I don't expect any changes related to this for platform code (since the `common/debug.hpp` header where this is defined is intended for core use and not a public/platform header unlike `toolchain.h` which is platform header)).