### PR TITLE
[style] add comment to indicate the which conditional endif is associated with

### DIFF
--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -1066,7 +1066,7 @@ public:
      *
      */
     void SetVendorRestorePropertiesCallback(otRadioSpinelVendorRestorePropertiesCallback aCallback, void *aContext);
-#endif
+#endif // OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_ENABLE
 
 private:
     enum


### PR DESCRIPTION
According to `style.md`, all #endif directives equal to or greater than 20 lines away from the #if or #ifdef directive to which they are related shall be decorated by language comment indicating the conditional they are associated with.