### PR TITLE
[net-diags] fix `GetNextDiagTlv()` when skipping over unknown TLVs

### DIFF
--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -572,7 +572,7 @@ static inline void ParseMacCounters(const MacCountersTlv &aMacCountersTlv, otNet
 
 Error Client::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator, TlvInfo &aTlvInfo)
 {
-    Error    error  = kErrorNotFound;
+    Error    error;
     uint16_t offset = (aIterator == 0) ? aMessage.GetOffset() : aIterator;
 
     while (offset < aMessage.GetLength())
@@ -774,9 +774,12 @@ Error Client::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator,
             // Exit if a TLV is recognized and parsed successfully.
             aTlvInfo.mType = tlv.GetType();
             aIterator      = offset;
+            error          = kErrorNone;
             ExitNow();
         }
     }
+
+    error = kErrorNotFound;
 
 exit:
     return error;


### PR DESCRIPTION
This commit fixes `GetNextDiagTlv()` to correctly return error `kErrorNotFound` if the message happens to end with an unknown TLV. We ensure to set the `error` after the end of `while()` loop. With the previous code we could return `kErrorNone` (since we would successfully read and skip over the unknown TLV which would set `error`).