### PR TITLE
[dns-client] fix finalizing query from `HandleTimer()`

### DIFF
--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -1450,7 +1450,7 @@ void Client::HandleTimer(void)
                 if (info.mTransmissionCount >= info.mConfig.GetMaxTxAttempts())
                 {
                     FinalizeQuery(*query, kErrorResponseTimeout);
-                    continue;
+                    break;
                 }
 
                 IgnoreError(SendQuery(*query, info, /* aUpdateTimer */ false));


### PR DESCRIPTION
This commit fixes an issue in `HandleTimer()` where we need to use `break` instead of `continue` after calling `FinalizeQuery()`. Note that we now have two loops, an outer loop on `mMainQueries` and then an inner loop on queries associated with a `mainQuery`. When we finalize a query, its related `mainQuery` (along with all its sub-queries) are finalized and removed.