### PR TITLE
[core] valgrind reported memory access bugs

### DIFF
--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -65,6 +65,7 @@ const uint8_t KeyManager::kTrelInfoString[] = {'T', 'h', 'r', 'e', 'a', 'd', 'O'
 
 void SecurityPolicy::SetToDefault(void)
 {
+    Clear();
     mRotationTime = kDefaultKeyRotationTime;
     SetToDefaultFlags();
 }

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -68,7 +68,7 @@ namespace ot {
  * Represents Security Policy Rotation and Flags.
  *
  */
-class SecurityPolicy : public otSecurityPolicy, public Equatable<SecurityPolicy>
+class SecurityPolicy : public otSecurityPolicy, public Equatable<SecurityPolicy>, public Clearable<SecurityPolicy>
 {
 public:
     /**

--- a/src/posix/platform/backtrace.cpp
+++ b/src/posix/platform/backtrace.cpp
@@ -164,6 +164,8 @@ void platformBacktraceInit(void)
 {
     struct sigaction sigact;
 
+    memset(&sigact, 0, sizeof(struct sigaction));
+
     sigact.sa_sigaction = &signalCritical;
     sigact.sa_flags     = SA_RESTART | SA_SIGINFO | SA_NOCLDWAIT;
 


### PR DESCRIPTION
Fix one serious and two less serious uninitialized memory access bugs in openthread. All of these were found using valgrind.

- zero signal handler memory access
- zero otSecurityPolicy structure during SecurityPolicy class constructor
- do *not* access netlink message error TLVs if the extended ack flag is not set in the message
	- this can happen when the kernel is too old to support the netlink socket option.
	- this bug has led to segmentation faults and in one case a livelock.