### PR TITLE
[thread-cert] use `ROUTER_STARTUP_DELAY` in `test_detach`

### DIFF
--- a/tests/scripts/thread-cert/test_detach.py
+++ b/tests/scripts/thread-cert/test_detach.py
@@ -105,7 +105,7 @@ class TestDetach(thread_cert.TestCase):
         self.assertFalse(list(filter(lambda x: x[1]['rloc16'] == router1_rloc16, leader.router_table().items())))
 
         router1.start()
-        self.simulator.go(5)
+        self.simulator.go(config.ROUTER_STARTUP_DELAY)
         self.assertEqual(router1.get_state(), 'router')
 
         child1.start()
@@ -121,7 +121,7 @@ class TestDetach(thread_cert.TestCase):
         self.assertEqual(child1.get_state(), 'disabled')
 
         router1.start()
-        self.simulator.go(5)
+        self.simulator.go(config.ROUTER_STARTUP_DELAY)
         self.assertEqual(router1.get_state(), 'router')
 
         child1.start()


### PR DESCRIPTION
Fixes intermittent failures: https://github.com/openthread/openthread/actions/runs/8283753232/job/22673887232