### PR TITLE
[posix] allow disabling CLI for daemon

### DIFF
--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -381,7 +381,10 @@ int main(int argc, char *argv[])
 #if !OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE
     otAppCliInit(instance);
 #endif
+
+#if !OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE || OPENTHREAD_POSIX_CONFIG_DAEMON_CLI_ENABLE
     IgnoreError(otCliSetUserCommands(kCommands, OT_ARRAY_LENGTH(kCommands), instance));
+#endif
 
     while (true)
     {

--- a/src/posix/platform/daemon.hpp
+++ b/src/posix/platform/daemon.hpp
@@ -47,6 +47,7 @@ public:
     void Process(const otSysMainloopContext &aContext) override;
 
 private:
+    int  OutputFormat(const char *aFormat, ...);
     int  OutputFormatV(const char *aFormat, va_list aArguments);
     void InitializeSessionSocket(void);
 

--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -76,6 +76,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_POSIX_CONFIG_DAEMON_CLI_ENABLE
+ *
+ * Define to 1 to enable CLI for the posix daemon.
+ *
+ */
+#ifndef OPENTHREAD_POSIX_CONFIG_DAEMON_CLI_ENABLE
+#define OPENTHREAD_POSIX_CONFIG_DAEMON_CLI_ENABLE 1
+#endif
+
+/**
  * RCP bus UART.
  *
  * @note This value is also for simulated UART bus.


### PR DESCRIPTION
The CLI interface for the posix daemon ise useful for testing and debugging
but may not be useful for release/user builds. on size sensitive plaforms such
as Android (disabling the daemon CLI will reduce the ot-daemon binary size
on Android by around 150 KB).

So this commit defines config "OPENTHREAD_POSIX_CONFIG_DAEMON_CLI_ENABLE"
to make the daemon CLI interface optional.

When CLI is disabled for the daemon, the ot-ctl output will be like:
```
➜  openthread git:(ot-optional-daemon-cli) ✗ sudo ./build/src/posix/ot-ctl -I wpan7    
[sudo] password for wgtdkp: 
Error: CLI is disabled!
Error: CLI is disabled!
```