### PR TITLE
[posix] ignore required anycast address

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (384)
+#define OPENTHREAD_API_VERSION (385)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -52,13 +52,13 @@ extern "C" {
  *
  */
 
-#define OT_IP6_PREFIX_SIZE 8                           ///< Size of an IPv6 prefix (bytes)
-#define OT_IP6_PREFIX_BITSIZE (OT_IP6_PREFIX_SIZE * 8) ///< Size of an IPv6 prefix (bits)
-#define OT_IP6_IID_SIZE 8                              ///< Size of an IPv6 Interface Identifier (bytes)
-#define OT_IP6_ADDRESS_SIZE 16                         ///< Size of an IPv6 address (bytes)
-#define OT_IP6_ADDRESS_BITSIZE (OT_IP6_ADDRESS_SIZE * 8)                     ///< Size of an IPv6 address (bits)
-#define OT_IP6_HEADER_SIZE 40                          ///< Size of an IPv6 header (bytes)
-#define OT_IP6_HEADER_PROTO_OFFSET 6                   ///< Offset of the proto field in the IPv6 header (bytes)
+#define OT_IP6_PREFIX_SIZE 8                             ///< Size of an IPv6 prefix (bytes)
+#define OT_IP6_PREFIX_BITSIZE (OT_IP6_PREFIX_SIZE * 8)   ///< Size of an IPv6 prefix (bits)
+#define OT_IP6_IID_SIZE 8                                ///< Size of an IPv6 Interface Identifier (bytes)
+#define OT_IP6_ADDRESS_SIZE 16                           ///< Size of an IPv6 address (bytes)
+#define OT_IP6_ADDRESS_BITSIZE (OT_IP6_ADDRESS_SIZE * 8) ///< Size of an IPv6 address (bits)
+#define OT_IP6_HEADER_SIZE 40                            ///< Size of an IPv6 header (bytes)
+#define OT_IP6_HEADER_PROTO_OFFSET 6                     ///< Offset of the proto field in the IPv6 header (bytes)
 
 /**
  * @struct otIp6InterfaceIdentifier

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -56,6 +56,7 @@ extern "C" {
 #define OT_IP6_PREFIX_BITSIZE (OT_IP6_PREFIX_SIZE * 8) ///< Size of an IPv6 prefix (bits)
 #define OT_IP6_IID_SIZE 8                              ///< Size of an IPv6 Interface Identifier (bytes)
 #define OT_IP6_ADDRESS_SIZE 16                         ///< Size of an IPv6 address (bytes)
+#define OT_IP6_ADDRESS_BITSIZE 128                     ///< Size of an IPv6 address (bits)
 #define OT_IP6_HEADER_SIZE 40                          ///< Size of an IPv6 header (bytes)
 #define OT_IP6_HEADER_PROTO_OFFSET 6                   ///< Offset of the proto field in the IPv6 header (bytes)
 

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -56,7 +56,7 @@ extern "C" {
 #define OT_IP6_PREFIX_BITSIZE (OT_IP6_PREFIX_SIZE * 8) ///< Size of an IPv6 prefix (bits)
 #define OT_IP6_IID_SIZE 8                              ///< Size of an IPv6 Interface Identifier (bytes)
 #define OT_IP6_ADDRESS_SIZE 16                         ///< Size of an IPv6 address (bytes)
-#define OT_IP6_ADDRESS_BITSIZE 128                     ///< Size of an IPv6 address (bits)
+#define OT_IP6_ADDRESS_BITSIZE (OT_IP6_ADDRESS_SIZE * 8)                     ///< Size of an IPv6 address (bits)
 #define OT_IP6_HEADER_SIZE 40                          ///< Size of an IPv6 header (bytes)
 #define OT_IP6_HEADER_PROTO_OFFSET 6                   ///< Offset of the proto field in the IPv6 header (bytes)
 

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -1102,6 +1102,7 @@ static bool isRequiredAnycast(const uint8_t *aAddress, uint8_t aPrefixLength)
         if ((aAddress[firstBytePos] & ((1 << remainingBits) - 1)) != 0)
         {
             isRequiredAnycast = false;
+            ExitNow();
         }
         firstBytePos++;
     }


### PR DESCRIPTION
Ignore Required Anycast address  when it is added to or deleted from wpan0 interface in openthread