### PR TITLE
[posix] support setting the ICMPv6 socket on infra netif

### DIFF
--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -242,6 +242,14 @@ typedef struct otSysInfraNetIfAddressCounters
  */
 void otSysCountInfraNetifAddresses(otSysInfraNetIfAddressCounters *aAddressCounters);
 
+/**
+ * This function sets the ICMPv6 socket on the infrastructure network interface.
+ *
+ * @param[in] aFd  The file descriptor of the ICMPv6 socket on the infrastructure network interface.
+ *
+ */
+void otSysInfraNetifSetIcmp6Socket(int aFd);
+
 #ifdef __cplusplus
 } // end of extern "C"
 #endif

--- a/src/posix/platform/infra_if.hpp
+++ b/src/posix/platform/infra_if.hpp
@@ -168,6 +168,14 @@ public:
     const char *GetNetifName(void) const { return (mInfraIfIndex != 0) ? mInfraIfName : nullptr; }
 
     /**
+     * Sets the ICMPv6 socket on the infrastructure network interface.
+     *
+     * @param[in] aFd  The file descriptor of the ICMPv6 socket.
+     *
+     */
+    void SetIcmp6Socket(int aFd);
+
+    /**
      * Gets the infrastructure network interface singleton.
      *
      * @returns The singleton object.

--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -420,4 +420,17 @@
 #ifndef OPENTHREAD_POSIX_CONFIG_RCP_TIME_SYNC_INTERVAL
 #define OPENTHREAD_POSIX_CONFIG_RCP_TIME_SYNC_INTERVAL (60 * 1000 * 1000)
 #endif
+
+/**
+ * @def OPENTHREAD_POSIX_CONFIG_CREATE_ICMP6_SOCKET_ON_INFRA_IF
+ *
+ * Defines whether to create the ICMPv6 socket on infrastructure network interface.
+ * If not, OpenThread depends on the otSysInfraNetifSetIcmp6Socket() API to get an ICMPv6
+ * socket to support border routing.
+ *
+ */
+#ifndef OPENTHREAD_POSIX_CONFIG_CREATE_ICMP6_SOCKET_ON_INFRA_IF
+#define OPENTHREAD_POSIX_CONFIG_CREATE_ICMP6_SOCKET_ON_INFRA_IF 1
+#endif
+
 #endif // OPENTHREAD_PLATFORM_CONFIG_H_


### PR DESCRIPTION
This PR introduces a new API `otSysInfraNetifSetIcmp6Socket` which specifies the ICMPv6 socket for `ot::Posix::InfraNetIf` to use. 

On Android, the OpenThread process may not have the permission to create a `SOCK_RAW` socket for sending/receiving ICMPv6 messages. In such a case a more privileged process can create such a socket and share it with OpenThread process via this API.

Because the `mInfraIfIcmp6Socket` may be invalid during lifetime of `ot::Posix::InfraNetIf`, this PR also looses some checks in `src/posix/platform/infra_if.cpp`.