### PR TITLE
[ip6] filter multicast packets to host

### DIFF
--- a/src/core/config/ip6.h
+++ b/src/core/config/ip6.h
@@ -228,6 +228,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_IP6_RESTRICT_FORWARDING_LARGER_SCOPE_MCAST_WITH_LOCAL_SRC
+ *
+ * Define as 1 to restrict multicast forwarding to larger scope from local sources.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_IP6_RESTRICT_FORWARDING_LARGER_SCOPE_MCAST_WITH_LOCAL_SRC
+#define OPENTHREAD_CONFIG_IP6_RESTRICT_FORWARDING_LARGER_SCOPE_MCAST_WITH_LOCAL_SRC 0
+#endif
+
+/**
  * @}
  *
  */


### PR DESCRIPTION
On Android, the platform doesn't restrict link-local/mesh-local source addresses when forwarding multicast packets. For multicast packets sent from link-local/mesh-local address to scope larger than realm-local, set the hoplimit to 1 so the packet can be delivered to host, and will not be forwarded to infrastructure link.

The feature is guarded by `OPENTHREAD_CONFIG_IP6_RESTRICT_FORWARDING_LARGER_SCOPE_MCAST_WITH_LOCAL_SRC `, set as 1 to enable.
