### PR TITLE
[mpl] remove mpl entry from forwarding queue if the address query matches the host or one of its children

### DIFF
--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -349,6 +349,11 @@ public:
      */
     void ResetBorderRoutingCounters(void) { ClearAllBytes(mBorderRoutingCounters); }
 #endif
+    /**
+     * Removes matching MPL entry.
+     *
+     */
+    void RemoveMplEntry(Message &aMessage) { mMpl.RemoveMatchedMessage(aMessage); }
 
 private:
     static constexpr uint8_t kDefaultHopLimit      = OPENTHREAD_CONFIG_IP6_HOP_LIMIT_DEFAULT;

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -334,6 +334,28 @@ uint8_t Mpl::DetermineMaxRetransmissions(void) const
     return maxRetx;
 }
 
+bool Mpl::RemoveMatchedMessage(Message &aMessage)
+{
+    bool     match = false;
+    uint16_t len   = aMessage.GetLength();
+    
+    VerifyOrExit(len > 0);
+    for (Message &message : mBufferedMessageSet)
+    {
+        if (message.GetLength() - sizeof(Metadata) >= len)
+        {
+            if (aMessage.CompareBytes(0, message, message.GetLength() - sizeof(Metadata) - len, len))
+            {
+                mBufferedMessageSet.DequeueAndFree(message);
+                match = true;
+                break;
+            }
+        }
+    }
+exit:
+    return match;
+}
+
 void Mpl::AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSequence)
 {
     Error    error       = kErrorNone;

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -212,6 +212,13 @@ public:
      */
     const MessageQueue &GetBufferedMessageSet(void) const { return mBufferedMessageSet; }
 #endif
+    /**
+     * Compare with the MPL messages in the buffered set and remove the first matched entry
+     *
+     * @retval true  Successfully found and removed
+     * @retval false Failed to find
+     */
+    bool RemoveMatchedMessage(Message &aMessage);
 
 private:
     static constexpr uint16_t kNumSeedEntries      = OPENTHREAD_CONFIG_MPL_SEED_SET_ENTRIES;

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -858,6 +858,7 @@ void AddressResolver::HandleTmf<kUriAddressQuery>(Coap::Message &aMessage, const
     {
         SendAddressQueryResponse(target, Get<Mle::MleRouter>().GetMeshLocal64().GetIid(), nullptr,
                                  aMessageInfo.GetPeerAddr());
+        Get<Ip6::Ip6>().RemoveMplEntry(aMessage);
         ExitNow();
     }
 
@@ -872,6 +873,7 @@ void AddressResolver::HandleTmf<kUriAddressQuery>(Coap::Message &aMessage, const
         {
             lastTransactionTime = Time::MsecToSec(TimerMilli::GetNow() - child.GetLastHeard());
             SendAddressQueryResponse(target, child.GetMeshLocalIid(), &lastTransactionTime, aMessageInfo.GetPeerAddr());
+            Get<Ip6::Ip6>().RemoveMplEntry(aMessage);
             ExitNow();
         }
     }


### PR DESCRIPTION
Remove the additional forwarding of AddressQuery messages if the current host or one of the children responds with AddressNotify