### PR TITLE
[link-metrics] update link metrics callback parameter

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (349)
+#define OPENTHREAD_API_VERSION (350)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/link_metrics.h
+++ b/include/openthread/link_metrics.h
@@ -118,7 +118,7 @@ typedef enum otLinkMetricsStatus
  */
 typedef void (*otLinkMetricsReportCallback)(const otIp6Address        *aSource,
                                             const otLinkMetricsValues *aMetricsValues,
-                                            uint8_t                    aStatus,
+                                            otLinkMetricsStatus        aStatus,
                                             void                      *aContext);
 /**
  * Pointer is called when a Link Metrics Management Response is received.
@@ -128,7 +128,9 @@ typedef void (*otLinkMetricsReportCallback)(const otIp6Address        *aSource,
  * @param[in]  aContext        A pointer to application-specific context.
  *
  */
-typedef void (*otLinkMetricsMgmtResponseCallback)(const otIp6Address *aSource, uint8_t aStatus, void *aContext);
+typedef void (*otLinkMetricsMgmtResponseCallback)(const otIp6Address *aSource,
+                                                  otLinkMetricsStatus aStatus,
+                                                  void               *aContext);
 
 /**
  * Pointer is called when Enh-ACK Probing IE is received.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3575,7 +3575,7 @@ exit:
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
 void Interpreter::HandleLinkMetricsReport(const otIp6Address        *aAddress,
                                           const otLinkMetricsValues *aMetricsValues,
-                                          uint8_t                    aStatus,
+                                          otLinkMetricsStatus        aStatus,
                                           void                      *aContext)
 {
     static_cast<Interpreter *>(aContext)->HandleLinkMetricsReport(aAddress, aMetricsValues, aStatus);
@@ -3608,7 +3608,7 @@ void Interpreter::PrintLinkMetricsValue(const otLinkMetricsValues *aMetricsValue
 
 void Interpreter::HandleLinkMetricsReport(const otIp6Address        *aAddress,
                                           const otLinkMetricsValues *aMetricsValues,
-                                          uint8_t                    aStatus)
+                                          otLinkMetricsStatus        aStatus)
 {
     OutputFormat("Received Link Metrics Report from: ");
     OutputIp6AddressLine(*aAddress);
@@ -3629,12 +3629,14 @@ void Interpreter::HandleLinkMetricsReport(const otIp6Address        *aAddress,
     }
 }
 
-void Interpreter::HandleLinkMetricsMgmtResponse(const otIp6Address *aAddress, uint8_t aStatus, void *aContext)
+void Interpreter::HandleLinkMetricsMgmtResponse(const otIp6Address *aAddress,
+                                                otLinkMetricsStatus aStatus,
+                                                void               *aContext)
 {
     static_cast<Interpreter *>(aContext)->HandleLinkMetricsMgmtResponse(aAddress, aStatus);
 }
 
-void Interpreter::HandleLinkMetricsMgmtResponse(const otIp6Address *aAddress, uint8_t aStatus)
+void Interpreter::HandleLinkMetricsMgmtResponse(const otIp6Address *aAddress, otLinkMetricsStatus aStatus)
 {
     OutputFormat("Received Link Metrics Management Response from: ");
     OutputIp6AddressLine(*aAddress);
@@ -3664,7 +3666,7 @@ void Interpreter::HandleLinkMetricsEnhAckProbingIe(otShortAddress             aS
     }
 }
 
-const char *Interpreter::LinkMetricsStatusToStr(uint8_t aStatus)
+const char *Interpreter::LinkMetricsStatusToStr(otLinkMetricsStatus aStatus)
 {
     static const char *const kStatusStrings[] = {
         "Success",                      // (0) OT_LINK_METRICS_STATUS_SUCCESS

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -512,16 +512,18 @@ private:
 
     static void HandleLinkMetricsReport(const otIp6Address        *aAddress,
                                         const otLinkMetricsValues *aMetricsValues,
-                                        uint8_t                    aStatus,
+                                        otLinkMetricsStatus        aStatus,
                                         void                      *aContext);
 
     void HandleLinkMetricsReport(const otIp6Address        *aAddress,
                                  const otLinkMetricsValues *aMetricsValues,
-                                 uint8_t                    aStatus);
+                                 otLinkMetricsStatus        aStatus);
 
-    static void HandleLinkMetricsMgmtResponse(const otIp6Address *aAddress, uint8_t aStatus, void *aContext);
+    static void HandleLinkMetricsMgmtResponse(const otIp6Address *aAddress,
+                                              otLinkMetricsStatus aStatus,
+                                              void               *aContext);
 
-    void HandleLinkMetricsMgmtResponse(const otIp6Address *aAddress, uint8_t aStatus);
+    void HandleLinkMetricsMgmtResponse(const otIp6Address *aAddress, otLinkMetricsStatus aStatus);
 
     static void HandleLinkMetricsEnhAckProbingIe(otShortAddress             aShortAddress,
                                                  const otExtAddress        *aExtAddress,
@@ -532,7 +534,7 @@ private:
                                           const otExtAddress        *aExtAddress,
                                           const otLinkMetricsValues *aMetricsValues);
 
-    const char *LinkMetricsStatusToStr(uint8_t aStatus);
+    const char *LinkMetricsStatusToStr(otLinkMetricsStatus aStatus);
 #endif // OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
 
     static void HandleDetachGracefullyResult(void *aContext);

--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -219,7 +219,7 @@ void Initiator::HandleReport(const Message &aMessage, uint16_t aOffset, uint16_t
     VerifyOrExit(hasStatus || hasReport);
 
     mReportCallback.Invoke(&aAddress, hasStatus ? nullptr : &values,
-                           hasStatus ? static_cast<Status>(status) : kStatusSuccess);
+                           hasStatus ? MapEnum(static_cast<Status>(status)) : MapEnum(kStatusSuccess));
 
 exit:
     LogDebg("HandleReport, error:%s", ErrorToString(error));
@@ -337,7 +337,7 @@ Error Initiator::HandleManagementResponse(const Message &aMessage, const Ip6::Ad
 
     VerifyOrExit(hasStatus, error = kErrorParse);
 
-    mMgmtResponseCallback.Invoke(&aAddress, status);
+    mMgmtResponseCallback.Invoke(&aAddress, MapEnum(static_cast<Status>(status)));
 
 exit:
     return error;

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -312,16 +312,18 @@ protected:
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
     static void HandleLinkMetricsReport_Jump(const otIp6Address        *aSource,
                                              const otLinkMetricsValues *aMetricsValues,
-                                             uint8_t                    aStatus,
+                                             otLinkMetricsStatus        aStatus,
                                              void                      *aContext);
 
     void HandleLinkMetricsReport(const otIp6Address        *aSource,
                                  const otLinkMetricsValues *aMetricsValues,
-                                 uint8_t                    aStatus);
+                                 otLinkMetricsStatus        aStatus);
 
-    static void HandleLinkMetricsMgmtResponse_Jump(const otIp6Address *aSource, uint8_t aStatus, void *aContext);
+    static void HandleLinkMetricsMgmtResponse_Jump(const otIp6Address *aSource,
+                                                   otLinkMetricsStatus aStatus,
+                                                   void               *aContext);
 
-    void HandleLinkMetricsMgmtResponse(const otIp6Address *aSource, uint8_t aStatus);
+    void HandleLinkMetricsMgmtResponse(const otIp6Address *aSource, otLinkMetricsStatus aStatus);
 
     static void HandleLinkMetricsEnhAckProbingIeReport_Jump(otShortAddress             aShortAddress,
                                                             const otExtAddress        *aExtAddress,

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -4230,7 +4230,7 @@ void NcpBase::HandleJoinerCallback(otError aError)
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
 void NcpBase::HandleLinkMetricsReport_Jump(const otIp6Address        *aSource,
                                            const otLinkMetricsValues *aMetricsValues,
-                                           uint8_t                    aStatus,
+                                           otLinkMetricsStatus        aStatus,
                                            void                      *aContext)
 {
     static_cast<NcpBase *>(aContext)->HandleLinkMetricsReport(aSource, aMetricsValues, aStatus);
@@ -4238,7 +4238,7 @@ void NcpBase::HandleLinkMetricsReport_Jump(const otIp6Address        *aSource,
 
 void NcpBase::HandleLinkMetricsReport(const otIp6Address        *aSource,
                                       const otLinkMetricsValues *aMetricsValues,
-                                      uint8_t                    aStatus)
+                                      otLinkMetricsStatus        aStatus)
 {
     SuccessOrExit(mEncoder.BeginFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_CMD_PROP_VALUE_IS,
                                       SPINEL_PROP_THREAD_LINK_METRICS_QUERY_RESULT));
@@ -4253,12 +4253,14 @@ exit:
     return;
 }
 
-void NcpBase::HandleLinkMetricsMgmtResponse_Jump(const otIp6Address *aSource, uint8_t aStatus, void *aContext)
+void NcpBase::HandleLinkMetricsMgmtResponse_Jump(const otIp6Address *aSource,
+                                                 otLinkMetricsStatus aStatus,
+                                                 void               *aContext)
 {
     static_cast<NcpBase *>(aContext)->HandleLinkMetricsMgmtResponse(aSource, aStatus);
 }
 
-void NcpBase::HandleLinkMetricsMgmtResponse(const otIp6Address *aSource, uint8_t aStatus)
+void NcpBase::HandleLinkMetricsMgmtResponse(const otIp6Address *aSource, otLinkMetricsStatus aStatus)
 {
     SuccessOrExit(mEncoder.BeginFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_CMD_PROP_VALUE_IS,
                                       SPINEL_PROP_THREAD_LINK_METRICS_MGMT_RESPONSE));


### PR DESCRIPTION
This PR updates the type of parameter `status` in `otLinkMetricsReportCallback`
and `otLinkMetricsMgmtResponseCallback` from `uint8_t` to `otLinkMetricsStatus`
for better readability.