### PR TITLE
[mac] prioritize indirect transmissions

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -645,12 +645,18 @@ void Mac::PerformNextOperation(void)
     {
         mOperation = kOperationWaitingForData;
     }
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+#if OPENTHREAD_FTD
+    else if (IsPending(kOperationTransmitDataIndirect))
+    {
+        mOperation = kOperationTransmitDataIndirect;
+    }
+#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
     else if (IsPending(kOperationTransmitDataCsl) && TimerMilli::GetNow() >= mCslTxFireTime)
     {
         mOperation = kOperationTransmitDataCsl;
     }
 #endif
+#endif // OPENTHREAD_FTD
     else if (IsPending(kOperationActiveScan))
     {
         mOperation = kOperationActiveScan;
@@ -663,12 +669,6 @@ void Mac::PerformNextOperation(void)
     {
         mOperation = kOperationTransmitBeacon;
     }
-#if OPENTHREAD_FTD
-    else if (IsPending(kOperationTransmitDataIndirect))
-    {
-        mOperation = kOperationTransmitDataIndirect;
-    }
-#endif // OPENTHREAD_FTD
     else if (IsPending(kOperationTransmitPoll) && (!IsPending(kOperationTransmitDataDirect) || mShouldTxPollBeforeData))
     {
         mOperation = kOperationTransmitPoll;


### PR DESCRIPTION
According to the Specification transmission priorities are set as following (where priority 1 is the highest):
1. Indirect responses to Data Requests
2. CSL
3. Direct transmissions

This commit fixes the current behavior of prioritizing CSL transmissions.