### PR TITLE
[dnssd-server] determine query type & simplify processing of query name

### DIFF
--- a/src/core/net/dns_types.cpp
+++ b/src/core/net/dns_types.cpp
@@ -167,11 +167,6 @@ exit:
 
 Error Name::AppendMultipleLabels(const char *aLabels, Message &aMessage)
 {
-    return AppendMultipleLabels(aLabels, kMaxNameLength, aMessage);
-}
-
-Error Name::AppendMultipleLabels(const char *aLabels, uint8_t aLength, Message &aMessage)
-{
     Error    error           = kErrorNone;
     uint16_t index           = 0;
     uint16_t labelStartIndex = 0;
@@ -181,7 +176,7 @@ Error Name::AppendMultipleLabels(const char *aLabels, uint8_t aLength, Message &
 
     do
     {
-        ch = index < aLength ? aLabels[index] : static_cast<char>(kNullChar);
+        ch = aLabels[index];
 
         if ((ch == kNullChar) || (ch == kLabelSeparatorChar))
         {
@@ -628,6 +623,35 @@ Error Name::LabelIterator::AppendLabel(Message &aMessage) const
     VerifyOrExit((0 < mLabelLength) && (mLabelLength <= kMaxLabelLength), error = kErrorInvalidArgs);
     SuccessOrExit(error = aMessage.Append(mLabelLength));
     error = aMessage.AppendBytesFromMessage(mMessage, mLabelStartOffset, mLabelLength);
+
+exit:
+    return error;
+}
+
+Error Name::ExtractLabels(const char *aName, const char *aSuffixName, char *aLabels, uint16_t aLabelsSize)
+{
+    Error       error        = kErrorParse;
+    uint16_t    nameLength   = StringLength(aName, kMaxNameSize);
+    uint16_t    suffixLength = StringLength(aSuffixName, kMaxNameSize);
+    const char *suffixStart;
+
+    VerifyOrExit(nameLength < kMaxNameSize);
+    VerifyOrExit(suffixLength < kMaxNameSize);
+
+    VerifyOrExit(nameLength > suffixLength);
+
+    suffixStart = aName + nameLength - suffixLength;
+    VerifyOrExit(StringMatch(suffixStart, aSuffixName, kStringCaseInsensitiveMatch));
+    suffixStart--;
+    VerifyOrExit(*suffixStart == kLabelSeparatorChar);
+
+    // Determine the labels length to copy
+    nameLength -= (suffixLength + 1);
+    VerifyOrExit(nameLength < aLabelsSize, error = kErrorNoBufs);
+
+    memcpy(aLabels, aName, nameLength);
+    aLabels[nameLength] = kNullChar;
+    error               = kErrorNone;
 
 exit:
     return error;

--- a/tests/unit/test_dns.cpp
+++ b/tests/unit/test_dns.cpp
@@ -68,6 +68,8 @@ void TestDnsName(void)
     const char  *subDomain;
     const char  *domain;
     const char  *domain2;
+    const char  *fullName;
+    const char  *suffixName;
 
     static const uint8_t kEncodedName1[] = {7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0};
     static const uint8_t kEncodedName2[] = {3, 'f', 'o', 'o', 1, 'a', 2, 'b', 'b', 3, 'e', 'd', 'u', 0};
@@ -246,6 +248,57 @@ void TestDnsName(void)
     domain  = "example.com.";
     domain2 = ".example.com.";
     VerifyOrQuit(!Dns::Name::IsSameDomain(domain, domain2));
+
+    printf("----------------------------------------------------------------\n");
+    printf("Extracting label(s) and removing domains:\n");
+
+    fullName   = "my-service._ipps._tcp.default.service.arpa.";
+    suffixName = "default.service.arpa.";
+    SuccessOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name, sizeof(name)));
+    VerifyOrQuit(strcmp(name, "my-service._ipps._tcp") == 0);
+
+    fullName   = "my.service._ipps._tcp.default.service.arpa.";
+    suffixName = "_ipps._tcp.default.service.arpa.";
+    SuccessOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name, sizeof(name)));
+    VerifyOrQuit(strcmp(name, "my.service") == 0);
+
+    fullName   = "my-service._ipps._tcp.default.service.arpa.";
+    suffixName = "DeFault.SerVice.ARPA.";
+    SuccessOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name, sizeof(name)));
+    VerifyOrQuit(strcmp(name, "my-service._ipps._tcp") == 0);
+
+    fullName   = "my-service._ipps._tcp.default.service.arpa.";
+    suffixName = "efault.service.arpa.";
+    VerifyOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name, sizeof(name)) == kErrorParse);
+
+    fullName   = "my-service._ipps._tcp.default.service.arpa.";
+    suffixName = "xdefault.service.arpa.";
+    VerifyOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name, sizeof(name)) == kErrorParse);
+
+    fullName   = "my-service._ipps._tcp.default.service.arpa.";
+    suffixName = ".default.service.arpa.";
+    VerifyOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name, sizeof(name)) == kErrorParse);
+
+    fullName   = "my-service._ipps._tcp.default.service.arpa.";
+    suffixName = "default.service.arp.";
+    VerifyOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name, sizeof(name)) == kErrorParse);
+
+    fullName   = "default.service.arpa.";
+    suffixName = "default.service.arpa.";
+    VerifyOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name, sizeof(name)) == kErrorParse);
+
+    fullName   = "efault.service.arpa.";
+    suffixName = "default.service.arpa.";
+    VerifyOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name, sizeof(name)) == kErrorParse);
+
+    fullName   = "my-service._ipps._tcp.default.service.arpa.";
+    suffixName = "default.service.arpa.";
+    SuccessOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name, 22));
+    VerifyOrQuit(strcmp(name, "my-service._ipps._tcp") == 0);
+
+    fullName   = "my-service._ipps._tcp.default.service.arpa.";
+    suffixName = "default.service.arpa.";
+    VerifyOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name, 21) == kErrorNoBufs);
 
     printf("----------------------------------------------------------------\n");
     printf("Append names, check encoded bytes, parse name and read labels:\n");

--- a/tests/unit/test_dns_client.cpp
+++ b/tests/unit/test_dns_client.cpp
@@ -242,9 +242,10 @@ static const char kService1Name[]     = "_srv._udp";
 static const char kService1FullName[] = "_srv._udp.default.service.arpa.";
 static const char kInstance1Label[]   = "srv-instance";
 
-static const char kService2Name[]     = "_game._udp";
-static const char kService2FullName[] = "_game._udp.default.service.arpa.";
-static const char kInstance2Label[]   = "last-ninja";
+static const char kService2Name[]            = "_game._udp";
+static const char kService2FullName[]        = "_game._udp.default.service.arpa.";
+static const char kService2SubTypeFullName[] = "_best._sub._game._udp.default.service.arpa.";
+static const char kInstance2Label[]          = "last-ninja";
 
 void PrepareService1(Srp::Client::Service &aService)
 {
@@ -277,7 +278,7 @@ void PrepareService1(Srp::Client::Service &aService)
 
 void PrepareService2(Srp::Client::Service &aService)
 {
-    static const char  kSub4[]       = "_44444444";
+    static const char  kSub4[]       = "_best";
     static const char *kSubLabels2[] = {kSub4, nullptr};
 
     memset(&aService, 0, sizeof(aService));
@@ -593,6 +594,15 @@ void TestDnsClient(void)
 
     Log("Browse(%s)", kService2FullName);
     SuccessOrQuit(dnsClient->Browse(kService2FullName, BrowseCallback, sInstance));
+    AdvanceTime(100);
+    VerifyOrQuit(sBrowseInfo.mCallbackCount == 1);
+    SuccessOrQuit(sBrowseInfo.mError);
+    VerifyOrQuit(sBrowseInfo.mNumInstances == 1);
+
+    sBrowseInfo.Reset();
+
+    Log("Browse(%s)", kService2SubTypeFullName);
+    SuccessOrQuit(dnsClient->Browse(kService2SubTypeFullName, BrowseCallback, sInstance));
     AdvanceTime(100);
     VerifyOrQuit(sBrowseInfo.mCallbackCount == 1);
     SuccessOrQuit(sBrowseInfo.mError);


### PR DESCRIPTION
This commit simplifies and enhances the DNSSD Server implementation:

- A new method, `ParseQuestions()`, has been added to process the questions in a received `Request` message and determine the `QueryType`.

- The processing and appending of the query DNS name has been simplified. The query name is now read and copied label by label from the `Request` message into the `Response`. When matching the name against SRP entries, the names are compared with the query name directly as it is encoded in the `Response` message using the `Dns::Name::CompareName()` method. This approach is more flexible and simpler, and it works for all query types and name formats, including service instance names where the first label can itself contain a dot (`.`) character. This simplification allows us to remove the helper functions that were previously used to parse the query name and deal with the ambiguity that arises when service instance names are read as strings of dot-separated labels.

- The management of offsets for DNS name compression has also been simplified. A new method, `Response::ParseQueryName()`, has been added to validate the query name (e.g., that it contains the correct domain) and determine all offsets.

- The `ResolveBySrp()` method has also been simplified using query type and the newly added flavors of `Append{Ptr/Srv/Txt}Record()` methods.

- Finally, this commit adds the `Dns::Name::ExtractLabels()` helper method, which extracts label(s) from a full DNS name string by first checking that it contains a given suffix name (e.g., the suffix name can be a domain name or a service name) and then removing it, returning the label(s).