### PR TITLE
[mesh-forwarder] prevent double freeing of aged message

### DIFF
--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -420,6 +420,21 @@ private:
         kAnycastService,
     };
 
+    /**
+     * This function pointer can be used to process messages dropped due to age.
+     *
+     * @param[in]  aMessage     A pointer to the dropped message.
+     * @param[in]  aContext     A pointer to callback context.
+     *
+     */
+    typedef void (*AgedMessageDroppedCallback)(Message *aMessage, void *aContext);
+
+    typedef struct
+    {
+        Message *mMessage;
+        bool    *mWasDropped;
+    } AgedMessageDroppedContext;
+
 #if OPENTHREAD_FTD
     class FragmentPriorityList : public Clearable<FragmentPriorityList>
     {
@@ -533,6 +548,7 @@ private:
 #if OPENTHREAD_CONFIG_DELAY_AWARE_QUEUE_MANAGEMENT_ENABLE
     Error UpdateEcnOrDrop(Message &aMessage, bool aPreparingToSend = true);
     Error RemoveAgedMessages(void);
+    Error RemoveAgedMessages(AgedMessageDroppedCallback aCallback, void *aContext);
 #endif
 #if (OPENTHREAD_CONFIG_MAX_FRAMES_IN_DIRECT_TX_QUEUE > 0)
     bool IsDirectTxQueueOverMaxFrameThreshold(void) const;
@@ -634,6 +650,8 @@ private:
                        Error               aError,
                        LogLevel            aLogLevel);
 #endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
+
+    static void AgedMessageDropped(Message *aMessage, void *aContext);
 
     using TxTask = TaskletIn<MeshForwarder, &MeshForwarder::ScheduleTransmissionTask>;
 


### PR DESCRIPTION
When TX message queue management was enabled, it was observed an attempt to dequeue and free the message, that was being processed at the time, has failed and led to an assert.
The message's buffer was previously freed while removing aged messages.

Add callback to `RemoveAgedMessages` method so freeing of currently processed message can be detected and further attempt to free it can be skipped.