### PR TITLE
﻿[tasklet] add generic tasklet functionality

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (404)
+#define OPENTHREAD_API_VERSION (405)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/tasklet.h
+++ b/include/openthread/tasklet.h
@@ -51,6 +51,33 @@ extern "C" {
  *
  */
 
+#if OPENTHREAD_CONFIG_GENERIC_TASKLET_ENABLE
+/**
+ * Callback function set to be executed from the context of the OpenThread task
+ *
+ * @param[in]  aContext   A pointer to the application-specific context.
+ *
+ */
+typedef void (*otTaskletCb)(void *aContext);
+
+/**
+ * Use the generic tasklet defined in the OpenThread instance to execute a callback function in
+ * the context of the OpenThread task. This is useful for OpenThread modules that process data from
+ * an external interface and want to execute the handling function in the context of OpenThread
+ * task.
+ *
+ * @param[in] aInstance A pointer to an OpenThread instance.
+ * @param[in] callback  The callback function that executes from the context of the OpenThread task.
+ * @param[in] context   A pointer to a context that will be used by the callback function.
+ *
+ * @retval OT_ERROR_NONE              Successfully allocated InternalContext.
+ * @retval OT_ERROR_NO_BUFS           Insufficient space to store the InternalContext.
+ * @retval OT_ERROR_INVALID_STATE     OpenThread Instance is not initialized.
+ *
+ */
+otError otTaskletExecute(otInstance *aInstance, otTaskletCb callback, void *context);
+#endif /*OPENTHREAD_CONFIG_GENERIC_TASKLET_ENABLE*/
+
 /**
  * Run all queued OpenThread tasklets at the time this is called.
  *

--- a/src/core/api/tasklet_api.cpp
+++ b/src/core/api/tasklet_api.cpp
@@ -60,4 +60,16 @@ exit:
     return retval;
 }
 
+#if OPENTHREAD_CONFIG_GENERIC_TASKLET_ENABLE
+otError otTaskletExecute(otInstance *aInstance, otTaskletCb callback, void *context)
+{
+    Error error = kErrorNone;
+    VerifyOrExit(otInstanceIsInitialized(aInstance), error = kErrorInvalidState);
+    error = AsCoreType(aInstance).Get<GenericTasklet>().PostWithCb(callback, context);
+
+exit:
+    return error;
+}
+#endif /*OPENTHREAD_CONFIG_GENERIC_TASKLET_ENABLE*/
+
 OT_TOOL_WEAK void otTaskletsSignalPending(otInstance *) {}

--- a/src/core/common/tasklet.cpp
+++ b/src/core/common/tasklet.cpp
@@ -94,4 +94,54 @@ void Tasklet::Scheduler::ProcessQueuedTasklets(void)
     }
 }
 
+#if OPENTHREAD_CONFIG_GENERIC_TASKLET_ENABLE
+void GenericTasklet::HandleGenericTasklet(Tasklet &aTasklet)
+{
+    GenericTasklet  *currentTasklet = static_cast<GenericTasklet *>(&aTasklet);
+    InternalContext *entry          = currentTasklet->mEventList.GetHead();
+
+    while (entry != nullptr)
+    {
+        entry->mCallback(entry->mContext);
+        currentTasklet->mEventList.Remove(*entry);
+        entry->Free();
+        entry = currentTasklet->mEventList.GetHead();
+    }
+}
+
+Error GenericTasklet::PostWithCb(TaskletCallback aCallback, void *aContext)
+{
+    Error            error    = kErrorNone;
+    InternalContext *tmpEntry = nullptr;
+    InternalContext *entry    = InternalContext::AllocateAndInit(aCallback, aContext);
+
+    VerifyOrExit(entry != nullptr, error = kErrorNoBufs);
+
+    tmpEntry = mEventList.GetTail();
+    if (tmpEntry != nullptr)
+    {
+        // Put the new element at the end of the list so it's easier to iterate from older to newer using list get head
+        mEventList.PushAfter(*entry, *tmpEntry);
+    }
+    else
+    {
+        // Push to head since there is no element in the list
+        mEventList.Push(*entry);
+    }
+    this->Post();
+
+exit:
+    return error;
+}
+
+Error GenericTasklet::InternalContext::Init(GenericTasklet::TaskletCallback aCallback, void *aContext)
+{
+    mCallback = aCallback;
+    mContext  = aContext;
+    mNext     = nullptr;
+
+    return kErrorNone;
+}
+#endif /*OPENTHREAD_CONFIG_GENERIC_TASKLET_ENABLE*/
+
 } // namespace ot

--- a/src/core/config/misc.h
+++ b/src/core/config/misc.h
@@ -610,6 +610,18 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_GENERIC_TASKLET_ENABLE
+ *
+ * Define as 1 to enable support for Generic Tasklet.
+ *
+ * @note This functionality requires 'heap.cpp' to be included in the build files.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_GENERIC_TASKLET_ENABLE
+#define OPENTHREAD_CONFIG_GENERIC_TASKLET_ENABLE 0
+#endif
+
+/**
  * @}
  *
  */

--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -77,6 +77,9 @@ Instance::Instance(void)
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
     , mTimerMicroScheduler(*this)
 #endif
+#if OPENTHREAD_CONFIG_GENERIC_TASKLET_ENABLE
+    , mGenericTasklet(*this)
+#endif
     , mRadio(*this)
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
     , mUptime(*this)

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -451,6 +451,10 @@ private:
     TimerMicro::Scheduler mTimerMicroScheduler;
 #endif
 
+#if OPENTHREAD_CONFIG_GENERIC_TASKLET_ENABLE
+    GenericTasklet mGenericTasklet;
+#endif // OPENTHREAD_CONFIG_GENERIC_TASKLET_ENABLE
+
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
     // Random::Manager is initialized before other objects. Note that it
     // requires MbedTls which itself may use Heap.
@@ -1094,6 +1098,10 @@ template <> inline Mac::SubMac &Instance::Get(void) { return mLinkRaw.mSubMac; }
 template <> inline Tasklet::Scheduler &Instance::Get(void) { return mTaskletScheduler; }
 
 template <> inline TimerMilli::Scheduler &Instance::Get(void) { return mTimerMilliScheduler; }
+
+#if OPENTHREAD_CONFIG_GENERIC_TASKLET_ENABLE
+template <> inline GenericTasklet &Instance::Get(void) { return mGenericTasklet; }
+#endif
 
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 template <> inline TimerMicro::Scheduler &Instance::Get(void) { return mTimerMicroScheduler; }


### PR DESCRIPTION
This commit adds support for a generic tasklet class and object that allows a callback to be executed on the context on the Thread task. This is very usefull for the platform UDP functionality and allows the execution of socket handlers on the context of the OT task instead of the task of the plaftorm UDP.

GenericTasklet functionality and API are now available when OPENTHREAD_CONFIG_GENERIC_TASKLET_ENABLE is enabled