### PR TITLE
[netdata] prefer BR acting as router over ED (when all other checks are same)

### DIFF
--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -296,6 +296,11 @@ int LeaderBase::CompareRouteEntries(int8_t   aFirstPreference,
     // that the first entry is preferred over the second one.
 
     result = ThreeWayCompare(Get<RouterTable>().GetPathCost(aSecondRloc), Get<RouterTable>().GetPathCost(aFirstRloc));
+    VerifyOrExit(result == 0);
+
+    // If all the same, prefer the BR acting as a router over an
+    // end device.
+    result = ThreeWayCompare(Mle::IsActiveRouter(aFirstRloc), Mle::IsActiveRouter(aSecondRloc));
 #endif
 
 exit:


### PR DESCRIPTION
This commit updates the `CompareRouteEntries()` method so that if all of the earlier checks (preference, path cost) are the same, it will prefer a border router (BR) acting as a router over one acting as an end device. The reason is that a device can more accurately calculate the path cost to a router node than to an end device. This is because the link quality between an end device and its parent is not known to other devices.