### PR TITLE
[instance] support get multi instance reference or index

### DIFF
--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -331,6 +331,19 @@ exit:
     return instance;
 }
 
+Instance &Instance::Get(uint8_t aIdx)
+{
+    void *instance = gMultiInstanceRaw + aIdx * INSTANCE_SIZE_ALIGNED;
+    return *static_cast<Instance *>(instance);
+}
+
+uint8_t Instance::GetIdx(Instance *aInstance)
+{
+    return static_cast<uint8_t>(
+        (reinterpret_cast<uint8_t *>(aInstance) - reinterpret_cast<uint8_t *>(gMultiInstanceRaw)) /
+        INSTANCE_SIZE_ALIGNED);
+}
+
 #endif // #if OPENTHREAD_CONFIG_MULTIPLE_STATIC_INSTANCE_ENABLE
 
 Instance *Instance::Init(void *aBuffer, size_t *aBufferSize)

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -202,6 +202,26 @@ public:
      *
      */
     static Instance *InitMultiple(uint8_t aIdx);
+
+    /**
+     * Returns a reference to the OpenThread instance.
+     *
+     * @param[in] aIdx The index of the OpenThread instance to get.
+     *
+     * @returns A reference to the OpenThread instance.
+     *
+     */
+    static Instance &Get(uint8_t aIdx);
+
+    /**
+     * Returns the index of the OpenThread instance.
+     *
+     * @param[in] aInstance The reference of the OpenThread instance to get index.
+     *
+     * @returns The index of the OpenThread instance.
+     *
+     */
+    static uint8_t GetIdx(Instance *aInstance);
 #endif
 
 #else // OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE


### PR DESCRIPTION
Provided  two methods  for OpenThread multipan : 
1. Get the index by an openthread instance reference.
2. Get the reference by an openthread instance index.