### PR TITLE
[ping-sender] allow setting multicast loop

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (363)
+#define OPENTHREAD_API_VERSION (364)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ping_sender.h
+++ b/include/openthread/ping_sender.h
@@ -120,6 +120,7 @@ typedef struct otPingSenderConfig
                                   ///< Zero to use default.
     uint8_t mHopLimit;            ///< Hop limit (used if `mAllowZeroHopLimit` is false). Zero for default.
     bool    mAllowZeroHopLimit;   ///< Indicates whether hop limit is zero.
+    bool    mMulticastLoop;       ///< Allow looping back pings to multicast address that device is subscribed to.
 } otPingSenderConfig;
 
 /**

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -89,7 +89,7 @@ Done
 - [parent](#parent)
 - [parentpriority](#parentpriority)
 - [partitionid](#partitionid)
-- [ping](#ping-async--i-source-ipaddr-size-count-interval-hoplimit-timeout)
+- [ping](#ping-async--i-source--m-ipaddr-size-count-interval-hoplimit-timeout)
 - [platform](#platform)
 - [pollperiod](#pollperiod-pollperiod)
 - [preferrouterid](#preferrouterid-routerid)
@@ -2728,12 +2728,13 @@ Set the preferred Thread Leader Partition ID.
 Done
 ```
 
-### ping \[async\] \[-I source\] \<ipaddr\> \[size\] \[count\] \[interval\] \[hoplimit\] \[timeout\]
+### ping \[async\] \[-I source\] \[-m] \<ipaddr\> \[size\] \[count\] \[interval\] \[hoplimit\] \[timeout\]
 
 Send an ICMPv6 Echo Request.
 
 - async: Use the non-blocking mode. New commands are allowed before the ping process terminates.
 - source: The source IPv6 address of the echo request.
+- -m: multicast loop, which allows looping back pings to multicast addresses that the device itself is subscribed to.
 - size: The number of data bytes to be sent.
 - count: The number of ICMPv6 Echo Requests to be sent.
 - interval: The interval between two consecutive ICMPv6 Echo Requests in seconds. The value may have fractional form, for example `0.5`.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -6019,13 +6019,16 @@ void Interpreter::HandlePingStatistics(const otPingSenderStatistics *aStatistics
  * 1 packets transmitted, 1 packets received. Packet loss = 0.0%. Round-trip min/avg/max = 0/0.0/0 ms.
  * Done
  * @endcode
- * @cparam ping [@ca{async}] [@ca{-I source}] @ca{ipaddrc} [@ca{size}] [@ca{count}] <!--
+ * @cparam ping [@ca{async}] [@ca{-I source}] [@ca{-m}] @ca{ipaddrc} [@ca{size}] [@ca{count}] <!--
  * -->          [@ca{interval}] [@ca{hoplimit}] [@ca{timeout}]
  * @par
  * Send an ICMPv6 Echo Request.
  * @par
  * The address can be an IPv4 address, which will be synthesized to an IPv6 address using the preferred NAT64 prefix
  * from the network data.
+ * @par
+ * The optional `-m` flag sets the multicast loop flag, which allows looping back pings to multicast addresses that the
+ * device itself is subscribed to.
  * @par
  * Note: The command will return InvalidState when the preferred NAT64 prefix is unavailable.
  * @sa otPingSenderPing
@@ -6083,6 +6086,12 @@ template <> otError Interpreter::Process<Cmd("ping")>(Arg aArgs[])
 #endif
 
         aArgs += 2;
+    }
+
+    if (aArgs[0] == "-m")
+    {
+        config.mMulticastLoop = true;
+        aArgs++;
     }
 
     SuccessOrExit(error = ParseToIp6Address(GetInstancePtr(), aArgs[0], config.mDestination, nat64SynthesizedAddress));

--- a/src/core/utils/ping_sender.cpp
+++ b/src/core/utils/ping_sender.cpp
@@ -134,6 +134,7 @@ void PingSender::SendPing(void)
     messageInfo.SetPeerAddr(mConfig.GetDestination());
     messageInfo.mHopLimit          = mConfig.mHopLimit;
     messageInfo.mAllowZeroHopLimit = mConfig.mAllowZeroHopLimit;
+    messageInfo.mMulticastLoop     = mConfig.mMulticastLoop;
 
     message = Get<Ip6::Icmp>().NewMessage();
     VerifyOrExit(message != nullptr);


### PR DESCRIPTION
This commit updates `PingSender` and its config to include a `mMulticastLoop` flag and allow the caller to set this flag. When set, multicast ping echo request messages are looped back and received by the device itself if it is subscribed to the same address. The `ping` CLI command is also updated to allow setting this flag.

This commit also updates `test-008-multicast-traffic.py` to add new test cases to cover the multicast loop flag behavior (pinging with or without this flag). In particular, it covers when the ping destination is a realm-local multicast address and when it is a larger-than-realm-local multicast address (where the `ot::Ip6` module would use a tunnel header for forwarding the message).