### PR TITLE
[joiner] check for non-zero joiner UDP port before electing a joiner router

### DIFF
--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -261,7 +261,7 @@ void Joiner::HandleDiscoverResult(Mle::DiscoverScanner::ScanResult *aResult)
 {
     VerifyOrExit(mState == kStateDiscover);
 
-    if (aResult != nullptr)
+    if (aResult != nullptr && aResult->mJoinerUdpPort > 0)
     {
         SaveDiscoveredJoinerRouter(*aResult);
     }


### PR DESCRIPTION
An invalid Discovery Response that carries no Joiner UDP Port TLV will be accepted by the joiner, but we shouldn't qualify it as a valid joiner router since we can only open a connection with a non-zero port.