### PR TITLE
[mle] simplify appending of Address Registration TLV entries

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1281,6 +1281,10 @@ protected:
          *
          */
         Error SendAfterDelay(const Ip6::Address &aDestination, uint16_t aDelay);
+
+    private:
+        Error AppendCompressedAddressEntry(uint8_t aContextId, const Ip6::Address &aAddress);
+        Error AppendAddressEntry(const Ip6::Address &aAddress);
     };
 
     /**

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -975,7 +975,39 @@ struct StatusTlv : public UintTlvInfo<Tlv::kStatus, uint8_t>
 };
 
 /**
- * This class implements Source Address TLV generation and parsing.
+ * This class provides constants and methods for generation and parsing of Address Registration TLV.
+ *
+ */
+class AddressRegistrationTlv : public TlvInfo<Tlv::kAddressRegistration>
+{
+public:
+    /**
+     * This constant defines the control byte to use in an uncompressed entry where the full IPv6 address is included in
+     * the TLV.
+     *
+     */
+    static constexpr uint8_t kControlByteUncompressed = 0;
+
+    /**
+     * This static method returns the control byte to use in a compressed entry where the 64-prefix is replaced with a
+     * 6LoWPAN context identifier.
+     *
+     * @param[in] aContextId   The 6LoWPAN context ID.
+     *
+     * @returns The control byte associated with compressed entry with @p aContextId.
+     *
+     */
+    static uint8_t ControlByteFor(uint8_t aContextId) { return kCompressed | (aContextId & kContextIdMask); }
+
+    AddressRegistrationTlv(void) = delete;
+
+private:
+    static constexpr uint8_t kCompressed    = 1 << 7;
+    static constexpr uint8_t kContextIdMask = 0xf;
+};
+
+/**
+ * This class implements Address Registration Entry generation and parsing.
  *
  */
 OT_TOOL_PACKED_BEGIN


### PR DESCRIPTION
This commit adds helper methods to append an IPv6 Address Entry in an Address Registration TLV using compressed format where the entry contains a lowpan context ID and the address's IID, or uncompressed format where the full IPv6 address is appended.