### PR TITLE
[bbr] simplify `DomainPrefixEvent`

### DIFF
--- a/src/core/backbone_router/bbr_leader.cpp
+++ b/src/core/backbone_router/bbr_leader.cpp
@@ -97,11 +97,6 @@ void Leader::LogBackboneRouterPrimary(State aState, const Config &aConfig) const
     }
 }
 
-void Leader::LogDomainPrefix(DomainPrefixState aState, const Ip6::Prefix &aPrefix) const
-{
-    LogInfo("Domain Prefix: %s, state: %s", aPrefix.ToString().AsCString(), DomainPrefixStateToString(aState));
-}
-
 const char *Leader::StateToString(State aState)
 {
     static const char *const kStateStrings[] = {
@@ -123,23 +118,21 @@ const char *Leader::StateToString(State aState)
     return kStateStrings[aState];
 }
 
-const char *Leader::DomainPrefixStateToString(DomainPrefixState aState)
+const char *Leader::DomainPrefixEventToString(DomainPrefixEvent aEvent)
 {
-    static const char *const kPrefixStateStrings[] = {
-        "None",      // (0) kDomainPrefixNone
-        "Added",     // (1) kDomainPrefixAdded
-        "Removed",   // (2) kDomainPrefixRemoved
-        "Refreshed", // (3) kDomainPrefixRefreshed
-        "Unchanged", // (4) kDomainPrefixUnchanged
+    static const char *const kEventStrings[] = {
+        "Added",     // (0) kDomainPrefixAdded
+        "Removed",   // (1) kDomainPrefixRemoved
+        "Refreshed", // (2) kDomainPrefixRefreshed
+        "Unchanged", // (3) kDomainPrefixUnchanged
     };
 
-    static_assert(0 == kDomainPrefixNone, "kDomainPrefixNone value is incorrect");
-    static_assert(1 == kDomainPrefixAdded, "kDomainPrefixAdded value is incorrect");
-    static_assert(2 == kDomainPrefixRemoved, "kDomainPrefixRemoved value is incorrect");
-    static_assert(3 == kDomainPrefixRefreshed, "kDomainPrefixRefreshed value is incorrect");
-    static_assert(4 == kDomainPrefixUnchanged, "kDomainPrefixUnchanged value is incorrect");
+    static_assert(0 == kDomainPrefixAdded, "kDomainPrefixAdded value is incorrect");
+    static_assert(1 == kDomainPrefixRemoved, "kDomainPrefixRemoved value is incorrect");
+    static_assert(2 == kDomainPrefixRefreshed, "kDomainPrefixRefreshed value is incorrect");
+    static_assert(3 == kDomainPrefixUnchanged, "kDomainPrefixUnchanged value is incorrect");
 
-    return kPrefixStateStrings[aState];
+    return kEventStrings[aEvent];
 }
 
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
@@ -225,7 +218,7 @@ void Leader::UpdateDomainPrefixConfig(void)
 {
     NetworkData::Iterator           iterator = NetworkData::kIteratorInit;
     NetworkData::OnMeshPrefixConfig config;
-    DomainPrefixState               state;
+    DomainPrefixEvent               event;
     bool                            found = false;
 
     while (Get<NetworkData::Leader>().GetNextOnMeshPrefix(iterator, config) == kErrorNone)
@@ -239,47 +232,39 @@ void Leader::UpdateDomainPrefixConfig(void)
 
     if (!found)
     {
-        if (mDomainPrefix.GetLength() != 0)
-        {
-            // Domain Prefix does not exist any more.
-            mDomainPrefix.SetLength(0);
-            state = kDomainPrefixRemoved;
-        }
-        else
-        {
-            state = kDomainPrefixNone;
-        }
+        VerifyOrExit(HasDomainPrefix());
+
+        // Domain Prefix does not exist any more.
+        mDomainPrefix.Clear();
+        event = kDomainPrefixRemoved;
     }
     else if (config.GetPrefix() == mDomainPrefix)
     {
-        state = kDomainPrefixUnchanged;
+        event = kDomainPrefixUnchanged;
     }
     else
     {
-        if (mDomainPrefix.mLength == 0)
-        {
-            state = kDomainPrefixAdded;
-        }
-        else
-        {
-            state = kDomainPrefixRefreshed;
-        }
-
+        event         = HasDomainPrefix() ? kDomainPrefixRefreshed : kDomainPrefixAdded;
         mDomainPrefix = config.GetPrefix();
     }
 
-    LogDomainPrefix(state, mDomainPrefix);
+    LogInfo("%s domain Prefix: %s", DomainPrefixEventToString(event), mDomainPrefix.ToString().AsCString());
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    Get<Local>().HandleDomainPrefixUpdate(state);
+    Get<Local>().HandleDomainPrefixUpdate(event);
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
-    Get<NdProxyTable>().HandleDomainPrefixUpdate(state);
+    Get<NdProxyTable>().HandleDomainPrefixUpdate(event);
 #endif
 #endif
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE)
-    Get<DuaManager>().HandleDomainPrefixUpdate(state);
+    Get<DuaManager>().HandleDomainPrefixUpdate(event);
+#else
+    OT_UNUSED_VARIABLE(event);
 #endif
+
+exit:
+    return;
 }
 
 bool Leader::IsDomainUnicast(const Ip6::Address &aAddress) const

--- a/src/core/backbone_router/bbr_leader.hpp
+++ b/src/core/backbone_router/bbr_leader.hpp
@@ -67,6 +67,18 @@ static_assert(kMaxMlrTimeout * 1000 > kMaxMlrTimeout, "SecToMsec(kMaxMlrTimeout)
 static_assert(kParentAggregateDelay > 1, "kParentAggregateDelay should be larger than 1 second");
 
 /**
+ * Represents Domain Prefix changes.
+ *
+ */
+enum DomainPrefixEvent : uint8_t
+{
+    kDomainPrefixAdded,     ///< Domain Prefix Added.
+    kDomainPrefixRemoved,   ///< Domain Prefix Removed.
+    kDomainPrefixRefreshed, ///< Domain Prefix Changed.
+    kDomainPrefixUnchanged, ///< Domain Prefix did not change.
+};
+
+/**
  * Implements the basic Primary Backbone Router service operations.
  *
  */
@@ -83,16 +95,6 @@ public:
                               ///< May also have ReregistrationDelay or MlrTimeout update.
         kStateRefreshed,      ///< Only ReregistrationDelay or MlrTimeout changes.
         kStateUnchanged,      ///< No change on Primary Backbone Router information (only for logging).
-    };
-
-    // Domain Prefix state or state change.
-    enum DomainPrefixState : uint8_t
-    {
-        kDomainPrefixNone = 0,  ///< Not available.
-        kDomainPrefixAdded,     ///< Added.
-        kDomainPrefixRemoved,   ///< Removed.
-        kDomainPrefixRefreshed, ///< Changed.
-        kDomainPrefixUnchanged, ///< Nothing changed.
     };
 
     /**
@@ -190,12 +192,10 @@ private:
     void UpdateDomainPrefixConfig(void);
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
     void               LogBackboneRouterPrimary(State aState, const Config &aConfig) const;
-    void               LogDomainPrefix(DomainPrefixState aState, const Ip6::Prefix &aPrefix) const;
     static const char *StateToString(State aState);
-    static const char *DomainPrefixStateToString(DomainPrefixState aState);
+    static const char *DomainPrefixEventToString(DomainPrefixEvent aEvent);
 #else
     void LogBackboneRouterPrimary(State, const Config &) const {}
-    void LogDomainPrefix(DomainPrefixState, const Ip6::Prefix &) const {}
 #endif
 
     Config      mConfig;       ///< Primary Backbone Router information.

--- a/src/core/backbone_router/bbr_local.cpp
+++ b/src/core/backbone_router/bbr_local.cpp
@@ -358,19 +358,19 @@ exit:
     return;
 }
 
-void Local::HandleDomainPrefixUpdate(Leader::DomainPrefixState aState)
+void Local::HandleDomainPrefixUpdate(DomainPrefixEvent aEvent)
 {
     if (!IsEnabled())
     {
         ExitNow();
     }
 
-    if (aState == Leader::kDomainPrefixRemoved || aState == Leader::kDomainPrefixRefreshed)
+    if (aEvent == kDomainPrefixRemoved || aEvent == kDomainPrefixRefreshed)
     {
         Get<BackboneTmfAgent>().UnsubscribeMulticast(mAllDomainBackboneRouters);
     }
 
-    if (aState == Leader::kDomainPrefixAdded || aState == Leader::kDomainPrefixRefreshed)
+    if (aEvent == kDomainPrefixAdded || aEvent == kDomainPrefixRefreshed)
     {
         mAllDomainBackboneRouters.SetMulticastNetworkPrefix(*Get<Leader>().GetDomainPrefix());
         Get<BackboneTmfAgent>().SubscribeMulticast(mAllDomainBackboneRouters);
@@ -378,15 +378,15 @@ void Local::HandleDomainPrefixUpdate(Leader::DomainPrefixState aState)
 
     if (mDomainPrefixCallback.IsSet())
     {
-        switch (aState)
+        switch (aEvent)
         {
-        case Leader::kDomainPrefixAdded:
+        case kDomainPrefixAdded:
             mDomainPrefixCallback.Invoke(OT_BACKBONE_ROUTER_DOMAIN_PREFIX_ADDED, Get<Leader>().GetDomainPrefix());
             break;
-        case Leader::kDomainPrefixRemoved:
+        case kDomainPrefixRemoved:
             mDomainPrefixCallback.Invoke(OT_BACKBONE_ROUTER_DOMAIN_PREFIX_REMOVED, Get<Leader>().GetDomainPrefix());
             break;
-        case Leader::kDomainPrefixRefreshed:
+        case kDomainPrefixRefreshed:
             mDomainPrefixCallback.Invoke(OT_BACKBONE_ROUTER_DOMAIN_PREFIX_CHANGED, Get<Leader>().GetDomainPrefix());
             break;
         default:

--- a/src/core/backbone_router/bbr_local.hpp
+++ b/src/core/backbone_router/bbr_local.hpp
@@ -250,10 +250,10 @@ public:
     /**
      * Updates the subscription of All Domain Backbone Routers Multicast Address.
      *
-     * @param[in]  aState  The Domain Prefix state or state change.
+     * @param[in]  aEvent  The Domain Prefix event.
      *
      */
-    void HandleDomainPrefixUpdate(Leader::DomainPrefixState aState);
+    void HandleDomainPrefixUpdate(DomainPrefixEvent aEvent);
 
     /**
      * Sets the Domain Prefix callback.

--- a/src/core/backbone_router/ndproxy_table.cpp
+++ b/src/core/backbone_router/ndproxy_table.cpp
@@ -125,10 +125,9 @@ void NdProxyTable::Iterator::Advance(void)
 
 void NdProxyTable::Erase(NdProxy &aNdProxy) { aNdProxy.mValid = false; }
 
-void NdProxyTable::HandleDomainPrefixUpdate(Leader::DomainPrefixState aState)
+void NdProxyTable::HandleDomainPrefixUpdate(DomainPrefixEvent aEvent)
 {
-    if (aState == Leader::kDomainPrefixAdded || aState == Leader::kDomainPrefixRemoved ||
-        aState == Leader::kDomainPrefixRefreshed)
+    if (aEvent == kDomainPrefixAdded || aEvent == kDomainPrefixRemoved || aEvent == kDomainPrefixRefreshed)
     {
         Clear();
     }

--- a/src/core/backbone_router/ndproxy_table.hpp
+++ b/src/core/backbone_router/ndproxy_table.hpp
@@ -188,12 +188,12 @@ public:
     bool IsRegistered(const Ip6::InterfaceIdentifier &aAddressIid) { return FindByAddressIid(aAddressIid) != nullptr; }
 
     /**
-     * Notifies Domain Prefix status.
+     * Notifies Domain Prefix event.
      *
-     * @param[in]  aState  The Domain Prefix state or state change.
+     * @param[in]  aEvent  The Domain Prefix event.
      *
      */
-    void HandleDomainPrefixUpdate(Leader::DomainPrefixState aState);
+    void HandleDomainPrefixUpdate(DomainPrefixEvent aEvent);
 
     /**
      * Notifies ND Proxy table of the timer tick.

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -78,10 +78,9 @@ DuaManager::DuaManager(Instance &aInstance)
 #endif
 }
 
-void DuaManager::HandleDomainPrefixUpdate(BackboneRouter::Leader::DomainPrefixState aState)
+void DuaManager::HandleDomainPrefixUpdate(BackboneRouter::DomainPrefixEvent aEvent)
 {
-    if ((aState == BackboneRouter::Leader::kDomainPrefixRemoved) ||
-        (aState == BackboneRouter::Leader::kDomainPrefixRefreshed))
+    if ((aEvent == BackboneRouter::kDomainPrefixRemoved) || (aEvent == BackboneRouter::kDomainPrefixRefreshed))
     {
         if (mIsDuaPending)
         {
@@ -102,16 +101,16 @@ void DuaManager::HandleDomainPrefixUpdate(BackboneRouter::Leader::DomainPrefixSt
     }
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
-    switch (aState)
+    switch (aEvent)
     {
-    case BackboneRouter::Leader::kDomainPrefixUnchanged:
+    case BackboneRouter::kDomainPrefixUnchanged:
         // In case removed for some reason e.g. the kDuaInvalid response from PBBR forcefully
         VerifyOrExit(!Get<ThreadNetif>().HasUnicastAddress(GetDomainUnicastAddress()));
 
         OT_FALL_THROUGH;
 
-    case BackboneRouter::Leader::kDomainPrefixRefreshed:
-    case BackboneRouter::Leader::kDomainPrefixAdded:
+    case BackboneRouter::kDomainPrefixRefreshed:
+    case BackboneRouter::kDomainPrefixAdded:
     {
         const Ip6::Prefix *prefix = Get<BackboneRouter::Leader>().GetDomainPrefix();
         OT_ASSERT(prefix != nullptr);

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -96,12 +96,12 @@ public:
     explicit DuaManager(Instance &aInstance);
 
     /**
-     * Notifies Domain Prefix status.
+     * Notifies Domain Prefix changes.
      *
-     * @param[in]  aState  The Domain Prefix state or state change.
+     * @param[in]  aEvent  The Domain Prefix event.
      *
      */
-    void HandleDomainPrefixUpdate(BackboneRouter::Leader::DomainPrefixState aState);
+    void HandleDomainPrefixUpdate(BackboneRouter::DomainPrefixEvent aEvent);
 
     /**
      * Notifies Primary Backbone Router status.


### PR DESCRIPTION
- Rename to `DomainPrefixEvent` from `DomainPrefixState`
- Remove the unused `kDomainPrefixNone` enumeration