### PR TITLE
[daemon] always initialize the OT CLI when setting up the daemon

### DIFF
--- a/src/posix/platform/daemon.cpp
+++ b/src/posix/platform/daemon.cpp
@@ -184,6 +184,7 @@ void Daemon::createListenSocketOrDie(void)
     // This returns the init-managed stream socket which is already bind to
     // /dev/socket/ot-daemon/<interface-name>.sock
     mListenSocket = android_get_control_socket(socketFile);
+
     if (mListenSocket == -1)
     {
         DieNowWithMessage("android_get_control_socket", OT_EXIT_ERROR_ERRNO);
@@ -284,13 +285,13 @@ void Daemon::SetUp(void)
         DieNowWithMessage("listen", OT_EXIT_ERROR_ERRNO);
     }
 
+exit:
 #if OPENTHREAD_POSIX_CONFIG_DAEMON_CLI_ENABLE
     otSysCliInitUsingDaemon(gInstance);
 #endif
 
     Mainloop::Manager::Get().Add(*this);
 
-exit:
     return;
 }
 


### PR DESCRIPTION
Preivously the OT CLI won't be re-iniitalized when it finds there's already a listening socket. It's actually necessary to do the initialize, considering this scenario:
1. Run `otSysDeinit()` and `otSysInit()` to reset the OT application.
1. Note that the OT instance is replaced by a new one in `otSysInit()`. We need to call `otCliInit()` in `Daemon` to initialize the CLI with the new instance. However, this step has been skipped in `Daemon` because the listening socket is not cleared.