### PR TITLE
[error] add an error code for coex grant timeout

### DIFF
--- a/include/openthread/error.h
+++ b/include/openthread/error.h
@@ -240,6 +240,11 @@ typedef enum OT_MUST_USE_RESULT otError
     OT_ERROR_REJECTED = 37,
 
     /**
+     * A transmission could not take place due to coex grant timeout.
+     */
+    OT_ERROR_COEX_GRANT_TIMEOUT = 38,
+
+    /**
      * The number of defined errors.
      */
     OT_NUM_ERRORS,

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (302)
+#define OPENTHREAD_API_VERSION (303)
 
 /**
  * @addtogroup api-instance

--- a/src/core/common/error.cpp
+++ b/src/core/common/error.cpp
@@ -79,6 +79,7 @@ const char *ErrorToString(Error aError)
         "InvalidCommand",             // (35) kErrorInvalidCommand
         "Pending",                    // (36) kErrorPending
         "Rejected",                   // (37) kErrorRejected
+        "CoexGrantTimeout",           // (38) kErrorCoexGrantTimeout
     };
 
     return aError < GetArrayLength(kErrorStrings) ? kErrorStrings[aError] : "UnknownErrorType";

--- a/src/core/common/error.hpp
+++ b/src/core/common/error.hpp
@@ -90,6 +90,7 @@ constexpr Error kErrorInvalidCommand             = OT_ERROR_INVALID_COMMAND;
 constexpr Error kErrorPending                    = OT_ERROR_PENDING;
 constexpr Error kErrorRejected                   = OT_ERROR_REJECTED;
 constexpr Error kErrorGeneric                    = OT_ERROR_GENERIC;
+constexpr Error kErrorCoexGrantTimeout           = OT_ERROR_COEX_GRANT_TIMEOUT;
 
 constexpr uint8_t kNumErrors = OT_NUM_ERRORS;
 


### PR DESCRIPTION
On real products, the radio platform may be integrated into a 3-wire
coex system. However currently OT cannot identify coex radio errors.
Currently it will be identified as an CHANNEL_ACCESS_FAILTURE on
some platform. This PR defines a new error for COEX_GRANT_TIMEOUT.