### PR TITLE
[posix] clear SPI tx buffer after usage

### DIFF
--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -569,6 +569,8 @@ otError SpiInterface::PushPullSpi(void)
             mInterfaceMetrics.mTxFrameCount++;
             mInterfaceMetrics.mTxFrameByteCount += mSpiTxPayloadSize;
 
+	    // Clear tx buffer after usage
+            memset(&mSpiTxFrameBuffer[kSpiFrameHeaderSize], 0, mSpiTxPayloadSize);
             mSpiTxIsReady      = false;
             mSpiTxPayloadSize  = 0;
             mSpiTxRefusedCount = 0;


### PR DESCRIPTION
This commit clear "mSpiTxPayloadSize" buffer once packet has been successfully transmitted.