### PR TITLE
[dataset] add `ValidateTlvs()`

### DIFF
--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -162,7 +162,7 @@ otError otDatasetParseTlvs(const otOperationalDatasetTlvs *aDatasetTlvs, otOpera
     AssertPointerIsNotNull(aDatasetTlvs);
 
     dataset.SetFrom(*aDatasetTlvs);
-    VerifyOrExit(dataset.IsValid(), error = kErrorInvalidArgs);
+    VerifyOrExit(dataset.ValidateTlvs() == kErrorNone, error = kErrorInvalidArgs);
     dataset.ConvertTo(AsCoreType(aDataset));
 
 exit:

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -365,38 +365,9 @@ Error Dataset::SetFrom(const Info &aDatasetInfo)
     return error;
 }
 
-Error Dataset::GetTimestamp(Type aType, Timestamp &aTimestamp) const
+Error Dataset::ReadTimestamp(Type aType, Timestamp &aTimestamp) const
 {
-    Error      error = kErrorNone;
-    const Tlv *tlv;
-
-    if (aType == kActive)
-    {
-        tlv = FindTlv(Tlv::kActiveTimestamp);
-        VerifyOrExit(tlv != nullptr, error = kErrorNotFound);
-        aTimestamp = tlv->ReadValueAs<ActiveTimestampTlv>();
-    }
-    else
-    {
-        tlv = FindTlv(Tlv::kPendingTimestamp);
-        VerifyOrExit(tlv != nullptr, error = kErrorNotFound);
-        aTimestamp = tlv->ReadValueAs<PendingTimestampTlv>();
-    }
-
-exit:
-    return error;
-}
-
-void Dataset::SetTimestamp(Type aType, const Timestamp &aTimestamp)
-{
-    if (aType == kActive)
-    {
-        IgnoreError(Write<ActiveTimestampTlv>(aTimestamp));
-    }
-    else
-    {
-        IgnoreError(Write<PendingTimestampTlv>(aTimestamp));
-    }
+    return (aType == kActive) ? Read<ActiveTimestampTlv>(aTimestamp) : Read<PendingTimestampTlv>(aTimestamp);
 }
 
 Error Dataset::WriteTlv(Tlv::Type aType, const void *aValue, uint8_t aLength)

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -172,12 +172,62 @@ bool Dataset::IsValid(void) const
 
     for (const Tlv *cur = GetTlvsStart(); cur < end; cur = cur->GetNext())
     {
-        VerifyOrExit(!cur->IsExtended() && (cur + 1) <= end && cur->GetNext() <= end && Tlv::IsValid(*cur),
-                     rval = false);
+        VerifyOrExit(!cur->IsExtended() && (cur + 1) <= end && cur->GetNext() <= end && IsTlvValid(*cur), rval = false);
     }
 
 exit:
     return rval;
+}
+
+bool Dataset::IsTlvValid(const Tlv &aTlv)
+{
+    bool    isValid   = true;
+    uint8_t minLength = 0;
+
+    switch (aTlv.GetType())
+    {
+    case Tlv::kPanId:
+        minLength = sizeof(PanIdTlv::UintValueType);
+        break;
+    case Tlv::kExtendedPanId:
+        minLength = sizeof(ExtendedPanIdTlv::ValueType);
+        break;
+    case Tlv::kPskc:
+        minLength = sizeof(PskcTlv::ValueType);
+        break;
+    case Tlv::kNetworkKey:
+        minLength = sizeof(NetworkKeyTlv::ValueType);
+        break;
+    case Tlv::kMeshLocalPrefix:
+        minLength = sizeof(MeshLocalPrefixTlv::ValueType);
+        break;
+    case Tlv::kChannel:
+        VerifyOrExit(aTlv.GetLength() >= sizeof(ChannelTlvValue), isValid = false);
+        isValid = aTlv.ReadValueAs<ChannelTlv>().IsValid();
+        break;
+    case Tlv::kNetworkName:
+        isValid = As<NetworkNameTlv>(aTlv).IsValid();
+        break;
+
+    case Tlv::kSecurityPolicy:
+        isValid = As<SecurityPolicyTlv>(aTlv).IsValid();
+        break;
+
+    case Tlv::kChannelMask:
+        isValid = As<ChannelMaskTlv>(aTlv).IsValid();
+        break;
+
+    default:
+        break;
+    }
+
+    if (minLength > 0)
+    {
+        isValid = (aTlv.GetLength() >= minLength);
+    }
+
+exit:
+    return isValid;
 }
 
 const Tlv *Dataset::FindTlv(Tlv::Type aType) const { return As<Tlv>(Tlv::FindTlv(mTlvs, mLength, aType)); }

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -245,12 +245,18 @@ public:
     void Clear(void);
 
     /**
-     * Indicates whether or not the dataset appears to be well-formed.
+     * Parses and validates all TLVs contained within the Dataset.
      *
-     * @returns TRUE if the dataset appears to be well-formed, FALSE otherwise.
+     * Performs the following checks all TLVs in the Dataset:
+     *  - Ensures correct TLV format and expected minimum length for known TLV types that may appear in a Dataset.
+     *  - Validates TLV value when applicable (e.g., Channel TLV using a supported channel).
+     *  - Ensures no duplicate occurrence of same TLV type.
+     *
+     * @retval kErrorNone   Successfully validated all the TLVs in the Dataset.
+     * @retval kErrorParse  Dataset TLVs is not well-formed.
      *
      */
-    bool IsValid(void) const;
+    Error ValidateTlvs(void) const;
 
     /**
      * Validates the format and value of a given MeshCoP TLV used in Dataset.
@@ -438,6 +444,21 @@ public:
      *
      */
     void RemoveTlv(Tlv::Type aType);
+
+    /**
+     * Merges TLVs from a given Dataset into this Dataset.
+     *
+     * TLVs from @p aDataset are parsed and updated in the current Dataset. If same TLV already exists, it will be
+     * replaced. Otherwise, the TLV will be appended.
+     *
+     * @param[in] aDataset   A Dataset.
+     *
+     * @retval kErrorNone    Successfully merged TLVs from @p Dataset into this Dataset.
+     * @retval kErrorParse   The @p aDataset is not valid.
+     * @retval kErrorNoBufs  Could not add the TLV due to insufficient buffer space.
+     *
+     */
+    Error MergeTlvsFrom(const Dataset &aDataset);
 
     /**
      * Returns a pointer to the byte representation of the Dataset.

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -298,6 +298,58 @@ public:
     const Tlv *FindTlv(Tlv::Type aType) const;
 
     /**
+     * Finds and reads a simple TLV in the Dataset.
+     *
+     * If the specified TLV type is not found, `kErrorNotFound` is reported.
+     *
+     * @tparam  SimpleTlvType   The simple TLV type (must be a sub-class of `SimpleTlvInfo`).
+     *
+     * @param[out] aValue       A reference to return the read TLV value.
+     *
+     * @retval kErrorNone      Successfully found and read the TLV value. @p aValue is updated.
+     * @retval kErrorNotFound  Could not find the TLV in the Dataset.
+     *
+     */
+    template <typename SimpleTlvType> Error Read(typename SimpleTlvType::ValueType &aValue) const
+    {
+        const Tlv *tlv = FindTlv(static_cast<Tlv::Type>(SimpleTlvType::kType));
+
+        return (tlv == nullptr) ? kErrorNotFound : (aValue = tlv->ReadValueAs<SimpleTlvType>(), kErrorNone);
+    }
+
+    /**
+     * Finds and reads an `uint` TLV in the Dataset.
+     *
+     * If the specified TLV type is not found, `kErrorNotFound` is reported.
+     *
+     * @tparam  UintTlvType     The integer simple TLV type (must be a sub-class of `UintTlvInfo`).
+     *
+     * @param[out] aValue       A reference to return the read TLV value.
+     *
+     * @retval kErrorNone      Successfully found and read the TLV value. @p aValue is updated.
+     * @retval kErrorNotFound  Could not find the TLV in the Dataset.
+     *
+     */
+    template <typename UintTlvType> Error Read(typename UintTlvType::UintValueType &aValue) const
+    {
+        const Tlv *tlv = FindTlv(static_cast<Tlv::Type>(UintTlvType::kType));
+
+        return (tlv == nullptr) ? kErrorNotFound : (aValue = tlv->ReadValueAs<UintTlvType>(), kErrorNone);
+    }
+
+    /**
+     * Reads the Timestamp (Active or Pending).
+     *
+     * @param[in]  aType       The type: active or pending.
+     * @param[out] aTimestamp  A reference to a `Timestamp` to output the value.
+     *
+     * @retval kErrorNone      Timestamp was read successfully. @p aTimestamp is updated.
+     * @retval kErrorNotFound  Could not find the requested Timestamp TLV.
+     *
+     */
+    Error ReadTimestamp(Type aType, Timestamp &aTimestamp) const;
+
+    /**
      * Writes a TLV to the Dataset.
      *
      * If the specified TLV type already exists, it will be replaced. Otherwise, the TLV will be appended.
@@ -428,27 +480,6 @@ public:
      *
      */
     TimeMilli GetUpdateTime(void) const { return mUpdateTime; }
-
-    /**
-     * Gets the Timestamp (Active or Pending).
-     *
-     * @param[in]  aType       The type: active or pending.
-     * @param[out] aTimestamp  A reference to a `Timestamp` to output the value.
-     *
-     * @retval kErrorNone      Timestamp was read successfully. @p aTimestamp is updated.
-     * @retval kErrorNotFound  Could not find the requested Timestamp TLV.
-     *
-     */
-    Error GetTimestamp(Type aType, Timestamp &aTimestamp) const;
-
-    /**
-     * Sets the Timestamp value.
-     *
-     * @param[in] aType        The type: active or pending.
-     * @param[in] aTimestamp   A Timestamp.
-     *
-     */
-    void SetTimestamp(Type aType, const Timestamp &aTimestamp);
 
     /**
      * Reads the Dataset from a given message and checks that it is well-formed and valid.

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -253,6 +253,20 @@ public:
     bool IsValid(void) const;
 
     /**
+     * Validates the format and value of a given MeshCoP TLV used in Dataset.
+     *
+     * TLV types that can appear in an Active or Pending Operational Dataset are validated. Other TLV types including
+     * unknown TLV types are considered as valid.
+     *
+     * @param[in]  aTlv    The TLV to validate.
+     *
+     * @retval  TRUE       The TLV format and value is valid, or TLV type is unknown (not supported in Dataset).
+     * @retval  FALSE      The TLV format or value is invalid.
+     *
+     */
+    static bool IsTlvValid(const Tlv &aTlv);
+
+    /**
      * Indicates whether or not a given TLV type is present in the Dataset.
      *
      * @param[in] aType  The TLV type to check.

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -82,7 +82,7 @@ Error DatasetLocal::Restore(Dataset &aDataset)
     SuccessOrExit(error);
 
     mSaved            = true;
-    mTimestampPresent = (aDataset.GetTimestamp(mType, mTimestamp) == kErrorNone);
+    mTimestampPresent = (aDataset.ReadTimestamp(mType, mTimestamp) == kErrorNone);
 
 exit:
     return error;
@@ -199,7 +199,7 @@ Error DatasetLocal::Save(const Dataset &aDataset)
         LogInfo("%s dataset set", Dataset::TypeToString(mType));
     }
 
-    mTimestampPresent = (aDataset.GetTimestamp(mType, mTimestamp) == kErrorNone);
+    mTimestampPresent = (aDataset.ReadTimestamp(mType, mTimestamp) == kErrorNone);
     mUpdateTime       = TimerMilli::GetNow();
 
 exit:

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -443,7 +443,7 @@ void PendingDatasetManager::ApplyActiveDataset(const Timestamp &aTimestamp, Coap
 
     IgnoreError(dataset.Write<DelayTimerTlv>(Get<Leader>().GetDelayTimerMinimal()));
 
-    dataset.SetTimestamp(Dataset::kPending, aTimestamp);
+    IgnoreError(dataset.Write<PendingTimestampTlv>(aTimestamp));
     IgnoreError(DatasetManager::Save(dataset));
 
     StartDelayTimer();

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -291,7 +291,7 @@ Error DatasetManager::DatasetTlv::ReadFromMessage(const Message &aMessage, uint1
     SuccessOrExit(error = aMessage.Read(aOffset, this, sizeof(Tlv)));
     VerifyOrExit(GetLength() <= Dataset::kMaxValueSize, error = kErrorParse);
     SuccessOrExit(error = aMessage.Read(aOffset + sizeof(Tlv), mValue, GetLength()));
-    VerifyOrExit(Tlv::IsValid(*this), error = kErrorParse);
+    VerifyOrExit(Dataset::IsTlvValid(*this), error = kErrorParse);
 
 exit:
     return error;

--- a/src/core/meshcop/dataset_updater.cpp
+++ b/src/core/meshcop/dataset_updater.cpp
@@ -139,14 +139,14 @@ void DatasetUpdater::PreparePendingDataset(void)
         }
 
         timestamp.AdvanceRandomTicks();
-        dataset.SetTimestamp(Dataset::kPending, timestamp);
+        IgnoreError(dataset.Write<PendingTimestampTlv>(timestamp));
     }
 
     {
         Timestamp timestamp = dataset.FindTlv(Tlv::kActiveTimestamp)->ReadValueAs<ActiveTimestampTlv>();
 
         timestamp.AdvanceRandomTicks();
-        dataset.SetTimestamp(Dataset::kActive, timestamp);
+        IgnoreError(dataset.Write<ActiveTimestampTlv>(timestamp));
     }
 
     SuccessOrExit(error = Get<PendingDatasetManager>().Save(dataset));

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -43,57 +43,6 @@
 namespace ot {
 namespace MeshCoP {
 
-bool Tlv::IsValid(const Tlv &aTlv)
-{
-    bool    isValid   = true;
-    uint8_t minLength = 0;
-
-    switch (aTlv.GetType())
-    {
-    case Tlv::kPanId:
-        minLength = sizeof(PanIdTlv::UintValueType);
-        break;
-    case Tlv::kExtendedPanId:
-        minLength = sizeof(ExtendedPanIdTlv::ValueType);
-        break;
-    case Tlv::kPskc:
-        minLength = sizeof(PskcTlv::ValueType);
-        break;
-    case Tlv::kNetworkKey:
-        minLength = sizeof(NetworkKeyTlv::ValueType);
-        break;
-    case Tlv::kMeshLocalPrefix:
-        minLength = sizeof(MeshLocalPrefixTlv::ValueType);
-        break;
-    case Tlv::kChannel:
-        VerifyOrExit(aTlv.GetLength() >= sizeof(ChannelTlvValue), isValid = false);
-        isValid = aTlv.ReadValueAs<ChannelTlv>().IsValid();
-        break;
-    case Tlv::kNetworkName:
-        isValid = As<NetworkNameTlv>(aTlv).IsValid();
-        break;
-
-    case Tlv::kSecurityPolicy:
-        isValid = As<SecurityPolicyTlv>(aTlv).IsValid();
-        break;
-
-    case Tlv::kChannelMask:
-        isValid = As<ChannelMaskTlv>(aTlv).IsValid();
-        break;
-
-    default:
-        break;
-    }
-
-    if (minLength > 0)
-    {
-        isValid = (aTlv.GetLength() >= minLength);
-    }
-
-exit:
-    return isValid;
-}
-
 NameData NetworkNameTlv::GetNetworkName(void) const
 {
     uint8_t len = GetLength();

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -160,16 +160,6 @@ public:
      */
     const Tlv *GetNext(void) const { return As<Tlv>(ot::Tlv::GetNext()); }
 
-    /**
-     * Indicates whether a TLV appears to be well-formed.
-     *
-     * @param[in]  aTlv  A reference to the TLV.
-     *
-     * @returns TRUE if the TLV appears to be well-formed, FALSE otherwise.
-     *
-     */
-    static bool IsValid(const Tlv &aTlv);
-
 } OT_TOOL_PACKED_END;
 
 /**


### PR DESCRIPTION
This commit adds `Dataset::ValidateTlvs()`, replacing and improving upon the `IsValid()` method. The new method parses and validates all TLVs within the Dataset. For supported Dataset TLV types, it checks the TLV format, expected minimum length, the TLV value, and prevents duplication. Unknown TLV types or TLV types not currently supported in a Dataset are intentionally skipped to enable future Dataset format extensions.

This commit also relocates `IsTlvValid()` to the `Dataset` class, emphasizing its specificity for validating Dataset TLVs and not other MeshCop TLVs.