### PR TITLE
[routing-manager] `PdPrefixManager` to clear prefix bits when extending length

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -3317,8 +3317,8 @@ Error RoutingManager::PdPrefixManager::Process(const Ip6::Nd::RouterAdvertMessag
             continue;
         }
 
-        entry.mPrefix.SetLength(kOmrPrefixLength);
         entry.mPrefix.Tidy();
+        entry.mPrefix.SetLength(kOmrPrefixLength);
 
         // The platform may send another RA message to announce that the current prefix we are using is no longer
         // preferred or no longer valid.


### PR DESCRIPTION
This commit updates the `RoutingManager::PdPrefixManager::Process()` method to `Tidy()` the prefix before setting the prefix length and potentially extending the prefix to `kOmrPrefixLength` (64 bits). This ensures that extended bits in the prefix are set to zero.

----

Should help address #9248 