### PR TITLE
[srp-server] simplify sub-type services

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (342)
+#define OPENTHREAD_API_VERSION (343)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/cli_srp_server.cpp
+++ b/src/cli/cli_srp_server.cpp
@@ -270,9 +270,6 @@ void SrpServer::OutputHostAddresses(const otSrpServerHost *aHost)
 
 template <> otError SrpServer::Process<Cmd("service")>(Arg aArgs[])
 {
-    static constexpr char *kAnyServiceName  = nullptr;
-    static constexpr char *kAnyInstanceName = nullptr;
-
     otError                error = OT_ERROR_NONE;
     const otSrpServerHost *host  = nullptr;
 
@@ -282,18 +279,15 @@ template <> otError SrpServer::Process<Cmd("service")>(Arg aArgs[])
     {
         const otSrpServerService *service = nullptr;
 
-        while ((service = otSrpServerHostFindNextService(host, service, OT_SRP_SERVER_FLAGS_BASE_TYPE_SERVICE_ONLY,
-                                                         kAnyServiceName, kAnyInstanceName)) != nullptr)
+        while ((service = otSrpServerHostGetNextService(host, service)) != nullptr)
         {
-            bool                      isDeleted    = otSrpServerServiceIsDeleted(service);
-            const char               *instanceName = otSrpServerServiceGetInstanceName(service);
-            const otSrpServerService *subService   = nullptr;
-            const uint8_t            *txtData;
-            uint16_t                  txtDataLength;
-            bool                      hasSubType = false;
-            otSrpServerLeaseInfo      leaseInfo;
+            bool                 isDeleted = otSrpServerServiceIsDeleted(service);
+            const uint8_t       *txtData;
+            uint16_t             txtDataLength;
+            bool                 hasSubType = false;
+            otSrpServerLeaseInfo leaseInfo;
 
-            OutputLine("%s", instanceName);
+            OutputLine("%s", otSrpServerServiceGetInstanceName(service));
             OutputLine(kIndentSize, "deleted: %s", isDeleted ? "true" : "false");
 
             if (isDeleted)
@@ -305,13 +299,17 @@ template <> otError SrpServer::Process<Cmd("service")>(Arg aArgs[])
 
             OutputFormat(kIndentSize, "subtypes: ");
 
-            while ((subService = otSrpServerHostFindNextService(
-                        host, subService, (OT_SRP_SERVER_SERVICE_FLAG_SUB_TYPE | OT_SRP_SERVER_SERVICE_FLAG_ACTIVE),
-                        kAnyServiceName, instanceName)) != nullptr)
+            for (uint16_t index = 0;; index++)
             {
-                char subLabel[OT_DNS_MAX_LABEL_SIZE];
+                char        subLabel[OT_DNS_MAX_LABEL_SIZE];
+                const char *subTypeName = otSrpServerServiceGetSubTypeServiceNameAt(service, index);
 
-                IgnoreError(otSrpServerServiceGetServiceSubTypeLabel(subService, subLabel, sizeof(subLabel)));
+                if (subTypeName == nullptr)
+                {
+                    break;
+                }
+
+                IgnoreError(otSrpServerParseSubTypeServiceName(subTypeName, subLabel, sizeof(subLabel)));
                 OutputFormat("%s%s", hasSubType ? "," : "", subLabel);
                 hasSubType = true;
             }

--- a/src/core/api/srp_server_api.cpp
+++ b/src/core/api/srp_server_api.cpp
@@ -139,6 +139,11 @@ bool otSrpServerHostIsDeleted(const otSrpServerHost *aHost) { return AsCoreType(
 
 const char *otSrpServerHostGetFullName(const otSrpServerHost *aHost) { return AsCoreType(aHost).GetFullName(); }
 
+bool otSrpServerHostMatchesFullName(const otSrpServerHost *aHost, const char *aFullName)
+{
+    return AsCoreType(aHost).Matches(aFullName);
+}
+
 const otIp6Address *otSrpServerHostGetAddresses(const otSrpServerHost *aHost, uint8_t *aAddressesNum)
 {
     return AsCoreType(aHost).GetAddresses(*aAddressesNum);
@@ -154,30 +159,24 @@ uint32_t otSrpServerHostGetKeyLease(const otSrpServerHost *aHost) { return AsCor
 const otSrpServerService *otSrpServerHostGetNextService(const otSrpServerHost    *aHost,
                                                         const otSrpServerService *aService)
 {
-    return AsCoreType(aHost).FindNextService(AsCoreTypePtr(aService), Srp::Server::kFlagsBaseTypeServiceOnly);
-}
-
-const otSrpServerService *otSrpServerHostFindNextService(const otSrpServerHost    *aHost,
-                                                         const otSrpServerService *aPrevService,
-                                                         otSrpServerServiceFlags   aFlags,
-                                                         const char               *aServiceName,
-                                                         const char               *aInstanceName)
-{
-    return AsCoreType(aHost).FindNextService(AsCoreTypePtr(aPrevService), aFlags, aServiceName, aInstanceName);
+    return AsCoreType(aHost).GetNextService(AsCoreTypePtr(aService));
 }
 
 bool otSrpServerServiceIsDeleted(const otSrpServerService *aService) { return AsCoreType(aService).IsDeleted(); }
 
-bool otSrpServerServiceIsSubType(const otSrpServerService *aService) { return AsCoreType(aService).IsSubType(); }
-
-const char *otSrpServerServiceGetFullName(const otSrpServerService *aService)
+const char *otSrpServerServiceGetInstanceName(const otSrpServerService *aService)
 {
     return AsCoreType(aService).GetInstanceName();
 }
 
-const char *otSrpServerServiceGetInstanceName(const otSrpServerService *aService)
+bool otSrpServerServiceMatchesInstanceName(const otSrpServerService *aService, const char *aInstanceName)
 {
-    return AsCoreType(aService).GetInstanceName();
+    return AsCoreType(aService).MatchesInstanceName(aInstanceName);
+}
+
+const char *otSrpServerServiceGetInstanceLabel(const otSrpServerService *aService)
+{
+    return AsCoreType(aService).GetInstanceLabel();
 }
 
 const char *otSrpServerServiceGetServiceName(const otSrpServerService *aService)
@@ -185,9 +184,29 @@ const char *otSrpServerServiceGetServiceName(const otSrpServerService *aService)
     return AsCoreType(aService).GetServiceName();
 }
 
-otError otSrpServerServiceGetServiceSubTypeLabel(const otSrpServerService *aService, char *aLabel, uint8_t aMaxSize)
+bool otSrpServerServiceMatchesServiceName(const otSrpServerService *aService, const char *aServiceName)
 {
-    return AsCoreType(aService).GetServiceSubTypeLabel(aLabel, aMaxSize);
+    return AsCoreType(aService).MatchesServiceName(aServiceName);
+}
+
+uint16_t otSrpServerServiceGetNumberOfSubTypes(const otSrpServerService *aService)
+{
+    return AsCoreType(aService).GetNumberOfSubTypes();
+}
+
+const char *otSrpServerServiceGetSubTypeServiceNameAt(const otSrpServerService *aService, uint16_t aIndex)
+{
+    return AsCoreType(aService).GetSubTypeServiceNameAt(aIndex);
+}
+
+bool otSrpServerServiceHasSubTypeServiceName(const otSrpServerService *aService, const char *aSubTypeServiceName)
+{
+    return AsCoreType(aService).HasSubTypeServiceName(aSubTypeServiceName);
+}
+
+otError otSrpServerParseSubTypeServiceName(const char *aSubTypeServiceName, char *aLabel, uint8_t aLabelSize)
+{
+    return Srp::Server::Service::ParseSubTypeServiceName(aSubTypeServiceName, aLabel, aLabelSize);
 }
 
 uint16_t otSrpServerServiceGetPort(const otSrpServerService *aService) { return AsCoreType(aService).GetPort(); }

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -485,18 +485,15 @@ private:
                                          const Ip6::MessageInfo &aMessageInfo,
                                          Ip6::Udp::Socket       &aSocket);
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
-    Header::Response                   ResolveBySrp(Header                   &aResponseHeader,
-                                                    Message                  &aResponseMessage,
-                                                    Server::NameCompressInfo &aCompressInfo);
-    Header::Response                   ResolveQuestionBySrp(const char       *aName,
-                                                            const Question   &aQuestion,
-                                                            Header           &aResponseHeader,
-                                                            Message          &aResponseMessage,
-                                                            NameCompressInfo &aCompressInfo,
-                                                            bool              aAdditional);
-    const Srp::Server::Host           *GetNextSrpHost(const Srp::Server::Host *aHost);
-    static const Srp::Server::Service *GetNextSrpService(const Srp::Server::Host    &aHost,
-                                                         const Srp::Server::Service *aService);
+    Header::Response ResolveBySrp(Header                   &aResponseHeader,
+                                  Message                  &aResponseMessage,
+                                  Server::NameCompressInfo &aCompressInfo);
+    Header::Response ResolveQuestionBySrp(const char       *aName,
+                                          const Question   &aQuestion,
+                                          Header           &aResponseHeader,
+                                          Message          &aResponseMessage,
+                                          NameCompressInfo &aCompressInfo,
+                                          bool              aAdditional);
 #endif
 
 #if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -188,37 +188,6 @@ public:
 
     public:
         /**
-         * Represents the flags which indicates which services to include or exclude when searching in (or
-         * iterating over) the list of SRP services.
-         *
-         */
-        typedef otSrpServerServiceFlags Flags;
-
-        /**
-         * This `Flags` constant indicates to include base services (not a sub-type).
-         *
-         */
-        static constexpr Flags kFlagBaseType = OT_SRP_SERVER_SERVICE_FLAG_BASE_TYPE;
-
-        /**
-         * This `Flags` constant indicates to include sub-type services.
-         *
-         */
-        static constexpr Flags kFlagSubType = OT_SRP_SERVER_SERVICE_FLAG_SUB_TYPE;
-
-        /**
-         * This `Flags` constant indicates to include active (not deleted) services.
-         *
-         */
-        static constexpr Flags kFlagActive = OT_SRP_SERVER_SERVICE_FLAG_ACTIVE;
-
-        /**
-         * This `Flags` constant indicates to include deleted services.
-         *
-         */
-        static constexpr Flags kFlagDeleted = OT_SRP_SERVER_SERVICE_FLAG_DELETED;
-
-        /**
          * Tells if the SRP service has been deleted.
          *
          * A SRP service can be deleted but retains its name for future uses.
@@ -231,21 +200,12 @@ public:
         bool IsDeleted(void) const { return mIsDeleted; }
 
         /**
-         * Indicates whether the SRP service is a sub-type.
-         *
-         * @retval TRUE    If the service is a sub-type.
-         * @retval FALSE   If the service is not a sub-type.
-         *
-         */
-        bool IsSubType(void) const { return mIsSubType; }
-
-        /**
          * Gets the full service instance name of the service.
          *
          * @returns  A pointer service instance name (as a null-terminated C string).
          *
          */
-        const char *GetInstanceName(void) const { return mDescription->GetInstanceName(); }
+        const char *GetInstanceName(void) const { return mInstanceName.AsCString(); }
 
         /**
          * Gets the service instance label of the service.
@@ -253,7 +213,7 @@ public:
          * @returns  A pointer service instance label (as a null-terminated C string).
          *
          */
-        const char *GetInstanceLabel(void) const { return mDescription->GetInstanceLabel(); }
+        const char *GetInstanceLabel(void) const { return mInstanceLabel.AsCString(); }
 
         /**
          * Gets the full service name of the service.
@@ -264,23 +224,52 @@ public:
         const char *GetServiceName(void) const { return mServiceName.AsCString(); }
 
         /**
-         * Gets the sub-type label from service name.
+         * Gets number of sub-types of this service.
          *
-         * The full service name for a sub-type service follows "<sub-label>._sub.<service-labels>.<domain>.". This
-         * method copies the `<sub-label>` into the @p aLabel buffer.
-         *
-         * The @p aLabel is ensured to always be null-terminated after returning even in case of failure.
-         *
-         * @param[out] aLabel        A pointer to a buffer to copy the sub-type label name.
-         * @param[in]  aMaxSize      Maximum size of @p aLabel buffer.
-         *
-         * @retval kErrorNone         @p aLabel was updated successfully.
-         * @retval kErrorNoBufs       The sub-type label could not fit in @p aLabel buffer (number of chars from label
-         *                            that could fit are copied in @p aLabel ensuring it is null-terminated).
-         * @retval kErrorInvalidArgs  SRP service is not a sub-type.
+         * @returns The number of sub-types.
          *
          */
-        Error GetServiceSubTypeLabel(char *aLabel, uint8_t aMaxSize) const;
+        uint16_t GetNumberOfSubTypes(void) const { return mSubTypes.GetLength(); }
+
+        /**
+         * Gets the sub-type service name (full name) at a given index.
+         *
+         * The full service name for a sub-type service follows "<sub-label>._sub.<service-labels>.<domain>.".
+         *
+         * @param[in] aIndex   The index to get.
+         *
+         * @returns A pointer to sub-type service name at @p aIndex, or `nullptr` if none at this index.
+         *
+         */
+        const char *GetSubTypeServiceNameAt(uint16_t aIndex) const;
+
+        /**
+         * Indicates whether or not service has a given sub-type.
+         *
+         * @param[in] aSubTypeServiceName  The sub-type service name (full name).
+         *
+         * @retval TRUE   Service contains the sub-type @p aSubTypeServiceName.
+         * @retval FALSE  Service does not contain the sub-type @p aSubTypeServiceName.
+         *
+         */
+        bool HasSubTypeServiceName(const char *aSubTypeServiceName) const;
+
+        /**
+         * Parses a sub-type service name (full name) and extracts the sub-type label.
+         *
+         * The full service name for a sub-type service follows "<sub-label>._sub.<service-labels>.<domain>.".
+         *
+         * @param[in]  aSubTypeServiceName  A sub-type service name (full name).
+         * @param[out] aLabel               A pointer to a buffer to copy the extracted sub-type label.
+         * @param[in]  aLabelSize           Maximum size of @p aLabel buffer.
+         *
+         * @retval kErrorNone         Name was successfully parsed and @p aLabel was updated.
+         * @retval kErrorNoBufs       The sub-type label could not fit in @p aLabel buffer (number of chars from label
+         *                            that could fit are copied in @p aLabel ensuring it is null-terminated).
+         * @retval kErrorInvalidArgs  @p aSubTypeServiceName is not a valid sub-type format.
+         *
+         */
+        static Error ParseSubTypeServiceName(const char *aSubTypeServiceName, char *aLabel, uint8_t aLabelSize);
 
         /**
          * Returns the TTL of the service instance.
@@ -288,7 +277,7 @@ public:
          * @returns The TTL of the service instance.
          *
          */
-        uint32_t GetTtl(void) const { return mDescription->mTtl; }
+        uint32_t GetTtl(void) const { return mTtl; }
 
         /**
          * Returns the port of the service instance.
@@ -296,7 +285,7 @@ public:
          * @returns  The port of the service.
          *
          */
-        uint16_t GetPort(void) const { return mDescription->mPort; }
+        uint16_t GetPort(void) const { return mPort; }
 
         /**
          * Returns the weight of the service instance.
@@ -304,7 +293,7 @@ public:
          * @returns  The weight of the service.
          *
          */
-        uint16_t GetWeight(void) const { return mDescription->mWeight; }
+        uint16_t GetWeight(void) const { return mWeight; }
 
         /**
          * Returns the priority of the service instance.
@@ -312,7 +301,7 @@ public:
          * @returns  The priority of the service.
          *
          */
-        uint16_t GetPriority(void) const { return mDescription->mPriority; }
+        uint16_t GetPriority(void) const { return mPriority; }
 
         /**
          * Returns the TXT record data of the service instance.
@@ -320,7 +309,7 @@ public:
          * @returns A pointer to the buffer containing the TXT record data.
          *
          */
-        const uint8_t *GetTxtData(void) const { return mDescription->mTxtData.GetBytes(); }
+        const uint8_t *GetTxtData(void) const { return mTxtData.GetBytes(); }
 
         /**
          * Returns the TXT record data length of the service instance.
@@ -328,7 +317,7 @@ public:
          * @return The TXT record data length (number of bytes in buffer returned from `GetTxtData()`).
          *
          */
-        uint16_t GetTxtDataLength(void) const { return mDescription->mTxtData.GetLength(); }
+        uint16_t GetTxtDataLength(void) const { return mTxtData.GetLength(); }
 
         /**
          * Returns the host which the service instance reside on.
@@ -336,7 +325,7 @@ public:
          * @returns  A reference to the host instance.
          *
          */
-        const Host &GetHost(void) const { return *mDescription->mHost; }
+        const Host &GetHost(void) const { return *mHost; }
 
         /**
          * Returns the LEASE time of the service.
@@ -344,7 +333,7 @@ public:
          * @returns  The LEASE time in seconds.
          *
          */
-        uint32_t GetLease(void) const { return mDescription->mLease; }
+        uint32_t GetLease(void) const { return mLease; }
 
         /**
          * Returns the KEY-LEASE time of the key of the service.
@@ -352,7 +341,7 @@ public:
          * @returns  The KEY-LEASE time in seconds.
          *
          */
-        uint32_t GetKeyLease(void) const { return mDescription->mKeyLease; }
+        uint32_t GetKeyLease(void) const { return mKeyLease; }
 
         /**
          * Returns the expire time (in milliseconds) of the service.
@@ -402,55 +391,41 @@ public:
         bool MatchesServiceName(const char *aServiceName) const;
 
     private:
-        struct Description : public LinkedListEntry<Description>,
-                             public Heap::Allocatable<Description>,
-                             public RetainCountable,
-                             private NonCopyable
-        {
-            Error       Init(const char *aInstanceName, const char *aInstanceLabel, Host &aHost);
-            const char *GetInstanceName(void) const { return mInstanceName.AsCString(); }
-            const char *GetInstanceLabel(void) const { return mInstanceLabel.AsCString(); }
-            bool        Matches(const char *aInstanceName) const;
-            void        ClearResources(void);
-            void        TakeResourcesFrom(Description &aDescription);
-            Error       SetTxtDataFromMessage(const Message &aMessage, uint16_t aOffset, uint16_t aLength);
-
-            Description *mNext;
-            Heap::String mInstanceName;
-            Heap::String mInstanceLabel;
-            Host        *mHost;
-            Heap::Data   mTxtData;
-            uint16_t     mPriority;
-            uint16_t     mWeight;
-            uint16_t     mPort;
-            uint32_t     mTtl;      // The TTL in seconds.
-            uint32_t     mLease;    // The LEASE time in seconds.
-            uint32_t     mKeyLease; // The KEY-LEASE time in seconds.
-            TimeMilli    mUpdateTime;
-        };
-
         enum Action : uint8_t
         {
             kAddNew,
             kUpdateExisting,
+            kKeepUnchanged,
             kRemoveButRetainName,
             kFullyRemove,
             kLeaseExpired,
             kKeyLeaseExpired,
         };
 
-        Error Init(const char *aServiceName, Description &aDescription, bool aIsSubType, TimeMilli aUpdateTime);
-        bool  MatchesFlags(Flags aFlags) const;
-        const TimeMilli &GetUpdateTime(void) const { return mUpdateTime; }
-        void             Log(Action aAction) const;
+        Error Init(const char *aInstanceName, const char *aInstanceLabel, Host &aHost, TimeMilli aUpdateTime);
+        Error SetTxtDataFromMessage(const Message &aMessage, uint16_t aOffset, uint16_t aLength);
+        bool  Matches(const char *aInstanceName) const;
+        void  Log(Action aAction) const;
 
-        Heap::String           mServiceName;
-        RetainPtr<Description> mDescription;
-        Service               *mNext;
-        TimeMilli              mUpdateTime;
-        bool                   mIsDeleted : 1;
-        bool                   mIsSubType : 1;
-        bool                   mIsCommitted : 1;
+        Service                  *mNext;
+        Heap::String              mInstanceName;
+        Heap::String              mInstanceLabel;
+        Heap::String              mServiceName;
+        Heap::Array<Heap::String> mSubTypes;
+        Host                     *mHost;
+        Heap::Data                mTxtData;
+        uint16_t                  mPriority;
+        uint16_t                  mWeight;
+        uint16_t                  mPort;
+        uint32_t                  mTtl;      // In seconds
+        uint32_t                  mLease;    // In seconds
+        uint32_t                  mKeyLease; // In seconds
+        TimeMilli                 mUpdateTime;
+        bool                      mIsDeleted : 1;
+        bool                      mIsCommitted : 1;
+        bool                      mParsedDeleteAllRrset : 1;
+        bool                      mParsedSrv : 1;
+        bool                      mParsedTxt : 1;
     };
 
     /**
@@ -568,21 +543,15 @@ public:
          */
         const LinkedList<Service> &GetServices(void) const { return mServices; }
 
-        /**
-         * Finds the next matching service on the host.
+        /*
+         * Returns the next service.
          *
          * @param[in] aPrevService   A pointer to the previous service or `nullptr` to start from beginning of the list.
-         * @param[in] aFlags         Flags indicating which services to include (base/sub-type, active/deleted).
-         * @param[in] aServiceName   The service name to match. Set to `nullptr` to accept any name.
-         * @param[in] aInstanceName  The service instance name to match. Set to `nullptr` to accept any name.
          *
-         * @returns  A pointer to the next matching service or `nullptr` if no matching service could be found.
+         * @returns  A pointer to the next service or `nullptr` if no more services can be found.
          *
          */
-        const Service *FindNextService(const Service *aPrevService,
-                                       Service::Flags aFlags        = kFlagsAnyService,
-                                       const char    *aServiceName  = nullptr,
-                                       const char    *aInstanceName = nullptr) const;
+        const Service *GetNextService(const Service *aPrevService) const;
 
         /**
          * Tells whether the host matches a given full name.
@@ -607,26 +576,15 @@ public:
         bool  ShouldUseShortLeaseOption(void) const { return mUseShortLeaseOption; }
         Error ProcessTtl(uint32_t aTtl);
 
-        LinkedList<Service> &GetServices(void) { return mServices; }
-        Service             *AddNewService(const char *aServiceName,
-                                           const char *aInstanceName,
-                                           const char *aInstanceLabel,
-                                           bool        aIsSubType,
-                                           TimeMilli   aUpdateTime);
-        Service             *AddNewService(const Service &aService, TimeMilli aUpdateTime);
-        void                 RemoveService(Service *aService, RetainName aRetainName, NotifyMode aNotifyServiceHandler);
-        Error                AddCopyOfServiceAsDeletedIfNotPresent(const Service &aService, TimeMilli aUpdateTime);
-        void                 FreeAllServices(void);
-        void                 ClearResources(void);
-        Error                MergeServicesAndResourcesFrom(Host &aHost);
-        Error                AddIp6Address(const Ip6::Address &aIp6Address);
-        bool                 HasServiceInstance(const char *aInstanceName) const;
-        RetainPtr<Service::Description>       FindServiceDescription(const char *aInstanceName);
-        const RetainPtr<Service::Description> FindServiceDescription(const char *aInstanceName) const;
-        Service                              *FindService(const char *aServiceName, const char *aInstanceName);
-        const Service                        *FindService(const char *aServiceName, const char *aInstanceName) const;
-        Service                              *FindBaseService(const char *aInstanceName);
-        const Service                        *FindBaseService(const char *aInstanceName) const;
+        Service       *AddNewService(const char *aInstanceName, const char *aInstanceLabel, TimeMilli aUpdateTime);
+        void           AddService(Service &aService);
+        void           RemoveService(Service *aService, RetainName aRetainName, NotifyMode aNotifyServiceHandler);
+        bool           HasService(const char *aInstanceName) const;
+        Service       *FindService(const char *aInstanceName);
+        const Service *FindService(const char *aInstanceName) const;
+        void           FreeAllServices(void);
+        void           ClearResources(void);
+        Error          AddIp6Address(const Ip6::Address &aIp6Address);
 
         Host                     *mNext;
         Heap::String              mFullName;
@@ -683,36 +641,6 @@ public:
         uint32_t GrantLease(uint32_t aLease) const;
         uint32_t GrantKeyLease(uint32_t aKeyLease) const;
     };
-
-    /**
-     * This constant defines a `Service::Flags` combination accepting any service (base/sub-type, active/deleted).
-     *
-     */
-    static constexpr Service::Flags kFlagsAnyService = OT_SRP_SERVER_FLAGS_ANY_SERVICE;
-
-    /**
-     * This constant defines a `Service::Flags` combination accepting base services only.
-     *
-     */
-    static constexpr Service::Flags kFlagsBaseTypeServiceOnly = OT_SRP_SERVER_FLAGS_BASE_TYPE_SERVICE_ONLY;
-
-    /**
-     * This constant defines a `Service::Flags` combination accepting sub-type services only.
-     *
-     */
-    static constexpr Service::Flags kFlagsSubTypeServiceOnly = OT_SRP_SERVER_FLAGS_SUB_TYPE_SERVICE_ONLY;
-
-    /**
-     * This constant defines a `Service::Flags` combination accepting any active services (not deleted).
-     *
-     */
-    static constexpr Service::Flags kFlagsAnyTypeActiveService = OT_SRP_SERVER_FLAGS_ANY_TYPE_ACTIVE_SERVICE;
-
-    /**
-     * This constant defines a `Service::Flags` combination accepting any deleted services.
-     *
-     */
-    static constexpr Service::Flags kFlagsAnyTypeDeletedService = OT_SRP_SERVER_FLAGS_ANY_TYPE_DELETED_SERVICE;
 
     /**
      * Initializes the SRP server object.
@@ -902,6 +830,14 @@ public:
     Error SetLeaseConfig(const LeaseConfig &aLeaseConfig);
 
     /**
+     * Returns the `Host` linked list.
+     *
+     * @returns The `Host` linked list.
+     *
+     */
+    const LinkedList<Host> &GetHosts(void) const { return mHosts; }
+
+    /**
      * Returns the next registered SRP host.
      *
      * @param[in]  aHost  The current SRP host; use `nullptr` to get the first SRP host.
@@ -1037,7 +973,6 @@ private:
                           uint16_t                      aSigRdataOffset,
                           uint16_t                      aSigRdataLength,
                           const char                   *aSignerName) const;
-    Error ValidateServiceSubTypes(Host &aHost, const MessageMetadata &aMetadata);
     Error ProcessZoneSection(const Message &aMessage, MessageMetadata &aMetadata) const;
     Error ProcessHostDescriptionInstruction(Host                  &aHost,
                                             const Message         &aMessage,
@@ -1050,7 +985,6 @@ private:
     static bool IsValidDeleteAllRecord(const Dns::ResourceRecord &aRecord);
 
     void        HandleUpdate(Host &aHost, const MessageMetadata &aMetadata);
-    void        AddHost(Host &aHost);
     void        RemoveHost(Host *aHost, RetainName aRetainName, NotifyMode aNotifyServiceHandler);
     bool        HasNameConflictsWith(Host &aHost) const;
     void        SendResponse(const Dns::UpdateHeader    &aHeader,


### PR DESCRIPTION
This commit updates and simplifies how `Srp::Server` stores the sub-type services. The earlier implementation treated each sub-type as its own service, which was tracked by a `Service` object. This design allowed sub-type services to be registered and deleted individually. However, the latest SRP RFC draft requires SRP servers to treat updates to a service and all its sub-types as atomic. This means that when a service and its sub-types are being updated, the SRP Update message must contain the entirety of information about that service and its sub-types. As a result of this change, we can simplify the server implementation by tracking sub-types as an array of sub-type names in the `Service` object.

This commit also updates the way the server commits a received SRP update info into its existing data. Previously, the server would try to merge the new information into existing `Host` and `Service` objects. However, this could be inefficient, as it would require moving heap-allocated items like "txt data" and/or array of host IPv6 addresses from one object to another. The new `CommitSrpUpdate()` implementation now starts from the new `Host` object that is constructed as the received SRP Update message from the client is parsed. Any previously registered services that are not present in the new `Host` object are then moved into it.

This commit adds new public OT APIs for retrieving the sub-types associated with a service and making it easier to iterate over the list of registered services by a host. Due to fundamental changes in how services are stored by the `Srp::Server` class, some existing public `otSrpServer` APIs for filtering and iterating over services are being removed.

----

Depends-On: openthread/ot-br-posix#1923
