### PR TITLE
[ip6-mpl] set `LoopbackToHostAllowed` to false for MPL retx

### DIFF
--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -445,7 +445,7 @@ void Mpl::HandleRetransmissionTimer(void)
             }
 
             metadata.RemoveFrom(*messageCopy);
-            messageCopy->SetLoopbackToHostAllowed(true);
+            messageCopy->SetLoopbackToHostAllowed(false);
             messageCopy->SetOrigin(Message::kOriginHostTrusted);
             Get<Ip6>().EnqueueDatagram(*messageCopy);
         }


### PR DESCRIPTION
This commit updates `Mpl::HandleRetransmissionTimer()` to set `SetLoopbackToHostAllowed(false)` on MPL message retransmissions.

If a multicast message originates from the host itself, it can be passed to the host when the original message is processed. If it originates from the Thread Netif (received over Thread radio), it can be passed to the host when the received message is processed. In both cases, we no longer need to pass the MPL retransmissions of the message to the host.

----

Some more background on this:
- Having `SetLoopbackToHostAllowed(true)` today does not cause the retx to be passed to host due to them being dropped from this check in `Ip6::HandleDatagram()`:
https://github.com/openthread/openthread/blob/8f6d6703a26b617cd7bbec624f74059c6706adef/src/core/net/ip6.cpp#L1226-L1228
- But the flag should technically not set in `Mpl` module (this seems to be the desired flag and expected behavior).
