### PR TITLE
[srp-server] process completed update from proxy from taskelt

### DIFF
--- a/src/core/common/linked_list.hpp
+++ b/src/core/common/linked_list.hpp
@@ -181,6 +181,26 @@ public:
     }
 
     /**
+     * Pushes an entry after the tail in the linked list.
+     *
+     * @param[in] aEntry       A reference to an entry to push into the list.
+     *
+     */
+    void PushAfterTail(Type &aEntry)
+    {
+        Type *tail = GetTail();
+
+        if (tail == nullptr)
+        {
+            Push(aEntry);
+        }
+        else
+        {
+            PushAfter(aEntry, *tail);
+        }
+    }
+
+    /**
      * Pops an entry from head of the linked list.
      *
      * @note This method does not change the popped entry itself, i.e., the popped entry next pointer stays as before.

--- a/tests/unit/test_linked_list.cpp
+++ b/tests/unit/test_linked_list.cpp
@@ -294,6 +294,16 @@ void TestLinkedList(void)
     list.RemoveAllMatching(kBetaType, removedList);
     VerifyLinkedListContent(&list, &a, &b, &e, nullptr);
     VerifyLinkedListContent(&removedList, &f, &d, &c, nullptr);
+
+    list.Clear();
+    list.PushAfterTail(a);
+    VerifyLinkedListContent(&list, &a, nullptr);
+    list.PushAfterTail(b);
+    VerifyLinkedListContent(&list, &a, &b, nullptr);
+    list.PushAfterTail(c);
+    VerifyLinkedListContent(&list, &a, &b, &c, nullptr);
+    list.PushAfterTail(d);
+    VerifyLinkedListContent(&list, &a, &b, &c, &d, nullptr);
 }
 
 void TestOwningList(void)


### PR DESCRIPTION
This commit enhances `Srp::Server` to process and commit the completed `UpdateMetadata` entries (signaled by the "proxy service handler" calling `HandleServiceUpdateResult()`) from a `Tasklet`. This change is helpful in the case where the `HandleServiceUpdateResult()` callback is invoked directly from the "update service handler" itself. While `Srp::Server` can handle this situation, the change makes it easier for platform implementations of advertising proxy.

In particular, it addresses an issue with the `otbr` advertising proxy implementation. This implementation can potentially access an already freed `Host` object. This can happen because the implementation may hold on to the `Host` object while iterating over its `Service` entries as advertising an earlier `Service` of the same `Host` may fail immediately and invoke the callback directly. This would then cause the `Host` to be freed by `Srp::Server`.


-----

- Should help address https://github.com/openthread/ot-br-posix/issues/1991