### PR TITLE
[posix] unify the spinel interface functions

### DIFF
--- a/src/lib/spinel/spinel_interface.hpp
+++ b/src/lib/spinel/spinel_interface.hpp
@@ -76,6 +76,87 @@ public:
         return (aLength >= sizeof(kSpinelResetCommand)) &&
                (memcmp(aFrame, kSpinelResetCommand, sizeof(kSpinelResetCommand)) == 0);
     }
+
+    /**
+     * Initializes the interface to the Radio Co-processor (RCP)
+     *
+     * @note This method should be called before reading and sending spinel frames to the interface.
+     *
+     * @param[in]  aRadioUrl          RadioUrl parsed from radio url.
+     *
+     * @retval OT_ERROR_NONE          The interface is initialized successfully
+     * @retval OT_ERROR_ALREADY       The interface is already initialized.
+     * @retval OT_ERROR_INVALID_ARGS  The UART device or executable cannot be found or failed to open/run.
+     *
+     */
+    virtual otError Init(const Url::Url &aRadioUrl) = 0;
+
+    /**
+     * Deinitializes the interface to the RCP.
+     *
+     */
+    virtual void Deinit(void) = 0;
+
+    /**
+     * Encodes and sends a spinel frame to Radio Co-processor (RCP) over the socket.
+     *
+     * @param[in] aFrame     A pointer to buffer containing the spinel frame to send.
+     * @param[in] aLength    The length (number of bytes) in the frame.
+     *
+     * @retval OT_ERROR_NONE     Successfully encoded and sent the spinel frame.
+     * @retval OT_ERROR_BUSY     Failed due to another operation is on going.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffer space available to encode the frame.
+     * @retval OT_ERROR_FAILED   Failed to call the SPI driver to send the frame.
+     *
+     */
+    virtual otError SendFrame(const uint8_t *aFrame, uint16_t aLength) = 0;
+
+    /**
+     * Waits for receiving part or all of spinel frame within specified interval.
+     *
+     * @param[in]  aTimeout  The timeout value in microseconds.
+     *
+     * @retval OT_ERROR_NONE             Part or all of spinel frame is received.
+     * @retval OT_ERROR_RESPONSE_TIMEOUT No spinel frame is received within @p aTimeout.
+     *
+     */
+    virtual otError WaitForFrame(uint64_t aTimeoutUs) = 0;
+
+    /**
+     * Updates the file descriptor sets with file descriptors used by the radio driver.
+     *
+     * @param[in,out]  aReadFdSet   A reference to the read file descriptors.
+     * @param[in,out]  aWriteFdSet  A reference to the write file descriptors.
+     * @param[in,out]  aMaxFd       A reference to the max file descriptor.
+     * @param[in,out]  aTimeout     A reference to the timeout.
+     *
+     */
+    virtual void UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, int &aMaxFd, struct timeval &aTimeout) = 0;
+
+    /**
+     * Performs radio driver processing.
+     *
+     * @param[in]  aContext  The context containing fd_sets.
+     *
+     */
+    virtual void Process(const RadioProcessContext &aContext) = 0;
+
+    /**
+     * Returns the bus speed between the host and the radio.
+     *
+     * @returns   Bus speed in bits/second.
+     *
+     */
+    virtual uint32_t GetBusSpeed(void) const = 0;
+
+    /**
+     * Hardware resets the RCP.
+     *
+     * @retval OT_ERROR_NONE            Successfully reset the RCP.
+     * @retval OT_ERROR_NOT_IMPLEMENT   The hardware reset is not implemented.
+     *
+     */
+    virtual otError HardwareReset(void) = 0;
 };
 } // namespace Spinel
 } // namespace ot

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -40,8 +40,6 @@
 #include "lib/spinel/openthread-spinel-config.h"
 #include "lib/spinel/spinel_interface.hpp"
 
-#if OPENTHREAD_POSIX_CONFIG_RCP_BUS == OT_POSIX_RCP_BUS_UART
-
 namespace ot {
 namespace Posix {
 
@@ -49,7 +47,7 @@ namespace Posix {
  * Defines an HDLC interface to the Radio Co-processor (RCP)
  *
  */
-class HdlcInterface
+class HdlcInterface : public ot::Spinel::SpinelInterface
 {
 public:
     /**
@@ -278,6 +276,4 @@ private:
 
 } // namespace Posix
 } // namespace ot
-
-#endif // OPENTHREAD_POSIX_CONFIG_RCP_BUS == OT_POSIX_RCP_BUS_UART
 #endif // POSIX_APP_HDLC_INTERFACE_HPP_

--- a/src/posix/platform/spi_interface.hpp
+++ b/src/posix/platform/spi_interface.hpp
@@ -42,8 +42,6 @@
 
 #include <openthread/openthread-system.h>
 
-#if OPENTHREAD_POSIX_CONFIG_RCP_BUS == OT_POSIX_RCP_BUS_SPI
-
 #include "ncp/ncp_spi.hpp"
 
 namespace ot {
@@ -53,7 +51,7 @@ namespace Posix {
  * Defines an SPI interface to the Radio Co-processor (RCP).
  *
  */
-class SpiInterface
+class SpiInterface : public ot::Spinel::SpinelInterface
 {
 public:
     /**
@@ -256,5 +254,4 @@ private:
 } // namespace Posix
 } // namespace ot
 
-#endif // OPENTHREAD_POSIX_CONFIG_RCP_BUS == OT_POSIX_RCP_BUS_SPI
 #endif // POSIX_APP_SPI_INTERFACE_HPP_

--- a/src/posix/platform/vendor_interface.hpp
+++ b/src/posix/platform/vendor_interface.hpp
@@ -41,8 +41,6 @@
 #include "platform-posix.h"
 #include "lib/spinel/spinel_interface.hpp"
 
-#if OPENTHREAD_POSIX_CONFIG_RCP_BUS == OT_POSIX_RCP_BUS_VENDOR
-
 namespace ot {
 namespace Posix {
 
@@ -50,7 +48,7 @@ namespace Posix {
  * Defines a vendor interface to the Radio Co-processor (RCP).
  *
  */
-class VendorInterface
+class VendorInterface : public ot::Spinel::SpinelInterface
 {
 public:
     /**
@@ -158,11 +156,10 @@ public:
      * @returns The RCP interface metrics.
      *
      */
-    const otRcpInterfaceMetrics *GetRcpInterfaceMetrics(void);
+    const otRcpInterfaceMetrics *GetRcpInterfaceMetrics(void) const;
 };
 
 } // namespace Posix
 } // namespace ot
 
-#endif // OPENTHREAD_POSIX_CONFIG_RCP_BUS == OT_POSIX_RCP_BUS_VENDOR
 #endif // POSIX_APP_VENDOR_INTERFACE_HPP_

--- a/src/posix/platform/vendor_interface_example.cpp
+++ b/src/posix/platform/vendor_interface_example.cpp
@@ -144,7 +144,7 @@ otError VendorInterface::SendFrame(const uint8_t *aFrame, uint16_t aLength)
     return OT_ERROR_NONE;
 }
 
-const otRcpInterfaceMetrics *VendorInterface::GetRcpInterfaceMetrics(void)
+const otRcpInterfaceMetrics *VendorInterface::GetRcpInterfaceMetrics(void) const
 {
     // TODO: Implement vendor code here.
 


### PR DESCRIPTION
This commit adds all Spinel interface functions to the `SpinelInterface` as pure virtual functions and inherits all Spinel interfaces from `SpinelInterface`, so that the Thread Network HAL can dynamically create the Spinel interface based on the configuration of the radio URL in Android. This commit also removes the macro guard from the Spinel interface header files.