### PR TITLE
[message] add `IsOrigin{}()` helper methods

### DIFF
--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -211,7 +211,7 @@ otError otCoapSendRequestBlockWiseWithParameters(otInstance                 *aIn
     Error                     error;
     const Coap::TxParameters &txParameters = Coap::TxParameters::From(aTxParameters);
 
-    VerifyOrExit(AsCoreType(aMessage).GetOrigin() != Message::kOriginThreadNetif, error = kErrorInvalidArgs);
+    VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
     if (aTxParameters != nullptr)
     {
@@ -238,7 +238,7 @@ otError otCoapSendRequestWithParameters(otInstance               *aInstance,
 
     const Coap::TxParameters &txParameters = Coap::TxParameters::From(aTxParameters);
 
-    VerifyOrExit(AsCoreType(aMessage).GetOrigin() != Message::kOriginThreadNetif, error = kErrorInvalidArgs);
+    VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
     if (aTxParameters != nullptr)
     {
@@ -296,7 +296,7 @@ otError otCoapSendResponseBlockWiseWithParameters(otInstance                 *aI
 {
     otError error;
 
-    VerifyOrExit(AsCoreType(aMessage).GetOrigin() != Message::kOriginThreadNetif, error = kErrorInvalidArgs);
+    VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
     error = AsCoreType(aInstance).GetApplicationCoap().SendMessage(AsCoapMessage(aMessage), AsCoreType(aMessageInfo),
                                                                    Coap::TxParameters::From(aTxParameters), nullptr,
@@ -313,7 +313,7 @@ otError otCoapSendResponseWithParameters(otInstance               *aInstance,
 {
     otError error;
 
-    VerifyOrExit(AsCoreType(aMessage).GetOrigin() != Message::kOriginThreadNetif, error = kErrorInvalidArgs);
+    VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
     error = AsCoreType(aInstance).GetApplicationCoap().SendMessage(
         AsCoapMessage(aMessage), AsCoreType(aMessageInfo), Coap::TxParameters::From(aTxParameters), nullptr, nullptr);

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -134,7 +134,7 @@ otError otIp6Send(otInstance *aInstance, otMessage *aMessage)
 {
     otError error;
 
-    VerifyOrExit(AsCoreType(aMessage).GetOrigin() != Message::kOriginThreadNetif, error = kErrorInvalidArgs);
+    VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
     error = AsCoreType(aInstance).Get<Ip6::Ip6>().SendRaw(AsCoreType(aMessage));
 

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -74,7 +74,7 @@ otError otUdpSend(otInstance *aInstance, otUdpSocket *aSocket, otMessage *aMessa
 {
     otError error;
 
-    VerifyOrExit(AsCoreType(aMessage).GetOrigin() != Message::kOriginThreadNetif, error = kErrorInvalidArgs);
+    VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
     error = AsCoreType(aInstance).Get<Ip6::Udp>().SendTo(AsCoreType(aSocket), AsCoreType(aMessage),
                                                          AsCoreType(aMessageInfo));
@@ -124,7 +124,7 @@ otError otUdpSendDatagram(otInstance *aInstance, otMessage *aMessage, otMessageI
 {
     otError error;
 
-    VerifyOrExit(AsCoreType(aMessage).GetOrigin() != Message::kOriginThreadNetif, error = kErrorInvalidArgs);
+    VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
     return AsCoreType(aInstance).Get<Ip6::Udp>().SendDatagram(AsCoreType(aMessage), AsCoreType(aMessageInfo),
                                                               Ip6::kProtoUdp);

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -1185,6 +1185,33 @@ public:
     void SetOrigin(Origin aOrigin) { GetMetadata().mOrigin = aOrigin; }
 
     /**
+     * Indicates whether or not the message origin is Thread Netif.
+     *
+     * @retval TRUE   If the message origin is Thread Netif.
+     * @retval FALSE  If the message origin is not Thread Netif.
+     *
+     */
+    bool IsOriginThreadNetif(void) const { return GetOrigin() == kOriginThreadNetif; }
+
+    /**
+     * Indicates whether or not the message origin is a trusted source on host.
+     *
+     * @retval TRUE   If the message origin is a trusted source on host.
+     * @retval FALSE  If the message origin is not a trusted source on host.
+     *
+     */
+    bool IsOriginHostTrusted(void) const { return GetOrigin() == kOriginHostTrusted; }
+
+    /**
+     * Indicates whether or not the message origin is an untrusted source on host.
+     *
+     * @retval TRUE   If the message origin is an untrusted source on host.
+     * @retval FALSE  If the message origin is not an untrusted source on host.
+     *
+     */
+    bool IsOriginHostUntrusted(void) const { return GetOrigin() == kOriginHostUntrusted; }
+
+    /**
      * Indicates whether or not link security is enabled for the message.
      *
      * @retval TRUE   If link security is enabled.


### PR DESCRIPTION
This commit adds helper methods to the `Message` class to check if the message origin matches a specific origin. These methods are used in the code as syntactic sugar to simplify the code.