### PR TITLE
[mac] fix channel switching issue during energy scan

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -340,6 +340,10 @@ void Mac::PerformEnergyScan(void)
     }
     else
     {
+        if(!GetRxOnWhenIdle())
+        {
+            SuccessOrAssert(Get().Receive(mScanChannel));
+        }
         error = mLinks.EnergyScan(mScanChannel, mScanDuration);
     }
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -340,7 +340,7 @@ void Mac::PerformEnergyScan(void)
     }
     else
     {
-        if(!GetRxOnWhenIdle())
+        if (!GetRxOnWhenIdle())
         {
             mLinks.Receive(mScanChannel);
         }

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -342,7 +342,7 @@ void Mac::PerformEnergyScan(void)
     {
         if(!GetRxOnWhenIdle())
         {
-            SuccessOrAssert(Get().Receive(mScanChannel));
+            mLinks.Receive(mScanChannel);
         }
         error = mLinks.EnergyScan(mScanChannel, mScanDuration);
     }


### PR DESCRIPTION
- This commit resolves inconsistency between Host and RCP channel on scan energy when network not created.
- Added fix in MAC layer to update the channel on scan energy

Fixes #9394