### PR TITLE
[key-manager] update how key guard time is determined and applied

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (399)
+#define OPENTHREAD_API_VERSION (400)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -709,7 +709,7 @@ void otThreadSetKeySequenceCounter(otInstance *aInstance, uint32_t aKeySequenceC
  * @sa otThreadSetKeySwitchGuardTime
  *
  */
-uint32_t otThreadGetKeySwitchGuardTime(otInstance *aInstance);
+uint16_t otThreadGetKeySwitchGuardTime(otInstance *aInstance);
 
 /**
  * Sets the thrKeySwitchGuardTime (in hours).
@@ -723,7 +723,7 @@ uint32_t otThreadGetKeySwitchGuardTime(otInstance *aInstance);
  * @sa otThreadGetKeySwitchGuardTime
  *
  */
-void otThreadSetKeySwitchGuardTime(otInstance *aInstance, uint32_t aKeySwitchGuardTime);
+void otThreadSetKeySwitchGuardTime(otInstance *aInstance, uint16_t aKeySwitchGuardTime);
 
 /**
  * Detach from the Thread network.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1826,6 +1826,8 @@ Done
 
 Set the Thread Key Sequence Counter.
 
+This command is reserved for testing and demo purposes only. Changing Key Sequence Counter will render a production application non-compliant with the Thread Specification.
+
 ```bash
 > keysequence counter 10
 Done
@@ -1843,7 +1845,9 @@ Done
 
 ### keysequence guardtime \<guardtime\>
 
-Set Thread Key Switch Guard Time (in hours) 0 means Thread Key Switch immediately if key index match
+Set Thread Key Switch Guard Time (in hours).
+
+This command is reserved for testing and demo purposes only. Changing Key Switch Guard Time will render a production application non-compliant with the Thread Specification.
 
 ```bash
 > keysequence guardtime 0

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -275,15 +275,15 @@ uint32_t otThreadGetKeySequenceCounter(otInstance *aInstance)
 
 void otThreadSetKeySequenceCounter(otInstance *aInstance, uint32_t aKeySequenceCounter)
 {
-    AsCoreType(aInstance).Get<KeyManager>().SetCurrentKeySequence(aKeySequenceCounter);
+    AsCoreType(aInstance).Get<KeyManager>().SetCurrentKeySequence(aKeySequenceCounter, KeyManager::kForceUpdate);
 }
 
-uint32_t otThreadGetKeySwitchGuardTime(otInstance *aInstance)
+uint16_t otThreadGetKeySwitchGuardTime(otInstance *aInstance)
 {
     return AsCoreType(aInstance).Get<KeyManager>().GetKeySwitchGuardTime();
 }
 
-void otThreadSetKeySwitchGuardTime(otInstance *aInstance, uint32_t aKeySwitchGuardTime)
+void otThreadSetKeySwitchGuardTime(otInstance *aInstance, uint16_t aKeySwitchGuardTime)
 {
     AsCoreType(aInstance).Get<KeyManager>().SetKeySwitchGuardTime(aKeySwitchGuardTime);
 }

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1637,7 +1637,7 @@ Error Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Neig
 
         if (keySequence > keyManager.GetCurrentKeySequence())
         {
-            keyManager.SetCurrentKeySequence(keySequence);
+            keyManager.SetCurrentKeySequence(keySequence, KeyManager::kApplyKeySwitchGuard);
         }
     }
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -378,7 +378,7 @@ void Mle::Restore(void)
 
     SuccessOrExit(Get<Settings>().Read(networkInfo));
 
-    Get<KeyManager>().SetCurrentKeySequence(networkInfo.GetKeySequence());
+    Get<KeyManager>().SetCurrentKeySequence(networkInfo.GetKeySequence(), KeyManager::kForceUpdate);
     Get<KeyManager>().SetMleFrameCounter(networkInfo.GetMleFrameCounter());
     Get<KeyManager>().SetAllMacFrameCounters(networkInfo.GetMacFrameCounter(), /* aSetIfLarger */ false);
 
@@ -2726,7 +2726,7 @@ void Mle::ProcessKeySequence(RxInfo &aRxInfo)
     switch (aRxInfo.mClass)
     {
     case RxInfo::kAuthoritativeMessage:
-        Get<KeyManager>().SetCurrentKeySequence(aRxInfo.mKeySequence);
+        Get<KeyManager>().SetCurrentKeySequence(aRxInfo.mKeySequence, KeyManager::kForceUpdate);
         break;
 
     case RxInfo::kPeerMessage:
@@ -2734,7 +2734,7 @@ void Mle::ProcessKeySequence(RxInfo &aRxInfo)
         {
             if (aRxInfo.mKeySequence - Get<KeyManager>().GetCurrentKeySequence() == 1)
             {
-                Get<KeyManager>().SetCurrentKeySequence(aRxInfo.mKeySequence);
+                Get<KeyManager>().SetCurrentKeySequence(aRxInfo.mKeySequence, KeyManager::kApplyKeySwitchGuard);
             }
             else
             {

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -690,7 +690,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_NET_KEY_SWITCH_GUARDT
 
     SuccessOrExit(error = mDecoder.ReadUint32(keyGuardTime));
 
-    otThreadSetKeySwitchGuardTime(mInstance, keyGuardTime);
+    otThreadSetKeySwitchGuardTime(mInstance, static_cast<uint16_t>(keyGuardTime));
 
 exit:
     return error;

--- a/tests/scripts/thread-cert/test_mle_msg_key_seq_jump.py
+++ b/tests/scripts/thread-cert/test_mle_msg_key_seq_jump.py
@@ -221,20 +221,20 @@ class MleMsgKeySeqJump(thread_cert.TestCase):
         self.assertEqual(reed.get_key_sequence_counter(), 20)
 
         #-------------------------------------------------------------------
-        # Move forward the key seq counter by one on router. Wait for max
+        # Move forward the key seq counter by two on router. Wait for max
         # time between advertisements. Validate that leader adopts the higher
         # counter value.
 
-        router.set_key_sequence_counter(21)
-        self.assertEqual(router.get_key_sequence_counter(), 21)
+        router.set_key_sequence_counter(22)
+        self.assertEqual(router.get_key_sequence_counter(), 22)
 
         self.simulator.go(52)
-        self.assertEqual(leader.get_key_sequence_counter(), 21)
-        self.assertEqual(reed.get_key_sequence_counter(), 21)
+        self.assertEqual(leader.get_key_sequence_counter(), 22)
+        self.assertEqual(reed.get_key_sequence_counter(), 22)
 
         child.set_mode('r')
         self.simulator.go(2)
-        self.assertEqual(child.get_key_sequence_counter(), 21)
+        self.assertEqual(child.get_key_sequence_counter(), 22)
 
         #-------------------------------------------------------------------
         # Force a reattachment from the child with a higher key seq counter,


### PR DESCRIPTION
This commit makes changes/fixes to `KeyManager` regarding key switch guard time.

Key Rotation Time updates:
- When the Key Rotation Time changes (due to security policy updates), the key switch guard time (`mKeySwitchGuardTime`) is also adjusted. It's set to 93% of the Rotation Time (rounded down).
- Immediately checks if the new rotation time indicates a rotation is due and keys are rotated.

New variable `mKeySwitchGuardTimer`:
- This is reset to the current guard time whenever the key sequence is updated.
- It decrements hourly until reaching zero.
- Key switch guard comparison is made with this value, aligning the implementation with the Thread specification.

`SetCurrentKeySequence()` modification:
- Now accepts a new input parameter that determines whether to apply or ignore the key switch guard when updating the key sequence.
- During a key rotation check (when the rotation time has passed), the key switch guard is ignored and we always move to the next key sequence number.

Other changes:
- Variables handling guard and rotation time now use `uint16_t` instead of `uint32_t` to align with security policy definitions.
- API and CLI command documentation for setting the "key switch guard time" emphasize that they are intended for testing purposes.


----

Related to [SPEC-1262](https://threadgroup.atlassian.net/browse/SPEC-1262)

**Important Note:**

Before this change, the OT stack used a fixed/constant key guard time of 624 hours. This had the following implications
- The key guard time would not update when there are changes in the Security Policy's Key Rotation Time.
- The fixed key guard time would be enforced even if the time since the last key rotation exceeded the specified Key Rotation Time.
- Consequently, reducing the Key Rotation Time below 624 hours would have partial effects, as the effective rotation period would remain at least 624 hours.