### PR TITLE
[routing-manager] update stale time calculation for local RA header

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1394,6 +1394,8 @@ private:
     void HandleRaPrefixTableChanged(void);
     void HandleLocalOnLinkPrefixChanged(void);
 
+    static TimeMilli CalculateExpirationTime(TimeMilli aUpdateTime, uint32_t aLifetime);
+
     static bool IsValidBrUlaPrefix(const Ip6::Prefix &aBrUlaPrefix);
     static bool IsValidOnLinkPrefix(const PrefixInfoOption &aPio);
     static bool IsValidOnLinkPrefix(const Ip6::Prefix &aOnLinkPrefix);


### PR DESCRIPTION
This commit updates the calculation of stale time for a discovered local RA header (to mirror), incorporating the default route lifetime specified in the header when it is non-zero, in addition to the RA stale time constant. This ensures proper behavior even if the RA header default route lifetime is shorter than the RA stale time.

Additionally, this commit adds `CalculateExpirationTime()` to determine the expiration time from a given update time and lifetime duration in seconds. If the given lifetime exceeds the supported range of `TimeMilli` (~24 days), it clamps the value to ensure time calculations remain within the valid `TimeMilli` range.