### PR TITLE
[alarm] `otPlatAlarm` requirements clarification

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (326)
+#define OPENTHREAD_API_VERSION (327)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/alarm-micro.h
+++ b/include/openthread/platform/alarm-micro.h
@@ -53,7 +53,8 @@ extern "C" {
 /**
  * Set the alarm to fire at @p aDt microseconds after @p aT0.
  *
- * For both @p aT0 and @p aDt, the platform MUST support all values in [0, 2^32-1].
+ * For @p aT0, the platform MUST support all values in [0, 2^32-1].
+ * For @p aDt, the platform MUST support all values in [0, 2^31-1].
  *
  * @param[in]  aInstance  The OpenThread instance structure.
  * @param[in]  aT0        The reference time.

--- a/include/openthread/platform/alarm-milli.h
+++ b/include/openthread/platform/alarm-milli.h
@@ -56,7 +56,8 @@ extern "C" {
 /**
  * Set the alarm to fire at @p aDt milliseconds after @p aT0.
  *
- * For both @p aT0 and @p aDt, the platform MUST support all values in [0, 2^32-1].
+ * For @p aT0 the platform MUST support all values in [0, 2^32-1].
+ * For @p aDt, the platform MUST support all values in [0, 2^31-1].
  *
  * @param[in] aInstance  The OpenThread instance structure.
  * @param[in] aT0        The reference time.


### PR DESCRIPTION
Based on discussion in https://github.com/openthread/openthread/discussions/9065#discussioncomment-5940126, it appears the requirement in the code comments is not completely accurate wrt to the example implementations. As such, the requirements are updated to match what is implemented for the posix platform.