### PR TITLE
[spinel] check the frame buffer size before reading the next frame

### DIFF
--- a/src/lib/spinel/multi_frame_buffer.hpp
+++ b/src/lib/spinel/multi_frame_buffer.hpp
@@ -371,7 +371,7 @@ public:
 
         aFrame = (aFrame == nullptr) ? mBuffer : aFrame + aLength;
 
-        if (HasSavedFrame() && (aFrame != mWriteFrameStart))
+        if (HasSavedFrame() && (aFrame != mWriteFrameStart) && ((aFrame + kHeaderSize) < GetArrayEnd(mBuffer)))
         {
             uint16_t totalLength = LittleEndian::ReadUint16(aFrame + kHeaderTotalLengthOffset);
             uint16_t skipLength  = LittleEndian::ReadUint16(aFrame + kHeaderSkipLengthOffset);


### PR DESCRIPTION
When the spinel rx multiple frame buffer is full, calling `GetNextSavedFrame()` may cause the code to access the area behind the multiple frame buffer.

This commit checks the received frame buffer size before reading the next frame to avoid accessing illegal area.