### PR TITLE
[ip6] deliver multicast to host if not from there

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1129,8 +1129,8 @@ Error Ip6::HandleDatagram(OwnedPtr<Message> aMessagePtr, bool aIsReassembled)
         }
 #endif
 
-        // Always forward multicast packets to host network stack
-        forwardHost = true;
+        // Forward multicast packets to host network stack unless they came from there.
+        forwardHost = !aMessagePtr->IsOriginHostUntrusted();
 
         if ((aMessagePtr->IsOriginThreadNetif() || aMessagePtr->GetMulticastLoop()) &&
             Get<ThreadNetif>().IsMulticastSubscribed(header.GetDestination()))


### PR DESCRIPTION
This commit filter out multicast traffic to host if they came from there, so
that a multicast packet will not be processed twice on host.
