### PR TITLE
[mle] simplify `ProcessRouteTlv()` call in `HandleAdvertisement()`

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1277,33 +1277,7 @@ Error MleRouter::HandleAdvertisement(RxInfo &aRxInfo, uint16_t aSourceAddress, c
 
     if (aRxInfo.IsNeighborStateValid() && mRouterTable.IsRouteTlvIdSequenceMoreRecent(routeTlv))
     {
-        bool processRouteTlv = false;
-
-        if (IsChild())
-        {
-            if (aSourceAddress == mParent.GetRloc16())
-            {
-                processRouteTlv = true;
-            }
-            else
-            {
-                router = mRouterTable.FindRouterById(routerId);
-
-                if (router != nullptr && router->IsStateValid())
-                {
-                    processRouteTlv = true;
-                }
-            }
-        }
-        else // Device is router or leader
-        {
-            processRouteTlv = true;
-        }
-
-        if (processRouteTlv)
-        {
-            SuccessOrExit(error = ProcessRouteTlv(routeTlv, aRxInfo));
-        }
+        SuccessOrExit(error = ProcessRouteTlv(routeTlv, aRxInfo));
     }
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This commit simplifies the checks to decide whether or not to call `ProcessRouteTlv()` in `MleRouter::HandleAdvertisement()`. The whole check is guarded by `aRxInfo.IsNeighborStateValid()`, which ensures that we only process Route TLVs for Advertisements received from valid neighbors. In particular, we can remove the additional checks in the case where the device is itself `IsChild()` (i.e., acting as an FED). In this case, `aRxInfo.mNeighbor` will be determined using `NeighborTable::FindNeighbor()`, which checks and accepts the parent as the only valid neighbor of the FED child.