### PR TITLE
[netdata-leader] simplify `HandleTmf<kUriCommissionerGet>`

### DIFF
--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -325,6 +325,11 @@ protected:
     void                        SignalNetDataChanged(void);
     const CommissioningDataTlv *FindCommissioningData(void) const;
     CommissioningDataTlv *FindCommissioningData(void) { return AsNonConst(AsConst(this)->FindCommissioningData()); }
+    const MeshCoP::Tlv   *FindCommissioningDataSubTlv(uint8_t aType) const;
+    MeshCoP::Tlv         *FindCommissioningDataSubTlv(uint8_t aType)
+    {
+        return AsNonConst(AsConst(this)->FindCommissioningDataSubTlv(aType));
+    }
 
     uint8_t mStableVersion;
     uint8_t mVersion;
@@ -347,11 +352,6 @@ private:
     Error SteeringDataCheck(const FilterIndexes &aFilterIndexes) const;
     void  GetContextForMeshLocalPrefix(Lowpan::Context &aContext) const;
     Error ReadCommissioningDataUint16SubTlv(MeshCoP::Tlv::Type aType, uint16_t &aValue) const;
-    const MeshCoP::Tlv *FindCommissioningDataSubTlv(uint8_t aType) const;
-    MeshCoP::Tlv       *FindCommissioningDataSubTlv(uint8_t aType)
-    {
-        return AsNonConst(AsConst(this)->FindCommissioningDataSubTlv(aType));
-    }
 
     uint8_t mTlvBuffer[kMaxSize];
     uint8_t mMaxLength;

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -329,9 +329,6 @@ private:
     UpdateStatus UpdateService(ServiceTlv &aService);
     UpdateStatus UpdateTlv(NetworkDataTlv &aTlv, const NetworkDataTlv *aSubTlvs);
 
-    void SendCommissioningGetResponse(const Coap::Message    &aRequest,
-                                      uint16_t                aLength,
-                                      const Ip6::MessageInfo &aMessageInfo);
     void SendCommissioningSetResponse(const Coap::Message     &aRequest,
                                       const Ip6::MessageInfo  &aMessageInfo,
                                       MeshCoP::StateTlv::State aState);


### PR DESCRIPTION
This commit simplifies the handling of `kUriCommissionerGet` TMF message and preparation of its response.
