### PR TITLE
[mle] send data polls after Child ID Request ack

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -808,7 +808,6 @@ Mac::TxFrame *MeshForwarder::HandleFrameRequest(Mac::TxFrames &aTxFrames)
             mMessageNextOffset = mSendMessage->GetLength();
             ExitNow(frame = nullptr);
         }
-
         break;
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
@@ -1308,18 +1307,7 @@ void MeshForwarder::UpdateSendMessage(Error aFrameTxError, Mac::Address &aMacDes
         break;
 
     case Message::kSubTypeMleChildIdRequest:
-        if (mSendMessage->IsLinkSecurityEnabled())
-        {
-            // If the Child ID Request requires fragmentation and therefore
-            // link layer security, the frame transmission will be aborted.
-            // When the message is being freed, we signal to MLE to prepare a
-            // shorter Child ID Request message (by only including mesh-local
-            // address in the Address Registration TLV).
-
-            LogInfo("Requesting shorter `Child ID Request`");
-            Get<Mle::Mle>().RequestShorterChildIdRequest();
-        }
-
+        Get<Mle::Mle>().HandleChildIdRequestTxDone(*mSendMessage);
         break;
 
     default:

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -644,6 +644,13 @@ public:
         mParentResponseCallback.Set(aCallback, aContext);
     }
 #endif
+    /**
+     * Notifies MLE whether the Child ID Request message was transmitted successfully.
+     *
+     * @param[in]  aMessage  The transmitted message.
+     *
+     */
+    void HandleChildIdRequestTxDone(Message &aMessage);
 
     /**
      * Requests MLE layer to prepare and send a shorter version of Child ID Request message by only


### PR DESCRIPTION
Currently, when SED sends out the Child ID request, the first data poll goes out immediately (from the SendChildIDRequest method in MeshForwarder (snippet A). This does not check for any failures in RCP or SubMac (Channel Access failures or Abort which can cause Child ID request to fail transmission). In such failure scenarios, additional data polls are sent out (to retrieve Child ID response which seems like wasted OTA transmissions).  Request to delay the start of data polling procedure after the Child ID request is sent successfully. 

Please check if this PR can address the requested change under all scenarios. Thanks for the review. 

Snippet A (SendChildIDRequest):

SuccessOrExit(error = message->SendTo(destination));

    Log(kMessageSend,
        (mAddressRegistrationMode == kAppendMeshLocalOnly) ? kTypeChildIdRequestShort : kTypeChildIdRequest,
        destination);

    if (!IsRxOnWhenIdle())
    {
        Get<DataPollSender>().SetAttachMode(true);
        Get<MeshForwarder>().SetRxOnWhenIdle(false);
    }
