### PR TITLE
[bbr-local] smaller enhancements

### DIFF
--- a/src/core/backbone_router/bbr_leader.hpp
+++ b/src/core/backbone_router/bbr_leader.hpp
@@ -39,6 +39,7 @@
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 
 #include <openthread/backbone_router.h>
+#include <openthread/backbone_router_ftd.h>
 #include <openthread/ip6.h>
 
 #include "coap/coap.hpp"
@@ -72,10 +73,10 @@ static_assert(kParentAggregateDelay > 1, "kParentAggregateDelay should be larger
  */
 enum DomainPrefixEvent : uint8_t
 {
-    kDomainPrefixAdded,     ///< Domain Prefix Added.
-    kDomainPrefixRemoved,   ///< Domain Prefix Removed.
-    kDomainPrefixRefreshed, ///< Domain Prefix Changed.
-    kDomainPrefixUnchanged, ///< Domain Prefix did not change.
+    kDomainPrefixAdded     = OT_BACKBONE_ROUTER_DOMAIN_PREFIX_ADDED,   ///< Domain Prefix Added.
+    kDomainPrefixRemoved   = OT_BACKBONE_ROUTER_DOMAIN_PREFIX_REMOVED, ///< Domain Prefix Removed.
+    kDomainPrefixRefreshed = OT_BACKBONE_ROUTER_DOMAIN_PREFIX_CHANGED, ///< Domain Prefix Changed.
+    kDomainPrefixUnchanged,                                            ///< Domain Prefix did not change.
 };
 
 /**


### PR DESCRIPTION
This commit contains smaller change in `bbr_local` module:
- `LogDomainPrefix()` and `LogService()` methods are updated to use newly added `Action` enumeration.
- `HandleDomainPrefixUpdate()` is simplfied to pass the event directly to `mDomainPrefixCallback`.
- `SetState()` is updated so we we first remove ALOC/multicast addresses based on the previous state before adding/updating any addresses  based on the new state.
- Some methods/variables are renamed (e.g., use shorter name).