### PR TITLE
[tests] rename `get_netdata_nat64_prefix()` to `get_netdata_nat64_routes()`

### DIFF
--- a/tests/scripts/thread-cert/border_router/nat64/test_multi_border_routers.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_multi_border_routers.py
@@ -131,8 +131,8 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         self.assertNotEqual(br2_local_nat64_prefix, br2.get_br_favored_nat64_prefix())
         br2_infra_nat64_prefix = br2.get_br_favored_nat64_prefix()
 
-        self.assertEqual(len(br1.get_netdata_nat64_prefix()), 1)
-        nat64_prefix = br1.get_netdata_nat64_prefix()[0]
+        self.assertEqual(len(br1.get_netdata_nat64_routes()), 1)
+        nat64_prefix = br1.get_netdata_nat64_routes()[0]
         self.assertEqual(nat64_prefix, br2_infra_nat64_prefix)
         self.assertNotEqual(nat64_prefix, br1_local_nat64_prefix)
         self.assertDictIncludes(br1.nat64_state, {
@@ -151,8 +151,8 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         br2.nat64_set_enabled(False)
         self.simulator.go(10)
 
-        self.assertEqual(len(br1.get_netdata_nat64_prefix()), 1)
-        nat64_prefix = br1.get_netdata_nat64_prefix()[0]
+        self.assertEqual(len(br1.get_netdata_nat64_routes()), 1)
+        nat64_prefix = br1.get_netdata_nat64_routes()[0]
         self.assertEqual(nat64_prefix, br1_local_nat64_prefix)
         self.assertDictIncludes(br1.nat64_state, {
             'PrefixManager': NAT64_STATE_ACTIVE,
@@ -174,8 +174,8 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         self.simulator.go(10)
         self.assertEqual(br2_local_nat64_prefix, br2.get_br_favored_nat64_prefix())
 
-        self.assertEqual(len(br1.get_netdata_nat64_prefix()), 1)
-        nat64_prefix = br1.get_netdata_nat64_prefix()[0]
+        self.assertEqual(len(br1.get_netdata_nat64_routes()), 1)
+        nat64_prefix = br1.get_netdata_nat64_routes()[0]
         self.assertEqual(nat64_prefix, br1_local_nat64_prefix)
         self.assertNotEqual(nat64_prefix, br2_local_nat64_prefix)
         self.assertDictIncludes(br1.nat64_state, {
@@ -194,8 +194,8 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         br1.nat64_set_enabled(False)
 
         self.simulator.go(10)
-        self.assertEqual(len(br1.get_netdata_nat64_prefix()), 1)
-        nat64_prefix = br1.get_netdata_nat64_prefix()[0]
+        self.assertEqual(len(br1.get_netdata_nat64_routes()), 1)
+        nat64_prefix = br1.get_netdata_nat64_routes()[0]
         self.assertEqual(br2_local_nat64_prefix, nat64_prefix)
         self.assertNotEqual(br1_local_nat64_prefix, nat64_prefix)
         self.assertDictIncludes(br1.nat64_state, {
@@ -214,8 +214,8 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         br1.nat64_set_enabled(True)
 
         self.simulator.go(10)
-        self.assertEqual(len(br1.get_netdata_nat64_prefix()), 1)
-        nat64_prefix = br1.get_netdata_nat64_prefix()[0]
+        self.assertEqual(len(br1.get_netdata_nat64_routes()), 1)
+        nat64_prefix = br1.get_netdata_nat64_routes()[0]
         self.assertEqual(br2_local_nat64_prefix, nat64_prefix)
         self.assertNotEqual(br1_local_nat64_prefix, nat64_prefix)
         self.assertDictIncludes(br1.nat64_state, {
@@ -233,8 +233,8 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         #
         br2.disable_br()
         self.simulator.go(10)
-        self.assertEqual(len(br1.get_netdata_nat64_prefix()), 1)
-        nat64_prefix = br1.get_netdata_nat64_prefix()[0]
+        self.assertEqual(len(br1.get_netdata_nat64_routes()), 1)
+        nat64_prefix = br1.get_netdata_nat64_routes()[0]
         self.assertEqual(br1_local_nat64_prefix, nat64_prefix)
         self.assertNotEqual(br2_local_nat64_prefix, nat64_prefix)
         self.assertDictIncludes(br1.nat64_state, {
@@ -252,8 +252,8 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         #
         br2.enable_br()
         self.simulator.go(10)
-        self.assertEqual(len(br1.get_netdata_nat64_prefix()), 1)
-        nat64_prefix = br1.get_netdata_nat64_prefix()[0]
+        self.assertEqual(len(br1.get_netdata_nat64_routes()), 1)
+        nat64_prefix = br1.get_netdata_nat64_routes()[0]
         self.assertEqual(br1_local_nat64_prefix, nat64_prefix)
         self.assertNotEqual(br2_local_nat64_prefix, nat64_prefix)
         self.assertDictIncludes(br1.nat64_state, {

--- a/tests/scripts/thread-cert/border_router/nat64/test_single_border_router.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_single_border_router.py
@@ -137,8 +137,8 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         self.simulator.go(5)
         local_nat64_prefix = br.get_br_nat64_prefix()
 
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
-        nat64_prefix = br.get_netdata_nat64_prefix()[0]
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 1)
+        nat64_prefix = br.get_netdata_nat64_routes()[0]
         self.assertEqual(nat64_prefix, local_nat64_prefix)
 
         #
@@ -150,15 +150,15 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         br.register_netdata()
         self.simulator.go(5)
 
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
-        self.assertNotEqual(local_nat64_prefix, br.get_netdata_nat64_prefix()[0])
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 1)
+        self.assertNotEqual(local_nat64_prefix, br.get_netdata_nat64_routes()[0])
 
         br.remove_route(SMALL_NAT64_PREFIX)
         br.register_netdata()
         self.simulator.go(10)
 
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
-        self.assertEqual(local_nat64_prefix, br.get_netdata_nat64_prefix()[0])
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 1)
+        self.assertEqual(local_nat64_prefix, br.get_netdata_nat64_routes()[0])
 
         #
         # Case 3.
@@ -169,15 +169,15 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         br.register_netdata()
         self.simulator.go(5)
 
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
-        self.assertNotEqual(local_nat64_prefix, br.get_netdata_nat64_prefix()[0])
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 1)
+        self.assertNotEqual(local_nat64_prefix, br.get_netdata_nat64_routes()[0])
 
         br.remove_route(LARGE_NAT64_PREFIX)
         br.register_netdata()
         self.simulator.go(10)
 
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
-        self.assertEqual(local_nat64_prefix, br.get_netdata_nat64_prefix()[0])
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 1)
+        self.assertEqual(local_nat64_prefix, br.get_netdata_nat64_routes()[0])
 
         #
         # Case 4. Disable and re-enable border routing on the border router.
@@ -186,7 +186,7 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         self.simulator.go(5)
 
         # NAT64 prefix is withdrawn from Network Data.
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 0)
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 0)
 
         br.enable_br()
         self.simulator.go(config.BORDER_ROUTER_STARTUP_DELAY)
@@ -256,17 +256,17 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         self.simulator.go(5)
 
         # NAT64 prefix is withdrawn from Network Data.
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 0)
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 0)
 
         br.enable_ether()
         self.simulator.go(80)
 
         # Same NAT64 prefix is advertised to Network Data.
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
-        self.assertEqual(nat64_prefix, br.get_netdata_nat64_prefix()[0])
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 1)
+        self.assertEqual(nat64_prefix, br.get_netdata_nat64_routes()[0])
         # Same NAT64 prefix is advertised to Network Data.
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
-        self.assertEqual(nat64_prefix, br.get_netdata_nat64_prefix()[0])
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 1)
+        self.assertEqual(nat64_prefix, br.get_netdata_nat64_routes()[0])
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/border_router/nat64/test_with_infrastructure_prefix.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_with_infrastructure_prefix.py
@@ -94,8 +94,8 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         # Case 1 No infra-derived OMR prefix. BR publishes its local prefix.
         local_nat64_prefix = br.get_br_nat64_prefix()
 
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
-        nat64_prefix = br.get_netdata_nat64_prefix()[0]
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 1)
+        nat64_prefix = br.get_netdata_nat64_routes()[0]
         self.assertEqual(nat64_prefix, local_nat64_prefix)
 
         self.assertDictIncludes(br.nat64_state, {
@@ -112,8 +112,8 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         self.assertNotEqual(favored_nat64_prefix, local_nat64_prefix)
         infra_nat64_prefix = favored_nat64_prefix
 
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
-        nat64_prefix = br.get_netdata_nat64_prefix()[0]
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 1)
+        nat64_prefix = br.get_netdata_nat64_routes()[0]
         self.assertEqual(nat64_prefix, infra_nat64_prefix)
         self.assertDictIncludes(br.nat64_state, {
             'PrefixManager': NAT64_STATE_ACTIVE,
@@ -126,8 +126,8 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         br.register_netdata()
         self.simulator.go(5)
 
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
-        self.assertNotEqual(infra_nat64_prefix, br.get_netdata_nat64_prefix()[0])
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 1)
+        self.assertNotEqual(infra_nat64_prefix, br.get_netdata_nat64_routes()[0])
         self.assertDictIncludes(br.nat64_state, {
             'PrefixManager': NAT64_STATE_IDLE,
             'Translator': NAT64_STATE_NOT_RUNNING
@@ -137,7 +137,7 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         br.register_netdata()
         self.simulator.go(10)
 
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 1)
         self.assertEqual(nat64_prefix, infra_nat64_prefix)
 
         # Case 4 No change when a smaller prefix in low preference is present
@@ -145,8 +145,8 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         br.register_netdata()
         self.simulator.go(5)
 
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 2)
-        self.assertEqual(br.get_netdata_nat64_prefix(), [infra_nat64_prefix, SMALL_NAT64_PREFIX])
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 2)
+        self.assertEqual(br.get_netdata_nat64_routes(), [infra_nat64_prefix, SMALL_NAT64_PREFIX])
         self.assertDictIncludes(br.nat64_state, {
             'PrefixManager': NAT64_STATE_ACTIVE,
             'Translator': NAT64_STATE_NOT_RUNNING
@@ -162,8 +162,8 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
 
         local_nat64_prefix = br.get_br_nat64_prefix()
         self.assertNotEqual(local_nat64_prefix, infra_nat64_prefix)
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
-        self.assertEqual(br.get_netdata_nat64_prefix()[0], local_nat64_prefix)
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 1)
+        self.assertEqual(br.get_netdata_nat64_routes()[0], local_nat64_prefix)
         self.assertDictIncludes(br.nat64_state, {
             'PrefixManager': NAT64_STATE_ACTIVE,
             'Translator': NAT64_STATE_ACTIVE
@@ -174,8 +174,8 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         self.simulator.go(NAT64_PREFIX_REFRESH_DELAY)
 
         self.assertEqual(br.get_br_favored_nat64_prefix(), infra_nat64_prefix)
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
-        self.assertEqual(br.get_netdata_nat64_prefix()[0], infra_nat64_prefix)
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 1)
+        self.assertEqual(br.get_netdata_nat64_routes()[0], infra_nat64_prefix)
         self.assertDictIncludes(br.nat64_state, {
             'PrefixManager': NAT64_STATE_ACTIVE,
             'Translator': NAT64_STATE_NOT_RUNNING
@@ -188,8 +188,8 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         self.simulator.go(NAT64_PREFIX_REFRESH_DELAY)
 
         self.assertEqual(br.get_br_favored_nat64_prefix(), SMALL_NAT64_PREFIX)
-        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
-        self.assertEqual(br.get_netdata_nat64_prefix()[0], SMALL_NAT64_PREFIX)
+        self.assertEqual(len(br.get_netdata_nat64_routes()), 1)
+        self.assertEqual(br.get_netdata_nat64_routes()[0], SMALL_NAT64_PREFIX)
         self.assertDictIncludes(br.nat64_state, {
             'PrefixManager': NAT64_STATE_ACTIVE,
             'Translator': NAT64_STATE_NOT_RUNNING

--- a/tests/scripts/thread-cert/border_router/test_multi_border_routers.py
+++ b/tests/scripts/thread-cert/border_router/test_multi_border_routers.py
@@ -141,10 +141,10 @@ class MultiBorderRouters(thread_cert.TestCase):
         self.assertEqual(br1_omr_prefix, br1.get_netdata_omr_prefixes()[0])
 
         # Each BR should independently register an external route for the on-link prefix.
-        self.assertEqual(len(br1.get_netdata_non_nat64_prefixes()), 2)
-        self.assertEqual(len(router1.get_netdata_non_nat64_prefixes()), 2)
-        self.assertEqual(len(br2.get_netdata_non_nat64_prefixes()), 2)
-        self.assertEqual(len(router2.get_netdata_non_nat64_prefixes()), 2)
+        self.assertEqual(len(br1.get_netdata_non_nat64_routes()), 2)
+        self.assertEqual(len(router1.get_netdata_non_nat64_routes()), 2)
+        self.assertEqual(len(br2.get_netdata_non_nat64_routes()), 2)
+        self.assertEqual(len(router2.get_netdata_non_nat64_routes()), 2)
 
         br1_on_link_prefix = br1.get_br_on_link_prefix()
 
@@ -192,10 +192,10 @@ class MultiBorderRouters(thread_cert.TestCase):
         # There should be no changes to the external route for the
         # on-link prefix, given that the on-link prefix is derived
         # from the Extended PAN ID.
-        self.assertEqual(len(br1.get_netdata_non_nat64_prefixes()), 1)
-        self.assertEqual(len(router1.get_netdata_non_nat64_prefixes()), 1)
-        self.assertEqual(len(br2.get_netdata_non_nat64_prefixes()), 1)
-        self.assertEqual(len(router2.get_netdata_non_nat64_prefixes()), 1)
+        self.assertEqual(len(br1.get_netdata_non_nat64_routes()), 1)
+        self.assertEqual(len(router1.get_netdata_non_nat64_routes()), 1)
+        self.assertEqual(len(br2.get_netdata_non_nat64_routes()), 1)
+        self.assertEqual(len(router2.get_netdata_non_nat64_routes()), 1)
 
         br2_on_link_prefix = br2.get_br_on_link_prefix()
 

--- a/tests/scripts/thread-cert/border_router/test_multi_thread_networks.py
+++ b/tests/scripts/thread-cert/border_router/test_multi_thread_networks.py
@@ -130,10 +130,10 @@ class MultiThreadNetworks(thread_cert.TestCase):
 
         # Each BR should independently register an external route for the on-link prefix
         # and OMR prefix in another Thread Network.
-        self.assertEqual(br1.get_netdata_non_nat64_prefixes(), ['fc00::/7'])
-        self.assertEqual(router1.get_netdata_non_nat64_prefixes(), ['fc00::/7'])
-        self.assertEqual(br2.get_netdata_non_nat64_prefixes(), ['fc00::/7'])
-        self.assertEqual(router2.get_netdata_non_nat64_prefixes(), ['fc00::/7'])
+        self.assertEqual(br1.get_netdata_non_nat64_routes(), ['fc00::/7'])
+        self.assertEqual(router1.get_netdata_non_nat64_routes(), ['fc00::/7'])
+        self.assertEqual(br2.get_netdata_non_nat64_routes(), ['fc00::/7'])
+        self.assertEqual(router2.get_netdata_non_nat64_routes(), ['fc00::/7'])
 
         self.assertTrue(len(router1.get_ip6_address(config.ADDRESS_TYPE.OMR)) == 1)
         self.assertTrue(len(router2.get_ip6_address(config.ADDRESS_TYPE.OMR)) == 1)

--- a/tests/scripts/thread-cert/border_router/test_on_link_prefix.py
+++ b/tests/scripts/thread-cert/border_router/test_on_link_prefix.py
@@ -126,7 +126,7 @@ class MultiThreadNetworks(thread_cert.TestCase):
         logging.info("ROUTER1 addrs: %r", router1.get_addrs())
         logging.info("HOST    addrs: %r", host.get_addrs())
 
-        self.assertEqual(len(br1.get_netdata_non_nat64_prefixes()), 1)
+        self.assertEqual(len(br1.get_netdata_non_nat64_routes()), 1)
 
         host_on_link_addr = host.get_matched_ula_addresses(ON_LINK_PREFIX)[0]
         self.assertTrue(router1.ping(host_on_link_addr))
@@ -166,10 +166,10 @@ class MultiThreadNetworks(thread_cert.TestCase):
         # but don't remove the external routes for the radvd on-link prefix
         # immediately, because the SLAAC addresses are still valid.
 
-        self.assertEqual(len(br1.get_netdata_non_nat64_prefixes()), 1)
-        self.assertEqual(len(router1.get_netdata_non_nat64_prefixes()), 1)
-        self.assertEqual(len(br2.get_netdata_non_nat64_prefixes()), 1)
-        self.assertEqual(len(router2.get_netdata_non_nat64_prefixes()), 1)
+        self.assertEqual(len(br1.get_netdata_non_nat64_routes()), 1)
+        self.assertEqual(len(router1.get_netdata_non_nat64_routes()), 1)
+        self.assertEqual(len(br2.get_netdata_non_nat64_routes()), 1)
+        self.assertEqual(len(router2.get_netdata_non_nat64_routes()), 1)
 
         br2_on_link_prefix = br2.get_br_on_link_prefix()
 

--- a/tests/scripts/thread-cert/border_router/test_radvd_coexist.py
+++ b/tests/scripts/thread-cert/border_router/test_radvd_coexist.py
@@ -102,8 +102,8 @@ class SingleBorderRouter(thread_cert.TestCase):
 
         self.assertEqual(len(br.get_netdata_omr_prefixes()), 1)
         self.assertEqual(len(router.get_netdata_omr_prefixes()), 1)
-        self.assertEqual(len(br.get_netdata_non_nat64_prefixes()), 1)
-        self.assertEqual(len(router.get_netdata_non_nat64_prefixes()), 1)
+        self.assertEqual(len(br.get_netdata_non_nat64_routes()), 1)
+        self.assertEqual(len(router.get_netdata_non_nat64_routes()), 1)
 
         self.assertEqual(len(br.get_ip6_address(config.ADDRESS_TYPE.OMR)), 1)
         self.assertEqual(len(router.get_ip6_address(config.ADDRESS_TYPE.OMR)), 1)
@@ -122,8 +122,8 @@ class SingleBorderRouter(thread_cert.TestCase):
 
         self.assertEqual(len(br.get_netdata_omr_prefixes()), 1)
         self.assertEqual(len(router.get_netdata_omr_prefixes()), 1)
-        self.assertEqual(len(br.get_netdata_non_nat64_prefixes()), 1)
-        self.assertEqual(len(router.get_netdata_non_nat64_prefixes()), 1)
+        self.assertEqual(len(br.get_netdata_non_nat64_routes()), 1)
+        self.assertEqual(len(router.get_netdata_non_nat64_routes()), 1)
 
         self.assertEqual(len(br.get_ip6_address(config.ADDRESS_TYPE.OMR)), 1)
         self.assertEqual(len(router.get_ip6_address(config.ADDRESS_TYPE.OMR)), 1)

--- a/tests/scripts/thread-cert/border_router/test_single_border_router.py
+++ b/tests/scripts/thread-cert/border_router/test_single_border_router.py
@@ -105,8 +105,8 @@ class SingleBorderRouter(thread_cert.TestCase):
 
         self.assertEqual(len(br.get_netdata_omr_prefixes()), 1)
         self.assertEqual(len(router.get_netdata_omr_prefixes()), 1)
-        self.assertEqual(len(br.get_netdata_non_nat64_prefixes()), 1)
-        self.assertEqual(len(router.get_netdata_non_nat64_prefixes()), 1)
+        self.assertEqual(len(br.get_netdata_non_nat64_routes()), 1)
+        self.assertEqual(len(router.get_netdata_non_nat64_routes()), 1)
 
         omr_prefix = br.get_br_omr_prefix()
         on_link_prefix = br.get_br_on_link_prefix()
@@ -145,8 +145,8 @@ class SingleBorderRouter(thread_cert.TestCase):
 
         self.assertEqual(len(br.get_netdata_omr_prefixes()), 2)
         self.assertEqual(len(router.get_netdata_omr_prefixes()), 2)
-        self.assertEqual(len(br.get_netdata_non_nat64_prefixes()), 1)
-        self.assertEqual(len(router.get_netdata_non_nat64_prefixes()), 1)
+        self.assertEqual(len(br.get_netdata_non_nat64_routes()), 1)
+        self.assertEqual(len(router.get_netdata_non_nat64_routes()), 1)
 
         self.assertEqual(len(br.get_ip6_address(config.ADDRESS_TYPE.OMR)), 2)
         self.assertEqual(len(router.get_ip6_address(config.ADDRESS_TYPE.OMR)), 2)
@@ -171,8 +171,8 @@ class SingleBorderRouter(thread_cert.TestCase):
 
         self.assertEqual(len(br.get_netdata_omr_prefixes()), 1)
         self.assertEqual(len(router.get_netdata_omr_prefixes()), 1)
-        self.assertEqual(len(br.get_netdata_non_nat64_prefixes()), 1)
-        self.assertEqual(len(router.get_netdata_non_nat64_prefixes()), 1)
+        self.assertEqual(len(br.get_netdata_non_nat64_routes()), 1)
+        self.assertEqual(len(router.get_netdata_non_nat64_routes()), 1)
 
         # The same local OMR and on-link prefix should be re-register.
         self.assertEqual(br.get_netdata_omr_prefixes(), [omr_prefix])
@@ -223,8 +223,8 @@ class SingleBorderRouter(thread_cert.TestCase):
 
         self.assertEqual(len(br.get_netdata_omr_prefixes()), 1)
         self.assertEqual(len(router.get_netdata_omr_prefixes()), 1)
-        self.assertEqual(len(br.get_netdata_non_nat64_prefixes()), 1)
-        self.assertEqual(len(router.get_netdata_non_nat64_prefixes()), 1)
+        self.assertEqual(len(br.get_netdata_non_nat64_routes()), 1)
+        self.assertEqual(len(router.get_netdata_non_nat64_routes()), 1)
 
         # The same local OMR and on-link prefix should be re-registered.
         self.assertEqual(br.get_netdata_omr_prefixes(), [omr_prefix])
@@ -275,8 +275,8 @@ class SingleBorderRouter(thread_cert.TestCase):
 
         self.assertEqual(len(br.get_netdata_omr_prefixes()), 1)
         self.assertEqual(len(router.get_netdata_omr_prefixes()), 1)
-        self.assertEqual(len(br.get_netdata_non_nat64_prefixes()), 1)
-        self.assertEqual(len(router.get_netdata_non_nat64_prefixes()), 1)
+        self.assertEqual(len(br.get_netdata_non_nat64_routes()), 1)
+        self.assertEqual(len(router.get_netdata_non_nat64_routes()), 1)
 
         # The same local OMR and on-link prefix should be re-registered.
         self.assertEqual(br.get_netdata_omr_prefixes(), [omr_prefix])
@@ -314,8 +314,8 @@ class SingleBorderRouter(thread_cert.TestCase):
         br.start_radvd_service(prefix=config.ONLINK_GUA_PREFIX, slaac=True)
         self.simulator.go(5)
 
-        self.assertEqual(len(br.get_netdata_non_nat64_prefixes()), 1)
-        self.assertEqual(len(router.get_netdata_non_nat64_prefixes()), 1)
+        self.assertEqual(len(br.get_netdata_non_nat64_routes()), 1)
+        self.assertEqual(len(router.get_netdata_non_nat64_routes()), 1)
 
         self.assertTrue(router.ping(host.get_ip6_address(config.ADDRESS_TYPE.ONLINK_GUA)[0]))
         self.assertTrue(router.ping(host.get_ip6_address(config.ADDRESS_TYPE.ONLINK_ULA)[0]))

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -2177,13 +2177,21 @@ class NodeImpl:
         self.send_command(cmd)
         return self._expect_command_output()[0]
 
-    def get_netdata_non_nat64_prefixes(self):
-        prefixes = []
+    def get_netdata_non_nat64_routes(self):
+        nat64_routes = []
         routes = self.get_routes()
         for route in routes:
             if 'n' not in route.split(' ')[1]:
-                prefixes.append(route.split(' ')[0])
-        return prefixes
+                nat64_routes.append(route.split(' ')[0])
+        return nat64_routes
+
+    def get_netdata_nat64_routes(self):
+        nat64_routes = []
+        routes = self.get_routes()
+        for route in routes:
+            if 'n' in route.split(' ')[1]:
+                nat64_routes.append(route.split(' ')[0])
+        return nat64_routes
 
     def get_br_nat64_prefix(self):
         cmd = 'br nat64prefix local'
@@ -2301,14 +2309,6 @@ class NodeImpl:
                 }
                 continue
         return {'protocol': protocol_counters, 'errors': error_counters}
-
-    def get_netdata_nat64_prefix(self):
-        prefixes = []
-        routes = self.get_routes()
-        for route in routes:
-            if 'n' in route.split(' ')[1]:
-                prefixes.append(route.split(' ')[0])
-        return prefixes
 
     def get_prefixes(self):
         return self.get_netdata()['Prefixes']


### PR DESCRIPTION
As @abtink mentioned in https://github.com/openthread/openthread/pull/9648#pullrequestreview-1751025580, `get_netdata_nat64_prefix()` is actually getting NAT64 routes from netdata. Therefore it seems more appropriate to call it `get_netdata_nat64_routes()`.