### PR TITLE
[dataset] highlight `SetTlv<ValueType>()` specializations in the docs

### DIFF
--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -770,6 +770,9 @@ public:
      *
      * @tparam ValueType    The type of TLV's Value.
      *
+     * Specializations of this template method are provided for `uint16_t` and `uint32_t` types which ensure big-endian
+     * encoding is used.
+     *
      * @param[in] aType     The TLV Type.
      * @param[in] aValue    The TLV Value (of type `ValueType`).
      *
@@ -780,6 +783,9 @@ public:
     template <typename ValueType> Error SetTlv(Tlv::Type aType, const ValueType &aValue)
     {
         static_assert(!TypeTraits::IsPointer<ValueType>::kValue, "ValueType must not be a pointer");
+        static_assert(!TypeTraits::IsSame<ValueType, uint16_t>::kValue, "Specialization must be used for uint16_t");
+        static_assert(!TypeTraits::IsSame<ValueType, uint32_t>::kValue, "Specialization must be used for uint32_t");
+        static_assert(!TypeTraits::IsSame<ValueType, uint64_t>::kValue, "Specialization must be used for uint64_t");
 
         return SetTlv(aType, &aValue, sizeof(ValueType));
     }


### PR DESCRIPTION
This commit updates the `Dataset::SetTlv<ValueType>()` documentation to mention its specifications for `uint` types (which use big-endian encoding). It also adds `static_assert` checks to ensure that the general template implementation is not used with `uint16/32/64` types.