### PR TITLE
[utils] Fixed to avoid compilation issue when disabling OPENTHREAD_CO…

### DIFF
--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -216,8 +216,10 @@ void ChannelManager::HandleTimer(void)
     switch (mState)
     {
     case kStateIdle:
+#if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
         LogInfo("Auto-triggered channel select");
         IgnoreError(RequestAutoChannelSelect(false));
+#endif
         StartAutoSelectTimer();
         break;
 
@@ -423,12 +425,14 @@ exit:
 #if OPENTHREAD_FTD
 void ChannelManager::SetAutoNetworkChannelSelectionEnabled(bool aEnabled)
 {
+#if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
     if (aEnabled != mAutoSelectEnabled)
     {
         mAutoSelectEnabled = aEnabled;
         IgnoreError(RequestNetworkChannelSelect(false));
         StartAutoSelectTimer();
     }
+#endif
 }
 #endif
 


### PR DESCRIPTION
…NFIG_CHANNEL_MONITOR_ENABLE

[Issue] Disabling channel monitor feature on ot-daemon by setting following flag "OT_CHANNEL_MONITOR = 0" a compilation error was present.

[Fix] Some pieces of code in OpenThread shall be under OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE.