### PR TITLE
[instance] init `BackboneRouter::Local` before `Mle`

### DIFF
--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -125,6 +125,9 @@ Instance::Instance(void)
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
     , mSntpClient(*this)
 #endif
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+    , mBackboneRouterLocal(*this)
+#endif
     , mActiveDataset(*this)
     , mPendingDataset(*this)
     , mExtendedPanIdManager(*this)
@@ -178,7 +181,6 @@ Instance::Instance(void)
     , mBackboneRouterLeader(*this)
 #endif
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    , mBackboneRouterLocal(*this)
     , mBackboneRouterManager(*this)
 #endif
 #if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -510,6 +510,10 @@ private:
     Sntp::Client mSntpClient;
 #endif
 
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+    BackboneRouter::Local mBackboneRouterLocal;
+#endif
+
     MeshCoP::ActiveDatasetManager  mActiveDataset;
     MeshCoP::PendingDatasetManager mPendingDataset;
     MeshCoP::ExtendedPanIdManager  mExtendedPanIdManager;
@@ -578,7 +582,6 @@ private:
 #endif
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    BackboneRouter::Local   mBackboneRouterLocal;
     BackboneRouter::Manager mBackboneRouterManager;
 #endif
 


### PR DESCRIPTION
This commit moves the `mBackboneRouterLocal` before `mMleRouter` in `Instance` class to ensure that it is initialized and its constructor is called before. This ensures when `Mle()` constructor invokes the `ApplyNewMeshLocalPrefix()` method on `BackboneRouter::Local`, it is already initialized.

----

Should help address: https://github.com/openthread/openthread/issues/9841
