### PR TITLE
[crypto] allow key reference usage for ECDSA

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (309)
+#define OPENTHREAD_API_VERSION (310)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/crypto.h
+++ b/include/openthread/platform/crypto.h
@@ -600,7 +600,7 @@ otError otPlatCryptoRandomGet(uint8_t *aBuffer, uint16_t aSize);
  * with the literal key.
  *
  * If OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE config is disabled, the
- * generated keypair is populated into mDerBytes in @p aKeyPair
+ * generated keypair is populated into mDerBytes in @p aKeyPair.
  *
  * @retval OT_ERROR_NONE         A new key pair was generated successfully.
  * @retval OT_ERROR_NO_BUFS      Failed to allocate buffer for key generation.

--- a/src/core/crypto/crypto_platform.cpp
+++ b/src/core/crypto/crypto_platform.cpp
@@ -657,7 +657,6 @@ exit:
 
     return error;
 }
-
 #endif // #if OPENTHREAD_CONFIG_ECDSA_ENABLE
 
 #endif // #if !OPENTHREAD_RADIO

--- a/src/core/crypto/storage.cpp
+++ b/src/core/crypto/storage.cpp
@@ -41,7 +41,7 @@ namespace Crypto {
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
 Error Key::ExtractKey(uint8_t *aKeyBuffer, uint16_t &aKeyLength) const
 {
-    Error  error;
+    Error  error = kErrorNone;
     size_t readKeyLength;
 
     OT_ASSERT(IsKeyRef());

--- a/src/core/crypto/storage.hpp
+++ b/src/core/crypto/storage.hpp
@@ -57,9 +57,10 @@ namespace Storage {
  */
 enum KeyType : uint8_t
 {
-    kKeyTypeRaw  = OT_CRYPTO_KEY_TYPE_RAW,  ///< Key Type: Raw Data.
-    kKeyTypeAes  = OT_CRYPTO_KEY_TYPE_AES,  ///< Key Type: AES.
-    kKeyTypeHmac = OT_CRYPTO_KEY_TYPE_HMAC, ///< Key Type: HMAC.
+    kKeyTypeRaw   = OT_CRYPTO_KEY_TYPE_RAW,   ///< Key Type: Raw Data.
+    kKeyTypeAes   = OT_CRYPTO_KEY_TYPE_AES,   ///< Key Type: AES.
+    kKeyTypeHmac  = OT_CRYPTO_KEY_TYPE_HMAC,  ///< Key Type: HMAC.
+    kKeyTypeEcdsa = OT_CRYPTO_KEY_TYPE_ECDSA, ///< Key Type: ECDSA.
 };
 
 /**
@@ -71,13 +72,15 @@ enum KeyAlgorithm : uint8_t
     kKeyAlgorithmVendor     = OT_CRYPTO_KEY_ALG_VENDOR,       ///< Key Algorithm: Vendor Defined.
     kKeyAlgorithmAesEcb     = OT_CRYPTO_KEY_ALG_AES_ECB,      ///< Key Algorithm: AES ECB.
     kKeyAlgorithmHmacSha256 = OT_CRYPTO_KEY_ALG_HMAC_SHA_256, ///< Key Algorithm: HMAC SHA-256.
+    kKeyAlgorithmEcdsa      = OT_CRYPTO_KEY_ALG_ECDSA,        ///< Key Algorithm: ECDSA.
 };
 
-constexpr uint8_t kUsageNone     = OT_CRYPTO_KEY_USAGE_NONE;      ///< Key Usage: Key Usage is empty.
-constexpr uint8_t kUsageExport   = OT_CRYPTO_KEY_USAGE_EXPORT;    ///< Key Usage: Key can be exported.
-constexpr uint8_t kUsageEncrypt  = OT_CRYPTO_KEY_USAGE_ENCRYPT;   ///< Key Usage: Encrypt (vendor defined).
-constexpr uint8_t kUsageDecrypt  = OT_CRYPTO_KEY_USAGE_DECRYPT;   ///< Key Usage: AES ECB.
-constexpr uint8_t kUsageSignHash = OT_CRYPTO_KEY_USAGE_SIGN_HASH; ///< Key Usage: HMAC SHA-256.
+constexpr uint8_t kUsageNone       = OT_CRYPTO_KEY_USAGE_NONE;        ///< Key Usage: Key Usage is empty.
+constexpr uint8_t kUsageExport     = OT_CRYPTO_KEY_USAGE_EXPORT;      ///< Key Usage: Key can be exported.
+constexpr uint8_t kUsageEncrypt    = OT_CRYPTO_KEY_USAGE_ENCRYPT;     ///< Key Usage: Encrypt (vendor defined).
+constexpr uint8_t kUsageDecrypt    = OT_CRYPTO_KEY_USAGE_DECRYPT;     ///< Key Usage: AES ECB.
+constexpr uint8_t kUsageSignHash   = OT_CRYPTO_KEY_USAGE_SIGN_HASH;   ///< Key Usage: Sign Hash.
+constexpr uint8_t kUsageVerifyHash = OT_CRYPTO_KEY_USAGE_VERIFY_HASH; ///< Key Usage: Verify Hash.
 
 /**
  * This enumeration defines the key storage types.
@@ -102,6 +105,7 @@ constexpr KeyRef kActiveDatasetNetworkKeyRef  = OPENTHREAD_CONFIG_PSA_ITS_NVM_OF
 constexpr KeyRef kActiveDatasetPskcRef        = OPENTHREAD_CONFIG_PSA_ITS_NVM_OFFSET + 4;
 constexpr KeyRef kPendingDatasetNetworkKeyRef = OPENTHREAD_CONFIG_PSA_ITS_NVM_OFFSET + 5;
 constexpr KeyRef kPendingDatasetPskcRef       = OPENTHREAD_CONFIG_PSA_ITS_NVM_OFFSET + 6;
+constexpr KeyRef kEcdsaRef                    = OPENTHREAD_CONFIG_PSA_ITS_NVM_OFFSET + 7;
 
 /**
  * Determine if a given `KeyRef` is valid or not.

--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -299,7 +299,7 @@ void KeyMaterial::SetFrom(const Key &aKey, bool aIsExportable)
 #endif
 }
 
-void KeyMaterial::ExtractKey(Key &aKey)
+void KeyMaterial::ExtractKey(Key &aKey) const
 {
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
     aKey.Clear();

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -540,7 +540,7 @@ public:
      * @param[out] aKey  A reference to the output the key.
      *
      */
-    void ExtractKey(Key &aKey);
+    void ExtractKey(Key &aKey) const;
 
     /**
      * This method converts `KeyMaterial` to a `Crypto::Key`.

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -901,6 +901,12 @@ Error Client::ReadOrGenerateKey(Crypto::Ecdsa::P256::KeyPair &aKeyPair)
         }
     }
 
+#if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
+    aKeyPair.Init(kSrpEcdsaKeyRef);
+#else
+    aKeyPair.Init();
+#endif
+
     SuccessOrExit(error = aKeyPair.Generate());
     IgnoreError(Get<Settings>().Save<Settings::SrpEcdsaKey>(aKeyPair));
 

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -92,6 +92,10 @@ public:
         kRemoved    = OT_SRP_CLIENT_ITEM_STATE_REMOVED,    ///< Item is removed.
     };
 
+#if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
+    static constexpr uint32_t kSrpEcdsaKeyRef = Crypto::Storage::kEcdsaRef;
+#endif
+
     /**
      * This function pointer type defines the callback used by SRP client to notify user of a changes/events/errors.
      *

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -284,7 +284,7 @@ exit:
     return;
 }
 
-void KeyManager::ComputeKeys(uint32_t aKeySequence, HashKeys &aHashKeys)
+void KeyManager::ComputeKeys(uint32_t aKeySequence, HashKeys &aHashKeys) const
 {
     Crypto::HmacSha256 hmac;
     uint8_t            keySequenceBytes[sizeof(uint32_t)];
@@ -306,7 +306,7 @@ void KeyManager::ComputeKeys(uint32_t aKeySequence, HashKeys &aHashKeys)
 }
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-void KeyManager::ComputeTrelKey(uint32_t aKeySequence, Mac::Key &aKey)
+void KeyManager::ComputeTrelKey(uint32_t aKeySequence, Mac::Key &aKey) const
 {
     Crypto::HkdfSha256 hkdf;
     uint8_t            salt[sizeof(uint32_t) + sizeof(kHkdfExtractSaltString)];

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -254,7 +254,7 @@ public:
      * @returns A key reference to the Thread Network Key.
      *
      */
-    NetworkKeyRef GetNetworkKeyRef(void) { return mNetworkKeyRef; }
+    NetworkKeyRef GetNetworkKeyRef(void) const { return mNetworkKeyRef; }
 
     /**
      * This method sets the Thread Network Key using Key Reference.
@@ -299,7 +299,7 @@ public:
      * @returns A key reference to the PSKc.
      *
      */
-    const PskcRef &GetPskcRef(void) { return mPskcRef; }
+    const PskcRef &GetPskcRef(void) const { return mPskcRef; }
 
     /**
      * This method sets the PSKc as a Key reference.
@@ -571,10 +571,10 @@ private:
         const Mac::Key &GetMacKey(void) const { return mKeys.mMacKey; }
     };
 
-    void ComputeKeys(uint32_t aKeySequence, HashKeys &aHashKeys);
+    void ComputeKeys(uint32_t aKeySequence, HashKeys &aHashKeys) const;
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    void ComputeTrelKey(uint32_t aKeySequence, Mac::Key &aKey);
+    void ComputeTrelKey(uint32_t aKeySequence, Mac::Key &aKey) const;
 #endif
 
     void StartKeyRotationTimer(void);

--- a/tests/unit/test_ecdsa.cpp
+++ b/tests/unit/test_ecdsa.cpp
@@ -88,9 +88,10 @@ void TestEcdsaVector(void)
     printf("\n===========================================================================\n");
     printf("Test ECDA with test vector from RFC 6979 (A.2.5)\n");
 
+    keyPair.Init();
+
     printf("\nLoading key-pair ----------------------------------------------------------\n");
-    memcpy(keyPair.GetDerBytes(), kKeyPairInfo, sizeof(kKeyPairInfo));
-    keyPair.SetDerLength(sizeof(kKeyPairInfo));
+    IgnoreError(keyPair.SetKeyPairFrom(kKeyPairInfo, sizeof(kKeyPairInfo)));
 
     DumpBuffer("KeyPair", keyPair.GetDerBytes(), keyPair.GetDerLength());
 


### PR DESCRIPTION
The current implementation of ECDSA always expects literal keys to be used. This PR updates the ECDSA module to use key references by:

- Update Crypto module to enable key references for ECDSA keypair.
- Updated the constructor to initialise the keypair. 
- Update the SRP code to initialise keypair before generating. 
- Adding a new abstraction to import keypair.
