### PR TITLE
[spinel] add time sync feature to the spinel

### DIFF
--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -151,6 +151,11 @@ void RadioSpinel::Init(SpinelInterface    &aSpinelInterface,
     mSpinelInterface = &aSpinelInterface;
     SuccessOrDie(mSpinelInterface->Init(HandleReceivedFrame, this, mRxFrameBuffer));
 
+#if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT && OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    memset(&mTxIeInfo, 0, sizeof(otRadioIeInfo));
+    mTxRadioFrame.mInfo.mTxInfo.mIeInfo = &mTxIeInfo;
+#endif
+
     VerifyOrDie(aIidList != nullptr, OT_EXIT_INVALID_ARGUMENTS);
     VerifyOrDie(aIidListLength != 0 && aIidListLength <= OT_ARRAY_LENGTH(mIidList), OT_EXIT_INVALID_ARGUMENTS);
     mIid = aIidList[0];
@@ -1804,6 +1809,43 @@ otError RadioSpinel::Transmit(otRadioFrame &aFrame)
     VerifyOrExit(mState == kStateReceive || (mState == kStateSleep && (sRadioCaps & OT_RADIO_CAPS_SLEEP_TO_TX)));
 
     mTransmitFrame = &aFrame;
+
+#if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT && OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    if (mTransmitFrame->mInfo.mTxInfo.mIeInfo->mTimeIeOffset != 0)
+    {
+        uint64_t netRadioTime = otPlatRadioGetNow(mInstance);
+        uint64_t netSyncTime;
+        uint8_t *timeIe = mTransmitFrame->mPsdu + mTransmitFrame->mInfo.mTxInfo.mIeInfo->mTimeIeOffset;
+
+        if (netRadioTime == UINT64_MAX)
+        {
+            // If we can't get the radio time, get the platform time
+            netSyncTime = static_cast<uint64_t>(static_cast<int64_t>(otPlatTimeGet()) +
+                                                mTransmitFrame->mInfo.mTxInfo.mIeInfo->mNetworkTimeOffset);
+        }
+        else
+        {
+            uint32_t transmitDelay = 0;
+
+            // If supported, add a delay and transmit the network time at a precise moment
+#if !OPENTHREAD_MTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+            transmitDelay                                  = kTxWaitUs / 10;
+            mTransmitFrame->mInfo.mTxInfo.mTxDelayBaseTime = static_cast<uint32_t>(netRadioTime);
+            mTransmitFrame->mInfo.mTxInfo.mTxDelay         = transmitDelay;
+#endif
+            netSyncTime = static_cast<uint64_t>(static_cast<int64_t>(netRadioTime) + transmitDelay +
+                                                mTransmitFrame->mInfo.mTxInfo.mIeInfo->mNetworkTimeOffset);
+        }
+
+        *(timeIe++) = mTransmitFrame->mInfo.mTxInfo.mIeInfo->mTimeSyncSeq;
+
+        for (uint8_t i = 0; i < sizeof(uint64_t); i++)
+        {
+            *(timeIe++) = static_cast<uint8_t>(netSyncTime & 0xff);
+            netSyncTime = netSyncTime >> 8;
+        }
+    }
+#endif // OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT && OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
     // `otPlatRadioTxStarted()` is triggered immediately for now, which may be earlier than real started time.
     mCallbacks.mTxStarted(mInstance, mTransmitFrame);

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -1266,6 +1266,10 @@ private:
     otRadioFrame  mAckRadioFrame;
     otRadioFrame *mTransmitFrame; ///< Points to the frame to send
 
+#if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT && OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    otRadioIeInfo mTxIeInfo;
+#endif
+
     otExtAddress        mExtendedAddress;
     uint16_t            mShortAddress;
     uint16_t            mPanId;


### PR DESCRIPTION
This commit add the structure needed to support time sync to spinel. 

Resolve :
https://github.com/openthread/openthread/issues/6028

Also resolve the same null pointer problem when time sync was enable on a multi core with a radio core device like nrf5340.