### PR TITLE
[mle] request "Route TLV" after quick re-attach as FED

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1565,13 +1565,11 @@ protected:
     /**
      * This method generates an MLE Child Update Request message.
      *
-     * @param[in] aAppendChallenge   Indicates whether or not to include a Challenge TLV (even when already attached).
-     *
      * @retval kErrorNone    Successfully generated an MLE Child Update Request message.
      * @retval kErrorNoBufs  Insufficient buffers to generate the MLE Child Update Request message.
      *
      */
-    Error SendChildUpdateRequest(bool aAppendChallenge = false);
+    Error SendChildUpdateRequest(void);
 
     /**
      * This method generates an MLE Child Update Response message.
@@ -1846,6 +1844,14 @@ private:
         kChildUpdateRequestActive,  // Child Update Request has been sent and Child Update Response is expected.
     };
 
+    enum ChildUpdateRequestMode : uint8_t // Used in `SendChildUpdateRequest()`
+    {
+        kNormalChildUpdateRequest,    // Normal Child Update Request.
+        kAppendChallengeTlv,          // Append Challenge TLV to Child Update Request even if currently attached.
+        kAppendTlvRequestTlvForRoute, // Append TLV Request TLV and ask for Route TLV.
+        kAppendZeroTimeout,           // Use zero timeout when appending Timeout TLV (used for graceful detach).
+    };
+
     enum DataRequestState : uint8_t
     {
         kDataRequestNone,   // Not waiting for a Data Response.
@@ -1979,6 +1985,7 @@ private:
     void        HandleDetachGracefullyTimer(void);
     bool        IsDetachingGracefully(void) { return mDetachGracefullyTimer.IsRunning(); }
     Error       SendChildUpdateRequest(bool aAppendChallenge, uint32_t aTimeout);
+    Error       SendChildUpdateRequest(ChildUpdateRequestMode aMode);
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
     Error SendDataRequest(const Ip6::Address                        &aDestination,

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3040,6 +3040,10 @@ void MleRouter::SendChildUpdateResponse(Child                  *aChild,
         case Tlv::kLinkFrameCounter:
             SuccessOrExit(error = message->AppendLinkFrameCounterTlv());
             break;
+
+        case Tlv::kRoute:
+            SuccessOrExit(error = message->AppendRouteTlv());
+            break;
         }
 
         // Make sure `child` is not null before adding TLV types

--- a/tests/toranj/cli/test-012-reset-recovery.py
+++ b/tests/toranj/cli/test-012-reset-recovery.py
@@ -55,7 +55,7 @@ child2 = cli.Node()
 # Form topology
 
 leader.form('reset')
-child1.join(leader, cli.JOIN_TYPE_END_DEVICE)
+child1.join(leader, cli.JOIN_TYPE_REED)
 child2.join(leader, cli.JOIN_TYPE_END_DEVICE)
 
 verify(leader.get_state() == 'leader')
@@ -134,6 +134,24 @@ def check_leader_neighbor_table():
 
 
 verify_within(check_leader_neighbor_table, 10)
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Reset `child` and make sure it re-attached successfully.
+
+del child1
+child1 = cli.Node(index=3)
+child1.set_router_eligible('disable')
+child1.interface_up()
+child1.thread_start()
+
+
+def check_child1_state():
+    verify(child1.get_state() == 'child')
+    table = child1.get_router_table()
+    verify(len(table) == 2)
+
+
+verify_within(check_child1_state, 10)
 
 # -----------------------------------------------------------------------------------------------------------------------
 # Test finished


### PR DESCRIPTION
This commit allows an FED child to request Route TLV (in "TLV Request TLV") in a "Child Update Request" message. Parent will include the Route TLV when requested by child.

An FED child uses this mechanism after successfully performing a quick re-attach upon reset. In a quick re-attach, the child exchanges Child Update Request/Response messages with its parent to re-establish their link. After the re-attach, the FED child sends another "Child Update Request" message asking for the Route TLV. This ensures that the FED child will quickly learn of all routers and update its routing table, including the path costs to all routers and border routers.

We do not request Route TLV in the first "Child Update Request" message when the FED is still detached. This is to keep the "Child Update Response" short and avoid fragmentation at the 6LoWPAN layer. The FED child cannot process fragmented 6LoWPAN frames while it is detached because it does not yet know the parent's MAC frame counter value and fragmented frames always use link layer security.

----

This is related to [SPEC-1145](https://threadgroup.atlassian.net/browse/SPEC-1145).