### PR TITLE
Dont assert in AddSrcMatchExtEntry and AddSrcMatchShortEntry

### DIFF
--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -1301,7 +1301,7 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::AddSrcMatchShortEntry(ui
     SuccessOrExit(error = Insert(SPINEL_PROP_MAC_SRC_MATCH_SHORT_ADDRESSES, SPINEL_DATATYPE_UINT16_S, aShortAddress));
 
 #if OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
-    assert(mSrcMatchShortEntryCount < OPENTHREAD_CONFIG_MLE_MAX_CHILDREN);
+    VerifyOrExit(mSrcMatchShortEntryCount < OPENTHREAD_CONFIG_MLE_MAX_CHILDREN);
 
     for (int i = 0; i < mSrcMatchShortEntryCount; ++i)
     {
@@ -1327,7 +1327,7 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::AddSrcMatchExtEntry(cons
                       Insert(SPINEL_PROP_MAC_SRC_MATCH_EXTENDED_ADDRESSES, SPINEL_DATATYPE_EUI64_S, aExtAddress.m8));
 
 #if OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
-    assert(mSrcMatchExtEntryCount < OPENTHREAD_CONFIG_MLE_MAX_CHILDREN);
+    VerifyOrExit(mSrcMatchExtEntryCount < OPENTHREAD_CONFIG_MLE_MAX_CHILDREN);
 
     for (int i = 0; i < mSrcMatchExtEntryCount; ++i)
     {


### PR DESCRIPTION
In the current version of SPINEL we maintain a local copy of src match tables, incase we need to do a RCP restoration. But if the local copy of the table is full, we assert irrespective of what RCP has returned as status. This PR changes this behaviour and instead of asserting radio SPINEL will just exit without updating the local copy of src match table.