### PR TITLE
[dataset] simplify `AppendMleDatasetTlv()`

### DIFF
--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -530,6 +530,22 @@ public:
      *
      * On success this method grows the message by the size of the TLV.
      *
+     * @param[in]  aMessage      The message to append to.
+     * @param[in]  aType         The TLV type to append.
+     * @param[in]  aValue        A buffer containing the TLV value.
+     * @param[in]  aLength       The value length (in bytes).
+     *
+     * @retval kErrorNone     Successfully appended the TLV to the message.
+     * @retval kErrorNoBufs   Insufficient available buffers to grow the message.
+     *
+     */
+    static Error AppendTlv(Message &aMessage, uint8_t aType, const void *aValue, uint8_t aLength);
+
+    /**
+     * Appends a TLV with a given type and value to a message.
+     *
+     * On success this method grows the message by the size of the TLV.
+     *
      * @tparam     TlvType       The TLV type to append.
      *
      * @param[in]  aMessage      A reference to the message to append to.
@@ -687,7 +703,6 @@ private:
     };
 
     static Error FindTlv(const Message &aMessage, uint8_t aType, void *aValue, uint16_t aLength);
-    static Error AppendTlv(Message &aMessage, uint8_t aType, const void *aValue, uint8_t aLength);
     static Error ReadStringTlv(const Message &aMessage, uint16_t aOffset, uint8_t aMaxStringLength, char *aValue);
     static Error FindStringTlv(const Message &aMessage, uint8_t aType, uint8_t aMaxStringLength, char *aValue);
     static Error AppendStringTlv(Message &aMessage, uint8_t aType, uint8_t aMaxStringLength, const char *aValue);

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -495,18 +495,6 @@ public:
     void SetFrom(const Tlvs &aTlvs);
 
     /**
-     * Appends the MLE Dataset TLV but excluding MeshCoP Sub Timestamp TLV.
-     *
-     * @param[in] aType          The type of the dataset, active or pending.
-     * @param[in] aMessage       A message to append to.
-     *
-     * @retval kErrorNone    Successfully append MLE Dataset TLV without MeshCoP Sub Timestamp TLV.
-     * @retval kErrorNoBufs  Insufficient available buffers to append the message with MLE Dataset TLV.
-     *
-     */
-    Error AppendMleDatasetTlv(Type aType, Message &aMessage) const;
-
-    /**
      * Applies the Active or Pending Dataset to the Thread interface.
      *
      * @param[in]  aInstance            A reference to the OpenThread instance.


### PR DESCRIPTION
- Inlines `AppendMleDatasetTlv()` in `DatasetManager` (removing from `Dataset` class).
- Updates the locally read `dataset` directly by removing the timestamp before appending it to the message as an MLE TLV value.
- Leverages `Read()` which already updates the `DelayTimerTlv` with the remaining delay, eliminating the need to re-calculate and update the delay.
- Uses `Tlv::AppendTlv()` to append the MLE TLV with `dataset` bytes as value.