### PR TITLE
[routing-manager] update and simplify RA beacon timing

### DIFF
--- a/src/core/common/random.cpp
+++ b/src/core/common/random.cpp
@@ -158,9 +158,15 @@ void FillBuffer(uint8_t *aBuffer, uint16_t aSize)
 
 uint32_t AddJitter(uint32_t aValue, uint16_t aJitter)
 {
-    aJitter = (aJitter <= aValue) ? aJitter : static_cast<uint16_t>(aValue);
+    uint32_t delay = 0;
 
-    return aValue + GetUint32InRange(0, 2 * aJitter + 1) - aJitter;
+    VerifyOrExit(aValue != 0);
+
+    aJitter = (aJitter <= aValue) ? aJitter : static_cast<uint16_t>(aValue);
+    delay   = aValue + GetUint32InRange(0, 2 * aJitter + 1) - aJitter;
+
+exit:
+    return delay;
 }
 
 } // namespace NonCrypto


### PR DESCRIPTION
This commit updates constants in `RoutingManager`. Timing constants are now consistently specified as an interval with an associated jitter, where the actual interval is randomly selected within the range `[interval - jitter, interval + jitter]`.

The initial transmission of three RAs with a short interval of 16 seconds (± 2 seconds jitter) remains unchanged. However, subsequent RA transmissions now use a regular beacon interval of 3 minutes (± 15 seconds jitter), replacing the previous random interval selection within `[200, 600]` seconds.

The selection of 3 minutes as the regular RA beacon interval aligns the implementation with the latest stub router RFC draft's `RA_BEACON_INTERVAL` default value.