### PR TITLE
[simulation] remove example log lines from `otPlatLogCrashDump()`

### DIFF
--- a/examples/platforms/simulation/misc.c
+++ b/examples/platforms/simulation/misc.c
@@ -111,11 +111,5 @@ otPlatMcuPowerState otPlatGetMcuPowerState(otInstance *aInstance)
 }
 
 #if OPENTHREAD_CONFIG_PLATFORM_LOG_CRASH_DUMP_ENABLE
-otError otPlatLogCrashDump(void)
-{
-    otLogCritPlat("LOGGING SIMULATED CRASH DUMP");
-    otLogCritPlat("Reset Reason: %d", sPlatResetReason);
-
-    return OT_ERROR_NONE;
-}
+otError otPlatLogCrashDump(void) { return OT_ERROR_NONE; }
 #endif


### PR DESCRIPTION
This commit removes the `LogCrit` example lines emitted from `otPlatLogCrashDump()` in simulation platform. These extra log lines can cause test failures.


---

Have been noticing these logs in some of the test output (those often ignored, but can cause failures in certain situations).
```
1: dataset commit active
2024-04-30 15:20:02,923 - INFO - Creating node 2: {'is_mtd': False, 'is_ftd': True, 'is_bbr': False, 'is_otbr': False, 'is_host': False, 'mode': 'rdn', 'allowlist': [1, 3], 'version': '1.3', 'router_selection_jitter': 1, 'name': 'LEADER', 'active_dataset': {'timestamp': 10, 'panid': 64206, 'channel': 19}, 'partition_id': 4294967295}
/Users/abtink/github/openthread/build/openthread-simulation-1.3/examples/apps/cli/ot-cli-ftd 2
2: extaddr 166e0a0000000002
2024-04-30 15:20:02,932 - WARNING - expecting echo 'extaddr 166e0a0000000002', but read '00:00:00.000 [C] Platform------: LOGGING SIMULATED CRASH DUMP'
2024-04-30 15:20:02,932 - WARNING - expecting echo 'extaddr 166e0a0000000002', but read '00:00:00.000 [C] Platform------: Reset Reason: 0'
2: mode rdn
2: partitionid preferred 4294967295
2: routerselectionjitter 1
2: dataset clear
2: dataset activetimestamp 10
2: dataset channel 19
2: dataset channelmask 134215680
2: dataset extpanid dead00beef00cafe
2: dataset meshlocalprefix fd00:db8::
2: dataset networkkey 00112233445566778899aabbccddeeff
2: dataset networkname OpenThread
2: dataset panid 64206
2: dataset pskc c23a76e98f1a6483639b1ac1271e2e27
2: dataset securitypolicy 672 onrc
2: dataset commit active
2024-04-30 15:20:02,937 - INFO - Creating node 3: {'is_mtd': False, 'is_ftd': True, 'is_bbr': False, 'is_otbr': False, 'is_host': False, 'mode': 'rdn', 'allowlist': [2, 4], 'version': '1.3', 'router_selection_jitter': 1, 'name': 'ROUTER_1', 'active_dataset': {'timestamp': 10, 'panid': 64206, 'channel': 19}}
/Users/abtink/github/openthread/build/openthread-simulation-1.3/examples/apps/cli/ot-cli-ftd 3
3: extaddr 166e0a0000000003
2024-04-30 15:20:02,947 - WARNING - expecting echo 'extaddr 166e0a0000000003', but read '00:00:00.000 [C] Platform------: LOGGING SIMULATED CRASH DUMP'
2024-04-30 15:20:02,947 - WARNING - expecting echo 'extaddr 166e0a0000000003', but read '00:00:00.000 [C] Platform------: Reset Reason: 0'
3: mode rdn
3: routerselectionjitter 1
3: dataset clear
3: dataset activetimestamp 10
3: dataset channel 19
3: dataset channelmask 134215680
```
