### PR TITLE
[routing-manager] ensure correct handling of shorter PD prefix

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -3775,8 +3775,8 @@ bool RoutingManager::PdPrefixManager::ProcessPrefixEntry(DiscoveredPrefixTable::
         ExitNow();
     }
 
-    aEntry.mPrefix.SetLength(kOmrPrefixLength);
     aEntry.mPrefix.Tidy();
+    aEntry.mPrefix.SetLength(kOmrPrefixLength);
 
     // Check if there is an update to the current prefix. The valid or
     // preferred lifetime may have changed.


### PR DESCRIPTION
This commit corrects the order of calls to prefix methods `Tidy()` and `SetLength(kOmrPrefixLength)`. This was unintentionally reversed in PR #10000.

PD prefixes can be shorter than `kOmrPrefixLength` (as allowed by `IsValidPdPrefix()`). To use them as OMR prefixes, `Tidy()` is called first to clear any extra bits before potentially extending the prefix to `kOmrPrefixLength`.