### PR TITLE
[srp-server] allow service instance label with dot character

### DIFF
--- a/src/core/net/dns_types.cpp
+++ b/src/core/net/dns_types.cpp
@@ -336,7 +336,7 @@ Error Name::ReadName(const Message &aMessage, uint16_t &aOffset, char *aNameBuff
             }
 
             labelLength = static_cast<uint8_t>(Min(static_cast<uint16_t>(kMaxLabelSize), aNameBufferSize));
-            SuccessOrExit(error = iterator.ReadLabel(aNameBuffer, labelLength, /* aAllowDotCharInLabel */ false));
+            SuccessOrExit(error = iterator.ReadLabel(aNameBuffer, labelLength, /* aAllowDotCharInLabel */ firstLabel));
             aNameBuffer += labelLength;
             aNameBufferSize -= labelLength;
             firstLabel = false;

--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -853,8 +853,8 @@ public:
      * On successful read, the read name follows  "<label1>.<label2>.<label3>.", i.e., a sequence of labels separated by
      * dot '.' character. The read name will ALWAYS end with a dot.
      *
-     * Verifies that the read labels in message do not contain any dot character, otherwise it returns
-     * `kErrorParse`).
+     * Verifies that the labels after the first label in message do not contain any dot character. If they do,
+     * returns `kErrorParse`.
      *
      * @param[in]     aMessage         The message to read the name from. `aMessage.GetOffset()` MUST point to
      *                                 the start of DNS header (this is used to handle compressed names).

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -245,7 +245,15 @@ public:
          * @returns  A pointer service instance name (as a null-terminated C string).
          *
          */
-        const char *GetInstanceName(void) const { return mDescription->mInstanceName.AsCString(); }
+        const char *GetInstanceName(void) const { return mDescription->GetInstanceName(); }
+
+        /**
+         * Gets the service instance label of the service.
+         *
+         * @returns  A pointer service instance label (as a null-terminated C string).
+         *
+         */
+        const char *GetInstanceLabel(void) const { return mDescription->GetInstanceLabel(); }
 
         /**
          * Gets the full service name of the service.
@@ -399,8 +407,9 @@ public:
                              public RetainCountable,
                              private NonCopyable
         {
-            Error       Init(const char *aInstanceName, Host &aHost);
+            Error       Init(const char *aInstanceName, const char *aInstanceLabel, Host &aHost);
             const char *GetInstanceName(void) const { return mInstanceName.AsCString(); }
+            const char *GetInstanceLabel(void) const { return mInstanceLabel.AsCString(); }
             bool        Matches(const char *aInstanceName) const;
             void        ClearResources(void);
             void        TakeResourcesFrom(Description &aDescription);
@@ -408,6 +417,7 @@ public:
 
             Description *mNext;
             Heap::String mInstanceName;
+            Heap::String mInstanceLabel;
             Host        *mHost;
             Heap::Data   mTxtData;
             uint16_t     mPriority;
@@ -600,8 +610,10 @@ public:
         LinkedList<Service> &GetServices(void) { return mServices; }
         Service             *AddNewService(const char *aServiceName,
                                            const char *aInstanceName,
+                                           const char *aInstanceLabel,
                                            bool        aIsSubType,
                                            TimeMilli   aUpdateTime);
+        Service             *AddNewService(const Service &aService, TimeMilli aUpdateTime);
         void                 RemoveService(Service *aService, RetainName aRetainName, NotifyMode aNotifyServiceHandler);
         Error                AddCopyOfServiceAsDeletedIfNotPresent(const Service &aService, TimeMilli aUpdateTime);
         void                 FreeAllServices(void);

--- a/tests/unit/test_srp_server.cpp
+++ b/tests/unit/test_srp_server.cpp
@@ -283,7 +283,7 @@ static const char kHostName[] = "myhost";
 void PrepareService1(Srp::Client::Service &aService)
 {
     static const char          kServiceName[]   = "_srv._udp";
-    static const char          kInstanceLabel[] = "srv-instance";
+    static const char          kInstanceLabel[] = "srv.instance";
     static const char          kSub1[]          = "_sub1";
     static const char          kSub2[]          = "_V1234567";
     static const char          kSub3[]          = "_XYZWS";


### PR DESCRIPTION
This commit updates the `Srp::Server` class to correctly handle the case where a service is registered with a dot character in its service instance name. The first label in a service instance name is intended as a user-friendly name and can contain dot characters (it has fewer restrictions than other labels in a DNS name).

In particular, this commit contains the following changes:
- The `PtrRecords::ReadPtrName()` method is used in `Srp::Server` to read and validate the first label and the rest of the labels separately. This also validates the format of the parsed PTR record.
- The `Service::Description` class now remembers the instance label in addition to the full instance name. This allows the instance label to be easily retrieved.
- The `Dns::Name::ReadName()` method is updated to only verify that the labels after the first label do not contain any dot characters. This allows it to be used to read instance service names.
- The tests are updated to validate the behavior of the SRP server when the instance label contains a dot character.