### PR TITLE
[routing-manager] fix and enhance prefix stale time calculation

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -672,12 +672,16 @@ private:
         bool Matches(const UlaChecker &aIsUla) const { return (mPrefix.IsUniqueLocal() == aIsUla); }
         bool Matches(const ExpirationChecker &aChecker) const { return (GetExpireTime() <= aChecker.mNow); }
 
+        void SetStaleTimeCalculated(bool aFlag) { mStaleTimeCalculated = aFlag; }
+        bool IsStaleTimeCalculated(void) const { return mStaleTimeCalculated; }
+
     protected:
         LifetimedPrefix(void) = default;
 
         TimeMilli CalculateExpirationTime(uint32_t aLifetime) const;
 
         Ip6::Prefix mPrefix;
+        bool        mStaleTimeCalculated : 1;
         uint32_t    mValidLifetime;
         TimeMilli   mLastUpdateTime;
     };
@@ -907,6 +911,8 @@ private:
         void RemoveExpiredEntries(void);
         void SignalTableChanged(void);
         void ScheduleStaleTimer(void);
+        void DetermineStaleTimeFor(const OnLinkPrefix &aPrefix, NextFireTime &aStaleTime);
+        void DetermineStaleTimeFor(const RoutePrefix &aPrefix, NextFireTime &aStaleTime);
         void UpdateRouterOnRx(Router &aRouter);
         void SendNeighborSolicitToRouter(const Router &aRouter);
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_USE_HEAP_ENABLE


### PR DESCRIPTION
This commit updates the determination of stale times for discovered on-link or route prefixes. The stale time is now calculated per unique prefix. If multiple routers advertise the same on-link or route prefix, the stale time for the prefix is set to the latest among all corresponding entries.

This addresses an issue in the previous implementation where, for on-link prefixes, the stale time was determined as the latest stale time over all on-link entries, regardless of the actual prefixes. For route prefixes, the earliest stale time was used, also disregarding the possibility of multiple routers advertising the same prefix.

This commit also updates the `test_routing_manager` unit test to validate the corrected stale time calculation.