### PR TITLE
[ncp] keep timeout zero during ramp-down in spinel `ADDRESS_CACHE_TABLE`

### DIFF
--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -1210,7 +1210,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_ADDRESS_CACHE_
         if (entry.mState != OT_CACHE_ENTRY_STATE_CACHED)
         {
             SuccessOrExit(error = mEncoder.WriteBool(entry.mCanEvict));
-            SuccessOrExit(error = mEncoder.WriteUint16(entry.mTimeout));
+            SuccessOrExit(error = mEncoder.WriteUint16(entry.mRampDown ? 0 : entry.mTimeout));
             SuccessOrExit(error = mEncoder.WriteUint16(entry.mRetryDelay));
         }
 


### PR DESCRIPTION
This commit updates the NCP code to set the timeout field in spinel `SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE` as zero when in ramp-down mode. This ensures that the behavior of the NCP remains unchanged and that test cases like `ncp/test-039-address-cache-table-snoop.py`, which expect the timeout to reach zero, to pass.