### PR TITLE
[dataset] simplify `SendSetRequest`

### DIFF
--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -358,8 +358,8 @@ private:
     bool  IsPendingDataset(void) const { return GetType() == Dataset::kPending; }
     void  SignalDatasetChange(void) const;
     void  HandleDatasetUpdated(void);
-    Error AppendDatasetToMessage(const Dataset::Info &aDatasetInfo, Message &aMessage) const;
     void  SendSet(void);
+    Error SendSetRequest(const Dataset &aDataset);
     void  SendGetResponse(const Coap::Message    &aRequest,
                           const Ip6::MessageInfo &aMessageInfo,
                           const TlvList          &aTlvList) const;


### PR DESCRIPTION
This commit adds a common `SendSetRequest(const Dataset &)` method that prepares and sends an MGMT_SET message with the given Dataset. This removes similar duplicate code.

----

~This PR currently contains the commit from #10111. Please check and review the last commit only. Thanks.~
