### PR TITLE
[mac] enable/disable radio together with MAC

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -119,7 +119,6 @@ Mac::Mac(Instance &aInstance)
     ResetCounters();
 
     SetEnabled(true);
-    mLinks.Enable();
 
     Get<KeyManager>().UpdateKeyMaterial();
     SetPanId(mPanId);
@@ -127,6 +126,20 @@ Mac::Mac(Instance &aInstance)
     SetShortAddress(GetShortAddress());
 
     mMode2KeyMaterial.SetFrom(AsCoreType(&sMode2Key));
+}
+
+void Mac::SetEnabled(bool aEnable)
+{
+    mEnabled = aEnable;
+
+    if (aEnable)
+    {
+        mLinks.Enable();
+    }
+    else
+    {
+        mLinks.Disable();
+    }
 }
 
 Error Mac::ActiveScan(uint32_t aScanChannels, uint16_t aScanDuration, ActiveScanHandler aHandler, void *aContext)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -576,7 +576,7 @@ public:
      * @param[in]  aEnable The requested State for the MAC layer. true - Start, false - Stop.
      *
      */
-    void SetEnabled(bool aEnable) { mEnabled = aEnable; }
+    void SetEnabled(bool aEnable);
 
     /**
      * Indicates whether or not the link layer is enabled.


### PR DESCRIPTION
Fix the behavior of `Mac::SetEnabled` for also enabling/disabling the radio.

This ensures that the radio is turned off when `otLinkSetEnabled(false)` is used.