### PR TITLE
[link-metrics] minimize the Link Metrics entry count for MTD

### DIFF
--- a/src/core/config/mle.h
+++ b/src/core/config/mle.h
@@ -314,4 +314,14 @@
 #define OPENTHREAD_CONFIG_MLE_LINK_METRICS_MAX_SERIES_SUPPORTED OPENTHREAD_CONFIG_MLE_MAX_CHILDREN
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_MLE_LINK_METRICS_SERIES_MTD
+ *
+ * The max number of series that a Link Metrics Subject (MTD device) can track simultaneously.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MLE_LINK_METRICS_SERIES_MTD
+#define OPENTHREAD_CONFIG_MLE_LINK_METRICS_SERIES_MTD 2
+#endif
+
 #endif // CONFIG_MLE_H_

--- a/src/core/thread/link_metrics.hpp
+++ b/src/core/thread/link_metrics.hpp
@@ -336,7 +336,11 @@ public:
 
 private:
     // Max number of SeriesInfo that could be allocated by the pool.
+#if OPENTHREAD_FTD
     static constexpr uint16_t kMaxSeriesSupported = OPENTHREAD_CONFIG_MLE_LINK_METRICS_MAX_SERIES_SUPPORTED;
+#elif OPENTHREAD_MTD
+    static constexpr uint16_t kMaxSeriesSupported = OPENTHREAD_CONFIG_MLE_LINK_METRICS_SERIES_MTD;
+#endif
 
     static Error ReadTypeIdsFromMessage(const Message &aMessage,
                                         uint16_t       aStartOffset,

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -54,7 +54,7 @@
 #include "radio/trel_link.hpp"
 #include "thread/csl_tx_scheduler.hpp"
 #include "thread/indirect_sender.hpp"
-#include "thread/link_metrics.hpp"
+#include "thread/link_metrics_types.hpp"
 #include "thread/link_quality.hpp"
 #include "thread/mle_tlvs.hpp"
 #include "thread/mle_types.hpp"


### PR DESCRIPTION
Currently to support Link Metrics Subject, we pre-allocate 128
entries. But this is unnecessary for MTD since it will only have one
neighbor. This PR minimizes the number to 2. (One for Enhanced-ACK
Probing and one for Forward Tracking Series.)