### PR TITLE
[key-manager] check if the key is present before exporting the key

### DIFF
--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -516,7 +516,7 @@ void KeyManager::HandleKeyRotationTimer(void)
 void KeyManager::GetNetworkKey(NetworkKey &aNetworkKey) const
 {
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
-    if (Crypto::Storage::IsKeyRefValid(mNetworkKeyRef))
+    if (Crypto::Storage::HasKey(mNetworkKeyRef))
     {
         size_t keyLen;
 
@@ -535,7 +535,7 @@ void KeyManager::GetNetworkKey(NetworkKey &aNetworkKey) const
 void KeyManager::GetPskc(Pskc &aPskc) const
 {
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
-    if (Crypto::Storage::IsKeyRefValid(mPskcRef))
+    if (Crypto::Storage::HasKey(mPskcRef))
     {
         size_t keyLen;
 


### PR DESCRIPTION
While trying to read the Pskc or networkkey, we check if the keyref is valid. We instead need to check if the key is present. There is a possibility that the persistent data was erased before trying to read the key, which might result in asserts. 