### PR TITLE
[radio-spinel] simplify `SetMacKey()`

### DIFF
--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -1011,6 +1011,15 @@ private:
         mRadioSpinelMetrics.mSpinelParseErrorCount += (aError == OT_ERROR_PARSE) ? 1 : 0;
     }
 
+    otError SetMacKey(uint8_t         aKeyIdMode,
+                      uint8_t         aKeyId,
+                      const otMacKey &aPrevKey,
+                      const otMacKey &aCurrKey,
+                      const otMacKey &NextKey);
+#if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
+    static otError ReadMacKey(const otMacKeyMaterial &aKeyMaterial, otMacKey &aKey);
+#endif
+
     static void LogIfFail(const char *aText, otError aError);
 
     static void LogCrit(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);


### PR DESCRIPTION
This commit simplifies the `RadioSpinel::SetMacKey()` method. A common `private` overload of `SetMacKey()` is added that uses `const otMacKey &` as its input key type.

When `KEY_REFERENCES_ENABLE` is not enable the `SetMacKey()` simply passes the key from the `otMacKeyMaterial` directly. This avoids the unnecessary copying of the key into a local variable.

When `KEY_REFERENCES_ENABLE` is enabled, the keys are read from secure storage. A new `ReadMacKey()` helper method is added which also validates that the read key size is correct.