### PR TITLE
[spinel] breakdown posix radio module

### DIFF
--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -159,6 +159,9 @@ public:
      * Initialize this radio transceiver.
      *
      * @param[in]  aSkipRcpCompatibilityCheck  TRUE to skip RCP compatibility check, FALSE to perform the check.
+     * @param[in]  aSoftwareReset              When doing RCP recovery, TRUE to try software reset first, FALSE to
+     *                                         directly do a hardware reset.
+     * @param[in]  aSpinelDriver               A pointer to the spinel driver instance that this object depends on.
      *
      */
     void Init(bool aSkipRcpCompatibilityCheck, bool aSoftwareReset, SpinelDriver *aSpinelDriver);

--- a/src/lib/spinel/spinel_driver.hpp
+++ b/src/lib/spinel/spinel_driver.hpp
@@ -34,6 +34,7 @@
 #include "lib/spinel/logger.hpp"
 #include "lib/spinel/spinel.h"
 #include "lib/spinel/spinel_interface.hpp"
+#include "posix/platform/coprocessor_type.h"
 
 namespace ot {
 namespace Spinel {
@@ -70,11 +71,15 @@ public:
      *                                         First entry must be the IID of the Host Application.
      * @param[in]  aIidListLength              The Length of the @p aIidList.
      *
+     * @retval  OT_COPROCESSOR_UNKNOWN  The initialization fails.
+     * @retval  OT_COPROCESSOR_RCP      The Co-processor is a RCP.
+     * @retval  OT_COPROCESSOR_NCP      The Co-processor is a NCP.
+     *
      */
-    void Init(SpinelInterface    &aSpinelInterface,
-              bool                aSoftwareReset,
-              const spinel_iid_t *aIidList,
-              uint8_t             aIidListLength);
+    CoprocessorType Init(SpinelInterface    &aSpinelInterface,
+                         bool                aSoftwareReset,
+                         const spinel_iid_t *aIidList,
+                         uint8_t             aIidListLength);
 
     /**
      * Deinitialize this SpinelDriver Instance.
@@ -272,9 +277,10 @@ private:
 
     otError SendCommand(uint32_t aCommand, spinel_prop_key_t aKey, spinel_tid_t aTid);
 
-    otError CheckSpinelVersion(void);
-    otError GetCoprocessorVersion(void);
-    otError GetCoprocessorCaps(void);
+    otError         CheckSpinelVersion(void);
+    otError         GetCoprocessorVersion(void);
+    otError         GetCoprocessorCaps(void);
+    CoprocessorType GetCoprocessorType(void);
 
     void ProcessFrameQueue(void);
 

--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -145,6 +145,7 @@ add_library(openthread-posix
     radio_url.cpp
     resolver.cpp
     settings.cpp
+    spinel_manager.cpp
     spi_interface.cpp
     system.cpp
     trel.cpp

--- a/src/posix/platform/coprocessor_type.h
+++ b/src/posix/platform/coprocessor_type.h
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OT_PLATFORM_COPROCESSOR_MODE_H_
+#define OT_PLATFORM_COPROCESSOR_MODE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Represents the mode of the co-processor.
+ * A co-processor could be either a RCP or NCP.
+ */
+enum CoprocessorType
+{
+    OT_COPROCESSOR_UNKNOWN = 0,
+    OT_COPROCESSOR_RCP     = 1,
+    OT_COPROCESSOR_NCP     = 2,
+};
+
+#ifdef __cplusplus
+}
+#endif
+#endif // OT_PLATFORM_COPROCESSOR_MODE_H_

--- a/src/posix/platform/coprocessor_type.h
+++ b/src/posix/platform/coprocessor_type.h
@@ -37,12 +37,12 @@ extern "C" {
  * Represents the mode of the co-processor.
  * A co-processor could be either a RCP or NCP.
  */
-enum CoprocessorType
+typedef enum CoprocessorType
 {
     OT_COPROCESSOR_UNKNOWN = 0,
     OT_COPROCESSOR_RCP     = 1,
     OT_COPROCESSOR_NCP     = 2,
-};
+} CoprocessorType;
 
 #ifdef __cplusplus
 }

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -52,6 +52,7 @@
 #include <openthread/openthread-system.h>
 #include <openthread/platform/time.h>
 
+#include "coprocessor_type.h"
 #include "lib/platform/exit_code.h"
 #include "lib/url/url.hpp"
 
@@ -338,13 +339,22 @@ void virtualTimeReceiveEvent(struct VirtualTimeEvent *aEvent);
 void virtualTimeSendSleepEvent(const struct timeval *aTimeout);
 
 /**
- * Performs radio spinel processing of virtual time simulation.
+ * Performs radio processing of virtual time simulation.
  *
  * @param[in]   aInstance   A pointer to the OpenThread instance.
  * @param[in]   aEvent      A pointer to the current event.
  *
  */
-void virtualTimeRadioSpinelProcess(otInstance *aInstance, const struct VirtualTimeEvent *aEvent);
+void virtualTimeRadioProcess(otInstance *aInstance, const struct VirtualTimeEvent *aEvent);
+
+/**
+ * Performs radio  processing of virtual time simulation.
+ *
+ * @param[in]   aInstance   A pointer to the OpenThread instance.
+ * @param[in]   aEvent      A pointer to the current event.
+ *
+ */
+void virtualTimeSpinelProcess(otInstance *aInstance, const struct VirtualTimeEvent *aEvent);
 
 enum SocketBlockOption
 {
@@ -420,6 +430,40 @@ extern otInstance *gInstance;
  *
  */
 void platformBacktraceInit(void);
+
+/**
+ * Initializes the spinel service used by OpenThread.
+ *
+ * @param[in]   aUrl  A pointer to the null-terminated spinel URL.
+ *
+ * @retval  OT_COPROCESSOR_UNKNOWN  The initialization fails.
+ * @retval  OT_COPROCESSOR_RCP      The Co-processor is a RCP.
+ * @retval  OT_COPROCESSOR_NCP      The Co-processor is a NCP.
+ */
+CoprocessorType platformSpinelManagerInit(const char *aUrl);
+
+/**
+ * Shuts down the spinel service used by OpenThread.
+ *
+ */
+void platformSpinelManagerDeinit(void);
+
+/**
+ * Performs spinel driver processing.
+ *
+ * @param[in]   aInstance   A pointer to the OT instance.
+ * @param[in]   aContext    A pointer to the mainloop context.
+ *
+ */
+void platformSpinelManagerProcess(otInstance *aInstance, const otSysMainloopContext *aContext);
+
+/**
+ * Updates the file descriptor sets with file descriptors used by the spinel driver.
+ *
+ * @param[in]   aContext    A pointer to the mainloop context.
+ *
+ */
+void platformSpinelManagerUpdateFdSet(otSysMainloopContext *aContext);
 
 #ifdef __cplusplus
 }

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -89,7 +89,7 @@ void Radio::Init(const char *aUrl)
     skipCompatibilityCheck = mRadioUrl.HasParam("skip-rcp-compatibility-check");
 
     mRadioSpinel.SetCallbacks(callbacks);
-    mRadioSpinel.Init(skipCompatibilityCheck, resetRadio, &GetSpinelDriver());
+    mRadioSpinel.Init(skipCompatibilityCheck, resetRadio, &SpinelManager::GetSpinelDriver());
 
     ProcessRadioUrl(mRadioUrl);
 }

--- a/src/posix/platform/radio.hpp
+++ b/src/posix/platform/radio.hpp
@@ -76,7 +76,7 @@ public:
      * @returns A reference to the radio's spinel interface instance.
      *
      */
-    Spinel::SpinelInterface &GetSpinelInterface(void) { return GetSpinelManager().GetSpinelInterface(); }
+    Spinel::SpinelInterface &GetSpinelInterface(void) { return SpinelManager::GetSpinelManager().GetSpinelInterface(); }
 
     /**
      * Acts as an accessor to the radio spinel instance used by the radio.

--- a/src/posix/platform/spinel_manager.cpp
+++ b/src/posix/platform/spinel_manager.cpp
@@ -43,9 +43,9 @@ static ot::Posix::SpinelManager sSpinelManager;
 namespace ot {
 namespace Posix {
 
-SpinelManager &GetSpinelManager(void) { return sSpinelManager; }
+SpinelManager &SpinelManager::GetSpinelManager(void) { return sSpinelManager; }
 
-ot::Spinel::SpinelDriver &GetSpinelDriver(void) { return sSpinelManager.GetSpinelDriver(); }
+Spinel::SpinelDriver &SpinelManager::GetSpinelDriver(void) { return sSpinelManager.mSpinelDriver; }
 
 SpinelManager::SpinelManager(void)
     : mUrl(nullptr)
@@ -59,7 +59,7 @@ SpinelManager::~SpinelManager(void) { Deinit(); }
 CoprocessorType SpinelManager::Init(const char *aUrl)
 {
     bool            swReset;
-    spinel_iid_t    iidList[ot::Spinel::kSpinelHeaderMaxNumIid];
+    spinel_iid_t    iidList[Spinel::kSpinelHeaderMaxNumIid];
     CoprocessorType mode;
 
     mUrl.Init(aUrl);
@@ -94,9 +94,9 @@ void SpinelManager::Deinit(void)
     mSpinelDriver.Deinit();
 }
 
-ot::Spinel::SpinelInterface *SpinelManager::CreateSpinelInterface(const char *aInterfaceName)
+Spinel::SpinelInterface *SpinelManager::CreateSpinelInterface(const char *aInterfaceName)
 {
-    ot::Spinel::SpinelInterface *interface;
+    Spinel::SpinelInterface *interface;
 
     if (aInterfaceName == nullptr)
     {
@@ -129,7 +129,7 @@ ot::Spinel::SpinelInterface *SpinelManager::CreateSpinelInterface(const char *aI
     return interface;
 }
 
-void SpinelManager::GetIidListFromUrl(spinel_iid_t (&aIidList)[ot::Spinel::kSpinelHeaderMaxNumIid])
+void SpinelManager::GetIidListFromUrl(spinel_iid_t (&aIidList)[Spinel::kSpinelHeaderMaxNumIid])
 {
     const char *iidString;
     const char *iidListString;
@@ -201,14 +201,14 @@ void platformSpinelManagerDeinit(void) { return sSpinelManager.Deinit(); }
 void virtualTimeSpinelProcess(otInstance *aInstance, const struct VirtualTimeEvent *aEvent)
 {
     OT_UNUSED_VARIABLE(aInstance);
-    sSpinelManager.GetSpinelDriver().Process(aEvent);
+    ot::Posix::SpinelManager::GetSpinelDriver().Process(aEvent);
 }
 #else
 void platformSpinelManagerProcess(otInstance *aInstance, const otSysMainloopContext *aContext)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    sSpinelManager.GetSpinelDriver().Process(aContext);
+    ot::Posix::SpinelManager::GetSpinelDriver().Process(aContext);
 }
 #endif // OPENTHREAD_POSIX_VIRTUAL_TIME
 
@@ -216,7 +216,7 @@ void platformSpinelManagerUpdateFdSet(otSysMainloopContext *aContext)
 {
     sSpinelManager.GetSpinelInterface().UpdateFdSet(aContext);
 
-    if (sSpinelManager.GetSpinelDriver().HasPendingFrame())
+    if (ot::Posix::SpinelManager::GetSpinelDriver().HasPendingFrame())
     {
         aContext->mTimeout.tv_sec  = 0;
         aContext->mTimeout.tv_usec = 0;

--- a/src/posix/platform/spinel_manager.cpp
+++ b/src/posix/platform/spinel_manager.cpp
@@ -1,0 +1,224 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "platform-posix.h"
+
+#include "posix/platform/spinel_manager.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/new.hpp"
+#include "lib/spinel/spinel_driver.hpp"
+#include "posix/platform/hdlc_interface.hpp"
+#include "posix/platform/radio_url.hpp"
+#include "posix/platform/spi_interface.hpp"
+#include "posix/platform/vendor_interface.hpp"
+
+static ot::Posix::SpinelManager sSpinelManager;
+
+namespace ot {
+namespace Posix {
+
+SpinelManager &GetSpinelManager(void) { return sSpinelManager; }
+
+ot::Spinel::SpinelDriver &GetSpinelDriver(void) { return sSpinelManager.GetSpinelDriver(); }
+
+SpinelManager::SpinelManager(void)
+    : mUrl(nullptr)
+    , mSpinelDriver()
+    , mSpinelInterface(nullptr)
+{
+}
+
+SpinelManager::~SpinelManager(void) { Deinit(); }
+
+CoprocessorType SpinelManager::Init(const char *aUrl)
+{
+    bool            swReset;
+    spinel_iid_t    iidList[ot::Spinel::kSpinelHeaderMaxNumIid];
+    CoprocessorType mode;
+
+    mUrl.Init(aUrl);
+    VerifyOrDie(mUrl.GetPath() != nullptr, OT_EXIT_INVALID_ARGUMENTS);
+
+    GetIidListFromUrl(iidList);
+
+#if OPENTHREAD_POSIX_VIRTUAL_TIME
+    VirtualTimeInit();
+#endif
+
+    mSpinelInterface = CreateSpinelInterface(mUrl.GetProtocol());
+    VerifyOrDie(mSpinelInterface != nullptr, OT_EXIT_FAILURE);
+
+    swReset = !mUrl.HasParam("no-reset");
+
+    mode = mSpinelDriver.Init(*mSpinelInterface, swReset, iidList, OT_ARRAY_LENGTH(iidList));
+
+    otLogDebgPlat("instance init:%p - iid = %d", (void *)&mSpinelDriver, iidList[0]);
+
+    return mode;
+}
+
+void SpinelManager::Deinit(void)
+{
+    if (mSpinelInterface != nullptr)
+    {
+        mSpinelInterface->Deinit();
+        mSpinelInterface = nullptr;
+    }
+
+    mSpinelDriver.Deinit();
+}
+
+ot::Spinel::SpinelInterface *SpinelManager::CreateSpinelInterface(const char *aInterfaceName)
+{
+    ot::Spinel::SpinelInterface *interface;
+
+    if (aInterfaceName == nullptr)
+    {
+        DieNow(OT_ERROR_FAILED);
+    }
+#if OPENTHREAD_POSIX_CONFIG_SPINEL_HDLC_INTERFACE_ENABLE
+    else if (HdlcInterface::IsInterfaceNameMatch(aInterfaceName))
+    {
+        interface = new (&mSpinelInterfaceRaw) HdlcInterface(mUrl);
+    }
+#endif
+#if OPENTHREAD_POSIX_CONFIG_SPINEL_SPI_INTERFACE_ENABLE
+    else if (Posix::SpiInterface::IsInterfaceNameMatch(aInterfaceName))
+    {
+        interface = new (&mSpinelInterfaceRaw) SpiInterface(mUrl);
+    }
+#endif
+#if OPENTHREAD_POSIX_CONFIG_SPINEL_VENDOR_INTERFACE_ENABLE
+    else if (VendorInterface::IsInterfaceNameMatch(aInterfaceName))
+    {
+        interface = new (&mSpinelInterfaceRaw) VendorInterface(mUrl);
+    }
+#endif
+    else
+    {
+        otLogCritPlat("The Spinel interface name \"%s\" is not supported!", aInterfaceName);
+        DieNow(OT_ERROR_FAILED);
+    }
+
+    return interface;
+}
+
+void SpinelManager::GetIidListFromUrl(spinel_iid_t (&aIidList)[ot::Spinel::kSpinelHeaderMaxNumIid])
+{
+    const char *iidString;
+    const char *iidListString;
+
+    memset(aIidList, SPINEL_HEADER_INVALID_IID, sizeof(aIidList));
+
+    iidString     = mUrl.GetValue("iid");
+    iidListString = mUrl.GetValue("iid-list");
+
+#if OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
+    // First entry to the aIidList must be the IID of the host application.
+    VerifyOrDie(iidString != nullptr, OT_EXIT_INVALID_ARGUMENTS);
+    aIidList[0] = static_cast<spinel_iid_t>(atoi(iidString));
+
+    if (iidListString != nullptr)
+    {
+        // Convert string to an array of integers.
+        // Integer i is for traverse the iidListString.
+        // Integer j is for aIidList array offset location.
+        // First entry of aIidList is for host application iid hence j start from 1.
+        for (uint8_t i = 0, j = 1; iidListString[i] != '\0' && j < Spinel::kSpinelHeaderMaxNumIid; i++)
+        {
+            if (iidListString[i] == ',')
+            {
+                j++;
+                continue;
+            }
+
+            if (iidListString[i] < '0' || iidListString[i] > '9')
+            {
+                DieNow(OT_EXIT_INVALID_ARGUMENTS);
+            }
+            else
+            {
+                aIidList[j] = iidListString[i] - '0';
+                VerifyOrDie(aIidList[j] < Spinel::kSpinelHeaderMaxNumIid, OT_EXIT_INVALID_ARGUMENTS);
+            }
+        }
+    }
+#else  // !OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
+    VerifyOrDie(iidString == nullptr, OT_EXIT_INVALID_ARGUMENTS);
+    VerifyOrDie(iidListString == nullptr, OT_EXIT_INVALID_ARGUMENTS);
+    aIidList[0] = 0;
+#endif // OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
+}
+
+#if OPENTHREAD_POSIX_VIRTUAL_TIME
+void SpinelManager::VirtualTimeInit(void)
+{
+    // The last argument must be the node id
+    const char *nodeId = nullptr;
+
+    for (const char *arg = nullptr; (arg = mUrl.GetValue("forkpty-arg", arg)) != nullptr; nodeId = arg)
+    {
+    }
+
+    virtualTimeInit(static_cast<uint16_t>(atoi(nodeId)));
+}
+#endif
+
+} // namespace Posix
+} // namespace ot
+
+CoprocessorType platformSpinelManagerInit(const char *aUrl) { return sSpinelManager.Init(aUrl); }
+
+void platformSpinelManagerDeinit(void) { return sSpinelManager.Deinit(); }
+
+#if OPENTHREAD_POSIX_VIRTUAL_TIME
+void virtualTimeSpinelProcess(otInstance *aInstance, const struct VirtualTimeEvent *aEvent)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    sSpinelManager.GetSpinelDriver().Process(aEvent);
+}
+#else
+void platformSpinelManagerProcess(otInstance *aInstance, const otSysMainloopContext *aContext)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    sSpinelManager.GetSpinelDriver().Process(aContext);
+}
+#endif // OPENTHREAD_POSIX_VIRTUAL_TIME
+
+void platformSpinelManagerUpdateFdSet(otSysMainloopContext *aContext)
+{
+    sSpinelManager.GetSpinelInterface().UpdateFdSet(aContext);
+
+    if (sSpinelManager.GetSpinelDriver().HasPendingFrame())
+    {
+        aContext->mTimeout.tv_sec  = 0;
+        aContext->mTimeout.tv_usec = 0;
+    }
+}

--- a/src/posix/platform/spinel_manager.hpp
+++ b/src/posix/platform/spinel_manager.hpp
@@ -43,6 +43,18 @@ class SpinelManager
 {
 public:
     /**
+     * Returns the static instance of the SpinelDriver.
+     *
+     */
+    static Spinel::SpinelDriver &GetSpinelDriver(void);
+
+    /**
+     * Returns the static instance of the SpinelManager.
+     *
+     */
+    static SpinelManager &GetSpinelManager(void);
+
+    /**
      * Constructor of the SpinelManager
      *
      */
@@ -78,51 +90,40 @@ public:
      * @returns The spinel interface.
      *
      */
-    ot::Spinel::SpinelInterface &GetSpinelInterface(void)
+    Spinel::SpinelInterface &GetSpinelInterface(void)
     {
         OT_ASSERT(mSpinelInterface != nullptr);
         return *mSpinelInterface;
     }
 
-    /**
-     * Returns the spinel driver.
-     *
-     * @returns The spinel driver.
-     *
-     */
-    ot::Spinel::SpinelDriver &GetSpinelDriver(void) { return mSpinelDriver; }
-
 private:
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
     void VirtualTimeInit(void);
 #endif
-    void GetIidListFromUrl(spinel_iid_t (&aIidList)[ot::Spinel::kSpinelHeaderMaxNumIid]);
+    void GetIidListFromUrl(spinel_iid_t (&aIidList)[Spinel::kSpinelHeaderMaxNumIid]);
 
-    ot::Spinel::SpinelInterface *CreateSpinelInterface(const char *aInterfaceName);
+    Spinel::SpinelInterface *CreateSpinelInterface(const char *aInterfaceName);
 
 #if OPENTHREAD_POSIX_CONFIG_SPINEL_HDLC_INTERFACE_ENABLE && OPENTHREAD_POSIX_CONFIG_SPINEL_SPI_INTERFACE_ENABLE
-    static constexpr size_t kSpinelInterfaceRawSize = sizeof(ot::Posix::SpiInterface) > sizeof(ot::Posix::HdlcInterface)
-                                                          ? sizeof(ot::Posix::SpiInterface)
-                                                          : sizeof(ot::Posix::HdlcInterface);
+    static constexpr size_t kSpinelInterfaceRawSize = sizeof(Posix::SpiInterface) > sizeof(Posix::HdlcInterface)
+                                                          ? sizeof(Posix::SpiInterface)
+                                                          : sizeof(Posix::HdlcInterface);
 #elif OPENTHREAD_POSIX_CONFIG_SPINEL_HDLC_INTERFACE_ENABLE
-    static constexpr size_t kSpinelInterfaceRawSize = sizeof(ot::Posix::HdlcInterface);
+    static constexpr size_t kSpinelInterfaceRawSize = sizeof(Posix::HdlcInterface);
 #elif OPENTHREAD_POSIX_CONFIG_SPINEL_SPI_INTERFACE_ENABLE
-    static constexpr size_t kSpinelInterfaceRawSize = sizeof(ot::Posix::SpiInterface);
+    static constexpr size_t kSpinelInterfaceRawSize = sizeof(Posix::SpiInterface);
 #elif OPENTHREAD_POSIX_CONFIG_SPINEL_VENDOR_INTERFACE_ENABLE
-    static constexpr size_t kSpinelInterfaceRawSize = sizeof(ot::Posix::VendorInterface);
+    static constexpr size_t kSpinelInterfaceRawSize = sizeof(Posix::VendorInterface);
 #else
 #error "No Spinel interface is specified!"
 #endif
 
-    RadioUrl                     mUrl;
-    ot::Spinel::SpinelDriver     mSpinelDriver;
-    ot::Spinel::SpinelInterface *mSpinelInterface;
+    RadioUrl                 mUrl;
+    Spinel::SpinelDriver     mSpinelDriver;
+    Spinel::SpinelInterface *mSpinelInterface;
 
     OT_DEFINE_ALIGNED_VAR(mSpinelInterfaceRaw, kSpinelInterfaceRawSize, uint64_t);
 };
-
-ot::Spinel::SpinelDriver &GetSpinelDriver(void);
-SpinelManager            &GetSpinelManager(void);
 
 } // namespace Posix
 } // namespace ot

--- a/src/posix/platform/virtual_time.cpp
+++ b/src/posix/platform/virtual_time.cpp
@@ -181,7 +181,8 @@ void virtualTimeProcess(otInstance *aInstance, const otSysMainloopContext *aCont
         virtualTimeReceiveEvent(&event);
     }
 
-    virtualTimeRadioSpinelProcess(aInstance, &event);
+    virtualTimeSpinelProcess(aInstance, &event);
+    virtualTimeRadioProcess(aInstance, &event);
 }
 
 uint64_t otPlatTimeGet(void) { return sNow; }


### PR DESCRIPTION
This PR is another subset of PR #9898.

This PR breaks down current posix radio module into `Radio` and
`SpinelManager`. The static instance of `SpinelDriver` is moved from
`Radio` to `SpinelManager`. The `platformRadioXXX` methods are also
broken down into `platformSpinelXXX` and `platformRadioXXX`. The
purpose is to make `platformSpinelXXX` resuable under both NCP and
RCP cases. And to use `platformSpinelInit` to detect to co-processor
type during initialization.