### PR TITLE
[daemon] remove log of CLI input

### DIFF
--- a/src/posix/platform/daemon.cpp
+++ b/src/posix/platform/daemon.cpp
@@ -341,7 +341,6 @@ void Daemon::Process(const otSysMainloopContext &aContext)
         if (rval > 0)
         {
             buffer[rval] = '\0';
-            otLogInfoPlat("> %s", reinterpret_cast<const char *>(buffer));
             otCliInputLine(reinterpret_cast<char *>(buffer));
         }
         else


### PR DESCRIPTION
This commit removes logging of the CLI input in `Daemon::Process()`. This ensures that sensitive info (e.g. dataset and/or network key) is not emitted in the logs. The CLI input/output can be logged using the CLI related configs `OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE` and/or `OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LEVEL`.