### PR TITLE
[nd6] add `RaFlagsExtOption` and track flags in received RAs

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -725,7 +725,7 @@ private:
             } mShared;
         };
 
-        struct Router
+        struct Router : public Clearable<Router>
         {
             // The timeout (in msec) for router staying in active state
             // before starting the Neighbor Solicitation (NS) probes.
@@ -750,6 +750,9 @@ private:
             LinkedList<Entry> mEntries;
             TimeMilli         mTimeout;
             uint8_t           mNsProbeCount;
+            bool              mManagedAddressConfigFlag : 1;
+            bool              mOtherConfigFlag : 1;
+            bool              mStubRouterFlag : 1;
         };
 
         class Iterator : public PrefixTableIterator
@@ -763,9 +766,10 @@ private:
             void          SetInitTime(void) { mData32 = TimerMilli::GetNow().GetValue(); }
         };
 
-        void         ProcessDefaultRoute(const Ip6::Nd::RouterAdvertMessage::Header &aRaHeader, Router &aRouter);
+        void         ProcessRaHeader(const Ip6::Nd::RouterAdvertMessage::Header &aRaHeader, Router &aRouter);
         void         ProcessPrefixInfoOption(const Ip6::Nd::PrefixInfoOption &aPio, Router &aRouter);
         void         ProcessRouteInfoOption(const Ip6::Nd::RouteInfoOption &aRio, Router &aRouter);
+        void         ProcessRaFlagsExtOption(const Ip6::Nd::RaFlagsExtOption &aFlagsOption, Router &aRouter);
         bool         Contains(const Entry::Checker &aChecker) const;
         void         RemovePrefix(const Entry::Matcher &aMatcher);
         void         RemoveOrDeprecateEntriesFromInactiveRouters(void);

--- a/src/core/net/nd6.cpp
+++ b/src/core/net/nd6.cpp
@@ -171,6 +171,16 @@ uint8_t RouteInfoOption::OptionLengthForPrefix(uint8_t aPrefixLength)
 }
 
 //----------------------------------------------------------------------------------------------------------------------
+// RaFlagsExtOption
+
+void RaFlagsExtOption::Init(void)
+{
+    Clear();
+    SetType(kTypeRaFlagsExtension);
+    SetSize(sizeof(RaFlagsExtOption));
+}
+
+//----------------------------------------------------------------------------------------------------------------------
 // RouterAdverMessage::Header
 
 void RouterAdvertMessage::Header::SetToDefault(void)


### PR DESCRIPTION
This commit adds the `RaFlagsExtOption` class to represent an "RA Flags Extension" Option. It also adds code to `RoutingManager` class to process this option in received RA messages and check whether or not the Stub Router Flag is set. Additionally, it checks and tracks whether or not the `M` (Managed Address) and `O` (Other Config) flags are set in the received RA message's header.

----

Related to [SPEC-1217](https://threadgroup.atlassian.net/browse/SPEC-1217)