### PR TITLE
[csl] fix 15.4-secured broadcast frames

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -907,7 +907,7 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame)
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     // Transmit security will be processed after time IE content is updated.
-    VerifyOrExit(aFrame.mInfo.mTxInfo.mCslPresent == 0);
+    VerifyOrExit(!aFrame.IsCslIePresent());
 #endif
 
     aFrame.ProcessTransmitAesCcm(*extAddress);

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -1423,6 +1423,22 @@ public:
     }
 
     /**
+     * Indicates whether or not the frame contains the CSL IE.
+     *
+     * @retval TRUE   The frame contains the CSL IE.
+     * @retval FALSE  The frame does not contain the CSL IE.
+     *
+     */
+    bool IsCslIePresent(void) const { return mInfo.mTxInfo.mCslPresent; }
+
+    /**
+     * Sets the CSL IE present flag.
+     *
+     * @param[in]  aCslPresent  TRUE if the frame contains the CSL IE.
+     */
+    void SetCslIePresent(bool aCslPresent) { mInfo.mTxInfo.mCslPresent = aCslPresent; }
+
+    /**
      * Indicates whether or not the frame header is updated.
      *
      * @retval TRUE   The frame already has the header updated.

--- a/src/core/mac/mac_links.hpp
+++ b/src/core/mac/mac_links.hpp
@@ -186,6 +186,9 @@ public:
         mTxFrame802154.SetTxDelay(0);
         mTxFrame802154.SetTxDelayBaseTime(0);
 #endif
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+        mTxFrame802154.SetCslIePresent(false);
+#endif
 #endif
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
         mTxFrameTrel.SetLength(0);

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1702,12 +1702,8 @@ void MeshForwarder::AppendHeaderIe(const Message *aMessage, Mac::TxFrame &aFrame
     if (Get<Mac::Mac>().IsCslEnabled())
     {
         IgnoreError(aFrame.AppendHeaderIeAt<Mac::CslIe>(index));
-        aFrame.mInfo.mTxInfo.mCslPresent = true;
-        iePresent                        = true;
-    }
-    else
-    {
-        aFrame.mInfo.mTxInfo.mCslPresent = false;
+        aFrame.SetCslIePresent(true);
+        iePresent = true;
     }
 #endif
 


### PR DESCRIPTION
The CSL present flag was not cleared in the frame structure, causing that the MAC security was not be processed for Key ID Mode 2 frames. Consequently, MLE Announcements would be rejected by the sub-MAC layer after a CSL receiver detached from its parent.