### PR TITLE
[cli] add `br pd omrprefix` command to display DHCPv6 PD OMR prefix

### DIFF
--- a/src/cli/README_BR.md
+++ b/src/cli/README_BR.md
@@ -209,6 +209,18 @@ running
 Done
 ```
 
+Usage `br pd omrprefix`
+
+Get the DHCPv6 Prefix Delegation (PD) provided off-mesh-routable (OMR) prefix.
+
+`OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE` is required.
+
+```bash
+> br pd omrprefix
+2001:db8:cafe:0:0/64 lifetime:1800 preferred:1800
+Done
+```
+
 ### prefixtable
 
 Usage: `br prefixtable`

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -7087,6 +7087,10 @@ template <> otError Interpreter::Process<Cmd("debug")>(Arg aArgs[])
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
         "br nat64prefix",
 #endif
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
+        "br pd state",
+        "br pd omrprefix",
+#endif
 #endif
         "bufferinfo",
     };

--- a/src/cli/cli_br.cpp
+++ b/src/cli/cli_br.cpp
@@ -485,6 +485,25 @@ template <> otError Br::Process<Cmd("pd")>(Arg aArgs[])
 
         OutputLine("%s", Stringify(otBorderRoutingDhcp6PdGetState(GetInstancePtr()), kDhcpv6PdStateStrings));
     }
+    /**
+     * @cli br pd omrprefix
+     * @code
+     * br pd omrprefix
+     * 2001:db8:cafe:0:0/64 lifetime:1800 preferred:1800
+     * Done
+     * @endcode
+     * @par api_copy
+     * #otBorderRoutingGetPdOmrPrefix
+     */
+    else if (aArgs[0] == "omrprefix")
+    {
+        otBorderRoutingPrefixTableEntry entry;
+
+        SuccessOrExit(error = otBorderRoutingGetPdOmrPrefix(GetInstancePtr(), &entry));
+
+        OutputIp6Prefix(entry.mPrefix);
+        OutputLine(" lifetime:%lu preferred:%lu", ToUlong(entry.mValidLifetime), ToUlong(entry.mPreferredLifetime));
+    }
     else
     {
         ExitNow(error = OT_ERROR_INVALID_COMMAND);


### PR DESCRIPTION
This commit introduces the `br pd omrprefix` command, which displays the DHCPv6 Prefix Delegation (PD) On-Mesh Routable (OMR) prefix when the DHCPv6 PD feature is enabled. Additionally, the `debug` command is updated to output `br pd state` and this new command when the feature is enabled