### PR TITLE
[github-actions] add job summary to `size.yml` workflow

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -67,3 +67,4 @@ jobs:
           export OT_SIZE_REPORTER=./size-report
         fi
         ./script/check-size
+        cat /tmp/ot-size-report/report_pr >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This commit uses `GITHUB_STEP_SUMMARY` to add a summary (in markdown format) to the GitHub action workflow `size.yml` runs.

----

Example of the output: https://github.com/openthread/openthread/actions/runs/6518855521
