### PR TITLE
[csl] ensure child is synchronized when preparing a CSL transmission

### DIFF
--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -181,6 +181,7 @@ Mac::TxFrame *CslTxScheduler::HandleFrameRequest(Mac::TxFrames &aTxFrames)
     uint32_t      delay;
 
     VerifyOrExit(mCslTxChild != nullptr);
+    VerifyOrExit(mCslTxChild->IsCslSynchronized());
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     frame = &aTxFrames.GetTxFrame(Mac::kRadioTypeIeee802154);


### PR DESCRIPTION
Avoid potential CSL Transmitter crash when using a CSL period with 0 value in `GetNextCslTransmissionDelay`.