### PR TITLE
[routing-manager] ignore checksum in RA hash calculation

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1259,8 +1259,8 @@ private:
         }
 
         void        IncrementTxCountAndSaveHash(const InfraIf::Icmp6Packet &aRaMessage);
-        bool        IsRaFromManager(const Ip6::Nd::RouterAdvert::RxMessage &aRaMessage) const;
-        static void CalculateHash(const InfraIf::Icmp6Packet &aRaMessage, Hash &aHash);
+        bool        IsRaFromManager(const RouterAdvert::RxMessage &aRaMessage) const;
+        static void CalculateHash(const RouterAdvert::RxMessage &aRaMessage, Hash &aHash);
 
         RouterAdvert::Header mHeader;
         TimeMilli            mHeaderUpdateTime;

--- a/src/core/net/nd6.hpp
+++ b/src/core/net/nd6.hpp
@@ -729,6 +729,22 @@ public:
          */
         bool ContainsAnyOptions(void) const { return (mData.GetLength() > sizeof(Header)); }
 
+        /**
+         * Returns pointer to the start of option bytes (after header).
+         *
+         * @returns Pointer to start of options.
+         *
+         */
+        const uint8_t *GetOptionStart(void) const { return (mData.GetBytes() + sizeof(Header)); }
+
+        /**
+         * Gets the length (number of bytes) of options.
+         *
+         * @returns Number of bytes after header specifying RA options.
+         *
+         */
+        uint16_t GetOptionLength(void) const { return ContainsAnyOptions() ? mData.GetLength() - sizeof(Header) : 0; }
+
         // The following methods are intended to support range-based `for`
         // loop iteration over `Option`s in the RA message.
 
@@ -736,7 +752,6 @@ public:
         Option::Iterator end(void) const { return Option::Iterator(); }
 
     private:
-        const uint8_t *GetOptionStart(void) const { return (mData.GetBytes() + sizeof(Header)); }
         const uint8_t *GetDataEnd(void) const { return mData.GetBytes() + mData.GetLength(); }
 
         Data<kWithUint16Length> mData;


### PR DESCRIPTION
This commit modifies the `CalculateHash()` method to use a zero checksum value for RA (ICMPv6) header for both received and emitted RA message. In prepared RA messages, the checksum is always set to zero, and the platform layer is responsible for calculating and updating it. For a received RA, while platforms typically zero out the checksum after validation, this behavior isn't explicitly required by `otPlatInfraIf` APIs. By ignoring the checksum(setting it to zero) during hash calculation, this change ensures correct calculation regardless of platform behavior.

This commit also updates `test_routing_manager` to intentionally modify the checksum field in an emitted RA message before passing it back to the OT stack. This validates the updated hash calculation behavior.

----

~This PR contains the commit from #10229. Please check and review the last commit. Thanks.~