### PR TITLE
[posix] fix netlink address deletion on posix

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -375,7 +375,7 @@ static void UpdateUnicastLinux(otInstance *aInstance, const otIp6AddressInfo &aA
     memset(&req, 0, sizeof(req));
 
     req.nh.nlmsg_len   = NLMSG_LENGTH(sizeof(struct ifaddrmsg));
-    req.nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL;
+    req.nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | (aIsAdded ? (NLM_F_CREATE | NLM_F_EXCL) : 0);
     req.nh.nlmsg_type  = aIsAdded ? RTM_NEWADDR : RTM_DELADDR;
     req.nh.nlmsg_pid   = 0;
     req.nh.nlmsg_seq   = ++sNetlinkSequence;


### PR DESCRIPTION
This PR fixes the netif address deletion issue on posix. 

Currently there is an issue when using netlink to delete ip addresses on the 
network interface. The operation of deletion actually failed. For example, if we start ot-daemon, then `ifconfig up` and `ifconfig down`. We can see error in the log:
```
2024-01-16T23:18:17.543742+08:00 ./build/posix/src/posix/ot-daemon[29108]: 00:01:49.870 [I] Platform------: [netif] Sent request#3 to remove fe80::e8f2:97e2:362e:bcfe/64                                                                                                                                                                                  
2024-01-16T23:18:17.544987+08:00 ./build/posix/src/posix/ot-daemon[29108]: 00:01:49.871 [W] Platform------: [netif] Failed to process request#3: Operation not supported 
```
And if we start the network first, then change the dataset and restart the network (without `ifconfig down`), then the wpan interface will have a few stale IP addresses:
```
> ifconfig wpan0                                                                                                                                                                                                                                                                         
wpan0: flags=4305<UP,POINTOPOINT,RUNNING,NOARP,MULTICAST>  mtu 1280
        inet6 fd3e:83a8:aa56:aafc:0:ff:fe00:6000  prefixlen 64  scopeid 0x0<global>
        inet6 fd7e:e96f:f22:47e9:0:ff:fe00:6000  prefixlen 64  scopeid 0x0<global>
        inet6 fd7e:e96f:f22:47e9:0:ff:fe00:fc00  prefixlen 64  scopeid 0x0<global>
        inet6 fd7e:e96f:f22:47e9:c5f5:cc71:d9e5:5289  prefixlen 64  scopeid 0x0<global>
        inet6 fd3e:83a8:aa56:aafc:0:ff:fe00:fc00  prefixlen 64  scopeid 0x0<global>
        inet6 fd3e:83a8:aa56:aafc:c5f5:cc71:d9e5:5289  prefixlen 64  scopeid 0x0<global>
        inet6 fe80::e8f2:97e2:362e:bcfe  prefixlen 64  scopeid 0x20<link>
        unspec 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00  txqueuelen 500  (UNSPEC)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 3  overruns 0  frame 0
        TX packets 17  bytes 2672 (2.6 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0   
```
The mesh-local addresses in the previous network aren't deleted.

I found a related [answer](https://stackoverflow.com/questions/14369043/add-and-remove-ip-addresses-to-an-interface-using-ioctl-or-netlink) on SO and have verified this solution can work.