### PR TITLE
[mle] ensure key sequence is updated in MLE responses

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1738,6 +1738,7 @@ protected:
 #endif
 
     void ScheduleMessageTransmissionTimer(void);
+    void ProcessKeySequence(RxInfo &aRxInfo);
 
 private:
     // Declare early so we can use in as `TimerMilli` callbacks.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -730,6 +730,7 @@ void MleRouter::HandleLinkRequest(RxInfo &aRxInfo)
 #endif
 
     aRxInfo.mClass = RxInfo::kPeerMessage;
+    ProcessKeySequence(aRxInfo);
 
     SuccessOrExit(error = SendLinkAccept(aRxInfo.mMessageInfo, neighbor, requestedTlvList, challenge));
 
@@ -1025,6 +1026,7 @@ Error MleRouter::HandleLinkAccept(RxInfo &aRxInfo, bool aRequest)
     mNeighborTable.Signal(NeighborTable::kRouterAdded, *router);
 
     aRxInfo.mClass = RxInfo::kAuthoritativeMessage;
+    ProcessKeySequence(aRxInfo);
 
     if (aRequest)
     {
@@ -1476,6 +1478,7 @@ void MleRouter::HandleParentRequest(RxInfo &aRxInfo)
     }
 
     aRxInfo.mClass = RxInfo::kPeerMessage;
+    ProcessKeySequence(aRxInfo);
 
     SendParentResponse(child, challenge, !ScanMaskTlv::IsEndDeviceFlagSet(scanMask));
 
@@ -2215,6 +2218,7 @@ void MleRouter::HandleChildIdRequest(RxInfo &aRxInfo)
     }
 
     aRxInfo.mClass = RxInfo::kAuthoritativeMessage;
+    ProcessKeySequence(aRxInfo);
 
     switch (mRole)
     {
@@ -2671,6 +2675,7 @@ void MleRouter::HandleDataRequest(RxInfo &aRxInfo)
     }
 
     aRxInfo.mClass = RxInfo::kPeerMessage;
+    ProcessKeySequence(aRxInfo);
 
     SendDataResponse(aRxInfo.mMessageInfo.GetPeerAddr(), tlvList, /* aDelay */ 0, &aRxInfo.mMessage);
 

--- a/tests/scripts/thread-cert/test_mle_msg_key_seq_jump.py
+++ b/tests/scripts/thread-cert/test_mle_msg_key_seq_jump.py
@@ -236,6 +236,30 @@ class MleMsgKeySeqJump(thread_cert.TestCase):
         self.simulator.go(2)
         self.assertEqual(child.get_key_sequence_counter(), 21)
 
+        #-------------------------------------------------------------------
+        # Force a reattachment from the child with a higher key seq counter,
+        # so that the leader generated a fragmented Child Id Response. Ensure
+        # the child becomes attached on first attempt while the leader adopts
+        # the higher counter value.
+
+        router.stop()
+        reed.stop()
+
+        child.factory_reset()
+        self.assertEqual(child.get_state(), 'disabled')
+
+        child.set_active_dataset(channel=leader.get_channel(),
+                                 network_key=leader.get_networkkey(),
+                                 panid=leader.get_panid())
+        child.set_key_sequence_counter(25)
+        self.assertEqual(child.get_key_sequence_counter(), 25)
+
+        child.start()
+        self.simulator.go(2)
+
+        self.assertEqual(child.get_state(), 'child')
+        self.assertEqual(leader.get_key_sequence_counter(), 25)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Processing of the Key Sequence is happening after each individual MLE command processing, which leads to generating MLE responses with outdated Key Sequence.

Make sure that the new greater Key Sequence is applied before generating any MLE response.

A test case is updated to catch the case in which fragmented Child Id Response was generated with the old Key Sequence whereas each individual MAC fragment is already updated with the new Key Sequence, leading to a security error.