### PR TITLE
[cli] refactor br command prefix type

### DIFF
--- a/src/cli/cli_br.cpp
+++ b/src/cli/cli_br.cpp
@@ -119,27 +119,25 @@ exit:
     return error;
 }
 
-otError Br::ParsePrefixTypeArgs(Arg aArgs[], bool &aOutputLocal, bool &aOutputFavored)
+otError Br::ParsePrefixTypeArgs(Arg aArgs[], PrefixType &aFlags)
 {
     otError error = OT_ERROR_NONE;
 
-    aOutputLocal   = false;
-    aOutputFavored = false;
+    aFlags = 0;
 
     if (aArgs[0].IsEmpty())
     {
-        aOutputLocal   = true;
-        aOutputFavored = true;
+        aFlags = kPrefixTypeFavored | kPrefixTypeLocal;
         ExitNow();
     }
 
     if (aArgs[0] == "local")
     {
-        aOutputLocal = true;
+        aFlags = kPrefixTypeLocal;
     }
     else if (aArgs[0] == "favored")
     {
-        aOutputFavored = true;
+        aFlags = kPrefixTypeFavored;
     }
     else
     {
@@ -167,11 +165,10 @@ exit:
  */
 template <> otError Br::Process<Cmd("omrprefix")>(Arg aArgs[])
 {
-    otError error = OT_ERROR_NONE;
-    bool    outputLocal;
-    bool    outputFavored;
+    otError    error = OT_ERROR_NONE;
+    PrefixType outputPrefixTypes;
 
-    SuccessOrExit(error = ParsePrefixTypeArgs(aArgs, outputLocal, outputFavored));
+    SuccessOrExit(error = ParsePrefixTypeArgs(aArgs, outputPrefixTypes));
 
     /**
      * @cli br omrprefix local
@@ -183,13 +180,13 @@ template <> otError Br::Process<Cmd("omrprefix")>(Arg aArgs[])
      * @par api_copy
      * #otBorderRoutingGetOmrPrefix
      */
-    if (outputLocal)
+    if (outputPrefixTypes & kPrefixTypeLocal)
     {
         otIp6Prefix local;
 
         SuccessOrExit(error = otBorderRoutingGetOmrPrefix(GetInstancePtr(), &local));
 
-        OutputFormat("%s", outputFavored ? "Local: " : "");
+        OutputFormat("%s", outputPrefixTypes == kPrefixTypeLocal ? "" : "Local: ");
         OutputIp6PrefixLine(local);
     }
 
@@ -203,14 +200,14 @@ template <> otError Br::Process<Cmd("omrprefix")>(Arg aArgs[])
      * @par api_copy
      * #otBorderRoutingGetFavoredOmrPrefix
      */
-    if (outputFavored)
+    if (outputPrefixTypes & kPrefixTypeFavored)
     {
         otIp6Prefix       favored;
         otRoutePreference preference;
 
         SuccessOrExit(error = otBorderRoutingGetFavoredOmrPrefix(GetInstancePtr(), &favored, &preference));
 
-        OutputFormat("%s", outputLocal ? "Favored: " : "");
+        OutputFormat("%s", outputPrefixTypes == kPrefixTypeFavored ? "" : "Favored: ");
         OutputIp6Prefix(favored);
         OutputLine(" prf:%s", Interpreter::PreferenceToString(preference));
     }
@@ -234,11 +231,10 @@ exit:
  */
 template <> otError Br::Process<Cmd("onlinkprefix")>(Arg aArgs[])
 {
-    otError error = OT_ERROR_NONE;
-    bool    outputLocal;
-    bool    outputFavored;
+    otError    error = OT_ERROR_NONE;
+    PrefixType outputPrefixTypes;
 
-    SuccessOrExit(error = ParsePrefixTypeArgs(aArgs, outputLocal, outputFavored));
+    SuccessOrExit(error = ParsePrefixTypeArgs(aArgs, outputPrefixTypes));
 
     /**
      * @cli br onlinkprefix local
@@ -250,13 +246,13 @@ template <> otError Br::Process<Cmd("onlinkprefix")>(Arg aArgs[])
      * @par api_copy
      * #otBorderRoutingGetOnLinkPrefix
      */
-    if (outputLocal)
+    if (outputPrefixTypes & kPrefixTypeLocal)
     {
         otIp6Prefix local;
 
         SuccessOrExit(error = otBorderRoutingGetOnLinkPrefix(GetInstancePtr(), &local));
 
-        OutputFormat("%s", outputFavored ? "Local: " : "");
+        OutputFormat("%s", outputPrefixTypes == kPrefixTypeLocal ? "" : "Local: ");
         OutputIp6PrefixLine(local);
     }
 
@@ -270,13 +266,13 @@ template <> otError Br::Process<Cmd("onlinkprefix")>(Arg aArgs[])
      * @par api_copy
      * #otBorderRoutingGetFavoredOnLinkPrefix
      */
-    if (outputFavored)
+    if (outputPrefixTypes & kPrefixTypeFavored)
     {
         otIp6Prefix favored;
 
         SuccessOrExit(error = otBorderRoutingGetFavoredOnLinkPrefix(GetInstancePtr(), &favored));
 
-        OutputFormat("%s", outputLocal ? "Favored: " : "");
+        OutputFormat("%s", outputPrefixTypes == kPrefixTypeFavored ? "" : "Favored: ");
         OutputIp6PrefixLine(favored);
     }
 
@@ -301,11 +297,10 @@ exit:
  */
 template <> otError Br::Process<Cmd("nat64prefix")>(Arg aArgs[])
 {
-    otError error = OT_ERROR_NONE;
-    bool    outputLocal;
-    bool    outputFavored;
+    otError    error = OT_ERROR_NONE;
+    PrefixType outputPrefixTypes;
 
-    SuccessOrExit(error = ParsePrefixTypeArgs(aArgs, outputLocal, outputFavored));
+    SuccessOrExit(error = ParsePrefixTypeArgs(aArgs, outputPrefixTypes));
 
     /**
      * @cli br nat64prefix local
@@ -317,13 +312,13 @@ template <> otError Br::Process<Cmd("nat64prefix")>(Arg aArgs[])
      * @par api_copy
      * #otBorderRoutingGetNat64Prefix
      */
-    if (outputLocal)
+    if (outputPrefixTypes & kPrefixTypeLocal)
     {
         otIp6Prefix local;
 
         SuccessOrExit(error = otBorderRoutingGetNat64Prefix(GetInstancePtr(), &local));
 
-        OutputFormat("%s", outputFavored ? "Local: " : "");
+        OutputFormat("%s", outputPrefixTypes == kPrefixTypeLocal ? "" : "Local: ");
         OutputIp6PrefixLine(local);
     }
 
@@ -337,14 +332,14 @@ template <> otError Br::Process<Cmd("nat64prefix")>(Arg aArgs[])
      * @par api_copy
      * #otBorderRoutingGetFavoredNat64Prefix
      */
-    if (outputFavored)
+    if (outputPrefixTypes & kPrefixTypeFavored)
     {
         otIp6Prefix       favored;
         otRoutePreference preference;
 
         SuccessOrExit(error = otBorderRoutingGetFavoredNat64Prefix(GetInstancePtr(), &favored, &preference));
 
-        OutputFormat("%s", outputLocal ? "Favored: " : "");
+        OutputFormat("%s", outputPrefixTypes == kPrefixTypeFavored ? "" : "Favored: ");
         OutputIp6Prefix(favored);
         OutputLine(" prf:%s", Interpreter::PreferenceToString(preference));
     }

--- a/src/cli/cli_br.hpp
+++ b/src/cli/cli_br.hpp
@@ -79,8 +79,8 @@ private:
     using PrefixType = uint8_t;
     enum : PrefixType
     {
-        kPrefixTypeLocal   = 0x01,
-        kPrefixTypeFavored = 0x02,
+        kPrefixTypeLocal   = 1u << 0,
+        kPrefixTypeFavored = 1u << 1,
     };
 
     template <CommandId kCommandId> otError Process(Arg aArgs[]);

--- a/src/cli/cli_br.hpp
+++ b/src/cli/cli_br.hpp
@@ -76,9 +76,16 @@ public:
 private:
     using Command = CommandEntry<Br>;
 
+    using PrefixType = uint8_t;
+    enum : PrefixType
+    {
+        kPrefixTypeLocal   = 0x01,
+        kPrefixTypeFavored = 0x02,
+    };
+
     template <CommandId kCommandId> otError Process(Arg aArgs[]);
 
-    otError ParsePrefixTypeArgs(Arg aArgs[], bool &aOutputLocal, bool &aOutputFavored);
+    otError ParsePrefixTypeArgs(Arg aArgs[], PrefixType &aFlags);
 };
 
 } // namespace Cli


### PR DESCRIPTION
In the PR for DHCPv6 PD, we are adding another new type of prefix. This PR refactors `ParsePrefixTypeArgs` to make it more flexible, 