### PR TITLE
[github-actions] limit "upload coverage" job to openthread repo

### DIFF
--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -233,6 +233,7 @@ jobs:
         retention-days: 1
 
   upload-coverage:
+    if: github.repository == 'openthread/openthread'
     needs:
     - backbone-router
     - thread-border-router

--- a/.github/workflows/otns.yml
+++ b/.github/workflows/otns.yml
@@ -201,6 +201,7 @@ jobs:
           retention-days: 1
 
   upload-coverage:
+    if: github.repository == 'openthread/openthread'
     needs:
       - unittests
       - examples

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -289,6 +289,7 @@ jobs:
         retention-days: 1
 
   upload-coverage:
+    if: github.repository == 'openthread/openthread'
     needs:
     - expects-linux
     - pty-linux

--- a/.github/workflows/simulation-1.1.yml
+++ b/.github/workflows/simulation-1.1.yml
@@ -365,6 +365,7 @@ jobs:
         retention-days: 1
 
   upload-coverage:
+    if: github.repository == 'openthread/openthread'
     needs:
     - packet-verification
     - cli-ftd

--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -396,6 +396,7 @@ jobs:
         retention-days: 1
 
   upload-coverage:
+    if: github.repository == 'openthread/openthread'
     needs:
     - thread-1-3
     - packet-verification-low-power

--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -182,6 +182,7 @@ jobs:
         ./tests/toranj/build.sh posix-15.4
 
   upload-coverage:
+    if: github.repository == 'openthread/openthread'
     needs:
     - toranj-cli
     runs-on: ubuntu-20.04

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -100,6 +100,7 @@ jobs:
         retention-days: 1
 
   upload-coverage:
+    if: github.repository == 'openthread/openthread'
     needs: unit-tests
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This commit updates the GitHub Action workflows to skip the "upload-coverage" job  when target repo is a fork of openthread.