### PR TITLE
[ip6] add API functions to enable multicast looping of a message

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (375)
+#define OPENTHREAD_API_VERSION (376)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/message.h
+++ b/include/openthread/message.h
@@ -212,6 +212,28 @@ bool otMessageIsLoopbackToHostAllowed(const otMessage *aMessage);
 void otMessageSetLoopbackToHostAllowed(otMessage *aMessage, bool aAllowLoopbackToHost);
 
 /**
+ * Indicates whether the given message may be looped back in a case of a multicast destination address.
+ *
+ * If @p aMessage is used along with an `otMessageInfo`, the `mMulticastLoop` field from `otMessageInfo` structure
+ * takes precedence and will be used instead of the the value set on @p aMessage.
+ *
+ * This API is mainly intended for use along with `otIp6Send()` which expects an already prepared IPv6 message.
+ *
+ * @param[in]  aMessage A pointer to the message.
+ *
+ */
+bool otMessageIsMulticastLoopEnabled(otMessage *aMessage);
+
+/**
+ * Controls whether the given message may be looped back in a case of a multicast destination address.
+ *
+ * @param[in]  aMessage  A pointer to the message.
+ * @param[in]  aEnabled  The configuration value.
+ *
+ */
+void otMessageSetMulticastLoopEnabled(otMessage *aMessage, bool aEnabled);
+
+/**
  * Gets the message origin.
  *
  * @param[in]  aMessage  A pointer to a message buffer.

--- a/src/core/api/message_api.cpp
+++ b/src/core/api/message_api.cpp
@@ -62,6 +62,13 @@ void otMessageSetLoopbackToHostAllowed(otMessage *aMessage, bool aAllowLoopbackT
     return AsCoreType(aMessage).SetLoopbackToHostAllowed(aAllowLoopbackToHost);
 }
 
+bool otMessageIsMulticastLoopEnabled(otMessage *aMessage) { return AsCoreType(aMessage).GetMulticastLoop(); }
+
+void otMessageSetMulticastLoopEnabled(otMessage *aMessage, bool aEnabled)
+{
+    AsCoreType(aMessage).SetMulticastLoop(aEnabled);
+}
+
 otMessageOrigin otMessageGetOrigin(const otMessage *aMessage) { return MapEnum(AsCoreType(aMessage).GetOrigin()); }
 
 void otMessageSetOrigin(otMessage *aMessage, otMessageOrigin aOrigin)


### PR DESCRIPTION
At the moment, C API does not allow to get/set the configuration flag which the message to be looped back to the Thread interface. It is important within the context of sending already prepared IPv6 mutlicast packets with `otIp6Send()`.