### PR TITLE
[mle] define separate `TxChallenge` and `RxChallenge` types

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -882,45 +882,6 @@ protected:
     };
 
     /**
-     * Represents a Challenge (or Response) data.
-     *
-     */
-    struct Challenge
-    {
-        uint8_t mBuffer[kMaxChallengeSize]; ///< Buffer containing the challenge/response byte sequence.
-        uint8_t mLength;                    ///< Challenge length (in bytes).
-
-        /**
-         * Generates a cryptographically secure random sequence to populate the challenge data.
-         *
-         */
-        void GenerateRandom(void);
-
-        /**
-         * Indicates whether the Challenge matches a given buffer.
-         *
-         * @param[in] aBuffer   A pointer to a buffer to compare with the Challenge.
-         * @param[in] aLength   Length of @p aBuffer (in bytes).
-         *
-         * @retval TRUE  If the Challenge matches the given buffer.
-         * @retval FALSE If the Challenge does not match the given buffer.
-         *
-         */
-        bool Matches(const uint8_t *aBuffer, uint8_t aLength) const;
-
-        /**
-         * Indicates whether two Challenge data byte sequences are equal or not.
-         *
-         * @param[in] aOther   Another Challenge data to compare.
-         *
-         * @retval TRUE  If the two Challenges match.
-         * @retval FALSE If the two Challenges do not match.
-         *
-         */
-        bool operator==(const Challenge &aOther) const { return Matches(aOther.mBuffer, aOther.mLength); }
-    };
-
-    /**
      * Represents an MLE Tx message.
      *
      */
@@ -961,36 +922,24 @@ protected:
         /**
          * Appends a Challenge TLV to the message.
          *
-         * @param[in]  aChallenge        A pointer to the Challenge value.
-         * @param[in]  aChallengeLength  The length of the Challenge value in bytes.
-         *
-         * @retval kErrorNone    Successfully appended the Challenge TLV.
-         * @retval kErrorNoBufs  Insufficient buffers available to append the Challenge TLV.
-         *
-         */
-        Error AppendChallengeTlv(const uint8_t *aChallenge, uint8_t aChallengeLength);
-
-        /**
-         * Appends a Challenge TLV to the message.
-         *
          * @param[in] aChallenge A reference to the Challenge data.
          *
          * @retval kErrorNone    Successfully appended the Challenge TLV.
          * @retval kErrorNoBufs  Insufficient buffers available to append the Challenge TLV.
          *
          */
-        Error AppendChallengeTlv(const Challenge &aChallenge);
+        Error AppendChallengeTlv(const TxChallenge &aChallenge);
 
         /**
          * Appends a Response TLV to the message.
          *
-         * @param[in] aResponse  A reference to the Response data.
+         * @param[in] aResponse  The Response data.
          *
          * @retval kErrorNone    Successfully appended the Response TLV.
          * @retval kErrorNoBufs  Insufficient buffers available to append the Response TLV.
          *
          */
-        Error AppendResponseTlv(const Challenge &aResponse);
+        Error AppendResponseTlv(const RxChallenge &aResponse);
 
         /**
          * Appends a Link Frame Counter TLV to the message.
@@ -1299,26 +1248,26 @@ protected:
         /**
          * Reads Challenge TLV from the message.
          *
-         * @param[out] aChallenge        A reference to the Challenge data where to output the read value.
+         * @param[out] aChallenge   A `RxChallenge` to output the read challenge data.
          *
          * @retval kErrorNone       Successfully read the Challenge TLV.
          * @retval kErrorNotFound   Challenge TLV was not found in the message.
          * @retval kErrorParse      Challenge TLV was found but could not be parsed.
          *
          */
-        Error ReadChallengeTlv(Challenge &aChallenge) const;
+        Error ReadChallengeTlv(RxChallenge &aChallenge) const;
 
         /**
          * Reads Response TLV from the message.
          *
-         * @param[out] aResponse        A reference to the Response data where to output the read value.
+         * @param[out] aResponse    A `RxChallenge` to output the read challenge data.
          *
          * @retval kErrorNone       Successfully read the Response TLV.
          * @retval kErrorNotFound   Response TLV was not found in the message.
          * @retval kErrorParse      Response TLV was found but could not be parsed.
          *
          */
-        Error ReadResponseTlv(Challenge &aResponse) const;
+        Error ReadResponseTlv(RxChallenge &aResponse) const;
 
         /**
          * Reads Link and MLE Frame Counters from the message.
@@ -1391,7 +1340,7 @@ protected:
 #endif
 
     private:
-        Error ReadChallengeOrResponse(uint8_t aTlvType, Challenge &aBuffer) const;
+        Error ReadChallengeOrResponse(uint8_t aTlvType, RxChallenge &aRxChallenge) const;
     };
 
     /**
@@ -1563,14 +1512,14 @@ protected:
     /**
      * Generates an MLE Child Update Response message.
      *
-     * @param[in]  aTlvList      A list of requested TLV types.
-     * @param[in]  aChallenge    The Challenge for the response.
+     * @param[in]  aTlvList     A list of requested TLV types.
+     * @param[in]  aChallenge   The challenge data to include in response.
      *
      * @retval kErrorNone     Successfully generated an MLE Child Update Response message.
      * @retval kErrorNoBufs   Insufficient buffers to generate the MLE Child Update Response message.
      *
      */
-    Error SendChildUpdateResponse(const TlvList &aTlvList, const Challenge &aChallenge);
+    Error SendChildUpdateResponse(const TlvList &aTlvList, const RxChallenge &aChallenge);
 
     /**
      * Sets the RLOC16 assigned to the Thread interface.
@@ -1898,16 +1847,16 @@ private:
         void Clear(void);
         void CopyTo(Parent &aParent) const;
 
-        Challenge  mChallenge;
-        int8_t     mPriority;
-        uint8_t    mLinkQuality3;
-        uint8_t    mLinkQuality2;
-        uint8_t    mLinkQuality1;
-        uint16_t   mSedBufferSize;
-        uint8_t    mSedDatagramCount;
-        uint8_t    mLinkMargin;
-        LeaderData mLeaderData;
-        bool       mIsSingleton;
+        RxChallenge mRxChallenge;
+        int8_t      mPriority;
+        uint8_t     mLinkQuality3;
+        uint8_t     mLinkQuality2;
+        uint8_t     mLinkQuality1;
+        uint16_t    mSedBufferSize;
+        uint8_t     mSedDatagramCount;
+        uint8_t     mLinkMargin;
+        LeaderData  mLeaderData;
+        bool        mIsSingleton;
     };
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
@@ -2068,7 +2017,7 @@ private:
 
     MessageQueue mDelayedResponses;
 
-    Challenge mParentRequestChallenge;
+    TxChallenge mParentRequestChallenge;
 
     AttachMode      mAttachMode;
     ParentCandidate mParentCandidate;

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -617,14 +617,14 @@ private:
     Error SendLinkAccept(const Ip6::MessageInfo &aMessageInfo,
                          Neighbor               *aNeighbor,
                          const TlvList          &aRequestedTlvList,
-                         const Challenge        &aChallenge);
-    void  SendParentResponse(Child *aChild, const Challenge &aChallenge, bool aRoutersOnlyRequest);
+                         const RxChallenge      &aChallenge);
+    void  SendParentResponse(Child *aChild, const RxChallenge &aChallenge, bool aRoutersOnlyRequest);
     Error SendChildIdResponse(Child &aChild);
     Error SendChildUpdateRequest(Child &aChild);
     void  SendChildUpdateResponse(Child                  *aChild,
                                   const Ip6::MessageInfo &aMessageInfo,
                                   const TlvList          &aTlvList,
-                                  const Challenge        &aChallenge);
+                                  const RxChallenge      &aChallenge);
     void  SendDataResponse(const Ip6::Address &aDestination,
                            const TlvList      &aTlvList,
                            uint16_t            aDelay,
@@ -668,8 +668,8 @@ private:
     ChildTable  mChildTable;
     RouterTable mRouterTable;
 
-    uint8_t   mChallengeTimeout;
-    Challenge mChallenge;
+    uint8_t     mChallengeTimeout;
+    TxChallenge mChallenge;
 
     uint16_t mNextChildId;
     uint8_t  mNetworkIdTimeout;

--- a/src/core/thread/mle_types.cpp
+++ b/src/core/thread/mle_types.cpp
@@ -35,6 +35,8 @@
 
 #include "common/array.hpp"
 #include "common/code_utils.hpp"
+#include "common/message.hpp"
+#include "common/random.hpp"
 
 namespace ot {
 namespace Mle {
@@ -148,6 +150,36 @@ uint8_t RouterIdSet::GetNumberOfAllocatedIds(void) const
     }
 
     return count;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+// TxChallenge
+
+void TxChallenge::GenerateRandom(void) { IgnoreError(Random::Crypto::Fill(*this)); }
+
+//---------------------------------------------------------------------------------------------------------------------
+// RxChallenge
+
+Error RxChallenge::ReadFrom(const Message &aMessage, uint16_t aOffset, uint16_t aLength)
+{
+    Error error = kErrorNone;
+
+    Clear();
+
+    aLength = Min<uint16_t>(aLength, kMaxChallengeSize);
+    VerifyOrExit(kMinChallengeSize <= aLength, error = kErrorParse);
+
+    SuccessOrExit(error = aMessage.Read(aOffset, mArray.GetArrayBuffer(), aLength));
+    mArray.SetLength(static_cast<uint8_t>(aLength));
+
+exit:
+    return error;
+}
+
+bool RxChallenge::operator==(const TxChallenge &aTxChallenge) const
+{
+    return (mArray.GetLength() == kMaxChallengeSize) &&
+           (memcmp(mArray.GetArrayBuffer(), aTxChallenge.m8, kMaxChallengeSize) == 0);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -196,12 +196,6 @@ bool Neighbor::IsLastRxFragmentTagSet(void) const
 }
 #endif
 
-void Neighbor::GenerateChallenge(void)
-{
-    IgnoreError(
-        Random::Crypto::FillBuffer(mValidPending.mPending.mChallenge, sizeof(mValidPending.mPending.mChallenge)));
-}
-
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
 void Neighbor::AggregateLinkMetrics(uint8_t aSeriesId, uint8_t aFrameType, uint8_t aLqi, int8_t aRss)
 {
@@ -491,11 +485,6 @@ exit:
     return addr;
 }
 #endif
-
-void Child::GenerateChallenge(void)
-{
-    IgnoreError(Random::Crypto::FillBuffer(mAttachChallenge, sizeof(mAttachChallenge)));
-}
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 bool Child::HasMlrRegisteredAddress(const Ip6::Address &aAddress) const

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -652,7 +652,7 @@ public:
      * Generates a new challenge value for MLE Link Request/Response exchanges.
      *
      */
-    void GenerateChallenge(void);
+    void GenerateChallenge(void) { mValidPending.mPending.mChallenge.GenerateRandom(); }
 
     /**
      * Returns the current challenge value for MLE Link Request/Response exchanges.
@@ -660,15 +660,7 @@ public:
      * @returns The current challenge value.
      *
      */
-    const uint8_t *GetChallenge(void) const { return mValidPending.mPending.mChallenge; }
-
-    /**
-     * Returns the size (bytes) of the challenge value for MLE Link Request/Response exchanges.
-     *
-     * @returns The size (bytes) of the challenge value for MLE Link Request/Response exchanges.
-     *
-     */
-    uint8_t GetChallengeSize(void) const { return sizeof(mValidPending.mPending.mChallenge); }
+    const Mle::TxChallenge &GetChallenge(void) const { return mValidPending.mPending.mChallenge; }
 
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
     /**
@@ -819,7 +811,7 @@ private:
         } mValid;
         struct
         {
-            uint8_t mChallenge[Mle::kMaxChallengeSize]; ///< The challenge value
+            Mle::TxChallenge mChallenge; ///< The challenge value
         } mPending;
     } mValidPending;
 
@@ -1183,7 +1175,7 @@ public:
      * Generates a new challenge value to use during a child attach.
      *
      */
-    void GenerateChallenge(void);
+    void GenerateChallenge(void) { mAttachChallenge.GenerateRandom(); }
 
     /**
      * Gets the current challenge value used during attach.
@@ -1191,15 +1183,7 @@ public:
      * @returns The current challenge value.
      *
      */
-    const uint8_t *GetChallenge(void) const { return mAttachChallenge; }
-
-    /**
-     * Gets the challenge size (bytes) used during attach.
-     *
-     * @returns The challenge size (bytes).
-     *
-     */
-    uint8_t GetChallengeSize(void) const { return sizeof(mAttachChallenge); }
+    const Mle::TxChallenge &GetChallenge(void) const { return mAttachChallenge; }
 
     /**
      * Clears the requested TLV list.
@@ -1355,8 +1339,8 @@ private:
 
     union
     {
-        uint8_t mRequestTlvs[kMaxRequestTlvs];            ///< Requested MLE TLVs
-        uint8_t mAttachChallenge[Mle::kMaxChallengeSize]; ///< The challenge value
+        uint8_t          mRequestTlvs[kMaxRequestTlvs]; ///< Requested MLE TLVs
+        Mle::TxChallenge mAttachChallenge;              ///< The challenge value
     };
 
     uint16_t mSupervisionInterval;     // Supervision interval for the child (in sec).


### PR DESCRIPTION
This commit defines two types to track challenge or response TLV data in MLE messages:

- `TxChallenge` represents the maximum-sized challenge data to include and send in MLE messages. OpenThread always uses the maximum size of 8 bytes for challenge data in the messages it sends.
- `RxChallenge` represents variable-length challenge data read from a received MLE message.

The two separate types help to simplify their use in code.