### PR TITLE
[backbone-router] use `TimeTicker` in `BackboneRouter::Local`

### DIFF
--- a/src/core/api/backbone_router_ftd_api.cpp
+++ b/src/core/api/backbone_router_ftd_api.cpp
@@ -57,7 +57,7 @@ void otBackboneRouterGetConfig(otInstance *aInstance, otBackboneRouterConfig *aC
 {
     AssertPointerIsNotNull(aConfig);
 
-    AsCoreType(aInstance).Get<BackboneRouter::Local>().GetConfig(*aConfig);
+    *aConfig = AsCoreType(aInstance).Get<BackboneRouter::Local>().GetConfig();
 }
 
 otError otBackboneRouterSetConfig(otInstance *aInstance, const otBackboneRouterConfig *aConfig)
@@ -161,9 +161,7 @@ otError otBackboneRouterMulticastListenerAdd(otInstance *aInstance, const otIp6A
 {
     if (aTimeout == 0)
     {
-        BackboneRouter::Config config;
-        AsCoreType(aInstance).Get<BackboneRouter::Local>().GetConfig(config);
-        aTimeout = config.mMlrTimeout;
+        aTimeout = AsCoreType(aInstance).Get<BackboneRouter::Local>().GetConfig().mMlrTimeout;
     }
 
     aTimeout = Min(aTimeout, Mle::kMlrTimeoutMax);

--- a/src/core/common/time_ticker.cpp
+++ b/src/core/common/time_ticker.cpp
@@ -84,6 +84,13 @@ void TimeTicker::HandleTimer(void)
         Get<Mle::MleRouter>().HandleTimeTick();
     }
 
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+    if (mReceivers & Mask(kBackboneRouter))
+    {
+        Get<BackboneRouter::Local>().HandleTimeTick();
+    }
+#endif
+
     if (mReceivers & Mask(kAddressResolver))
     {
         Get<AddressResolver>().HandleTimeTick();

--- a/src/core/common/time_ticker.hpp
+++ b/src/core/common/time_ticker.hpp
@@ -73,6 +73,7 @@ public:
         kMlrManager,             ///< `MlrManager`
         kNetworkDataNotifier,    ///< `NetworkData::Notifier`
         kIp6Mpl,                 ///< `Ip6::Mpl`
+        kBackboneRouter,         ///< 'BackboneRouter::Local`
 
         kNumReceivers, ///< Number of receivers.
     };

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -86,9 +86,6 @@ MleRouter::MleRouter(Instance &aInstance)
     , mRouterSelectionJitterTimeout(0)
     , mChildRouterLinks(kChildRouterLinks)
     , mParentPriority(kParentPriorityUnspecified)
-#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    , mBackboneRouterRegistrationDelay(0)
-#endif
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     , mMaxChildIpAddresses(0)
 #endif
@@ -1506,26 +1503,6 @@ void MleRouter::HandleTimeTick(void)
             routerStateUpdate = true;
         }
     }
-#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    // Delay register only when `mRouterSelectionJitterTimeout` is 0,
-    // that is, when the device has decided to stay as REED or Router.
-    else if (mBackboneRouterRegistrationDelay > 0)
-    {
-        mBackboneRouterRegistrationDelay--;
-
-        if (mBackboneRouterRegistrationDelay == 0)
-        {
-            // If no Backbone Router service after jitter, try to register its own Backbone Router Service.
-            if (!Get<BackboneRouter::Leader>().HasPrimary())
-            {
-                if (Get<BackboneRouter::Local>().AddService() == kErrorNone)
-                {
-                    Get<NetworkData::Notifier>().HandleServerDataUpdated();
-                }
-            }
-        }
-    }
-#endif
 
     switch (mRole)
     {

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -511,16 +511,6 @@ public:
     Error SendTimeSync(void);
 #endif
 
-#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    /**
-     * Sets the delay before registering Backbone Router service.
-     *
-     * @param[in]  aDelay  The delay before registering Backbone Router service.
-     *
-     */
-    void SetBackboneRouterRegistrationDelay(uint8_t aDelay) { mBackboneRouterRegistrationDelay = aDelay; }
-#endif
-
     /**
      * Gets the maximum number of IP addresses that each MTD child may register with this device as parent.
      *
@@ -692,9 +682,6 @@ private:
     uint8_t mChildRouterLinks;
 
     int8_t mParentPriority; ///< The assigned parent priority value, -2 means not assigned.
-#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    uint8_t mBackboneRouterRegistrationDelay; ///< Delay before registering Backbone Router service.
-#endif
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     uint8_t mMaxChildIpAddresses;
 #endif


### PR DESCRIPTION
This commit contains smaller enhancements:
- The `Local` class will directly use `TimeTicker` to count down registration delay (instead of using `MleRouter`).
- `mConfig` is added to track the related config parameters.
- `RemoveService()` checks that service was added before trying to remove it (avoid unnecessary error logs).
- Skip calling `HandleServerDataUpdated()` after `AddService()`. `AddService()` already calls it internally.