### PR TITLE
[tmf] determine received TMF message priority from DSCP

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (309)
+#define OPENTHREAD_API_VERSION (310)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -237,6 +237,7 @@ typedef struct otMessageInfo
     bool    mIsHostInterface : 1;   ///< TRUE if packets sent/received via host interface, FALSE otherwise.
     bool    mAllowZeroHopLimit : 1; ///< TRUE to allow IPv6 Hop Limit 0 in `mHopLimit`, FALSE otherwise.
     bool    mMulticastLoop : 1;     ///< TRUE to allow looping back multicast, FALSE otherwise.
+    uint8_t mDscp : 6;              ///< Diff Services Code Point in IPv6 header (provided for a rx msg, ignored on tx).
 } otMessageInfo;
 
 /**

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1150,6 +1150,7 @@ start:
     messageInfo.SetSockAddr(header.GetDestination());
     messageInfo.SetHopLimit(header.GetHopLimit());
     messageInfo.SetEcn(header.GetEcn());
+    messageInfo.SetDscp(header.GetDscp());
     messageInfo.SetLinkInfo(aLinkMessageInfo);
 
     // Determine `forwardThread`, `forwardHost` and `receive`

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -221,6 +221,22 @@ public:
     void SetEcn(Ecn aEcn) { mEcn = aEcn; }
 
     /**
+     * This method gets the DSCP value.
+     *
+     * @returns the DSCP value as represented in the IPv6 header.
+     *
+     */
+    uint8_t GetDscp(void) const { return mDscp; }
+
+    /**
+     * This method sets the DSCP value.
+     *
+     * @param[in] aDscp   The DSCP value.
+     *
+     */
+    void SetDscp(uint8_t aDscp) { mDscp = aDscp; }
+
+    /**
      * This method indicates whether peer is via the host interface.
      *
      * @retval TRUE if the peer is via the host interface.

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -113,6 +113,8 @@ bool Agent::HandleResource(const char *aUriPath, Message &aMessage, const Ip6::M
     bool didHandle = true;
     Uri  uri       = UriFromPath(aUriPath);
 
+    IgnoreError(aMessage.SetPriority(DscpToPriority(aMessageInfo.GetDscp())));
+
 #define Case(kUri, Type)                                     \
     case kUri:                                               \
         Get<Type>().HandleTmf<kUri>(aMessage, aMessageInfo); \


### PR DESCRIPTION
This commit adds `mDscp` in `otMessageInfo` so we can track the DCSP from IPv6 header on a received message (it is ignored on `otMessageInfo` associated with a message to be sent). This is then used to determine the priority of a received TMF message.

---

Related to [SPEC-1178](https://threadgroup.atlassian.net/browse/SPEC-1178).