### PR TITLE
[dataset] define template method to check/get/set components

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -104,49 +104,49 @@ bool Dataset::Info::IsSubsetOf(const Info &aOther) const
 {
     bool isSubset = false;
 
-    if (IsNetworkKeyPresent())
+    if (IsPresent<kNetworkKey>())
     {
-        VerifyOrExit(aOther.IsNetworkKeyPresent() && GetNetworkKey() == aOther.GetNetworkKey());
+        VerifyOrExit(aOther.IsPresent<kNetworkKey>() && Get<kNetworkKey>() == aOther.Get<kNetworkKey>());
     }
 
-    if (IsNetworkNamePresent())
+    if (IsPresent<kNetworkName>())
     {
-        VerifyOrExit(aOther.IsNetworkNamePresent() && GetNetworkName() == aOther.GetNetworkName());
+        VerifyOrExit(aOther.IsPresent<kNetworkName>() && Get<kNetworkName>() == aOther.Get<kNetworkName>());
     }
 
-    if (IsExtendedPanIdPresent())
+    if (IsPresent<kExtendedPanId>())
     {
-        VerifyOrExit(aOther.IsExtendedPanIdPresent() && GetExtendedPanId() == aOther.GetExtendedPanId());
+        VerifyOrExit(aOther.IsPresent<kExtendedPanId>() && Get<kExtendedPanId>() == aOther.Get<kExtendedPanId>());
     }
 
-    if (IsMeshLocalPrefixPresent())
+    if (IsPresent<kMeshLocalPrefix>())
     {
-        VerifyOrExit(aOther.IsMeshLocalPrefixPresent() && GetMeshLocalPrefix() == aOther.GetMeshLocalPrefix());
+        VerifyOrExit(aOther.IsPresent<kMeshLocalPrefix>() && Get<kMeshLocalPrefix>() == aOther.Get<kMeshLocalPrefix>());
     }
 
-    if (IsPanIdPresent())
+    if (IsPresent<kPanId>())
     {
-        VerifyOrExit(aOther.IsPanIdPresent() && GetPanId() == aOther.GetPanId());
+        VerifyOrExit(aOther.IsPresent<kPanId>() && Get<kPanId>() == aOther.Get<kPanId>());
     }
 
-    if (IsChannelPresent())
+    if (IsPresent<kChannel>())
     {
-        VerifyOrExit(aOther.IsChannelPresent() && GetChannel() == aOther.GetChannel());
+        VerifyOrExit(aOther.IsPresent<kChannel>() && Get<kChannel>() == aOther.Get<kChannel>());
     }
 
-    if (IsPskcPresent())
+    if (IsPresent<kPskc>())
     {
-        VerifyOrExit(aOther.IsPskcPresent() && GetPskc() == aOther.GetPskc());
+        VerifyOrExit(aOther.IsPresent<kPskc>() && Get<kPskc>() == aOther.Get<kPskc>());
     }
 
-    if (IsSecurityPolicyPresent())
+    if (IsPresent<kSecurityPolicy>())
     {
-        VerifyOrExit(aOther.IsSecurityPolicyPresent() && GetSecurityPolicy() == aOther.GetSecurityPolicy());
+        VerifyOrExit(aOther.IsPresent<kSecurityPolicy>() && Get<kSecurityPolicy>() == aOther.Get<kSecurityPolicy>());
     }
 
-    if (IsChannelMaskPresent())
+    if (IsPresent<kChannelMask>())
     {
-        VerifyOrExit(aOther.IsChannelMaskPresent() && GetChannelMask() == aOther.GetChannelMask());
+        VerifyOrExit(aOther.IsPresent<kChannelMask>() && Get<kChannelMask>() == aOther.Get<kChannelMask>());
     }
 
     isSubset = true;
@@ -190,11 +190,11 @@ void Dataset::ConvertTo(Info &aDatasetInfo) const
         switch (cur->GetType())
         {
         case Tlv::kActiveTimestamp:
-            aDatasetInfo.SetActiveTimestamp(cur->ReadValueAs<ActiveTimestampTlv>());
+            aDatasetInfo.Set<kActiveTimestamp>(cur->ReadValueAs<ActiveTimestampTlv>());
             break;
 
         case Tlv::kChannel:
-            aDatasetInfo.SetChannel(cur->ReadValueAs<ChannelTlv>().GetChannel());
+            aDatasetInfo.Set<kChannel>(cur->ReadValueAs<ChannelTlv>().GetChannel());
             break;
 
         case Tlv::kChannelMask:
@@ -203,46 +203,46 @@ void Dataset::ConvertTo(Info &aDatasetInfo) const
 
             if (As<ChannelMaskTlv>(cur)->ReadChannelMask(mask) == kErrorNone)
             {
-                aDatasetInfo.SetChannelMask(mask);
+                aDatasetInfo.Set<kChannelMask>(mask);
             }
 
             break;
         }
 
         case Tlv::kDelayTimer:
-            aDatasetInfo.SetDelay(cur->ReadValueAs<DelayTimerTlv>());
+            aDatasetInfo.Set<kDelay>(cur->ReadValueAs<DelayTimerTlv>());
             break;
 
         case Tlv::kExtendedPanId:
-            aDatasetInfo.SetExtendedPanId(cur->ReadValueAs<ExtendedPanIdTlv>());
+            aDatasetInfo.Set<kExtendedPanId>(cur->ReadValueAs<ExtendedPanIdTlv>());
             break;
 
         case Tlv::kMeshLocalPrefix:
-            aDatasetInfo.SetMeshLocalPrefix(cur->ReadValueAs<MeshLocalPrefixTlv>());
+            aDatasetInfo.Set<kMeshLocalPrefix>(cur->ReadValueAs<MeshLocalPrefixTlv>());
             break;
 
         case Tlv::kNetworkKey:
-            aDatasetInfo.SetNetworkKey(cur->ReadValueAs<NetworkKeyTlv>());
+            aDatasetInfo.Set<kNetworkKey>(cur->ReadValueAs<NetworkKeyTlv>());
             break;
 
         case Tlv::kNetworkName:
-            aDatasetInfo.SetNetworkName(As<NetworkNameTlv>(cur)->GetNetworkName());
+            IgnoreError(aDatasetInfo.Update<kNetworkName>().Set(As<NetworkNameTlv>(cur)->GetNetworkName()));
             break;
 
         case Tlv::kPanId:
-            aDatasetInfo.SetPanId(cur->ReadValueAs<PanIdTlv>());
+            aDatasetInfo.Set<kPanId>(cur->ReadValueAs<PanIdTlv>());
             break;
 
         case Tlv::kPendingTimestamp:
-            aDatasetInfo.SetPendingTimestamp(cur->ReadValueAs<PendingTimestampTlv>());
+            aDatasetInfo.Set<kPendingTimestamp>(cur->ReadValueAs<PendingTimestampTlv>());
             break;
 
         case Tlv::kPskc:
-            aDatasetInfo.SetPskc(cur->ReadValueAs<PskcTlv>());
+            aDatasetInfo.Set<kPskc>(cur->ReadValueAs<PskcTlv>());
             break;
 
         case Tlv::kSecurityPolicy:
-            aDatasetInfo.SetSecurityPolicy(As<SecurityPolicyTlv>(cur)->GetSecurityPolicy());
+            aDatasetInfo.Set<kSecurityPolicy>(As<SecurityPolicyTlv>(cur)->GetSecurityPolicy());
             break;
 
         default:
@@ -281,81 +281,81 @@ Error Dataset::SetFrom(const Info &aDatasetInfo)
 {
     Error error = kErrorNone;
 
-    if (aDatasetInfo.IsActiveTimestampPresent())
+    if (aDatasetInfo.IsPresent<kActiveTimestamp>())
     {
         Timestamp activeTimestamp;
 
-        aDatasetInfo.GetActiveTimestamp(activeTimestamp);
+        aDatasetInfo.Get<kActiveTimestamp>(activeTimestamp);
         IgnoreError(Write<ActiveTimestampTlv>(activeTimestamp));
     }
 
-    if (aDatasetInfo.IsPendingTimestampPresent())
+    if (aDatasetInfo.IsPresent<kPendingTimestamp>())
     {
         Timestamp pendingTimestamp;
 
-        aDatasetInfo.GetPendingTimestamp(pendingTimestamp);
+        aDatasetInfo.Get<kPendingTimestamp>(pendingTimestamp);
         IgnoreError(Write<PendingTimestampTlv>(pendingTimestamp));
     }
 
-    if (aDatasetInfo.IsDelayPresent())
+    if (aDatasetInfo.IsPresent<kDelay>())
     {
-        IgnoreError(Write<DelayTimerTlv>(aDatasetInfo.GetDelay()));
+        IgnoreError(Write<DelayTimerTlv>(aDatasetInfo.Get<kDelay>()));
     }
 
-    if (aDatasetInfo.IsChannelPresent())
+    if (aDatasetInfo.IsPresent<kChannel>())
     {
         ChannelTlvValue channelValue;
 
-        channelValue.SetChannelAndPage(aDatasetInfo.GetChannel());
+        channelValue.SetChannelAndPage(aDatasetInfo.Get<kChannel>());
         IgnoreError(Write<ChannelTlv>(channelValue));
     }
 
-    if (aDatasetInfo.IsChannelMaskPresent())
+    if (aDatasetInfo.IsPresent<kChannelMask>())
     {
         ChannelMaskTlv::Value value;
 
-        ChannelMaskTlv::PrepareValue(value, aDatasetInfo.GetChannelMask());
+        ChannelMaskTlv::PrepareValue(value, aDatasetInfo.Get<kChannelMask>());
         IgnoreError(WriteTlv(Tlv::kChannelMask, value.mData, value.mLength));
     }
 
-    if (aDatasetInfo.IsExtendedPanIdPresent())
+    if (aDatasetInfo.IsPresent<kExtendedPanId>())
     {
-        IgnoreError(Write<ExtendedPanIdTlv>(aDatasetInfo.GetExtendedPanId()));
+        IgnoreError(Write<ExtendedPanIdTlv>(aDatasetInfo.Get<kExtendedPanId>()));
     }
 
-    if (aDatasetInfo.IsMeshLocalPrefixPresent())
+    if (aDatasetInfo.IsPresent<kMeshLocalPrefix>())
     {
-        IgnoreError(Write<MeshLocalPrefixTlv>(aDatasetInfo.GetMeshLocalPrefix()));
+        IgnoreError(Write<MeshLocalPrefixTlv>(aDatasetInfo.Get<kMeshLocalPrefix>()));
     }
 
-    if (aDatasetInfo.IsNetworkKeyPresent())
+    if (aDatasetInfo.IsPresent<kNetworkKey>())
     {
-        IgnoreError(Write<NetworkKeyTlv>(aDatasetInfo.GetNetworkKey()));
+        IgnoreError(Write<NetworkKeyTlv>(aDatasetInfo.Get<kNetworkKey>()));
     }
 
-    if (aDatasetInfo.IsNetworkNamePresent())
+    if (aDatasetInfo.IsPresent<kNetworkName>())
     {
-        NameData nameData = aDatasetInfo.GetNetworkName().GetAsData();
+        NameData nameData = aDatasetInfo.Get<kNetworkName>().GetAsData();
 
         IgnoreError(WriteTlv(Tlv::kNetworkName, nameData.GetBuffer(), nameData.GetLength()));
     }
 
-    if (aDatasetInfo.IsPanIdPresent())
+    if (aDatasetInfo.IsPresent<kPanId>())
     {
-        IgnoreError(Write<PanIdTlv>(aDatasetInfo.GetPanId()));
+        IgnoreError(Write<PanIdTlv>(aDatasetInfo.Get<kPanId>()));
     }
 
-    if (aDatasetInfo.IsPskcPresent())
+    if (aDatasetInfo.IsPresent<kPskc>())
     {
-        IgnoreError(Write<PskcTlv>(aDatasetInfo.GetPskc()));
+        IgnoreError(Write<PskcTlv>(aDatasetInfo.Get<kPskc>()));
     }
 
-    if (aDatasetInfo.IsSecurityPolicyPresent())
+    if (aDatasetInfo.IsPresent<kSecurityPolicy>())
     {
         SecurityPolicyTlv tlv;
 
         tlv.Init();
-        tlv.SetSecurityPolicy(aDatasetInfo.GetSecurityPolicy());
+        tlv.SetSecurityPolicy(aDatasetInfo.Get<kSecurityPolicy>());
         IgnoreError(WriteTlv(tlv));
     }
 

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -82,107 +82,51 @@ public:
     typedef otOperationalDatasetTlvs Tlvs;
 
     /**
+     * Represents a component in Dataset.
+     *
+     */
+    enum Component : uint8_t
+    {
+        kActiveTimestamp,  ///< Active Timestamp
+        kPendingTimestamp, ///< Pending Timestamp
+        kNetworkKey,       ///< Network Key
+        kNetworkName,      ///< Network Name
+        kExtendedPanId,    ///< Extended PAN Identifier
+        kMeshLocalPrefix,  ///< Mesh Local Prefix
+        kDelay,            ///< Delay
+        kPanId,            ///< PAN Identifier
+        kChannel,          ///< Channel
+        kPskc,             ///< PSKc
+        kSecurityPolicy,   ///< Security Policy
+        kChannelMask,      ///< Channel Mask
+    };
+
+    template <Component kComponent> struct TypeFor; ///< Specifies the associate type for a given `Component`.
+
+    class Info;
+
+    /**
      * Represents presence of different components in Active or Pending Operational Dataset.
      *
      */
     class Components : public otOperationalDatasetComponents, public Clearable<Components>
     {
+        friend class Info;
+
     public:
         /**
-         * Indicates whether or not the Active Timestamp is present in the Dataset.
+         * Indicates whether or not the specified `kComponent` is present in the Dataset.
          *
-         * @returns TRUE if Active Timestamp is present, FALSE otherwise.
+         * @tparam kComponent  The component to check.
+         *
+         * @retval TRUE   The component is present in the Dataset.
+         * @retval FALSE  The component is not present in the Dataset.
          *
          */
-        bool IsActiveTimestampPresent(void) const { return mIsActiveTimestampPresent; }
+        template <Component kComponent> bool IsPresent(void) const;
 
-        /**
-         * Indicates whether or not the Pending Timestamp is present in the Dataset.
-         *
-         * @returns TRUE if Pending Timestamp is present, FALSE otherwise.
-         *
-         */
-        bool IsPendingTimestampPresent(void) const { return mIsPendingTimestampPresent; }
-
-        /**
-         * Indicates whether or not the Network Key is present in the Dataset.
-         *
-         * @returns TRUE if Network Key is present, FALSE otherwise.
-         *
-         */
-        bool IsNetworkKeyPresent(void) const { return mIsNetworkKeyPresent; }
-
-        /**
-         * Indicates whether or not the Network Name is present in the Dataset.
-         *
-         * @returns TRUE if Network Name is present, FALSE otherwise.
-         *
-         */
-        bool IsNetworkNamePresent(void) const { return mIsNetworkNamePresent; }
-
-        /**
-         * Indicates whether or not the Extended PAN ID is present in the Dataset.
-         *
-         * @returns TRUE if Extended PAN ID is present, FALSE otherwise.
-         *
-         */
-        bool IsExtendedPanIdPresent(void) const { return mIsExtendedPanIdPresent; }
-
-        /**
-         * Indicates whether or not the Mesh Local Prefix is present in the Dataset.
-         *
-         * @returns TRUE if Mesh Local Prefix is present, FALSE otherwise.
-         *
-         */
-        bool IsMeshLocalPrefixPresent(void) const { return mIsMeshLocalPrefixPresent; }
-
-        /**
-         * Indicates whether or not the Delay Timer is present in the Dataset.
-         *
-         * @returns TRUE if Delay Timer is present, FALSE otherwise.
-         *
-         */
-        bool IsDelayPresent(void) const { return mIsDelayPresent; }
-
-        /**
-         * Indicates whether or not the PAN ID is present in the Dataset.
-         *
-         * @returns TRUE if PAN ID is present, FALSE otherwise.
-         *
-         */
-        bool IsPanIdPresent(void) const { return mIsPanIdPresent; }
-
-        /**
-         * Indicates whether or not the Channel is present in the Dataset.
-         *
-         * @returns TRUE if Channel is present, FALSE otherwise.
-         *
-         */
-        bool IsChannelPresent(void) const { return mIsChannelPresent; }
-
-        /**
-         * Indicates whether or not the PSKc is present in the Dataset.
-         *
-         * @returns TRUE if PSKc is present, FALSE otherwise.
-         *
-         */
-        bool IsPskcPresent(void) const { return mIsPskcPresent; }
-
-        /**
-         * Indicates whether or not the Security Policy is present in the Dataset.
-         *
-         * @returns TRUE if Security Policy is present, FALSE otherwise.
-         *
-         */
-        bool IsSecurityPolicyPresent(void) const { return mIsSecurityPolicyPresent; }
-
-        /**
-         * Indicates whether or not the Channel Mask is present in the Dataset.
-         *
-         * @returns TRUE if Channel Mask is present, FALSE otherwise.
-         *
-         */
-        bool IsChannelMaskPresent(void) const { return mIsChannelMaskPresent; }
+    private:
+        template <Component kComponent> void MarkAsPresent(void);
     };
 
     /**
@@ -193,389 +137,66 @@ public:
     {
     public:
         /**
-         * Indicates whether or not the Active Timestamp is present in the Dataset.
+         * Indicates whether or not the specified component is present in the Dataset.
          *
-         * @returns TRUE if Active Timestamp is present, FALSE otherwise.
+         * @tparam kComponent  The component to check.
+         *
+         * @retval TRUE   The component is present in the Dataset.
+         * @retval FALSE  The component is not present in the Dataset.
          *
          */
-        bool IsActiveTimestampPresent(void) const { return mComponents.mIsActiveTimestampPresent; }
+        template <Component kComponent> bool IsPresent(void) const { return GetComponents().IsPresent<kComponent>(); }
 
         /**
-         * Gets the Active Timestamp in the Dataset.
+         * Gets the specified component in the Dataset.
          *
-         * MUST be used when Active Timestamp component is present in the Dataset, otherwise its behavior is
-         * undefined.
+         * @tparam  kComponent  The component to check.
          *
-         * @param[out] aTimestamp  A reference to output the Active Timestamp in the Dataset.
+         * MUST be used when component is present in the Dataset, otherwise its behavior is undefined.
+         *
+         * @returns The component value.
          *
          */
-        void GetActiveTimestamp(Timestamp &aTimestamp) const { aTimestamp.SetFromTimestamp(mActiveTimestamp); }
+        template <Component kComponent> const typename TypeFor<kComponent>::Type &Get(void) const;
 
         /**
-         * Sets the Active Timestamp in the Dataset.
+         * Gets the specified component in the Dataset.
          *
-         * @param[in] aTimestamp   A Timestamp value.
+         * @tparam  kComponent  The component to check.
+         *
+         * MUST be used when component is present in the Dataset, otherwise its behavior is undefined.
+         *
+         * @pram[out] aComponent  A reference to output the component value.
          *
          */
-        void SetActiveTimestamp(const Timestamp &aTimestamp)
+        template <Component kComponent> void Get(typename TypeFor<kComponent>::Type &aComponent) const;
+
+        /**
+         * Sets the specified component in the Dataset.
+         *
+         * @tparam  kComponent  The component to set.
+         *
+         * @param[in] aComponent   The component value.
+         *
+         */
+        template <Component kComponent> void Set(const typename TypeFor<kComponent>::Type &aComponent)
         {
-            aTimestamp.ConvertTo(mActiveTimestamp);
-            mComponents.mIsActiveTimestampPresent = true;
+            GetComponents().MarkAsPresent<kComponent>();
+            AsNonConst(Get<kComponent>()) = aComponent;
         }
 
         /**
-         * Indicates whether or not the Pending Timestamp is present in the Dataset.
+         * Returns a reference to the specified component in the Dataset to be updated by caller.
          *
-         * @returns TRUE if Pending Timestamp is present, FALSE otherwise.
+         * @tparam  kComponent  The component to set.
          *
-         */
-        bool IsPendingTimestampPresent(void) const { return mComponents.mIsPendingTimestampPresent; }
-
-        /**
-         * Gets the Pending Timestamp in the Dataset.
-         *
-         * MUST be used when Pending Timestamp component is present in the Dataset, otherwise its behavior
-         * is undefined.
-         *
-         * @param[out] aTimestamp  A reference to output the Pending Timestamp in the Dataset.
+         * @returns A reference to the component in the Dataset.
          *
          */
-        void GetPendingTimestamp(Timestamp &aTimestamp) const { aTimestamp.SetFromTimestamp(mPendingTimestamp); }
-
-        /**
-         * Sets the Pending Timestamp in the Dataset.
-         *
-         * @param[in] aTimestamp   A Timestamp value.
-         *
-         */
-        void SetPendingTimestamp(const Timestamp &aTimestamp)
+        template <Component kComponent> typename TypeFor<kComponent>::Type &Update(void)
         {
-            aTimestamp.ConvertTo(mPendingTimestamp);
-            mComponents.mIsPendingTimestampPresent = true;
-        }
-
-        /**
-         * Indicates whether or not the Network Key is present in the Dataset.
-         *
-         * @returns TRUE if Network Key is present, FALSE otherwise.
-         *
-         */
-        bool IsNetworkKeyPresent(void) const { return mComponents.mIsNetworkKeyPresent; }
-
-        /**
-         * Gets the Network Key in the Dataset.
-         *
-         * MUST be used when Network Key component is present in the Dataset, otherwise its behavior
-         * is undefined.
-         *
-         * @returns The Network Key in the Dataset.
-         *
-         */
-        const NetworkKey &GetNetworkKey(void) const { return AsCoreType(&mNetworkKey); }
-
-        /**
-         * Sets the Network Key in the Dataset.
-         *
-         * @param[in] aNetworkKey  A Network Key.
-         *
-         */
-        void SetNetworkKey(const NetworkKey &aNetworkKey)
-        {
-            mNetworkKey                      = aNetworkKey;
-            mComponents.mIsNetworkKeyPresent = true;
-        }
-
-        /**
-         * Returns a reference to the Network Key in the Dataset to be updated by caller.
-         *
-         * @returns A reference to the Network Key in the Dataset.
-         *
-         */
-        NetworkKey &UpdateNetworkKey(void)
-        {
-            mComponents.mIsNetworkKeyPresent = true;
-            return AsCoreType(&mNetworkKey);
-        }
-
-        /**
-         * Indicates whether or not the Network Name is present in the Dataset.
-         *
-         * @returns TRUE if Network Name is present, FALSE otherwise.
-         *
-         */
-        bool IsNetworkNamePresent(void) const { return mComponents.mIsNetworkNamePresent; }
-
-        /**
-         * Gets the Network Name in the Dataset.
-         *
-         * MUST be used when Network Name component is present in the Dataset, otherwise its behavior is
-         * undefined.
-         *
-         * @returns The Network Name in the Dataset.
-         *
-         */
-        const NetworkName &GetNetworkName(void) const { return AsCoreType(&mNetworkName); }
-
-        /**
-         * Sets the Network Name in the Dataset.
-         *
-         * @param[in] aNetworkNameData   A Network Name Data.
-         *
-         */
-        void SetNetworkName(const NameData &aNetworkNameData)
-        {
-            IgnoreError(AsCoreType(&mNetworkName).Set(aNetworkNameData));
-            mComponents.mIsNetworkNamePresent = true;
-        }
-
-        /**
-         * Indicates whether or not the Extended PAN ID is present in the Dataset.
-         *
-         * @returns TRUE if Extended PAN ID is present, FALSE otherwise.
-         *
-         */
-        bool IsExtendedPanIdPresent(void) const { return mComponents.mIsExtendedPanIdPresent; }
-
-        /**
-         * Gets the Extended PAN ID in the Dataset.
-         *
-         * MUST be used when Extended PAN ID component is present in the Dataset, otherwise its behavior is
-         * undefined.
-         *
-         * @returns The Extended PAN ID in the Dataset.
-         *
-         */
-        const ExtendedPanId &GetExtendedPanId(void) const { return AsCoreType(&mExtendedPanId); }
-
-        /**
-         * Sets the Extended PAN ID in the Dataset.
-         *
-         * @param[in] aExtendedPanId   An Extended PAN ID.
-         *
-         */
-        void SetExtendedPanId(const ExtendedPanId &aExtendedPanId)
-        {
-            mExtendedPanId                      = aExtendedPanId;
-            mComponents.mIsExtendedPanIdPresent = true;
-        }
-
-        /**
-         * Indicates whether or not the Mesh Local Prefix is present in the Dataset.
-         *
-         * @returns TRUE if Mesh Local Prefix is present, FALSE otherwise.
-         *
-         */
-        bool IsMeshLocalPrefixPresent(void) const { return mComponents.mIsMeshLocalPrefixPresent; }
-
-        /**
-         * Gets the Mesh Local Prefix in the Dataset.
-         *
-         * MUST be used when Mesh Local Prefix component is present in the Dataset, otherwise its behavior
-         * is undefined.
-         *
-         * @returns The Mesh Local Prefix in the Dataset.
-         *
-         */
-        const Ip6::NetworkPrefix &GetMeshLocalPrefix(void) const
-        {
-            return static_cast<const Ip6::NetworkPrefix &>(mMeshLocalPrefix);
-        }
-
-        /**
-         * Sets the Mesh Local Prefix in the Dataset.
-         *
-         * @param[in] aMeshLocalPrefix   A Mesh Local Prefix.
-         *
-         */
-        void SetMeshLocalPrefix(const Ip6::NetworkPrefix &aMeshLocalPrefix)
-        {
-            mMeshLocalPrefix                      = aMeshLocalPrefix;
-            mComponents.mIsMeshLocalPrefixPresent = true;
-        }
-
-        /**
-         * Indicates whether or not the Delay Timer is present in the Dataset.
-         *
-         * @returns TRUE if Delay Timer is present, FALSE otherwise.
-         *
-         */
-        bool IsDelayPresent(void) const { return mComponents.mIsDelayPresent; }
-
-        /**
-         * Gets the Delay Timer in the Dataset.
-         *
-         * MUST be used when Delay Timer component is present in the Dataset, otherwise its behavior is
-         * undefined.
-         *
-         * @returns The Delay Timer in the Dataset.
-         *
-         */
-        uint32_t GetDelay(void) const { return mDelay; }
-
-        /**
-         * Sets the Delay Timer in the Dataset.
-         *
-         * @param[in] aDelay  A Delay value.
-         *
-         */
-        void SetDelay(uint32_t aDelay)
-        {
-            mDelay                      = aDelay;
-            mComponents.mIsDelayPresent = true;
-        }
-
-        /**
-         * Indicates whether or not the PAN ID is present in the Dataset.
-         *
-         * @returns TRUE if PAN ID is present, FALSE otherwise.
-         *
-         */
-        bool IsPanIdPresent(void) const { return mComponents.mIsPanIdPresent; }
-
-        /**
-         * Gets the PAN ID in the Dataset.
-         *
-         * MUST be used when PAN ID component is present in the Dataset, otherwise its behavior is
-         * undefined.
-         *
-         * @returns The PAN ID in the Dataset.
-         *
-         */
-        Mac::PanId GetPanId(void) const { return mPanId; }
-
-        /**
-         * Sets the PAN ID in the Dataset.
-         *
-         * @param[in] aPanId  A PAN ID.
-         *
-         */
-        void SetPanId(Mac::PanId aPanId)
-        {
-            mPanId                      = aPanId;
-            mComponents.mIsPanIdPresent = true;
-        }
-
-        /**
-         * Indicates whether or not the Channel is present in the Dataset.
-         *
-         * @returns TRUE if Channel is present, FALSE otherwise.
-         *
-         */
-        bool IsChannelPresent(void) const { return mComponents.mIsChannelPresent; }
-
-        /**
-         * Gets the Channel in the Dataset.
-         *
-         * MUST be used when Channel component is present in the Dataset, otherwise its behavior is
-         * undefined.
-         *
-         * @returns The Channel in the Dataset.
-         *
-         */
-        uint16_t GetChannel(void) const { return mChannel; }
-
-        /**
-         * Sets the Channel in the Dataset.
-         *
-         * @param[in] aChannel  A Channel.
-         *
-         */
-        void SetChannel(uint16_t aChannel)
-        {
-            mChannel                      = aChannel;
-            mComponents.mIsChannelPresent = true;
-        }
-
-        /**
-         * Indicates whether or not the PSKc is present in the Dataset.
-         *
-         * @returns TRUE if PSKc is present, FALSE otherwise.
-         *
-         */
-        bool IsPskcPresent(void) const { return mComponents.mIsPskcPresent; }
-
-        /**
-         * Gets the PSKc in the Dataset.
-         *
-         * MUST be used when PSKc component is present in the Dataset, otherwise its behavior is undefined.
-         *
-         * @returns The PSKc in the Dataset.
-         *
-         */
-        const Pskc &GetPskc(void) const { return AsCoreType(&mPskc); }
-
-        /**
-         * Set the PSKc in the Dataset.
-         *
-         * @param[in] aPskc  A PSKc value.
-         *
-         */
-        void SetPskc(const Pskc &aPskc)
-        {
-            mPskc                      = aPskc;
-            mComponents.mIsPskcPresent = true;
-        }
-
-        /**
-         * Indicates whether or not the Security Policy is present in the Dataset.
-         *
-         * @returns TRUE if Security Policy is present, FALSE otherwise.
-         *
-         */
-        bool IsSecurityPolicyPresent(void) const { return mComponents.mIsSecurityPolicyPresent; }
-
-        /**
-         * Gets the Security Policy in the Dataset.
-         *
-         * MUST be used when Security Policy component is present in the Dataset, otherwise its behavior is
-         * undefined.
-         *
-         * @returns The Security Policy in the Dataset.
-         *
-         */
-        const SecurityPolicy &GetSecurityPolicy(void) const { return AsCoreType(&mSecurityPolicy); }
-
-        /**
-         * Sets the Security Policy in the Dataset.
-         *
-         * @param[in] aSecurityPolicy  A Security Policy to set in Dataset.
-         *
-         */
-        void SetSecurityPolicy(const SecurityPolicy &aSecurityPolicy)
-        {
-            mSecurityPolicy                      = aSecurityPolicy;
-            mComponents.mIsSecurityPolicyPresent = true;
-        }
-
-        /**
-         * Indicates whether or not the Channel Mask is present in the Dataset.
-         *
-         * @returns TRUE if Channel Mask is present, FALSE otherwise.
-         *
-         */
-        bool IsChannelMaskPresent(void) const { return mComponents.mIsChannelMaskPresent; }
-
-        /**
-         * Gets the Channel Mask in the Dataset.
-         *
-         * MUST be used when Channel Mask component is present in the Dataset, otherwise its behavior is
-         * undefined.
-         *
-         * @returns The Channel Mask in the Dataset.
-         *
-         */
-        otChannelMask GetChannelMask(void) const { return mChannelMask; }
-
-        /**
-         * Sets the Channel Mask in the Dataset.
-         *
-         * @param[in] aChannelMask   A Channel Mask value.
-         *
-         */
-        void SetChannelMask(otChannelMask aChannelMask)
-        {
-            mChannelMask                      = aChannelMask;
-            mComponents.mIsChannelMaskPresent = true;
+            GetComponents().MarkAsPresent<kComponent>();
+            return AsNonConst(Get<kComponent>());
         }
 
         /**
@@ -606,6 +227,10 @@ public:
          *
          */
         bool IsSubsetOf(const Info &aOther) const;
+
+    private:
+        Components       &GetComponents(void) { return static_cast<Components &>(mComponents); }
+        const Components &GetComponents(void) const { return static_cast<const Components &>(mComponents); }
     };
 
     /**
@@ -982,6 +607,121 @@ private:
     TimeMilli mUpdateTime;     ///< Local time last updated
     uint16_t  mLength;         ///< The number of valid bytes in @var mTlvs
 };
+
+//---------------------------------------------------------------------------------------------------------------------
+// Template specializations
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// `Dataset::Components::IsPresent()` and `Dataset::Components::MarkAsPresent()`
+
+#define DefineIsPresentAndMarkAsPresent(Component)                                            \
+    template <> inline bool Dataset::Components::IsPresent<Dataset::k##Component>(void) const \
+    {                                                                                         \
+        return mIs##Component##Present;                                                       \
+    }                                                                                         \
+                                                                                              \
+    template <> inline void Dataset::Components::MarkAsPresent<Dataset::k##Component>(void)   \
+    {                                                                                         \
+        mIs##Component##Present = true;                                                       \
+    }
+
+// clang-format off
+
+DefineIsPresentAndMarkAsPresent(ActiveTimestamp)
+DefineIsPresentAndMarkAsPresent(PendingTimestamp)
+DefineIsPresentAndMarkAsPresent(NetworkKey)
+DefineIsPresentAndMarkAsPresent(NetworkName)
+DefineIsPresentAndMarkAsPresent(ExtendedPanId)
+DefineIsPresentAndMarkAsPresent(MeshLocalPrefix)
+DefineIsPresentAndMarkAsPresent(Delay)
+DefineIsPresentAndMarkAsPresent(PanId)
+DefineIsPresentAndMarkAsPresent(Channel)
+DefineIsPresentAndMarkAsPresent(Pskc)
+DefineIsPresentAndMarkAsPresent(SecurityPolicy)
+DefineIsPresentAndMarkAsPresent(ChannelMask)
+
+#undef DefineIsPresentAndMarkAsPresent
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// `Dataset::TypeFor<>`
+
+template <> struct Dataset::TypeFor<Dataset::kActiveTimestamp>  { using Type = Timestamp; };
+template <> struct Dataset::TypeFor<Dataset::kPendingTimestamp> { using Type = Timestamp; };
+template <> struct Dataset::TypeFor<Dataset::kNetworkKey>       { using Type = NetworkKey; };
+template <> struct Dataset::TypeFor<Dataset::kNetworkName>      { using Type = NetworkName; };
+template <> struct Dataset::TypeFor<Dataset::kExtendedPanId>    { using Type = ExtendedPanId; };
+template <> struct Dataset::TypeFor<Dataset::kMeshLocalPrefix>  { using Type = Ip6::NetworkPrefix; };
+template <> struct Dataset::TypeFor<Dataset::kDelay>            { using Type = uint32_t; };
+template <> struct Dataset::TypeFor<Dataset::kPanId>            { using Type = Mac::PanId; };
+template <> struct Dataset::TypeFor<Dataset::kChannel>          { using Type = uint16_t; };
+template <> struct Dataset::TypeFor<Dataset::kPskc>             { using Type = Pskc; };
+template <> struct Dataset::TypeFor<Dataset::kSecurityPolicy>   { using Type = SecurityPolicy; };
+template <> struct Dataset::TypeFor<Dataset::kChannelMask>      { using Type = uint32_t; };
+
+// clang-format on
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Dataset::Info::Get<>()
+
+template <> inline const NetworkKey &Dataset::Info::Get<Dataset::kNetworkKey>(void) const
+{
+    return AsCoreType(&mNetworkKey);
+}
+
+template <> inline const NetworkName &Dataset::Info::Get<Dataset::kNetworkName>(void) const
+{
+    return AsCoreType(&mNetworkName);
+}
+
+template <> inline const ExtendedPanId &Dataset::Info::Get<Dataset::kExtendedPanId>(void) const
+{
+    return AsCoreType(&mExtendedPanId);
+}
+
+template <> inline const Ip6::NetworkPrefix &Dataset::Info::Get<Dataset::kMeshLocalPrefix>(void) const
+{
+    return static_cast<const Ip6::NetworkPrefix &>(mMeshLocalPrefix);
+}
+
+template <> inline const uint32_t &Dataset::Info::Get<Dataset::kDelay>(void) const { return mDelay; }
+
+template <> inline const Mac::PanId &Dataset::Info::Get<Dataset::kPanId>(void) const { return mPanId; }
+
+template <> inline const uint16_t &Dataset::Info::Get<Dataset::kChannel>(void) const { return mChannel; }
+
+template <> inline const Pskc &Dataset::Info::Get<Dataset::kPskc>(void) const { return AsCoreType(&mPskc); }
+
+template <> inline const SecurityPolicy &Dataset::Info::Get<Dataset::kSecurityPolicy>(void) const
+{
+    return AsCoreType(&mSecurityPolicy);
+}
+
+template <> inline const uint32_t &Dataset::Info::Get<Dataset::kChannelMask>(void) const { return mChannelMask; }
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Active and Pending Timestamp
+
+template <> inline void Dataset::Info::Get<Dataset::kActiveTimestamp>(Timestamp &aTimestamp) const
+{
+    aTimestamp.SetFromTimestamp(mActiveTimestamp);
+}
+
+template <> inline void Dataset::Info::Get<Dataset::kPendingTimestamp>(Timestamp &aTimestamp) const
+{
+    aTimestamp.SetFromTimestamp(mPendingTimestamp);
+}
+
+template <> inline void Dataset::Info::Set<Dataset::kActiveTimestamp>(const Timestamp &aTimestamp)
+{
+    GetComponents().MarkAsPresent<kActiveTimestamp>();
+    aTimestamp.ConvertTo(mActiveTimestamp);
+}
+
+template <> inline void Dataset::Info::Set<Dataset::kPendingTimestamp>(const Timestamp &aTimestamp)
+{
+    GetComponents().MarkAsPresent<kPendingTimestamp>();
+    aTimestamp.ConvertTo(mPendingTimestamp);
+}
 
 } // namespace MeshCoP
 

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -525,62 +525,62 @@ Error DatasetManager::SendGetRequest(const Dataset::Components &aDatasetComponen
 
     length = 0;
 
-    if (aDatasetComponents.IsActiveTimestampPresent())
+    if (aDatasetComponents.IsPresent<Dataset::kActiveTimestamp>())
     {
         datasetTlvs[length++] = Tlv::kActiveTimestamp;
     }
 
-    if (aDatasetComponents.IsPendingTimestampPresent())
+    if (aDatasetComponents.IsPresent<Dataset::kPendingTimestamp>())
     {
         datasetTlvs[length++] = Tlv::kPendingTimestamp;
     }
 
-    if (aDatasetComponents.IsNetworkKeyPresent())
+    if (aDatasetComponents.IsPresent<Dataset::kNetworkKey>())
     {
         datasetTlvs[length++] = Tlv::kNetworkKey;
     }
 
-    if (aDatasetComponents.IsNetworkNamePresent())
+    if (aDatasetComponents.IsPresent<Dataset::kNetworkName>())
     {
         datasetTlvs[length++] = Tlv::kNetworkName;
     }
 
-    if (aDatasetComponents.IsExtendedPanIdPresent())
+    if (aDatasetComponents.IsPresent<Dataset::kExtendedPanId>())
     {
         datasetTlvs[length++] = Tlv::kExtendedPanId;
     }
 
-    if (aDatasetComponents.IsMeshLocalPrefixPresent())
+    if (aDatasetComponents.IsPresent<Dataset::kMeshLocalPrefix>())
     {
         datasetTlvs[length++] = Tlv::kMeshLocalPrefix;
     }
 
-    if (aDatasetComponents.IsDelayPresent())
+    if (aDatasetComponents.IsPresent<Dataset::kDelay>())
     {
         datasetTlvs[length++] = Tlv::kDelayTimer;
     }
 
-    if (aDatasetComponents.IsPanIdPresent())
+    if (aDatasetComponents.IsPresent<Dataset::kPanId>())
     {
         datasetTlvs[length++] = Tlv::kPanId;
     }
 
-    if (aDatasetComponents.IsChannelPresent())
+    if (aDatasetComponents.IsPresent<Dataset::kChannel>())
     {
         datasetTlvs[length++] = Tlv::kChannel;
     }
 
-    if (aDatasetComponents.IsPskcPresent())
+    if (aDatasetComponents.IsPresent<Dataset::kPskc>())
     {
         datasetTlvs[length++] = Tlv::kPskc;
     }
 
-    if (aDatasetComponents.IsSecurityPolicyPresent())
+    if (aDatasetComponents.IsPresent<Dataset::kSecurityPolicy>())
     {
         datasetTlvs[length++] = Tlv::kSecurityPolicy;
     }
 
-    if (aDatasetComponents.IsChannelMaskPresent())
+    if (aDatasetComponents.IsPresent<Dataset::kChannelMask>())
     {
         datasetTlvs[length++] = Tlv::kChannelMask;
     }
@@ -638,8 +638,9 @@ bool ActiveDatasetManager::IsCommissioned(void) const
 
     SuccessOrExit(Read(datasetInfo));
 
-    isValid = (datasetInfo.IsNetworkKeyPresent() && datasetInfo.IsNetworkNamePresent() &&
-               datasetInfo.IsExtendedPanIdPresent() && datasetInfo.IsPanIdPresent() && datasetInfo.IsChannelPresent());
+    isValid = (datasetInfo.IsPresent<Dataset::kNetworkKey>() && datasetInfo.IsPresent<Dataset::kNetworkName>() &&
+               datasetInfo.IsPresent<Dataset::kExtendedPanId>() && datasetInfo.IsPresent<Dataset::kPanId>() &&
+               datasetInfo.IsPresent<Dataset::kChannel>());
 
 exit:
     return isValid;

--- a/src/core/meshcop/dataset_updater.cpp
+++ b/src/core/meshcop/dataset_updater.cpp
@@ -61,7 +61,7 @@ Error DatasetUpdater::RequestUpdate(const Dataset::Info &aDataset, UpdaterCallba
     VerifyOrExit(!Get<Mle::Mle>().IsDisabled(), error = kErrorInvalidState);
     VerifyOrExit(mDataset == nullptr, error = kErrorBusy);
 
-    VerifyOrExit(!aDataset.IsActiveTimestampPresent() && !aDataset.IsPendingTimestampPresent(),
+    VerifyOrExit(!aDataset.IsPresent<Dataset::kActiveTimestamp>() && !aDataset.IsPresent<Dataset::kPendingTimestamp>(),
                  error = kErrorInvalidArgs);
 
     message = Get<MessagePool>().Allocate(Message::kTypeOther);
@@ -119,7 +119,7 @@ void DatasetUpdater::PreparePendingDataset(void)
 
     IgnoreError(dataset.SetFrom(requestedDataset));
 
-    if (!requestedDataset.IsDelayPresent())
+    if (!requestedDataset.IsPresent<Dataset::kDelay>())
     {
         uint32_t delay = kDefaultDelay;
 
@@ -190,8 +190,8 @@ void DatasetUpdater::HandleNotifierEvents(Events aEvents)
             Timestamp requestedDatasetTimestamp;
             Timestamp activeDatasetTimestamp;
 
-            requestedDataset.GetActiveTimestamp(requestedDatasetTimestamp);
-            dataset.GetActiveTimestamp(activeDatasetTimestamp);
+            requestedDataset.Get<MeshCoP::Dataset::kActiveTimestamp>(requestedDatasetTimestamp);
+            dataset.Get<MeshCoP::Dataset::kActiveTimestamp>(activeDatasetTimestamp);
             if (Timestamp::Compare(requestedDatasetTimestamp, activeDatasetTimestamp) <= 0)
             {
                 Finish(kErrorAlready);

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -528,10 +528,10 @@ template <> void Joiner::HandleTmf<kUriJoinerEntrust>(Coap::Message &aMessage, c
 
     datasetInfo.Clear();
 
-    SuccessOrExit(error = Tlv::Find<NetworkKeyTlv>(aMessage, datasetInfo.UpdateNetworkKey()));
+    SuccessOrExit(error = Tlv::Find<NetworkKeyTlv>(aMessage, datasetInfo.Update<Dataset::kNetworkKey>()));
 
-    datasetInfo.SetChannel(Get<Mac::Mac>().GetPanChannel());
-    datasetInfo.SetPanId(Get<Mac::Mac>().GetPanId());
+    datasetInfo.Set<Dataset::kChannel>(Get<Mac::Mac>().GetPanChannel());
+    datasetInfo.Set<Dataset::kPanId>(Get<Mac::Mac>().GetPanId());
 
     IgnoreError(Get<ActiveDatasetManager>().Save(datasetInfo));
 

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -224,14 +224,14 @@ bool TcatAgent::CheckCommandClassAuthorizationFlags(CommandClassFlags aCommissio
 
         if (datasetError == kErrorNone)
         {
-            if (datasetInfo.IsNetworkNamePresent() && mCommissionerHasNetworkName &&
-                (datasetInfo.GetNetworkName() == mCommissionerNetworkName))
+            if (datasetInfo.IsPresent<Dataset::kNetworkName>() && mCommissionerHasNetworkName &&
+                (datasetInfo.Get<Dataset::kNetworkName>() == mCommissionerNetworkName))
             {
                 networkNamesMatch = true;
             }
 
-            if (datasetInfo.IsExtendedPanIdPresent() && mCommissionerHasExtendedPanId &&
-                (datasetInfo.GetExtendedPanId() == mCommissionerExtendedPanId))
+            if (datasetInfo.IsPresent<Dataset::kExtendedPanId>() && mCommissionerHasExtendedPanId &&
+                (datasetInfo.Get<Dataset::kExtendedPanId>() == mCommissionerExtendedPanId))
             {
                 extendedPanIdsMatch = true;
             }
@@ -487,7 +487,7 @@ Error TcatAgent::HandleStartThreadInterface(void)
     Dataset::Info datasetInfo;
 
     VerifyOrExit(Get<ActiveDatasetManager>().Read(datasetInfo) == kErrorNone, error = kErrorInvalidState);
-    VerifyOrExit(datasetInfo.IsNetworkKeyPresent(), error = kErrorInvalidState);
+    VerifyOrExit(datasetInfo.IsPresent<Dataset::kNetworkKey>(), error = kErrorInvalidState);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
     VerifyOrExit(!Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -162,8 +162,8 @@ void ChannelManager::StartDatasetUpdate(void)
     MeshCoP::Dataset::Info dataset;
 
     dataset.Clear();
-    dataset.SetChannel(mChannel);
-    dataset.SetDelay(Time::SecToMsec(mDelay));
+    dataset.Set<MeshCoP::Dataset::kChannel>(mChannel);
+    dataset.Set<MeshCoP::Dataset::kDelay>(Time::SecToMsec(mDelay));
 
     switch (Get<MeshCoP::DatasetUpdater>().RequestUpdate(dataset, HandleDatasetUpdateDone, this))
     {


### PR DESCRIPTION
This commit introduces a `Component` enum to represent dataset components, and defines templated methods (`IsPresent<>`, `Get<>`, `Set<>`, etc) for streamlined access. This reduces boilerplate code for individual component management.