### PR TITLE
[border-agent] fix struct typedef for `otBorderAgentId`

### DIFF
--- a/include/openthread/border_agent.h
+++ b/include/openthread/border_agent.h
@@ -70,7 +70,6 @@ struct otBorderAgentId
 } OT_TOOL_PACKED_END;
 
 /**
- *
  * Represents a Border Agent ID.
  *
  */

--- a/include/openthread/border_agent.h
+++ b/include/openthread/border_agent.h
@@ -70,6 +70,13 @@ struct otBorderAgentId
 } OT_TOOL_PACKED_END;
 
 /**
+ *
+ * Represents a Border Agent ID.
+ *
+ */
+typedef struct otBorderAgentId otBorderAgentId;
+
+/**
  * Defines the Border Agent state.
  *
  */

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (343)
+#define OPENTHREAD_API_VERSION (344)
 
 /**
  * @addtogroup api-instance


### PR DESCRIPTION
I encountered a compiling issue `unknown type name 'otBorderAgentId'` related to function `otBorderAgentGetId(otInstance *aInstance, otBorderAgentId *aId)` and `otBorderAgentSetId(otInstance *aInstance, const otBorderAgentId *aId)` when I update the upstream code for ESP. I found this struct variable does not use `typedef` like other struct variables under the directory `include/openthread`.

related MR: [[border-agent] set Border Agent ID via CLI](https://github.com/openthread/openthread/pull/9049)