### PR TITLE
[posix] refactor radio spinel

### DIFF
--- a/src/lib/spinel/BUILD.gn
+++ b/src/lib/spinel/BUILD.gn
@@ -45,6 +45,8 @@ spinel_sources = [
   "spinel_buffer.hpp",
   "spinel_decoder.cpp",
   "spinel_decoder.hpp",
+  "spinel_driver.cpp",
+  "spinel_driver.hpp",
   "spinel_encoder.cpp",
   "spinel_encoder.hpp",
   "spinel_platform.h",

--- a/src/lib/spinel/CMakeLists.txt
+++ b/src/lib/spinel/CMakeLists.txt
@@ -93,6 +93,7 @@ target_sources(openthread-radio-spinel
     PRIVATE
         logger.cpp
         radio_spinel.cpp
+        spinel_driver.cpp
 )
 target_sources(openthread-spinel-ncp PRIVATE ${COMMON_SOURCES})
 target_sources(openthread-spinel-rcp PRIVATE ${COMMON_SOURCES})

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -1045,9 +1045,17 @@ public:
     void SetVendorRestorePropertiesCallback(otRadioSpinelVendorRestorePropertiesCallback aCallback, void *aContext);
 #endif
 
-    bool HasPendingFrame(void) { return mSpinelDriver->HasPendingFrame(); }
-
-    otError SendReset(uint8_t aResetType) { return mSpinelDriver->SendReset(aResetType); }
+    /**
+     * Sends a reset command to the RCP.
+     *
+     * @param[in] aResetType The reset type.
+     *
+     * @retval  OT_ERROR_NONE               Successfully removed item from the property.
+     * @retval  OT_ERROR_BUSY               Failed due to another operation is on going.
+     * @retval  OT_ERROR_NOT_CAPABLE        Requested reset type is not supported by the co-processor
+     *
+     */
+    otError SendReset(uint8_t aResetType);
 
 private:
     enum

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -801,20 +801,6 @@ public:
 #endif
 
     /**
-     * Checks whether the spinel interface is radio-only.
-     *
-     * @param[out] aSupportsRcpApiVersion          A reference to a boolean variable to update whether the list of
-     *                                             spinel capabilities includes `SPINEL_CAP_RCP_API_VERSION`.
-     * @param[out] aSupportsRcpMinHostApiVersion   A reference to a boolean variable to update whether the list of
-     *                                             spinel capabilities includes `SPINEL_CAP_RCP_MIN_HOST_API_VERSION`.
-     *
-     * @retval  TRUE    The radio chip is in radio-only mode.
-     * @retval  FALSE   Otherwise.
-     *
-     */
-    bool IsRcp(bool &aSupportsRcpApiVersion, bool &aSupportsRcpMinHostApiVersion);
-
-    /**
      * Returns the next timepoint to recalculate RCP time offset.
      *
      * @returns The timepoint to start the recalculation of RCP time offset.
@@ -1093,6 +1079,7 @@ private:
     otError CheckSpinelVersion(void);
     otError CheckRadioCapabilities(void);
     otError CheckRcpApiVersion(bool aSupportsRcpApiVersion, bool aSupportsRcpMinHostApiVersion);
+    void    InitializeCaps(bool &aSupportsRcpApiVersion, bool &aSupportsRcpMinHostApiVersion);
 
     /**
      * Triggers a state transfer of the state machine.

--- a/src/lib/spinel/spinel_driver.cpp
+++ b/src/lib/spinel/spinel_driver.cpp
@@ -1,0 +1,434 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "spinel_driver.hpp"
+
+#include <assert.h>
+
+#include <openthread/platform/time.h>
+
+#include "common/code_utils.hpp"
+#include "common/new.hpp"
+#include "common/num_utils.hpp"
+#include "lib/platform/exit_code.h"
+#include "lib/spinel/spinel.h"
+
+namespace ot {
+namespace Spinel {
+
+constexpr spinel_tid_t sTid = 1; ///< In Spinel Driver, only use Tid as 1.
+
+SpinelDriver::SpinelDriver(void)
+    : Logger("SpinelDriver")
+    , mSpinelInterface(nullptr)
+    , mWaitingKey(SPINEL_PROP_LAST_STATUS)
+    , mIsWaitingForResponse(false)
+    , mIid(SPINEL_HEADER_INVALID_IID)
+    , mSpinelVersionMajor(-1)
+    , mSpinelVersionMinor(-1)
+    , mIsCoProcessorReady(false)
+{
+    memset(mVersion, 0, sizeof(mVersion));
+
+    mReceivedFrameHandler.Set(&HandleInitialFrame, this);
+}
+
+void SpinelDriver::Init(SpinelInterface    &aSpinelInterface,
+                        bool                aSoftwareReset,
+                        const spinel_iid_t *aIidList,
+                        uint8_t             aIidListLength)
+{
+    mSpinelInterface = &aSpinelInterface;
+    mRxFrameBuffer.Clear();
+    SuccessOrDie(mSpinelInterface->Init(HandleReceivedFrame, this, mRxFrameBuffer));
+
+    VerifyOrDie(aIidList != nullptr, OT_EXIT_INVALID_ARGUMENTS);
+    VerifyOrDie(aIidListLength != 0 && aIidListLength <= mIidList.GetMaxSize(), OT_EXIT_INVALID_ARGUMENTS);
+
+    for (uint8_t i = 0; i < aIidListLength; i++)
+    {
+        SuccessOrDie(mIidList.PushBack(aIidList[i]));
+    }
+    mIid = aIidList[0];
+
+    ResetCoProcessor(aSoftwareReset);
+    SuccessOrDie(CheckSpinelVersion());
+    SuccessOrDie(GetCoprocessorVersion());
+
+    // TODO: Check Capability and decide the mode
+}
+
+void SpinelDriver::Deinit(void)
+{
+    // This allows implementing pseudo reset.
+    new (this) SpinelDriver();
+}
+
+otError SpinelDriver::SendReset(uint8_t aResetType)
+{
+    otError        error = OT_ERROR_NONE;
+    uint8_t        buffer[kMaxSpinelFrame];
+    spinel_ssize_t packed;
+
+    VerifyOrExit(aResetType != SPINEL_RESET_BOOTLOADER, error = OT_ERROR_NOT_CAPABLE);
+
+    // Pack the header, command and key
+    packed = spinel_datatype_pack(buffer, sizeof(buffer), SPINEL_DATATYPE_COMMAND_S SPINEL_DATATYPE_UINT8_S,
+                                  SPINEL_HEADER_FLAG | SPINEL_HEADER_IID(mIid), SPINEL_CMD_RESET, aResetType);
+
+    VerifyOrExit(packed > 0 && static_cast<size_t>(packed) <= sizeof(buffer), error = OT_ERROR_NO_BUFS);
+
+    SuccessOrExit(error = mSpinelInterface->SendFrame(buffer, static_cast<uint16_t>(packed)));
+    LogSpinelFrame(buffer, static_cast<uint16_t>(packed), true);
+
+exit:
+    return error;
+}
+
+void SpinelDriver::ResetCoProcessor(bool aSoftwareReset)
+{
+    bool hardwareReset;
+    bool resetDone = false;
+
+    // Avoid resetting the device twice in a row in Multipan RCP architecture
+    VerifyOrExit(!mIsCoProcessorReady, resetDone = true);
+
+    mWaitingKey = SPINEL_PROP_LAST_STATUS;
+
+    if (aSoftwareReset && (SendReset(SPINEL_RESET_STACK) == OT_ERROR_NONE) && (!mIsCoProcessorReady) &&
+        (WaitResponse() == OT_ERROR_NONE))
+    {
+        VerifyOrExit(mIsCoProcessorReady, resetDone = false);
+        LogCrit("Software reset Co-Processor successfully");
+        ExitNow(resetDone = true);
+    }
+
+    hardwareReset = (mSpinelInterface->HardwareReset() == OT_ERROR_NONE);
+
+    if (hardwareReset)
+    {
+        SuccessOrExit(WaitResponse());
+    }
+
+    resetDone = true;
+
+    if (hardwareReset)
+    {
+        LogInfo("Hardware reset Co-Processor successfully");
+    }
+    else
+    {
+        LogInfo("Co-Processor self reset successfully");
+    }
+
+exit:
+    if (!resetDone)
+    {
+        LogCrit("Failed to reset Co-Processor!");
+        DieNow(OT_EXIT_FAILURE);
+    }
+}
+
+void SpinelDriver::Process(const void *aContext)
+{
+    if (mRxFrameBuffer.HasSavedFrame())
+    {
+        ProcessFrameQueue();
+    }
+
+    mSpinelInterface->Process(aContext);
+
+    if (mRxFrameBuffer.HasSavedFrame())
+    {
+        ProcessFrameQueue();
+    }
+}
+
+otError SpinelDriver::SendCommand(uint32_t aCommand, spinel_prop_key_t aKey, spinel_tid_t aTid)
+{
+    otError        error = OT_ERROR_NONE;
+    uint8_t        buffer[kMaxSpinelFrame];
+    spinel_ssize_t packed;
+    uint16_t       offset;
+
+    // Pack the header, command and key
+    packed = spinel_datatype_pack(buffer, sizeof(buffer), "Cii", SPINEL_HEADER_FLAG | SPINEL_HEADER_IID(mIid) | aTid,
+                                  aCommand, aKey);
+
+    VerifyOrExit(packed > 0 && static_cast<size_t>(packed) <= sizeof(buffer), error = OT_ERROR_NO_BUFS);
+
+    offset = static_cast<uint16_t>(packed);
+
+    SuccessOrExit(error = mSpinelInterface->SendFrame(buffer, offset));
+
+exit:
+    return error;
+}
+
+otError SpinelDriver::SendCommand(uint32_t          aCommand,
+                                  spinel_prop_key_t aKey,
+                                  spinel_tid_t      aTid,
+                                  const char       *aFormat,
+                                  va_list           aArgs)
+{
+    otError        error = OT_ERROR_NONE;
+    uint8_t        buffer[kMaxSpinelFrame];
+    spinel_ssize_t packed;
+    uint16_t       offset;
+
+    // Pack the header, command and key
+    packed = spinel_datatype_pack(buffer, sizeof(buffer), "Cii", SPINEL_HEADER_FLAG | SPINEL_HEADER_IID(mIid) | aTid,
+                                  aCommand, aKey);
+
+    VerifyOrExit(packed > 0 && static_cast<size_t>(packed) <= sizeof(buffer), error = OT_ERROR_NO_BUFS);
+
+    offset = static_cast<uint16_t>(packed);
+
+    // Pack the data (if any)
+    if (aFormat)
+    {
+        packed = spinel_datatype_vpack(buffer + offset, sizeof(buffer) - offset, aFormat, aArgs);
+        VerifyOrExit(packed > 0 && static_cast<size_t>(packed + offset) <= sizeof(buffer), error = OT_ERROR_NO_BUFS);
+
+        offset += static_cast<uint16_t>(packed);
+    }
+
+    SuccessOrExit(error = mSpinelInterface->SendFrame(buffer, offset));
+
+exit:
+    return error;
+}
+
+void SpinelDriver::SetFrameHandler(ReceivedFrameHandler aReceivedFrameHandler,
+                                   SavedFrameHandler    aSavedFrameHandler,
+                                   void                *aContext)
+{
+    mReceivedFrameHandler.Set(aReceivedFrameHandler, aContext);
+    mSavedFrameHandler.Set(aSavedFrameHandler, aContext);
+}
+
+otError SpinelDriver::WaitResponse()
+{
+    otError  error = OT_ERROR_NONE;
+    uint64_t end   = otPlatTimeGet() + kMaxWaitTime * kUsPerMs;
+
+    LogDebg("Waiting response: key=%lu", ToUlong(mWaitingKey));
+
+    do
+    {
+        uint64_t now = otPlatTimeGet();
+
+        if ((end <= now) || (mSpinelInterface->WaitForFrame(end - now) != OT_ERROR_NONE))
+        {
+            LogWarn("Wait for response timeout");
+            ExitNow(error = OT_ERROR_RESPONSE_TIMEOUT);
+        }
+    } while (mIsWaitingForResponse || !mIsCoProcessorReady);
+
+    mWaitingKey = SPINEL_PROP_LAST_STATUS;
+
+exit:
+    return error;
+}
+
+void SpinelDriver::HandleReceivedFrame(void *aContext) { static_cast<SpinelDriver *>(aContext)->HandleReceivedFrame(); }
+
+void SpinelDriver::HandleReceivedFrame(void)
+{
+    otError        error = OT_ERROR_NONE;
+    uint8_t        header;
+    spinel_ssize_t unpacked;
+    bool           shouldSave = true;
+
+    LogSpinelFrame(mRxFrameBuffer.GetFrame(), mRxFrameBuffer.GetLength(), false);
+    unpacked = spinel_datatype_unpack(mRxFrameBuffer.GetFrame(), mRxFrameBuffer.GetLength(), "C", &header);
+
+    // Accept spinel messages with the correct IID or broadcast IID.
+    spinel_iid_t iid = SPINEL_HEADER_GET_IID(header);
+
+    if (!mIidList.Contains(iid))
+    {
+        mRxFrameBuffer.DiscardFrame();
+        ExitNow();
+    }
+
+    VerifyOrExit(unpacked > 0 && (header & SPINEL_HEADER_FLAG) == SPINEL_HEADER_FLAG, error = OT_ERROR_PARSE);
+
+    mReceivedFrameHandler.InvokeIfSet(mRxFrameBuffer.GetFrame(), mRxFrameBuffer.GetLength(), header, shouldSave);
+    if (shouldSave)
+    {
+        error = mRxFrameBuffer.SaveFrame();
+    }
+    else
+    {
+        mRxFrameBuffer.DiscardFrame();
+    }
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        mRxFrameBuffer.DiscardFrame();
+        LogWarn("Error handling hdlc frame: %s", otThreadErrorToString(error));
+    }
+}
+
+void SpinelDriver::HandleInitialFrame(const uint8_t *aFrame,
+                                      uint16_t       aLength,
+                                      uint8_t        aHeader,
+                                      bool          &aSave,
+                                      void          *aContext)
+{
+    static_cast<SpinelDriver *>(aContext)->HandleInitialFrame(aFrame, aLength, aHeader, aSave);
+}
+
+void SpinelDriver::HandleInitialFrame(const uint8_t *aFrame, uint16_t aLength, uint8_t aHeader, bool &aSave)
+{
+    spinel_prop_key_t key;
+    uint8_t          *data   = nullptr;
+    spinel_size_t     len    = 0;
+    uint8_t           header = 0;
+    uint32_t          cmd    = 0;
+    spinel_ssize_t    rval   = 0;
+    spinel_ssize_t    unpacked;
+    otError           error = OT_ERROR_NONE;
+
+    OT_UNUSED_VARIABLE(aHeader);
+
+    rval = spinel_datatype_unpack(aFrame, aLength, "CiiD", &header, &cmd, &key, &data, &len);
+    VerifyOrExit(rval > 0 && cmd >= SPINEL_CMD_PROP_VALUE_IS && cmd <= SPINEL_CMD_PROP_VALUE_REMOVED,
+                 error = OT_ERROR_PARSE);
+
+    if (cmd == SPINEL_CMD_PROP_VALUE_IS)
+    {
+        if (key == SPINEL_PROP_LAST_STATUS)
+        {
+            spinel_status_t status = SPINEL_STATUS_OK;
+
+            unpacked = spinel_datatype_unpack(data, len, "i", &status);
+            VerifyOrExit(unpacked > 0, error = OT_ERROR_PARSE);
+
+            if (status >= SPINEL_STATUS_RESET__BEGIN && status <= SPINEL_STATUS_RESET__END)
+            {
+                // this clear is necessary in case the RCP has sent messages between disable and reset
+                mRxFrameBuffer.Clear();
+
+                LogInfo("Co-Processor reset: %s", spinel_status_to_cstr(status));
+                mIsCoProcessorReady = true;
+            }
+            else
+            {
+                LogInfo("Co-Processor last status: %s", spinel_status_to_cstr(status));
+                ExitNow();
+            }
+        }
+        else
+        {
+            // Drop other frames when the key isn't waiting key.
+            VerifyOrExit(mWaitingKey == key, error = OT_ERROR_DROP);
+
+            if (key == SPINEL_PROP_PROTOCOL_VERSION)
+            {
+                unpacked =
+                    spinel_datatype_unpack(data, len, (SPINEL_DATATYPE_UINT_PACKED_S SPINEL_DATATYPE_UINT_PACKED_S),
+                                           &mSpinelVersionMajor, &mSpinelVersionMinor);
+
+                VerifyOrExit(unpacked > 0, error = OT_ERROR_PARSE);
+            }
+            else if (key == SPINEL_PROP_NCP_VERSION)
+            {
+                unpacked =
+                    spinel_datatype_unpack_in_place(data, len, SPINEL_DATATYPE_UTF8_S, mVersion, sizeof(mVersion));
+
+                VerifyOrExit(unpacked > 0, error = OT_ERROR_PARSE);
+            }
+
+            mIsWaitingForResponse = false;
+        }
+
+        // mWaitingKey = SPINEL_PROP_LAST_STATUS;
+    }
+    else
+    {
+        ExitNow(error = OT_ERROR_DROP);
+    }
+
+exit:
+    aSave = false;
+    LogIfFail("Error processing frame", error);
+}
+
+otError SpinelDriver::CheckSpinelVersion(void)
+{
+    otError error = OT_ERROR_NONE;
+
+    SuccessOrExit(error = SendCommand(SPINEL_CMD_PROP_VALUE_GET, SPINEL_PROP_PROTOCOL_VERSION, sTid));
+    mIsWaitingForResponse = true;
+    mWaitingKey           = SPINEL_PROP_PROTOCOL_VERSION;
+
+    SuccessOrExit(error = WaitResponse());
+
+    if ((mSpinelVersionMajor != SPINEL_PROTOCOL_VERSION_THREAD_MAJOR) ||
+        (mSpinelVersionMinor != SPINEL_PROTOCOL_VERSION_THREAD_MINOR))
+    {
+        LogCrit("Spinel version mismatch - Posix:%d.%d, Co-Processor:%d.%d", SPINEL_PROTOCOL_VERSION_THREAD_MAJOR,
+                SPINEL_PROTOCOL_VERSION_THREAD_MINOR, mSpinelVersionMajor, mSpinelVersionMinor);
+        DieNow(OT_EXIT_RADIO_SPINEL_INCOMPATIBLE);
+    }
+
+exit:
+    return error;
+}
+
+otError SpinelDriver::GetCoprocessorVersion(void)
+{
+    otError error = OT_ERROR_NONE;
+
+    SuccessOrExit(error = SendCommand(SPINEL_CMD_PROP_VALUE_GET, SPINEL_PROP_NCP_VERSION, sTid));
+    mIsWaitingForResponse = true;
+    mWaitingKey           = SPINEL_PROP_NCP_VERSION;
+
+    SuccessOrExit(error = WaitResponse());
+exit:
+    return error;
+}
+
+void SpinelDriver::ProcessFrameQueue(void)
+{
+    uint8_t *frame = nullptr;
+    uint16_t length;
+
+    while (mRxFrameBuffer.GetNextSavedFrame(frame, length) == OT_ERROR_NONE)
+    {
+        mSavedFrameHandler.InvokeIfSet(frame, length);
+    }
+
+    mRxFrameBuffer.ClearSavedFrames();
+}
+
+} // namespace Spinel
+} // namespace ot

--- a/src/lib/spinel/spinel_driver.cpp
+++ b/src/lib/spinel/spinel_driver.cpp
@@ -59,12 +59,12 @@ SpinelDriver::SpinelDriver(void)
     mReceivedFrameHandler.Set(&HandleInitialFrame, this);
 }
 
-CoprocessorMode SpinelDriver::Init(SpinelInterface    &aSpinelInterface,
+CoprocessorType SpinelDriver::Init(SpinelInterface    &aSpinelInterface,
                                    bool                aSoftwareReset,
                                    const spinel_iid_t *aIidList,
                                    uint8_t             aIidListLength)
 {
-    CoprocessorMode mode;
+    CoprocessorType mode;
 
     mSpinelInterface = &aSpinelInterface;
     mRxFrameBuffer.Clear();
@@ -84,7 +84,7 @@ CoprocessorMode SpinelDriver::Init(SpinelInterface    &aSpinelInterface,
     SuccessOrDie(GetCoprocessorVersion());
     SuccessOrDie(GetCoprocessorCaps());
 
-    mode = CheckCoprocessorMode();
+    mode = CheckCoprocessorType();
     if (mode == OT_COPROCESSOR_UNKNOWN)
     {
         LogCrit("The coprocessor mode is unknown!");
@@ -453,9 +453,9 @@ exit:
     return error;
 }
 
-CoprocessorMode SpinelDriver::CheckCoprocessorMode(void)
+CoprocessorType SpinelDriver::CheckCoprocessorType(void)
 {
-    CoprocessorMode mode       = OT_COPROCESSOR_UNKNOWN;
+    CoprocessorType mode       = OT_COPROCESSOR_UNKNOWN;
     const uint8_t  *capsData   = mCapsBuffer;
     spinel_size_t   capsLength = mCapsLength;
 

--- a/src/lib/spinel/spinel_driver.hpp
+++ b/src/lib/spinel/spinel_driver.hpp
@@ -31,6 +31,7 @@
 
 #include <openthread/instance.h>
 
+#include "common/array.hpp"
 #include "common/callback.hpp"
 #include "lib/spinel/logger.hpp"
 #include "lib/spinel/spinel.h"
@@ -104,7 +105,6 @@ public:
      *
      * @retval  OT_ERROR_NONE               Successfully removed item from the property.
      * @retval  OT_ERROR_BUSY               Failed due to another operation is on going.
-     * @retval  OT_ERROR_NOT_CAPABLE        Requested reset type is not supported by the co-processor
      *
      */
     otError SendReset(uint8_t aResetType);
@@ -117,7 +117,7 @@ public:
      * method will first try a software reset. If the software reset succeeds, the method exits. Otherwise the method
      * will then try a hardware reset. If `aSoftwareReset` is `false`, then method will directly try a hardware reset.
      *
-     * @param[in]  aSwReset                 TRUE to try SW reset at first, FALSE to directly try HW reset.
+     * @param[in]  aSoftwareReset                 TRUE to try SW reset at first, FALSE to directly try HW reset.
      *
      */
     void ResetCoProcessor(bool aSoftwareReset);
@@ -190,7 +190,15 @@ public:
      */
     SpinelInterface *GetSpinelInterface(void) const { return mSpinelInterface; }
 
-    const uint8_t *GetCapsBuffer(spinel_size_t &aCapsLength);
+    /**
+     * Returns if the co-processor has some capability
+     *
+     * @param[in] aCapability  The capability queried.
+     *
+     * @returns `true` if the co-processor has the capability. `false` otherwise.
+     *
+     */
+    bool CoprocessorHasCap(unsigned int aCapability) { return mCoprocessorCaps.Contains(aCapability); }
 
 private:
     static constexpr uint16_t kMaxSpinelFrame    = SPINEL_FRAME_MAX_SIZE;
@@ -198,17 +206,6 @@ private:
     static constexpr uint32_t kUsPerMs           = 1000; ///< Microseconds per millisecond.
     static constexpr uint32_t kMaxWaitTime       = 2000; ///< Max time to wait for response in milliseconds.
     static constexpr uint16_t kCapsBufferSize    = 100;  ///< Max buffer size used to store `SPINEL_PROP_CAPS` value.
-
-    /**
-     * Checks whether given interface ID is part of list of IIDs to be allowed.
-     *
-     * @param[in] aIid    Spinel Interface ID.
-     *
-     * @retval  TRUE    Given IID present in allow list.
-     * @retval  FALSE   Otherwise.
-     *
-     */
-    inline bool IsFrameForUs(spinel_iid_t aIid);
 
     otError WaitResponse(void);
 
@@ -249,8 +246,7 @@ private:
     bool mIsCoProcessorReady;
     char mVersion[kVersionStringSize];
 
-    uint8_t       mCapsBuffer[kCapsBufferSize];
-    spinel_size_t mCapsLength;
+    ot::Array<unsigned int, kCapsBufferSize> mCoprocessorCaps;
 };
 
 } // namespace Spinel

--- a/src/lib/spinel/spinel_driver.hpp
+++ b/src/lib/spinel/spinel_driver.hpp
@@ -1,0 +1,250 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SPINEL_DRIVER_HPP_
+#define SPINEL_DRIVER_HPP_
+
+#include <openthread/instance.h>
+
+#include "common/callback.hpp"
+#include "lib/spinel/logger.hpp"
+#include "lib/spinel/spinel.h"
+#include "lib/spinel/spinel_interface.hpp"
+
+namespace ot {
+namespace Spinel {
+
+/**
+ * Maximum number of Spinel Interface IDs.
+ *
+ */
+#if OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
+static constexpr uint8_t kSpinelHeaderMaxNumIid = 4;
+#else
+static constexpr uint8_t kSpinelHeaderMaxNumIid = 1;
+#endif
+
+typedef void (
+    *ReceivedFrameHandler)(const uint8_t *aFrame, uint16_t aLength, uint8_t aHeader, bool &aSave, void *aContext);
+typedef void (*SavedFrameHandler)(const uint8_t *aFrame, uint16_t aLength, void *aContext);
+
+class SpinelDriver : public Logger
+{
+public:
+    /**
+     * Constructor of the SpinelDriver.
+     *
+     */
+    SpinelDriver(void);
+
+    /**
+     * Initialize this SpinelDriver Instance.
+     *
+     * @param[in]  aSpinelInterface            A reference to the Spinel interface.
+     * @param[in]  aSoftwareReset              TRUE to reset on init, FALSE to not reset on init.
+     * @param[in]  aIidList                    A Pointer to the list of IIDs to receive spinel frame from.
+     *                                         First entry must be the IID of the Host Application.
+     * @param[in]  aIidListLength              The Length of the @p aIidList.
+     *
+     */
+    void Init(SpinelInterface    &aSpinelInterface,
+              bool                aSoftwareReset,
+              const spinel_iid_t *aIidList,
+              uint8_t             aIidListLength);
+
+    /**
+     * Deinitialize this SpinelDriver Instance.
+     *
+     */
+    void Deinit(void);
+
+    /**
+     * Clear the rx frame buffer.
+     *
+     */
+    void ClearRxBuffer(void) { mRxFrameBuffer.Clear(); }
+
+    /**
+     * Set the internal state of co-processor as ready.
+     *
+     * This method is used to skip a reset.
+     */
+    void SetCoProcessorReady(void) { mIsCoProcessorReady = true; }
+
+    /**
+     * Send a reset command to the co-processor.
+     *
+     * @prarm[in] aResetType    The reset type, SPINEL_RESET_PLATFORM, SPINEL_RESET_STACK, or SPINEL_RESET_BOOTLOADER.
+     *
+     * @retval  OT_ERROR_NONE               Successfully removed item from the property.
+     * @retval  OT_ERROR_BUSY               Failed due to another operation is on going.
+     * @retval  OT_ERROR_NOT_CAPABLE        Requested reset type is not supported by the co-processor
+     *
+     */
+    otError SendReset(uint8_t aResetType);
+
+    /**
+     * Reset the co-processor.
+     *
+     * This method will reset the co-processor and wait until the co-process is ready (receiving SPINEL_PROP_LAST_STATUS
+     * from the NCP). The reset will be either a software or hardware reset. If `aSoftwareReset` is `true`, then the
+     * method will first try a software reset. If the software reset succeeds, the method exits. Otherwise the method
+     * will then try a hardware reset. If `aSoftwareReset` is `false`, then method will directly try a hardware reset.
+     *
+     * @param[in]  aSwReset                 TRUE to try SW reset at first, FALSE to directly try HW reset.
+     *
+     */
+    void ResetCoProcessor(bool aSoftwareReset);
+
+    /**
+     * Processes any pending the I/O data.
+     *
+     * The method should be called by the system loop to process received spinel frames.
+     *
+     * @param[in]  aContext   The process context.
+     *
+     */
+    void Process(const void *aContext);
+
+    /**
+     * Checks whether there is pending frame in the buffer.
+     *
+     * The method is required by the system loop to update timer fd.
+     *
+     * @returns Whether there is pending frame in the buffer.
+     *
+     */
+    bool HasPendingFrame(void) const { return mRxFrameBuffer.HasSavedFrame(); }
+
+    /**
+     * Returns the co-processor sw version string.
+     *
+     * @returns A pointer to the co-processor version string.
+     *
+     */
+    const char *GetVersion(void) const { return mVersion; }
+
+    /*
+     * Sends a spinel command to the co-processor.
+     *
+     * @param[in] aCommand    The spinel command.
+     * @param[in] aKey        The spinel property key.
+     * @param[in] aTid        The spinel transaction id.
+     * @param[in] aFormat     The format string of the arguments to send.
+     * @param[in] aArgs       The argument list.
+     *
+     * @retval  OT_ERROR_NONE Successfully sent the command through spinel interface.
+     * @retval  OT_ERROR_INVALID_STATE  The spinel interface is in an invalid state.
+     * @retval  OT_ERROR_NO_BUFS        The spinel interface doesn't have enough buffer.
+     *
+     */
+    otError SendCommand(uint32_t          aCommand,
+                        spinel_prop_key_t aKey,
+                        spinel_tid_t      aTid,
+                        const char       *aFormat,
+                        va_list           aArgs);
+
+    /*
+     * Sets the handler to process the received spinel frame.
+     *
+     * @param[in] aReceivedFrameHandler  The handler to process received spinel frames.
+     * @param[in] aSavedFrameHandler     The handler to process saved spinel frames.
+     * @param[in] aContext               The context to call the handler.
+     *
+     */
+    void SetFrameHandler(ReceivedFrameHandler aReceivedFrameHandler,
+                         SavedFrameHandler    aSavedFrameHandler,
+                         void                *aContext);
+
+    /*
+     * Returns the spinel interface.
+     *
+     * @returns A pointer to the spinel interface object.
+     *
+     */
+    SpinelInterface *GetSpinelInterface(void) const { return mSpinelInterface; }
+
+private:
+    static constexpr uint16_t kMaxSpinelFrame    = SPINEL_FRAME_MAX_SIZE;
+    static constexpr uint16_t kVersionStringSize = 128;
+    static constexpr uint32_t kUsPerMs           = 1000; ///< Microseconds per millisecond.
+    static constexpr uint32_t kMaxWaitTime       = 2000; ///< Max time to wait for response in milliseconds.
+
+    /**
+     * Checks whether given interface ID is part of list of IIDs to be allowed.
+     *
+     * @param[in] aIid    Spinel Interface ID.
+     *
+     * @retval  TRUE    Given IID present in allow list.
+     * @retval  FALSE   Otherwise.
+     *
+     */
+    inline bool IsFrameForUs(spinel_iid_t aIid);
+
+    otError WaitResponse(void);
+
+    static void HandleReceivedFrame(void *aContext);
+    void        HandleReceivedFrame(void);
+
+    static void HandleInitialFrame(const uint8_t *aFrame,
+                                   uint16_t       aLength,
+                                   uint8_t        aHeader,
+                                   bool          &aSave,
+                                   void          *aContext);
+    void        HandleInitialFrame(const uint8_t *aFrame, uint16_t aLength, uint8_t aHeader, bool &aSave);
+
+    otError SendCommand(uint32_t aCommand, spinel_prop_key_t aKey, spinel_tid_t aTid);
+
+    otError CheckSpinelVersion(void);
+    otError GetCoprocessorVersion(void);
+
+    void ProcessFrameQueue(void);
+
+    SpinelInterface::RxFrameBuffer mRxFrameBuffer;
+    SpinelInterface               *mSpinelInterface;
+
+    spinel_prop_key_t mWaitingKey; ///< The property key of current transaction.
+    bool              mIsWaitingForResponse;
+
+    spinel_iid_t                                    mIid;
+    ot::Array<spinel_iid_t, kSpinelHeaderMaxNumIid> mIidList;
+
+    Callback<ReceivedFrameHandler> mReceivedFrameHandler;
+    Callback<SavedFrameHandler>    mSavedFrameHandler;
+
+    int mSpinelVersionMajor;
+    int mSpinelVersionMinor;
+
+    bool mIsCoProcessorReady;
+    char mVersion[kVersionStringSize];
+};
+
+} // namespace Spinel
+} // namespace ot
+
+#endif // SPINEL_DRIVER_HPP_

--- a/src/lib/spinel/spinel_driver.hpp
+++ b/src/lib/spinel/spinel_driver.hpp
@@ -35,6 +35,7 @@
 #include "lib/spinel/logger.hpp"
 #include "lib/spinel/spinel.h"
 #include "lib/spinel/spinel_interface.hpp"
+#include "posix/platform/coprocessor_mode.h"
 
 namespace ot {
 namespace Spinel {
@@ -72,10 +73,10 @@ public:
      * @param[in]  aIidListLength              The Length of the @p aIidList.
      *
      */
-    void Init(SpinelInterface    &aSpinelInterface,
-              bool                aSoftwareReset,
-              const spinel_iid_t *aIidList,
-              uint8_t             aIidListLength);
+    CoprocessorMode Init(SpinelInterface    &aSpinelInterface,
+                         bool                aSoftwareReset,
+                         const spinel_iid_t *aIidList,
+                         uint8_t             aIidListLength);
 
     /**
      * Deinitialize this SpinelDriver Instance.
@@ -189,11 +190,14 @@ public:
      */
     SpinelInterface *GetSpinelInterface(void) const { return mSpinelInterface; }
 
+    const uint8_t *GetCapsBuffer(spinel_size_t &aCapsLength);
+
 private:
     static constexpr uint16_t kMaxSpinelFrame    = SPINEL_FRAME_MAX_SIZE;
     static constexpr uint16_t kVersionStringSize = 128;
     static constexpr uint32_t kUsPerMs           = 1000; ///< Microseconds per millisecond.
     static constexpr uint32_t kMaxWaitTime       = 2000; ///< Max time to wait for response in milliseconds.
+    static constexpr uint16_t kCapsBufferSize    = 100;  ///< Max buffer size used to store `SPINEL_PROP_CAPS` value.
 
     /**
      * Checks whether given interface ID is part of list of IIDs to be allowed.
@@ -220,8 +224,10 @@ private:
 
     otError SendCommand(uint32_t aCommand, spinel_prop_key_t aKey, spinel_tid_t aTid);
 
-    otError CheckSpinelVersion(void);
-    otError GetCoprocessorVersion(void);
+    otError         CheckSpinelVersion(void);
+    otError         GetCoprocessorVersion(void);
+    otError         GetCoprocessorCaps(void);
+    CoprocessorMode CheckCoprocessorMode(void);
 
     void ProcessFrameQueue(void);
 
@@ -242,6 +248,9 @@ private:
 
     bool mIsCoProcessorReady;
     char mVersion[kVersionStringSize];
+
+    uint8_t       mCapsBuffer[kCapsBufferSize];
+    spinel_size_t mCapsLength;
 };
 
 } // namespace Spinel

--- a/src/lib/spinel/spinel_driver.hpp
+++ b/src/lib/spinel/spinel_driver.hpp
@@ -35,7 +35,7 @@
 #include "lib/spinel/logger.hpp"
 #include "lib/spinel/spinel.h"
 #include "lib/spinel/spinel_interface.hpp"
-#include "posix/platform/coprocessor_mode.h"
+#include "posix/platform/coprocessor_type.h"
 
 namespace ot {
 namespace Spinel {
@@ -73,7 +73,7 @@ public:
      * @param[in]  aIidListLength              The Length of the @p aIidList.
      *
      */
-    CoprocessorMode Init(SpinelInterface    &aSpinelInterface,
+    CoprocessorType Init(SpinelInterface    &aSpinelInterface,
                          bool                aSoftwareReset,
                          const spinel_iid_t *aIidList,
                          uint8_t             aIidListLength);
@@ -227,7 +227,7 @@ private:
     otError         CheckSpinelVersion(void);
     otError         GetCoprocessorVersion(void);
     otError         GetCoprocessorCaps(void);
-    CoprocessorMode CheckCoprocessorMode(void);
+    CoprocessorType CheckCoprocessorType(void);
 
     void ProcessFrameQueue(void);
 

--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -145,6 +145,7 @@ add_library(openthread-posix
     radio_url.cpp
     resolver.cpp
     settings.cpp
+    spinel_manager.cpp
     spi_interface.cpp
     system.cpp
     trel.cpp

--- a/src/posix/platform/coprocessor_mode.h
+++ b/src/posix/platform/coprocessor_mode.h
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OT_PLATFORM_COPROCESSOR_MODE_H_
+#define OT_PLATFORM_COPROCESSOR_MODE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Represents the mode of the co-processor.
+ * A co-processor could be either a RCP or NCP.
+ */
+enum CoprocessorMode
+{
+    OT_COPROCESSOR_UNKNOWN = 0,
+    OT_COPROCESSOR_RCP     = 1,
+    OT_COPROCESSOR_NCP     = 2,
+};
+
+#ifdef __cplusplus
+}
+#endif
+#endif // OT_PLATFORM_COPROCESSOR_MODE_H_

--- a/src/posix/platform/coprocessor_type.h
+++ b/src/posix/platform/coprocessor_type.h
@@ -37,7 +37,7 @@ extern "C" {
  * Represents the mode of the co-processor.
  * A co-processor could be either a RCP or NCP.
  */
-enum CoprocessorMode
+enum CoprocessorType
 {
     OT_COPROCESSOR_UNKNOWN = 0,
     OT_COPROCESSOR_RCP     = 1,

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -439,9 +439,9 @@ void platformBacktraceInit(void);
  *
  * @param[in]   aUrl  A pointer to the null-terminated spinel URL.
  *
- * @retval  UNKNOWN  The initialization fails.
- * @retval  RCP      The Co-processor is a RCP.
- * @retval  NCP      The Co-processor is a NCP.
+ * @retval  OT_COPROCESSOR_UNKNOWN  The initialization fails.
+ * @retval  OT_COPROCESSOR_RCP      The Co-processor is a RCP.
+ * @retval  OT_COPROCESSOR_NCP      The Co-processor is a NCP.
  */
 CoprocessorType platformSpinelInit(const char *aUrl);
 

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -52,6 +52,7 @@
 #include <openthread/openthread-system.h>
 #include <openthread/platform/time.h>
 
+#include "coprocessor_mode.h"
 #include "lib/platform/exit_code.h"
 #include "lib/url/url.hpp"
 
@@ -82,17 +83,6 @@ enum
     OT_SIM_EVENT_UART_WRITE         = 2,
     OT_SIM_EVENT_RADIO_SPINEL_WRITE = 3,
     OT_EVENT_DATA_MAX_SIZE          = 1024,
-};
-
-/**
- * Represents the mode of the co-processor.
- * A co-processor could be either a RCP or NCP.
- */
-enum CoprocessorMode
-{
-    OT_COPROCESSOR_UNKNOWN = 0,
-    OT_COPROCESSOR_RCP     = 1,
-    OT_COPROCESSOR_NCP     = 2,
 };
 
 OT_TOOL_PACKED_BEGIN

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -84,6 +84,17 @@ enum
     OT_EVENT_DATA_MAX_SIZE          = 1024,
 };
 
+/**
+ * Represents the mode of the co-processor.
+ * A co-processor could be either a RCP or NCP.
+ */
+enum CoprocessorMode
+{
+    OT_COPROCESSOR_UNKNOWN = 0,
+    OT_COPROCESSOR_RCP     = 1,
+    OT_COPROCESSOR_NCP     = 2,
+};
+
 OT_TOOL_PACKED_BEGIN
 struct VirtualTimeEvent
 {
@@ -338,13 +349,22 @@ void virtualTimeReceiveEvent(struct VirtualTimeEvent *aEvent);
 void virtualTimeSendSleepEvent(const struct timeval *aTimeout);
 
 /**
- * Performs radio spinel processing of virtual time simulation.
+ * Performs radio  processing of virtual time simulation.
  *
  * @param[in]   aInstance   A pointer to the OpenThread instance.
  * @param[in]   aEvent      A pointer to the current event.
  *
  */
-void virtualTimeRadioSpinelProcess(otInstance *aInstance, const struct VirtualTimeEvent *aEvent);
+void virtualTimeRadioProcess(otInstance *aInstance, const struct VirtualTimeEvent *aEvent);
+
+/**
+ * Performs radio  processing of virtual time simulation.
+ *
+ * @param[in]   aInstance   A pointer to the OpenThread instance.
+ * @param[in]   aEvent      A pointer to the current event.
+ *
+ */
+void virtualTimeSpinelProcess(otInstance *aInstance, const struct VirtualTimeEvent *aEvent);
 
 enum SocketBlockOption
 {
@@ -420,6 +440,43 @@ extern otInstance *gInstance;
  *
  */
 void platformBacktraceInit(void);
+
+/**
+ * Initializes the spinel service used by OpenThread.
+ *
+ * @note Even when @p aPlatformConfig->mResetRadio is false, a reset event (i.e. a PROP_LAST_STATUS between
+ * [SPINEL_STATUS_RESET__BEGIN, SPINEL_STATUS_RESET__END]) is still expected from RCP.
+ *
+ * @param[in]   aUrl  A pointer to the null-terminated spinel URL.
+ *
+ * @retval  UNKNOWN  The initialization fails.
+ * @retval  RCP      The Co-processor is a RCP.
+ * @retval  NCP      The Co-processor is a NCP.
+ */
+CoprocessorMode platformSpinelInit(const char *aUrl);
+
+/**
+ * Shuts down the spinel service used by OpenThread.
+ *
+ */
+void platformSpinelDeinit(void);
+
+/**
+ * Performs spinel driver processing.
+ *
+ * @param[in]   aInstance   A pointer to the OT instance.
+ * @param[in]   aContext    A pointer to the mainloop context.
+ *
+ */
+void platformSpinelProcess(otInstance *aInstance, const otSysMainloopContext *aContext);
+
+/**
+ * Updates the file descriptor sets with file descriptors used by the spinel driver.
+ *
+ * @param[in]   aContext    A pointer to the mainloop context.
+ *
+ */
+void platformSpinelUpdateFdSet(otSysMainloopContext *aContext);
 
 #ifdef __cplusplus
 }

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -52,7 +52,7 @@
 #include <openthread/openthread-system.h>
 #include <openthread/platform/time.h>
 
-#include "coprocessor_mode.h"
+#include "coprocessor_type.h"
 #include "lib/platform/exit_code.h"
 #include "lib/url/url.hpp"
 
@@ -443,7 +443,7 @@ void platformBacktraceInit(void);
  * @retval  RCP      The Co-processor is a RCP.
  * @retval  NCP      The Co-processor is a NCP.
  */
-CoprocessorMode platformSpinelInit(const char *aUrl);
+CoprocessorType platformSpinelInit(const char *aUrl);
 
 /**
  * Shuts down the spinel service used by OpenThread.

--- a/src/posix/platform/spinel_manager.cpp
+++ b/src/posix/platform/spinel_manager.cpp
@@ -58,8 +58,9 @@ SpinelManager::~SpinelManager(void) { Deinit(); }
 
 CoprocessorMode SpinelManager::Init(const char *aUrl)
 {
-    bool         swReset;
-    spinel_iid_t iidList[ot::Spinel::kSpinelHeaderMaxNumIid];
+    bool            swReset;
+    spinel_iid_t    iidList[ot::Spinel::kSpinelHeaderMaxNumIid];
+    CoprocessorMode mode;
 
     mUrl.Init(aUrl);
     VerifyOrDie(mUrl.GetPath() != nullptr, OT_EXIT_INVALID_ARGUMENTS);
@@ -75,12 +76,11 @@ CoprocessorMode SpinelManager::Init(const char *aUrl)
 
     swReset = !mUrl.HasParam("no-reset");
 
-    mSpinelDriver.Init(*mSpinelInterface, swReset, iidList, OT_ARRAY_LENGTH(iidList));
+    mode = mSpinelDriver.Init(*mSpinelInterface, swReset, iidList, OT_ARRAY_LENGTH(iidList));
 
     otLogDebgPlat("instance init:%p - iid = %d", (void *)&mSpinelDriver, iidList[0]);
 
-    // TODO: Fix it as RCP mode for now
-    return OT_COPROCESSOR_RCP;
+    return mode;
 }
 
 void SpinelManager::Deinit(void)

--- a/src/posix/platform/spinel_manager.cpp
+++ b/src/posix/platform/spinel_manager.cpp
@@ -1,0 +1,224 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "platform-posix.h"
+
+#include "posix/platform/spinel_manager.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/new.hpp"
+#include "lib/spinel/spinel_driver.hpp"
+#include "posix/platform/hdlc_interface.hpp"
+#include "posix/platform/radio_url.hpp"
+#include "posix/platform/spi_interface.hpp"
+#include "posix/platform/vendor_interface.hpp"
+
+static ot::Posix::SpinelManager sSpinelManager;
+
+namespace ot {
+namespace Posix {
+
+SpinelManager &GetSpinelManager(void) { return sSpinelManager; }
+
+ot::Spinel::SpinelDriver &GetSpinelDriver(void) { return sSpinelManager.GetSpinelDriver(); }
+
+SpinelManager::SpinelManager(void)
+    : mUrl(nullptr)
+    , mSpinelDriver()
+    , mSpinelInterface(nullptr)
+{
+}
+
+SpinelManager::~SpinelManager(void) { Deinit(); }
+
+CoprocessorMode SpinelManager::Init(const char *aUrl)
+{
+    bool         swReset;
+    spinel_iid_t iidList[ot::Spinel::kSpinelHeaderMaxNumIid];
+
+    mUrl.Init(aUrl);
+    VerifyOrDie(mUrl.GetPath() != nullptr, OT_EXIT_INVALID_ARGUMENTS);
+
+    GetIidListFromUrl(iidList);
+
+#if OPENTHREAD_POSIX_VIRTUAL_TIME
+    VirtualTimeInit();
+#endif
+
+    mSpinelInterface = CreateSpinelInterface(mUrl.GetProtocol());
+    VerifyOrDie(mSpinelInterface != nullptr, OT_EXIT_FAILURE);
+
+    swReset = !mUrl.HasParam("no-reset");
+
+    mSpinelDriver.Init(*mSpinelInterface, swReset, iidList, OT_ARRAY_LENGTH(iidList));
+
+    otLogDebgPlat("instance init:%p - iid = %d", (void *)&mSpinelDriver, iidList[0]);
+
+    // TODO: Fix it as RCP mode for now
+    return OT_COPROCESSOR_RCP;
+}
+
+void SpinelManager::Deinit(void)
+{
+    if (mSpinelInterface != nullptr)
+    {
+        mSpinelInterface->Deinit();
+        mSpinelInterface = nullptr;
+    }
+
+    mSpinelDriver.Deinit();
+}
+
+ot::Spinel::SpinelInterface *SpinelManager::CreateSpinelInterface(const char *aInterfaceName)
+{
+    ot::Spinel::SpinelInterface *interface;
+
+    if (aInterfaceName == nullptr)
+    {
+        DieNow(OT_ERROR_FAILED);
+    }
+#if OPENTHREAD_POSIX_CONFIG_SPINEL_HDLC_INTERFACE_ENABLE
+    else if (HdlcInterface::IsInterfaceNameMatch(aInterfaceName))
+    {
+        interface = new (&mSpinelInterfaceRaw) HdlcInterface(mUrl);
+    }
+#endif
+#if OPENTHREAD_POSIX_CONFIG_SPINEL_SPI_INTERFACE_ENABLE
+    else if (Posix::SpiInterface::IsInterfaceNameMatch(aInterfaceName))
+    {
+        interface = new (&mSpinelInterfaceRaw) SpiInterface(mUrl);
+    }
+#endif
+#if OPENTHREAD_POSIX_CONFIG_SPINEL_VENDOR_INTERFACE_ENABLE
+    else if (VendorInterface::IsInterfaceNameMatch(aInterfaceName))
+    {
+        interface = new (&mSpinelInterfaceRaw) VendorInterface(mUrl);
+    }
+#endif
+    else
+    {
+        otLogCritPlat("The Spinel interface name \"%s\" is not supported!", aInterfaceName);
+        DieNow(OT_ERROR_FAILED);
+    }
+
+    return interface;
+}
+
+void SpinelManager::GetIidListFromUrl(spinel_iid_t (&aIidList)[ot::Spinel::kSpinelHeaderMaxNumIid])
+{
+    const char *iidString;
+    const char *iidListString;
+
+    memset(aIidList, SPINEL_HEADER_INVALID_IID, sizeof(aIidList));
+
+    iidString     = (mUrl.GetValue("iid"));
+    iidListString = (mUrl.GetValue("iid-list"));
+
+#if OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
+    // First entry to the aIidList must be the IID of the host application.
+    VerifyOrDie(iidString != nullptr, OT_EXIT_INVALID_ARGUMENTS);
+    aIidList[0] = static_cast<spinel_iid_t>(atoi(iidString));
+
+    if (iidListString != nullptr)
+    {
+        // Convert string to an array of integers.
+        // Integer i is for traverse the iidListString.
+        // Integer j is for aIidList array offset location.
+        // First entry of aIidList is for host application iid hence j start from 1.
+        for (uint8_t i = 0, j = 1; iidListString[i] != '\0' && j < Spinel::kSpinelHeaderMaxNumIid; i++)
+        {
+            if (iidListString[i] == ',')
+            {
+                j++;
+                continue;
+            }
+
+            if (iidListString[i] < '0' || iidListString[i] > '9')
+            {
+                DieNow(OT_EXIT_INVALID_ARGUMENTS);
+            }
+            else
+            {
+                aIidList[j] = iidListString[i] - '0';
+                VerifyOrDie(aIidList[j] < Spinel::kSpinelHeaderMaxNumIid, OT_EXIT_INVALID_ARGUMENTS);
+            }
+        }
+    }
+#else  // !OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
+    VerifyOrDie(iidString == nullptr, OT_EXIT_INVALID_ARGUMENTS);
+    VerifyOrDie(iidListString == nullptr, OT_EXIT_INVALID_ARGUMENTS);
+    aIidList[0] = 0;
+#endif // OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
+}
+
+#if OPENTHREAD_POSIX_VIRTUAL_TIME
+void SpinelManager::VirtualTimeInit(void)
+{
+    // The last argument must be the node id
+    const char *nodeId = nullptr;
+
+    for (const char *arg = nullptr; (arg = mUrl.GetValue("forkpty-arg", arg)) != nullptr; nodeId = arg)
+    {
+    }
+
+    virtualTimeInit(static_cast<uint16_t>(atoi(nodeId)));
+}
+#endif
+
+} // namespace Posix
+} // namespace ot
+
+CoprocessorMode platformSpinelInit(const char *aUrl) { return sSpinelManager.Init(aUrl); }
+
+void platformSpinelDeinit(void) { return sSpinelManager.Deinit(); }
+
+#if OPENTHREAD_POSIX_VIRTUAL_TIME
+void virtualTimeSpinelProcess(otInstance *aInstance, const struct VirtualTimeEvent *aEvent)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    sSpinelManager.GetSpinelDriver().Process(aEvent);
+}
+#else
+void platformSpinelProcess(otInstance *aInstance, const otSysMainloopContext *aContext)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    sSpinelManager.GetSpinelDriver().Process(aContext);
+}
+#endif // OPENTHREAD_POSIX_VIRTUAL_TIME
+
+void platformSpinelUpdateFdSet(otSysMainloopContext *aContext)
+{
+    sSpinelManager.GetSpinelInterface().UpdateFdSet(aContext);
+
+    if (sSpinelManager.GetSpinelDriver().HasPendingFrame())
+    {
+        aContext->mTimeout.tv_sec  = 0;
+        aContext->mTimeout.tv_usec = 0;
+    }
+}

--- a/src/posix/platform/spinel_manager.cpp
+++ b/src/posix/platform/spinel_manager.cpp
@@ -56,11 +56,11 @@ SpinelManager::SpinelManager(void)
 
 SpinelManager::~SpinelManager(void) { Deinit(); }
 
-CoprocessorMode SpinelManager::Init(const char *aUrl)
+CoprocessorType SpinelManager::Init(const char *aUrl)
 {
     bool            swReset;
     spinel_iid_t    iidList[ot::Spinel::kSpinelHeaderMaxNumIid];
-    CoprocessorMode mode;
+    CoprocessorType mode;
 
     mUrl.Init(aUrl);
     VerifyOrDie(mUrl.GetPath() != nullptr, OT_EXIT_INVALID_ARGUMENTS);
@@ -193,7 +193,7 @@ void SpinelManager::VirtualTimeInit(void)
 } // namespace Posix
 } // namespace ot
 
-CoprocessorMode platformSpinelInit(const char *aUrl) { return sSpinelManager.Init(aUrl); }
+CoprocessorType platformSpinelInit(const char *aUrl) { return sSpinelManager.Init(aUrl); }
 
 void platformSpinelDeinit(void) { return sSpinelManager.Deinit(); }
 

--- a/src/posix/platform/spinel_manager.hpp
+++ b/src/posix/platform/spinel_manager.hpp
@@ -46,7 +46,7 @@ public:
 
     ~SpinelManager(void);
 
-    CoprocessorMode Init(const char *aUrl);
+    CoprocessorType Init(const char *aUrl);
 
     void Deinit(void);
 

--- a/src/posix/platform/spinel_manager.hpp
+++ b/src/posix/platform/spinel_manager.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021, The OpenThread Authors.
+ *  Copyright (c) 2024, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,69 +26,45 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef OT_POSIX_PLATFORM_RADIO_HPP_
-#define OT_POSIX_PLATFORM_RADIO_HPP_
+#ifndef POSIX_PLATFORM_SPINEL_MANAGER_HPP_
+#define POSIX_PLATFORM_SPINEL_MANAGER_HPP_
 
-#include "hdlc_interface.hpp"
-#include "logger.hpp"
-#include "radio_url.hpp"
-#include "spi_interface.hpp"
-#include "spinel_manager.hpp"
-#include "vendor_interface.hpp"
 #include "common/code_utils.hpp"
-#include "lib/spinel/radio_spinel.hpp"
 #include "lib/spinel/spinel_driver.hpp"
-#if OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_ENABLE
-#ifdef OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_HEADER
-#include OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_HEADER
-#endif
-#endif
+#include "posix/platform/hdlc_interface.hpp"
+#include "posix/platform/radio_url.hpp"
+#include "posix/platform/spi_interface.hpp"
+#include "posix/platform/vendor_interface.hpp"
 
 namespace ot {
 namespace Posix {
 
-/**
- * Manages Thread radio.
- *
- */
-class Radio : public Logger<Radio>
+class SpinelManager
 {
 public:
-    static const char kLogModuleName[]; ///< Module name used for logging.
+    SpinelManager(void);
 
-    /**
-     * Creates the radio manager.
-     *
-     */
-    Radio(void);
+    ~SpinelManager(void);
 
-    /**
-     * Initialize the Thread radio.
-     *
-     * @param[in]   aUrl    A pointer to the null-terminated URL.
-     *
-     */
-    void Init(const char *aUrl);
+    CoprocessorMode Init(const char *aUrl);
 
-    /**
-     * Acts as an accessor to the spinel interface instance used by the radio.
-     *
-     * @returns A reference to the radio's spinel interface instance.
-     *
-     */
-    Spinel::SpinelInterface &GetSpinelInterface(void) { return GetSpinelManager().GetSpinelInterface(); }
+    void Deinit(void);
 
-    /**
-     * Acts as an accessor to the radio spinel instance used by the radio.
-     *
-     * @returns A reference to the radio spinel instance.
-     *
-     */
-    Spinel::RadioSpinel &GetRadioSpinel(void) { return mRadioSpinel; }
+    ot::Spinel::SpinelInterface &GetSpinelInterface(void)
+    {
+        OT_ASSERT(mSpinelInterface != nullptr);
+        return *mSpinelInterface;
+    }
+
+    ot::Spinel::SpinelDriver &GetSpinelDriver(void) { return mSpinelDriver; }
 
 private:
-    void ProcessRadioUrl(const RadioUrl &aRadioUrl);
-    void ProcessMaxPowerTable(const RadioUrl &aRadioUrl);
+#if OPENTHREAD_POSIX_VIRTUAL_TIME
+    void VirtualTimeInit(void);
+#endif
+    void GetIidListFromUrl(spinel_iid_t (&aIidList)[ot::Spinel::kSpinelHeaderMaxNumIid]);
+
+    ot::Spinel::SpinelInterface *CreateSpinelInterface(const char *aInterfaceName);
 
 #if OPENTHREAD_POSIX_CONFIG_SPINEL_HDLC_INTERFACE_ENABLE && OPENTHREAD_POSIX_CONFIG_SPINEL_SPI_INTERFACE_ENABLE
     static constexpr size_t kSpinelInterfaceRawSize = sizeof(ot::Posix::SpiInterface) > sizeof(ot::Posix::HdlcInterface)
@@ -104,15 +80,17 @@ private:
 #error "No Spinel interface is specified!"
 #endif
 
-    RadioUrl mRadioUrl;
-#if OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_ENABLE
-    Spinel::VendorRadioSpinel mRadioSpinel;
-#else
-    Spinel::RadioSpinel     mRadioSpinel;
-#endif
+    RadioUrl                     mUrl;
+    ot::Spinel::SpinelDriver     mSpinelDriver;
+    ot::Spinel::SpinelInterface *mSpinelInterface;
+
+    OT_DEFINE_ALIGNED_VAR(mSpinelInterfaceRaw, kSpinelInterfaceRawSize, uint64_t);
 };
+
+ot::Spinel::SpinelDriver &GetSpinelDriver(void);
+SpinelManager            &GetSpinelManager(void);
 
 } // namespace Posix
 } // namespace ot
 
-#endif // OT_POSIX_PLATFORM_RADIO_HPP_
+#endif // POSIX_PLATFORM_SPINEL_MANAGER_HPP_

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -134,6 +134,7 @@ void platformInit(otPlatformConfig *aPlatformConfig)
 #endif
 
     platformAlarmInit(aPlatformConfig->mSpeedUpFactor, aPlatformConfig->mRealTimeSignal);
+    platformSpinelInit(get802154RadioUrl(aPlatformConfig));
     platformRadioInit(get802154RadioUrl(aPlatformConfig));
 
     // For Dry-Run option, only init the radio.
@@ -266,6 +267,7 @@ void platformDeinit(void)
     virtualTimeDeinit();
 #endif
     platformRadioDeinit();
+    platformSpinelDeinit();
 
     // For Dry-Run option, only the radio is initialized.
     VerifyOrExit(!gDryRun);
@@ -343,6 +345,7 @@ void otSysMainloopUpdate(otInstance *aInstance, otSysMainloopContext *aMainloop)
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
     virtualTimeUpdateFdSet(aMainloop);
 #else
+    platformSpinelUpdateFdSet(aMainloop);
     platformRadioUpdateFdSet(aMainloop);
 #endif
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
@@ -406,6 +409,7 @@ void otSysMainloopProcess(otInstance *aInstance, const otSysMainloopContext *aMa
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
     virtualTimeProcess(aInstance, aMainloop);
 #else
+    platformSpinelProcess(aInstance, aMainloop);
     platformRadioProcess(aInstance, aMainloop);
 #endif
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -129,12 +129,21 @@ void otSysSetInfraNetif(const char *aInfraNetifName, int aIcmp6Socket)
 
 void platformInit(otPlatformConfig *aPlatformConfig)
 {
+    CoprocessorType type;
+
 #if OPENTHREAD_POSIX_CONFIG_BACKTRACE_ENABLE
     platformBacktraceInit();
 #endif
 
     platformAlarmInit(aPlatformConfig->mSpeedUpFactor, aPlatformConfig->mRealTimeSignal);
-    platformSpinelInit(get802154RadioUrl(aPlatformConfig));
+
+    type = platformSpinelInit(get802154RadioUrl(aPlatformConfig));
+    if (type != OT_COPROCESSOR_RCP)
+    {
+        printf("Only RCP is supported!\n");
+        exit(OT_EXIT_FAILURE);
+    }
+
     platformRadioInit(get802154RadioUrl(aPlatformConfig));
 
     // For Dry-Run option, only init the radio.

--- a/src/posix/platform/virtual_time.cpp
+++ b/src/posix/platform/virtual_time.cpp
@@ -181,7 +181,8 @@ void virtualTimeProcess(otInstance *aInstance, const otSysMainloopContext *aCont
         virtualTimeReceiveEvent(&event);
     }
 
-    virtualTimeRadioSpinelProcess(aInstance, &event);
+    virtualTimeSpinelProcess(aInstance, &event);
+    virtualTimeRadioProcess(aInstance, &event);
 }
 
 uint64_t otPlatTimeGet(void) { return sNow; }


### PR DESCRIPTION
This PR refactors the posix radio module and radio spinel.

Background: We plan to make ot-br-posix work with not only RCP, but
also NCP. For both, spinel communication is required. Currently the
RadioSpinel is designed only for host+RCP mode. This PR refactors
the class so that some code in RadioSpinel can be reused for new
architecture.

The PR does these things:
* Split the RadioSpinel into two parts: `SpinelDriver` and `RadioSpinel`.
    - SpinelDriver contains the common spinel functions, including initialization,
      receive spinel frames, send spinel command.
    - RadioSpinel contains the host+rcp mode specific functions and 
    uses SpinelDriver.
* Split the posix platform radio component into spinel and radio. 
That is, some process that was done in `platformRadioXXX` is now 
done in `platformSpinelXXX`. These processes are only related with 
spinel hence is not specific to host+rcp mode.
