### PR TITLE
[mdns] ensure callback is invoked when registering host with no address

### DIFF
--- a/src/core/net/mdns.hpp
+++ b/src/core/net/mdns.hpp
@@ -907,6 +907,7 @@ private:
         void Init(Instance &aInstance);
         void SetCallback(const Callback &aCallback);
         void ClearCallback(void) { mCallback.Clear(); }
+        void MarkToInvokeCallbackUnconditionally(void);
         void StartProbing(void);
         void SetStateToConflict(void);
         void SetStateToRemoving(void);
@@ -939,6 +940,7 @@ private:
         bool       mMulticastNsecPending : 1;
         bool       mUnicastNsecPending : 1;
         bool       mAppendedNsec : 1;
+        bool       mBypassCallbackStateCheck : 1;
         TimeMilli  mNsecAnswerTime;
         Heap::Data mKeyData;
         Callback   mCallback;


### PR DESCRIPTION
This commit updates the native mDNS implementation to ensure the callback is invoked when a host is registered without any address (effectively unregistering the host and removing any previously registered addresses for the host-name).

The implementation ensures the callback is invoked after returning from the `RegisterHost()` call (invoked from a posted tasklet), as required by the mDNS API definitions.

Additionally, the `test_mdns` unit test is updated to cover registering a host with no address for the first time or updating a previous registration.


----

Fixes https://github.com/openthread/openthread/issues/10262