### PR TITLE
[spinel] remove including openthread-core-config.h

### DIFF
--- a/src/lib/spinel/openthread-spinel-config.h
+++ b/src/lib/spinel/openthread-spinel-config.h
@@ -34,8 +34,6 @@
 #ifndef OPENTHREAD_SPINEL_CONFIG_H_
 #define OPENTHREAD_SPINEL_CONFIG_H_
 
-#include "openthread-core-config.h"
-
 /**
  * @def OPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE
  *


### PR DESCRIPTION
Following #10212, this PR removes the including of `openthread-core-config.h`
to make `lib/spinel` more portable.

`openthread-spinel-config.h` is included by many modules like 
`spinel_encoder`, `spinel_decoder`. To use these modules in external
projects, we need to remove the including of `openthread-core-config.h`.