### PR TITLE
[mesh-forwarder] drop msg if frag tx delay exceeds reassembly timeout

### DIFF
--- a/src/core/config/mesh_forwarder.h
+++ b/src/core/config/mesh_forwarder.h
@@ -53,13 +53,15 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_6LOWPAN_REASSEMBLY_TIMEOUT
+ * @def OPENTHREAD_CONFIG_DROP_MSG_IF_NEXT_FRAG_TX_DELAYED_BY_REASSEMBLY_TIMEOUT
  *
- * The reassembly timeout between 6LoWPAN fragments in seconds.
+ * Define as 1 for OpenThread to drops a message if the transmission between two fragments is delayed by more than the
+ * reassembly timeout (2 seconds) on the receiver. After the reassembly timeout sending the remaining fragments would
+ * not be useful since the receiver have already dropped the message and would ignore the new received fragments.
  *
  */
-#ifndef OPENTHREAD_CONFIG_6LOWPAN_REASSEMBLY_TIMEOUT
-#define OPENTHREAD_CONFIG_6LOWPAN_REASSEMBLY_TIMEOUT 2
+#ifndef OPENTHREAD_CONFIG_DROP_MSG_IF_NEXT_FRAG_TX_DELAYED_BY_REASSEMBLY_TIMEOUT
+#define OPENTHREAD_CONFIG_DROP_MSG_IF_NEXT_FRAG_TX_DELAYED_BY_REASSEMBLY_TIMEOUT 1
 #endif
 
 /**

--- a/src/core/config/openthread-core-config-check.h
+++ b/src/core/config/openthread-core-config-check.h
@@ -673,4 +673,9 @@
         "OPENTHREAD_CONFIG_MIN_RECEIVE_ON_AHEAD and OPENTHREAD_CONFIG_MIN_RECEIVE_ON_AFTER"
 #endif
 
+#ifdef OPENTHREAD_CONFIG_6LOWPAN_REASSEMBLY_TIMEOUT
+#error "OPENTHREAD_CONFIG_6LOWPAN_REASSEMBLY_TIMEOUT was removed; "\
+       " And the timeout constant is now fixed within the Thread spec to two seconds"
+#endif
+
 #endif // OPENTHREAD_CORE_CONFIG_CHECK_H_

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -379,7 +379,7 @@ private:
     static constexpr uint8_t kFailedRouterTransmissions      = 4;
     static constexpr uint8_t kFailedCslDataPollTransmissions = 15;
 
-    static constexpr uint8_t kReassemblyTimeout      = OPENTHREAD_CONFIG_6LOWPAN_REASSEMBLY_TIMEOUT; // in seconds.
+    static constexpr uint8_t kReassemblyTimeout      = 2;                       // in seconds.
     static constexpr uint8_t kMeshHeaderFrameMtu     = OT_RADIO_FRAME_MAX_SIZE; // Max MTU with a Mesh Header frame.
     static constexpr uint8_t kMeshHeaderFrameFcsSize = sizeof(uint16_t);        // Frame FCS size for Mesh Header frame.
 
@@ -398,19 +398,16 @@ private:
 
     enum MessageAction : uint8_t
     {
-        kMessageReceive,         // Indicates that the message was received.
-        kMessageTransmit,        // Indicates that the message was sent.
-        kMessagePrepareIndirect, // Indicates that the message is being prepared for indirect tx.
-        kMessageDrop,            // Indicates that the outbound message is dropped (e.g., dst unknown).
-        kMessageReassemblyDrop,  // Indicates that the message is being dropped from reassembly list.
-        kMessageEvict,           // Indicates that the message was evicted.
-#if OPENTHREAD_CONFIG_DELAY_AWARE_QUEUE_MANAGEMENT_ENABLE
-        kMessageMarkEcn,       // Indicates that ECN is marked on an outbound message by delay-aware queue management.
-        kMessageQueueMgmtDrop, // Indicates that an outbound message is dropped by delay-aware queue management.
-#endif
-#if (OPENTHREAD_CONFIG_MAX_FRAMES_IN_DIRECT_TX_QUEUE > 0)
-        kMessageFullQueueDrop, // Indicates message drop due to reaching max allowed frames in direct tx queue.
-#endif
+        kMessageReceive,           // Message was received.
+        kMessageTransmit,          // Message was sent.
+        kMessagePrepareIndirect,   // Message is being prepared for indirect tx.
+        kMessageDrop,              // Outbound message is dropped (e.g., dst unknown).
+        kMessageReassemblyDrop,    // Received message is being dropped from reassembly list.
+        kMessageEvict,             // Message was evicted.
+        kMessageMarkEcn,           // ECN is marked on a message by delay-aware queue management.
+        kMessageQueueMgmtDrop,     // Message is dropped by delay-aware queue management (too long in queue).
+        kMessageFullQueueDrop,     // Message drop due to reaching max allowed frames in direct tx queue.
+        kMessageNextFragDelayDrop, // Message is dropped since next fragment tx is delayed by more than timeout.
     };
 
     enum AnycastType : uint8_t


### PR DESCRIPTION
This commit introduces a new mechanism in `MeshForwarder` to drop a `Message` if the transmission delay between its fragments exceeds the reassembly timeout (2 seconds). This improves performance by preventing the transmission of fragments that are unlikely to be reassembled successfully at the receiver.

This commit also adds a new `MessageAction` to log such message drops for better visibility and debugging.

Finally, this commit removes the previous config option `OPENTHREAD_CONFIG_6LOWPAN_REASSEMBLY_TIMEOUT`, fixing the timeout to the value of 2 seconds.

-----
- ~This PR currently contains the commit from https://github.com/openthread/openthread/pull/9682 (please review and check the last commit on this PR. Thanks).~
- I decided to add a config `OPENTHREAD_CONFIG_DROP_MSG_IF_NEXT_FRAG_TX_DELAYED_BY_REASSEMBLY_TIMEOUT` to control this behavior (which is enabled by default) so we have a way to disable it if needed.
- This is related to https://github.com/openthread/openthread/issues/9604
- Also related Thread Tech Committee JIRA [SPEC-1239](https://threadgroup.atlassian.net/browse/SPEC-1239)