### PR TITLE
[dtls] fix undesired kernel filtering of connected UDP

### DIFF
--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -220,17 +220,11 @@ void SecureTransport::HandleReceive(Message &aMessage, const Ip6::MessageInfo &a
             mRemainingConnectionAttempts--;
         }
 
-        IgnoreError(mSocket.Connect(Ip6::SockAddr(aMessageInfo.GetPeerAddr(), aMessageInfo.GetPeerPort())));
-
         mMessageInfo.SetPeerAddr(aMessageInfo.GetPeerAddr());
         mMessageInfo.SetPeerPort(aMessageInfo.GetPeerPort());
         mMessageInfo.SetIsHostInterface(aMessageInfo.IsHostInterface());
 
-        if (Get<ThreadNetif>().HasUnicastAddress(aMessageInfo.GetSockAddr()))
-        {
-            mMessageInfo.SetSockAddr(aMessageInfo.GetSockAddr());
-        }
-
+        mMessageInfo.SetSockAddr(aMessageInfo.GetSockAddr());
         mMessageInfo.SetSockPort(aMessageInfo.GetSockPort());
 
         SuccessOrExit(Setup(false));
@@ -514,7 +508,6 @@ void SecureTransport::Disconnect(void)
     mTimer.Start(kGuardTimeNewConnectionMilli);
 
     mMessageInfo.Clear();
-    IgnoreError(mSocket.Connect());
 
     FreeMbedtls();
 


### PR DESCRIPTION
This commit fixes again the same issue which was fixed by https://github.com/openthread/openthread/pull/8168 with the same approach.
The regression was unintentionally introduced by the initial TCAT commit https://github.com/openthread/openthread/pull/9210

See https://github.com/openthread/openthread/pull/8168 for the background and discussion.