### PR TITLE
[posix] fix rcp reset flow in `ResetRcp`

### DIFF
--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -259,7 +259,11 @@ template <typename InterfaceType> void RadioSpinel<InterfaceType>::ResetRcp(bool
     }
 
     hardwareReset = (mSpinelInterface.HardwareReset() == OT_ERROR_NONE);
-    SuccessOrExit(WaitResponse(false));
+
+    if (hardwareReset)
+    {
+        SuccessOrExit(WaitResponse(false));
+    }
 
     resetDone = true;
 

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -235,7 +235,7 @@ private:
     {
         kMaxWaitTime   = 2000, ///< Maximum wait time in Milliseconds for socket to become writable (see `SendFrame`).
         kResetTimeout  = 5000, ///< Maximum wait time in Milliseconds for file to become ready (see `ResetConnection`).
-        kOpenFileDelay = 500,  ///< Delay between open file calls, in Milliseconds (see `ResetConnection`).
+        kOpenFileDelay = 50,   ///< Delay between open file calls, in Milliseconds (see `ResetConnection`).
         kRemoveRcpDelay =
             2000, ///< Delay for removing RCP device from host OS after hard reset (see `ResetConnection`).
     };


### PR DESCRIPTION
Remove call to `WaitResponse` after calling `HardwareReset` which didn't
trigger any spinel transaction.

`kOpenFileDelay` change form 500 to 50.