### PR TITLE
[spinel] fix multipan rcp enable config

### DIFF
--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -50,7 +50,7 @@ namespace Spinel {
  * Maximum number of Spinel Interface IDs.
  *
  */
-#ifdef OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
+#if OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
 static constexpr uint8_t kSpinelHeaderMaxNumIid = 4;
 #else
 static constexpr uint8_t kSpinelHeaderMaxNumIid = 1;


### PR DESCRIPTION
`MULTIPAN RCP` is enabled when `OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE` is set to `1`, so `#if` should be used instead of `#ifdef`.