### PR TITLE
[posix] verify in `otPlatUdpBindToNetif` if Backbone Interface is set

### DIFF
--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -323,6 +323,11 @@ otError otPlatUdpBindToNetif(otUdpSocket *aUdpSocket, otNetifIdentifier aNetifId
     case OT_NETIF_BACKBONE:
     {
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+        if (otSysGetInfraNetifName() == nullptr || otSysGetInfraNetifName()[0] == '\0')
+        {
+            otLogWarnPlat("No backbone interface given, %s fails.", __func__);
+            ExitNow(error = OT_ERROR_INVALID_ARGS);
+        }
 #if __linux__
         VerifyOrExit(setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, otSysGetInfraNetifName(),
                                 strlen(otSysGetInfraNetifName())) == 0,


### PR DESCRIPTION
Commit adds check to `otPlatUdpBindToNetif` if backbone interface is set to correct value to prevent `setsockopt` from crashing the ot-daemon.