### PR TITLE
[spinel] save MAC frame counter to a local variable

### DIFF
--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -1097,6 +1097,7 @@ private:
     int8_t       mCcaEnergyDetectThreshold;
     int8_t       mTransmitPower;
     int8_t       mFemLnaGain;
+    uint32_t     mMacFrameCounter;
     bool         mCoexEnabled : 1;
 
     bool mMacKeySet : 1;                   ///< Whether MAC key has been set.
@@ -1106,6 +1107,7 @@ private:
     bool mFemLnaGainSet : 1;               ///< Whether FEM LNA gain has been set.
     bool mRcpFailed : 1;                   ///< RCP failure happened, should recover and retry operation.
     bool mEnergyScanning : 1;              ///< If fails while scanning, restarts scanning.
+    bool mMacFrameCounterSet : 1;          ///< Whether the MAC frame counter has been set.
 
 #endif // OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
 

--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -836,8 +836,11 @@ otError RadioSpinel<InterfaceType>::ParseRadioFrame(otRadioFrame   &aFrame,
         aUnpacked += unpacked;
 
 #if OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
-        mMacFrameCounterSet = true;
-        mMacFrameCounter    = aFrame.mInfo.mRxInfo.mAckFrameCounter;
+        if (flags & SPINEL_MD_FLAG_ACKED_SEC)
+        {
+            mMacFrameCounterSet = true;
+            mMacFrameCounter    = aFrame.mInfo.mRxInfo.mAckFrameCounter;
+        }
 #endif
     }
 
@@ -2158,7 +2161,7 @@ template <typename InterfaceType> void RadioSpinel<InterfaceType>::RestoreProper
 
     if (mMacFrameCounterSet)
     {
-        const uint8_t kFrameCounterGuard = 10;
+        static constexpr uint8_t kFrameCounterGuard = 10;
 
         // There is a chance that radio/RCP has used some counters after `mMacFrameCounter` (for enh ack) and they
         // are in queue to be sent to host (not yet processed by host RadioSpinel). Here we add some guard jump

--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -2164,7 +2164,7 @@ template <typename InterfaceType> void RadioSpinel<InterfaceType>::RestoreProper
         // There is a chance that radio/RCP has used some counters after `mMacFrameCounter` (for enh ack) and they
         // are in queue to be sent to host (not yet processed by host RadioSpinel). Here we add some guard jump
         // when we restore the frame counter.
-        // Consider the worst case: the radio/RCP continuously receives the shortest data frame and replys with the
+        // Consider the worst case: the radio/RCP continuously receives the shortest data frame and replies with the
         // shortest enhanced ACK. The radio/RCP consumes at most 992 frame counters during the timeout time.
         // The frame counter guard is set to 1000 which should ensure that the restored frame counter is unused.
         //


### PR DESCRIPTION
This commit saves the MAC counter to a local variable to avoid calling the core function `Get<Settings>().Read()` in `radio_spinel_impl.hpp`. This is useful when spinel module is used as a lib in other projects.