### PR TITLE
[netif] add diagnostic log for when no valid route is found

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1448,14 +1448,20 @@ Error Ip6::RouteLookup(const Address &aSource, const Address &aDestination) cons
     Error    error;
     uint16_t rloc;
 
-    SuccessOrExit(error = Get<NetworkData::Leader>().RouteLookup(aSource, aDestination, rloc));
+    error = Get<NetworkData::Leader>().RouteLookup(aSource, aDestination, rloc);
 
-    if (rloc == Get<Mle::Mle>().GetRloc16())
+    if (error == kErrorNone)
     {
-        error = kErrorNoRoute;
+        if (rloc == Get<Mle::MleRouter>().GetRloc16())
+        {
+            error = kErrorNoRoute;
+        }
+    }
+    else
+    {
+        LogNote("Failed to find the valid route for: %s", aDestination.ToString().AsCString());
     }
 
-exit:
     return error;
 }
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1459,7 +1459,7 @@ Error Ip6::RouteLookup(const Address &aSource, const Address &aDestination) cons
     }
     else
     {
-        LogNote("Failed to find the valid route for: %s", aDestination.ToString().AsCString());
+        LogNote("Failed to find valid route for: %s", aDestination.ToString().AsCString());
     }
 
     return error;


### PR DESCRIPTION
The added log may assist in diagnosing problems where packet transmission over the air is absent.

OpenThread quietly discards the packet when a valid route is not found. This happened recently in Matter testing where the Border Router sent an IPv6 packet to the Thread node, but had improperly set up external routes and/or had not been designated as the default route.