### PR TITLE
 [mle] fix uninitialized `mLinkRequestAttempts`

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -92,6 +92,9 @@ Mle::Mle(Instance &aInstance)
     , mDataRequestAttempts(0)
     , mAnnounceChannel(0)
     , mAlternateChannel(0)
+#if OPENTHREAD_FTD
+    , mLinkRequestAttempts(0)
+#endif
     , mRloc16(Mac::kShortAddrInvalid)
     , mPreviousParentRloc(Mac::kShortAddrInvalid)
     , mAttachCounter(0)


### PR DESCRIPTION
[MLE] class member variable mLinkRequestAttempts is not initialized to zero causing it to get a random value during power cycle. This causes MTD thread device to send linkrequest after power cycle.
Create a thread network with two devices with DUT with mode rn. Reset both devices simultaneously, enable leader and then child device (DUT). Because class member variable mLinkRequestAttempts is not initialized to zero during initialization. it will get random value, and value greater than zero will lead to send a link request message which should not be the case for a MTD device.
