### PR TITLE
[gitignore] ignore files genereated by running toranj unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ cmake-build-*/**
 
 # Python bytecodes
 __pycache__
+
+# Unit test files
+CTestTestfile.cmake
+ot-test-*
+Testing/


### PR DESCRIPTION
When running toranj unit tests locally there are many temporary files generated and they are not ignored. This PR ignores these files.