### PR TITLE
[routing-manager] new API to get list of discovered routers

### DIFF
--- a/include/openthread/border_routing.h
+++ b/include/openthread/border_routing.h
@@ -89,21 +89,33 @@ typedef struct otBorderRoutingPrefixTableIterator
 } otBorderRoutingPrefixTableIterator;
 
 /**
+ * Represents a discovered router on the infrastructure link.
+ *
+ */
+typedef struct otBorderRoutingRouterEntry
+{
+    otIp6Address mAddress;                      ///< IPv6 address of the router.
+    bool         mManagedAddressConfigFlag : 1; ///< The router's Managed Address Config flag (`M` flag).
+    bool         mOtherConfigFlag : 1;          ///< The router's Other Config flag (`O` flag).
+    bool         mStubRouterFlag : 1;           ///< The router's Stub Router flag.
+} otBorderRoutingRouterEntry;
+
+/**
  * Represents an entry from the discovered prefix table.
  *
  * The entries in the discovered table track the Prefix/Route Info Options in the received Router Advertisement messages
- * from other routers on infrastructure link.
+ * from other routers on the infrastructure link.
  *
  */
 typedef struct otBorderRoutingPrefixTableEntry
 {
-    otIp6Address      mRouterAddress;       ///< IPv6 address of the router.
-    otIp6Prefix       mPrefix;              ///< The discovered IPv6 prefix.
-    bool              mIsOnLink;            ///< Indicates whether the prefix is on-link or route prefix.
-    uint32_t          mMsecSinceLastUpdate; ///< Milliseconds since last update of this prefix.
-    uint32_t          mValidLifetime;       ///< Valid lifetime of the prefix (in seconds).
-    otRoutePreference mRoutePreference;     ///< Route preference when `mIsOnlink` is false.
-    uint32_t          mPreferredLifetime;   ///< Preferred lifetime of the on-link prefix when `mIsOnLink` is true.
+    otBorderRoutingRouterEntry mRouter;              ///< Information about the router advertising this prefix.
+    otIp6Prefix                mPrefix;              ///< The discovered IPv6 prefix.
+    bool                       mIsOnLink;            ///< Indicates whether the prefix is on-link or route prefix.
+    uint32_t                   mMsecSinceLastUpdate; ///< Milliseconds since last update of this prefix.
+    uint32_t                   mValidLifetime;       ///< Valid lifetime of the prefix (in seconds).
+    otRoutePreference          mRoutePreference;     ///< Route preference when `mIsOnlink` is false.
+    uint32_t                   mPreferredLifetime;   ///< Preferred lifetime of the on-link prefix when `mIsOnLink`.
 } otBorderRoutingPrefixTableEntry;
 
 /**
@@ -391,6 +403,9 @@ void otBorderRoutingPrefixTableInitIterator(otInstance *aInstance, otBorderRouti
 /**
  * Iterates over the entries in the Border Router's discovered prefix table.
  *
+ * Prefix entries associated with the same discovered router on an infrastructure link are guaranteed to be grouped
+ * together (retrieved back-to-back).
+ *
  * @param[in]     aInstance    The OpenThread instance.
  * @param[in,out] aIterator    A pointer to the iterator.
  * @param[out]    aEntry       A pointer to the entry to populate.
@@ -402,6 +417,21 @@ void otBorderRoutingPrefixTableInitIterator(otInstance *aInstance, otBorderRouti
 otError otBorderRoutingGetNextPrefixTableEntry(otInstance                         *aInstance,
                                                otBorderRoutingPrefixTableIterator *aIterator,
                                                otBorderRoutingPrefixTableEntry    *aEntry);
+
+/**
+ * Iterates over the discovered router entries on the infrastructure link.
+ *
+ * @param[in]     aInstance    The OpenThread instance.
+ * @param[in,out] aIterator    A pointer to the iterator.
+ * @param[out]    aEntry       A pointer to the entry to populate.
+ *
+ * @retval OT_ERROR_NONE        Iterated to the next router, @p aEntry and @p aIterator are updated.
+ * @retval OT_ERROR_NOT_FOUND   No more router entries.
+ *
+ */
+otError otBorderRoutingGetNextRouterEntry(otInstance                         *aInstance,
+                                          otBorderRoutingPrefixTableIterator *aIterator,
+                                          otBorderRoutingRouterEntry         *aEntry);
 
 /**
  * Enables / Disables DHCPv6 Prefix Delegation.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (374)
+#define OPENTHREAD_API_VERSION (375)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README_BR.md
+++ b/src/cli/README_BR.md
@@ -15,6 +15,7 @@ Usage : `br [command] ...`
 - [prefixtable](#prefixtable)
 - [rioprf](#rioprf)
 - [routeprf](#routeprf)
+- [routers](#routers)
 - [state](#state)
 
 ## Command Details
@@ -35,6 +36,7 @@ onlinkprefix
 prefixtable
 rioprf
 routeprf
+routers
 state
 Done
 ```
@@ -180,10 +182,24 @@ Usage: `br prefixtable`
 
 Get the discovered prefixes by Border Routing Manager on the infrastructure link.
 
+Info per prefix entry:
+
+- The prefix
+- Whether the prefix is on-link or route
+- Milliseconds since last received Router Advertisement containing this prefix
+- Prefix lifetime in seconds
+- Preferred lifetime in seconds only if prefix is on-link
+- Route preference (low, med, high) only if prefix is route (not on-link)
+- The router IPv6 address which advertising this prefix
+- Flags in received Router Advertisement header:
+  - M: Managed Address Config flag
+  - O: Other Config flag
+  - Stub: Stub Router flag (indicates whether the router is a stub router)
+
 ```bash
 > br prefixtable
-prefix:fd00:1234:5678:0::/64, on-link:no, ms-since-rx:29526, lifetime:1800, route-prf:med, router:ff02:0:0:0:0:0:0:1
-prefix:1200:abba:baba:0::/64, on-link:yes, ms-since-rx:29527, lifetime:1800, preferred:1800, router:ff02:0:0:0:0:0:0:1
+prefix:fd00:1234:5678:0::/64, on-link:no, ms-since-rx:29526, lifetime:1800, route-prf:med, router:ff02:0:0:0:0:0:0:1 (M:0 O:0 Stub:1)
+prefix:1200:abba:baba:0::/64, on-link:yes, ms-since-rx:29527, lifetime:1800, preferred:1800, router:ff02:0:0:0:0:0:0:1 (M:0 O:0 Stub:1)
 Done
 ```
 
@@ -252,5 +268,25 @@ Clear a previously set preference value for publishing routes in Thread Network 
 
 ```bash
 > br routeprf clear
+Done
+```
+
+### routers
+
+Usage: `br routers`
+
+Get the list of discovered routers by Border Routing Manager on the infrastructure link.
+
+Info per router:
+
+- The router IPv6 address
+- Flags in received Router Advertisement header:
+  - M: Managed Address Config flag
+  - O: Other Config flag
+  - Stub: Stub Router flag (indicates whether the router is a stub router)
+
+```bash
+> br routers
+ff02:0:0:0:0:0:0:1 (M:0 O:0 Stub:1)
 Done
 ```

--- a/src/cli/cli_br.hpp
+++ b/src/cli/cli_br.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#include <openthread/border_routing.h>
+
 #include "cli/cli_config.h"
 #include "cli/cli_output.hpp"
 
@@ -92,6 +94,7 @@ private:
     template <CommandId kCommandId> otError Process(Arg aArgs[]);
 
     otError ParsePrefixTypeArgs(Arg aArgs[], PrefixType &aFlags);
+    void    OutputRouterInfo(const otBorderRoutingRouterEntry &aEntry);
 };
 
 } // namespace Cli

--- a/src/core/api/border_routing_api.cpp
+++ b/src/core/api/border_routing_api.cpp
@@ -172,6 +172,16 @@ otError otBorderRoutingGetNextPrefixTableEntry(otInstance                       
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetNextPrefixTableEntry(*aIterator, *aEntry);
 }
 
+otError otBorderRoutingGetNextRouterEntry(otInstance                         *aInstance,
+                                          otBorderRoutingPrefixTableIterator *aIterator,
+                                          otBorderRoutingRouterEntry         *aEntry)
+{
+    AssertPointerIsNotNull(aIterator);
+    AssertPointerIsNotNull(aEntry);
+
+    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetNextRouterEntry(*aIterator, *aEntry);
+}
+
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
 void otBorderRoutingDhcp6PdSetEnabled(otInstance *aInstance, bool aEnabled)
 {

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -945,7 +945,7 @@ void VerifyPrefixTable(const OnLinkPrefix *aOnLinkPrefixes,
         {
             Log("   on-link prefix:%s, valid:%u, preferred:%u, router:%s, age:%u",
                 AsCoreType(&entry.mPrefix).ToString().AsCString(), entry.mValidLifetime, entry.mPreferredLifetime,
-                AsCoreType(&entry.mRouterAddress).ToString().AsCString(), entry.mMsecSinceLastUpdate / 1000);
+                AsCoreType(&entry.mRouter.mAddress).ToString().AsCString(), entry.mMsecSinceLastUpdate / 1000);
 
             onLinkPrefixCount++;
 
@@ -954,7 +954,7 @@ void VerifyPrefixTable(const OnLinkPrefix *aOnLinkPrefixes,
                 const OnLinkPrefix &onLinkPrefix = aOnLinkPrefixes[index];
 
                 if ((onLinkPrefix.mPrefix == AsCoreType(&entry.mPrefix)) &&
-                    (AsCoreType(&entry.mRouterAddress) == onLinkPrefix.mRouterAddress))
+                    (AsCoreType(&entry.mRouter.mAddress) == onLinkPrefix.mRouterAddress))
                 {
                     VerifyOrQuit(entry.mValidLifetime == onLinkPrefix.mValidLifetime);
                     VerifyOrQuit(entry.mPreferredLifetime == onLinkPrefix.mPreferredLifetime);
@@ -967,7 +967,7 @@ void VerifyPrefixTable(const OnLinkPrefix *aOnLinkPrefixes,
         {
             Log("   route prefix:%s, valid:%u, prf:%s, router:%s, age:%u",
                 AsCoreType(&entry.mPrefix).ToString().AsCString(), entry.mValidLifetime,
-                PreferenceToString(entry.mRoutePreference), AsCoreType(&entry.mRouterAddress).ToString().AsCString(),
+                PreferenceToString(entry.mRoutePreference), AsCoreType(&entry.mRouter.mAddress).ToString().AsCString(),
                 entry.mMsecSinceLastUpdate / 1000);
 
             routePrefixCount++;
@@ -977,7 +977,7 @@ void VerifyPrefixTable(const OnLinkPrefix *aOnLinkPrefixes,
                 const RoutePrefix &routePrefix = aRoutePrefixes[index];
 
                 if ((routePrefix.mPrefix == AsCoreType(&entry.mPrefix)) &&
-                    (AsCoreType(&entry.mRouterAddress) == routePrefix.mRouterAddress))
+                    (AsCoreType(&entry.mRouter.mAddress) == routePrefix.mRouterAddress))
                 {
                     VerifyOrQuit(entry.mValidLifetime == routePrefix.mValidLifetime);
                     VerifyOrQuit(static_cast<int8_t>(entry.mRoutePreference) == routePrefix.mPreference);


### PR DESCRIPTION
This commit adds `otBorderRoutingGetNextRouterEntry` as a new API to iterate over discovered routers on the infrastructure link and get information about them such as their address, their Managed Address Configuration (`M`), Other Configuration (`O`), and Stub Router flags.

The `otBorderRoutingPrefixTableEntry` is also updated to contain the same information.

This commit also updates the CLI `br` sub-commands to provide this information, adding `br routers` to obtain a list of discovered routers.