### PR TITLE
[routing-manager] add `SetState()` in `OnLinkPrefixManager`

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -2166,6 +2166,18 @@ RoutingManager::OnLinkPrefixManager::OnLinkPrefixManager(Instance &aInstance)
     mOldLocalPrefixes.Clear();
 }
 
+void RoutingManager::OnLinkPrefixManager::SetState(State aState)
+{
+    VerifyOrExit(mState != aState);
+
+    LogInfo("Local on-link prefix state: %s -> %s (%s)", StateToString(mState), StateToString(aState),
+            mLocalPrefix.ToString().AsCString());
+    mState = aState;
+
+exit:
+    return;
+}
+
 void RoutingManager::OnLinkPrefixManager::Init(void)
 {
     TimeMilli                now = TimerMilli::GetNow();
@@ -2249,19 +2261,19 @@ void RoutingManager::OnLinkPrefixManager::GenerateLocalPrefix(void)
     LogNote("Local on-link prefix: %s", mLocalPrefix.ToString().AsCString());
 
     // Check if the new local prefix happens to be in `mOldLocalPrefixes` array.
-    // If so, we remove it from the array and set `mState` accordingly.
+    // If so, we remove it from the array and update the state accordingly.
 
     entry = mOldLocalPrefixes.FindMatching(mLocalPrefix);
 
     if (entry != nullptr)
     {
-        mState      = kDeprecating;
+        SetState(kDeprecating);
         mExpireTime = entry->mExpireTime;
         mOldLocalPrefixes.Remove(*entry);
     }
     else
     {
-        mState = kIdle;
+        SetState(kIdle);
     }
 
 exit:
@@ -2274,7 +2286,7 @@ void RoutingManager::OnLinkPrefixManager::Stop(void)
 {
     mFavoredDiscoveredPrefix.Clear();
 
-    switch (mState)
+    switch (GetState())
     {
     case kIdle:
         break;
@@ -2282,7 +2294,7 @@ void RoutingManager::OnLinkPrefixManager::Stop(void)
     case kPublishing:
     case kAdvertising:
     case kDeprecating:
-        mState = kDeprecating;
+        SetState(kDeprecating);
         break;
     }
 }
@@ -2372,7 +2384,7 @@ void RoutingManager::OnLinkPrefixManager::PublishAndAdvertise(void)
     // Start publishing and advertising the local on-link prefix if
     // not already.
 
-    switch (mState)
+    switch (GetState())
     {
     case kIdle:
     case kDeprecating:
@@ -2383,10 +2395,8 @@ void RoutingManager::OnLinkPrefixManager::PublishAndAdvertise(void)
         ExitNow();
     }
 
-    mState = kPublishing;
+    SetState(kPublishing);
     ResetExpireTime(TimerMilli::GetNow());
-
-    LogInfo("Publishing route for local on-link prefix %s", mLocalPrefix.ToString().AsCString());
 
     // We wait for the ULA `fc00::/7` route or a sub-prefix of it (e.g.,
     // default route) to be added in Network Data before
@@ -2397,7 +2407,7 @@ void RoutingManager::OnLinkPrefixManager::PublishAndAdvertise(void)
 
     if (Get<RoutingManager>().NetworkDataContainsUlaRoute())
     {
-        EnterAdvertisingState();
+        SetState(kAdvertising);
     }
 
 exit:
@@ -2413,12 +2423,11 @@ void RoutingManager::OnLinkPrefixManager::Deprecate(void)
     // with zero preferred lifetime and the remaining valid lifetime
     // until the timer expires.
 
-    switch (mState)
+    switch (GetState())
     {
     case kPublishing:
     case kAdvertising:
-        mState = kDeprecating;
-        LogInfo("Deprecating local on-link prefix %s", mLocalPrefix.ToString().AsCString());
+        SetState(kDeprecating);
         break;
 
     case kIdle:
@@ -2434,7 +2443,7 @@ bool RoutingManager::OnLinkPrefixManager::ShouldPublishUlaRoute(void) const
     // or `kDeprecating` states, or if there is at least one old local
     // prefix being deprecated.
 
-    return (mState != kIdle) || !mOldLocalPrefixes.IsEmpty();
+    return (GetState() != kIdle) || !mOldLocalPrefixes.IsEmpty();
 }
 
 void RoutingManager::OnLinkPrefixManager::ResetExpireTime(TimeMilli aNow)
@@ -2444,15 +2453,9 @@ void RoutingManager::OnLinkPrefixManager::ResetExpireTime(TimeMilli aNow)
     SavePrefix(mLocalPrefix, mExpireTime);
 }
 
-void RoutingManager::OnLinkPrefixManager::EnterAdvertisingState(void)
-{
-    mState = kAdvertising;
-    LogInfo("Advertising local on-link prefix %s", mLocalPrefix.ToString().AsCString());
-}
-
 bool RoutingManager::OnLinkPrefixManager::IsPublishingOrAdvertising(void) const
 {
-    return (mState == kPublishing) || (mState == kAdvertising);
+    return (GetState() == kPublishing) || (GetState() == kAdvertising);
 }
 
 void RoutingManager::OnLinkPrefixManager::AppendAsPiosTo(Ip6::Nd::RouterAdvertMessage &aRaMessage)
@@ -2474,7 +2477,7 @@ void RoutingManager::OnLinkPrefixManager::AppendCurPrefix(Ip6::Nd::RouterAdvertM
     uint32_t  preferredLifetime = kDefaultOnLinkPrefixLifetime;
     TimeMilli now               = TimerMilli::GetNow();
 
-    switch (mState)
+    switch (GetState())
     {
     case kAdvertising:
         ResetExpireTime(now);
@@ -2520,11 +2523,11 @@ void RoutingManager::OnLinkPrefixManager::AppendOldPrefixes(Ip6::Nd::RouterAdver
 
 void RoutingManager::OnLinkPrefixManager::HandleNetDataChange(void)
 {
-    VerifyOrExit(mState == kPublishing);
+    VerifyOrExit(GetState() == kPublishing);
 
     if (Get<RoutingManager>().NetworkDataContainsUlaRoute())
     {
-        EnterAdvertisingState();
+        SetState(kAdvertising);
         Get<RoutingManager>().ScheduleRoutingPolicyEvaluation(kAfterRandomDelay);
     }
 
@@ -2541,7 +2544,7 @@ void RoutingManager::OnLinkPrefixManager::HandleExtPanIdChange(void)
     // so to allow Thread nodes to continue to communicate with `InfraIf`
     // device using addresses based on this prefix.
 
-    uint16_t    oldState  = mState;
+    uint16_t    oldState  = GetState();
     Ip6::Prefix oldPrefix = mLocalPrefix;
 
     GenerateLocalPrefix();
@@ -2630,7 +2633,7 @@ void RoutingManager::OnLinkPrefixManager::HandleTimer(void)
     TimeMilli                           nextExpireTime = now.GetDistantFuture();
     Array<Ip6::Prefix, kMaxOldPrefixes> expiredPrefixes;
 
-    switch (mState)
+    switch (GetState())
     {
     case kIdle:
         break;
@@ -2639,9 +2642,8 @@ void RoutingManager::OnLinkPrefixManager::HandleTimer(void)
     case kDeprecating:
         if (now >= mExpireTime)
         {
-            LogInfo("Removing expired local on-link prefix %s", mLocalPrefix.ToString().AsCString());
             IgnoreError(Get<Settings>().RemoveBrOnLinkPrefix(mLocalPrefix));
-            mState = kIdle;
+            SetState(kIdle);
         }
         else
         {
@@ -2675,6 +2677,23 @@ void RoutingManager::OnLinkPrefixManager::HandleTimer(void)
     }
 
     Get<RoutingManager>().mRoutePublisher.Evaluate();
+}
+
+const char *RoutingManager::OnLinkPrefixManager::StateToString(State aState)
+{
+    static const char *const kStateStrings[] = {
+        "Removed",     // (0) kIdle
+        "Publishing",  // (1) kPublishing
+        "Advertising", // (2) kAdvertising
+        "Deprecating", // (3) kDeprecating
+    };
+
+    static_assert(0 == kIdle, "kIdle value is incorrect");
+    static_assert(1 == kPublishing, "kPublishing value is incorrect");
+    static_assert(2 == kAdvertising, "kAdvertising value is incorrect");
+    static_assert(3 == kDeprecating, "kDeprecating value is incorrect");
+
+    return kStateStrings[aState];
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -899,15 +899,18 @@ private:
             TimeMilli   mExpireTime;
         };
 
-        void GenerateLocalPrefix(void);
-        void PublishAndAdvertise(void);
-        void Deprecate(void);
-        void ResetExpireTime(TimeMilli aNow);
-        void EnterAdvertisingState(void);
-        void AppendCurPrefix(Ip6::Nd::RouterAdvertMessage &aRaMessage);
-        void AppendOldPrefixes(Ip6::Nd::RouterAdvertMessage &aRaMessage);
-        void DeprecateOldPrefix(const Ip6::Prefix &aPrefix, TimeMilli aExpireTime);
-        void SavePrefix(const Ip6::Prefix &aPrefix, TimeMilli aExpireTime);
+        State GetState(void) const { return mState; }
+        void  SetState(State aState);
+        void  GenerateLocalPrefix(void);
+        void  PublishAndAdvertise(void);
+        void  Deprecate(void);
+        void  ResetExpireTime(TimeMilli aNow);
+        void  AppendCurPrefix(Ip6::Nd::RouterAdvertMessage &aRaMessage);
+        void  AppendOldPrefixes(Ip6::Nd::RouterAdvertMessage &aRaMessage);
+        void  DeprecateOldPrefix(const Ip6::Prefix &aPrefix, TimeMilli aExpireTime);
+        void  SavePrefix(const Ip6::Prefix &aPrefix, TimeMilli aExpireTime);
+
+        static const char *StateToString(State aState);
 
         using ExpireTimer = TimerMilliIn<RoutingManager, &RoutingManager::HandleOnLinkPrefixManagerTimer>;
 


### PR DESCRIPTION
This commit adds `SetState()` method to the `OnLinkPrefixManager` class. This method allows the state of the on-link prefix manager to be changed in a single place, which simplifies the logging and makes it easier to take additional actions on state change. For example, the `SetState()` can be used to update the Advertising PIO (AP) flag in the published route in Network Data.

