### PR TITLE
[dataset-manager] simplify `Restore()`

### DIFF
--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -200,14 +200,6 @@ public:
     Error ApplyConfiguration(void) const;
 
     /**
-     * Updates the Operational Dataset when detaching from the network.
-     *
-     * On detach, the Operational Dataset is restored from non-volatile memory.
-     *
-     */
-    void HandleDetach(void);
-
-    /**
      * Sends a MGMT_SET request to the Leader.
      *
      * @param[in]  aDatasetInfo  The Operational Dataset.
@@ -305,6 +297,7 @@ private:
 
     bool  IsActiveDataset(void) const { return (mType == Dataset::kActive); }
     bool  IsPendingDataset(void) const { return (mType == Dataset::kPending); }
+    void  Restore(const Dataset &aDataset);
     Error ApplyConfiguration(const Dataset &aDataset) const;
     void  HandleGet(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo) const;
     void  HandleTimer(void);

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -383,7 +383,7 @@ Error ActiveDatasetManager::GenerateLocal(void)
     }
 
     LocalSave(dataset);
-    IgnoreError(Restore());
+    Restore(dataset);
 
     LogInfo("Generated local dataset");
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -236,8 +236,8 @@ void Mle::Stop(StopMode aMode)
 {
     if (aMode == kUpdateNetworkDatasets)
     {
-        Get<MeshCoP::ActiveDatasetManager>().HandleDetach();
-        Get<MeshCoP::PendingDatasetManager>().HandleDetach();
+        IgnoreError(Get<MeshCoP::ActiveDatasetManager>().Restore());
+        IgnoreError(Get<MeshCoP::PendingDatasetManager>().Restore());
     }
 
     VerifyOrExit(!IsDisabled());
@@ -530,7 +530,7 @@ Error Mle::BecomeDetached(void)
     // Not in reattach stage after reset
     if (mReattachState == kReattachStop)
     {
-        Get<MeshCoP::PendingDatasetManager>().HandleDetach();
+        IgnoreError(Get<MeshCoP::PendingDatasetManager>().Restore());
     }
 
 #if OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE


### PR DESCRIPTION
This commit simplifies the `Restore()` methods:

- A private overload `Restore(const Dataset&)` is added, taking the read `Dataset` as input to avoid duplicate reads.
- The public `Restore(void)` is updated to use the new private `Restore(const Dataset&)`.
- The `HandleDetach()` method is removed, and its use in the `Mle` class is replaced with `Restore()`.