### PR TITLE
[tmf] set default snoop cache entry count to 1/16 of total

### DIFF
--- a/src/core/config/tmf.h
+++ b/src/core/config/tmf.h
@@ -57,9 +57,11 @@
  * The maximum number of EID-to-RLOC cache entries that can be used for "snoop optimization" where an entry is created
  * by inspecting a received message.
  *
+ * By default a 1/16 fraction of `OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_ENTRIES` is used.
+ *
  */
 #ifndef OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES
-#define OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES 2
+#define OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES (OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_ENTRIES / 16)
 #endif
 
 /**


### PR DESCRIPTION
This commit sets the default value of the configuration `TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES` to `1/16` of the total number of address cache entries. This ensures that the snoop entries scale with the total number of entries.

~To accommodate this change, the default configuration for the total number of entries on a Border Router is also increased to 273, of which 17 can be used for snoop optimization~.