### PR TITLE
Add otSysCliInitUsingDaemon API on POSIX system

### DIFF
--- a/src/posix/platform/daemon.cpp
+++ b/src/posix/platform/daemon.cpp
@@ -285,12 +285,7 @@ void Daemon::SetUp(void)
     }
 
 #if OPENTHREAD_POSIX_CONFIG_DAEMON_CLI_ENABLE
-    otCliInit(
-        gInstance,
-        [](void *aContext, const char *aFormat, va_list aArguments) -> int {
-            return static_cast<Daemon *>(aContext)->OutputFormatV(aFormat, aArguments);
-        },
-        this);
+    otSysCliInitUsingDaemon(gInstance);
 #endif
 
     Mainloop::Manager::Get().Add(*this);

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -254,6 +254,11 @@ void otSysSetInfraNetif(const char *aInfraNetifName, int aIcmp6Socket);
  */
 bool otSysInfraIfIsRunning(void);
 
+/**
+ * 
+ */
+void otSysCliInitUsingDaemon(otInstance *aInstance);
+
 #ifdef __cplusplus
 } // end of extern "C"
 #endif

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -401,3 +401,14 @@ void otSysMainloopProcess(otInstance *aInstance, const otSysMainloopContext *aMa
 }
 
 bool IsSystemDryRun(void) { return gDryRun; }
+
+#if OPENTHREAD_POSIX_CONFIG_DAEMON_CLI_ENABLE
+void otSysCliInitUsingDaemon(otInstance *aInstance) {
+    otCliInit(
+        aInstance,
+        [](void *aContext, const char *aFormat, va_list aArguments) -> int {
+            return static_cast<Daemon *>(aContext)->OutputFormatV(aFormat, aArguments);
+        },
+        ot::Posix::Daemon::Get());
+}
+#endif


### PR DESCRIPTION
This is to initialize CLI for daemon instance.

With this API, user can redirect the OTBR CLI output when needed, and then reset back after the redirection is finished.