### PR TITLE
[sub-mac] check key-id to match before `SignalFrameCounterUsed()`

### DIFF
--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -604,7 +604,7 @@ private:
     bool ShouldHandleTransmitTargetTime(void) const;
 
     void ProcessTransmitSecurity(void);
-    void SignalFrameCounterUsed(uint32_t aFrameCounter);
+    void SignalFrameCounterUsed(uint32_t aFrameCounter, uint8_t aKeyId);
     void StartCsmaBackoff(void);
     void StartTimerForBackoff(uint8_t aBackoffExponent);
     void BeginTransmit(void);


### PR DESCRIPTION
This commit ensures to check that `KeyId` on a frame matches the current `mKeyId` before `SignalFrameCounterUsed()`. This addresses corner-case situation where on key sequence change, an ongoing frame tx (or enhanced ack to a received frame) can be processed  after the `mKeyId` change.