### PR TITLE
[include] remove include of core config file

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (357)
+#define OPENTHREAD_API_VERSION (358)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/link_metrics.h
+++ b/include/openthread/link_metrics.h
@@ -35,8 +35,6 @@
 #ifndef LINK_METRICS_H_
 #define LINK_METRICS_H_
 
-#include "openthread-core-config.h"
-
 #include <openthread/ip6.h>
 #include <openthread/message.h>
 #include <openthread/platform/radio.h>


### PR DESCRIPTION
The core config file shouldn't be included in public API headers
because they will be included from high level project code (like 
ot-br-posix) and the config file cannot be located if included here.