### PR TITLE
[dataset] simplify saving/reading of TLVs in/from secure storage

### DIFF
--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -918,6 +918,35 @@ public:
      */
     static const char *TypeToString(Type aType);
 
+#if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
+
+    /**
+     * Saves a given TLV value in secure storage and clears the TLV value by setting all value bytes to zero.
+     *
+     * If the Dataset does not contain the @p aTlvType, no action is performed.
+     *
+     * @param[in] aTlvType    The TLV type.
+     * @param[in] aKeyRef     The `KeyRef` to use with secure storage.
+     *
+     */
+    void SaveTlvInSecureStorageAndClearValue(Tlv::Type aTlvType, Crypto::Storage::KeyRef aKeyRef);
+
+    /**
+     * Reads and updates a given TLV value in Dataset from secure storage.
+     *
+     * If the Dataset does not contain the @p aTlvType, no action is performed and `kErrorNone` is returned.
+     *
+     * @param[in] aTlvType    The TLV type.
+     * @param[in] aKeyRef     The `KeyRef` to use with secure storage.
+     *
+     * @retval kErrorNone    Successfully read the TLV value from secure storage and updated the Dataset.
+     * @retval KErrorFailed  Could not read the @aKeyRef from secure storage.
+     *
+     */
+    Error ReadTlvFromSecureStorage(Tlv::Type aTlvType, Crypto::Storage::KeyRef aKeyRef);
+
+#endif // OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
+
 private:
     void RemoveTlv(Tlv *aTlv);
 

--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -184,13 +184,28 @@ public:
     Error Save(const Dataset &aDataset);
 
 private:
-    bool IsActive(void) const { return (mType == Dataset::kActive); }
-    void SetTimestamp(const Dataset &aDataset);
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
+    struct SecurelyStoredTlv
+    {
+        Crypto::Storage::KeyRef GetKeyRef(Dataset::Type aType) const
+        {
+            return (aType == Dataset::kActive) ? mActiveKeyRef : mPendingKeyRef;
+        }
+
+        Tlv::Type               mTlvType;
+        Crypto::Storage::KeyRef mActiveKeyRef;
+        Crypto::Storage::KeyRef mPendingKeyRef;
+    };
+
+    static const SecurelyStoredTlv kSecurelyStoredTlvs[];
+
     void MoveKeysToSecureStorage(Dataset &aDataset) const;
     void DestroySecurelyStoredKeys(void) const;
     void EmplaceSecurelyStoredKeys(Dataset &aDataset) const;
 #endif
+
+    bool IsActive(void) const { return (mType == Dataset::kActive); }
+    void SetTimestamp(const Dataset &aDataset);
 
     Timestamp     mTimestamp;            ///< Active or Pending Timestamp
     TimeMilli     mUpdateTime;           ///< Local time last updated


### PR DESCRIPTION
This commit simplifies the handling of Dataset TLVs that need to be securely stored when the `PLATFORM_KEY_REFERENCES_ENABLE` feature is enabled. Two new methods are added to the `Dataset` class:

- `SaveTlvInSecureStorageAndClearValue()` which  saves the value of a given TLV type in secure storage and clears the TLV value by setting all value bytes to zero.

- `ReadTlvFromSecureStorage()` which reads the TLV value back from secure storage and updates it in the `Dataset`.

These methods are used by `DatasetLocal` to manage the set of TLVs that need to be securely stored defined by a constant array of `SecurelyStoredTlv` entries. Each entry provides the TLV type along with the associated `Crypto::Storage::KeyRef` to use for active or pending Dataset.