### PR TITLE
[routing-manager] require valid on-link prefix to be /64

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -845,7 +845,9 @@ bool RoutingManager::IsValidOnLinkPrefix(const Ip6::Nd::PrefixInfoOption &aPio)
 
 bool RoutingManager::IsValidOnLinkPrefix(const Ip6::Prefix &aOnLinkPrefix)
 {
-    return aOnLinkPrefix.IsValid() && (aOnLinkPrefix.GetLength() > 0) && !aOnLinkPrefix.IsLinkLocal() &&
+    static constexpr uint8_t kOnLinkPrefixLength = 64;
+
+    return (aOnLinkPrefix.GetLength() == kOnLinkPrefixLength) && !aOnLinkPrefix.IsLinkLocal() &&
            !aOnLinkPrefix.IsMulticast();
 }
 


### PR DESCRIPTION
Context: https://mailarchive.ietf.org/arch/msg/snac/0wzbsMx_1uHFHEdw-cftEufoi-k/