### PR TITLE
[mle] simplify reattach on losing connectivity to leader

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1378,8 +1378,7 @@ Error Mle::DetermineParentRequestType(ParentRequestType &aType) const
         // During reattach to the same partition all the Parent
         // Request are sent to Routers and REEDs.
 
-        if ((mAttachMode != kSamePartition) && (mAttachMode != kSamePartitionRetry) &&
-            (mParentRequestCounter <= kFirstAttachCycleNumParentRequestToRouters))
+        if ((mAttachMode != kSamePartition) && (mParentRequestCounter <= kFirstAttachCycleNumParentRequestToRouters))
         {
             aType = kToRouters;
         }
@@ -1621,10 +1620,6 @@ uint32_t Mle::Reattach(void)
         break;
 
     case kSamePartition:
-        Attach(kSamePartitionRetry);
-        break;
-
-    case kSamePartitionRetry:
     case kDowngradeToReed:
         Attach(kAnyPartition);
         break;
@@ -3224,7 +3219,6 @@ void Mle::HandleParentResponse(RxInfo &aRxInfo)
             break;
 
         case kSamePartition:
-        case kSamePartitionRetry:
             VerifyOrExit(isPartitionIdSame && isIdSequenceGreater);
             break;
 
@@ -4263,20 +4257,18 @@ const char *Mle::MessageTypeActionToSuffixString(MessageType aType, MessageActio
 const char *Mle::AttachModeToString(AttachMode aMode)
 {
     static const char *const kAttachModeStrings[] = {
-        "AnyPartition",       // (0) kAnyPartition
-        "SamePartition",      // (1) kSamePartition
-        "SamePartitionRetry", // (2) kSamePartitionRetry
-        "BetterPartition",    // (3) kBetterPartition
-        "DowngradeToReed",    // (4) kDowngradeToReed
-        "BetterParent",       // (5) kBetterParent
+        "AnyPartition",    // (0) kAnyPartition
+        "SamePartition",   // (1) kSamePartition
+        "BetterPartition", // (2) kBetterPartition
+        "DowngradeToReed", // (3) kDowngradeToReed
+        "BetterParent",    // (4) kBetterParent
     };
 
     static_assert(kAnyPartition == 0, "kAnyPartition value is incorrect");
     static_assert(kSamePartition == 1, "kSamePartition value is incorrect");
-    static_assert(kSamePartitionRetry == 2, "kSamePartitionRetry value is incorrect");
-    static_assert(kBetterPartition == 3, "kBetterPartition value is incorrect");
-    static_assert(kDowngradeToReed == 4, "kDowngradeToReed value is incorrect");
-    static_assert(kBetterParent == 5, "kBetterParent value is incorrect");
+    static_assert(kBetterPartition == 2, "kBetterPartition value is incorrect");
+    static_assert(kDowngradeToReed == 3, "kDowngradeToReed value is incorrect");
+    static_assert(kBetterParent == 4, "kBetterParent value is incorrect");
 
     return kAttachModeStrings[aMode];
 }

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -813,12 +813,11 @@ private:
 
     enum AttachMode : uint8_t
     {
-        kAnyPartition,       // Attach to any Thread partition.
-        kSamePartition,      // Attach to the same Thread partition (attempt 1 when losing connectivity).
-        kSamePartitionRetry, // Attach to the same Thread partition (attempt 2 when losing connectivity).
-        kBetterPartition,    // Attach to a better (i.e. higher weight/partition id) Thread partition.
-        kDowngradeToReed,    // Attach to the same Thread partition during downgrade process.
-        kBetterParent,       // Attach to a better parent.
+        kAnyPartition,    // Attach to any Thread partition.
+        kSamePartition,   // Attach to the same Thread partition (when losing connectivity).
+        kBetterPartition, // Attach to a better (i.e. higher weight/partition id) Thread partition.
+        kDowngradeToReed, // Attach to the same Thread partition during downgrade process.
+        kBetterParent,    // Attach to a better parent.
     };
 
     enum AttachState : uint8_t

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -360,7 +360,6 @@ void MleRouter::HandleChildStart(AttachMode aMode)
         break;
 
     case kSamePartition:
-    case kSamePartitionRetry:
         if (HasChildren())
         {
             IgnoreError(BecomeRouter(ThreadStatusTlv::kHaveChildIdRequest));


### PR DESCRIPTION
This commit updates the attach process to the same partition after a router/REED losing connectivity to the leader. It removes the `kSamePartitionRetry` enumerator from `AttachMode`. With this change, after trying to attach using `kSamePartition` attach mode (with a total of six Parent Request attempts to Routers and REEDs), the device will switch to `kAnyPartition` attach mode. This helps to reduce the total number of attempts before the device can decide to take the leader role.

----

- Related to [disc#9478](https://github.com/orgs/openthread/discussions/9478) and [SPEC-1036](https://threadgroup.atlassian.net/browse/SPEC-1036).