### PR TITLE
[spinel] allow registering callback to restore vendor properties

### DIFF
--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -122,6 +122,10 @@ RadioSpinel::RadioSpinel(void)
     , mTxRadioEndUs(UINT64_MAX)
     , mRadioTimeRecalcStart(UINT64_MAX)
     , mRadioTimeOffset(UINT64_MAX)
+#if OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_ENABLE
+    , mVendorRestorePropertiesCallback(nullptr)
+    , mVendorRestorePropertiesContext(nullptr)
+#endif
 {
     memset(mIidList, SPINEL_HEADER_INVALID_IID, sizeof(mIidList));
     memset(&mRadioSpinelMetrics, 0, sizeof(mRadioSpinelMetrics));
@@ -758,6 +762,15 @@ exit:
     UpdateParseErrorCount(error);
     LogIfFail("Failed to handle ValueIs", error);
 }
+
+#if OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_ENABLE
+void RadioSpinel::SetVendorRestorePropertiesCallback(otRadioSpinelVendorRestorePropertiesCallback aCallback,
+                                                     void                                        *aContext)
+{
+    mVendorRestorePropertiesCallback = aCallback;
+    mVendorRestorePropertiesContext  = aContext;
+}
+#endif
 
 otError RadioSpinel::ParseRadioFrame(otRadioFrame   &aFrame,
                                      const uint8_t  *aBuffer,
@@ -2266,6 +2279,13 @@ void RadioSpinel::RestoreProperties(void)
     {
         SuccessOrDie(Set(SPINEL_PROP_MAC_RX_ON_WHEN_IDLE_MODE, SPINEL_DATATYPE_BOOL_S, mRxOnWhenIdle));
     }
+
+#if OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_ENABLE
+    if (mVendorRestorePropertiesCallback)
+    {
+        mVendorRestorePropertiesCallback(mVendorRestorePropertiesContext);
+    }
+#endif
 
     CalcRcpTimeOffset();
 }

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -1086,7 +1086,6 @@ public:
     otError VendorHandleValueIs(spinel_prop_key_t aPropKey);
 
     /**
-     *
      *  A callback type for restoring vendor properties.
      *
      */
@@ -1096,7 +1095,7 @@ public:
      * Registers a callback to restore vendor properties.
      *
      * This function is used to register a callback for vendor properties recovery. When an event which needs to restore
-     * properties occurs(such as an unexpected RCP reset), the user can restore the vendor properties via the callback.
+     * properties occurs (such as an unexpected RCP reset), the user can restore the vendor properties via the callback.
      *
      * @param[in] aCallback The callback.
      * @param[in] aContext  The context.

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -1084,6 +1084,25 @@ public:
      *
      */
     otError VendorHandleValueIs(spinel_prop_key_t aPropKey);
+
+    /**
+     *
+     *  A callback type for restoring vendor properties.
+     *
+     */
+    typedef void (*otRadioSpinelVendorRestorePropertiesCallback)(void *context);
+
+    /**
+     * Registers a callback to restore vendor properties.
+     *
+     * This function is used to register a callback for vendor properties recovery. When an event which needs to restore
+     * properties occurs(such as an unexpected RCP reset), the user can restore the vendor properties via the callback.
+     *
+     * @param[in] aCallback The callback.
+     * @param[in] aContext  The context.
+     *
+     */
+    void SetVendorRestorePropertiesCallback(otRadioSpinelVendorRestorePropertiesCallback aCallback, void *aContext);
 #endif
 
 private:
@@ -1331,6 +1350,11 @@ private:
     MaxPowerTable mMaxPowerTable;
 
     otRadioSpinelMetrics mRadioSpinelMetrics;
+
+#if OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_ENABLE
+    otRadioSpinelVendorRestorePropertiesCallback mVendorRestorePropertiesCallback;
+    void                                        *mVendorRestorePropertiesContext;
+#endif
 };
 
 } // namespace Spinel


### PR DESCRIPTION
Currently the `RadioSpinel::RestoreProperties` only restores some properties defined in `spinel.h`. 
But if `OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_ENABLE` is selected, users may set some properties of RCP via vendor command. So the radio spinel should allow users to register a callback to restore the vendor properties of RCP.