### PR TITLE
[meshcop] `MeshCoP::ChannelTlv` to utilize `Mle::ChannelTlvValue`

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -194,7 +194,7 @@ void Dataset::ConvertTo(Info &aDatasetInfo) const
             break;
 
         case Tlv::kChannel:
-            aDatasetInfo.SetChannel(As<ChannelTlv>(cur)->GetChannel());
+            aDatasetInfo.SetChannel(cur->ReadValueAs<ChannelTlv>().GetChannel());
             break;
 
         case Tlv::kChannelMask:
@@ -304,10 +304,10 @@ Error Dataset::SetFrom(const Info &aDatasetInfo)
 
     if (aDatasetInfo.IsChannelPresent())
     {
-        ChannelTlv tlv;
-        tlv.Init();
-        tlv.SetChannel(aDatasetInfo.GetChannel());
-        IgnoreError(WriteTlv(tlv));
+        ChannelTlvValue channelValue;
+
+        channelValue.SetChannelAndPage(aDatasetInfo.GetChannel());
+        IgnoreError(Write<ChannelTlv>(channelValue));
     }
 
     if (aDatasetInfo.IsChannelMaskPresent())
@@ -527,7 +527,7 @@ Error Dataset::ApplyConfiguration(Instance &aInstance, bool *aIsNetworkKeyUpdate
         {
         case Tlv::kChannel:
         {
-            uint8_t channel = static_cast<uint8_t>(As<ChannelTlv>(cur)->GetChannel());
+            uint8_t channel = static_cast<uint8_t>(cur->ReadValueAs<ChannelTlv>().GetChannel());
 
             error = mac.SetPanChannel(channel);
 

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -82,7 +82,7 @@ Error DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInfo 
     StateTlv::State    state                    = StateTlv::kReject;
     Dataset            dataset;
     Timestamp          activeTimestamp;
-    ChannelTlv         channel;
+    ChannelTlvValue    channelValue;
     uint16_t           sessionId;
     Ip6::NetworkPrefix meshLocalPrefix;
     NetworkKey         networkKey;
@@ -116,12 +116,11 @@ Error DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInfo 
         VerifyOrExit(Timestamp::Compare(&activeTimestamp, mLocal.GetTimestamp()) > 0);
     }
 
-    // check channel
-    if (Tlv::FindTlv(aMessage, channel) == kErrorNone)
+    if (Tlv::Find<ChannelTlv>(aMessage, channelValue) == kErrorNone)
     {
-        VerifyOrExit(channel.IsValid());
+        VerifyOrExit(channelValue.IsValid());
 
-        if (channel.GetChannel() != Get<Mac::Mac>().GetPanChannel())
+        if (channelValue.GetChannel() != Get<Mac::Mac>().GetPanChannel())
         {
             doesAffectConnectivity = true;
         }
@@ -312,10 +311,10 @@ Error ActiveDatasetManager::GenerateLocal(void)
 
     if (!dataset.Contains<ChannelTlv>())
     {
-        ChannelTlv tlv;
-        tlv.Init();
-        tlv.SetChannel(Get<Mac::Mac>().GetPanChannel());
-        IgnoreError(dataset.WriteTlv(tlv));
+        ChannelTlvValue channelValue;
+
+        channelValue.SetChannelAndPage(Get<Mac::Mac>().GetPanChannel());
+        IgnoreError(dataset.Write<ChannelTlv>(channelValue));
     }
 
     if (!dataset.Contains<ChannelMaskTlv>())

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -54,6 +54,7 @@
 #include "net/ip6_address.hpp"
 #include "radio/radio.hpp"
 #include "thread/key_manager.hpp"
+#include "thread/mle_tlvs.hpp"
 #include "thread/mle_types.hpp"
 
 namespace ot {
@@ -245,75 +246,22 @@ typedef UintTlvInfo<Tlv::kPeriod, uint16_t> PeriodTlv;
 typedef UintTlvInfo<Tlv::kScanDuration, uint16_t> ScanDurationTlv;
 
 /**
- * Defines Commissioner ID TLV constants and type.s
+ * Defines Commissioner ID TLV constants and types.
  *
  */
 typedef StringTlvInfo<Tlv::kCommissionerId, Tlv::kMaxCommissionerIdLength> CommissionerIdTlv;
 
 /**
- * Implements Channel TLV generation and parsing.
+ * Implements Channel TLV value format.
  *
  */
-OT_TOOL_PACKED_BEGIN
-class ChannelTlv : public Tlv, public TlvInfo<Tlv::kChannel>
-{
-public:
-    /**
-     * Initializes the TLV.
-     *
-     */
-    void Init(void)
-    {
-        SetType(kChannel);
-        SetLength(sizeof(*this) - sizeof(Tlv));
-    }
+typedef Mle::ChannelTlvValue ChannelTlvValue;
 
-    /**
-     * Indicates whether or not the TLV appears to be well-formed.
-     *
-     * @retval TRUE   If the TLV appears to be well-formed.
-     * @retval FALSE  If the TLV does not appear to be well-formed.
-     *
-     */
-    bool IsValid(void) const;
-
-    /**
-     * Returns the ChannelPage value.
-     *
-     * @returns The ChannelPage value.
-     *
-     */
-    uint8_t GetChannelPage(void) const { return mChannelPage; }
-
-    /**
-     * Sets the ChannelPage value.
-     *
-     * @param[in]  aChannelPage  The ChannelPage value.
-     *
-     */
-    void SetChannelPage(uint8_t aChannelPage) { mChannelPage = aChannelPage; }
-
-    /**
-     * Returns the Channel value.
-     *
-     * @returns The Channel value.
-     *
-     */
-    uint16_t GetChannel(void) const { return BigEndian::HostSwap16(mChannel); }
-
-    /**
-     * Sets the Channel value.
-     * Note: This method also sets the channel page according to the channel value.
-     *
-     * @param[in]  aChannel  The Channel value.
-     *
-     */
-    void SetChannel(uint16_t aChannel);
-
-private:
-    uint8_t  mChannelPage;
-    uint16_t mChannel;
-} OT_TOOL_PACKED_END;
+/**
+ * Defines Channel TLV constants and types.
+ *
+ */
+typedef SimpleTlvInfo<Tlv::kChannel, ChannelTlvValue> ChannelTlv;
 
 /**
  * Defines PAN ID TLV constants and types.

--- a/src/core/thread/mle_tlvs.cpp
+++ b/src/core/thread/mle_tlvs.cpp
@@ -34,6 +34,8 @@
 #include "mle_tlvs.hpp"
 
 #include "common/code_utils.hpp"
+#include "common/numeric_limits.hpp"
+#include "radio/radio.hpp"
 
 namespace ot {
 namespace Mle {
@@ -92,6 +94,47 @@ int8_t ConnectivityTlv::GetParentPriority(void) const
 void ConnectivityTlv::SetParentPriority(int8_t aParentPriority)
 {
     mFlags = static_cast<uint8_t>(Preference::To2BitUint(aParentPriority) << kFlagsParentPriorityOffset);
+}
+
+void ChannelTlvValue::SetChannelAndPage(uint16_t aChannel)
+{
+    uint8_t channelPage = OT_RADIO_CHANNEL_PAGE_0;
+
+#if OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT
+    if ((OT_RADIO_915MHZ_OQPSK_CHANNEL_MIN <= aChannel) && (aChannel <= OT_RADIO_915MHZ_OQPSK_CHANNEL_MAX))
+    {
+        channelPage = OT_RADIO_CHANNEL_PAGE_2;
+    }
+#endif
+
+#if OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_SUPPORT
+    if ((OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_MIN == aChannel) ||
+        ((OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_MIN < aChannel) &&
+         (aChannel <= OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_MAX)))
+    {
+        channelPage = OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_PAGE;
+    }
+#endif
+
+    SetChannelPage(channelPage);
+    SetChannel(aChannel);
+}
+
+bool ChannelTlvValue::IsValid(void) const
+{
+    bool     isValid = false;
+    uint16_t channel;
+
+    VerifyOrExit(mChannelPage < BitSizeOf(uint32_t));
+    VerifyOrExit((1U << mChannelPage) & Radio::kSupportedChannelPages);
+
+    channel = GetChannel();
+    VerifyOrExit((Radio::kChannelMin <= channel) && (channel <= Radio::kChannelMax));
+
+    isValid = true;
+
+exit:
+    return isValid;
 }
 
 } // namespace Mle

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -1096,6 +1096,23 @@ public:
      */
     void SetChannel(uint16_t aChannel) { mChannel = BigEndian::HostSwap16(aChannel); }
 
+    /**
+     * Sets the Channel and determines and sets the Channel Page from the given channel.
+     *
+     * @param[in]  aChannel  The Channel value.
+     *
+     */
+    void SetChannelAndPage(uint16_t aChannel);
+
+    /**
+     * Indicates whether or not the Channel and Channel Page values are valid.
+     *
+     * @retval TRUE   If the Channel and Channel Page values are valid.
+     * @retval FALSE  If the Channel and Channel Page values are not valid.
+     *
+     */
+    bool IsValid(void) const;
+
 private:
     uint8_t  mChannelPage;
     uint16_t mChannel;


### PR DESCRIPTION
This commit introduces `IsValid()` and `SetChannelAndPage()` methods to `Mle::ChannelTlvValue`, enabling its use as the value of `MeshCoP::ChannelTlv`.