### PR TITLE
[build] address new warnings with clang-14

### DIFF
--- a/examples/platforms/simulation/diag.c
+++ b/examples/platforms/simulation/diag.c
@@ -60,7 +60,7 @@ static uint16_t   sRawPowerSettingLength = 0;
 
 void otPlatDiagModeSet(bool aMode) { sDiagMode = aMode; }
 
-bool otPlatDiagModeGet() { return sDiagMode; }
+bool otPlatDiagModeGet(void) { return sDiagMode; }
 
 void otPlatDiagChannelSet(uint8_t aChannel) { OT_UNUSED_VARIABLE(aChannel); }
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3574,7 +3574,7 @@ template <> otError Interpreter::Process<Cmd("eidcache")>(Arg aArgs[])
 
     memset(&iterator, 0, sizeof(iterator));
 
-    for (uint8_t i = 0;; i++)
+    while (true)
     {
         SuccessOrExit(otThreadGetNextCacheEntry(GetInstancePtr(), &entry, &iterator));
         OutputEidCacheEntry(entry);

--- a/third_party/mbedtls/CMakeLists.txt
+++ b/third_party/mbedtls/CMakeLists.txt
@@ -45,6 +45,8 @@ find_program(SED_EXE sed)
 string(REPLACE "-Wconversion" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 string(REPLACE "-Wconversion" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
+set(MBEDTLS_FATAL_WARNINGS OFF CACHE BOOL "Compiler warnings treated as errors" FORCE)
+
 add_subdirectory(repo)
 
 if(UNIFDEFALL_EXE AND SED_EXE AND UNIFDEF_VERSION VERSION_GREATER_EQUAL 2.10)


### PR DESCRIPTION
This commit adds two small changes to address new warnings when
building with clang-14.

It also updates `mbedtls` CMakeLists to set `MBEDTLS_FATAL_WARNINGS`
option as `OFF` (so that compiler warnings are not treated as errors).
This avoid issues with new warning for `unused-but-set-variable` emitted
by clang-14.

----

This should help address https://github.com/openthread/openthread/issues/8923.