### PR TITLE
[posix] update upstream DNS addresses after a few minutes 

### DIFF
--- a/src/posix/platform/resolver.cpp
+++ b/src/posix/platform/resolver.cpp
@@ -109,8 +109,6 @@ void Resolver::LoadDnsServerListFromConf(void)
     }
 
     mUpstreamDnsServerListFreshness = otPlatTimeGet();
-
-    return;
 }
 
 void Resolver::Query(otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery)

--- a/src/posix/platform/resolver.hpp
+++ b/src/posix/platform/resolver.hpp
@@ -90,6 +90,9 @@ public:
     void Process(const fd_set *aReadFdSet, const fd_set *aErrorFdSet);
 
 private:
+    static constexpr uint64_t kDnsServerListNullCacheTimeoutMs = 1 * 60 * 1000;  // 1 minute
+    static constexpr uint64_t kDnsServerListCacheTimeoutMs     = 10 * 60 * 1000; // 10 minutes
+
     struct Transaction
     {
         otPlatDnsUpstreamQuery *mThreadTxn;
@@ -103,10 +106,12 @@ private:
     void ForwardResponse(Transaction *aTxn);
     void CloseTransaction(Transaction *aTxn);
     void FinishTransaction(int aFd);
+    void TryRefreshDnsServerList(void);
     void LoadDnsServerListFromConf(void);
 
     int       mUpstreamDnsServerCount = 0;
     in_addr_t mUpstreamDnsServerList[kMaxUpstreamServerCount];
+    uint64_t  mUpstreamDnsServerListFreshness = 0;
 
     Transaction mUpstreamTransaction[kMaxUpstreamTransactionCount];
 };


### PR DESCRIPTION
On some platforms, the /etc/resolv.conf might be a generated file, and is not available at the first few minutes after boot.

This PR records the time when we read the DNS server addresses from the upstream, and reload the server list when it expires.

We may want to use inotify or add a platform specific API to notify the openthread about the change of DNS server list in the future.