### PR TITLE
[net-diag] handle `MleCounterTlv` in `AppendDiagTlv()`

### DIFF
--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -299,6 +299,15 @@ Error Server::AppendDiagTlv(uint8_t aTlvType, Message &aMessage)
         error = AppendMacCounters(aMessage);
         break;
 
+    case Tlv::kMleCounters:
+    {
+        MleCountersTlv tlv;
+
+        tlv.Init(Get<Mle::Mle>().GetCounters());
+        error = tlv.AppendTo(aMessage);
+        break;
+    }
+
     case Tlv::kVendorName:
         error = Tlv::Append<VendorNameTlv>(aMessage, GetVendorName());
         break;

--- a/tests/toranj/cli/test-020-net-diag-vendor-info.py
+++ b/tests/toranj/cli/test-020-net-diag-vendor-info.py
@@ -68,6 +68,7 @@ VENDOR_NAME_TLV = 25
 VENDOR_MODEL_TLV = 26
 VENDOR_SW_VERSION_TLV = 27
 THREAD_STACK_VERSION_TLV = 28
+MLE_COUNTERS_TLV = 34
 
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Check setting vendor name, model, ans sw version
@@ -175,6 +176,10 @@ for line in result[1:]:
         verify(r2.get_version().startswith(line.split(':', 1)[1].strip()))
     else:
         verify(False)
+
+result = r2.cli('networkdiagnostic get', r1_rloc, MLE_COUNTERS_TLV)
+print(len(result) >= 1)
+verify(result[1].startswith("MLE Counters:"))
 
 # -----------------------------------------------------------------------------------------------------------------------
 # Test finished


### PR DESCRIPTION
Adds support for responding to `MleCounterTlv` in `AppendDiagTlv()` Processing the TLV is a received response is already implemented and supported. Updates `test-020-net-diag` to check query of MLE counters TLV.