### PR TITLE
[mle-router] remove address cache entries when dest RLOC16 is unreachable

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3426,6 +3426,8 @@ Error MleRouter::CheckReachability(uint16_t aMeshDest, const Ip6::Header &aIp6He
 
     error = kErrorNoRoute;
 
+    Get<AddressResolver>().RemoveEntriesForRloc16(aMeshDest);
+
 exit:
     return error;
 }


### PR DESCRIPTION
This commit updates `MleRouter::CheckReachability()` such that when we determine the `mMeshDest` destination RLOC16 is unreachable to ask `AddressResolver` to clear any address cache entries associated with this RLOC16.

---

Should help address/safeguard against situation in https://github.com/openthread/openthread/issues/9409.