### PR TITLE
[routing-manager] exclude on-link prefixes with short preferred lifetime

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1247,7 +1247,8 @@ void RoutingManager::DiscoveredPrefixTable::FindFavoredOnLinkPrefix(Ip6::Prefix 
     {
         for (const Entry &entry : router.mEntries)
         {
-            if (!entry.IsOnLinkPrefix() || entry.IsDeprecated())
+            if (!entry.IsOnLinkPrefix() || entry.IsDeprecated() ||
+                (entry.GetPreferredLifetime() < kFavoredOnLinkPrefixMinPreferredLifetime))
             {
                 continue;
             }

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -715,6 +715,8 @@ private:
         void HandleRouterTimer(void);
 
     private:
+        static constexpr uint32_t kFavoredOnLinkPrefixMinPreferredLifetime = 1800; // In sec.
+
 #if !OPENTHREAD_CONFIG_BORDER_ROUTING_USE_HEAP_ENABLE
         static constexpr uint16_t kMaxRouters = OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_ROUTERS;
         static constexpr uint16_t kMaxEntries = OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_PREFIXES;

--- a/tests/scripts/thread-cert/border_router/test_on_link_prefix.py
+++ b/tests/scripts/thread-cert/border_router/test_on_link_prefix.py
@@ -188,20 +188,6 @@ class MultiThreadNetworks(thread_cert.TestCase):
 
         host_on_link_addr = host.get_matched_ula_addresses(ON_LINK_PREFIX)[0]
 
-        # Wait 30 seconds for the radvd `ON_LINK_PREFIX` to be invalidated
-        # and make sure that Thread devices in both networks can't reach
-        # the on-link address.
-        self.simulator.go(30)  # Valid Lifetime of radvd PIO is set to 60 seconds.
-        self.assertEqual(len(host.get_matched_ula_addresses(ON_LINK_PREFIX)), 0)
-        self.assertFalse(router1.ping(host_on_link_addr))
-        self.assertFalse(host.ping(router1_omr_addr, backbone=True, interface=host_on_link_addr))
-        self.assertFalse(router2.ping(host_on_link_addr))
-        self.assertFalse(host.ping(router2_omr_addr, backbone=True, interface=host_on_link_addr))
-
-        # Verify connectivity between the two networks.
-        self.assertTrue(router1.ping(router2.get_ip6_address(config.ADDRESS_TYPE.OMR)[0]))
-        self.assertTrue(router2.ping(router1.get_ip6_address(config.ADDRESS_TYPE.OMR)[0]))
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -3982,8 +3982,8 @@ interface eth0
         AdvOnLink on;
         AdvAutonomous %s;
         AdvRouterAddr off;
-        AdvPreferredLifetime 40;
-        AdvValidLifetime 60;
+        AdvPreferredLifetime 1800;
+        AdvValidLifetime 1800;
     };
 };
 EOF


### PR DESCRIPTION
This commit updates `FindFavoredOnLinkPrefix()` to exclude discovered on-link prefixes with preferred lifetimes under 30 minutes.