### PR TITLE
[test] ensure to `FinalizeTest()` in `TestProcessPlatfromGeneratedNd()`

### DIFF
--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -3546,6 +3546,8 @@ void TestBorderRoutingProcessPlatfromGeneratedNd(void)
     VerifyOrQuit(sHeapAllocatedPtrs.GetLength() <= heapAllocations);
 
     Log("End of TestBorderRoutingProcessPlatfromGeneratedNd");
+
+    FinalizeTest();
 }
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
 


### PR DESCRIPTION

---

Add missing `FinalizeTest()` to `TestBorderRoutingProcessPlatfromGeneratedNd()`. 
The test ran okay today since this test case is the last one (so not finalizing did not cause any issue).