### PR TITLE
[mle] disable MLE retransmissions when detaching

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2052,8 +2052,13 @@ Error Mle::SendChildUpdateRequest(ChildUpdateRequestMode aMode)
         ExitNow();
     }
 
-    mChildUpdateRequestState = kChildUpdateRequestActive;
-    ScheduleMessageTransmissionTimer();
+    if (aMode != kAppendZeroTimeout)
+    {
+        // Enable MLE retransmissions on all Child Update Request
+        // messages, except when actively detaching.
+        mChildUpdateRequestState = kChildUpdateRequestActive;
+        ScheduleMessageTransmissionTimer();
+    }
 
     VerifyOrExit((message = NewMleMessage(kCommandChildUpdateRequest)) != nullptr, error = kErrorNoBufs);
     SuccessOrExit(error = message->AppendModeTlv(mDeviceMode));


### PR DESCRIPTION
When detaching, a child transmits a Child Update Request message with Timeout TLV set to 0. The child waits for 1 second after sending the Child Update Request message before stopping Thread operation. However, during this time, the MLE retransmission timer may fire and retransmit the Child Update Request message, which can cause it to send a new Child Update Request message with a non-zero Timeout TLV.

This commit update the behavior to avoid retransmitting the Child Update Request message when detaching.