### PR TITLE
[udp] add DHCP ports to `ShouldUsePlatformUdpFunction`

### DIFF
--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -552,6 +552,12 @@ bool Udp::ShouldUsePlatformUdp(uint16_t aPort) const
 #if OPENTHREAD_FTD
             && aPort != Get<MeshCoP::JoinerRouter>().GetJoinerUdpPort()
 #endif
+#if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
+            && aPort != Dhcp6::kDhcpServerPort
+#endif
+#if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
+            && aPort != Dhcp6::kDhcpClientPort
+#endif
     );
 }
 


### PR DESCRIPTION
This commit aims to add more flags to the `ShouldUsePlatformUdp` function, to let sockets with ports belonging to the stack send their packets without using the UDP platform abstractization layer.

Without this change, when Platform UDP is enabled, packets originating from the DHCPv6 Server/Client will take an undesired route from socket -> platform UDP -> external IPv6 stack -> Thread IP stack -> packet over the air.