### PR TITLE
[link-quality] fix corner case of `ScaleRawValueToRssi`

### DIFF
--- a/src/core/common/num_utils.hpp
+++ b/src/core/common/num_utils.hpp
@@ -132,6 +132,27 @@ template <typename UintType> uint16_t ClampToUint16(UintType aValue)
 }
 
 /**
+ * This template function returns a clamped version of given integer to a `int8_t`.
+ *
+ * If @p aValue is smaller than min value of a `int8_t`, the min value of `int8_t` is returned.
+ *
+ * @tparam IntType    The value type (MUST be `int16_t`, `int32_t`, or `int64_t`).
+ *
+ * @param[in] aValue  The value to clamp.
+ *
+ * @returns The clamped version of @p aValue to `int8_t`.
+ *
+ */
+template <typename IntType> int8_t ClampToInt8L(IntType aValue)
+{
+    static_assert(TypeTraits::IsSame<IntType, int16_t>::kValue || TypeTraits::IsSame<IntType, int32_t>::kValue ||
+                      TypeTraits::IsSame<IntType, int64_t>::kValue,
+                  "IntType must be `int16_t, `int32_t`, or `int64_t`");
+
+    return static_cast<int8_t>(Max(aValue, static_cast<IntType>(NumericLimits<int8_t>::kMin)));
+}
+
+/**
  * This template function performs a three-way comparison between two values.
  *
  * @tparam Type   The value type.

--- a/src/core/common/num_utils.hpp
+++ b/src/core/common/num_utils.hpp
@@ -135,6 +135,7 @@ template <typename UintType> uint16_t ClampToUint16(UintType aValue)
  * This template function returns a clamped version of given integer to a `int8_t`.
  *
  * If @p aValue is smaller than min value of a `int8_t`, the min value of `int8_t` is returned.
+ * If @p aValue is larger than max value of a `int8_t`, the max value of `int8_t` is returned.
  *
  * @tparam IntType    The value type (MUST be `int16_t`, `int32_t`, or `int64_t`).
  *
@@ -143,13 +144,14 @@ template <typename UintType> uint16_t ClampToUint16(UintType aValue)
  * @returns The clamped version of @p aValue to `int8_t`.
  *
  */
-template <typename IntType> int8_t ClampToInt8L(IntType aValue)
+template <typename IntType> int8_t ClampToInt8(IntType aValue)
 {
     static_assert(TypeTraits::IsSame<IntType, int16_t>::kValue || TypeTraits::IsSame<IntType, int32_t>::kValue ||
                       TypeTraits::IsSame<IntType, int64_t>::kValue,
                   "IntType must be `int16_t, `int32_t`, or `int64_t`");
 
-    return static_cast<int8_t>(Max(aValue, static_cast<IntType>(NumericLimits<int8_t>::kMin)));
+    return static_cast<int8_t>(Clamp(aValue, static_cast<IntType>(NumericLimits<int8_t>::kMin),
+                                     static_cast<IntType>(NumericLimits<int8_t>::kMax)));
 }
 
 /**

--- a/src/core/common/num_utils.hpp
+++ b/src/core/common/num_utils.hpp
@@ -132,7 +132,7 @@ template <typename UintType> uint16_t ClampToUint16(UintType aValue)
 }
 
 /**
- * This template function returns a clamped version of given integer to a `int8_t`.
+ * Returns a clamped version of given integer to a `int8_t`.
  *
  * If @p aValue is smaller than min value of a `int8_t`, the min value of `int8_t` is returned.
  * If @p aValue is larger than max value of a `int8_t`, the max value of `int8_t` is returned.

--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -812,7 +812,7 @@ int8_t ScaleRawValueToRssi(uint8_t aRawValue)
     value = DivideAndRoundToClosest<int32_t>(value, NumericLimits<uint8_t>::kMax);
     value += kMinRssi;
 
-    return ClampToInt8L(value);
+    return ClampToInt8(value);
 }
 
 } // namespace LinkMetrics

--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -809,7 +809,8 @@ int8_t ScaleRawValueToRssi(uint8_t aRawValue)
     int32_t value = aRawValue;
 
     value = value * (kMaxRssi - kMinRssi);
-    value = DivideAndRoundToClosest<int32_t>(value, NumericLimits<uint8_t>::kMax);
+    // 0 or 1 plus kMinRssi (-130) will cause overflow on int8_t
+    value = Max(static_cast<int32_t>(2), DivideAndRoundToClosest<int32_t>(value, NumericLimits<uint8_t>::kMax));
     value += kMinRssi;
 
     return static_cast<int8_t>(value);

--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -809,11 +809,10 @@ int8_t ScaleRawValueToRssi(uint8_t aRawValue)
     int32_t value = aRawValue;
 
     value = value * (kMaxRssi - kMinRssi);
-    // 0 or 1 plus kMinRssi (-130) will cause overflow on int8_t
-    value = Max(static_cast<int32_t>(2), DivideAndRoundToClosest<int32_t>(value, NumericLimits<uint8_t>::kMax));
+    value = DivideAndRoundToClosest<int32_t>(value, NumericLimits<uint8_t>::kMax);
     value += kMinRssi;
 
-    return static_cast<int8_t>(value);
+    return ClampToInt8L(value);
 }
 
 } // namespace LinkMetrics

--- a/tests/unit/test_link_quality.cpp
+++ b/tests/unit/test_link_quality.cpp
@@ -518,6 +518,13 @@ public:
         VerifyOrQuit(LinkMetrics::ScaleRssiToRawValue(1) == 255);
         VerifyOrQuit(LinkMetrics::ScaleRssiToRawValue(10) == 255);
         VerifyOrQuit(LinkMetrics::ScaleRssiToRawValue(127) == 255);
+
+        // Test corner case of ScaleRawValueToRssi
+        for (uint8_t rawValue = 0; rawValue < 2; rawValue++)
+        {
+            int8_t rssi = LinkMetrics::ScaleRawValueToRssi(rawValue);
+            printf("\nRaw Value: %u -> RSSI : %-3d", rawValue, rssi);
+        }
     }
 };
 


### PR DESCRIPTION
Currrently if we call `ScaleRawValueToRssi` with value 0 or 1, the result is incorrect. 
Because it tries to static_cast `-130` or `-129` to `int8_t`. I think it's not worthwhile
to widen int8_t to int16_t only for the 2 corner cases. So I prefer returning the smallest
value -128 for the 2 cases.
