### PR TITLE
[address-resolver] set minimum `kMaxNonEvictableSnoopedEntries` to `1`

### DIFF
--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -242,8 +242,9 @@ public:
                           const Ip6::Address             *aDestination);
 
 private:
-    static constexpr uint16_t kCacheEntries                  = OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_ENTRIES;
-    static constexpr uint16_t kMaxNonEvictableSnoopedEntries = OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES;
+    static constexpr uint16_t kCacheEntries = OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_ENTRIES;
+    static constexpr uint16_t kMaxNonEvictableSnoopedEntries =
+        OT_MAX(1, OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES);
 
     // All time/delay values are in seconds
     static constexpr uint16_t kAddressQueryTimeout           = OPENTHREAD_CONFIG_TMF_ADDRESS_QUERY_TIMEOUT;


### PR DESCRIPTION
Resolves issues when `OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_ENTRIES` is too small.

Example: https://github.com/openthread/ot-cc2538/actions/runs/6300278091/job/17102757934