### PR TITLE
[clang-format] accept different patch versions of `clang-format`

### DIFF
--- a/script/clang-format
+++ b/script/clang-format
@@ -43,7 +43,7 @@ if command -v clang-format-14 >/dev/null; then
     alias clang-format=clang-format-14
 elif command -v clang-format >/dev/null; then
     case "$(clang-format --version)" in
-        "$CLANG_FORMAT_VERSION"*) ;;
+        *"$CLANG_FORMAT_VERSION"*) ;;
 
         *)
             die "$(clang-format --version); clang-format 14.0 required"


### PR DESCRIPTION
Homebrew installation of clang-format (satisfying >14.0 requirement) outputs the following version string:
```
Homebrew clang-format version 14.0.6
```

This change fixes the following error while running make-pretty:
```
 *** ERROR: Homebrew clang-format version 14.0.6; clang-format 14.0 required
```