### PR TITLE
[cli-tcat] define `VendorInfo` as a member variable

### DIFF
--- a/src/cli/cli_tcat.cpp
+++ b/src/cli/cli_tcat.cpp
@@ -79,9 +79,8 @@ namespace ot {
 
 namespace Cli {
 
-otTcatVendorInfo sVendorInfo;
-const char       kPskdVendor[] = "J01NM3";
-const char       kUrl[]        = "dummy_url";
+const char kPskdVendor[] = "J01NM3";
+const char kUrl[]        = "dummy_url";
 
 static void HandleBleSecureReceive(otInstance               *aInstance,
                                    const otMessage          *aMessage,
@@ -114,8 +113,9 @@ template <> otError Tcat::Process<Cmd("start")>(Arg aArgs[])
 
     otError error = OT_ERROR_NONE;
 
-    sVendorInfo.mPskdString      = kPskdVendor;
-    sVendorInfo.mProvisioningUrl = kUrl;
+    ClearAllBytes(mVendorInfo);
+    mVendorInfo.mPskdString      = kPskdVendor;
+    mVendorInfo.mProvisioningUrl = kUrl;
 
     otBleSecureSetCertificate(GetInstancePtr(), reinterpret_cast<const uint8_t *>(OT_CLI_TCAT_X509_CERT),
                               sizeof(OT_CLI_TCAT_X509_CERT), reinterpret_cast<const uint8_t *>(OT_CLI_TCAT_PRIV_KEY),
@@ -128,7 +128,7 @@ template <> otError Tcat::Process<Cmd("start")>(Arg aArgs[])
     otBleSecureSetSslAuthMode(GetInstancePtr(), true);
 
     SuccessOrExit(error = otBleSecureStart(GetInstancePtr(), nullptr, HandleBleSecureReceive, true, nullptr));
-    SuccessOrExit(error = otBleSecureTcatStart(GetInstancePtr(), &sVendorInfo, nullptr));
+    SuccessOrExit(error = otBleSecureTcatStart(GetInstancePtr(), &mVendorInfo, nullptr));
 
 exit:
     return error;

--- a/src/cli/cli_tcat.hpp
+++ b/src/cli/cli_tcat.hpp
@@ -31,6 +31,8 @@
 
 #include "openthread-core-config.h"
 
+#include <openthread/tcat.h>
+
 #include "cli/cli_output.hpp"
 
 #if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE && OPENTHREAD_CONFIG_CLI_BLE_SECURE_ENABLE
@@ -78,6 +80,8 @@ private:
     using Command = CommandEntry<Tcat>;
 
     template <CommandId kCommandId> otError Process(Arg aArgs[]);
+
+    otTcatVendorInfo mVendorInfo;
 };
 
 } // namespace Cli


### PR DESCRIPTION
Change `mVendorInfo` to be a member variable of `Tcat` class instead of a static variable.