### PR TITLE
[posix] add spinel driver getter to allow external app to access

### DIFF
--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -41,6 +41,7 @@
 #include "common/code_utils.hpp"
 #include "common/new.hpp"
 #include "posix/platform/radio.hpp"
+#include "posix/platform/spinel_driver_getter.hpp"
 #include "posix/platform/spinel_manager.hpp"
 #include "utils/parse_cmdline.hpp"
 
@@ -89,7 +90,7 @@ void Radio::Init(const char *aUrl)
     skipCompatibilityCheck = mRadioUrl.HasParam("skip-rcp-compatibility-check");
 
     mRadioSpinel.SetCallbacks(callbacks);
-    mRadioSpinel.Init(skipCompatibilityCheck, resetRadio, &SpinelManager::GetSpinelDriver());
+    mRadioSpinel.Init(skipCompatibilityCheck, resetRadio, &GetSpinelDriver());
 
     ProcessRadioUrl(mRadioUrl);
 }

--- a/src/posix/platform/spinel_driver_getter.hpp
+++ b/src/posix/platform/spinel_driver_getter.hpp
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file is used to expose the API to the external posix app so that the
+ *   app can access to the posix spinel driver.
+ *
+ */
+
+#ifndef POSIX_PLATFORM_SPINEL_DRIVER_GETTER_HPP_
+#define POSIX_PLATFORM_SPINEL_DRIVER_GETTER_HPP_
+
+#include "lib/spinel/spinel_driver.hpp"
+
+namespace ot {
+namespace Posix {
+
+/**
+ * Returns the static instance of the SpinelDriver.
+ *
+ */
+extern Spinel::SpinelDriver &GetSpinelDriver(void);
+
+} // namespace Posix
+} // namespace ot
+
+#endif // POSIX_PLATFORM_SPINEL_DRIVER_GETTER_HPP_

--- a/src/posix/platform/spinel_manager.cpp
+++ b/src/posix/platform/spinel_manager.cpp
@@ -36,6 +36,7 @@
 #include "posix/platform/hdlc_interface.hpp"
 #include "posix/platform/radio_url.hpp"
 #include "posix/platform/spi_interface.hpp"
+#include "posix/platform/spinel_driver_getter.hpp"
 #include "posix/platform/vendor_interface.hpp"
 
 static ot::Posix::SpinelManager sSpinelManager;
@@ -43,9 +44,10 @@ static ot::Posix::SpinelManager sSpinelManager;
 namespace ot {
 namespace Posix {
 
-SpinelManager &SpinelManager::GetSpinelManager(void) { return sSpinelManager; }
+// Implements `GetSpinelDriver` in spinel_driver_getter.hpp for external access to SpinelDriver
+Spinel::SpinelDriver &GetSpinelDriver(void) { return sSpinelManager.GetSpinelDriver(); }
 
-Spinel::SpinelDriver &SpinelManager::GetSpinelDriver(void) { return sSpinelManager.mSpinelDriver; }
+SpinelManager &SpinelManager::GetSpinelManager(void) { return sSpinelManager; }
 
 SpinelManager::SpinelManager(void)
     : mUrl(nullptr)
@@ -201,14 +203,14 @@ void platformSpinelManagerDeinit(void) { return sSpinelManager.Deinit(); }
 void virtualTimeSpinelProcess(otInstance *aInstance, const struct VirtualTimeEvent *aEvent)
 {
     OT_UNUSED_VARIABLE(aInstance);
-    ot::Posix::SpinelManager::GetSpinelDriver().Process(aEvent);
+    ot::Posix::GetSpinelDriver().Process(aEvent);
 }
 #else
 void platformSpinelManagerProcess(otInstance *aInstance, const otSysMainloopContext *aContext)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    ot::Posix::SpinelManager::GetSpinelDriver().Process(aContext);
+    ot::Posix::GetSpinelDriver().Process(aContext);
 }
 #endif // OPENTHREAD_POSIX_VIRTUAL_TIME
 
@@ -216,7 +218,7 @@ void platformSpinelManagerUpdateFdSet(otSysMainloopContext *aContext)
 {
     sSpinelManager.GetSpinelInterface().UpdateFdSet(aContext);
 
-    if (ot::Posix::SpinelManager::GetSpinelDriver().HasPendingFrame())
+    if (ot::Posix::GetSpinelDriver().HasPendingFrame())
     {
         aContext->mTimeout.tv_sec  = 0;
         aContext->mTimeout.tv_usec = 0;

--- a/src/posix/platform/spinel_manager.hpp
+++ b/src/posix/platform/spinel_manager.hpp
@@ -45,16 +45,16 @@ class SpinelManager
 {
 public:
     /**
-     * Returns the static instance of the SpinelDriver.
-     *
-     */
-    static Spinel::SpinelDriver &GetSpinelDriver(void);
-
-    /**
      * Returns the static instance of the SpinelManager.
      *
      */
     static SpinelManager &GetSpinelManager(void);
+
+    /**
+     * Returns the static instance of the SpinelDriver.
+     *
+     */
+    Spinel::SpinelDriver &GetSpinelDriver(void) { return mSpinelDriver; }
 
     /**
      * Constructor of the SpinelManager


### PR DESCRIPTION
This PR tries to resolve the issue in #10221 in another approach.

The PR adds a seperate header `posix/platform/spinel_driver_getter.hpp`
to expose `GetSpinelDriver` to the external posix app. `spinel_driver_getter.hpp`
doesn't include anything from OT core and is safe to be included by external
code. The API isn't added in `openthread-system.h` because it's a C header
while spinel_driver.hpp is a cpp header.