### PR TITLE
[dnssd-server] skip additional records on a PTR query with multiple answers

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1240,15 +1240,23 @@ The parameters after `service-name` are optional. Any unspecified (or zero) valu
 > dns browse _service._udp.example.com
 DNS browse response for _service._udp.example.com.
 inst1
+inst2
+inst3
+Done
+```
+
+The detailed service info (port number, weight, host name, TXT data, host addresses) is outputted only when provided by server/resolver in the browse response (in additional Data Section). This is a SHOULD and not a MUST requirement, and servers/resolvers are not required to provide this.
+
+The recommended behavior, which is supported by the OpenThread DNS-SD resolver, is to only provide the additional data when there is a single instance in the response. However, users should assume that the browse response may only contain the list of matching service instances and not any detail service info. To resolve a service instance, users can use the `dns service` or `dns servicehost` commands.
+
+```bash
+> dns browse _service._udp.example.com
+DNS browse response for _service._udp.example.com.
+inst1
     Port:1234, Priority:1, Weight:2, TTL:7200
     Host:host.example.com.
     HostAddress:fd00:0:0:0:0:0:0:abcd TTL:7200
     TXT:[a=6531, b=6c12] TTL:7300
-instance2
-    Port:1234, Priority:1, Weight:2, TTL:7200
-    Host:host.example.com.
-    HostAddress:fd00:0:0:0:0:0:0:abcd TTL:7200
-    TXT:[a=1234] TTL:7300
 Done
 ```
 

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -734,6 +734,15 @@ Header::Response Server::ResolveBySrp(Header                   &aResponseHeader,
             IgnoreError(aResponseMessage.Read(readOffset, question));
             readOffset += sizeof(question);
 
+            if ((question.GetType() == ResourceRecord::kTypePtr) && (aResponseHeader.GetAnswerCount() > 1))
+            {
+                // Skip adding additional records, when answering a
+                // PTR query with more than one answer. This is the
+                // recommended behavior to keep the size of the
+                // response small.
+                continue;
+            }
+
             VerifyOrExit(Header::kResponseServerFailure != ResolveQuestionBySrp(name, question, aResponseHeader,
                                                                                 aResponseMessage, aCompressInfo,
                                                                                 /* aAdditional */ true),

--- a/tests/scripts/thread-cert/border_router/test_dnssd_instance_name_with_space.py
+++ b/tests/scripts/thread-cert/border_router/test_dnssd_instance_name_with_space.py
@@ -114,6 +114,8 @@ class TestDnssdInstanceNameWithSpace(thread_cert.TestCase):
         full_instance_name = f'{INSTANCE_NAME}.{SERVICE_FULL_NAME}'
         EMPTY_TXT = {}
 
+        # In all cases, there is one match, so server should include
+        # service info in additional section of PTR query response.
         self._verify_service_browse_result(client.dns_browse(SERVICE_FULL_NAME, server=br1.get_rloc()))
         self._verify_service_browse_result(client.dns_browse(SERVICE_FULL_NAME, server=br2.get_rloc()))
         self._verify_service_browse_result(client.dns_browse(SERVICE_FULL_NAME.lower(), server=br2.get_rloc()))

--- a/tests/scripts/thread-cert/border_router/test_dnssd_server.py
+++ b/tests/scripts/thread-cert/border_router/test_dnssd_server.py
@@ -136,16 +136,6 @@ class TestDnssdServerOnBr(thread_cert.TestCase):
                 'QUESTION': [(SERVICE_FULL_NAME, 'IN', 'PTR')],
                 'ANSWER': [(SERVICE_FULL_NAME, 'IN', 'PTR', f'ins1.{SERVICE_FULL_NAME}'),
                            (SERVICE_FULL_NAME, 'IN', 'PTR', f'ins2.{SERVICE_FULL_NAME}')],
-                'ADDITIONAL': [
-                    (ins1_full_name, 'IN', 'SRV', 1, 1, 11111, host1_full_name),
-                    (ins1_full_name, 'IN', 'TXT', EMPTY_TXT),
-                    (host1_full_name, 'IN', 'AAAA', client1_addrs[0]),
-                    (host1_full_name, 'IN', 'AAAA', client1_addrs[1]),
-                    (ins2_full_name, 'IN', 'SRV', 2, 2, 22222, host2_full_name),
-                    (ins2_full_name, 'IN', 'TXT', EMPTY_TXT),
-                    (host2_full_name, 'IN', 'AAAA', client2_addrs[0]),
-                    (host2_full_name, 'IN', 'AAAA', client2_addrs[1]),
-                ],
             })
 
         # check if SRV query works

--- a/tests/scripts/thread-cert/border_router/test_mdns_restart.py
+++ b/tests/scripts/thread-cert/border_router/test_mdns_restart.py
@@ -152,6 +152,9 @@ class MdnsRestart(thread_cert.TestCase):
         self.assertEqual(len(host.browse_mdns_services('_ed2._tcp')), 1)
 
         ed1.dns_set_config(br1.get_ip6_address(config.ADDRESS_TYPE.ML_EID))
+
+        # Since there is only one match, server should include
+        # service info in additional section of its response.
         browsed_services = ed1.dns_browse('_ed2._tcp.default.service.arpa')
         self.assertEqual(len(browsed_services), 1)
         self.assertEqual(browsed_services['ed2']['port'], 12345)

--- a/tests/scripts/thread-cert/test_dnssd.py
+++ b/tests/scripts/thread-cert/test_dnssd.py
@@ -172,16 +172,14 @@ class TestDnssd(thread_cert.TestCase):
         # Browse for main service
         service_instances = client1.dns_browse(f'{SERVICE}.{DOMAIN}'.upper(), server.get_mleid(), 53)
         self.assertEqual({'ins1', 'ins2', 'ins3'}, set(service_instances.keys()))
-        self._assert_service_instance_equal(service_instances['ins1'], instance1_verify_info)
-        self._assert_service_instance_equal(service_instances['ins2'], instance2_verify_info)
-        self._assert_service_instance_equal(service_instances['ins3'], instance3_verify_info)
 
         # Browse for service sub-type _s1.
         service_instances = client1.dns_browse(f'_s1._sub.{SERVICE}.{DOMAIN}'.upper(), server.get_mleid(), 53)
         self.assertEqual({'ins1', 'ins3'}, set(service_instances.keys()))
-        self._assert_service_instance_equal(service_instances['ins1'], instance1_verify_info)
 
         # Browse for service sub-type _s2.
+        # Since there is only one matching instance, validate that
+        # server included the service info in additional section.
         service_instances = client1.dns_browse(f'_s2._sub.{SERVICE}.{DOMAIN}'.upper(), server.get_mleid(), 53)
         self.assertEqual({'ins1'}, set(service_instances.keys()))
         self._assert_service_instance_equal(service_instances['ins1'], instance1_verify_info)
@@ -195,6 +193,9 @@ class TestDnssd(thread_cert.TestCase):
         service_instance = client1.dns_resolve_service('ins2', f'{SERVICE}.{DOMAIN}'.upper(), server.get_mleid(), 53)
         self._assert_service_instance_equal(service_instance, instance2_verify_info)
 
+        service_instance = client1.dns_resolve_service('ins3', f'{SERVICE}.{DOMAIN}'.upper(), server.get_mleid(), 53)
+        self._assert_service_instance_equal(service_instance, instance3_verify_info)
+
         #---------------------------------------------------------------
         # Add another service with TXT entries to the existing host and
         # verify that it is properly merged.
@@ -204,10 +205,9 @@ class TestDnssd(thread_cert.TestCase):
 
         service_instances = client1.dns_browse(f'{SERVICE}.{DOMAIN}', server.get_mleid(), 53)
         self.assertEqual({'ins1', 'ins2', 'ins3', 'ins4'}, set(service_instances.keys()))
-        self._assert_service_instance_equal(service_instances['ins1'], instance1_verify_info)
-        self._assert_service_instance_equal(service_instances['ins2'], instance2_verify_info)
-        self._assert_service_instance_equal(service_instances['ins3'], instance3_verify_info)
-        self._assert_service_instance_equal(service_instances['ins4'], instance4_verify_info)
+
+        service_instance = client1.dns_resolve_service('ins4', f'{SERVICE}.{DOMAIN}'.upper(), server.get_mleid(), 53)
+        self._assert_service_instance_equal(service_instance, instance4_verify_info)
 
     def _assert_service_instance_equal(self, instance, info):
         self.assertEqual(instance['host'].lower(), info['host'].lower(), instance)

--- a/tests/scripts/thread-cert/test_srp_server_anycast_mode.py
+++ b/tests/scripts/thread-cert/test_srp_server_anycast_mode.py
@@ -177,7 +177,8 @@ class TestSrpServerAnycastMode(thread_cert.TestCase):
 
             #---------------------------------------------------------------
             # Browse for a matching service name and verify that the registered
-            # service is successfully found.
+            # service is successfully found. Since there is only one match the
+            # server should include the service info in additional section.
 
             service_instances = browser.dns_browse(f'{SERVICE}.{DOMAIN}', server.get_mleid(), DNS_RESOLVER_PORT)
             self.assertEqual({INSTANCE}, set(service_instances.keys()))


### PR DESCRIPTION
This commit updates `Dns::ServiceDiscovery::Server` such that when answering a PTR query with more than one answer, it does not include additional records. This is to keep the size of the response small.

This commit also updates the test scripts validating browse (PTR query) function to check the new behavior. In particular, a common python function `_parse_dns_service_info()` is added to parse service info in CLI output of "dns browse" or "dns service" commands and handle if output of "dns browse" does not include service info.

----

Related to [SPEC-1181](https://threadgroup.atlassian.net/browse/SPEC-1181).