### PR TITLE
[csl] fix `TimerMicro::GetNow()` call in `sub_mac.cpp`

### DIFF
--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -142,6 +142,9 @@ jobs:
     - name: Build
       run: |
         ./script/test build
+    - name: Build with OT_CSL_RECEIVER_LOCAL_TIME_SYNC
+      run: |
+        OT_BUILDDIR="${PWD}/build_csl_receiver_local_time_sync" OT_OPTIONS="-DOT_CSL_RECEIVER_LOCAL_TIME_SYNC=ON" ./script/test build
     - name: Get Thread-Wireshark
       run: |
         ./script/test get_thread_wireshark
@@ -153,6 +156,9 @@ jobs:
         do
           ./script/test cert_suite ./tests/scripts/thread-cert/v1_2_LowPower*.py
         done
+    - name: Run with OT_CSL_RECEIVER_LOCAL_TIME_SYNC
+      run: |
+        OT_BUILDDIR="${PWD}/build_csl_receiver_local_time_sync" ./script/test cert_suite ./tests/scripts/thread-cert/v1_2_LowPower*.py
     - name: Check Crash
       if: ${{ failure() }}
       run: |

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -1268,7 +1268,7 @@ void SubMac::GetCslWindowEdges(uint32_t &aAhead, uint32_t &aAfter)
     uint32_t curTime, elapsed, semiWindow;
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_LOCAL_TIME_SYNC
-    curTime = TimerMicro::GetNow();
+    curTime = TimerMicro::GetNow().GetValue();
 #else
     curTime = static_cast<uint32_t>(otPlatRadioGetNow(&GetInstance()));
 #endif


### PR DESCRIPTION
Add missing `.GetValue()` for getting values from `TimerMicro`

related PR: https://github.com/openthread/openthread/pull/9568