### PR TITLE
[data-poll-handler] reset tx attempts when replacing a frame

### DIFF
--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -64,13 +64,8 @@ inline void DataPollHandler::Callbacks::HandleSentFrameToChild(const Mac::TxFram
     Get<IndirectSender>().HandleSentFrameToChild(aFrame, aContext, aError, aChild);
 }
 
-void DataPollHandler::Callbacks::HandleFrameChangeDone(Child &aChild)
+inline void DataPollHandler::Callbacks::HandleFrameChangeDone(Child &aChild)
 {
-    aChild.ResetIndirectTxAttempts();
-#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-    aChild.ResetCslTxAttempts();
-#endif
-
     Get<IndirectSender>().HandleFrameChangeDone(aChild);
 }
 
@@ -126,6 +121,7 @@ void DataPollHandler::RequestFrameChange(FrameChange aChange, Child &aChild)
     }
     else
     {
+        ResetTxAttempts(aChild);
         mCallbacks.HandleFrameChangeDone(aChild);
     }
 }
@@ -240,6 +236,7 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, 
     {
         aChild.SetFramePurgePending(false);
         aChild.SetFrameReplacePending(false);
+        ResetTxAttempts(aChild);
         mCallbacks.HandleFrameChangeDone(aChild);
         ExitNow();
     }
@@ -247,10 +244,7 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, 
     switch (aError)
     {
     case kErrorNone:
-        aChild.ResetIndirectTxAttempts();
-#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-        aChild.ResetCslTxAttempts();
-#endif
+        ResetTxAttempts(aChild);
         aChild.SetFrameReplacePending(false);
         break;
 
@@ -269,6 +263,7 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, 
         if (aChild.IsFrameReplacePending())
         {
             aChild.SetFrameReplacePending(false);
+            ResetTxAttempts(aChild);
             mCallbacks.HandleFrameChangeDone(aChild);
             ExitNow();
         }
@@ -331,6 +326,15 @@ void DataPollHandler::ProcessPendingPolls(void)
         mIndirectTxChild->SetDataPollPending(false);
         Get<Mac::Mac>().RequestIndirectFrameTransmission();
     }
+}
+
+void DataPollHandler::ResetTxAttempts(Child &aChild)
+{
+    aChild.ResetIndirectTxAttempts();
+
+#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+    aChild.ResetCslTxAttempts();
+#endif
 }
 
 } // namespace ot

--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -64,8 +64,13 @@ inline void DataPollHandler::Callbacks::HandleSentFrameToChild(const Mac::TxFram
     Get<IndirectSender>().HandleSentFrameToChild(aFrame, aContext, aError, aChild);
 }
 
-inline void DataPollHandler::Callbacks::HandleFrameChangeDone(Child &aChild)
+void DataPollHandler::Callbacks::HandleFrameChangeDone(Child &aChild)
 {
+    aChild.ResetIndirectTxAttempts();
+#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+    aChild.ResetCslTxAttempts();
+#endif
+
     Get<IndirectSender>().HandleFrameChangeDone(aChild);
 }
 
@@ -235,7 +240,6 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, 
     {
         aChild.SetFramePurgePending(false);
         aChild.SetFrameReplacePending(false);
-        aChild.ResetIndirectTxAttempts();
         mCallbacks.HandleFrameChangeDone(aChild);
         ExitNow();
     }
@@ -265,7 +269,6 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, 
         if (aChild.IsFrameReplacePending())
         {
             aChild.SetFrameReplacePending(false);
-            aChild.ResetIndirectTxAttempts();
             mCallbacks.HandleFrameChangeDone(aChild);
             ExitNow();
         }

--- a/src/core/mac/data_poll_handler.hpp
+++ b/src/core/mac/data_poll_handler.hpp
@@ -275,6 +275,7 @@ private:
 
     void HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, Child &aChild);
     void ProcessPendingPolls(void);
+    void ResetTxAttempts(Child &aChild);
 
     // In the current implementation of `DataPollHandler`, we can have a
     // single indirect tx operation active at MAC layer at each point of


### PR DESCRIPTION
Whenever an indirect/CSL transmitted frame is being purged or replaced,
make sure that both indirect and CSL transmission attempts counts are
reset in order to avoid issues like considering a new frame as a
retransmission.