### PR TITLE
[nat64] notify platform when NAT64 CIDR is updated

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -681,25 +681,44 @@ template <> otError Interpreter::Process<Cmd("nat64")>(Arg aArgs[])
 #endif
     }
 #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
-    /**
-     * @cli nat64 cidr
-     * @code
-     * nat64 cidr
-     * 192.168.255.0/24
-     * Done
-     * @endcode
-     * @par api_copy
-     * #otNat64GetCidr
-     *
-     */
     else if (aArgs[0] == "cidr")
     {
         otIp4Cidr cidr;
-        char      cidrString[OT_IP4_CIDR_STRING_SIZE];
 
-        SuccessOrExit(error = otNat64GetCidr(GetInstancePtr(), &cidr));
-        otIp4CidrToString(&cidr, cidrString, sizeof(cidrString));
-        OutputLine("%s", cidrString);
+        /**
+         * @cli nat64 cidr
+         * @code
+         * nat64 cidr
+         * 192.168.255.0/24
+         * Done
+         * @endcode
+         * @par api_copy
+         * #otNat64GetCidr
+         *
+         */
+        if (aArgs[1].IsEmpty())
+        {
+            char cidrString[OT_IP4_CIDR_STRING_SIZE];
+
+            SuccessOrExit(error = otNat64GetCidr(GetInstancePtr(), &cidr));
+            otIp4CidrToString(&cidr, cidrString, sizeof(cidrString));
+            OutputLine("%s", cidrString);
+        }
+        /**
+         * @cli nat64 cidr <cidr>
+         * @code
+         * nat64 cidr 192.168.255.0/24
+         * Done
+         * @endcode
+         * @par api_copy
+         * #otPlatNat64SetIp4Cidr
+         *
+         */
+        else
+        {
+            SuccessOrExit(error = otIp4CidrFromString(aArgs[1].GetCString(), &cidr));
+            error = otNat64SetIp4Cidr(GetInstancePtr(), &cidr);
+        }
     }
     /**
      * @cli nat64 mappings

--- a/src/core/net/nat64_translator.cpp
+++ b/src/core/net/nat64_translator.cpp
@@ -36,6 +36,8 @@
 
 #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
 
+#include <openthread/platform/toolchain.h>
+
 #include "common/code_utils.hpp"
 #include "common/locator_getters.hpp"
 #include "common/log.hpp"
@@ -507,7 +509,8 @@ Error Translator::SetIp4Cidr(const Ip4::Cidr &aCidr)
             numberOfHosts);
     mIp4Cidr = aCidr;
 
-    UpdateState();
+    // Always notify the platform when the CIDR is changed.
+    UpdateState(true /* aAlwaysNotify */);
 
 exit:
     return err;
@@ -631,7 +634,7 @@ void Translator::ProtocolCounters::Count4To6Packet(uint8_t aProtocol, uint64_t a
     mTotal.m4To6Bytes += aPacketSize;
 }
 
-void Translator::UpdateState(void)
+void Translator::UpdateState(bool aAlwaysNotify)
 {
     State newState;
 
@@ -651,7 +654,14 @@ void Translator::UpdateState(void)
         newState = kStateDisabled;
     }
 
-    SuccessOrExit(Get<Notifier>().Update(mState, newState, kEventNat64TranslatorStateChanged));
+    if (aAlwaysNotify)
+    {
+        Get<Notifier>().Signal(kEventNat64TranslatorStateChanged);
+    }
+    else
+    {
+        SuccessOrExit(Get<Notifier>().Update(mState, newState, kEventNat64TranslatorStateChanged));
+    }
     LogInfo("NAT64 translator is now %s", StateToString(mState));
 
 exit:

--- a/src/core/net/nat64_translator.hpp
+++ b/src/core/net/nat64_translator.hpp
@@ -380,7 +380,7 @@ private:
 
     using MappingTimer = TimerMilliIn<Translator, &Translator::HandleMappingExpirerTimer>;
 
-    void UpdateState(void);
+    void UpdateState(bool aAlwaysNotify = false);
 
     bool  mEnabled;
     State mState;

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -49,7 +49,6 @@
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/logging.h>
-#include <openthread/nat64.h>
 #include <openthread/openthread-system.h>
 #include <openthread/platform/time.h>
 
@@ -447,11 +446,6 @@ extern char gNetifName[IFNAMSIZ];
  *
  */
 extern unsigned int gNetifIndex;
-
-/**
- * The CIDR for NAT64
- */
-extern otIp4Cidr gNat64Cidr;
 
 /**
  * Initializes platform Backbone network.

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -148,13 +148,6 @@ void platformInit(otPlatformConfig *aPlatformConfig)
 
     gNetifName[0] = '\0';
 
-#if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
-    if (otIp4CidrFromString(OPENTHREAD_POSIX_CONFIG_NAT64_CIDR, &gNat64Cidr) != OT_ERROR_NONE)
-    {
-        gNat64Cidr.mLength = 0;
-    }
-#endif
-
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
     platformNetifInit(aPlatformConfig);
 #endif

--- a/tests/scripts/thread-cert/border_router/nat64/test_single_border_router.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_single_border_router.py
@@ -63,6 +63,9 @@ SMALL_NAT64_PREFIX = "fd00:00:00:01:00:00::/96"
 # So the BR will remove the random-generated one.
 LARGE_NAT64_PREFIX = "ff00:00:00:01:00:00::/96"
 
+DEFAULT_NAT64_CIDR = ipaddress.IPv4Network("192.168.255.0/24")
+UPDATED_NAT64_CIDR = ipaddress.IPv4Network("100.64.64.0/24")
+
 
 class Nat64SingleBorderRouter(thread_cert.TestCase):
     USE_MESSAGE_FACTORY = False
@@ -235,7 +238,16 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         self.assertEqual(counters['protocol']['ICMP']['6to4']['packets'], 2)
 
         #
-        # Case 6. Disable and re-enable ethernet on the border router.
+        # Case 6. Change the CIDR used by NAT64 during runtime
+        #
+        self.assertEqual(br.nat64_cidr, DEFAULT_NAT64_CIDR)
+
+        br.nat64_cidr = UPDATED_NAT64_CIDR
+        self.assertEqual(br.nat64_cidr, UPDATED_NAT64_CIDR)
+        self.assertTrue(router.ping(ipaddr=host_ip))
+
+        #
+        # Case 7. Disable and re-enable ethernet on the border router.
         # Note: disable_ether will remove default route but enable_ether won't add it back,
         # NAT64 connectivity tests will fail after this.
         # TODO: Add a default IPv4 route after enable_ether.

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -414,6 +414,19 @@ class OtbrDocker:
         return self.call_dbus_method('io.openthread.BorderRouter', 'SetNat64Enabled', enable)
 
     @property
+    def nat64_cidr(self):
+        self.send_command('nat64 cidr')
+        cidr = self._expect_command_output()[0].strip()
+        return ipaddress.IPv4Network(cidr, strict=False)
+
+    @nat64_cidr.setter
+    def nat64_cidr(self, cidr: ipaddress.IPv4Network):
+        if not isinstance(cidr, ipaddress.IPv4Network):
+            raise ValueError("cidr is expected to be an instance of ipaddress.IPv4Network")
+        self.send_command(f'nat64 cidr {cidr}')
+        self._expect_done()
+
+    @property
     def nat64_state(self):
         state = self.get_dbus_property('Nat64State')
         return {'PrefixManager': state[0], 'Translator': state[1]}


### PR DESCRIPTION
We should notice that the default CIDR (`192.168.255.0/24`) is not safe to use, however, in most cases, the CIDR used can only be determined during runtime since the single binary might be distributed to BRs in different network conditions. And we cannot conclude an always safe CIDR in all conditions.

This PR will emit an event when NAT64 CIDR is changed. So the platform driver can update the route for NAT64.