### PR TITLE
[spinel] use local variables to export mac key before sending over SPINEL

### DIFF
--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -902,9 +902,9 @@ otError RadioSpinel::SetMacKey(uint8_t                 aKeyIdMode,
 #else
     OT_UNUSED_VARIABLE(aKeySize);
 
-    memcpy(prevKey.m8, aPrevKey->mKeyMaterial.mKey.m8, OT_MAC_KEY_SIZE);
-    memcpy(currKey.m8, aCurrKey->mKeyMaterial.mKey.m8, OT_MAC_KEY_SIZE);
-    memcpy(nextKey.m8, aNextKey->mKeyMaterial.mKey.m8, OT_MAC_KEY_SIZE);
+    prevKey = aPrevKey->mKeyMaterial.mKey;
+    currKey = aCurrKey->mKeyMaterial.mKey;
+    nextKey = aNextKey->mKeyMaterial.mKey;
 #endif
 
     SuccessOrExit(error = Set(SPINEL_PROP_RCP_MAC_KEY,
@@ -917,9 +917,9 @@ otError RadioSpinel::SetMacKey(uint8_t                 aKeyIdMode,
     mKeyIdMode = aKeyIdMode;
     mKeyId     = aKeyId;
 
-    memcpy(mPrevKey.m8, prevKey.m8, OT_MAC_KEY_SIZE);
-    memcpy(mCurrKey.m8, currKey.m8, OT_MAC_KEY_SIZE);
-    memcpy(mNextKey.m8, nextKey.m8, OT_MAC_KEY_SIZE);
+    mPrevKey = prevKey;
+    mCurrKey = currKey;
+    mNextKey = nextKey;
 
     mMacKeySet = true;
 #endif


### PR DESCRIPTION
In RadioSpinel::SetMacKey we try to reuse the otMacKey passed to export the literal key from PSA to be sent over SPINEL to RCP. But as the passed param is const, we cant really use this. Better option is to extract it into a local buffer and use that to pass the keys to RCP.

Use OT_MAC_KEY_SIZE instead of sizeof.
Simplify RCP restoration code.

Fixes #9515 