### PR TITLE
[dns] clarify trailing dot in `Name::ExtractLabels()`

### DIFF
--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -992,14 +992,14 @@ public:
     static Error CompareName(const Message &aMessage, uint16_t &aOffset, const Name &aName);
 
     /**
-     * Extracts label(s) from a full name by checking that it contains a given suffix name (e.g., suffix name can be
+     * Extracts label(s) from a name by checking that it contains a given suffix name (e.g., suffix name can be
      * a domain name) and removing it.
      *
-     * Both @p aName and @p aSuffixName must be full DNS name and end with ('.'), otherwise the behavior of this method
-     * is undefined.
+     * Both @p aName and @p aSuffixName MUST follow the same style regarding inclusion of trailing dot ('.'). Otherwise
+     * `kErrorParse` is returned.
      *
-     * @param[in]   aName           The full name to extract labels from.
-     * @param[in]   aSuffixName     The suffix name (e.g. can be domain name).
+     * @param[in]   aName           The name to extract labels from.
+     * @param[in]   aSuffixName     The suffix name (e.g., can be domain name).
      * @param[out]  aLabels         Pointer to buffer to copy the extracted labels.
      * @param[in]   aLabelsSize     Size of @p aLabels buffer.
      *
@@ -1011,16 +1011,16 @@ public:
     static Error ExtractLabels(const char *aName, const char *aSuffixName, char *aLabels, uint16_t aLabelsSize);
 
     /**
-     * Extracts label(s) from a full name by checking that it contains a given suffix name (e.g., suffix name can be
+     * Extracts label(s) from a name by checking that it contains a given suffix name (e.g., suffix name can be
      * a domain name) and removing it.
      *
-     * Both @p aName and @p aSuffixName must be full DNS name and end with ('.'), otherwise the behavior of this method
-     * is undefined.
+     * Both @p aName and @p aSuffixName MUST follow the same style regarding inclusion of trailing dot ('.'). Otherwise
+     * `kErrorParse` is returned.
      *
      * @tparam      kLabelsBufferSize   Size of the buffer string.
      *
-     * @param[in]   aName           The full name to extract labels from.
-     * @param[in]   aSuffixName     The suffix name (e.g. can be domain name).
+     * @param[in]   aName           The name to extract labels from.
+     * @param[in]   aSuffixName     The suffix name (e.g., can be domain name).
      * @param[out]  aLabelsBuffer   A buffer to copy the extracted labels.
      *
      * @retval kErrorNone     Successfully extracted the labels, @p aLabels is updated.

--- a/tests/unit/test_dns.cpp
+++ b/tests/unit/test_dns.cpp
@@ -285,6 +285,19 @@ void TestDnsName(void)
     SuccessOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name));
     VerifyOrQuit(strcmp(name, "my-service._ipps._tcp") == 0);
 
+    fullName   = "my-service._ipps._tcp.default.service.arpa";
+    suffixName = "default.service.arpa";
+    SuccessOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name));
+    VerifyOrQuit(strcmp(name, "my-service._ipps._tcp") == 0);
+
+    fullName   = "my-service._ipps._tcp.default.service.arpa";
+    suffixName = "default.service.arpa.";
+    VerifyOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name) == kErrorParse);
+
+    fullName   = "my-service._ipps._tcp.default.service.arpa.";
+    suffixName = "default.service.arpa";
+    VerifyOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name) == kErrorParse);
+
     fullName   = "my.service._ipps._tcp.default.service.arpa.";
     suffixName = "_ipps._tcp.default.service.arpa.";
     SuccessOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name));
@@ -295,8 +308,17 @@ void TestDnsName(void)
     SuccessOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name));
     VerifyOrQuit(strcmp(name, "my-service._ipps._tcp") == 0);
 
+    fullName   = "my-service._ipps._tcp.default.service.arpa";
+    suffixName = "DeFault.SerVice.ARPA";
+    SuccessOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name));
+    VerifyOrQuit(strcmp(name, "my-service._ipps._tcp") == 0);
+
     fullName   = "my-service._ipps._tcp.default.service.arpa.";
     suffixName = "efault.service.arpa.";
+    VerifyOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name) == kErrorParse);
+
+    fullName   = "my-service._ipps._tcp.default.service.arpa";
+    suffixName = "efault.service.arpa";
     VerifyOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name) == kErrorParse);
 
     fullName   = "my-service._ipps._tcp.default.service.arpa.";
@@ -313,6 +335,10 @@ void TestDnsName(void)
 
     fullName   = "default.service.arpa.";
     suffixName = "default.service.arpa.";
+    VerifyOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name) == kErrorParse);
+
+    fullName   = "default.service.arpa";
+    suffixName = "default.service.arpa";
     VerifyOrQuit(Dns::Name::ExtractLabels(fullName, suffixName, name) == kErrorParse);
 
     fullName   = "efault.service.arpa.";


### PR DESCRIPTION
This commit updates `ExtractLabels()` documentation to clarify that name and suffix name can include or exclude the trailing dot but both inputs must follow the same style. It also updates `test_dns` unit test to validate this behavior.