### PR TITLE
[posix] fix the snprintf buffer overflow issue

### DIFF
--- a/src/posix/platform/daemon.cpp
+++ b/src/posix/platform/daemon.cpp
@@ -81,7 +81,8 @@ int Daemon::OutputFormatV(const char *aFormat, va_list aArguments)
 
     rval = vsnprintf(buf, sizeof(buf) - 1, aFormat, aArguments);
 
-    VerifyOrExit(rval >= 0, otLogWarnPlat("Failed to format CLI output: %s", strerror(errno)));
+    VerifyOrExit((rval >= 0) && (rval <= (sizeof(buf) - 1)),
+                 otLogWarnPlat("Failed to format CLI output: %s", strerror(errno)));
 
     VerifyOrExit(mSessionSocket != -1);
 


### PR DESCRIPTION
Based on the description of the function [snprintf](https://linux.die.net/man/3/vsnprintf), the return value of size or more means that the output was truncated. If the return value is larger than the buffer size and the code access the buffer using the return value as the buffer length, it causes the buffer overflow.