### PR TITLE
[dnssd-server] simplifications and enhancements

### DIFF
--- a/examples/platforms/simulation/CMakeLists.txt
+++ b/examples/platforms/simulation/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(openthread-simulation
     alarm.c
     crypto.c
     diag.c
+    dns.c
     dso_transport.c
     entropy.c
     flash.c

--- a/examples/platforms/simulation/dns.c
+++ b/examples/platforms/simulation/dns.c
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2023, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "platform-simulation.h"
+
+#include <openthread/platform/dns.h>
+
+#if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE
+
+void otPlatDnsStartUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aTxn);
+    OT_UNUSED_VARIABLE(aQuery);
+}
+
+void otPlatDnsCancelUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery *aTxn)
+{
+    otPlatDnsUpstreamQueryDone(aInstance, aTxn, NULL);
+}
+
+#endif


### PR DESCRIPTION
This commit contains changes and enhancements in the DNS-SD server/resolver class `Dns::ServiceDiscovery::Server`.

- It defines `Request` and `Response` structures, which contain all related information for a DNS query request and response. These structures simplify the code by encapsulating all the related information in one place.
- The `Response` class provides methods for preparing the response, such as appending records, DNS names to the response, or checking the questions or updating the header. These methods replace the previous `static` methods, which required all the information to be passed as input parameters.
- The `QueryTransacation` type is simplified by declaring it as a subclass of `Response`. It inherits all the helper methods from `Response`. Other previously defined `static` methods are now defined as methods of `QueryTransacation` (such as `CanAnswer()`).
- `ResolveBySrp()` and its related methods now directly populate the DNS response code in the `Response` DNS header instead of returning it.
- `ResolveBySrp()` is updated such that if a failure is encountered when preparing the answer section, no further processing is performed. This ensures that a previous failure `rcode` is not overwritten. When preparing the additional section, certain `rcode` failures are allowed, such as if the DNS name is not found.
- The processing of `Timer` is simplified, using `FiretAtIfEarlier()` and determining next expire time from `HandleTimer()`.
- This commit also adds an empty implementation of the `otPlatDns{}` functions (used with `OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE`) under the simulation platform.


----

Thie PR  also contains the commit from PR https://github.com/openthread/openthread/pull/9331.
