### PR TITLE
[simulation] rename local host to local interface

### DIFF
--- a/examples/platforms/simulation/simul_utils.c
+++ b/examples/platforms/simulation/simul_utils.c
@@ -39,7 +39,7 @@
 #define UTILS_SOCKET_GROUP_ADDR "224.0.0.116"
 #define UTILS_SOCKET_GROUP_ADDR6 "ff02::116"
 
-const char *gLocalHost = UTILS_SOCKET_LOCAL_HOST_ADDR;
+const char *gLocalInterface = UTILS_SOCKET_LOCAL_HOST_ADDR;
 
 void utilsAddFdToFdSet(int aFd, fd_set *aFdSet, int *aMaxFd)
 {
@@ -210,7 +210,7 @@ exit:
     }
 }
 
-static bool TryInitSocketIfname(utilsSocket *aSocket, const char *aLocalHost)
+static bool TryInitSocketIfname(utilsSocket *aSocket, const char *aLocalInterface)
 {
     const struct in6_addr *addr6   = NULL;
     const struct in6_addr *addr6ll = NULL;
@@ -218,7 +218,7 @@ static bool TryInitSocketIfname(utilsSocket *aSocket, const char *aLocalHost)
     struct ifaddrs        *ifaddr  = NULL;
     unsigned int           ifIndex = 0;
 
-    otEXPECT((ifIndex = if_nametoindex(aLocalHost)));
+    otEXPECT((ifIndex = if_nametoindex(aLocalInterface)));
 
     if (getifaddrs(&ifaddr) == -1)
     {
@@ -228,7 +228,7 @@ static bool TryInitSocketIfname(utilsSocket *aSocket, const char *aLocalHost)
 
     for (struct ifaddrs *ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
     {
-        if (ifa->ifa_addr == NULL || strcmp(ifa->ifa_name, aLocalHost) != 0)
+        if (ifa->ifa_addr == NULL || strcmp(ifa->ifa_name, aLocalInterface) != 0)
         {
             continue;
         }
@@ -280,11 +280,11 @@ exit:
     return aSocket->mInitialized;
 }
 
-static bool TryInitSocketIp4(utilsSocket *aSocket, const char *aLocalHost)
+static bool TryInitSocketIp4(utilsSocket *aSocket, const char *aLocalInterface)
 {
     struct in_addr addr4;
 
-    otEXPECT(inet_pton(AF_INET, aLocalHost, &addr4));
+    otEXPECT(inet_pton(AF_INET, aLocalInterface, &addr4));
 
     InitTxSocketIp4(aSocket, &addr4);
     InitRxSocket(aSocket, &addr4, 0);
@@ -295,12 +295,12 @@ exit:
     return aSocket->mInitialized;
 }
 
-static bool TryInitSocketIp6(utilsSocket *aSocket, const char *aLocalHost)
+static bool TryInitSocketIp6(utilsSocket *aSocket, const char *aLocalInterface)
 {
     struct in6_addr addr6;
     struct ifaddrs *ifaddr = NULL;
 
-    otEXPECT(inet_pton(AF_INET6, aLocalHost, &addr6));
+    otEXPECT(inet_pton(AF_INET6, aLocalInterface, &addr6));
 
     if (getifaddrs(&ifaddr) == -1)
     {
@@ -351,10 +351,10 @@ void utilsInitSocket(utilsSocket *aSocket, uint16_t aPortBase)
     aSocket->mRxFd        = -1;
     aSocket->mPort        = (uint16_t)(aSocket->mPortBase + gNodeId);
 
-    if (!TryInitSocketIfname(aSocket, gLocalHost) && !TryInitSocketIp4(aSocket, gLocalHost) &&
-        !TryInitSocketIp6(aSocket, gLocalHost))
+    if (!TryInitSocketIfname(aSocket, gLocalInterface) && !TryInitSocketIp4(aSocket, gLocalInterface) &&
+        !TryInitSocketIp6(aSocket, gLocalInterface))
     {
-        fprintf(stderr, "Failed to simulate node %d on %s\n", gNodeId, gLocalHost);
+        fprintf(stderr, "Failed to simulate node %d on %s\n", gNodeId, gLocalInterface);
         exit(EXIT_FAILURE);
     }
 }

--- a/examples/platforms/simulation/simul_utils.h
+++ b/examples/platforms/simulation/simul_utils.h
@@ -52,7 +52,7 @@ typedef struct utilsSocket
     } mGroupAddr;                       ///< The group sock address for simulating radio.
 } utilsSocket;
 
-extern const char *gLocalHost; ///< Local host address to use for sockets
+extern const char *gLocalInterface; ///< Local interface name or address to use for sockets
 
 /**
  * Adds a file descriptor (FD) to a given FD set.

--- a/examples/platforms/simulation/system.c
+++ b/examples/platforms/simulation/system.c
@@ -76,7 +76,7 @@ enum
 {
     OT_SIM_OPT_HELP               = 'h',
     OT_SIM_OPT_ENABLE_ENERGY_SCAN = 'E',
-    OT_SIM_OPT_LOCAL_HOST         = 'L',
+    OT_SIM_OPT_LOCAL_INTERFACE    = 'L',
     OT_SIM_OPT_SLEEP_TO_TX        = 't',
     OT_SIM_OPT_TIME_SPEED         = 's',
     OT_SIM_OPT_LOG_FILE           = 'l',
@@ -90,6 +90,7 @@ static void PrintUsage(const char *aProgramName, int aExitCode)
             "    %s [Options] NodeId\n"
             "Options:\n"
             "    -h --help                  Display this usage information.\n"
+            "    -L --local-interface=val   The address or name of the netif to simulate Thread radio.\n"
             "    -E --enable-energy-scan    Enable energy scan capability.\n"
             "    -t --sleep-to-tx           Let radio support direct transition from sleep to TX with CSMA.\n"
             "    -s --time-speed=val        Speed up the time in simulation.\n"
@@ -112,7 +113,7 @@ void otSysInit(int aArgCount, char *aArgVector[])
         {"enable-energy-scan", no_argument, 0, OT_SIM_OPT_ENABLE_ENERGY_SCAN},
         {"sleep-to-tx", no_argument, 0, OT_SIM_OPT_SLEEP_TO_TX},
         {"time-speed", required_argument, 0, OT_SIM_OPT_TIME_SPEED},
-        {"local-host", required_argument, 0, OT_SIM_OPT_LOCAL_HOST},
+        {"local-interface", required_argument, 0, OT_SIM_OPT_LOCAL_INTERFACE},
 #if (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED)
         {"log-file", required_argument, 0, OT_SIM_OPT_LOG_FILE},
 #endif
@@ -156,8 +157,8 @@ void otSysInit(int aArgCount, char *aArgVector[])
         case OT_SIM_OPT_SLEEP_TO_TX:
             gRadioCaps |= OT_RADIO_CAPS_SLEEP_TO_TX;
             break;
-        case OT_SIM_OPT_LOCAL_HOST:
-            gLocalHost = optarg;
+        case OT_SIM_OPT_LOCAL_INTERFACE:
+            gLocalInterface = optarg;
             break;
         case OT_SIM_OPT_TIME_SPEED:
             speedUpFactor = (uint32_t)strtol(optarg, &endptr, 10);


### PR DESCRIPTION
This commit renames command line argument --local-host to --local-interface to reduce confusion as discussed in #10194.

This commit also add help message for local interface.