### PR TITLE
[dns-client] check all responses in `GetHostAddress()`

### DIFF
--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -639,7 +639,7 @@ Error Client::ServiceResponse::GetHostAddress(const char   *aHostName,
 
     for (const Response *response = this; response != nullptr; response = response->mNext)
     {
-        error = FindHostAddress(kAdditionalDataSection, Name(aHostName), aIndex, aAddress, aTtl);
+        error = response->FindHostAddress(kAdditionalDataSection, Name(aHostName), aIndex, aAddress, aTtl);
 
         if (error == kErrorNone)
         {


### PR DESCRIPTION
This commit fixes an issue with `ServiceResponse::GetHostAddress()` method. The issue only occurs when separate queries (e.g., for SRV and TXT records) are used, and therefore separate `Response` objects are collected and chained together as a linked list. The change ensures that we check every response in the list when getting host addresses.