### PR TITLE
[dataset] send 'reject' response to `MGMT_SET` on non-leader

### DIFF
--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -212,6 +212,8 @@ Error DatasetManager::HandleSet(const Coap::Message &aMessage, const Ip6::Messag
     StateTlv::State state = StateTlv::kReject;
     SetRequestInfo  info;
 
+    VerifyOrExit(Get<Mle::Mle>().IsLeader());
+
     SuccessOrExit(ProcessSetRequest(aMessage, info));
 
     if (IsActiveDataset() && info.mAffectsConnectivity)
@@ -374,7 +376,6 @@ void ActiveDatasetManager::StartLeader(void) {}
 template <>
 void ActiveDatasetManager::HandleTmf<kUriActiveSet>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    VerifyOrExit(Get<Mle::Mle>().IsLeader());
     SuccessOrExit(DatasetManager::HandleSet(aMessage, aMessageInfo));
     IgnoreError(ApplyConfiguration());
 
@@ -387,7 +388,6 @@ void PendingDatasetManager::StartLeader(void) { StartDelayTimer(); }
 template <>
 void PendingDatasetManager::HandleTmf<kUriPendingSet>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    VerifyOrExit(Get<Mle::Mle>().IsLeader());
     SuccessOrExit(DatasetManager::HandleSet(aMessage, aMessageInfo));
     StartDelayTimer();
 


### PR DESCRIPTION
This commit simplifies the code and adheres to the SHOULD requirement in the Thread specification, which states: "A Thread Device that is not a Leader MUST NOT process this message. Instead it SHOULD respond with 'Reject' state value".