### PR TITLE
[routing-manager] fix deprecating on-link prefix from inactive router

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1478,10 +1478,13 @@ void RoutingManager::DiscoveredPrefixTable::RemoveOrDeprecateEntriesFromInactive
 
         for (Entry &entry : router.mEntries)
         {
-            if (entry.IsOnLinkPrefix() && !entry.IsDeprecated())
+            if (entry.IsOnLinkPrefix())
             {
-                entry.ClearPreferredLifetime();
-                SignalTableChanged();
+                if (!entry.IsDeprecated())
+                {
+                    entry.ClearPreferredLifetime();
+                    SignalTableChanged();
+                }
             }
             else
             {


### PR DESCRIPTION
This commit fixes `RemoveOrDeprecateEntriesFromInactiveRouters()` to ensure to skip over an already deprecating on-link prefix (and not remove it).

---

Thanks to @superwhd  for finding this issue.