### PR TITLE
[cli] fix namespace usage

### DIFF
--- a/src/cli/cli_dns.cpp
+++ b/src/cli/cli_dns.cpp
@@ -94,7 +94,7 @@ template <> otError Dns::Process<Cmd("compression")>(Arg aArgs[])
     {
         bool enable;
 
-        SuccessOrExit(error = Interpreter::ParseEnableOrDisable(aArgs[0], enable));
+        SuccessOrExit(error = ParseEnableOrDisable(aArgs[0], enable));
         otDnsSetNameCompressionEnabled(enable);
     }
 

--- a/src/cli/cli_srp_client.cpp
+++ b/src/cli/cli_srp_client.cpp
@@ -89,7 +89,7 @@ template <> otError SrpClient::Process<Cmd("autostart")>(Arg aArgs[])
         ExitNow();
     }
 
-    SuccessOrExit(error = Interpreter::ParseEnableOrDisable(aArgs[0], enable));
+    SuccessOrExit(error = ParseEnableOrDisable(aArgs[0], enable));
 
     /**
      * @cli srp client autostart enable
@@ -173,7 +173,7 @@ template <> otError SrpClient::Process<Cmd("callback")>(Arg aArgs[])
         ExitNow();
     }
 
-    error = Interpreter::ParseEnableOrDisable(aArgs[0], mCallbackEnabled);
+    error = ParseEnableOrDisable(aArgs[0], mCallbackEnabled);
 
 exit:
     return error;

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -360,7 +360,7 @@ template <> otError UdpExample::Process<Cmd("linksecurity")>(Arg aArgs[])
      */
     else
     {
-        error = Interpreter::ParseEnableOrDisable(aArgs[0], mLinkSecurityEnabled);
+        error = ParseEnableOrDisable(aArgs[0], mLinkSecurityEnabled);
     }
 
     return error;


### PR DESCRIPTION
The method `ParseEnableOrDisable` has been moved to  the `Utils` class and these components inherit the `Utils` class so there is no need to add namespace.