### PR TITLE
[mle] handle received Advertisements from `RxOnlyNeighbor` on FED

### DIFF
--- a/src/core/radio/trel_interface.cpp
+++ b/src/core/radio/trel_interface.cpp
@@ -324,15 +324,9 @@ Interface::Peer *Interface::GetNewPeerEntry(void)
         }
 
 #if OPENTHREAD_FTD
+        if (Get<NeighborTable>().FindRxOnlyNeighborRouter(entry.GetExtAddress()) != nullptr)
         {
-            Mac::Address macAddress;
-
-            macAddress.SetExtended(entry.GetExtAddress());
-
-            if (Get<NeighborTable>().FindRxOnlyNeighborRouter(macAddress) != nullptr)
-            {
-                continue;
-            }
+            continue;
         }
 #endif
 

--- a/src/core/thread/neighbor_table.cpp
+++ b/src/core/thread/neighbor_table.cpp
@@ -167,6 +167,15 @@ exit:
     return neighbor;
 }
 
+Neighbor *NeighborTable::FindRxOnlyNeighborRouter(const Mac::ExtAddress &aExtAddress)
+{
+    Mac::Address macAddress;
+
+    macAddress.SetExtended(aExtAddress);
+
+    return FindRxOnlyNeighborRouter(macAddress);
+}
+
 Neighbor *NeighborTable::FindRxOnlyNeighborRouter(const Mac::Address &aMacAddress)
 {
     Neighbor *neighbor = nullptr;

--- a/src/core/thread/neighbor_table.hpp
+++ b/src/core/thread/neighbor_table.hpp
@@ -181,6 +181,17 @@ public:
      * Searches in the neighbor table to find a `Neighbor` for which a one-way link is maintained (as in the
      * case of an FTD child with neighbor routers).
      *
+     * @param[in]  aExtAddress  An Extended address.
+     *
+     * @returns A pointer to the Neighbor corresponding to @p aExtAddress, `nullptr` otherwise.
+     *
+     */
+    Neighbor *FindRxOnlyNeighborRouter(const Mac::ExtAddress &aExtAddress);
+
+    /**
+     * Searches in the neighbor table to find a `Neighbor` for which a one-way link is maintained (as in the
+     * case of an FTD child with neighbor routers).
+     *
      * @param[in]  aMacAddress  A MAC address.
      *
      * @returns A pointer to the Neighbor corresponding to @p aMacAddress, `nullptr` otherwise.


### PR DESCRIPTION
This commit updates `Mle` class such that on an FED (FTD child) when an MLE message is received, we use `FindRxOnlyNeighborRouter()` in addition to `FindNeighbor()` before performing security check. This ensures that the key sequence and frame counters are validated for all messages from rx-only neighbors.

After security check and before calling `Handle{MleCommand}()` we clear the `neighbor` if it is a rx-only except for a subset of MLE messages such as MLE Advertisement. This ensures that, as an FED, we are selective about which messages to process from rx-only neighbors.

This commit also adds a new flavor of `FindRxOnlyNeighborRouter()` that accepts an `Mac::ExtAddress` as its input parameter.