### PR TITLE
[github-actions] avoid `dependabot` pull requests in forks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,7 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    if: github.repository == "openthread/openthread"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
OpenThread forks typically inherit all commits in the repo, including the `dependabot` changes, so it's not needed to generate the same PRs in the forks as well.