### PR TITLE
[thread-cert] set device mode in `test_mle_msg_key_seq_jump`

### DIFF
--- a/tests/scripts/thread-cert/test_mle_msg_key_seq_jump.py
+++ b/tests/scripts/thread-cert/test_mle_msg_key_seq_jump.py
@@ -247,6 +247,7 @@ class MleMsgKeySeqJump(thread_cert.TestCase):
 
         child.factory_reset()
         self.assertEqual(child.get_state(), 'disabled')
+        child.set_mode('r')
 
         child.set_active_dataset(channel=leader.get_channel(),
                                  network_key=leader.get_networkkey(),


### PR DESCRIPTION
Fixes the following intermittent failure:
```
======================================================================
FAIL: test (__main__.MleMsgKeySeqJump)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/openthread/openthread/tests/scripts/thread-cert/test_mle_msg_key_seq_jump.py", line 260, in test
    self.assertEqual(child.get_state(), 'child')
AssertionError: 'router' != 'child'
- router
+ child
```