### PR TITLE
[posix] replace RCP vendor extension find package with include command

### DIFF
--- a/src/posix/platform/FindExampleVendorDeps.cmake
+++ b/src/posix/platform/FindExampleVendorDeps.cmake
@@ -36,9 +36,7 @@ files used by a vendor implementation in the posix library.
 
 The name of this file and the name of the targets it defines are
 conventionally related. For the purpose of this reference, targets
-will be based off of the identifier "ExampleRcpVendorDeps". Derived
-references should be based off of the value of the cache variable,
-"OT_POSIX_CONFIG_RCP_VENDOR_DEPS_PACKAGE".
+will be based off of the identifier "ExampleRcpVendorDeps".
 
 For more information about package resolution using CMake find modules,
 reference the cmake-developer documentation.

--- a/src/posix/platform/vendor_extension_example.cmake
+++ b/src/posix/platform/vendor_extension_example.cmake
@@ -26,36 +26,32 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-set(OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE "vendor_interface_example.cpp"
-    CACHE STRING "vendor interface implementation")
+# This file provides an example on how to implement a RCP vendor extension.
 
-set(OT_POSIX_CONFIG_RCP_VENDOR_DEPS_PACKAGE "" CACHE STRING
-    "path to CMake file to define and link posix vendor extension")
+# Set name of the cmake target to link with rcp-vendor-intf
+set(OT_POSIX_RCP_VENDOR_TARGET "vendor-lib")
 
-set(OT_POSIX_RCP_VENDOR_TARGET "" CACHE STRING 
-    "name of vendor extension CMake target to link with posix library")
+# Create library target using source file "vendor_source.cpp"
+add_library(${OT_POSIX_RCP_VENDOR_TARGET} vendor_source.cpp)
 
-if(OT_POSIX_CONFIG_RCP_BUS STREQUAL "VENDOR")
-    add_library(rcp-vendor-intf ${OT_POSIX_CONFIG_RCP_VENDOR_INTERFACE})
+# Include header files located at "${VENDOR_INCLUDE_PATH}"
+target_include_directories(${OT_POSIX_RCP_VENDOR_TARGET}
+    PRIVATE
+        ${VENDOR_INCLUDE_PATH}
+)
 
-    target_link_libraries(rcp-vendor-intf PUBLIC ot-posix-config)
+set(EXAMPLE_DEPS_ENABLE OFF CACHE BOOL "Include example deps library if enabled")
 
-    target_include_directories(rcp-vendor-intf
-        PUBLIC
-            ${CMAKE_CURRENT_SOURCE_DIR}
-        PRIVATE
-            ${PROJECT_SOURCE_DIR}/include
-            ${PROJECT_SOURCE_DIR}/src
-            ${PROJECT_SOURCE_DIR}/src/core
-            ${PROJECT_SOURCE_DIR}/src/posix/platform/include
-    )
+# Search for and include an optional library using the module file
+# "FindExampleRcpDeps.cmake" at path "${VENDOR_MODULE_PATH}"
+if (EXAMPLE_DEPS_ENABLE)
+    list(APPEND CMAKE_MODULE_PATH ${VENDOR_MODULE_PATH})
+    find_package(ExampleRcpVendorDeps)
 
-    target_link_libraries(openthread-posix PUBLIC rcp-vendor-intf)
-
-    if (OT_POSIX_CONFIG_RCP_VENDOR_DEPS_PACKAGE)
-        include(${OT_POSIX_CONFIG_RCP_VENDOR_DEPS_PACKAGE})
-        if (OT_POSIX_CONFIG_RCP_VENDOR_TARGET)
-            target_link_libraries(rcp-vendor-intf PRIVATE ${OT_POSIX_RCP_VENDOR_TARGET})
-        endif()
+    if(ExampleRcpVendorDeps_FOUND)
+        target_link_libraries(${OT_POSIX_RCP_VENDOR_TARGET} 
+            PRIVATE
+            ${ExampleRcpVendorDeps::ExampleRcpVendorDeps}
+        )
     endif()
 endif()


### PR DESCRIPTION
This change updates the mechanism used by vendor.cmake to include a cmake file to define the required vendor targets used by the rcp vendor interface library instead of the find_package command that was previously used.

The find_package command would allow for a package to be searched for and a target to be linked unconditionally if defined by the CMake project. This would lead to problems if the target was already defined, perhaps as a subdirectory of a super project, and the cache variable is still set for the openthread build. Additionally, this change also brings the vendor extension of the posix library more in line with the cli vendor extension, which was created after find_package was used in vendor.cmake.