### PR TITLE
[netif] skip processing netlink address add events after interface is disabled

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -1251,6 +1251,15 @@ static void processNetifAddrEvent(otInstance *aInstance, struct rt_msghdr *rtm)
 
     addr6.sin6_family   = 0;
     netmask.sin6_family = 0;
+    // Skip processing RTM_NEWADDR or RTM_NEWMADDR after interface disabled
+    if (false == otIp6IsEnabled(aInstance))
+    {
+        if ((rtm->rtm_type == RTM_NEWADDR) || (rtm->rtm_type == RTM_NEWMADDR))
+        {
+            error = OT_ERROR_NONE;
+            goto exit;
+        }
+    }
 
     if ((rtm->rtm_type == RTM_NEWADDR) || (rtm->rtm_type == RTM_DELADDR))
     {

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -1252,7 +1252,7 @@ static void processNetifAddrEvent(otInstance *aInstance, struct rt_msghdr *rtm)
     addr6.sin6_family   = 0;
     netmask.sin6_family = 0;
     // Skip processing RTM_NEWADDR or RTM_NEWMADDR after interface disabled
-    if (false == otIp6IsEnabled(aInstance))
+    if (!otIp6IsEnabled(aInstance))
     {
         if ((rtm->rtm_type == RTM_NEWADDR) || (rtm->rtm_type == RTM_NEWMADDR))
         {


### PR DESCRIPTION
In back-to-back thread start and thread stop stress tests, the netlink address add events are getting handled after interface down causing addresses not getting cleaned up. 