### PR TITLE
[mac] Deduplication of SSED retransmissions

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -803,7 +803,7 @@ private:
 #endif
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-    void ProcessCsl(const RxFrame &aFrame, const Address &aSrcAddr);
+    Error ProcessCsl(const RxFrame &aFrame, const Address &aSrcAddr);
 #endif
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
     void ProcessEnhAckProbing(const RxFrame &aFrame, const Neighbor &aNeighbor);

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -102,6 +102,7 @@ void CslTxScheduler::Clear(void)
     {
         child.ResetCslTxAttempts();
         child.SetCslSynchronized(false);
+        child.SetCslPrevSnValid(false);
         child.SetCslChannel(0);
         child.SetCslTimeout(0);
         child.SetCslPeriod(0);
@@ -292,6 +293,7 @@ void CslTxScheduler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, C
         {
             // CSL transmission attempts reach max, consider child out of sync
             aChild.SetCslSynchronized(false);
+            aChild.SetCslPrevSnValid(false);
             aChild.ResetCslTxAttempts();
         }
 

--- a/src/core/thread/csl_tx_scheduler.hpp
+++ b/src/core/thread/csl_tx_scheduler.hpp
@@ -82,6 +82,12 @@ public:
         bool IsCslSynchronized(void) const { return mCslSynchronized && mCslPeriod > 0; }
         void SetCslSynchronized(bool aCslSynchronized) { mCslSynchronized = aCslSynchronized; }
 
+        bool IsCslPrevSnValid(void) const { return mCslPrevSnValid; }
+        void SetCslPrevSnValid(bool aCslPrevSnValid) { mCslPrevSnValid = aCslPrevSnValid; }
+
+        uint8_t GetCslPrevSn(void) const { return mCslPrevSn; }
+        void    SetCslPrevSn(uint8_t aCslPrevSn) { mCslPrevSn = aCslPrevSn; }
+
         uint8_t GetCslChannel(void) const { return mCslChannel; }
         void    SetCslChannel(uint8_t aChannel) { mCslChannel = aChannel; }
 
@@ -101,8 +107,10 @@ public:
         void     SetLastRxTimestamp(uint64_t aLastRxTimestamp) { mLastRxTimestamp = aLastRxTimestamp; }
 
     private:
-        uint8_t  mCslTxAttempts : 7;   ///< Number of CSL triggered tx attempts.
+        uint8_t  mCslTxAttempts : 6;   ///< Number of CSL triggered tx attempts.
         bool     mCslSynchronized : 1; ///< Indicates whether or not the child is CSL synchronized.
+        bool     mCslPrevSnValid : 1;  ///< Indicates whether or not the previous MAC frame sequence number was set.
+        uint8_t  mCslPrevSn;           ///< The previous MAC frame sequence number (for MAC-level frame deduplication).
         uint8_t  mCslChannel;          ///< The channel the device will listen on.
         uint32_t mCslTimeout;          ///< The sync timeout, in seconds.
         uint16_t mCslPeriod; ///< CSL sampled listening period between consecutive channel samples in units of 10


### PR DESCRIPTION
When a frame with CSL IE is retransmitted, the CSL phase must be recalculated, and the frame must be re-secured with a new frame counter. Therefore, the MAC-level deduplication of such a frame should rely on the sequence number rather than the frame counter.

This implements Thread 1.3.0 Spec 4.6.5.1.3.

Remarks:
1. I am not sure if all platforms implement SSED retransmissions correctly as at least OpenThread core doesn't seem to handle this scenario. If a frame with CSL IE is retransmitted without recalculating the CSL phase, the phase may no longer be valid and it may lead to de-synchronization of the parent and the child.

   However, I think that before SSED retransmissions are fixed, the existing routers in the field should have a chance to be updated with a proper deduplication of SSED retransmissions. Otherwise, fixing SSED retransmissions alone may cause more harm than good.

3. The PR is lacking implementation of the following requirement from the spec:
   > If an MLE message is received from the SSED, and that frame is secured and passes security, then 'prevSNValid' SHALL be set to 'False'.

   I am not sure how to interpret that - does it mean that when a frame uses MLE security only then we should set `prevSNValid` to `False`? Any thoughts are welcome :)