### PR TITLE
[dataset] add `ContainsAllTlvs()` helper method

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -238,34 +238,48 @@ exit:
     return isValid;
 }
 
-bool Dataset::ContainsAllRequiredTlvsFor(Type aType) const
+bool Dataset::ContainsAllTlvs(const Tlv::Type aTlvTypes[], uint8_t aLength) const
 {
-    static const Tlv::Type kActiveDatasetTlvs[] = {
-        Tlv::kActiveTimestamp, Tlv::kChannel,     Tlv::kChannelMask, Tlv::kExtendedPanId, Tlv::kMeshLocalPrefix,
-        Tlv::kNetworkKey,      Tlv::kNetworkName, Tlv::kPanId,       Tlv::kPskc,          Tlv::kSecurityPolicy,
-    };
+    bool containsAll = true;
 
-    static const Tlv::Type kPendingDatasetExtraTlvs[] = {Tlv::kPendingTimestamp, Tlv::kDelayTimer};
-
-    bool containsAll = false;
-
-    for (Tlv::Type tlvType : kActiveDatasetTlvs)
+    for (uint8_t index = 0; index < aLength; index++)
     {
-        VerifyOrExit(ContainsTlv(tlvType));
-    }
-
-    if (aType == kPending)
-    {
-        for (Tlv::Type tlvType : kPendingDatasetExtraTlvs)
+        if (!ContainsTlv(aTlvTypes[index]))
         {
-            VerifyOrExit(ContainsTlv(tlvType));
+            containsAll = false;
+            break;
         }
     }
 
-    containsAll = true;
-
-exit:
     return containsAll;
+}
+
+bool Dataset::ContainsAllRequiredTlvsFor(Type aType) const
+{
+    static const Tlv::Type kDatasetTlvs[] = {
+        Tlv::kActiveTimestamp,
+        Tlv::kChannel,
+        Tlv::kChannelMask,
+        Tlv::kExtendedPanId,
+        Tlv::kMeshLocalPrefix,
+        Tlv::kNetworkKey,
+        Tlv::kNetworkName,
+        Tlv::kPanId,
+        Tlv::kPskc,
+        Tlv::kSecurityPolicy,
+        // The last two TLVs are for Pending Dataset
+        Tlv::kPendingTimestamp,
+        Tlv::kDelayTimer,
+    };
+
+    uint8_t length = sizeof(kDatasetTlvs);
+
+    if (aType == kActive)
+    {
+        length -= 2;
+    }
+
+    return ContainsAllTlvs(kDatasetTlvs, length);
 }
 
 const Tlv *Dataset::FindTlv(Tlv::Type aType) const { return As<Tlv>(Tlv::FindTlv(mTlvs, mLength, aType)); }

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -297,6 +297,18 @@ public:
     }
 
     /**
+     * Indicates whether or not the Dataset contains all the TLVs from a given array.
+     *
+     * @param[in] aTlvTypes    An array of TLV types.
+     * @param[in] aLength      Length of @p aTlvTypes array.
+     *
+     * @retval TRUE    The Dataset contains all the TLVs in @p aTlvTypes array.
+     * @retval FALSE   The Dataset does not contain all the TLVs in @p aTlvTypes array.
+     *
+     */
+    bool ContainsAllTlvs(const Tlv::Type aTlvTypes[], uint8_t aLength) const;
+
+    /**
      * Indicates whether or not the Dataset contains all the required TLVs for an Active or Pending Dataset.
      *
      * @param[in] aType  The Dataset type, Active or Pending.

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -593,14 +593,15 @@ bool ActiveDatasetManager::IsComplete(void) const { return mLocal.IsSaved() && m
 
 bool ActiveDatasetManager::IsCommissioned(void) const
 {
-    Dataset::Info datasetInfo;
-    bool          isValid = false;
+    static const Tlv::Type kRequiredTlvs[] = {
+        Tlv::kNetworkKey, Tlv::kNetworkName, Tlv::kExtendedPanId, Tlv::kPanId, Tlv::kChannel,
+    };
 
-    SuccessOrExit(Read(datasetInfo));
+    Dataset dataset;
+    bool    isValid = false;
 
-    isValid = (datasetInfo.IsPresent<Dataset::kNetworkKey>() && datasetInfo.IsPresent<Dataset::kNetworkName>() &&
-               datasetInfo.IsPresent<Dataset::kExtendedPanId>() && datasetInfo.IsPresent<Dataset::kPanId>() &&
-               datasetInfo.IsPresent<Dataset::kChannel>());
+    SuccessOrExit(Read(dataset));
+    isValid = dataset.ContainsAllTlvs(kRequiredTlvs, sizeof(kRequiredTlvs));
 
 exit:
     return isValid;


### PR DESCRIPTION
This commit introduces the `ContainsAllTlvs()` method to `Dataset`, which checks if a dataset contains all the specified TLVs. This new method simplifies the implementation of `IsCommissioned()` and `ContainsAllRequiredTlvsFor(Type)`