### PR TITLE
[platform] fix compiling issue when use `SuccessOrDie`

### DIFF
--- a/src/lib/platform/BUILD.gn
+++ b/src/lib/platform/BUILD.gn
@@ -38,5 +38,6 @@ config("platform_config") {
 
 static_library("libopenthread-platform") {
   sources = platform_sources
+  public_deps = [ "../../core:libopenthread_core_headers" ]
   public_configs = [ ":platform_config" ]
 }

--- a/src/lib/platform/exit_code.h
+++ b/src/lib/platform/exit_code.h
@@ -38,6 +38,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <openthread/logging.h>
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Missing a header file included in the file `exit_code.h`, and 'otLogCritPlat' will not be declared. If using the function `SuccessOrDie` with only inlcude the file `src/lib/platform/exit_code.h`, it will have a compiling error `'otLogCritPlat' was not declared in this scope`. 

This PR fix it.