### PR TITLE
[random] add `Fill<ObjectType>()` function

### DIFF
--- a/src/core/common/random.cpp
+++ b/src/core/common/random.cpp
@@ -54,7 +54,7 @@ Manager::Manager(void)
 
 #if !OPENTHREAD_RADIO
     otPlatCryptoRandomInit();
-    SuccessOrAssert(Random::Crypto::FillBuffer(reinterpret_cast<uint8_t *>(&seed), sizeof(seed)));
+    SuccessOrAssert(Random::Crypto::Fill(seed));
 #else
     SuccessOrAssert(otPlatEntropyGet(reinterpret_cast<uint8_t *>(&seed), sizeof(seed)));
 #endif

--- a/src/core/common/random.hpp
+++ b/src/core/common/random.hpp
@@ -43,6 +43,7 @@
 #include "common/debug.hpp"
 #include "common/error.hpp"
 #include "common/non_copyable.hpp"
+#include "common/type_traits.hpp"
 
 namespace ot {
 namespace Random {
@@ -175,6 +176,21 @@ uint32_t GetUint32InRange(uint32_t aMin, uint32_t aMax);
 void FillBuffer(uint8_t *aBuffer, uint16_t aSize);
 
 /**
+ * Fills a given object with random bytes.
+ *
+ * @tparam    ObjectType   The object type to fill.
+ *
+ * @param[in] aObject      A reference to the object to fill.
+ *
+ */
+template <typename ObjectType> void Fill(ObjectType &aObject)
+{
+    static_assert(!TypeTraits::IsPointer<ObjectType>::kValue, "ObjectType must not be a pointer");
+
+    FillBuffer(reinterpret_cast<uint8_t *>(&aObject), sizeof(ObjectType));
+}
+
+/**
  * Adds a random jitter within a given range to a given value.
  *
  * @param[in]  aValue     A value to which the random jitter is added.
@@ -201,6 +217,24 @@ namespace Crypto {
  *
  */
 inline Error FillBuffer(uint8_t *aBuffer, uint16_t aSize) { return Manager::CryptoFillBuffer(aBuffer, aSize); }
+
+/**
+ * Fills a given object with cryptographically secure random bytes.
+ *
+ * @tparam    ObjectType   The object type to fill.
+ *
+ * @param[in] aObject      A reference to the object to fill.
+ *
+ * @retval kErrorNone    Successfully filled @p aObject with random values.
+ * @retval kErrorFailed  Failed to generate secure random bytes to fill the object.
+ *
+ */
+template <typename ObjectType> Error Fill(ObjectType &aObject)
+{
+    static_assert(!TypeTraits::IsPointer<ObjectType>::kValue, "ObjectType must not be a pointer");
+
+    return FillBuffer(reinterpret_cast<uint8_t *>(&aObject), sizeof(ObjectType));
+}
 
 } // namespace Crypto
 

--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -57,7 +57,7 @@ PanId GenerateRandomPanId(void)
 #if !OPENTHREAD_RADIO
 void ExtAddress::GenerateRandom(void)
 {
-    IgnoreError(Random::Crypto::FillBuffer(m8, sizeof(ExtAddress)));
+    IgnoreError(Random::Crypto::Fill(*this));
     SetGroup(false);
     SetLocal(true);
 }

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -243,7 +243,7 @@ Error BorderAgent::GetId(Id &aId)
 
     if (Get<Settings>().Read(id) != kErrorNone)
     {
-        Random::NonCrypto::FillBuffer(id.GetId().mId, sizeof(id));
+        Random::NonCrypto::Fill(id.GetId());
         SuccessOrExit(error = Get<Settings>().Save(id));
     }
 

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -80,7 +80,7 @@ Error Dataset::Info::GenerateRandom(Instance &aInstance)
 
     SuccessOrExit(error = AsCoreType(&mNetworkKey).GenerateRandom());
     SuccessOrExit(error = AsCoreType(&mPskc).GenerateRandom());
-    SuccessOrExit(error = Random::Crypto::FillBuffer(mExtendedPanId.m8, sizeof(mExtendedPanId.m8)));
+    SuccessOrExit(error = Random::Crypto::Fill(mExtendedPanId));
     SuccessOrExit(error = AsCoreType(&mMeshLocalPrefix).GenerateRandomUla());
 
     snprintf(mNetworkName.m8, sizeof(mNetworkName), "%s-%04x", NetworkName::kNetworkNameInit, mPanId);

--- a/src/core/net/dhcp6.hpp
+++ b/src/core/net/dhcp6.hpp
@@ -107,7 +107,12 @@ public:
      * @retval kErrorFailed   Failed to generate random sequence.
      *
      */
-    Error GenerateRandom(void) { return Random::Crypto::FillBuffer(m8, kSize); }
+    Error GenerateRandom(void)
+    {
+        OT_UNUSED_VARIABLE(m8);
+
+        return Random::Crypto::Fill(*this);
+    }
 
 private:
     uint8_t m8[kSize];

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -255,7 +255,7 @@ bool InterfaceIdentifier::IsReservedSubnetAnycast(void) const
             mFields.m8[7] >= 0x80);
 }
 
-void InterfaceIdentifier::GenerateRandom(void) { SuccessOrAssert(Random::Crypto::FillBuffer(mFields.m8, kSize)); }
+void InterfaceIdentifier::GenerateRandom(void) { SuccessOrAssert(Random::Crypto::Fill(*this)); }
 
 void InterfaceIdentifier::SetBytes(const uint8_t *aBuffer) { memcpy(mFields.m8, aBuffer, kSize); }
 

--- a/src/core/net/nat64_translator.cpp
+++ b/src/core/net/nat64_translator.cpp
@@ -70,7 +70,7 @@ Translator::Translator(Instance &aInstance)
     , mState(State::kStateDisabled)
     , mMappingExpirerTimer(aInstance)
 {
-    Random::NonCrypto::FillBuffer(reinterpret_cast<uint8_t *>(&mNextMappingId), sizeof(mNextMappingId));
+    Random::NonCrypto::Fill(mNextMappingId);
 
     mNat64Prefix.Clear();
     mIp4Cidr.Clear();

--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -1114,7 +1114,7 @@ bool tcplp_sys_autobind(otInstance       *aInstance,
 uint32_t tcplp_sys_generate_isn()
 {
     uint32_t isn;
-    IgnoreError(Random::Crypto::FillBuffer(reinterpret_cast<uint8_t *>(&isn), sizeof(isn)));
+    IgnoreError(Random::Crypto::Fill(isn));
     return isn;
 }
 

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -148,7 +148,7 @@ public:
      * @retval kErrorFailed   Failed to generate random sequence.
      *
      */
-    Error GenerateRandom(void) { return Random::Crypto::FillBuffer(m8, sizeof(m8)); }
+    Error GenerateRandom(void) { return Random::Crypto::Fill(*this); }
 #endif
 
 } OT_TOOL_PACKED_END;
@@ -178,7 +178,7 @@ public:
      * @retval kErrorNone  Successfully generated a random Thread PSKc.
      *
      */
-    Error GenerateRandom(void) { return Random::Crypto::FillBuffer(m8, sizeof(m8)); }
+    Error GenerateRandom(void) { return Random::Crypto::Fill(*this); }
 #endif
 } OT_TOOL_PACKED_END;
 

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -335,11 +335,11 @@ void Slaac::GetIidSecretKey(IidSecretKey &aKey) const
     // If there is no previously saved secret key, generate
     // a random one and save it.
 
-    error = Random::Crypto::FillBuffer(aKey.m8, sizeof(IidSecretKey));
+    error = Random::Crypto::Fill(aKey);
 
     if (error != kErrorNone)
     {
-        IgnoreError(Random::Crypto::FillBuffer(aKey.m8, sizeof(IidSecretKey)));
+        IgnoreError(Random::Crypto::Fill(aKey));
     }
 
     IgnoreError(Get<Settings>().Save<Settings::SlaacIidSecretKey>(aKey));

--- a/tests/unit/test_checksum.cpp
+++ b/tests/unit/test_checksum.cpp
@@ -190,7 +190,7 @@ void TestUdpMessageChecksum(void)
 
         // Write UDP header with a random payload.
 
-        Random::NonCrypto::FillBuffer(reinterpret_cast<uint8_t *>(&udpHeader), sizeof(udpHeader));
+        Random::NonCrypto::Fill(udpHeader);
         udpHeader.SetChecksum(0);
         message->Write(0, udpHeader);
 
@@ -258,7 +258,7 @@ void TestIcmp6MessageChecksum(void)
 
         // Write ICMP6 header with a random payload.
 
-        Random::NonCrypto::FillBuffer(reinterpret_cast<uint8_t *>(&icmp6Header), sizeof(icmp6Header));
+        Random::NonCrypto::Fill(icmp6Header);
         icmp6Header.SetChecksum(0);
         message->Write(0, icmp6Header);
 
@@ -332,7 +332,7 @@ void TestTcp4MessageChecksum(void)
 
         // Write TCP header with a random payload.
 
-        Random::NonCrypto::FillBuffer(reinterpret_cast<uint8_t *>(&tcpHeader), sizeof(tcpHeader));
+        Random::NonCrypto::Fill(tcpHeader);
         message->Write(0, tcpHeader);
 
         if (size > sizeof(tcpHeader))
@@ -387,7 +387,7 @@ void TestUdp4MessageChecksum(void)
 
         // Write UDP header with a random payload.
 
-        Random::NonCrypto::FillBuffer(reinterpret_cast<uint8_t *>(&udpHeader), sizeof(udpHeader));
+        Random::NonCrypto::Fill(udpHeader);
         udpHeader.SetChecksum(0);
         message->Write(0, udpHeader);
 

--- a/tests/unit/test_ndproxy_table.cpp
+++ b/tests/unit/test_ndproxy_table.cpp
@@ -50,7 +50,7 @@ Ip6::InterfaceIdentifier generateRandomIid(uint16_t aIndex)
 {
     Ip6::InterfaceIdentifier iid;
 
-    Random::NonCrypto::FillBuffer(iid.mFields.m8, sizeof(iid));
+    Random::NonCrypto::Fill(iid);
     iid.mFields.m16[3] = aIndex;
 
     return iid;

--- a/tests/unit/test_spinel_buffer.cpp
+++ b/tests/unit/test_spinel_buffer.cpp
@@ -891,7 +891,7 @@ uint32_t GetRandom(uint32_t max)
 
     if (kUseTrueRandomNumberGenerator)
     {
-        SuccessOrQuit(Random::Crypto::FillBuffer(reinterpret_cast<uint8_t *>(&value), sizeof(value)));
+        SuccessOrQuit(Random::Crypto::Fill(value));
     }
     else
     {


### PR DESCRIPTION
This commit adds template `Fill<ObjectType>(ObjectType &aObject)` functions for both `Crypto` and `NonCrypto` random number generation modules. These functions fill a given object with random byes.