### PR TITLE
[nat64] check OMR prefix before favoring AIL NAT64 prefix

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -2834,16 +2834,14 @@ void RoutingManager::Nat64PrefixManager::GenerateLocalPrefix(const Ip6::Prefix &
 
 const Ip6::Prefix &RoutingManager::Nat64PrefixManager::GetFavoredPrefix(RoutePreference &aPreference) const
 {
-    const Ip6::Prefix *favoredPrefix = &mInfraIfPrefix;
+    const Ip6::Prefix *favoredPrefix = &mLocalPrefix;
 
-    if (mInfraIfPrefix.IsValidNat64())
+    aPreference = NetworkData::kRoutePreferenceLow;
+
+    if (mInfraIfPrefix.IsValidNat64() && Get<RoutingManager>().mFavoredOmrPrefix.IsInfrastructureDerived())
     {
-        aPreference = NetworkData::kRoutePreferenceMedium;
-    }
-    else
-    {
-        favoredPrefix = &mLocalPrefix;
-        aPreference   = NetworkData::kRoutePreferenceLow;
+        favoredPrefix = &mInfraIfPrefix;
+        aPreference   = NetworkData::kRoutePreferenceMedium;
     }
 
     return *favoredPrefix;

--- a/tests/scripts/thread-cert/border_router/nat64/test_multi_border_routers.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_multi_border_routers.py
@@ -49,6 +49,8 @@ ROUTER = 2
 BR2 = 3
 HOST = 4
 
+OMR_PREFIX = "2000:0:1111:4444::/64"
+
 NAT64_PREFIX_REFRESH_DELAY = 305
 
 NAT64_STATE_DISABLED = 'disabled'
@@ -118,9 +120,15 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         self.simulator.go(config.BORDER_ROUTER_STARTUP_DELAY)
         self.assertEqual('router', br2.get_state())
 
+        br2.add_prefix(OMR_PREFIX)
+        br2.register_netdata()
+        self.simulator.go(10)
+
         self.simulator.go(10)
         self.assertNotEqual(br1.get_br_favored_nat64_prefix(), br2.get_br_favored_nat64_prefix())
         br1_local_nat64_prefix = br1.get_br_nat64_prefix()
+        br2_local_nat64_prefix = br2.get_br_nat64_prefix()
+        self.assertNotEqual(br2_local_nat64_prefix, br2.get_br_favored_nat64_prefix())
         br2_infra_nat64_prefix = br2.get_br_favored_nat64_prefix()
 
         self.assertEqual(len(br1.get_netdata_nat64_prefix()), 1)
@@ -164,8 +172,7 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         br2.nat64_set_enabled(True)
 
         self.simulator.go(10)
-        self.assertNotEqual(br2_infra_nat64_prefix, br2.get_br_favored_nat64_prefix())
-        br2_local_nat64_prefix = br2.get_br_nat64_prefix()
+        self.assertEqual(br2_local_nat64_prefix, br2.get_br_favored_nat64_prefix())
 
         self.assertEqual(len(br1.get_netdata_nat64_prefix()), 1)
         nat64_prefix = br1.get_netdata_nat64_prefix()[0]

--- a/tests/toranj/openthread-core-toranj-config.h
+++ b/tests/toranj/openthread-core-toranj-config.h
@@ -76,6 +76,14 @@
 #define OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE 1
 
 /**
+ * @def OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
+ *
+ * Define to 1 to enable NAT64 support in Border Routing Manager.
+ *
+ */
+#define OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE 1
+
+/**
  * @def OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
  *
  * Define as 1 to enable IPv6 Border Routing counters.


### PR DESCRIPTION
This PR adds a check on OMR prefix before selecting AIL prefix as the favored NAT64 prefix for publishing.