### PR TITLE
[netdata-publisher] remove SRP unicast on anycast entry added by a BR

### DIFF
--- a/src/core/thread/network_data_publisher.cpp
+++ b/src/core/thread/network_data_publisher.cpp
@@ -658,10 +658,29 @@ void Publisher::DnsSrpServiceEntry::Process(void)
         desiredNumEntries = kDesiredNumAnycast;
         break;
 
-    case kTypeUnicast:
     case kTypeUnicastMeshLocalEid:
+    {
+        Service::DnsSrpAnycast::Info anycastInfo;
+
         CountUnicastEntries(numEntries, numPreferredEntries);
         desiredNumEntries = kDesiredNumUnicast;
+
+        if (Get<Service::Manager>().FindPreferredDnsSrpAnycastInfo(anycastInfo) == kErrorNone)
+        {
+            // If there is any anycast entry in netdata, we set the
+            // desired number of unicast entries (with address added
+            // in server TLV) to zero to remove any added unicast
+            // entry.
+
+            desiredNumEntries = 0;
+        }
+
+        break;
+    }
+
+    case kTypeUnicast:
+        desiredNumEntries = kDesiredNumUnicast;
+        CountUnicastEntries(numEntries, numPreferredEntries);
         break;
     }
 


### PR DESCRIPTION
This commit updates how the `NetworkData::Publisher` handles "DNS/SRP Service Unicast Address" entries. Specifically, when a "DNS/SRP Service Anycast" entry is added by another BR, the publisher will set the desired count of unicast entries to zero. This effectively removes any previously added unicast entry. This new behavior is only applied when the address and port are included in the Server TLV data in a "DNS/SRP Service Unicast Address" entry.

The `test_netdata_publisher` has been updated to verify this new behavior.

---

Related to [SPEC-1240](https://threadgroup.atlassian.net/browse/SPEC-1240)