### PR TITLE
[thci] revert spellcheck in THCI method names

### DIFF
--- a/.code-spell-ignore
+++ b/.code-spell-ignore
@@ -10,6 +10,7 @@ apending
 asender
 asent
 ect
+intialize
 nd
 ot
 shashes

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -225,7 +225,7 @@ class OpenThreadTHCI(object):
             **kwargs: Arbitrary keyword arguments
                       Includes 'EUI' and 'SerialPort'
         """
-        self.initialize(kwargs)
+        self.intialize(kwargs)
 
     @abstractmethod
     def _connect(self):
@@ -399,7 +399,7 @@ class OpenThreadTHCI(object):
         time.sleep(duration)
 
     @API
-    def initialize(self, params):
+    def intialize(self, params):
         """initialize the serial port with baudrate, timeout parameters"""
         self.mac = params.get('EUI')
         self.backboneNetif = params.get('Param8') or 'eth0'

--- a/tools/harness-thci/OpenThread_WpanCtl.py
+++ b/tools/harness-thci/OpenThread_WpanCtl.py
@@ -90,7 +90,7 @@ class OpenThread_WpanCtl(IThci):
                 self.password = kwargs.get('Param7').strip() if kwargs.get('Param7') else None
             else:
                 self.port = kwargs.get('SerialPort')
-            self.initialize()
+            self.intialize()
         except Exception as e:
             ModuleHelper.WriteIntoDebugLogger('initialize() Error: ' + str(e))
 
@@ -794,7 +794,7 @@ class OpenThread_WpanCtl(IThci):
         except Exception as e:
             ModuleHelper.WriteIntoDebugLogger('closeConnection() Error: ' + str(e))
 
-    def initialize(self):
+    def intialize(self):
         """initialize the serial port with baudrate, timeout parameters"""
         print('%s call intialize' % self.port)
         try:


### PR DESCRIPTION
Reverting name change intialize -> initalize. To fix thread harness issues.