### PR TITLE
[dataset] simplify dataset manager `MGMT_SET` request handling

### DIFF
--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -61,8 +61,7 @@ class Dataset
     friend class DatasetLocal;
 
 public:
-    static constexpr uint8_t kMaxLength    = OT_OPERATIONAL_DATASET_MAX_LENGTH; ///< Max length of Dataset (bytes)
-    static constexpr uint8_t kMaxValueSize = 16;                                ///< Max size of a TLV value (bytes)
+    static constexpr uint8_t kMaxLength = OT_OPERATIONAL_DATASET_MAX_LENGTH; ///< Max length of Dataset (bytes)
 
     /**
      * Represents the Dataset type (active or pending).


### PR DESCRIPTION
This commit adds `ProcessSetRequest()` to process a received `MGMT_SET` request message, validate the included `Dataset`, and determine if it affects connectivity or changes the network key. The now unused `DatasetTlv` is removed as TLVs are read directly from the `Message`. This change will also enable future support for `MGMT_REPLACE` request.

----

~This PR currently contains the commit from #10111. Please check and review the last commit only. Thanks.~