### PR TITLE
[mac] update the cached supported channel mask when the region code changes

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (367)
+#define OPENTHREAD_API_VERSION (368)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -1183,6 +1183,21 @@ bool otLinkIsCslSupported(otInstance *aInstance);
 otError otLinkSendEmptyData(otInstance *aInstance);
 
 /**
+ * Sets the region code.
+ *
+ * The radio region format is the 2-bytes ascii representation of the ISO 3166 alpha-2 code.
+ *
+ * @param[in]  aInstance    The OpenThread instance structure.
+ * @param[in]  aRegionCode  The radio region.
+ *
+ * @retval  OT_ERROR_FAILED           Other platform specific errors.
+ * @retval  OT_ERROR_NONE             Successfully set region code.
+ * @retval  OT_ERROR_NOT_IMPLEMENTED  The feature is not implemented.
+ *
+ */
+otError otLinkSetRegion(otInstance *aInstance, uint16_t aRegionCode);
+
+/**
  * @}
  *
  */

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -1199,6 +1199,23 @@ otError otLinkSendEmptyData(otInstance *aInstance);
 otError otLinkSetRegion(otInstance *aInstance, uint16_t aRegionCode);
 
 /**
+ * Get the region code.
+ *
+ * The radio region format is the 2-bytes ascii representation of the ISO 3166 alpha-2 code.
+
+ * @param[in]  aInstance    The OpenThread instance structure.
+ * @param[out] aRegionCode  The radio region code. The `aRegionCode >> 8` is first ascii char
+ *                          and the `aRegionCode & 0xff` is the second ascii char.
+ *
+ * @retval  OT_ERROR_INVALID_ARGS     @p aRegionCode is nullptr.
+ * @retval  OT_ERROR_FAILED           Other platform specific errors.
+ * @retval  OT_ERROR_NONE             Successfully got region code.
+ * @retval  OT_ERROR_NOT_IMPLEMENTED  The feature is not implemented.
+ *
+ */
+otError otLinkGetRegion(otInstance *aInstance, uint16_t *aRegionCode);
+
+/**
  * @}
  *
  */

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -1188,7 +1188,8 @@ otError otLinkSendEmptyData(otInstance *aInstance);
  * The radio region format is the 2-bytes ascii representation of the ISO 3166 alpha-2 code.
  *
  * @param[in]  aInstance    The OpenThread instance structure.
- * @param[in]  aRegionCode  The radio region.
+ * @param[in]  aRegionCode  The radio region code. The `aRegionCode >> 8` is first ascii char
+ *                          and the `aRegionCode & 0xff` is the second ascii char.
  *
  * @retval  OT_ERROR_FAILED           Other platform specific errors.
  * @retval  OT_ERROR_NONE             Successfully set region code.

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -1186,7 +1186,8 @@ otError otPlatRadioSetChannelMaxTransmitPower(otInstance *aInstance, uint8_t aCh
  * ISO 3166 alpha-2 code.
  *
  * @param[in]  aInstance    The OpenThread instance structure.
- * @param[in]  aRegionCode  The radio region.
+ * @param[in]  aRegionCode  The radio region code. The `aRegionCode >> 8` is first ascii char
+ *                          and the `aRegionCode & 0xff` is the second ascii char.
  *
  * @retval  OT_ERROR_FAILED           Other platform specific errors.
  * @retval  OT_ERROR_NONE             Successfully set region code.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -6658,7 +6658,7 @@ exit:
  * Done
  * @endcode
  * @par api_copy
- * #otPlatRadioGetRegion
+ * #otLinkGetRegion
  */
 template <> otError Interpreter::Process<Cmd("region")>(Arg aArgs[])
 {
@@ -6667,7 +6667,7 @@ template <> otError Interpreter::Process<Cmd("region")>(Arg aArgs[])
 
     if (aArgs[0].IsEmpty())
     {
-        SuccessOrExit(error = otPlatRadioGetRegion(GetInstancePtr(), &regionCode));
+        SuccessOrExit(error = otLinkGetRegion(GetInstancePtr(), &regionCode));
         OutputLine("%c%c", regionCode >> 8, regionCode & 0xff);
     }
     /**

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -6677,7 +6677,7 @@ template <> otError Interpreter::Process<Cmd("region")>(Arg aArgs[])
      * Done
      * @endcode
      * @par api_copy
-     * #otPlatRadioSetRegion
+     * #otLinkSetRegion
      * @par
      * Changing this can affect the transmit power limit.
      */
@@ -6688,7 +6688,7 @@ template <> otError Interpreter::Process<Cmd("region")>(Arg aArgs[])
 
         regionCode = static_cast<uint16_t>(static_cast<uint16_t>(aArgs[0].GetCString()[0]) << 8) +
                      static_cast<uint16_t>(aArgs[0].GetCString()[1]);
-        error = otPlatRadioSetRegion(GetInstancePtr(), regionCode);
+        error = otLinkSetRegion(GetInstancePtr(), regionCode);
     }
 
 exit:

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -468,6 +468,16 @@ otError otLinkSetRegion(otInstance *aInstance, uint16_t aRegionCode)
 
 otError otLinkGetRegion(otInstance *aInstance, uint16_t *aRegionCode)
 {
-    AssertPointerIsNotNull(aRegionCode);
-    return AsCoreType(aInstance).Get<Mac::Mac>().GetRegion(*aRegionCode);
+    Error error;
+
+    if (aRegionCode == nullptr)
+    {
+        error = kErrorInvalidArgs;
+    }
+    else
+    {
+        error = AsCoreType(aInstance).Get<Mac::Mac>().GetRegion(*aRegionCode);
+    }
+
+    return error;
 }

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -460,3 +460,8 @@ otError otLinkSendEmptyData(otInstance *aInstance)
     return AsCoreType(aInstance).Get<MeshForwarder>().SendEmptyMessage();
 }
 #endif
+
+otError otLinkSetRegion(otInstance *aInstance, uint16_t aRegionCode)
+{
+    return AsCoreType(aInstance).Get<Mac::Mac>().SetRegion(aRegionCode);
+}

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -465,3 +465,9 @@ otError otLinkSetRegion(otInstance *aInstance, uint16_t aRegionCode)
 {
     return AsCoreType(aInstance).Get<Mac::Mac>().SetRegion(aRegionCode);
 }
+
+otError otLinkGetRegion(otInstance *aInstance, uint16_t *aRegionCode)
+{
+    AssertPointerIsNotNull(aRegionCode);
+    return AsCoreType(aInstance).Get<Mac::Mac>().SetRegion(*aRegionCode);
+}

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -469,5 +469,5 @@ otError otLinkSetRegion(otInstance *aInstance, uint16_t aRegionCode)
 otError otLinkGetRegion(otInstance *aInstance, uint16_t *aRegionCode)
 {
     AssertPointerIsNotNull(aRegionCode);
-    return AsCoreType(aInstance).Get<Mac::Mac>().SetRegion(*aRegionCode);
+    return AsCoreType(aInstance).Get<Mac::Mac>().GetRegion(*aRegionCode);
 }

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2118,6 +2118,8 @@ exit:
     return error;
 }
 
+Error Mac::GetRegion(uint16_t &aRegionCode) { return Get<Radio>().GetRegion(aRegionCode); }
+
 #if OPENTHREAD_CONFIG_MAC_RETRY_SUCCESS_HISTOGRAM_ENABLE
 const uint32_t *Mac::GetDirectRetrySuccessHistogram(uint8_t &aNumberOfEntries)
 {

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2118,7 +2118,7 @@ exit:
     return error;
 }
 
-Error Mac::GetRegion(uint16_t &aRegionCode) { return Get<Radio>().GetRegion(aRegionCode); }
+Error Mac::GetRegion(uint16_t &aRegionCode) const { return Get<Radio>().GetRegion(aRegionCode); }
 
 #if OPENTHREAD_CONFIG_MAC_RETRY_SUCCESS_HISTOGRAM_ENABLE
 const uint32_t *Mac::GetDirectRetrySuccessHistogram(uint8_t &aNumberOfEntries)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -315,7 +315,7 @@ public:
      * @returns The supported channel mask.
      *
      */
-    const ChannelMask &GetSupportedChannelMask(void) const { return mSupportedChannelMask; }
+    ChannelMask GetSupportedChannelMask(void) const;
 
     /**
      * Sets the supported channel mask
@@ -833,7 +833,6 @@ private:
     PanId       mPanId;
     uint8_t     mPanChannel;
     uint8_t     mRadioChannel;
-    ChannelMask mSupportedChannelMask;
     uint8_t     mScanChannel;
     uint16_t    mScanDuration;
     ChannelMask mScanChannelMask;

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -735,6 +735,21 @@ public:
      */
     Error SetRegion(uint16_t aRegionCode);
 
+    /**
+     * Get the region code.
+     *
+     * The radio region format is the 2-bytes ascii representation of the ISO 3166 alpha-2 code.
+     *
+     * @param[out] aRegionCode  The radio region code. The `aRegionCode >> 8` is first ascii char
+     *                          and the `aRegionCode & 0xff` is the second ascii char.
+     *
+     * @retval  kErrorFailed          Other platform specific errors.
+     * @retval  kErrorNone            Successfully set region code.
+     * @retval  kErrorNotImplemented  The feature is not implemented.
+     *
+     */
+    Error GetRegion(uint16_t &aRegionCode);
+
 private:
     static constexpr uint16_t kMaxCcaSampleCount = OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW;
 

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -725,7 +725,8 @@ public:
      *
      * The radio region format is the 2-bytes ascii representation of the ISO 3166 alpha-2 code.
      *
-     * @param[in]  aRegionCode  The radio region.
+     * @param[in]  aRegionCode  The radio region code. The `aRegionCode >> 8` is first ascii char
+     *                          and the `aRegionCode & 0xff` is the second ascii char.
      *
      * @retval  kErrorFailed          Other platform specific errors.
      * @retval  kErrorNone            Successfully set region code.

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -315,7 +315,7 @@ public:
      * @returns The supported channel mask.
      *
      */
-    ChannelMask GetSupportedChannelMask(void) const;
+    const ChannelMask &GetSupportedChannelMask(void) const { return mSupportedChannelMask; }
 
     /**
      * Sets the supported channel mask
@@ -720,6 +720,20 @@ public:
     bool IsRadioFilterEnabled(void) const { return mLinks.GetSubMac().IsRadioFilterEnabled(); }
 #endif
 
+    /**
+     * Sets the region code.
+     *
+     * The radio region format is the 2-bytes ascii representation of the ISO 3166 alpha-2 code.
+     *
+     * @param[in]  aRegionCode  The radio region.
+     *
+     * @retval  kErrorFailed          Other platform specific errors.
+     * @retval  kErrorNone            Successfully set region code.
+     * @retval  kErrorNotImplemented  The feature is not implemented.
+     *
+     */
+    Error SetRegion(uint16_t aRegionCode);
+
 private:
     static constexpr uint16_t kMaxCcaSampleCount = OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW;
 
@@ -833,6 +847,7 @@ private:
     PanId       mPanId;
     uint8_t     mPanChannel;
     uint8_t     mRadioChannel;
+    ChannelMask mSupportedChannelMask;
     uint8_t     mScanChannel;
     uint16_t    mScanDuration;
     ChannelMask mScanChannelMask;

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -748,7 +748,7 @@ public:
      * @retval  kErrorNotImplemented  The feature is not implemented.
      *
      */
-    Error GetRegion(uint16_t &aRegionCode);
+    Error GetRegion(uint16_t &aRegionCode) const;
 
 private:
     static constexpr uint16_t kMaxCcaSampleCount = OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW;

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -679,7 +679,7 @@ public:
      * @returns The radio supported channel mask.
      *
      */
-    uint32_t GetSupportedChannelMask(void);
+    uint32_t GetSupportedChannelMask(void) const;
 
     /**
      * Gets the radio preferred channel mask that the device prefers to form on.
@@ -752,7 +752,10 @@ inline void Radio::GetIeeeEui64(Mac::ExtAddress &aIeeeEui64)
     otPlatRadioGetIeeeEui64(GetInstancePtr(), aIeeeEui64.m8);
 }
 
-inline uint32_t Radio::GetSupportedChannelMask(void) { return otPlatRadioGetSupportedChannelMask(GetInstancePtr()); }
+inline uint32_t Radio::GetSupportedChannelMask(void) const
+{
+    return otPlatRadioGetSupportedChannelMask(GetInstancePtr());
+}
 
 inline uint32_t Radio::GetPreferredChannelMask(void) { return otPlatRadioGetPreferredChannelMask(GetInstancePtr()); }
 

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -761,7 +761,7 @@ public:
      * @retval  kErrorNotImplemented  The feature is not implemented.
      *
      */
-    Error GetRegion(uint16_t &aRegionCode) { return otPlatRadioGetRegion(GetInstancePtr(), &aRegionCode); }
+    Error GetRegion(uint16_t &aRegionCode) const { return otPlatRadioGetRegion(GetInstancePtr(), &aRegionCode); }
 
 private:
     otInstance *GetInstancePtr(void) const { return reinterpret_cast<otInstance *>(&InstanceLocator::GetInstance()); }

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -748,6 +748,21 @@ public:
      */
     Error SetRegion(uint16_t aRegionCode) { return otPlatRadioSetRegion(GetInstancePtr(), aRegionCode); }
 
+    /**
+     * Get the region code.
+     *
+     * The radio region format is the 2-bytes ascii representation of the ISO 3166 alpha-2 code.
+     *
+     * @param[out] aRegionCode  The radio region code. The `aRegionCode >> 8` is first ascii char
+     *                          and the `aRegionCode & 0xff` is the second ascii char.
+     *
+     * @retval  kErrorFailed          Other platform specific errors.
+     * @retval  kErrorNone            Successfully set region code.
+     * @retval  kErrorNotImplemented  The feature is not implemented.
+     *
+     */
+    Error GetRegion(uint16_t &aRegionCode) { return otPlatRadioGetRegion(GetInstancePtr(), &aRegionCode); }
+
 private:
     otInstance *GetInstancePtr(void) const { return reinterpret_cast<otInstance *>(&InstanceLocator::GetInstance()); }
 

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -738,7 +738,8 @@ public:
      *
      * The radio region format is the 2-bytes ascii representation of the ISO 3166 alpha-2 code.
      *
-     * @param[in]  aRegionCode  The radio region.
+     * @param[in]  aRegionCode  The radio region code. The `aRegionCode >> 8` is first ascii char
+     *                          and the `aRegionCode & 0xff` is the second ascii char.
      *
      * @retval  kErrorFailed          Other platform specific errors.
      * @retval  kErrorNone            Successfully set region code.

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -679,7 +679,7 @@ public:
      * @returns The radio supported channel mask.
      *
      */
-    uint32_t GetSupportedChannelMask(void) const;
+    uint32_t GetSupportedChannelMask(void);
 
     /**
      * Gets the radio preferred channel mask that the device prefers to form on.
@@ -733,6 +733,20 @@ public:
                 ((kChannelMin == aCslChannel) || ((kChannelMin < aCslChannel) && (aCslChannel <= kChannelMax))));
     }
 
+    /**
+     * Sets the region code.
+     *
+     * The radio region format is the 2-bytes ascii representation of the ISO 3166 alpha-2 code.
+     *
+     * @param[in]  aRegionCode  The radio region.
+     *
+     * @retval  kErrorFailed          Other platform specific errors.
+     * @retval  kErrorNone            Successfully set region code.
+     * @retval  kErrorNotImplemented  The feature is not implemented.
+     *
+     */
+    Error SetRegion(uint16_t aRegionCode) { return otPlatRadioSetRegion(GetInstancePtr(), aRegionCode); }
+
 private:
     otInstance *GetInstancePtr(void) const { return reinterpret_cast<otInstance *>(&InstanceLocator::GetInstance()); }
 
@@ -752,10 +766,7 @@ inline void Radio::GetIeeeEui64(Mac::ExtAddress &aIeeeEui64)
     otPlatRadioGetIeeeEui64(GetInstancePtr(), aIeeeEui64.m8);
 }
 
-inline uint32_t Radio::GetSupportedChannelMask(void) const
-{
-    return otPlatRadioGetSupportedChannelMask(GetInstancePtr());
-}
+inline uint32_t Radio::GetSupportedChannelMask(void) { return otPlatRadioGetSupportedChannelMask(GetInstancePtr()); }
 
 inline uint32_t Radio::GetPreferredChannelMask(void) { return otPlatRadioGetPreferredChannelMask(GetInstancePtr()); }
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1208,7 +1208,7 @@ void Mle::HandleNotifierEvents(Events aEvents)
 
         if (!channelMask.ContainsChannel(Get<Mac::Mac>().GetPanChannel()) && (mRole != kRoleDisabled))
         {
-            LogCrit("Channel %u is not in the supported channel mask %s, detach the network gracefully!",
+            LogWarn("Channel %u is not in the supported channel mask %s, detach the network gracefully!",
                     Get<Mac::Mac>().GetPanChannel(), channelMask.ToString().AsCString());
             IgnoreError(DetachGracefully(nullptr, nullptr));
         }

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1202,6 +1202,18 @@ void Mle::HandleNotifierEvents(Events aEvents)
     }
 #endif
 
+    if (aEvents.Contains(kEventSupportedChannelMaskChanged))
+    {
+        Mac::ChannelMask channelMask = Get<Mac::Mac>().GetSupportedChannelMask();
+
+        if (!channelMask.ContainsChannel(Get<Mac::Mac>().GetPanChannel()) && (mRole != kRoleDisabled))
+        {
+            LogCrit("Channel %u is not in the supported channel mask %s, detach the network gracefully!",
+                    Get<Mac::Mac>().GetPanChannel(), channelMask.ToString().AsCString());
+            IgnoreError(DetachGracefully(nullptr, nullptr));
+        }
+    }
+
 exit:
     return;
 }

--- a/tests/scripts/expect/posix-channel-mask.exp
+++ b/tests/scripts/expect/posix-channel-mask.exp
@@ -61,4 +61,38 @@ send "channel preferred\n"
 expect "0x1fff800"
 expect_line "Done"
 
+send "region US\n"
+expect_line "Done"
+
+send "channel supported\n"
+expect "0x7fff800"
+expect_line "Done"
+
+send "dataset init new\n"
+expect_line "Done"
+send "dataset channel 26\n"
+expect_line "Done"
+send "dataset commit active\n"
+expect_line "Done"
+
+attach "leader"
+
+send "channel\n"
+expect "26"
+expect_line "Done"
+
+send "region WW\n"
+expect_line "Done"
+
+wait_for "state" "disabled"
+expect_line "Done"
+
+send "channel supported\n"
+expect "0x3fff800"
+expect_line "Done"
+
+send "channel\n"
+expect "26"
+expect_line "Done"
+
 dispose_node 1


### PR DESCRIPTION
The current code of the `mac.cpp` caches the supported channel mask to a local variable. But the supported channel mask may be changed after the country code is changed. This will cause the supported channel mask used in `mac.cpp` to be inconsistent with the actual supported channel mask.

This commit adds an API `otLinkSetRegion()` to set the region code and then update the cached supported channel mask to avoid the channel mask inconsistencies. The current Thread channel may be not included in the new supported channel mask. When the Thread stack detects this case, it detaches the current Thread network gracefully.