### PR TITLE
[routing-manager] fix lifetime management of PD prefix

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -692,8 +692,8 @@ private:
         uint32_t  GetPreferredLifetime(void) const { return mPreferredLifetime; }
         void      ClearPreferredLifetime(void) { mPreferredLifetime = 0; }
         bool      IsDeprecated(void) const;
+        TimeMilli GetDeprecationTime(void) const;
         TimeMilli GetStaleTime(void) const;
-        TimeMilli GetStaleTimeFromPreferredLifetime(void) const;
         void      AdoptValidAndPreferredLifetimesFrom(const OnLinkPrefix &aPrefix);
         void      CopyInfoTo(PrefixTableEntry &aEntry, TimeMilli aNow) const;
 


### PR DESCRIPTION
This commit updates `PdPrefixManager` to use the newly added `GetDeprecationTime()` method for managing the lifetime of a DHCPv6 PD prefix. This method calculates the deprecation time using the prefix preferred lifetime directly, instead of relying on the RA stale time constant  `GetStaleTime()`.

While the PD prefix may be determined by processing RA messages received on the Thread interface, the RA stale time is not relevant in this context. The RA stale time is only applicable to RA messages received over infra-if. It specifies the time that can pass after the last RA from a particular router on infra-if before assuming the router might be unavailable and triggering Router Solicitation (RS) messages.