### PR TITLE
[test] address occasional failure of `test_routing_manager`

### DIFF
--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -3543,7 +3543,7 @@ void TestBorderRoutingProcessPlatfromGeneratedNd(void)
     }
 
     SuccessOrQuit(otBorderRoutingSetEnabled(sInstance, false));
-    VerifyOrQuit(sHeapAllocatedPtrs.GetLength() == heapAllocations);
+    VerifyOrQuit(sHeapAllocatedPtrs.GetLength() <= heapAllocations);
 
     Log("End of TestBorderRoutingProcessPlatfromGeneratedNd");
 }


### PR DESCRIPTION
This commit addresses occasional failures in `test_routing_manager` in the `TestBorderRoutingProcessPlatfromGeneratedNd` case. Unlike other tests, this test sets the `heapAllocations` after the call `InitTest (/* aEnableBorderRouting */ true)` (which enables `RoutingManager`). This means that depending on the random timing, the `heapAllocations` may already count some allocated heap items by `RoutingManager` itself. With the change in this commit, at the end of the test, we check that the number of remaining heap allocations is less than `heapAllocations`.

----

Should address #9602.