### PR TITLE
[routing-manager] determine local OMR prefix from partition ID

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -99,10 +99,11 @@ public:
      * The number of published entries accounts for:
      * - Route prefix `fc00::/7` or `::/0`
      * - One entry for NAT64 published prefix.
-     * - One extra entry for transitions.
+     * - Local OMR prefix.
+     * - Two extra entries for transitions.
      *
      */
-    static constexpr uint16_t kMaxPublishedPrefixes = 3;
+    static constexpr uint16_t kMaxPublishedPrefixes = 5;
 
     /**
      * Represents the states of `RoutingManager`.
@@ -913,6 +914,10 @@ private:
         const Ip6::Prefix      &GetGeneratedPrefix(void) const { return mGeneratedPrefix; }
         const OmrPrefix        &GetLocalPrefix(void) const { return mLocalPrefix; }
         const FavoredOmrPrefix &GetFavoredPrefix(void) const { return mFavoredPrefix; }
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_LOCAL_OMR_FROM_PARTITION_ID_ENABLE
+        void GeneratePrefixFromPartitionId(Ip6::Prefix &aPrefix) const;
+        void HandlePatitionIdChanged(void);
+#endif
 
     private:
         static constexpr uint16_t kInfoStringSize = 85;
@@ -920,15 +925,15 @@ private:
         typedef String<kInfoStringSize> InfoString;
 
         void       DetermineFavoredPrefix(void);
-        Error      AddLocalToNetData(void);
-        Error      AddOrUpdateLocalInNetData(void);
-        void       RemoveLocalFromNetData(void);
+        void       PublishLocalPrefix(void);
+        void       PublishOrUpdateLocalPrefix(void);
+        void       UnpublishLocalPrefix(void);
         InfoString LocalToString(void) const;
 
         OmrPrefix        mLocalPrefix;
         Ip6::Prefix      mGeneratedPrefix;
         FavoredOmrPrefix mFavoredPrefix;
-        bool             mIsLocalAddedInNetData;
+        bool             mIsLocalPublished;
         bool             mDefaultRoute;
     };
 

--- a/src/core/config/border_routing.h
+++ b/src/core/config/border_routing.h
@@ -148,6 +148,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_LOCAL_OMR_FROM_PARTITION_ID_ENABLE
+ *
+ * Define to 1 so for the routing manager to determine the local OMR prefix from Partition ID.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_LOCAL_OMR_FROM_PARTITION_ID_ENABLE
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_LOCAL_OMR_FROM_PARTITION_ID_ENABLE 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
  *
  * Specifies whether to support handling platform generated ND messages.

--- a/tests/scripts/thread-cert/border_router/test_multi_border_routers.py
+++ b/tests/scripts/thread-cert/border_router/test_multi_border_routers.py
@@ -132,13 +132,19 @@ class MultiBorderRouters(thread_cert.TestCase):
         logging.info("ROUTER2 addrs: %r", router2.get_addrs())
         logging.info("HOST    addrs: %r", host.get_addrs())
 
-        self.assertEqual(len(br1.get_netdata_omr_prefixes()), 1)
-        self.assertEqual(len(router1.get_netdata_omr_prefixes()), 1)
-        self.assertEqual(len(br2.get_netdata_omr_prefixes()), 1)
-        self.assertEqual(len(router2.get_netdata_omr_prefixes()), 1)
+        # The same OMR prefix (derived from partition ID) should be
+        # published by both BRs
+
+        self.assertEqual(len(br1.get_netdata_omr_prefixes()), 2)
+        self.assertEqual(len(router1.get_netdata_omr_prefixes()), 2)
+        self.assertEqual(len(br2.get_netdata_omr_prefixes()), 2)
+        self.assertEqual(len(router2.get_netdata_omr_prefixes()), 2)
+
+        omr_prefixes = br1.get_netdata_omr_prefixes()
+        self.assertEqual(omr_prefixes[0], omr_prefixes[1])
 
         br1_omr_prefix = br1.get_br_omr_prefix()
-        self.assertEqual(br1_omr_prefix, br1.get_netdata_omr_prefixes()[0])
+        self.assertEqual(br1_omr_prefix, omr_prefixes[0])
 
         # Each BR should independently register an external route for the on-link prefix.
         self.assertEqual(len(br1.get_netdata_non_nat64_routes()), 2)

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -2245,6 +2245,9 @@ void TestExtPanIdChange(void)
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(true));
 
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().GetOmrPrefix(localOmr));
+    Log("Local OMR prefix is changed to %s", localOmr.ToString().AsCString());
+
     AdvanceTime(300000);
     VerifyOrQuit(sRaValidated);
     VerifyOrQuit(sDeprecatingPrefixes.GetLength() == 1);
@@ -2542,6 +2545,7 @@ void TestExtPanIdChange(void)
     sExpectedPio = kPioDeprecatingLocalOnLink;
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+
     AdvanceTime(100);
 
     VerifyOrQuit(sRaValidated);
@@ -2575,6 +2579,9 @@ void TestExtPanIdChange(void)
     sExpectedPio = kPioAdvertisingLocalOnLink;
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(true));
+
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().GetOmrPrefix(localOmr));
+    Log("Local OMR prefix is changed to %s", localOmr.ToString().AsCString());
 
     AdvanceTime(30000);
 
@@ -3229,6 +3236,9 @@ void TestSavedOnLinkPrefixes(void)
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(true));
 
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().GetOmrPrefix(localOmr));
+    Log("Local OMR prefix is changed to %s", localOmr.ToString().AsCString());
+
     sExpectedPio = kPioAdvertisingLocalOnLink;
 
     AdvanceTime(30000);
@@ -3264,6 +3274,9 @@ void TestSavedOnLinkPrefixes(void)
     testFreeInstance(sInstance);
 
     InitTest(/* aEnablBorderRouting */ true, /* aAfterReset */ true);
+
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().GetOmrPrefix(localOmr));
+    Log("Local OMR prefix is changed to %s", localOmr.ToString().AsCString());
 
     sExpectedPio = kPioAdvertisingLocalOnLink;
 
@@ -3316,6 +3329,9 @@ void TestSavedOnLinkPrefixes(void)
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(true));
 
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().GetOmrPrefix(localOmr));
+    Log("Local OMR prefix is changed to %s", localOmr.ToString().AsCString());
+
     AdvanceTime(100);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3361,6 +3377,10 @@ void TestSavedOnLinkPrefixes(void)
     InitTest(/* aEnablBorderRouting */ false, /* aAfterReset */ true);
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(true));
+
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().GetOmrPrefix(localOmr));
+    Log("Local OMR prefix is changed to %s", localOmr.ToString().AsCString());
+
     AdvanceTime(100);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This commit updates `OmrPrefixManager` in `RoutingManager` to determine the locally generated OMR prefix from the Thread Network's partition ID. This guarantees that all border routers within the same partition use the same local OMR prefix.

The commit also updates `OmrPrefixManager` to employ "Network Data Publisher" for the local OMR prefix. This allows multiple BRs (up to a limit of 3) to add the same prefix to the Network Data, enhancing redundancy and stability. Consequently, a single BR reboot/restart won't lead to OMR address changes within the network, potentially triggering unnecessary SRP registrations across all nodes.