### PR TITLE
[dataset-updater] enhance `DatasetUpdater`

### DIFF
--- a/include/openthread/dataset_updater.h
+++ b/include/openthread/dataset_updater.h
@@ -82,7 +82,8 @@ typedef void (*otDatasetUpdaterCallback)(otError aError, void *aContext);
  * @param[in]  aContext                An arbitrary context passed to callback.
  *
  * @retval OT_ERROR_NONE           Dataset update started successfully (@p aCallback will be invoked on completion).
- * @retval OT_ERROR_INVALID_STATE  Device is disabled (MLE is disabled).
+ * @retval OT_ERROR_INVALID_STATE  Device is disabled or not fully configured (missing or incomplete Active Dataset).
+ * @retval OT_ERROR_ALREADY        The @p aDataset fields already match the existing Active Dataset.
  * @retval OT_ERROR_INVALID_ARGS   The @p aDataset is not valid (contains Active or Pending Timestamp).
  * @retval OT_ERROR_BUSY           Cannot start update, a previous one is ongoing.
  * @retval OT_ERROR_NO_BUFS        Could not allocated buffer to save Dataset.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (415)
+#define OPENTHREAD_API_VERSION (416)
 
 /**
  * @addtogroup api-instance

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -101,17 +101,6 @@ exit:
     return error;
 }
 
-bool Dataset::Info::IsSubsetOf(const Info &aOther) const
-{
-    Dataset dataset;
-    Dataset other;
-
-    dataset.SetFrom(*this);
-    other.SetFrom(aOther);
-
-    return dataset.IsSubsetOf(other);
-}
-
 Dataset::Dataset(void)
     : mLength(0)
     , mUpdateTime(0)

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -212,20 +212,6 @@ public:
          */
         Error GenerateRandom(Instance &aInstance);
 
-        /**
-         * Checks whether the Dataset is a subset of another one, i.e., all the components in the current
-         * Dataset are also present in the @p aOther and the component values fully match.
-         *
-         * The matching of components in the two Datasets excludes Active/Pending Timestamp and Delay components.
-         *
-         * @param[in] aOther   The other Dataset to check against.
-         *
-         * @retval TRUE   The current Dataset is a subset of @p aOther.
-         * @retval FALSE  The current Dataset is not a subset of @p aOther.
-         *
-         */
-        bool IsSubsetOf(const Info &aOther) const;
-
     private:
         Components       &GetComponents(void) { return static_cast<Components &>(mComponents); }
         const Components &GetComponents(void) const { return static_cast<const Components &>(mComponents); }
@@ -680,7 +666,7 @@ public:
      *
      * @param[in] aOther   The other Dataset to check against.
      *
-     * @retval TRUE   The current dataset is a subset of @p aOther.
+     * @retval TRUE   The current Dataset is a subset of @p aOther.
      * @retval FALSE  The current Dataset is not a subset of @p aOther.
      *
      */


### PR DESCRIPTION
This commit simplifies the `DatasetUpdater`:

- Restricts `DatasetUpdater::RequestUpdate()` to be used only when the device is fully configured and has a valid Active Dataset; otherwise, it returns `kErrorInvalidState`. This simplification allows for the removal of the timer (previously used to delay the update if no Active Dataset was present).
- Adds a check in `RequestUpdate()` to determine if the requested Dataset changes are already present in the current Active Dataset, returning `kErrorAlready` if so.
- Enhances `RequestUpdate()` to prepare and set the Pending Dataset immediately. It stores the requested Dataset as a sequence of TLVs and retains the Active and Pending Timestamp values for later use in determining update success or failure.
- Simplifies the code for checking Dataset changes and reporting update outcomes. A common `HandleDatasetChanged(Dataset::Type)` method is added, which can be used when the Active or Pending Dataset changes and performs the necessary checks, eliminating duplicate code.