### PR TITLE
[net-diag] define child IPv6 address list TLV

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (308)
+#define OPENTHREAD_API_VERSION (309)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/mesh_diag.h
+++ b/include/openthread/mesh_diag.h
@@ -198,10 +198,12 @@ otError otMeshDiagDiscoverTopology(otInstance                     *aInstance,
 void otMeshDiagCancel(otInstance *aInstance);
 
 /**
- * This function iterates through the discovered IPv6 address of a router.
+ * This function iterates through the discovered IPv6 address of a router or an MTD child.
  *
- * This function MUST be used from the callback `otMeshDiagDiscoverCallback()` and use the `mIp6AddrIterator` from the
- * `aRouterInfo` struct that is provided as input to the callback.
+ * This function MUST be used
+ * - from the callback `otMeshDiagDiscoverCallback()` and use the `mIp6AddrIterator` from the `aRouterInfo` struct that
+ *   is provided as input to the callback, or
+ * - from the callback `otMeshDiagChildIp6AddrsCallback()` along with provided `aIp6AddrIterator`.
  *
  * @param[in,out]  aIterator    The address iterator to use.
  * @param[out]     aIp6Address  A pointer to return the next IPv6 address (if any).
@@ -290,6 +292,47 @@ otError otMeshDiagQueryChildTable(otInstance                       *aInstance,
                                   uint16_t                          aRloc16,
                                   otMeshDiagQueryChildTableCallback aCallback,
                                   void                             *aContext);
+
+/**
+ * This function pointer type represents the callback used by `otMeshDiagQueryChildrenIp6Addrs()` to provide
+ * information about an MTD child and its list of IPv6 addresses.
+ *
+ * When @p aError is `OT_ERROR_PENDING`, it indicates that there are more children and the callback will be invoked
+ * again.
+ *
+ * @param[in] aError            OT_ERROR_PENDING            Indicates there are more children in the table.
+ *                              OT_ERROR_NONE               Indicates the table is finished.
+ *                              OT_ERROR_RESPONSE_TIMEOUT   Timed out waiting for response.
+ * @param[in] aChildRloc16      The RLOC16 of the child. `0xfffe` is used on `OT_ERROR_RESPONSE_TIMEOUT`.
+ * @param[in] aIp6AddrIterator  An iterator to go through the IPv6 addresses of the child with @p aRloc using
+ *                              `otMeshDiagGetNextIp6Address()`. Set to NULL on `OT_ERROR_RESPONSE_TIMEOUT`.
+ * @param[in] aContext          Application-specific context.
+ *
+ */
+typedef void (*otMeshDiagChildIp6AddrsCallback)(otError                    aError,
+                                                uint16_t                   aChildRloc16,
+                                                otMeshDiagIp6AddrIterator *aIp6AddrIterator,
+                                                void                      *aContext);
+
+/**
+ * This function sends a query to a parent to retrieve the IPv6 addresses of all its MTD children.
+ *
+ * @param[in] aInstance        The OpenThread instance.
+ * @param[in] aRouter16        The RLOC16 of parent to query.
+ * @param[in] aCallback        The callback to report the queried child IPv6 address list.
+ * @param[in] aContext         A context to pass in @p aCallback.
+ *
+ * @retval OT_ERROR_NONE           The query started successfully.
+ * @retval OT_ERROR_BUSY           A previous discovery or query request is still ongoing.
+ * @retval OT_ERROR_INVALID_ARGS   The @p aRloc16 is not a valid  RLOC16.
+ * @retval OT_ERROR_INVALID_STATE  Device is not attached.
+ * @retval OT_ERROR_NO_BUFS        Could not allocate buffer to send query messages.
+ *
+ */
+otError otMeshDiagQueryChildrenIp6Addrs(otInstance                     *aInstance,
+                                        uint16_t                        aRloc16,
+                                        otMeshDiagChildIp6AddrsCallback aCallback,
+                                        void                           *aContext);
 
 /**
  * @}

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -2038,6 +2038,44 @@ id:62 rloc16:0xf800 ext-addr:ce349873897233a5 ver:4 - br
    children: none
 ```
 
+### meshdiag childtable \<router-rloc16\>
+
+Start a query for child table of a router with a given RLOC16.
+
+Output lists all child entries. Information per child:
+
+- RLOC16
+- Extended MAC address
+- Thread Version
+- Timeout (in seconds)
+- Age (seconds since last heard)
+- Supervision interval (in seconds)
+- Number of queued message (in case sleepy)
+- Device Mode
+- RSS (average and last)
+- Error rates (frame, IPv6 message)
+- CSL info
+  - If synchronized
+  - Period (in unit of 10s symbol)
+  - Timeout (in seconds)
+
+```bash
+> meshdiag childtable 0x6400
+rloc16:0x6402 ext-addr:8e6f4d323bbed1fe ver:4
+    timeout:120 age:36 supvn:129 q-msg:0
+    rx-on:yes type:ftd full-net:yes
+    rss - ave:-20 last:-20
+    err-rate - frame:11.51% msg:0.76%
+    csl - sync:no period:0 timeout:0
+rloc16:0x6403 ext-addr:ee24e64ecf8c079a ver:4
+    timeout:120 age:19 supvn:129 q-msg:0
+    rx-on:no type:mtd full-net:no
+    rss - ave:-20 last:-20
+    err-rate - frame:0.73% msg:0.00%
+    csl - sync:no period:0 timeout:0
+Done
+```
+
 ### mliid \<iid\>
 
 Set the Mesh Local IID.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -2076,6 +2076,23 @@ rloc16:0x6403 ext-addr:ee24e64ecf8c079a ver:4
 Done
 ```
 
+### meshdiag childrenip6addrs \<parent-rloc16>
+
+Send a query to a parent to retrieve the IPv6 addresses of all its MTD children.
+
+```bash
+> meshdiag childrenip6addr 0xdc00
+child-rloc16: 0xdc02
+    fdde:ad00:beef:0:ded8:cd58:b73:2c21
+    fd00:2:0:0:c24a:456:3b6b:c597
+    fd00:1:0:0:120b:95fe:3ecc:d238
+child-rloc16: 0xdc03
+    fdde:ad00:beef:0:3aa6:b8bf:e7d6:eefe
+    fd00:2:0:0:8ff8:a188:7436:6720
+    fd00:1:0:0:1fcf:5495:790a:370f
+Done
+```
+
 ### mliid \<iid\>
 
 Set the Mesh Local IID.

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -407,6 +407,11 @@ private:
 #if OPENTHREAD_CONFIG_MESH_DIAG_ENABLE && OPENTHREAD_FTD
     static void HandleMeshDiagDiscoverDone(otError aError, otMeshDiagRouterInfo *aRouterInfo, void *aContext);
     void        HandleMeshDiagDiscoverDone(otError aError, otMeshDiagRouterInfo *aRouterInfo);
+    static void HandleMeshDiagQueryChildTableResult(otError                     aError,
+                                                    const otMeshDiagChildEntry *aChildEntry,
+                                                    void                       *aContext);
+    void        HandleMeshDiagQueryChildTableResult(otError aError, const otMeshDiagChildEntry *aChildEntry);
+
 #endif
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
     static void HandleMlrRegResult(void               *aContext,

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -411,6 +411,13 @@ private:
                                                     const otMeshDiagChildEntry *aChildEntry,
                                                     void                       *aContext);
     void        HandleMeshDiagQueryChildTableResult(otError aError, const otMeshDiagChildEntry *aChildEntry);
+    static void HandleMeshDiagQueryChildIp6Addrs(otError                    aError,
+                                                 uint16_t                   aChildRloc16,
+                                                 otMeshDiagIp6AddrIterator *aIp6AddrIterator,
+                                                 void                      *aContext);
+    void        HandleMeshDiagQueryChildIp6Addrs(otError                    aError,
+                                                 uint16_t                   aChildRloc16,
+                                                 otMeshDiagIp6AddrIterator *aIp6AddrIterator);
 
 #endif
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -667,6 +667,7 @@ openthread_core_files = [
   "thread/network_data_types.hpp",
   "thread/network_diagnostic.cpp",
   "thread/network_diagnostic.hpp",
+  "thread/network_diagnostic_tlvs.cpp",
   "thread/network_diagnostic_tlvs.hpp",
   "thread/panid_query_server.cpp",
   "thread/panid_query_server.hpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -225,6 +225,7 @@ set(COMMON_SOURCES
     thread/network_data_tlvs.cpp
     thread/network_data_types.cpp
     thread/network_diagnostic.cpp
+    thread/network_diagnostic_tlvs.cpp
     thread/panid_query_server.cpp
     thread/radio_selector.cpp
     thread/router_table.cpp

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -315,6 +315,7 @@ SOURCES_COMMON                                  = \
     thread/network_data_tlvs.cpp                  \
     thread/network_data_types.cpp                 \
     thread/network_diagnostic.cpp                 \
+    thread/network_diagnostic_tlvs.cpp            \
     thread/panid_query_server.cpp                 \
     thread/radio_selector.cpp                     \
     thread/router_table.cpp                       \

--- a/src/core/api/mesh_diag_api.cpp
+++ b/src/core/api/mesh_diag_api.cpp
@@ -64,4 +64,12 @@ otError otMeshDiagGetNextChildInfo(otMeshDiagChildIterator *aIterator, otMeshDia
     return AsCoreType(aIterator).GetNextChildInfo(AsCoreType(aChildInfo));
 }
 
+otError otMeshDiagQueryChildTable(otInstance                       *aInstance,
+                                  uint16_t                          aRloc16,
+                                  otMeshDiagQueryChildTableCallback aCallback,
+                                  void                             *aContext)
+{
+    return AsCoreType(aInstance).Get<Utils::MeshDiag>().QueryChildTable(aRloc16, aCallback, aContext);
+}
+
 #endif // OPENTHREAD_CONFIG_MESH_DIAG_ENABLE && OPENTHREAD_FTD

--- a/src/core/api/mesh_diag_api.cpp
+++ b/src/core/api/mesh_diag_api.cpp
@@ -72,4 +72,12 @@ otError otMeshDiagQueryChildTable(otInstance                       *aInstance,
     return AsCoreType(aInstance).Get<Utils::MeshDiag>().QueryChildTable(aRloc16, aCallback, aContext);
 }
 
+otError otMeshDiagQueryChildrenIp6Addrs(otInstance                     *aInstance,
+                                        uint16_t                        aRloc16,
+                                        otMeshDiagChildIp6AddrsCallback aCallback,
+                                        void                           *aContext)
+{
+    return AsCoreType(aInstance).Get<Utils::MeshDiag>().QueryChildrenIp6Addrs(aRloc16, aCallback, aContext);
+}
+
 #endif // OPENTHREAD_CONFIG_MESH_DIAG_ENABLE && OPENTHREAD_FTD

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -97,6 +97,9 @@ private:
 #if OPENTHREAD_FTD
     Error AppendChildTable(Message &aMessage);
     Error AppendChildTableAsChildTlvs(Coap::Message *&aAnswer, const Ip6::MessageInfo &aAnswerInfo);
+    Error AppendChildTableIp6AddressList(Coap::Message *&aAnswer, const Ip6::MessageInfo &aAnswerInfo);
+    Error AppendChildIp6AddressListTlv(Coap::Message &aAnswer, const Child &aChild);
+
 #endif
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/thread/network_diagnostic_tlvs.cpp
+++ b/src/core/thread/network_diagnostic_tlvs.cpp
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2023, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements methods for generating and processing Network Diagnostics TLVs.
+ */
+
+#include "network_diagnostic_tlvs.hpp"
+
+#include "common/time.hpp"
+
+namespace ot {
+namespace NetworkDiagnostic {
+
+using ot::Encoding::BigEndian::HostSwap16;
+using ot::Encoding::BigEndian::HostSwap32;
+
+#if OPENTHREAD_FTD
+
+void ChildTlv::InitFrom(const Child &aChild)
+{
+    Clear();
+
+    SetType(kChild);
+    SetLength(sizeof(*this) - sizeof(Tlv));
+
+    mFlags |= aChild.IsRxOnWhenIdle() ? kFlagsRxOnWhenIdle : 0;
+    mFlags |= aChild.IsFullThreadDevice() ? kFlagsFtd : 0;
+    mFlags |= (aChild.GetNetworkDataType() == NetworkData::kFullSet) ? kFlagsFullNetdta : 0;
+    mFlags |= kFlagsTrackErrRate;
+
+    mRloc16              = HostSwap16(aChild.GetRloc16());
+    mExtAddress          = aChild.GetExtAddress();
+    mVersion             = HostSwap16(aChild.GetVersion());
+    mTimeout             = HostSwap32(aChild.GetTimeout());
+    mAge                 = HostSwap32(Time::MsecToSec(TimerMilli::GetNow() - aChild.GetLastHeard()));
+    mSupervisionInterval = HostSwap16(aChild.GetSupervisionInterval());
+    mAverageRssi         = aChild.GetLinkInfo().GetAverageRss();
+    mLastRssi            = aChild.GetLinkInfo().GetLastRss();
+    mFrameErrorRate      = HostSwap16(aChild.GetLinkInfo().GetFrameErrorRate());
+    mMessageErrorRate    = HostSwap16(aChild.GetLinkInfo().GetMessageErrorRate());
+    mQueuedMessageCount  = HostSwap16(aChild.GetIndirectMessageCount());
+
+#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+    mFlags |= aChild.IsCslSynchronized() ? kFlagsCslSync : 0;
+    mCslPeriod  = HostSwap16(aChild.GetCslPeriod());
+    mCslTimeout = HostSwap32(aChild.GetCslTimeout());
+#endif
+}
+
+#endif // OPENTHREAD_FTD
+
+} // namespace NetworkDiagnostic
+} // namespace ot

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -70,24 +70,25 @@ public:
      */
     enum Type : uint8_t
     {
-        kExtMacAddress   = OT_NETWORK_DIAGNOSTIC_TLV_EXT_ADDRESS,
-        kAddress16       = OT_NETWORK_DIAGNOSTIC_TLV_SHORT_ADDRESS,
-        kMode            = OT_NETWORK_DIAGNOSTIC_TLV_MODE,
-        kTimeout         = OT_NETWORK_DIAGNOSTIC_TLV_TIMEOUT,
-        kConnectivity    = OT_NETWORK_DIAGNOSTIC_TLV_CONNECTIVITY,
-        kRoute           = OT_NETWORK_DIAGNOSTIC_TLV_ROUTE,
-        kLeaderData      = OT_NETWORK_DIAGNOSTIC_TLV_LEADER_DATA,
-        kNetworkData     = OT_NETWORK_DIAGNOSTIC_TLV_NETWORK_DATA,
-        kIp6AddressList  = OT_NETWORK_DIAGNOSTIC_TLV_IP6_ADDR_LIST,
-        kMacCounters     = OT_NETWORK_DIAGNOSTIC_TLV_MAC_COUNTERS,
-        kBatteryLevel    = OT_NETWORK_DIAGNOSTIC_TLV_BATTERY_LEVEL,
-        kSupplyVoltage   = OT_NETWORK_DIAGNOSTIC_TLV_SUPPLY_VOLTAGE,
-        kChildTable      = OT_NETWORK_DIAGNOSTIC_TLV_CHILD_TABLE,
-        kChannelPages    = OT_NETWORK_DIAGNOSTIC_TLV_CHANNEL_PAGES,
-        kTypeList        = OT_NETWORK_DIAGNOSTIC_TLV_TYPE_LIST,
-        kMaxChildTimeout = OT_NETWORK_DIAGNOSTIC_TLV_MAX_CHILD_TIMEOUT,
-        kVersion         = OT_NETWORK_DIAGNOSTIC_TLV_VERSION,
-        kChild           = 25,
+        kExtMacAddress       = OT_NETWORK_DIAGNOSTIC_TLV_EXT_ADDRESS,
+        kAddress16           = OT_NETWORK_DIAGNOSTIC_TLV_SHORT_ADDRESS,
+        kMode                = OT_NETWORK_DIAGNOSTIC_TLV_MODE,
+        kTimeout             = OT_NETWORK_DIAGNOSTIC_TLV_TIMEOUT,
+        kConnectivity        = OT_NETWORK_DIAGNOSTIC_TLV_CONNECTIVITY,
+        kRoute               = OT_NETWORK_DIAGNOSTIC_TLV_ROUTE,
+        kLeaderData          = OT_NETWORK_DIAGNOSTIC_TLV_LEADER_DATA,
+        kNetworkData         = OT_NETWORK_DIAGNOSTIC_TLV_NETWORK_DATA,
+        kIp6AddressList      = OT_NETWORK_DIAGNOSTIC_TLV_IP6_ADDR_LIST,
+        kMacCounters         = OT_NETWORK_DIAGNOSTIC_TLV_MAC_COUNTERS,
+        kBatteryLevel        = OT_NETWORK_DIAGNOSTIC_TLV_BATTERY_LEVEL,
+        kSupplyVoltage       = OT_NETWORK_DIAGNOSTIC_TLV_SUPPLY_VOLTAGE,
+        kChildTable          = OT_NETWORK_DIAGNOSTIC_TLV_CHILD_TABLE,
+        kChannelPages        = OT_NETWORK_DIAGNOSTIC_TLV_CHANNEL_PAGES,
+        kTypeList            = OT_NETWORK_DIAGNOSTIC_TLV_TYPE_LIST,
+        kMaxChildTimeout     = OT_NETWORK_DIAGNOSTIC_TLV_MAX_CHILD_TIMEOUT,
+        kVersion             = OT_NETWORK_DIAGNOSTIC_TLV_VERSION,
+        kChild               = 25,
+        kChildIp6AddressList = 26,
     };
 
     /**
@@ -173,6 +174,12 @@ typedef UintTlvInfo<Tlv::kMaxChildTimeout, uint32_t> MaxChildTimeoutTlv;
  *
  */
 typedef UintTlvInfo<Tlv::kVersion, uint16_t> VersionTlv;
+
+/**
+ * This class defines Child IPv6 Address List TLV constants and types.
+ *
+ */
+typedef TlvInfo<Tlv::kChildIp6AddressList> ChildIp6AddressListTlv;
 
 typedef otNetworkDiagConnectivity Connectivity; ///< Network Diagnostic Connectivity value.
 
@@ -784,6 +791,38 @@ private:
     uint16_t        mQueuedMessageCount;  // Number of queued message for indirect tx to child.
     uint16_t        mCslPeriod;           // CSL Period in unit of 10 symbols. Zero indicates disabled.
     uint32_t        mCslTimeout;          // CSL Timeout in seconds. Zero if not suppurated.
+} OT_TOOL_PACKED_END;
+
+/**
+ * This class implements Child IPv6 Address List Value generation and parsing.
+ *
+ * This TLV can use  extended or normal format depending on the number of IPv6 addresses.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+class ChildIp6AddressListTlvValue
+{
+public:
+    /**
+     * This method returns the RLOC16 of the child.
+     *
+     * @returns The RLOC16 of the child.
+     *
+     */
+    uint16_t GetRloc16(void) const { return HostSwap16(mRloc16); }
+
+    /**
+     * This method sets the RLOC16.
+     *
+     * @param[in] aRloc16   The RLOC16 value.
+     *
+     */
+    void SetRloc16(uint16_t aRloc16) { mRloc16 = HostSwap16(aRloc16); }
+
+private:
+    uint16_t mRloc16;
+    // Followed by zero or more IPv6 address(es).
+
 } OT_TOOL_PACKED_END;
 
 #endif // OPENTHREAD_FTD

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   This file includes definitions for generating and processing MLE TLVs.
+ *   This file includes definitions for generating and processing Network Diagnostics TLVs.
  */
 
 #ifndef NETWORK_DIAGNOSTIC_TLVS_HPP_
@@ -48,6 +48,7 @@
 #include "thread/link_quality.hpp"
 #include "thread/mle_tlvs.hpp"
 #include "thread/mle_types.hpp"
+#include "thread/topology.hpp"
 
 namespace ot {
 namespace NetworkDiagnostic {
@@ -86,6 +87,7 @@ public:
         kTypeList        = OT_NETWORK_DIAGNOSTIC_TLV_TYPE_LIST,
         kMaxChildTimeout = OT_NETWORK_DIAGNOSTIC_TLV_MAX_CHILD_TIMEOUT,
         kVersion         = OT_NETWORK_DIAGNOSTIC_TLV_VERSION,
+        kChild           = 25,
     };
 
     /**
@@ -614,6 +616,177 @@ public:
         SetLength(sizeof(*this) - sizeof(Tlv));
     }
 } OT_TOOL_PACKED_END;
+
+#if OPENTHREAD_FTD
+
+/**
+ * This class implements Child TLV generation and parsing.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+class ChildTlv : public Tlv, public TlvInfo<Tlv::kChild>, public Clearable<ChildTlv>
+{
+public:
+    static constexpr uint8_t kFlagsRxOnWhenIdle = 1 << 7; ///< Device mode - Rx-on when idle.
+    static constexpr uint8_t kFlagsFtd          = 1 << 6; ///< Device mode - Full Thread Device (FTD).
+    static constexpr uint8_t kFlagsFullNetdta   = 1 << 5; ///< Device mode - Full Network Data.
+    static constexpr uint8_t kFlagsCslSync      = 1 << 4; ///< Is CSL capable and CSL synchronized.
+    static constexpr uint8_t kFlagsTrackErrRate = 1 << 3; ///< Supports tracking error rates.
+
+    /**
+     * This method initializes the TLV using information from a given `Child`.
+     *
+     * @param[in] aChild   The child to initialize the TLV from.
+     *
+     */
+    void InitFrom(const Child &aChild);
+
+    /**
+     * This method initializes the TLV as empty (zero length).
+     *
+     */
+    void InitAsEmpty(void)
+    {
+        SetType(kChild);
+        SetLength(0);
+    }
+
+    /**
+     * This method returns the Flags field (`kFlags*` constants define bits in flags).
+     *
+     * @returns The Flags field.
+     *
+     */
+    uint8_t GetFlags(void) const { return mFlags; }
+
+    /**
+     * This method returns the RLOC16 field.
+     *
+     * @returns The RLOC16 of the child.
+     *
+     */
+    uint16_t GetRloc16(void) const { return HostSwap16(mRloc16); }
+
+    /**
+     * This method returns the Extended Address.
+     *
+     * @returns The Extended Address of the child.
+     *
+     */
+    const Mac::ExtAddress &GetExtAddress(void) const { return mExtAddress; }
+
+    /**
+     * This method returns the Version field.
+     *
+     * @returns The Version of the child.
+     *
+     */
+    uint16_t GetVersion(void) const { return HostSwap16(mVersion); }
+
+    /**
+     * This method returns the Timeout field
+     *
+     * @returns The Timeout value in seconds.
+     *
+     */
+    uint32_t GetTimeout(void) const { return HostSwap32(mTimeout); }
+
+    /**
+     * This method returns the Age field.
+     *
+     * @returns The Age field (seconds since last heard from the child).
+     *
+     */
+    uint32_t GetAge(void) const { return HostSwap32(mAge); }
+
+    /**
+     * This method returns the Supervision Interval field
+     *
+     * @returns The Supervision Interval in seconds. Zero indicates not used.
+     *
+     */
+    uint16_t GetSupervisionInterval(void) const { return HostSwap16(mSupervisionInterval); }
+
+    /**
+     * This method returns the Average RSSI field.
+     *
+     * @returns The Average RSSI in dBm. 127 if not available or unknown.
+     *
+     */
+    int8_t GetAverageRssi(void) const { return mAverageRssi; }
+
+    /**
+     * This method returns the Last RSSI field (RSSI of last received frame from child).
+     *
+     * @returns The Last RSSI field in dBm. 127 if not available or unknown.
+     *
+     */
+    int8_t GetLastRssi(void) const { return mLastRssi; }
+
+    /**
+     * This method returns the Frame Error Rate field.
+     *
+     * `kFlagsTrackErrRate` from `GetFlags()` indicates whether or not the implementation supports tracking of error
+     * rates and whether or not the value in this field is valid.
+     *
+     * @returns The Frame Error Rate (0xffff->100%).
+     *
+     */
+    uint16_t GetFrameErrorRate(void) const { return HostSwap16(mFrameErrorRate); }
+
+    /**
+     * This method returns the Message Error Rate field.
+     *
+     * `kFlagsTrackErrRate` from `GetFlags()` indicates whether or not the implementation supports tracking of error
+     * rates and whether or not the value in this field is valid.
+     *
+     * @returns The Message Error Rate (0xffff->100%). Zero if not known or supported.
+     *
+     */
+    uint16_t GetMessageErrorRate(void) const { return HostSwap16(mMessageErrorRate); }
+
+    /**
+     * This method returns the Queued Message Count field.
+     *
+     * @returns The Queued Message Count (number of queued message for indirect tx to child).
+     *
+     */
+    uint16_t GetQueuedMessageCount(void) const { return HostSwap16(mQueuedMessageCount); }
+
+    /**
+     * This method returns the CSL Period in unit of 10 symbols.
+     *
+     * @returns The CSL Period in unit of 10 symbols. Zero if CSL is not supported.
+     *
+     */
+    uint16_t GetCslPeriod(void) const { return HostSwap16(mCslPeriod); }
+
+    /**
+     * This method returns the CSL Timeout in seconds.
+     *
+     * @returns The CSL Timeout in seconds. Zero if CSL is not supported.
+     *
+     */
+    uint32_t GetCslTimeout(void) const { return HostSwap32(mCslTimeout); }
+
+private:
+    uint8_t         mFlags;               // Flags (`kFlags*` constants).
+    uint16_t        mRloc16;              // RLOC16.
+    Mac::ExtAddress mExtAddress;          // Extended Address.
+    uint16_t        mVersion;             // Version.
+    uint32_t        mTimeout;             // Timeout in seconds.
+    uint32_t        mAge;                 // Seconds since last heard from the child.
+    uint16_t        mSupervisionInterval; // Supervision interval in seconds. Zero to indicate not used.
+    int8_t          mAverageRssi;         // Average RSSI. 127 if not available or unknown
+    int8_t          mLastRssi;            // RSSI of last received frame. 127 if not available or unknown.
+    uint16_t        mFrameErrorRate;      // Frame error rate (0xffff->100%). Zero if not known or supported.
+    uint16_t        mMessageErrorRate;    // (IPv6) msg error rate (0xffff->100%). Zero if not known or supported.
+    uint16_t        mQueuedMessageCount;  // Number of queued message for indirect tx to child.
+    uint16_t        mCslPeriod;           // CSL Period in unit of 10 symbols. Zero indicates disabled.
+    uint32_t        mCslTimeout;          // CSL Timeout in seconds. Zero if not suppurated.
+} OT_TOOL_PACKED_END;
+
+#endif // OPENTHREAD_FTD
 
 } // namespace NetworkDiagnostic
 } // namespace ot

--- a/src/core/utils/mesh_diag.hpp
+++ b/src/core/utils/mesh_diag.hpp
@@ -38,6 +38,10 @@
 
 #if OPENTHREAD_CONFIG_MESH_DIAG_ENABLE && OPENTHREAD_FTD
 
+#if !OPENTHREAD_CONFIG_TMF_NETDIAG_CLIENT_ENABLE
+#error "OPENTHREAD_CONFIG_MESH_DIAG_ENABLE requires OPENTHREAD_CONFIG_TMF_NETDIAG_CLIENT_ENABLE"
+#endif
+
 #include <openthread/mesh_diag.h>
 
 #include "coap/coap.hpp"
@@ -46,6 +50,7 @@
 #include "common/message.hpp"
 #include "common/timer.hpp"
 #include "net/ip6_address.hpp"
+#include "thread/network_diagnostic.hpp"
 #include "thread/network_diagnostic_tlvs.hpp"
 
 struct otMeshDiagIp6AddrIterator
@@ -65,11 +70,14 @@ namespace Utils {
  */
 class MeshDiag : public InstanceLocator
 {
+    friend class ot::NetworkDiagnostic::Client;
+
 public:
     static constexpr uint16_t kVersionUnknown = OT_MESH_DIAG_VERSION_UNKNOWN; ///< Unknown version.
 
-    typedef otMeshDiagDiscoverConfig   DiscoverConfig;   ///< The discovery configuration.
-    typedef otMeshDiagDiscoverCallback DiscoverCallback; ///< The discovery callback function pointer type.
+    typedef otMeshDiagDiscoverConfig          DiscoverConfig;          ///< Discovery configuration.
+    typedef otMeshDiagDiscoverCallback        DiscoverCallback;        ///< Discovery callback.
+    typedef otMeshDiagQueryChildTableCallback QueryChildTableCallback; ///< Query Child Table callback.
 
     /**
      * This type represents an iterator to go over list of IPv6 addresses of a router.
@@ -148,6 +156,14 @@ public:
         uint16_t       mParentRloc16;
     };
 
+    class ChildEntry : public otMeshDiagChildEntry
+    {
+        friend class MeshDiag;
+
+    private:
+        void SetFrom(const NetworkDiagnostic::ChildTlv &aChildTlv);
+    };
+
     /**
      * This constructor initializes the `MeshDiag` instance.
      *
@@ -164,7 +180,7 @@ public:
      * @param[in] aContext         A context to pass in @p aCallback.
      *
      * @retval kErrorNone          The network topology discovery started successfully.
-     * @retval kErrorBusy          A previous discovery request is still ongoing.
+     * @retval kErrorBusy          A previous discovery or query request is still ongoing.
      * @retval kErrorInvalidState  Device is not attached.
      * @retval kErrorNoBufs        Could not allocate buffer to send discovery messages.
      *
@@ -172,9 +188,26 @@ public:
     Error DiscoverTopology(const DiscoverConfig &aConfig, DiscoverCallback aCallback, void *aContext);
 
     /**
-     * This method cancels an ongoing topology discovery if there one, otherwise no action.
+     * This method starts query for child table for a given router.
      *
-     * When ongoing discovery is cancelled, the callback from `DiscoverTopology()` will not be called anymore.
+     * @param[in] aRouter16        The RLOC16 of router to query.
+     * @param[in] aCallback        The callback to report the queried child table.
+     * @param[in] aContext         A context to pass in @p aCallback.
+     *
+     * @retval kErrorNone          The query started successfully.
+     * @retval kErrorBusy          A previous discovery or query request is still ongoing.
+     * @retval kErrorInvalidArgs   The @p aRloc16 is not a valid router RLOC16.
+     * @retval kErrorInvalidState  Device is not attached.
+     * @retval kErrorNoBufs        Could not allocate buffer to send query messages.
+     *
+     */
+    Error QueryChildTable(uint16_t aRloc16, QueryChildTableCallback aCallback, void *aContext);
+
+    /**
+     * This method cancels an ongoing discovery or query operation if there one, otherwise no action.
+     *
+     * When ongoing discovery is cancelled, the callback from `DiscoverTopology()` or  `QueryChildTable()` will not be
+     * called anymore.
      *
      */
     void Cancel(void);
@@ -184,9 +217,28 @@ private:
 
     static constexpr uint32_t kResponseTimeout = OPENTHREAD_CONFIG_MESH_DIAG_RESPONSE_TIMEOUT;
 
-    Error SendDiagGetTo(uint16_t aRloc16, const DiscoverConfig &aConfig);
-    void  HandleTimer(void);
-    void  HandleDiagGetResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
+    enum State : uint8_t
+    {
+        kStateIdle,
+        kStateDicoverTopology,
+        kStateQueryChildTable,
+    };
+
+    struct DiscoverInfo
+    {
+        Callback<DiscoverCallback> mCallback;
+        Mle::RouterIdSet           mExpectedRouterIdSet;
+    };
+
+    struct QueryChildTableInfo
+    {
+        Callback<QueryChildTableCallback> mCallback;
+        uint16_t                          mRouterRloc16;
+    };
+
+    void HandleTimer(void);
+    bool HandleDiagnosticGetAnswer(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void HandleDiagGetResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
 
     static void HandleDiagGetResponse(void                *aContext,
                                       otMessage           *aMessage,
@@ -195,9 +247,14 @@ private:
 
     using TimeoutTimer = TimerMilliIn<MeshDiag, &MeshDiag::HandleTimer>;
 
-    Callback<DiscoverCallback> mDiscoverCallback;
-    Mle::RouterIdSet           mExpectedRouterIdSet;
-    TimeoutTimer               mTimer;
+    State        mState;
+    TimeoutTimer mTimer;
+
+    union
+    {
+        DiscoverInfo        mDiscover;
+        QueryChildTableInfo mQueryChildTable;
+    };
 };
 
 } // namespace Utils

--- a/tests/toranj/cli/test-021-mesh-diag.py
+++ b/tests/toranj/cli/test-021-mesh-diag.py
@@ -82,6 +82,11 @@ sed2.allowlist_node(r3)
 sed3.allowlist_node(r3)
 
 r1.form('mesh-diag')
+
+r1.add_prefix('fd00:1::/64', 'poas')
+r1.add_prefix('fd00:2::/64', 'poas')
+r1.register_netdata()
+
 r2.join(r1)
 r3.join(r1)
 fed1.join(r1, cli.JOIN_TYPE_REED)
@@ -137,6 +142,13 @@ verify(len([line for line in childtable if line.startswith('rloc16')]) == 3)
 
 childtable = r1.cli('meshdiag childtable', r2_rloc)
 verify(len([line for line in childtable if line.startswith('rloc16')]) == 0)
+
+childrenip6addrs = r2.cli('meshdiag childrenip6addrs', r1_rloc)
+verify(len([line for line in childrenip6addrs if line.startswith('child-rloc16')]) == 1)
+verify(len([line for line in childrenip6addrs if line.startswith('   ')]) == 3)
+
+childrenip6addrs = r1.cli('meshdiag childrenip6addrs', r3_rloc)
+verify(len([line for line in childrenip6addrs if line.startswith('child-rloc16')]) == 2)
 
 # -----------------------------------------------------------------------------------------------------------------------
 # Test finished

--- a/tests/toranj/cli/test-021-mesh-diag.py
+++ b/tests/toranj/cli/test-021-mesh-diag.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2023, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+
+from cli import verify
+from cli import verify_within
+import cli
+import time
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test description: Validate Mesh Diag module commands.
+#
+# Network topology
+#
+#    r1 ---- r2 ---- r3
+#    /\              /|\
+#   /  \            / | \
+#  f1  s1          f2 s2 s3
+
+test_name = __file__[:-3] if __file__.endswith('.py') else __file__
+print('-' * 120)
+print('Starting \'{}\''.format(test_name))
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Creating `cli.Node` instances
+
+speedup = 40
+cli.Node.set_time_speedup_factor(speedup)
+
+r1 = cli.Node()
+r2 = cli.Node()
+r3 = cli.Node()
+fed1 = cli.Node()
+fed2 = cli.Node()
+sed1 = cli.Node()
+sed2 = cli.Node()
+sed3 = cli.Node()
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Form topology
+
+r1.allowlist_node(r2)
+r1.allowlist_node(fed1)
+r1.allowlist_node(sed1)
+
+r2.allowlist_node(r1)
+r2.allowlist_node(r3)
+
+r3.allowlist_node(r2)
+r3.allowlist_node(fed2)
+r3.allowlist_node(sed2)
+r3.allowlist_node(sed3)
+
+fed1.allowlist_node(r1)
+fed2.allowlist_node(r3)
+sed1.allowlist_node(r1)
+sed2.allowlist_node(r3)
+sed3.allowlist_node(r3)
+
+r1.form('mesh-diag')
+r2.join(r1)
+r3.join(r1)
+fed1.join(r1, cli.JOIN_TYPE_REED)
+fed2.join(r1, cli.JOIN_TYPE_REED)
+sed1.join(r1, cli.JOIN_TYPE_SLEEPY_END_DEVICE)
+sed2.join(r1, cli.JOIN_TYPE_SLEEPY_END_DEVICE)
+sed3.join(r1, cli.JOIN_TYPE_SLEEPY_END_DEVICE)
+
+verify(r1.get_state() == 'leader')
+verify(r2.get_state() == 'router')
+verify(r3.get_state() == 'router')
+verify(fed1.get_state() == 'child')
+verify(fed2.get_state() == 'child')
+verify(sed1.get_state() == 'child')
+verify(sed2.get_state() == 'child')
+verify(sed3.get_state() == 'child')
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test Implementation
+
+r1_rloc = int(r1.get_rloc16(), 16)
+r2_rloc = int(r2.get_rloc16(), 16)
+r3_rloc = int(r3.get_rloc16(), 16)
+
+fed1_rloc = int(fed1.get_rloc16(), 16)
+fed2_rloc = int(fed2.get_rloc16(), 16)
+
+sed1_rloc = int(sed1.get_rloc16(), 16)
+sed2_rloc = int(sed2.get_rloc16(), 16)
+sed3_rloc = int(sed3.get_rloc16(), 16)
+
+topo = r1.cli('meshdiag topology')
+verify(len(topo) == 6)
+
+routers = []
+for line in topo:
+    if line.startswith('id:'):
+        routers.append(int(line.split(' ')[1].split(':')[1], 16))
+
+verify(r1_rloc in routers)
+verify(r2_rloc in routers)
+verify(r3_rloc in routers)
+
+r2.cli('meshdiag topology ip6-addrs')
+r3.cli('meshdiag topology ip6-addrs children')
+r1.cli('meshdiag topology children')
+
+childtable = r2.cli('meshdiag childtable', r1_rloc)
+verify(len([line for line in childtable if line.startswith('rloc16')]) == 2)
+
+childtable = r1.cli('meshdiag childtable', r3_rloc)
+verify(len([line for line in childtable if line.startswith('rloc16')]) == 3)
+
+childtable = r1.cli('meshdiag childtable', r2_rloc)
+verify(len([line for line in childtable if line.startswith('rloc16')]) == 0)
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test finished
+
+cli.Node.finalize_all_nodes()
+
+print('\'{}\' passed.'.format(test_name))

--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -184,6 +184,7 @@ if [ "$TORANJ_CLI" = 1 ]; then
     run cli/test-017-network-data-versions.py
     run cli/test-018-next-hop-and-path-cost.py
     run cli/test-019-netdata-context-id.py
+    run cli/test-021-mesh-diag.py
     run cli/test-400-srp-client-server.py
     run cli/test-601-channel-manager-channel-change.py
     # Skip the "channel-select" test on a TREL only radio link, since it


### PR DESCRIPTION
This commit adds Network Diagnostic Child IPv6 Address List TLV (with TLV type 26). This TLV provides the list of IPv6 addresses which an MTD child has registered with its parent.
    
This commit adds mechanism to a query to a parent to retrieve the IPv6 addresses of all its MTD children using this TLV. `MeshDiag` is updated to provide this functionality.