### PR TITLE
[mac-frame] check rx frame security level in `GenerateEnhAck()`

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1362,6 +1362,8 @@ Error TxFrame::GenerateEnhAck(const RxFrame &aFrame, bool aIsFramePending, const
         SuccessOrExit(error = aFrame.GetSecurityControlField(securityControlField));
         SuccessOrExit(error = aFrame.GetKeyId(keyId));
 
+        VerifyOrExit((securityControlField & kSecLevelMask) == kSecurityEncMic32, error = kErrorParse);
+
         SetSecurityControlField(securityControlField);
         SetKeyId(keyId);
     }


### PR DESCRIPTION
This commit updates the `Mac::TxFrame::GenerateEnhAck()` method to check the security level of the received frame. If the security level is not `kSecurityEncMic32`, it will return `kErrorParse`. This should help prevent radio platform implementations from trying to perform tx security on an invalid generated enhanced ack frame. Specifically, it can help prevent radio platforms from calling `ProcessTxSecurity()` on an enhanced ack frame with a security level of `kSecurityNone` which can cause an assert in `AesCcm::Init()` due to the tag length being zero.

----

Thanks and credit to Jordan Crafts (@jcrafts-lutron) for finding and reporting this issue.