### PR TITLE
[github-actions] fix the `codespell` version in `spell-check` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Bootstrap
       run: |
           python -m pip install --upgrade pip
-          pip install codespell
+          pip install --force-reinstall codespell==2.2.4
     - name: Check
       run: |
         script/code-spell check


### PR DESCRIPTION
This commit fixes the version of `codespell` installed in the `spell-check` job of `build` workflow to version `2.2.4`.

----

- Addresses https://github.com/openthread/openthread/issues/9480