### PR TITLE
[meshcop] update `Timestamp::AdvanceRandomTicks()`

### DIFF
--- a/src/core/meshcop/dataset_updater.cpp
+++ b/src/core/meshcop/dataset_updater.cpp
@@ -95,6 +95,7 @@ Error DatasetUpdater::RequestUpdate(Dataset &aDataset, UpdaterCallback aCallback
     else
     {
         pendingTimestamp.Clear();
+        pendingTimestamp.SetSeconds(1);
     }
 
     pendingTimestamp.AdvanceRandomTicks();

--- a/src/core/meshcop/timestamp.cpp
+++ b/src/core/meshcop/timestamp.cpp
@@ -99,10 +99,11 @@ void Timestamp::AdvanceRandomTicks(void)
 {
     uint16_t ticks = GetTicks();
 
-    ticks += Random::NonCrypto::GetUint32InRange(1, kMaxRandomTicks);
+    ticks += Random::NonCrypto::GetUint32InRange(1, kMaxTicks + 1);
 
-    if (ticks & (kTicksMask >> kTicksOffset))
+    if (ticks > kMaxTicks)
     {
+        ticks -= (kMaxTicks + 1);
         SetSeconds(GetSeconds() + 1);
     }
 

--- a/src/core/meshcop/timestamp.hpp
+++ b/src/core/meshcop/timestamp.hpp
@@ -179,9 +179,9 @@ public:
 private:
     static constexpr uint8_t  kTicksOffset         = 1;
     static constexpr uint16_t kTicksMask           = 0x7fff << kTicksOffset;
-    static constexpr uint16_t kMaxRandomTicks      = 0x7fff;
     static constexpr uint8_t  kAuthoritativeOffset = 0;
     static constexpr uint16_t kAuthoritativeMask   = 1 << kAuthoritativeOffset;
+    static constexpr uint16_t kMaxTicks            = 0x7fff;
 
     uint16_t mSeconds16; // bits 32-47
     uint32_t mSeconds32; // bits 0-31


### PR DESCRIPTION
This commit updates `Timestamp::AdvanceRandomTicks()` to ensure that the seconds value is incremented only if the ticks value overflows.