### PR TITLE
[spinel] add openthread config header file

### DIFF
--- a/src/lib/spinel/openthread-spinel-config.h
+++ b/src/lib/spinel/openthread-spinel-config.h
@@ -34,6 +34,8 @@
 #ifndef OPENTHREAD_SPINEL_CONFIG_H_
 #define OPENTHREAD_SPINEL_CONFIG_H_
 
+#include "openthread-core-config.h"
+
 /**
  * @def OPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE
  *


### PR DESCRIPTION
This commit adds the openthread config header file to the spinel config file to allow developers to configure the spinel configurations in the openthread config file.