### PR TITLE
[routing-manager] new config to use heap for `PrefixTable` entries

### DIFF
--- a/src/core/config/border_routing.h
+++ b/src/core/config/border_routing.h
@@ -46,9 +46,28 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_USE_HEAP_ENABLE
+ *
+ * Define to 1 to allow using heap by Routing Manager.
+ *
+ * When enabled heap allocated entries will be used to track discovered prefix table contain information about
+ * discovered routers and the advertised on-link prefixes on infra link.
+ *
+ * When disabled pre-allocated pools are used instead where max number of entries are specified by
+ * `OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_ROUTERS` and `MAX_DISCOVERED_PREFIXES` configurations.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_USE_HEAP_ENABLE
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_USE_HEAP_ENABLE 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_ROUTERS
  *
  * Specifies maximum number of routers (on infra link) to track by routing manager.
+ *
+ * Applicable only when heap allocation is not used, i.e., `OPENTHREAD_CONFIG_BORDER_ROUTING_USE_HEAP_ENABLE` is
+ * disabled.
  *
  */
 #ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_ROUTERS
@@ -59,6 +78,9 @@
  * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_PREFIXES
  *
  * Specifies maximum number of discovered prefixes (on-link prefixes on the infra link) maintained by routing manager.
+ *
+ * Applicable only when heap allocation is not used, i.e., `OPENTHREAD_CONFIG_BORDER_ROUTING_USE_HEAP_ENABLE` is
+ * disabled.
  *
  */
 #ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_PREFIXES


### PR DESCRIPTION
This commit introduces a new configuration option for the routing manager to use heap-allocated entries in the `DiscoveredPrefixTable`, which maintains a list of discovered routers and their advertised on-link prefixes. This makes the implementation more flexible when dealing with a large number of routers and/or discovered prefix entries.

The config option `OPENTHREAD_CONFIG_BORDER_ROUTING_USE_HEAP_ENABLE` enables this behavior. By default, it is enabled. When disabled, the previous model, which uses pre-allocated arrays and pools, is used instead.

This commit also updates the unit test `test_routing_manager` to track heap allocations and validate that all heap allocations by the routing manager are freed when it is stopped.

-------

- This PR currently contains the commit from https://github.com/openthread/openthread/pull/9448
- This is to avoid fixing conflict later.
- Please check and review the last commit on this PR. Thanks.
