### PR TITLE
[posix] add return of co-processor type in otSysInit and allow posix plat run with NCP

### DIFF
--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -64,10 +64,10 @@
 #endif
 #include <common/code_utils.hpp>
 #include <lib/platform/exit_code.h>
+#include <lib/platform/reset_util.h>
+#include <lib/spinel/coprocessor_type.h>
 #include <openthread/openthread-system.h>
 #include <openthread/platform/misc.h>
-
-#include "lib/platform/reset_util.h"
 
 /**
  * Initializes NCP app.
@@ -297,6 +297,12 @@ static otInstance *InitInstance(PosixConfig *aConfig)
     instance = otSysInit(&aConfig->mPlatformConfig);
     VerifyOrDie(instance != NULL, OT_EXIT_FAILURE);
     syslog(LOG_INFO, "Thread interface: %s", otSysGetThreadNetifName());
+
+    if (aConfig->mPlatformConfig.mCoprocessorType != OT_COPROCESSOR_RCP)
+    {
+        printf("Only RCP is supported by posix app now!\n");
+        exit(OT_EXIT_FAILURE);
+    }
 
     if (aConfig->mPrintRadioVersion)
     {

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -45,6 +45,7 @@
 #include <openthread/instance.h>
 #include <openthread/platform/misc.h>
 
+#include "lib/spinel/coprocessor_type.h"
 #include "lib/spinel/radio_spinel_metrics.h"
 
 #ifdef __cplusplus
@@ -83,6 +84,8 @@ typedef struct otPlatformConfig
     bool        mPersistentInterface;                          ///< Whether persistent the interface
     bool        mDryRun;                                       ///< If 'DryRun' is set, the posix daemon will exit
                                                                ///< directly after initialization.
+    CoprocessorType mCoprocessorType;                          ///< The co-processor type. This field is used to pass
+                                                               ///< the type to the app layer.
 } otPlatformConfig;
 
 /**


### PR DESCRIPTION
This PR lets posix `otSysInit` return the Co-processor type by adding 
a field in `otPlatformConfig`. (This avoids breaking the existing 
code that uses `otSysInit`.) Returning the Co-processor type allows
the app layer has the information and can do initialization. For
example, the dbus server.

The PR also allows `otSysInit` and `otSysDeinit` to be completed when
the co-processor type is NCP. This doesn't mean `ot-daemon` can work
with NCP now. But this is required by further developing NCP support
in `otbr-agent` because these two methods are required. The native
posix app (ot-daemon) will still exit when it detects a co-processor other
than RCP.

When the co-processor type is RCP, `otSysInit` and `otSysDeinit` work
as usual. When the type is NCP, only spinel manager will be 
initialized and ot::Instance will not be created.