### PR TITLE
[mbedtls] make debug logging independent from builtin

### DIFF
--- a/src/core/crypto/mbedtls.cpp
+++ b/src/core/crypto/mbedtls.cpp
@@ -53,11 +53,11 @@ namespace Crypto {
 
 MbedTls::MbedTls(void)
 {
-#if OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS_MANAGEMENT
 #ifdef MBEDTLS_DEBUG_C
     // mbedTLS's debug level is almost the same as OpenThread's
     mbedtls_debug_set_threshold(OPENTHREAD_CONFIG_LOG_LEVEL);
 #endif
+#if OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS_MANAGEMENT
     mbedtls_platform_set_calloc_free(Heap::CAlloc, Heap::Free);
 #endif // OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS_MANAGEMENT
 }


### PR DESCRIPTION
Currently mbedtls debug logging can only be set for builtin mbedtls. With an extenal mbedtls the log level does not get configured. This commit removes the builtin requirement.