### PR TITLE
[mle] clear address cache entries on promotion of child to router

### DIFF
--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -163,12 +163,12 @@ exit:
     return error;
 }
 
-void AddressResolver::Remove(uint8_t aRouterId)
+void AddressResolver::RemoveEntriesForRouterId(uint8_t aRouterId)
 {
     Remove(Mle::Rloc16FromRouterId(aRouterId), /* aMatchRouterId */ true);
 }
 
-void AddressResolver::Remove(uint16_t aRloc16) { Remove(aRloc16, /* aMatchRouterId */ false); }
+void AddressResolver::RemoveEntriesForRloc16(uint16_t aRloc16) { Remove(aRloc16, /* aMatchRouterId */ false); }
 
 AddressResolver::CacheEntry *AddressResolver::GetEntryAfter(CacheEntry *aPrev, CacheEntryList &aList)
 {
@@ -221,7 +221,7 @@ exit:
     return entry;
 }
 
-void AddressResolver::Remove(const Ip6::Address &aEid) { Remove(aEid, kReasonRemovingEid); }
+void AddressResolver::RemoveEntryForAddress(const Ip6::Address &aEid) { Remove(aEid, kReasonRemovingEid); }
 
 void AddressResolver::Remove(const Ip6::Address &aEid, Reason aReason)
 {
@@ -237,6 +237,22 @@ void AddressResolver::Remove(const Ip6::Address &aEid, Reason aReason)
 
 exit:
     return;
+}
+
+void AddressResolver::ReplaceEntriesForRloc16(uint16_t aOldRloc16, uint16_t aNewRloc16)
+{
+    CacheEntryList *lists[] = {&mCachedList, &mSnoopedList};
+
+    for (CacheEntryList *list : lists)
+    {
+        for (CacheEntry &entry : *list)
+        {
+            if (entry.GetRloc16() == aOldRloc16)
+            {
+                entry.SetRloc16(aNewRloc16);
+            }
+        }
+    }
 }
 
 AddressResolver::CacheEntry *AddressResolver::NewCacheEntry(bool aSnoopedEntry)

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -139,7 +139,7 @@ public:
      * @param[in]  aRloc16  The RLOC16 address.
      *
      */
-    void Remove(Mac::ShortAddress aRloc16);
+    void RemoveEntriesForRloc16(Mac::ShortAddress aRloc16);
 
     /**
      * This method removes all EID-to-RLOC cache entries associated with a Router ID.
@@ -147,7 +147,7 @@ public:
      * @param[in]  aRouterId  The Router ID.
      *
      */
-    void Remove(uint8_t aRouterId);
+    void RemoveEntriesForRouterId(uint8_t aRouterId);
 
     /**
      * This method removes the cache entry for the EID.
@@ -155,7 +155,16 @@ public:
      * @param[in]  aEid               A reference to the EID.
      *
      */
-    void Remove(const Ip6::Address &aEid);
+    void RemoveEntryForAddress(const Ip6::Address &aEid);
+
+    /**
+     * This method replaces all EID-to-RLOC cache entries corresponding to an old RLOC16 with a new RLOC16.
+     *
+     * @param[in] aOldRloc16    The old RLOC16.
+     * @param[in] aNewRloc16    The new RLOC16.
+     *
+     */
+    void ReplaceEntriesForRloc16(uint16_t aOldRloc16, uint16_t aNewRloc16);
 
     /**
      * This method updates an existing entry or adds a snooped cache entry for a given EID.

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -216,7 +216,7 @@ Error RouterTable::Release(uint8_t aRouterId)
     mRouterIdSequence++;
     mRouterIdSequenceLastUpdated = TimerMilli::GetNow();
 
-    Get<AddressResolver>().Remove(aRouterId);
+    Get<AddressResolver>().RemoveEntriesForRouterId(aRouterId);
     Get<NetworkData::Leader>().RemoveBorderRouter(Mle::Rloc16FromRouterId(aRouterId),
                                                   NetworkData::Leader::kMatchModeRouterId);
     Get<Mle::MleRouter>().ResetAdvertiseInterval();
@@ -255,7 +255,7 @@ void RouterTable::RemoveRouterLink(Router &aRouter)
         Get<Mle::MleRouter>().ResetAdvertiseInterval();
 
         // Clear all EID-to-RLOC entries associated with the router.
-        Get<AddressResolver>().Remove(aRouter.GetRouterId());
+        Get<AddressResolver>().RemoveEntriesForRouterId(aRouter.GetRouterId());
     }
 }
 


### PR DESCRIPTION
This commit contains two related changes where we clear any address cache entries associated with an old (child) RLOC16:
- On a parent, when we detect that a former child has been promoted to router role by receiving an MLE Advertisement from it.
- On leader, when we successfully reply to an "Address Solicit" message and assign a new RLOC16 to a node.