### PR TITLE
[posix] do not loop back to host

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -1164,7 +1164,6 @@ static void processTransmit(otInstance *aInstance)
         message = otIp6NewMessage(aInstance, &settings);
 #endif
         VerifyOrExit(message != nullptr, error = OT_ERROR_NO_BUFS);
-        otMessageSetLoopbackToHostAllowed(message, true);
         otMessageSetOrigin(message, OT_MESSAGE_ORIGIN_HOST_UNTRUSTED);
     }
 


### PR DESCRIPTION
There's no clear use case for looping back packets to host. And it would probably result in host processing duplicate messages. This commit disables looping packets back to host.