### PR TITLE
[logging] fix print format for some variables requiring `%u` or `%lu`

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -302,8 +302,8 @@ void SubMac::HandleReceiveDone(RxFrame *aFrame, Error aError)
         LogDebg("Received frame in state (SubMac %s, CSL %s), timestamp %lu", StateToString(mState),
                 mIsCslSampling ? "CslSample" : "CslSleep",
                 ToUlong(static_cast<uint32_t>(aFrame->mInfo.mRxInfo.mTimestamp)));
-        LogDebg("Target sample start time %lu, time drift %d", ToUlong(mCslSampleTime.GetValue()),
-                static_cast<uint32_t>(aFrame->mInfo.mRxInfo.mTimestamp) - mCslSampleTime.GetValue());
+        LogDebg("Target sample start time %lu, time drift %lu", ToUlong(mCslSampleTime.GetValue()),
+                ToUlong(static_cast<uint32_t>(aFrame->mInfo.mRxInfo.mTimestamp) - mCslSampleTime.GetValue()));
 #endif
     }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE

--- a/src/core/utils/history_tracker.cpp
+++ b/src/core/utils/history_tracker.cpp
@@ -469,7 +469,7 @@ void HistoryTracker::EntryAgeToString(uint32_t aEntryAge, char *aBuffer, uint16_
 
     if (aEntryAge >= kMaxAge)
     {
-        writer.Append("more than %u days", kMaxAge / Time::kOneDayInMsec);
+        writer.Append("more than %u days", static_cast<uint16_t>(kMaxAge / Time::kOneDayInMsec));
     }
     else
     {
@@ -477,14 +477,14 @@ void HistoryTracker::EntryAgeToString(uint32_t aEntryAge, char *aBuffer, uint16_
 
         if (days > 0)
         {
-            writer.Append("%u day%s ", days, (days == 1) ? "" : "s");
+            writer.Append("%lu day%s ", ToUlong(days), (days == 1) ? "" : "s");
             aEntryAge -= days * Time::kOneDayInMsec;
         }
 
-        writer.Append("%02u:%02u:%02u.%03u", (aEntryAge / Time::kOneHourInMsec),
-                      (aEntryAge % Time::kOneHourInMsec) / Time::kOneMinuteInMsec,
-                      (aEntryAge % Time::kOneMinuteInMsec) / Time::kOneSecondInMsec,
-                      (aEntryAge % Time::kOneSecondInMsec));
+        writer.Append("%02u:%02u:%02u.%03u", static_cast<uint16_t>(aEntryAge / Time::kOneHourInMsec),
+                      static_cast<uint16_t>((aEntryAge % Time::kOneHourInMsec) / Time::kOneMinuteInMsec),
+                      static_cast<uint16_t>((aEntryAge % Time::kOneMinuteInMsec) / Time::kOneSecondInMsec),
+                      static_cast<uint16_t>(aEntryAge % Time::kOneSecondInMsec));
     }
 }
 


### PR DESCRIPTION
cc for code review: @jwhui @abtink 