### PR TITLE
[spinel] only request crash logs on RCP recovery if capable

### DIFF
--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -2002,7 +2002,11 @@ void RadioSpinel::RecoverFromRcpFailure(void)
 
     --mRcpFailureCount;
 
-    SuccessOrDie(Set(SPINEL_PROP_RCP_LOG_CRASH_DUMP, nullptr));
+    if (sSupportsLogCrashDump)
+    {
+        LogDebg("RCP supports crash dump logging. Requesting crash dump.");
+        SuccessOrDie(Set(SPINEL_PROP_RCP_LOG_CRASH_DUMP, nullptr));
+    }
 
     LogNote("RCP recovery is done");
 


### PR DESCRIPTION
During RCP recovery, the Host does not check if the RCP supports logging a crash dump. This causes RCP recovery to fail when the RCP is built with `OPENTHREAD_CONFIG_PLATFORM_LOG_CRASH_DUMP_ENABLE = 0`. This bug was introduced in #10061

This PR will make the Host only request crash logs from the RCP if the RCP supports it.


## Example of what's currently happening
In this example, I have an RCP built with `OPENTHREAD_CONFIG_PLATFORM_LOG_CRASH_DUMP_ENABLE = 0` that is reset externally. When the Host runs through the RCP recovery, it fails here https://github.com/openthread/openthread/blob/226f239c5d85bfc0eb02cd771ddca65a34ca8f73/src/lib/spinel/radio_spinel.cpp#L2005
```php
May 08 15:37:16 test-machine ot-cli[3967014]: 00:00:03.535 [D] P-SpinelDrive-: Received spinel frame, flg:0x2, iid:0, tid:0, cmd:PROP_VALUE_IS, key:LAST_STATUS, status:RESET_EXTERNAL
May 08 15:37:16 test-machine ot-cli[3967014]: 00:00:03.535 [C] P-RadioSpinel-: Unexpected RCP reset: RESET_EXTERNAL
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.327 [W] P-RadioSpinel-: Wait for response timeout
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.327 [W] P-RadioSpinel-: RCP failure detected
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.327 [W] P-RadioSpinel-: Trying to recover (1/2)
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.327 [D] P-RadioSpinel-: Wait response: tid=1 key=32
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.330 [D] P-SpinelDrive-: Received spinel frame, flg:0x2, iid:0, tid:1, cmd:PROP_VALUE_IS, key:PHY_ENABLED, enabled:1
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.330 [D] P-RadioSpinel-: Wait response: tid=2 key=54
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.334 [D] P-SpinelDrive-: Received spinel frame, flg:0x2, iid:0, tid:2, cmd:PROP_VALUE_IS, key:MAC_15_4_PANID, panid:0xffff
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.334 [D] P-RadioSpinel-: Wait response: tid=3 key=53
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.339 [D] P-SpinelDrive-: Received spinel frame, flg:0x2, iid:0, tid:3, cmd:PROP_VALUE_IS, key:MAC_15_4_SADDR, saddr:0xfffe
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.339 [D] P-RadioSpinel-: Wait response: tid=4 key=52
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.343 [D] P-SpinelDrive-: Received spinel frame, flg:0x2, iid:0, tid:4, cmd:PROP_VALUE_IS, key:MAC_15_4_LADDR, laddr:ee4eab67dd60bd4f
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.343 [D] P-RadioSpinel-: Wait response: tid=5 key=33
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.348 [D] P-SpinelDrive-: Received spinel frame, flg:0x2, iid:0, tid:5, cmd:PROP_VALUE_IS, key:PHY_CHAN, channel:0
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.348 [D] P-RadioSpinel-: Wait response: tid=6 key=2048
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.356 [D] P-SpinelDrive-: Received spinel frame, flg:0x2, iid:0, tid:6, cmd:PROP_VALUE_IS, key:LAST_STATUS, status:OK
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.357 [D] P-RadioSpinel-: Trying to get RCP time offset
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.357 [D] P-RadioSpinel-: Wait response: tid=7 key=2050
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.362 [D] P-SpinelDrive-: Received spinel frame, flg:0x2, iid:0, tid:7, cmd:PROP_VALUE_IS, key:TIMESTAMP, timestamp:1826682
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.362 [D] P-RadioSpinel-: Wait response: tid=8 key=178
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.365 [D] P-SpinelDrive-: Received spinel frame, flg:0x2, iid:0, tid:8, cmd:PROP_VALUE_IS, key:LAST_STATUS, status:PROP_NOT_FOUND
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.365 [W] P-RadioSpinel-: Error processing result: NotImplemented
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.365 [W] P-RadioSpinel-: Error waiting response: NotImplemented
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.366 [D] P-RadioSpinel-: Wait response: tid=9 key=178
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.369 [D] P-SpinelDrive-: Received spinel frame, flg:0x2, iid:0, tid:9, cmd:PROP_VALUE_IS, key:LAST_STATUS, status:PROP_NOT_FOUND
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.369 [W] P-RadioSpinel-: Error processing result: NotImplemented
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.369 [W] P-RadioSpinel-: Error waiting response: NotImplemented
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.369 [C] Platform------: RecoverFromRcpFailure() at radio_spinel.cpp:2005: Failure
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.369 [D] P-RadioSpinel-: Wait response: tid=10 key=178
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.373 [D] P-SpinelDrive-: Received spinel frame, flg:0x2, iid:0, tid:10, cmd:PROP_VALUE_IS, key:LAST_STATUS, status:PROP_NOT_FOUND
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.373 [W] P-RadioSpinel-: Error processing result: NotImplemented
May 08 15:37:18 test-machine ot-cli[3967014]: 00:00:05.373 [W] P-RadioSpinel-: Error waiting response: NotImplemented

```


