### PR TITLE
[message] remove child mask from message metadata in MTD

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -785,6 +785,7 @@ exit:
     return messageCopy;
 }
 
+#if OPENTHREAD_FTD
 bool Message::GetChildMask(uint16_t aChildIndex) const { return GetMetadata().mChildMask.Get(aChildIndex); }
 
 void Message::ClearChildMask(uint16_t aChildIndex) { GetMetadata().mChildMask.Set(aChildIndex, false); }
@@ -792,6 +793,7 @@ void Message::ClearChildMask(uint16_t aChildIndex) { GetMetadata().mChildMask.Se
 void Message::SetChildMask(uint16_t aChildIndex) { GetMetadata().mChildMask.Set(aChildIndex, true); }
 
 bool Message::IsChildPending(void) const { return GetMetadata().mChildMask.HasAny(); }
+#endif
 
 void Message::SetLinkInfo(const ThreadLinkInfo &aLinkInfo)
 {

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -978,7 +978,7 @@ public:
      *
      */
     bool IsChildPending(void) const;
-#endif
+#endif // OPENTHREAD_FTD
 
     /**
      * Returns the RLOC16 of the mesh destination.

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -203,7 +203,9 @@ protected:
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
         LqiAverager mLqiAverager; // The averager maintaining the Link quality indicator (LQI) average.
 #endif
+#if OPENTHREAD_FTD
         ChildMask mChildMask; // ChildMask to indicate which sleepy children need to receive this.
+#endif
 
         uint8_t mType : 3;             // The message type.
         uint8_t mSubType : 4;          // The message sub type.
@@ -940,6 +942,7 @@ public:
      */
     void SetDatagramTag(uint32_t aTag) { GetMetadata().mDatagramTag = aTag; }
 
+#if OPENTHREAD_FTD
     /**
      * Returns whether or not the message forwarding is scheduled for the child.
      *
@@ -975,6 +978,7 @@ public:
      *
      */
     bool IsChildPending(void) const;
+#endif
 
     /**
      * Returns the RLOC16 of the mesh destination.

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1268,7 +1268,11 @@ exit:
 
 void MeshForwarder::RemoveMessageIfNoPendingTx(Message &aMessage)
 {
+#if OPENTHREAD_FTD
     VerifyOrExit(!aMessage.IsDirectTransmission() && !aMessage.IsChildPending());
+#else
+    VerifyOrExit(!aMessage.IsDirectTransmission());
+#endif
 
     if (mSendMessage == &aMessage)
     {


### PR DESCRIPTION
Saves a few bytes in MTD message metadata since they don't need the child mask.