### PR TITLE
[script] exclude `ot_testing` and `__pycache__` when building the OTBR docker

### DIFF
--- a/script/test
+++ b/script/test
@@ -382,6 +382,8 @@ do_build_otbr_docker()
         rm -rf third_party/openthread/repo
         rsync -r \
             --exclude=build \
+            --exclude=ot_testing \
+            --exclude=__pycache__ \
             "${otdir}/." \
             third_party/openthread/repo
         rm -rf .git


### PR DESCRIPTION
This PR excludes `ot_testing` and `__pycache__` directories when copying the files before building the docker.

Such files are usually generated by root user and will cause errors when copying them as a non-root user.