### PR TITLE
[dns] add checks for multi-label looped compressed DNS names

### DIFF
--- a/src/core/net/dns_types.cpp
+++ b/src/core/net/dns_types.cpp
@@ -612,8 +612,9 @@ Error Name::LabelIterator::GetNextLabel(void)
             // `mMessage.GetOffset()` must point to the start of the
             // DNS header.
             nextLabelOffset = mMessage.GetOffset() + (BigEndian::HostSwap16(pointerValue) & kPointerLabelOffsetMask);
-            VerifyOrExit(nextLabelOffset < mNextLabelOffset, error = kErrorParse);
+            VerifyOrExit(nextLabelOffset < mMinLabelOffset, error = kErrorParse);
             mNextLabelOffset = nextLabelOffset;
+            mMinLabelOffset  = nextLabelOffset;
 
             // Go back through the `while(true)` loop to get the next label.
         }

--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -1145,6 +1145,7 @@ private:
             : mMessage(aMessage)
             , mNextLabelOffset(aLabelOffset)
             , mNameEndOffset(kUnsetNameEndOffset)
+            , mMinLabelOffset(aLabelOffset)
         {
         }
 
@@ -1162,6 +1163,7 @@ private:
         uint8_t        mLabelLength;      // Length of current label (number of chars).
         uint16_t       mNextLabelOffset;  // Offset in `mMessage` to the start of the next label.
         uint16_t       mNameEndOffset;    // Offset in `mMessage` to the byte after the end of domain name field.
+        uint16_t       mMinLabelOffset;   // Offset in `mMessage` to the start of the earliest parsed label.
     };
 
     Name(const char *aString, const Message *aMessage, uint16_t aOffset)


### PR DESCRIPTION
This commit enhances `Dns::Name` to detect and handle cases where a compressed DNS name contains a loop spanning multiple labels. The `test_dns` unit test has been updated to include test cases for these invalid names.