### PR TITLE
[cli] add UDP socket openness check before sending with `udp send`

### DIFF
--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -256,6 +256,8 @@ template <> otError UdpExample::Process<Cmd("send")>(Arg aArgs[])
     otMessageInfo     messageInfo;
     otMessageSettings messageSettings = {mLinkSecurityEnabled, OT_MESSAGE_PRIORITY_NORMAL};
 
+    VerifyOrExit(otUdpIsOpen(GetInstancePtr(), &mSocket), error = OT_ERROR_INVALID_STATE);
+
     ClearAllBytes(messageInfo);
 
     // Possible argument formats:


### PR DESCRIPTION
**Problem:**

Executing the `udp send` command in CLI without previously opening the example udp socket results in an unhandled null-pointer exception.

**Solution:**

Before anything is processed in the `UdpExample::Process<Cmd("send")>(Arg aArgs[])` method, the UDP socket is checked whether it's open or not. If not, the method returns with OT_ERROR_INVALID_STATE error avoiding the null-pointer exception.