### PR TITLE
[key-manager] move `KeyManager` and `Mac` init to after `Settings` init

### DIFF
--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -322,9 +322,12 @@ void Instance::AfterInit(void)
     mIsInitialized = true;
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
 
-    // Restore datasets and network information
+    // Restore datasets and network information, initialize KeyManager and Mac
 
     Get<Settings>().Init();
+    Get<KeyManager>().Init();
+    Get<Mac::Mac>().Init();
+
     Get<Mle::MleRouter>().Restore();
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -108,6 +108,10 @@ Mac::Mac(Instance &aInstance)
     , mTxError(kErrorNone)
 #endif
 {
+}
+
+void Mac::Init(void)
+{
     ExtAddress randomExtAddress;
 
     static const otMacKey sMode2Key = {

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -130,6 +130,15 @@ public:
     explicit Mac(Instance &aInstance);
 
     /**
+     * Resets CCA Success Rate Tracker and MAC counters, updates MAC and MLE keys, sets IEEE 802.15.4 PAN ID,
+     * IEEE 802.15.4 Extended Address, IEEE 802.15.4 Short Address and MAC Key Material.
+     *
+     * This should be called before any other method from this class.
+     *
+     */
+    void Init(void);
+
+    /**
      * Starts an IEEE 802.15.4 Active Scan.
      *
      * @param[in]  aScanChannels  A bit vector indicating which channels to scan. Zero is mapped to all channels.

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -176,6 +176,10 @@ KeyManager::KeyManager(Instance &aInstance)
     , mKekFrameCounter(0)
     , mIsPskcSet(false)
 {
+}
+
+void KeyManager::Init(void)
+{
     otPlatCryptoInit();
 
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -220,6 +220,14 @@ public:
     explicit KeyManager(Instance &aInstance);
 
     /**
+     * Initializes the Crypto module, generates Network Key and resets all link Frame Counters.
+     *
+     * This should be called before any other method from this class.
+     *
+     */
+    void Init(void);
+
+    /**
      * Starts KeyManager rotation timer and sets guard timer to initial value.
      *
      */


### PR DESCRIPTION
Storing Network key in `KeyManager` initialization requires platform settings module to be initialized first.
Also as Mac calls `Get<KeyManager>().UpdateKeyMaterial()`, it's initialization should be moved to after `KeyManager`'s.

Created initialization function for `KeyManager` to call it in `instance.cpp` after `Settings` are initialized.

Created initialization function for `Mac`to call it in `instance.cpp` after `KeyManager` is initialized.