### PR TITLE
[posix] only add IPv4 route if NAT64 is enabled

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -1357,7 +1357,7 @@ static void processNetifLinkEvent(otInstance *aInstance, struct nlmsghdr *aNetli
     }
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE && OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
-    if (isUp && sActiveNat64Cidr.mLength > 0)
+    if (isUp && otNat64GetTranslatorState(gInstance) == OT_NAT64_STATE_ACTIVE)
     {
         // Recover NAT64 route.
         if ((error = AddIp4Route(sActiveNat64Cidr, kNat64RoutePriority)) != OT_ERROR_NONE)


### PR DESCRIPTION
Currently, when netlink informs that the network interface is up, an IPv4 route is added if a valid one is specified. However, elsewhere we only add/update the route when NAT64 is actually enabled. Since IPv4 route is not useful when NAT64 is not enabled, apply the same logic when the network interface is started.

This avoids warnings when NAT64 is compiled in but disabled: incoming message is an IPv4 datagram but no NAT64 prefix configured, drop