### PR TITLE
[spinel] return error from `SaveFrame` if not enough space is available

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (336)
+#define OPENTHREAD_API_VERSION (337)
 
 /**
  * @addtogroup api-instance

--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -530,13 +530,14 @@ void RadioSpinel<InterfaceType>::HandleNotification(SpinelInterface::RxFrameBuff
     }
 
 exit:
-    if (shouldSaveFrame)
-    {
-        aFrameBuffer.SaveFrame();
-    }
-    else
+    if (!shouldSaveFrame || aFrameBuffer.SaveFrame() != OT_ERROR_NONE)
     {
         aFrameBuffer.DiscardFrame();
+
+        if (shouldSaveFrame)
+        {
+            otLogCritPlat("RX Spinel buffer full, dropped incoming frame");
+        }
     }
 
     UpdateParseErrorCount(error);


### PR DESCRIPTION
`SaveFrame()` makes assumptions that there is enough space in the buffer to store the received buffer. This PR adds a error check to ensure that there is at least 4 bytes before initiating the save.