### PR TITLE
[coap] fix copying option

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -621,8 +621,6 @@ Error CoapBase::PrepareNextBlockRequest(Message::BlockType aType,
     bool             isOptionSet = false;
     uint16_t         blockOption = 0;
     Option::Iterator iterator;
-    // Option uri should be supported to copy
-    uint8_t optionBuf[Message::kMaxReceivedUriPath];
 
     blockOption = (aType == Message::kBlockType1) ? kOptionBlock1 : kOptionBlock2;
 
@@ -656,9 +654,9 @@ Error CoapBase::PrepareNextBlockRequest(Message::BlockType aType,
         }
 
         // Copy option
-        VerifyOrExit(optionBuf + iterator.GetOption()->GetLength() <= GetArrayEnd(optionBuf), error = kErrorNoBufs);
-        SuccessOrExit(error = iterator.ReadOptionValue(optionBuf));
-        SuccessOrExit(error = aRequest.AppendOption(optionNumber, iterator.GetOption()->GetLength(), optionBuf));
+        SuccessOrExit(error = aRequest.AppendOptionFromMessage(optionNumber, iterator.GetOption()->GetLength(),
+                                                               iterator.GetMessage(),
+                                                               iterator.GetOptionValueMessageOffset()));
     }
 
     if (!isOptionSet)

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -619,9 +619,10 @@ Error CoapBase::PrepareNextBlockRequest(Message::BlockType aType,
 {
     Error            error       = kErrorNone;
     bool             isOptionSet = false;
-    uint64_t         optionBuf   = 0;
     uint16_t         blockOption = 0;
     Option::Iterator iterator;
+    // Option uri should be supported to copy
+    uint8_t optionBuf[Message::kMaxReceivedUriPath];
 
     blockOption = (aType == Message::kBlockType1) ? kOptionBlock1 : kOptionBlock2;
 
@@ -655,8 +656,9 @@ Error CoapBase::PrepareNextBlockRequest(Message::BlockType aType,
         }
 
         // Copy option
-        SuccessOrExit(error = iterator.ReadOptionValue(&optionBuf));
-        SuccessOrExit(error = aRequest.AppendOption(optionNumber, iterator.GetOption()->GetLength(), &optionBuf));
+        VerifyOrExit(optionBuf + iterator.GetOption()->GetLength() <= GetArrayEnd(optionBuf), error = kErrorNoBufs);
+        SuccessOrExit(error = iterator.ReadOptionValue(optionBuf));
+        SuccessOrExit(error = aRequest.AppendOption(optionNumber, iterator.GetOption()->GetLength(), optionBuf));
     }
 
     if (!isOptionSet)

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -148,6 +148,14 @@ uint8_t Message::WriteExtendedOptionField(uint16_t aValue, uint8_t *&aBuffer)
 
 Error Message::AppendOptionHeader(uint16_t aDelta, uint16_t aLength)
 {
+    /*
+     * Appends a CoAP Option header field (Option Delta/Length) per RFC 7252.
+     *
+     * @retval kErrorNone    Successfully appended the bytes.
+     * @retval kErrorNoBufs  Insufficient available buffers to grow the message.
+     *
+     */
+
     Error    error = kErrorNone;
     uint8_t  header[kMaxOptionHeaderSize];
     uint16_t headerLength;

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -402,6 +402,23 @@ public:
     Error AppendOption(uint16_t aNumber, uint16_t aLength, const void *aValue);
 
     /**
+     * Appends a CoAP option reading Option value from another or potentially the same message.
+     *
+     * @param[in] aNumber   The CoAP Option number.
+     * @param[in] aLength   The CoAP Option length.
+     * @param[in] aMessage  The message to read the CoAP Option value from (it can be the same as the current message).
+     * @param[in] aOffset   The offset in @p aMessage to start reading the CoAP Option value from (@p aLength bytes are
+     *                      used as Option value).
+     *
+     * @retval kErrorNone         Successfully appended the option.
+     * @retval kErrorInvalidArgs  The option type is not equal or greater than the last option type.
+     * @retval kErrorNoBufs       The option length exceeds the buffer size.
+     * @retval kErrorParse        Not enough bytes in @p aMessage to read @p aLength bytes from @p aOffset.
+     *
+     */
+    Error AppendOptionFromMessage(uint16_t aNumber, uint16_t aLength, const Message &aMessage, uint16_t aOffset);
+
+    /**
      * Appends an unsigned integer CoAP option as specified in RFC-7252 section-3.2
      *
      * @param[in]  aNumber  The CoAP Option number.
@@ -1186,6 +1203,16 @@ public:
          *
          */
         uint16_t GetPayloadMessageOffset(void) const { return mNextOptionOffset; }
+
+        /**
+         * Gets the offset of beginning of the CoAP Option Value.
+         *
+         * MUST be used during the iterator is in progress.
+         *
+         * @returns The offset of beginning of the CoAP Option Value
+         *
+         */
+        uint16_t GetOptionValueMessageOffset(void) const { return mNextOptionOffset - mOption.mLength; }
 
     private:
         // `mOption.mLength` value to indicate iterator is done.

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -983,6 +983,8 @@ private:
     }
 
     uint8_t WriteExtendedOptionField(uint16_t aValue, uint8_t *&aBuffer);
+
+    Error AppendOptionHeader(uint16_t aDelta, uint16_t aLength);
 };
 
 /**

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -984,7 +984,7 @@ private:
 
     uint8_t WriteExtendedOptionField(uint16_t aValue, uint8_t *&aBuffer);
 
-    Error AppendOptionHeader(uint16_t aDelta, uint16_t aLength);
+    Error AppendOptionHeader(uint16_t aNumber, uint16_t aLength);
 };
 
 /**


### PR DESCRIPTION
- remove typo that passed a uint64_t pointer to a function which need a sufficiently large buffer [#9884](https://github.com/openthread/openthread/issues/9884)
    -  this bug has led to segmentation faults.

- fix bug that coap copying uri path option or any other long option failed
    - this bug causes coap fail to request next block.
