### PR TITLE
[spinel] expose RestoreProperties as a public method within RadioSpinel

### DIFF
--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -895,6 +895,14 @@ public:
      */
     static otError SpinelStatusToOtError(spinel_status_t aStatus);
 
+#if OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
+    /**
+     * Restore the properties of Radio Co-processor (RCP).
+     *
+     */
+    void RestoreProperties(void);
+#endif
+
 private:
     enum
     {
@@ -1003,9 +1011,6 @@ private:
     void HandleRcpTimeout(void);
     void RecoverFromRcpFailure(void);
 
-#if OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
-    void RestoreProperties(void);
-#endif
     void UpdateParseErrorCount(otError aError)
     {
         mRadioSpinelMetrics.mSpinelParseErrorCount += (aError == OT_ERROR_PARSE) ? 1 : 0;


### PR DESCRIPTION
When running border routers, users have the option to perform RCP firmware updates. After completing the update, users prefer not to restart or reinitialize the master device but only want to restart and restore the RCP device.

Restarting can be initiated by the user; for example, they can restart the RCP device by triggering the reset pin. However, after this restart is done, certain RCP information needs to be restored, such as the panid and extended address.

Typically, the master device can restore the RCP by triggering `RecoverFromRcpFailure`, but this behavior is not user-controllable. So there's a need to implement a callable API for RCP restoration.

If the `RestoreProperties` is made public, users can actively restore the RCP by calling it and some other public functions.