### PR TITLE
Write NCP LAST STATUS for any failing Vendor Get status

### DIFF
--- a/src/ncp/example_vendor_hook.cpp
+++ b/src/ncp/example_vendor_hook.cpp
@@ -77,7 +77,7 @@ otError NcpBase::VendorGetPropertyHandler(spinel_prop_key_t aPropKey)
         // TODO: Implement your property get handlers here.
         //
         // Get handler should retrieve the property value and then encode and write the
-        // value into the NCP buffer. If the "get" operation itself fails, handler should
+        // value into the NCP buffer. If the "get" operation itself fails, `NcpBase` will
         // write a `LAST_STATUS` with the error status into the NCP buffer. `OT_ERROR_NO_BUFS`
         // should be returned if NCP buffer is full and response cannot be written.
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1134,11 +1134,11 @@ otError NcpBase::WritePropertyValueIsFrame(uint8_t aHeader, spinel_prop_key_t aP
 
         error = VendorGetPropertyHandler(aPropKey);
 
-        // An `OT_ERROR_NOT_FOUND` status from vendor handler indicates that
-        // it did not support the given property key. In that case, we fall
-        // through to prepare a `LAST_STATUS` response.
+        // Fall through to prepare a `LAST_STATUS` response if
+        // handler does not support the given property key or
+        // if get operation is not successful
 
-        if (error != OT_ERROR_NOT_FOUND)
+        if (error == OT_ERROR_NONE)
         {
             SuccessOrExit(error);
             ExitNow(error = mEncoder.EndFrame());
@@ -1148,7 +1148,10 @@ otError NcpBase::WritePropertyValueIsFrame(uint8_t aHeader, spinel_prop_key_t aP
 
     if (aIsGetResponse)
     {
-        SuccessOrExit(error = WriteLastStatusFrame(aHeader, SPINEL_STATUS_PROP_NOT_FOUND));
+        // Write a `LAST_STATUS` into NCP buffer if get operation fails
+        // or if vendor handler does not support given property key.
+
+        SuccessOrExit(error = WriteLastStatusFrame(aHeader, ThreadErrorToSpinelStatus(error)));
     }
     else
     {


### PR DESCRIPTION
The description of the NcpBase::VendorGetPropertyHandler function suggests that the Get handler itself should "write a `LAST_STATUS` with the error status into the NCP buffer."

The way that this is done for a Get handler which doesn't support the given property key is by calling `WriteLastStatusFrame` with the spinel header and the error code; however, the vendor Get handler does not have access to the header.

A simpler way to write the `LAST_STATUS` after a failing operation would be to allow `NcpBase::WritePropertyValueIsFrame` to handle all failure statuses in its fall through case rather than just OT_ERROR_NOT_FOUND.