### PR TITLE
[dataset] move `Read()` overload implementations to `DatasetManager`

### DIFF
--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -118,34 +118,6 @@ exit:
     return error;
 }
 
-Error DatasetLocal::Read(Dataset::Info &aDatasetInfo) const
-{
-    Dataset dataset;
-    Error   error;
-
-    aDatasetInfo.Clear();
-
-    SuccessOrExit(error = Read(dataset));
-    dataset.ConvertTo(aDatasetInfo);
-
-exit:
-    return error;
-}
-
-Error DatasetLocal::Read(Dataset::Tlvs &aDatasetTlvs) const
-{
-    Dataset dataset;
-    Error   error;
-
-    ClearAllBytes(aDatasetTlvs);
-
-    SuccessOrExit(error = Read(dataset));
-    dataset.ConvertTo(aDatasetTlvs);
-
-exit:
-    return error;
-}
-
 void DatasetLocal::Save(const Dataset &aDataset)
 {
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE

--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -121,28 +121,6 @@ public:
     Error Read(Dataset &aDataset) const;
 
     /**
-     * Retrieves the dataset from non-volatile memory.
-     *
-     * @param[out]  aDatasetInfo  Where to place the dataset as `Dataset::Info`.
-     *
-     * @retval kErrorNone      Successfully retrieved the dataset.
-     * @retval kErrorNotFound  There is no corresponding dataset stored in non-volatile memory.
-     *
-     */
-    Error Read(Dataset::Info &aDatasetInfo) const;
-
-    /**
-     * Retrieves the dataset from non-volatile memory.
-     *
-     * @param[out]  aDatasetTlvs  Where to place the dataset.
-     *
-     * @retval kErrorNone      Successfully retrieved the dataset.
-     * @retval kErrorNotFound  There is no corresponding dataset stored in non-volatile memory.
-     *
-     */
-    Error Read(Dataset::Tlvs &aDatasetTlvs) const;
-
-    /**
      * Returns the local time this dataset was last updated or restored.
      *
      * @returns The local time this dataset was last updated or restored.
@@ -178,9 +156,6 @@ private:
     void DestroySecurelyStoredKeys(void) const;
     void EmplaceSecurelyStoredKeys(Dataset &aDataset) const;
 #endif
-
-    bool IsActive(void) const { return (mType == Dataset::kActive); }
-    void SetTimestamp(const Dataset &aDataset);
 
     Timestamp     mTimestamp;            ///< Active or Pending Timestamp
     TimeMilli     mUpdateTime;           ///< Local time last updated

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -92,6 +92,34 @@ exit:
     return error;
 }
 
+Error DatasetManager::Read(Dataset::Info &aDatasetInfo) const
+{
+    Dataset dataset;
+    Error   error;
+
+    aDatasetInfo.Clear();
+
+    SuccessOrExit(error = Read(dataset));
+    dataset.ConvertTo(aDatasetInfo);
+
+exit:
+    return error;
+}
+
+Error DatasetManager::Read(Dataset::Tlvs &aDatasetTlvs) const
+{
+    Dataset dataset;
+    Error   error;
+
+    ClearAllBytes(aDatasetTlvs);
+
+    SuccessOrExit(error = Read(dataset));
+    dataset.ConvertTo(aDatasetTlvs);
+
+exit:
+    return error;
+}
+
 Error DatasetManager::ApplyConfiguration(void) const
 {
     Error   error;

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -97,7 +97,7 @@ public:
      * @retval kErrorNotFound  There is no corresponding dataset stored in non-volatile memory.
      *
      */
-    Error Read(Dataset::Info &aDatasetInfo) const { return mLocal.Read(aDatasetInfo); }
+    Error Read(Dataset::Info &aDatasetInfo) const;
 
     /**
      * Retrieves the dataset from non-volatile memory.
@@ -108,7 +108,7 @@ public:
      * @retval kErrorNotFound  There is no corresponding dataset stored in non-volatile memory.
      *
      */
-    Error Read(Dataset::Tlvs &aDatasetTlvs) const { return mLocal.Read(aDatasetTlvs); }
+    Error Read(Dataset::Tlvs &aDatasetTlvs) const;
 
     /**
      * Saves the Operational Dataset in non-volatile memory.


### PR DESCRIPTION
This commit simplifies `DatasetLocal` by moving the different overload implementations of `Read()` to `DatasetManager`. This aligns the code so that overloads are provided by `DatasetManager` and `DatasetLocal` provides one version of `Save()` or `Read()`. Unused/undefined methods in `DatasetLocal` are also removed.