### PR TITLE
[gitignore] do not ignore .cmake files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@
 *.trs
 *.bak
 *.map
-*.cmake
 *~
 .DS_Store
 .vagrant


### PR DESCRIPTION
I noticed that there are a few `.cmake` files in the repo that shouldn't be ignored:
* etc/cmake/*.cmake
* examples/apps/cli/{ftd/mtd/radio}.cmake
* examples/apps/ncp/{ftd/mtd/radio}.cmake
* src/core/{ftd/mtd/radio}.cmake
* src/ncp/{ftd/mtd/radio}.cmake
* src/cli/{ftd/mtd/radio}.cmake
* src/posix/daemon.cmake                                                                                                                                               
* src/posix/platform/vendor.cmake                                                                                                                                      
* src/posix/platform/vendor_extension_example.cmake                                                                                                                    
* src/posix/platform/FindExampleVendorDeps.cmake                                                                                                                       
* src/posix/cli.cmake 

So I think we can only ignore specific .cmake files.