### PR TITLE
[routing-manager] include Stub Router flag in emitted RAs by BR

### DIFF
--- a/src/core/config/border_routing.h
+++ b/src/core/config/border_routing.h
@@ -127,6 +127,17 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_STUB_ROUTER_FLAG_IN_EMITTED_RA_ENABLE
+ *
+ * Define to 1 so for the routing manager to include the Flags Extension Option with Stub Router flag in the emitted
+ * Router Advertisement messages from this Border Router.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_STUB_ROUTER_FLAG_IN_EMITTED_RA_ENABLE
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_STUB_ROUTER_FLAG_IN_EMITTED_RA_ENABLE 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
  *
  * Specifies whether to support handling platform generated ND messages.

--- a/src/core/net/nd6.cpp
+++ b/src/core/net/nd6.cpp
@@ -269,7 +269,7 @@ exit:
     return error;
 }
 
-Error RouterAdvertMessage::AppendFlagsExtensionOption(bool aStubsRouterFlag)
+Error RouterAdvertMessage::AppendFlagsExtensionOption(bool aStubRouterFlag)
 {
     Error             error = kErrorNone;
     RaFlagsExtOption *flagsOption;
@@ -279,7 +279,7 @@ Error RouterAdvertMessage::AppendFlagsExtensionOption(bool aStubsRouterFlag)
 
     flagsOption->Init();
 
-    if (aStubsRouterFlag)
+    if (aStubRouterFlag)
     {
         flagsOption->SetStubRouterFlag();
     }

--- a/src/core/net/nd6.cpp
+++ b/src/core/net/nd6.cpp
@@ -269,6 +269,25 @@ exit:
     return error;
 }
 
+Error RouterAdvertMessage::AppendFlagsExtensionOption(bool aStubsRouterFlag)
+{
+    Error             error = kErrorNone;
+    RaFlagsExtOption *flagsOption;
+
+    flagsOption = static_cast<RaFlagsExtOption *>(AppendOption(sizeof(RaFlagsExtOption)));
+    VerifyOrExit(flagsOption != nullptr, error = kErrorNoBufs);
+
+    flagsOption->Init();
+
+    if (aStubsRouterFlag)
+    {
+        flagsOption->SetStubRouterFlag();
+    }
+
+exit:
+    return error;
+}
+
 //----------------------------------------------------------------------------------------------------------------------
 // RouterSolicitMessage
 

--- a/src/core/net/nd6.hpp
+++ b/src/core/net/nd6.hpp
@@ -770,7 +770,7 @@ public:
      * @retval kErrorNoBufs  No more space in the buffer to append the option.
      *
      */
-    Error AppendFlagsExtensionOption(bool aStubsRouterFlag);
+    Error AppendFlagsExtensionOption(bool aStubRouterFlag);
 
     /**
      * Indicates whether or not the RA message contains any options.

--- a/src/core/net/nd6.hpp
+++ b/src/core/net/nd6.hpp
@@ -762,6 +762,17 @@ public:
     Error AppendRouteInfoOption(const Prefix &aPrefix, uint32_t aRouteLifetime, RoutePreference aPreference);
 
     /**
+     * Appends a Flags Extension Option to the RA message.
+     *
+     * @param[in] aStubRouterFlag    The stub router flag.
+     *
+     * @retval kErrorNone    Option is appended successfully.
+     * @retval kErrorNoBufs  No more space in the buffer to append the option.
+     *
+     */
+    Error AppendFlagsExtensionOption(bool aStubsRouterFlag);
+
+    /**
      * Indicates whether or not the RA message contains any options.
      *
      * @retval TRUE   If the RA message contains at least one option.

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -449,6 +449,17 @@ void ValidateRouterAdvert(const Icmp6Packet &aPacket)
             break;
         }
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_STUB_ROUTER_FLAG_IN_EMITTED_RA_ENABLE
+        case Ip6::Nd::Option::kTypeRaFlagsExtension:
+        {
+            const Ip6::Nd::RaFlagsExtOption &flagsOption = static_cast<const Ip6::Nd::RaFlagsExtOption &>(option);
+
+            VerifyOrQuit(flagsOption.IsValid());
+            VerifyOrQuit(flagsOption.IsStubRouterFlagSet());
+            break;
+        }
+#endif
+
         default:
             VerifyOrQuit(false, "Unexpected option type in RA msg");
         }
@@ -542,6 +553,15 @@ void LogRouterAdvert(const Icmp6Packet &aPacket)
             rio.GetPrefix(prefix);
             Log("     RIO - %s, prf:%s, lifetime:%u", prefix.ToString().AsCString(),
                 PreferenceToString(rio.GetPreference()), rio.GetRouteLifetime());
+            break;
+        }
+
+        case Ip6::Nd::Option::kTypeRaFlagsExtension:
+        {
+            const Ip6::Nd::RaFlagsExtOption &flagsOption = static_cast<const Ip6::Nd::RaFlagsExtOption &>(option);
+
+            VerifyOrQuit(flagsOption.IsValid());
+            Log("     FlagsExt - StubRouter:%u", flagsOption.IsStubRouterFlagSet());
             break;
         }
 


### PR DESCRIPTION
This commit updates `RoutingManager` to include the Flags Extension Option with Stub Router flag in its emitted Router Advertisement messages.

Config `STUB_ROUTER_FLAG_IN_EMITTED_RA_ENABLE` can be used to enable or disable this behavior which is enabled by default.