### PR TITLE
[ncp] fix RegisterPeekPokeDelegates call

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -2608,7 +2608,7 @@ void otNcpRegisterPeekPoke(otNcpDelegateAllowPeekPoke aAllowPeekDelegate, otNcpD
 
     if (ncp != nullptr)
     {
-        ncp->RegisterPeekPoke(aAllowPeekDelegate, aAllowPokeDelegate);
+        ncp->RegisterPeekPokeDelegates(aAllowPeekDelegate, aAllowPokeDelegate);
     }
 }
 #endif // OPENTHREAD_CONFIG_NCP_ENABLE_PEEK_POKE


### PR DESCRIPTION
This commit fixes an issue where 'RegisterPeekPoke' was called instead of 'RegisterPeekPokeDelegates', causing compilation errors in some builds.