### PR TITLE
[dhcp6-pd] stop `PrefixManager` when `RoutingManager` is stopped

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -3329,7 +3329,7 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
-const char *RoutingManager::Dhcp6PdStateToString(Dhcp6PdState aState)
+const char *RoutingManager::PdPrefixManager::StateToString(Dhcp6PdState aState)
 {
     static const char *const kStateStrings[] = {
         "Disabled", // (0) kDisabled
@@ -3382,14 +3382,12 @@ void RoutingManager::PdPrefixManager::EvaluateStateChange(Dhcp6PdState aOldState
     Dhcp6PdState newState = GetState();
 
     VerifyOrExit(aOldState != newState);
-    LogInfo("PdPrefixManager: %s -> %s", Dhcp6PdStateToString(aOldState), Dhcp6PdStateToString(newState));
+    LogInfo("PdPrefixManager: %s -> %s", StateToString(aOldState), StateToString(newState));
 
     // TODO: We may also want to inform the platform that PD is stopped.
     switch (newState)
     {
     case kDhcp6PdStateDisabled:
-        WithdrawPrefix();
-        break;
     case kDhcp6PdStateStopped:
         WithdrawPrefix();
         break;

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1149,6 +1149,8 @@ private:
         Error GetPrefixInfo(PrefixTableEntry &aInfo) const;
         void  HandleTimer(void) { WithdrawPrefix(); }
 
+        static const char *StateToString(Dhcp6PdState aState);
+
         static bool IsValidPdPrefix(const Ip6::Prefix &aPrefix)
         {
             // We should accept ULA prefix since it could be used by the internet infrastructure like NAT64.
@@ -1207,10 +1209,6 @@ private:
 
     static void LogPrefixInfoOption(const Ip6::Prefix &aPrefix, uint32_t aValidLifetime, uint32_t aPreferredLifetime);
     static void LogRouteInfoOption(const Ip6::Prefix &aPrefix, uint32_t aLifetime, RoutePreference aPreference);
-
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
-    static const char *Dhcp6PdStateToString(Dhcp6PdState aState);
-#endif
 
     using RoutingPolicyTimer         = TimerMilliIn<RoutingManager, &RoutingManager::EvaluateRoutingPolicy>;
     using DiscoveredPrefixStaleTimer = TimerMilliIn<RoutingManager, &RoutingManager::HandleDiscoveredPrefixStaleTimer>;

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1208,6 +1208,10 @@ private:
     static void LogPrefixInfoOption(const Ip6::Prefix &aPrefix, uint32_t aValidLifetime, uint32_t aPreferredLifetime);
     static void LogRouteInfoOption(const Ip6::Prefix &aPrefix, uint32_t aLifetime, RoutePreference aPreference);
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
+    static const char *Dhcp6PdStateToString(Dhcp6PdState aState);
+#endif
+
     using RoutingPolicyTimer         = TimerMilliIn<RoutingManager, &RoutingManager::EvaluateRoutingPolicy>;
     using DiscoveredPrefixStaleTimer = TimerMilliIn<RoutingManager, &RoutingManager::HandleDiscoveredPrefixStaleTimer>;
 

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1138,16 +1138,12 @@ private:
         explicit PdPrefixManager(Instance &aInstance);
 
         void               SetEnabled(bool aEnabled);
-        void               Start(void);
-        void               Stop(void);
+        void               Start(void) { StartStop(/* aStart= */ true); }
+        void               Stop(void) { StartStop(/* aStart= */ false); }
         bool               IsRunning(void) const { return GetState() == Dhcp6PdState::kDhcp6PdStateRunning; }
         bool               HasPrefix(void) const { return IsValidOmrPrefix(mPrefix.GetPrefix()); }
         const Ip6::Prefix &GetPrefix(void) const { return mPrefix.GetPrefix(); }
-        Dhcp6PdState       GetState(void) const
-        {
-            return mEnabled ? (mIsRunning ? Dhcp6PdState::kDhcp6PdStateRunning : Dhcp6PdState::kDhcp6PdStateStopped)
-                            : Dhcp6PdState::kDhcp6PdStateDisabled;
-        }
+        Dhcp6PdState       GetState(void) const;
 
         void  ProcessPlatformGeneratedRa(const uint8_t *aRouterAdvert, uint16_t aLength);
         Error GetPrefixInfo(PrefixTableEntry &aInfo) const;
@@ -1164,6 +1160,7 @@ private:
         Error Process(const Ip6::Nd::RouterAdvertMessage &aMessage);
         void  EvaluateStateChange(Dhcp6PdState aOldState);
         void  WithdrawPrefix(void);
+        void  StartStop(bool aStart);
 
         using PlatformOmrPrefixTimer = TimerMilliIn<RoutingManager, &RoutingManager::HandlePdPrefixManagerTimer>;
 


### PR DESCRIPTION
When InfraIf is down and we received a RA from the host interface, we may trigger the EvaluateRoutingPolicy unexpectly.

This might happen when infra if and uplink are separate interfaces.

This PR fixes this by adding Start and Stop to `PdPrefixManager` to start / stop handling RA messages.