### PR TITLE
[dataset] simplify `DatasetManager::HandleGet()` & `SendGetResponse()`

### DIFF
--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -63,7 +63,6 @@ class Dataset
 public:
     static constexpr uint8_t kMaxSize      = OT_OPERATIONAL_DATASET_MAX_LENGTH; ///< Max size of MeshCoP Dataset (bytes)
     static constexpr uint8_t kMaxValueSize = 16;                                ///< Max size of a TLV value (bytes)
-    static constexpr uint8_t kMaxGetTypes  = 64;                                ///< Max number of types in MGMT_GET.req
 
     /**
      * Represents the Dataset type (active or pending).

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -339,6 +339,15 @@ protected:
     bool         mTimestampValid : 1;
 
 private:
+    static constexpr uint8_t kMaxGetTypes = 64; // Max number of types in MGMT_GET.req
+
+    class TlvList : public Array<uint8_t, kMaxGetTypes>
+    {
+    public:
+        TlvList(void) = default;
+        void Add(uint8_t aTlvType);
+    };
+
     static void HandleMgmtSetResponse(void                *aContext,
                                       otMessage           *aMessage,
                                       const otMessageInfo *aMessageInfo,
@@ -353,8 +362,7 @@ private:
     void  SendSet(void);
     void  SendGetResponse(const Coap::Message    &aRequest,
                           const Ip6::MessageInfo &aMessageInfo,
-                          uint8_t                *aTlvs,
-                          uint8_t                 aLength) const;
+                          const TlvList          &aTlvList) const;
 
 #if OPENTHREAD_FTD
     void SendSetResponse(const Coap::Message &aRequest, const Ip6::MessageInfo &aMessageInfo, StateTlv::State aState);


### PR DESCRIPTION
This commit contains the following:
- Use `FindTlvValueOffset()` to find `Tlv::kGet` in message.
- Define and use `TlvList` to get list of requested TLV type.
- `TlvList` is an array of TLV types, not allowing duplicate values to be added to the list.
- Simplify `SendGetResponse()` to handle including all or a subset of TLVs in response.