### PR TITLE
[cli] style fixes & remove core defined error constants

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -504,12 +504,13 @@ otError Interpreter::ParseToIp6Address(otInstance   *aInstance,
                                        otIp6Address &aAddress,
                                        bool         &aSynthesized)
 {
-    Error error = kErrorNone;
+    Error error = OT_ERROR_NONE;
 
     VerifyOrExit(!aArg.IsEmpty(), error = OT_ERROR_INVALID_ARGS);
     error        = aArg.ParseAsIp6Address(aAddress);
     aSynthesized = false;
-    if (error != kErrorNone)
+
+    if (error != OT_ERROR_NONE)
     {
         // It might be an IPv4 address, let's have a try.
         otIp4Address ip4Address;
@@ -758,9 +759,6 @@ template <> otError Interpreter::Process<Cmd("nat64")>(Arg aArgs[])
      */
     else if (aArgs[0] == "mappings")
     {
-        otNat64AddressMappingIterator iterator;
-        otNat64AddressMapping         mapping;
-
         static const char *const kNat64StatusLevel1Title[] = {"", "Address", "", "4 to 6", "6 to 4"};
 
         static const uint8_t kNat64StatusLevel1ColumnWidths[] = {
@@ -774,6 +772,9 @@ template <> otError Interpreter::Process<Cmd("nat64")>(Arg aArgs[])
         static const uint8_t kNat64StatusTableColumnWidths[] = {
             18, 42, 18, 8, 10, 14, 10, 14,
         };
+
+        otNat64AddressMappingIterator iterator;
+        otNat64AddressMapping         mapping;
 
         OutputTableHeader(kNat64StatusLevel1Title, kNat64StatusLevel1ColumnWidths);
         OutputTableHeader(kNat64StatusTableHeader, kNat64StatusTableColumnWidths);
@@ -7563,7 +7564,7 @@ template <> otError Interpreter::Process<Cmd("trel")>(Arg aArgs[])
         }
         else
         {
-            VerifyOrExit(aArgs[1].IsEmpty(), error = kErrorInvalidArgs);
+            VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
         }
 
         if (isTable)

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -258,14 +258,14 @@ public:
      * If the argument string is an IPv4 address, this method will try to synthesize an IPv6 address using preferred
      * NAT64 prefix in the network data.
      *
-     * @param[in]  aInstance       A pointer to openthread instance.
+     * @param[in]  aInstance       A pointer to OpenThread instance.
      * @param[in]  aArg            The argument string to parse.
      * @param[out] aAddress        A reference to an `otIp6Address` to output the parsed IPv6 address.
      * @param[out] aSynthesized    Whether @p aAddress is synthesized from an IPv4 address.
      *
-     * @retval OT_ERROR_NONE          The argument was parsed successfully.
-     * @retval OT_ERROR_INVALID_ARGS  The argument is empty or does not contain valid IP address.
-     * @retval OT_ERROR_INVALID_STATE No valid NAT64 prefix in the network data.
+     * @retval OT_ERROR_NONE           The argument was parsed successfully.
+     * @retval OT_ERROR_INVALID_ARGS   The argument is empty or does not contain a valid IP address.
+     * @retval OT_ERROR_INVALID_STATE  No valid NAT64 prefix in the network data.
      *
      */
     static otError ParseToIp6Address(otInstance   *aInstance,

--- a/src/cli/cli_dns.cpp
+++ b/src/cli/cli_dns.cpp
@@ -416,15 +416,15 @@ otError Dns::GetDnsConfig(Arg aArgs[], otDnsQueryConfig *&aConfig)
 
     otError error = OT_ERROR_NONE;
     bool    recursionDesired;
-    bool    nat64SynthesizedAddress;
+    bool    nat64Synth;
 
     ClearAllBytes(*aConfig);
 
     VerifyOrExit(!aArgs[0].IsEmpty(), aConfig = nullptr);
 
     SuccessOrExit(error = Interpreter::ParseToIp6Address(GetInstancePtr(), aArgs[0], aConfig->mServerSockAddr.mAddress,
-                                                         nat64SynthesizedAddress));
-    if (nat64SynthesizedAddress)
+                                                         nat64Synth));
+    if (nat64Synth)
     {
         OutputFormat("Synthesized IPv6 DNS server address: ");
         OutputIp6AddressLine(aConfig->mServerSockAddr.mAddress);

--- a/src/cli/cli_ping.cpp
+++ b/src/cli/cli_ping.cpp
@@ -55,7 +55,7 @@ otError PingSender::Process(Arg aArgs[])
     otError            error = OT_ERROR_NONE;
     otPingSenderConfig config;
     bool               async = false;
-    bool               nat64SynthesizedAddress;
+    bool               nat64Synth;
 
     /**
      * @cli ping stop
@@ -96,9 +96,9 @@ otError PingSender::Process(Arg aArgs[])
         aArgs++;
     }
 
-    SuccessOrExit(error = Interpreter::GetInterpreter().ParseToIp6Address(
-                      GetInstancePtr(), aArgs[0], config.mDestination, nat64SynthesizedAddress));
-    if (nat64SynthesizedAddress)
+    SuccessOrExit(error = Interpreter::ParseToIp6Address(GetInstancePtr(), aArgs[0], config.mDestination, nat64Synth));
+
+    if (nat64Synth)
     {
         OutputFormat("Pinging synthesized IPv6 address: ");
         OutputIp6AddressLine(config.mDestination);

--- a/src/cli/cli_tcat.cpp
+++ b/src/cli/cli_tcat.cpp
@@ -93,10 +93,12 @@ static void HandleBleSecureReceive(otInstance               *aInstance,
     OT_UNUSED_VARIABLE(aContext);
     OT_UNUSED_VARIABLE(aTcatApplicationProtocol);
     OT_UNUSED_VARIABLE(aServiceName);
+
     static constexpr int     kTextMaxLen   = 100;
     static constexpr uint8_t kBufPrefixLen = 5;
-    uint16_t                 nLen;
-    uint8_t                  buf[kTextMaxLen];
+
+    uint16_t nLen;
+    uint8_t  buf[kTextMaxLen];
 
     nLen = otMessageRead(aMessage, (uint16_t)aOffset, buf + kBufPrefixLen, sizeof(buf) - kBufPrefixLen - 1);
 
@@ -137,11 +139,10 @@ exit:
 template <> otError Tcat::Process<Cmd("stop")>(Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);
-    otError error = OT_ERROR_NONE;
 
     otBleSecureStop(GetInstancePtr());
 
-    return error;
+    return OT_ERROR_NONE;
 }
 
 otError Tcat::Process(Arg aArgs[])

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -132,11 +132,11 @@ template <> otError UdpExample::Process<Cmd("connect")>(Arg aArgs[])
 {
     otError    error;
     otSockAddr sockaddr;
-    bool       nat64SynthesizedAddress;
+    bool       nat64Synth;
 
-    SuccessOrExit(
-        error = Interpreter::ParseToIp6Address(GetInstancePtr(), aArgs[0], sockaddr.mAddress, nat64SynthesizedAddress));
-    if (nat64SynthesizedAddress)
+    SuccessOrExit(error = Interpreter::ParseToIp6Address(GetInstancePtr(), aArgs[0], sockaddr.mAddress, nat64Synth));
+
+    if (nat64Synth)
     {
         OutputFormat("Connecting to synthesized IPv6 address: ");
         OutputIp6AddressLine(sockaddr.mAddress);
@@ -267,11 +267,12 @@ template <> otError UdpExample::Process<Cmd("send")>(Arg aArgs[])
 
     if (!aArgs[2].IsEmpty())
     {
-        bool nat64SynthesizedAddress;
+        bool nat64Synth;
 
-        SuccessOrExit(error = Interpreter::ParseToIp6Address(GetInstancePtr(), aArgs[0], messageInfo.mPeerAddr,
-                                                             nat64SynthesizedAddress));
-        if (nat64SynthesizedAddress)
+        SuccessOrExit(
+            error = Interpreter::ParseToIp6Address(GetInstancePtr(), aArgs[0], messageInfo.mPeerAddr, nat64Synth));
+
+        if (nat64Synth)
         {
             OutputFormat("Sending to synthesized IPv6 address: ");
             OutputIp6AddressLine(messageInfo.mPeerAddr);


### PR DESCRIPTION
This commit contains small changes in the CLI modules:

- Replace use of core-internal `kError` with `OT_ERROR` constants.
- Remove `#endif` comments when the corresponding `#if` is less than 20 lines away adhering to OT style guide.
- Adhere to single `return` policy (use `ExitNow()`).
- Avoid calling `static` method `ParseToIp6Address()` with an object.
- Smaller style fixes: New lines after variable declaration, use shorter local variable names, etc.