### PR TITLE
[fuzz] fix memory leak in TCP and enhance fuzzing

### DIFF
--- a/tests/fuzz/fuzzer_platform.cpp
+++ b/tests/fuzz/fuzzer_platform.cpp
@@ -35,8 +35,10 @@
 #include <openthread/platform/alarm-micro.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
+#include <openthread/platform/dnssd.h>
 #include <openthread/platform/entropy.h>
 #include <openthread/platform/logging.h>
+#include <openthread/platform/mdns_socket.h>
 #include <openthread/platform/misc.h>
 #include <openthread/platform/multipan.h>
 #include <openthread/platform/radio.h>
@@ -146,6 +148,8 @@ void FuzzerPlatformProcess(otInstance *aInstance)
 }
 
 bool FuzzerPlatformResetWasRequested(void) { return sResetWasRequested; }
+
+extern "C" {
 
 uint32_t otPlatAlarmMilliGetNow(void) { return sAlarmNow / 1000; }
 
@@ -515,3 +519,129 @@ void otPlatDiagRadioReceived(otInstance *aInstance, otRadioFrame *aFrame, otErro
 }
 
 void otPlatDiagAlarmCallback(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
+
+otPlatDnssdState otPlatDnssdGetState(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    return OT_PLAT_DNSSD_STOPPED;
+}
+
+void otPlatDnssdRegisterService(otInstance                 *aInstance,
+                                const otPlatDnssdService   *aService,
+                                otPlatDnssdRequestId        aRequestId,
+                                otPlatDnssdRegisterCallback aCallback)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aService);
+    OT_UNUSED_VARIABLE(aRequestId);
+    OT_UNUSED_VARIABLE(aCallback);
+}
+
+void otPlatDnssdUnregisterService(otInstance                 *aInstance,
+                                  const otPlatDnssdService   *aService,
+                                  otPlatDnssdRequestId        aRequestId,
+                                  otPlatDnssdRegisterCallback aCallback)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aService);
+    OT_UNUSED_VARIABLE(aRequestId);
+    OT_UNUSED_VARIABLE(aCallback);
+}
+
+void otPlatDnssdRegisterHost(otInstance                 *aInstance,
+                             const otPlatDnssdHost      *aHost,
+                             otPlatDnssdRequestId        aRequestId,
+                             otPlatDnssdRegisterCallback aCallback)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aHost);
+    OT_UNUSED_VARIABLE(aRequestId);
+    OT_UNUSED_VARIABLE(aCallback);
+}
+
+void otPlatDnssdUnregisterHost(otInstance                 *aInstance,
+                               const otPlatDnssdHost      *aHost,
+                               otPlatDnssdRequestId        aRequestId,
+                               otPlatDnssdRegisterCallback aCallback)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aHost);
+    OT_UNUSED_VARIABLE(aRequestId);
+    OT_UNUSED_VARIABLE(aCallback);
+}
+
+void otPlatDnssdRegisterKey(otInstance                 *aInstance,
+                            const otPlatDnssdKey       *aKey,
+                            otPlatDnssdRequestId        aRequestId,
+                            otPlatDnssdRegisterCallback aCallback)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aKey);
+    OT_UNUSED_VARIABLE(aRequestId);
+    OT_UNUSED_VARIABLE(aCallback);
+}
+
+void otPlatDnssdUnregisterKey(otInstance                 *aInstance,
+                              const otPlatDnssdKey       *aKey,
+                              otPlatDnssdRequestId        aRequestId,
+                              otPlatDnssdRegisterCallback aCallback)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aKey);
+    OT_UNUSED_VARIABLE(aRequestId);
+    OT_UNUSED_VARIABLE(aCallback);
+}
+
+otError otPlatMdnsSetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aEnable);
+    OT_UNUSED_VARIABLE(aInfraIfIndex);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+void otPlatMdnsSendMulticast(otInstance *aInstance, otMessage *aMessage, uint32_t aInfraIfIndex)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aMessage);
+    OT_UNUSED_VARIABLE(aInfraIfIndex);
+}
+
+void otPlatMdnsSendUnicast(otInstance *aInstance, otMessage *aMessage, const otPlatMdnsAddressInfo *aAddress)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aMessage);
+    OT_UNUSED_VARIABLE(aAddress);
+}
+
+bool otPlatInfraIfHasAddress(uint32_t aInfraIfIndex, const otIp6Address *aAddress)
+{
+    OT_UNUSED_VARIABLE(aInfraIfIndex);
+    OT_UNUSED_VARIABLE(aAddress);
+
+    return false;
+}
+
+otError otPlatInfraIfSendIcmp6Nd(uint32_t            aInfraIfIndex,
+                                 const otIp6Address *aDestAddress,
+                                 const uint8_t      *aBuffer,
+                                 uint16_t            aBufferLength)
+{
+    OT_UNUSED_VARIABLE(aInfraIfIndex);
+    OT_UNUSED_VARIABLE(aDestAddress);
+    OT_UNUSED_VARIABLE(aBuffer);
+    OT_UNUSED_VARIABLE(aBufferLength);
+
+    return OT_ERROR_FAILED;
+}
+
+otError otPlatInfraIfDiscoverNat64Prefix(uint32_t aInfraIfIndex)
+{
+    OT_UNUSED_VARIABLE(aInfraIfIndex);
+
+    return OT_ERROR_FAILED;
+}
+
+} // extern "C"

--- a/tests/fuzz/oss-fuzz-build
+++ b/tests/fuzz/oss-fuzz-build
@@ -44,6 +44,7 @@ set -euxo pipefail
         -DOT_RCP=OFF \
         -DOT_BORDER_AGENT=ON \
         -DOT_BORDER_ROUTER=ON \
+        -DOT_BORDER_ROUTING=ON \
         -DOT_CHANNEL_MANAGER=ON \
         -DOT_CHANNEL_MONITOR=ON \
         -DOT_COAP=ON \
@@ -55,6 +56,7 @@ set -euxo pipefail
         -DOT_DHCP6_CLIENT=ON \
         -DOT_DHCP6_SERVER=ON \
         -DOT_DNS_CLIENT=ON \
+        -DOT_DNSSD_SERVER=ON \
         -DOT_ECDSA=ON \
         -DOT_HISTORY_TRACKER=ON \
         -DOT_IP6_FRAGM=ON \
@@ -63,13 +65,14 @@ set -euxo pipefail
         -DOT_LINK_RAW=ON \
         -DOT_LOG_OUTPUT=APP \
         -DOT_MAC_FILTER=ON \
+        -DOT_MDNS=ON \
         -DOT_NETDATA_PUBLISHER=ON \
         -DOT_NETDIAG_CLIENT=ON \
         -DOT_PING_SENDER=ON \
         -DOT_SERVICE=ON \
         -DOT_SLAAC=ON \
         -DOT_SNTP_CLIENT=ON \
-        -DOT_SRN_ADV_PROXY=ON \
+        -DOT_SRP_ADV_PROXY=ON \
         -DOT_SRP_CLIENT=ON \
         -DOT_SRP_SERVER=ON \
         -DOT_THREAD_VERSION=1.3 \


### PR DESCRIPTION
The #10286 detected the issue with OSS-Fuzz. This PR introduces two independent commits which should resolve the issue (checked on my fork) and enhance fuzzing by fixing a typo.

**[cli] fix memory leak on TCP init failure**

This commit fixes potential memory leak for CLI TCP module (`tcp init tls [...]`)

**[fuzz] fix typo and enable SRP Advertising Proxy**

This commit fixes the typo and enables SRP_ADV_PROXY - now, when typo is fixed,
dependent components had to be enabled.