### PR TITLE
[cli] fix `childsupervision` commands documentation

### DIFF
--- a/include/openthread/child_supervision.h
+++ b/include/openthread/child_supervision.h
@@ -45,18 +45,18 @@ extern "C" {
  * @addtogroup api-child-supervision
  *
  * @brief
- *   This module includes functions for child supervision feature.
+ *   This module includes functions for Child Supervision feature.
  *
  * @{
  *
  */
 
 /**
- * Gets the child supervision interval (in seconds) on a child.
+ * Gets the Child Supervision interval (in seconds) on a child.
  *
- * Child supervision feature provides a mechanism for a sleepy child to ask its parent to ensure to send a message to
- * it within the supervision interval. If there is no transmission to the child within the supervision interval,
- * parent sends a supervision message (a data message with empty payload) to the child.
+ * Child Supervision feature provides a mechanism for parent to ensure that a message is sent to each sleepy child
+ * within the supervision interval. If there is no transmission to the child within the supervision interval, OpenThread
+ * enqueues and sends a Child Supervision Message to the child.
  *
  * @param[in]  aInstance       A pointer to an OpenThread instance.
  *
@@ -88,7 +88,7 @@ void otChildSupervisionSetInterval(otInstance *aInstance, uint16_t aInterval);
 uint16_t otChildSupervisionGetCheckTimeout(otInstance *aInstance);
 
 /**
- * Sets the supervision check timeout interval (in seconds).
+ * Sets the supervision check timeout interval (in seconds) on the child.
  *
  * @param[in]  aInstance       A pointer to an OpenThread instance.
  * @param[in]  aTimeout        The check timeout (in seconds). Zero to disable supervision check on the child.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (339)
+#define OPENTHREAD_API_VERSION (340)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -707,9 +707,9 @@ Done
 
 ### childsupervision interval
 
-Get the Child Supervision Interval value.
+Get the Child Supervision interval value on the child.
 
-Child supervision feature provides a mechanism for parent to ensure that a message is sent to each sleepy child within the supervision interval. If there is no transmission to the child within the supervision interval, OpenThread enqueues and sends a supervision message (a data message with empty payload) to the child. This command can only be used with FTD devices.
+Child Supervision feature provides a mechanism for parent to ensure that a message is sent to each sleepy child within the supervision interval. If there is no transmission to the child within the supervision interval, OpenThread enqueues and sends a Child Supervision Message to the child.
 
 ```bash
 > childsupervision interval
@@ -719,7 +719,7 @@ Done
 
 ### childsupervision interval \<interval\>
 
-Set the Child Supervision Interval value. This command can only be used with FTD devices.
+Set the Child Supervision interval value on the child.
 
 ```bash
 > childsupervision interval 30
@@ -728,7 +728,7 @@ Done
 
 ### childsupervision checktimeout
 
-Get the Child Supervision Check Timeout value.
+Get the Child Supervision Check Timeout value on the child.
 
 If the device is a sleepy child and it does not hear from its parent within the specified check timeout, it initiates the re-attach process (MLE Child Update Request/Response exchange with its parent).
 
@@ -740,7 +740,7 @@ Done
 
 ### childsupervision checktimeout \<timeout\>
 
-Set the Child Supervision Check Timeout value.
+Set the Child Supervision Check Timeout value on the child.
 
 ```bash
 > childsupervision checktimeout 30


### PR DESCRIPTION
Previous documentation could be wrongly interpreted as that the supervision interval should be set on the parent (FTD).