### PR TITLE
[tlvs] new helper to find the start and end offsets of a TLV value

### DIFF
--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -74,18 +74,6 @@ exit:
     return error;
 }
 
-Error Tlv::FindTlvOffset(const Message &aMessage, uint8_t aType, uint16_t &aOffset)
-{
-    Error      error;
-    ParsedInfo info;
-
-    SuccessOrExit(error = info.FindIn(aMessage, aType));
-    aOffset = info.mOffset;
-
-exit:
-    return error;
-}
-
 Error Tlv::FindTlvValueOffset(const Message &aMessage, uint8_t aType, uint16_t &aValueOffset, uint16_t &aLength)
 {
     Error      error;
@@ -95,6 +83,23 @@ Error Tlv::FindTlvValueOffset(const Message &aMessage, uint8_t aType, uint16_t &
 
     aValueOffset = info.mValueOffset;
     aLength      = info.mLength;
+
+exit:
+    return error;
+}
+
+Error Tlv::FindTlvValueStartEndOffsets(const Message &aMessage,
+                                       uint8_t        aType,
+                                       uint16_t      &aValueStartOffset,
+                                       uint16_t      &aValueEndOffset)
+{
+    Error      error;
+    ParsedInfo info;
+
+    SuccessOrExit(error = info.FindIn(aMessage, aType));
+
+    aValueStartOffset = info.mValueOffset;
+    aValueEndOffset   = info.mValueOffset + info.mLength;
 
 exit:
     return error;
@@ -232,11 +237,11 @@ exit:
 
 Error Tlv::FindStringTlv(const Message &aMessage, uint8_t aType, uint8_t aMaxStringLength, char *aValue)
 {
-    Error    error = kErrorNone;
-    uint16_t offset;
+    Error      error;
+    ParsedInfo info;
 
-    SuccessOrExit(error = FindTlvOffset(aMessage, aType, offset));
-    error = ReadStringTlv(aMessage, offset, aMaxStringLength, aValue);
+    SuccessOrExit(error = info.FindIn(aMessage, aType));
+    error = ReadStringTlv(aMessage, info.mOffset, aMaxStringLength, aValue);
 
 exit:
     return error;
@@ -244,11 +249,11 @@ exit:
 
 template <typename UintType> Error Tlv::FindUintTlv(const Message &aMessage, uint8_t aType, UintType &aValue)
 {
-    Error    error = kErrorNone;
-    uint16_t offset;
+    Error      error;
+    ParsedInfo info;
 
-    SuccessOrExit(error = FindTlvOffset(aMessage, aType, offset));
-    error = ReadUintTlv<UintType>(aMessage, offset, aValue);
+    SuccessOrExit(error = info.FindIn(aMessage, aType));
+    error = ReadUintTlv<UintType>(aMessage, info.mOffset, aValue);
 
 exit:
     return error;

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -283,22 +283,7 @@ public:
     }
 
     /**
-     * Obtains the offset of a TLV within @p aMessage.
-     *
-     * Can be used independent of whether the read TLV (from message) is an Extended TLV or not.
-     *
-     * @param[in]   aMessage    A reference to the message.
-     * @param[in]   aType       The Type value to search for.
-     * @param[out]  aOffset     A reference to the offset of the TLV.
-     *
-     * @retval kErrorNone       Successfully copied the TLV.
-     * @retval kErrorNotFound   Could not find the TLV with Type @p aType.
-     *
-     */
-    static Error FindTlvOffset(const Message &aMessage, uint8_t aType, uint16_t &aOffset);
-
-    /**
-     * Finds the offset and length of a given TLV type.
+     * Finds the offset and length of TLV value for a given TLV type within @p aMessage.
      *
      * Can be used independent of whether the read TLV (from message) is an Extended TLV or not.
      *
@@ -312,6 +297,25 @@ public:
      *
      */
     static Error FindTlvValueOffset(const Message &aMessage, uint8_t aType, uint16_t &aValueOffset, uint16_t &aLength);
+
+    /**
+     * Finds the start and end offset of TLV value for a given TLV type with @p aMessage.
+     *
+     * Can be used independent of whether the read TLV (from message) is an Extended TLV or not.
+     *
+     * @param[in]   aMessage           A reference to the message.
+     * @param[in]   aType              The Type value to search for.
+     * @param[out]  aValueStartOffset  The offset where the value starts.
+     * @param[out]  aValueEndOffset    The offset immediately after the last byte of value.
+     *
+     * @retval kErrorNone       Successfully found the TLV.
+     * @retval kErrorNotFound   Could not find the TLV with Type @p aType.
+     *
+     */
+    static Error FindTlvValueStartEndOffsets(const Message &aMessage,
+                                             uint8_t        aType,
+                                             uint16_t      &aValueStartOffset,
+                                             uint16_t      &aValueEndOffset);
 
     /**
      * Searches for a TLV with a given type in a message, ensures its length is same or larger than

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -948,8 +948,8 @@ template <> void Commissioner::HandleTmf<kUriRelayRx>(Coap::Message &aMessage, c
     Ip6::InterfaceIdentifier joinerIid;
     uint16_t                 joinerRloc;
     Ip6::MessageInfo         joinerMessageInfo;
-    uint16_t                 offset;
-    uint16_t                 length;
+    uint16_t                 startOffset;
+    uint16_t                 endOffset;
 
     VerifyOrExit(mState == kStateActive, error = kErrorInvalidState);
 
@@ -959,8 +959,8 @@ template <> void Commissioner::HandleTmf<kUriRelayRx>(Coap::Message &aMessage, c
     SuccessOrExit(error = Tlv::Find<JoinerIidTlv>(aMessage, joinerIid));
     SuccessOrExit(error = Tlv::Find<JoinerRouterLocatorTlv>(aMessage, joinerRloc));
 
-    SuccessOrExit(error = Tlv::FindTlvValueOffset(aMessage, Tlv::kJoinerDtlsEncapsulation, offset, length));
-    VerifyOrExit(length <= aMessage.GetLength() - offset, error = kErrorParse);
+    SuccessOrExit(
+        error = Tlv::FindTlvValueStartEndOffsets(aMessage, Tlv::kJoinerDtlsEncapsulation, startOffset, endOffset));
 
     if (!Get<Tmf::SecureAgent>().IsConnectionActive())
     {
@@ -997,8 +997,8 @@ template <> void Commissioner::HandleTmf<kUriRelayRx>(Coap::Message &aMessage, c
 
     LogInfo("Received %s (%s, 0x%04x)", UriToString<kUriRelayRx>(), mJoinerIid.ToString().AsCString(), mJoinerRloc);
 
-    aMessage.SetOffset(offset);
-    SuccessOrExit(error = aMessage.SetLength(offset + length));
+    aMessage.SetOffset(startOffset);
+    SuccessOrExit(error = aMessage.SetLength(endOffset));
 
     joinerMessageInfo.SetPeerAddr(Get<Mle::MleRouter>().GetMeshLocal64());
     joinerMessageInfo.GetPeerAddr().SetIid(mJoinerIid);

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -359,8 +359,7 @@ uint32_t ChannelMaskTlv::GetChannelMask(const Message &aMessage)
     uint16_t offset;
     uint16_t end;
 
-    SuccessOrExit(FindTlvValueOffset(aMessage, kChannelMask, offset, end));
-    end += offset;
+    SuccessOrExit(FindTlvValueStartEndOffsets(aMessage, kChannelMask, offset, end));
 
     while (offset + sizeof(ChannelMaskEntryBase) <= end)
     {

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -302,7 +302,6 @@ void DiscoverScanner::HandleDiscoveryResponse(Mle::RxInfo &aRxInfo) const
     MeshCoP::NetworkNameTlv       networkName;
     ScanResult                    result;
     uint16_t                      offset;
-    uint16_t                      length;
     uint16_t                      end;
     bool                          didCheckSteeringData = false;
 
@@ -311,8 +310,7 @@ void DiscoverScanner::HandleDiscoveryResponse(Mle::RxInfo &aRxInfo) const
     VerifyOrExit(mState == kStateScanning, error = kErrorDrop);
 
     // Find MLE Discovery TLV
-    SuccessOrExit(error = Tlv::FindTlvValueOffset(aRxInfo.mMessage, Tlv::kDiscovery, offset, length));
-    end = offset + length;
+    SuccessOrExit(error = Tlv::FindTlvValueStartEndOffsets(aRxInfo.mMessage, Tlv::kDiscovery, offset, end));
 
     memset(&result, 0, sizeof(result));
     result.mDiscover = true;

--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -306,14 +306,13 @@ Error Initiator::HandleManagementResponse(const Message &aMessage, const Ip6::Ad
     Error    error = kErrorNone;
     uint16_t offset;
     uint16_t endOffset;
-    uint16_t length;
     uint8_t  status;
     bool     hasStatus = false;
 
     VerifyOrExit(mMgmtResponseCallback.IsSet());
 
-    SuccessOrExit(error = Tlv::FindTlvValueOffset(aMessage, Mle::Tlv::Type::kLinkMetricsManagement, offset, length));
-    endOffset = offset + length;
+    SuccessOrExit(
+        error = Tlv::FindTlvValueStartEndOffsets(aMessage, Mle::Tlv::Type::kLinkMetricsManagement, offset, endOffset));
 
     while (offset < endOffset)
     {
@@ -434,9 +433,8 @@ Error Subject::AppendReport(Message &aMessage, const Message &aRequestMessage, N
     // Parse MLE Link Metrics Query TLV and its sub-TLVs from
     // `aRequestMessage`.
 
-    SuccessOrExit(error = Tlv::FindTlvValueOffset(aRequestMessage, Mle::Tlv::Type::kLinkMetricsQuery, offset, length));
-
-    endOffset = offset + length;
+    SuccessOrExit(error = Tlv::FindTlvValueStartEndOffsets(aRequestMessage, Mle::Tlv::Type::kLinkMetricsQuery, offset,
+                                                           endOffset));
 
     while (offset < endOffset)
     {
@@ -519,13 +517,12 @@ Error Subject::HandleManagementRequest(const Message &aMessage, Neighbor &aNeigh
     uint16_t            offset;
     uint16_t            endOffset;
     uint16_t            tlvEndOffset;
-    uint16_t            length;
     FwdProbingRegSubTlv fwdProbingSubTlv;
     EnhAckConfigSubTlv  enhAckConfigSubTlv;
     Metrics             metrics;
 
-    SuccessOrExit(error = Tlv::FindTlvValueOffset(aMessage, Mle::Tlv::Type::kLinkMetricsManagement, offset, length));
-    endOffset = offset + length;
+    SuccessOrExit(
+        error = Tlv::FindTlvValueStartEndOffsets(aMessage, Mle::Tlv::Type::kLinkMetricsManagement, offset, endOffset));
 
     // Set sub-TLV lengths to zero to indicate that we have
     // not yet seen them in the message.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1792,7 +1792,6 @@ Error MleRouter::ProcessAddressRegistrationTlv(RxInfo &aRxInfo, Child &aChild)
 {
     Error    error;
     uint16_t offset;
-    uint16_t length;
     uint16_t endOffset;
     uint8_t  count       = 0;
     uint8_t  storedCount = 0;
@@ -1806,9 +1805,8 @@ Error MleRouter::ProcessAddressRegistrationTlv(RxInfo &aRxInfo, Child &aChild)
     uint16_t     oldMlrRegisteredAddressNum = 0;
 #endif
 
-    SuccessOrExit(error = Tlv::FindTlvValueOffset(aRxInfo.mMessage, Tlv::kAddressRegistration, offset, length));
-
-    endOffset = offset + length;
+    SuccessOrExit(error =
+                      Tlv::FindTlvValueStartEndOffsets(aRxInfo.mMessage, Tlv::kAddressRegistration, offset, endOffset));
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE
     if ((oldDuaPtr = aChild.GetDomainUnicastAddress()) != nullptr)
@@ -2712,7 +2710,6 @@ void MleRouter::HandleDiscoveryRequest(RxInfo &aRxInfo)
     MeshCoP::DiscoveryRequestTlv discoveryRequestTlv;
     MeshCoP::ExtendedPanId       extPanId;
     uint16_t                     offset;
-    uint16_t                     length;
     uint16_t                     end;
 
     Log(kMessageReceive, kTypeDiscoveryRequest, aRxInfo.mMessageInfo.GetPeerAddr());
@@ -2722,8 +2719,7 @@ void MleRouter::HandleDiscoveryRequest(RxInfo &aRxInfo)
     // only Routers and REEDs respond
     VerifyOrExit(IsRouterEligible(), error = kErrorInvalidState);
 
-    SuccessOrExit(error = Tlv::FindTlvValueOffset(aRxInfo.mMessage, Tlv::kDiscovery, offset, length));
-    end = offset + length;
+    SuccessOrExit(error = Tlv::FindTlvValueStartEndOffsets(aRxInfo.mMessage, Tlv::kDiscovery, offset, end));
 
     while (offset < end)
     {

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -250,11 +250,9 @@ Error Server::AppendRequestedTlvs(const Message &aRequest, Message &aResponse)
 {
     Error    error;
     uint16_t offset;
-    uint16_t length;
     uint16_t endOffset;
 
-    SuccessOrExit(error = Tlv::FindTlvValueOffset(aRequest, Tlv::kTypeList, offset, length));
-    endOffset = offset + length;
+    SuccessOrExit(error = Tlv::FindTlvValueStartEndOffsets(aRequest, Tlv::kTypeList, offset, endOffset));
 
     for (; offset < endOffset; offset++)
     {

--- a/src/core/utils/mesh_diag.cpp
+++ b/src/core/utils/mesh_diag.cpp
@@ -239,12 +239,10 @@ exit:
 
 Error MeshDiag::Ip6AddrIterator::InitFrom(const Message &aMessage)
 {
-    Error    error;
-    uint16_t tlvLength;
+    Error error;
 
-    SuccessOrExit(error = Tlv::FindTlvValueOffset(aMessage, Ip6AddressListTlv::kType, mCurOffset, tlvLength));
-    mEndOffset = mCurOffset + tlvLength;
-    mMessage   = &aMessage;
+    SuccessOrExit(error = Tlv::FindTlvValueStartEndOffsets(aMessage, Ip6AddressListTlv::kType, mCurOffset, mEndOffset));
+    mMessage = &aMessage;
 
 exit:
     return error;
@@ -269,11 +267,9 @@ exit:
 
 Error MeshDiag::ChildIterator::InitFrom(const Message &aMessage, uint16_t aParentRloc16)
 {
-    Error    error;
-    uint16_t tlvLength;
+    Error error;
 
-    SuccessOrExit(error = Tlv::FindTlvValueOffset(aMessage, ChildTableTlv::kType, mCurOffset, tlvLength));
-    mEndOffset    = mCurOffset + tlvLength;
+    SuccessOrExit(error = Tlv::FindTlvValueStartEndOffsets(aMessage, ChildTableTlv::kType, mCurOffset, mCurOffset));
     mMessage      = &aMessage;
     mParentRloc16 = aParentRloc16;
 


### PR DESCRIPTION
This commit adds two changes to the `Tlvs` class:
- A new method, `FindTlvValueStartEndOffsets()`, has been added to find the start and end offsets of a TLV value within a `Message`. This method is useful for code that needs to find the value of a TLV and then search within that value.
- The unused method, `FindTlvOffset()`, has been removed. This method was previously only used by the `Tlvs` class itself.