### PR TITLE
[net-diag] add TLV for MLE counters

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (316)
+#define OPENTHREAD_API_VERSION (317)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/netdiag.h
+++ b/include/openthread/netdiag.h
@@ -92,6 +92,8 @@ enum
     OT_NETWORK_DIAGNOSTIC_TLV_NEIGHBOR             = 31, ///< Neighbor TLV (router only)
     OT_NETWORK_DIAGNOSTIC_TLV_ANSWER               = 32, ///< Answer TLV
     OT_NETWORK_DIAGNOSTIC_TLV_QUERY_ID             = 33, ///< Query ID TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_MLE_COUNTERS         = 34, ///< MLE Counters TLV
+
 };
 
 #define OT_NETWORK_DIAGNOSTIC_MAX_VENDOR_NAME_TLV_LENGTH 32          ///< Max length of Vendor Name TLV.
@@ -207,6 +209,29 @@ typedef struct otNetworkDiagMacCounters
 } otNetworkDiagMacCounters;
 
 /**
+ * This structure represents a Network Diagnostics MLE Counters value.
+ *
+ */
+typedef struct otNetworkDiagMleCounters
+{
+    uint16_t mDisabledRole;                  ///< Number of times device entered disabled role.
+    uint16_t mDetachedRole;                  ///< Number of times device entered detached role.
+    uint16_t mChildRole;                     ///< Number of times device entered child role.
+    uint16_t mRouterRole;                    ///< Number of times device entered router role.
+    uint16_t mLeaderRole;                    ///< Number of times device entered leader role.
+    uint16_t mAttachAttempts;                ///< Number of attach attempts while device was detached.
+    uint16_t mPartitionIdChanges;            ///< Number of changes to partition ID.
+    uint16_t mBetterPartitionAttachAttempts; ///< Number of attempts to attach to a better partition.
+    uint16_t mParentChanges;                 ///< Number of time device changed its parent.
+    uint64_t mTrackedTime;                   ///< Milliseconds tracked by next counters (zero if not supported)
+    uint64_t mDisabledTime;                  ///< Milliseconds device has been in disabled role.
+    uint64_t mDetachedTime;                  ///< Milliseconds device has been in detached role.
+    uint64_t mChildTime;                     ///< Milliseconds device has been in child role.
+    uint64_t mRouterTime;                    ///< Milliseconds device has been in router role.
+    uint64_t mLeaderTime;                    ///< Milliseconds device has been in leader role.
+} otNetworkDiagMleCounters;
+
+/**
  * This structure represents a Network Diagnostic Child Table Entry.
  *
  */
@@ -257,6 +282,7 @@ typedef struct otNetworkDiagTlv
         otNetworkDiagRoute        mRoute;
         otLeaderData              mLeaderData;
         otNetworkDiagMacCounters  mMacCounters;
+        otNetworkDiagMleCounters  mMleCounters;
         uint8_t                   mBatteryLevel;
         uint16_t                  mSupplyVoltage;
         uint32_t                  mMaxChildTimeout;

--- a/include/openthread/netdiag.h
+++ b/include/openthread/netdiag.h
@@ -87,6 +87,11 @@ enum
     OT_NETWORK_DIAGNOSTIC_TLV_VENDOR_MODEL         = 26, ///< Vendor Model TLV
     OT_NETWORK_DIAGNOSTIC_TLV_VENDOR_SW_VERSION    = 27, ///< Vendor SW Version TLV
     OT_NETWORK_DIAGNOSTIC_TLV_THREAD_STACK_VERSION = 28, ///< Thread Stack Version TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_CHILD                = 29, ///< Child TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_CHILD_IP6_ADDR_LIST  = 30, ///< Child IPv6 Address List TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_NEIGHBOR             = 31, ///< Neighbor TLV (router only)
+    OT_NETWORK_DIAGNOSTIC_TLV_ANSWER               = 32, ///< Answer TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_QUERY_ID             = 33, ///< Query ID TLV
 };
 
 #define OT_NETWORK_DIAGNOSTIC_MAX_VENDOR_NAME_TLV_LENGTH 32          ///< Max length of Vendor Name TLV.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -2039,6 +2039,87 @@ id:62 rloc16:0xf800 ext-addr:ce349873897233a5 ver:4 - br
    children: none
 ```
 
+### meshdiag childtable \<router-rloc16\>
+
+Start a query for child table of a router with a given RLOC16.
+
+Output lists all child entries. Information per child:
+
+- RLOC16
+- Extended MAC address
+- Thread Version
+- Timeout (in seconds)
+- Age (seconds since last heard)
+- Supervision interval (in seconds)
+- Number of queued messages (in case the child is sleepy)
+- Device Mode
+- RSS (average and last) and link margin
+- Error rates, frame tx (at MAC layer), IPv6 message tx (above MAC)
+- CSL info
+  - If synchronized
+  - Period (in unit of 10-symbols-time)
+  - Timeout (in seconds)
+  - Channel
+
+```bash
+> meshdiag childtable 0x6400
+rloc16:0x6402 ext-addr:8e6f4d323bbed1fe ver:4
+    timeout:120 age:36 supvn:129 q-msg:0
+    rx-on:yes type:ftd full-net:yes
+    rss - ave:-20 last:-20 margin:80
+    err-rate - frame:11.51% msg:0.76%
+    csl - sync:no period:0 timeout:0 channel:0
+rloc16:0x6403 ext-addr:ee24e64ecf8c079a ver:4
+    timeout:120 age:19 supvn:129 q-msg:0
+    rx-on:no type:mtd full-net:no
+    rss - ave:-20 last:-20 margin:80
+    err-rate - frame:0.73% msg:0.00%
+    csl - sync:no period:0 timeout:0 channel:0
+Done
+```
+
+### meshdiag childip6 \<parent-rloc16>
+
+Send a query to a parent to retrieve the IPv6 addresses of all its MTD children.
+
+```bash
+> meshdiag childip6 0xdc00
+child-rloc16: 0xdc02
+    fdde:ad00:beef:0:ded8:cd58:b73:2c21
+    fd00:2:0:0:c24a:456:3b6b:c597
+    fd00:1:0:0:120b:95fe:3ecc:d238
+child-rloc16: 0xdc03
+    fdde:ad00:beef:0:3aa6:b8bf:e7d6:eefe
+    fd00:2:0:0:8ff8:a188:7436:6720
+    fd00:1:0:0:1fcf:5495:790a:370f
+Done
+```
+
+### meshdiag neighbortable \<router-rloc16\>
+
+Start a query for router neighbor table of a router with a given RLOC16.
+
+Output lists all router neighbor entries. Information per entry:
+
+- RLOC16
+- Extended MAC address
+- Thread Version
+- Device Mode
+- RSS (average and last) and link margin
+- Error rates, frame tx (at MAC layer), IPv6 message tx (above MAC)
+
+```bash
+> meshdiag neighbortable 0x7400
+rloc16:0x9c00 ext-addr:764788cf6e57a4d2 ver:4
+   rx-on:yes type:ftd full-net:yes
+   rss - ave:-20 last:-20 margin:80
+   err-rate - frame:1.38% msg:0.00%
+rloc16:0x7c00 ext-addr:4ed24fceec9bf6d3 ver:4
+   rx-on:yes type:ftd full-net:yes
+   rss - ave:-20 last:-20 margin:80
+   err-rate - frame:0.72% msg:0.00%
+```
+
 ### mliid \<iid\>
 
 Set the Mesh Local IID.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -5798,6 +5798,122 @@ template <> otError Interpreter::Process<Cmd("meshdiag")>(Arg aArgs[])
         SuccessOrExit(error = otMeshDiagDiscoverTopology(GetInstancePtr(), &config, HandleMeshDiagDiscoverDone, this));
         error = OT_ERROR_PENDING;
     }
+    /**
+     * @cli meshdiag childtable
+     * @code
+     * meshdiag childtable 0x6400
+     * rloc16:0x6402 ext-addr:8e6f4d323bbed1fe ver:4
+     *     timeout:120 age:36 supvn:129 q-msg:0
+     *     rx-on:yes type:ftd full-net:yes
+     *     rss - ave:-20 last:-20 margin:80
+     *     err-rate - frame:11.51% msg:0.76%
+     *     csl - sync:no period:0 timeout:0 channel:0
+     * rloc16:0x6403 ext-addr:ee24e64ecf8c079a ver:4
+     *     timeout:120 age:19 supvn:129 q-msg:0
+     *     rx-on:no type:mtd full-net:no
+     *     rss - ave:-20 last:-20  margin:80
+     *     err-rate - frame:0.73% msg:0.00%
+     *     csl - sync:no period:0 timeout:0 channel:0
+     * @endcode
+     * @par
+     * Start a query for child table of a router with a given RLOC16.
+     * Output lists all child entries. Information per child:
+     * * RLOC16
+     * * Extended MAC address
+     * * Thread Version
+     * * Timeout (in seconds)
+     * * Age (seconds since last heard)
+     * * Supervision interval (in seconds)
+     * * Number of queued messages (in case child is sleepy)
+     * * Device Mode
+     * * RSS (average and last)
+     * * Error rates: frame tx (at MAC layer), IPv6 message tx (above MAC)
+     * * CSL info
+     *   * If synchronized
+     *   * Period (in unit of 10-symbols-time)
+     *   * Timeout (in seconds)
+     * @cparam meshdiag childtable @ca{router-rloc16}
+     * @sa otMeshDiagQueryChildTable
+     */
+    else if (aArgs[0] == "childtable")
+    {
+        uint16_t routerRloc16;
+
+        SuccessOrExit(error = aArgs[1].ParseAsUint16(routerRloc16));
+        VerifyOrExit(aArgs[2].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+
+        SuccessOrExit(error = otMeshDiagQueryChildTable(GetInstancePtr(), routerRloc16,
+                                                        HandleMeshDiagQueryChildTableResult, this));
+
+        error = OT_ERROR_PENDING;
+    }
+    /**
+     * @cli meshdiag childip6
+     * @code
+     * meshdiag childrenip6addr 0xdc00
+     * child-rloc16: 0xdc02
+     *     fdde:ad00:beef:0:ded8:cd58:b73:2c21
+     *     fd00:2:0:0:c24a:456:3b6b:c597
+     *     fd00:1:0:0:120b:95fe:3ecc:d238
+     * child-rloc16: 0xdc03
+     *     fdde:ad00:beef:0:3aa6:b8bf:e7d6:eefe
+     *     fd00:2:0:0:8ff8:a188:7436:6720
+     *     fd00:1:0:0:1fcf:5495:790a:370f
+     * @endcode
+     * @par
+     * Send a query to a parent to retrieve the IPv6 addresses of all its MTD children.
+     * @cparam meshdiag childip6 @ca{parent-rloc16}
+     * @sa otMeshDiagQueryChildrenIp6Addrs
+     */
+    else if (aArgs[0] == "childip6")
+    {
+        uint16_t parentRloc16;
+
+        SuccessOrExit(error = aArgs[1].ParseAsUint16(parentRloc16));
+        VerifyOrExit(aArgs[2].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+
+        SuccessOrExit(error = otMeshDiagQueryChildrenIp6Addrs(GetInstancePtr(), parentRloc16,
+                                                              HandleMeshDiagQueryChildIp6Addrs, this));
+
+        error = OT_ERROR_PENDING;
+    }
+    /**
+     * @cli meshdiag neighbortable
+     * @code
+     * meshdiag neighbortable 0x7400
+     * rloc16:0x9c00 ext-addr:764788cf6e57a4d2 ver:4
+     *    rx-on:yes type:ftd full-net:yes
+     *    rss - ave:-20 last:-20 margin:80
+     *    err-rate - frame:1.38% msg:0.00%
+     * rloc16:0x7c00 ext-addr:4ed24fceec9bf6d3 ver:4
+     *    rx-on:yes type:ftd full-net:yes
+     *    rss - ave:-20 last:-20 margin:80
+     *    err-rate - frame:0.72% msg:0.00%
+     * @endcode
+     * @par
+     * Start a query for router neighbor table of a router with a given RLOC16.
+     * Output lists all router neighbor entries. Information per entry:
+     *  - RLOC16
+     *  - Extended MAC address
+     *  - Thread Version
+     *  - Device Mode
+     *  - RSS (average and last) and link margin
+     *  - Error rates, frame tx (at MAC layer), IPv6 message tx (above MAC)
+     * @cparam meshdiag neighbortable @ca{router-rloc16}
+     * @sa otMeshDiagQueryNeighborTable
+     */
+    else if (aArgs[0] == "neighbortable")
+    {
+        uint16_t routerRloc16;
+
+        SuccessOrExit(error = aArgs[1].ParseAsUint16(routerRloc16));
+        VerifyOrExit(aArgs[2].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+
+        SuccessOrExit(error = otMeshDiagQueryNeighborTable(GetInstancePtr(), routerRloc16,
+                                                           HandleMeshDiagQueryNeighborTableResult, this));
+
+        error = OT_ERROR_PENDING;
+    }
     else
     {
         error = OT_ERROR_INVALID_COMMAND;
@@ -5922,6 +6038,110 @@ void Interpreter::HandleMeshDiagDiscoverDone(otError aError, otMeshDiagRouterInf
         {
             OutputLine(kIndentSize, "children: none");
         }
+    }
+
+exit:
+    OutputResult(aError);
+}
+
+void Interpreter::HandleMeshDiagQueryChildTableResult(otError                     aError,
+                                                      const otMeshDiagChildEntry *aChildEntry,
+                                                      void                       *aContext)
+{
+    reinterpret_cast<Interpreter *>(aContext)->HandleMeshDiagQueryChildTableResult(aError, aChildEntry);
+}
+
+void Interpreter::HandleMeshDiagQueryChildTableResult(otError aError, const otMeshDiagChildEntry *aChildEntry)
+{
+    PercentageStringBuffer stringBuffer;
+
+    VerifyOrExit(aChildEntry != nullptr);
+
+    OutputFormat("rloc16:0x%04x ext-addr:", aChildEntry->mRloc16);
+    OutputExtAddress(aChildEntry->mExtAddress);
+    OutputLine(" ver:%u", aChildEntry->mVersion);
+
+    OutputLine(kIndentSize, "timeout:%lu age:%lu supvn:%u q-msg:%u", ToUlong(aChildEntry->mTimeout),
+               ToUlong(aChildEntry->mAge), aChildEntry->mSupervisionInterval, aChildEntry->mQueuedMessageCount);
+
+    OutputLine(kIndentSize, "rx-on:%s type:%s full-net:%s", aChildEntry->mRxOnWhenIdle ? "yes" : "no",
+               aChildEntry->mDeviceTypeFtd ? "ftd" : "mtd", aChildEntry->mFullNetData ? "yes" : "no");
+
+    OutputLine(kIndentSize, "rss - ave:%d last:%d margin:%d", aChildEntry->mAverageRssi, aChildEntry->mLastRssi,
+               aChildEntry->mLinkMargin);
+
+    if (aChildEntry->mSupportsErrRate)
+    {
+        OutputFormat(kIndentSize, "err-rate - frame:%s%% ",
+                     PercentageToString(aChildEntry->mFrameErrorRate, stringBuffer));
+        OutputLine("msg:%s%% ", PercentageToString(aChildEntry->mMessageErrorRate, stringBuffer));
+    }
+
+    OutputLine(kIndentSize, "csl - sync:%s period:%u timeout:%lu channel:%u",
+               aChildEntry->mCslSynchronized ? "yes" : "no", aChildEntry->mCslPeriod, ToUlong(aChildEntry->mCslTimeout),
+               aChildEntry->mCslChannel);
+
+exit:
+    OutputResult(aError);
+}
+
+void Interpreter::HandleMeshDiagQueryNeighborTableResult(otError                        aError,
+                                                         const otMeshDiagNeighborEntry *aNeighborEntry,
+                                                         void                          *aContext)
+{
+    reinterpret_cast<Interpreter *>(aContext)->HandleMeshDiagQueryNeighborTableResult(aError, aNeighborEntry);
+}
+
+void Interpreter::HandleMeshDiagQueryNeighborTableResult(otError aError, const otMeshDiagNeighborEntry *aNeighborEntry)
+{
+    PercentageStringBuffer stringBuffer;
+
+    VerifyOrExit(aNeighborEntry != nullptr);
+
+    OutputFormat("rloc16:0x%04x ext-addr:", aNeighborEntry->mRloc16);
+    OutputExtAddress(aNeighborEntry->mExtAddress);
+    OutputLine(" ver:%u", aNeighborEntry->mVersion);
+
+    OutputLine(kIndentSize, "rx-on:%s type:%s full-net:%s", aNeighborEntry->mRxOnWhenIdle ? "yes" : "no",
+               aNeighborEntry->mDeviceTypeFtd ? "ftd" : "mtd", aNeighborEntry->mFullNetData ? "yes" : "no");
+
+    OutputLine(kIndentSize, "rss - ave:%d last:%d margin:%d", aNeighborEntry->mAverageRssi, aNeighborEntry->mLastRssi,
+               aNeighborEntry->mLinkMargin);
+
+    if (aNeighborEntry->mSupportsErrRate)
+    {
+        OutputFormat(kIndentSize, "err-rate - frame:%s%% ",
+                     PercentageToString(aNeighborEntry->mFrameErrorRate, stringBuffer));
+        OutputLine("msg:%s%% ", PercentageToString(aNeighborEntry->mMessageErrorRate, stringBuffer));
+    }
+
+exit:
+    OutputResult(aError);
+}
+
+void Interpreter::HandleMeshDiagQueryChildIp6Addrs(otError                    aError,
+                                                   uint16_t                   aChildRloc16,
+                                                   otMeshDiagIp6AddrIterator *aIp6AddrIterator,
+                                                   void                      *aContext)
+{
+    reinterpret_cast<Interpreter *>(aContext)->HandleMeshDiagQueryChildIp6Addrs(aError, aChildRloc16, aIp6AddrIterator);
+}
+
+void Interpreter::HandleMeshDiagQueryChildIp6Addrs(otError                    aError,
+                                                   uint16_t                   aChildRloc16,
+                                                   otMeshDiagIp6AddrIterator *aIp6AddrIterator)
+{
+    otIp6Address ip6Address;
+
+    VerifyOrExit(aError == OT_ERROR_NONE || aError == OT_ERROR_PENDING);
+    VerifyOrExit(aIp6AddrIterator != nullptr);
+
+    OutputLine("child-rloc16: 0x%04x", aChildRloc16);
+
+    while (otMeshDiagGetNextIp6Address(aIp6AddrIterator, &ip6Address) == OT_ERROR_NONE)
+    {
+        OutputSpaces(kIndentSize);
+        OutputIp6AddressLine(ip6Address);
     }
 
 exit:

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -8384,6 +8384,10 @@ void Interpreter::HandleDiagnosticGetResponse(otError                 aError,
             OutputLine("MAC Counters:");
             OutputNetworkDiagMacCounters(kIndentSize, diagTlv.mData.mMacCounters);
             break;
+        case OT_NETWORK_DIAGNOSTIC_TLV_MLE_COUNTERS:
+            OutputLine("MLE Counters:");
+            OutputNetworkDiagMleCounters(kIndentSize, diagTlv.mData.mMleCounters);
+            break;
         case OT_NETWORK_DIAGNOSTIC_TLV_BATTERY_LEVEL:
             OutputLine("Battery Level: %u%%", diagTlv.mData.mBatteryLevel);
             break;
@@ -8479,15 +8483,75 @@ void Interpreter::OutputLeaderData(uint8_t aIndentSize, const otLeaderData &aLea
 
 void Interpreter::OutputNetworkDiagMacCounters(uint8_t aIndentSize, const otNetworkDiagMacCounters &aMacCounters)
 {
-    OutputLine(aIndentSize, "IfInUnknownProtos: %lu", ToUlong(aMacCounters.mIfInUnknownProtos));
-    OutputLine(aIndentSize, "IfInErrors: %lu", ToUlong(aMacCounters.mIfInErrors));
-    OutputLine(aIndentSize, "IfOutErrors: %lu", ToUlong(aMacCounters.mIfOutErrors));
-    OutputLine(aIndentSize, "IfInUcastPkts: %lu", ToUlong(aMacCounters.mIfInUcastPkts));
-    OutputLine(aIndentSize, "IfInBroadcastPkts: %lu", ToUlong(aMacCounters.mIfInBroadcastPkts));
-    OutputLine(aIndentSize, "IfInDiscards: %lu", ToUlong(aMacCounters.mIfInDiscards));
-    OutputLine(aIndentSize, "IfOutUcastPkts: %lu", ToUlong(aMacCounters.mIfOutUcastPkts));
-    OutputLine(aIndentSize, "IfOutBroadcastPkts: %lu", ToUlong(aMacCounters.mIfOutBroadcastPkts));
-    OutputLine(aIndentSize, "IfOutDiscards: %lu", ToUlong(aMacCounters.mIfOutDiscards));
+    struct CounterName
+    {
+        const uint32_t otNetworkDiagMacCounters::*mValuePtr;
+        const char                               *mName;
+    };
+
+    static const CounterName kCounterNames[] = {
+        {&otNetworkDiagMacCounters::mIfInUnknownProtos, "IfInUnknownProtos"},
+        {&otNetworkDiagMacCounters::mIfInErrors, "IfInErrors"},
+        {&otNetworkDiagMacCounters::mIfOutErrors, "IfOutErrors"},
+        {&otNetworkDiagMacCounters::mIfInUcastPkts, "IfInUcastPkts"},
+        {&otNetworkDiagMacCounters::mIfInBroadcastPkts, "IfInBroadcastPkts"},
+        {&otNetworkDiagMacCounters::mIfInDiscards, "IfInDiscards"},
+        {&otNetworkDiagMacCounters::mIfOutUcastPkts, "IfOutUcastPkts"},
+        {&otNetworkDiagMacCounters::mIfOutBroadcastPkts, "IfOutBroadcastPkts"},
+        {&otNetworkDiagMacCounters::mIfOutDiscards, "IfOutDiscards"},
+    };
+
+    for (const CounterName &counter : kCounterNames)
+    {
+        OutputLine(aIndentSize, "%s: %lu", counter.mName, ToUlong(aMacCounters.*counter.mValuePtr));
+    }
+}
+
+void Interpreter::OutputNetworkDiagMleCounters(uint8_t aIndentSize, const otNetworkDiagMleCounters &aMleCounters)
+{
+    struct CounterName
+    {
+        const uint16_t otNetworkDiagMleCounters::*mValuePtr;
+        const char                               *mName;
+    };
+
+    struct TimeCounterName
+    {
+        const uint64_t otNetworkDiagMleCounters::*mValuePtr;
+        const char                               *mName;
+    };
+
+    static const CounterName kCounterNames[] = {
+        {&otNetworkDiagMleCounters::mDisabledRole, "DisabledRole"},
+        {&otNetworkDiagMleCounters::mDetachedRole, "DetachedRole"},
+        {&otNetworkDiagMleCounters::mChildRole, "ChildRole"},
+        {&otNetworkDiagMleCounters::mRouterRole, "RouterRole"},
+        {&otNetworkDiagMleCounters::mLeaderRole, "LeaderRole"},
+        {&otNetworkDiagMleCounters::mAttachAttempts, "AttachAttempts"},
+        {&otNetworkDiagMleCounters::mPartitionIdChanges, "PartitionIdChanges"},
+        {&otNetworkDiagMleCounters::mBetterPartitionAttachAttempts, "BetterPartitionAttachAttempts"},
+        {&otNetworkDiagMleCounters::mParentChanges, "ParentChanges"},
+    };
+
+    static const TimeCounterName kTimeCounterNames[] = {
+        {&otNetworkDiagMleCounters::mTrackedTime, "TrackedTime"},
+        {&otNetworkDiagMleCounters::mDisabledTime, "DisabledTime"},
+        {&otNetworkDiagMleCounters::mDetachedTime, "DetachedTime"},
+        {&otNetworkDiagMleCounters::mChildTime, "ChildTime"},
+        {&otNetworkDiagMleCounters::mRouterTime, "RouterTime"},
+        {&otNetworkDiagMleCounters::mLeaderTime, "LeaderTime"},
+    };
+
+    for (const CounterName &counter : kCounterNames)
+    {
+        OutputLine(aIndentSize, "%s: %u", counter.mName, aMleCounters.*counter.mValuePtr);
+    }
+
+    for (const TimeCounterName &counter : kTimeCounterNames)
+    {
+        OutputFormat("%s: ", counter.mName);
+        OutputUint64Line(aMleCounters.*counter.mValuePtr);
+    }
 }
 
 void Interpreter::OutputChildTableEntry(uint8_t aIndentSize, const otNetworkDiagChildEntry &aChildEntry)

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -473,6 +473,7 @@ private:
     void OutputRouteData(uint8_t aIndentSize, const otNetworkDiagRouteData &aRouteData);
     void OutputLeaderData(uint8_t aIndentSize, const otLeaderData &aLeaderData);
     void OutputNetworkDiagMacCounters(uint8_t aIndentSize, const otNetworkDiagMacCounters &aMacCounters);
+    void OutputNetworkDiagMleCounters(uint8_t aIndentSize, const otNetworkDiagMleCounters &aMleCounters);
     void OutputChildTableEntry(uint8_t aIndentSize, const otNetworkDiagChildEntry &aChildEntry);
 #endif
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -412,6 +412,22 @@ private:
 #if OPENTHREAD_CONFIG_MESH_DIAG_ENABLE && OPENTHREAD_FTD
     static void HandleMeshDiagDiscoverDone(otError aError, otMeshDiagRouterInfo *aRouterInfo, void *aContext);
     void        HandleMeshDiagDiscoverDone(otError aError, otMeshDiagRouterInfo *aRouterInfo);
+    static void HandleMeshDiagQueryChildTableResult(otError                     aError,
+                                                    const otMeshDiagChildEntry *aChildEntry,
+                                                    void                       *aContext);
+    void        HandleMeshDiagQueryChildTableResult(otError aError, const otMeshDiagChildEntry *aChildEntry);
+    static void HandleMeshDiagQueryChildIp6Addrs(otError                    aError,
+                                                 uint16_t                   aChildRloc16,
+                                                 otMeshDiagIp6AddrIterator *aIp6AddrIterator,
+                                                 void                      *aContext);
+    void        HandleMeshDiagQueryChildIp6Addrs(otError                    aError,
+                                                 uint16_t                   aChildRloc16,
+                                                 otMeshDiagIp6AddrIterator *aIp6AddrIterator);
+    static void HandleMeshDiagQueryNeighborTableResult(otError                        aError,
+                                                       const otMeshDiagNeighborEntry *aNeighborEntry,
+                                                       void                          *aContext);
+    void        HandleMeshDiagQueryNeighborTableResult(otError aError, const otMeshDiagNeighborEntry *aNeighborEntry);
+
 #endif
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
     static void HandleMlrRegResult(void               *aContext,

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -667,6 +667,7 @@ openthread_core_files = [
   "thread/network_data_types.hpp",
   "thread/network_diagnostic.cpp",
   "thread/network_diagnostic.hpp",
+  "thread/network_diagnostic_tlvs.cpp",
   "thread/network_diagnostic_tlvs.hpp",
   "thread/panid_query_server.cpp",
   "thread/panid_query_server.hpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -225,6 +225,7 @@ set(COMMON_SOURCES
     thread/network_data_tlvs.cpp
     thread/network_data_types.cpp
     thread/network_diagnostic.cpp
+    thread/network_diagnostic_tlvs.cpp
     thread/panid_query_server.cpp
     thread/radio_selector.cpp
     thread/router_table.cpp

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -315,6 +315,7 @@ SOURCES_COMMON                                  = \
     thread/network_data_tlvs.cpp                  \
     thread/network_data_types.cpp                 \
     thread/network_diagnostic.cpp                 \
+    thread/network_diagnostic_tlvs.cpp            \
     thread/panid_query_server.cpp                 \
     thread/radio_selector.cpp                     \
     thread/router_table.cpp                       \

--- a/src/core/api/mesh_diag_api.cpp
+++ b/src/core/api/mesh_diag_api.cpp
@@ -64,4 +64,28 @@ otError otMeshDiagGetNextChildInfo(otMeshDiagChildIterator *aIterator, otMeshDia
     return AsCoreType(aIterator).GetNextChildInfo(AsCoreType(aChildInfo));
 }
 
+otError otMeshDiagQueryChildTable(otInstance                       *aInstance,
+                                  uint16_t                          aRloc16,
+                                  otMeshDiagQueryChildTableCallback aCallback,
+                                  void                             *aContext)
+{
+    return AsCoreType(aInstance).Get<Utils::MeshDiag>().QueryChildTable(aRloc16, aCallback, aContext);
+}
+
+otError otMeshDiagQueryChildrenIp6Addrs(otInstance                     *aInstance,
+                                        uint16_t                        aRloc16,
+                                        otMeshDiagChildIp6AddrsCallback aCallback,
+                                        void                           *aContext)
+{
+    return AsCoreType(aInstance).Get<Utils::MeshDiag>().QueryChildrenIp6Addrs(aRloc16, aCallback, aContext);
+}
+
+otError otMeshDiagQueryNeighborTable(otInstance                          *aInstance,
+                                     uint16_t                             aRloc16,
+                                     otMeshDiagQueryNeighborTableCallback aCallback,
+                                     void                                *aContext)
+{
+    return AsCoreType(aInstance).Get<Utils::MeshDiag>().QueryNeighborTable(aRloc16, aCallback, aContext);
+}
+
 #endif // OPENTHREAD_CONFIG_MESH_DIAG_ENABLE && OPENTHREAD_FTD

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -830,6 +830,10 @@ template <> void Server::HandleTmf<kUriDiagnosticReset>(Coap::Message &aMessage,
             Get<Mac::Mac>().ResetCounters();
             break;
 
+        case Tlv::kMleCounters:
+            Get<Mle::Mle>().ResetCounters();
+            break;
+
         default:
             break;
         }
@@ -1136,6 +1140,16 @@ Error Client::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator,
             SuccessOrExit(error = aMessage.Read(offset, macCountersTlv));
             VerifyOrExit(macCountersTlv.IsValid(), error = kErrorParse);
             ParseMacCounters(macCountersTlv, aTlvInfo.mData.mMacCounters);
+            break;
+        }
+
+        case Tlv::kMleCounters:
+        {
+            MleCountersTlv mleCoutersTlv;
+
+            SuccessOrExit(error = aMessage.Read(offset, mleCoutersTlv));
+            VerifyOrExit(mleCoutersTlv.IsValid(), error = kErrorParse);
+            mleCoutersTlv.Read(aTlvInfo.mData.mMleCounters);
             break;
         }
 

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -42,6 +42,7 @@
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
 #include "common/log.hpp"
+#include "common/random.hpp"
 #include "mac/mac.hpp"
 #include "net/netif.hpp"
 #include "thread/mesh_forwarder.hpp"
@@ -403,11 +404,7 @@ exit:
 template <>
 void Server::HandleTmf<kUriDiagnosticGetQuery>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    Error            error    = kErrorNone;
-    Coap::Message   *response = nullptr;
-    Tmf::MessageInfo responseInfo(GetInstance());
-
-    VerifyOrExit(aMessage.IsPostRequest(), error = kErrorDrop);
+    VerifyOrExit(aMessage.IsPostRequest());
 
     LogInfo("Received %s from %s", UriToString<kUriDiagnosticGetQuery>(),
             aMessageInfo.GetPeerAddr().ToString().AsCString());
@@ -418,17 +415,372 @@ void Server::HandleTmf<kUriDiagnosticGetQuery>(Coap::Message &aMessage, const Ip
         IgnoreError(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
     }
 
-    response = Get<Tmf::Agent>().NewConfirmablePostMessage(kUriDiagnosticGetAnswer);
-    VerifyOrExit(response != nullptr, error = kErrorNoBufs);
-
-    SuccessOrExit(error = AppendRequestedTlvs(aMessage, *response));
-
-    PrepareMessageInfoForDest(aMessageInfo.GetPeerAddr(), responseInfo);
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*response, responseInfo));
+#if OPENTHREAD_MTD
+    SendAnswer(aMessageInfo.GetPeerAddr(), aMessage);
+#elif OPENTHREAD_FTD
+    PrepareAndSendAnswers(aMessageInfo.GetPeerAddr(), aMessage);
+#endif
 
 exit:
-    FreeMessageOnError(response, error);
+    return;
 }
+
+#if OPENTHREAD_MTD
+
+void Server::SendAnswer(const Ip6::Address &aDestination, const Message &aRequest)
+{
+    Error            error  = kErrorNone;
+    Coap::Message   *answer = nullptr;
+    Tmf::MessageInfo messageInfo(GetInstance());
+    AnswerTlv        answerTlv;
+    uint16_t         queryId;
+
+    answer = Get<Tmf::Agent>().NewConfirmablePostMessage(kUriDiagnosticGetAnswer);
+    VerifyOrExit(answer != nullptr, error = kErrorNoBufs);
+
+    if (Tlv::Find<QueryIdTlv>(aRequest, queryId) == kErrorNone)
+    {
+        SuccessOrExit(error = Tlv::Append<QueryIdTlv>(*answer, queryId));
+    }
+
+    SuccessOrExit(error = AppendRequestedTlvs(aRequest, *answer));
+
+    answerTlv.Init(0, /* aIsLast */ true);
+    SuccessOrExit(answer->Append(answerTlv));
+
+    PrepareMessageInfoForDest(aDestination, messageInfo);
+
+    error = Get<Tmf::Agent>().SendMessage(*answer, messageInfo);
+
+exit:
+    FreeMessageOnError(answer, error);
+}
+
+#endif // OPENTHREAD_MTD
+
+#if OPENTHREAD_FTD
+
+Error Server::AllocateAnswer(Coap::Message *&aAnswer, AnswerInfo &aInfo)
+{
+    // Allocate an `Answer` message, adds it in `mAnswerQueue`,
+    // update the `aInfo.mFirstAnswer` if it is the first allocated
+    // messages, and appends `QueryIdTlv` to the message (if needed).
+
+    Error error = kErrorNone;
+
+    aAnswer = Get<Tmf::Agent>().NewConfirmablePostMessage(kUriDiagnosticGetAnswer);
+    VerifyOrExit(aAnswer != nullptr, error = kErrorNoBufs);
+
+    mAnswerQueue.Enqueue(*aAnswer);
+
+    if (aInfo.mFirstAnswer == nullptr)
+    {
+        aInfo.mFirstAnswer = aAnswer;
+    }
+
+    if (aInfo.mHasQueryId)
+    {
+        SuccessOrExit(error = Tlv::Append<QueryIdTlv>(*aAnswer, aInfo.mQueryId));
+    }
+
+exit:
+    return error;
+}
+
+bool Server::IsLastAnswer(const Coap::Message &aAnswer) const
+{
+    // Indicates whether `aAnswer` is the last one associated with
+    // the same query.
+
+    bool      isLast = true;
+    AnswerTlv answerTlv;
+
+    // If there is no Answer TLV, we assume it is the last answer.
+
+    SuccessOrExit(Tlv::FindTlv(aAnswer, answerTlv));
+    isLast = answerTlv.IsLast();
+
+exit:
+    return isLast;
+}
+
+void Server::FreeAllRelatedAnswers(Coap::Message &aFirstAnswer)
+{
+    // This method dequeues and frees all answer messages related to
+    // same query as `aFirstAnswer`. Note that related answers are
+    // enqueued in order.
+
+    Coap::Message *answer = &aFirstAnswer;
+
+    while (answer != nullptr)
+    {
+        Coap::Message *next = IsLastAnswer(*answer) ? nullptr : answer->GetNextCoapMessage();
+
+        mAnswerQueue.DequeueAndFree(*answer);
+        answer = next;
+    }
+}
+
+void Server::PrepareAndSendAnswers(const Ip6::Address &aDestination, const Message &aRequest)
+{
+    Coap::Message *answer;
+    Error          error;
+    AnswerInfo     info;
+    uint16_t       offset;
+    uint16_t       length;
+    uint16_t       endOffset;
+    AnswerTlv      answerTlv;
+
+    if (Tlv::Find<QueryIdTlv>(aRequest, info.mQueryId) == kErrorNone)
+    {
+        info.mHasQueryId = true;
+    }
+
+    SuccessOrExit(error = AllocateAnswer(answer, info));
+
+    SuccessOrExit(error = Tlv::FindTlvValueOffset(aRequest, Tlv::kTypeList, offset, length));
+    endOffset = offset + length;
+
+    for (; offset < endOffset; offset++)
+    {
+        uint8_t tlvType;
+
+        SuccessOrExit(error = aRequest.Read(offset, tlvType));
+
+        if (tlvType == ChildTlv::kType)
+        {
+            SuccessOrExit(error = AppendChildTableAsChildTlvs(answer, info));
+        }
+        else if (tlvType == ChildIp6AddressListTlv::kType)
+        {
+            SuccessOrExit(error = AppendChildTableIp6AddressList(answer, info));
+        }
+        else if (tlvType == NeighborTlv::kType)
+        {
+            SuccessOrExit(error = AppendNeighborTlvs(answer, info));
+        }
+        else
+        {
+            SuccessOrExit(error = AppendDiagTlv(tlvType, *answer));
+        }
+
+        SuccessOrExit(error = CheckAnswerLength(answer, info));
+    }
+
+    answerTlv.Init(info.mAnswerIndex, /* aIsLast */ true);
+    SuccessOrExit(error = answer->Append(answerTlv));
+
+    SendNextAnswer(*info.mFirstAnswer, aDestination);
+
+exit:
+    if ((error != kErrorNone) && (info.mFirstAnswer != nullptr))
+    {
+        FreeAllRelatedAnswers(*info.mFirstAnswer);
+    }
+}
+
+Error Server::CheckAnswerLength(Coap::Message *&aAnswer, AnswerInfo &aInfo)
+{
+    // This method checks the length of the `aAnswer` message and if it
+    // is above the threshold, it enqueues the message for transmission
+    // after appending an Answer TLV with the current index to the
+    // message. In this case, it will also allocate a new answer
+    // message.
+
+    Error     error = kErrorNone;
+    AnswerTlv answerTlv;
+
+    VerifyOrExit(aAnswer->GetLength() >= kAnswerMessageLengthThreshold);
+
+    answerTlv.Init(aInfo.mAnswerIndex++, /* aIsLast */ false);
+    SuccessOrExit(error = aAnswer->Append(answerTlv));
+
+    error = AllocateAnswer(aAnswer, aInfo);
+
+exit:
+    return error;
+}
+
+void Server::SendNextAnswer(Coap::Message &aAnswer, const Ip6::Address &aDestination)
+{
+    // This method send the given next `aAnswer` associated with
+    // a query to the  `aDestination`.
+
+    Error            error      = kErrorNone;
+    Coap::Message   *nextAnswer = IsLastAnswer(aAnswer) ? nullptr : aAnswer.GetNextCoapMessage();
+    Tmf::MessageInfo messageInfo(GetInstance());
+
+    mAnswerQueue.Dequeue(aAnswer);
+
+    PrepareMessageInfoForDest(aDestination, messageInfo);
+
+    // When sending the message, we pass `nextAnswer` as `aContext`
+    // to be used when invoking callback `HandleAnswerResponse()`.
+
+    error = Get<Tmf::Agent>().SendMessage(aAnswer, messageInfo, HandleAnswerResponse, nextAnswer);
+
+    if (error != kErrorNone)
+    {
+        // If the `SendMessage()` fails, we `Free` the dequeued
+        // `aAnswer` and all the related next answers in the queue.
+
+        aAnswer.Free();
+
+        if (nextAnswer != nullptr)
+        {
+            FreeAllRelatedAnswers(*nextAnswer);
+        }
+    }
+}
+
+void Server::HandleAnswerResponse(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo, Error aResult)
+{
+    Coap::Message *nextAnswer = static_cast<Coap::Message *>(aContext);
+
+    VerifyOrExit(nextAnswer != nullptr);
+
+    nextAnswer->Get<Server>().HandleAnswerResponse(*nextAnswer, AsCoapMessagePtr(aMessage), AsCoreTypePtr(aMessageInfo),
+                                                   aResult);
+
+exit:
+    return;
+}
+
+void Server::HandleAnswerResponse(Coap::Message          &aNextAnswer,
+                                  Coap::Message          *aResponse,
+                                  const Ip6::MessageInfo *aMessageInfo,
+                                  Error                   aResult)
+{
+    Error error = aResult;
+
+    SuccessOrExit(error);
+    VerifyOrExit(aResponse != nullptr && aMessageInfo != nullptr, error = kErrorDrop);
+    VerifyOrExit(aResponse->GetCode() == Coap::kCodeChanged, error = kErrorDrop);
+
+    SendNextAnswer(aNextAnswer, aMessageInfo->GetPeerAddr());
+
+exit:
+    if (error != kErrorNone)
+    {
+        FreeAllRelatedAnswers(aNextAnswer);
+    }
+}
+
+Error Server::AppendChildTableAsChildTlvs(Coap::Message *&aAnswer, AnswerInfo &aInfo)
+{
+    Error    error = kErrorNone;
+    ChildTlv childTlv;
+
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
+    {
+        childTlv.InitFrom(child);
+
+        SuccessOrExit(error = childTlv.AppendTo(*aAnswer));
+        SuccessOrExit(error = CheckAnswerLength(aAnswer, aInfo));
+    }
+
+    // Add empty TLV to indicate end of the list
+
+    childTlv.InitAsEmpty();
+    SuccessOrExit(error = childTlv.AppendTo(*aAnswer));
+
+exit:
+    return error;
+}
+
+Error Server::AppendNeighborTlvs(Coap::Message *&aAnswer, AnswerInfo &aInfo)
+{
+    Error       error = kErrorNone;
+    NeighborTlv neighborTlv;
+
+    for (Router &router : Get<RouterTable>())
+    {
+        if (!router.IsStateValid())
+        {
+            continue;
+        }
+
+        neighborTlv.InitFrom(router);
+
+        SuccessOrExit(error = neighborTlv.AppendTo(*aAnswer));
+        SuccessOrExit(error = CheckAnswerLength(aAnswer, aInfo));
+    }
+
+    // Add empty TLV to indicate end of the list
+
+    neighborTlv.InitAsEmpty();
+    SuccessOrExit(error = neighborTlv.AppendTo(*aAnswer));
+
+exit:
+    return error;
+}
+
+Error Server::AppendChildTableIp6AddressList(Coap::Message *&aAnswer, AnswerInfo &aInfo)
+{
+    Error error = kErrorNone;
+    Tlv   tlv;
+
+    for (const Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
+    {
+        SuccessOrExit(error = AppendChildIp6AddressListTlv(*aAnswer, child));
+        SuccessOrExit(error = CheckAnswerLength(aAnswer, aInfo));
+    }
+
+    // Add empty TLV to indicate end of the list
+
+    tlv.SetType(Tlv::kChildIp6AddressList);
+    tlv.SetLength(0);
+    SuccessOrExit(error = aAnswer->Append(tlv));
+
+exit:
+    return error;
+}
+
+Error Server::AppendChildIp6AddressListTlv(Coap::Message &aAnswer, const Child &aChild)
+{
+    Error                       error      = kErrorNone;
+    uint16_t                    numIp6Addr = 0;
+    ChildIp6AddressListTlvValue tlvValue;
+
+    for (const Ip6::Address &address : aChild.IterateIp6Addresses())
+    {
+        OT_UNUSED_VARIABLE(address);
+        numIp6Addr++;
+    }
+
+    VerifyOrExit(numIp6Addr > 0);
+
+    if ((numIp6Addr * sizeof(Ip6::Address) + sizeof(ChildIp6AddressListTlvValue)) <= Tlv::kBaseTlvMaxLength)
+    {
+        Tlv tlv;
+
+        tlv.SetType(Tlv::kChildIp6AddressList);
+        tlv.SetLength(static_cast<uint8_t>(numIp6Addr * sizeof(Ip6::Address) + sizeof(ChildIp6AddressListTlvValue)));
+        SuccessOrExit(error = aAnswer.Append(tlv));
+    }
+    else
+    {
+        ExtendedTlv extTlv;
+
+        extTlv.SetType(Tlv::kChildIp6AddressList);
+        extTlv.SetLength(numIp6Addr * sizeof(Ip6::Address) + sizeof(ChildIp6AddressListTlvValue));
+        SuccessOrExit(error = aAnswer.Append(extTlv));
+    }
+
+    tlvValue.SetRloc16(aChild.GetRloc16());
+
+    SuccessOrExit(error = aAnswer.Append(tlvValue));
+
+    for (const Ip6::Address &address : aChild.IterateIp6Addresses())
+    {
+        SuccessOrExit(error = aAnswer.Append(address));
+    }
+
+exit:
+    return error;
+}
+
+#endif // OPENTHREAD_FTD
 
 template <>
 void Server::HandleTmf<kUriDiagnosticGetRequest>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -496,6 +848,7 @@ exit:
 
 Client::Client(Instance &aInstance)
     : InstanceLocator(aInstance)
+    , mQueryId(Random::NonCrypto::GetUint16())
 {
 }
 
@@ -509,11 +862,12 @@ Error Client::SendDiagnosticGet(const Ip6::Address &aDestination,
 
     if (aDestination.IsMulticast())
     {
-        error = SendCommand(kUriDiagnosticGetQuery, aDestination, aTlvTypes, aCount);
+        error = SendCommand(kUriDiagnosticGetQuery, Message::kPriorityNormal, aDestination, aTlvTypes, aCount);
     }
     else
     {
-        error = SendCommand(kUriDiagnosticGetRequest, aDestination, aTlvTypes, aCount, &HandleGetResponse, this);
+        error = SendCommand(kUriDiagnosticGetRequest, Message::kPriorityNormal, aDestination, aTlvTypes, aCount,
+                            &HandleGetResponse, this);
     }
 
     SuccessOrExit(error);
@@ -525,6 +879,7 @@ exit:
 }
 
 Error Client::SendCommand(Uri                   aUri,
+                          Message::Priority     aPriority,
                           const Ip6::Address   &aDestination,
                           const uint8_t         aTlvTypes[],
                           uint8_t               aCount,
@@ -551,10 +906,16 @@ Error Client::SendCommand(Uri                   aUri,
     }
 
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+    IgnoreError(message->SetPriority(aPriority));
 
     if (aCount > 0)
     {
         SuccessOrExit(error = Tlv::Append<TypeListTlv>(*message, aTlvTypes, aCount));
+    }
+
+    if (aUri == kUriDiagnosticGetQuery)
+    {
+        SuccessOrExit(error = Tlv::Append<QueryIdTlv>(*message, ++mQueryId));
     }
 
     Get<Server>().PrepareMessageInfoForDest(aDestination, messageInfo);
@@ -591,7 +952,13 @@ void Client::HandleTmf<kUriDiagnosticGetAnswer>(Coap::Message &aMessage, const I
     LogInfo("Received %s from %s", ot::UriToString<kUriDiagnosticGetAnswer>(),
             aMessageInfo.GetPeerAddr().ToString().AsCString());
 
-    mGetCallback.InvokeIfSet(kErrorNone, &aMessage, &aMessageInfo);
+#if OPENTHREAD_CONFIG_MESH_DIAG_ENABLE && OPENTHREAD_FTD
+    // Let the `MeshDiag` process the message first.
+    if (!Get<Utils::MeshDiag>().HandleDiagnosticGetAnswer(aMessage, aMessageInfo))
+#endif
+    {
+        mGetCallback.InvokeIfSet(kErrorNone, &aMessage, &aMessageInfo);
+    }
 
     IgnoreError(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
 
@@ -601,7 +968,7 @@ exit:
 
 Error Client::SendDiagnosticReset(const Ip6::Address &aDestination, const uint8_t aTlvTypes[], uint8_t aCount)
 {
-    return SendCommand(kUriDiagnosticReset, aDestination, aTlvTypes, aCount);
+    return SendCommand(kUriDiagnosticReset, Message::kPriorityNormal, aDestination, aTlvTypes, aCount);
 }
 
 static void ParseRoute(const RouteTlv &aRouteTlv, otNetworkDiagRoute &aNetworkDiagRoute)

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -48,6 +48,10 @@
 
 namespace ot {
 
+namespace Utils {
+class MeshDiag;
+}
+
 namespace NetworkDiagnostic {
 
 /**
@@ -144,7 +148,26 @@ public:
 #endif // OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
 
 private:
-    static constexpr uint16_t kMaxChildEntries = 398;
+    static constexpr uint16_t kMaxChildEntries              = 398;
+    static constexpr uint16_t kAnswerMessageLengthThreshold = 800;
+
+#if OPENTHREAD_FTD
+    struct AnswerInfo
+    {
+        AnswerInfo(void)
+            : mAnswerIndex(0)
+            , mQueryId(0)
+            , mHasQueryId(false)
+            , mFirstAnswer(nullptr)
+        {
+        }
+
+        uint16_t       mAnswerIndex;
+        uint16_t       mQueryId;
+        bool           mHasQueryId;
+        Coap::Message *mFirstAnswer;
+    };
+#endif
 
     static const char kVendorName[];
     static const char kVendorModel[];
@@ -153,9 +176,34 @@ private:
     Error AppendDiagTlv(uint8_t aTlvType, Message &aMessage);
     Error AppendIp6AddressList(Message &aMessage);
     Error AppendMacCounters(Message &aMessage);
-    Error AppendChildTable(Message &aMessage);
     Error AppendRequestedTlvs(const Message &aRequest, Message &aResponse);
     void  PrepareMessageInfoForDest(const Ip6::Address &aDestination, Tmf::MessageInfo &aMessageInfo) const;
+
+#if OPENTHREAD_MTD
+    void SendAnswer(const Ip6::Address &aDestination, const Message &aRequest);
+#elif OPENTHREAD_FTD
+    Error       AllocateAnswer(Coap::Message *&aAnswer, AnswerInfo &aInfo);
+    Error       CheckAnswerLength(Coap::Message *&aAnswer, AnswerInfo &aInfo);
+    bool        IsLastAnswer(const Coap::Message &aAnswer) const;
+    void        FreeAllRelatedAnswers(Coap::Message &aFirstAnswer);
+    void        PrepareAndSendAnswers(const Ip6::Address &aDestination, const Message &aRequest);
+    void        SendNextAnswer(Coap::Message &aAnswer, const Ip6::Address &aDestination);
+    Error       AppendChildTable(Message &aMessage);
+    Error       AppendChildTableAsChildTlvs(Coap::Message *&aAnswer, AnswerInfo &aInfo);
+    Error       AppendNeighborTlvs(Coap::Message *&aAnswer, AnswerInfo &aInfo);
+    Error       AppendChildTableIp6AddressList(Coap::Message *&aAnswer, AnswerInfo &aInfo);
+    Error       AppendChildIp6AddressListTlv(Coap::Message &aAnswer, const Child &aChild);
+
+    static void HandleAnswerResponse(void                *aContext,
+                                     otMessage           *aMessage,
+                                     const otMessageInfo *aMessageInfo,
+                                     Error                aResult);
+    void        HandleAnswerResponse(Coap::Message          &aNextAnswer,
+                                     Coap::Message          *aResponse,
+                                     const Ip6::MessageInfo *aMessageInfo,
+                                     Error                   aResult);
+
+#endif
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
@@ -165,6 +213,10 @@ private:
     VendorNameTlv::StringType      mVendorName;
     VendorModelTlv::StringType     mVendorModel;
     VendorSwVersionTlv::StringType mVendorSwVersion;
+#endif
+
+#if OPENTHREAD_FTD
+    Coap::MessageQueue mAnswerQueue;
 #endif
 };
 
@@ -181,6 +233,7 @@ DeclareTmfHandler(Server, kUriDiagnosticGetAnswer);
 class Client : public InstanceLocator, private NonCopyable
 {
     friend class Tmf::Agent;
+    friend class Utils::MeshDiag;
 
 public:
     typedef otNetworkDiagIterator          Iterator;    ///< Iterator to go through TLVs in `GetNextDiagTlv()`.
@@ -239,8 +292,17 @@ public:
      */
     static Error GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator, TlvInfo &aTlvInfo);
 
+    /**
+     * This method returns the query ID used for the last Network Diagnostic Query command.
+     *
+     * @returns The query ID used for last query.
+     *
+     */
+    uint16_t GetLastQueryId(void) const { return mQueryId; }
+
 private:
     Error SendCommand(Uri                   aUri,
+                      Message::Priority     aPriority,
                       const Ip6::Address   &aDestination,
                       const uint8_t         aTlvTypes[],
                       uint8_t               aCount,
@@ -259,6 +321,7 @@ private:
     static const char *UriToString(Uri aUri);
 #endif
 
+    uint16_t              mQueryId;
     Callback<GetCallback> mGetCallback;
 };
 

--- a/src/core/thread/network_diagnostic_tlvs.cpp
+++ b/src/core/thread/network_diagnostic_tlvs.cpp
@@ -40,6 +40,7 @@ namespace NetworkDiagnostic {
 
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;
+using ot::Encoding::BigEndian::HostSwap64;
 
 #if OPENTHREAD_FTD
 
@@ -106,6 +107,47 @@ void AnswerTlv::Init(uint16_t aIndex, bool aIsLast)
     SetLength(sizeof(*this) - sizeof(Tlv));
 
     SetFlagsIndex((aIndex & kIndexMask) | (aIsLast ? kIsLastFlag : 0));
+}
+
+void MleCountersTlv::Init(const Mle::Counters &aMleCounters)
+{
+    SetType(kMleCounters);
+    SetLength(sizeof(*this) - sizeof(Tlv));
+
+    mDisabledRole                  = HostSwap16(aMleCounters.mDisabledRole);
+    mDetachedRole                  = HostSwap16(aMleCounters.mDetachedRole);
+    mChildRole                     = HostSwap16(aMleCounters.mChildRole);
+    mRouterRole                    = HostSwap16(aMleCounters.mRouterRole);
+    mLeaderRole                    = HostSwap16(aMleCounters.mLeaderRole);
+    mAttachAttempts                = HostSwap16(aMleCounters.mAttachAttempts);
+    mPartitionIdChanges            = HostSwap16(aMleCounters.mPartitionIdChanges);
+    mBetterPartitionAttachAttempts = HostSwap16(aMleCounters.mBetterPartitionAttachAttempts);
+    mParentChanges                 = HostSwap16(aMleCounters.mParentChanges);
+    mTrackedTime                   = HostSwap64(aMleCounters.mTrackedTime);
+    mDisabledTime                  = HostSwap64(aMleCounters.mDisabledTime);
+    mDetachedTime                  = HostSwap64(aMleCounters.mDetachedTime);
+    mChildTime                     = HostSwap64(aMleCounters.mChildTime);
+    mRouterTime                    = HostSwap64(aMleCounters.mRouterTime);
+    mLeaderTime                    = HostSwap64(aMleCounters.mLeaderTime);
+}
+
+void MleCountersTlv::Read(MleCounters &aDiagMleCounters) const
+{
+    aDiagMleCounters.mDisabledRole                  = HostSwap16(mDisabledRole);
+    aDiagMleCounters.mDetachedRole                  = HostSwap16(mDetachedRole);
+    aDiagMleCounters.mChildRole                     = HostSwap16(mChildRole);
+    aDiagMleCounters.mRouterRole                    = HostSwap16(mRouterRole);
+    aDiagMleCounters.mLeaderRole                    = HostSwap16(mLeaderRole);
+    aDiagMleCounters.mAttachAttempts                = HostSwap16(mAttachAttempts);
+    aDiagMleCounters.mPartitionIdChanges            = HostSwap16(mPartitionIdChanges);
+    aDiagMleCounters.mBetterPartitionAttachAttempts = HostSwap16(mBetterPartitionAttachAttempts);
+    aDiagMleCounters.mParentChanges                 = HostSwap16(mParentChanges);
+    aDiagMleCounters.mTrackedTime                   = HostSwap64(mTrackedTime);
+    aDiagMleCounters.mDisabledTime                  = HostSwap64(mDisabledTime);
+    aDiagMleCounters.mDetachedTime                  = HostSwap64(mDetachedTime);
+    aDiagMleCounters.mChildTime                     = HostSwap64(mChildTime);
+    aDiagMleCounters.mRouterTime                    = HostSwap64(mRouterTime);
+    aDiagMleCounters.mLeaderTime                    = HostSwap64(mLeaderTime);
 }
 
 } // namespace NetworkDiagnostic

--- a/src/core/thread/network_diagnostic_tlvs.cpp
+++ b/src/core/thread/network_diagnostic_tlvs.cpp
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (c) 2023, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements methods for generating and processing Network Diagnostics TLVs.
+ */
+
+#include "network_diagnostic_tlvs.hpp"
+
+#include "common/time.hpp"
+
+namespace ot {
+namespace NetworkDiagnostic {
+
+using ot::Encoding::BigEndian::HostSwap16;
+using ot::Encoding::BigEndian::HostSwap32;
+
+#if OPENTHREAD_FTD
+
+void ChildTlv::InitFrom(const Child &aChild)
+{
+    Clear();
+
+    SetType(kChild);
+    SetLength(sizeof(*this) - sizeof(Tlv));
+
+    mFlags |= aChild.IsRxOnWhenIdle() ? kFlagsRxOnWhenIdle : 0;
+    mFlags |= aChild.IsFullThreadDevice() ? kFlagsFtd : 0;
+    mFlags |= (aChild.GetNetworkDataType() == NetworkData::kFullSet) ? kFlagsFullNetdta : 0;
+    mFlags |= kFlagsTrackErrRate;
+
+    mRloc16              = HostSwap16(aChild.GetRloc16());
+    mExtAddress          = aChild.GetExtAddress();
+    mVersion             = HostSwap16(aChild.GetVersion());
+    mTimeout             = HostSwap32(aChild.GetTimeout());
+    mAge                 = HostSwap32(Time::MsecToSec(TimerMilli::GetNow() - aChild.GetLastHeard()));
+    mSupervisionInterval = HostSwap16(aChild.GetSupervisionInterval());
+    mLinkMargin          = aChild.GetLinkInfo().GetLinkMargin();
+    mAverageRssi         = aChild.GetLinkInfo().GetAverageRss();
+    mLastRssi            = aChild.GetLinkInfo().GetLastRss();
+    mFrameErrorRate      = HostSwap16(aChild.GetLinkInfo().GetFrameErrorRate());
+    mMessageErrorRate    = HostSwap16(aChild.GetLinkInfo().GetMessageErrorRate());
+    mQueuedMessageCount  = HostSwap16(aChild.GetIndirectMessageCount());
+
+#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+    mFlags |= aChild.IsCslSynchronized() ? kFlagsCslSync : 0;
+    mCslPeriod  = HostSwap16(aChild.GetCslPeriod());
+    mCslTimeout = HostSwap32(aChild.GetCslTimeout());
+    mCslChannel = aChild.GetCslChannel();
+#endif
+}
+
+void NeighborTlv::InitFrom(const Router &aRouter)
+{
+    Clear();
+
+    SetType(kNeighbor);
+    SetLength(sizeof(*this) - sizeof(Tlv));
+
+    mFlags |= aRouter.IsRxOnWhenIdle() ? kFlagsRxOnWhenIdle : 0;
+    mFlags |= aRouter.IsFullThreadDevice() ? kFlagsFtd : 0;
+    mFlags |= (aRouter.GetNetworkDataType() == NetworkData::kFullSet) ? kFlagsFullNetdta : 0;
+    mFlags |= kFlagsTrackErrRate;
+
+    mRloc16           = HostSwap16(aRouter.GetRloc16());
+    mExtAddress       = aRouter.GetExtAddress();
+    mVersion          = HostSwap16(aRouter.GetVersion());
+    mLinkMargin       = aRouter.GetLinkInfo().GetLinkMargin();
+    mAverageRssi      = aRouter.GetLinkInfo().GetAverageRss();
+    mLastRssi         = aRouter.GetLinkInfo().GetLastRss();
+    mFrameErrorRate   = HostSwap16(aRouter.GetLinkInfo().GetFrameErrorRate());
+    mMessageErrorRate = HostSwap16(aRouter.GetLinkInfo().GetMessageErrorRate());
+}
+
+#endif // OPENTHREAD_FTD
+
+void AnswerTlv::Init(uint16_t aIndex, bool aIsLast)
+{
+    SetType(kAnswer);
+    SetLength(sizeof(*this) - sizeof(Tlv));
+
+    SetFlagsIndex((aIndex & kIndexMask) | (aIsLast ? kIsLastFlag : 0));
+}
+
+} // namespace NetworkDiagnostic
+} // namespace ot

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -96,6 +96,7 @@ public:
         kNeighbor            = OT_NETWORK_DIAGNOSTIC_TLV_NEIGHBOR,
         kAnswer              = OT_NETWORK_DIAGNOSTIC_TLV_ANSWER,
         kQueryId             = OT_NETWORK_DIAGNOSTIC_TLV_QUERY_ID,
+        kMleCounters         = OT_NETWORK_DIAGNOSTIC_TLV_MLE_COUNTERS,
     };
 
     /**
@@ -1069,6 +1070,64 @@ private:
     void     SetFlagsIndex(uint16_t aFlagsIndex) { mFlagsIndex = HostSwap16(aFlagsIndex); }
 
     uint16_t mFlagsIndex;
+} OT_TOOL_PACKED_END;
+
+/**
+ * This structure represents the MLE Counters.
+ *
+ */
+typedef otNetworkDiagMleCounters MleCounters;
+
+/**
+ * This class implements MLE Counters TLV generation and parsing.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+class MleCountersTlv : public Tlv, public TlvInfo<Tlv::kMleCounters>
+{
+public:
+    /**
+     * This method initializes the TLV.
+     *
+     * @param[in] aMleCounter    The MLE counters to initialize the TLV with.
+     *
+     */
+    void Init(const Mle::Counters &aMleCounters);
+
+    /**
+     * This method indicates whether or not the TLV appears to be well-formed.
+     *
+     * @retval TRUE   If the TLV appears to be well-formed.
+     * @retval FALSE  If the TLV does not appear to be well-formed.
+     *
+     */
+    bool IsValid(void) const { return GetLength() >= sizeof(*this) - sizeof(Tlv); }
+
+    /**
+     *
+     * This method reads the counters from TLV.
+     *
+     * @param[out] aDiagMleCounters   A reference to `NetworkDiagnostic::MleCounters` to populate.
+     *
+     */
+    void Read(MleCounters &aDiagMleCounters) const;
+
+private:
+    uint16_t mDisabledRole;                  // Number of times device entered disabled role.
+    uint16_t mDetachedRole;                  // Number of times device entered detached role.
+    uint16_t mChildRole;                     // Number of times device entered child role.
+    uint16_t mRouterRole;                    // Number of times device entered router role.
+    uint16_t mLeaderRole;                    // Number of times device entered leader role.
+    uint16_t mAttachAttempts;                // Number of attach attempts while device was detached.
+    uint16_t mPartitionIdChanges;            // Number of changes to partition ID.
+    uint16_t mBetterPartitionAttachAttempts; // Number of attempts to attach to a better partition.
+    uint16_t mParentChanges;                 // Number of time device changed its parent.
+    uint64_t mTrackedTime;                   // Milliseconds tracked by next counters.
+    uint64_t mDisabledTime;                  // Milliseconds device has been in disabled role.
+    uint64_t mDetachedTime;                  // Milliseconds device has been in detached role.
+    uint64_t mChildTime;                     // Milliseconds device has been in child role.
+    uint64_t mRouterTime;                    // Milliseconds device has been in router role.
+    uint64_t mLeaderTime;                    // Milliseconds device has been in leader role.
 } OT_TOOL_PACKED_END;
 
 } // namespace NetworkDiagnostic

--- a/src/core/utils/mesh_diag.cpp
+++ b/src/core/utils/mesh_diag.cpp
@@ -45,7 +45,7 @@
 namespace ot {
 namespace Utils {
 
-using namespace ot::NetworkDiagnostic;
+using namespace NetworkDiagnostic;
 
 RegisterLogModule("MeshDiag");
 
@@ -54,54 +54,23 @@ RegisterLogModule("MeshDiag");
 
 MeshDiag::MeshDiag(Instance &aInstance)
     : InstanceLocator(aInstance)
+    , mState(kStateIdle)
+    , mExpectedQueryId(0)
+    , mExpectedAnswerIndex(0)
     , mTimer(aInstance)
 {
 }
 
 Error MeshDiag::DiscoverTopology(const DiscoverConfig &aConfig, DiscoverCallback aCallback, void *aContext)
 {
-    Error error = kErrorNone;
-
-    VerifyOrExit(Get<Mle::Mle>().IsAttached(), error = kErrorInvalidState);
-    VerifyOrExit(!mTimer.IsRunning(), error = kErrorBusy);
-
-    Get<RouterTable>().GetRouterIdSet(mExpectedRouterIdSet);
-
-    for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
-    {
-        if (mExpectedRouterIdSet.Contains(routerId))
-        {
-            SuccessOrExit(error = SendDiagGetTo(Mle::Rloc16FromRouterId(routerId), aConfig));
-        }
-    }
-
-    mDiscoverCallback.Set(aCallback, aContext);
-    mTimer.Start(kResponseTimeout);
-
-exit:
-    return error;
-}
-
-void MeshDiag::Cancel(void)
-{
-    mTimer.Stop();
-    IgnoreError(Get<Tmf::Agent>().AbortTransaction(HandleDiagGetResponse, this));
-}
-
-Error MeshDiag::SendDiagGetTo(uint16_t aRloc16, const DiscoverConfig &aConfig)
-{
     static constexpr uint8_t kMaxTlvsToRequest = 6;
 
-    Error            error   = kErrorNone;
-    Coap::Message   *message = nullptr;
-    Tmf::MessageInfo messageInfo(GetInstance());
-    uint8_t          tlvs[kMaxTlvsToRequest];
-    uint8_t          tlvsLength = 0;
+    Error   error = kErrorNone;
+    uint8_t tlvs[kMaxTlvsToRequest];
+    uint8_t tlvsLength = 0;
 
-    message = Get<Tmf::Agent>().NewConfirmablePostMessage(kUriDiagnosticGetRequest);
-    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
-
-    IgnoreError(message->SetPriority(Message::kPriorityLow));
+    VerifyOrExit(Get<Mle::Mle>().IsAttached(), error = kErrorInvalidState);
+    VerifyOrExit(mState == kStateIdle, error = kErrorBusy);
 
     tlvs[tlvsLength++] = Address16Tlv::kType;
     tlvs[tlvsLength++] = ExtMacAddressTlv::kType;
@@ -118,13 +87,29 @@ Error MeshDiag::SendDiagGetTo(uint16_t aRloc16, const DiscoverConfig &aConfig)
         tlvs[tlvsLength++] = ChildTableTlv::kType;
     }
 
-    SuccessOrExit(error = Tlv::Append<TypeListTlv>(*message, tlvs, tlvsLength));
+    Get<RouterTable>().GetRouterIdSet(mDiscover.mExpectedRouterIdSet);
 
-    messageInfo.SetSockAddrToRlocPeerAddrTo(aRloc16);
-    error = Get<Tmf::Agent>().SendMessage(*message, messageInfo, HandleDiagGetResponse, this);
+    for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
+    {
+        Ip6::Address destination;
+
+        if (!mDiscover.mExpectedRouterIdSet.Contains(routerId))
+        {
+            continue;
+        }
+
+        destination = Get<Mle::MleRouter>().GetMeshLocal16();
+        destination.GetIid().SetLocator(Mle::Rloc16FromRouterId(routerId));
+
+        SuccessOrExit(error = Get<Client>().SendCommand(kUriDiagnosticGetRequest, Message::kPriorityLow, destination,
+                                                        tlvs, tlvsLength, HandleDiagGetResponse, this));
+    }
+
+    mDiscover.mCallback.Set(aCallback, aContext);
+    mState = kStateDicoverTopology;
+    mTimer.Start(kResponseTimeout);
 
 exit:
-    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -147,7 +132,8 @@ void MeshDiag::HandleDiagGetResponse(Coap::Message *aMessage, const Ip6::Message
     ChildIterator   childIterator;
 
     SuccessOrExit(aResult);
-    VerifyOrExit((aMessage != nullptr) && mTimer.IsRunning());
+    VerifyOrExit(aMessage != nullptr);
+    VerifyOrExit(mState == kStateDicoverTopology);
 
     SuccessOrExit(routerInfo.ParseFrom(*aMessage));
 
@@ -161,11 +147,12 @@ void MeshDiag::HandleDiagGetResponse(Coap::Message *aMessage, const Ip6::Message
         routerInfo.mChildIterator = &childIterator;
     }
 
-    mExpectedRouterIdSet.Remove(routerInfo.mRouterId);
+    mDiscover.mExpectedRouterIdSet.Remove(routerInfo.mRouterId);
 
-    if (mExpectedRouterIdSet.GetNumberOfAllocatedIds() == 0)
+    if (mDiscover.mExpectedRouterIdSet.GetNumberOfAllocatedIds() == 0)
     {
-        error = kErrorNone;
+        error  = kErrorNone;
+        mState = kStateIdle;
         mTimer.Stop();
     }
     else
@@ -173,20 +160,353 @@ void MeshDiag::HandleDiagGetResponse(Coap::Message *aMessage, const Ip6::Message
         error = kErrorPending;
     }
 
-    mDiscoverCallback.InvokeIfSet(error, &routerInfo);
+    mDiscover.mCallback.InvokeIfSet(error, &routerInfo);
 
 exit:
     return;
 }
 
-void MeshDiag::HandleTimer(void)
+Error MeshDiag::SendQuery(uint16_t aRloc16, const uint8_t *aTlvs, uint8_t aTlvsLength)
 {
-    // Timed out waiting for response from one or more routers.
+    Error        error = kErrorNone;
+    Ip6::Address destination;
 
-    IgnoreError(Get<Tmf::Agent>().AbortTransaction(HandleDiagGetResponse, this));
+    VerifyOrExit(Get<Mle::Mle>().IsAttached(), error = kErrorInvalidState);
+    VerifyOrExit(mState == kStateIdle, error = kErrorBusy);
+    VerifyOrExit(Mle::IsActiveRouter(aRloc16), error = kErrorInvalidArgs);
+    VerifyOrExit(Get<RouterTable>().IsAllocated(Mle::RouterIdFromRloc16(aRloc16)), error = kErrorNotFound);
 
-    mDiscoverCallback.InvokeIfSet(kErrorResponseTimeout, nullptr);
+    destination = Get<Mle::MleRouter>().GetMeshLocal16();
+    destination.GetIid().SetLocator(aRloc16);
+
+    SuccessOrExit(error = Get<Client>().SendCommand(kUriDiagnosticGetQuery, Message::kPriorityNormal, destination,
+                                                    aTlvs, aTlvsLength));
+
+    mExpectedQueryId     = Get<Client>().GetLastQueryId();
+    mExpectedAnswerIndex = 0;
+
+    mTimer.Start(kResponseTimeout);
+
+exit:
+    return error;
 }
+
+Error MeshDiag::QueryChildTable(uint16_t aRloc16, QueryChildTableCallback aCallback, void *aContext)
+{
+    static const uint8_t kTlvTypes[] = {ChildTlv::kType};
+
+    Error error;
+
+    SuccessOrExit(error = SendQuery(aRloc16, kTlvTypes, sizeof(kTlvTypes)));
+
+    mQueryChildTable.mCallback.Set(aCallback, aContext);
+    mQueryChildTable.mRouterRloc16 = aRloc16;
+    mState                         = kStateQueryChildTable;
+
+exit:
+    return error;
+}
+
+Error MeshDiag::QueryChildrenIp6Addrs(uint16_t aRloc16, ChildIp6AddrsCallback aCallback, void *aContext)
+{
+    static const uint8_t kTlvTypes[] = {ChildIp6AddressListTlv::kType};
+
+    Error error;
+
+    SuccessOrExit(error = SendQuery(aRloc16, kTlvTypes, sizeof(kTlvTypes)));
+
+    mQueryChildrenIp6Addrs.mCallback.Set(aCallback, aContext);
+    mQueryChildrenIp6Addrs.mParentRloc16 = aRloc16;
+    mState                               = kStateQueryChildrenIp6Addrs;
+
+exit:
+    return error;
+}
+
+Error MeshDiag::QueryNeighborTable(uint16_t aRloc16, NeighborTableCallback aCallback, void *aContext)
+{
+    static const uint8_t kTlvTypes[] = {NeighborTlv::kType};
+
+    Error error;
+
+    SuccessOrExit(error = SendQuery(aRloc16, kTlvTypes, sizeof(kTlvTypes)));
+
+    mQueryNeighborTable.mCallback.Set(aCallback, aContext);
+    mQueryNeighborTable.mRouterRloc16 = aRloc16;
+    mState                            = kStateQueryNeighborTable;
+
+exit:
+    return error;
+}
+
+bool MeshDiag::HandleDiagnosticGetAnswer(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+{
+    bool didPorcess = false;
+
+    switch (mState)
+    {
+    case kStateQueryChildTable:
+        didPorcess = ProcessChildTableAnswer(aMessage, aMessageInfo);
+        break;
+
+    case kStateQueryChildrenIp6Addrs:
+        didPorcess = ProcessChildrenIp6AddrsAnswer(aMessage, aMessageInfo);
+        break;
+
+    case kStateQueryNeighborTable:
+        didPorcess = ProcessNeighborTableAnswer(aMessage, aMessageInfo);
+        break;
+
+    default:
+        break;
+    }
+
+    return didPorcess;
+}
+
+Error MeshDiag::ProcessMessage(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, uint16_t aSenderRloc16)
+{
+    // This method processes the received answer message to
+    // check whether it is from the intended sender and matches
+    // the expected query ID and answer index.
+
+    Error     error = kErrorFailed;
+    AnswerTlv answerTlv;
+    uint16_t  queryId;
+
+    VerifyOrExit(Get<Mle::Mle>().IsRoutingLocator(aMessageInfo.GetPeerAddr()));
+    VerifyOrExit(aMessageInfo.GetPeerAddr().GetIid().GetLocator() == aSenderRloc16);
+
+    SuccessOrExit(Tlv::Find<QueryIdTlv>(aMessage, queryId));
+    VerifyOrExit(queryId == mExpectedQueryId);
+
+    SuccessOrExit(Tlv::FindTlv(aMessage, answerTlv));
+
+    if (answerTlv.GetIndex() != mExpectedAnswerIndex)
+    {
+        Finalize(kErrorResponseTimeout);
+        ExitNow();
+    }
+
+    mExpectedAnswerIndex++;
+    error = kErrorNone;
+
+exit:
+    return error;
+}
+
+bool MeshDiag::ProcessChildTableAnswer(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+{
+    bool       didPorcess = false;
+    ChildTlv   childTlv;
+    ChildEntry entry;
+    uint16_t   offset;
+
+    SuccessOrExit(ProcessMessage(aMessage, aMessageInfo, mQueryChildTable.mRouterRloc16));
+
+    while (true)
+    {
+        SuccessOrExit(Tlv::FindTlvOffset(aMessage, ChildTlv::kType, offset));
+
+        IgnoreError(aMessage.Read(offset, &childTlv, sizeof(Tlv)));
+        VerifyOrExit(!childTlv.IsExtended());
+
+        didPorcess = true;
+
+        if (childTlv.GetLength() == 0)
+        {
+            // We reached end of the list.
+            mState = kStateIdle;
+            mTimer.Stop();
+            mQueryChildTable.mCallback.InvokeIfSet(kErrorNone, nullptr);
+            ExitNow();
+        }
+
+        VerifyOrExit(childTlv.GetLength() >= sizeof(ChildTlv) - sizeof(Tlv));
+        IgnoreError(aMessage.Read(offset, childTlv));
+
+        entry.SetFrom(childTlv);
+        mQueryChildTable.mCallback.InvokeIfSet(kErrorPending, &entry);
+
+        // Make sure query operation is not canceled from the
+        // callback.
+        VerifyOrExit(mState == kStateQueryChildTable);
+
+        aMessage.SetOffset(static_cast<uint16_t>(offset + childTlv.GetSize()));
+    }
+
+exit:
+    return didPorcess;
+}
+
+bool MeshDiag::ProcessNeighborTableAnswer(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+{
+    bool          didPorcess = false;
+    NeighborTlv   neighborTlv;
+    NeighborEntry entry;
+    uint16_t      offset;
+
+    SuccessOrExit(ProcessMessage(aMessage, aMessageInfo, mQueryNeighborTable.mRouterRloc16));
+
+    while (true)
+    {
+        SuccessOrExit(Tlv::FindTlvOffset(aMessage, NeighborTlv::kType, offset));
+
+        IgnoreError(aMessage.Read(offset, &neighborTlv, sizeof(Tlv)));
+        VerifyOrExit(!neighborTlv.IsExtended());
+
+        didPorcess = true;
+
+        if (neighborTlv.GetLength() == 0)
+        {
+            // We reached end of the list.
+            mState = kStateIdle;
+            mTimer.Stop();
+            mQueryNeighborTable.mCallback.InvokeIfSet(kErrorNone, nullptr);
+            ExitNow();
+        }
+
+        VerifyOrExit(neighborTlv.GetLength() >= sizeof(NeighborTlv) - sizeof(Tlv));
+        IgnoreError(aMessage.Read(offset, neighborTlv));
+
+        entry.SetFrom(neighborTlv);
+        mQueryNeighborTable.mCallback.InvokeIfSet(kErrorPending, &entry);
+
+        // Make sure query operation is not canceled from the
+        // callback.
+        VerifyOrExit(mState == kStateQueryNeighborTable);
+
+        aMessage.SetOffset(static_cast<uint16_t>(offset + neighborTlv.GetSize()));
+    }
+
+exit:
+    return didPorcess;
+}
+
+bool MeshDiag::ProcessChildrenIp6AddrsAnswer(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+{
+    bool                        didPorcess = false;
+    uint16_t                    offset;
+    uint16_t                    endOffset;
+    ChildIp6AddressListTlvValue tlvValue;
+    Ip6AddrIterator             ip6AddrIterator;
+    union
+    {
+        Tlv         tlv;
+        ExtendedTlv extTlv;
+    };
+
+    SuccessOrExit(ProcessMessage(aMessage, aMessageInfo, mQueryChildrenIp6Addrs.mParentRloc16));
+
+    while (true)
+    {
+        SuccessOrExit(Tlv::FindTlvOffset(aMessage, ChildIp6AddressListTlv::kType, offset));
+
+        SuccessOrExit(aMessage.Read(offset, tlv));
+
+        if (tlv.IsExtended())
+        {
+            SuccessOrExit(aMessage.Read(offset, extTlv));
+            VerifyOrExit(offset + extTlv.GetSize() <= aMessage.GetLength());
+
+            offset += sizeof(extTlv);
+            endOffset = offset + extTlv.GetLength();
+        }
+        else
+        {
+            VerifyOrExit(offset + tlv.GetSize() <= aMessage.GetLength());
+
+            offset += sizeof(Tlv);
+            endOffset = offset + tlv.GetLength();
+        }
+
+        didPorcess = true;
+
+        if (offset == endOffset)
+        {
+            // We reached end of the list
+            mState = kStateIdle;
+            mTimer.Stop();
+            mQueryChildrenIp6Addrs.mCallback.InvokeIfSet(kErrorNone, Mle::kInvalidRloc16, nullptr);
+            ExitNow();
+        }
+
+        // Read the `ChildIp6AddressListTlvValue` (which contains the
+        // child RLOC16) and then prepare the `Ip6AddrIterator`.
+
+        VerifyOrExit(offset + sizeof(tlvValue) <= endOffset);
+        IgnoreError(aMessage.Read(offset, tlvValue));
+        offset += sizeof(tlvValue);
+
+        ip6AddrIterator.mMessage   = &aMessage;
+        ip6AddrIterator.mCurOffset = offset;
+        ip6AddrIterator.mEndOffset = endOffset;
+
+        mQueryChildrenIp6Addrs.mCallback.InvokeIfSet(kErrorPending, tlvValue.GetRloc16(), &ip6AddrIterator);
+
+        // Make sure query operation is not canceled from the
+        // callback.
+        VerifyOrExit(mState == kStateQueryChildrenIp6Addrs);
+
+        aMessage.SetOffset(endOffset);
+    }
+
+exit:
+    return didPorcess;
+}
+
+void MeshDiag::Cancel(void)
+{
+    switch (mState)
+    {
+    case kStateIdle:
+    case kStateQueryChildTable:
+    case kStateQueryChildrenIp6Addrs:
+    case kStateQueryNeighborTable:
+        break;
+
+    case kStateDicoverTopology:
+        IgnoreError(Get<Tmf::Agent>().AbortTransaction(HandleDiagGetResponse, this));
+        break;
+    }
+
+    mState = kStateIdle;
+    mTimer.Stop();
+}
+
+void MeshDiag::Finalize(Error aError)
+{
+    // Finalize an ongoing query operation (if any) invoking
+    // the corresponding callback with `aError`.
+
+    State oldState = mState;
+
+    Cancel();
+
+    switch (oldState)
+    {
+    case kStateIdle:
+        break;
+
+    case kStateDicoverTopology:
+        mDiscover.mCallback.InvokeIfSet(aError, nullptr);
+        break;
+
+    case kStateQueryChildTable:
+        mQueryChildTable.mCallback.InvokeIfSet(aError, nullptr);
+        break;
+
+    case kStateQueryChildrenIp6Addrs:
+        mQueryChildrenIp6Addrs.mCallback.InvokeIfSet(aError, Mle::kInvalidRloc16, nullptr);
+        break;
+
+    case kStateQueryNeighborTable:
+        mQueryNeighborTable.mCallback.InvokeIfSet(aError, nullptr);
+        break;
+    }
+}
+
+void MeshDiag::HandleTimer(void) { Finalize(kErrorResponseTimeout); }
 
 //---------------------------------------------------------------------------------------------------------------------
 // MeshDiag::RouterInfo
@@ -301,6 +621,52 @@ Error MeshDiag::ChildIterator::GetNextChildInfo(ChildInfo &aChildInfo)
 
 exit:
     return error;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+// MeshDiag::ChildEntry
+
+void MeshDiag::ChildEntry::SetFrom(const ChildTlv &aChildTlv)
+{
+    mRxOnWhenIdle        = (aChildTlv.GetFlags() & ChildTlv::kFlagsRxOnWhenIdle);
+    mDeviceTypeFtd       = (aChildTlv.GetFlags() & ChildTlv::kFlagsFtd);
+    mFullNetData         = (aChildTlv.GetFlags() & ChildTlv::kFlagsFullNetdta);
+    mCslSynchronized     = (aChildTlv.GetFlags() & ChildTlv::kFlagsCslSync);
+    mSupportsErrRate     = (aChildTlv.GetFlags() & ChildTlv::kFlagsTrackErrRate);
+    mRloc16              = aChildTlv.GetRloc16();
+    mExtAddress          = aChildTlv.GetExtAddress();
+    mVersion             = aChildTlv.GetVersion();
+    mTimeout             = aChildTlv.GetTimeout();
+    mAge                 = aChildTlv.GetAge();
+    mSupervisionInterval = aChildTlv.GetSupervisionInterval();
+    mLinkMargin          = aChildTlv.GetLinkMargin();
+    mAverageRssi         = aChildTlv.GetAverageRssi();
+    mLastRssi            = aChildTlv.GetLastRssi();
+    mFrameErrorRate      = aChildTlv.GetFrameErrorRate();
+    mMessageErrorRate    = aChildTlv.GetMessageErrorRate();
+    mQueuedMessageCount  = aChildTlv.GetQueuedMessageCount();
+    mCslPeriod           = aChildTlv.GetCslPeriod();
+    mCslTimeout          = aChildTlv.GetCslTimeout();
+    mCslChannel          = aChildTlv.GetCslChannel();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+// MeshDiag::NeighborEntry
+
+void MeshDiag::NeighborEntry::SetFrom(const NeighborTlv &aTlv)
+{
+    mRxOnWhenIdle     = (aTlv.GetFlags() & NeighborTlv::kFlagsRxOnWhenIdle);
+    mDeviceTypeFtd    = (aTlv.GetFlags() & NeighborTlv::kFlagsFtd);
+    mFullNetData      = (aTlv.GetFlags() & NeighborTlv::kFlagsFullNetdta);
+    mSupportsErrRate  = (aTlv.GetFlags() & NeighborTlv::kFlagsTrackErrRate);
+    mRloc16           = aTlv.GetRloc16();
+    mExtAddress       = aTlv.GetExtAddress();
+    mVersion          = aTlv.GetVersion();
+    mLinkMargin       = aTlv.GetLinkMargin();
+    mAverageRssi      = aTlv.GetAverageRssi();
+    mLastRssi         = aTlv.GetLastRssi();
+    mFrameErrorRate   = aTlv.GetFrameErrorRate();
+    mMessageErrorRate = aTlv.GetMessageErrorRate();
 }
 
 } // namespace Utils

--- a/src/core/utils/mesh_diag.hpp
+++ b/src/core/utils/mesh_diag.hpp
@@ -38,6 +38,10 @@
 
 #if OPENTHREAD_CONFIG_MESH_DIAG_ENABLE && OPENTHREAD_FTD
 
+#if !OPENTHREAD_CONFIG_TMF_NETDIAG_CLIENT_ENABLE
+#error "OPENTHREAD_CONFIG_MESH_DIAG_ENABLE requires OPENTHREAD_CONFIG_TMF_NETDIAG_CLIENT_ENABLE"
+#endif
+
 #include <openthread/mesh_diag.h>
 
 #include "coap/coap.hpp"
@@ -46,6 +50,7 @@
 #include "common/message.hpp"
 #include "common/timer.hpp"
 #include "net/ip6_address.hpp"
+#include "thread/network_diagnostic.hpp"
 #include "thread/network_diagnostic_tlvs.hpp"
 
 struct otMeshDiagIp6AddrIterator
@@ -65,14 +70,19 @@ namespace Utils {
  */
 class MeshDiag : public InstanceLocator
 {
+    friend class ot::NetworkDiagnostic::Client;
+
 public:
     static constexpr uint16_t kVersionUnknown = OT_MESH_DIAG_VERSION_UNKNOWN; ///< Unknown version.
 
-    typedef otMeshDiagDiscoverConfig   DiscoverConfig;   ///< The discovery configuration.
-    typedef otMeshDiagDiscoverCallback DiscoverCallback; ///< The discovery callback function pointer type.
+    typedef otMeshDiagDiscoverConfig             DiscoverConfig;          ///< Discovery configuration.
+    typedef otMeshDiagDiscoverCallback           DiscoverCallback;        ///< Discovery callback.
+    typedef otMeshDiagQueryChildTableCallback    QueryChildTableCallback; ///< Query Child Table callback.
+    typedef otMeshDiagChildIp6AddrsCallback      ChildIp6AddrsCallback;   ///< Child IPv6 addresses callback.
+    typedef otMeshDiagQueryNeighborTableCallback NeighborTableCallback;   ///< Neighbor Route table callback.
 
     /**
-     * This type represents an iterator to go over list of IPv6 addresses of a router.
+     * This type represents an iterator to go over list of IPv6 addresses of a router or an MTD child.
      *
      */
     class Ip6AddrIterator : public otMeshDiagIp6AddrIterator
@@ -164,7 +174,7 @@ public:
      * @param[in] aContext         A context to pass in @p aCallback.
      *
      * @retval kErrorNone          The network topology discovery started successfully.
-     * @retval kErrorBusy          A previous discovery request is still ongoing.
+     * @retval kErrorBusy          A previous discovery or query request is still ongoing.
      * @retval kErrorInvalidState  Device is not attached.
      * @retval kErrorNoBufs        Could not allocate buffer to send discovery messages.
      *
@@ -172,9 +182,58 @@ public:
     Error DiscoverTopology(const DiscoverConfig &aConfig, DiscoverCallback aCallback, void *aContext);
 
     /**
-     * This method cancels an ongoing topology discovery if there one, otherwise no action.
+     * This method starts query for child table for a given router.
      *
-     * When ongoing discovery is cancelled, the callback from `DiscoverTopology()` will not be called anymore.
+     * @param[in] aRouter16        The RLOC16 of router to query.
+     * @param[in] aCallback        The callback to report the queried child table.
+     * @param[in] aContext         A context to pass in @p aCallback.
+     *
+     * @retval kErrorNone          The query started successfully.
+     * @retval kErrorBusy          A previous discovery or query request is still ongoing.
+     * @retval kErrorInvalidArgs   The @p aRloc16 is not a valid router RLOC16.
+     * @retval kErrorInvalidState  Device is not attached.
+     * @retval kErrorNoBufs        Could not allocate buffer to send query messages.
+     *
+     */
+    Error QueryChildTable(uint16_t aRloc16, QueryChildTableCallback aCallback, void *aContext);
+
+    /**
+     * This method sends a query to a parent to retrieve the IPv6 addresses of all its MTD children.
+     *
+     * @param[in] aRouter16        The RLOC16 of parent to query.
+     * @param[in] aCallback        The callback to report the queried child IPv6 address list.
+     * @param[in] aContext         A context to pass in @p aCallback.
+     *
+     * @retval kErrorNone          The query started successfully.
+     * @retval kErrorBusy          A previous discovery or query request is still ongoing.
+     * @retval kErrorInvalidArgs   The @p aRloc16 is not a valid  RLOC16.
+     * @retval kErrorInvalidState  Device is not attached.
+     * @retval kErrorNoBufs        Could not allocate buffer to send query messages.
+     *
+     */
+    Error QueryChildrenIp6Addrs(uint16_t aRloc16, ChildIp6AddrsCallback aCallback, void *aContext);
+
+    /**
+     * This method starts query for router neighbor table for a given router.
+     *
+     * @param[in] aRouter16        The RLOC16 of router to query.
+     * @param[in] aCallback        The callback to report the queried table.
+     * @param[in] aContext         A context to pass in @p aCallback.
+     *
+     * @retval kErrorNone          The query started successfully.
+     * @retval kErrorBusy          A previous discovery or query request is still ongoing.
+     * @retval kErrorInvalidArgs   The @p aRloc16 is not a valid router RLOC16.
+     * @retval kErrorInvalidState  Device is not attached.
+     * @retval kErrorNoBufs        Could not allocate buffer to send query messages.
+     *
+     */
+    Error QueryNeighborTable(uint16_t aRloc16, NeighborTableCallback aCallback, void *aContext);
+
+    /**
+     * This method cancels an ongoing discovery or query operation if there one, otherwise no action.
+     *
+     * When ongoing discovery is cancelled, the callback from `DiscoverTopology()` or  `QueryChildTable()` will not be
+     * called anymore.
      *
      */
     void Cancel(void);
@@ -184,9 +243,65 @@ private:
 
     static constexpr uint32_t kResponseTimeout = OPENTHREAD_CONFIG_MESH_DIAG_RESPONSE_TIMEOUT;
 
-    Error SendDiagGetTo(uint16_t aRloc16, const DiscoverConfig &aConfig);
+    enum State : uint8_t
+    {
+        kStateIdle,
+        kStateDicoverTopology,
+        kStateQueryChildTable,
+        kStateQueryChildrenIp6Addrs,
+        kStateQueryNeighborTable,
+    };
+
+    struct DiscoverInfo
+    {
+        Callback<DiscoverCallback> mCallback;
+        Mle::RouterIdSet           mExpectedRouterIdSet;
+    };
+
+    struct QueryChildTableInfo
+    {
+        Callback<QueryChildTableCallback> mCallback;
+        uint16_t                          mRouterRloc16;
+    };
+
+    struct QueryChildrenIp6AddrsInfo
+    {
+        Callback<ChildIp6AddrsCallback> mCallback;
+        uint16_t                        mParentRloc16;
+    };
+
+    struct QueryNeighborTableInfo
+    {
+        Callback<NeighborTableCallback> mCallback;
+        uint16_t                        mRouterRloc16;
+    };
+
+    class ChildEntry : public otMeshDiagChildEntry
+    {
+        friend class MeshDiag;
+
+    private:
+        void SetFrom(const NetworkDiagnostic::ChildTlv &aChildTlv);
+    };
+
+    class NeighborEntry : public otMeshDiagNeighborEntry
+    {
+        friend class MeshDiag;
+
+    private:
+        void SetFrom(const NetworkDiagnostic::NeighborTlv &aTlv);
+    };
+
+    Error SendQuery(uint16_t aRloc16, const uint8_t *aTlvs, uint8_t aTlvsLength);
+    void  Finalize(Error aError);
     void  HandleTimer(void);
-    void  HandleDiagGetResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
+    bool  HandleDiagnosticGetAnswer(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    Error ProcessMessage(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, uint16_t aSenderRloc16);
+    bool  ProcessChildTableAnswer(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    bool  ProcessChildrenIp6AddrsAnswer(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    bool  ProcessNeighborTableAnswer(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+
+    void HandleDiagGetResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
 
     static void HandleDiagGetResponse(void                *aContext,
                                       otMessage           *aMessage,
@@ -195,9 +310,18 @@ private:
 
     using TimeoutTimer = TimerMilliIn<MeshDiag, &MeshDiag::HandleTimer>;
 
-    Callback<DiscoverCallback> mDiscoverCallback;
-    Mle::RouterIdSet           mExpectedRouterIdSet;
-    TimeoutTimer               mTimer;
+    State        mState;
+    uint16_t     mExpectedQueryId;
+    uint16_t     mExpectedAnswerIndex;
+    TimeoutTimer mTimer;
+
+    union
+    {
+        DiscoverInfo              mDiscover;
+        QueryChildTableInfo       mQueryChildTable;
+        QueryChildrenIp6AddrsInfo mQueryChildrenIp6Addrs;
+        QueryNeighborTableInfo    mQueryNeighborTable;
+    };
 };
 
 } // namespace Utils

--- a/tests/scripts/thread-cert/Cert_5_7_02_CoapDiagCommands.py
+++ b/tests/scripts/thread-cert/Cert_5_7_02_CoapDiagCommands.py
@@ -250,7 +250,7 @@ class Cert_5_7_02_CoapDiagCommands(thread_cert.TestCase):
         pkts.filter_wpan_src64(LEADER).\
             filter_ipv6_dst(DUT_RLOC).\
             filter_coap_request(DIAG_GET_URI).\
-            filter(lambda p: dut_payload_tlvs == set(p.thread_diagnostic.tlv.type)).\
+            filter(lambda p: dut_payload_tlvs <= set(p.thread_diagnostic.tlv.type)).\
             must_next()
         dut_payload_tlvs.remove(DG_TYPE_LIST_TLV)
         dut_payload_tlvs.remove(DG_ROUTE64_TLV)
@@ -277,7 +277,7 @@ class Cert_5_7_02_CoapDiagCommands(thread_cert.TestCase):
             filter(lambda p: {
                               DG_TYPE_LIST_TLV,
                               DG_MAC_COUNTERS_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
         pkts.filter_wpan_src64(DUT).\
@@ -285,7 +285,7 @@ class Cert_5_7_02_CoapDiagCommands(thread_cert.TestCase):
             filter_coap_ack(DIAG_GET_URI).\
             filter(lambda p: {
                               DG_MAC_COUNTERS_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
 
@@ -304,7 +304,7 @@ class Cert_5_7_02_CoapDiagCommands(thread_cert.TestCase):
                               DG_TYPE_LIST_TLV,
                               DG_TIMEOUT_TLV,
                               DG_CHILD_TABLE_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
         pkts.filter_wpan_src64(DUT).\
@@ -327,7 +327,7 @@ class Cert_5_7_02_CoapDiagCommands(thread_cert.TestCase):
                               DG_TYPE_LIST_TLV,
                               DG_BATTERY_LEVEL_TLV,
                               DG_SUPPLY_VOLTAGE_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
         pkts.filter_wpan_src64(DUT).\
@@ -347,7 +347,7 @@ class Cert_5_7_02_CoapDiagCommands(thread_cert.TestCase):
             filter(lambda p: {
                               DG_TYPE_LIST_TLV,
                               DG_MAC_COUNTERS_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
         pkts.filter_wpan_src64(DUT).\
@@ -370,7 +370,7 @@ class Cert_5_7_02_CoapDiagCommands(thread_cert.TestCase):
             filter(lambda p: {
                               DG_TYPE_LIST_TLV,
                               DG_MAC_COUNTERS_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
         pkts.filter_wpan_src64(DUT).\
@@ -378,7 +378,7 @@ class Cert_5_7_02_CoapDiagCommands(thread_cert.TestCase):
             filter_coap_ack(DIAG_GET_URI).\
             filter(lambda p: {
                               DG_MAC_COUNTERS_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
 
@@ -401,7 +401,7 @@ class Cert_5_7_02_CoapDiagCommands(thread_cert.TestCase):
         pkts.filter_wpan_src64(LEADER).\
             filter_ipv6_dst(REALM_LOCAL_All_THREAD_NODES_MULTICAST_ADDRESS).\
             filter_coap_request(DIAG_GET_QRY_URI).\
-            filter(lambda p: dut_payload_tlvs == set(p.thread_diagnostic.tlv.type)).\
+            filter(lambda p: dut_payload_tlvs <= set(p.thread_diagnostic.tlv.type)).\
             must_next()
 
         dut_payload_tlvs.remove(DG_TYPE_LIST_TLV)

--- a/tests/scripts/thread-cert/Cert_5_7_03_CoapDiagCommands.py
+++ b/tests/scripts/thread-cert/Cert_5_7_03_CoapDiagCommands.py
@@ -189,7 +189,7 @@ class Cert_5_7_03_CoapDiagCommands_Base(thread_cert.TestCase):
         }
         if self.TOPOLOGY[ROUTER1]['name'] == 'DUT':
             dut_payload_tlvs.update({DG_CONNECTIVITY_TLV, DG_ROUTE64_TLV, DG_CHILD_TABLE_TLV})
-            _qr_pkt.must_verify(lambda p: dut_payload_tlvs == set(p.thread_diagnostic.tlv.type))
+            _qr_pkt.must_verify(lambda p: dut_payload_tlvs <= set(p.thread_diagnostic.tlv.type))
 
             # Step 3: The DUT automatically responds with a DIAG_GET.ans response
             #         MUST contain the requested diagnostic TLVs:
@@ -208,7 +208,7 @@ class Cert_5_7_03_CoapDiagCommands_Base(thread_cert.TestCase):
                 filter_ipv6_dst(LEADER_RLOC).\
                 filter_coap_request(DIAG_GET_ANS_URI).\
                 filter(lambda p:
-                       dut_payload_tlvs == set(p.thread_diagnostic.tlv.type) and\
+                       dut_payload_tlvs <= set(p.thread_diagnostic.tlv.type) and\
                        {str(p.wpan.src64), colon_hex(dut_addr16, 2), '0f'}
                        < set(p.thread_diagnostic.tlv.general)
                       ).\
@@ -221,7 +221,7 @@ class Cert_5_7_03_CoapDiagCommands_Base(thread_cert.TestCase):
                 filter_ipv6_dst(REALM_LOCAL_All_THREAD_NODES_MULTICAST_ADDRESS).\
                 filter_coap_request(DIAG_GET_QRY_URI).\
                 filter(lambda p:
-                       dut_payload_tlvs == set(p.thread_diagnostic.tlv.type)
+                       dut_payload_tlvs <= set(p.thread_diagnostic.tlv.type)
                       ).\
                 must_next()
 
@@ -240,7 +240,7 @@ class Cert_5_7_03_CoapDiagCommands_Base(thread_cert.TestCase):
                 filter_ipv6_dst(LEADER_RLOC).\
                 filter_coap_request(DIAG_GET_ANS_URI).\
                 filter(lambda p:
-                       dut_payload_tlvs == set(p.thread_diagnostic.tlv.type) and\
+                       dut_payload_tlvs <= set(p.thread_diagnostic.tlv.type) and\
                        {str(p.wpan.src64), colon_hex(dut_addr16, 2), '0f'}
                        < set(p.thread_diagnostic.tlv.general)
                       ).\

--- a/tests/toranj/cli/test-021-mesh-diag.py
+++ b/tests/toranj/cli/test-021-mesh-diag.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2023, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+
+from cli import verify
+from cli import verify_within
+import cli
+import time
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test description: Validate Mesh Diag module commands.
+#
+# Network topology
+#
+#    r1 ---- r2 ---- r3
+#    /\              /|\
+#   /  \            / | \
+#  f1  s1          f2 s2 s3
+
+test_name = __file__[:-3] if __file__.endswith('.py') else __file__
+print('-' * 120)
+print('Starting \'{}\''.format(test_name))
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Creating `cli.Node` instances
+
+speedup = 40
+cli.Node.set_time_speedup_factor(speedup)
+
+r1 = cli.Node()
+r2 = cli.Node()
+r3 = cli.Node()
+fed1 = cli.Node()
+fed2 = cli.Node()
+sed1 = cli.Node()
+sed2 = cli.Node()
+sed3 = cli.Node()
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Form topology
+
+r1.allowlist_node(r2)
+r1.allowlist_node(fed1)
+r1.allowlist_node(sed1)
+
+r2.allowlist_node(r1)
+r2.allowlist_node(r3)
+
+r3.allowlist_node(r2)
+r3.allowlist_node(fed2)
+r3.allowlist_node(sed2)
+r3.allowlist_node(sed3)
+
+fed1.allowlist_node(r1)
+fed2.allowlist_node(r3)
+sed1.allowlist_node(r1)
+sed2.allowlist_node(r3)
+sed3.allowlist_node(r3)
+
+r1.form('mesh-diag')
+
+r1.add_prefix('fd00:1::/64', 'poas')
+r1.add_prefix('fd00:2::/64', 'poas')
+r1.register_netdata()
+
+r2.join(r1)
+r3.join(r1)
+fed1.join(r1, cli.JOIN_TYPE_REED)
+fed2.join(r1, cli.JOIN_TYPE_REED)
+sed1.join(r1, cli.JOIN_TYPE_SLEEPY_END_DEVICE)
+sed2.join(r1, cli.JOIN_TYPE_SLEEPY_END_DEVICE)
+sed3.join(r1, cli.JOIN_TYPE_SLEEPY_END_DEVICE)
+
+verify(r1.get_state() == 'leader')
+verify(r2.get_state() == 'router')
+verify(r3.get_state() == 'router')
+verify(fed1.get_state() == 'child')
+verify(fed2.get_state() == 'child')
+verify(sed1.get_state() == 'child')
+verify(sed2.get_state() == 'child')
+verify(sed3.get_state() == 'child')
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test Implementation
+
+r1_rloc = int(r1.get_rloc16(), 16)
+r2_rloc = int(r2.get_rloc16(), 16)
+r3_rloc = int(r3.get_rloc16(), 16)
+
+fed1_rloc = int(fed1.get_rloc16(), 16)
+fed2_rloc = int(fed2.get_rloc16(), 16)
+
+sed1_rloc = int(sed1.get_rloc16(), 16)
+sed2_rloc = int(sed2.get_rloc16(), 16)
+sed3_rloc = int(sed3.get_rloc16(), 16)
+
+topo = r1.cli('meshdiag topology')
+verify(len(topo) == 6)
+
+routers = []
+for line in topo:
+    if line.startswith('id:'):
+        routers.append(int(line.split(' ')[1].split(':')[1], 16))
+
+verify(r1_rloc in routers)
+verify(r2_rloc in routers)
+verify(r3_rloc in routers)
+
+r2.cli('meshdiag topology ip6-addrs')
+r3.cli('meshdiag topology ip6-addrs children')
+r1.cli('meshdiag topology children')
+
+childtable = r2.cli('meshdiag childtable', r1_rloc)
+verify(len([line for line in childtable if line.startswith('rloc16')]) == 2)
+
+childtable = r1.cli('meshdiag childtable', r3_rloc)
+verify(len([line for line in childtable if line.startswith('rloc16')]) == 3)
+
+childtable = r1.cli('meshdiag childtable', r2_rloc)
+verify(len([line for line in childtable if line.startswith('rloc16')]) == 0)
+
+childrenip6addrs = r2.cli('meshdiag childip6', r1_rloc)
+verify(len([line for line in childrenip6addrs if line.startswith('child-rloc16')]) == 1)
+verify(len([line for line in childrenip6addrs if line.startswith('   ')]) == 3)
+
+childrenip6addrs = r1.cli('meshdiag childip6', r3_rloc)
+verify(len([line for line in childrenip6addrs if line.startswith('child-rloc16')]) == 2)
+
+neightable = r1.cli('meshdiag neighbortable', r2_rloc)
+verify(len([line for line in neightable if line.startswith('rloc16')]) == 2)
+
+neightable = r3.cli('meshdiag neighbortable', r1_rloc)
+verify(len([line for line in neightable if line.startswith('rloc16')]) == 1)
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test finished
+
+cli.Node.finalize_all_nodes()
+
+print('\'{}\' passed.'.format(test_name))

--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -185,6 +185,7 @@ if [ "$TORANJ_CLI" = 1 ]; then
     run cli/test-018-next-hop-and-path-cost.py
     run cli/test-019-netdata-context-id.py
     run cli/test-020-net-diag-vendor-info.py
+    run cli/test-021-mesh-diag.py
     run cli/test-400-srp-client-server.py
     run cli/test-601-channel-manager-channel-change.py
     # Skip the "channel-select" test on a TREL only radio link, since it


### PR DESCRIPTION
This commit introduces Network Diagnostic TLV for MLE counters.
It updates `NetworkDiagnostic::Server` to provide this TLV when
queried and provide support for retrieving on `Client`.

----

This PR contains the commit from https://github.com/openthread/openthread/pull/8866

Related to [SPEC-1186](https://threadgroup.atlassian.net/browse/SPEC-1186).
