### PR TITLE
[firewall] implement packet filtering in OT core

### DIFF
--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -156,6 +156,13 @@ jobs:
             packet_verification: 2
             nat64: 0
             description: ""
+          - otbr_mdns: "avahi"
+            otbr_trel: 0
+            cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
+            packet_verification: 1
+            nat64: 0
+            use_core_firewall: 1
+            description: "core firewall"
     name: BR ${{ matrix.description }} (${{ matrix.otbr_mdns }}, TREL=${{matrix.otbr_trel}})
     env:
       REFERENCE_DEVICE: 1
@@ -173,6 +180,10 @@ jobs:
       MAX_JOBS: 3
     steps:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+    - name: Set firewall environment variables
+      if: ${{ matrix.use_core_firewall }}
+      run: |
+        echo "FIREWALL=0" >> $GITHUB_ENV
     - name: Build OTBR Docker
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/script/test
+++ b/script/test
@@ -342,6 +342,7 @@ do_build_otbr_docker()
         "REST_API=0"
         "WEB_GUI=0"
         "MDNS=${OTBR_MDNS:-mDNSResponder}"
+        "FIREWALL=${FIREWALL:-1}"
     )
 
     if [[ ${NAT64} != 1 ]]; then

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -391,6 +391,7 @@ private:
                      const MessageInfo &aMessageInfo,
                      uint8_t            aIpProto,
                      bool               aApplyFilter,
+                     bool               aReceive,
                      Message::Ownership aMessageOwnership);
     Error HandleExtensionHeaders(Message      &aMessage,
                                  MessageOrigin aOrigin,

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -3630,6 +3630,24 @@ class LinuxHost():
 
         return resp_count
 
+    def get_ip6_address(self, address_type: config.ADDRESS_TYPE):
+        """Get specific type of IPv6 address configured on thread device.
+
+        Args:
+            address_type: the config.ADDRESS_TYPE type of IPv6 address.
+
+        Returns:
+            IPv6 address string.
+        """
+        if address_type == config.ADDRESS_TYPE.BACKBONE_GUA:
+            return self._getBackboneGua()
+        elif address_type == config.ADDRESS_TYPE.ONLINK_ULA:
+            return self._getInfraUla()
+        elif address_type == config.ADDRESS_TYPE.ONLINK_GUA:
+            return self._getInfraGua()
+        else:
+            raise ValueError(f'unsupported address type: {address_type}')
+
     def _getBackboneGua(self) -> Optional[str]:
         for addr in self.get_ether_addrs():
             if re.match(config.BACKBONE_PREFIX_REGEX_PATTERN, addr, re.I):
@@ -3885,6 +3903,12 @@ class OtbrNode(LinuxHost, NodeImpl, OtbrDocker):
         cmd = f'python3 /app/third_party/openthread/repo/tests/scripts/thread-cert/mcast6.py {self.TUN_DEV} {ip} &'
         self.bash(cmd)
 
+    def get_ip6_address(self, address_type: config.ADDRESS_TYPE):
+        try:
+            return super(OtbrNode, self).get_ip6_address(address_type)
+        except Exception as e:
+            return super(LinuxHost, self).get_ip6_address(address_type)
+
 
 class HostNode(LinuxHost, OtbrDocker):
     is_host = True
@@ -3921,25 +3945,6 @@ class HostNode(LinuxHost, OtbrDocker):
                 addrs.append(addr)
 
         return addrs
-
-    def get_ip6_address(self, address_type: config.ADDRESS_TYPE):
-        """Get specific type of IPv6 address configured on thread device.
-
-        Args:
-            address_type: the config.ADDRESS_TYPE type of IPv6 address.
-
-        Returns:
-            IPv6 address string.
-        """
-
-        if address_type == config.ADDRESS_TYPE.BACKBONE_GUA:
-            return self._getBackboneGua()
-        elif address_type == config.ADDRESS_TYPE.ONLINK_ULA:
-            return self._getInfraUla()
-        elif address_type == config.ADDRESS_TYPE.ONLINK_GUA:
-            return self._getInfraGua()
-        else:
-            raise ValueError(f'unsupported address type: {address_type}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR implements the packet logic in OT core. It aims to have the same effect as what's already achieved by our iptables-based firewall. Instead of leveraging iptables, this PR filters the border routing packets in user space by checking the source/destination addresses of a packet. 

This PR also adds a job to do BR regression test when this feature is enabled and iptables-based firewall is disabled.

Depends-On: openthread/ot-br-posix#1997