### PR TITLE
[tlv] fix `ReadStringTlv()`

### DIFF
--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -193,7 +193,7 @@ Error Tlv::ReadStringTlv(const Message &aMessage, uint16_t aOffset, uint8_t aMax
     length = Min(info.mLength, static_cast<uint16_t>(aMaxStringLength));
 
     aMessage.ReadBytes(info.mValueOffset, aValue, length);
-    aValue[length + 1] = '\0';
+    aValue[length] = '\0';
 
 exit:
     return error;


### PR DESCRIPTION
This commit fixes `ReadStringTlv()` avoid returning an extra character and making sure `\0` is added at the correct index at `[length]`.

----

This is not critical since `StringTlv` is currently only used for "vendor name, model" etc in MeshCoP (part of joining/commissioning process). 