### PR TITLE
[ip6] add `PrepareMulticastToLargerThanRealmLocal()`

### DIFF
--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -387,7 +387,7 @@ private:
     void SendIcmpError(Message &aMessage, Icmp::Header::Type aIcmpType, Icmp::Header::Code aIcmpCode);
 #endif
     Error AddMplOption(Message &aMessage, Header &aHeader);
-    Error AddTunneledMplOption(Message &aMessage, Header &aHeader);
+    Error PrepareMulticastToLargerThanRealmLocal(Message &aMessage, const Header &aHeader);
     Error InsertMplOption(Message &aMessage, Header &aHeader);
     Error RemoveMplOption(Message &aMessage);
     Error HandleOptions(Message &aMessage, Header &aHeader, bool &aReceive);


### PR DESCRIPTION
This commit adds `Ip6::PrepareMulticastToLargerThanRealmLocal()`, which prepares to transmit a multicast message with destination larger than realm-local address. It checks if any sleepy child of device is subscribed to the multicast address and clones the message for indirect tx if needed, before adding the IP-in-IP tunnel header. The new method helps remove repeated code in `SendRaw()` and `SenDatagram()`.