### PR TITLE
[crypto-platform] fix build issue with mbedtls v3.5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       with:
         repository: ARMmbed/mbedtls
-        ref: v3.2.1
+        ref: v3.5.0
         path: third_party/mbedtls/repo
     - name: Build
       run: |

--- a/src/core/crypto/crypto_platform.cpp
+++ b/src/core/crypto/crypto_platform.cpp
@@ -724,15 +724,19 @@ OT_TOOL_WEAK void otPlatCryptoPbkdf2GenerateKey(const uint8_t *aPassword,
                                                 uint16_t       aKeyLen,
                                                 uint8_t       *aKey)
 {
+#if (MBEDTLS_VERSION_NUMBER >= 0x03050000)
+    const size_t kBlockSize = MBEDTLS_CMAC_MAX_BLOCK_SIZE;
+#else
     const size_t kBlockSize = MBEDTLS_CIPHER_BLKSIZE_MAX;
-    uint8_t      prfInput[OT_CRYPTO_PBDKF2_MAX_SALT_SIZE + 4]; // Salt || INT(), for U1 calculation
-    long         prfOne[kBlockSize / sizeof(long)];
-    long         prfTwo[kBlockSize / sizeof(long)];
-    long         keyBlock[kBlockSize / sizeof(long)];
-    uint32_t     blockCounter = 0;
-    uint8_t     *key          = aKey;
-    uint16_t     keyLen       = aKeyLen;
-    uint16_t     useLen       = 0;
+#endif
+    uint8_t  prfInput[OT_CRYPTO_PBDKF2_MAX_SALT_SIZE + 4]; // Salt || INT(), for U1 calculation
+    long     prfOne[kBlockSize / sizeof(long)];
+    long     prfTwo[kBlockSize / sizeof(long)];
+    long     keyBlock[kBlockSize / sizeof(long)];
+    uint32_t blockCounter = 0;
+    uint8_t *key          = aKey;
+    uint16_t keyLen       = aKeyLen;
+    uint16_t useLen       = 0;
 
     OT_ASSERT(aSaltLen <= sizeof(prfInput));
     memcpy(prfInput, aSalt, aSaltLen);

--- a/third_party/mbedtls/mbedtls-config.h
+++ b/third_party/mbedtls/mbedtls-config.h
@@ -144,6 +144,12 @@
 #include MBEDTLS_USER_CONFIG_FILE
 #endif
 
+#include "mbedtls/version.h"
+// Include in the legacy config name adjustment file for mbedtls >= 3.5.0
+#if (MBEDTLS_VERSION_NUMBER >= 0x03050000)
+    #include "mbedtls/config_adjust_legacy_crypto.h"
+#endif
+
 #include "mbedtls/check_config.h"
 
 #endif /* MBEDTLS_CONFIG_H */


### PR DESCRIPTION
As per the mbedTLS v3.5.0 release notes:

Ref: https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.5.0


`MBEDTLS_CIPHER_BLKSIZE_MAX is deprecated in favor of MBEDTLS_MAX_BLOCK_LENGTH (if you intended what the name suggests: maximum size of any supported block cipher) or the new name MBEDTLS_CMAC_MAX_BLOCK_SIZE (if you intended the actual semantics: maximum size of a block cipher supported by the CMAC module).`


This commit fixes the build issue keeping the backward compatibility intact.