### PR TITLE
[spinel] restore the source address match feature configuration

### DIFF
--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -1278,6 +1278,7 @@ private:
     int8_t       mFemLnaGain;
     uint32_t     mMacFrameCounter;
     bool         mCoexEnabled : 1;
+    bool         mSrcMatchEnabled : 1;
 
     bool mMacKeySet : 1;                   ///< Whether MAC key has been set.
     bool mCcaEnergyDetectThresholdSet : 1; ///< Whether CCA energy detect threshold has been set.
@@ -1286,6 +1287,7 @@ private:
     bool mFemLnaGainSet : 1;               ///< Whether FEM LNA gain has been set.
     bool mEnergyScanning : 1;              ///< If fails while scanning, restarts scanning.
     bool mMacFrameCounterSet : 1;          ///< Whether the MAC frame counter has been set.
+    bool mSrcMatchSet : 1;                 ///< Whether the source match feature has been set.
 
 #endif // OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
 


### PR DESCRIPTION
The RCP Restoration feature missed restoring the source address match feature configuration. It causes the source match table to be disabled by default after the RCP restarts. This commit restores the source address match feature configuration.

Fixes https://github.com/openthread/ot-br-posix/issues/2261