### PR TITLE
[link metrics] add Subject status check when getting link metrics data

### DIFF
--- a/src/core/utils/link_metrics_manager.cpp
+++ b/src/core/utils/link_metrics_manager.cpp
@@ -85,6 +85,7 @@ Error LinkMetricsManager::GetLinkMetricsValueByExtAddr(const Mac::ExtAddress    
 
     subject = mSubjectList.FindMatching(aExtAddress);
     VerifyOrExit(subject != nullptr, error = kErrorNotFound);
+    VerifyOrExit(subject->mState == kActive || subject->mState == kRenewing, error = kErrorInvalidState);
 
     aMetricsValues.mLinkMarginValue = subject->mData.mLinkMargin;
     aMetricsValues.mRssiValue       = subject->mData.mRssi;


### PR DESCRIPTION
This PR adds a check when returning Link Metrics data collected by
the Link Metrics manager so that only subjects in 'active' or 'renew'
state will return the data. This is to avoid showing N/A results for
neighbors that don't support being a Link Metrics Subject. Based on
current implementation, a 'Subject' object is created when the device
is trying to register a Link Metrics probing at its neighbor. If the 
neighbor deivce doesn't support being a Subject, the device won't get a 
LinkMetricsManagement response. During this period (before timeout),
the 'Subject' object is in 'kConfiguring' state. So it's unnecessary
to return any value for Subject in such states.