### PR TITLE
[tlv] add helper method to find/read TLVs in a sequence of TLVs

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -179,7 +179,7 @@ exit:
     return rval;
 }
 
-const Tlv *Dataset::GetTlv(Tlv::Type aType) const { return Tlv::FindTlv(mTlvs, mLength, aType); }
+const Tlv *Dataset::GetTlv(Tlv::Type aType) const { return As<Tlv>(Tlv::FindTlv(mTlvs, mLength, aType)); }
 
 void Dataset::ConvertTo(Info &aDatasetInfo) const
 {

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -91,31 +91,6 @@ bool Tlv::IsValid(const Tlv &aTlv)
     return rval;
 }
 
-const Tlv *Tlv::FindTlv(const uint8_t *aTlvsStart, uint16_t aTlvsLength, Type aType)
-{
-    const Tlv *tlv;
-    const Tlv *end = reinterpret_cast<const Tlv *>(aTlvsStart + aTlvsLength);
-
-    for (tlv = reinterpret_cast<const Tlv *>(aTlvsStart); tlv < end; tlv = tlv->GetNext())
-    {
-        VerifyOrExit((tlv + 1) <= end, tlv = nullptr);
-        VerifyOrExit(!tlv->IsExtended() ||
-                         (reinterpret_cast<const ExtendedTlv *>(tlv) + 1 <= reinterpret_cast<const ExtendedTlv *>(end)),
-                     tlv = nullptr);
-        VerifyOrExit(tlv->GetNext() <= end, tlv = nullptr);
-
-        if (tlv->GetType() == aType)
-        {
-            ExitNow();
-        }
-    }
-
-    tlv = nullptr;
-
-exit:
-    return tlv;
-}
-
 NameData NetworkNameTlv::GetNetworkName(void) const
 {
     uint8_t len = GetLength();

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -164,43 +164,6 @@ public:
     const Tlv *GetNext(void) const { return As<Tlv>(ot::Tlv::GetNext()); }
 
     /**
-     * Reads the requested TLV out of @p aMessage.
-     *
-     * @param[in]   aMessage    A reference to the message.
-     * @param[in]   aType       The Type value to search for.
-     * @param[in]   aMaxLength  Maximum number of bytes to read.
-     * @param[out]  aTlv        A reference to the TLV that will be copied to.
-     *
-     * @retval kErrorNone      Successfully copied the TLV.
-     * @retval kErrorNotFound  Could not find the TLV with Type @p aType.
-     *
-     */
-    static Error FindTlv(const Message &aMessage, Type aType, uint16_t aMaxLength, Tlv &aTlv)
-    {
-        return ot::Tlv::FindTlv(aMessage, static_cast<uint8_t>(aType), aMaxLength, aTlv);
-    }
-
-    /**
-     * Reads the requested TLV out of @p aMessage.
-     *
-     * Can be used independent of whether the read TLV (from message) is an Extended TLV or not.
-     *
-     * @tparam      TlvType     The TlvType to search for (must be a sub-class of `Tlv`).
-     *
-     * @param[in]   aMessage    A reference to the message.
-     * @param[out]  aTlv        A reference to the TLV that will be copied to.
-     *
-     * @retval kErrorNone      Successfully copied the TLV.
-     * @retval kErrorNotFound  Could not find the TLV with Type @p aType.
-     *
-     */
-
-    template <typename TlvType> static Error FindTlv(const Message &aMessage, TlvType &aTlv)
-    {
-        return ot::Tlv::FindTlv(aMessage, aTlv);
-    }
-
-    /**
      * Indicates whether a TLV appears to be well-formed.
      *
      * @param[in]  aTlv  A reference to the TLV.
@@ -209,63 +172,6 @@ public:
      *
      */
     static bool IsValid(const Tlv &aTlv);
-
-    /**
-     * Searches in a given sequence of TLVs to find the first TLV with a given template Type.
-     *
-     * @param[in]  aTlvsStart  A pointer to the start of the sequence of TLVs to search within.
-     * @param[in]  aTlvsLength The length (number of bytes) in TLV sequence.
-     * @param[in]  aType       The TLV Type to search for.
-     *
-     * @returns A pointer to the TLV if found, or `nullptr` if not found.
-     *
-     */
-    static Tlv *FindTlv(uint8_t *aTlvsStart, uint16_t aTlvsLength, Type aType)
-    {
-        return AsNonConst(FindTlv(AsConst(aTlvsStart), aTlvsLength, aType));
-    }
-
-    /**
-     * Searches in a given sequence of TLVs to find the first TLV with a given template Type.
-     *
-     * @param[in]  aTlvsStart  A pointer to the start of the sequence of TLVs to search within.
-     * @param[in]  aTlvsLength The length (number of bytes) in TLV sequence.
-     * @param[in]  aType       The TLV Type to search for.
-     *
-     * @returns A pointer to the TLV if found, or `nullptr` if not found.
-     *
-     */
-    static const Tlv *FindTlv(const uint8_t *aTlvsStart, uint16_t aTlvsLength, Type aType);
-
-    /**
-     * This static template method searches in a given sequence of TLVs to find the first TLV with a give template
-     * `TlvType`.
-     *
-     * @param[in]  aTlvsStart  A pointer to the start of the sequence of TLVs to search within.
-     * @param[in]  aTlvsLength The length (number of bytes) in TLV sequence.
-     *
-     * @returns A pointer to the TLV if found, or `nullptr` if not found.
-     *
-     */
-    template <typename TlvType> static TlvType *FindTlv(uint8_t *aTlvsStart, uint16_t aTlvsLength)
-    {
-        return As<TlvType>(FindTlv(aTlvsStart, aTlvsLength, static_cast<Tlv::Type>(TlvType::kType)));
-    }
-
-    /**
-     * This static template method searches in a given sequence of TLVs to find the first TLV with a give template
-     * `TlvType`.
-     *
-     * @param[in]  aTlvsStart  A pointer to the start of the sequence of TLVs to search within.
-     * @param[in]  aTlvsLength The length (number of bytes) in TLV sequence.
-     *
-     * @returns A pointer to the TLV if found, or `nullptr` if not found.
-     *
-     */
-    template <typename TlvType> static const TlvType *FindTlv(const uint8_t *aTlvsStart, uint16_t aTlvsLength)
-    {
-        return As<TlvType>(FindTlv(aTlvsStart, aTlvsLength, static_cast<Tlv::Type>(TlvType::kType)));
-    }
 
 } OT_TOOL_PACKED_END;
 

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -466,7 +466,7 @@ const MeshCoP::Tlv *LeaderBase::GetCommissioningDataSubTlv(MeshCoP::Tlv::Type aT
     commissioningDataTlv = GetCommissioningData();
     VerifyOrExit(commissioningDataTlv != nullptr);
 
-    rval = MeshCoP::Tlv::FindTlv(commissioningDataTlv->GetValue(), commissioningDataTlv->GetLength(), aType);
+    rval = As<MeshCoP::Tlv>(Tlv::FindTlv(commissioningDataTlv->GetValue(), commissioningDataTlv->GetLength(), aType));
 
 exit:
     return rval;


### PR DESCRIPTION
This commit moves the helper methods to find a specific TLV in a sequence of TLVs from the `MeshCoP::Tlv` class to the base `Tlv` class. This makes these helper methods accessible to all subclasses.