### PR TITLE
[ip6-mpl] remove `aIsOutbound` input and use `aMessage.GetOrigin()`

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -516,7 +516,7 @@ void Ip6::HandleSendQueue(void)
     }
 }
 
-Error Ip6::HandleOptions(Message &aMessage, Header &aHeader, bool aIsOutbound, bool &aReceive)
+Error Ip6::HandleOptions(Message &aMessage, Header &aHeader, bool &aReceive)
 {
     Error          error = kErrorNone;
     HopByHopHeader hbhHeader;
@@ -542,7 +542,7 @@ Error Ip6::HandleOptions(Message &aMessage, Header &aHeader, bool aIsOutbound, b
 
         if (option.GetType() == MplOption::kType)
         {
-            SuccessOrExit(error = mMpl.ProcessOption(aMessage, offset, aHeader.GetSource(), aIsOutbound, aReceive));
+            SuccessOrExit(error = mMpl.ProcessOption(aMessage, offset, aHeader.GetSource(), aReceive));
             continue;
         }
 
@@ -829,8 +829,8 @@ Error Ip6::HandleExtensionHeaders(Message     &aMessage,
                                   uint8_t     &aNextHeader,
                                   bool        &aReceive)
 {
-    Error           error      = kErrorNone;
-    bool            isOutbound = !aMessage.IsOriginThreadNetif();
+    Error error = kErrorNone;
+
     ExtensionHeader extHeader;
 
     while (aReceive || aNextHeader == kProtoHopOpts)
@@ -840,7 +840,7 @@ Error Ip6::HandleExtensionHeaders(Message     &aMessage,
         switch (aNextHeader)
         {
         case kProtoHopOpts:
-            SuccessOrExit(error = HandleOptions(aMessage, aHeader, isOutbound, aReceive));
+            SuccessOrExit(error = HandleOptions(aMessage, aHeader, aReceive));
             break;
 
         case kProtoFragment:
@@ -850,7 +850,7 @@ Error Ip6::HandleExtensionHeaders(Message     &aMessage,
             break;
 
         case kProtoDstOpts:
-            SuccessOrExit(error = HandleOptions(aMessage, aHeader, isOutbound, aReceive));
+            SuccessOrExit(error = HandleOptions(aMessage, aHeader, aReceive));
             break;
 
         case kProtoIp6:

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -390,7 +390,7 @@ private:
     Error AddTunneledMplOption(Message &aMessage, Header &aHeader);
     Error InsertMplOption(Message &aMessage, Header &aHeader);
     Error RemoveMplOption(Message &aMessage);
-    Error HandleOptions(Message &aMessage, Header &aHeader, bool aIsOutbound, bool &aReceive);
+    Error HandleOptions(Message &aMessage, Header &aHeader, bool &aReceive);
     Error HandlePayload(Header            &aIp6Header,
                         Message           &aMessage,
                         MessageInfo       &aMessageInfo,

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -194,7 +194,6 @@ public:
      * @param[in]  aMessage    A reference to the message.
      * @param[in]  aOffset     The offset in @p aMessage to read the MPL option.
      * @param[in]  aAddress    A reference to the IPv6 Source Address.
-     * @param[in]  aIsOutbound TRUE if this message was locally generated, FALSE otherwise.
      * @param[out] aReceive    Set to FALSE if the MPL message is a duplicate and must not
      *                         go through the receiving process again, untouched otherwise.
      *
@@ -202,7 +201,7 @@ public:
      * @retval kErrorDrop  The MPL message is a duplicate and should be dropped.
      *
      */
-    Error ProcessOption(Message &aMessage, uint16_t aOffset, const Address &aAddress, bool aIsOutbound, bool &aReceive);
+    Error ProcessOption(Message &aMessage, uint16_t aOffset, const Address &aAddress, bool &aReceive);
 
 #if OPENTHREAD_FTD
     /**
@@ -254,7 +253,7 @@ private:
 
     uint8_t GetTimerExpirations(void) const;
     void    HandleRetransmissionTimer(void);
-    void    AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSequence, bool aIsOutbound);
+    void    AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSequence);
 
     using RetxTimer = TimerMilliIn<Mpl, &Mpl::HandleRetransmissionTimer>;
 


### PR DESCRIPTION
With the recent addition of `GetOrigin()`, the origin of a message is tracked by `Message` itself. With this change, we no longer need to pass `aIsOutbound` to `Ip6::Mpl` methods, as it can be determined from the origin of `aMessage`. This commit simplifies the code by removing the `aIsOutbound` input parameter.