### PR TITLE
[ip6] `SelectSourceAddress()` rule 1 on preferring same address

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1330,17 +1330,17 @@ const Address *Ip6::SelectSourceAddress(const Address &aDestination) const
             overrideScope = destScope;
         }
 
-        if (bestAddr == nullptr)
-        {
-            // Rule 0: Prefer any address
-            bestAddr     = &addr;
-            bestMatchLen = matchLen;
-        }
-        else if (addr.GetAddress() == aDestination)
+        if (addr.GetAddress() == aDestination)
         {
             // Rule 1: Prefer same address
             bestAddr = &addr;
             ExitNow();
+        }
+
+        if (bestAddr == nullptr)
+        {
+            bestAddr     = &addr;
+            bestMatchLen = matchLen;
         }
         else if (addr.GetScope() < bestAddr->GetScope())
         {


### PR DESCRIPTION
This commit moves the check for rule 1 on preferring same address as the destination before the `(bestAddr == nullptr)` check. This ensures that rule 1 will be correctly applied even when the address happens to be first one in the `GetUnicastAddresses()` list.