### PR TITLE
[meshcop-leader] simplify adding `CommissioningData`

### DIFF
--- a/src/core/meshcop/meshcop_leader.hpp
+++ b/src/core/meshcop/meshcop_leader.hpp
@@ -49,21 +49,6 @@
 namespace ot {
 namespace MeshCoP {
 
-OT_TOOL_PACKED_BEGIN
-class CommissioningData
-{
-public:
-    uint8_t GetLength(void) const
-    {
-        return sizeof(Tlv) + mBorderAgentLocator.GetLength() + sizeof(Tlv) + mCommissionerSessionId.GetLength() +
-               sizeof(Tlv) + mSteeringData.GetLength();
-    }
-
-    BorderAgentLocatorTlv    mBorderAgentLocator;
-    CommissionerSessionIdTlv mCommissionerSessionId;
-    SteeringDataTlv          mSteeringData;
-} OT_TOOL_PACKED_END;
-
 class Leader : public InstanceLocator, private NonCopyable
 {
     friend class Tmf::Agent;
@@ -112,6 +97,19 @@ public:
 
 private:
     static constexpr uint32_t kTimeoutLeaderPetition = 50; // TIMEOUT_LEAD_PET (seconds)
+
+    OT_TOOL_PACKED_BEGIN
+    class CommissioningData
+    {
+    public:
+        void    Init(uint16_t aBorderAgentRloc16, uint16_t aSessionId);
+        uint8_t GetLength(void) const;
+
+    private:
+        BorderAgentLocatorTlv    mBorderAgentLocatorTlv;
+        CommissionerSessionIdTlv mSessionIdTlv;
+        SteeringDataTlv          mSteeringDataTlv;
+    } OT_TOOL_PACKED_END;
 
     void HandleTimer(void);
 

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -428,7 +428,7 @@ exit:
     return error;
 }
 
-Error LeaderBase::SetCommissioningData(const uint8_t *aValue, uint8_t aValueLength)
+Error LeaderBase::SetCommissioningData(const void *aValue, uint8_t aValueLength)
 {
     Error                 error = kErrorNone;
     CommissioningDataTlv *commissioningDataTlv;

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -240,7 +240,7 @@ public:
      * @retval kErrorNoBufs   Insufficient space to add the Commissioning Data.
      *
      */
-    Error SetCommissioningData(const uint8_t *aValue, uint8_t aValueLength);
+    Error SetCommissioningData(const void *aValue, uint8_t aValueLength);
 
     /**
      * Checks if the steering data includes a Joiner.


### PR DESCRIPTION
This commit contains smaller changes in` MeshCoP::Leader` class:
- Changes `CommissioningData` to be a `private` type in this class
- Adds `Init()` to `CommisioningData()` to init all sub-tlvs.