### PR TITLE
[misc] remove stale forward declaration

### DIFF
--- a/src/core/common/tasklet.hpp
+++ b/src/core/common/tasklet.hpp
@@ -45,8 +45,6 @@
 
 namespace ot {
 
-class TaskletScheduler;
-
 /**
  * @addtogroup core-tasklet
  *


### PR DESCRIPTION
The forward declaration in `tasklet.hpp` is stale. This PR removes it.