### PR TITLE
[mac] document and adjust to standards based timing concepts

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (356)
+#define OPENTHREAD_API_VERSION (357)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/time.h
+++ b/include/openthread/platform/time.h
@@ -52,7 +52,20 @@ extern "C" {
  */
 
 /**
- * Get the current time (64bits width).
+ * Get the current platform time in microseconds referenced to a continuous
+ * monotonic local clock (64 bits width).
+ *
+ * The clock SHALL NOT wrap during the device's uptime. Implementations SHALL
+ * therefore identify and compensate for internal counter overflows. The clock
+ * does not have a defined epoch and it SHALL NOT introduce any continuous or
+ * discontinuous adjustments (e.g. leap seconds). Implementations SHALL
+ * compensate for any sleep times of the device.
+ *
+ * Implementations MAY choose to discipline the platform clock and compensate
+ * for sleep times by any means (e.g. by combining a high precision/low power
+ * RTC with a high resolution counter) as long as the exposed combined clock
+ * provides continuous monotonic microsecond resolution ticks within the
+ * accuracy limits announced by @ref otPlatTimeGetXtalAccuracy.
  *
  * @returns The current time in microseconds.
  *
@@ -60,9 +73,18 @@ extern "C" {
 uint64_t otPlatTimeGet(void);
 
 /**
- * Get the device's XTAL accuracy.
+ * Get the current estimated worst case accuracy (maximum ± deviation from the
+ * nominal frequency) of the local platform clock in units of PPM.
  *
- * @returns The device's XTAL accuracy, in ppm.
+ * @note Implementations MAY estimate this value based on current operating
+ * conditions (e.g. temperature).
+ *
+ * In case the implementation does not estimate the current value but returns a
+ * fixed value, this value MUST be the worst-case accuracy over all possible
+ * foreseen operating conditions (temperature, pressure, etc) of the
+ * implementation.
+ *
+ * @returns The current platform clock accuracy, in PPM.
  *
  */
 uint16_t otPlatTimeGetXtalAccuracy(void);

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -1211,10 +1211,18 @@ public:
 
     /**
      * Returns the timestamp when the frame was received.
-     * The timestamp marks the frame detection time: the end of the last symbol of SFD.
      *
-     * @returns The timestamp when the frame SFD was received, in microseconds.
+     * The value SHALL be the time of the local radio clock in
+     * microseconds when the end of the SFD (or equivalently: the start
+     * of the first symbol of the PHR) was present at the local antenna,
+     * see the definition of a "symbol boundary" in IEEE 802.15.4-2020,
+     * section 6.5.2 or equivalently the RMARKER definition in section
+     * 6.9.1 (albeit both unrelated to OT).
      *
+     * The time is relative to the local radio clock as defined by
+     * `otPlatRadioGetNow`.
+     *
+     * @returns The timestamp in microseconds.
      */
     const uint64_t &GetTimestamp(void) const { return mInfo.mRxInfo.mTimestamp; }
 

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -468,10 +468,10 @@ void SubMac::StartCsmaBackoff(void)
         {
             if (Time(static_cast<uint32_t>(otPlatRadioGetNow(&GetInstance()))) <
                 Time(mTransmitFrame.mInfo.mTxInfo.mTxDelayBaseTime) + mTransmitFrame.mInfo.mTxInfo.mTxDelay -
-                    kCcaSampleInterval - kCslTransmitTimeAhead)
+                    kCcaSampleInterval - kCslTransmitTimeAhead - kRadioHeaderShrDuration)
             {
                 mTimer.StartAt(Time(mTransmitFrame.mInfo.mTxInfo.mTxDelayBaseTime) - kCcaSampleInterval -
-                                   kCslTransmitTimeAhead,
+                                   kCslTransmitTimeAhead - kRadioHeaderShrDuration,
                                mTransmitFrame.mInfo.mTxInfo.mTxDelay);
             }
             else // Transmit without delay

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -316,7 +316,7 @@ void SubMac::LogReceived(RxFrame *aFrame)
     // Treat as a warning when the deviation is not within the margins. Neither kCslReceiveTimeAhead
     // or kMinReceiveOnAhead/kMinReceiveOnAfter are considered for the margin since they have no
     // impact on understanding possible deviation errors between transmitter and receiver. So in this
-    // case ahead equals after.
+    // case only `ahead` is used, as an allowable max deviation in both +/- directions.
     if ((deviation + ahead > 0) && (deviation < static_cast<int32_t>(ahead)))
     {
         LogDebg("%s", logString.AsCString());

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -667,7 +667,7 @@ private:
     bool mIsCslSampling : 1;  // Indicates that the radio is receiving in CSL state for platforms not supporting delayed
                               // reception.
     uint16_t    mCslPeerShort;      // The CSL peer short address.
-    TimeMicro   mCslSampleTime;     // The CSL sample time of the current period.
+    TimeMicro   mCslSampleTime;     // The CSL sample time of the current period relative to the local radio clock.
     TimeMicro   mCslLastSync;       // The timestamp of the last successful CSL synchronization.
     CslAccuracy mCslParentAccuracy; // The parent's CSL accuracy (clock accuracy and uncertainty).
     TimerMicro  mCslTimer;

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -158,9 +158,10 @@ uint32_t CslTxScheduler::GetNextCslTransmissionDelay(const Child &aChild,
 {
     uint64_t radioNow   = otPlatRadioGetNow(&GetInstance());
     uint32_t periodInUs = aChild.GetCslPeriod() * kUsPerTenSymbols;
-    uint64_t firstTxWindow =
-        aChild.GetLastRxTimestamp() - kRadioHeaderShrDuration + aChild.GetCslPhase() * kUsPerTenSymbols;
-    uint64_t nextTxWindow = radioNow - (radioNow % periodInUs) + (firstTxWindow % periodInUs);
+
+    /* see CslTxScheduler::ChildInfo::mCslPhase */
+    uint64_t firstTxWindow = aChild.GetLastRxTimestamp() + aChild.GetCslPhase() * kUsPerTenSymbols;
+    uint64_t nextTxWindow  = radioNow - (radioNow % periodInUs) + (firstTxWindow % periodInUs);
 
     while (nextTxWindow < radioNow + aAheadUs)
     {

--- a/src/core/thread/csl_tx_scheduler.hpp
+++ b/src/core/thread/csl_tx_scheduler.hpp
@@ -101,14 +101,59 @@ public:
         void     SetLastRxTimestamp(uint64_t aLastRxTimestamp) { mLastRxTimestamp = aLastRxTimestamp; }
 
     private:
-        uint8_t   mCslTxAttempts : 7;   ///< Number of CSL triggered tx attempts.
-        bool      mCslSynchronized : 1; ///< Indicates whether or not the child is CSL synchronized.
-        uint8_t   mCslChannel;          ///< The channel the device will listen on.
-        uint32_t  mCslTimeout;          ///< The sync timeout, in seconds.
-        uint16_t  mCslPeriod;           ///< CSL sampled listening period in units of 10 symbols (160 microseconds).
-        uint16_t  mCslPhase;            ///< The time when the next CSL sample will start.
-        TimeMilli mCslLastHeard;        ///< Time when last frame containing CSL IE was heard.
-        uint64_t  mLastRxTimestamp;     ///< Time when last frame containing CSL IE was received, in microseconds.
+        uint8_t  mCslTxAttempts : 7;   ///< Number of CSL triggered tx attempts.
+        bool     mCslSynchronized : 1; ///< Indicates whether or not the child is CSL synchronized.
+        uint8_t  mCslChannel;          ///< The channel the device will listen on.
+        uint32_t mCslTimeout;          ///< The sync timeout, in seconds.
+        uint16_t mCslPeriod; ///< CSL sampled listening period between consecutive channel samples in units of 10
+                             ///< symbols (160 microseconds).
+
+        /**
+         * The time in units of 10 symbols from the first symbol of the frame
+         * containing the CSL IE was transmitted until the next channel sample,
+         * see IEEE 802.15.4-2015, section 6.12.2.
+         *
+         * The Thread standard further defines the CSL phase (see Thread 1.3.1,
+         * section 3.2.6.3.4, also conforming to IEEE 802.15.4-2020, section
+         * 6.12.2.1):
+         *  * The "first symbol" from the definition SHALL be interpreted as the
+         *    first symbol of the MAC Header.
+         *  * "until the next channel sample":
+         *     * The CSL Receiver SHALL be ready to receive when the preamble
+         *       time T_pa as specified below is reached.
+         *     * The CSL Receiver SHOULD be ready to receive earlier than T_pa
+         *       and SHOULD stay ready to receive until after the time specified
+         *       in CSL Phase, according to the implementation and accuracy
+         *       expectations.
+         *     * The CSL Transmitter SHALL start transmitting the first symbol
+         *       of the preamble of the frame to transmit at the preamble time
+         *       T_pa = (CSL-Phase-Time – 192 us) (that is, CCA must be
+         *       performed before time T_pa). Here, CSL-Phase-Time is the time
+         *       duration specified by the CslPhase field value (in units of 10
+         *       symbol periods).
+         *     * This implies that the CSL Transmitter SHALL start transmitting
+         *       the first symbol of the MAC Header at the time T_mh =
+         *       CSL-Phase-Time.
+         *
+         * Derivation of the next TX timestamp based on this definition and the
+         * RX timestamp of the packet containing the CSL IE:
+         *
+         * Note that RX and TX timestamps are defined to point to the end of the
+         * synchronization header (SHR).
+         *
+         * lastTmh = lastRxTimestamp + phrDuration
+         *
+         * nextTmh = lastTmh + symbolPeriod * 10 * (n * cslPeriod + cslPhase)
+         *         = lastTmh + 160us * (n * cslPeriod + cslPhase)
+         *
+         * nextTxTimestamp
+         *         = nextTmh - phrDuration
+         *         = lastRxTimestamp + 160us * (n * cslPeriod + cslPhase)
+         */
+        uint16_t  mCslPhase;
+        TimeMilli mCslLastHeard; ///< Radio clock time when last frame containing CSL IE was heard.
+        uint64_t
+            mLastRxTimestamp; ///< Radio clock time when last frame containing CSL IE was received, in microseconds.
 
         static_assert(kMaxCslTriggeredTxAttempts < (1 << 7), "mCslTxAttempts cannot fit max!");
     };


### PR DESCRIPTION
Hi OpenThread community and above all @edmont , I'm heading over to you guys to adjust OpenThread to a recent unification of timing concepts in the Zephyr IEEE 802.15.4 implementation.

In a nutshell this small change set proposes to align some of the timing sensitive aspects of OpenThread even more closely with concepts from the underlying standards. Unification and closer specification of timing along original IEEE 802.15.4 concepts enables implementation of additional non-Thread IEEE 802.15.4 features in Zephyr (namely TSCH).

Most of this change set is documentation - only a small change is being made to the interpretation of the TX timestamp that seems not to be particularly restricted in OpenThread so far. I propose that we make use of this leeway to jointly move closer to standards-conforming timing primitives.

AFAIK, Zephyr and its derivatives and radio drivers (notably the nRF Connect SDK and nRF radio driver) are the only platforms that depend on this code and those have already made the corresponding changes on their side.

See https://github.com/zephyrproject-rtos/zephyr/issues/59245 for more context as well as @edmont 's regression test result with real hardware based on this change set.