### PR TITLE
[ip6] update where `HandlePayload()` check `message` is not null

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -901,8 +901,10 @@ Error Ip6::HandlePayload(Header            &aIp6Header,
 
     if (aMessageOwnership == Message::kCopyToUse)
     {
-        VerifyOrExit((message = aMessage.Clone()) != nullptr, error = kErrorNoBufs);
+        message = aMessage.Clone();
     }
+
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     switch (aIpProto)
     {


### PR DESCRIPTION
This commit updates `Ip6::HandlePayload()` to check the `message` pointer for null in the common flow, instead of in the `if()` block where the message is cloned when `aMessageOwnership` is set to `kCopyToUse`. If `aMessageOwnership` is `kTakeCustody` the `message` is initialized as `&aMessage` already which cannot be `nullptr`.

This protects against code checker warnings that `message` may remain null if the given `aMessageOwnership` enum value is not one of its two defined enumerator values.