### PR TITLE
[posix] fix uninitialized pointer read (#9552)

### DIFF
--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -671,9 +671,9 @@ exit:
 
 otError InfraNetif::DiscoverNat64Prefix(uint32_t aInfraIfIndex)
 {
-    otError          error = OT_ERROR_NONE;
-    struct addrinfo *hints = nullptr;
-    struct gaicb    *reqs[1];
+    otError          error   = OT_ERROR_NONE;
+    struct addrinfo *hints   = nullptr;
+    struct gaicb    *reqs[1] = {nullptr};
     struct sigevent  sig;
     int              status;
 


### PR DESCRIPTION
This commit added validation for whether the pointer (reqs) being freed is nullptr or not.