### PR TITLE
[posix] define posix `RadioSpinel` accessor

### DIFF
--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -201,6 +201,8 @@ void Radio::Init(void)
 #endif // OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
 }
 
+void *Radio::GetSpinelInstance(void) { return &sRadioSpinel; }
+
 } // namespace Posix
 } // namespace ot
 

--- a/src/posix/platform/radio.hpp
+++ b/src/posix/platform/radio.hpp
@@ -55,6 +55,14 @@ public:
      */
     void Init(void);
 
+    /**
+     * This method acts as an accessor to the spinel instance used by the radio.
+     *
+     * @returns A pointer to the radio's spinel interface instance.
+     *
+     */
+    static void *GetSpinelInstance(void);
+
 private:
     RadioUrl mRadioUrl;
 };


### PR DESCRIPTION
When adding cli commands to be used by a posix platform is is useful to have access to the spinel interface when trying to communicate with a RCP using vendor specific spinel properties. It is inadvisable to create a separate spinel interface for custom properties as the two interfaces would need to avoid contention on the hardware interface.

This accessor method allows access to the static spinel interface defined in radio.cpp for external code segments. Dependent source files can do so with:
`(RadioSpinel<InterfaceType, ProcessContextType>*)Posix::Radio::getSpinelInstance()` or similar.