### PR TITLE
[netdata] remove unallocated router ID entries on recovery after reset

### DIFF
--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -1319,8 +1319,33 @@ void Leader::HandleNetworkDataRestoredAfterReset(void)
 {
     const PrefixTlv *prefix;
     TlvIterator      tlvIterator(GetTlvsStart(), GetTlvsEnd());
+    Iterator         iterator = kIteratorInit;
+    ChangedFlags     flags;
+    uint16_t         rloc16;
 
     mWaitingForNetDataSync = false;
+
+    // Remove entries in Network Data from any un-allocated Router ID.
+    // This acts as a safeguard against an edge case where the leader
+    // is reset at an inopportune time, such as right after it removed
+    // an allocated router ID and sent MLE advertisement but before it
+    // got the chance to send the updated Network Data to other
+    // routers.
+
+    while (GetNextServer(iterator, rloc16) == kErrorNone)
+    {
+        if (!Get<RouterTable>().IsAllocated(Mle::RouterIdFromRloc16(rloc16)))
+        {
+            // After we `RemoveRloc()` the Network Data gets changed
+            // and the `iterator` will not be valid anymore. So we set
+            // it to `kIteratorInit` to restart the loop.
+
+            RemoveRloc(rloc16, kMatchModeRouterId, flags);
+            iterator = kIteratorInit;
+        }
+    }
+
+    IncrementVersions(flags);
 
     // Synchronize internal 6LoWPAN Context ID Set with the
     // recently obtained Network Data.


### PR DESCRIPTION
This commit updates `HandleNetworkDataRestoredAfterReset()` which is called when a leader device is reset and recovers the Network Data from other routers. With the new code, leader will now check and remove entries in the restored Network Data that are from any currently unallocated router ID.

This change acts as a safeguard against an edge case where the leader is reset at an inopportune time, such as right after it removed an allocated router ID and sent MLE advertisement but before it got the chance to send the updated Network Data to other routers.