### PR TITLE
[cli] move `Process{Get/Set/Enable/Disable}` methods to separate class

### DIFF
--- a/src/cli/BUILD.gn
+++ b/src/cli/BUILD.gn
@@ -55,8 +55,6 @@ openthread_cli_sources = [
   "cli_mac_filter.hpp",
   "cli_network_data.cpp",
   "cli_network_data.hpp",
-  "cli_output.cpp",
-  "cli_output.hpp",
   "cli_ping.cpp",
   "cli_ping.hpp",
   "cli_srp_client.cpp",
@@ -67,6 +65,8 @@ openthread_cli_sources = [
   "cli_tcp.hpp",
   "cli_udp.cpp",
   "cli_udp.hpp",
+  "cli_utils.cpp",
+  "cli_utils.hpp",
   "x509_cert_key.hpp",
 ]
 

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -45,13 +45,13 @@ set(COMMON_SOURCES
     cli_link_metrics.cpp
     cli_mac_filter.cpp
     cli_network_data.cpp
-    cli_output.cpp
     cli_ping.cpp
     cli_srp_client.cpp
     cli_srp_server.cpp
     cli_tcat.cpp
     cli_tcp.cpp
     cli_udp.cpp
+    cli_utils.cpp
 )
 
 set(OT_CLI_VENDOR_EXTENSION "" CACHE STRING "Path to CMake file to define and link cli vendor extension")

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -68,13 +68,13 @@
 #include "cli/cli_link_metrics.hpp"
 #include "cli/cli_mac_filter.hpp"
 #include "cli/cli_network_data.hpp"
-#include "cli/cli_output.hpp"
 #include "cli/cli_ping.hpp"
 #include "cli/cli_srp_client.hpp"
 #include "cli/cli_srp_server.hpp"
 #include "cli/cli_tcat.hpp"
 #include "cli/cli_tcp.hpp"
 #include "cli/cli_udp.hpp"
+#include "cli/cli_utils.hpp"
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
 #include "cli/cli_coap.hpp"
 #endif
@@ -108,7 +108,7 @@ extern "C" void otCliOutputFormat(const char *aFmt, ...);
  * Implements the CLI interpreter.
  *
  */
-class Interpreter : public OutputImplementer, public Output
+class Interpreter : public OutputImplementer, public Utils
 {
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
     friend class Br;
@@ -128,8 +128,6 @@ class Interpreter : public OutputImplementer, public Output
     friend void otCliOutputFormat(const char *aFmt, ...);
 
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor
      *
@@ -177,19 +175,6 @@ public:
      *
      */
     void ProcessLine(char *aBuf);
-
-    /**
-     * Checks a given argument string against "enable" or "disable" commands.
-     *
-     * @param[in]  aArg     The argument string to parse.
-     * @param[out] aEnable  Boolean variable to return outcome on success.
-     *                      Set to TRUE for "enable" command, and FALSE for "disable" command.
-     *
-     * @retval OT_ERROR_NONE             Successfully parsed the @p aString and updated @p aEnable.
-     * @retval OT_ERROR_INVALID_COMMAND  The @p aString is not "enable" or "disable" command.
-     *
-     */
-    static otError ParseEnableOrDisable(const Arg &aArg, bool &aEnable);
 
     /**
      * Adds commands to the user command table.
@@ -288,94 +273,6 @@ private:
     static constexpr uint16_t kMaxTxtDataSize = OPENTHREAD_CONFIG_CLI_TXT_RECORD_MAX_SIZE;
 
     using Command = CommandEntry<Interpreter>;
-
-    template <typename ValueType> using GetHandler         = ValueType (&)(otInstance *);
-    template <typename ValueType> using SetHandler         = void (&)(otInstance *, ValueType);
-    template <typename ValueType> using SetHandlerFailable = otError (&)(otInstance *, ValueType);
-    using IsEnabledHandler                                 = bool (&)(otInstance *);
-    using SetEnabledHandler                                = void (&)(otInstance *, bool);
-    using SetEnabledHandlerFailable                        = otError (&)(otInstance *, bool);
-
-    // Returns format string to output a `ValueType` (e.g., "%u" for `uint16_t`).
-    template <typename ValueType> static constexpr const char *FormatStringFor(void);
-
-    // General template implementation.
-    // Specializations for `uint32_t` and `int32_t` are added at the end.
-    template <typename ValueType> otError ProcessGet(Arg aArgs[], GetHandler<ValueType> aGetHandler)
-    {
-        static_assert(
-            TypeTraits::IsSame<ValueType, uint8_t>::kValue || TypeTraits::IsSame<ValueType, uint16_t>::kValue ||
-                TypeTraits::IsSame<ValueType, int8_t>::kValue || TypeTraits::IsSame<ValueType, int16_t>::kValue ||
-                TypeTraits::IsSame<ValueType, const char *>::kValue,
-            "ValueType must be an  8, 16 `int` or `uint` type, or a `const char *`");
-
-        otError error = OT_ERROR_NONE;
-
-        VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
-        OutputLine(FormatStringFor<ValueType>(), aGetHandler(GetInstancePtr()));
-
-    exit:
-        return error;
-    }
-
-    template <typename ValueType> otError ProcessSet(Arg aArgs[], SetHandler<ValueType> aSetHandler)
-    {
-        otError   error;
-        ValueType value;
-
-        SuccessOrExit(error = aArgs[0].ParseAs<ValueType>(value));
-        VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
-
-        aSetHandler(GetInstancePtr(), value);
-
-    exit:
-        return error;
-    }
-
-    template <typename ValueType> otError ProcessSet(Arg aArgs[], SetHandlerFailable<ValueType> aSetHandler)
-    {
-        otError   error;
-        ValueType value;
-
-        SuccessOrExit(error = aArgs[0].ParseAs<ValueType>(value));
-        VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
-
-        error = aSetHandler(GetInstancePtr(), value);
-
-    exit:
-        return error;
-    }
-
-    template <typename ValueType>
-    otError ProcessGetSet(Arg aArgs[], GetHandler<ValueType> aGetHandler, SetHandler<ValueType> aSetHandler)
-    {
-        otError error = ProcessGet(aArgs, aGetHandler);
-
-        VerifyOrExit(error != OT_ERROR_NONE);
-        error = ProcessSet(aArgs, aSetHandler);
-
-    exit:
-        return error;
-    }
-
-    template <typename ValueType>
-    otError ProcessGetSet(Arg aArgs[], GetHandler<ValueType> aGetHandler, SetHandlerFailable<ValueType> aSetHandler)
-    {
-        otError error = ProcessGet(aArgs, aGetHandler);
-
-        VerifyOrExit(error != OT_ERROR_NONE);
-        error = ProcessSet(aArgs, aSetHandler);
-
-    exit:
-        return error;
-    }
-
-    otError ProcessEnableDisable(Arg aArgs[], SetEnabledHandler aSetEnabledHandler);
-    otError ProcessEnableDisable(Arg aArgs[], SetEnabledHandlerFailable aSetEnabledHandler);
-    otError ProcessEnableDisable(Arg aArgs[], IsEnabledHandler aIsEnabledHandler, SetEnabledHandler aSetEnabledHandler);
-    otError ProcessEnableDisable(Arg                       aArgs[],
-                                 IsEnabledHandler          aIsEnabledHandler,
-                                 SetEnabledHandlerFailable aSetEnabledHandler);
 
     void OutputPrompt(void);
     void OutputResult(otError aError);
@@ -603,46 +500,6 @@ private:
     bool mLocateInProgress : 1;
 #endif
 };
-
-// Specializations of `FormatStringFor<ValueType>()`
-
-template <> inline constexpr const char *Interpreter::FormatStringFor<uint8_t>(void) { return "%u"; }
-
-template <> inline constexpr const char *Interpreter::FormatStringFor<uint16_t>(void) { return "%u"; }
-
-template <> inline constexpr const char *Interpreter::FormatStringFor<uint32_t>(void) { return "%lu"; }
-
-template <> inline constexpr const char *Interpreter::FormatStringFor<int8_t>(void) { return "%d"; }
-
-template <> inline constexpr const char *Interpreter::FormatStringFor<int16_t>(void) { return "%d"; }
-
-template <> inline constexpr const char *Interpreter::FormatStringFor<int32_t>(void) { return "%ld"; }
-
-template <> inline constexpr const char *Interpreter::FormatStringFor<const char *>(void) { return "%s"; }
-
-// Specialization of ProcessGet<> for `uint32_t` and `int32_t`
-
-template <> inline otError Interpreter::ProcessGet<uint32_t>(Arg aArgs[], GetHandler<uint32_t> aGetHandler)
-{
-    otError error = OT_ERROR_NONE;
-
-    VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
-    OutputLine(FormatStringFor<uint32_t>(), ToUlong(aGetHandler(GetInstancePtr())));
-
-exit:
-    return error;
-}
-
-template <> inline otError Interpreter::ProcessGet<int32_t>(Arg aArgs[], GetHandler<int32_t> aGetHandler)
-{
-    otError error = OT_ERROR_NONE;
-
-    VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
-    OutputLine(FormatStringFor<int32_t>(), static_cast<long int>(aGetHandler(GetInstancePtr())));
-
-exit:
-    return error;
-}
 
 } // namespace Cli
 } // namespace ot

--- a/src/cli/cli_bbr.cpp
+++ b/src/cli/cli_bbr.cpp
@@ -290,8 +290,7 @@ template <> otError Bbr::Process<Cmd("disable")>(Arg aArgs[])
  */
 template <> otError Bbr::Process<Cmd("jitter")>(Arg aArgs[])
 {
-    return Interpreter::GetInterpreter().ProcessGetSet(aArgs, otBackboneRouterGetRegistrationJitter,
-                                                       otBackboneRouterSetRegistrationJitter);
+    return ProcessGetSet(aArgs, otBackboneRouterGetRegistrationJitter, otBackboneRouterSetRegistrationJitter);
 }
 
 /**

--- a/src/cli/cli_bbr.hpp
+++ b/src/cli/cli_bbr.hpp
@@ -42,7 +42,7 @@
 #include <openthread/backbone_router_ftd.h>
 
 #include "cli/cli_config.h"
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 namespace ot {
 namespace Cli {
@@ -51,11 +51,9 @@ namespace Cli {
  * Implements the BBR CLI interpreter.
  *
  */
-class Bbr : private Output
+class Bbr : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor.
      *
@@ -64,7 +62,7 @@ public:
      *
      */
     Bbr(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Output(aInstance, aOutputImplementer)
+        : Utils(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_br.cpp
+++ b/src/cli/cli_br.cpp
@@ -455,7 +455,7 @@ template <> otError Br::Process<Cmd("pd")>(Arg aArgs[])
      * #otBorderRoutingDhcp6PdSetEnabled
      *
      */
-    if (Interpreter::GetInterpreter().ProcessEnableDisable(aArgs, otBorderRoutingDhcp6PdSetEnabled) == OT_ERROR_NONE)
+    if (ProcessEnableDisable(aArgs, otBorderRoutingDhcp6PdSetEnabled) == OT_ERROR_NONE)
     {
     }
     /**

--- a/src/cli/cli_br.hpp
+++ b/src/cli/cli_br.hpp
@@ -39,7 +39,7 @@
 #include <openthread/border_routing.h>
 
 #include "cli/cli_config.h"
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 
@@ -50,11 +50,9 @@ namespace Cli {
  * Implements the Border Router CLI interpreter.
  *
  */
-class Br : private Output
+class Br : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor
      *
@@ -63,7 +61,7 @@ public:
      *
      */
     Br(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Output(aInstance, aOutputImplementer)
+        : Utils(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -45,7 +45,7 @@ namespace ot {
 namespace Cli {
 
 Coap::Coap(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Output(aInstance, aOutputImplementer)
+    : Utils(aInstance, aOutputImplementer)
     , mUseDefaultRequestTxParameters(true)
     , mUseDefaultResponseTxParameters(true)
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE

--- a/src/cli/cli_coap.hpp
+++ b/src/cli/cli_coap.hpp
@@ -40,7 +40,7 @@
 
 #include <openthread/coap.h>
 
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 namespace ot {
 namespace Cli {
@@ -49,11 +49,9 @@ namespace Cli {
  * Implements the CLI CoAP server and client.
  *
  */
-class Coap : private Output
+class Coap : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor
      *

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -47,7 +47,7 @@ namespace ot {
 namespace Cli {
 
 CoapSecure::CoapSecure(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Output(aInstance, aOutputImplementer)
+    : Utils(aInstance, aOutputImplementer)
     , mShutdownFlag(false)
     , mUseCertificate(false)
     , mPskLength(0)

--- a/src/cli/cli_coap_secure.hpp
+++ b/src/cli/cli_coap_secure.hpp
@@ -42,7 +42,7 @@
 
 #include <openthread/coap_secure.h>
 
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 #ifndef CLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER
 #define CLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER 0
@@ -55,11 +55,9 @@ namespace Cli {
  * Implements the CLI CoAP Secure server and client.
  *
  */
-class CoapSecure : private Output
+class CoapSecure : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor
      *

--- a/src/cli/cli_commissioner.hpp
+++ b/src/cli/cli_commissioner.hpp
@@ -38,7 +38,7 @@
 
 #include <openthread/commissioner.h>
 
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
 
@@ -49,11 +49,9 @@ namespace Cli {
  * Implements the Commissioner CLI interpreter.
  *
  */
-class Commissioner : private Output
+class Commissioner : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor
      *
@@ -62,7 +60,7 @@ public:
      *
      */
     Commissioner(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Output(aInstance, aOutputImplementer)
+        : Utils(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -40,7 +40,7 @@
 
 #include <openthread/dataset.h>
 
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 namespace ot {
 namespace Cli {
@@ -49,13 +49,11 @@ namespace Cli {
  * Implements the Dataset CLI interpreter.
  *
  */
-class Dataset : private Output
+class Dataset : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     Dataset(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Output(aInstance, aOutputImplementer)
+        : Utils(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_dns.cpp
+++ b/src/cli/cli_dns.cpp
@@ -679,8 +679,7 @@ template <> otError Dns::Process<Cmd("server")>(Arg aArgs[])
          * @par api_copy
          * #otDnssdUpstreamQuerySetEnabled
          */
-        error = Interpreter::GetInterpreter().ProcessEnableDisable(aArgs + 1, otDnssdUpstreamQueryIsEnabled,
-                                                                   otDnssdUpstreamQuerySetEnabled);
+        error = ProcessEnableDisable(aArgs + 1, otDnssdUpstreamQueryIsEnabled, otDnssdUpstreamQuerySetEnabled);
     }
 #endif // OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE
     else

--- a/src/cli/cli_dns.hpp
+++ b/src/cli/cli_dns.hpp
@@ -54,7 +54,7 @@
 #include <openthread/dnssd_server.h>
 
 #include "cli/cli_config.h"
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 namespace ot {
 namespace Cli {
@@ -63,11 +63,9 @@ namespace Cli {
  * Implements the DNS CLI interpreter.
  *
  */
-class Dns : private Output
+class Dns : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor.
      *
@@ -76,7 +74,7 @@ public:
      *
      */
     Dns(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Output(aInstance, aOutputImplementer)
+        : Utils(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_history.hpp
+++ b/src/cli/cli_history.hpp
@@ -39,7 +39,7 @@
 #include <openthread/history_tracker.h>
 
 #include "cli/cli_config.h"
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
 
@@ -50,11 +50,9 @@ namespace Cli {
  * Implements the History Tracker CLI interpreter.
  *
  */
-class History : private Output
+class History : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor
      *
@@ -63,7 +61,7 @@ public:
      *
      */
     History(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Output(aInstance, aOutputImplementer)
+        : Utils(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_joiner.hpp
+++ b/src/cli/cli_joiner.hpp
@@ -38,7 +38,7 @@
 
 #include <openthread/joiner.h>
 
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
 
@@ -49,11 +49,9 @@ namespace Cli {
  * Implements the Joiner CLI interpreter.
  *
  */
-class Joiner : private Output
+class Joiner : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor
      *
@@ -62,7 +60,7 @@ public:
      *
      */
     Joiner(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Output(aInstance, aOutputImplementer)
+        : Utils(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_link_metrics.cpp
+++ b/src/cli/cli_link_metrics.cpp
@@ -36,7 +36,7 @@
 #include <openthread/link_metrics.h>
 
 #include "cli/cli.hpp"
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 #include "common/code_utils.hpp"
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
@@ -45,7 +45,7 @@ namespace ot {
 namespace Cli {
 
 LinkMetrics::LinkMetrics(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Output(aInstance, aOutputImplementer)
+    : Utils(aInstance, aOutputImplementer)
     , mLinkMetricsQueryInProgress(false)
 {
 }

--- a/src/cli/cli_link_metrics.hpp
+++ b/src/cli/cli_link_metrics.hpp
@@ -38,7 +38,7 @@
 
 #include <openthread/link_metrics.h>
 
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
 
@@ -50,11 +50,9 @@ namespace Cli {
  *
  */
 
-class LinkMetrics : private Output
+class LinkMetrics : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor
      *

--- a/src/cli/cli_mac_filter.hpp
+++ b/src/cli/cli_mac_filter.hpp
@@ -41,7 +41,7 @@
 #include <openthread/link.h>
 
 #include "cli/cli_config.h"
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 namespace ot {
 namespace Cli {
@@ -50,11 +50,9 @@ namespace Cli {
  * Implements the MAC Filter CLI interpreter.
  *
  */
-class MacFilter : private Output
+class MacFilter : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor.
      *
@@ -63,7 +61,7 @@ public:
      *
      */
     MacFilter(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Output(aInstance, aOutputImplementer)
+        : Utils(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_network_data.cpp
+++ b/src/cli/cli_network_data.cpp
@@ -44,7 +44,7 @@ namespace ot {
 namespace Cli {
 
 NetworkData::NetworkData(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Output(aInstance, aOutputImplementer)
+    : Utils(aInstance, aOutputImplementer)
 {
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_SIGNAL_NETWORK_DATA_FULL
     mFullCallbackWasCalled = false;

--- a/src/cli/cli_network_data.hpp
+++ b/src/cli/cli_network_data.hpp
@@ -38,7 +38,7 @@
 
 #include <openthread/netdata.h>
 
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 namespace ot {
 namespace Cli {
@@ -47,11 +47,9 @@ namespace Cli {
  * Implements the Network Data CLI.
  *
  */
-class NetworkData : private Output
+class NetworkData : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * This constant specifies the string size for representing Network Data prefix/route entry flags.
      *

--- a/src/cli/cli_ping.cpp
+++ b/src/cli/cli_ping.cpp
@@ -36,7 +36,7 @@
 #include <openthread/ping_sender.h>
 
 #include "cli/cli.hpp"
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 #include "common/code_utils.hpp"
 
 #if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
@@ -45,7 +45,7 @@ namespace ot {
 namespace Cli {
 
 PingSender::PingSender(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Output(aInstance, aOutputImplementer)
+    : Utils(aInstance, aOutputImplementer)
     , mPingIsAsync(false)
 {
 }

--- a/src/cli/cli_ping.hpp
+++ b/src/cli/cli_ping.hpp
@@ -38,7 +38,7 @@
 
 #include <openthread/ping_sender.h>
 
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 #if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
 
@@ -50,11 +50,9 @@ namespace Cli {
  *
  */
 
-class PingSender : private Output
+class PingSender : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor
      *

--- a/src/cli/cli_srp_client.cpp
+++ b/src/cli/cli_srp_client.cpp
@@ -58,7 +58,7 @@ exit:
 }
 
 SrpClient::SrpClient(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Output(aInstance, aOutputImplementer)
+    : Utils(aInstance, aOutputImplementer)
     , mCallbackEnabled(false)
 {
     otSrpClientSetCallback(GetInstancePtr(), SrpClient::HandleCallback, this);
@@ -453,7 +453,7 @@ exit:
  */
 template <> otError SrpClient::Process<Cmd("leaseinterval")>(Arg aArgs[])
 {
-    return Interpreter::GetInterpreter().ProcessGetSet(aArgs, otSrpClientGetLeaseInterval, otSrpClientSetLeaseInterval);
+    return ProcessGetSet(aArgs, otSrpClientGetLeaseInterval, otSrpClientSetLeaseInterval);
 }
 
 /**
@@ -475,8 +475,7 @@ template <> otError SrpClient::Process<Cmd("leaseinterval")>(Arg aArgs[])
  */
 template <> otError SrpClient::Process<Cmd("keyleaseinterval")>(Arg aArgs[])
 {
-    return Interpreter::GetInterpreter().ProcessGetSet(aArgs, otSrpClientGetKeyLeaseInterval,
-                                                       otSrpClientSetKeyLeaseInterval);
+    return ProcessGetSet(aArgs, otSrpClientGetKeyLeaseInterval, otSrpClientSetKeyLeaseInterval);
 }
 
 template <> otError SrpClient::Process<Cmd("server")>(Arg aArgs[])
@@ -577,9 +576,9 @@ template <> otError SrpClient::Process<Cmd("service")>(Arg aArgs[])
      * * -->                          [@ca{weight}] [@ca{txt}]
      * The `servicename` parameter can optionally include a list of service subtype labels that are
      * separated by commas. The examples here use generic naming. The `priority` and `weight` (both are `uint16_t`
-     * values) parameters are optional, and if not provided zero is used. The optional `txt` parameter sets the TXT data
-     * associated with the service. The `txt` value must be in hex-string format and is treated as an already encoded
-     * TXT data byte sequence.
+     * values) parameters are optional, and if not provided zero is used. The optional `txt` parameter sets the TXT
+     * data associated with the service. The `txt` value must be in hex-string format and is treated as an already
+     * encoded TXT data byte sequence.
      * @par
      * Adds a service with a given instance name, service name, and port number.
      * @moreinfo{@srp}.
@@ -664,8 +663,8 @@ template <> otError SrpClient::Process<Cmd("service")>(Arg aArgs[])
     {
         // `key [enable/disable]`
 
-        error = Interpreter::GetInterpreter().ProcessEnableDisable(aArgs + 1, otSrpClientIsServiceKeyRecordEnabled,
-                                                                   otSrpClientSetServiceKeyRecordEnabled);
+        error = ProcessEnableDisable(aArgs + 1, otSrpClientIsServiceKeyRecordEnabled,
+                                     otSrpClientSetServiceKeyRecordEnabled);
     }
 #endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     else
@@ -929,7 +928,7 @@ exit:
  */
 template <> otError SrpClient::Process<Cmd("ttl")>(Arg aArgs[])
 {
-    return Interpreter::GetInterpreter().ProcessGetSet(aArgs, otSrpClientGetTtl, otSrpClientSetTtl);
+    return ProcessGetSet(aArgs, otSrpClientGetTtl, otSrpClientSetTtl);
 }
 
 void SrpClient::HandleCallback(otError                    aError,

--- a/src/cli/cli_srp_client.hpp
+++ b/src/cli/cli_srp_client.hpp
@@ -40,7 +40,7 @@
 #include <openthread/srp_client_buffers.h>
 
 #include "cli/cli_config.h"
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
 
@@ -51,11 +51,9 @@ namespace Cli {
  * Implements the SRP Client CLI interpreter.
  *
  */
-class SrpClient : private Output
+class SrpClient : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor
      *

--- a/src/cli/cli_srp_server.cpp
+++ b/src/cli/cli_srp_server.cpp
@@ -121,8 +121,7 @@ template <> otError SrpServer::Process<Cmd("addrmode")>(Arg aArgs[])
  */
 template <> otError SrpServer::Process<Cmd("auto")>(Arg aArgs[])
 {
-    return Interpreter::GetInterpreter().ProcessEnableDisable(aArgs, otSrpServerIsAutoEnableMode,
-                                                              otSrpServerSetAutoEnableMode);
+    return ProcessEnableDisable(aArgs, otSrpServerIsAutoEnableMode, otSrpServerSetAutoEnableMode);
 }
 #endif
 

--- a/src/cli/cli_srp_server.hpp
+++ b/src/cli/cli_srp_server.hpp
@@ -38,7 +38,7 @@
 
 #include <openthread/srp_server.h>
 
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
 
@@ -49,11 +49,9 @@ namespace Cli {
  * Implements the SRP Server CLI interpreter.
  *
  */
-class SrpServer : private Output
+class SrpServer : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor
      *
@@ -62,7 +60,7 @@ public:
      *
      */
     SrpServer(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Output(aInstance, aOutputImplementer)
+        : Utils(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_tcat.cpp
+++ b/src/cli/cli_tcat.cpp
@@ -28,7 +28,7 @@
 
 #include "openthread-core-config.h"
 
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 #include "cli/cli_tcat.hpp"
 

--- a/src/cli/cli_tcat.hpp
+++ b/src/cli/cli_tcat.hpp
@@ -33,7 +33,7 @@
 
 #include <openthread/tcat.h>
 
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 #if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE && OPENTHREAD_CONFIG_CLI_BLE_SECURE_ENABLE
 
@@ -45,11 +45,9 @@ namespace Cli {
  * Implements the Tcat CLI interpreter.
  *
  */
-class Tcat : private Output
+class Tcat : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor
      *
@@ -58,7 +56,7 @@ public:
      *
      */
     Tcat(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Output(aInstance, aOutputImplementer)
+        : Utils(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_tcp.cpp
+++ b/src/cli/cli_tcp.cpp
@@ -61,7 +61,7 @@ const int TcpExample::sCipherSuites[] = {MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8,
 #endif
 
 TcpExample::TcpExample(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Output(aInstance, aOutputImplementer)
+    : Utils(aInstance, aOutputImplementer)
     , mInitialized(false)
     , mEndpointConnected(false)
     , mEndpointConnectedFastOpen(false)

--- a/src/cli/cli_tcp.hpp
+++ b/src/cli/cli_tcp.hpp
@@ -49,7 +49,7 @@
 #endif
 
 #include "cli/cli_config.h"
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 #include "common/time.hpp"
 
 namespace ot {
@@ -59,11 +59,9 @@ namespace Cli {
  * Implements a CLI-based TCP example.
  *
  */
-class TcpExample : private Output
+class TcpExample : private Utils
 {
 public:
-    using Arg = Utils::CmdLineParser::Arg;
-
     /**
      * Constructor
      *

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -44,7 +44,7 @@ namespace ot {
 namespace Cli {
 
 UdpExample::UdpExample(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Output(aInstance, aOutputImplementer)
+    : Utils(aInstance, aOutputImplementer)
     , mLinkSecurityEnabled(true)
 {
     ClearAllBytes(mSocket);
@@ -408,7 +408,7 @@ otError UdpExample::PrepareHexStringPayload(otMessage &aMessage, const char *aHe
     while (!done)
     {
         length = sizeof(buf);
-        error  = Utils::CmdLineParser::ParseAsHexStringSegment(aHexString, length, buf);
+        error  = ot::Utils::CmdLineParser::ParseAsHexStringSegment(aHexString, length, buf);
 
         VerifyOrExit((error == OT_ERROR_NONE) || (error == OT_ERROR_PENDING));
         done = (error == OT_ERROR_NONE);

--- a/src/cli/cli_udp.hpp
+++ b/src/cli/cli_udp.hpp
@@ -38,7 +38,7 @@
 
 #include <openthread/udp.h>
 
-#include "cli/cli_output.hpp"
+#include "cli/cli_utils.hpp"
 
 namespace ot {
 namespace Cli {
@@ -47,11 +47,9 @@ namespace Cli {
  * Implements a CLI-based UDP example.
  *
  */
-class UdpExample : private Output
+class UdpExample : private Utils
 {
 public:
-    typedef Utils::CmdLineParser::Arg Arg;
-
     /**
      * Constructor
      *

--- a/src/cli/cli_utils.cpp
+++ b/src/cli/cli_utils.cpp
@@ -31,7 +31,7 @@
  *   This file contains implementation of the CLI output module.
  */
 
-#include "cli_output.hpp"
+#include "cli_utils.hpp"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -48,7 +48,7 @@
 namespace ot {
 namespace Cli {
 
-const char Output::kUnknownString[] = "unknown";
+const char Utils::kUnknownString[] = "unknown";
 
 OutputImplementer::OutputImplementer(otCliOutputCallback aCallback, void *aCallbackContext)
     : mCallback(aCallback)
@@ -60,7 +60,7 @@ OutputImplementer::OutputImplementer(otCliOutputCallback aCallback, void *aCallb
 {
 }
 
-void Output::OutputFormat(const char *aFormat, ...)
+void Utils::OutputFormat(const char *aFormat, ...)
 {
     va_list args;
 
@@ -69,7 +69,7 @@ void Output::OutputFormat(const char *aFormat, ...)
     va_end(args);
 }
 
-void Output::OutputFormat(uint8_t aIndentSize, const char *aFormat, ...)
+void Utils::OutputFormat(uint8_t aIndentSize, const char *aFormat, ...)
 {
     va_list args;
 
@@ -80,7 +80,7 @@ void Output::OutputFormat(uint8_t aIndentSize, const char *aFormat, ...)
     va_end(args);
 }
 
-void Output::OutputLine(const char *aFormat, ...)
+void Utils::OutputLine(const char *aFormat, ...)
 {
     va_list args;
 
@@ -91,7 +91,7 @@ void Output::OutputLine(const char *aFormat, ...)
     OutputNewLine();
 }
 
-void Output::OutputLine(uint8_t aIndentSize, const char *aFormat, ...)
+void Utils::OutputLine(uint8_t aIndentSize, const char *aFormat, ...)
 {
     va_list args;
 
@@ -104,11 +104,11 @@ void Output::OutputLine(uint8_t aIndentSize, const char *aFormat, ...)
     OutputNewLine();
 }
 
-void Output::OutputNewLine(void) { OutputFormat("\r\n"); }
+void Utils::OutputNewLine(void) { OutputFormat("\r\n"); }
 
-void Output::OutputSpaces(uint8_t aCount) { OutputFormat("%*s", aCount, ""); }
+void Utils::OutputSpaces(uint8_t aCount) { OutputFormat("%*s", aCount, ""); }
 
-void Output::OutputBytes(const uint8_t *aBytes, uint16_t aLength)
+void Utils::OutputBytes(const uint8_t *aBytes, uint16_t aLength)
 {
     for (uint16_t i = 0; i < aLength; i++)
     {
@@ -116,13 +116,13 @@ void Output::OutputBytes(const uint8_t *aBytes, uint16_t aLength)
     }
 }
 
-void Output::OutputBytesLine(const uint8_t *aBytes, uint16_t aLength)
+void Utils::OutputBytesLine(const uint8_t *aBytes, uint16_t aLength)
 {
     OutputBytes(aBytes, aLength);
     OutputNewLine();
 }
 
-const char *Output::Uint64ToString(uint64_t aUint64, Uint64StringBuffer &aBuffer)
+const char *Utils::Uint64ToString(uint64_t aUint64, Uint64StringBuffer &aBuffer)
 {
     char *cur = &aBuffer.mChars[Uint64StringBuffer::kSize - 1];
 
@@ -143,24 +143,24 @@ const char *Output::Uint64ToString(uint64_t aUint64, Uint64StringBuffer &aBuffer
     return cur;
 }
 
-void Output::OutputUint64(uint64_t aUint64)
+void Utils::OutputUint64(uint64_t aUint64)
 {
     Uint64StringBuffer buffer;
 
     OutputFormat("%s", Uint64ToString(aUint64, buffer));
 }
 
-void Output::OutputUint64Line(uint64_t aUint64)
+void Utils::OutputUint64Line(uint64_t aUint64)
 {
     OutputUint64(aUint64);
     OutputNewLine();
 }
 
-void Output::OutputEnabledDisabledStatus(bool aEnabled) { OutputLine(aEnabled ? "Enabled" : "Disabled"); }
+void Utils::OutputEnabledDisabledStatus(bool aEnabled) { OutputLine(aEnabled ? "Enabled" : "Disabled"); }
 
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
 
-void Output::OutputIp6Address(const otIp6Address &aAddress)
+void Utils::OutputIp6Address(const otIp6Address &aAddress)
 {
     char string[OT_IP6_ADDRESS_STRING_SIZE];
 
@@ -169,13 +169,13 @@ void Output::OutputIp6Address(const otIp6Address &aAddress)
     return OutputFormat("%s", string);
 }
 
-void Output::OutputIp6AddressLine(const otIp6Address &aAddress)
+void Utils::OutputIp6AddressLine(const otIp6Address &aAddress)
 {
     OutputIp6Address(aAddress);
     OutputNewLine();
 }
 
-void Output::OutputIp6Prefix(const otIp6Prefix &aPrefix)
+void Utils::OutputIp6Prefix(const otIp6Prefix &aPrefix)
 {
     char string[OT_IP6_PREFIX_STRING_SIZE];
 
@@ -184,25 +184,25 @@ void Output::OutputIp6Prefix(const otIp6Prefix &aPrefix)
     OutputFormat("%s", string);
 }
 
-void Output::OutputIp6PrefixLine(const otIp6Prefix &aPrefix)
+void Utils::OutputIp6PrefixLine(const otIp6Prefix &aPrefix)
 {
     OutputIp6Prefix(aPrefix);
     OutputNewLine();
 }
 
-void Output::OutputIp6Prefix(const otIp6NetworkPrefix &aPrefix)
+void Utils::OutputIp6Prefix(const otIp6NetworkPrefix &aPrefix)
 {
     OutputFormat("%x:%x:%x:%x::/64", (aPrefix.m8[0] << 8) | aPrefix.m8[1], (aPrefix.m8[2] << 8) | aPrefix.m8[3],
                  (aPrefix.m8[4] << 8) | aPrefix.m8[5], (aPrefix.m8[6] << 8) | aPrefix.m8[7]);
 }
 
-void Output::OutputIp6PrefixLine(const otIp6NetworkPrefix &aPrefix)
+void Utils::OutputIp6PrefixLine(const otIp6NetworkPrefix &aPrefix)
 {
     OutputIp6Prefix(aPrefix);
     OutputNewLine();
 }
 
-void Output::OutputSockAddr(const otSockAddr &aSockAddr)
+void Utils::OutputSockAddr(const otSockAddr &aSockAddr)
 {
     char string[OT_IP6_SOCK_ADDR_STRING_SIZE];
 
@@ -211,13 +211,13 @@ void Output::OutputSockAddr(const otSockAddr &aSockAddr)
     return OutputFormat("%s", string);
 }
 
-void Output::OutputSockAddrLine(const otSockAddr &aSockAddr)
+void Utils::OutputSockAddrLine(const otSockAddr &aSockAddr)
 {
     OutputSockAddr(aSockAddr);
     OutputNewLine();
 }
 
-void Output::OutputDnsTxtData(const uint8_t *aTxtData, uint16_t aTxtDataLength)
+void Utils::OutputDnsTxtData(const uint8_t *aTxtData, uint16_t aTxtDataLength)
 {
     otDnsTxtEntry         entry;
     otDnsTxtEntryIterator iterator;
@@ -262,7 +262,7 @@ void Output::OutputDnsTxtData(const uint8_t *aTxtData, uint16_t aTxtDataLength)
     OutputFormat("]");
 }
 
-const char *Output::PercentageToString(uint16_t aValue, PercentageStringBuffer &aBuffer)
+const char *Utils::PercentageToString(uint16_t aValue, PercentageStringBuffer &aBuffer)
 {
     uint32_t     scaledValue = aValue;
     StringWriter writer(aBuffer.mChars, sizeof(aBuffer.mChars));
@@ -275,7 +275,7 @@ const char *Output::PercentageToString(uint16_t aValue, PercentageStringBuffer &
 
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD
 
-void Output::OutputFormatV(const char *aFormat, va_list aArguments) { mImplementer.OutputV(aFormat, aArguments); }
+void Utils::OutputFormatV(const char *aFormat, va_list aArguments) { mImplementer.OutputV(aFormat, aArguments); }
 
 void OutputImplementer::OutputV(const char *aFormat, va_list aArguments)
 {
@@ -370,7 +370,7 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
-void Output::LogInput(const Arg *aArgs)
+void Utils::LogInput(const Arg *aArgs)
 {
     String<kInputOutputLogStringSize> inputString;
 
@@ -383,7 +383,7 @@ void Output::LogInput(const Arg *aArgs)
 }
 #endif
 
-void Output::OutputTableHeader(uint8_t aNumColumns, const char *const aTitles[], const uint8_t aWidths[])
+void Utils::OutputTableHeader(uint8_t aNumColumns, const char *const aTitles[], const uint8_t aWidths[])
 {
     for (uint8_t index = 0; index < aNumColumns; index++)
     {
@@ -412,7 +412,7 @@ void Output::OutputTableHeader(uint8_t aNumColumns, const char *const aTitles[],
     OutputTableSeparator(aNumColumns, aWidths);
 }
 
-void Output::OutputTableSeparator(uint8_t aNumColumns, const uint8_t aWidths[])
+void Utils::OutputTableSeparator(uint8_t aNumColumns, const uint8_t aWidths[])
 {
     for (uint8_t index = 0; index < aNumColumns; index++)
     {
@@ -425,6 +425,96 @@ void Output::OutputTableSeparator(uint8_t aNumColumns, const uint8_t aWidths[])
     }
 
     OutputLine("+");
+}
+
+otError Utils::ParseEnableOrDisable(const Arg &aArg, bool &aEnable)
+{
+    otError error = OT_ERROR_NONE;
+
+    if (aArg == "enable")
+    {
+        aEnable = true;
+    }
+    else if (aArg == "disable")
+    {
+        aEnable = false;
+    }
+    else
+    {
+        error = OT_ERROR_INVALID_COMMAND;
+    }
+
+    return error;
+}
+
+otError Utils::ProcessEnableDisable(Arg aArgs[], SetEnabledHandler aSetEnabledHandler)
+{
+    otError error = OT_ERROR_NONE;
+    bool    enable;
+
+    if (ParseEnableOrDisable(aArgs[0], enable) == OT_ERROR_NONE)
+    {
+        aSetEnabledHandler(GetInstancePtr(), enable);
+    }
+    else
+    {
+        error = OT_ERROR_INVALID_COMMAND;
+    }
+
+    return error;
+}
+
+otError Utils::ProcessEnableDisable(Arg aArgs[], SetEnabledHandlerFailable aSetEnabledHandler)
+{
+    otError error = OT_ERROR_NONE;
+    bool    enable;
+
+    if (ParseEnableOrDisable(aArgs[0], enable) == OT_ERROR_NONE)
+    {
+        error = aSetEnabledHandler(GetInstancePtr(), enable);
+    }
+    else
+    {
+        error = OT_ERROR_INVALID_COMMAND;
+    }
+
+    return error;
+}
+
+otError Utils::ProcessEnableDisable(Arg               aArgs[],
+                                    IsEnabledHandler  aIsEnabledHandler,
+                                    SetEnabledHandler aSetEnabledHandler)
+{
+    otError error = OT_ERROR_NONE;
+
+    if (aArgs[0].IsEmpty())
+    {
+        OutputEnabledDisabledStatus(aIsEnabledHandler(GetInstancePtr()));
+    }
+    else
+    {
+        error = ProcessEnableDisable(aArgs, aSetEnabledHandler);
+    }
+
+    return error;
+}
+
+otError Utils::ProcessEnableDisable(Arg                       aArgs[],
+                                    IsEnabledHandler          aIsEnabledHandler,
+                                    SetEnabledHandlerFailable aSetEnabledHandler)
+{
+    otError error = OT_ERROR_NONE;
+
+    if (aArgs[0].IsEmpty())
+    {
+        OutputEnabledDisabledStatus(aIsEnabledHandler(GetInstancePtr()));
+    }
+    else
+    {
+        error = ProcessEnableDisable(aArgs, aSetEnabledHandler);
+    }
+
+    return error;
 }
 
 } // namespace Cli

--- a/src/cli/radio.cmake
+++ b/src/cli/radio.cmake
@@ -45,7 +45,7 @@ target_include_directories(openthread-cli-radio PUBLIC ${OT_PUBLIC_INCLUDES} PRI
 target_sources(openthread-cli-radio
     PRIVATE
         cli.cpp
-        cli_output.cpp
+        cli_utils.cpp
 )
 
 if(NOT DEFINED OT_MBEDTLS_RCP)


### PR DESCRIPTION
This PR moves the Process Get/Set/Enable/Disable methods to the
Output class and rename the 'Output' class to 'Utils'.
The purpose is to reduce code size in the Interpreter class to 
make the class focus more on the command handling and easier for
further refactoring.

The PR also removes the alias typedef of 'Arg' in each cli module
because they are unnecessary. (Having one definition in the parent 
class is enough)
