### PR TITLE
[timer] add `NextFireTime` class

### DIFF
--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -41,6 +41,25 @@
 
 namespace ot {
 
+//---------------------------------------------------------------------------------------------------------------------
+// `NextFireTime`
+
+NextFireTime::NextFireTime(void)
+    : NextFireTime(TimerMilli::GetNow())
+{
+}
+
+NextFireTime::NextFireTime(Time aNow)
+    : mNow(aNow)
+    , mNextTime(aNow.GetDistantFuture())
+{
+}
+
+void NextFireTime::UpdateIfEarlier(Time aTime) { mNextTime = Min(mNextTime, Max(mNow, aTime)); }
+
+//---------------------------------------------------------------------------------------------------------------------
+// `Timer`
+
 const Timer::Scheduler::AlarmApi TimerMilli::Scheduler::sAlarmMilliApi = {
     &otPlatAlarmMilliStartAt,
     &otPlatAlarmMilliStop,
@@ -77,6 +96,9 @@ bool Timer::DoesFireBefore(const Timer &aSecondTimer, Time aNow) const
     return retval;
 }
 
+//---------------------------------------------------------------------------------------------------------------------
+// `TimerMilli`
+
 void TimerMilli::Start(uint32_t aDelay) { StartAt(GetNow(), aDelay); }
 
 void TimerMilli::StartAt(TimeMilli aStartTime, uint32_t aDelay)
@@ -91,6 +113,18 @@ void TimerMilli::FireAt(TimeMilli aFireTime)
     Get<Scheduler>().Add(*this);
 }
 
+void TimerMilli::FireAt(const NextFireTime &aNextFireTime)
+{
+    if (aNextFireTime.IsSet())
+    {
+        FireAt(aNextFireTime.GetNextTime());
+    }
+    else
+    {
+        Stop();
+    }
+}
+
 void TimerMilli::FireAtIfEarlier(TimeMilli aFireTime)
 {
     if (!IsRunning() || (mFireTime > aFireTime))
@@ -99,9 +133,20 @@ void TimerMilli::FireAtIfEarlier(TimeMilli aFireTime)
     }
 }
 
+void TimerMilli::FireAtIfEarlier(const NextFireTime &aNextFireTime)
+{
+    if (aNextFireTime.IsSet())
+    {
+        FireAtIfEarlier(aNextFireTime.GetNextTime());
+    }
+}
+
 void TimerMilli::Stop(void) { Get<Scheduler>().Remove(*this); }
 
 void TimerMilli::RemoveAll(Instance &aInstance) { aInstance.Get<Scheduler>().RemoveAll(); }
+
+//---------------------------------------------------------------------------------------------------------------------
+// `Timer::Scheduler`
 
 void Timer::Scheduler::Add(Timer &aTimer, const AlarmApi &aAlarmApi)
 {
@@ -211,6 +256,9 @@ extern "C" void otPlatAlarmMilliFired(otInstance *aInstance)
 exit:
     return;
 }
+
+//---------------------------------------------------------------------------------------------------------------------
+// `TimerMicro`
 
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 const Timer::Scheduler::AlarmApi TimerMicro::Scheduler::sAlarmMicroApi = {

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -62,6 +62,70 @@ namespace ot {
  */
 
 /**
+ * Represents an object tracking the next fire time along with the current time (now).
+ *
+ */
+class NextFireTime
+{
+public:
+    /**
+     * Initializes the `NextFireTime` with a given current time.
+     *
+     * @pram[in] aNow    The current time.
+     *
+     */
+    explicit NextFireTime(Time aNow);
+
+    /**
+     * Initializes the `NextFireTime` using `TimerMilli::GetNow()` for current time.
+     *
+     */
+    NextFireTime(void);
+
+    /**
+     * Gets the current time (now) tracked by the `NextFireTime` object.
+     *
+     * @returns The current time.
+     *
+     */
+    Time GetNow(void) const { return mNow; }
+
+    /**
+     * Updates the tracked next fire time with a new given time only if it is earlier.
+     *
+     * If the given @p aTime is in the past relative to the tracked `GetNow()`, the `GetNow()` time is used instead.
+     * This ensures that the next fire time is never scheduled before the current time.
+     *
+     * @param[in] aTime   The new time.
+     *
+     */
+    void UpdateIfEarlier(Time aTime);
+
+    /**
+     * Indicates whether or not next fire time is set.
+     *
+     * @retval TRUE   The next fire time is set.
+     * @retval FALSE  The next fire time is not set.
+     *
+     */
+    bool IsSet(void) const { return (mNextTime != mNow.GetDistantFuture()); }
+
+    /**
+     * Gets the next fire time.
+     *
+     * If the next fire time is not, `GetNow().GetDistantFuture()` will be returned.
+     *
+     * @returns The next fire time.
+     *
+     */
+    Time GetNextTime(void) const { return mNextTime; }
+
+private:
+    Time mNow;
+    Time mNextTime;
+};
+
+/**
  * Implements a timer.
  *
  */
@@ -220,13 +284,32 @@ public:
     void FireAt(TimeMilli aFireTime);
 
     /**
-     * This method (re-)schedules the timer with a given a fire time only if the timer is not running or the new given
+     * Schedules the timer to fire at a given fire time.
+     *
+     * Is @p aNextFireTime is not set, the timer is stopped.
+     *
+     * @param[in]  aNextFireTime  The fire time.
+     *
+     */
+    void FireAt(const NextFireTime &aNextFireTime);
+
+    /**
+     * Re-schedules the timer with a given a fire time only if the timer is not running or the new given
      * fire time is earlier than the current fire time.
      *
      * @param[in]  aFireTime  The fire time.
      *
      */
     void FireAtIfEarlier(TimeMilli aFireTime);
+
+    /**
+     * Re-schedules the timer with a given a fire time only if the timer is not running or the new given
+     * fire time is earlier than the current fire time.
+     *
+     * @param[in]  aNextFireTime  The fire time.
+     *
+     */
+    void FireAtIfEarlier(const NextFireTime &aNextFireTime);
 
     /**
      * Stops the timer.

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -598,8 +598,7 @@ void Commissioner::HandleTimer(void)
 
 void Commissioner::HandleJoinerExpirationTimer(void)
 {
-    TimeMilli now  = TimerMilli::GetNow();
-    TimeMilli next = now.GetDistantFuture();
+    NextFireTime nextTime;
 
     for (Joiner &joiner : mJoiners)
     {
@@ -608,21 +607,18 @@ void Commissioner::HandleJoinerExpirationTimer(void)
             continue;
         }
 
-        if (joiner.mExpirationTime <= now)
+        if (joiner.mExpirationTime <= nextTime.GetNow())
         {
             LogDebg("removing joiner due to timeout or successfully joined");
             RemoveJoinerEntry(joiner);
         }
         else
         {
-            next = Min(joiner.mExpirationTime, next);
+            nextTime.UpdateIfEarlier(joiner.mExpirationTime);
         }
     }
 
-    if (next != now.GetDistantFuture())
-    {
-        mJoinerExpirationTimer.FireAtIfEarlier(next);
-    }
+    mJoinerExpirationTimer.FireAtIfEarlier(nextTime);
 }
 
 Error Commissioner::SendMgmtCommissionerGetRequest(const uint8_t *aTlvs, uint8_t aLength)

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -227,8 +227,7 @@ void Client::FinalizeSntpTransaction(Message             &aQuery,
 
 void Client::HandleRetransmissionTimer(void)
 {
-    TimeMilli        now      = TimerMilli::GetNow();
-    TimeMilli        nextTime = now.GetDistantFuture();
+    NextFireTime     nextTime;
     QueryMetadata    queryMetadata;
     Ip6::MessageInfo messageInfo;
 
@@ -236,7 +235,7 @@ void Client::HandleRetransmissionTimer(void)
     {
         queryMetadata.ReadFrom(message);
 
-        if (now >= queryMetadata.mTransmissionTime)
+        if (nextTime.GetNow() >= queryMetadata.mTransmissionTime)
         {
             if (queryMetadata.mRetransmissionCount >= kMaxRetransmit)
             {
@@ -247,7 +246,7 @@ void Client::HandleRetransmissionTimer(void)
 
             // Increment retransmission counter and timer.
             queryMetadata.mRetransmissionCount++;
-            queryMetadata.mTransmissionTime = now + kResponseTimeout;
+            queryMetadata.mTransmissionTime = nextTime.GetNow() + kResponseTimeout;
             queryMetadata.UpdateIn(message);
 
             // Retransmit
@@ -258,13 +257,10 @@ void Client::HandleRetransmissionTimer(void)
             SendCopy(message, messageInfo);
         }
 
-        nextTime = Min(nextTime, queryMetadata.mTransmissionTime);
+        nextTime.UpdateIfEarlier(queryMetadata.mTransmissionTime);
     }
 
-    if (nextTime < now.GetDistantFuture())
-    {
-        mRetransmissionTimer.FireAt(nextTime);
-    }
+    mRetransmissionTimer.FireAt(nextTime);
 }
 
 void Client::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)

--- a/src/core/net/srp_advertising_proxy.cpp
+++ b/src/core/net/srp_advertising_proxy.cpp
@@ -1253,23 +1253,19 @@ exit:
 
 void AdvertisingProxy::HandleTimer(void)
 {
-    TimeMilli           now      = TimerMilli::GetNow();
-    TimeMilli           nextTime = now.GetDistantFuture();
+    NextFireTime        nextTime;
     OwningList<AdvInfo> expiredList;
 
     VerifyOrExit(mState == kStateRunning);
 
-    mAdvInfoList.RemoveAllMatching(AdvInfo::ExpirationChecker(now), expiredList);
+    mAdvInfoList.RemoveAllMatching(AdvInfo::ExpirationChecker(nextTime.GetNow()), expiredList);
 
     for (AdvInfo &adv : mAdvInfoList)
     {
-        nextTime = Min(adv.mExpireTime, nextTime);
+        nextTime.UpdateIfEarlier(adv.mExpireTime);
     }
 
-    if (nextTime != now.GetDistantFuture())
-    {
-        mTimer.FireAtIfEarlier(nextTime);
-    }
+    mTimer.FireAtIfEarlier(nextTime);
 
     for (AdvInfo &adv : expiredList)
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1600,8 +1600,7 @@ exit:
 
 void Mle::HandleDelayedResponseTimer(void)
 {
-    TimeMilli now          = TimerMilli::GetNow();
-    TimeMilli nextSendTime = now.GetDistantFuture();
+    NextFireTime nextSendTime;
 
     for (Message &message : mDelayedResponses)
     {
@@ -1609,9 +1608,9 @@ void Mle::HandleDelayedResponseTimer(void)
 
         metadata.ReadFrom(message);
 
-        if (now < metadata.mSendTime)
+        if (nextSendTime.GetNow() < metadata.mSendTime)
         {
-            nextSendTime = Min(nextSendTime, metadata.mSendTime);
+            nextSendTime.UpdateIfEarlier(metadata.mSendTime);
         }
         else
         {
@@ -1620,10 +1619,7 @@ void Mle::HandleDelayedResponseTimer(void)
         }
     }
 
-    if (nextSendTime < now.GetDistantFuture())
-    {
-        mDelayedResponseTimer.FireAt(nextSendTime);
-    }
+    mDelayedResponseTimer.FireAt(nextSendTime);
 }
 
 void Mle::SendDelayedResponse(TxMessage &aMessage, const DelayedResponseMetadata &aMetadata)

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -1434,8 +1434,7 @@ void Leader::ContextIds::SetRemoveTime(uint8_t aId, TimeMilli aTime)
 
 void Leader::ContextIds::HandleTimer(void)
 {
-    TimeMilli now      = TimerMilli::GetNow();
-    TimeMilli nextTime = now.GetDistantFuture();
+    NextFireTime nextTime;
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_SIGNAL_NETWORK_DATA_FULL
     OT_ASSERT(!mIsClone);
@@ -1448,21 +1447,18 @@ void Leader::ContextIds::HandleTimer(void)
             continue;
         }
 
-        if (now >= GetRemoveTime(id))
+        if (nextTime.GetNow() >= GetRemoveTime(id))
         {
             MarkAsUnallocated(id);
             Get<Leader>().RemoveContext(id);
         }
         else
         {
-            nextTime = Min(nextTime, GetRemoveTime(id));
+            nextTime.UpdateIfEarlier(GetRemoveTime(id));
         }
     }
 
-    if (nextTime != now.GetDistantFuture())
-    {
-        Get<Leader>().mTimer.FireAt(nextTime);
-    }
+    Get<Leader>().mTimer.FireAt(nextTime);
 }
 
 } // namespace NetworkData

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -359,8 +359,7 @@ exit:
 
 void Slaac::HandleTimer(void)
 {
-    TimeMilli now      = TimerMilli::GetNow();
-    TimeMilli nextTime = now.GetDistantFuture();
+    NextFireTime nextTime;
 
     for (SlaacAddress &slaacAddr : mSlaacAddresses)
     {
@@ -369,20 +368,17 @@ void Slaac::HandleTimer(void)
             continue;
         }
 
-        if (slaacAddr.GetExpirationTime() <= now)
+        if (slaacAddr.GetExpirationTime() <= nextTime.GetNow())
         {
             RemoveAddress(slaacAddr);
         }
         else
         {
-            nextTime = Min(nextTime, slaacAddr.GetExpirationTime());
+            nextTime.UpdateIfEarlier(slaacAddr.GetExpirationTime());
         }
     }
 
-    if (nextTime != now.GetDistantFuture())
-    {
-        mTimer.FireAtIfEarlier(nextTime);
-    }
+    mTimer.FireAtIfEarlier(nextTime);
 }
 
 Error Slaac::GenerateIid(Ip6::Netif::UnicastAddress &aAddress, uint8_t &aDadCounter) const


### PR DESCRIPTION
This commit introduces `NextFireTime`, a helper object for tracking the next fire time along with the current time. It provides an `UpdateIfEarlier(Time)` method to update the tracked next fire time with a new given time only if it is earlier.

The `NextFireTime` class simplifies a common code pattern used across modules to determine the earliest fire time when scheduling a timer. It also ensures that the next fire time is never set before the current time, improving code safety.