### PR TITLE
[posix] reset the signal actions after processing signals

### DIFF
--- a/src/posix/platform/backtrace.cpp
+++ b/src/posix/platform/backtrace.cpp
@@ -132,6 +132,17 @@ exit:
     return;
 }
 #endif // OPENTHREAD_POSIX_CONFIG_ANDROID_ENABLE
+static constexpr uint8_t kNumSignals           = 6;
+static constexpr int     kSignals[kNumSignals] = {SIGABRT, SIGILL, SIGSEGV, SIGBUS, SIGTRAP, SIGFPE};
+static struct sigaction  sSigActions[kNumSignals];
+
+static void resetSignalActions(void)
+{
+    for (uint8_t i = 0; i < kNumSignals; i++)
+    {
+        sigaction(kSignals[i], &sSigActions[i], (struct sigaction *)nullptr);
+    }
+}
 
 static void signalCritical(int sig, siginfo_t *info, void *ucontext)
 {
@@ -144,7 +155,9 @@ static void signalCritical(int sig, siginfo_t *info, void *ucontext)
     dumpStack();
 
     otLogCritPlat("------------------ END OF CRASH ------------------");
-    exit(EXIT_FAILURE);
+
+    resetSignalActions();
+    raise(sig);
 }
 
 void platformBacktraceInit(void)
@@ -154,12 +167,10 @@ void platformBacktraceInit(void)
     sigact.sa_sigaction = &signalCritical;
     sigact.sa_flags     = SA_RESTART | SA_SIGINFO | SA_NOCLDWAIT;
 
-    sigaction(SIGABRT, &sigact, (struct sigaction *)nullptr);
-    sigaction(SIGILL, &sigact, (struct sigaction *)nullptr);
-    sigaction(SIGSEGV, &sigact, (struct sigaction *)nullptr);
-    sigaction(SIGBUS, &sigact, (struct sigaction *)nullptr);
-    sigaction(SIGTRAP, &sigact, (struct sigaction *)nullptr);
-    sigaction(SIGFPE, &sigact, (struct sigaction *)nullptr);
+    for (uint8_t i = 0; i < kNumSignals; i++)
+    {
+        sigaction(kSignals[i], &sigact, &sSigActions[i]);
+    }
 }
 #else  // OPENTHREAD_POSIX_CONFIG_ANDROID_ENABLE || defined(__GLIBC__)
 void platformBacktraceInit(void) {}


### PR DESCRIPTION
When compiling the otbr-agent in Android, Android will link the function [debuggerd_init()](https://android.googlesource.com/platform/system/core/+/refs/heads/master/debuggerd/handler/debuggerd_handler.cpp#715) and call it before calling the function main(). The function debuggerd_init() sets signal handlers to catch signals. This commit resets the signal actions to default and re-raises the original signal to let the pre-configured functions to catch signals.