### PR TITLE
[posix] expose `platformInfraIfIsRunning()` as `otSysInfraIfIsRunning()`

### DIFF
--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -246,6 +246,14 @@ void otSysCountInfraNetifAddresses(otSysInfraNetIfAddressCounters *aAddressCount
  */
 void otSysSetInfraNetif(const char *aInfraNetifName, int aIcmp6Socket);
 
+/**
+ * Returns TRUE if the infrastructure interface is running.
+ *
+ * @returns TRUE if the infrastructure interface is running, FALSE if not.
+ *
+ */
+bool otSysInfraIfIsRunning(void);
+
 #ifdef __cplusplus
 } // end of extern "C"
 #endif

--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -112,7 +112,7 @@ otError otPlatInfraIfDiscoverNat64Prefix(uint32_t aInfraIfIndex)
 #endif
 }
 
-bool platformInfraIfIsRunning(void) { return ot::Posix::InfraNetif::Get().IsRunning(); }
+bool otSysInfraIfIsRunning(void) { return ot::Posix::InfraNetif::Get().IsRunning(); }
 
 const char *otSysGetInfraNetifName(void) { return ot::Posix::InfraNetif::Get().GetNetifName(); }
 
@@ -452,7 +452,7 @@ void InfraNetif::SetUp(void)
     VerifyOrExit(mNetLinkSocket != -1);
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-    SuccessOrDie(otBorderRoutingInit(gInstance, mInfraIfIndex, platformInfraIfIsRunning()));
+    SuccessOrDie(otBorderRoutingInit(gInstance, mInfraIfIndex, otSysInfraIfIsRunning()));
     SuccessOrDie(otBorderRoutingSetEnabled(gInstance, /* aEnabled */ true));
 #endif
 
@@ -546,7 +546,7 @@ void InfraNetif::ReceiveNetLinkMessage(void)
         case RTM_NEWLINK:
         case RTM_DELLINK:
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-            SuccessOrDie(otPlatInfraIfStateChanged(gInstance, mInfraIfIndex, platformInfraIfIsRunning()));
+            SuccessOrDie(otPlatInfraIfStateChanged(gInstance, mInfraIfIndex, otSysInfraIfIsRunning()));
 #endif
             break;
         case NLMSG_ERROR:

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -416,14 +416,6 @@ extern unsigned int gNetifIndex;
 extern otInstance *gInstance;
 
 /**
- * Tells if the infrastructure interface is running.
- *
- * @returns TRUE if the infrastructure interface is running, FALSE if not.
- *
- */
-bool platformInfraIfIsRunning(void);
-
-/**
  * Initializes backtrace module.
  *
  */


### PR DESCRIPTION
This PR exposes `otSysInfraIfIsRunning()`.

When we are switching to another infra netif via `otBorderRoutingInit()`, we may want to read the state of the new infra netif via  `otSysInfraIfIsRunning()`.