### PR TITLE
[routing-manager] support Advertising PIO (AP) flag in published route

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (344)
+#define OPENTHREAD_API_VERSION (345)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/netdata.h
+++ b/include/openthread/netdata.h
@@ -94,6 +94,7 @@ typedef struct otExternalRouteConfig
     bool        mNat64 : 1;               ///< Whether this is a NAT64 prefix.
     bool        mStable : 1;              ///< Whether this configuration is considered Stable Network Data.
     bool        mNextHopIsThisDevice : 1; ///< Whether the next hop is this device (value ignored on config add).
+    bool        mAdvPio : 1;              ///< Whether or not BR is advertising a ULA prefix in PIO (AP flag).
 } otExternalRouteConfig;
 
 /**

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -3020,12 +3020,13 @@ Get the external route list in the local Network Data.
 Done
 ```
 
-### route add \<prefix\> [sn][prf]
+### route add \<prefix\> [sna][prf]
 
 Add a valid external route to the Network Data.
 
 - s: Stable flag
 - n: NAT64 flag
+- a: Advertising PIO (AP) flag
 - prf: Default Router Preference, which may be: 'high', 'med', or 'low'.
 
 ```bash

--- a/src/cli/README_NETDATA.md
+++ b/src/cli/README_NETDATA.md
@@ -297,6 +297,7 @@ Publish an external route entry.
 
 - s: Stable flag
 - n: NAT64 flag
+- a: Advertising PIO (AP) flag
 - prf: Preference, which may be: 'high', 'med', or 'low'.
 
 ```bash
@@ -312,6 +313,7 @@ If there is no previously published external route matching old prefix, this com
 
 - s: Stable flag
 - n: NAT64 flag
+- a: Advertising PIO (AP) flag
 - prf: Preference, which may be: 'high', 'med', or 'low'.
 
 ```bash
@@ -358,6 +360,7 @@ External Routes are listed under `Routes` header:
 - Flags
   - s: Stable flag
   - n: NAT64 flag
+  - a: Advertising PIO (AP) flag
 - Preference `high`, `med`, or `low`
 - RLOC16 of device which added the route prefix
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -6321,6 +6321,10 @@ otError Interpreter::ParseRoute(Arg aArgs[], otExternalRouteConfig &aConfig)
                     aConfig.mNat64 = true;
                     break;
 
+                case 'a':
+                    aConfig.mAdvPio = true;
+                    break;
+
                 case '-':
                     break;
 

--- a/src/cli/cli_network_data.cpp
+++ b/src/cli/cli_network_data.cpp
@@ -134,6 +134,11 @@ void NetworkData::RouteFlagsToString(const otExternalRouteConfig &aConfig, Flags
         *flagsPtr++ = 'n';
     }
 
+    if (aConfig.mAdvPio)
+    {
+        *flagsPtr++ = 'a';
+    }
+
     *flagsPtr = '\0';
 }
 

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -2174,6 +2174,12 @@ void RoutingManager::OnLinkPrefixManager::SetState(State aState)
             mLocalPrefix.ToString().AsCString());
     mState = aState;
 
+    // Mark the Advertising PIO (AP) flag in the published route, when
+    // the local on-link prefix is being published, advertised, or
+    // deprecated.
+
+    Get<RoutingManager>().mRoutePublisher.UpdateAdvPioFlags(aState != kIdle);
+
 exit:
     return;
 }
@@ -2745,6 +2751,7 @@ RoutingManager::RoutePublisher::RoutePublisher(Instance &aInstance)
     , mState(kDoNotPublish)
     , mPreference(NetworkData::kRoutePreferenceMedium)
     , mUserSetPreference(false)
+    , mAdvPioFlag(false)
     , mTimer(aInstance)
 {
 }
@@ -2799,7 +2806,8 @@ void RoutingManager::RoutePublisher::UpdatePublishedRoute(State aNewState)
 {
     // Updates the published route entry in Network Data, transitioning
     // from current `mState` to new `aNewState`. This method can be used
-    // when there is no change to `mState` but a change to `mPreference`.
+    // when there is no change to `mState` but a change to `mPreference`
+    // or `mAdvPioFlag`.
 
     Ip6::Prefix                      oldPrefix;
     NetworkData::ExternalRouteConfig routeConfig;
@@ -2815,6 +2823,7 @@ void RoutingManager::RoutePublisher::UpdatePublishedRoute(State aNewState)
 
     routeConfig.Clear();
     routeConfig.mPreference = mPreference;
+    routeConfig.mAdvPio     = mAdvPioFlag;
     routeConfig.mStable     = true;
     DeterminePrefixFor(aNewState, routeConfig.GetPrefix());
 
@@ -2850,6 +2859,16 @@ void RoutingManager::RoutePublisher::Unpublish(void)
     DeterminePrefixFor(mState, prefix);
     IgnoreError(Get<NetworkData::Publisher>().UnpublishPrefix(prefix));
     mState = kDoNotPublish;
+
+exit:
+    return;
+}
+
+void RoutingManager::RoutePublisher::UpdateAdvPioFlags(bool aAdvPioFlag)
+{
+    VerifyOrExit(mAdvPioFlag != aAdvPioFlag);
+    mAdvPioFlag = aAdvPioFlag;
+    UpdatePublishedRoute(mState);
 
 exit:
     return;

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -988,6 +988,8 @@ private:
         void Stop(void) { Unpublish(); }
         void Evaluate(void);
 
+        void UpdateAdvPioFlags(bool aAdvPioFlag);
+
         RoutePreference GetPreference(void) const { return mPreference; }
         void            SetPreference(RoutePreference aPreference);
         void            ClearPreference(void);
@@ -1022,6 +1024,7 @@ private:
         State           mState;
         RoutePreference mPreference;
         bool            mUserSetPreference;
+        bool            mAdvPioFlag;
         DelayTimer      mTimer;
     };
 

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -468,6 +468,15 @@ public:
     bool IsNat64(void) const { return (mFlags & kNat64Flag) != 0; }
 
     /**
+     * Indicates whether or not the Advertising PIO (AP) flag is set.
+     *
+     * @retval TRUE   If the AP flag is set.
+     * @retval FALSE  If the AP flag is not set.
+     *
+     */
+    bool IsAdvPio(void) const { return (mFlags & kAdvPioFlag) != 0; }
+
+    /**
      * Returns a pointer to the next HasRouteEntry.
      *
      * @returns A pointer to the next HasRouteEntry.
@@ -508,6 +517,7 @@ private:
     static constexpr uint8_t kPreferenceOffset = 6;
     static constexpr uint8_t kPreferenceMask   = 3 << kPreferenceOffset;
     static constexpr uint8_t kNat64Flag        = 1 << 5;
+    static constexpr uint8_t kAdvPioFlag       = 1 << 4;
 
     uint16_t mRloc;
     uint8_t  mFlags;

--- a/src/core/thread/network_data_types.cpp
+++ b/src/core/thread/network_data_types.cpp
@@ -184,6 +184,11 @@ uint8_t ExternalRouteConfig::ConvertToTlvFlags(void) const
         flags |= HasRouteEntry::kNat64Flag;
     }
 
+    if (mAdvPio)
+    {
+        flags |= HasRouteEntry::kAdvPioFlag;
+    }
+
     flags |= (RoutePreferenceToValue(mPreference) << HasRouteEntry::kPreferenceOffset);
 
     return flags;
@@ -208,6 +213,7 @@ void ExternalRouteConfig::SetFrom(Instance            &aInstance,
 void ExternalRouteConfig::SetFromTlvFlags(uint8_t aFlags)
 {
     mNat64      = ((aFlags & HasRouteEntry::kNat64Flag) != 0);
+    mAdvPio     = ((aFlags & HasRouteEntry::kAdvPioFlag) != 0);
     mPreference = RoutePreferenceFromValue(aFlags >> HasRouteEntry::kPreferenceOffset);
 }
 

--- a/tests/toranj/cli/test-021-br-route-prf.py
+++ b/tests/toranj/cli/test-021-br-route-prf.py
@@ -97,7 +97,7 @@ def check_published_route_1():
     verify(br.br_get_state() == 'running')
     routes = br.get_netdata_routes()
     verify(len(routes) == 1)
-    verify(routes[0].startswith('fc00::/7 s med'))
+    verify(routes[0].startswith('fc00::/7 sa med'))
     verify(br.br_get_routeprf() == 'med')
 
 
@@ -118,7 +118,7 @@ def check_published_route_2():
     verify(br.get_state() == 'child')
     routes = br.get_netdata_routes()
     verify(len(routes) == 1)
-    verify(routes[0].startswith('fc00::/7 s low'))
+    verify(routes[0].startswith('fc00::/7 sa low'))
     verify(br.br_get_routeprf() == 'low')
 
 
@@ -135,7 +135,7 @@ def check_published_route_3():
     verify(br.get_state() == 'child')
     routes = br.get_netdata_routes()
     verify(len(routes) == 1)
-    verify(routes[0].startswith('fc00::/7 s high'))
+    verify(routes[0].startswith('fc00::/7 sa high'))
     verify(br.br_get_routeprf() == 'high')
 
 
@@ -148,7 +148,7 @@ def check_published_route_4():
     verify(br.get_state() == 'child')
     routes = br.get_netdata_routes()
     verify(len(routes) == 1)
-    verify(routes[0].startswith('fc00::/7 s med'))
+    verify(routes[0].startswith('fc00::/7 sa med'))
     verify(br.br_get_routeprf() == 'med')
 
 
@@ -166,7 +166,7 @@ def check_published_route_5():
     verify(br.get_state() == 'child')
     routes = br.get_netdata_routes()
     verify(len(routes) == 1)
-    verify(routes[0].startswith('fc00::/7 s low'))
+    verify(routes[0].startswith('fc00::/7 sa low'))
     verify(br.br_get_routeprf() == 'low')
 
 
@@ -183,7 +183,7 @@ def check_published_route_6():
     verify(br.get_state() == 'router')
     routes = br.get_netdata_routes()
     verify(len(routes) == 1)
-    verify(routes[0].startswith('fc00::/7 s med'))
+    verify(routes[0].startswith('fc00::/7 sa med'))
     verify(br.br_get_routeprf() == 'med')
 
 
@@ -204,7 +204,7 @@ def check_published_route_7():
     verify(br.get_state() == 'child')
     routes = br.get_netdata_routes()
     verify(len(routes) == 1)
-    verify(routes[0].startswith('fc00::/7 s med'))
+    verify(routes[0].startswith('fc00::/7 sa med'))
     verify(br.br_get_routeprf() == 'med')
 
 
@@ -224,7 +224,7 @@ def check_published_route_8():
     verify(br.get_state() == 'child')
     routes = br.get_netdata_routes()
     verify(len(routes) == 1)
-    verify(routes[0].startswith('fc00::/7 s low'))
+    verify(routes[0].startswith('fc00::/7 sa low'))
     verify(br.br_get_routeprf() == 'low')
 
 
@@ -247,7 +247,7 @@ def check_published_route_9():
     verify(br.get_state() == 'child')
     routes = br.get_netdata_routes()
     verify(len(routes) == 1)
-    verify(routes[0].startswith('fc00::/7 s med'))
+    verify(routes[0].startswith('fc00::/7 sa med'))
     verify(br.br_get_routeprf() == 'med')
 
 

--- a/tests/unit/test_network_data.cpp
+++ b/tests/unit/test_network_data.cpp
@@ -134,6 +134,7 @@ void TestNetworkDataIterator(void)
                 false,  // mNat64
                 false,  // mStable
                 false,  // mNextHopIsThisDevice
+                false,  // mAdvPio
             },
             {
                 {
@@ -146,6 +147,7 @@ void TestNetworkDataIterator(void)
                 false,  // mNat64
                 true,   // mStable
                 false,  // mNextHopIsThisDevice
+                false,  // mAdvPio
             },
         };
 


### PR DESCRIPTION
This commit adds support for the Advertising PIO (AP) flag in Network Data `ExternalRoute` entries. It also updates the `RoutingManager` class to set the AP flag on its published Network Data route when the local on-link prefix is included as PIO in emitted RA messages, which is equivalent to when the local on-link prefix is being published, advertised, or deprecated.

This commit also updates the `test_routing_manager` unit test to validate the AP flag in the published route under different scenarios.

----

This is related to [SPEC-1180](https://threadgroup.atlassian.net/browse/SPEC-1180).
~This PR currently contains the commit from PR https://github.com/openthread/openthread/pull/9273.~