### PR TITLE
[spinel] fix passing an unexpected transmit error to mac layer

### DIFF
--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -1763,8 +1763,7 @@ void RadioSpinel::HandleTransmitDone(uint32_t          aCommand,
     }
 
 exit:
-    // If current spinel frame is parsed failed, there should be some issues related to current transaction.
-    // At this time, recover the RCP immediatly.
+    // A parse error indicates an RCP misbehavior, so recover the RCP immediately.
     mState = kStateTransmitDone;
     if (error != OT_ERROR_PARSE)
     {

--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -1763,8 +1763,19 @@ void RadioSpinel::HandleTransmitDone(uint32_t          aCommand,
     }
 
 exit:
-    mState   = kStateTransmitDone;
-    mTxError = error;
+    // If current spinel frame is parsed failed, there should be some issues related to current transaction.
+    // At this time, recover the RCP immediatly.
+    mState = kStateTransmitDone;
+    if (error != OT_ERROR_PARSE)
+    {
+        mTxError = error;
+    }
+    else
+    {
+        mTxError = kErrorAbort;
+        HandleRcpTimeout();
+        RecoverFromRcpFailure();
+    }
     UpdateParseErrorCount(error);
     LogIfFail("Handle transmit done failed", error);
 }


### PR DESCRIPTION
For the Spinel layer, when the state is transmitting, if the received Spinel frame fails parsing, the current implementation passes the `OT_ERROR_PARSE` error code to the sub_mac layer via the tx done handler. This causes an assert because the error code `OT_ERROR_PARSE` is not a valid one for `SubMac::HandleTransmitDone`. Additionally, I believe that when the received Spinel frame fails parsing, we should not trigger a transmit done to the sub_mac layer, as the `TxFrame` and the `AckFrame` may not be valid for further processing.

In this corner case, I suggest considering ignoring the parsing-failed received packets, waiting for the tx timeout, and then raising a tx timeout failure to recover the RCP. This might be a reasonable approach.