### PR TITLE
[bbr-local] simplify `AddService()` and its use

### DIFF
--- a/src/core/api/backbone_router_ftd_api.cpp
+++ b/src/core/api/backbone_router_ftd_api.cpp
@@ -69,7 +69,7 @@ otError otBackboneRouterSetConfig(otInstance *aInstance, const otBackboneRouterC
 
 otError otBackboneRouterRegister(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<BackboneRouter::Local>().AddService(true /* Force registration */);
+    return AsCoreType(aInstance).Get<BackboneRouter::Local>().AddService(BackboneRouter::Local::kForceRegistration);
 }
 
 uint8_t otBackboneRouterGetRegistrationJitter(otInstance *aInstance)

--- a/src/core/backbone_router/bbr_local.hpp
+++ b/src/core/backbone_router/bbr_local.hpp
@@ -85,6 +85,16 @@ public:
     };
 
     /**
+     * Represents registration mode used as input to `AddService()` method.
+     *
+     */
+    enum RegisterMode : uint8_t
+    {
+        kDecideBasedOnState, ///< Decide based on current state.
+        kForceRegistration,  ///< Force registration regardless of current state.
+    };
+
+    /**
      * Initializes the local Backbone Router.
      *
      * @param[in] aInstance  A reference to the OpenThread instance.
@@ -137,16 +147,14 @@ public:
     /**
      * Registers Backbone Router Dataset to Leader.
      *
-     * @param[in]  aForce True to force registration regardless of current state.
-     *                    False to decide based on current state.
-     *
+     * @param[in]  aMode  The registration mode to use (decide based on current state or force registration).
      *
      * @retval kErrorNone            Successfully added the Service entry.
      * @retval kErrorInvalidState    Not in the ready state to register.
      * @retval kErrorNoBufs          Insufficient space to add the Service entry.
      *
      */
-    Error AddService(bool aForce = false);
+    Error AddService(RegisterMode aMode);
 
     /**
      * Indicates whether or not the Backbone Router is Primary.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1550,14 +1550,7 @@ void MleRouter::HandleTimeTick(void)
 
         if (mBackboneRouterRegistrationDelay == 0)
         {
-            // If no Backbone Router service after jitter, try to register its own Backbone Router Service.
-            if (!Get<BackboneRouter::Leader>().HasPrimary())
-            {
-                if (Get<BackboneRouter::Local>().AddService() == kErrorNone)
-                {
-                    Get<NetworkData::Notifier>().HandleServerDataUpdated();
-                }
-            }
+            IgnoreError(Get<BackboneRouter::Local>().AddService(BackboneRouter::Local::kDecideBasedOnState));
         }
     }
 #endif


### PR DESCRIPTION
This commit contains smaller changes in `BackbonRouter::Local`:

- `AddService()` now gets a `RegisterationMode` enum as its input either decide based on current state or force registration.
- We remove the `NetworkData::Notifier::HandleServerDataUpdated()` calls after calling `AddService()` since `AddService()` method itself will already call this (when successfully adds the service to Network Data)
- We also remove the extra state check before calling `AddService()` as it is done by the `AddService()` method itself.