### PR TITLE
[posix] update the default channel masks in the configuration file

### DIFF
--- a/src/posix/platform/openthread.conf.example
+++ b/src/posix/platform/openthread.conf.example
@@ -23,13 +23,12 @@ calibrated_power=11,25,1000,223344
 calibrated_power=26,26,1500,334455
 calibrated_power=26,26,700,445566
 
-
 # The radio supported channel mask that the device is allowed to be on.
 # supported_channel_mask=<RegulatoryDomain>,<ChannelMask>
-supported_channel_mask=ETSI,0x7fff800
-supported_channel_mask=FCC,0x7fff000
+supported_channel_mask=ETSI,0x3fff800
+supported_channel_mask=FCC,0x7fff800
 
 # The radio preferred channel mask that the device prefers to form on.
 # preferred_channel_mask=<RegulatoryDomain>,<ChannelMask>
-preferred_channel_mask=ETSI,0x7fff000
-preferred_channel_mask=FCC,0x7ff7000
+preferred_channel_mask=ETSI,0x1fff800
+preferred_channel_mask=FCC,0x3fff800

--- a/tests/scripts/expect/posix-channel-mask.exp
+++ b/tests/scripts/expect/posix-channel-mask.exp
@@ -43,22 +43,22 @@ send "region US\n"
 expect_line "Done"
 
 send "channel supported\n"
-expect "0x7fff000"
+expect "0x7fff800"
 expect_line "Done"
 
 send "channel preferred\n"
-expect "0x7ff7000"
+expect "0x3fff800"
 expect_line "Done"
 
 send "region WW\n"
 expect_line "Done"
 
 send "channel supported\n"
-expect "0x7fff800"
+expect "0x3fff800"
 expect_line "Done"
 
 send "channel preferred\n"
-expect "0x7fff000"
+expect "0x1fff800"
 expect_line "Done"
 
 dispose_node 1


### PR DESCRIPTION
The default supported channel mask is set to 0x7fff000 in the default configuration file. The dbus client test case sets the channel to 11 which is not valid in the supported channel mask. It causes the CI test failures in https://github.com/openthread/ot-br-posix/pull/2027.

This commit updates the default supported and preferred channel masks in the configuration file to avoid the ot-br-posix CI test failures.