### PR TITLE
[github-action] install `prettier@2.0.4` in `pretty` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
         sudo apt-get --no-install-recommends install -y clang-format-14 clang-tidy-14 shellcheck
         python3 -m pip install yapf==0.31.0
         sudo snap install shfmt
+        npm install prettier@2.0.4
     - name: Check
       run: |
         script/make-pretty check


### PR DESCRIPTION
This commit adds command to install `prettier@2.0.4` from the Bootstrap step in `pretty` job of `build.yml` GitHub Action workflow. This should help with occasional failure of `pretty` check.