### PR TITLE
Missing check for NULL pointer

### DIFF
--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -73,7 +73,7 @@ bool otPlatInfraIfHasAddress(uint32_t aInfraIfIndex, const otIp6Address *aAddres
     {
         struct sockaddr_in6 *ip6Addr;
 
-        if (if_nametoindex(addr->ifa_name) != aInfraIfIndex || addr->ifa_addr->sa_family != AF_INET6)
+        if (if_nametoindex(addr->ifa_name) != aInfraIfIndex || addr->ifa_addr == NULL || addr->ifa_addr->sa_family != AF_INET6)
         {
             continue;
         }
@@ -316,7 +316,7 @@ void InfraNetif::CountAddresses(otSysInfraNetIfAddressCounters &aAddressCounters
     {
         in6_addr *in6Addr;
 
-        if (strncmp(addr->ifa_name, mInfraIfName, sizeof(mInfraIfName)) != 0 || addr->ifa_addr->sa_family != AF_INET6)
+        if (strncmp(addr->ifa_name, mInfraIfName, sizeof(mInfraIfName)) != 0 || addr->ifa_addr == NULL || addr->ifa_addr->sa_family != AF_INET6)
         {
             continue;
         }
@@ -348,7 +348,7 @@ bool InfraNetif::HasLinkLocalAddress(void) const
     {
         struct sockaddr_in6 *ip6Addr;
 
-        if (strncmp(addr->ifa_name, mInfraIfName, sizeof(mInfraIfName)) != 0 || addr->ifa_addr->sa_family != AF_INET6)
+        if (strncmp(addr->ifa_name, mInfraIfName, sizeof(mInfraIfName)) != 0 || addr->ifa_addr == NULL || addr->ifa_addr->sa_family != AF_INET6)
         {
             continue;
         }


### PR DESCRIPTION
Avoid segmentation fault for interfaces without link.