### PR TITLE
[udp] remove `aIpProto` from `Ip6::Udp::SendDatagram()`

### DIFF
--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -126,8 +126,7 @@ otError otUdpSendDatagram(otInstance *aInstance, otMessage *aMessage, otMessageI
 
     VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
-    return AsCoreType(aInstance).Get<Ip6::Udp>().SendDatagram(AsCoreType(aMessage), AsCoreType(aMessageInfo),
-                                                              Ip6::kProtoUdp);
+    return AsCoreType(aInstance).Get<Ip6::Udp>().SendDatagram(AsCoreType(aMessage), AsCoreType(aMessageInfo));
 exit:
     return error;
 }

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -334,7 +334,7 @@ template <> void BorderAgent::HandleTmf<kUriProxyTx>(Coap::Message &aMessage, co
 
     SuccessOrExit(error = Tlv::Find<Ip6AddressTlv>(aMessage, messageInfo.GetPeerAddr()));
 
-    SuccessOrExit(error = Get<Ip6::Udp>().SendDatagram(*message, messageInfo, Ip6::kProtoUdp));
+    SuccessOrExit(error = Get<Ip6::Udp>().SendDatagram(*message, messageInfo));
     mUdpProxyPort = udpEncapHeader.GetSourcePort();
 
     LogInfo("Proxy transmit sent to %s", messageInfo.GetPeerAddr().ToString().AsCString());

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -355,7 +355,7 @@ Error Udp::SendTo(SocketHandle &aSocket, Message &aMessage, const MessageInfo &a
     else
 #endif
     {
-        SuccessOrExit(error = SendDatagram(aMessage, messageInfoLocal, kProtoUdp));
+        SuccessOrExit(error = SendDatagram(aMessage, messageInfoLocal));
     }
 
 exit:
@@ -427,7 +427,7 @@ Message *Udp::NewMessage(uint16_t aReserved, const Message::Settings &aSettings)
     return Get<Ip6>().NewMessage(sizeof(Header) + aReserved, aSettings);
 }
 
-Error Udp::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aIpProto)
+Error Udp::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo)
 {
     Error error = kErrorNone;
 
@@ -451,7 +451,7 @@ Error Udp::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aI
         SuccessOrExit(error = aMessage.Prepend(udpHeader));
         aMessage.SetOffset(0);
 
-        error = Get<Ip6>().SendDatagram(aMessage, aMessageInfo, aIpProto);
+        error = Get<Ip6>().SendDatagram(aMessage, aMessageInfo, kProtoUdp);
     }
 
 exit:

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -585,13 +585,12 @@ public:
      *
      * @param[in]  aMessage      A reference to the message.
      * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
-     * @param[in]  aIpProto      The Internet Protocol value.
      *
      * @retval kErrorNone    Successfully enqueued the message into an output interface.
      * @retval kErrorNoBufs  Insufficient available buffer to add the IPv6 headers.
      *
      */
-    Error SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aIpProto);
+    Error SendDatagram(Message &aMessage, MessageInfo &aMessageInfo);
 
     /**
      * Handles a received UDP message.


### PR DESCRIPTION
This commit removes the input `aIpProto` in `Upd::HandleDatagram()` method and assumes `kProtoUdp`.