### PR TITLE
[ip6] allow delivering RLOC/ALOC traffic to host

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -955,17 +955,6 @@ Error Ip6::PassToHost(OwnedPtr<Message> &aMessagePtr,
 
     if (mIsReceiveIp6FilterEnabled && aApplyFilter)
     {
-#if !OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
-        // Do not pass messages sent to an RLOC/ALOC, except
-        // Service Locator
-
-        bool isLocator = Get<Mle::Mle>().IsMeshLocalAddress(aMessageInfo.GetSockAddr()) &&
-                         aMessageInfo.GetSockAddr().GetIid().IsLocator();
-
-        VerifyOrExit(!isLocator || aMessageInfo.GetSockAddr().GetIid().IsAnycastServiceLocator(),
-                     error = kErrorNoRoute);
-#endif
-
         switch (aIpProto)
         {
         case kProtoIcmp6:


### PR DESCRIPTION
Filtering out traffic to/from RLOC/ALOC was added by #423 for #419. The intention was to filter out Thread's control traffic.

Now we already added filtering out traffic by checking whether it is destined to a service hosted in OpenThread stack(https://github.com/openthread/openthread/pull/6711), so filtering out by RLOC/ALOC is not necessary anymore.

This commit removes this filter, as a result, the core lib gets rid of the `PLATFORM_NETIF` flag.