### PR TITLE
 [dataset] introduce `ContainsTlv()` method

### DIFF
--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -144,6 +144,12 @@ jobs:
         ninja test
         # Validate posix builds with different radio configs
         git clean -dfx
+        ./tests/toranj/build.sh ncp-15.4
+        git clean -dfx
+        ./tests/toranj/build.sh ncp-trel
+        git clean -dfx
+        ./tests/toranj/build.sh ncp-15.4+trel
+        git clean -dfx
         ./tests/toranj/build.sh posix-15.4
         git clean -dfx
         ./tests/toranj/build.sh posix-15.4+trel

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -623,6 +623,31 @@ public:
     bool IsValid(void) const;
 
     /**
+     * Indicates whether or not a given TLV type is present in the Dataset.
+     *
+     * @param[in] aType  The TLV type to check.
+     *
+     * @retval TRUE    TLV with @p aType is present in the Dataset.
+     * @retval FALSE   TLV with @p aType is not present in the Dataset.
+     *
+     */
+    bool ContainsTlv(Tlv::Type aType) const { return (GetTlv(aType) != nullptr); }
+
+    /**
+     * Indicates whether or not a given TLV type is present in the Dataset.
+     *
+     * @tparam  aTlvType  The TLV type to check.
+     *
+     * @retval TRUE    TLV of @p aTlvType is present in the Dataset.
+     * @retval FALSE   TLV of @p aTlvType is not present in the Dataset.
+     *
+     */
+    template <typename TlvType> bool Contains(void) const
+    {
+        return ContainsTlv(static_cast<Tlv::Type>(TlvType::kType));
+    }
+
+    /**
      * Returns a pointer to the TLV with a given type.
      *
      * @param[in] aType  A TLV type.

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -302,7 +302,7 @@ Error ActiveDatasetManager::GenerateLocal(void)
 
     IgnoreError(Read(dataset));
 
-    if (dataset.GetTlv<ActiveTimestampTlv>() == nullptr)
+    if (!dataset.Contains<ActiveTimestampTlv>())
     {
         Timestamp timestamp;
 
@@ -310,7 +310,7 @@ Error ActiveDatasetManager::GenerateLocal(void)
         IgnoreError(dataset.SetTlv(Tlv::kActiveTimestamp, timestamp));
     }
 
-    if (dataset.GetTlv<ChannelTlv>() == nullptr)
+    if (!dataset.Contains<ChannelTlv>())
     {
         ChannelTlv tlv;
         tlv.Init();
@@ -318,7 +318,7 @@ Error ActiveDatasetManager::GenerateLocal(void)
         IgnoreError(dataset.SetTlv(tlv));
     }
 
-    if (dataset.GetTlv<ChannelMaskTlv>() == nullptr)
+    if (!dataset.Contains<ChannelMaskTlv>())
     {
         ChannelMaskTlv tlv;
         tlv.Init();
@@ -326,17 +326,17 @@ Error ActiveDatasetManager::GenerateLocal(void)
         IgnoreError(dataset.SetTlv(tlv));
     }
 
-    if (dataset.GetTlv<ExtendedPanIdTlv>() == nullptr)
+    if (!dataset.Contains<ExtendedPanIdTlv>())
     {
         IgnoreError(dataset.SetTlv(Tlv::kExtendedPanId, Get<ExtendedPanIdManager>().GetExtPanId()));
     }
 
-    if (dataset.GetTlv<MeshLocalPrefixTlv>() == nullptr)
+    if (!dataset.Contains<MeshLocalPrefixTlv>())
     {
         IgnoreError(dataset.SetTlv(Tlv::kMeshLocalPrefix, Get<Mle::MleRouter>().GetMeshLocalPrefix()));
     }
 
-    if (dataset.GetTlv<NetworkKeyTlv>() == nullptr)
+    if (!dataset.Contains<NetworkKeyTlv>())
     {
         NetworkKey networkKey;
 
@@ -344,19 +344,19 @@ Error ActiveDatasetManager::GenerateLocal(void)
         IgnoreError(dataset.SetTlv(Tlv::kNetworkKey, networkKey));
     }
 
-    if (dataset.GetTlv<NetworkNameTlv>() == nullptr)
+    if (!dataset.Contains<NetworkNameTlv>())
     {
         NameData nameData = Get<NetworkNameManager>().GetNetworkName().GetAsData();
 
         IgnoreError(dataset.SetTlv(Tlv::kNetworkName, nameData.GetBuffer(), nameData.GetLength()));
     }
 
-    if (dataset.GetTlv<PanIdTlv>() == nullptr)
+    if (!dataset.Contains<PanIdTlv>())
     {
         IgnoreError(dataset.SetTlv(Tlv::kPanId, Get<Mac::Mac>().GetPanId()));
     }
 
-    if (dataset.GetTlv<PskcTlv>() == nullptr)
+    if (!dataset.Contains<PskcTlv>())
     {
         Pskc pskc;
 
@@ -372,7 +372,7 @@ Error ActiveDatasetManager::GenerateLocal(void)
         IgnoreError(dataset.SetTlv(Tlv::kPskc, pskc));
     }
 
-    if (dataset.GetTlv<SecurityPolicyTlv>() == nullptr)
+    if (!dataset.Contains<SecurityPolicyTlv>())
     {
         SecurityPolicyTlv tlv;
 


### PR DESCRIPTION
This commit introduces two new methods, `ContainsTlv()` and its template variant `Contains<TlvType>()`, in the `Dataset` class. These methods enable checking whether a specified TLV type exists among the Dataset's TLVs.

----

This PR also include a second commit:

**[github-actions] cover NCP build with `OT_OPERATIONAL_DATASET_AUTO_INIT`**
    
This commit updates  `unittest` job in `toranj.yml` workflow to validate `ncp` builds (with `OT_OPERATIONAL_DATASET_AUTO_INIT` feature enabled).

