### PR TITLE
[ip6] mesh-local addresses as preferred, platform control flag on host stack

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (393)
+#define OPENTHREAD_API_VERSION (394)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -479,6 +479,7 @@ typedef struct otIp6AddressInfo
     uint8_t             mPrefixLength;  ///< The prefix length of mAddress if it is a unicast address.
     uint8_t             mScope : 4;     ///< The scope of this address.
     bool                mPreferred : 1; ///< Whether this is a preferred address.
+    bool                mMeshLocal : 1; ///< Whether this is a mesh-local unicast/anycast address.
 } otIp6AddressInfo;
 
 /**

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -253,6 +253,7 @@ void Netif::SignalMulticastAddressChange(AddressEvent aEvent, const MulticastAdd
         info.mPrefixLength = kMulticastPrefixLength;
         info.mScope        = aAddress.GetAddress().GetScope();
         info.mPreferred    = false;
+        info.mMeshLocal    = false;
 
         mAddressCallback.Invoke(&info, aEvent);
     }
@@ -427,6 +428,7 @@ void Netif::SignalUnicastAddressChange(AddressEvent aEvent, const UnicastAddress
         info.mPrefixLength = aAddress.mPrefixLength;
         info.mScope        = aAddress.GetScope();
         info.mPreferred    = aAddress.mPreferred;
+        info.mMeshLocal    = aAddress.mMeshLocal;
 
         mAddressCallback.Invoke(&info, aEvent);
     }
@@ -539,12 +541,12 @@ void Netif::ApplyNewMeshLocalPrefix(void)
 //---------------------------------------------------------------------------------------------------------------------
 // Netif::UnicastAddress
 
-void Netif::UnicastAddress::InitAsThreadOrigin(bool aPreferred)
+void Netif::UnicastAddress::InitAsThreadOrigin(void)
 {
     Clear();
     mPrefixLength  = NetworkPrefix::kLength;
     mAddressOrigin = kOriginThread;
-    mPreferred     = aPreferred;
+    mPreferred     = true;
     mValid         = true;
 }
 

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -116,10 +116,8 @@ public:
          * Clears and initializes the unicast address as a preferred, valid, thread-origin address with
          * 64-bit prefix length.
          *
-         * @param[in]   aPreferred  Whether to initialize as a preferred address.
-         *
          */
-        void InitAsThreadOrigin(bool aPreferred = false);
+        void InitAsThreadOrigin(void);
 
         /**
          * Clears and initializes the unicast address as a valid (but not preferred), thread-origin,

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -123,7 +123,7 @@ Mle::Mle(Instance &aInstance)
     mParentCandidate.Clear();
     ResetCounters();
 
-    mLinkLocal64.InitAsThreadOrigin(/* aPreferred */ true);
+    mLinkLocal64.InitAsThreadOrigin();
     mLinkLocal64.GetAddress().SetToLinkLocalAddress(Get<Mac::Mac>().GetExtAddress());
 
     mMeshLocal64.InitAsThreadOriginMeshLocal();

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -388,7 +388,7 @@ static void UpdateUnicastLinux(otInstance *aInstance, const otIp6AddressInfo &aA
 
     AddRtAttr(&req.nh, sizeof(req), IFA_LOCAL, aAddressInfo.mAddress, sizeof(*aAddressInfo.mAddress));
 
-    if (!aAddressInfo.mPreferred)
+    if (!aAddressInfo.mPreferred || aAddressInfo.mMeshLocal)
     {
         struct ifa_cacheinfo cacheinfo;
 
@@ -456,12 +456,13 @@ static void UpdateUnicast(otInstance *aInstance, const otIp6AddressInfo &aAddres
         ifr6.ifra_prefixmask.sin6_family = AF_INET6;
         ifr6.ifra_prefixmask.sin6_len    = sizeof(ifr6.ifra_prefixmask);
         InitNetaskWithPrefixLength(&ifr6.ifra_prefixmask.sin6_addr, aAddressInfo.mPrefixLength);
-        ifr6.ifra_lifetime.ia6t_vltime    = ND6_INFINITE_LIFETIME;
-        ifr6.ifra_lifetime.ia6t_pltime    = ND6_INFINITE_LIFETIME;
+        ifr6.ifra_lifetime.ia6t_vltime = ND6_INFINITE_LIFETIME;
+        ifr6.ifra_lifetime.ia6t_pltime = ND6_INFINITE_LIFETIME;
 
 #if defined(__APPLE__)
-        ifr6.ifra_lifetime.ia6t_expire    = ND6_INFINITE_LIFETIME;
-        ifr6.ifra_lifetime.ia6t_preferred = (aAddressInfo.mPreferred ? ND6_INFINITE_LIFETIME : 0);
+        ifr6.ifra_lifetime.ia6t_expire = ND6_INFINITE_LIFETIME;
+        ifr6.ifra_lifetime.ia6t_preferred =
+            (aAddressInfo.mPreferred && !aAddressInfo.mMeshLocal ? ND6_INFINITE_LIFETIME : 0);
 #endif
 
         rval = ioctl(sIpFd, aIsAdded ? SIOCAIFADDR_IN6 : SIOCDIFADDR_IN6, &ifr6);


### PR DESCRIPTION
This commit updates mesh-local addresses to be marked as preferred (reverting the change from #6532). This ensures that mesh-local addresses are not skipped over in `Ip6::SelectSourceAddress()`.

The intention behind #6532 was to ensure that mesh-local addresses, when added to the platform host IPv6 stack (such as lwIP or the Linux kernel), are not preferred and therefore not selected by the host stack as the source address of application layer traffic unless explicitly assigned.

This PR delegates this responsibility to the platform code and updates `posix/platform/netif` to change the preferred flag for mesh-local addresses when adding them on the platform IPv6 stack.

To make this easier, the `otIp6AddressInfo` is updated to include `mMeshLocal` to indicate whether or not the address is mesh-local. `otNetifAddress` already provides such a variable.


----

- Related to discussions in https://github.com/openthread/openthread/issues/9800.