### PR TITLE
[dataset] simplify dataset `Save()` methods

### DIFF
--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -61,14 +61,14 @@ otError otDatasetGetActiveTlvs(otInstance *aInstance, otOperationalDatasetTlvs *
 
 otError otDatasetSetActive(otInstance *aInstance, const otOperationalDataset *aDataset)
 {
-    return AsCoreType(aInstance).Get<MeshCoP::ActiveDatasetManager>().Save(AsCoreType(aDataset));
+    return AsCoreType(aInstance).Get<MeshCoP::ActiveDatasetManager>().SaveLocal(AsCoreType(aDataset));
 }
 
 otError otDatasetSetActiveTlvs(otInstance *aInstance, const otOperationalDatasetTlvs *aDataset)
 {
     AssertPointerIsNotNull(aDataset);
 
-    return AsCoreType(aInstance).Get<MeshCoP::ActiveDatasetManager>().Save(*aDataset);
+    return AsCoreType(aInstance).Get<MeshCoP::ActiveDatasetManager>().SaveLocal(*aDataset);
 }
 
 otError otDatasetGetPending(otInstance *aInstance, otOperationalDataset *aDataset)
@@ -85,14 +85,14 @@ otError otDatasetGetPendingTlvs(otInstance *aInstance, otOperationalDatasetTlvs 
 
 otError otDatasetSetPending(otInstance *aInstance, const otOperationalDataset *aDataset)
 {
-    return AsCoreType(aInstance).Get<MeshCoP::PendingDatasetManager>().Save(AsCoreType(aDataset));
+    return AsCoreType(aInstance).Get<MeshCoP::PendingDatasetManager>().SaveLocal(AsCoreType(aDataset));
 }
 
 otError otDatasetSetPendingTlvs(otInstance *aInstance, const otOperationalDatasetTlvs *aDataset)
 {
     AssertPointerIsNotNull(aDataset);
 
-    return AsCoreType(aInstance).Get<MeshCoP::PendingDatasetManager>().Save(*aDataset);
+    return AsCoreType(aInstance).Get<MeshCoP::PendingDatasetManager>().SaveLocal(*aDataset);
 }
 
 otError otDatasetSendMgmtActiveGet(otInstance                           *aInstance,

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -146,30 +146,6 @@ exit:
     return error;
 }
 
-Error DatasetLocal::Save(const Dataset::Info &aDatasetInfo)
-{
-    Error   error;
-    Dataset dataset;
-
-    dataset.SetFrom(aDatasetInfo);
-    SuccessOrExit(error = Save(dataset));
-
-exit:
-    return error;
-}
-
-Error DatasetLocal::Save(const Dataset::Tlvs &aDatasetTlvs)
-{
-    Error   error = kErrorNone;
-    Dataset dataset;
-
-    SuccessOrExit(error = dataset.SetFrom(aDatasetTlvs));
-    error = Save(dataset);
-
-exit:
-    return error;
-}
-
 Error DatasetLocal::Save(const Dataset &aDataset)
 {
     Error error = kErrorNone;

--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -153,29 +153,6 @@ public:
     /**
      * Stores the dataset into non-volatile memory.
      *
-     * @param[in] aDatasetInfo     The Dataset to save as `Dataset::Info`.
-     *
-     * @retval kErrorNone             Successfully saved the dataset.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
-     *
-     */
-    Error Save(const Dataset::Info &aDatasetInfo);
-
-    /**
-     * Stores the dataset into non-volatile memory.
-     *
-     * @param[in]  aDatasetTlvs  The Dataset to save as `Dataset::Tlvs`.
-     *
-     * @retval kErrorNone             Successfully saved the dataset.
-     * @retval kErrorInvalidArgs      The dataset TLVs is invalid, its length is longer than `Dataset::kMaxLength`.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
-     *
-     */
-    Error Save(const Dataset::Tlvs &aDatasetTlvs);
-
-    /**
-     * Stores the dataset into non-volatile memory.
-     *
      * @param[in]  aDataset  The Dataset to save.
      *
      * @retval kErrorNone             Successfully saved the dataset.

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -433,7 +433,7 @@ void PendingDatasetManager::ApplyActiveDataset(Dataset &aDataset)
     SuccessOrExit(aDataset.Write<DelayTimerTlv>(Get<Leader>().GetDelayTimerMinimal()));
 
     IgnoreError(DatasetManager::Save(aDataset));
-    StartDelayTimer();
+    StartDelayTimer(aDataset);
 
 exit:
     return;

--- a/src/core/meshcop/dataset_updater.cpp
+++ b/src/core/meshcop/dataset_updater.cpp
@@ -149,7 +149,7 @@ void DatasetUpdater::PreparePendingDataset(void)
         IgnoreError(dataset.Write<ActiveTimestampTlv>(timestamp));
     }
 
-    SuccessOrExit(error = Get<PendingDatasetManager>().Save(dataset));
+    SuccessOrExit(error = Get<PendingDatasetManager>().SaveLocal(dataset));
 
 exit:
     if (error != kErrorNone)

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -533,7 +533,7 @@ template <> void Joiner::HandleTmf<kUriJoinerEntrust>(Coap::Message &aMessage, c
     datasetInfo.Set<Dataset::kChannel>(Get<Mac::Mac>().GetPanChannel());
     datasetInfo.Set<Dataset::kPanId>(Get<Mac::Mac>().GetPanId());
 
-    IgnoreError(Get<ActiveDatasetManager>().Save(datasetInfo));
+    IgnoreError(Get<ActiveDatasetManager>().SaveLocal(datasetInfo));
 
     LogInfo("Joiner successful!");
 

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -476,7 +476,7 @@ Error TcatAgent::HandleSetActiveOperationalDataset(const Message &aIncommingMess
     }
 
     dataset.ConvertTo(datasetTlvs);
-    error = Get<ActiveDatasetManager>().Save(datasetTlvs);
+    error = Get<ActiveDatasetManager>().SaveLocal(datasetTlvs);
 
 exit:
     return error;


### PR DESCRIPTION
This commit streamlines dataset-related helper methods:

- Renames all methods that save local dataset to `SaveLocal()` for consistency and to distinguish them from `Save()` methods, which set the partition's dataset and perform additional checks (e.g., ensuring the timestamp is ahead).
- Renames `SendSet()` to `SyncLocalWithLeader()` and passes `aDataset` as an input parameter to avoid redundant dataset reads.
- Removes the now unnecessary `HandleDatasetUpdated()` method, as its functionality can be inlined within `SaveLocal(const Dataset &)`.
- Consolidates additional dataset type-specific actions (e.g., starting a delay timer for Pending Dataset changes) into the base class `DatasetManager` methods `Save()` and `SaveLocal()`, simplifying the code and reducing redundancy.
- Modifies `DatasetLocal` to provide a single `Save()` method with a `const Dataset &` input. `DatasetManager` now handles conversions from various dataset representations (e.g., component-wise structures or TLV sequences).