### PR TITLE
[posix] vendor support with lib dependencies

### DIFF
--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -95,9 +95,6 @@ if(NOT OT_CONFIG)
     set(OT_CONFIG "openthread-core-posix-config.h" PARENT_SCOPE)
 endif()
 
-set(OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE "vendor_interface_example.cpp"
-       CACHE STRING "vendor interface implementation")
-
 set(CMAKE_EXE_LINKER_FLAGS "-rdynamic ${CMAKE_EXE_LINKER_FLAGS}" PARENT_SCOPE)
 
 add_library(openthread-posix
@@ -128,8 +125,9 @@ add_library(openthread-posix
     udp.cpp
     utils.cpp
     virtual_time.cpp
-    ${OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE}
 )
+
+include(vendor.cmake)
 
 target_link_libraries(openthread-posix
     PUBLIC

--- a/src/posix/platform/FindExampleVendorDeps.cmake
+++ b/src/posix/platform/FindExampleVendorDeps.cmake
@@ -1,0 +1,127 @@
+#
+#  Copyright (c) 2023, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+#[=======================================================================[.rst:
+FindExampleRcpVendorDeps
+------------------------
+
+This file provides a reference for how to implement an RCP vendor
+dependency CMake module to resolve external libraries and header
+files used by a vendor implementation in the posix library.
+
+The name of this file and the name of the targets it defines are
+conventionally related. For the purpose of this reference, targets
+will be based off of the identifier "ExampleRcpVendorDeps". Derived
+references should be based off of the value of the cache variable,
+"OT_POSIX_CONFIG_RCP_VENDOR_DEPS_PACKAGE".
+
+For more information about package resolution using CMake find modules,
+reference the cmake-developer documentation.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``ExampleRcpVendorDeps::ExampleRcpVendorDeps``
+  RCP vendor interface library dependencies
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``ExampleRcpVendorDeps_FOUND``
+  True if the system has all of the required external dependencies
+``ExampleRcpVendorDeps_INCLUDE_DIRS``
+  Include directories needed by vendor interface
+``ExampleRcpVendorDeps_LIBRARIES``
+  Libraries needed by vendor interface
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+Vendors modules may configure various cache variables
+while resolving dependencies:
+
+``Dependency0_INCLUDE_DIR``
+  The directory containing include files for dependency 0
+``Dependency0_LIBRARY``
+  The path to the library containing symbols for dependency 0
+``Dependency1_INCLUDE_DIR``
+  The directory containing include files for dependency 1
+``Dependency1_LIBRARY``
+  The path to the library containing symbols for dependency 1
+
+#]=======================================================================]
+
+include(FindPackageHandleStandardArgs)
+
+find_path(Dependency0_INCLUDE_DIR
+    NAMES example0/example.h
+    PATH  ${EXAMPLES_ROOT}/include
+)
+
+find_library(Dependency0_LIBRARY
+    NAMES example0
+    PATH  ${EXAMPLES_ROOT}/lib
+)
+
+find_path(Dependency1_INCLUDE_DIR
+    NAMES example1/example.h
+    PATH ${EXAMPLES_ROOT}/include
+)
+
+find_library(Dependency1_LIBRARY
+    NAMES example1
+    PATH ${EXAMPLES_ROOT}/lib
+)
+
+find_package_handle_standard_args(ExampleRcpVendorDeps
+    FOUND_VAR ExampleRcpVendorDeps_FOUND
+    REQUIRED_VARS Dependency0_INCLUDE_DIR Dependency0_LIBRARY Dependency1_INCLUDE_DIR Dependency1_LIBRARY
+)
+
+if(ExampleRcpVendorDeps_FOUND AND NOT ExampleRcpVendorDeps::ExampleRcpVendorDeps)
+    set(ExampleRcpVendorDeps_INCLUDE_DIRS ${Dependency0_INCLUDE_DIR} ${Dependency1_INCLUDE_DIR})
+    set(ExampleRcpVendorDeps_LIBRARIES ${Dependency0_LIBRARY} ${Dependency1_LIBRARY})
+
+    add_library(ExampleRcpVendorDeps::ExampleRcpVendorDeps UNKNOWN IMPORTED)
+    set_target_properties(ExampleRcpVendorDeps::ExampleRcpVendorDeps PROPERTIES
+        IMPORTED_LOCATION "${ExampleRcpVendorDeps_LIBRARIES}"
+        INTERFACE_INCLUDE_DIRECTORIES "${ExampleRcpVendorDeps_INCLUDE_DIRS}"
+    )
+
+    mark_as_advanced(
+        Dependency0_INCLUDE_DIR
+        Dependency0_LIBRARY
+        Dependency1_INCLUDE_DIR
+        Dependency1_LIBRARY
+    )
+endif()
+

--- a/src/posix/platform/radio_url.cpp
+++ b/src/posix/platform/radio_url.cpp
@@ -63,8 +63,7 @@ const char *otSysGetRadioUrlHelpString(void)
     "    spi-small-packet=[n]          Specify the smallest packet we can receive in a single transaction.\n"  \
     "                                  (larger packets will require two transactions). Default value is 32.\n"
 
-#else
-
+#elif OPENTHREAD_POSIX_CONFIG_RCP_BUS == OT_POSIX_RCP_BUS_UART
 #define OT_RADIO_URL_HELP_BUS                                                                        \
     "    forkpty-arg[=argument string]  Command line arguments for subprocess, can be repeated.\n"   \
     "    spinel+hdlc+uart://${PATH_TO_UART_DEVICE}?${Parameters} for real uart device\n"             \
@@ -75,6 +74,14 @@ const char *otSysGetRadioUrlHelpString(void)
     "    uart-baudrate[=baudrate]       Uart baud rate, default is 115200.\n"                        \
     "    uart-flow-control              Enable flow control, disabled by default.\n"                 \
     "    uart-reset                     Reset connection after hard resetting RCP(USB CDC ACM).\n"
+
+#elif OPENTHREAD_POSIX_CONFIG_RCP_BUS == OT_POSIX_RCP_BUS_VENDOR
+
+#ifndef OT_VENDOR_RADIO_URL_HELP_BUS
+#define OT_VENDOR_RADIO_URL_HELP_BUS "\n"
+#endif // OT_VENDOR_RADIO_URL_HELP_BUS
+
+#define OT_RADIO_URL_HELP_BUS OT_VENDOR_RADIO_URL_HELP_BUS
 
 #endif // OPENTHREAD_POSIX_CONFIG_RCP_BUS == OT_POSIX_RCP_BUS_SPI
 

--- a/src/posix/platform/vendor.cmake
+++ b/src/posix/platform/vendor.cmake
@@ -1,0 +1,56 @@
+#
+#  Copyright (c) 2023, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+set(OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE "vendor_interface_example.cpp"
+       CACHE STRING "vendor interface implementation")
+
+if(OT_POSIX_CONFIG_RCP_BUS MATCHES "VENDOR")
+    add_library(rcp-vendor-intf ${OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE})
+
+    target_link_libraries(rcp-vendor-intf PUBLIC ot-posix-config)
+
+    target_include_directories(rcp-vendor-intf
+        PUBLIC
+	    ${CMAKE_CURRENT_SOURCE_DIR}
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src
+            ${PROJECT_SOURCE_DIR}/src/core
+            ${PROJECT_SOURCE_DIR}/src/posix/platform/include
+    )
+
+    target_link_libraries(openthread-posix PUBLIC rcp-vendor-intf)
+
+    find_package(RcpVendorDeps)
+    if(RcpVendorDeps_FOUND)
+	    target_link_libraries(rcp-vendor-intf PUBLIC RcpVendorDeps::RcpVendorDeps)
+    else()
+        message(WARNING "Vendor RCP Bus specified but dependency package was not found... \n"
+                "Continuing build with ${OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE}")
+    endif()
+endif()

--- a/src/posix/platform/vendor.cmake
+++ b/src/posix/platform/vendor.cmake
@@ -27,16 +27,19 @@
 #
 
 set(OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE "vendor_interface_example.cpp"
-       CACHE STRING "vendor interface implementation")
+    CACHE STRING "vendor interface implementation")
 
-if(OT_POSIX_CONFIG_RCP_BUS MATCHES "VENDOR")
+set(OT_POSIX_CONFIG_RCP_VENDOR_DEPS_PACKAGE "" CACHE STRING
+    "name of optional external package to link to rcp vendor implementation")
+
+if(OT_POSIX_CONFIG_RCP_BUS STREQUAL "VENDOR")
     add_library(rcp-vendor-intf ${OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE})
 
     target_link_libraries(rcp-vendor-intf PUBLIC ot-posix-config)
 
     target_include_directories(rcp-vendor-intf
         PUBLIC
-	    ${CMAKE_CURRENT_SOURCE_DIR}
+            ${CMAKE_CURRENT_SOURCE_DIR}
         PRIVATE
             ${PROJECT_SOURCE_DIR}/include
             ${PROJECT_SOURCE_DIR}/src
@@ -46,11 +49,12 @@ if(OT_POSIX_CONFIG_RCP_BUS MATCHES "VENDOR")
 
     target_link_libraries(openthread-posix PUBLIC rcp-vendor-intf)
 
-    find_package(RcpVendorDeps)
-    if(RcpVendorDeps_FOUND)
-	    target_link_libraries(rcp-vendor-intf PUBLIC RcpVendorDeps::RcpVendorDeps)
-    else()
-        message(WARNING "Vendor RCP Bus specified but dependency package was not found... \n"
-                "Continuing build with ${OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE}")
+    if (OT_POSIX_CONFIG_RCP_VENDOR_DEPS_PACKAGE)
+        set(DEPS_TARGET ${OT_POSIX_CONFIG_RCP_VENDOR_DEPS_PACKAGE}::${OT_POSIX_CONFIG_RCP_VENDOR_DEPS_PACKAGE})
+        find_package(${OT_POSIX_CONFIG_RCP_VENDOR_DEPS_PACKAGE})
+
+        if(${OT_POSIX_CONFIG_RCP_VENDOR_DEPS_PACKAGE}_FOUND)
+            target_link_libraries(rcp-vendor-intf PUBLIC ${DEPS_TARGET})
+        endif()
     endif()
 endif()


### PR DESCRIPTION
A vendor interface implementation for the posix library is currently supported through linking a specified c++ source file. However, this is unable to accomodate dependencies for external libraries or header files that this vendor implementation source file may need.

The posix vendor support is changed to allow a vendor to specify a cmake RcpVendorDeps module file to resolve missing dependencies for a provided vendor support source file.

Additionally, this commit adds the ability for a vendor to define a radio url help message when the vendor rcp bus is selected instead of defaulting to the UART help message.