### PR TITLE
[cli] fix CoAP response code for POST 2.03 -> 2.04 per RFC 7252

### DIFF
--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -949,7 +949,7 @@ void Coap::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo)
         }
         else
         {
-            responseCode = OT_COAP_CODE_VALID;
+            responseCode = OT_COAP_CODE_CHANGED;
         }
 
         responseMessage = otCoapNewMessage(GetInstancePtr(), nullptr);


### PR DESCRIPTION
CoAP response code 2.04 Changed is the default response to a successful POST request. See RFC 7252 5.8.2 and 5.9.1.4.