### PR TITLE
[build] move `radio_spinel.cpp` to new lib `openthread-radio-spinel`

### DIFF
--- a/src/lib/spinel/CMakeLists.txt
+++ b/src/lib/spinel/CMakeLists.txt
@@ -30,20 +30,10 @@ add_library(openthread-spinel-ncp)
 add_library(openthread-spinel-rcp)
 
 target_compile_definitions(openthread-spinel-ncp PRIVATE
-    OPENTHREAD_FTD=1
     PUBLIC OPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE=1
 )
 
-if (OT_NCP_SPI)
-    target_compile_definitions(openthread-spinel-ncp PRIVATE OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=0)
-    target_compile_definitions(openthread-spinel-rcp PRIVATE OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=0)
-else()
-    target_compile_definitions(openthread-spinel-ncp PRIVATE OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=1)
-    target_compile_definitions(openthread-spinel-rcp PRIVATE OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=1)
-endif()
-
 target_compile_definitions(openthread-spinel-rcp PRIVATE
-    OPENTHREAD_RADIO=1
     PUBLIC OPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE=0
 )
 

--- a/src/lib/spinel/CMakeLists.txt
+++ b/src/lib/spinel/CMakeLists.txt
@@ -26,6 +26,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+add_library(openthread-radio-spinel)
 add_library(openthread-spinel-ncp)
 add_library(openthread-spinel-rcp)
 
@@ -35,6 +36,10 @@ target_compile_definitions(openthread-spinel-ncp PRIVATE
 
 target_compile_definitions(openthread-spinel-rcp PRIVATE
     PUBLIC OPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE=0
+)
+
+target_compile_options(openthread-radio-spinel PRIVATE
+    ${OT_CFLAGS}
 )
 
 target_compile_options(openthread-spinel-ncp PRIVATE
@@ -57,14 +62,17 @@ set(COMMON_SOURCES
     spinel_encoder.cpp
 )
 
+target_include_directories(openthread-radio-spinel PUBLIC ${OT_PUBLIC_INCLUDES} PRIVATE ${COMMON_INCLUDES})
 target_include_directories(openthread-spinel-ncp PUBLIC ${OT_PUBLIC_INCLUDES} PRIVATE ${COMMON_INCLUDES})
 target_include_directories(openthread-spinel-rcp PUBLIC ${OT_PUBLIC_INCLUDES} PRIVATE ${COMMON_INCLUDES})
 
+target_sources(openthread-radio-spinel PRIVATE radio_spinel.cpp)
 target_sources(openthread-spinel-ncp PRIVATE ${COMMON_SOURCES})
-target_sources(openthread-spinel-rcp
+target_sources(openthread-spinel-rcp PRIVATE ${COMMON_SOURCES})
+
+target_link_libraries(openthread-radio-spinel
     PRIVATE
-        ${COMMON_SOURCES}
-        radio_spinel.cpp
+        ot-config
 )
 
 target_link_libraries(openthread-spinel-ncp

--- a/src/lib/spinel/CMakeLists.txt
+++ b/src/lib/spinel/CMakeLists.txt
@@ -61,7 +61,6 @@ set(COMMON_INCLUDES
 )
 
 set(COMMON_SOURCES
-    radio_spinel.cpp
     spinel.c
     spinel_buffer.cpp
     spinel_decoder.cpp
@@ -72,7 +71,11 @@ target_include_directories(openthread-spinel-ncp PUBLIC ${OT_PUBLIC_INCLUDES} PR
 target_include_directories(openthread-spinel-rcp PUBLIC ${OT_PUBLIC_INCLUDES} PRIVATE ${COMMON_INCLUDES})
 
 target_sources(openthread-spinel-ncp PRIVATE ${COMMON_SOURCES})
-target_sources(openthread-spinel-rcp PRIVATE ${COMMON_SOURCES})
+target_sources(openthread-spinel-rcp
+    PRIVATE
+        ${COMMON_SOURCES}
+        radio_spinel.cpp
+)
 
 target_link_libraries(openthread-spinel-ncp
     PRIVATE

--- a/src/posix/cli.cmake
+++ b/src/posix/cli.cmake
@@ -50,6 +50,7 @@ target_link_libraries(ot-cli PRIVATE
     openthread-posix
     openthread-cli-ftd
     openthread-hdlc
+    openthread-radio-spinel
     openthread-spinel-rcp
     ${OT_MBEDTLS}
     ${READLINE_LINK_LIBRARIES}

--- a/src/posix/daemon.cmake
+++ b/src/posix/daemon.cmake
@@ -42,6 +42,7 @@ target_link_libraries(ot-daemon PRIVATE
     openthread-ftd
     openthread-posix
     openthread-hdlc
+    openthread-radio-spinel
     openthread-spinel-rcp
     ${OT_MBEDTLS}
     ot-posix-config

--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -154,6 +154,7 @@ target_link_libraries(openthread-posix
         openthread-cli-ftd
         openthread-ftd
         openthread-hdlc
+        openthread-radio-spinel
         openthread-spinel-rcp
         openthread-url
         ot-config-ftd


### PR DESCRIPTION
The lib `openthread-spinel-ncp` is used by the NCP build and the lib `openthread-spinel-rcp` is used by the RCP build. Both of them don't need the file `radio_spinel.cpp`. This commit removes the `radio_spinel.cpp` from lib `openthread-spinel-ncp` and  `openthread-spinel-rcp`, and adds a new lib `openthread-radio-spinel` to include the `radio_spinel.cpp`. This commit also remove some useless configurations from `src/lib/spinel/CMakeLists.txt`.

Depends-On: openthread/ot-br-posix#2068
