### PR TITLE
[tests] enhance expect test for link metrics manager feature

### DIFF
--- a/tests/scripts/expect/v1_2-linkmetricsmgr.exp
+++ b/tests/scripts/expect/v1_2-linkmetricsmgr.exp
@@ -57,4 +57,81 @@ expect_line "Done"
 send "linkmetricsmgr xxx\n"
 expect_line "InvalidCommand"
 
+# Test continuous enable
+send "linkmetricsmgr enable\n"
+expect_line "Done"
+send "linkmetricsmgr enable\n"
+expect_line "Done"
+send "linkmetricsmgr enable\n"
+expect_line "Done"
+
+send "ping $addr\n"
+expect "16 bytes from $addr: icmp_seq="
+
+sleep 10
+
+send "ping $addr\n"
+expect "16 bytes from $addr: icmp_seq="
+
+send "linkmetricsmgr show\n"
+expect -re {ExtAddr:([0-9a-f]){16}, LinkMargin:\d+, Rssi:\-?\d+}
+expect "Done"
+
+# Test continuous disable
+send "linkmetricsmgr disable\n"
+expect_line "Done"
+send "linkmetricsmgr disable\n"
+expect_line "Done"
+send "linkmetricsmgr disable\n"
+expect_line "Done"
+
+send "ping $addr\n"
+expect "16 bytes from $addr: icmp_seq="
+
+sleep 10
+
+send "ping $addr\n"
+expect "16 bytes from $addr: icmp_seq="
+
+send "linkmetricsmgr show\n"
+expect_line "Done"
+
+# Test continuous switch
+send "linkmetricsmgr enable\n"
+expect_line "Done"
+send "linkmetricsmgr disable\n"
+expect_line "Done"
+send "linkmetricsmgr enable\n"
+expect_line "Done"
+
+send "ping $addr\n"
+expect "16 bytes from $addr: icmp_seq="
+
+sleep 10
+
+send "ping $addr\n"
+expect "16 bytes from $addr: icmp_seq="
+
+send "linkmetricsmgr show\n"
+expect -re {ExtAddr:([0-9a-f]){16}, LinkMargin:\d+, Rssi:\-?\d+}
+expect "Done"
+
+send "linkmetricsmgr disable\n"
+expect_line "Done"
+send "linkmetricsmgr enable\n"
+expect_line "Done"
+send "linkmetricsmgr disable\n"
+expect_line "Done"
+
+send "ping $addr\n"
+expect "16 bytes from $addr: icmp_seq="
+
+sleep 10
+
+send "ping $addr\n"
+expect "16 bytes from $addr: icmp_seq="
+
+send "linkmetricsmgr show\n"
+expect_line "Done"
+
 dispose_all


### PR DESCRIPTION
The PR enhances the expect test against link metrics manager feature
to ensure that the feature can be continuously turned on or off and
work well. Because the feature will be controlled by the feature flag
in ot-br-posix.