### PR TITLE
[routing-manager] utilize `Network::Leader::ContainsOmrPrefix()`

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1399,7 +1399,6 @@ private:
     bool ShouldProcessPrefixInfoOption(const PrefixInfoOption &aPio, const Ip6::Prefix &aPrefix);
     bool ShouldProcessRouteInfoOption(const RouteInfoOption &aRio, const Ip6::Prefix &aPrefix);
     void UpdateDiscoveredPrefixTableOnNetDataChange(void);
-    bool NetworkDataContainsOmrPrefix(const Ip6::Prefix &aPrefix) const;
     bool NetworkDataContainsUlaRoute(void) const;
     void UpdateRouterAdvertHeader(const RouterAdvert::RxMessage *aRaMsg, RouterAdvOrigin aRaOrigin);
     void ResetDiscoveredPrefixStaleTimer(void);

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -421,20 +421,23 @@ public:
      */
     const ServiceTlv *FindServiceById(uint8_t aServiceId) const;
 
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+#endif // OPENTHREAD_FTD
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
     /**
-     * Indicates whether a given Prefix can act as a valid OMR prefix and exists in the network data.
+     * Indicates whether Network Data contains a valid OMR prefix.
+     *
+     * If the given @p aPrefix is itself not a valid OMR prefix, this method will return `false`, regardless of
+     * whether the prefix is present in the Network Data.
      *
      * @param[in]  aPrefix   The OMR prefix to check.
      *
-     * @retval TRUE  If @p aPrefix is a valid OMR prefix and Network Data contains @p aPrefix.
-     * @retval FALSE Otherwise.
+     * @retval TRUE   Network Data contains a valid OMR prefix entry matching @p aPrefix.
+     * @retval FALSE  Network Data does not contain a valid OMR prefix entry matching @p aPrefix.
      *
      */
     bool ContainsOmrPrefix(const Ip6::Prefix &aPrefix) const;
 #endif
-
-#endif // OPENTHREAD_FTD
 
 private:
     using FilterIndexes = MeshCoP::SteeringData::HashBitIndexes;

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -1358,41 +1358,6 @@ void Leader::HandleTimer(void)
     }
 }
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-
-bool Leader::ContainsOmrPrefix(const Ip6::Prefix &aPrefix) const
-{
-    bool                   contains = false;
-    const PrefixTlv       *prefixTlv;
-    const BorderRouterTlv *brSubTlv;
-
-    VerifyOrExit(BorderRouter::RoutingManager::IsValidOmrPrefix(aPrefix));
-
-    prefixTlv = FindPrefix(aPrefix);
-    VerifyOrExit(prefixTlv != nullptr);
-
-    brSubTlv = prefixTlv->FindSubTlv<BorderRouterTlv>(/* aStable */ true);
-
-    VerifyOrExit(brSubTlv != nullptr);
-
-    for (const BorderRouterEntry *entry = brSubTlv->GetFirstEntry(); entry <= brSubTlv->GetLastEntry(); entry++)
-    {
-        OnMeshPrefixConfig config;
-
-        config.SetFrom(*prefixTlv, *brSubTlv, *entry);
-
-        if (BorderRouter::RoutingManager::IsValidOmrPrefix(config))
-        {
-            ExitNow(contains = true);
-        }
-    }
-
-exit:
-    return contains;
-}
-
-#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-
 //---------------------------------------------------------------------------------------------------------------------
 // Leader::ContextIds
 


### PR DESCRIPTION
This commit optimizes `RoutingManager`:

- Replaces `RoutingManager::NetworkDataContainsOmrPrefix()` with `ContainsOmrPrefix()`.
- Simplifies `OmrPrefixManager::ShouldAdvertiseLocalAsRio()` by utilizing `ContainsOmrPrefix()`.
- Relocates `ContainsOmrPrefix()` to `network_data_leader.cpp` and removes its FTD-only restriction.

----

~This PR contains the commit from https://github.com/openthread/openthread/pull/10239. Please check and review last commit. Thanks.~
