### PR TITLE
[mlr] use shorter variable/method names

### DIFF
--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -249,8 +249,8 @@ otError otIp6RegisterMulticastListeners(otInstance                             *
                                         otIp6RegisterMulticastListenersCallback aCallback,
                                         void                                   *aContext)
 {
-    return AsCoreType(aInstance).Get<MlrManager>().RegisterMulticastListeners(aAddresses, aAddressNum, aTimeout,
-                                                                              aCallback, aContext);
+    return AsCoreType(aInstance).Get<MlrManager>().RegisterMulticastListeners(AsCoreTypePtr(aAddresses), aAddressNum,
+                                                                              aTimeout, aCallback, aContext);
 }
 #endif
 

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -81,6 +81,8 @@ class MlrManager : public InstanceLocator, private NonCopyable
     friend class ot::TimeTicker;
 
 public:
+    typedef otIp6RegisterMulticastListenersCallback MlrCallback;
+
     /**
      * Initializes the object.
      *
@@ -136,11 +138,11 @@ public:
      * @retval kErrorNoBufs        If insufficient message buffers available.
      *
      */
-    Error RegisterMulticastListeners(const otIp6Address                     *aAddresses,
-                                     uint8_t                                 aAddressNum,
-                                     const uint32_t                         *aTimeout,
-                                     otIp6RegisterMulticastListenersCallback aCallback,
-                                     void                                   *aContext);
+    Error RegisterMulticastListeners(const Ip6::Address *aAddresses,
+                                     uint8_t             aAddressNum,
+                                     const uint32_t     *aTimeout,
+                                     MlrCallback         aCallback,
+                                     void               *aContext);
 #endif
 
 private:
@@ -153,33 +155,29 @@ private:
 
     void HandleNotifierEvents(Events aEvents);
 
-    void  SendMulticastListenerRegistration(void);
-    Error SendMulticastListenerRegistrationMessage(const otIp6Address   *aAddresses,
-                                                   uint8_t               aAddressNum,
-                                                   const uint32_t       *aTimeout,
-                                                   Coap::ResponseHandler aResponseHandler,
-                                                   void                 *aResponseContext);
+    void  SendMlr(void);
+    Error SendMlrMessage(const Ip6::Address   *aAddresses,
+                         uint8_t               aAddressNum,
+                         const uint32_t       *aTimeout,
+                         Coap::ResponseHandler aResponseHandler,
+                         void                 *aResponseContext);
 
-    static void  HandleMulticastListenerRegistrationResponse(void                *aContext,
-                                                             otMessage           *aMessage,
-                                                             const otMessageInfo *aMessageInfo,
-                                                             Error                aResult);
-    void         HandleMulticastListenerRegistrationResponse(Coap::Message          *aMessage,
-                                                             const Ip6::MessageInfo *aMessageInfo,
-                                                             Error                   aResult);
-    static Error ParseMulticastListenerRegistrationResponse(Error          aResult,
-                                                            Coap::Message *aMessage,
-                                                            uint8_t       &aStatus,
-                                                            AddressArray  &aFailedAddresses);
+    static void  HandleMlrResponse(void                *aContext,
+                                   otMessage           *aMessage,
+                                   const otMessageInfo *aMessageInfo,
+                                   Error                aResult);
+    void         HandleMlrResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
+    static Error ParseMlrResponse(Error          aResult,
+                                  Coap::Message *aMessage,
+                                  uint8_t       &aStatus,
+                                  AddressArray  &aFailedAddresses);
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
-    static void HandleRegisterMulticastListenersResponse(void                *aContext,
-                                                         otMessage           *aMessage,
-                                                         const otMessageInfo *aMessageInfo,
-                                                         Error                aResult);
-    void        HandleRegisterMulticastListenersResponse(otMessage           *aMessage,
-                                                         const otMessageInfo *aMessageInfo,
-                                                         Error                aResult);
+    static void HandleRegisterResponse(void                *aContext,
+                                       otMessage           *aMessage,
+                                       const otMessageInfo *aMessageInfo,
+                                       Error                aResult);
+    void        HandleRegisterResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo, Error aResult);
 #endif
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
@@ -196,7 +194,7 @@ private:
 #endif
 
     void SetMulticastAddressMlrState(MlrState aFromState, MlrState aToState);
-    void FinishMulticastListenerRegistration(bool aSuccess, const AddressArray &aFailedAddresses);
+    void FinishMlr(bool aSuccess, const AddressArray &aFailedAddresses);
 
     void ScheduleSend(uint16_t aDelay);
     void UpdateTimeTickerRegistration(void);
@@ -209,7 +207,7 @@ private:
     static void LogMlrResponse(Error aResult, Error aError, uint8_t aStatus, const AddressArray &aFailedAddresses);
 
 #if (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE) && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
-    Callback<otIp6RegisterMulticastListenersCallback> mRegisterMulticastListenersCallback;
+    Callback<MlrCallback> mRegisterCallback;
 #endif
 
     uint32_t mReregistrationDelay;
@@ -217,7 +215,7 @@ private:
 
     bool mMlrPending : 1;
 #if (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE) && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
-    bool mRegisterMulticastListenersPending : 1;
+    bool mRegisterPending : 1;
 #endif
 };
 


### PR DESCRIPTION
This commit contains smaller enhancements in `MlrManager`:
- Use shorter names for variables and methods
- Avoid the use of normal `enum` name as a namespace
- Use core type `Ip6::Address` instead of `otIp6Address`

---

This PR contains commit from https://github.com/openthread/openthread/pull/9633 (please check the second commit on this PR).
