### PR TITLE
[posix] loose check for NETLINK_EXT_ACK and NETLINK_CAP_ACK

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -2004,10 +2004,18 @@ static void platformConfigureNetLink(void)
     {
         int enable = 1;
 
-        VerifyOrDie(setsockopt(sNetlinkFd, SOL_NETLINK, NETLINK_EXT_ACK, &enable, sizeof(enable)) == 0,
-                    OT_EXIT_ERROR_ERRNO);
-        VerifyOrDie(setsockopt(sNetlinkFd, SOL_NETLINK, NETLINK_CAP_ACK, &enable, sizeof(enable)) == 0,
-                    OT_EXIT_ERROR_ERRNO);
+#if defined(NETLINK_EXT_ACK)
+        if (setsockopt(sNetlinkFd, SOL_NETLINK, NETLINK_EXT_ACK, &enable, sizeof(enable)) != 0)
+        {
+            otLogWarnPlat("[netif] Failed to enable NETLINK_EXT_ACK: %s", strerror(errno));
+        }
+#endif
+#if defined(NETLINK_CAP_ACK)
+        if (setsockopt(sNetlinkFd, SOL_NETLINK, NETLINK_CAP_ACK, &enable, sizeof(enable)) != 0)
+        {
+            otLogWarnPlat("[netif] Failed to enable NETLINK_CAP_ACK: %s", strerror(errno));
+        }
+#endif
     }
 #endif
 


### PR DESCRIPTION
`NETLINK_EXT_ACK` and `NETLINK_CAP_ACK` are for getting netlink reply details from the kernel
and we can still function without the two options.

This commit loose the check of enabling the two options to make ot-posix works on platforms where
the features are missing.

-------
Background: https://github.com/openthread/openthread/issues/9298 