### PR TITLE
[border-router] add missing `otBorderRoutingDhcp6PdGetState()` declaration

### DIFF
--- a/include/openthread/border_routing.h
+++ b/include/openthread/border_routing.h
@@ -445,6 +445,18 @@ otError otBorderRoutingGetNextRouterEntry(otInstance                         *aI
 void otBorderRoutingDhcp6PdSetEnabled(otInstance *aInstance, bool aEnabled);
 
 /**
+ * Gets the current state of DHCPv6 Prefix Delegation.
+ *
+ * Requires `OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE` to be enabled.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ *
+ * @returns The current state of DHCPv6 Prefix Delegation.
+ *
+ */
+otBorderRoutingDhcp6PdState otBorderRoutingDhcp6PdGetState(otInstance *aInstance);
+
+/**
  * @}
  *
  */

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (377)
+#define OPENTHREAD_API_VERSION (378)
 
 /**
  * @addtogroup api-instance


### PR DESCRIPTION
This commit adds `otBorderRoutingDhcp6PdGetState()` function declaration in `border_routing.h` which was already implemented in `border_routing_api.cpp` file.