### PR TITLE
[message-pool] evict message from coap pending request queue if send queue is empty

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -558,6 +558,20 @@ exit:
     return messageCopy;
 }
 
+Error CoapBase::EvictMessage(void)
+{
+    Error    error = kErrorNone;
+    Message *message;
+
+    message = mPendingRequests.GetHead();
+
+    VerifyOrExit(message != nullptr, error = kErrorNotFound);
+    LogInfo("Evicting message from head of CoAP pending requests queue");
+    DequeueMessage(*message);
+exit:
+    return error;
+}
+
 void CoapBase::DequeueMessage(Message &aMessage)
 {
     mPendingRequests.Dequeue(aMessage);

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -732,6 +732,13 @@ public:
      * @returns A reference to the cached response list.
      */
     const MessageQueue &GetCachedResponses(void) const { return mResponsesQueue.GetResponses(); }
+    /**
+     * Evicts a message from the pending requests queue.
+     *
+     * @retval kErrorNone       Successfully evicted a message.
+     * @retval kErrorNotFound   No message in the queue to evict.
+     */
+    otError EvictMessage(void);
 
 protected:
     /**

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -149,7 +149,15 @@ void MessagePool::FreeBuffers(Buffer *aBuffer)
     }
 }
 
-Error MessagePool::ReclaimBuffers(Message::Priority aPriority) { return Get<MeshForwarder>().EvictMessage(aPriority); }
+Error MessagePool::ReclaimBuffers(Message::Priority aPriority)
+{
+    Error error = kErrorNotFound;
+    error       = Get<MeshForwarder>().EvictMessage(aPriority);
+    VerifyOrExit(error == kErrorNotFound);
+    error = Get<Tmf::Agent>().EvictMessage();
+exit:
+    return error;
+}
 
 uint16_t MessagePool::GetFreeBufferCount(void) const
 {


### PR DESCRIPTION
If the send queue is empty, currently the messages are not evicted and this could cause received messages to be dropped when too many pending address query notifications. The changes made are to evict the message from head of the coap pending request queue if send queue is empty and new buffer cannot be allocated