### PR TITLE
[srp-client] use higher delays before sending updates on SRP service changes to avoid congestion

### DIFF
--- a/include/openthread/netdata_publisher.h
+++ b/include/openthread/netdata_publisher.h
@@ -102,11 +102,12 @@ typedef void (*otNetDataPrefixPublisherCallback)(otNetDataPublisherEvent aEvent,
  * A call to this function will remove and replace any previous "DNS/SRP Service" entry that was being published (from
  * earlier call to any of `otNetDataPublishDnsSrpService{Type}()` functions).
  *
- * @param[in] aInstance        A pointer to an OpenThread instance.
- * @param[in] aSequenceNUmber  The sequence number of DNS/SRP Anycast Service.
+ * @param[in] aInstance        	    A pointer to an OpenThread instance.
+ * @param[in] aSequenceNumber  	    The sequence number of DNS/SRP Anycast Service.
+ * @param[in] aMaxJitter            The max jitter to be used by SRP client for updates
  *
  */
-void otNetDataPublishDnsSrpServiceAnycast(otInstance *aInstance, uint8_t aSequenceNUmber);
+void otNetDataPublishDnsSrpServiceAnycast(otInstance *aInstance, uint8_t aSequenceNumber, uint8_t aMaxJitter);
 
 /**
  * Requests "DNS/SRP Service Unicast Address" to be published in the Thread Network Data.
@@ -119,12 +120,16 @@ void otNetDataPublishDnsSrpServiceAnycast(otInstance *aInstance, uint8_t aSequen
  * Publishes the "DNS/SRP Service Unicast Address" by including the address and port info in the Service
  * TLV data.
  *
- * @param[in] aInstance  A pointer to an OpenThread instance.
- * @param[in] aAddress   The DNS/SRP server address to publish (MUST NOT be NULL).
- * @param[in] aPort      The SRP server port number to publish.
+ * @param[in] aInstance  	    A pointer to an OpenThread instance.
+ * @param[in] aAddress   	    The DNS/SRP server address to publish (MUST NOT be NULL).
+ * @param[in] aPort      	    The SRP server port number to publish.
+ * @param[in] aMaxJitter        The max jitter to be used by SRP client for updates
  *
  */
-void otNetDataPublishDnsSrpServiceUnicast(otInstance *aInstance, const otIp6Address *aAddress, uint16_t aPort);
+void otNetDataPublishDnsSrpServiceUnicast(otInstance         *aInstance,
+                                          const otIp6Address *aAddress,
+                                          uint16_t            aPort,
+                                          uint8_t             aMaxJitter);
 
 /**
  * Requests "DNS/SRP Service Unicast Address" to be published in the Thread Network Data.
@@ -138,11 +143,12 @@ void otNetDataPublishDnsSrpServiceUnicast(otInstance *aInstance, const otIp6Addr
  * info in the Service TLV data, this function uses the device's mesh-local EID and includes the info in the Server TLV
  * data.
  *
- * @param[in] aInstance  A pointer to an OpenThread instance.
- * @param[in] aPort      The SRP server port number to publish.
+ * @param[in] aInstance  	    A pointer to an OpenThread instance.
+ * @param[in] aPort      	    The SRP server port number to publish.
+ * @param[in] aMaxJitter        The max jitter to be used by SRP client for updates
  *
  */
-void otNetDataPublishDnsSrpServiceUnicastMeshLocalEid(otInstance *aInstance, uint16_t aPort);
+void otNetDataPublishDnsSrpServiceUnicastMeshLocalEid(otInstance *aInstance, uint16_t aPort, uint8_t aMaxJitter);
 
 /**
  * Indicates whether or not currently the "DNS/SRP Service" entry is added to the Thread Network Data.

--- a/include/openthread/srp_server.h
+++ b/include/openthread/srp_server.h
@@ -218,6 +218,30 @@ otSrpServerAddressMode otSrpServerGetAddressMode(otInstance *aInstance);
 otError otSrpServerSetAddressMode(otInstance *aInstance, otSrpServerAddressMode aMode);
 
 /**
+ * Returns the max jitter for SRP client updates
+ *
+ * The max jitter is included in "DNS/SRP Service Anycast/Unicast" entry published in the Network Data.
+ *
+ * @param[in] aInstance  A pointer to an OpenThread instance.
+ *
+ * @returns The max jitter value in seconds
+ *
+ */
+uint8_t otSrpServerGetMaxJitter(otInstance *aInstance);
+
+/**
+ * Sets the sequence number used with anycast address mode.
+ *
+ * @param[in] aInstance        A pointer to an OpenThread instance.
+ * @param[in] aDelay           The  max jitter value for SRP client updates.
+ *
+ * @retval OT_ERROR_NONE            Successfully set the max jitter value
+ * @retval OT_ERROR_INVALID_STATE   The SRP server is enabled and the sequence number cannot be changed.
+ *
+ */
+otError otSrpServerSetMaxJitter(otInstance *aInstance, uint8_t aDelay);
+
+/**
  * Returns the sequence number used with anycast address mode.
  *
  * The sequence number is included in "DNS/SRP Service Anycast Address" entry published in the Network Data.

--- a/src/cli/cli_network_data.cpp
+++ b/src/cli/cli_network_data.cpp
@@ -244,17 +244,17 @@ template <> otError NetworkData::Process<Cmd("publish")>(Arg aArgs[])
         /**
          * @cli netdata publish dnssrp anycast
          * @code
-         * netdata publish dnssrp anycast 1
+         * netdata publish dnssrp anycast 1 5
          * Done
          * @endcode
-         * @cparam netdata publish dnssrp anycast @ca{seq-num}
+         * @cparam netdata publish dnssrp anycast @ca{seq-num} @ca{maxjitter}
          * @par
-         * Publishes a DNS/SRP Service Anycast Address with a sequence number. Any current
+         * Publishes a DNS/SRP Service Anycast Address with a sequence number and max jitter value. Any current
          * DNS/SRP Service entry being published from a previous `publish dnssrp{anycast|unicast}`
          * command is removed and replaced with the new arguments.
          * @par
          * `OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE` must be enabled.
-         * @csa{netdata publish dnssrp unicast (addr,port)}
+         * @csa{netdata publish dnssrp unicast (addr,port,maxjitter)}
          * @csa{netdata publish dnssrp unicast (mle)}
          * @sa otNetDataPublishDnsSrpServiceAnycast
          * @endcli
@@ -262,9 +262,11 @@ template <> otError NetworkData::Process<Cmd("publish")>(Arg aArgs[])
         if (aArgs[1] == "anycast")
         {
             uint8_t sequenceNumber;
+            uint8_t maxJitter;
 
             SuccessOrExit(error = aArgs[2].ParseAsUint8(sequenceNumber));
-            otNetDataPublishDnsSrpServiceAnycast(GetInstancePtr(), sequenceNumber);
+            SuccessOrExit(error = aArgs[3].ParseAsUint8(maxJitter));
+            otNetDataPublishDnsSrpServiceAnycast(GetInstancePtr(), sequenceNumber, maxJitter);
             ExitNow();
         }
 
@@ -272,46 +274,48 @@ template <> otError NetworkData::Process<Cmd("publish")>(Arg aArgs[])
         {
             otIp6Address address;
             uint16_t     port;
+            uint8_t      maxJitter;
 
             /**
              * @cli netdata publish dnssrp unicast (mle)
              * @code
-             * netdata publish dnssrp unicast 50152
+             * netdata publish dnssrp unicast 50152 5
              * Done
              * @endcode
-             * @cparam netdata publish dnssrp unicast @ca{port}
+             * @cparam netdata publish dnssrp unicast @ca{port} @ca{maxJitter}
              * @par
-             * Publishes the device's Mesh-Local EID with a port number. MLE and port information is
-             * included in the Server TLV data. To use a different Unicast address, use the
-             * `netdata publish dnssrp unicast (addr,port)` command.
+             * Publishes the device's Mesh-Local EID with a port number and max jitter value for SRP client updates. MLE
+             * and port and maxjitter information information is included in the Server TLV data. To use a different
+             * Unicast address, use the `netdata publish dnssrp unicast (addr,port,maxjitter)` command.
              * @par
              * Any current DNS/SRP Service entry being published from a previous
              * `publish dnssrp{anycast|unicast}` command is removed and replaced with the new arguments.
              * @par
              * `OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE` must be enabled.
-             * @csa{netdata publish dnssrp unicast (addr,port)}
+             * @csa{netdata publish dnssrp unicast (addr,port,maxjitter)}
              * @csa{netdata publish dnssrp anycast}
              * @sa otNetDataPublishDnsSrpServiceUnicastMeshLocalEid
              */
             if (aArgs[3].IsEmpty())
             {
                 SuccessOrExit(error = aArgs[2].ParseAsUint16(port));
-                otNetDataPublishDnsSrpServiceUnicastMeshLocalEid(GetInstancePtr(), port);
+                SuccessOrExit(error = aArgs[3].ParseAsUint8(maxJitter));
+                otNetDataPublishDnsSrpServiceUnicastMeshLocalEid(GetInstancePtr(), port, maxJitter);
                 ExitNow();
             }
 
             /**
-             * @cli netdata publish dnssrp unicast (addr,port)
+             * @cli netdata publish dnssrp unicast (addr,port,maxjitter)
              * @code
-             * netdata publish dnssrp unicast fd00::1234 51525
+             * netdata publish dnssrp unicast fd00::1234 51525 5
              * Done
              * @endcode
-             * @cparam netdata publish dnssrp unicast @ca{address} @ca{port}
+             * @cparam netdata publish dnssrp unicast @ca{address} @ca{port} @ca{maxjitter}
              * @par
-             * Publishes a DNS/SRP Service Unicast Address with an address and port number. The address
-             * and port information is included in Service TLV data. Any current DNS/SRP Service entry being
-             * published from a previous `publish dnssrp{anycast|unicast}` command is removed and replaced
-             * with the new arguments.
+             * Publishes a DNS/SRP Service Unicast Address with an address, port number and max jitter delay for SRP
+             * client updates. The address port and max jitter value information is included in Service TLV data. Any
+             * current DNS/SRP Service entry being published from a previous `publish dnssrp{anycast|unicast}` command
+             * is removed and replaced with the new arguments.
              * @par
              * `OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE` must be enabled.
              * @csa{netdata publish dnssrp unicast (mle)}
@@ -320,7 +324,8 @@ template <> otError NetworkData::Process<Cmd("publish")>(Arg aArgs[])
              */
             SuccessOrExit(error = aArgs[2].ParseAsIp6Address(address));
             SuccessOrExit(error = aArgs[3].ParseAsUint16(port));
-            otNetDataPublishDnsSrpServiceUnicast(GetInstancePtr(), &address, port);
+            SuccessOrExit(error = aArgs[4].ParseAsUint8(maxJitter));
+            otNetDataPublishDnsSrpServiceUnicast(GetInstancePtr(), &address, port, maxJitter);
             ExitNow();
         }
     }

--- a/src/cli/cli_srp_server.cpp
+++ b/src/cli/cli_srp_server.cpp
@@ -42,6 +42,44 @@
 
 namespace ot {
 namespace Cli {
+/**
+ * @cli srp server maxjitter (get,set)
+ * @code
+ * srp server maxjitter
+ * Done
+ * @endcode
+ * @code
+ * srp server maxjitter
+ * 20000
+ * Done
+ * @endcode
+ * @cparam srp server maxjitter [@ca{value}]
+ * @par
+ * Gets or sets the max jitter value to be used by the SRP client for updates.
+ * @par
+ * The max jitter value is sent in the network data and tells the maximum jitter the SRP
+ * client should use before updates
+ * @sa otSrpServerGetMaxJitter
+ * @sa otSrpServerSetMaxJitter
+ */
+template <> otError SrpServer::Process<Cmd("maxjitter")>(Arg aArgs[])
+{
+    otError  error     = OT_ERROR_INVALID_ARGS;
+    uint32_t maxjitter = 0;
+
+    if (aArgs[0].IsEmpty())
+    {
+        OutputLine("%u", otSrpServerGetMaxJitter(GetInstancePtr()));
+        error = OT_ERROR_NONE;
+    }
+    else
+    {
+        SuccessOrExit(error = aArgs[0].ParseAsUint32(maxjitter));
+        error = otSrpServerSetMaxJitter(GetInstancePtr(), maxjitter);
+    }
+exit:
+    return error;
+}
 
 /**
  * @cli srp server addrmode (get,set)
@@ -54,7 +92,7 @@ namespace Cli {
  * anycast
  * Done
  * @endcode
- * @cparam srp server addrmode [@ca{anycast}|@ca{unicast}]
+ * @cparam srp server addrmode [@ca{value}|@ca{unicast}]
  * @par
  * Gets or sets the address mode used by the SRP server.
  * @par

--- a/src/core/api/netdata_publisher_api.cpp
+++ b/src/core/api/netdata_publisher_api.cpp
@@ -44,19 +44,23 @@ using namespace ot;
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
-void otNetDataPublishDnsSrpServiceAnycast(otInstance *aInstance, uint8_t aSequenceNumber)
+void otNetDataPublishDnsSrpServiceAnycast(otInstance *aInstance, uint8_t aSequenceNumber, uint8_t aMaxJitter)
 {
-    AsCoreType(aInstance).Get<NetworkData::Publisher>().PublishDnsSrpServiceAnycast(aSequenceNumber);
+    AsCoreType(aInstance).Get<NetworkData::Publisher>().PublishDnsSrpServiceAnycast(aSequenceNumber, aMaxJitter);
 }
 
-void otNetDataPublishDnsSrpServiceUnicast(otInstance *aInstance, const otIp6Address *aAddress, uint16_t aPort)
+void otNetDataPublishDnsSrpServiceUnicast(otInstance         *aInstance,
+                                          const otIp6Address *aAddress,
+                                          uint16_t            aPort,
+                                          uint8_t             aMaxJitter)
 {
-    AsCoreType(aInstance).Get<NetworkData::Publisher>().PublishDnsSrpServiceUnicast(AsCoreType(aAddress), aPort);
+    AsCoreType(aInstance).Get<NetworkData::Publisher>().PublishDnsSrpServiceUnicast(AsCoreType(aAddress), aPort,
+                                                                                    aMaxJitter);
 }
 
-void otNetDataPublishDnsSrpServiceUnicastMeshLocalEid(otInstance *aInstance, uint16_t aPort)
+void otNetDataPublishDnsSrpServiceUnicastMeshLocalEid(otInstance *aInstance, uint16_t aPort, uint8_t aMaxJitter)
 {
-    AsCoreType(aInstance).Get<NetworkData::Publisher>().PublishDnsSrpServiceUnicast(aPort);
+    AsCoreType(aInstance).Get<NetworkData::Publisher>().PublishDnsSrpServiceUnicast(aPort, aMaxJitter);
 }
 
 bool otNetDataIsDnsSrpServiceAdded(otInstance *aInstance)

--- a/src/core/api/srp_server_api.cpp
+++ b/src/core/api/srp_server_api.cpp
@@ -56,6 +56,16 @@ otSrpServerState otSrpServerGetState(otInstance *aInstance)
 
 uint16_t otSrpServerGetPort(otInstance *aInstance) { return AsCoreType(aInstance).Get<Srp::Server>().GetPort(); }
 
+uint8_t otSrpServerGetMaxJitter(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).Get<Srp::Server>().GetMaxJitter();
+}
+
+otError otSrpServerSetMaxJitter(otInstance *aInstance, uint8_t aJitter)
+{
+    return AsCoreType(aInstance).Get<Srp::Server>().SetMaxJitter(aJitter);
+}
+
 otSrpServerAddressMode otSrpServerGetAddressMode(otInstance *aInstance)
 {
     return MapEnum(AsCoreType(aInstance).Get<Srp::Server>().GetAddressMode());

--- a/src/core/config/srp_client.h
+++ b/src/core/config/srp_client.h
@@ -258,6 +258,18 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_SRP_CLIENT_UPDATE_TX_MAX_DELAY_LONG
+ *
+ * Specifies the maximum value (in msec) for the long random delay wait time before sending an update message.
+ * Used when SRP client is not running and there is a service change in network data
+ * (e.g., SRP unicast server change or anycast sequence number change)
+ * The random delay is chosen uniformly from the min `OPENTHREAD_CONFIG_SRP_CLIENT_UPDATE_TX_MIN_DELAY` up to max value.
+ */
+#ifndef OPENTHREAD_CONFIG_SRP_CLIENT_UPDATE_TX_MAX_DELAY_LONG
+#define OPENTHREAD_CONFIG_SRP_CLIENT_UPDATE_TX_MAX_DELAY_LONG 5000
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_SRP_CLIENT_MIN_RETRY_WAIT_INTERVAL
  *
  * Specifies the minimum wait interval (in msec) between SRP update message retries.

--- a/src/core/config/srp_server.h
+++ b/src/core/config/srp_server.h
@@ -130,6 +130,18 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_SRP_SERVER_UPDATE_TX_MAX_DELAY_LONG
+ *
+ * Specifies the maximum value (in sec) for the long random delay wait time for the clients before sending an update
+ * message. Used when SRP client is not running and there is a service change in network data (e.g., SRP unicast server
+ * change or anycast sequence number change) The random delay is chosen uniformly from the min
+ * `OPENTHREAD_CONFIG_SRP_CLIENT_UPDATE_TX_MIN_DELAY` up to max value.
+ */
+#ifndef OPENTHREAD_CONFIG_SRP_SERVER_UPDATE_TX_MAX_DELAY_LONG
+#define OPENTHREAD_CONFIG_SRP_SERVER_UPDATE_TX_MAX_DELAY_LONG 20
+#endif
+
+/**
  * @}
  *
  */

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -846,9 +846,13 @@ private:
     // that requires an update, the SRP client will wait for a short
     // delay as specified by `kUpdateTxDelay` before sending an SRP
     // update to server. This allows the user to provide more change
-    // that are then all sent in same update message.
-    static constexpr uint32_t kUpdateTxMinDelay = OPENTHREAD_CONFIG_SRP_CLIENT_UPDATE_TX_MIN_DELAY; // in msec.
-    static constexpr uint32_t kUpdateTxMaxDelay = OPENTHREAD_CONFIG_SRP_CLIENT_UPDATE_TX_MAX_DELAY; // in msec.
+    // that are then all sent in same update message.If the SRP client is
+    // already registered to a server and there is a change in service (e.g., SRP unicast server address
+    // or anycast sequence number changes) `kUpdateTxMaxDelayLong` is chosen as max delay
+    // else `kUpdateTxMaxDelay` is chosen
+    static constexpr uint32_t kUpdateTxMinDelay     = OPENTHREAD_CONFIG_SRP_CLIENT_UPDATE_TX_MIN_DELAY;      // in msec.
+    static constexpr uint32_t kUpdateTxMaxDelay     = OPENTHREAD_CONFIG_SRP_CLIENT_UPDATE_TX_MAX_DELAY;      // in msec.
+    static constexpr uint32_t kUpdateTxMaxDelayLong = OPENTHREAD_CONFIG_SRP_CLIENT_UPDATE_TX_MAX_DELAY_LONG; // in msec.
 
     // -------------------------------
     // Retry related constants
@@ -1076,6 +1080,8 @@ private:
     uint16_t mUpdateMessageId;
     uint16_t mAutoHostAddressCount;
     uint32_t mRetryWaitInterval;
+    uint32_t mTxDelayLong;
+    bool     mUseUpdateTxDelayLong;
 
     TimeMilli mLeaseRenewTime;
     uint32_t  mTtl;

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -744,7 +744,28 @@ public:
      * @retval kErrorInvalidState   The SRP server is enabled and the address mode cannot be changed.
      *
      */
+
     Error SetAddressMode(AddressMode aMode);
+    /**
+     * Gets the max jitter value used by SRP client for updates
+     *
+     * The max jitter value  is included in "DNS/SRP Service Unicast/Anycast" entry published in the Network Data.
+     *
+     * @returns The max jitter value
+     *
+     */
+    uint8_t GetMaxJitter(void) const { return mMaxJitter; }
+
+    /**
+     * Sets the max jitter value for SRP client updates
+     *
+     * @param[in] aDelay  The  max jitter value to use
+     *
+     * @retval kErrorNone           Successfully set the max jitter for SRP client updates
+     * @retval kErrorInvalidState   The SRP server is enabled and the e max jitter cannot be changed.
+     *
+     */
+    Error SetMaxJitter(uint8_t aMaxJitter);
 
     /**
      * Gets the sequence number used with anycast address mode.
@@ -914,7 +935,8 @@ private:
 
     static constexpr uint16_t kUninitializedPort      = 0;
     static constexpr uint16_t kAnycastAddressModePort = 53;
-
+    static constexpr uint8_t  kUpdateTxMaxDelayLong = OPENTHREAD_CONFIG_SRP_SERVER_UPDATE_TX_MAX_DELAY_LONG; // in sec.
+    
     // Metadata for a received SRP Update message.
     struct MessageMetadata
     {
@@ -1073,6 +1095,7 @@ private:
     State           mState;
     AddressMode     mAddressMode;
     uint8_t         mAnycastSequenceNumber;
+    uint8_t         mMaxJitter;
     bool            mHasRegisteredAnyService : 1;
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
     bool mAutoEnable : 1;

--- a/src/core/thread/network_data_publisher.hpp
+++ b/src/core/thread/network_data_publisher.hpp
@@ -136,9 +136,13 @@ public:
      * (from earlier call to any of `PublishDnsSrpService{Type}()` methods).
      *
      * @param[in] aSequenceNumber  The sequence number of DNS/SRP Anycast Service.
+     * @param[in] aMaxJitter       The max jitter to be used by SRP client for updates
      *
      */
-    void PublishDnsSrpServiceAnycast(uint8_t aSequenceNumber) { mDnsSrpServiceEntry.PublishAnycast(aSequenceNumber); }
+    void PublishDnsSrpServiceAnycast(uint8_t aSequenceNumber, uint8_t aMaxJitter)
+    {
+        mDnsSrpServiceEntry.PublishAnycast(aSequenceNumber, aMaxJitter);
+    }
 
     /**
      * Requests "DNS/SRP Service Unicast Address" to be published in the Thread Network Data.
@@ -151,11 +155,12 @@ public:
      *
      * @param[in] aAddress   The DNS/SRP server address to publish.
      * @param[in] aPort      The SRP server port number to publish.
+     * @param[in] aMaxJitter The max jitter to be used by SRP client for updates
      *
      */
-    void PublishDnsSrpServiceUnicast(const Ip6::Address &aAddress, uint16_t aPort)
+    void PublishDnsSrpServiceUnicast(const Ip6::Address &aAddress, uint16_t aPort, uint8_t aMaxJitter)
     {
-        mDnsSrpServiceEntry.PublishUnicast(aAddress, aPort);
+        mDnsSrpServiceEntry.PublishUnicast(aAddress, aPort, aMaxJitter);
     }
 
     /**
@@ -169,10 +174,13 @@ public:
      * in the Server TLV data.
      *
      * @param[in] aPort      The SRP server port number to publish.
+     * @param[in] aMaxJitter The max jitter to be used by SRP client for updates
      *
      */
-    void PublishDnsSrpServiceUnicast(uint16_t aPort) { mDnsSrpServiceEntry.PublishUnicast(aPort); }
-
+    void PublishDnsSrpServiceUnicast(uint16_t aPort, uint8_t aMaxJitter)
+    {
+        mDnsSrpServiceEntry.PublishUnicast(aPort, aMaxJitter);
+    }
     /**
      * Indicates whether or not currently the "DNS/SRP Service" entry is added to the Thread Network Data.
      *
@@ -385,9 +393,9 @@ private:
     public:
         explicit DnsSrpServiceEntry(Instance &aInstance);
         void SetCallback(DnsSrpServiceCallback aCallback, void *aContext) { mCallback.Set(aCallback, aContext); }
-        void PublishAnycast(uint8_t aSequenceNumber);
-        void PublishUnicast(const Ip6::Address &aAddress, uint16_t aPort);
-        void PublishUnicast(uint16_t aPort);
+        void PublishAnycast(uint8_t aSequenceNumber, uint8_t aMaxJitter);
+        void PublishUnicast(const Ip6::Address &aAddress, uint16_t aPort, uint8_t aMaxJitter);
+        void PublishUnicast(uint16_t aPort, uint8_t aMaxJitter);
         void Unpublish(void);
         void HandleTimer(void) { Entry::HandleTimer(); }
         void HandleNotifierEvents(Events aEvents);
@@ -414,20 +422,25 @@ private:
             uint8_t             GetSequenceNumber(void) const { return static_cast<uint8_t>(mPortOrSeqNumber); }
             uint16_t            GetPort(void) const { return mPortOrSeqNumber; }
             const Ip6::Address &GetAddress(void) const { return mAddress; }
+            uint8_t             GetMaxJitter(void) const { return static_cast<uint8_t>(mMaxJitter); }
             void                SetAddress(const Ip6::Address &aAddress) { mAddress = aAddress; }
 
-            static Info InfoAnycast(uint8_t aSequenceNumber) { return Info(kTypeAnycast, aSequenceNumber); }
-            static Info InfoUnicast(Type aType, const Ip6::Address &aAddress, uint16_t aPort)
+            static Info InfoAnycast(uint8_t aSequenceNumber, uint8_t aMaxJitter)
             {
-                return Info(aType, aPort, &aAddress);
+                return Info(kTypeAnycast, aSequenceNumber, aMaxJitter);
+            }
+            static Info InfoUnicast(Type aType, const Ip6::Address &aAddress, uint16_t aPort, uint8_t aMaxJitter)
+            {
+                return Info(aType, aPort, aMaxJitter, &aAddress);
             }
 
         private:
-            Info(Type aType, uint16_t aPortOrSeqNumber, const Ip6::Address *aAddress = nullptr);
+            Info(Type aType, uint16_t aPortOrSeqNumber, uint8_t aMaxJitter, const Ip6::Address *aAddress = nullptr);
 
             Ip6::Address mAddress;
             uint16_t     mPortOrSeqNumber;
             Type         mType;
+            uint8_t      mMaxJitter;
         };
 
         Type GetType(void) const { return mInfo.GetType(); }

--- a/src/core/thread/network_data_service.hpp
+++ b/src/core/thread/network_data_service.hpp
@@ -173,6 +173,7 @@ public:
     {
         Ip6::Address mAnycastAddress; ///< The anycast address associated with the DNS/SRP servers.
         uint8_t      mSequenceNumber; ///< Sequence number used to notify SRP client if they need to re-register.
+        uint8_t      mMaxJitter;      ///< Max jitter to be used by SRP client if they need to re-register.
     };
 
     /**
@@ -189,9 +190,10 @@ public:
          * @param[in] aSequenceNumber   The sequence number of "DNS/SRP server" service.
          *
          */
-        explicit ServiceData(uint8_t aSequenceNumber)
+        explicit ServiceData(uint8_t aSequenceNumber, uint8_t aMaxJitter)
             : mServiceNumber(kServiceNumber)
             , mSequenceNumber(aSequenceNumber)
+            , mMaxJitter(aMaxJitter)
         {
             OT_UNUSED_VARIABLE(mServiceNumber);
         }
@@ -211,10 +213,19 @@ public:
          *
          */
         uint8_t GetSequenceNumber(void) const { return mSequenceNumber; }
+        
+        /**
+         * Returns the max jitter value for SRP client 
+         *
+         * @returns The max jitter value
+         *
+         */
+        uint8_t GetMaxJitter(void) const { return mMaxJitter; }
 
     private:
         uint8_t mServiceNumber;
         uint8_t mSequenceNumber;
+        uint8_t mMaxJitter;
     } OT_TOOL_PACKED_END;
 
     DnsSrpAnycast(void) = delete;
@@ -273,10 +284,11 @@ public:
          * @param[in] aPort      The port number of DNS/SRP server.
          *
          */
-        explicit ServiceData(const Ip6::Address &aAddress, uint16_t aPort)
+        explicit ServiceData(const Ip6::Address &aAddress, uint16_t aPort, uint8_t aMaxJitter)
             : mServiceNumber(kServiceNumber)
             , mAddress(aAddress)
             , mPort(BigEndian::HostSwap16(aPort))
+            , mMaxJitter(aMaxJitter)
         {
             OT_UNUSED_VARIABLE(mServiceNumber);
         }
@@ -305,10 +317,19 @@ public:
          */
         uint16_t GetPort(void) const { return BigEndian::HostSwap16(mPort); }
 
+        /**
+         * Returns the max jitter to be used by SRP client for updates
+         *
+         * @returns The max jitter to be used by SRP client for updates
+         *
+         */
+        uint8_t GetMaxJitter(void) const { return mMaxJitter; }
+        
     private:
         uint8_t      mServiceNumber;
         Ip6::Address mAddress;
         uint16_t     mPort;
+	    uint8_t      mMaxJitter;
     } OT_TOOL_PACKED_END;
 
     /**
@@ -322,13 +343,15 @@ public:
         /**
          * Initializes the `ServerData` object.
          *
-         * @param[in] aAddress   The IPv6 address of DNS/SRP server.
-         * @param[in] aPort      The port number of DNS/SRP server.
+         * @param[in] aAddress   		The IPv6 address of DNS/SRP server.
+         * @param[in] aPort      		The port number of DNS/SRP server.
+         * @param[in] aMaxJitter      The max jitter to be used by DNS/SRP client before reregistration
          *
          */
-        ServerData(const Ip6::Address &aAddress, uint16_t aPort)
+        ServerData(const Ip6::Address &aAddress, uint16_t aPort, uint8_t aMaxJitter)
             : mAddress(aAddress)
             , mPort(BigEndian::HostSwap16(aPort))
+            , mMaxJitter(aMaxJitter)
         {
         }
 
@@ -356,9 +379,26 @@ public:
          */
         uint16_t GetPort(void) const { return BigEndian::HostSwap16(mPort); }
 
+        /**
+         * Returns the max jitter to be used by SRP client for updates (in seconds)
+         *
+         * @returns Value (in seconds) used to determine max jitter used by clients.
+         *
+         */
+        uint8_t GetMaxJitter(void) const { return mMaxJitter; }
+
+        /**
+         * Sets the Max Jitter Delay for SRP client updates (in seconds)
+         *
+         * @param[in]  aMaxJitter  The Max Jitter Delay for SRP client updates (in seconds)
+         *
+         */
+        void SetMaxJitter(uint16_t aMaxJitter) { mMaxJitter = aMaxJitter; }
+
     private:
         Ip6::Address mAddress;
         uint16_t     mPort;
+        uint8_t      mMaxJitter;
     } OT_TOOL_PACKED_END;
 
     DnsSrpUnicast(void) = delete;


### PR DESCRIPTION
use higher delays before sending updates, in scenarios where anycast seqnum changes or unicast server address changes, to avoid congestion
This is related to discussions in [SPEC-1284](https://threadgroup.atlassian.net/browse/SPEC-1284)