### PR TITLE
[slaac] simplify adding/removing addresses and other enhancements

### DIFF
--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -146,7 +146,7 @@ Error DuaManager::GenerateDomainUnicastAddressIid(void)
     Error   error;
     uint8_t dadCounter = mDadCounter;
 
-    if ((error = Get<Utils::Slaac>().GenerateIid(mDomainUnicastAddress, nullptr, 0, &dadCounter)) == kErrorNone)
+    if ((error = Get<Utils::Slaac>().GenerateIid(mDomainUnicastAddress, dadCounter)) == kErrorNone)
     {
         if (dadCounter != mDadCounter)
         {

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -282,7 +282,7 @@ Error Slaac::GenerateIid(Ip6::Netif::UnicastAddress &aAddress, uint8_t &aDadCoun
      *  - RID is random (but stable) Identifier.
      *  - For pseudo-random function `F()` SHA-256 is used in this method.
      *  - `Net_Iface` is set to constant string "wpan".
-     *  - `Network_ID` is not used  (optional per RF-7217).
+     *  - `Network_ID` is not used  (optional per RFC 7217).
      *  - The `secret_key` is randomly generated on first use (using true
      *    random number generator) and saved in non-volatile settings for
      *    future use.


### PR DESCRIPTION
This commit makes the following smaller enhancements in `Slaac` class:
- Adds a new `ShouldUseForSlaac()` method to check if a network data prefix should be used for SLAAC, checking flags and applying the filter if set.
- Introduces separate `RemoveAddresses()` and `AddAddresses()` methods to manage SLAAC addresses, replacing the previous `Update()` method.
- Adds helper methods to `RemoveAllAddresses()`, `RemoveAddress()` to remove a specific address, and `AddAddressFor(prefix)` to  generate and add an address for a given prefix.
- Simplifies `GenerateIid()` by removing unused input parameters.