### PR TITLE
[dns] add `otDnsEncodeTxtData()` API

### DIFF
--- a/include/openthread/dns.h
+++ b/include/openthread/dns.h
@@ -142,6 +142,24 @@ void otDnsInitTxtEntryIterator(otDnsTxtEntryIterator *aIterator, const uint8_t *
 otError otDnsGetNextTxtEntry(otDnsTxtEntryIterator *aIterator, otDnsTxtEntry *aEntry);
 
 /**
+ * Encodes a given list of TXT record entries (key/value pairs) into TXT data (following format specified by RFC 6763).
+ *
+ * @param[in]      aTxtEntries      Pointer to an array of `otDnsTxtEntry`.
+ * @param[in]      aNumTxtEntries   Number of entries in @p aTxtEntries array.
+ * @param[out]     aTxtData         A pointer to a buffer to output the encoded TXT data.
+ * @param[in,out]  aTxtDataLength   On input, size of buffer @p aTxtData. On output, length of the encoded TXT data.
+ *
+ * @retval OT_ERROR_NONE          Encoded TXT data successfully, @p aTxtData and @p aTxtDataLength are updated.
+ * @retval OT_ERROR_INVALID_ARGS  The @p aTxtEntries is not valid.
+ * @retval OT_ERROR_NO_BUS        Could not fit the encoded data in @p aTxtData buffer with its @p aTxtDataLength.
+ *
+ */
+otError otDnsEncodeTxtData(const otDnsTxtEntry *aTxtEntries,
+                           uint16_t             aNumTxtEntries,
+                           uint8_t             *aTxtData,
+                           uint16_t            *aTxtDataLength);
+
+/**
  * Enables/disables the "DNS name compression" mode.
  *
  * By default DNS name compression is enabled. When disabled, DNS names are appended as full and never compressed. This

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (335)
+#define OPENTHREAD_API_VERSION (336)
 
 /**
  * @addtogroup api-instance

--- a/src/core/api/dns_api.cpp
+++ b/src/core/api/dns_api.cpp
@@ -50,6 +50,26 @@ otError otDnsGetNextTxtEntry(otDnsTxtEntryIterator *aIterator, otDnsTxtEntry *aE
     return AsCoreType(aIterator).GetNextEntry(AsCoreType(aEntry));
 }
 
+otError otDnsEncodeTxtData(const otDnsTxtEntry *aTxtEntries,
+                           uint8_t              aNumTxtEntries,
+                           uint8_t             *aTxtData,
+                           uint16_t            *aTxtDataLength)
+{
+    Error                          error;
+    MutableData<kWithUint16Length> data;
+
+    AssertPointerIsNotNull(aTxtEntries);
+    AssertPointerIsNotNull(aTxtData);
+    AssertPointerIsNotNull(aTxtDataLength);
+
+    data.Init(aTxtData, *aTxtDataLength);
+    SuccessOrExit(error = Dns::TxtEntry::AppendEntries(AsCoreTypePtr(aTxtEntries), aNumTxtEntries, data));
+    *aTxtDataLength = data.GetLength();
+
+exit:
+    return error;
+}
+
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 void otDnsSetNameCompressionEnabled(bool aEnabled) { Instance::SetDnsNameCompressionEnabled(aEnabled); }
 

--- a/src/core/net/dns_types.cpp
+++ b/src/core/net/dns_types.cpp
@@ -1037,14 +1037,14 @@ exit:
     return error;
 }
 
-Error TxtEntry::AppendEntries(const TxtEntry *aEntries, uint8_t aNumEntries, Message &aMessage)
+Error TxtEntry::AppendEntries(const TxtEntry *aEntries, uint16_t aNumEntries, Message &aMessage)
 {
     Appender appender(aMessage);
 
     return AppendEntries(aEntries, aNumEntries, appender);
 }
 
-Error TxtEntry::AppendEntries(const TxtEntry *aEntries, uint8_t aNumEntries, MutableData<kWithUint16Length> &aData)
+Error TxtEntry::AppendEntries(const TxtEntry *aEntries, uint16_t aNumEntries, MutableData<kWithUint16Length> &aData)
 {
     Error    error;
     Appender appender(aData.GetBytes(), aData.GetLength());
@@ -1056,11 +1056,11 @@ exit:
     return error;
 }
 
-Error TxtEntry::AppendEntries(const TxtEntry *aEntries, uint8_t aNumEntries, Appender &aAppender)
+Error TxtEntry::AppendEntries(const TxtEntry *aEntries, uint16_t aNumEntries, Appender &aAppender)
 {
     Error error = kErrorNone;
 
-    for (uint8_t index = 0; index < aNumEntries; index++)
+    for (uint16_t index = 0; index < aNumEntries; index++)
     {
         SuccessOrExit(error = aEntries[index].AppendTo(aAppender));
     }

--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -1192,7 +1192,7 @@ public:
      * @retval kErrorNoBufs        Insufficient available buffers to grow the message.
      *
      */
-    static Error AppendEntries(const TxtEntry *aEntries, uint8_t aNumEntries, Message &aMessage);
+    static Error AppendEntries(const TxtEntry *aEntries, uint16_t aNumEntries, Message &aMessage);
 
     /**
      * Appends an array of `TxtEntry` items to a `MutableData` buffer.
@@ -1206,11 +1206,11 @@ public:
      * @retval kErrorNoBufs        Insufficient available buffers.
      *
      */
-    static Error AppendEntries(const TxtEntry *aEntries, uint8_t aNumEntries, MutableData<kWithUint16Length> &aData);
+    static Error AppendEntries(const TxtEntry *aEntries, uint16_t aNumEntries, MutableData<kWithUint16Length> &aData);
 
 private:
     Error        AppendTo(Appender &aAppender) const;
-    static Error AppendEntries(const TxtEntry *aEntries, uint8_t aNumEntries, Appender &aAppender);
+    static Error AppendEntries(const TxtEntry *aEntries, uint16_t aNumEntries, Appender &aAppender);
 
     static constexpr uint8_t kMaxKeyValueEncodedSize = 255;
     static constexpr char    kKeyValueSeparator      = '=';


### PR DESCRIPTION
This commit adds the `otDnsEncodeTxtData()` public API, which encodes a given list of TXT record entries (key/value pairs) into TXT data (following the format specified by RFC 6763). The decoding of TXT data was previously provided by the `otDnsGetNextTxtEntry()` API.