### PR TITLE
[dns-client] update API docs

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (313)
+#define OPENTHREAD_API_VERSION (314)
 
 /**
  * @addtogroup api-instance


### PR DESCRIPTION
This commit updates `otDnsClient` API documentation making the service resolution `otDnsClientResolveService()` behavior more clear, in particular that it sends queries for SRV/TXT records. The new documents also highlight how records in Additional Data section in a query response is parsed and provided in the callbacks and that servers/resolvers may not provide the records.