### PR TITLE
[meshcop] print TLV State after receiving responses

### DIFF
--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -766,10 +766,18 @@ void Commissioner::HandleMgmtCommissionerSetResponse(Coap::Message          *aMe
                                                      Error                   aResult)
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
+    Error   error = kErrorParse;
+    uint8_t state;
 
     VerifyOrExit(aResult == kErrorNone && aMessage->GetCode() == Coap::kCodeChanged);
-    LogInfo("Received %s response", UriToString<kUriCommissionerSet>());
 
+    if (Tlv::Find<StateTlv>(*aMessage, state) == kErrorNone && state != StateTlv::kPending)
+    {
+        error = StateTlv::StateTlvToError(static_cast<StateTlv::State>(state));
+    }
+
+    OT_UNUSED_VARIABLE(error);
+    LogInfo("Received %s response: %s", UriToString<kUriCommissionerSet>(), ErrorToString(error));
 exit:
     return;
 }

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -766,19 +766,16 @@ void Commissioner::HandleMgmtCommissionerSetResponse(Coap::Message          *aMe
                                                      Error                   aResult)
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
-    Error   error = kErrorParse;
+
+    Error   error;
     uint8_t state;
 
-    VerifyOrExit(aResult == kErrorNone && aMessage->GetCode() == Coap::kCodeChanged);
-
-    if (Tlv::Find<StateTlv>(*aMessage, state) == kErrorNone && state != StateTlv::kPending)
-    {
-        error = StateTlv::StateTlvToError(static_cast<StateTlv::State>(state));
-    }
+    SuccessOrExit(error = aResult);
+    VerifyOrExit(aMessage->GetCode() == Coap::kCodeChanged && Tlv::Find<StateTlv>(*aMessage, state) == kErrorNone && state != StateTlv::kPending, error = kErrorParse);
 
     OT_UNUSED_VARIABLE(error);
-    LogInfo("Received %s response: %s", UriToString<kUriCommissionerSet>(), ErrorToString(error));
 exit:
+    LogInfo("Received %s response: %s", UriToString<kUriCommissionerSet>(), error == kErrorNone ? StateTlv::StateToString(static_cast<StateTlv::State>(state)) : ErrorToString(error));
     return;
 }
 

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -771,12 +771,14 @@ void Commissioner::HandleMgmtCommissionerSetResponse(Coap::Message          *aMe
     uint8_t state;
 
     SuccessOrExit(error = aResult);
-    VerifyOrExit(aMessage->GetCode() == Coap::kCodeChanged && Tlv::Find<StateTlv>(*aMessage, state) == kErrorNone && state != StateTlv::kPending, error = kErrorParse);
+    VerifyOrExit(aMessage->GetCode() == Coap::kCodeChanged && Tlv::Find<StateTlv>(*aMessage, state) == kErrorNone &&
+                     state != StateTlv::kPending,
+                 error = kErrorParse);
 
     OT_UNUSED_VARIABLE(error);
 exit:
-    LogInfo("Received %s response: %s", UriToString<kUriCommissionerSet>(), error == kErrorNone ? StateTlv::StateToString(static_cast<StateTlv::State>(state)) : ErrorToString(error));
-    return;
+    LogInfo("Received %s response: %s", UriToString<kUriCommissionerSet>(),
+            error == kErrorNone ? StateTlv::StateToString(static_cast<StateTlv::State>(state)) : ErrorToString(error));
 }
 
 Error Commissioner::SendPetition(void)

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -317,17 +317,9 @@ void DatasetManager::HandleMgmtSetResponse(Coap::Message *aMessage, const Ip6::M
     SuccessOrExit(error = aError);
     VerifyOrExit(Tlv::Find<StateTlv>(*aMessage, state) == kErrorNone, error = kErrorParse);
 
-    switch (state)
+    if (state != StateTlv::kPending)
     {
-    case StateTlv::kReject:
-        error = kErrorRejected;
-        break;
-    case StateTlv::kAccept:
-        error = kErrorNone;
-        break;
-    default:
-        error = kErrorParse;
-        break;
+        error = StateTlv::StateTlvToError(static_cast<StateTlv::State>(state));
     }
 
 exit:

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -315,15 +315,10 @@ void DatasetManager::HandleMgmtSetResponse(Coap::Message *aMessage, const Ip6::M
     uint8_t state;
 
     SuccessOrExit(error = aError);
-    VerifyOrExit(Tlv::Find<StateTlv>(*aMessage, state) == kErrorNone, error = kErrorParse);
-
-    if (state != StateTlv::kPending)
-    {
-        error = StateTlv::StateTlvToError(static_cast<StateTlv::State>(state));
-    }
+    VerifyOrExit(Tlv::Find<StateTlv>(*aMessage, state) == kErrorNone && state != StateTlv::kPending, error = kErrorParse);
 
 exit:
-    LogInfo("MGMT_SET finished: %s", ErrorToString(error));
+    LogInfo("MGMT_SET finished: %s", error == kErrorNone ? StateTlv::StateToString(static_cast<StateTlv::State>(state)) : ErrorToString(error));
 
     mMgmtPending = false;
 

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -315,10 +315,12 @@ void DatasetManager::HandleMgmtSetResponse(Coap::Message *aMessage, const Ip6::M
     uint8_t state;
 
     SuccessOrExit(error = aError);
-    VerifyOrExit(Tlv::Find<StateTlv>(*aMessage, state) == kErrorNone && state != StateTlv::kPending, error = kErrorParse);
+    VerifyOrExit(Tlv::Find<StateTlv>(*aMessage, state) == kErrorNone && state != StateTlv::kPending,
+                 error = kErrorParse);
 
 exit:
-    LogInfo("MGMT_SET finished: %s", error == kErrorNone ? StateTlv::StateToString(static_cast<StateTlv::State>(state)) : ErrorToString(error));
+    LogInfo("MGMT_SET finished: %s",
+            error == kErrorNone ? StateTlv::StateToString(static_cast<StateTlv::State>(state)) : ErrorToString(error));
 
     mMgmtPending = false;
 

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -211,12 +211,12 @@ void ChannelTlv::SetChannel(uint16_t aChannel)
     mChannel = HostSwap16(aChannel);
 }
 
-const char *StateTlv::StateToString(StateTlv::State aState)
+const char *StateTlv::StateToString(State aState)
 {
     static const char *const kStateStrings[] = {
-        "Pending",              // (0) kPending,
-        "Accept",               // (1) kAccept
-        "Reject",               // (2) kReject,
+        "Pending", // (0) kPending,
+        "Accept",  // (1) kAccept
+        "Reject",  // (2) kReject,
     };
 
     static_assert(0 == kPending, "kPending value is incorrect");

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -211,26 +211,18 @@ void ChannelTlv::SetChannel(uint16_t aChannel)
     mChannel = HostSwap16(aChannel);
 }
 
-Error StateTlv::StateTlvToError(StateTlv::State aState)
+const char *StateTlv::StateToString(StateTlv::State aState)
 {
-    Error ret;
+    static const char *const kStateStrings[] = {
+        "Pending",              // (0) kPending,
+        "Accept",               // (1) kAccept
+        "Reject",               // (2) kReject,
+    };
 
-    switch (aState)
-    {
-    case StateTlv::kReject:
-        ret = kErrorRejected;
-        break;
-    case StateTlv::kAccept:
-        ret = kErrorNone;
-        break;
-    case StateTlv::kPending:
-        ret = kErrorPending;
-        break;
-    default:
-        ret = kErrorParse;
-        break;
-    }
-    return ret;
+    static_assert(0 == kPending, "kPending value is incorrect");
+    static_assert(1 == kAccept, "kAccept value is incorrect");
+
+    return aState == kReject ? kStateStrings[2] : kStateStrings[aState];
 }
 
 bool ChannelMaskBaseTlv::IsValid(void) const

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -211,6 +211,28 @@ void ChannelTlv::SetChannel(uint16_t aChannel)
     mChannel = HostSwap16(aChannel);
 }
 
+Error StateTlv::StateTlvToError(StateTlv::State aState)
+{
+    Error ret;
+
+    switch (aState)
+    {
+    case StateTlv::kReject:
+        ret = kErrorRejected;
+        break;
+    case StateTlv::kAccept:
+        ret = kErrorNone;
+        break;
+    case StateTlv::kPending:
+        ret = kErrorPending;
+        break;
+    default:
+        ret = kErrorParse;
+        break;
+    }
+    return ret;
+}
+
 bool ChannelMaskBaseTlv::IsValid(void) const
 {
     const ChannelMaskEntryBase *cur = GetFirstEntry();

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -1089,14 +1089,14 @@ public:
     };
 
     /**
-     * Convert State value to Error code.
+     * Converts a `StateTlv::State` to a string.
      *
-     * @param[in]  aState  TLV state value that will be converted.
+     * @param[in] aState  An item state.
      *
-     * @returns  Error code.
+     * @returns A string representation of @p aState.
      *
      */
-    static Error StateTlvToError(StateTlv::State aState);
+    static const char *StateToString(StateTlv::State aState); // todo probably I don't need to add StateTlv I guess, check it
 };
 
 /**

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -1089,14 +1089,14 @@ public:
     };
 
     /**
-     * Converts a `StateTlv::State` to a string.
+     * Converts a `State` to a string.
      *
      * @param[in] aState  An item state.
      *
      * @returns A string representation of @p aState.
      *
      */
-    static const char *StateToString(StateTlv::State aState); // todo probably I don't need to add StateTlv I guess, check it
+    static const char *StateToString(State aState);
 };
 
 /**

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -1087,6 +1087,16 @@ public:
         kPending = 0,    ///< Pending
         kAccept  = 1,    ///< Accept
     };
+
+    /**
+     * Convert State value to Error code.
+     *
+     * @param[in]  aState  TLV state value that will be converted.
+     *
+     * @returns  Error code.
+     *
+     */
+    static Error StateTlvToError(StateTlv::State aState);
 };
 
 /**


### PR DESCRIPTION
Hi,
Because of problems that I encountered while using `commissioner mgmtset` command (described [here](https://github.com/openthread/openthread/discussions/9326)), I decided to extend the log message to include a State value sent by the Leader.