### PR TITLE
[trel] protect against invalid long TXT data keys from TREL peer

### DIFF
--- a/src/core/radio/trel_interface.cpp
+++ b/src/core/radio/trel_interface.cpp
@@ -262,6 +262,15 @@ Error Interface::ParsePeerInfoTxtData(const Peer::Info       &aInfo,
 
     while ((error = iterator.GetNextEntry(entry)) == kErrorNone)
     {
+        // If the TXT data happens to have entries with key longer
+        // than `kMaxKeyLength`, `mKey` would be `nullptr` and full
+        // entry would be placed in `mValue`. We skip over such
+        // entries.
+        if (entry.mKey == nullptr)
+        {
+            continue;
+        }
+
         if (strcmp(entry.mKey, kTxtRecordExtAddressKey) == 0)
         {
             VerifyOrExit(!parsedExtAddress, error = kErrorParse);


### PR DESCRIPTION
This commit adds checks to protect against an edge-case where TXT data entries from a TREL peer mat contain invalid and long keys. If the TXT data happens to include keys longer than `Dns::kMaxKeyLength`, the `mKey` in `Dns::TxtEntry` will be set to `nullptr` and the entire entry will be provided in `mValue`. This commit adds code to skip over such entries (check that `entry.mKey` is not null) at beginning of the loop to avoid using a potential null `mKey` in `strcmp`.