### PR TITLE
[secure-transport] rename `HandleUdpReceive` to `HandleReceive`

### DIFF
--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -382,7 +382,7 @@ public:
      */
     void HandleUdpReceive(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
     {
-        return mDtls.HandleUdpReceive(aMessage, aMessageInfo);
+        return mDtls.HandleReceive(aMessage, aMessageInfo);
     }
 
     /**

--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -144,7 +144,7 @@ Error SecureTransport::Open(ReceiveHandler aReceiveHandler, ConnectedHandler aCo
 
     VerifyOrExit(mState == kStateClosed, error = kErrorAlready);
 
-    SuccessOrExit(error = mSocket.Open(&SecureTransport::HandleUdpReceive, this));
+    SuccessOrExit(error = mSocket.Open(&SecureTransport::HandleReceive, this));
 
     mConnectedCallback.Set(aConnectedHandler, aContext);
     mReceiveCallback.Set(aReceiveHandler, aContext);
@@ -169,12 +169,12 @@ exit:
     return error;
 }
 
-void SecureTransport::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
+void SecureTransport::HandleReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<SecureTransport *>(aContext)->HandleUdpReceive(AsCoreType(aMessage), AsCoreType(aMessageInfo));
+    static_cast<SecureTransport *>(aContext)->HandleReceive(AsCoreType(aMessage), AsCoreType(aMessageInfo));
 }
 
-void SecureTransport::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void SecureTransport::HandleReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     switch (mState)
     {

--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -435,7 +435,15 @@ public:
      */
     const Ip6::MessageInfo &GetMessageInfo(void) const { return mMessageInfo; }
 
-    void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    /**
+     * Checks and handles a received message provided to the SecureTransport object. If checks based on
+     * the message info and current connection state pass, the message is processed.
+     *
+     * @param[in]  aMessage  A reference to the message to receive.
+     * @param[in]  aMessageInfo A reference to the message info associated with @p aMessage.
+     *
+     */
+    void HandleReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
 private:
     enum State : uint8_t
@@ -530,9 +538,9 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
-    static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
+    static void HandleReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 
-    void  HandleSecureTransportReceive(const uint8_t *aBuf, uint16_t aLength);
+    void  HandleReceive(const uint8_t *aBuf, uint16_t aLength);
     Error HandleSecureTransportSend(const uint8_t *aBuf, uint16_t aLength, Message::SubType aMessageSubType);
 
     void Process(void);

--- a/src/core/radio/ble_secure.cpp
+++ b/src/core/radio/ble_secure.cpp
@@ -253,7 +253,7 @@ Error BleSecure::HandleBleReceive(uint8_t *aBuf, uint16_t aLength)
     SuccessOrExit(error = message->AppendBytes(aBuf, aLength));
 
     // Cannot call Receive(..) directly because Setup(..) and mState are private
-    mTls.HandleUdpReceive(*message, messageInfo);
+    mTls.HandleReceive(*message, messageInfo);
 
 exit:
     FreeMessage(message);


### PR DESCRIPTION
Documentation of `HandleSecureTransportReceive` previously called `HandleUdpReceive`. As requested in #9631