### PR TITLE
[tests] fix the check of external routes in `test_multi_thread_networks.py`

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_multi_thread_networks.py
+++ b/tests/scripts/thread-cert/border_router/test_multi_thread_networks.py
@@ -130,17 +130,10 @@ class MultiThreadNetworks(thread_cert.TestCase):
 
         # Each BR should independently register an external route for the on-link prefix
         # and OMR prefix in another Thread Network.
-        self.assertTrue(len(br1.get_netdata_non_nat64_prefixes()) == 1)
-        self.assertTrue(len(router1.get_netdata_non_nat64_prefixes()) == 1)
-        self.assertTrue(len(br2.get_netdata_non_nat64_prefixes()) == 1)
-        self.assertTrue(len(router2.get_netdata_non_nat64_prefixes()) == 1)
-
-        br1_external_routes = br1.get_routes()
-        br2_external_routes = br2.get_routes()
-
-        br1_external_routes.sort()
-        br2_external_routes.sort()
-        self.assertNotEqual(br1_external_routes, br2_external_routes)
+        self.assertEqual(br1.get_netdata_non_nat64_prefixes(), ['fc00::/7'])
+        self.assertEqual(router1.get_netdata_non_nat64_prefixes(), ['fc00::/7'])
+        self.assertEqual(br2.get_netdata_non_nat64_prefixes(), ['fc00::/7'])
+        self.assertEqual(router2.get_netdata_non_nat64_prefixes(), ['fc00::/7'])
 
         self.assertTrue(len(router1.get_ip6_address(config.ADDRESS_TYPE.OMR)) == 1)
         self.assertTrue(len(router2.get_ip6_address(config.ADDRESS_TYPE.OMR)) == 1)


### PR DESCRIPTION
There was a check `self.assertNotEqual(br1_external_routes, br2_external_routes)` that verifies the external route entries of BR1 and BR2 are different, based on the fact that their external route prefixes (in /64) were different. However, today we're using generic external routes like `fc00::/7` so the external route entries will be the same when BR1 and BR2 have the same RLOC16. 

I updated the test case to verify that the devices have expected external route entries respectively.