### PR TITLE
[core] add instance id

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (324)
+#define OPENTHREAD_API_VERSION (325)
 
 /**
  * @addtogroup api-instance
@@ -101,6 +101,17 @@ otInstance *otInstanceInit(void *aInstanceBuffer, size_t *aInstanceBufferSize);
  *
  */
 otInstance *otInstanceInitSingle(void);
+
+/**
+ * Gets the instance identifier.
+ *
+ * The instance identifier is set to a random value when the instance is constructed, and then its value will not
+ * change after initialization.
+ *
+ * @returns The instance identifier.
+ *
+ */
+uint32_t otInstanceGetId(otInstance *aInstance);
 
 /**
  * This function indicates whether or not the instance is valid/initialized.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -56,6 +56,7 @@ Done
 - [fem](#fem)
 - [history](README_HISTORY.md)
 - [ifconfig](#ifconfig)
+- [instanceid](#instanceid)
 - [ipaddr](#ipaddr)
 - [ipmaddr](#ipmaddr)
 - [joiner](README_JOINER.md)
@@ -1488,6 +1489,16 @@ Bring down the IPv6 interface.
 
 ```bash
 > ifconfig down
+Done
+```
+
+### instanceid
+
+Show OpenThread instance identifier.
+
+```bash
+> instanceid
+468697314
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -4002,6 +4002,29 @@ exit:
     return error;
 }
 
+template <> otError Interpreter::Process<Cmd("instanceid")>(Arg aArgs[])
+{
+    otError error = OT_ERROR_INVALID_ARGS;
+
+    /**
+     * @cli instanceid
+     * @code
+     * instanceid
+     * 468697314
+     * Done
+     * @endcode
+     * @par api_copy
+     * #otInstanceGetId
+     */
+    if (aArgs[0].IsEmpty())
+    {
+        OutputLine("%lu", ToUlong(otInstanceGetId(GetInstancePtr())));
+        error = OT_ERROR_NONE;
+    }
+
+    return error;
+}
+
 const char *Interpreter::AddressOriginToString(uint8_t aOrigin)
 {
     static const char *const kOriginStrings[4] = {
@@ -8605,6 +8628,7 @@ otError Interpreter::ProcessCommand(Arg aArgs[])
         CmdEntry("history"),
 #endif
         CmdEntry("ifconfig"),
+        CmdEntry("instanceid"),
         CmdEntry("ipaddr"),
         CmdEntry("ipmaddr"),
 #if OPENTHREAD_CONFIG_JOINER_ENABLE

--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -70,6 +70,8 @@ otInstance *otInstanceInit(void *aInstanceBuffer, size_t *aInstanceBufferSize)
 otInstance *otInstanceInitSingle(void) { return &Instance::InitSingle(); }
 #endif // #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
 
+uint32_t otInstanceGetId(otInstance *aInstance) { return AsCoreType(aInstance).GetId(); }
+
 bool otInstanceIsInitialized(otInstance *aInstance)
 {
 #if OPENTHREAD_MTD || OPENTHREAD_FTD

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -245,6 +245,7 @@ Instance::Instance(void)
     , mPowerCalibration(*this)
 #endif
     , mIsInitialized(false)
+    , mId(Random::NonCrypto::GetUint32())
 {
 }
 

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -208,6 +208,17 @@ public:
 #endif
 
     /**
+     * Gets the instance identifier.
+     *
+     * The instance identifier is set to a random value when the instance is constructed, and then its value will not
+     * change after initialization.
+     *
+     * @returns The instance identifier.
+     *
+     */
+    uint32_t GetId(void) const { return mId; }
+
+    /**
      * This method indicates whether or not the instance is valid/initialized and not yet finalized.
      *
      * @returns TRUE if the instance is valid/initialized, FALSE otherwise.
@@ -645,6 +656,8 @@ private:
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE && (OPENTHREAD_FTD || OPENTHREAD_MTD)
     static bool sDnsNameCompressionEnabled;
 #endif
+
+    uint32_t mId;
 };
 
 DefineCoreType(otInstance, Instance);

--- a/tests/scripts/expect/cli-misc.exp
+++ b/tests/scripts/expect/cli-misc.exp
@@ -86,6 +86,10 @@ send "ifconfig\n"
 expect "up"
 expect_line "Done"
 
+send "instanceid\n"
+expect -re {\d+}
+expect_line "Done"
+
 send "ipaddr add ::\n"
 expect_line "Done"
 send "ipaddr del ::\n"


### PR DESCRIPTION
It is difficult for testers to know whether the stack has been automatically restarted in the background. This commit adds an instance id to indicate whether the stack has been restarted. The instance id is set to a random value when the OpenThread instance is constructed and its vaule will not change after initialization.