### PR TITLE
[routing-manager] move tracking of local RA header to `RxRaTracker`

### DIFF
--- a/src/core/net/nd6.hpp
+++ b/src/core/net/nd6.hpp
@@ -539,7 +539,7 @@ public:
      *
      */
     OT_TOOL_PACKED_BEGIN
-    class Header : public Equatable<Header>, private Clearable<Header>
+    class Header : public Equatable<Header>, public Clearable<Header>
     {
         friend class Clearable<Header>;
 
@@ -550,6 +550,15 @@ public:
          *
          */
         Header(void) { SetToDefault(); }
+
+        /**
+         * Indicates whether the header is valid by checking the type field to match Router Advertisement ICMPv6 type.
+         *
+         * @retval TRUE  The header is valid.
+         * @retval FALSE The header is not valid.
+         *
+         */
+        bool IsValid(void) const { return GetType() == Icmp::Header::kTypeRouterAdvert; }
 
         /**
          * Sets the RA message to default values.


### PR DESCRIPTION
This commit moves the tracking of the RA header of locally generated RA messages from `TxRaInfo` to the `RxRaTracker` class. The tracked RA header is used when `RoutingManager` sends an RA, ensuring consistent RA headers across all RAs emitted from the device.

This aligns the logic by having `RxRaTracker` track all information from received RAs and simplifies stale time calculations.

----

~This PR contains the commit from https://github.com/openthread/openthread/pull/10255. Please check and review the last commit. Thanks.~