### PR TITLE
[mle] simplify signaling of DUA address change

### DIFF
--- a/src/core/thread/child.cpp
+++ b/src/core/thread/child.cpp
@@ -251,9 +251,9 @@ exit:
 }
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE
-const Ip6::Address *Child::GetDomainUnicastAddress(void) const
+Error Child::GetDomainUnicastAddress(Ip6::Address &aAddress) const
 {
-    const Ip6::Address *addr = nullptr;
+    Error error = kErrorNotFound;
 
     for (const Ip6::Address &ip6Address : mIp6Address)
     {
@@ -261,12 +261,14 @@ const Ip6::Address *Child::GetDomainUnicastAddress(void) const
 
         if (Get<BackboneRouter::Leader>().IsDomainUnicast(ip6Address))
         {
-            ExitNow(addr = &ip6Address);
+            aAddress = ip6Address;
+            error    = kErrorNone;
+            ExitNow();
         }
     }
 
 exit:
-    return addr;
+    return error;
 }
 #endif
 

--- a/src/core/thread/child.hpp
+++ b/src/core/thread/child.hpp
@@ -325,10 +325,13 @@ public:
     /**
      * Retrieves the Domain Unicast Address registered by the child.
      *
-     * @returns A pointer to Domain Unicast Address registered by the child if there is.
+     * @param[out] aAddress    A reference to return the DUA address.
+     *
+     * @retval kErrorNone      Successfully retrieved the DUA address, @p aAddress is updated.
+     * @retval kErrorNotFound  Could not find any DUA address.
      *
      */
-    const Ip6::Address *GetDomainUnicastAddress(void) const;
+    Error GetDomainUnicastAddress(Ip6::Address &aAddress) const;
 #endif
 
     /**

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -480,9 +480,8 @@ void DuaManager::PerformNextRegistration(void)
 #endif // OPENTHREAD_CONFIG_DUA_ENABLE
     {
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE
-        uint32_t            lastTransactionTime;
-        const Ip6::Address *duaPtr = nullptr;
-        Child              *child  = nullptr;
+        uint32_t lastTransactionTime;
+        Child   *child = nullptr;
 
         OT_ASSERT(mChildIndexDuaRegistering == Mle::kMaxChildren);
 
@@ -497,12 +496,9 @@ void DuaManager::PerformNextRegistration(void)
             }
         }
 
-        child  = Get<ChildTable>().GetChildAtIndex(mChildIndexDuaRegistering);
-        duaPtr = child->GetDomainUnicastAddress();
+        child = Get<ChildTable>().GetChildAtIndex(mChildIndexDuaRegistering);
+        SuccessOrAssert(child->GetDomainUnicastAddress(dua));
 
-        OT_ASSERT(duaPtr != nullptr);
-
-        dua = *duaPtr;
         SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, dua));
         SuccessOrExit(error = Tlv::Append<ThreadMeshLocalEidTlv>(*message, child->GetMeshLocalIid()));
 

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -687,6 +687,9 @@ private:
     Error ProcessAddressRegistrationTlv(RxInfo &aRxInfo, Child &aChild);
     Error UpdateChildAddresses(const Message &aMessage, uint16_t aOffset, uint16_t aLength, Child &aChild);
     bool  HasNeighborWithGoodLinkQuality(void) const;
+#if OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE
+    void SignalDuaAddressEvent(const Child &aChild, const Ip6::Address &aOldDua) const;
+#endif
 
     static void HandleAddressSolicitResponse(void                *aContext,
                                              otMessage           *aMessage,


### PR DESCRIPTION
This commit simplifies how `ProcessAddressRegistrationTlv()` signals DUA address changes. Signaling now occurs after all child addresses are registered, using a new `SignalDuaAddressEvent()` method. This method checks the old and new DUA addresses to determine the appropriate event to signal.

Additionally, `Child::GetDomainUnicastAddress()` is updated to return an `Error` and copy the DUA address into a provided `Ip6::Address` reference.