### PR TITLE
[ip6-mpl] simplify `Mpl::HandleRetransmissionTimer()`

### DIFF
--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -234,8 +234,8 @@ private:
     uint8_t   mSequence;
 
 #if OPENTHREAD_FTD
-    static constexpr uint8_t kChildTimerExpirations  = 0; // MPL retransmissions for Children.
-    static constexpr uint8_t kRouterTimerExpirations = 2; // MPL retransmissions for Routers.
+    static constexpr uint8_t kChildRetransmissions  = 0; // MPL retransmissions for Children.
+    static constexpr uint8_t kRouterRetransmissions = 2; // MPL retransmissions for Routers.
 
     struct Metadata
     {
@@ -252,7 +252,7 @@ private:
         uint8_t   mIntervalOffset;
     };
 
-    uint8_t GetTimerExpirations(void) const;
+    uint8_t DetermineMaxRetransmissions(void) const;
     void    HandleRetransmissionTimer(void);
     void    AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSequence, bool aIsOutbound);
 


### PR DESCRIPTION
This commit contains smaller changes in `HandleRetransmissionTimer()`:

- Remove nested if/else blocks and use `continue`.
- We clone the MPL message if more retx are needed, otherwise use the `message` directly.
- In both cases, we now use the same code path for preparing and sending the `message`, avoiding repeated code.
- Rename `GetTimerExpirations()` to `DetermineMaxRetransmissions()`.