### PR TITLE
[dataset] simplify `IsSubsetOf()`

### DIFF
--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -220,7 +220,7 @@ public:
          *
          * @param[in] aOther   The other Dataset to check against.
          *
-         * @retval TRUE   The current dataset is a subset of @p aOther.
+         * @retval TRUE   The current Dataset is a subset of @p aOther.
          * @retval FALSE  The current Dataset is not a subset of @p aOther.
          *
          */
@@ -671,6 +671,20 @@ public:
      *
      */
     const Tlv *GetTlvsEnd(void) const { return reinterpret_cast<const Tlv *>(mTlvs + mLength); }
+
+    /**
+     * Determines whether this Dataset is a subset of another Dataset.
+     *
+     * The Dataset is considered a subset if all of its TLVs, excluding Active/Pending Timestamp and Delay Timer TLVs,
+     * are present in the @p aOther Dataset and the TLV values match exactly.
+     *
+     * @param[in] aOther   The other Dataset to check against.
+     *
+     * @retval TRUE   The current dataset is a subset of @p aOther.
+     * @retval FALSE  The current Dataset is not a subset of @p aOther.
+     *
+     */
+    bool IsSubsetOf(const Dataset &aOther) const;
 
     /**
      * Converts a Dataset Type to a string.

--- a/tests/unit/test_dataset.cpp
+++ b/tests/unit/test_dataset.cpp
@@ -224,6 +224,41 @@ void TestDataset(void)
     VerifyOrQuit(memcmp(dataset.GetBytes() + sizeof(kTlvBytes), kTlvBytes, sizeof(kTlvBytes)) == 0);
 
     VerifyOrQuit(dataset.ValidateTlvs() == kErrorParse);
+
+    // Validate `IsSubsetOf()`
+
+    SuccessOrQuit(dataset.SetFrom(kTlvBytes, sizeof(kTlvBytes)));
+
+    datasetInfo.Clear();
+    datasetInfo.mComponents.mIsPanIdPresent      = true;
+    datasetInfo.mComponents.mIsNetworkKeyPresent = true;
+    datasetInfo.mPanId                           = 0xface;
+    datasetInfo.mNetworkKey                      = kNetworkKey;
+
+    dataset2.SetFrom(datasetInfo);
+
+    SuccessOrQuit(dataset2.ValidateTlvs());
+    SuccessOrQuit(dataset.ValidateTlvs());
+
+    VerifyOrQuit(dataset2.IsSubsetOf(dataset));
+    VerifyOrQuit(!dataset.IsSubsetOf(dataset2));
+
+    datasetInfo.mComponents.mIsActiveTimestampPresent  = true;
+    datasetInfo.mComponents.mIsPendingTimestampPresent = true;
+    datasetInfo.mComponents.mIsDelayPresent            = true;
+    datasetInfo.mActiveTimestamp.mSeconds              = 0xffff;
+    datasetInfo.mPendingTimestamp.mSeconds             = 0x1000;
+    datasetInfo.mDelay                                 = 5000;
+    dataset2.SetFrom(datasetInfo);
+
+    VerifyOrQuit(dataset2.IsSubsetOf(dataset));
+    VerifyOrQuit(!dataset.IsSubsetOf(dataset2));
+
+    datasetInfo.mPanId = 0xcafe;
+    dataset2.SetFrom(datasetInfo);
+
+    VerifyOrQuit(!dataset2.IsSubsetOf(dataset));
+    VerifyOrQuit(!dataset.IsSubsetOf(dataset2));
 }
 
 } // namespace MeshCoP


### PR DESCRIPTION
This commit adds a method `Dataset::IsSubsetOf()` to check whether one dataset is a subset of another. A dataset is considered a subset if all its TLVs, excluding Active/Pending Timestamp and Delay Timer TLVs, are present in the other dataset with exactly matching values.

This new method simplifies `Dataset::Info::IsSubsetOf()`. The unit test `test_dataset` is updated to validate the `IsSubsetOf()()` method.