### PR TITLE
[cli] simplify `dataset` commands

### DIFF
--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -201,18 +201,18 @@ typedef uint32_t otChannelMask;
  */
 typedef struct otOperationalDatasetComponents
 {
-    bool mIsActiveTimestampPresent : 1;  ///< TRUE if Active Timestamp is present, FALSE otherwise.
-    bool mIsPendingTimestampPresent : 1; ///< TRUE if Pending Timestamp is present, FALSE otherwise.
-    bool mIsNetworkKeyPresent : 1;       ///< TRUE if Network Key is present, FALSE otherwise.
-    bool mIsNetworkNamePresent : 1;      ///< TRUE if Network Name is present, FALSE otherwise.
-    bool mIsExtendedPanIdPresent : 1;    ///< TRUE if Extended PAN ID is present, FALSE otherwise.
-    bool mIsMeshLocalPrefixPresent : 1;  ///< TRUE if Mesh Local Prefix is present, FALSE otherwise.
-    bool mIsDelayPresent : 1;            ///< TRUE if Delay Timer is present, FALSE otherwise.
-    bool mIsPanIdPresent : 1;            ///< TRUE if PAN ID is present, FALSE otherwise.
-    bool mIsChannelPresent : 1;          ///< TRUE if Channel is present, FALSE otherwise.
-    bool mIsPskcPresent : 1;             ///< TRUE if PSKc is present, FALSE otherwise.
-    bool mIsSecurityPolicyPresent : 1;   ///< TRUE if Security Policy is present, FALSE otherwise.
-    bool mIsChannelMaskPresent : 1;      ///< TRUE if Channel Mask is present, FALSE otherwise.
+    bool mIsActiveTimestampPresent;  ///< TRUE if Active Timestamp is present, FALSE otherwise.
+    bool mIsPendingTimestampPresent; ///< TRUE if Pending Timestamp is present, FALSE otherwise.
+    bool mIsNetworkKeyPresent;       ///< TRUE if Network Key is present, FALSE otherwise.
+    bool mIsNetworkNamePresent;      ///< TRUE if Network Name is present, FALSE otherwise.
+    bool mIsExtendedPanIdPresent;    ///< TRUE if Extended PAN ID is present, FALSE otherwise.
+    bool mIsMeshLocalPrefixPresent;  ///< TRUE if Mesh Local Prefix is present, FALSE otherwise.
+    bool mIsDelayPresent;            ///< TRUE if Delay Timer is present, FALSE otherwise.
+    bool mIsPanIdPresent;            ///< TRUE if PAN ID is present, FALSE otherwise.
+    bool mIsChannelPresent;          ///< TRUE if Channel is present, FALSE otherwise.
+    bool mIsPskcPresent;             ///< TRUE if PSKc is present, FALSE otherwise.
+    bool mIsSecurityPolicyPresent;   ///< TRUE if Security Policy is present, FALSE otherwise.
+    bool mIsChannelMaskPresent;      ///< TRUE if Channel Mask is present, FALSE otherwise.
 } otOperationalDatasetComponents;
 
 /**

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (352)
+#define OPENTHREAD_API_VERSION (353)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -74,7 +74,53 @@ public:
     otError Process(Arg aArgs[]);
 
 private:
-    using Command = CommandEntry<Dataset>;
+    using Command    = CommandEntry<Dataset>;
+    using Components = otOperationalDatasetComponents;
+
+    struct ComponentMapper
+    {
+        int Compare(const char *aName) const { return strcmp(aName, mName); }
+
+        constexpr static bool AreInOrder(const ComponentMapper &aFirst, const ComponentMapper &aSecond)
+        {
+            return AreStringsInOrder(aFirst.mName, aSecond.mName);
+        }
+
+        const char *mName;
+        bool Components::*mIsPresentPtr;
+        void (Dataset::*mOutput)(const otOperationalDataset &aDataset);
+        otError (Dataset::*mParse)(Arg *&aArgs, otOperationalDataset &aDataset);
+    };
+
+    const ComponentMapper *LookupMapper(const char *aName) const;
+
+    void OutputActiveTimestamp(const otOperationalDataset &aDataset);
+    void OutputChannel(const otOperationalDataset &aDataset);
+    void OutputChannelMask(const otOperationalDataset &aDataset);
+    void OutputDelay(const otOperationalDataset &aDataset);
+    void OutputExtendedPanId(const otOperationalDataset &aDataset);
+    void OutputMeshLocalPrefix(const otOperationalDataset &aDataset);
+    void OutputNetworkKey(const otOperationalDataset &aDataset);
+    void OutputNetworkName(const otOperationalDataset &aDataset);
+    void OutputPanId(const otOperationalDataset &aDataset);
+    void OutputPendingTimestamp(const otOperationalDataset &aDataset);
+    void OutputPskc(const otOperationalDataset &aDataset);
+    void OutputSecurityPolicy(const otOperationalDataset &aDataset);
+
+    otError ParseActiveTimestamp(Arg *&aArgs, otOperationalDataset &aDataset);
+    otError ParseChannel(Arg *&aArgs, otOperationalDataset &aDataset);
+    otError ParseChannelMask(Arg *&aArgs, otOperationalDataset &aDataset);
+    otError ParseDelay(Arg *&aArgs, otOperationalDataset &aDataset);
+    otError ParseExtendedPanId(Arg *&aArgs, otOperationalDataset &aDataset);
+    otError ParseMeshLocalPrefix(Arg *&aArgs, otOperationalDataset &aDataset);
+    otError ParseNetworkKey(Arg *&aArgs, otOperationalDataset &aDataset);
+    otError ParseNetworkName(Arg *&aArgs, otOperationalDataset &aDataset);
+    otError ParsePanId(Arg *&aArgs, otOperationalDataset &aDataset);
+    otError ParsePendingTimestamp(Arg *&aArgs, otOperationalDataset &aDataset);
+    otError ParsePskc(Arg *&aArgs, otOperationalDataset &aDataset);
+    otError ParseSecurityPolicy(Arg *&aArgs, otOperationalDataset &aDataset);
+
+    otError ProcessCommand(const ComponentMapper &aMapper, Arg aArgs[]);
 
     template <CommandId kCommandId> otError Process(Arg aArgs[]);
 


### PR DESCRIPTION
This commit simplifies the `Cli::Dataset` implementation by defining an array of `ComponentMapper` structures. Each `ComponentMapper` structure corresponds to a Dataset component, and provides the following information:
- The component's CLI name
- A method pointer to output that component
- A method pointer to parse that component
- A pointer to the component's mIsPresent boolean flag

A new `LookupMapper()` method allows us to find (using binary search) the entry corresponding to a given component name. This model allows us to reuse code patterns for the main dataset sub-commands, `mgmtsetcommand`, and `mgmtgetcommand` commands when outputting or parsing dataset components.