### PR TITLE
[network-data] change 6LoWPAN context ID reuse delay to 5 minutes

### DIFF
--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -234,7 +234,7 @@ private:
         void     HandleTimer(void);
 
     private:
-        static constexpr uint32_t kReuseDelay = 48 * 60 * 60; // in seconds
+        static constexpr uint32_t kReuseDelay = 5 * 60; // 5 minutes (in seconds).
 
         static constexpr uint8_t kMinId = 1;
         static constexpr uint8_t kMaxId = 15;

--- a/tests/toranj/cli/cli.py
+++ b/tests/toranj/cli/cli.py
@@ -274,6 +274,12 @@ class Node(object):
     def set_router_eligible(self, enable):
         self._cli_no_output('routereligible', enable)
 
+    def get_context_reuse_delay(self):
+        return self._cli_single_output('contextreusedelay')
+
+    def set_context_reuse_delay(self, delay):
+        self._cli_no_output('contextreusedelay', delay)
+
     def interface_up(self):
         self._cli_no_output('ifconfig up')
 

--- a/tests/toranj/cli/test-019-netdata-context-id.py
+++ b/tests/toranj/cli/test-019-netdata-context-id.py
@@ -74,10 +74,14 @@ verify(r3.get_state() == 'router')
 # -----------------------------------------------------------------------------------------------------------------------
 # Test Implementation
 
-# Change the reuse delay on `r1 (leader) to 5 seconds.
+# Check the default reuse delay on `r1` to be 5 minutes.
 
-r1.cli('contextreusedelay 5')
-verify(int(r1.cli('contextreusedelay')[0]) == 5)
+verify(int(r1.get_context_reuse_delay()) == 5 * 60)
+
+# Change the reuse delay on `r1` (leader) to 5 seconds.
+
+r1.set_context_reuse_delay(5)
+verify(int(r1.get_context_reuse_delay()) == 5)
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Add an on-mesh prefix from each router `r1`, r2`, and `r3`.


### PR DESCRIPTION
This commit changes the context ID reuse delay from 48 hours to 5 minutes. It also updates `test-019-netdata-context-id.py` to check the default value.


----

Related to [SPEC-1163](https://threadgroup.atlassian.net/browse/SPEC-1163).