### PR TITLE
[posix] more robust netlink message handler

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -1665,6 +1665,12 @@ static void processNetlinkEvent(otInstance *aInstance)
 #endif
         switch (msg->nlmsg_type)
         {
+#if defined(__linux__)
+        case NLMSG_DONE:
+            // NLMSG_DONE indicates the end of the netlink message, exits now
+            ExitNow();
+#endif
+
         case RTM_NEWADDR:
         case RTM_DELADDR:
             processNetifAddrEvent(aInstance, msg);


### PR DESCRIPTION
1st commit:
Check and ensure at least the netlink header is received in the netlink socket to be safe before interpreting the buffer as a netlink message.

2nd commit:
Per https://linux.die.net/man/3/netlink, check current message type is not NLMSG_DONE before calling NLMSG_NEXT to properly handle multi-part netlink message.