### PR TITLE
[test] update unit test emulating radio

### DIFF
--- a/tests/unit/test_dns_client.cpp
+++ b/tests/unit/test_dns_client.cpp
@@ -83,6 +83,8 @@ void AdvanceTime(uint32_t aDuration);
 
 extern "C" {
 
+otRadioCaps otPlatRadioGetCaps(otInstance *) { return OT_RADIO_CAPS_ACK_TIMEOUT | OT_RADIO_CAPS_CSMA_BACKOFF; }
+
 otError otPlatRadioTransmit(otInstance *, otRadioFrame *)
 {
     sRadioTxOngoing = true;
@@ -191,10 +193,12 @@ void InitTest(void)
     // Initialize OT instance.
 
     sNow      = 0;
+    sAlarmOn  = false;
     sInstance = static_cast<Instance *>(testInitInstance());
 
     memset(&sRadioTxFrame, 0, sizeof(sRadioTxFrame));
     sRadioTxFrame.mPsdu = sRadioTxFramePsdu;
+    sRadioTxOngoing     = false;
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Initialize Border Router and start Thread operation.

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -182,6 +182,8 @@ void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat
 
 extern "C" {
 
+otRadioCaps otPlatRadioGetCaps(otInstance *) { return OT_RADIO_CAPS_ACK_TIMEOUT | OT_RADIO_CAPS_CSMA_BACKOFF; }
+
 otError otPlatRadioTransmit(otInstance *, otRadioFrame *)
 {
     sRadioTxOngoing = true;
@@ -885,13 +887,15 @@ void VerifyPrefixTableIsEmpty(void) { VerifyPrefixTable(nullptr, 0, nullptr, 0);
 
 void InitTest(bool aEnablBorderRouting = false, bool aAfterReset = false)
 {
+    uint32_t delay = 10000;
+
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Initialize OT instance.
 
     sNow      = 0;
+    sAlarmOn  = false;
     sInstance = static_cast<Instance *>(testInitInstance());
 
-    uint32_t delay = 10000;
     if (aAfterReset)
     {
         delay += 26000; // leader reset sync delay
@@ -899,6 +903,7 @@ void InitTest(bool aEnablBorderRouting = false, bool aAfterReset = false)
 
     memset(&sRadioTxFrame, 0, sizeof(sRadioTxFrame));
     sRadioTxFrame.mPsdu = sRadioTxFramePsdu;
+    sRadioTxOngoing     = false;
 
     SuccessOrQuit(sInfraIfAddress.FromString(kInfraIfAddress));
 

--- a/tests/unit/test_srp_server.cpp
+++ b/tests/unit/test_srp_server.cpp
@@ -80,6 +80,8 @@ void AdvanceTime(uint32_t aDuration);
 
 extern "C" {
 
+otRadioCaps otPlatRadioGetCaps(otInstance *) { return OT_RADIO_CAPS_ACK_TIMEOUT | OT_RADIO_CAPS_CSMA_BACKOFF; }
+
 otError otPlatRadioTransmit(otInstance *, otRadioFrame *)
 {
     sRadioTxOngoing = true;
@@ -188,10 +190,12 @@ void InitTest(void)
     // Initialize OT instance.
 
     sNow      = 0;
+    sAlarmOn  = false;
     sInstance = static_cast<Instance *>(testInitInstance());
 
     memset(&sRadioTxFrame, 0, sizeof(sRadioTxFrame));
     sRadioTxFrame.mPsdu = sRadioTxFramePsdu;
+    sRadioTxOngoing     = false;
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Initialize Border Router and start Thread operation.


### PR DESCRIPTION
This commit updates the unit tests that emulate the radio platform API to define `otPlatRadioGetCaps()`, which returns the ACK_TIMEOUT and CSMA capabilities. This is to avoid having CSMA being implemented by the `SubMac`, which then uses the microsecond timer that is not emulated in the unit test platform.

It also updates the `InitTest()` function to clear the radio platform variable `sRadioTxOngoing`. This is to avoid the possible (though unlikely) situation where an earlier test finishes in the middle of a transmission, causing an extra `TxDone` event in the following test.