### PR TITLE
[mle] echo back "Supervision TLV" in Child ID Response

### DIFF
--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -873,7 +873,7 @@ class Child : public Neighbor,
     class AddressIteratorBuilder;
 
 public:
-    static constexpr uint8_t kMaxRequestTlvs = 5;
+    static constexpr uint8_t kMaxRequestTlvs = 6;
 
     /**
      * This class represents diagnostic information for a Thread Child.


### PR DESCRIPTION
This commit updates the `MleRouter` to echo back the "Supervision TLV" in MLE Child ID Response message when it is included in MLE Child ID Request by a child.