### PR TITLE
[csl] reset data poll timer after successful csl transmission

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1311,6 +1311,12 @@ void Mac::HandleTransmitDone(TxFrame &aFrame, RxFrame *aAckFrame, Error aError)
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
                 ProcessCsl(*aAckFrame, dstAddr);
 #endif
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+                if (!GetRxOnWhenIdle() && aFrame.GetHeaderIe(CslIe::kHeaderIeId) != nullptr)
+                {
+                    Get<DataPollSender>().ResetKeepAliveTimer();
+                }
+#endif
             }
         }
     }


### PR DESCRIPTION
Currently the the data poll timer is used to maintain synchronization with the parent. It sends a data poll once per csl timeout. However often this is not necessary as other packets that are sent cause synchronization to be maintained. This commit resets the data poll timer each time a frame containing the csl ie is successfully transmitted. 