### PR TITLE
[commissioner] simplify and fix scheduling of expiration timer

### DIFF
--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -549,8 +549,6 @@ private:
     void HandleTimer(void);
     void HandleJoinerExpirationTimer(void);
 
-    void UpdateJoinerExpirationTimer(void);
-
     static void HandleMgmtCommissionerSetResponse(void                *aContext,
                                                   otMessage           *aMessage,
                                                   const otMessageInfo *aMessageInfo,


### PR DESCRIPTION
This commit simplifies scheduling of `mJoinerExpirationTimer` by using `FireAtIfEarlier()` when adding or updating a `Joiner` entry instead of recalculating the fire time. When a `Joiner` entry is removed, we keep the timer unchanged and let it be rescheduled when the currently scheduled timer expires. The next expiration time is determined in `HandleJoinerExpirationTimer()`, which ensures that all expiration times are strictly after `now` and avoids any potential issue with the order of comparison between `now` and `next` being `now.GetDistantFuture()`.

----

Should help address https://github.com/openthread/openthread/issues/9255, also related to https://github.com/openthread/openthread/pull/9258