### PR TITLE
[routing-manager] simplify how `RxRaTracker` handles local on-link prefix

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -755,8 +755,8 @@ private:
 
         void FindFavoredOnLinkPrefix(Ip6::Prefix &aPrefix) const;
 
+        void HandleLocalOnLinkPrefixChanged(void);
         void HandleNetDataChange(void);
-        void RemoveOnLinkPrefix(const Ip6::Prefix &aPrefix);
 
         void RemoveOrDeprecateOldEntries(TimeMilli aTimeThreshold);
 
@@ -1028,7 +1028,6 @@ private:
         void               HandleRaPrefixTableChanged(void);
         bool               ShouldPublishUlaRoute(void) const;
         Error              AppendAsPiosTo(RouterAdvert::TxMessage &aRaMessage);
-        bool               IsPublishingOrAdvertising(void) const;
         void               HandleNetDataChange(void);
         void               HandleExtPanIdChange(void);
         void               HandleTimer(void);
@@ -1052,6 +1051,7 @@ private:
 
         State GetState(void) const { return mState; }
         void  SetState(State aState);
+        bool  IsPublishingOrAdvertising(void) const;
         void  GenerateLocalPrefix(void);
         void  PublishAndAdvertise(void);
         void  Deprecate(void);
@@ -1392,6 +1392,7 @@ private:
     bool NetworkDataContainsUlaRoute(void) const;
 
     void HandleRaPrefixTableChanged(void);
+    void HandleLocalOnLinkPrefixChanged(void);
 
     static bool IsValidBrUlaPrefix(const Ip6::Prefix &aBrUlaPrefix);
     static bool IsValidOnLinkPrefix(const PrefixInfoOption &aPio);


### PR DESCRIPTION
This commit introduces the following changes:

- Adds a new callback `HandleLocalOnLinkPrefixChanged()` for `OnLinkPrefixManager` to signal changes to the local on-link prefix (derived from the extended PAN ID).
- Modifies `RxRaTracker` to always ignore a PIO prefix matching the local on-link prefix, regardless of the current state of `OnLinkPrefixManager`. Such a PIO originates from another Thread border router connected to the same Thread network and is not used by `OnLinkPrefixManager` to decide whether it needs to advertise the local on-link prefix.
- Updates `RxRaTracker` to be notified when the local on-link prefix changes. In its `HandleLocalOnLinkPrefixChanged()`, it removes any prefixes in the table matching the new prefix.