### PR TITLE
[mac-frame] update `InitMacFrame()`

### DIFF
--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -577,8 +577,7 @@ Mac::TxFrame *DataPollSender::PrepareDataRequest(Mac::TxFrames &aTxFrames)
         addresses.mSource.SetShort(Get<Mac::Mac>().GetShortAddress());
     }
 
-    panIds.mSource      = Get<Mac::Mac>().GetPanId();
-    panIds.mDestination = Get<Mac::Mac>().GetPanId();
+    panIds.SetBothSourceDestination(Get<Mac::Mac>().GetPanId());
 
     Get<MeshForwarder>().PrepareMacHeaders(*frame, Mac::Frame::kTypeMacCmd, addresses, panIds,
                                            Mac::Frame::kSecurityEncMic32, Mac::Frame::kKeyIdMode1, nullptr);

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -738,7 +738,7 @@ TxFrame *Mac::PrepareBeaconRequest(void)
 
     addrs.mSource.SetNone();
     addrs.mDestination.SetShort(kShortAddrBroadcast);
-    panIds.mDestination = kShortAddrBroadcast;
+    panIds.SetDestination(kShortAddrBroadcast);
 
     frame.InitMacHeader(Frame::kTypeMacCmd, Frame::kVersion2003, addrs, panIds, Frame::kSecurityNone);
 
@@ -769,7 +769,7 @@ TxFrame *Mac::PrepareBeacon(void)
 #endif
 
     addrs.mSource.SetExtended(GetExtAddress());
-    panIds.mSource = mPanId;
+    panIds.SetSource(mPanId);
     addrs.mDestination.SetNone();
 
     frame->InitMacHeader(Frame::kTypeBeacon, Frame::kVersion2003, addrs, panIds, Frame::kSecurityNone);

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -383,8 +383,8 @@ public:
      * Determines and writes the Frame Control Field (FCF) and Security Control in the frame along with
      * given source and destination addresses and PAN IDs.
      *
-     * The Ack Request bit in FCF is set if there is destination and it is not broadcast. The Frame Pending and IE
-     * Present bits are not set.
+     * The Ack Request bit in FCF is set if there is destination and it is not broadcast and frame type @p aType is not
+     * ACK. The Frame Pending and IE Present bits are not set.
      *
      * @param[in] aType          Frame type.
      * @param[in] aVerion        Frame version.

--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -110,6 +110,24 @@ Address::InfoString Address::ToString(void) const
     return string;
 }
 
+void PanIds::SetSource(PanId aPanId)
+{
+    mSource          = aPanId;
+    mIsSourcePresent = true;
+}
+
+void PanIds::SetDestination(PanId aPanId)
+{
+    mDestination          = aPanId;
+    mIsDestinationPresent = true;
+}
+
+void PanIds::SetBothSourceDestination(PanId aPanId)
+{
+    SetSource(aPanId);
+    SetDestination(aPanId);
+}
+
 #if OPENTHREAD_CONFIG_MULTI_RADIO
 
 const RadioType RadioTypes::kAllRadioTypes[kNumRadioTypes] = {

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -425,10 +425,78 @@ struct Addresses
  * Represents two PAN IDs corresponding to source and destination.
  *
  */
-struct PanIds
+class PanIds : public Clearable<PanIds>
 {
-    PanId mSource;      ///< Source PAN ID.
-    PanId mDestination; ///< Destination PAN ID.
+public:
+    /**
+     * Initializes PAN IDs as empty (no source or destination PAN ID).
+     *
+     */
+    PanIds(void) { Clear(); }
+
+    /**
+     * Indicates whether or not source PAN ID is present.
+     *
+     * @retval TRUE   The source PAN ID is present.
+     * @retval FALSE  The source PAN ID is not present.
+     *
+     */
+    bool IsSourcePresent(void) const { return mIsSourcePresent; }
+
+    /**
+     * Gets the source PAN ID when it is present.
+     *
+     * @returns The source PAN ID.
+     *
+     */
+    PanId GetSource(void) const { return mSource; }
+
+    /**
+     * Indicates whether or not destination PAN ID is present.
+     *
+     * @retval TRUE   The destination PAN ID is present.
+     * @retval FALSE  The destination PAN ID is not present.
+     *
+     */
+    bool IsDestinationPresent(void) const { return mIsDestinationPresent; }
+
+    /**
+     * Gets the destination PAN ID when it is present.
+     *
+     * @returns The destination PAN ID.
+     *
+     */
+    PanId GetDestination(void) const { return mDestination; }
+
+    /**
+     * Sets the source PAN ID.
+     *
+     * @param[in] aPanId  The source PAN ID.
+     *
+     */
+    void SetSource(PanId aPanId);
+
+    /**
+     * Sets the destination PAN ID.
+     *
+     * @param[in] aPanId  The source PAN ID.
+     *
+     */
+    void SetDestination(PanId aPanId);
+
+    /**
+     * Sets both source and destination PAN IDs to the same value.
+     *
+     * @param[in] aPanId  The PAN ID.
+     *
+     */
+    void SetBothSourceDestination(PanId aPanId);
+
+private:
+    PanId mSource;
+    PanId mDestination;
+    bool  mIsSourcePresent;
+    bool  mIsDestinationPresent;
 };
 
 /**

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -193,8 +193,7 @@ void MeshForwarder::PrepareEmptyFrame(Mac::TxFrame &aFrame, const Mac::Address &
     }
 
     addresses.mDestination = aMacDest;
-    panIds.mSource         = Get<Mac::Mac>().GetPanId();
-    panIds.mDestination    = Get<Mac::Mac>().GetPanId();
+    panIds.SetBothSourceDestination(Get<Mac::Mac>().GetPanId());
 
     PrepareMacHeaders(aFrame, Mac::Frame::kTypeData, addresses, panIds, Mac::Frame::kSecurityEncMic32,
                       Mac::Frame::kKeyIdMode1, nullptr);
@@ -908,20 +907,19 @@ start:
         }
     }
 
-    panIds.mSource      = Get<Mac::Mac>().GetPanId();
-    panIds.mDestination = Get<Mac::Mac>().GetPanId();
+    panIds.SetBothSourceDestination(Get<Mac::Mac>().GetPanId());
 
     switch (aMessage.GetSubType())
     {
     case Message::kSubTypeMleAnnounce:
         aFrame.SetChannel(aMessage.GetChannel());
         aFrame.SetRxChannelAfterTxDone(Get<Mac::Mac>().GetPanChannel());
-        panIds.mDestination = Mac::kPanIdBroadcast;
+        panIds.SetDestination(Mac::kPanIdBroadcast);
         break;
 
     case Message::kSubTypeMleDiscoverRequest:
     case Message::kSubTypeMleDiscoverResponse:
-        panIds.mDestination = aMessage.GetPanId();
+        panIds.SetDestination(aMessage.GetPanId());
         break;
 
     default:

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -349,8 +349,7 @@ void MeshForwarder::SendMesh(Message &aMessage, Mac::TxFrame &aFrame)
 {
     Mac::PanIds panIds;
 
-    panIds.mSource      = Get<Mac::Mac>().GetPanId();
-    panIds.mDestination = Get<Mac::Mac>().GetPanId();
+    panIds.SetBothSourceDestination(Get<Mac::Mac>().GetPanId());
 
     PrepareMacHeaders(aFrame, Mac::Frame::kTypeData, mMacAddrs, panIds, Mac::Frame::kSecurityEncMic32,
                       Mac::Frame::kKeyIdMode1, &aMessage);

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -33,7 +33,7 @@
 #include "radio/radio.hpp"
 
 #include "test_platform.h"
-#include "test_util.h"
+#include "test_util.hpp"
 
 namespace ot {
 
@@ -189,16 +189,18 @@ void TestMacHeader(void)
 
     enum PanIdMode
     {
-        kSamePanIds,
-        kDiffPanIds,
+        kNoPanId,
+        kUsePanId1,
+        kUsePanId2,
     };
 
     struct TestCase
     {
         Mac::Frame::Version       mVersion;
         AddrType                  mSrcAddrType;
+        PanIdMode                 mSrcPanIdMode;
         AddrType                  mDstAddrType;
-        PanIdMode                 mPanIdMode;
+        PanIdMode                 mDstPanIdMode;
         Mac::Frame::SecurityLevel mSecurity;
         Mac::Frame::KeyIdMode     mKeyIdMode;
         uint8_t                   mHeaderLength;
@@ -214,37 +216,55 @@ void TestMacHeader(void)
     static constexpr Mac::Frame::KeyIdMode kModeId1 = Mac::Frame::kKeyIdMode1;
     static constexpr Mac::Frame::KeyIdMode kModeId2 = Mac::Frame::kKeyIdMode2;
 
-    static constexpr TestCase kTestCases[] = {
-        {kVer2006, kNoneAddr, kNoneAddr, kSamePanIds, kNoSec, kModeId1, 3, 2},
-        {kVer2006, kShrtAddr, kNoneAddr, kSamePanIds, kNoSec, kModeId1, 7, 2},
-        {kVer2006, kExtdAddr, kNoneAddr, kSamePanIds, kNoSec, kModeId1, 13, 2},
-        {kVer2006, kNoneAddr, kShrtAddr, kSamePanIds, kNoSec, kModeId1, 7, 2},
-        {kVer2006, kNoneAddr, kExtdAddr, kSamePanIds, kNoSec, kModeId1, 13, 2},
-        {kVer2006, kShrtAddr, kShrtAddr, kDiffPanIds, kNoSec, kModeId1, 11, 2},
-        {kVer2006, kShrtAddr, kExtdAddr, kDiffPanIds, kNoSec, kModeId1, 17, 2},
-        {kVer2006, kExtdAddr, kShrtAddr, kDiffPanIds, kNoSec, kModeId1, 17, 2},
-        {kVer2006, kExtdAddr, kExtdAddr, kDiffPanIds, kNoSec, kModeId1, 23, 2},
-        {kVer2006, kShrtAddr, kShrtAddr, kSamePanIds, kNoSec, kModeId1, 9, 2},
-        {kVer2006, kShrtAddr, kExtdAddr, kSamePanIds, kNoSec, kModeId1, 15, 2},
-        {kVer2006, kExtdAddr, kShrtAddr, kSamePanIds, kNoSec, kModeId1, 15, 2},
-        {kVer2006, kExtdAddr, kExtdAddr, kSamePanIds, kNoSec, kModeId1, 21, 2},
-        {kVer2006, kShrtAddr, kShrtAddr, kSamePanIds, kMic32, kModeId1, 15, 6},
-        {kVer2006, kShrtAddr, kShrtAddr, kSamePanIds, kMic32, kModeId2, 19, 6},
+    static const char *kAddrTypeStrings[]  = {"None", "Short", "Extd"};
+    static const char *kPanIdModeStrings[] = {"No", "Id1", "Id2"};
 
-        {kVer2015, kNoneAddr, kNoneAddr, kSamePanIds, kNoSec, kModeId1, 3, 2},
-        {kVer2015, kShrtAddr, kNoneAddr, kSamePanIds, kNoSec, kModeId1, 7, 2},
-        {kVer2015, kExtdAddr, kNoneAddr, kSamePanIds, kNoSec, kModeId1, 13, 2},
-        {kVer2015, kNoneAddr, kShrtAddr, kSamePanIds, kNoSec, kModeId1, 7, 2},
-        {kVer2015, kNoneAddr, kExtdAddr, kSamePanIds, kNoSec, kModeId1, 13, 2},
-        {kVer2015, kShrtAddr, kShrtAddr, kDiffPanIds, kNoSec, kModeId1, 11, 2},
-        {kVer2015, kShrtAddr, kExtdAddr, kDiffPanIds, kNoSec, kModeId1, 17, 2},
-        {kVer2015, kExtdAddr, kShrtAddr, kDiffPanIds, kNoSec, kModeId1, 17, 2},
-        {kVer2015, kShrtAddr, kShrtAddr, kSamePanIds, kNoSec, kModeId1, 9, 2},
-        {kVer2015, kShrtAddr, kExtdAddr, kSamePanIds, kNoSec, kModeId1, 15, 2},
-        {kVer2015, kExtdAddr, kShrtAddr, kSamePanIds, kNoSec, kModeId1, 15, 2},
-        {kVer2015, kExtdAddr, kExtdAddr, kSamePanIds, kNoSec, kModeId1, 21, 2},
-        {kVer2015, kShrtAddr, kShrtAddr, kSamePanIds, kMic32, kModeId1, 15, 6},
-        {kVer2015, kShrtAddr, kShrtAddr, kSamePanIds, kMic32, kModeId2, 19, 6},
+    static constexpr TestCase kTestCases[] = {
+        {kVer2006, kNoneAddr, kNoPanId, kNoneAddr, kNoPanId, kNoSec, kModeId1, 3, 2},
+        {kVer2006, kShrtAddr, kUsePanId1, kNoneAddr, kNoPanId, kNoSec, kModeId1, 7, 2},
+        {kVer2006, kExtdAddr, kUsePanId1, kNoneAddr, kNoPanId, kNoSec, kModeId1, 13, 2},
+        {kVer2006, kNoneAddr, kNoPanId, kShrtAddr, kUsePanId1, kNoSec, kModeId1, 7, 2},
+        {kVer2006, kNoneAddr, kNoPanId, kExtdAddr, kUsePanId1, kNoSec, kModeId1, 13, 2},
+        {kVer2006, kShrtAddr, kUsePanId1, kShrtAddr, kUsePanId2, kNoSec, kModeId1, 11, 2},
+        {kVer2006, kShrtAddr, kUsePanId1, kExtdAddr, kUsePanId2, kNoSec, kModeId1, 17, 2},
+        {kVer2006, kExtdAddr, kUsePanId1, kShrtAddr, kUsePanId2, kNoSec, kModeId1, 17, 2},
+        {kVer2006, kExtdAddr, kUsePanId1, kExtdAddr, kUsePanId2, kNoSec, kModeId1, 23, 2},
+        {kVer2006, kShrtAddr, kUsePanId1, kShrtAddr, kUsePanId1, kNoSec, kModeId1, 9, 2},
+        {kVer2006, kShrtAddr, kUsePanId1, kExtdAddr, kUsePanId1, kNoSec, kModeId1, 15, 2},
+        {kVer2006, kExtdAddr, kUsePanId1, kShrtAddr, kUsePanId1, kNoSec, kModeId1, 15, 2},
+        {kVer2006, kExtdAddr, kUsePanId1, kExtdAddr, kUsePanId1, kNoSec, kModeId1, 21, 2},
+        {kVer2006, kShrtAddr, kUsePanId1, kShrtAddr, kUsePanId1, kMic32, kModeId1, 15, 6},
+        {kVer2006, kShrtAddr, kUsePanId1, kShrtAddr, kUsePanId1, kMic32, kModeId2, 19, 6},
+
+        {kVer2015, kNoneAddr, kNoPanId, kNoneAddr, kNoPanId, kNoSec, kModeId1, 3, 2},
+        {kVer2015, kShrtAddr, kUsePanId1, kNoneAddr, kNoPanId, kNoSec, kModeId1, 7, 2},
+        {kVer2015, kExtdAddr, kUsePanId1, kNoneAddr, kNoPanId, kNoSec, kModeId1, 13, 2},
+        {kVer2015, kNoneAddr, kNoPanId, kShrtAddr, kUsePanId1, kNoSec, kModeId1, 7, 2},
+        {kVer2015, kNoneAddr, kNoPanId, kExtdAddr, kUsePanId1, kNoSec, kModeId1, 13, 2},
+        {kVer2015, kShrtAddr, kUsePanId1, kShrtAddr, kUsePanId2, kNoSec, kModeId1, 11, 2},
+        {kVer2015, kShrtAddr, kUsePanId1, kExtdAddr, kUsePanId2, kNoSec, kModeId1, 17, 2},
+        {kVer2015, kExtdAddr, kUsePanId1, kShrtAddr, kUsePanId2, kNoSec, kModeId1, 17, 2},
+        {kVer2015, kShrtAddr, kUsePanId1, kShrtAddr, kUsePanId1, kNoSec, kModeId1, 9, 2},
+        {kVer2015, kShrtAddr, kUsePanId1, kExtdAddr, kUsePanId1, kNoSec, kModeId1, 15, 2},
+        {kVer2015, kExtdAddr, kUsePanId1, kShrtAddr, kUsePanId1, kNoSec, kModeId1, 15, 2},
+        {kVer2015, kExtdAddr, kUsePanId1, kExtdAddr, kUsePanId1, kNoSec, kModeId1, 21, 2},
+        {kVer2015, kShrtAddr, kUsePanId1, kShrtAddr, kUsePanId1, kMic32, kModeId1, 15, 6},
+        {kVer2015, kShrtAddr, kUsePanId1, kShrtAddr, kUsePanId1, kMic32, kModeId2, 19, 6},
+
+        {kVer2015, kNoneAddr, kNoPanId, kShrtAddr, kNoPanId, kNoSec, kModeId1, 5, 2},
+        {kVer2015, kNoneAddr, kNoPanId, kShrtAddr, kNoPanId, kMic32, kModeId1, 11, 6},
+        {kVer2015, kNoneAddr, kNoPanId, kNoneAddr, kUsePanId1, kNoSec, kModeId1, 5, 2},
+        {kVer2015, kNoneAddr, kNoPanId, kNoneAddr, kUsePanId1, kMic32, kModeId1, 11, 6},
+        {kVer2015, kNoneAddr, kNoPanId, kShrtAddr, kNoPanId, kNoSec, kModeId1, 5, 2},
+        {kVer2015, kNoneAddr, kNoPanId, kExtdAddr, kNoPanId, kNoSec, kModeId1, 11, 2},
+        {kVer2015, kNoneAddr, kNoPanId, kShrtAddr, kNoPanId, kMic32, kModeId1, 11, 6},
+        {kVer2015, kNoneAddr, kNoPanId, kExtdAddr, kNoPanId, kMic32, kModeId1, 17, 6},
+        {kVer2015, kShrtAddr, kNoPanId, kNoneAddr, kNoPanId, kNoSec, kModeId1, 5, 2},
+        {kVer2015, kShrtAddr, kNoPanId, kNoneAddr, kNoPanId, kMic32, kModeId1, 11, 6},
+        {kVer2015, kExtdAddr, kNoPanId, kNoneAddr, kNoPanId, kNoSec, kModeId1, 11, 2},
+        {kVer2015, kExtdAddr, kNoPanId, kNoneAddr, kNoPanId, kMic32, kModeId1, 17, 6},
+        {kVer2015, kExtdAddr, kNoPanId, kExtdAddr, kNoPanId, kNoSec, kModeId1, 19, 2},
+        {kVer2015, kExtdAddr, kNoPanId, kExtdAddr, kNoPanId, kMic32, kModeId1, 25, 6},
     };
 
     const uint16_t kPanId1     = 0xbaba;
@@ -254,6 +274,7 @@ void TestMacHeader(void)
     const uint8_t  kExtAddr1[] = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0};
     const uint8_t  kExtAddr2[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
 
+    char            string[100];
     Mac::ExtAddress extAddr1;
     Mac::ExtAddress extAddr2;
 
@@ -274,6 +295,11 @@ void TestMacHeader(void)
         frame.mPsdu      = psdu;
         frame.mLength    = 0;
         frame.mRadioType = 0;
+
+        VerifyOrQuit(addresses.mSource.IsNone());
+        VerifyOrQuit(addresses.mDestination.IsNone());
+        VerifyOrQuit(!panIds.IsSourcePresent());
+        VerifyOrQuit(!panIds.IsDestinationPresent());
 
         switch (testCase.mSrcAddrType)
         {
@@ -301,14 +327,27 @@ void TestMacHeader(void)
             break;
         }
 
-        switch (testCase.mPanIdMode)
+        switch (testCase.mSrcPanIdMode)
         {
-        case kSamePanIds:
-            panIds.mSource = panIds.mDestination = kPanId1;
+        case kNoPanId:
             break;
-        case kDiffPanIds:
-            panIds.mSource      = kPanId1;
-            panIds.mDestination = kPanId2;
+        case kUsePanId1:
+            panIds.SetSource(kPanId1);
+            break;
+        case kUsePanId2:
+            panIds.SetSource(kPanId2);
+            break;
+        }
+
+        switch (testCase.mDstPanIdMode)
+        {
+        case kNoPanId:
+            break;
+        case kUsePanId1:
+            panIds.SetDestination(kPanId1);
+            break;
+        case kUsePanId2:
+            panIds.SetDestination(kPanId2);
             break;
         }
 
@@ -334,17 +373,20 @@ void TestMacHeader(void)
         SuccessOrQuit(frame.GetDstAddr(address));
         VerifyOrQuit(CompareAddresses(address, addresses.mDestination));
 
-        if (testCase.mDstAddrType != kNoneAddr)
+        VerifyOrQuit(frame.IsDstPanIdPresent() == (testCase.mDstPanIdMode != kNoPanId));
+
+        if (frame.IsDstPanIdPresent())
         {
-            VerifyOrQuit(frame.IsDstPanIdPresent());
             SuccessOrQuit(frame.GetDstPanId(panId));
-            VerifyOrQuit(panId == panIds.mDestination);
+            VerifyOrQuit(panId == panIds.GetDestination());
+            VerifyOrQuit(panIds.IsDestinationPresent());
         }
 
         if (frame.IsSrcPanIdPresent())
         {
             SuccessOrQuit(frame.GetSrcPanId(panId));
-            VerifyOrQuit(panId == panIds.mSource);
+            VerifyOrQuit(panId == panIds.GetSource());
+            VerifyOrQuit(panIds.IsSourcePresent());
         }
 
         if (frame.GetSecurityEnabled())
@@ -359,7 +401,12 @@ void TestMacHeader(void)
             VerifyOrQuit(keyIdMode == testCase.mKeyIdMode);
         }
 
-        printf(" %d, %d\n", testCase.mHeaderLength, testCase.mFooterLength);
+        snprintf(string, sizeof(string), "\nver:%s, src[addr:%s, pan:%s], dst[addr:%s, pan:%s], sec:%s",
+                 (testCase.mVersion == kVer2006) ? "2006" : "2015", kAddrTypeStrings[testCase.mSrcAddrType],
+                 kPanIdModeStrings[testCase.mSrcPanIdMode], kAddrTypeStrings[testCase.mDstAddrType],
+                 kPanIdModeStrings[testCase.mDstPanIdMode], testCase.mSecurity == kNoSec ? "no" : "mic32");
+
+        DumpBuffer(string, frame.GetPsdu(), frame.GetLength());
     }
 }
 


### PR DESCRIPTION
This commit updates the `InitMacFrame()` method to allow the caller to specify whether the source or destination PAN IDs are present or not. It also handles all cases related to PAN ID compression as defined by IEEE 802.15.4-2015. While these cases are not used by the Thread stack itself, adding them to `InitMacFrame()` makes it more capable allowing future use-cases of this method such as generating enhanced ACKs based on a received frame.

The `test_mac_frame` unit test has been updated to cover the newly added cases.