### PR TITLE
[cli] fix RTT compiling issue

### DIFF
--- a/examples/platforms/utils/uart_rtt.c
+++ b/examples/platforms/utils/uart_rtt.c
@@ -40,11 +40,11 @@
 #include <utils/code_utils.h>
 #include <openthread/error.h>
 
+#if OPENTHREAD_UART_RTT_ENABLE
+
 #include "SEGGER_RTT.h"
 #include "uart.h"
 #include "uart_rtt.h"
-
-#if OPENTHREAD_UART_RTT_ENABLE
 
 static bool sUartInitialized = false;
 static bool sUartPendingUp   = false;


### PR DESCRIPTION
This PR fix a compiling issue involved by PR  [[cli] support RTT as cli interface #9148 ](https://github.com/openthread/openthread/pull/9148). If macro `OPENTHREAD_UART_RTT_ENABLE` is not enabled, the file `SEGGER_RTT.h` and related should not be inlcuded.