### PR TITLE
[mle] add helper methods to `RxMessage`

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1061,8 +1061,11 @@ private:
     {
     public:
         bool  ContainsTlv(Tlv::Type aTlvType) const;
+        Error ReadModeTlv(DeviceMode &aMode) const;
+        Error ReadVersionTlv(uint16_t &aVersion) const;
         Error ReadChallengeTlv(RxChallenge &aChallenge) const;
         Error ReadResponseTlv(RxChallenge &aResponse) const;
+        Error ReadAndMatchResponseTlvWith(const TxChallenge &aChallenge) const;
         Error ReadFrameCounterTlvs(uint32_t &aLinkFrameCounter, uint32_t &aMleFrameCounter) const;
         Error ReadTlvRequestTlv(TlvList &aTlvList) const;
         Error ReadLeaderDataTlv(LeaderData &aLeaderData) const;


### PR DESCRIPTION
This commit adds helper methods to `Mle::RxMessage` for reading and processing specific TLVs:

- `ReadModeTlv()`: Reads the Mode TLV as a bit mask and converts it to a `DeviceMode`.
- `ReadVersionTlv()`: Reads the Version TLV and verifies that it is at least 1.1 (the minimum supported version).
- `ReadAndMatchResponseTlvWith(const TxChallenge &)`: Reads the Response TLV and matches it against a given challenge.