### PR TITLE
[utils] add API to reset/clear linked list of enh-ack link metrics

### DIFF
--- a/examples/platforms/utils/link_metrics.cpp
+++ b/examples/platforms/utils/link_metrics.cpp
@@ -177,7 +177,11 @@ static inline bool IsLinkMetricsClear(otLinkMetrics aLinkMetrics)
     return !aLinkMetrics.mPduCount && !aLinkMetrics.mLqi && !aLinkMetrics.mLinkMargin && !aLinkMetrics.mRssi;
 }
 
-void otLinkMetricsInit(int8_t aNoiseFloor) { sNoiseFloor = aNoiseFloor; }
+void otLinkMetricsInit(int8_t aNoiseFloor)
+{
+    sNoiseFloor = aNoiseFloor;
+    otLinkMetricsResetEnhAckProbing();
+}
 
 otError otLinkMetricsConfigureEnhAckProbing(otShortAddress      aShortAddress,
                                             const otExtAddress *aExtAddress,
@@ -256,5 +260,11 @@ uint8_t otLinkMetricsEnhAckGetDataLen(const otMacAddress *aMacAddress)
 
 exit:
     return len;
+}
+
+void otLinkMetricsResetEnhAckProbing(void)
+{
+    GetLinkMetricsDataInfoActiveList().Clear();
+    GetLinkMetricsDataInfoPool().FreeAll();
 }
 #endif // OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE

--- a/examples/platforms/utils/link_metrics.h
+++ b/examples/platforms/utils/link_metrics.h
@@ -107,6 +107,12 @@ uint8_t otLinkMetricsEnhAckGenData(const otMacAddress *aMacAddress, uint8_t aLqi
  */
 uint8_t otLinkMetricsEnhAckGetDataLen(const otMacAddress *aMacAddress);
 
+/**
+ * This method resets Enhanced-ACK Based Probing data.
+ *
+ */
+void otLinkMetricsResetEnhAckProbing(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
Enh-ack link metrics required to reset/clear when radio(RCP) is reset to clear existing data. To support it, added API to reset/clear linked list of enh-ack link metrics.