### PR TITLE
[routing-manager] advertise local OMR in RA after present in netdata

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -909,7 +909,7 @@ private:
         void                    Stop(void);
         void                    Evaluate(void);
         void                    UpdateDefaultRouteFlag(bool aDefaultRoute);
-        bool                    IsLocalAddedInNetData(void) const { return mIsLocalAddedInNetData; }
+        bool                    ShouldAdvertiseLocalAsRio(void) const;
         const Ip6::Prefix      &GetGeneratedPrefix(void) const { return mGeneratedPrefix; }
         const OmrPrefix        &GetLocalPrefix(void) const { return mLocalPrefix; }
         const FavoredOmrPrefix &GetFavoredPrefix(void) const { return mFavoredPrefix; }


### PR DESCRIPTION
This commit adds `OmrPrefixManager::ShouldAdvertiseLocalAsRio()` which determines whether the local OMR prefix should be advertised as RIO in emitted RAs. To advertise, we must have decided to publish it, and it must already be added and present in the Network Data. This ensures that we only advertise the local OMR prefix in emitted RAs when, as a Border Router, we can accept and route messages using an OMR-based address destination, which requires the prefix to be present in Network Data. Similarly, we stop advertising (and start deprecating) the OMR prefix in RAs as soon as we decide to remove it. After requesting its removal from Network Data, it may still be present in Network Data for a short interval due to delays in registering changes with the leader.

---

- ~To avoid rebase, I added this enhancement on top of the commit from https://github.com/openthread/openthread/pull/9599 (please check the last commit on this PR).~