### PR TITLE
[ip6] use encapsulated destination while processing MPL tunneled packets

### DIFF
--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -398,6 +398,7 @@ private:
                         Message::Ownership aMessageOwnership);
     bool  IsOnLink(const Address &aAddress) const;
     Error RouteLookup(const Address &aSource, const Address &aDestination) const;
+    bool  ShouldReceiveMulticastMessage(const Message &aMessage, const Header &aHeader) const;
 #if OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
     void UpdateBorderRoutingCounters(const Header &aHeader, uint16_t aMessageLength, bool aIsInbound);
 #endif

--- a/src/core/net/ip6_headers.cpp
+++ b/src/core/net/ip6_headers.cpp
@@ -41,13 +41,13 @@ namespace Ip6 {
 //---------------------------------------------------------------------------------------------------------------------
 // Header
 
-Error Header::ParseFrom(const Message &aMessage)
+Error Header::ParseFrom(const Message &aMessage, uint16_t aOffset)
 {
     Error error = kErrorParse;
 
-    SuccessOrExit(aMessage.Read(0, *this));
+    SuccessOrExit(aMessage.Read(aOffset, *this));
     VerifyOrExit(IsValid());
-    VerifyOrExit(sizeof(Header) + GetPayloadLength() == aMessage.GetLength());
+    VerifyOrExit((aOffset + sizeof(Header) + GetPayloadLength()) == (aMessage.GetLength()));
 
     error = kErrorNone;
 

--- a/src/core/net/ip6_headers.hpp
+++ b/src/core/net/ip6_headers.hpp
@@ -331,7 +331,7 @@ public:
      * @retval kErrorParse  Malformed IPv6 header or message (e.g., message does not contained expected payload length).
      *
      */
-    Error ParseFrom(const Message &aMessage);
+    Error ParseFrom(const Message &aMessage, uint16_t aOffset = 0);
 
 private:
     // IPv6 header `mVerTcFlow` field:


### PR DESCRIPTION
When `Ip6::HandleDatagram()` method checks if a multicast destination address is subscribed it ignores a packet that should be handled when it is tunneled as it looks for MPL forwarders' address (ff03::fc). This commit resolves this issue by searching the subscription list using the original destination address.