### PR TITLE
[nat64] enable discovering NAT64 AIL prefix for OpenWRT

### DIFF
--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -150,7 +150,7 @@ target_link_libraries(openthread-posix
 )
 
 option(OT_TARGET_OPENWRT "enable openthread posix for OpenWRT" OFF)
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT OT_TARGET_OPENWRT)
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     target_compile_definitions(ot-posix-config
         INTERFACE "OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE=1"
     )


### PR DESCRIPTION
This PR is associated with [ot-br-posix/pull/2011](https://github.com/openthread/ot-br-posix/pull/2011#issuecomment-1726709515) and [openthread/pull/8065](https://github.com/openthread/openthread/pull/8065).

According to the description of https://github.com/openwrt/openwrt/pull/11559, libanl is already included in the musl c library, so we can turn this option on.

We enable OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE on OpenWrt platform for better experience.