### PR TITLE
[csl] new API to convert CSL period between msec and ten symbols unit

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (327)
+#define OPENTHREAD_API_VERSION (328)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -1069,6 +1069,34 @@ uint16_t otLinkCslGetPeriod(otInstance *aInstance);
 otError otLinkCslSetPeriod(otInstance *aInstance, uint16_t aPeriod);
 
 /**
+ * Converts a given CSL period in units of 10 symbols to milliseconds.
+ *
+ * When converting from 10 symbols unit (which is 160 microseconds) to milliseconds, the function rounds to the nearest
+ * value. For example, if @p aPeriodInTenSymbols is 212 which maps to 212 x 0.160 = 33.92 msec, the return value will
+ * be 34 msec.
+ *
+ * @param[in] aPeriodInTenSymbols   The CSL period in unit of 10 symbols to convert.
+ *
+ * @returns The converted value in msec corresponding to @p aPeriodInTenSymbols.
+ *
+ */
+uint16_t otLinkCslPeriodToMsec(uint16_t aPeriodInTenSymbols);
+
+/**
+ * Converts a given CSL period in milliseconds to units of 10 symbols.
+ *
+ * When converting from milliseconds to 10 symbols unit (which is 160 microseconds), this function rounds to the
+ * nearest value. For example, if the target CSL period is 23 msec, the returned value will be 144 (in unit of 10
+ * symbols) which maps to 144 x 0.160 = 23.04 msec instead of 143 which maps to 22.88 msec.
+ *
+ * @param[in] aPeriodInMsec   The CSL period in msec.
+ *
+ * @returns The converted value in units of 10 symbols corresponding to @p aPeriodInMsec.
+ *
+ */
+uint16_t otLinkCslPeriodFromMsec(uint16_t aPeriodInMsec);
+
+/**
  * This function gets the CSL timeout.
  *
  * @param[in]  aInstance      A pointer to an OpenThread instance.

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -1059,7 +1059,7 @@ otError otPlatRadioGetCoexMetrics(otInstance *aInstance, otRadioCoexMetrics *aCo
  * Enable or disable CSL receiver.
  *
  * @param[in]  aInstance     The OpenThread instance structure.
- * @param[in]  aCslPeriod    CSL period, 0 for disabling CSL.
+ * @param[in]  aCslPeriod    CSL period, 0 for disabling CSL. CSL period is in unit of 10 symbols.
  * @param[in]  aShortAddr    The short source address of CSL receiver's peer.
  * @param[in]  aExtAddr      The extended source address of CSL receiver's peer.
  *

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2752,9 +2752,10 @@ template <> otError Interpreter::Process<Cmd("csl")>(Arg aArgs[])
      */
     if (aArgs[0].IsEmpty())
     {
+        uint16_t cslPeriod = otLinkCslGetPeriod(GetInstancePtr());
+
         OutputLine("Channel: %u", otLinkCslGetChannel(GetInstancePtr()));
-        OutputLine("Period: %u(in units of 10 symbols), %lums", otLinkCslGetPeriod(GetInstancePtr()),
-                   ToUlong(otLinkCslGetPeriod(GetInstancePtr()) * kUsPerTenSymbols / 1000));
+        OutputLine("Period: %u(in units of 10 symbols), %ums", cslPeriod, otLinkCslPeriodToMsec(cslPeriod));
         OutputLine("Timeout: %lus", ToUlong(otLinkCslGetTimeout(GetInstancePtr())));
     }
     /**

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -418,6 +418,10 @@ exit:
     return error;
 }
 
+uint16_t otLinkCslPeriodToMsec(uint16_t aPeriodInTenSymbols) { return Mac::Mac::CslPeriodToMsec(aPeriodInTenSymbols); }
+
+uint16_t otLinkCslPeriodFromMsec(uint16_t aPeriodInMsec) { return Mac::Mac::CslPeriodFromMsec(aPeriodInMsec); }
+
 uint32_t otLinkCslGetTimeout(otInstance *aInstance)
 {
     return AsCoreType(aInstance).Get<Mle::MleRouter>().GetCslTimeout();

--- a/src/core/common/time.hpp
+++ b/src/core/common/time.hpp
@@ -65,6 +65,7 @@ public:
     static constexpr uint32_t kOneMinuteInMsec = kOneSecondInMsec * 60; ///< One minute interval in msec.
     static constexpr uint32_t kOneHourInMsec   = kOneMinuteInMsec * 60; ///< One hour interval in msec.
     static constexpr uint32_t kOneDayInMsec    = kOneHourInMsec * 24;   ///< One day interval in msec.
+    static constexpr uint32_t kOneMsecInUsec   = 1000u;                 ///< One millisecond in microseconds.
 
     /**
      * This constant defines a maximum time duration ensured to be longer than any other duration.

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2268,6 +2268,18 @@ void Mac::SetCslPeriod(uint16_t aPeriod)
     UpdateCsl();
 }
 
+uint16_t Mac::CslPeriodToMsec(uint16_t aPeriodInTenSymbols)
+{
+    return ClampToUint16(
+        DivideAndRoundToClosest(static_cast<uint32_t>(aPeriodInTenSymbols) * kUsPerTenSymbols, Time::kOneMsecInUsec));
+}
+
+uint16_t Mac::CslPeriodFromMsec(uint16_t aPeriodInMsec)
+{
+    return ClampToUint16(
+        DivideAndRoundToClosest(static_cast<uint32_t>(aPeriodInMsec) * Time::kOneMsecInUsec, kUsPerTenSymbols));
+}
+
 bool Mac::IsCslEnabled(void) const { return !Get<Mle::Mle>().IsRxOnWhenIdle() && IsCslCapable(); }
 
 bool Mac::IsCslCapable(void) const { return (GetCslPeriod() > 0) && IsCslSupported(); }

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -630,7 +630,7 @@ public:
      * @returns CSL period in milliseconds.
      *
      */
-    uint32_t GetCslPeriodMs(void) const { return mCslPeriod * kUsPerTenSymbols / 1000; }
+    uint32_t GetCslPeriodMs(void) const { return CslPeriodToMsec(mCslPeriod); }
 
     /**
      * This method sets the CSL period.
@@ -639,6 +639,34 @@ public:
      *
      */
     void SetCslPeriod(uint16_t aPeriod);
+
+    /**
+     * This method converts a given CSL period in units of 10 symbols to milliseconds.
+     *
+     * When converting from 10 symbols unit (which is 160 microseconds) to milliseconds, the method rounds to the
+     * nearest value. For example, if @p aPeriodInTenSymbols is 212 which maps to 212 x 0.160 = 33.92 msec, the return
+     * value will be 34 (msec).
+     *
+     * @param[in] aPeriodInTenSymbols   The CSL period in unit of 10 symbols.
+     *
+     * @returns The converted value in msec corresponding to @p aPeriodInTenSymbols.
+     *
+     */
+    static uint16_t CslPeriodToMsec(uint16_t aPeriodInTenSymbols);
+
+    /**
+     * This method converts a given CSL period in milliseconds to units of 10 symbols.
+     *
+     * When converting from milliseconds to 10 symbols unit (which is 160 microseconds), this function rounds to the
+     * nearest value. For example, if the target CSL period is 23 msec, the returned value will be 144 (in unit of 10
+     * symbols) which maps to 144 x 0.160 = 23.04 msec instead of 143 which maps to 22.88 msec.
+     *
+     * @param[in] aPeriodInMsec   The CSL period in msec.
+     *
+     * @returns The converted value in units of 10 symbols corresponding to @p aPeriodInMsec.
+     *
+     */
+    static uint16_t CslPeriodFromMsec(uint16_t aPeriodInMsec);
 
     /**
      * This method indicates whether CSL is started at the moment.
@@ -685,7 +713,6 @@ public:
     {
         mLinks.GetSubMac().SetCslParentAccuracy(aCslAccuracy);
     }
-
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE && OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -400,7 +400,7 @@ public:
     /**
      * This method configures CSL parameters in 'SubMac'.
      *
-     * @param[in]  aPeriod    The CSL period.
+     * @param[in]  aPeriod    The CSL period (in unit of 10 symbols).
      * @param[in]  aChannel   The CSL channel.
      * @param[in]  aShortAddr The short source address of CSL receiver's peer.
      * @param[in]  aExtAddr   The extended source address of CSL receiver's peer.

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -721,6 +721,37 @@ void TestMacFrameAckGeneration(void)
 #endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 }
 
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+void TestMacCslPeriod(void)
+{
+    static constexpr uint32_t kTenSymbolsInUs  = 160;
+    static constexpr uint16_t kMaxPeriodInMsec = 10485; // Mapping to `0xffff` in units of 10 symbols.
+    static constexpr uint32_t kUsInMs          = 1000;
+
+    printf("Testing Mac::CslPeriodTo/FromMsec\n");
+
+    for (uint16_t period = 0; period < 0xffff; period++)
+    {
+        uint16_t periodInMsec = Mac::Mac::CslPeriodToMsec(period);
+
+        VerifyOrQuit(periodInMsec == ((period * kTenSymbolsInUs) + kUsInMs / 2) / kUsInMs);
+    }
+
+    for (uint16_t periodInMsec = 0; periodInMsec <= kMaxPeriodInMsec; periodInMsec++)
+    {
+        uint16_t period   = Mac::Mac::CslPeriodFromMsec(periodInMsec);
+        uint32_t expected = ((periodInMsec * kUsInMs) + kTenSymbolsInUs / 2) / kTenSymbolsInUs;
+
+        VerifyOrQuit(period == expected);
+    }
+
+    for (uint16_t periodInMsec = kMaxPeriodInMsec + 1; periodInMsec <= 2 * kMaxPeriodInMsec; periodInMsec++)
+    {
+        VerifyOrQuit(Mac::Mac::CslPeriodFromMsec(periodInMsec) == 0xffff);
+    }
+}
+#endif
+
 } // namespace ot
 
 int main(void)
@@ -730,6 +761,9 @@ int main(void)
     ot::TestMacChannelMask();
     ot::TestMacFrameApi();
     ot::TestMacFrameAckGeneration();
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+    ot::TestMacCslPeriod();
+#endif
     printf("All tests passed\n");
     return 0;
 }


### PR DESCRIPTION
This commit adds new APIs to convert CSL period, which is specified in units of ten symbols, to and from milliseconds.

When converting between units, the new APIs round to the nearest value. For example, if the CSL period is `212` (in ten symbols unit) which maps to `212 x 0.160 = 33.92` milliseconds, the value of `34` milliseconds is returned. Or if the target CSL period is `23` milliseconds, the converted value will be `144` (in units of ten symbols) which maps to `144 x 0.160 = 23.04` milliseconds instead of `143` which maps to `22.88` milliseconds.