### PR TITLE
[routing-manager] add `SetIfIndex` in `RoutingManager`

### DIFF
--- a/include/openthread/border_routing.h
+++ b/include/openthread/border_routing.h
@@ -133,6 +133,8 @@ typedef enum
  * Initializes the Border Routing Manager on given infrastructure interface.
  *
  * @note  This method MUST be called before any other otBorderRouting* APIs.
+ * @note  This method can be re-called to change the infrastructure interface, but the Border Routing Manager should be
+ *        disabled first, and re-enabled after.
  *
  * @param[in]  aInstance          A pointer to an OpenThread instance.
  * @param[in]  aInfraIfIndex      The infrastructure interface index.
@@ -140,11 +142,12 @@ typedef enum
  *                                interface is running.
  *
  * @retval  OT_ERROR_NONE           Successfully started the Border Routing Manager on given infrastructure.
- * @retval  OT_ERROR_INVALID_STATE  The Border Routing Manager has already been initialized.
+ * @retval  OT_ERROR_INVALID_STATE  The Border Routing Manager is in a state other than disabled or uninitialized.
  * @retval  OT_ERROR_INVALID_ARGS   The index of the infrastructure interface is not valid.
  * @retval  OT_ERROR_FAILED         Internal failure. Usually due to failure in generating random prefixes.
  *
  * @sa otPlatInfraIfStateChanged.
+ * @sa otBorderRoutingSetEnabled.
  *
  */
 otError otBorderRoutingInit(otInstance *aInstance, uint32_t aInfraIfIndex, bool aInfraIfIsRunning);

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (347)
+#define OPENTHREAD_API_VERSION (348)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README_BR.md
+++ b/src/cli/README_BR.md
@@ -8,6 +8,7 @@ Usage : `br [command] ...`
 - [disable](#disable)
 - [enable](#enable)
 - [help](#help)
+- [init](#init)
 - [nat64prefix](#nat64prefix)
 - [omrprefix](#omrprefix)
 - [onlinkprefix](#onlinkprefix)
@@ -35,6 +36,17 @@ prefixtable
 rioprf
 routeprf
 state
+Done
+```
+
+### init
+
+Usage: `br init <interface> <enabled>`
+
+Initializes the Border Routing Manager on given infrastructure interface.
+
+```bash
+> br init 2 1
 Done
 ```
 

--- a/src/core/border_router/infra_if.hpp
+++ b/src/core/border_router/infra_if.hpp
@@ -115,6 +115,14 @@ public:
     uint32_t GetIfIndex(void) const { return mIfIndex; }
 
     /**
+     * Sets the infrastructure interface index.
+     *
+     * @param[in]  aIfIndex        The infrastructure interface index.
+     *
+     */
+    void SetIfIndex(uint32_t aIfIndex) { mIfIndex = aIfIndex; }
+
+    /**
      * Indicates whether or not the infra interface has the given IPv6 address assigned.
      *
      * MUST be used when interface is initialized.


### PR DESCRIPTION
This commit adds `ChangeInfraIf()` method to `RoutingManager` class. This method allows the infrastructure interface to be changed. The user may initialize multiple interfaces and choose one interface as infrastructure interface. Around the run-time, there might be some  networking congestion or other network issue. The user can change the infrastructure interface via this function.

There is a missing introduction to the command `init` for the `README_BR.md`, this PR also adds it.