### PR TITLE
[spinel] remove `mIsCoprocessorReady` flag check (#10134)

### DIFF
--- a/src/lib/spinel/spinel_driver.cpp
+++ b/src/lib/spinel/spinel_driver.cpp
@@ -129,8 +129,7 @@ void SpinelDriver::ResetCoprocessor(bool aSoftwareReset)
 
     mWaitingKey = SPINEL_PROP_LAST_STATUS;
 
-    if (aSoftwareReset && (SendReset(SPINEL_RESET_STACK) == OT_ERROR_NONE) && (!mIsCoprocessorReady) &&
-        (WaitResponse() == OT_ERROR_NONE))
+    if (aSoftwareReset && (SendReset(SPINEL_RESET_STACK) == OT_ERROR_NONE) && (WaitResponse() == OT_ERROR_NONE))
     {
         VerifyOrExit(mIsCoprocessorReady, resetDone = false);
         LogCrit("Software reset co-processor successfully");


### PR DESCRIPTION
- If we check inbetween SendReset() and WaitResponse(), mIsCoprocessorReady may become true before waitResponse() and if loop becomes false even successfully reset done.
- mIsCoprocessorReady is already checked before sendReset() to avoid resetting in case of Mulipan architecture. There is no need to check inbetween sendReset() and waitResponse().

- Removed mIsCoprocessorReady from if loop check between sendReset() and waitResponse().