### PR TITLE
[cli] fix config check for "vendor" command

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -3408,8 +3408,6 @@ Done
 
 ### vendor name
 
-This command requires `OPENTHREAD_FTD` or `OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE`.
-
 Get the vendor name.
 
 ```bash
@@ -3427,8 +3425,6 @@ Done
 
 ### vendor model
 
-This command requires `OPENTHREAD_FTD` or `OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE`.
-
 Get the vendor model.
 
 ```bash
@@ -3445,8 +3441,6 @@ Done
 ```
 
 ### vendor swversion
-
-This command requires `OPENTHREAD_FTD` or `OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE`.
 
 Get the vendor SW version.
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -8703,9 +8703,7 @@ otError Interpreter::ProcessCommand(Arg aArgs[])
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
         CmdEntry("uptime"),
 #endif
-#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
         CmdEntry("vendor"),
-#endif
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD
         CmdEntry("version"),
     };


### PR DESCRIPTION
The `"vendor"` command should be available on both FTD and MTD.