### PR TITLE
[mac-frame] update `GenerateEnhAck()` to use `InitMacHeader()`

### DIFF
--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -505,6 +505,14 @@ public:
     bool IsIePresent(void) const { return (GetFrameControlField() & kFcfIePresent) != 0; }
 
     /**
+     * Sets the IE Present bit.
+     *
+     * @param[in]  aIePresent   The IE Present bit.
+     *
+     */
+    void SetIePresent(bool aIePresent);
+
+    /**
      * Returns the Sequence Number value.
      *
      * @returns The Sequence Number value.
@@ -1122,6 +1130,7 @@ protected:
     static constexpr uint8_t kMaxPsduSize   = kInvalidSize - 1;
     static constexpr uint8_t kSequenceIndex = kFcfSize;
 
+    void    SetFrameControlField(uint16_t aFcf);
     uint8_t FindDstPanIdIndex(void) const;
     uint8_t FindDstAddrIndex(void) const;
     uint8_t FindSrcPanIdIndex(void) const;
@@ -1148,8 +1157,6 @@ protected:
     static uint8_t CalculateAddrFieldSize(uint16_t aFcf);
     static uint8_t CalculateSecurityHeaderSize(uint8_t aSecurityControl);
     static uint8_t CalculateMicSize(uint8_t aSecurityControl);
-
-public:
 };
 
 /**
@@ -1502,16 +1509,16 @@ public:
     /**
      * Generate Enh-Ack in this frame object.
      *
-     * @param[in]    aFrame             A reference to the frame received.
+     * @param[in]    aRxFrame           A reference to the received frame.
      * @param[in]    aIsFramePending    Value of the ACK's frame pending bit.
      * @param[in]    aIeData            A pointer to the IE data portion of the ACK to be sent.
      * @param[in]    aIeLength          The length of IE data portion of the ACK to be sent.
      *
      * @retval  kErrorNone           Successfully generated Enh Ack.
-     * @retval  kErrorParse          @p aFrame has incorrect format.
+     * @retval  kErrorParse          @p aRxFrame has incorrect format.
      *
      */
-    Error GenerateEnhAck(const RxFrame &aFrame, bool aIsFramePending, const uint8_t *aIeData, uint8_t aIeLength);
+    Error GenerateEnhAck(const RxFrame &aRxFrame, bool aIsFramePending, const uint8_t *aIeData, uint8_t aIeLength);
 
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
     /**

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -747,13 +747,14 @@ void TestMacFrameAckGeneration(void)
     uint8_t     ie_data[6] = {0x04, 0x0d, 0x21, 0x0c, 0x35, 0x0c};
     Mac::CslIe *csl;
 
-    IgnoreError(ackFrame.GenerateEnhAck(receivedFrame, false, ie_data, sizeof(ie_data)));
+    SuccessOrQuit(ackFrame.GenerateEnhAck(receivedFrame, false, ie_data, sizeof(ie_data)));
+
     csl = reinterpret_cast<Mac::CslIe *>(ackFrame.GetHeaderIe(Mac::CslIe::kHeaderIeId) + sizeof(Mac::HeaderIe));
-    VerifyOrQuit(ackFrame.mLength == 23);
+    VerifyOrQuit(ackFrame.mLength == 25);
     VerifyOrQuit(ackFrame.GetType() == Mac::Frame::kTypeAck);
     VerifyOrQuit(ackFrame.GetSecurityEnabled());
     VerifyOrQuit(ackFrame.IsIePresent());
-    VerifyOrQuit(!ackFrame.IsDstPanIdPresent());
+    VerifyOrQuit(ackFrame.IsDstPanIdPresent());
     VerifyOrQuit(ackFrame.IsDstAddrPresent());
     VerifyOrQuit(!ackFrame.IsSrcAddrPresent());
     VerifyOrQuit(ackFrame.GetVersion() == Mac::Frame::kVersion2015);


### PR DESCRIPTION
This commit updates the `GenerateEnhAck()` method to add checks to validate the received frame before preparing the ACK. These checks are added as a safeguard in case the caller (radio platform implementation) does not validate the received frame before calling this method to generate the ACK.

Specifically, the checks verify that the received frame is using the 2015 version, has the "Ack Request" flag, has a valid source address (which is used as the destination in the generated ACK), and has a valid destination address that is not broadcast. The checks also verify that if the received frame is secured, it uses security level `kSecurityEncMic32`.

The commit also simplifies the code by using `InitMacHeader()` to prepare the header and addresses. Enhanced ACK frames always have a destination address and no source address (to keep the frame shorter). If the received frame has a source PAN ID, it is used in the ACK frame. If it does not, the code checks if the received frame has a destination PAN ID and uses that in the ACK frame.

---

- This PR currently contains the commit from https://github.com/openthread/openthread/pull/9337.