### PR TITLE
[test] disable INTER_OP_BBR by default

### DIFF
--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -56,6 +56,7 @@ jobs:
       THREAD_VERSION: 1.3
       VIRTUAL_TIME: 1
       INTER_OP: 1
+      INTER_OP_BBR: 1
       CC: ${{ matrix.compiler.c }}
       CXX: ${{ matrix.compiler.cxx }}
     strategy:
@@ -186,6 +187,7 @@ jobs:
       VIRTUAL_TIME: 1
       PACKET_VERIFICATION: 1
       THREAD_VERSION: 1.3
+      INTER_OP_BBR: 1
       MULTIPLY: 3
     steps:
     - name: Harden Runner

--- a/script/test
+++ b/script/test
@@ -74,7 +74,7 @@ readonly NAT64
 NAT64_SERVICE="${NAT64_SERVICE:-openthread}"
 readonly NAT64_SERVICE
 
-INTER_OP_BBR="${INTER_OP_BBR:-1}"
+INTER_OP_BBR="${INTER_OP_BBR:-0}"
 readonly INTER_OP_BBR
 
 OT_COREDUMP_DIR="${PWD}/ot-core-dump"


### PR DESCRIPTION
This commit disables `INTER_OP_BBR` by default to avoid unnecessary build in most times.