### PR TITLE
[routing-manager] delay sending RAs until after initial policy evaluation

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -478,7 +478,10 @@ void RoutingManager::EvaluateRoutingPolicy(void)
     mNat64PrefixManager.Evaluate();
 #endif
 
-    SendRouterAdvertisement(kAdvPrefixesFromNetData);
+    if (IsInitalPolicyEvaluationDone())
+    {
+        SendRouterAdvertisement(kAdvPrefixesFromNetData);
+    }
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
     if (Get<Srp::Server>().IsAutoEnableMode() && IsInitalPolicyEvaluationDone())


### PR DESCRIPTION
This commit modifies the `RoutingManager` to not send any Router Advertisements (RAs) until the initial policy evaluation has completed.

This change leverages the `IsInitialPolicyEvaluationDone()` method which ensures that both OMR and on-link prefixes have been determined. Specifically, this guarantees that we wait for the initial set of Router Solicitation (RS) messages to be sent and that we discover all other routers on the AIL before sending the first RA. This is because on-link prefix evaluation itself is dependent on the `mRsSender.IsInProgress()` check that waits till all RS messages are sent and RAs from other routers are received and processed.

Without this change, the BR could receive its own RS message, triggering it to send an RA prematurely, potentially with incorrect M and O flags.