### PR TITLE
[mle] remove `MleRouter` class definition under `MTD` build

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -395,7 +395,18 @@ otError otThreadSetEnabled(otInstance *aInstance, bool aEnabled)
 
 uint16_t otThreadGetVersion(void) { return kThreadVersion; }
 
-bool otThreadIsSingleton(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mle::MleRouter>().IsSingleton(); }
+bool otThreadIsSingleton(otInstance *aInstance)
+{
+    bool isSingleton = false;
+
+#if OPENTHREAD_FTD
+    isSingleton = AsCoreType(aInstance).Get<Mle::MleRouter>().IsSingleton();
+#else
+    OT_UNUSED_VARIABLE(aInstance);
+#endif
+
+    return isSingleton;
+}
 
 otError otThreadDiscover(otInstance              *aInstance,
                          uint32_t                 aScanChannels,

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -713,7 +713,9 @@ template <> inline RadioSelector &Instance::Get(void) { return mRadioSelector; }
 
 template <> inline Mle::Mle &Instance::Get(void) { return mMleRouter; }
 
+#if OPENTHREAD_FTD
 template <> inline Mle::MleRouter &Instance::Get(void) { return mMleRouter; }
+#endif
 
 template <> inline Mle::DiscoverScanner &Instance::Get(void) { return mDiscoverScanner; }
 

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1157,7 +1157,11 @@ void MeshForwarder::UpdateNeighborLinkFailures(Neighbor &aNeighbor,
         if (aAllowNeighborRemove && (Mle::IsActiveRouter(aNeighbor.GetRloc16())) &&
             (aNeighbor.GetLinkFailures() >= aFailLimit))
         {
+#if OPENTHREAD_FTD
             Get<Mle::MleRouter>().RemoveRouterLink(static_cast<Router &>(aNeighbor));
+#else
+            IgnoreError(Get<Mle::Mle>().BecomeDetached());
+#endif
         }
     }
 }

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -96,7 +96,9 @@ namespace Mle {
  *
  */
 
+#if OPENTHREAD_FTD
 class MleRouter;
+#endif
 
 /**
  * Implements MLE functionality required by the Thread EndDevices, Router, and Leader roles.
@@ -104,7 +106,9 @@ class MleRouter;
  */
 class Mle : public InstanceLocator, private NonCopyable
 {
+#if OPENTHREAD_FTD
     friend class MleRouter;
+#endif
     friend class DiscoverScanner;
     friend class ot::Instance;
     friend class ot::Notifier;
@@ -699,6 +703,16 @@ public:
         return (&aAddress == &mLinkLocalAllThreadNodes) || (&aAddress == &mRealmLocalAllThreadNodes);
     }
 
+    /**
+     * Determines the next hop towards an RLOC16 destination.
+     *
+     * @param[in]  aDestination  The RLOC16 of the destination.
+     *
+     * @returns A RLOC16 of the next hop if a route is known, kInvalidRloc16 otherwise.
+     *
+     */
+    uint16_t GetNextHop(uint16_t aDestination) const;
+
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     /**
      * Gets the CSL timeout.
@@ -1219,7 +1233,6 @@ private:
     void       InitNeighbor(Neighbor &aNeighbor, const RxInfo &aRxInfo);
     void       ClearParentCandidate(void) { mParentCandidate.Clear(); }
     Error      CheckReachability(uint16_t aMeshDest, const Ip6::Header &aIp6Header);
-    uint16_t   GetNextHop(uint16_t aDestination) const;
     Error      SendDataRequest(const Ip6::Address &aDestination);
     void       HandleNotifierEvents(Events aEvents);
     void       SendDelayedResponse(TxMessage &aMessage, const DelayedResponseMetadata &aMetadata);

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -770,33 +770,9 @@ DeclareTmfHandler(MleRouter, kUriAddressRelease);
 
 #if OPENTHREAD_MTD
 
-class MleRouter : public Mle
-{
-    friend class Mle;
-    friend class ot::Instance;
+typedef Mle MleRouter;
 
-public:
-    explicit MleRouter(Instance &aInstance)
-        : Mle(aInstance)
-    {
-    }
-
-    bool IsSingleton(void) const { return false; }
-
-    uint16_t GetNextHop(uint16_t aDestination) const { return Mle::GetNextHop(aDestination); }
-
-    Error RemoveNeighbor(Neighbor &) { return BecomeDetached(); }
-    void  RemoveRouterLink(Router &) { IgnoreError(BecomeDetached()); }
-
-    Error SendChildUpdateRequest(void) { return Mle::SendChildUpdateRequest(); }
-
-    Error CheckReachability(uint16_t aMeshDest, const Ip6::Header &aIp6Header)
-    {
-        return Mle::CheckReachability(aMeshDest, aIp6Header);
-    }
-};
-
-#endif // OPENTHREAD_MTD
+#endif
 
 } // namespace Mle
 


### PR DESCRIPTION
---

Under `MTD` the `MleRouter` class provided the following methods: 

- `bool IsSingleton(void) const` - Used from `otThreadIsSingleton()` - Now directly returns `false` when `MTD`
- `Error RemoveNeighbor(Neighbor &)` - Was not used under `MTD`
- `void  RemoveRouterLink(Router &)` - Used in `MeshForwarder` - Now directly calls `BecomeDetached()` when `MTD`

And the following 3 which called the `Mle::` methods of the same name (which now works directly due `typedef Mle MleRouter`).
- `uint16_t GetNextHop(uint16_t aDestination) const;` (changed to be `public` method in `Mle`)
- `Error SendChildUpdateRequest(void)`
- `Error CheckReachability(uint16_t aMeshDest, const Ip6::Header &aIp6Header)`