### PR TITLE
[api] add api to indicate if platform should request DHCPv6 PD

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (389)
+#define OPENTHREAD_API_VERSION (390)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/border_routing.h
+++ b/include/openthread/platform/border_routing.h
@@ -65,6 +65,22 @@ extern "C" {
  */
 extern void otPlatBorderRoutingProcessIcmp6Ra(otInstance *aInstance, const uint8_t *aMessage, uint16_t aLength);
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
+#if !OPENTHREAD_BORDER_ROUTING_DHCP6_PD_REQUESTOR
+/**
+ * Requests or releases a prefix via DHCPv6 Prefix Delegation (PD) for Thread interface.
+ *
+ * Requires `OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE`.
+ * Requires `OPENTHREAD_BORDER_ROUTING_DHCP6_PD_REQUESTOR = 0`.
+ *
+ * @param[in] aInstance A pointer to an OpenThread instance.
+ * @param[in] aRequest  Indicates whether to request (when `true`) or release (when `false`) the prefix.
+ *
+ */
+void otPlatBorderRoutingRequestDhcp6Pd(otInstance *aInstance, bool aRequest);
+#endif // OPENTHREAD_BORDER_ROUTING_DHCP6_PD_REQUESTOR
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -3591,7 +3591,6 @@ void RoutingManager::PdPrefixManager::EvaluateStateChange(Dhcp6PdState aOldState
     VerifyOrExit(aOldState != newState);
     LogInfo("PdPrefixManager: %s -> %s", StateToString(aOldState), StateToString(newState));
 
-    // TODO: We may also want to inform the platform that PD is stopped.
     switch (newState)
     {
     case kDhcp6PdStateDisabled:
@@ -3601,6 +3600,11 @@ void RoutingManager::PdPrefixManager::EvaluateStateChange(Dhcp6PdState aOldState
     case kDhcp6PdStateRunning:
         break;
     }
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
+#if !OPENTHREAD_BORDER_ROUTING_DHCP6_PD_REQUESTOR
+    otPlatBorderRoutingRequestDhcp6Pd(&GetInstance(), newState == kDhcp6PdStateRunning);
+#endif // OPENTHREAD_BORDER_ROUTING_DHCP6_PD_REQUESTOR
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
 
 exit:
     return;
@@ -3762,6 +3766,15 @@ extern "C" void otPlatBorderRoutingProcessIcmp6Ra(otInstance *aInstance, const u
 {
     AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().ProcessPlatformGeneratedRa(aMessage, aLength);
 }
+
+#if !OPENTHREAD_BORDER_ROUTING_DHCP6_PD_REQUESTOR
+extern "C" void otPlatBorderRoutingRequestDhcp6Pd(otInstance *aInstance, bool aRequest)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aRequest);
+}
+#endif // OPENTHREAD_BORDER_ROUTING_DHCP6_PD_REQUESTOR
+
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
 
 } // namespace BorderRouter


### PR DESCRIPTION
Add API to notify the platform whether they should request an prefix via DHCPv6 PD for Thread interface.
When aShouldRequest is false, the platform must release the prefix lease.