### PR TITLE
[spinel] fix error code when waiting rcp response timeout

### DIFF
--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -1500,7 +1500,7 @@ template <typename InterfaceType> otError RadioSpinel<InterfaceType>::WaitRespon
             {
                 HandleRcpTimeout();
             }
-            ExitNow(mError = OT_ERROR_NONE);
+            ExitNow(mError = OT_ERROR_RESPONSE_TIMEOUT);
         }
     } while (mWaitingTid || !mIsReady);
 


### PR DESCRIPTION
The PR [[posix] unify the RCP reset sequence](https://github.com/openthread/openthread/pull/8858) refactors the logic related to RCP reset and recover. But there is a bug: 

For the RCP waiting response timeout handle logic: https://github.com/openthread/openthread/blob/main/src/lib/spinel/radio_spinel_impl.hpp#L255, the error code of processing `WaitResponse()` will be checked, if there is no error, the function `ResetRcp` will return with a log "Software reset RCP successfully". But the implementation of the [`WaitResponse`](https://github.com/openthread/openthread/blob/main/src/lib/spinel/radio_spinel_impl.hpp#L1496) it will always return OT_ERROR_NONE even if waiting response timeout.

In this PR fix, if waiting response timeout, `OT_ERROR_RESPONSE_TIMEOUT` will be returned from function `WaitResponse()`.