### PR TITLE
[trel] bugfix for MAC security failure on key sequence change

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1593,6 +1593,7 @@ Error Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Neig
         {
             aNeighbor->SetKeySequence(keySequence);
             aNeighbor->SetMleFrameCounter(0);
+            aNeighbor->GetLinkFrameCounters().Reset();
         }
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO


### PR DESCRIPTION
In multi-radio scenarios, any key sequence change currently resets the MAC frame counter for the PHY link over which the first frame (with new keyId and frame counter) is received. Since the neighbor key sequence is already modified, any subsequent frame received over the alternate PHY would have match the neighbor key sequence, but potentially smaller frame counter, which leads to drops due to security failure