### PR TITLE
[mle] fix how time per role is tracked after counters are reset

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -259,6 +259,14 @@ exit:
     }
 }
 
+void Mle::ResetCounters(void)
+{
+    memset(&mCounters, 0, sizeof(mCounters));
+#if OPENTHREAD_CONFIG_UPTIME_ENABLE
+    mLastUpdatedTimestamp = Get<Uptime>().GetUptime();
+#endif
+}
+
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
 void Mle::UpdateRoleTimeCounters(DeviceRole aRole)
 {

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -610,7 +610,7 @@ public:
      * @returns A reference to the MLE counters.
      *
      */
-    const otMleCounters &GetCounters(void)
+    const Counters &GetCounters(void)
     {
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
         UpdateRoleTimeCounters(mRole);
@@ -622,7 +622,7 @@ public:
      * This method resets the MLE counters.
      *
      */
-    void ResetCounters(void) { memset(&mCounters, 0, sizeof(mCounters)); }
+    void ResetCounters(void);
 
 #if OPENTHREAD_CONFIG_MLE_PARENT_RESPONSE_CALLBACK_API_ENABLE
     /**
@@ -2122,10 +2122,11 @@ private:
     ServiceAloc mServiceAlocs[kMaxServiceAlocs];
 #endif
 
-    otMleCounters mCounters;
+    Counters mCounters;
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
     uint64_t mLastUpdatedTimestamp;
 #endif
+
     static const otMeshLocalPrefix sMeshLocalPrefixInit;
 
     Ip6::Netif::UnicastAddress   mLinkLocal64;

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -647,6 +647,12 @@ typedef Mac::KeyMaterial KeyMaterial;
 typedef Mac::Key Key;
 
 /**
+ * This structure represents the Thread MLE counters.
+ *
+ */
+typedef otMleCounters Counters;
+
+/**
  * This function derives the Child ID from a given RLOC16.
  *
  * @param[in]  aRloc16  The RLOC16 value.


### PR DESCRIPTION
This commit fixes an issue with tracking time spent in each role after `Mle::ResetCounters()`. The  `mLastUpdatedTimestamp` is now updated from `ResetCounters()`.