### PR TITLE
[mle] restrict `otDeviceProperties` to version 1.3.1 or later

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (329)
+#define OPENTHREAD_API_VERSION (330)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -236,6 +236,8 @@ typedef struct otDeviceProperties
 /**
  * Get the current device properties.
  *
+ * Requires `OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1`.
+ *
  * @returns The device properties `otDeviceProperties`.
  *
  */
@@ -243,6 +245,8 @@ const otDeviceProperties *otThreadGetDeviceProperties(otInstance *aInstance);
 
 /**
  * Set the device properties which are then used to determine and set the Leader Weight.
+ *
+ * Requires `OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1`.
  *
  * @param[in]  aInstance           A pointer to an OpenThread instance.
  * @param[in]  aDeviceProperties   The device properties.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3434,6 +3434,7 @@ template <> otError Interpreter::Process<Cmd("leaderweight")>(Arg aArgs[])
     return ProcessGetSet(aArgs, otThreadGetLocalLeaderWeight, otThreadSetLocalLeaderWeight);
 }
 
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
 template <> otError Interpreter::Process<Cmd("deviceprops")>(Arg aArgs[])
 {
     static const char *const kPowerSupplyStrings[4] = {
@@ -3532,6 +3533,7 @@ template <> otError Interpreter::Process<Cmd("deviceprops")>(Arg aArgs[])
 exit:
     return error;
 }
+#endif // #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
 
 #endif // OPENTHREAD_FTD
 
@@ -7326,7 +7328,7 @@ otError Interpreter::ProcessCommand(Arg aArgs[])
 #endif
         CmdEntry("detach"),
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD
-#if OPENTHREAD_FTD
+#if OPENTHREAD_FTD && (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
         CmdEntry("deviceprops"),
 #endif
 #if OPENTHREAD_CONFIG_DIAG_ENABLE

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -79,6 +79,7 @@ otError otThreadSetPreferredRouterId(otInstance *aInstance, uint8_t aRouterId)
     return AsCoreType(aInstance).Get<Mle::MleRouter>().SetPreferredRouterId(aRouterId);
 }
 
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
 const otDeviceProperties *otThreadGetDeviceProperties(otInstance *aInstance)
 {
     return &AsCoreType(aInstance).Get<Mle::MleRouter>().GetDeviceProperties();
@@ -88,6 +89,7 @@ void otThreadSetDeviceProperties(otInstance *aInstance, const otDeviceProperties
 {
     AsCoreType(aInstance).Get<Mle::MleRouter>().SetDeviceProperties(AsCoreType(aDeviceProperties));
 }
+#endif
 
 uint8_t otThreadGetLocalLeaderWeight(otInstance *aInstance)
 {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -94,7 +94,12 @@ MleRouter::MleRouter(Instance &aInstance)
 #endif
 {
     mDeviceMode.Set(mDeviceMode.Get() | DeviceMode::kModeFullThreadDevice | DeviceMode::kModeFullNetworkData);
+
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
     mLeaderWeight = mDeviceProperties.CalculateLeaderWeight();
+#else
+    mLeaderWeight = kDefaultLeaderWeight;
+#endif
 
     SetRouterId(kInvalidRouterId);
 
@@ -183,12 +188,14 @@ exit:
     return error;
 }
 
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
 void MleRouter::SetDeviceProperties(const DeviceProperties &aDeviceProperties)
 {
     mDeviceProperties = aDeviceProperties;
     mDeviceProperties.ClampWeightAdjustment();
     SetLeaderWeight(mDeviceProperties.CalculateLeaderWeight());
 }
+#endif
 
 Error MleRouter::BecomeRouter(ThreadStatusTlv::Status aStatus)
 {

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -143,6 +143,7 @@ public:
      */
     Error BecomeLeader(void);
 
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
     /**
      * Gets the device properties which are used to determine the Leader Weight.
      *
@@ -158,6 +159,7 @@ public:
      *
      */
     void SetDeviceProperties(const DeviceProperties &aDeviceProperties);
+#endif
 
     /**
      * Returns the Leader Weighting value for this Thread interface.
@@ -564,6 +566,7 @@ private:
     static constexpr uint16_t kDiscoveryMaxJitter            = 250; // Max jitter delay Discovery Responses (in msec).
     static constexpr uint16_t kChallengeTimeout              = 2;   // Challenge timeout (in sec).
     static constexpr uint16_t kUnsolicitedDataResponseJitter = 500; // Max delay for unsol Data Response (in msec).
+    static constexpr uint8_t  kDefaultLeaderWeight           = 64;
 
     // Threshold to accept a router upgrade request with reason
     // `kBorderRouterRequest` (number of BRs acting as router in
@@ -656,7 +659,9 @@ private:
 
     TrickleTimer mAdvertiseTrickleTimer;
 
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
     DeviceProperties mDeviceProperties;
+#endif
 
     ChildTable  mChildTable;
     RouterTable mRouterTable;

--- a/src/core/thread/mle_types.cpp
+++ b/src/core/thread/mle_types.cpp
@@ -70,7 +70,7 @@ DeviceMode::InfoString DeviceMode::ToString(void) const
 //---------------------------------------------------------------------------------------------------------------------
 // DeviceProperties
 
-#if OPENTHREAD_FTD
+#if OPENTHREAD_FTD && (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
 
 DeviceProperties::DeviceProperties(void)
 {
@@ -133,7 +133,7 @@ uint8_t DeviceProperties::CalculateLeaderWeight(void) const
     return weight;
 }
 
-#endif // OPENTHREAD_FTD
+#endif // #if OPENTHREAD_FTD && (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
 
 //---------------------------------------------------------------------------------------------------------------------
 // RouterIdSet

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -377,7 +377,7 @@ private:
     uint8_t mMode;
 };
 
-#if OPENTHREAD_FTD
+#if OPENTHREAD_FTD && (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
 /**
  * Represents device properties.
  *
@@ -436,7 +436,7 @@ private:
     static_assert(kDefaultAdjustment <= kMaxAdjustment, "Invalid default weight adjustment");
 };
 
-#endif // OPENTHREAD_FTD
+#endif // #if OPENTHREAD_FTD && (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
 
 /**
  * Represents the Thread Leader Data.
@@ -702,7 +702,7 @@ const char *RoleToString(DeviceRole aRole);
 
 DefineCoreType(otLeaderData, Mle::LeaderData);
 DefineMapEnum(otDeviceRole, Mle::DeviceRole);
-#if OPENTHREAD_FTD
+#if OPENTHREAD_FTD && (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
 DefineCoreType(otDeviceProperties, Mle::DeviceProperties);
 DefineMapEnum(otPowerSupply, Mle::DeviceProperties::PowerSupply);
 #endif

--- a/tests/unit/test_mle.cpp
+++ b/tests/unit/test_mle.cpp
@@ -36,7 +36,8 @@
 
 namespace ot {
 
-#if OPENTHREAD_FTD
+#if OPENTHREAD_FTD && (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
+
 void TestDefaultDeviceProperties(void)
 {
     Instance                 *instance;
@@ -169,13 +170,13 @@ void TestLeaderWeightCalculation(void)
     printf("TestLeaderWeightCalculation passed\n");
 }
 
-#endif // OPENTHREAD_FTD
+#endif // #if OPENTHREAD_FTD && (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
 
 } // namespace ot
 
 int main(void)
 {
-#if OPENTHREAD_FTD
+#if OPENTHREAD_FTD && (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_3_1)
     ot::TestDefaultDeviceProperties();
     ot::TestLeaderWeightCalculation();
 #endif


### PR DESCRIPTION
This commit restricts the `otDeviceProperties` functionality to OpenThread builds with `OT_THREAD_VERSION` set to `1.3.1` or later. This functionality was added in PR #8670 and is used to calculate and set the local Leader Weight on the device based on its properties, such as power supply configuration and whether or the device is acting as a Border Router, etc.

---

Related to [DEV-2376](https://threadgroup.atlassian.net/browse/DEV-2376).