### PR TITLE
[routing-manager] add `CalculateExpirationTime()`

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -813,7 +813,7 @@ private:
             RoutePreference GetRoutePreference(void) const { return mShared.mRoutePreference; }
 
         private:
-            static uint32_t CalculateExpireDelay(uint32_t aValidLifetime);
+            TimeMilli CalculateExpirationTime(uint32_t aLifetime) const;
 
             Entry      *mNext;
             Ip6::Prefix mPrefix;


### PR DESCRIPTION
This commit adds `CalculateExpirationTime()`, which simplifies the calculation of expiration times of discovered prefix entry by clamping a given lifetime to the maximum value (in seconds) first before converting to milliseconds.