### PR TITLE
[coap] resolve the issue where pending requests cannot be matched with     their corresponding response messages with UDP port

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1011,10 +1011,10 @@ Message *CoapBase::FindRelatedRequest(const Message          &aResponse,
     {
         aMetadata.ReadFrom(message);
 
-        if (((aMetadata.mDestinationAddress == aMessageInfo.GetPeerAddr()) ||
+        if (((aMetadata.mDestinationAddress == aMessageInfo.GetSockAddr()) ||
              aMetadata.mDestinationAddress.IsMulticast() ||
              aMetadata.mDestinationAddress.GetIid().IsAnycastLocator()) &&
-            (aMetadata.mDestinationPort == aMessageInfo.GetPeerPort()))
+            (aMetadata.mDestinationPort == aMessageInfo.GetSockPort()))
         {
             switch (aResponse.GetType())
             {

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1011,7 +1011,7 @@ Message *CoapBase::FindRelatedRequest(const Message          &aResponse,
     {
         aMetadata.ReadFrom(message);
 
-        if (((aMetadata.mDestinationAddress == aMessageInfo.GetSockAddr()) ||
+        if (((aMetadata.mDestinationAddress == aMessageInfo.GetPeerAddr()) ||
              aMetadata.mDestinationAddress.IsMulticast() ||
              aMetadata.mDestinationAddress.GetIid().IsAnycastLocator()) &&
             (aMetadata.mDestinationPort == aMessageInfo.GetSockPort()))


### PR DESCRIPTION
In function `FindRelatedRequest`, parameter `aMessageInfo` represents the message received from the peer device. When iterating through pending requests, the outgoing message's destination address and port should match the source address and port of the received message instead of the destination address and port of the received message.