### PR TITLE
[spinel] breakdown radio spinel

### DIFF
--- a/src/lib/spinel/BUILD.gn
+++ b/src/lib/spinel/BUILD.gn
@@ -45,6 +45,8 @@ spinel_sources = [
   "spinel_buffer.hpp",
   "spinel_decoder.cpp",
   "spinel_decoder.hpp",
+  "spinel_driver.cpp",
+  "spinel_driver.hpp",
   "spinel_encoder.cpp",
   "spinel_encoder.hpp",
   "spinel_platform.h",

--- a/src/lib/spinel/CMakeLists.txt
+++ b/src/lib/spinel/CMakeLists.txt
@@ -93,6 +93,7 @@ target_sources(openthread-radio-spinel
     PRIVATE
         logger.cpp
         radio_spinel.cpp
+        spinel_driver.cpp
 )
 target_sources(openthread-spinel-ncp PRIVATE ${COMMON_SOURCES})
 target_sources(openthread-spinel-rcp PRIVATE ${COMMON_SOURCES})

--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -197,19 +197,21 @@ exit:
 
 void RadioSpinel::InitializeCaps(bool &aSupportsRcpApiVersion, bool &aSupportsRcpMinHostApiVersion)
 {
-    bool supportsRawRadio;
-
-    supportsRawRadio              = mSpinelDriver.CoprocessorHasCap(SPINEL_CAP_MAC_RAW);
-    sSupportsLogStream            = mSpinelDriver.CoprocessorHasCap(SPINEL_CAP_OPENTHREAD_LOG_METADATA);
-    aSupportsRcpApiVersion        = mSpinelDriver.CoprocessorHasCap(SPINEL_CAP_RCP_API_VERSION);
-    sSupportsResetToBootloader    = mSpinelDriver.CoprocessorHasCap(SPINEL_CAP_RCP_RESET_TO_BOOTLOADER);
-    aSupportsRcpMinHostApiVersion = mSpinelDriver.CoprocessorHasCap(SPINEL_PROP_RCP_MIN_HOST_API_VERSION);
-
-    if (!supportsRawRadio)
+    if (!mSpinelDriver.CoprocessorHasCap(SPINEL_CAP_CONFIG_RADIO))
+    {
+        LogCrit("The co-processor isn't a RCP!");
+        DieNow(OT_EXIT_RADIO_SPINEL_INCOMPATIBLE);
+    }
+    if (!mSpinelDriver.CoprocessorHasCap(SPINEL_CAP_MAC_RAW))
     {
         LogCrit("RCP capability list does not include support for radio/raw mode");
         DieNow(OT_EXIT_RADIO_SPINEL_INCOMPATIBLE);
     }
+
+    sSupportsLogStream            = mSpinelDriver.CoprocessorHasCap(SPINEL_CAP_OPENTHREAD_LOG_METADATA);
+    aSupportsRcpApiVersion        = mSpinelDriver.CoprocessorHasCap(SPINEL_CAP_RCP_API_VERSION);
+    sSupportsResetToBootloader    = mSpinelDriver.CoprocessorHasCap(SPINEL_CAP_RCP_RESET_TO_BOOTLOADER);
+    aSupportsRcpMinHostApiVersion = mSpinelDriver.CoprocessorHasCap(SPINEL_PROP_RCP_MIN_HOST_API_VERSION);
 }
 
 otError RadioSpinel::CheckRadioCapabilities(void)
@@ -513,7 +515,7 @@ void RadioSpinel::HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, 
 
             // this clear is necessary in case the RCP has sent messages between disable and reset
             mSpinelDriver.ClearRxBuffer();
-            mSpinelDriver.SetCoProcessorReady();
+            mSpinelDriver.SetCoprocessorReady();
 
             LogInfo("RCP reset: %s", spinel_status_to_cstr(status));
             sIsReady = true;
@@ -1933,11 +1935,11 @@ void RadioSpinel::RecoverFromRcpFailure(void)
     mSpinelDriver.ClearRxBuffer();
     if (skipReset)
     {
-        mSpinelDriver.SetCoProcessorReady();
+        mSpinelDriver.SetCoprocessorReady();
     }
     else
     {
-        mSpinelDriver.ResetCoProcessor(mResetRadioOnStartup);
+        mSpinelDriver.ResetCoprocessor(mResetRadioOnStartup);
     }
 
     mCmdTidsInUse = 0;

--- a/src/lib/spinel/spinel_driver.cpp
+++ b/src/lib/spinel/spinel_driver.cpp
@@ -1,0 +1,465 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "spinel_driver.hpp"
+
+#include <assert.h>
+
+#include <openthread/platform/time.h>
+
+#include "common/code_utils.hpp"
+#include "common/new.hpp"
+#include "common/num_utils.hpp"
+#include "lib/platform/exit_code.h"
+#include "lib/spinel/spinel.h"
+
+namespace ot {
+namespace Spinel {
+
+constexpr spinel_tid_t sTid = 1; ///< In Spinel Driver, only use Tid as 1.
+
+SpinelDriver::SpinelDriver(void)
+    : Logger("SpinelDriver")
+    , mSpinelInterface(nullptr)
+    , mWaitingKey(SPINEL_PROP_LAST_STATUS)
+    , mIsWaitingForResponse(false)
+    , mIid(SPINEL_HEADER_INVALID_IID)
+    , mSpinelVersionMajor(-1)
+    , mSpinelVersionMinor(-1)
+    , mIsCoProcessorReady(false)
+{
+    memset(mVersion, 0, sizeof(mVersion));
+
+    mReceivedFrameHandler.Set(&HandleInitialFrame, this);
+}
+
+void SpinelDriver::Init(SpinelInterface    &aSpinelInterface,
+                        bool                aSoftwareReset,
+                        const spinel_iid_t *aIidList,
+                        uint8_t             aIidListLength)
+{
+    mSpinelInterface = &aSpinelInterface;
+    mRxFrameBuffer.Clear();
+    SuccessOrDie(mSpinelInterface->Init(HandleReceivedFrame, this, mRxFrameBuffer));
+
+    VerifyOrDie(aIidList != nullptr, OT_EXIT_INVALID_ARGUMENTS);
+    VerifyOrDie(aIidListLength != 0 && aIidListLength <= mIidList.GetMaxSize(), OT_EXIT_INVALID_ARGUMENTS);
+
+    for (uint8_t i = 0; i < aIidListLength; i++)
+    {
+        SuccessOrDie(mIidList.PushBack(aIidList[i]));
+    }
+    mIid = aIidList[0];
+
+    ResetCoProcessor(aSoftwareReset);
+    SuccessOrDie(CheckSpinelVersion());
+    SuccessOrDie(GetCoprocessorVersion());
+    SuccessOrDie(GetCoprocessorCaps());
+}
+
+void SpinelDriver::Deinit(void)
+{
+    // This allows implementing pseudo reset.
+    new (this) SpinelDriver();
+}
+
+otError SpinelDriver::SendReset(uint8_t aResetType)
+{
+    otError        error = OT_ERROR_NONE;
+    uint8_t        buffer[kMaxSpinelFrame];
+    spinel_ssize_t packed;
+
+    // Pack the header, command and key
+    packed = spinel_datatype_pack(buffer, sizeof(buffer), SPINEL_DATATYPE_COMMAND_S SPINEL_DATATYPE_UINT8_S,
+                                  SPINEL_HEADER_FLAG | SPINEL_HEADER_IID(mIid), SPINEL_CMD_RESET, aResetType);
+
+    VerifyOrExit(packed > 0 && static_cast<size_t>(packed) <= sizeof(buffer), error = OT_ERROR_NO_BUFS);
+
+    SuccessOrExit(error = mSpinelInterface->SendFrame(buffer, static_cast<uint16_t>(packed)));
+    LogSpinelFrame(buffer, static_cast<uint16_t>(packed), true /* aTx */);
+
+exit:
+    return error;
+}
+
+void SpinelDriver::ResetCoProcessor(bool aSoftwareReset)
+{
+    bool hardwareReset;
+    bool resetDone = false;
+
+    // Avoid resetting the device twice in a row in Multipan RCP architecture
+    VerifyOrExit(!mIsCoProcessorReady, resetDone = true);
+
+    mWaitingKey = SPINEL_PROP_LAST_STATUS;
+
+    if (aSoftwareReset && (SendReset(SPINEL_RESET_STACK) == OT_ERROR_NONE) && (!mIsCoProcessorReady) &&
+        (WaitResponse() == OT_ERROR_NONE))
+    {
+        VerifyOrExit(mIsCoProcessorReady, resetDone = false);
+        LogCrit("Software reset Co-Processor successfully");
+        ExitNow(resetDone = true);
+    }
+
+    hardwareReset = (mSpinelInterface->HardwareReset() == OT_ERROR_NONE);
+
+    if (hardwareReset)
+    {
+        SuccessOrExit(WaitResponse());
+    }
+
+    resetDone = true;
+
+    if (hardwareReset)
+    {
+        LogInfo("Hardware reset Co-Processor successfully");
+    }
+    else
+    {
+        LogInfo("Co-Processor self reset successfully");
+    }
+
+exit:
+    if (!resetDone)
+    {
+        LogCrit("Failed to reset Co-Processor!");
+        DieNow(OT_EXIT_FAILURE);
+    }
+}
+
+void SpinelDriver::Process(const void *aContext)
+{
+    if (mRxFrameBuffer.HasSavedFrame())
+    {
+        ProcessFrameQueue();
+    }
+
+    mSpinelInterface->Process(aContext);
+
+    if (mRxFrameBuffer.HasSavedFrame())
+    {
+        ProcessFrameQueue();
+    }
+}
+
+otError SpinelDriver::SendCommand(uint32_t aCommand, spinel_prop_key_t aKey, spinel_tid_t aTid)
+{
+    otError        error = OT_ERROR_NONE;
+    uint8_t        buffer[kMaxSpinelFrame];
+    spinel_ssize_t packed;
+    uint16_t       offset;
+
+    // Pack the header, command and key
+    packed = spinel_datatype_pack(buffer, sizeof(buffer), "Cii", SPINEL_HEADER_FLAG | SPINEL_HEADER_IID(mIid) | aTid,
+                                  aCommand, aKey);
+
+    VerifyOrExit(packed > 0 && static_cast<size_t>(packed) <= sizeof(buffer), error = OT_ERROR_NO_BUFS);
+
+    offset = static_cast<uint16_t>(packed);
+
+    SuccessOrExit(error = mSpinelInterface->SendFrame(buffer, offset));
+
+exit:
+    return error;
+}
+
+otError SpinelDriver::SendCommand(uint32_t          aCommand,
+                                  spinel_prop_key_t aKey,
+                                  spinel_tid_t      aTid,
+                                  const char       *aFormat,
+                                  va_list           aArgs)
+{
+    otError        error = OT_ERROR_NONE;
+    uint8_t        buffer[kMaxSpinelFrame];
+    spinel_ssize_t packed;
+    uint16_t       offset;
+
+    // Pack the header, command and key
+    packed = spinel_datatype_pack(buffer, sizeof(buffer), "Cii", SPINEL_HEADER_FLAG | SPINEL_HEADER_IID(mIid) | aTid,
+                                  aCommand, aKey);
+
+    VerifyOrExit(packed > 0 && static_cast<size_t>(packed) <= sizeof(buffer), error = OT_ERROR_NO_BUFS);
+
+    offset = static_cast<uint16_t>(packed);
+
+    // Pack the data (if any)
+    if (aFormat)
+    {
+        packed = spinel_datatype_vpack(buffer + offset, sizeof(buffer) - offset, aFormat, aArgs);
+        VerifyOrExit(packed > 0 && static_cast<size_t>(packed + offset) <= sizeof(buffer), error = OT_ERROR_NO_BUFS);
+
+        offset += static_cast<uint16_t>(packed);
+    }
+
+    SuccessOrExit(error = mSpinelInterface->SendFrame(buffer, offset));
+
+exit:
+    return error;
+}
+
+void SpinelDriver::SetFrameHandler(ReceivedFrameHandler aReceivedFrameHandler,
+                                   SavedFrameHandler    aSavedFrameHandler,
+                                   void                *aContext)
+{
+    mReceivedFrameHandler.Set(aReceivedFrameHandler, aContext);
+    mSavedFrameHandler.Set(aSavedFrameHandler, aContext);
+}
+
+otError SpinelDriver::WaitResponse()
+{
+    otError  error = OT_ERROR_NONE;
+    uint64_t end   = otPlatTimeGet() + kMaxWaitTime * kUsPerMs;
+
+    LogDebg("Waiting response: key=%lu", ToUlong(mWaitingKey));
+
+    do
+    {
+        uint64_t now = otPlatTimeGet();
+
+        if ((end <= now) || (mSpinelInterface->WaitForFrame(end - now) != OT_ERROR_NONE))
+        {
+            LogWarn("Wait for response timeout");
+            ExitNow(error = OT_ERROR_RESPONSE_TIMEOUT);
+        }
+    } while (mIsWaitingForResponse || !mIsCoProcessorReady);
+
+    mWaitingKey = SPINEL_PROP_LAST_STATUS;
+
+exit:
+    return error;
+}
+
+void SpinelDriver::HandleReceivedFrame(void *aContext) { static_cast<SpinelDriver *>(aContext)->HandleReceivedFrame(); }
+
+void SpinelDriver::HandleReceivedFrame(void)
+{
+    otError        error = OT_ERROR_NONE;
+    uint8_t        header;
+    spinel_ssize_t unpacked;
+    bool           shouldSave = true;
+
+    LogSpinelFrame(mRxFrameBuffer.GetFrame(), mRxFrameBuffer.GetLength(), false);
+    unpacked = spinel_datatype_unpack(mRxFrameBuffer.GetFrame(), mRxFrameBuffer.GetLength(), "C", &header);
+
+    // Accept spinel messages with the correct IID or broadcast IID.
+    spinel_iid_t iid = SPINEL_HEADER_GET_IID(header);
+
+    if (!mIidList.Contains(iid))
+    {
+        mRxFrameBuffer.DiscardFrame();
+        ExitNow();
+    }
+
+    VerifyOrExit(unpacked > 0 && (header & SPINEL_HEADER_FLAG) == SPINEL_HEADER_FLAG, error = OT_ERROR_PARSE);
+
+    mReceivedFrameHandler.InvokeIfSet(mRxFrameBuffer.GetFrame(), mRxFrameBuffer.GetLength(), header, shouldSave);
+    if (shouldSave)
+    {
+        error = mRxFrameBuffer.SaveFrame();
+    }
+    else
+    {
+        mRxFrameBuffer.DiscardFrame();
+    }
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        mRxFrameBuffer.DiscardFrame();
+        LogWarn("Error handling spinel frame: %s", otThreadErrorToString(error));
+    }
+}
+
+void SpinelDriver::HandleInitialFrame(const uint8_t *aFrame,
+                                      uint16_t       aLength,
+                                      uint8_t        aHeader,
+                                      bool          &aSave,
+                                      void          *aContext)
+{
+    static_cast<SpinelDriver *>(aContext)->HandleInitialFrame(aFrame, aLength, aHeader, aSave);
+}
+
+void SpinelDriver::HandleInitialFrame(const uint8_t *aFrame, uint16_t aLength, uint8_t aHeader, bool &aSave)
+{
+    spinel_prop_key_t key;
+    uint8_t          *data   = nullptr;
+    spinel_size_t     len    = 0;
+    uint8_t           header = 0;
+    uint32_t          cmd    = 0;
+    spinel_ssize_t    rval   = 0;
+    spinel_ssize_t    unpacked;
+    otError           error = OT_ERROR_NONE;
+
+    OT_UNUSED_VARIABLE(aHeader);
+
+    rval = spinel_datatype_unpack(aFrame, aLength, "CiiD", &header, &cmd, &key, &data, &len);
+    VerifyOrExit(rval > 0 && cmd >= SPINEL_CMD_PROP_VALUE_IS && cmd <= SPINEL_CMD_PROP_VALUE_REMOVED,
+                 error = OT_ERROR_PARSE);
+
+    if (cmd == SPINEL_CMD_PROP_VALUE_IS)
+    {
+        if (key == SPINEL_PROP_LAST_STATUS)
+        {
+            spinel_status_t status = SPINEL_STATUS_OK;
+
+            unpacked = spinel_datatype_unpack(data, len, "i", &status);
+            VerifyOrExit(unpacked > 0, error = OT_ERROR_PARSE);
+
+            if (status >= SPINEL_STATUS_RESET__BEGIN && status <= SPINEL_STATUS_RESET__END)
+            {
+                // this clear is necessary in case the RCP has sent messages between disable and reset
+                mRxFrameBuffer.Clear();
+
+                LogInfo("Co-Processor reset: %s", spinel_status_to_cstr(status));
+                mIsCoProcessorReady = true;
+            }
+            else
+            {
+                LogInfo("Co-Processor last status: %s", spinel_status_to_cstr(status));
+                ExitNow();
+            }
+        }
+        else
+        {
+            // Drop other frames when the key isn't waiting key.
+            VerifyOrExit(mWaitingKey == key, error = OT_ERROR_DROP);
+
+            if (key == SPINEL_PROP_PROTOCOL_VERSION)
+            {
+                unpacked =
+                    spinel_datatype_unpack(data, len, (SPINEL_DATATYPE_UINT_PACKED_S SPINEL_DATATYPE_UINT_PACKED_S),
+                                           &mSpinelVersionMajor, &mSpinelVersionMinor);
+
+                VerifyOrExit(unpacked > 0, error = OT_ERROR_PARSE);
+            }
+            else if (key == SPINEL_PROP_NCP_VERSION)
+            {
+                unpacked =
+                    spinel_datatype_unpack_in_place(data, len, SPINEL_DATATYPE_UTF8_S, mVersion, sizeof(mVersion));
+
+                VerifyOrExit(unpacked > 0, error = OT_ERROR_PARSE);
+            }
+            else if (key == SPINEL_PROP_CAPS)
+            {
+                uint8_t        capsBuffer[kCapsBufferSize];
+                spinel_size_t  capsLength = sizeof(capsBuffer);
+                const uint8_t *capsData   = capsBuffer;
+
+                unpacked = spinel_datatype_unpack_in_place(data, len, SPINEL_DATATYPE_DATA_S, capsBuffer, &capsLength);
+
+                VerifyOrExit(unpacked > 0, error = OT_ERROR_PARSE);
+
+                while (capsLength > 0)
+                {
+                    unsigned int capability;
+
+                    unpacked = spinel_datatype_unpack(capsData, capsLength, SPINEL_DATATYPE_UINT_PACKED_S, &capability);
+                    VerifyOrExit(unpacked > 0, error = OT_ERROR_PARSE);
+
+                    SuccessOrExit(error = mCoprocessorCaps.PushBack(capability));
+
+                    capsData += unpacked;
+                    capsLength -= static_cast<spinel_size_t>(unpacked);
+                }
+            }
+
+            mIsWaitingForResponse = false;
+        }
+    }
+    else
+    {
+        ExitNow(error = OT_ERROR_DROP);
+    }
+
+exit:
+    aSave = false;
+    LogIfFail("Error processing frame", error);
+}
+
+otError SpinelDriver::CheckSpinelVersion(void)
+{
+    otError error = OT_ERROR_NONE;
+
+    SuccessOrExit(error = SendCommand(SPINEL_CMD_PROP_VALUE_GET, SPINEL_PROP_PROTOCOL_VERSION, sTid));
+    mIsWaitingForResponse = true;
+    mWaitingKey           = SPINEL_PROP_PROTOCOL_VERSION;
+
+    SuccessOrExit(error = WaitResponse());
+
+    if ((mSpinelVersionMajor != SPINEL_PROTOCOL_VERSION_THREAD_MAJOR) ||
+        (mSpinelVersionMinor != SPINEL_PROTOCOL_VERSION_THREAD_MINOR))
+    {
+        LogCrit("Spinel version mismatch - Posix:%d.%d, Co-Processor:%d.%d", SPINEL_PROTOCOL_VERSION_THREAD_MAJOR,
+                SPINEL_PROTOCOL_VERSION_THREAD_MINOR, mSpinelVersionMajor, mSpinelVersionMinor);
+        DieNow(OT_EXIT_RADIO_SPINEL_INCOMPATIBLE);
+    }
+
+exit:
+    return error;
+}
+
+otError SpinelDriver::GetCoprocessorVersion(void)
+{
+    otError error = OT_ERROR_NONE;
+
+    SuccessOrExit(error = SendCommand(SPINEL_CMD_PROP_VALUE_GET, SPINEL_PROP_NCP_VERSION, sTid));
+    mIsWaitingForResponse = true;
+    mWaitingKey           = SPINEL_PROP_NCP_VERSION;
+
+    SuccessOrExit(error = WaitResponse());
+exit:
+    return error;
+}
+
+otError SpinelDriver::GetCoprocessorCaps(void)
+{
+    otError error = OT_ERROR_NONE;
+
+    SuccessOrExit(error = SendCommand(SPINEL_CMD_PROP_VALUE_GET, SPINEL_PROP_CAPS, sTid));
+    mIsWaitingForResponse = true;
+    mWaitingKey           = SPINEL_PROP_CAPS;
+
+    SuccessOrExit(error = WaitResponse());
+exit:
+    return error;
+}
+
+void SpinelDriver::ProcessFrameQueue(void)
+{
+    uint8_t *frame = nullptr;
+    uint16_t length;
+
+    while (mRxFrameBuffer.GetNextSavedFrame(frame, length) == OT_ERROR_NONE)
+    {
+        mSavedFrameHandler.InvokeIfSet(frame, length);
+    }
+
+    mRxFrameBuffer.ClearSavedFrames();
+}
+
+} // namespace Spinel
+} // namespace ot

--- a/src/lib/spinel/spinel_driver.cpp
+++ b/src/lib/spinel/spinel_driver.cpp
@@ -122,7 +122,7 @@ void SpinelDriver::ResetCoProcessor(bool aSoftwareReset)
         (WaitResponse() == OT_ERROR_NONE))
     {
         VerifyOrExit(mIsCoProcessorReady, resetDone = false);
-        LogCrit("Software reset Co-Processor successfully");
+        LogCrit("Software reset co-processor successfully");
         ExitNow(resetDone = true);
     }
 
@@ -137,17 +137,17 @@ void SpinelDriver::ResetCoProcessor(bool aSoftwareReset)
 
     if (hardwareReset)
     {
-        LogInfo("Hardware reset Co-Processor successfully");
+        LogInfo("Hardware reset co-processor successfully");
     }
     else
     {
-        LogInfo("Co-Processor self reset successfully");
+        LogInfo("co-processor self reset successfully");
     }
 
 exit:
     if (!resetDone)
     {
-        LogCrit("Failed to reset Co-Processor!");
+        LogCrit("Failed to reset co-processor!");
         DieNow(OT_EXIT_FAILURE);
     }
 }
@@ -231,7 +231,7 @@ void SpinelDriver::SetFrameHandler(ReceivedFrameHandler aReceivedFrameHandler,
     mFrameHandlerContext  = aContext;
 }
 
-otError SpinelDriver::WaitResponse()
+otError SpinelDriver::WaitResponse(void)
 {
     otError  error = OT_ERROR_NONE;
     uint64_t end   = otPlatTimeGet() + kMaxWaitTime * kUsPerMs;
@@ -340,12 +340,12 @@ void SpinelDriver::HandleInitialFrame(const uint8_t *aFrame, uint16_t aLength, u
                 // this clear is necessary in case the RCP has sent messages between disable and reset
                 mRxFrameBuffer.Clear();
 
-                LogInfo("Co-Processor reset: %s", spinel_status_to_cstr(status));
+                LogInfo("co-processor reset: %s", spinel_status_to_cstr(status));
                 mIsCoProcessorReady = true;
             }
             else
             {
-                LogInfo("Co-Processor last status: %s", spinel_status_to_cstr(status));
+                LogInfo("co-processor last status: %s", spinel_status_to_cstr(status));
                 ExitNow();
             }
         }
@@ -419,7 +419,7 @@ otError SpinelDriver::CheckSpinelVersion(void)
     if ((mSpinelVersionMajor != SPINEL_PROTOCOL_VERSION_THREAD_MAJOR) ||
         (mSpinelVersionMinor != SPINEL_PROTOCOL_VERSION_THREAD_MINOR))
     {
-        LogCrit("Spinel version mismatch - Posix:%d.%d, Co-Processor:%d.%d", SPINEL_PROTOCOL_VERSION_THREAD_MAJOR,
+        LogCrit("Spinel version mismatch - Posix:%d.%d, co-processor:%d.%d", SPINEL_PROTOCOL_VERSION_THREAD_MAJOR,
                 SPINEL_PROTOCOL_VERSION_THREAD_MINOR, mSpinelVersionMajor, mSpinelVersionMinor);
         DieNow(OT_EXIT_RADIO_SPINEL_INCOMPATIBLE);
     }

--- a/src/lib/spinel/spinel_driver.hpp
+++ b/src/lib/spinel/spinel_driver.hpp
@@ -31,7 +31,6 @@
 
 #include <openthread/instance.h>
 
-#include "common/callback.hpp"
 #include "lib/spinel/logger.hpp"
 #include "lib/spinel/spinel.h"
 #include "lib/spinel/spinel_interface.hpp"

--- a/src/lib/spinel/spinel_driver.hpp
+++ b/src/lib/spinel/spinel_driver.hpp
@@ -94,7 +94,7 @@ public:
      *
      * This method is used to skip a reset.
      */
-    void SetCoProcessorReady(void) { mIsCoProcessorReady = true; }
+    void SetCoprocessorReady(void) { mIsCoprocessorReady = true; }
 
     /**
      * Send a reset command to the co-processor.
@@ -118,7 +118,7 @@ public:
      * @param[in]  aSoftwareReset                 TRUE to try SW reset first, FALSE to directly try HW reset.
      *
      */
-    void ResetCoProcessor(bool aSoftwareReset);
+    void ResetCoprocessor(bool aSoftwareReset);
 
     /**
      * Processes any pending the I/O data.
@@ -295,7 +295,7 @@ private:
     int mSpinelVersionMajor;
     int mSpinelVersionMinor;
 
-    bool mIsCoProcessorReady;
+    bool mIsCoprocessorReady;
     char mVersion[kVersionStringSize];
 
     Array<unsigned int, kCapsBufferSize> mCoprocessorCaps;

--- a/src/lib/spinel/spinel_driver.hpp
+++ b/src/lib/spinel/spinel_driver.hpp
@@ -1,0 +1,253 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SPINEL_DRIVER_HPP_
+#define SPINEL_DRIVER_HPP_
+
+#include <openthread/instance.h>
+
+#include "common/array.hpp"
+#include "common/callback.hpp"
+#include "lib/spinel/logger.hpp"
+#include "lib/spinel/spinel.h"
+#include "lib/spinel/spinel_interface.hpp"
+
+namespace ot {
+namespace Spinel {
+
+/**
+ * Maximum number of Spinel Interface IDs.
+ *
+ */
+#if OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
+static constexpr uint8_t kSpinelHeaderMaxNumIid = 4;
+#else
+static constexpr uint8_t kSpinelHeaderMaxNumIid = 1;
+#endif
+
+typedef void (
+    *ReceivedFrameHandler)(const uint8_t *aFrame, uint16_t aLength, uint8_t aHeader, bool &aSave, void *aContext);
+typedef void (*SavedFrameHandler)(const uint8_t *aFrame, uint16_t aLength, void *aContext);
+
+class SpinelDriver : public Logger
+{
+public:
+    /**
+     * Constructor of the SpinelDriver.
+     *
+     */
+    SpinelDriver(void);
+
+    /**
+     * Initialize this SpinelDriver Instance.
+     *
+     * @param[in]  aSpinelInterface            A reference to the Spinel interface.
+     * @param[in]  aSoftwareReset              TRUE to reset on init, FALSE to not reset on init.
+     * @param[in]  aIidList                    A Pointer to the list of IIDs to receive spinel frame from.
+     *                                         First entry must be the IID of the Host Application.
+     * @param[in]  aIidListLength              The Length of the @p aIidList.
+     *
+     */
+    void Init(SpinelInterface    &aSpinelInterface,
+              bool                aSoftwareReset,
+              const spinel_iid_t *aIidList,
+              uint8_t             aIidListLength);
+
+    /**
+     * Deinitialize this SpinelDriver Instance.
+     *
+     */
+    void Deinit(void);
+
+    /**
+     * Clear the rx frame buffer.
+     *
+     */
+    void ClearRxBuffer(void) { mRxFrameBuffer.Clear(); }
+
+    /**
+     * Set the internal state of co-processor as ready.
+     *
+     * This method is used to skip a reset.
+     */
+    void SetCoProcessorReady(void) { mIsCoProcessorReady = true; }
+
+    /**
+     * Send a reset command to the co-processor.
+     *
+     * @prarm[in] aResetType    The reset type, SPINEL_RESET_PLATFORM, SPINEL_RESET_STACK, or SPINEL_RESET_BOOTLOADER.
+     *
+     * @retval  OT_ERROR_NONE               Successfully removed item from the property.
+     * @retval  OT_ERROR_BUSY               Failed due to another operation is on going.
+     *
+     */
+    otError SendReset(uint8_t aResetType);
+
+    /**
+     * Reset the co-processor.
+     *
+     * This method will reset the co-processor and wait until the co-process is ready (receiving SPINEL_PROP_LAST_STATUS
+     * from the NCP). The reset will be either a software or hardware reset. If `aSoftwareReset` is `true`, then the
+     * method will first try a software reset. If the software reset succeeds, the method exits. Otherwise the method
+     * will then try a hardware reset. If `aSoftwareReset` is `false`, then method will directly try a hardware reset.
+     *
+     * @param[in]  aSoftwareReset                 TRUE to try SW reset at first, FALSE to directly try HW reset.
+     *
+     */
+    void ResetCoProcessor(bool aSoftwareReset);
+
+    /**
+     * Processes any pending the I/O data.
+     *
+     * The method should be called by the system loop to process received spinel frames.
+     *
+     * @param[in]  aContext   The process context.
+     *
+     */
+    void Process(const void *aContext);
+
+    /**
+     * Checks whether there is pending frame in the buffer.
+     *
+     * The method is required by the system loop to update timer fd.
+     *
+     * @returns Whether there is pending frame in the buffer.
+     *
+     */
+    bool HasPendingFrame(void) const { return mRxFrameBuffer.HasSavedFrame(); }
+
+    /**
+     * Returns the co-processor sw version string.
+     *
+     * @returns A pointer to the co-processor version string.
+     *
+     */
+    const char *GetVersion(void) const { return mVersion; }
+
+    /*
+     * Sends a spinel command to the co-processor.
+     *
+     * @param[in] aCommand    The spinel command.
+     * @param[in] aKey        The spinel property key.
+     * @param[in] aTid        The spinel transaction id.
+     * @param[in] aFormat     The format string of the arguments to send.
+     * @param[in] aArgs       The argument list.
+     *
+     * @retval  OT_ERROR_NONE Successfully sent the command through spinel interface.
+     * @retval  OT_ERROR_INVALID_STATE  The spinel interface is in an invalid state.
+     * @retval  OT_ERROR_NO_BUFS        The spinel interface doesn't have enough buffer.
+     *
+     */
+    otError SendCommand(uint32_t          aCommand,
+                        spinel_prop_key_t aKey,
+                        spinel_tid_t      aTid,
+                        const char       *aFormat,
+                        va_list           aArgs);
+
+    /*
+     * Sets the handler to process the received spinel frame.
+     *
+     * @param[in] aReceivedFrameHandler  The handler to process received spinel frames.
+     * @param[in] aSavedFrameHandler     The handler to process saved spinel frames.
+     * @param[in] aContext               The context to call the handler.
+     *
+     */
+    void SetFrameHandler(ReceivedFrameHandler aReceivedFrameHandler,
+                         SavedFrameHandler    aSavedFrameHandler,
+                         void                *aContext);
+
+    /*
+     * Returns the spinel interface.
+     *
+     * @returns A pointer to the spinel interface object.
+     *
+     */
+    SpinelInterface *GetSpinelInterface(void) const { return mSpinelInterface; }
+
+    /**
+     * Returns if the co-processor has some capability
+     *
+     * @param[in] aCapability  The capability queried.
+     *
+     * @returns `true` if the co-processor has the capability. `false` otherwise.
+     *
+     */
+    bool CoprocessorHasCap(unsigned int aCapability) { return mCoprocessorCaps.Contains(aCapability); }
+
+private:
+    static constexpr uint16_t kMaxSpinelFrame    = SPINEL_FRAME_MAX_SIZE;
+    static constexpr uint16_t kVersionStringSize = 128;
+    static constexpr uint32_t kUsPerMs           = 1000; ///< Microseconds per millisecond.
+    static constexpr uint32_t kMaxWaitTime       = 2000; ///< Max time to wait for response in milliseconds.
+    static constexpr uint16_t kCapsBufferSize    = 100;  ///< Max buffer size used to store `SPINEL_PROP_CAPS` value.
+
+    otError WaitResponse(void);
+
+    static void HandleReceivedFrame(void *aContext);
+    void        HandleReceivedFrame(void);
+
+    static void HandleInitialFrame(const uint8_t *aFrame,
+                                   uint16_t       aLength,
+                                   uint8_t        aHeader,
+                                   bool          &aSave,
+                                   void          *aContext);
+    void        HandleInitialFrame(const uint8_t *aFrame, uint16_t aLength, uint8_t aHeader, bool &aSave);
+
+    otError SendCommand(uint32_t aCommand, spinel_prop_key_t aKey, spinel_tid_t aTid);
+
+    otError CheckSpinelVersion(void);
+    otError GetCoprocessorVersion(void);
+    otError GetCoprocessorCaps(void);
+
+    void ProcessFrameQueue(void);
+
+    SpinelInterface::RxFrameBuffer mRxFrameBuffer;
+    SpinelInterface               *mSpinelInterface;
+
+    spinel_prop_key_t mWaitingKey; ///< The property key of current transaction.
+    bool              mIsWaitingForResponse;
+
+    spinel_iid_t                                    mIid;
+    ot::Array<spinel_iid_t, kSpinelHeaderMaxNumIid> mIidList;
+
+    Callback<ReceivedFrameHandler> mReceivedFrameHandler;
+    Callback<SavedFrameHandler>    mSavedFrameHandler;
+
+    int mSpinelVersionMajor;
+    int mSpinelVersionMinor;
+
+    bool mIsCoProcessorReady;
+    char mVersion[kVersionStringSize];
+
+    ot::Array<unsigned int, kCapsBufferSize> mCoprocessorCaps;
+};
+
+} // namespace Spinel
+} // namespace ot
+
+#endif // SPINEL_DRIVER_HPP_


### PR DESCRIPTION
This PR is a breakdown of PR#9898 for easier review.

The PR separates the spinel handling from other rcp specific handling
in `RadioSpinel` by putting the spinel handling into a new class
`SpinelDriver`. The purpose is to make the spinel handling resuable
in further change (for new architecture).

`SpinelDriver` has the following functions:
1. Co-processor initialization
2. Send a spinel command to the co-processor without waiting
3. Drive the processing of received spinel frames. But it will not do the
actual handling.

In this PR, `SpinelDriver` is added as a member of `RadioSpinel` and
`RadioSpinel` uses `SpinelDriver` to implement some of the existing
functions.

With `SpinelDriver`, it is possible to implement a new RadioSpinel-like
module that provides non-blocking APIs (No `WaitResponse` is used).
Note that there is a private, simpler version of `WaitResponse` in 
`SpinelDriver` which is only used during Co-processor initialization.
The initialization process of spinel is still blocking.