### PR TITLE
[wip][nat64] use c-ares impl to replace getaddrinfo_a

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "third_party/c-ares/repo"]
+	path = third_party/c-ares/repo
+	url = https://github.com/c-ares/c-ares.git
+    tag = cares-1_23_0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,8 @@ endif()
 include("${PROJECT_SOURCE_DIR}/etc/cmake/options.cmake")
 include("${PROJECT_SOURCE_DIR}/etc/cmake/functions.cmake")
 
+execute_process(COMMAND git submodule update --init WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
 if(NOT CMAKE_BUILD_TYPE)
     # Check if this is a top-level CMake.
     # If it is not, do not set the CMAKE_BUILD_TYPE because OpenThread is a part of something bigger.

--- a/script/check-arm-build
+++ b/script/check-arm-build
@@ -83,7 +83,11 @@ build_nrf52840()
 
     script/git-tool clone https://github.com/openthread/ot-nrf528xx.git "${OT_TMP_DIR}"
     rm -rf "${OT_TMP_DIR}/openthread/*"
-    git archive "${OT_SHA_NEW}" | tar x -C "${OT_TMP_DIR}/openthread"
+
+    # use git clone to keep git submodule info
+    git clone "$(pwd)" "${OT_TMP_DIR}/openthread"
+    cd "${OT_TMP_DIR}/openthread"
+    git checkout "${OT_SHA_NEW}"
 
     cd "${OT_TMP_DIR}"
     script/build nrf52840 UART_trans "${options[@]}"

--- a/script/check-size
+++ b/script/check-size
@@ -121,7 +121,11 @@ build_nrf52840()
     mkdir -p "${OT_TMP_DIR}/${folder}"
     script/git-tool clone https://github.com/openthread/ot-nrf528xx.git "${OT_TMP_DIR}/${folder}"
     rm -rf "${OT_TMP_DIR}/${folder}/openthread/*" # replace openthread submodule with latest commit
-    git archive "${sha}" | tar x -C "${OT_TMP_DIR}/${folder}/openthread"
+
+    # use git clone to keep git submodule info
+    git clone "$(pwd)" "${OT_TMP_DIR}/${folder}/openthread"
+    cd "${OT_TMP_DIR}/${folder}/openthread"
+    git checkout "${sha}"
 
     if [ ! -e "${OT_TMP_DIR}/${folder}/openthread/examples/config/${config_name}" ]; then
         # Check if the the config headers are not present, copy from
@@ -129,7 +133,9 @@ build_nrf52840()
         case "$1" in
             br)
                 rm -rf "${OT_TMP_DIR}/${folder}/openthread/*"
-                git archive "${OT_SHA_NEW}" | tar x -C "${OT_TMP_DIR}/${folder}/openthread"
+                git clone "$(pwd)" "${OT_TMP_DIR}/${folder}/openthread"
+                cd "${OT_TMP_DIR}/${folder}/openthread"
+                git checkout "${OT_SHA_NEW}"
                 ;;
             *)
                 mkdir -p "${OT_TMP_DIR}/${folder}/openthread/examples/config"
@@ -137,6 +143,8 @@ build_nrf52840()
                 ;;
         esac
     fi
+
+    cd "${OT_TMP_DIR}/${folder}/openthread"
 
     local cur_dir
 

--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -172,11 +172,11 @@ target_link_libraries(openthread-posix
 )
 
 option(OT_TARGET_OPENWRT "enable openthread posix for OpenWRT" OFF)
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT OT_TARGET_OPENWRT)
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     target_compile_definitions(ot-posix-config
         INTERFACE "OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE=1"
     )
-    target_link_libraries(openthread-posix PRIVATE anl)
+    target_link_libraries(openthread-posix PRIVATE c-ares::cares)
 endif()
 
 target_compile_definitions(openthread-posix

--- a/src/posix/platform/infra_if.hpp
+++ b/src/posix/platform/infra_if.hpp
@@ -231,7 +231,7 @@ private:
 
     void        ReceiveNetLinkMessage(void);
     bool        HasLinkLocalAddress(void) const;
-    static void DiscoverNat64PrefixDone(union sigval sv);
+    static void DiscoverNat64PrefixDone(void *arg, int status, int timeouts, struct hostent *host);
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
     void SetInfraNetifIcmp6SocketForBorderRouting(int aIcmp6Socket);
     void ReceiveIcmp6Message(void);

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -26,6 +26,8 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+add_subdirectory(c-ares)
+
 if(NOT OT_EXTERNAL_MBEDTLS)
     add_subdirectory(mbedtls)
 endif()

--- a/third_party/c-ares/.clang-tidy
+++ b/third_party/c-ares/.clang-tidy
@@ -1,0 +1,23 @@
+---
+Checks: >
+  -*,
+  bugprone-argument-comment,
+  bugprone-too-small-loop-variable,
+  google-explicit-constructor,
+  google-readability-casting,
+  misc-unused-using-decls,
+  modernize-loop-convert,
+  modernize-use-bool-literals,
+  modernize-use-equals-default,
+  modernize-use-equals-delete,
+  modernize-use-nullptr,
+  readability-avoid-const-params-in-decls,
+  readability-else-after-return,
+  readability-inconsistent-declaration-parameter-name,
+  readability-make-member-function-const,
+  readability-redundant-control-flow,
+  readability-redundant-member-init,
+  readability-simplify-boolean-expr,
+  readability-static-accessed-through-instance
+WarningsAsErrors: ''
+HeaderFilterRegex: '(examples|include|src).*(?<!third_party.*repo)'

--- a/third_party/c-ares/CMakeLists.txt
+++ b/third_party/c-ares/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(CARES_STATIC ON CACHE BOOL "Build as a static library" FORCE)
+set(CARES_SHARED OFF CACHE BOOL "Build as a shared library" FORCE)
+set(CARES_INSTALL OFF CACHE BOOL "Create installation targets (chain builders may want to disable this)" FORCE)
+set(CARES_STATIC_PIC ON CACHE BOOL "Build the static library as PIC (position independent)" FORCE)
+
+add_subdirectory(repo)
+
+target_compile_options(c-ares 
+    PRIVATE 
+    
+        "-Wno-error"
+        "-Wno-dev"
+)
+
+target_include_directories(c-ares
+    PUBLIC
+    
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/repo>
+    $<INSTALL_INTERFACE:repo>
+)


### PR DESCRIPTION
https://github.com/openthread/ot-br-posix/issues/2033
This commit replaces functions such as `getaddrinfo_a`, which now rely on `glibc`, with a solution from the `c-ares` library to enable asynchronous address parsing functionality for either `glibc` or `musl` libc.

After this commit, the `OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE` functionality should be properly enabled on the OpenWrt platform.

Feel free to give your comments. @jwhui 