### PR TITLE
[build] add cmake option for generating .map files

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -34,6 +34,8 @@ option(OT_FTD "enable FTD" ON)
 option(OT_MTD "enable MTD" ON)
 option(OT_RCP "enable RCP" ON)
 
+option(OT_LINKER_MAP "generate .map files for example apps" ON)
+
 message(STATUS OT_APP_CLI=${OT_APP_CLI})
 message(STATUS OT_APP_NCP=${OT_APP_NCP})
 message(STATUS OT_APP_RCP=${OT_APP_RCP})

--- a/examples/apps/cli/ftd.cmake
+++ b/examples/apps/cli/ftd.cmake
@@ -48,5 +48,13 @@ target_link_libraries(ot-cli-ftd PRIVATE
     ot-config
 )
 
+if(OT_LINKER_MAP)
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
+        target_link_libraries(ot-cli-ftd PRIVATE -Wl,-map,ot-cli-ftd.map)
+    else()
+        target_link_libraries(ot-cli-ftd PRIVATE -Wl,-Map=ot-cli-ftd.map)
+    endif()
+endif()
+
 install(TARGETS ot-cli-ftd
     DESTINATION bin)

--- a/examples/apps/cli/mtd.cmake
+++ b/examples/apps/cli/mtd.cmake
@@ -48,5 +48,13 @@ target_link_libraries(ot-cli-mtd PRIVATE
     ot-config
 )
 
+if(OT_LINKER_MAP)
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
+        target_link_libraries(ot-cli-mtd PRIVATE -Wl,-map,ot-cli-mtd.map)
+    else()
+        target_link_libraries(ot-cli-mtd PRIVATE -Wl,-Map=ot-cli-mtd.map)
+    endif()
+endif()
+
 install(TARGETS ot-cli-mtd
     DESTINATION bin)

--- a/examples/apps/cli/radio.cmake
+++ b/examples/apps/cli/radio.cmake
@@ -52,6 +52,14 @@ target_link_libraries(ot-cli-radio PRIVATE
     ot-config
 )
 
+if(OT_LINKER_MAP)
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
+        target_link_libraries(ot-cli-radio PRIVATE -Wl,-map,ot-cli-radio.map)
+    else()
+        target_link_libraries(ot-cli-radio PRIVATE -Wl,-Map=ot-cli-radio.map)
+    endif()
+endif()
+
 install(TARGETS ot-cli-radio
     DESTINATION bin
 )

--- a/examples/apps/ncp/ftd.cmake
+++ b/examples/apps/ncp/ftd.cmake
@@ -48,4 +48,12 @@ target_link_libraries(ot-ncp-ftd PRIVATE
     ot-config
 )
 
+if(OT_LINKER_MAP)
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
+        target_link_libraries(ot-ncp-ftd PRIVATE -Wl,-map,ot-ncp-ftd.map)
+    else()
+        target_link_libraries(ot-ncp-ftd PRIVATE -Wl,-Map=ot-ncp-ftd.map)
+    endif()
+endif()
+
 install(TARGETS ot-ncp-ftd DESTINATION bin)

--- a/examples/apps/ncp/mtd.cmake
+++ b/examples/apps/ncp/mtd.cmake
@@ -48,4 +48,12 @@ target_link_libraries(ot-ncp-mtd PRIVATE
     ot-config
 )
 
+if(OT_LINKER_MAP)
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
+        target_link_libraries(ot-ncp-mtd PRIVATE -Wl,-map,ot-ncp-mtd.map)
+    else()
+        target_link_libraries(ot-ncp-mtd PRIVATE -Wl,-Map=ot-ncp-mtd.map)
+    endif()
+endif()
+
 install(TARGETS ot-ncp-mtd DESTINATION bin)

--- a/examples/apps/ncp/rcp.cmake
+++ b/examples/apps/ncp/rcp.cmake
@@ -47,4 +47,12 @@ target_link_libraries(ot-rcp PRIVATE
     ot-config
 )
 
+if(OT_LINKER_MAP)
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
+        target_link_libraries(ot-rcp PRIVATE -Wl,-map,ot-rcp.map)
+    else()
+        target_link_libraries(ot-rcp PRIVATE -Wl,-Map=ot-rcp.map)
+    endif()
+endif()
+
 install(TARGETS ot-rcp DESTINATION bin)

--- a/src/posix/cli.cmake
+++ b/src/posix/cli.cmake
@@ -43,7 +43,7 @@ target_compile_options(ot-cli PRIVATE
     ${OT_CFLAGS}
 )
 
-target_link_libraries(ot-cli
+target_link_libraries(ot-cli PRIVATE
     openthread-cli-ftd
     openthread-posix
     openthread-ftd
@@ -57,6 +57,13 @@ target_link_libraries(ot-cli
     ot-config
 )
 
+if(OT_LINKER_MAP)
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
+        target_link_libraries(ot-cli PRIVATE -Wl,-map,ot-cli.map)
+    else()
+        target_link_libraries(ot-cli PRIVATE -Wl,-Map=ot-cli.map)
+    endif()
+endif()
 
 install(TARGETS ot-cli DESTINATION bin)
 

--- a/src/posix/daemon.cmake
+++ b/src/posix/daemon.cmake
@@ -49,6 +49,14 @@ target_link_libraries(ot-daemon PRIVATE
     ot-config
 )
 
+if(OT_LINKER_MAP)
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
+        target_link_libraries(ot-daemon PRIVATE -Wl,-map,ot-daemon.map)
+    else()
+        target_link_libraries(ot-daemon PRIVATE -Wl,-Map=ot-daemon.map)
+    endif()
+endif()
+
 add_executable(ot-ctl
     client.cpp
 )
@@ -67,6 +75,14 @@ target_link_libraries(ot-ctl PRIVATE
     ot-posix-config
     ot-config
 )
+
+if(OT_LINKER_MAP)
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
+        target_link_libraries(ot-ctl PRIVATE -Wl,-map,ot-ctl.map)
+    else()
+        target_link_libraries(ot-ctl PRIVATE -Wl,-Map=ot-ctl.map)
+    endif()
+endif()
 
 target_include_directories(ot-ctl PRIVATE ${COMMON_INCLUDES})
 


### PR DESCRIPTION
This adds the CMake option `OT_LINKER_MAP` which will generate `.map` files for any executables built when the option is `ON`. 

This should be functionally equivalent to the Makefile option [`OPENTHREAD_ENABLE_LINKER_MAP`](https://github.com/openthread/openthread/blob/674cbfaa5c02b8be443de02c4db489049f6ea007/configure.ac#L779)

To test: 

```bash
matran@matran-ubuntu in ~/openthread
$ rm -rf build/ && ./script/cmake-build posix -DOT_LINKER_MAP=ON
...
OPENTHREAD_CONFIG_FILE=openthread-core-posix-config.h
OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=1
[862/862] Linking CXX executable tests/unit/ot-test-tlv

matran@matran-ubuntu in ~/openthread
$ find build -type f -name '*.map'
build/posix/ot-cli.map

```