### PR TITLE
[dataset] simplify `Clear()` methods

### DIFF
--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -257,6 +257,12 @@ void DatasetManager::Clear(void)
     Get<Settings>().DeleteOperationalDataset(mType);
 
     mTimer.Stop();
+
+    if (IsPendingDataset())
+    {
+        Get<PendingDatasetManager>().mDelayTimer.Stop();
+    }
+
     SignalDatasetChange();
 }
 
@@ -861,21 +867,6 @@ PendingDatasetManager::PendingDatasetManager(Instance &aInstance)
     : DatasetManager(aInstance, Dataset::kPending, PendingDatasetManager::HandleTimer)
     , mDelayTimer(aInstance)
 {
-}
-
-void PendingDatasetManager::Clear(void)
-{
-    DatasetManager::Clear();
-    mDelayTimer.Stop();
-}
-
-void PendingDatasetManager::ClearNetwork(void)
-{
-    Dataset dataset;
-
-    mNetworkTimestamp.Clear();
-    mNetworkTimestampValid = false;
-    IgnoreError(DatasetManager::Save(dataset));
 }
 
 void PendingDatasetManager::StartDelayTimer(void)

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -74,6 +74,12 @@ public:
     const Timestamp *GetTimestamp(void) const;
 
     /**
+     * Clears the Operational Dataset.
+     *
+     */
+    void Clear(void);
+
+    /**
      * Restores the Operational Dataset from non-volatile memory.
      *
      * @retval kErrorNone      Successfully restore the dataset.
@@ -299,7 +305,6 @@ private:
 
     bool  IsActiveDataset(void) const { return (mType == Dataset::kActive); }
     bool  IsPendingDataset(void) const { return (mType == Dataset::kPending); }
-    void  Clear(void);
     Error ApplyConfiguration(const Dataset &aDataset) const;
     void  HandleGet(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo) const;
     void  HandleTimer(void);
@@ -391,12 +396,6 @@ public:
      */
     bool IsCommissioned(void) const;
 
-    /**
-     * Clears the Active Operational Dataset.
-     *
-     */
-    void Clear(void) { DatasetManager::Clear(); }
-
 #if OPENTHREAD_FTD
 
     /**
@@ -457,22 +456,6 @@ public:
      *
      */
     explicit PendingDatasetManager(Instance &aInstance);
-
-    /**
-     * Clears the Pending Operational Dataset.
-     *
-     * Also stops the Delay Timer if it was active.
-     *
-     */
-    void Clear(void);
-
-    /**
-     * Clears the network Pending Operational Dataset.
-     *
-     * Also stops the Delay Timer if it was active.
-     *
-     */
-    void ClearNetwork(void);
 
 #if OPENTHREAD_FTD
     /**

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3380,7 +3380,7 @@ void Mle::HandleChildIdResponse(RxInfo &aRxInfo)
         break;
 
     case kErrorNotFound:
-        Get<MeshCoP::PendingDatasetManager>().ClearNetwork();
+        Get<MeshCoP::PendingDatasetManager>().Clear();
         break;
 
     default:


### PR DESCRIPTION
- Update `DatasetManager::Clear()` to stop delay timer if it is Pending Dataset.
- Remove `PendingDatasetManager::ClearNetwork()` (use `Clear()` instead).