### PR TITLE
[callback] add `InvokeAndClearIfSet()` helper

### DIFF
--- a/src/core/common/callback.hpp
+++ b/src/core/common/callback.hpp
@@ -206,6 +206,25 @@ public:
             Invoke(static_cast<Args &&>(aArgs)...);
         }
     }
+
+    /**
+     * Invokes the callback handler if it is set and clears it.
+     *
+     * The method MUST be used when the handler function returns `void`.
+     *
+     * The callback is cleared first before invoking its handler to allow it to be set again from the handler
+     * implementation.
+     *
+     * @param[in] aArgs   The args to pass to the callback handler.
+     *
+     */
+    template <typename... Args> void InvokeAndClearIfSet(Args &&...aArgs)
+    {
+        Callback<HandlerType, kContextAsLastArg> callbackCopy = *this;
+
+        CallbackBase<HandlerType>::Clear();
+        callbackCopy.InvokeIfSet(static_cast<Args &&>(aArgs)...);
+    }
 };
 
 // Specialization for `kContextAsFirstArg`
@@ -235,6 +254,25 @@ public:
         {
             Invoke(static_cast<Args &&>(aArgs)...);
         }
+    }
+
+    /**
+     * Invokes the callback handler if it is set and clears it.
+     *
+     * The method MUST be used when the handler function returns `void`.
+     *
+     * The callback is cleared first before invoking its handler to allow it to be set again from the handler
+     * implementation.
+     *
+     * @param[in] aArgs   The args to pass to the callback handler.
+     *
+     */
+    template <typename... Args> void InvokeAndClearIfSet(Args &&...aArgs)
+    {
+        Callback<HandlerType, kContextAsFirstArg> callbackCopy = *this;
+
+        CallbackBase<HandlerType>::Clear();
+        callbackCopy.InvokeIfSet(static_cast<Args &&>(aArgs)...);
     }
 };
 

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -323,6 +323,7 @@ void DatasetManager::HandleMgmtSetResponse(Coap::Message *aMessage, const Ip6::M
     SuccessOrExit(error = aError);
     VerifyOrExit(Tlv::Find<StateTlv>(*aMessage, state) == kErrorNone && state != StateTlv::kPending,
                  error = kErrorParse);
+
     if (state == StateTlv::kReject)
     {
         error = kErrorRejected;
@@ -333,13 +334,7 @@ exit:
 
     mMgmtPending = false;
 
-    if (mMgmtSetCallback.IsSet())
-    {
-        Callback<otDatasetMgmtSetCallback> callbackCopy = mMgmtSetCallback;
-
-        mMgmtSetCallback.Clear();
-        callbackCopy.Invoke(error);
-    }
+    mMgmtSetCallback.InvokeAndClearIfSet(error);
 
     mTimer.Start(kSendSetDelay);
 }

--- a/src/core/thread/anycast_locator.cpp
+++ b/src/core/thread/anycast_locator.cpp
@@ -109,13 +109,7 @@ void AnycastLocator::HandleResponse(Coap::Message *aMessage, const Ip6::MessageI
     address = &meshLocalAddress;
 
 exit:
-    if (mCallback.IsSet())
-    {
-        Callback<LocatorCallback> callbackCopy = mCallback;
-
-        mCallback.Clear();
-        callbackCopy.Invoke(aError, address, rloc16);
-    }
+    mCallback.InvokeAndClearIfSet(aError, address, rloc16);
 }
 
 #if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_SEND_RESPONSE

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -253,14 +253,7 @@ void Mle::Stop(StopMode aMode)
 
 exit:
     mDetachGracefullyTimer.Stop();
-
-    if (mDetachGracefullyCallback.IsSet())
-    {
-        Callback<otDetachGracefullyCallback> callbackCopy = mDetachGracefullyCallback;
-
-        mDetachGracefullyCallback.Clear();
-        callbackCopy.Invoke();
-    }
+    mDetachGracefullyCallback.InvokeAndClearIfSet();
 }
 
 void Mle::ResetCounters(void)

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -344,17 +344,15 @@ void MlrManager::HandleRegisterResponse(otMessage *aMessage, const otMessageInfo
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
-    uint8_t               status;
-    Error                 error;
-    AddressArray          failedAddresses;
-    Callback<MlrCallback> callbackCopy = mRegisterCallback;
+    uint8_t      status;
+    Error        error;
+    AddressArray failedAddresses;
 
     mRegisterPending = false;
-    mRegisterCallback.Clear();
 
     error = ParseMlrResponse(aResult, AsCoapMessagePtr(aMessage), status, failedAddresses);
 
-    callbackCopy.InvokeIfSet(error, status, failedAddresses.GetArrayBuffer(), failedAddresses.GetLength());
+    mRegisterCallback.InvokeAndClearIfSet(error, status, failedAddresses.GetArrayBuffer(), failedAddresses.GetLength());
 }
 
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE


### PR DESCRIPTION
Will first clear the callback before invoking its handler so to allow the callback to be set again from the handler implementation.