### PR TITLE
[posix] prevent implicit conversion of `aUrl` to `RadioUrl`

### DIFF
--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -71,7 +71,7 @@ void Radio::Init(const char *aUrl)
     spinel_iid_t                            iidList[Spinel::kSpinelHeaderMaxNumIid];
     struct ot::Spinel::RadioSpinelCallbacks callbacks;
 
-    mRadioUrl = aUrl;
+    mRadioUrl.Init(aUrl);
     VerifyOrDie(mRadioUrl.GetPath() != nullptr, OT_EXIT_INVALID_ARGUMENTS);
 
     memset(&callbacks, 0, sizeof(callbacks));

--- a/src/posix/platform/radio_url.cpp
+++ b/src/posix/platform/radio_url.cpp
@@ -135,7 +135,7 @@ const char *otSysGetRadioUrlHelpString(void)
 namespace ot {
 namespace Posix {
 
-RadioUrl::RadioUrl(const char *aUrl)
+void RadioUrl::Init(const char *aUrl)
 {
     if (aUrl != nullptr)
     {

--- a/src/posix/platform/radio_url.hpp
+++ b/src/posix/platform/radio_url.hpp
@@ -52,7 +52,20 @@ public:
      * @param[in]   aUrl    The null-terminated URL string.
      *
      */
-    RadioUrl(const char *aUrl);
+    explicit RadioUrl(const char *aUrl) { Init(aUrl); };
+
+    /**
+     * Initializes the radio URL.
+     *
+     * @param[in]   aUrl    The null-terminated URL string.
+     *
+     */
+    void Init(const char *aUrl);
+
+    RadioUrl(const RadioUrl &)            = delete;
+    RadioUrl(RadioUrl &&)                 = delete;
+    RadioUrl &operator=(const RadioUrl &) = delete;
+    RadioUrl &operator=(RadioUrl &&)      = delete;
 
 private:
     enum


### PR DESCRIPTION
When compiling `mRadioUrl=aUrl` in `Radio::Init()`, some compilers may implicitly convert `aUrl` to a temporary `RadioUrl` object and then copy the temporary `RadioUrl` to `mRadioUrl` via a default copy constructor. The pointer members of `mRadioUrl` point to the content of the temporary `RadioUrl`, and it eventually causes the program to access the memory that has been released, which causes the program to crash.

This commit disables the compiler from implicitly converting `aUrl` to a `RadioUrl` object and deletes the default copy and move constructors.