### PR TITLE
[spinel] networkInfo may not exist when recovering from RCP failure

### DIFF
--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -2143,9 +2143,11 @@ template <typename InterfaceType> void RadioSpinel<InterfaceType>::RestoreProper
 
     if (mInstance != nullptr)
     {
-        SuccessOrDie(static_cast<Instance *>(mInstance)->template Get<Settings>().Read(networkInfo));
-        SuccessOrDie(
-            Set(SPINEL_PROP_RCP_MAC_FRAME_COUNTER, SPINEL_DATATYPE_UINT32_S, networkInfo.GetMacFrameCounter()));
+        if (static_cast<Instance *>(mInstance)->template Get<Settings>().Read(networkInfo) == OT_ERROR_NONE)
+        {
+            SuccessOrDie(
+                Set(SPINEL_PROP_RCP_MAC_FRAME_COUNTER, SPINEL_DATATYPE_UINT32_S, networkInfo.GetMacFrameCounter()));
+        }
     }
 
     for (int i = 0; i < mSrcMatchShortEntryCount; ++i)

--- a/tests/scripts/expect/posix-rcp-restoration.exp
+++ b/tests/scripts/expect/posix-rcp-restoration.exp
@@ -54,17 +54,6 @@ puts "RCP PID: $rcp_pid"
 try {
     puts "Before enabling"
 
-    spawn_node 1 "rcp" "spinel+hdlc_uart://$host_pty"
-
-    exec kill $rcp_pid
-    puts "Killed $rcp_pid"
-    sleep 1
-    set rcp_pid [exec $::env(OT_SIMULATION_APPS)/ncp/ot-rcp 1 < $radio_pty > $radio_pty &]
-    puts "RCP PID: $rcp_pid"
-
-    expect eof
-
-
     puts "Queued parent-to-child packets, as parent"
 
     spawn_node 1 "rcp" "spinel+hdlc_uart://$host_pty"


### PR DESCRIPTION
Current implementation of RestoreProperties() assumes there's always a networkInfo structure stored in the settings. But, it's possible the RCP device needs to be recovered before this structure is populated.
This commit change this behavior and allows the structure to not exist yet.