### PR TITLE
[plat-utils] enhance `otMacFrameDoesAddrMatch()`

### DIFF
--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -43,7 +43,7 @@ bool otMacFrameDoesAddrMatch(const otRadioFrame *aFrame,
     Mac::Address      dst;
     Mac::PanId        panid;
 
-    SuccessOrExit(frame.GetDstAddr(dst));
+    VerifyOrExit(frame.GetDstAddr(dst) == kErrorNone, rval = false);
 
     switch (dst.GetType())
     {


### PR DESCRIPTION
This commit updates `otMacFrameDoesAddrMatch()` to ensure it does not match if frame is malformed (`Frame::GetDstAddr()` fails).