### PR TITLE
[ip6] always deliver multicast to host

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1121,7 +1121,8 @@ Error Ip6::HandleDatagram(OwnedPtr<Message> aMessagePtr, const void *aLinkMessag
         }
 #endif
 
-        forwardHost = header.GetDestination().IsMulticastLargerThanRealmLocal();
+        // Always forward multicast packets to host network stack
+        forwardHost = true;
 
         if ((aMessagePtr->IsOriginThreadNetif() || aMessagePtr->GetMulticastLoop()) &&
             Get<ThreadNetif>().IsMulticastSubscribed(header.GetDestination()))


### PR DESCRIPTION
This commit always delivers multicast traffic to the host.

Without this change, host will not be able to receive link-local and mesh-local multicast traffic, even the host subscribes to some multicast addresses in these scopes.

Note that this does not change the host forwarding rules, as link-local and mesh-local traffic are not supposed to be forwarded to adjacent links.