### PR TITLE
[mle] fix responding to "Child Update Request" from non-parent device

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2121,10 +2121,9 @@ Error Mle::SendChildUpdateResponse(const TlvList      &aTlvList,
                                    const RxChallenge  &aChallenge,
                                    const Ip6::Address &aDestination)
 {
-    Error        error = kErrorNone;
-    Ip6::Address destination;
-    TxMessage   *message;
-    bool         checkAddress = false;
+    Error      error = kErrorNone;
+    TxMessage *message;
+    bool       checkAddress = false;
 
     VerifyOrExit((message = NewMleMessage(kCommandChildUpdateResponse)) != nullptr, error = kErrorNoBufs);
     SuccessOrExit(error = message->AppendSourceAddressTlv());
@@ -2185,7 +2184,7 @@ Error Mle::SendChildUpdateResponse(const TlvList      &aTlvList,
 
     SuccessOrExit(error = message->SendTo(aDestination));
 
-    Log(kMessageSend, kTypeChildUpdateResponseAsChild, destination);
+    Log(kMessageSend, kTypeChildUpdateResponseAsChild, aDestination);
 
     if (checkAddress && HasUnregisteredAddress())
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2096,7 +2096,7 @@ Error Mle::SendChildUpdateRequest(ChildUpdateRequestMode aMode)
     destination.SetToLinkLocalAddress(mParent.GetExtAddress());
     SuccessOrExit(error = message->SendTo(destination));
 
-    Log(kMessageSend, kTypeChildUpdateRequestOfParent, destination);
+    Log(kMessageSend, kTypeChildUpdateRequestAsChild, destination);
 
     if (!IsRxOnWhenIdle())
     {
@@ -2117,7 +2117,7 @@ exit:
     return error;
 }
 
-Error Mle::SendChildUpdateResponse(const TlvList &aTlvList, const RxChallenge &aChallenge)
+Error Mle::SendChildUpdateResponse(const TlvList &aTlvList, const RxChallenge &aChallenge, const Mac::ExtAddress &aExtAddress)
 {
     Error        error = kErrorNone;
     Ip6::Address destination;
@@ -2181,10 +2181,10 @@ Error Mle::SendChildUpdateResponse(const TlvList &aTlvList, const RxChallenge &a
         }
     }
 
-    destination.SetToLinkLocalAddress(mParent.GetExtAddress());
+    destination.SetToLinkLocalAddress(aExtAddress);
     SuccessOrExit(error = message->SendTo(destination));
 
-    Log(kMessageSend, kTypeChildUpdateResponseOfParent, destination);
+    Log(kMessageSend, kTypeChildUpdateResponseAsChild, destination);
 
     if (checkAddress && HasUnregisteredAddress())
     {
@@ -3463,16 +3463,17 @@ exit:
 
 void Mle::HandleChildUpdateRequest(RxInfo &aRxInfo)
 {
-    Error       error = kErrorNone;
-    uint16_t    sourceAddress;
-    RxChallenge challenge;
-    TlvList     requestedTlvList;
-    TlvList     tlvList;
+    Error           error = kErrorNone;
+    uint16_t        sourceAddress;
+    RxChallenge     challenge;
+    TlvList         requestedTlvList;
+    TlvList         tlvList;
+    Mac::ExtAddress extAddr;
 
     // Source Address
     SuccessOrExit(error = Tlv::Find<SourceAddressTlv>(aRxInfo.mMessage, sourceAddress));
 
-    Log(kMessageReceive, kTypeChildUpdateRequestOfParent, aRxInfo.mMessageInfo.GetPeerAddr(), sourceAddress);
+    Log(kMessageReceive, kTypeChildUpdateRequestAsChild, aRxInfo.mMessageInfo.GetPeerAddr(), sourceAddress);
 
     // Challenge
     switch (aRxInfo.mMessage.ReadChallengeTlv(challenge))
@@ -3553,10 +3554,12 @@ void Mle::HandleChildUpdateRequest(RxInfo &aRxInfo)
     }
 #endif
 
-    SuccessOrExit(error = SendChildUpdateResponse(tlvList, challenge));
+    // Send the response to the requester, regardless if it's this device's parent or not
+    aRxInfo.mMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddr);
+    SuccessOrExit(error = SendChildUpdateResponse(tlvList, challenge, extAddr));
 
 exit:
-    LogProcessError(kTypeChildUpdateRequestOfParent, error);
+    LogProcessError(kTypeChildUpdateRequestAsChild, error);
 }
 
 void Mle::HandleChildUpdateResponse(RxInfo &aRxInfo)
@@ -3570,7 +3573,7 @@ void Mle::HandleChildUpdateResponse(RxInfo &aRxInfo)
     uint16_t    sourceAddress;
     uint32_t    timeout;
 
-    Log(kMessageReceive, kTypeChildUpdateResponseOfParent, aRxInfo.mMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeChildUpdateResponseAsChild, aRxInfo.mMessageInfo.GetPeerAddr());
 
     switch (aRxInfo.mMessage.ReadResponseTlv(response))
     {
@@ -3711,7 +3714,7 @@ exit:
         }
     }
 
-    LogProcessError(kTypeChildUpdateResponseOfParent, error);
+    LogProcessError(kTypeChildUpdateResponseAsChild, error);
 }
 
 void Mle::HandleAnnounce(RxInfo &aRxInfo)
@@ -4137,8 +4140,8 @@ const char *Mle::MessageTypeToString(MessageType aType)
         "Child ID Request",      // (2)  kTypeChildIdRequest
         "Child ID Request",      // (3)  kTypeChildIdRequestShort
         "Child ID Response",     // (4)  kTypeChildIdResponse
-        "Child Update Request",  // (5)  kTypeChildUpdateRequestOfParent
-        "Child Update Response", // (6)  kTypeChildUpdateResponseOfParent
+        "Child Update Request",  // (5)  kTypeChildUpdateRequestAsChild
+        "Child Update Response", // (6)  kTypeChildUpdateResponseAsChild
         "Data Request",          // (7)  kTypeDataRequest
         "Data Response",         // (8)  kTypeDataResponse
         "Discovery Request",     // (9)  kTypeDiscoveryRequest
@@ -4177,8 +4180,8 @@ const char *Mle::MessageTypeToString(MessageType aType)
     static_assert(kTypeChildIdRequest == 2, "kTypeChildIdRequest value is incorrect");
     static_assert(kTypeChildIdRequestShort == 3, "kTypeChildIdRequestShort value is incorrect");
     static_assert(kTypeChildIdResponse == 4, "kTypeChildIdResponse value is incorrect");
-    static_assert(kTypeChildUpdateRequestOfParent == 5, "kTypeChildUpdateRequestOfParent value is incorrect");
-    static_assert(kTypeChildUpdateResponseOfParent == 6, "kTypeChildUpdateResponseOfParent value is incorrect");
+    static_assert(kTypeChildUpdateRequestAsChild == 5, "kTypeChildUpdateRequestAsChild value is incorrect");
+    static_assert(kTypeChildUpdateResponseAsChild == 6, "kTypeChildUpdateResponseAsChild value is incorrect");
     static_assert(kTypeDataRequest == 7, "kTypeDataRequest value is incorrect");
     static_assert(kTypeDataResponse == 8, "kTypeDataResponse value is incorrect");
     static_assert(kTypeDiscoveryRequest == 9, "kTypeDiscoveryRequest value is incorrect");
@@ -4235,9 +4238,9 @@ const char *Mle::MessageTypeActionToSuffixString(MessageType aType, MessageActio
     case kTypeChildIdRequestShort:
         str = " - short";
         break;
-    case kTypeChildUpdateRequestOfParent:
-    case kTypeChildUpdateResponseOfParent:
-        str = (aAction == kMessageReceive) ? " from parent" : " to parent";
+    case kTypeChildUpdateRequestAsChild:
+    case kTypeChildUpdateResponseAsChild:
+        str = " as child";
         break;
     case kTypeParentRequestToRouters:
         str = " to routers";

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2117,7 +2117,9 @@ exit:
     return error;
 }
 
-Error Mle::SendChildUpdateResponse(const TlvList &aTlvList, const RxChallenge &aChallenge, const Mac::ExtAddress &aExtAddress)
+Error Mle::SendChildUpdateResponse(const TlvList &aTlvList,
+                                   const RxChallenge &aChallenge,
+                                   const Mac::ExtAddress &aExtAddress)
 {
     Error        error = kErrorNone;
     Ip6::Address destination;
@@ -3518,7 +3520,7 @@ void Mle::HandleChildUpdateRequest(RxInfo &aRxInfo)
         {
             Mac::CslAccuracy cslAccuracy;
 
-            if (aRxInfo.mMessage.ReadCslClockAccuracyTlv(cslAccuracy) == kErrorNone)
+            if (aRxInfo.mMessage.ReadCslClocAccuracyTlv(cslAccuracy) == kErrorNone)
             {
                 // MUST include CSL timeout TLV when request includes CSL accuracy
                 tlvList.Add(Tlv::kCslTimeout);
@@ -4232,6 +4234,8 @@ const char *Mle::MessageTypeToString(MessageType aType)
 const char *Mle::MessageTypeActionToSuffixString(MessageType aType, MessageAction aAction)
 {
     const char *str = "";
+
+    OT_UNUSED_VARIABLE(aAction); // Not currently used in non-FTD builds
 
     switch (aType)
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2117,9 +2117,9 @@ exit:
     return error;
 }
 
-Error Mle::SendChildUpdateResponse(const TlvList         &aTlvList,
-                                   const RxChallenge     &aChallenge,
-                                   const Mac::ExtAddress &aExtAddress)
+Error Mle::SendChildUpdateResponse(const TlvList      &aTlvList,
+                                   const RxChallenge  &aChallenge,
+                                   const Ip6::Address &aDestination)
 {
     Error        error = kErrorNone;
     Ip6::Address destination;
@@ -2183,8 +2183,7 @@ Error Mle::SendChildUpdateResponse(const TlvList         &aTlvList,
         }
     }
 
-    destination.SetToLinkLocalAddress(aExtAddress);
-    SuccessOrExit(error = message->SendTo(destination));
+    SuccessOrExit(error = message->SendTo(aDestination));
 
     Log(kMessageSend, kTypeChildUpdateResponseAsChild, destination);
 
@@ -3470,7 +3469,6 @@ void Mle::HandleChildUpdateRequest(RxInfo &aRxInfo)
     RxChallenge     challenge;
     TlvList         requestedTlvList;
     TlvList         tlvList;
-    Mac::ExtAddress extAddr;
 
     // Source Address
     SuccessOrExit(error = Tlv::Find<SourceAddressTlv>(aRxInfo.mMessage, sourceAddress));
@@ -3557,8 +3555,7 @@ void Mle::HandleChildUpdateRequest(RxInfo &aRxInfo)
 #endif
 
     // Send the response to the requester, regardless if it's this device's parent or not
-    aRxInfo.mMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddr);
-    SuccessOrExit(error = SendChildUpdateResponse(tlvList, challenge, extAddr));
+    SuccessOrExit(error = SendChildUpdateResponse(tlvList, challenge, aRxInfo.mMessageInfo.GetPeerAddr()));
 
 exit:
     LogProcessError(kTypeChildUpdateRequestAsChild, error);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3464,11 +3464,11 @@ exit:
 
 void Mle::HandleChildUpdateRequest(RxInfo &aRxInfo)
 {
-    Error           error = kErrorNone;
-    uint16_t        sourceAddress;
-    RxChallenge     challenge;
-    TlvList         requestedTlvList;
-    TlvList         tlvList;
+    Error       error = kErrorNone;
+    uint16_t    sourceAddress;
+    RxChallenge challenge;
+    TlvList     requestedTlvList;
+    TlvList     tlvList;
 
     // Source Address
     SuccessOrExit(error = Tlv::Find<SourceAddressTlv>(aRxInfo.mMessage, sourceAddress));

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3520,7 +3520,7 @@ void Mle::HandleChildUpdateRequest(RxInfo &aRxInfo)
         {
             Mac::CslAccuracy cslAccuracy;
 
-            if (aRxInfo.mMessage.ReadCslClocAccuracyTlv(cslAccuracy) == kErrorNone)
+            if (aRxInfo.mMessage.ReadCslClockAccuracyTlv(cslAccuracy) == kErrorNone)
             {
                 // MUST include CSL timeout TLV when request includes CSL accuracy
                 tlvList.Add(Tlv::kCslTimeout);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2117,8 +2117,8 @@ exit:
     return error;
 }
 
-Error Mle::SendChildUpdateResponse(const TlvList &aTlvList,
-                                   const RxChallenge &aChallenge,
+Error Mle::SendChildUpdateResponse(const TlvList         &aTlvList,
+                                   const RxChallenge     &aChallenge,
                                    const Mac::ExtAddress &aExtAddress)
 {
     Error        error = kErrorNone;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1230,9 +1230,9 @@ private:
     Error      SendChildUpdateRequest(ChildUpdateRequestMode aMode);
     Error      SendDataRequestAfterDelay(const Ip6::Address &aDestination, uint16_t aDelay);
     Error      SendChildUpdateRequest(void);
-    Error      SendChildUpdateResponse(const TlvList         &aTlvList,
-                                       const RxChallenge     &aChallenge,
-                                       const Mac::ExtAddress &aExtAddress);
+    Error      SendChildUpdateResponse(const TlvList      &aTlvList,
+                                       const RxChallenge  &aChallenge,
+                                       const Ip6::Address &aDestination);
     void       SetRloc16(uint16_t aRloc16);
     void       SetStateDetached(void);
     void       SetStateChild(uint16_t aRloc16);

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1230,7 +1230,9 @@ private:
     Error      SendChildUpdateRequest(ChildUpdateRequestMode aMode);
     Error      SendDataRequestAfterDelay(const Ip6::Address &aDestination, uint16_t aDelay);
     Error      SendChildUpdateRequest(void);
-    Error      SendChildUpdateResponse(const TlvList &aTlvList, const RxChallenge &aChallenge, const Mac::ExtAddress &aExtAddress);
+    Error      SendChildUpdateResponse(const TlvList         &aTlvList,
+                                       const RxChallenge     &aChallenge,
+                                       const Mac::ExtAddress &aExtAddress);
     void       SetRloc16(uint16_t aRloc16);
     void       SetStateDetached(void);
     void       SetStateChild(uint16_t aRloc16);

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -927,8 +927,8 @@ private:
         kTypeChildIdRequest,
         kTypeChildIdRequestShort,
         kTypeChildIdResponse,
-        kTypeChildUpdateRequestOfParent,
-        kTypeChildUpdateResponseOfParent,
+        kTypeChildUpdateRequestAsChild,
+        kTypeChildUpdateResponseAsChild,
         kTypeDataRequest,
         kTypeDataResponse,
         kTypeDiscoveryRequest,
@@ -1230,7 +1230,7 @@ private:
     Error      SendChildUpdateRequest(ChildUpdateRequestMode aMode);
     Error      SendDataRequestAfterDelay(const Ip6::Address &aDestination, uint16_t aDelay);
     Error      SendChildUpdateRequest(void);
-    Error      SendChildUpdateResponse(const TlvList &aTlvList, const RxChallenge &aChallenge);
+    Error      SendChildUpdateResponse(const TlvList &aTlvList, const RxChallenge &aChallenge, const Mac::ExtAddress &aExtAddress);
     void       SetRloc16(uint16_t aRloc16);
     void       SetStateDetached(void);
     void       SetStateChild(uint16_t aRloc16);


### PR DESCRIPTION
After a router with children downgrades, it's former children will still send child update requests until they timeout. This allows the downgraded device to respond with status TLV indicating error to help those children realize they need to reattach sooner.