### PR TITLE
[config] update docs for `SED_BUFFER_SIZE` & `SED_DATAGRAM_COUNT`

### DIFF
--- a/src/core/config/misc.h
+++ b/src/core/config/misc.h
@@ -424,9 +424,14 @@
 /**
  * @def OPENTHREAD_CONFIG_DEFAULT_SED_BUFFER_SIZE
  *
- * This setting configures the default buffer size for IPv6 datagram destined for an attached SED.
- * A Thread Router MUST be able to buffer at least one 1280-octet IPv6 datagram for an attached SED according to
- * the Thread Conformance Specification.
+ * Specifies the value used in emitted Connectivity TLV "Rx-off Child Buffer Size" field which indicates the
+ * guaranteed buffer capacity for all IPv6 datagrams destined to a given rx-off-when-idle child.
+ *
+ * Changing this config does not automatically adjust message buffers. Vendors should ensure their device can support
+ * the specified value based on the message buffer model used:
+ *  - OT internal message pool (refer to `OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS` and `MESSAGE_BUFFER_SIZE`), or
+ *  - Heap allocated message buffers (refer to `OPENTHREAD_CONFIG_MESSAGE_USE_HEAP_ENABLE),
+ *  - Platform-specific message management (refer to`OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT`).
  *
  */
 #ifndef OPENTHREAD_CONFIG_DEFAULT_SED_BUFFER_SIZE
@@ -436,9 +441,11 @@
 /**
  * @def OPENTHREAD_CONFIG_DEFAULT_SED_DATAGRAM_COUNT
  *
- * This setting configures the default datagram count of 106-octet IPv6 datagram per attached SED.
- * A Thread Router MUST be able to buffer at least one 106-octet IPv6 datagram per attached SED according to
- * the Thread Conformance Specification.
+ * Specifies the value used in emitted Connectivity TLV "Rx-off Child Datagram Count" field which indicates the
+ * guaranteed queue capacity in number of IPv6 datagrams destined to a given rx-off-when-idle child.
+ *
+ * Similar to `OPENTHREAD_CONFIG_DEFAULT_SED_BUFFER_SIZE`, vendors should ensure their device can support the specified
+ * value based on the message buffer model used.
  *
  */
 #ifndef OPENTHREAD_CONFIG_DEFAULT_SED_DATAGRAM_COUNT


### PR DESCRIPTION
This commit updates the documentation for two configs `OPENTHREAD_CONFIG_DEFAULT_SED_BUFFER_SIZE` and `SED_DATAGRAM_COUNT` clarifying their intended use.