### PR TITLE
[netata] simplify `RemoveTemporaryData()`

### DIFF
--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -769,8 +769,8 @@ protected:
     void RemoveTemporaryData(void);
 
 private:
-    void RemoveTemporaryDataIn(PrefixTlv &aPrefix);
-    void RemoveTemporaryDataIn(ServiceTlv &aService);
+    bool RemoveTemporaryDataIn(PrefixTlv &aPrefix);
+    bool RemoveTemporaryDataIn(ServiceTlv &aService);
 
     uint8_t mSize;
 };


### PR DESCRIPTION
This commit simplifies `MutableNetworkData::RemoveTemporaryData()`:
- The `RemoveTemporaryDataIn()` methods return a `bool` indicating whether the whole TLV can be removed.
- The code is refactored to combine the call to `RemoveTlv()` for all TLV types.