### PR TITLE
[common] implement ot::BitFlags and refactor Cli::Br::ParsePrefixTypeArgs

### DIFF
--- a/src/cli/cli_br.cpp
+++ b/src/cli/cli_br.cpp
@@ -119,27 +119,25 @@ exit:
     return error;
 }
 
-otError Br::ParsePrefixTypeArgs(Arg aArgs[], bool &aOutputLocal, bool &aOutputFavored)
+otError Br::ParsePrefixTypeArgs(Arg aArgs[], PrefixTypeFlags &aFlags)
 {
     otError error = OT_ERROR_NONE;
 
-    aOutputLocal   = false;
-    aOutputFavored = false;
+    aFlags.Clear();
 
     if (aArgs[0].IsEmpty())
     {
-        aOutputLocal   = true;
-        aOutputFavored = true;
+        aFlags.Set(PrefixType::kFavored, PrefixType::kLocal);
         ExitNow();
     }
 
     if (aArgs[0] == "local")
     {
-        aOutputLocal = true;
+        aFlags.Set(PrefixType::kLocal);
     }
     else if (aArgs[0] == "favored")
     {
-        aOutputFavored = true;
+        aFlags.Set(PrefixType::kFavored);
     }
     else
     {
@@ -167,11 +165,10 @@ exit:
  */
 template <> otError Br::Process<Cmd("omrprefix")>(Arg aArgs[])
 {
-    otError error = OT_ERROR_NONE;
-    bool    outputLocal;
-    bool    outputFavored;
+    otError         error = OT_ERROR_NONE;
+    PrefixTypeFlags outputPrefixTypes;
 
-    SuccessOrExit(error = ParsePrefixTypeArgs(aArgs, outputLocal, outputFavored));
+    SuccessOrExit(error = ParsePrefixTypeArgs(aArgs, outputPrefixTypes));
 
     /**
      * @cli br omrprefix local
@@ -183,13 +180,13 @@ template <> otError Br::Process<Cmd("omrprefix")>(Arg aArgs[])
      * @par api_copy
      * #otBorderRoutingGetOmrPrefix
      */
-    if (outputLocal)
+    if (outputPrefixTypes.HasAll(PrefixType::kLocal))
     {
         otIp6Prefix local;
 
         SuccessOrExit(error = otBorderRoutingGetOmrPrefix(GetInstancePtr(), &local));
 
-        OutputFormat("%s", outputFavored ? "Local: " : "");
+        OutputFormat("%s", outputPrefixTypes.HasExactly(PrefixType::kLocal) ? "" : "Local: ");
         OutputIp6PrefixLine(local);
     }
 
@@ -203,14 +200,14 @@ template <> otError Br::Process<Cmd("omrprefix")>(Arg aArgs[])
      * @par api_copy
      * #otBorderRoutingGetFavoredOmrPrefix
      */
-    if (outputFavored)
+    if (outputPrefixTypes.HasAll(PrefixType::kFavored))
     {
         otIp6Prefix       favored;
         otRoutePreference preference;
 
         SuccessOrExit(error = otBorderRoutingGetFavoredOmrPrefix(GetInstancePtr(), &favored, &preference));
 
-        OutputFormat("%s", outputLocal ? "Favored: " : "");
+        OutputFormat("%s", outputPrefixTypes.HasExactly(PrefixType::kFavored) ? "" : "Favored: ");
         OutputIp6Prefix(favored);
         OutputLine(" prf:%s", Interpreter::PreferenceToString(preference));
     }
@@ -234,11 +231,10 @@ exit:
  */
 template <> otError Br::Process<Cmd("onlinkprefix")>(Arg aArgs[])
 {
-    otError error = OT_ERROR_NONE;
-    bool    outputLocal;
-    bool    outputFavored;
+    otError         error = OT_ERROR_NONE;
+    PrefixTypeFlags outputPrefixTypes;
 
-    SuccessOrExit(error = ParsePrefixTypeArgs(aArgs, outputLocal, outputFavored));
+    SuccessOrExit(error = ParsePrefixTypeArgs(aArgs, outputPrefixTypes));
 
     /**
      * @cli br onlinkprefix local
@@ -250,13 +246,13 @@ template <> otError Br::Process<Cmd("onlinkprefix")>(Arg aArgs[])
      * @par api_copy
      * #otBorderRoutingGetOnLinkPrefix
      */
-    if (outputLocal)
+    if (outputPrefixTypes.HasAll(PrefixType::kLocal))
     {
         otIp6Prefix local;
 
         SuccessOrExit(error = otBorderRoutingGetOnLinkPrefix(GetInstancePtr(), &local));
 
-        OutputFormat("%s", outputFavored ? "Local: " : "");
+        OutputFormat("%s", outputPrefixTypes.HasExactly(PrefixType::kLocal) ? "" : "Local: ");
         OutputIp6PrefixLine(local);
     }
 
@@ -270,13 +266,13 @@ template <> otError Br::Process<Cmd("onlinkprefix")>(Arg aArgs[])
      * @par api_copy
      * #otBorderRoutingGetFavoredOnLinkPrefix
      */
-    if (outputFavored)
+    if (outputPrefixTypes.HasAll(PrefixType::kFavored))
     {
         otIp6Prefix favored;
 
         SuccessOrExit(error = otBorderRoutingGetFavoredOnLinkPrefix(GetInstancePtr(), &favored));
 
-        OutputFormat("%s", outputLocal ? "Favored: " : "");
+        OutputFormat("%s", outputPrefixTypes.HasExactly(PrefixType::kFavored) ? "" : "Favored: ");
         OutputIp6PrefixLine(favored);
     }
 
@@ -301,11 +297,10 @@ exit:
  */
 template <> otError Br::Process<Cmd("nat64prefix")>(Arg aArgs[])
 {
-    otError error = OT_ERROR_NONE;
-    bool    outputLocal;
-    bool    outputFavored;
+    otError         error = OT_ERROR_NONE;
+    PrefixTypeFlags outputPrefixTypes;
 
-    SuccessOrExit(error = ParsePrefixTypeArgs(aArgs, outputLocal, outputFavored));
+    SuccessOrExit(error = ParsePrefixTypeArgs(aArgs, outputPrefixTypes));
 
     /**
      * @cli br nat64prefix local
@@ -317,13 +312,13 @@ template <> otError Br::Process<Cmd("nat64prefix")>(Arg aArgs[])
      * @par api_copy
      * #otBorderRoutingGetNat64Prefix
      */
-    if (outputLocal)
+    if (outputPrefixTypes.HasAll(PrefixType::kLocal))
     {
         otIp6Prefix local;
 
         SuccessOrExit(error = otBorderRoutingGetNat64Prefix(GetInstancePtr(), &local));
 
-        OutputFormat("%s", outputFavored ? "Local: " : "");
+        OutputFormat("%s", outputPrefixTypes.HasExactly(PrefixType::kLocal) ? "" : "Local: ");
         OutputIp6PrefixLine(local);
     }
 
@@ -337,14 +332,14 @@ template <> otError Br::Process<Cmd("nat64prefix")>(Arg aArgs[])
      * @par api_copy
      * #otBorderRoutingGetFavoredNat64Prefix
      */
-    if (outputFavored)
+    if (outputPrefixTypes.HasAll(PrefixType::kFavored))
     {
         otIp6Prefix       favored;
         otRoutePreference preference;
 
         SuccessOrExit(error = otBorderRoutingGetFavoredNat64Prefix(GetInstancePtr(), &favored, &preference));
 
-        OutputFormat("%s", outputLocal ? "Favored: " : "");
+        OutputFormat("%s", outputPrefixTypes.HasExactly(PrefixType::kFavored) ? "" : "Favored: ");
         OutputIp6Prefix(favored);
         OutputLine(" prf:%s", Interpreter::PreferenceToString(preference));
     }

--- a/src/cli/cli_br.hpp
+++ b/src/cli/cli_br.hpp
@@ -39,6 +39,8 @@
 #include "cli/cli_config.h"
 #include "cli/cli_output.hpp"
 
+#include "common/bitflags.hpp"
+
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 
 namespace ot {
@@ -76,9 +78,17 @@ public:
 private:
     using Command = CommandEntry<Br>;
 
+    enum PrefixType : uint8_t
+    {
+        kLocal   = 0,
+        kFavored = 1,
+    };
+
+    using PrefixTypeFlags = BitFlags<PrefixType>;
+
     template <CommandId kCommandId> otError Process(Arg aArgs[]);
 
-    otError ParsePrefixTypeArgs(Arg aArgs[], bool &aOutputLocal, bool &aOutputFavored);
+    otError ParsePrefixTypeArgs(Arg aArgs[], PrefixTypeFlags &aFlags);
 };
 
 } // namespace Cli

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -382,6 +382,7 @@ openthread_core_files = [
   "common/binary_search.cpp",
   "common/binary_search.hpp",
   "common/bit_vector.hpp",
+  "common/bitflags.hpp",
   "common/callback.hpp",
   "common/clearable.hpp",
   "common/code_utils.hpp",

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -439,6 +439,7 @@ HEADERS_COMMON                                  = \
     common/as_core_type.hpp                       \
     common/binary_search.hpp                      \
     common/bit_vector.hpp                         \
+    common/bitflags.hpp                           \
     common/callback.hpp                           \
     common/clearable.hpp                          \
     common/code_utils.hpp                         \

--- a/src/core/common/bitflags.hpp
+++ b/src/core/common/bitflags.hpp
@@ -1,0 +1,187 @@
+/*
+ *  Copyright (c) 2023, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for a bit-vector.
+ */
+
+#ifndef BITFLAGS_HPP_
+#define BITFLAGS_HPP_
+
+#include "openthread-core-config.h"
+
+#include <type_traits>
+
+#include "common/clearable.hpp"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/encoding.hpp"
+#include "common/equatable.hpp"
+
+namespace ot {
+
+/**
+ * @addtogroup core-bitflags
+ *
+ * @brief
+ *   This module includes definitions for bitflags.
+ *
+ * @{
+ *
+ */
+
+/**
+ * This class represents a bitflags.
+ *
+ * Note: The value of the enum is the index of the bit set, numbered from 0.
+ *
+ * @tparam EnumType  Specifies the underlying enum.
+ *
+ */
+template <typename EnumType, typename std::enable_if<std::is_enum<EnumType>::value, int>::type = 0>
+class BitFlags : public Equatable<BitFlags<EnumType>>, public Clearable<BitFlags<EnumType>>
+{
+public:
+    using BaseType = typename std::underlying_type<EnumType>::type;
+
+    BitFlags()
+        : mBits(0)
+    {
+    }
+
+    template <typename... T0> explicit BitFlags(T0... aVals) { mBits = BuildBits(GetBit(aVals)...); }
+
+    /**
+     * This method indicates whether all of the given bits are set in the bit flags.
+     *
+     * @param[in] aVals  The bits.
+     *
+     * @retval TRUE   If the given bits are all set.
+     * @retval FALSE  If the given bits are not all set.
+     *
+     */
+    template <typename... T0> bool HasAll(T0... aVals)
+    {
+        BaseType expectedBits = BuildBits(GetBit(aVals)...);
+
+        return (mBits & expectedBits) == expectedBits;
+    }
+
+    /**
+     * This method sets the given bits.
+     *
+     * @param[in] aVals  The bits.
+     *
+     */
+    template <typename... T0> void Set(T0... aVals) { mBits |= BuildBits(GetBit(aVals)...); }
+
+    /**
+     * This method unsets the given bits.
+     *
+     * @param[in] aVals  The bits.
+     *
+     */
+    template <typename... T0> void Unset(T0... aVals) { mBits &= ~BuildBits(GetBit(aVals)...); }
+
+    /**
+     * This method indicates whether any of the given bit is set in the bit flags.
+     *
+     * @param[in] aVals  The bits.
+     *
+     * @retval TRUE   If any of the given bits is all set.
+     * @retval FALSE  If none of given bits are all set.
+     *
+     */
+    template <typename... T0> bool HasAny(T0... aVals) { return (mBits & BuildBits(GetBit(aVals)...)) != 0; }
+
+    /**
+     * This method indicates whether all of and only the given flags are set.
+     *
+     * @param[in] aVals  The bits.
+     *
+     * @retval TRUE   If the given bits are all set.
+     * @retval FALSE  If the given bits are not all set.
+     *
+     */
+    template <typename... T0> bool HasExactly(T0... aVals) { return mBits == BuildBits(GetBit(aVals)...); }
+
+    /**
+     * This method indicates whether none of the given flags are set.
+     *
+     * @param[in] aVals  The bits.
+     *
+     * @retval TRUE   If the given bits are all set.
+     * @retval FALSE  If the given bits are not all set.
+     *
+     */
+    template <typename... T0> bool HasNone(T0... aVals) { return (mBits & BuildBits(GetBit(aVals)...)) == 0; }
+
+    /**
+     * This method returns the raw value of the bit flags.
+     *
+     * Note: This is for testing purpose only.
+     *
+     * @returns The raw value of the bit flag.
+     *
+     */
+    BaseType GetRaw(void) { return mBits; }
+
+    /**
+     * This method sets the raw value of the bit flags.
+     *
+     * Note: This is for testing purpose only.
+     *
+     * @param[in] The raw value of the bit flag.
+     *
+     */
+    void SetRaw(BaseType aVal) { mBits = aVal; }
+
+private:
+    // A series of helper functions got actual calculation.
+
+    static BaseType GetBit(EnumType aVal) { return static_cast<BaseType>(1) << static_cast<BaseType>(aVal); };
+
+    template <typename T1, typename... T0> static T1 BuildBits(T1 aVal, T0... aRemaining)
+    {
+        return aVal | BuildBits(aRemaining...);
+    }
+
+    template <typename T1> static T1 BuildBits(T1 aVal) { return aVal; }
+
+    BaseType mBits;
+};
+
+/**
+ * @}
+ *
+ */
+
+} // namespace ot
+
+#endif // BITFLAGS_HPP_

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -131,6 +131,27 @@ target_link_libraries(ot-test-binary-search
 
 add_test(NAME ot-test-binary-search COMMAND ot-test-binary-search)
 
+add_executable(ot-test-bitflags
+    test_bitflags.cpp
+)
+
+target_include_directories(ot-test-bitflags
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_options(ot-test-bitflags
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
+target_link_libraries(ot-test-bitflags
+    PRIVATE
+        ${COMMON_LIBS}
+)
+
+add_test(NAME ot-test-bitflags COMMAND ot-test-bitflags)
+
 add_executable(ot-test-child
     test_child.cpp
 )

--- a/tests/unit/test_bitflags.cpp
+++ b/tests/unit/test_bitflags.cpp
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (c) 2023, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <cinttypes>
+
+#include "test_util.hpp"
+#include "common/bitflags.hpp"
+
+namespace ot {
+
+namespace {
+enum Values : uint8_t
+{
+    k0 = 0,
+    k1 = 1,
+    k2 = 2,
+    k3 = 3,
+};
+}
+
+void TestBitFlags(void)
+{
+    using Flags = BitFlags<Values>;
+
+    {
+        Flags a;
+
+        VerifyOrQuit(a.HasNone(Values::k0, Values::k1, Values::k2, Values::k3));
+        VerifyOrQuit(a.GetRaw() == 0);
+    }
+
+    {
+        Flags a;
+        a.Set(Values::k0);
+        VerifyOrQuit(a.GetRaw() == 0b00000001);
+        VerifyOrQuit(a.HasNone(Values::k1, Values::k2, Values::k3));
+        VerifyOrQuit(a.HasAll(Values::k0));
+        VerifyOrQuit(!a.HasAll(Values::k1));
+        VerifyOrQuit(a.HasExactly(Values::k0));
+        VerifyOrQuit(a.HasAny(Values::k0));
+        VerifyOrQuit(a.HasAny(Values::k0, Values::k1));
+    }
+
+    {
+        Flags a(Values::k0, Values::k2);
+        VerifyOrQuit(a.GetRaw() == 0b00000101);
+        VerifyOrQuit(a.HasNone(Values::k1, Values::k3));
+        VerifyOrQuit(a.HasAll(Values::k0));
+        VerifyOrQuit(!a.HasExactly(Values::k0));
+        VerifyOrQuit(!a.HasExactly(Values::k1));
+        VerifyOrQuit(!a.HasExactly(Values::k0, Values::k1));
+        VerifyOrQuit(a.HasExactly(Values::k0, Values::k2));
+        VerifyOrQuit(a.HasAny(Values::k0));
+        VerifyOrQuit(a.HasAny(Values::k0, Values::k2));
+        VerifyOrQuit(a.HasAny(Values::k0, Values::k2, Values::k3));
+    }
+
+    {
+        Flags a;
+        a.SetRaw(0b00000001);
+        VerifyOrQuit(a.HasNone(Values::k1, Values::k2, Values::k3));
+        VerifyOrQuit(a.HasAll(Values::k0));
+        VerifyOrQuit(!a.HasAll(Values::k1));
+        VerifyOrQuit(a.HasExactly(Values::k0));
+        VerifyOrQuit(a.HasAny(Values::k0, Values::k1));
+    }
+
+    {
+        Flags a;
+        a.SetRaw(0b00000101);
+        VerifyOrQuit(a.HasNone(Values::k1, Values::k3));
+        VerifyOrQuit(a.HasAll(Values::k0));
+        VerifyOrQuit(!a.HasExactly(Values::k0));
+        VerifyOrQuit(!a.HasExactly(Values::k1));
+        VerifyOrQuit(!a.HasExactly(Values::k0, Values::k1));
+        VerifyOrQuit(a.HasExactly(Values::k0, Values::k2));
+        VerifyOrQuit(a.HasAny(Values::k0));
+        VerifyOrQuit(a.HasAny(Values::k0, Values::k2));
+        VerifyOrQuit(a.HasAny(Values::k0, Values::k2, Values::k3));
+
+        a.Unset(Values::k2);
+        VerifyOrQuit(a.HasNone(Values::k1, Values::k2, Values::k3));
+        VerifyOrQuit(a.HasAll(Values::k0));
+        VerifyOrQuit(!a.HasAll(Values::k1));
+        VerifyOrQuit(a.HasExactly(Values::k0));
+        VerifyOrQuit(a.HasAny(Values::k0, Values::k1));
+    }
+}
+
+} // namespace ot
+
+int main(void)
+{
+    ot::TestBitFlags();
+    printf("All tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
In the PR for DHCPv6 PD, we are adding another new type of prefix, to make ParsePrefixTypeArgs more flexible, this PR implements the ot::BitFlags with common operations of BitFlags. And refactors Cli::Br::ParsePrefixTypeArgs as an example.