### PR TITLE
[logging] fix print format when enabling csl debug

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -333,8 +333,8 @@ void SubMac::LogReceived(RxFrame *aFrame)
     //   be due to clocks drift and/or CSL Phase rounding error.
     // This means that a deviation absolute value greater than the margin would result in the frame
     // not being received out of the debug mode.
-    logString.Append("Expected sample time %lu, margin ±%lu, deviation %d", ToUlong(sampleTime), ToUlong(ahead),
-                     deviation);
+    logString.Append("Expected sample time %lu, margin ±%lu, deviation %ld", ToUlong(sampleTime), ToUlong(ahead),
+                     static_cast<long>(deviation));
 
     // Treat as a warning when the deviation is not within the margins. Neither kCslReceiveTimeAhead
     // or kMinReceiveOnAhead/kMinReceiveOnAfter are considered for the margin since they have no


### PR DESCRIPTION
Fix -Wformat trigger on some platforms as an int32_t is printed using %d

    ```
    src/core/mac/sub_mac.cpp:336:73: warning: format '%d' expects argument of type 'int', but argument 5 has type 'int32_t' {aka 'long int'} [-Wformat=]
      336 |     logString.Append("Expected sample time %lu, margin ±%lu, deviation %d", ToUlong(sampleTime), ToUlong(ahead),
          |                                                                        ~^
          |                                                                         |
          |                                                                         int
          |                                                                        %ld
      337 |                      deviation);
          |                      ~~~~~~~~~
          |                      |
          |                      int32_t {aka long int}
    ```