### PR TITLE
[netif] simplify signaling address events

### DIFF
--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -43,30 +43,6 @@
 namespace ot {
 namespace Ip6 {
 
-class AddressInfo : public otIp6AddressInfo
-{
-public:
-    explicit AddressInfo(const Netif::UnicastAddress &aAddress)
-    {
-        mAddress      = &aAddress.mAddress;
-        mPrefixLength = aAddress.mPrefixLength;
-        mScope        = aAddress.GetScope();
-        mPreferred    = aAddress.mPreferred;
-    }
-
-    explicit AddressInfo(const Netif::MulticastAddress &aAddress)
-    {
-        mAddress      = &aAddress.GetAddress();
-        mPrefixLength = kMulticastPrefixLength;
-        mScope        = aAddress.GetAddress().GetScope();
-        mPreferred    = false;
-    }
-
-private:
-    static constexpr uint8_t kMulticastPrefixLength =
-        128; ///< Multicast prefix length used to notify internal address changes.
-};
-
 /*
  * Certain fixed multicast addresses are defined as a set of chained (linked-list) constant `otNetifMulticastAddress`
  * entries:
@@ -141,7 +117,7 @@ void Netif::SubscribeAllNodesMulticast(void)
         tail->SetNext(&linkLocalAllNodesAddress);
     }
 
-    SignalMulticastAddressChange(kAddressAdded, &linkLocalAllNodesAddress, nullptr);
+    SignalMulticastAddressesChange(kAddressAdded, &linkLocalAllNodesAddress, nullptr);
 
 exit:
     return;
@@ -179,7 +155,7 @@ void Netif::UnsubscribeAllNodesMulticast(void)
         prev->SetNext(nullptr);
     }
 
-    SignalMulticastAddressChange(kAddressRemoved, &linkLocalAllNodesAddress, nullptr);
+    SignalMulticastAddressesChange(kAddressRemoved, &linkLocalAllNodesAddress, nullptr);
 
 exit:
     return;
@@ -222,7 +198,7 @@ void Netif::SubscribeAllRoutersMulticast(void)
         prev->SetNext(&linkLocalAllRoutersAddress);
     }
 
-    SignalMulticastAddressChange(kAddressAdded, &linkLocalAllRoutersAddress, &linkLocalAllNodesAddress);
+    SignalMulticastAddressesChange(kAddressAdded, &linkLocalAllRoutersAddress, &linkLocalAllNodesAddress);
 
 exit:
     return;
@@ -255,45 +231,44 @@ void Netif::UnsubscribeAllRoutersMulticast(void)
         prev->SetNext(&linkLocalAllNodesAddress);
     }
 
-    SignalMulticastAddressChange(kAddressRemoved, &linkLocalAllRoutersAddress, &linkLocalAllNodesAddress);
+    SignalMulticastAddressesChange(kAddressRemoved, &linkLocalAllRoutersAddress, &linkLocalAllNodesAddress);
 
 exit:
     return;
 }
 
-void Netif::SignalMulticastAddressChange(AddressEvent            aAddressEvent,
-                                         const MulticastAddress *aStart,
-                                         const MulticastAddress *aEnd)
+void Netif::SignalMulticastAddressChange(AddressEvent aEvent, const MulticastAddress &aAddress, AddressOrigin aOrigin)
+{
+    Get<Notifier>().Signal(aEvent == kAddressAdded ? kEventIp6MulticastSubscribed : kEventIp6MulticastUnsubscribed);
+
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+    Get<Utils::HistoryTracker>().RecordAddressEvent(aEvent, aAddress, aOrigin);
+#endif
+
+    if ((aOrigin == kOriginThread) && mAddressCallback.IsSet())
+    {
+        AddressInfo info;
+
+        info.mAddress      = &aAddress.GetAddress();
+        info.mPrefixLength = kMulticastPrefixLength;
+        info.mScope        = aAddress.GetAddress().GetScope();
+        info.mPreferred    = false;
+
+        mAddressCallback.Invoke(&info, aEvent);
+    }
+}
+
+void Netif::SignalMulticastAddressesChange(AddressEvent            aEvent,
+                                           const MulticastAddress *aStart,
+                                           const MulticastAddress *aEnd)
 {
     // Signal changes to fixed multicast addresses from `aStart` up to
-    // (not including) `aEnd`. `aAddressEvent` indicates whether
-    // addresses were subscribed or unsubscribed.
-
-    Get<Notifier>().Signal(aAddressEvent == kAddressAdded ? kEventIp6MulticastSubscribed
-                                                          : kEventIp6MulticastUnsubscribed);
-
-#if !OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    VerifyOrExit(mAddressCallback.IsSet());
-#endif
+    // (not including) `aEnd`.
 
     for (const MulticastAddress *entry = aStart; entry != aEnd; entry = entry->GetNext())
     {
-#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-        Get<Utils::HistoryTracker>().RecordAddressEvent(aAddressEvent, *entry, kOriginThread);
-
-        if (mAddressCallback.IsSet())
-#endif
-        {
-            AddressInfo addressInfo(*entry);
-
-            mAddressCallback.Invoke(&addressInfo, aAddressEvent);
-        }
+        SignalMulticastAddressChange(aEvent, *entry, kOriginThread);
     }
-
-    ExitNow();
-
-exit:
-    return;
 }
 
 bool Netif::IsMulticastAddressExternal(const MulticastAddress &aAddress) const
@@ -304,19 +279,7 @@ bool Netif::IsMulticastAddressExternal(const MulticastAddress &aAddress) const
 void Netif::SubscribeMulticast(MulticastAddress &aAddress)
 {
     SuccessOrExit(mMulticastAddresses.Add(aAddress));
-
-    Get<Notifier>().Signal(kEventIp6MulticastSubscribed);
-
-#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressAdded, aAddress, kOriginThread);
-#endif
-
-    if (mAddressCallback.IsSet())
-    {
-        AddressInfo addressInfo(aAddress);
-
-        mAddressCallback.Invoke(&addressInfo, kAddressAdded);
-    }
+    SignalMulticastAddressChange(kAddressAdded, aAddress, kOriginThread);
 
 exit:
     return;
@@ -325,19 +288,7 @@ exit:
 void Netif::UnsubscribeMulticast(const MulticastAddress &aAddress)
 {
     SuccessOrExit(mMulticastAddresses.Remove(aAddress));
-
-    Get<Notifier>().Signal(kEventIp6MulticastUnsubscribed);
-
-#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressRemoved, aAddress, kOriginThread);
-#endif
-
-    if (mAddressCallback.IsSet())
-    {
-        AddressInfo addressInfo(aAddress);
-
-        mAddressCallback.Invoke(&addressInfo, kAddressRemoved);
-    }
+    SignalMulticastAddressChange(kAddressRemoved, aAddress, kOriginThread);
 
 exit:
     return;
@@ -370,11 +321,7 @@ Error Netif::SubscribeExternalMulticast(const Address &aAddress)
 #endif
     mMulticastAddresses.Push(*entry);
 
-#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressAdded, *entry, kOriginManual);
-#endif
-
-    Get<Notifier>().Signal(kEventIp6MulticastSubscribed);
+    SignalMulticastAddressChange(kAddressAdded, *entry, kOriginManual);
 
 exit:
     return error;
@@ -393,13 +340,9 @@ Error Netif::UnsubscribeExternalMulticast(const Address &aAddress)
 
     mMulticastAddresses.PopAfter(prev);
 
-#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressRemoved, *entry, kOriginManual);
-#endif
+    SignalMulticastAddressChange(kAddressRemoved, *entry, kOriginManual);
 
     mExtMulticastAddressPool.Free(static_cast<ExternalMulticastAddress &>(*entry));
-
-    Get<Notifier>().Signal(kEventIp6MulticastUnsubscribed);
 
 exit:
     return error;
@@ -423,19 +366,7 @@ void Netif::UnsubscribeAllExternalMulticastAddresses(void)
 void Netif::AddUnicastAddress(UnicastAddress &aAddress)
 {
     SuccessOrExit(mUnicastAddresses.Add(aAddress));
-
-    Get<Notifier>().Signal(aAddress.mRloc ? kEventThreadRlocAdded : kEventIp6AddressAdded);
-
-#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressAdded, aAddress);
-#endif
-
-    if (mAddressCallback.IsSet())
-    {
-        AddressInfo addressInfo(aAddress);
-
-        mAddressCallback.Invoke(&addressInfo, kAddressAdded);
-    }
+    SignalUnicastAddressChange(kAddressAdded, aAddress);
 
 exit:
     return;
@@ -444,22 +375,42 @@ exit:
 void Netif::RemoveUnicastAddress(const UnicastAddress &aAddress)
 {
     SuccessOrExit(mUnicastAddresses.Remove(aAddress));
-
-    Get<Notifier>().Signal(aAddress.mRloc ? kEventThreadRlocRemoved : kEventIp6AddressRemoved);
-
-#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressRemoved, aAddress);
-#endif
-
-    if (mAddressCallback.IsSet())
-    {
-        AddressInfo addressInfo(aAddress);
-
-        mAddressCallback.Invoke(&addressInfo, kAddressRemoved);
-    }
+    SignalUnicastAddressChange(kAddressRemoved, aAddress);
 
 exit:
     return;
+}
+
+void Netif::SignalUnicastAddressChange(AddressEvent aEvent, const UnicastAddress &aAddress)
+{
+    Event event;
+
+    if (aAddress.mRloc)
+    {
+        event = (aEvent == kAddressAdded) ? kEventThreadRlocAdded : kEventThreadRlocRemoved;
+    }
+    else
+    {
+        event = (aEvent == kAddressAdded) ? kEventIp6AddressAdded : kEventIp6AddressRemoved;
+    }
+
+    Get<Notifier>().Signal(event);
+
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+    Get<Utils::HistoryTracker>().RecordAddressEvent(aEvent, aAddress);
+#endif
+
+    if (!IsUnicastAddressExternal(aAddress) && mAddressCallback.IsSet())
+    {
+        AddressInfo info;
+
+        info.mAddress      = &aAddress.mAddress;
+        info.mPrefixLength = aAddress.mPrefixLength;
+        info.mScope        = aAddress.GetScope();
+        info.mPreferred    = aAddress.mPreferred;
+
+        mAddressCallback.Invoke(&info, aEvent);
+    }
 }
 
 Error Netif::AddExternalUnicastAddress(const UnicastAddress &aAddress)
@@ -487,14 +438,10 @@ Error Netif::AddExternalUnicastAddress(const UnicastAddress &aAddress)
     entry = mExtUnicastAddressPool.Allocate();
     VerifyOrExit(entry != nullptr, error = kErrorNoBufs);
 
-    *entry = aAddress;
+    *entry       = aAddress;
+    entry->mRloc = false;
     mUnicastAddresses.Push(*entry);
-
-#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressAdded, *entry);
-#endif
-
-    Get<Notifier>().Signal(kEventIp6AddressAdded);
+    SignalUnicastAddressChange(kAddressAdded, *entry);
 
 exit:
     return error;
@@ -513,12 +460,9 @@ Error Netif::RemoveExternalUnicastAddress(const Address &aAddress)
 
     mUnicastAddresses.PopAfter(prev);
 
-#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressRemoved, *entry);
-#endif
+    SignalUnicastAddressChange(kAddressRemoved, *entry);
 
     mExtUnicastAddressPool.Free(*entry);
-    Get<Notifier>().Signal(kEventIp6AddressRemoved);
 
 exit:
     return error;

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -648,9 +648,15 @@ protected:
     void UnsubscribeAllNodesMulticast(void);
 
 private:
-    void SignalMulticastAddressChange(AddressEvent            aAddressEvent,
-                                      const MulticastAddress *aStart,
-                                      const MulticastAddress *aEnd);
+    typedef otIp6AddressInfo AddressInfo;
+
+    static constexpr uint8_t kMulticastPrefixLength = 128; // Multicast prefix length used in `AdressInfo`.
+
+    void SignalUnicastAddressChange(AddressEvent aEvent, const UnicastAddress &aAddress);
+    void SignalMulticastAddressChange(AddressEvent aEvent, const MulticastAddress &aAddress, AddressOrigin aOrigin);
+    void SignalMulticastAddressesChange(AddressEvent            aEvent,
+                                        const MulticastAddress *aStart,
+                                        const MulticastAddress *aEnd);
 
     LinkedList<UnicastAddress>   mUnicastAddresses;
     LinkedList<MulticastAddress> mMulticastAddresses;


### PR DESCRIPTION
This commit adds two new methods, `SignalUnicastAddressChange()` and `SignalMulticastAddressChange()`. These methods signal changes to unicast or multicast addresses to the `Notifier`, `HistoryTracker`, and user address callback.