### PR TITLE
[cli] store cli user commands in container and support list prepend

### DIFF
--- a/examples/apps/cli/main.c
+++ b/examples/apps/cli/main.c
@@ -126,7 +126,7 @@ pseudo_reset:
     otAppCliInit(instance);
 
 #if OPENTHREAD_POSIX && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
-    otCliSetUserCommands(kCommands, OT_ARRAY_LENGTH(kCommands), instance);
+    IgnoreError(otCliSetUserCommands(kCommands, OT_ARRAY_LENGTH(kCommands), instance));
 #endif
 
     while (!otSysPseudoResetWasRequested())

--- a/include/openthread/cli.h
+++ b/include/openthread/cli.h
@@ -104,8 +104,10 @@ void otCliInputLine(char *aBuf);
  * @param[in]  aLength        @p aUserCommands length.
  * @param[in]  aContext       @p The context passed to the handler.
  *
+ * @retval OT_ERROR_NONE    Successfully updated command table with commands from @p aUserCommands.
+ * @retval OT_ERROR_FAILED  Maximum number of command entries have already been set.
  */
-void otCliSetUserCommands(const otCliCommand *aUserCommands, uint8_t aLength, void *aContext);
+otError otCliSetUserCommands(const otCliCommand *aUserCommands, uint8_t aLength, void *aContext);
 
 /**
  * Write a number of bytes to the CLI console as a hex string.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (311)
+#define OPENTHREAD_API_VERSION (312)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -147,6 +147,7 @@ Interpreter::Interpreter(Instance *aInstance, otCliOutputCallback aCallback, voi
 #if (OPENTHREAD_FTD || OPENTHREAD_MTD) && OPENTHREAD_CONFIG_CLI_REGISTER_IP6_RECV_CALLBACK
     otIp6SetReceiveCallback(GetInstancePtr(), &Interpreter::HandleIp6Receive, this);
 #endif
+    memset(&mUserCommands, 0, sizeof(mUserCommands));
 
     OutputPrompt();
 }

--- a/src/cli/cli_config.h
+++ b/src/cli/cli_config.h
@@ -88,6 +88,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_CLI_MAX_USER_CMD_ENTRIES
+ *
+ * The maximum number of user CLI command lists that can be registered by the interpreter.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CLI_MAX_USER_CMD_ENTRIES
+#define OPENTHREAD_CONFIG_CLI_MAX_USER_CMD_ENTRIES 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
  *
  * Define as 1 for CLI to emit its command input string and the resulting output to the logs.

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -380,7 +380,7 @@ int main(int argc, char *argv[])
 #if !OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE
     otAppCliInit(instance);
 #endif
-    otCliSetUserCommands(kCommands, OT_ARRAY_LENGTH(kCommands), instance);
+    IgnoreError(otCliSetUserCommands(kCommands, OT_ARRAY_LENGTH(kCommands), instance));
 
     while (true)
     {


### PR DESCRIPTION
Calls to otCliSetUserCommand overwrite the pointer user command list pointer each time it is invoked, which results in successive calls to otCliSetUserCommand replacing the previously registered command list instead of appending to it. This is particularly relevant for the posix platform in which the main function registers a set of posix specific commands without any way to extend the set.

This commit replaces the command list pointer with a container of command lists associated with a registered context in order to support prepending the active list of user commands up to a configurable value which defaults to 1 to maintain current behavior.