### PR TITLE
[link-metrics] fix race condition

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1220,9 +1220,11 @@ void Frame::SetEnhAckProbingIe(const uint8_t *aValue, uint8_t aLen)
 {
     uint8_t *cur = GetThreadIe(ThreadIe::kEnhAckProbingIe);
 
-    OT_ASSERT(cur != nullptr);
-
+    VerifyOrExit(cur != nullptr);
     memcpy(cur + sizeof(HeaderIe) + sizeof(VendorIeHeader), aValue, aLen);
+
+exit:
+    return;
 }
 #endif // OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
 


### PR DESCRIPTION
Currently for Enh-ACK based probing feature, the result IE is written in ISR context (for example, `nrf_802154_tx_ack_started`, just like CSL IE). This may cause a race condition:

When the device configures Enh-ACK Probing for a neighbor, [otPlatRadioConfigureEnhAckProbing](https://github.com/openthread/ot-nrf528xx/blob/main/src/src/radio.c#L1429) is called:
```
    error = otLinkMetricsConfigureEnhAckProbing(aShortAddress, aExtAddress, aLinkMetrics);
    otEXPECT(error == OT_ERROR_NONE);
    updateIeData(aInstance, aShortAddress, aExtAddress);
```

If `otLinkMetricsConfigureEnhAckProbing` is completed but `updateIeData` hasn't been done, and `nrf_802154_tx_ack_started` is called, then it will think there should be link metrics IE for this neighbor however the IE hasn't been added into the ACK template for this neighbor in the platform thus we cannot find Thread IE from the generated Enh ACK. So if we call `SetEnhAckProbingIe` at this moment with an assert, we will get a crash.

So we should just exit at this moment. [SetCslIe](https://github.com/openthread/openthread/blob/main/src/core/mac/mac_frame.cpp#L1208) does the same thing.