### PR TITLE
[coap-secure] introduce maximum connection attempt limit for CoAP agent

### DIFF
--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -129,6 +129,15 @@ public:
     typedef Error (*TransportCallback)(void *aContext, ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     /**
+     * Callback to notify when the socket is automatically closed due to reaching the maximum number of connection
+     * attempts (set from `SetMaxConnectionAttempts()`).
+     *
+     * @param[in] aContext    A pointer to arbitrary context information.
+     *
+     */
+    typedef void (*AutoCloseCallback)(void *aContext);
+
+    /**
      * Opens the socket.
      *
      * @param[in]  aReceiveHandler      A pointer to a function that is called to receive payload.
@@ -140,6 +149,24 @@ public:
      *
      */
     Error Open(ReceiveHandler aReceiveHandler, ConnectedHandler aConnectedHandler, void *aContext);
+
+    /**
+     * Sets the maximum number of allowed connection requests before socket is automatically closed.
+     *
+     * This method can be called when socket is closed. Otherwise `kErrorInvalidSatet` is returned.
+     *
+     * If @p aMaxAttempts is zero, no limit is applied and connections are allowed until the socket is closed. This is
+     * the default behavior if `SetMaxConnectionAttempts()` is not called.
+     *
+     * @param[in] aMaxAttempts    Maximum number of allowed connection attempts.
+     * @param[in] aCallback       Callback to notify when max number of attempts has reached and socket is closed.
+     * @param[in] aContext        A pointer to arbitrary context to use with `AutoCloseCallback`.
+     *
+     * @retval kErrorNone          Successfully set the maximum allowed connection attempts and callback.
+     * @retval kErrorInvalidState  Socket is not closed.
+     *
+     */
+    Error SetMaxConnectionAttempts(uint16_t aMaxAttempts, AutoCloseCallback aCallback, void *aContext);
 
     /**
      * Binds this DTLS to a UDP port.
@@ -615,6 +642,10 @@ private:
 
     bool mLayerTwoSecurity : 1;
     bool mDatagramTransport : 1;
+
+    uint16_t                    mMaxConnectionAttempts;
+    uint16_t                    mRemainingConnectionAttempts;
+    Callback<AutoCloseCallback> mAutoCloseCallback;
 
     Message *mReceiveMessage;
 


### PR DESCRIPTION
This commit introduces a new feature in `SecureTransport` and `CoapSecure` that allows us to specify the maximum number of allowed connection attempts before the socket is automatically closed and the CoAP agent is stopped. This can be used to enhance security by preventing attacks and excessive retries. This commit also adds a callback mechanism to notify when the limit is reached and the CoAP agent is stopped.

----

Related to [SPEC-1216](https://threadgroup.atlassian.net/browse/SPEC-1216) and for use with ephemeral PSK mechasnim (PR https://github.com/openthread/openthread/pull/9435)