### PR TITLE
[spinel] reset `mState` to `kStateDisabled` if recovering from `kStateDisabled`

### DIFF
--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -2115,6 +2115,8 @@ template <typename InterfaceType> void RadioSpinel<InterfaceType>::RecoverFromRc
     switch (recoveringState)
     {
     case kStateDisabled:
+        mState = kStateDisabled;
+        break;
     case kStateSleep:
         break;
     case kStateReceive:


### PR DESCRIPTION
This commit changes openthread rcp recovery code to keep mstate as kStateDisabled if the state before recovery was kStateDisabled. This is needed to avoid otbr-agent crash in the scenario where rcp recovery is triggered before otbr initialization.