### PR TITLE
[mle] fix warning with storedCount

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1782,6 +1782,8 @@ Error MleRouter::ProcessAddressRegistrationTlv(RxInfo &aRxInfo, Child &aChild)
     MlrManager::MlrAddressArray oldMlrRegisteredAddresses;
 #endif
 
+    OT_UNUSED_VARIABLE(storedCount);
+
     SuccessOrExit(error =
                       Tlv::FindTlvValueStartEndOffsets(aRxInfo.mMessage, Tlv::kAddressRegistration, offset, endOffset));
 


### PR DESCRIPTION
This commit fixes the warning, when logs are disabled:

`src/core/thread/mle_router.cpp:1775:14: warning: variable "storedCount" set but not used [-Wunused-but-set-variable]`