### PR TITLE
Revert "[nat64] enable discovering NAT64 AIL prefix for OpenWRT"

### DIFF
--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -150,7 +150,7 @@ target_link_libraries(openthread-posix
 )
 
 option(OT_TARGET_OPENWRT "enable openthread posix for OpenWRT" OFF)
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT OT_TARGET_OPENWRT)
     target_compile_definitions(ot-posix-config
         INTERFACE "OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE=1"
     )


### PR DESCRIPTION
Reverts openthread/openthread#9441

See https://github.com/openthread/ot-br-posix/issues/2033