### PR TITLE
[ip6] update `Ip6::SelectSourceAddress()` to prefer non-deprecated addresses

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1366,11 +1366,19 @@ const Address *Ip6::SelectSourceAddress(const Address &aDestination) const
                 continue;
             }
         }
-        else if (addr.mPreferred && !bestAddr->mPreferred)
+        else if (addr.mPreferred != bestAddr->mPreferred)
         {
             // Rule 3: Avoid deprecated addresses
-            bestAddr     = &addr;
-            bestMatchLen = matchLen;
+
+            if (addr.mPreferred)
+            {
+                bestAddr     = &addr;
+                bestMatchLen = matchLen;
+            }
+            else
+            {
+                continue;
+            }
         }
         else if (matchLen > bestMatchLen)
         {


### PR DESCRIPTION
This commit updates `SelectSourceAddress()` to ensure that non-deprecated addresses are always preferred over deprecated ones. When iterating over addresses, the best option is tracked in `bestAddr`. If the new address is not preferred and the currently selected `bestAddr` is, the new address is skipped to ensure that it is not picked.