### PR TITLE
[netdata] resign active commissioner on NetData restore on leader

### DIFF
--- a/src/core/meshcop/meshcop_leader.hpp
+++ b/src/core/meshcop/meshcop_leader.hpp
@@ -63,6 +63,14 @@ public:
     explicit Leader(Instance &aInstance);
 
     /**
+     * Sets the session ID.
+     *
+     * @param[in] aSessionId  The session ID to use.
+     *
+     */
+    void SetSessionId(uint16_t aSessionId) { mSessionId = aSessionId; }
+
+    /**
      * Sends a MGMT_DATASET_CHANGED message to commissioner.
      *
      * @param[in]  aAddress   The IPv6 address of destination.

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -1301,6 +1301,7 @@ void Leader::HandleNetworkDataRestoredAfterReset(void)
     Iterator         iterator = kIteratorInit;
     ChangedFlags     flags;
     uint16_t         rloc16;
+    uint16_t         sessionId;
 
     mWaitingForNetDataSync = false;
 
@@ -1344,6 +1345,20 @@ void Leader::HandleNetworkDataRestoredAfterReset(void)
         {
             mContextIds.ScheduleToRemove(context->GetContextId());
         }
+    }
+
+    // Update Commissioning Data. We adopt the same session ID
+    // (if any) and resign active commissioner (if any) by
+    // clearing the Commissioning Data.
+
+    if (FindCommissioningSessionId(sessionId) == kErrorNone)
+    {
+        Get<MeshCoP::Leader>().SetSessionId(sessionId);
+    }
+
+    if (FindBorderAgentRloc(rloc16) == kErrorNone)
+    {
+        Get<MeshCoP::Leader>().SetEmptyCommissionerData();
     }
 }
 


### PR DESCRIPTION
This commit updates `HandleNetworkDataRestoredAfterReset()`, which is called after Network Data is restored on the leader after a leader reset and recovery.

We now resign any active Commissioner by clearing the Commissioning Data and adopt the Session ID from the restored Network Data Commissioning Data. This ensures that any stale Commissioning Data is not retained in Network Data for longer after a leader reset