### PR TITLE
[owning-list] add `RemoveAndFreeAllMatching()` to `OwningList` class

### DIFF
--- a/src/core/common/owning_list.hpp
+++ b/src/core/common/owning_list.hpp
@@ -149,6 +149,29 @@ public:
     {
         LinkedList<Type>::RemoveAllMatching(aIndicator, aRemovedList);
     }
+
+    /**
+     * Removes and frees all entries in the list matching a given entry indicator.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
+     * in the list. To check that an entry matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` entry in the list. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * @param[in] aIndicator   An entry indicator to match against entries in the list.
+     *
+     * @retval TRUE    At least one matching entry was removed.
+     * @retval FALSE   No matching entry was found.
+     *
+     */
+    template <typename Indicator> bool RemoveAndFreeAllMatching(const Indicator &aIndicator)
+    {
+        OwningList removedList;
+
+        RemoveAllMatching(aIndicator, removedList);
+        return !removedList.IsEmpty();
+    }
 };
 
 } // namespace ot

--- a/tests/unit/test_linked_list.cpp
+++ b/tests/unit/test_linked_list.cpp
@@ -313,6 +313,7 @@ void TestOwningList(void)
     OwningList<Entry> list;
     OwningList<Entry> removedList;
     OwnedPtr<Entry>   ptr;
+    bool              didRemove;
 
     printf("TestOwningList\n");
 
@@ -433,6 +434,42 @@ void TestOwningList(void)
     VerifyOrQuit(list.IsEmpty());
     VerifyLinkedListContent(&removedList, &c, &d, &f, nullptr);
     VerifyOrQuit(!c.WasFreed());
+
+    // Test `RemoveAndFreeAllMatching()`
+
+    a.ResetTestFlags();
+    b.ResetTestFlags();
+    c.ResetTestFlags();
+    d.ResetTestFlags();
+    e.ResetTestFlags();
+    f.ResetTestFlags();
+    list.Push(a);
+    list.Push(b);
+    list.Push(c);
+    list.Push(d);
+    list.Push(e);
+    list.Push(f);
+    VerifyLinkedListContent(&list, &f, &e, &d, &c, &b, &a, nullptr);
+
+    didRemove = list.RemoveAndFreeAllMatching(kAlphaType);
+    VerifyLinkedListContent(&list, &f, &d, &c, nullptr);
+    VerifyOrQuit(didRemove);
+    VerifyOrQuit(a.WasFreed());
+    VerifyOrQuit(b.WasFreed());
+    VerifyOrQuit(e.WasFreed());
+    VerifyOrQuit(!c.WasFreed());
+
+    didRemove = list.RemoveAndFreeAllMatching(kAlphaType);
+    VerifyOrQuit(!didRemove);
+    VerifyLinkedListContent(&list, &f, &d, &c, nullptr);
+    VerifyOrQuit(!c.WasFreed());
+
+    didRemove = list.RemoveAndFreeAllMatching(kBetaType);
+    VerifyOrQuit(list.IsEmpty());
+    VerifyOrQuit(didRemove);
+    VerifyOrQuit(c.WasFreed());
+    VerifyOrQuit(d.WasFreed());
+    VerifyOrQuit(f.WasFreed());
 }
 
 } // namespace ot


### PR DESCRIPTION
This commit introduces a new method, `RemoveAndFreeAllMatching()`, to the `OwningList<Type>` class. This method removes and frees all entries in the list that match a given indicator. This is used to simplify the native mDNS implementation. The unit test `test_linked_list` is also updated to validate the newly added helper method.