### PR TITLE
[nedata] add API to retrieve Commissioning Dataset

### DIFF
--- a/include/openthread/commissioner.h
+++ b/include/openthread/commissioner.h
@@ -111,6 +111,7 @@ typedef struct otCommissioningDataset
     bool mIsSessionIdSet : 1;     ///< TRUE if Commissioner Session Id is set, FALSE otherwise.
     bool mIsSteeringDataSet : 1;  ///< TRUE if Steering Data is set, FALSE otherwise.
     bool mIsJoinerUdpPortSet : 1; ///< TRUE if Joiner UDP Port is set, FALSE otherwise.
+    bool mHasExtraTlv : 1;        ///< TRUE if the Dataset contains any extra unknown sub-TLV, FALSE otherwise.
 } otCommissioningDataset;
 
 #define OT_JOINER_MAX_PSKD_LENGTH 32 ///< Maximum string length of a Joiner PSKd (does not include null char).

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (367)
+#define OPENTHREAD_API_VERSION (368)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/netdata.h
+++ b/include/openthread/netdata.h
@@ -35,6 +35,7 @@
 #ifndef OPENTHREAD_NETDATA_H_
 #define OPENTHREAD_NETDATA_H_
 
+#include <openthread/commissioner.h>
 #include <openthread/ip6.h>
 
 #ifdef __cplusplus
@@ -241,6 +242,15 @@ otError otNetDataGetNextService(otInstance *aInstance, otNetworkDataIterator *aI
 otError otNetDataGetNextLowpanContextInfo(otInstance            *aInstance,
                                           otNetworkDataIterator *aIterator,
                                           otLowpanContextInfo   *aContextInfo);
+
+/**
+ * Gets the Commissioning Dataset from the partition's Network Data.
+ *
+ * @param[in]  aInstance   A pointer to the OpenThread instance.
+ * @param[out] aDataset    A pointer to a `otCommissioningDataset` to populate.
+ *
+ */
+void otNetDataGetCommissioningDataset(otInstance *aInstance, otCommissioningDataset *aDataset);
 
 /**
  * Get the Network Data Version.

--- a/src/cli/README_NETDATA.md
+++ b/src/cli/README_NETDATA.md
@@ -379,6 +379,15 @@ Service entries are listed under `Services` header:
 - Context ID
 - Compress flag (`c` if marked or `-` otherwise).
 
+Commissioning Dataset information is printed under `Commissioning` header:
+
+- Session ID if present in Dataset or `-` otherwise
+- Border Agent RLOC16 (in hex) if present in Dataset or `-` otherwise
+- Joiner UDP port number if present in Dataset or `-` otherwise
+- Steering Data (as hex bytes) if present in Dataset or `-` otherwise
+- Flags:
+  - e: if Dataset contains any extra unknown TLV
+
 Print Network Data received from the Leader.
 
 ```bash
@@ -392,6 +401,8 @@ Services:
 44970 5d fddead00beef00007bad0069ce45948504d2 s a000
 Contexts:
 fd00:dead:beef:cafe::/64 1 c
+Commissioning:
+1248 dc00 9988 00000000000120000000000000000000 e
 Done
 ```
 

--- a/src/cli/cli_network_data.cpp
+++ b/src/cli/cli_network_data.cpp
@@ -662,6 +662,33 @@ exit:
     return;
 }
 
+void NetworkData::OutputCommissioningDataset(bool aLocal)
+{
+    otCommissioningDataset dataset;
+
+    VerifyOrExit(!aLocal);
+
+    otNetDataGetCommissioningDataset(GetInstancePtr(), &dataset);
+
+    OutputLine("Commissioning:");
+
+    dataset.mIsSessionIdSet ? OutputFormat("%u ", dataset.mSessionId) : OutputFormat("- ");
+    dataset.mIsLocatorSet ? OutputFormat("%04x ", dataset.mLocator) : OutputFormat("- ");
+    dataset.mIsJoinerUdpPortSet ? OutputFormat("%u ", dataset.mJoinerUdpPort) : OutputFormat("- ");
+    dataset.mIsSteeringDataSet ? OutputBytes(dataset.mSteeringData.m8, dataset.mSteeringData.mLength)
+                               : OutputFormat("-");
+
+    if (dataset.mHasExtraTlv)
+    {
+        OutputFormat(" e");
+    }
+
+    OutputNewLine();
+
+exit:
+    return;
+}
+
 otError NetworkData::OutputBinary(bool aLocal)
 {
     otError error;
@@ -701,6 +728,8 @@ exit:
  * 44970 01 9a04b000000e10 s 4000
  * Contexts:
  * fd00:dead:beef:cafe::/64 1 c
+ * Commissioning:
+ * 1248 dc00 9988 00000000000120000000000000000000 e
  * Done
  * @endcode
  * @code
@@ -750,6 +779,14 @@ exit:
  * * The prefix
  * * Context ID
  * * Compress flag (`c` if marked or `-` otherwise).
+ * @par
+ * Commissioning Dataset information is printed under `Commissioning` header:
+ * * Session ID if present in Dataset or `-` otherwise
+ * * Border Agent RLOC16 (in hex) if present in Dataset or `-` otherwise
+ * * Joiner UDP port number if present in Dataset or `-` otherwise
+ * * Steering Data (as hex bytes) if present in Dataset or `-` otherwise
+ * * Flags:
+ *   * e: If Dataset contains any extra unknown TLV
  * @par
  * @moreinfo{@netdata}.
  * @csa{br omrprefix}
@@ -809,6 +846,7 @@ template <> otError NetworkData::Process<Cmd("show")>(Arg aArgs[])
         OutputRoutes(local);
         OutputServices(local);
         OutputLowpanContexts(local);
+        OutputCommissioningDataset(local);
         error = OT_ERROR_NONE;
     }
 

--- a/src/cli/cli_network_data.hpp
+++ b/src/cli/cli_network_data.hpp
@@ -143,6 +143,7 @@ private:
     void    OutputRoutes(bool aLocal);
     void    OutputServices(bool aLocal);
     void    OutputLowpanContexts(bool aLocal);
+    void    OutputCommissioningDataset(bool aLocal);
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_SIGNAL_NETWORK_DATA_FULL
     static void HandleNetdataFull(void *aContext) { static_cast<NetworkData *>(aContext)->HandleNetdataFull(); }

--- a/src/core/api/netdata_api.cpp
+++ b/src/core/api/netdata_api.cpp
@@ -104,6 +104,11 @@ otError otNetDataGetNextLowpanContextInfo(otInstance            *aInstance,
                                                                                      AsCoreType(aContextInfo));
 }
 
+void otNetDataGetCommissioningDataset(otInstance *aInstance, otCommissioningDataset *aDataset)
+{
+    return AsCoreType(aInstance).Get<NetworkData::Leader>().GetCommissioningDataset(AsCoreType(aDataset));
+}
+
 uint8_t otNetDataGetVersion(otInstance *aInstance)
 {
     return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderData().GetDataVersion(NetworkData::kFullSet);

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -392,8 +392,8 @@ exit:
 
 void Commissioner::SendCommissionerSet(void)
 {
-    Error   error = kErrorNone;
-    Dataset dataset;
+    Error                error = kErrorNone;
+    CommissioningDataset dataset;
 
     VerifyOrExit(mState == kStateActive, error = kErrorInvalidState);
 
@@ -671,7 +671,9 @@ exit:
     return;
 }
 
-Error Commissioner::SendMgmtCommissionerSetRequest(const Dataset &aDataset, const uint8_t *aTlvs, uint8_t aLength)
+Error Commissioner::SendMgmtCommissionerSetRequest(const CommissioningDataset &aDataset,
+                                                   const uint8_t              *aTlvs,
+                                                   uint8_t                     aLength)
 {
     Error            error = kErrorNone;
     Coap::Message   *message;

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -97,134 +97,6 @@ public:
     typedef otCommissionerJoinerCallback JoinerCallback; ///< Joiner state change callback function pointer type.
 
     /**
-     * Represents a Commissioning Dataset.
-     *
-     */
-    class Dataset : public otCommissioningDataset, public Clearable<Dataset>
-    {
-    public:
-        /**
-         * Indicates whether or not the Border Router RLOC16 Locator is set in the Dataset.
-         *
-         * @returns TRUE if Border Router RLOC16 Locator is set, FALSE otherwise.
-         *
-         */
-        bool IsLocatorSet(void) const { return mIsLocatorSet; }
-
-        /**
-         * Gets the Border Router RLOC16 Locator in the Dataset.
-         *
-         * MUST be used when Locator is set in the Dataset, otherwise its behavior is undefined.
-         *
-         * @returns The Border Router RLOC16 Locator in the Dataset.
-         *
-         */
-        uint16_t GetLocator(void) const { return mLocator; }
-
-        /**
-         * Sets the Border Router RLOCG16 Locator in the Dataset.
-         *
-         * @param[in] aLocator  A Locator.
-         *
-         */
-        void SetLocator(uint16_t aLocator)
-        {
-            mIsLocatorSet = true;
-            mLocator      = aLocator;
-        }
-
-        /**
-         * Indicates whether or not the Session ID is set in the Dataset.
-         *
-         * @returns TRUE if Session ID is set, FALSE otherwise.
-         *
-         */
-        bool IsSessionIdSet(void) const { return mIsSessionIdSet; }
-
-        /**
-         * Gets the Session ID in the Dataset.
-         *
-         * MUST be used when Session ID is set in the Dataset, otherwise its behavior is undefined.
-         *
-         * @returns The Session ID in the Dataset.
-         *
-         */
-        uint16_t GetSessionId(void) const { return mSessionId; }
-
-        /**
-         * Sets the Session ID in the Dataset.
-         *
-         * @param[in] aSessionId  The Session ID.
-         *
-         */
-        void SetSessionId(uint16_t aSessionId)
-        {
-            mIsSessionIdSet = true;
-            mSessionId      = aSessionId;
-        }
-
-        /**
-         * Indicates whether or not the Steering Data is set in the Dataset.
-         *
-         * @returns TRUE if Steering Data is set, FALSE otherwise.
-         *
-         */
-        bool IsSteeringDataSet(void) const { return mIsSteeringDataSet; }
-
-        /**
-         * Gets the Steering Data in the Dataset.
-         *
-         * MUST be used when Steering Data is set in the Dataset, otherwise its behavior is undefined.
-         *
-         * @returns The Steering Data in the Dataset.
-         *
-         */
-        const SteeringData &GetSteeringData(void) const { return AsCoreType(&mSteeringData); }
-
-        /**
-         * Returns a reference to the Steering Data in the Dataset to be updated by caller.
-         *
-         * @returns A reference to the Steering Data in the Dataset.
-         *
-         */
-        SteeringData &UpdateSteeringData(void)
-        {
-            mIsSteeringDataSet = true;
-            return AsCoreType(&mSteeringData);
-        }
-
-        /**
-         * Indicates whether or not the Joiner UDP port is set in the Dataset.
-         *
-         * @returns TRUE if Joiner UDP port is set, FALSE otherwise.
-         *
-         */
-        bool IsJoinerUdpPortSet(void) const { return mIsJoinerUdpPortSet; }
-
-        /**
-         * Gets the Joiner UDP port in the Dataset.
-         *
-         * MUST be used when Joiner UDP port is set in the Dataset, otherwise its behavior is undefined.
-         *
-         * @returns The Joiner UDP port in the Dataset.
-         *
-         */
-        uint16_t GetJoinerUdpPort(void) const { return mJoinerUdpPort; }
-
-        /**
-         * Sets the Joiner UDP Port in the Dataset.
-         *
-         * @param[in] aJoinerUdpPort  The Joiner UDP Port.
-         *
-         */
-        void SetJoinerUdpPort(uint16_t aJoinerUdpPort)
-        {
-            mIsJoinerUdpPortSet = true;
-            mJoinerUdpPort      = aJoinerUdpPort;
-        }
-    };
-
-    /**
      * Initializes the Commissioner object.
      *
      * @param[in]  aInstance     A reference to the OpenThread instance.
@@ -460,7 +332,7 @@ public:
      * @retval kErrorInvalidState  Commissioner service is not started.
      *
      */
-    Error SendMgmtCommissionerSetRequest(const Dataset &aDataset, const uint8_t *aTlvs, uint8_t aLength);
+    Error SendMgmtCommissionerSetRequest(const CommissioningDataset &aDataset, const uint8_t *aTlvs, uint8_t aLength);
 
     /**
      * Returns a reference to the AnnounceBeginClient instance.
@@ -633,7 +505,6 @@ DeclareTmfHandler(Commissioner, kUriJoinerFinalize);
 
 DefineMapEnum(otCommissionerState, MeshCoP::Commissioner::State);
 DefineMapEnum(otCommissionerJoinerEvent, MeshCoP::Commissioner::JoinerEvent);
-DefineCoreType(otCommissioningDataset, MeshCoP::Commissioner::Dataset);
 
 } // namespace ot
 

--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -407,6 +407,134 @@ private:
 };
 
 /**
+ * Represents a Commissioning Dataset.
+ *
+ */
+class CommissioningDataset : public otCommissioningDataset, public Clearable<CommissioningDataset>
+{
+public:
+    /**
+     * Indicates whether or not the Border Router RLOC16 Locator is set in the Dataset.
+     *
+     * @returns TRUE if Border Router RLOC16 Locator is set, FALSE otherwise.
+     *
+     */
+    bool IsLocatorSet(void) const { return mIsLocatorSet; }
+
+    /**
+     * Gets the Border Router RLOC16 Locator in the Dataset.
+     *
+     * MUST be used when Locator is set in the Dataset, otherwise its behavior is undefined.
+     *
+     * @returns The Border Router RLOC16 Locator in the Dataset.
+     *
+     */
+    uint16_t GetLocator(void) const { return mLocator; }
+
+    /**
+     * Sets the Border Router RLOCG16 Locator in the Dataset.
+     *
+     * @param[in] aLocator  A Locator.
+     *
+     */
+    void SetLocator(uint16_t aLocator)
+    {
+        mIsLocatorSet = true;
+        mLocator      = aLocator;
+    }
+
+    /**
+     * Indicates whether or not the Session ID is set in the Dataset.
+     *
+     * @returns TRUE if Session ID is set, FALSE otherwise.
+     *
+     */
+    bool IsSessionIdSet(void) const { return mIsSessionIdSet; }
+
+    /**
+     * Gets the Session ID in the Dataset.
+     *
+     * MUST be used when Session ID is set in the Dataset, otherwise its behavior is undefined.
+     *
+     * @returns The Session ID in the Dataset.
+     *
+     */
+    uint16_t GetSessionId(void) const { return mSessionId; }
+
+    /**
+     * Sets the Session ID in the Dataset.
+     *
+     * @param[in] aSessionId  The Session ID.
+     *
+     */
+    void SetSessionId(uint16_t aSessionId)
+    {
+        mIsSessionIdSet = true;
+        mSessionId      = aSessionId;
+    }
+
+    /**
+     * Indicates whether or not the Steering Data is set in the Dataset.
+     *
+     * @returns TRUE if Steering Data is set, FALSE otherwise.
+     *
+     */
+    bool IsSteeringDataSet(void) const { return mIsSteeringDataSet; }
+
+    /**
+     * Gets the Steering Data in the Dataset.
+     *
+     * MUST be used when Steering Data is set in the Dataset, otherwise its behavior is undefined.
+     *
+     * @returns The Steering Data in the Dataset.
+     *
+     */
+    const SteeringData &GetSteeringData(void) const { return static_cast<const SteeringData &>(mSteeringData); }
+
+    /**
+     * Returns a reference to the Steering Data in the Dataset to be updated by caller.
+     *
+     * @returns A reference to the Steering Data in the Dataset.
+     *
+     */
+    SteeringData &UpdateSteeringData(void)
+    {
+        mIsSteeringDataSet = true;
+        return static_cast<SteeringData &>(mSteeringData);
+    }
+
+    /**
+     * Indicates whether or not the Joiner UDP port is set in the Dataset.
+     *
+     * @returns TRUE if Joiner UDP port is set, FALSE otherwise.
+     *
+     */
+    bool IsJoinerUdpPortSet(void) const { return mIsJoinerUdpPortSet; }
+
+    /**
+     * Gets the Joiner UDP port in the Dataset.
+     *
+     * MUST be used when Joiner UDP port is set in the Dataset, otherwise its behavior is undefined.
+     *
+     * @returns The Joiner UDP port in the Dataset.
+     *
+     */
+    uint16_t GetJoinerUdpPort(void) const { return mJoinerUdpPort; }
+
+    /**
+     * Sets the Joiner UDP Port in the Dataset.
+     *
+     * @param[in] aJoinerUdpPort  The Joiner UDP Port.
+     *
+     */
+    void SetJoinerUdpPort(uint16_t aJoinerUdpPort)
+    {
+        mIsJoinerUdpPortSet = true;
+        mJoinerUdpPort      = aJoinerUdpPort;
+    }
+};
+
+/**
  * Generates PSKc.
  *
  * PSKc is used to establish the Commissioner Session.
@@ -455,6 +583,7 @@ inline void LogError(const char *, Error) {}
 DefineCoreType(otJoinerPskd, MeshCoP::JoinerPskd);
 DefineCoreType(otJoinerDiscerner, MeshCoP::JoinerDiscerner);
 DefineCoreType(otSteeringData, MeshCoP::SteeringData);
+DefineCoreType(otCommissioningDataset, MeshCoP::CommissioningDataset);
 
 } // namespace ot
 

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -182,6 +182,14 @@ public:
                          uint16_t       aLength);
 
     /**
+     * Gets the Commissioning Dataset from Network Data.
+     *
+     * @param[out] aDataset    A reference to a `MeshCoP::CommissioningDataset` to populate.
+     *
+     */
+    void GetCommissioningDataset(MeshCoP::CommissioningDataset &aDataset) const;
+
+    /**
      * Searches for given sub-TLV in Commissioning Data TLV.
      *
      * @tparam SubTlvType    The sub-TLV type to search for.
@@ -242,6 +250,17 @@ public:
      *
      */
     Error FindJoinerUdpPort(uint16_t &aPort) const;
+
+    /**
+     * Finds and read the Steering Data in Commissioning Data TLV.
+     *
+     * @param[out] aSteeringData  A reference to return the read Steering Data.
+     *
+     * @retval kErrorNone       Successfully read the Steering Data, @p aSteeringData is updated.
+     * @retval kErrorNotFound   Did not find Steering Data sub-TLV.
+     *
+     */
+    Error FindSteeringData(MeshCoP::SteeringData &aSteeringData) const;
 
     /**
      * Indicates whether or not the Commissioning Data TLV indicates Joining is allowed.

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -2336,8 +2336,8 @@ class NodeImpl:
 
     def get_netdata(self):
         raw_netdata = self.netdata_show()
-        netdata = {'Prefixes': [], 'Routes': [], 'Services': [], 'Contexts': []}
-        key_list = ['Prefixes', 'Routes', 'Services', 'Contexts']
+        netdata = {'Prefixes': [], 'Routes': [], 'Services': [], 'Contexts': [], 'Commissioning': []}
+        key_list = ['Prefixes', 'Routes', 'Services', 'Contexts', 'Commissioning']
         key = None
 
         for i in range(0, len(raw_netdata)):

--- a/tests/toranj/cli/cli.py
+++ b/tests/toranj/cli/cli.py
@@ -387,11 +387,13 @@ class Node(object):
         routes_index = outputs.index('Routes:')
         services_index = outputs.index('Services:')
         contexts_index = outputs.index('Contexts:')
+        commissioning_index = outputs.index('Commissioning:')
         result = {}
         result['prefixes'] = outputs[1:routes_index]
         result['routes'] = outputs[routes_index + 1:services_index]
         result['services'] = outputs[services_index + 1:contexts_index]
-        result['contexts'] = outputs[contexts_index + 1:]
+        result['contexts'] = outputs[contexts_index + 1:commissioning_index]
+        result['commissioning'] = outputs[commissioning_index + 1:]
 
         return result
 

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1701,7 +1701,7 @@ class OpenThreadTHCI(object):
     @watched
     def getNetworkData(self):
         lines = self.__executeCommand('netdata show')
-        prefixes, routes, services, contexts = [], [], [], []
+        prefixes, routes, services, contexts, commissioning = [], [], [], []
         classify = None
 
         for line in lines:
@@ -1713,6 +1713,8 @@ class OpenThreadTHCI(object):
                 classify = services
             elif line == 'Contexts:':
                 classify = contexts
+            elif line == 'Commissioning':
+                classify = commissioning
             elif line == 'Done':
                 classify = None
             else:
@@ -1723,6 +1725,7 @@ class OpenThreadTHCI(object):
             'Routes': routes,
             'Services': services,
             'Contexts': contexts,
+            'Commissioning': commissioning,
         }
 
     @API


### PR DESCRIPTION
This commit adds `otNetDataGetCommissioningDataset()` as a public API to retrieve the Commissioning Dataset from the Network Data.

It also updates CLI `netdata show` command to output the Commissioning Dataset information. The documentation in `README_NETDATA.md` and in `cli_network_data` are also updated. The test scripts that parse `netdata show` output are also updated.