### PR TITLE
[routing-manager] update and simplify decisions for processing PIO/RIO

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -898,9 +898,7 @@ private:
 
         void ProcessRaHeader(const RouterAdvert::Header &aRaHeader, Router &aRouter, RouterAdvOrigin aRaOrigin);
         void ProcessPrefixInfoOption(const PrefixInfoOption &aPio, Router &aRouter);
-        bool ShouldProcessPrefixInfoOption(const PrefixInfoOption &aPio, const Ip6::Prefix &aPrefix) const;
         void ProcessRouteInfoOption(const RouteInfoOption &aRio, Router &aRouter);
-        bool ShouldProcessRouteInfoOption(const RouteInfoOption &aRio, const Ip6::Prefix &aPrefix) const;
         void ProcessRaFlagsExtOption(const RaFlagsExtOption &aFlagsOption, Router &aRouter);
         bool ContainsOnLinkPrefix(OnLinkPrefix::UlaChecker aUlaChecker) const;
         void RemoveOrDeprecateEntriesFromInactiveRouters(void);


### PR DESCRIPTION
This commit updates how `RxRaTracker` decides whether to process PIO/RIO from a received RA message:

- The checks are performed directly in related `Process()` methods, removing the `ShouldProcess()` methods.
- The check `Get<RoutingManager>().IsRunning()` is removed as it is already checked before processing the RA message.
- The check `IsValidOmrPrefix()` is removed for RIO route prefixes. Instead, all route prefixes are tracked, regardless of length (excluding link-local or multicast prefixes). With this change, there is no longer a need to specifically check and allow the default route.


----

~This PR currently contains the commit from https://github.com/openthread/openthread/pull/10270. Please check and review the last commit. Thanks.~ 