### PR TITLE
[spinel] drop received frames between RCP disable and reset

### DIFF
--- a/src/lib/spinel/multi_frame_buffer.hpp
+++ b/src/lib/spinel/multi_frame_buffer.hpp
@@ -371,7 +371,7 @@ public:
 
         aFrame = (aFrame == nullptr) ? mBuffer : aFrame + aLength;
 
-        if (aFrame != mWriteFrameStart)
+        if (HasSavedFrame() && (aFrame != mWriteFrameStart))
         {
             uint16_t totalLength = LittleEndian::ReadUint16(aFrame + kHeaderTotalLengthOffset);
             uint16_t skipLength  = LittleEndian::ReadUint16(aFrame + kHeaderSkipLengthOffset);

--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -666,6 +666,9 @@ void RadioSpinel::HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, 
                 ExitNow();
             }
 
+            // this clear is necessary in case the RCP has sent messages between disable and reset
+            mRxFrameBuffer.Clear();
+
             LogInfo("RCP reset: %s", spinel_status_to_cstr(status));
             sIsReady = true;
         }

--- a/src/lib/spinel/spinel_encoder.cpp
+++ b/src/lib/spinel/spinel_encoder.cpp
@@ -291,5 +291,7 @@ exit:
     return error;
 }
 
+void Encoder::ClearNcpBuffer(void) { mNcpBuffer.Clear(); }
+
 } // namespace Spinel
 } // namespace ot

--- a/src/lib/spinel/spinel_encoder.hpp
+++ b/src/lib/spinel/spinel_encoder.hpp
@@ -676,6 +676,12 @@ public:
      */
     otError ResetToSaved(void);
 
+    /**
+     * Clear NCP buffer on reset command.
+     *
+     */
+    void ClearNcpBuffer(void);
+
 private:
     enum
     {

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1285,6 +1285,8 @@ otError NcpBase::CommandHandler_RESET(uint8_t aHeader)
 
         ResetCounters();
 
+        mEncoder.ClearNcpBuffer();
+
         SuccessOrAssert(error = WriteLastStatusFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_TX_NOTIFICATION_IID,
                                                      SPINEL_STATUS_RESET_POWER_ON));
     }


### PR DESCRIPTION
when device sends SPINEL frames during RCP reset procedure. This is not handled correctly on host device. It tries to handle the received frames right after the reset, but there are some issues when handling them.

- Cleared reset buffer after reset.
- In GetNextSavedFrame method from class MultiFrameBuffer, Check that the parameter used as read pointer is in the buffer range, else return nullptr.