### PR TITLE
[network-data] optimize `ContainsOmrPrefix()`

### DIFF
--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -431,7 +431,7 @@ public:
      * @retval FALSE Otherwise.
      *
      */
-    bool ContainsOmrPrefix(const Ip6::Prefix &aPrefix);
+    bool ContainsOmrPrefix(const Ip6::Prefix &aPrefix) const;
 #endif
 
 #endif // OPENTHREAD_FTD


### PR DESCRIPTION
This commit simplifies the `Leader::ContainsOmrPrefix()` method by eliminating the loop over sub-TLVs based on stable flag status. Since OMR prefixes must be marked as stable, the search for a given OMR prefix can be restricted to stable sub-TLV only.