### PR TITLE
[routing-manager] learn and copy `M` & `O` flags from discovered routers

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -635,6 +635,8 @@ private:
 
         TimeMilli CalculateNextStaleTime(TimeMilli aNow) const;
 
+        void DetermineAndSetFlags(Ip6::Nd::RouterAdvertMessage &aRaMessage) const;
+
         void  InitIterator(PrefixTableIterator &aIterator) const;
         Error GetNextEntry(PrefixTableIterator &aIterator, PrefixTableEntry &aEntry) const;
         Error GetNextRouter(PrefixTableIterator &aIterator, RouterEntry &aEntry) const;
@@ -770,11 +772,11 @@ private:
 
             enum EmptyChecker : uint8_t
             {
-                kContainsNoEntries
+                kContainsNoEntriesOrFlags
             };
 
             bool Matches(const Ip6::Address &aAddress) const { return aAddress == mAddress; }
-            bool Matches(EmptyChecker) const { return mEntries.IsEmpty(); }
+            bool Matches(EmptyChecker aChecker) const;
             void CopyInfoTo(RouterEntry &aEntry) const;
 
             Router           *mNext;
@@ -816,7 +818,7 @@ private:
         bool         Contains(const Entry::Checker &aChecker) const;
         void         RemovePrefix(const Entry::Matcher &aMatcher);
         void         RemoveOrDeprecateEntriesFromInactiveRouters(void);
-        void         RemoveRoutersWithNoEntries(void);
+        void         RemoveRoutersWithNoEntriesOrFlags(void);
         void         FreeRouters(LinkedList<Router> &aRouters);
         void         FreeEntries(LinkedList<Entry> &aEntries);
         void         UpdateNetworkDataOnChangeTo(Entry &aEntry);

--- a/src/core/net/nd6.hpp
+++ b/src/core/net/nd6.hpp
@@ -734,6 +734,14 @@ public:
     const Header &GetHeader(void) const { return *reinterpret_cast<const Header *>(mData.GetBytes()); }
 
     /**
+     * Gets the RA message's header.
+     *
+     * @returns The RA message's header.
+     *
+     */
+    Header &GetHeader(void) { return *reinterpret_cast<Header *>(AsNonConst(mData.GetBytes())); }
+
+    /**
      * Appends a Prefix Info Option to the RA message.
      *
      * The appended Prefix Info Option will have both on-link (L) and autonomous address-configuration (A) flags set.


### PR DESCRIPTION
This commit implements a mechanism in `RoutingManager` to learn the Managed Address Config (`M`) and Other Config (`O`) flags in received RA message from discovered routers on the infrastructure link and copy the same flags in the emitted RA 
message from BR.

If any discovered router on the infrastructure that is not itself a stub router (i.e., does not include the Stub Router flag) includes the `M` or `O` flags, the same flag are included in the emitted RA message. If a discovered router has failed to respond to the maximum number of NS probe attempts, we consider it as offline and ignore its flags.

This commit also adds a detailed test case in `test_routing_manager` to validate the newly added mechanism.

---

- This is related [SPEC-1217](https://threadgroup.atlassian.net/browse/SPEC-1217)
- ~The PR currently contains the commit from https://github.com/openthread/openthread/pull/9601 (please check and review the last commit on this PR. thanks).~