### PR TITLE
[spinel] move definition of coprocessor type to `lib/spinel`

### DIFF
--- a/src/lib/spinel/coprocessor_type.h
+++ b/src/lib/spinel/coprocessor_type.h
@@ -26,8 +26,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef OT_PLATFORM_COPROCESSOR_MODE_H_
-#define OT_PLATFORM_COPROCESSOR_MODE_H_
+#ifndef COPROCESSOR_TYPE_H_
+#define COPROCESSOR_TYPE_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,4 +47,4 @@ typedef enum CoprocessorType
 #ifdef __cplusplus
 }
 #endif
-#endif // OT_PLATFORM_COPROCESSOR_MODE_H_
+#endif // COPROCESSOR_TYPE_H_

--- a/src/lib/spinel/spinel_driver.hpp
+++ b/src/lib/spinel/spinel_driver.hpp
@@ -31,10 +31,10 @@
 
 #include <openthread/instance.h>
 
+#include "lib/spinel/coprocessor_type.h"
 #include "lib/spinel/logger.hpp"
 #include "lib/spinel/spinel.h"
 #include "lib/spinel/spinel_interface.hpp"
-#include "posix/platform/coprocessor_type.h"
 
 namespace ot {
 namespace Spinel {

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -52,8 +52,8 @@
 #include <openthread/openthread-system.h>
 #include <openthread/platform/time.h>
 
-#include "coprocessor_type.h"
 #include "lib/platform/exit_code.h"
+#include "lib/spinel/coprocessor_type.h"
 #include "lib/url/url.hpp"
 
 /**


### PR DESCRIPTION
This PR moves the definition of coprocessor_type from posix to
lib/spinel directory. There are two reasons to do so:
1. Allow platforms other than posix to access the definition. For
example, nxp imt-rx.
2. Allow the user (posix/main.c) of OT system API to access the 
defifition. Currently the posix main depends on OT system API but
doesn't depend on definitions in 'platform-posix.h'. This should
be kept.