### PR TITLE
[random] remove mbedtls header from api

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (345)
+#define OPENTHREAD_API_VERSION (346)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/random_crypto.h
+++ b/include/openthread/random_crypto.h
@@ -37,7 +37,6 @@
 
 #include <stdint.h>
 
-#include <mbedtls/ctr_drbg.h>
 #include <openthread/error.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
When trying to opaquely bind to the public facing API, including <mbedtls/ctr_drbg.h> forces an external dependency on mbedtls.