### PR TITLE
[routing_manager] new API to check if an external route is published

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -683,6 +683,53 @@ bool RoutingManager::IsValidOnLinkPrefix(const Ip6::Prefix &aOnLinkPrefix)
            !aOnLinkPrefix.IsMulticast();
 }
 
+bool RoutingManager::IsExternalRoutePublished() const
+{
+    NetworkData::Iterator            iterator = NetworkData::kIteratorInit;
+    NetworkData::ExternalRouteConfig routeConfig;
+    bool                             isPublished = false;
+    uint16_t                         rloc16;
+
+    rloc16 = Get<Mle::MleRouter>().GetRloc16();
+
+    // Iterate through the external routes in the network data
+    while (Get<NetworkData::Leader>().GetNextExternalRoute(iterator, routeConfig) == kErrorNone)
+    {
+        // Check if the route is stable and matches the current RLOC16
+        if (routeConfig.mStable && (routeConfig.GetRloc16() == rloc16))
+        {
+            isPublished = true;
+            break;
+        }
+    }
+
+    return isPublished;
+}
+
+bool RoutingManager::IsDefaultRoutePublished() const
+{
+    NetworkData::Iterator            iterator = NetworkData::kIteratorInit;
+    NetworkData::ExternalRouteConfig routeConfig;
+    bool                             isPublished = false;
+    Ip6::Prefix                      defaultRoutePrefix = AsCoreType(&Ip6::kDefaultRoutePrefix);
+    uint16_t                         rloc16;
+
+    rloc16 = Get<Mle::MleRouter>().GetRloc16();
+
+    // Iterate through the external routes in the network data
+    while (Get<NetworkData::Leader>().GetNextExternalRoute(iterator, routeConfig) == kErrorNone)
+    {
+        // Check if the route is stable, matches the current RLOC16 and is the default route
+        if (routeConfig.mStable && (routeConfig.GetRloc16() == rloc16) && (routeConfig.GetPrefix() == defaultRoutePrefix))
+        {
+            isPublished = true;
+            break;
+        }
+    }
+
+    return isPublished;
+}
+
 void RoutingManager::HandleRsSenderFinished(TimeMilli aStartTime)
 {
     // This is a callback from `RsSender` and is invoked when it

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -2941,11 +2941,6 @@ exit:
 //---------------------------------------------------------------------------------------------------------------------
 // RoutePublisher
 
-const otIp6Prefix RoutingManager::RoutePublisher::kUlaPrefix = {
-    {{{0xfc, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}},
-    7,
-};
-
 RoutingManager::RoutePublisher::RoutePublisher(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mState(kDoNotPublish)

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -454,6 +454,28 @@ public:
     static bool IsValidOmrPrefix(const Ip6::Prefix &aPrefix);
 
     /**
+     * @brief Checks if any external route is published.
+     *
+     * This function iterates through the external routes in the network data and checks
+     * if there is a stable route that matches the current RLOC16.
+     *
+     * @retval TRUE   an external route is published,
+     * @retval FALSE  no external route is published.
+     */
+    bool IsExternalRoutePublished(void) const;
+
+    /**
+     * @brief Checks if the default route is published.
+     *
+     * This function iterates through the external routes in the network data and checks if
+     * there is a stable route that matches the current RLOC16 and is the default route prefix.
+     *
+     * @retval TRUE  an default route (::/0) is published
+     * @retval FALSE no default route is published.
+     */
+    bool IsDefaultRoutePublished(void) const;
+
+    /**
      * Initializes a `PrefixTableIterator`.
      *
      * An iterator can be initialized again to start from the beginning of the table.

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1161,12 +1161,10 @@ private:
         void HandleNotifierEvents(Events aEvents);
         void HandleTimer(void);
 
-        static const Ip6::Prefix &GetUlaPrefix(void) { return AsCoreType(&kUlaPrefix); }
+        static const Ip6::Prefix &GetUlaPrefix(void) { return AsCoreType(&Ip6::kUlaPrefix); }
 
     private:
         static constexpr uint32_t kDelayBeforePrfUpdateOnLinkQuality3 = TimeMilli::SecToMsec(5 * 60);
-
-        static const otIp6Prefix kUlaPrefix;
 
         enum State : uint8_t
         {

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -1069,6 +1069,28 @@ private:
 
 } OT_TOOL_PACKED_END;
 
+// define "fc00::/7" - prefix of Unique Local Unicast Addresses (RFC 4193)
+constexpr otIp6Prefix kUlaPrefix = {
+    { // mPrefix
+        { // mFields
+            0xfc, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        }
+    },
+    7 // mLength
+};
+
+// define "::/0" - the default route prefix
+constexpr otIp6Prefix kDefaultRoutePrefix = {
+    { // mPrefix
+        { // mFields
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        }
+    },
+    0  // mLength
+};
+
 /**
  * @}
  *

--- a/src/core/thread/network_data_types.hpp
+++ b/src/core/thread/network_data_types.hpp
@@ -286,6 +286,14 @@ public:
      */
     void SetPrefix(const Ip6::Prefix &aPrefix) { mPrefix = aPrefix; }
 
+    /**
+     * Gets the RLOC16.
+     *
+     * @return The border router's RLOC16.
+     *
+     */
+    uint16_t GetRloc16(void) const { return mRloc16; }
+
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
     /**
      * Indicates whether or not the external route configuration is valid.

--- a/tests/unit/test_ip_address.cpp
+++ b/tests/unit/test_ip_address.cpp
@@ -580,6 +580,10 @@ void TestIp6Prefix(void)
     VerifyOrQuit(!PrefixFrom("fc00::", 6).IsUniqueLocal());
     VerifyOrQuit(!PrefixFrom("f800::", 7).IsUniqueLocal());
     VerifyOrQuit(!PrefixFrom("fe00::", 7).IsUniqueLocal());
+
+    // Test default route and ULA prefix data structure, as well as the operator==
+    VerifyOrQuit(PrefixFrom("::",     0) == AsCoreType(&Ip6::kDefaultRoutePrefix));
+    VerifyOrQuit(PrefixFrom("fc00::", 7) == AsCoreType(&Ip6::kUlaPrefix));
 }
 
 void TestIp6PrefixTidy(void)


### PR DESCRIPTION
This commit add two public functions to `RoutingManager`:
- `IsExternalRoutePublished()` to check if network data contains the BR's external route;
- `IsDefaultRoutePublished()` to check if network data contains the BR's default route(`::/0`)
(combining these two functions into one may be considered in the future)

This commit also defines `kDefaultRoutePrefix` in ip6_address.hpp to represent `::/0` prefix, as well as  moves `RoutePublisher::kUlaPrefix` definition from `RoutingManager` to ip6_address.hpp as constexpr to track with
`kDefaultRoutePrefix`.