### PR TITLE
[dns-client] new API resolve host and address

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (322)
+#define OPENTHREAD_API_VERSION (323)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1269,6 +1269,14 @@ The parameters after `service-name` are optional. Any unspecified (or zero) valu
 
 > Note: The DNS server IP can be an IPv4 address, which will be synthesized to an IPv6 address using the preferred NAT64 prefix from the network data. The command will return `InvalidState` when the DNS server IP is an IPv4 address but the preferred NAT64 prefix is unavailable.
 
+### dns servicehost \<service-instance-label\> \<service-name\> \[DNS server IP\] \[DNS server port\] \[response timeout (ms)\] \[max tx attempts\] \[recursion desired (boolean)\]
+
+Send a service instance resolution DNS query for a given service instance with a potential follow-up address resolution for the host name discovered for the service instance (if the server/resolver does not provide AAAA/A records for the host name in the response to SRV query).
+
+Service instance label is provided first, followed by the service name (note that service instance label can contain dot '.' character).
+
+The parameters after `service-name` are optional. Any unspecified (or zero) value for these optional parameters is replaced by the value from the current default config (`dns config`).
+
 ### dns compression \[enable|disable\]
 
 Enable/Disable the "DNS name compression" mode.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3162,7 +3162,7 @@ template <> otError Interpreter::Process<Cmd("dns")>(Arg aArgs[])
      * `InvalidState` when the DNS server IP is an IPv4 address but the preferred NAT64 prefix
      * is unavailable. When testing DNS-SD discovery proxy, the zone is not `local` and
      * instead should be `default.service.arpa`.
-     * 'OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE' is required.
+     * `OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE` is required.
      */
     else if (aArgs[0] == "browse")
     {
@@ -3191,9 +3191,9 @@ template <> otError Interpreter::Process<Cmd("dns")>(Arg aArgs[])
      * @par
      * Note: The DNS server IP can be an IPv4 address, which will be synthesized
      * to an IPv6 address using the preferred NAT64 prefix from the network data.
-     * The command will return `InvalidState` when the DNS * server IP is an IPv4
+     * The command will return `InvalidState` when the DNS server IP is an IPv4
      * address but the preferred NAT64 prefix is unavailable.
-     * 'OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE' is required.
+     * `OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE` is required.
      */
     else if (aArgs[0] == "service")
     {
@@ -3201,6 +3201,39 @@ template <> otError Interpreter::Process<Cmd("dns")>(Arg aArgs[])
         SuccessOrExit(error = GetDnsConfig(aArgs + 3, config));
         SuccessOrExit(error = otDnsClientResolveService(GetInstancePtr(), aArgs[1].GetCString(), aArgs[2].GetCString(),
                                                         &Interpreter::HandleDnsServiceResponse, this, config));
+        error = OT_ERROR_PENDING;
+    }
+    /**
+     * @cli dns servicehost
+     * @cparam dns servicehost @ca{service-instance-label} @ca{service-name} <!--
+     * -->                 [@ca{DNS-server-IP}] [@ca{DNS-server-port}] <!--
+     * -->                 [@ca{response-timeout-ms}] [@ca{max-tx-attempts}] <!--
+     * -->                 [@ca{recursion-desired-boolean}]
+     * @par api_copy
+     * #otDnsClientResolveServiceAndHostAddress
+     * @par
+     * Send a service instance resolution DNS query for a given service instance
+     * with potential follow-up host name resolution.
+     * Service instance label is provided first, followed by the service name
+     * (note that service instance label can contain dot '.' character).
+     * @par
+     * The parameters after `service-name` are optional. Any unspecified (or zero)
+     * value for these optional parameters is replaced by the value from the
+     * current default config (`dns config`).
+     * @par
+     * Note: The DNS server IP can be an IPv4 address, which will be synthesized
+     * to an IPv6 address using the preferred NAT64 prefix from the network data.
+     * The command will return `InvalidState` when the DNS server IP is an IPv4
+     * address but the preferred NAT64 prefix is unavailable.
+     * `OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE` is required.
+     */
+    else if (aArgs[0] == "servicehost")
+    {
+        VerifyOrExit(!aArgs[2].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+        SuccessOrExit(error = GetDnsConfig(aArgs + 3, config));
+        SuccessOrExit(error = otDnsClientResolveServiceAndHostAddress(
+                          GetInstancePtr(), aArgs[1].GetCString(), aArgs[2].GetCString(),
+                          &Interpreter::HandleDnsServiceResponse, this, config));
         error = OT_ERROR_PENDING;
     }
 #endif // OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE

--- a/src/core/api/dns_api.cpp
+++ b/src/core/api/dns_api.cpp
@@ -188,6 +188,20 @@ otError otDnsClientResolveService(otInstance             *aInstance,
                                                                    AsCoreTypePtr(aConfig));
 }
 
+otError otDnsClientResolveServiceAndHostAddress(otInstance             *aInstance,
+                                                const char             *aInstanceLabel,
+                                                const char             *aServiceName,
+                                                otDnsServiceCallback    aCallback,
+                                                void                   *aContext,
+                                                const otDnsQueryConfig *aConfig)
+{
+    AssertPointerIsNotNull(aInstanceLabel);
+    AssertPointerIsNotNull(aServiceName);
+
+    return AsCoreType(aInstance).Get<Dns::Client>().ResolveServiceAndHostAddress(
+        aInstanceLabel, aServiceName, aCallback, aContext, AsCoreTypePtr(aConfig));
+}
+
 otError otDnsServiceResponseGetServiceName(const otDnsServiceResponse *aResponse,
                                            char                       *aLabelBuffer,
                                            uint8_t                     aLabelBufferSize,

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -263,25 +263,27 @@ public:
     const Counters &GetCounters(void) const { return mCounters; };
 
     /**
-     * This enumeration represents different test modes.
-     *
-     * The test mode is intended for testing the client by having server behave in certain ways, e.g., reject messages
-     * with certain format (e.g., more than one question in query).
+     * This enumeration represents different test mode flags for use in `SetTestMode()`.
      *
      */
-    enum TestMode : uint8_t
+    enum TestModeFlags : uint8_t
     {
-        kTestModeDisabled,           ///< Test mode is disabled.
-        kTestModeSingleQuestionOnly, ///< Allow single question in query message, send `FormatError` for two or more.
+        kTestModeSingleQuestionOnly     = 1 << 0, ///< Allow single question in query, send `FormatError` otherwise.
+        kTestModeEmptyAdditionalSection = 1 << 1, ///< Do not include any RR in additional section.
     };
+
+    static constexpr uint8_t kTestModeDisabled = 0; ///< Test mode is disabled (no flags).
 
     /**
      * This method sets the test mode for `Server`.
      *
-     * @param[in] aTestMode   The new test mode.
+     * The test mode flags are intended for testing the client by having server behave in certain ways, e.g., reject
+     * messages with certain format (e.g., more than one question in query).
+     *
+     * @param[in] aTestMode   The new test mode (combination of `TestModeFlags`).
      *
      */
-    void SetTestMode(TestMode aTestMode) { mTestMode = aTestMode; }
+    void SetTestMode(uint8_t aTestMode) { mTestMode = aTestMode; }
 
 private:
     class NameCompressInfo : public Clearable<NameCompressInfo>
@@ -553,7 +555,7 @@ private:
 
     ServerTimer mTimer;
     Counters    mCounters;
-    TestMode    mTestMode;
+    uint8_t     mTestMode;
 };
 
 } // namespace ServiceDiscovery


### PR DESCRIPTION
This commit adds `otDnsClientResolveServiceAndHostAddress()` function as a new DNS Client API. This function starts a DNS service instance resolution for a given service instance, with a potential follow-up address resolution for the host name discovered for the service instance (when the server/resolver does not provide AAAA/A records for the host name in the response to SRV query).

In order to test the behavior of the newly added function, `TestMode` in `Dns::ServiceDiscovery::Server` is updated to add a new mode where no RR is added in the Additional Data section of a DNS query response.

This commit adds a related CLI command for the new API and updates `test_dns_client` to validate the behavior of new API using the new `TestMode` on `Server`.