### PR TITLE
[lint] explicitly initialize failedAddresses

### DIFF
--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -351,7 +351,7 @@ void MlrManager::HandleRegisterMulticastListenersResponse(otMessage           *a
 
     uint8_t                                           status;
     Error                                             error;
-    Ip6::Address                                      failedAddresses[Ip6AddressesTlv::kMaxAddresses];
+    Ip6::Address                                      failedAddresses[Ip6AddressesTlv::kMaxAddresses]{};
     uint8_t                                           failedAddressNum = 0;
     Callback<otIp6RegisterMulticastListenersCallback> callbackCopy     = mRegisterMulticastListenersCallback;
 
@@ -447,7 +447,7 @@ void MlrManager::HandleMulticastListenerRegistrationResponse(Coap::Message      
 
     uint8_t      status;
     Error        error;
-    Ip6::Address failedAddresses[Ip6AddressesTlv::kMaxAddresses];
+    Ip6::Address failedAddresses[Ip6AddressesTlv::kMaxAddresses]{};
     uint8_t      failedAddressNum = 0;
 
     error = ParseMulticastListenerRegistrationResponse(aResult, aMessage, status, failedAddresses, failedAddressNum);


### PR DESCRIPTION
Compiling with GCC 13.2.0, got the maybe-uninitialized error. This commit fixes it by initializing the array.