### PR TITLE
[commissioner] fix joiner removal issue on timeout

### DIFF
--- a/src/core/common/time.hpp
+++ b/src/core/common/time.hpp
@@ -259,9 +259,15 @@ public:
     static uint32_t constexpr MsecToSec(uint32_t aMilliseconds) { return aMilliseconds / 1000u; }
 
 private:
-    static constexpr uint32_t kDistantFuture = (1UL << 31);
-
-    uint32_t mValue;
+    /**
+     * minus 1 to guarantee that `now.GetDistantFuture()` is a future time, and `now.GetDistantPast()` is a past time:
+     *  - `Min(now, now.GetDistantFuture())` and `Min(now.GetDistantFuture(), now)` all return `now`
+     *  - `Max(now, now.GetDistantFuture())` and `Max(now.GetDistantFuture(), now)` all return `now.GetDistantFuture()`
+     *  - `Min(now, now.GetDistantPast())` and `Min(now.GetDistantPast(), now)` all return `now.GetDistantPast()`
+     *  - `Max(now, now.GetDistantPast())` and `Max(now.GetDistantPast(), now)` all return `now`
+     */
+    static constexpr uint32_t kDistantFuture = ((1UL << 31) - 1);
+    uint32_t                  mValue;
 };
 
 /**

--- a/tests/unit/test_timer.cpp
+++ b/tests/unit/test_timer.cpp
@@ -652,12 +652,12 @@ int TestTimerTime(void)
             t2 = t1.GetDistantFuture();
             VerifyOrQuit((t1 < t2), "GetDistanceFuture() failed");
             t2 += 1;
-            VerifyOrQuit(!(t1 < t2), "GetDistanceFuture() failed");
+            VerifyOrQuit((t1 > t2), "GetDistanceFuture() failed");
 
             t2 = t1.GetDistantPast();
             VerifyOrQuit((t1 > t2), "GetDistantPast() failed");
             t2 -= 1;
-            VerifyOrQuit(!(t1 > t2), "GetDistantPast() failed");
+            VerifyOrQuit((t1 < t2), "GetDistantPast() failed");
 
             printf("--> PASSED\n");
         }


### PR DESCRIPTION
The issue occurs when the timeout values for some joiners are very close, and a bit long delay in the joiner removed callback. In case all remaining joiners have timed out, the `UpdateJoinerExpirationTimer` function mistakenly stops the timer.

The root cause is that the function `Min(now, now.GetDistantFuture());` returns `now.GetDistantFuture()`.

This PR resolves the issue by removing the joiner if it has already timed out.

Another possible solution is to change [kDistantFuture](https://github.com/openthread/openthread/blob/main/src/core/common/time.hpp#L262) to `((1UL << 31) -1)`, so then `Min(now, now.GetDistantFuture());` will return `now`. However, I'm uncertain if this change would affect other use cases, @abtink What's your opinion on this?