### PR TITLE
[mle] unicast Link Request to 1.2.1 or earlier parent on router role promo

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3535,6 +3535,16 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message          *aMessage,
         leader->SetNextHopAndCost(RouterIdFromRloc16(mParent.GetRloc16()), mParent.GetLeaderCost());
     }
 
+    // We send a unicast Link Request to our former parent if its
+    // version is earlier than 1.3. This is to address a potential
+    // compatibility issue with some non-OpenThread stacks which may
+    // ignore MLE Advertisements from a former/existing child.
+
+    if (mParent.GetVersion() < kThreadVersion1p3)
+    {
+        IgnoreError(SendLinkRequest(&mParent));
+    }
+
     // We send an Advertisement to inform our former parent of our
     // newly allocated Router ID. This will cause the parent to
     // reset its advertisement trickle timer which can help speed


### PR DESCRIPTION
This commit adds a new mechanism to send a unicast MLE Link Request to
the device's former parent if its version is earlier than 1.3.0, when
the device is promoted from a child to a router role. This is to
address a potential compatibility issue with some non-OpenThread
stacks which may ignore MLE Advertisements from a previous/existing
child.

----

Related to [SPEC-1131](https://threadgroup.atlassian.net/browse/SPEC-1131).