### PR TITLE
[cli] update `ip6addr -v` to include more info about address

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1549,13 +1549,19 @@ fe80:0:0:0:f3d9:2a82:c8d8:fe43
 Done
 ```
 
-Use `-v` to get more verbose information about the address.
+Use `-v` to get more verbose information about the address:
+
+- `origin`: can be `thread`, `slaac`, `dhcp6`, or `manual`, and indicates the origin of the address
+- `plen`: prefix length (in bits)
+- `preferred`: preferred flag (boolean)
+- `valid`: valid flag (boolean)
 
 ```bash
 > ipaddr -v
-fdde:ad00:beef:0:0:ff:fe00:0 origin:thread
-fdde:ad00:beef:0:558:f56b:d688:799 origin:thread
-fe80:0:0:0:f3d9:2a82:c8d8:fe43 origin:thread
+fd5e:18fa:f4a5:b8:0:ff:fe00:fc00 origin:thread plen:64 preferred:0 valid:1
+fd5e:18fa:f4a5:b8:0:ff:fe00:dc00 origin:thread plen:64 preferred:0 valid:1
+fd5e:18fa:f4a5:b8:f8e:5d95:87a0:e82c origin:thread plen:64 preferred:0 valid:1
+fe80:0:0:0:4891:b191:e277:8826 origin:thread plen:64 preferred:1 valid:1
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3125,13 +3125,18 @@ template <> otError Interpreter::Process<Cmd("ipaddr")>(Arg aArgs[])
      * @endcode
      * @code
      * ipaddr -v
-     * fdde:ad00:beef:0:0:ff:fe00:0 origin:thread
-     * fdde:ad00:beef:0:558:f56b:d688:799 origin:thread
-     * fe80:0:0:0:f3d9:2a82:c8d8:fe43 origin:thread
+     * fd5e:18fa:f4a5:b8:0:ff:fe00:fc00 origin:thread plen:64 preferred:0 valid:1
+     * fd5e:18fa:f4a5:b8:0:ff:fe00:dc00 origin:thread plen:64 preferred:0 valid:1
+     * fd5e:18fa:f4a5:b8:f8e:5d95:87a0:e82c origin:thread plen:64 preferred:0 valid:1
+     * fe80:0:0:0:4891:b191:e277:8826 origin:thread plen:64 preferred:1 valid:1
      * Done
      * @endcode
      * @cparam ipaddr [@ca{-v}]
-     * Use `-v` to get verbose IP Address information.
+     * Use `-v` to get more verbose information about the address:
+     * - `origin`: can be `thread`, `slaac`, `dhcp6`, `manual` and indicates the origin of the address
+     * - `plen`: prefix length
+     * - `preferred`: preferred flag (boolean)
+     * - `valid`: valid flag (boolean)
      * @par api_copy
      * #otIp6GetUnicastAddresses
      */
@@ -3145,7 +3150,8 @@ template <> otError Interpreter::Process<Cmd("ipaddr")>(Arg aArgs[])
 
             if (verbose)
             {
-                OutputFormat(" origin:%s", AddressOriginToString(addr->mAddressOrigin));
+                OutputFormat(" origin:%s plen:%u preferred:%u valid:%u", AddressOriginToString(addr->mAddressOrigin),
+                             addr->mPrefixLength, addr->mPreferred, addr->mValid);
             }
 
             OutputNewLine();


### PR DESCRIPTION
This commit updates the `ip6addr -v` CLI command to provide more information about each address including origin, prefix length, and preferred and valid flags.