### PR TITLE
[address-resolver] remove cache entry if its RLOC16 is unreachable

### DIFF
--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -491,6 +491,34 @@ Error AddressResolver::Resolve(const Ip6::Address &aEid, Mac::ShortAddress &aRlo
 
     entry = FindCacheEntry(aEid, list, prev);
 
+    if ((entry != nullptr) && ((list == &mCachedList) || (list == &mSnoopedList)))
+    {
+        list->PopAfter(prev);
+
+        if (Get<RouterTable>().GetNextHop(entry->GetRloc16()) == Mle::kInvalidRloc16)
+        {
+            // If the `entry->GetRloc16()` is unreachable (there is no valid
+            // next hop towards it), we clear the entry so to start a new
+            // address query.
+
+            mCacheEntryPool.Free(*entry);
+            entry = nullptr;
+        }
+        else
+        {
+            // Push the entry at the head of cached list.
+
+            if (list == &mSnoopedList)
+            {
+                entry->MarkLastTransactionTimeAsInvalid();
+            }
+
+            mCachedList.Push(*entry);
+            aRloc16 = entry->GetRloc16();
+            ExitNow();
+        }
+    }
+
     if (entry == nullptr)
     {
         // If the entry is not present in any of the lists, try to
@@ -508,23 +536,6 @@ Error AddressResolver::Resolve(const Ip6::Address &aEid, Mac::ShortAddress &aRlo
         entry->SetRetryDelay(kAddressQueryInitialRetryDelay);
         entry->SetCanEvict(false);
         list = nullptr;
-    }
-
-    if ((list == &mCachedList) || (list == &mSnoopedList))
-    {
-        // Remove the entry from its current list and push it at the
-        // head of cached list.
-
-        list->PopAfter(prev);
-
-        if (list == &mSnoopedList)
-        {
-            entry->MarkLastTransactionTimeAsInvalid();
-        }
-
-        mCachedList.Push(*entry);
-        aRloc16 = entry->GetRloc16();
-        ExitNow();
     }
 
     // Note that if `aAllowAddressQuery` is `false` then the `entry`


### PR DESCRIPTION
This commit updates `AddressResolver::Resolve()` to validate that the associated RLOC16 is reachable in the sense that a valid next hop can be found towards it, before using a matching cache entry in `mCachedList` or `mSnoopedList`. If the RLOC16 is not reachable, the cache entry is removed to trigger a new address query.

----

Should address https://github.com/openthread/openthread/issues/9409