### PR TITLE
[srp-client] track registered addresses

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (379)
+#define OPENTHREAD_API_VERSION (380)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -189,6 +189,7 @@ typedef struct otNetifAddress
     unsigned int mScopeOverride : 4;      ///< The IPv6 scope of this address.
     bool         mRloc : 1;               ///< TRUE if the address is an RLOC, FALSE otherwise.
     bool         mMeshLocal : 1;          ///< TRUE if the address is mesh-local, FALSE otherwise.
+    bool         mSrpRegistered : 1;      ///< Used by OT core only (indicates whether registered by SRP Client).
     const struct otNetifAddress *mNext;   ///< A pointer to the next network interface address.
 } otNetifAddress;
 

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -398,6 +398,14 @@ public:
     const LinkedList<UnicastAddress> &GetUnicastAddresses(void) const { return mUnicastAddresses; }
 
     /**
+     * Returns the linked list of unicast addresses.
+     *
+     * @returns The linked list of unicast addresses.
+     *
+     */
+    LinkedList<UnicastAddress> &GetUnicastAddresses(void) { return mUnicastAddresses; }
+
+    /**
      * Adds a unicast address to the network interface.
      *
      * Is intended for addresses internal to OpenThread. The @p aAddress instance is directly added in the
@@ -421,7 +429,19 @@ public:
      * @param[in]  aAddress  A reference to the unicast address.
      *
      */
-    void RemoveUnicastAddress(const UnicastAddress &aAddress);
+    void RemoveUnicastAddress(UnicastAddress &aAddress);
+
+    /**
+     * Updates the preferred flag on a previously added (internal to OpenThread core) unicast address.
+     *
+     * If the address is not added to the network interface or the current preferred flag of @p aAddress is the same as
+     * the given @p aPreferred, no action is performed.
+     *
+     * @param[in] aAddress        The unicast address
+     * @param[in] aPreferred The new value for preferred flag.
+     *
+     */
+    void UpdatePreferredFlagOn(UnicastAddress &aAddress, bool aPreferred);
 
     /**
      * Indicates whether or not an address is assigned to the interface.

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -1001,6 +1001,8 @@ private:
     void  Pause(void);
     void  HandleNotifierEvents(Events aEvents);
     void  HandleRoleChanged(void);
+    bool  ShouldUpdateHostAutoAddresses(void) const;
+    bool  ShouldHostAutoAddressRegister(const Ip6::Netif::UnicastAddress &aUnicastAddress) const;
     Error UpdateHostInfoStateOnAddressChange(void);
     void  UpdateServiceStateToRemove(Service &aService);
     State GetState(void) const { return mState; }
@@ -1065,7 +1067,6 @@ private:
     State   mState;
     uint8_t mTxFailureRetryCount : 4;
     bool    mShouldRemoveKeyLease : 1;
-    bool    mAutoHostAddressAddedMeshLocal : 1;
     bool    mSingleServiceMode : 1;
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     bool mServiceKeyRecordEnabled : 1;
@@ -1073,6 +1074,7 @@ private:
 #endif
 
     uint16_t mUpdateMessageId;
+    uint16_t mAutoHostAddressCount;
     uint32_t mRetryWaitInterval;
 
     TimeMilli mLeaseRenewTime;

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -785,7 +785,7 @@ void AddressResolver::HandleTmf<kUriAddressError>(Coap::Message &aMessage, const
     SuccessOrExit(error = Tlv::Find<ThreadTargetTlv>(aMessage, target));
     SuccessOrExit(error = Tlv::Find<ThreadMeshLocalEidTlv>(aMessage, meshLocalIid));
 
-    for (const Ip6::Netif::UnicastAddress &address : Get<ThreadNetif>().GetUnicastAddresses())
+    for (Ip6::Netif::UnicastAddress &address : Get<ThreadNetif>().GetUnicastAddresses())
     {
         if (address.GetAddress() == target && Get<Mle::MleRouter>().GetMeshLocal64().GetIid() != meshLocalIid)
         {

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -531,6 +531,14 @@ public:
     const Ip6::Address &GetMeshLocal64(void) const { return mMeshLocal64.GetAddress(); }
 
     /**
+     * Returns a reference to the ML-EID as a `Netif::UnicastAddress`.
+     *
+     * @returns A reference to the ML-EID.
+     *
+     */
+    Ip6::Netif::UnicastAddress &GetMeshLocal64UnicastAddress(void) { return mMeshLocal64; }
+
+    /**
      * Returns the Router ID of the Leader.
      *
      * @returns The Router ID of the Leader.


### PR DESCRIPTION
This commit enhances the SRP client to track registered addresses when auto host address mode is enabled. A new field `mSrpRegistered` is added to `Ip6::Netif::UnicastAddress` to track whether the address is registered by the SRP client.

This optimization ensures that the SRP client only performs registration when there is a change to the list of addresses that
need to be registered, preventing unnecessary re-registration and reduces communication overhead, e.g., when a deprecating non-preferred address which is not registered by SRP client is timed out and removed.


----

- ~The PR contains the commit from https://github.com/openthread/openthread/pull/9642 (Please check and review the last commit on this PR. Thanks).~