### PR TITLE
Update ip6.hpp

### DIFF
--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -379,7 +379,7 @@ private:
     static constexpr uint8_t kDefaultHopLimit      = OPENTHREAD_CONFIG_IP6_HOP_LIMIT_DEFAULT;
     static constexpr uint8_t kIp6ReassemblyTimeout = OPENTHREAD_CONFIG_IP6_REASSEMBLY_TIMEOUT;
 
-    static constexpr uint16_t kMinimalMtu = 1280;
+    static constexpr uint16_t kMinimalMtu = OPENTHREAD_CONFIG_IP6_MAX_DATAGRAM_LENGTH;
 
     void HandleSendQueue(void);
 


### PR DESCRIPTION
I suggest modifying the kMinimalMtu to match the OPENTHREAD_CONFIG_IP6_MAX_DATAGRAM_LENGTH in order to enable dynamic adjustment.