### PR TITLE
[mesh-forwarder] set initial nexthop and cost for the router in `HandleMesh`

### DIFF
--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -561,6 +561,14 @@ exit:
     return;
 }
 
+void RouterTable::SetRouterNextHopAndCost(Router &aRouter, uint8_t aNextHop, uint8_t aCost)
+{
+    if (aRouter.SetNextHopAndCost(aNextHop, aCost))
+    {
+        SignalTableChanged();
+    }
+}
+
 void RouterTable::UpdateRoutes(const Mle::RouteTlv &aRouteTlv, uint8_t aNeighborId)
 {
     Router          *neighbor;

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -359,6 +359,16 @@ public:
     void UpdateRouterIdSet(uint8_t aRouterIdSequence, const Mle::RouterIdSet &aRouterIdSet);
 
     /**
+     * Updates the Router ID allocation set.
+     *
+     * @param[in]  aRouter  A reference to the router.
+     * @param[in]  aNextHop The Router ID of the next hop to this router.
+     * @param[in]  aCost    The cost to this router.
+     *
+     */
+    void SetRouterNextHopAndCost(Router &aRouter, uint8_t aNextHop, uint8_t aCost);
+
+    /**
      * Updates the routes based on a received `RouteTlv` from a neighboring router.
      *
      * @param[in]  aRouteTlv    The received `RouteTlv`


### PR DESCRIPTION
When a Thread router device re-joins the network through `link request` and `link accept`, the `nexthop` and `cost` in its router table depend on the `Route64` TLV in `advertisement` packets sent by other devices. However, other devices may not necessarily broadcast `advertisement` packets immediately after this device comes back online, which can result in the device possibly being unable to send unicast data to its non-directly connected routers, as follows:

**Topology**:
```
                             dut(router)---helper1(leader)---helper2(router)
```
When `dut` re-joins the network, the `nexthop` and `cost` of `helper2` in router table of dut will only be updated after receiving the advertisement packet. Before that, unicast packets sent from `helper2` to `dut` will be forwarded correctly because the `helper2` and `helper1` both have correct router table. However, unicast packets sent from `dut` to `helper2` will fail because the `dut` can not find the next hop.

This pull request supports: 
When `dut` receives a unicast packet from a non-directly connected router(forwarded by one of its neighbors), it will set an initial `nexthop` and `cost` for that non-directly connected router. The cost will be set to a sufficiently large value. This way, `dut` can know the next hop when sending data to the non-directly connected router without waiting for advertisement packets. Additionally, a large initial cost value will not affect subsequent updates of the `nexthop` and `cost` through advertisement packets.