### PR TITLE
[spinel] add spinel net role DISABLED

### DIFF
--- a/src/lib/spinel/spinel.c
+++ b/src/lib/spinel/spinel.c
@@ -1500,11 +1500,9 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
 const char *spinel_net_role_to_cstr(uint8_t net_role)
 {
     static const struct spinel_cstr spinel_net_cstr[] = {
-        {SPINEL_NET_ROLE_DETACHED, "NET_ROLE_DETACHED"},
-        {SPINEL_NET_ROLE_CHILD, "NET_ROLE_CHILD"},
-        {SPINEL_NET_ROLE_ROUTER, "NET_ROLE_ROUTER"},
-        {SPINEL_NET_ROLE_LEADER, "NET_ROLE_LEADER"},
-        {0, NULL},
+        {SPINEL_NET_ROLE_DETACHED, "NET_ROLE_DETACHED"}, {SPINEL_NET_ROLE_CHILD, "NET_ROLE_CHILD"},
+        {SPINEL_NET_ROLE_ROUTER, "NET_ROLE_ROUTER"},     {SPINEL_NET_ROLE_LEADER, "NET_ROLE_LEADER"},
+        {SPINEL_NET_ROLE_DISABLED, "NET_ROLE_DISABLED"}, {0, NULL},
     };
 
     return spinel_to_cstr(spinel_net_cstr, net_role);

--- a/src/lib/spinel/spinel.h
+++ b/src/lib/spinel/spinel.h
@@ -598,6 +598,7 @@ typedef enum
     SPINEL_NET_ROLE_CHILD    = 1,
     SPINEL_NET_ROLE_ROUTER   = 2,
     SPINEL_NET_ROLE_LEADER   = 3,
+    SPINEL_NET_ROLE_DISABLED = 4,
 } spinel_net_role_t;
 
 typedef enum
@@ -2296,6 +2297,7 @@ enum
      *  SPINEL_NET_ROLE_CHILD    = 1,
      *  SPINEL_NET_ROLE_ROUTER   = 2,
      *  SPINEL_NET_ROLE_LEADER   = 3,
+     *  SPINEL_NET_ROLE_DISABLED = 4,
      *
      */
     SPINEL_PROP_NET_ROLE = SPINEL_PROP_NET__BEGIN + 3,


### PR DESCRIPTION
This PR adds net role 'DISABLED' into `spinel_net_role_t` to
differentiate between 'DISABLED' and 'DETACHED' status of NCP.

Since this is only used for NCP and not related with RCP, the `RCP_API_VERSION`
is not updated.