### PR TITLE
[trel] Update errorCode when sending packet over disabled trel radio

### DIFF
--- a/src/core/radio/trel_interface.cpp
+++ b/src/core/radio/trel_interface.cpp
@@ -363,7 +363,7 @@ Error Interface::Send(const Packet &aPacket, bool aIsDiscovery)
     Error error = kErrorNone;
     Peer *peerEntry;
 
-    VerifyOrExit(mInitialized && mEnabled, error = kErrorAbort);
+    VerifyOrExit(mInitialized && mEnabled, error = kErrorInvalidState);
     VerifyOrExit(!mFiltered);
 
     switch (aPacket.GetHeader().GetType())


### PR DESCRIPTION
When trel is disabled intentionally, sending broadcast packets can cause log entries of 
`INFO: [I] Mac-----------: Frame tx failed, error:Abort, len:73, seqnum:213, type:Data, src:1234567887654321, dst:0xffff, sec:no, ackreq:no, radio:trel`

The error code Abort is used both in this case and other cases e.g. when a trel peer cannot be found. Changing the error code to InvalidState to differentiate with other Abort cases.