### PR TITLE
[encoding] declare `HostSwap()` functions as `constexpr`

### DIFF
--- a/src/core/common/encoding.hpp
+++ b/src/core/common/encoding.hpp
@@ -49,15 +49,18 @@
 
 namespace ot {
 
-inline uint16_t Swap16(uint16_t v) { return (((v & 0x00ffU) << 8) & 0xff00) | (((v & 0xff00U) >> 8) & 0x00ff); }
+inline constexpr uint16_t Swap16(uint16_t v)
+{
+    return (((v & 0x00ffU) << 8) & 0xff00) | (((v & 0xff00U) >> 8) & 0x00ff);
+}
 
-inline uint32_t Swap32(uint32_t v)
+inline constexpr uint32_t Swap32(uint32_t v)
 {
     return ((v & static_cast<uint32_t>(0x000000ffUL)) << 24) | ((v & static_cast<uint32_t>(0x0000ff00UL)) << 8) |
            ((v & static_cast<uint32_t>(0x00ff0000UL)) >> 8) | ((v & static_cast<uint32_t>(0xff000000UL)) >> 24);
 }
 
-inline uint64_t Swap64(uint64_t v)
+inline uint64_t constexpr Swap64(uint64_t v)
 {
     return ((v & static_cast<uint64_t>(0x00000000000000ffULL)) << 56) |
            ((v & static_cast<uint64_t>(0x000000000000ff00ULL)) << 40) |
@@ -84,15 +87,15 @@ namespace BigEndian {
 
 #if BYTE_ORDER_BIG_ENDIAN
 
-inline uint16_t HostSwap16(uint16_t v) { return v; }
-inline uint32_t HostSwap32(uint32_t v) { return v; }
-inline uint64_t HostSwap64(uint64_t v) { return v; }
+inline constexpr uint16_t HostSwap16(uint16_t v) { return v; }
+inline constexpr uint32_t HostSwap32(uint32_t v) { return v; }
+inline constexpr uint64_t HostSwap64(uint64_t v) { return v; }
 
 #else /* BYTE_ORDER_LITTLE_ENDIAN */
 
-inline uint16_t HostSwap16(uint16_t v) { return Swap16(v); }
-inline uint32_t HostSwap32(uint32_t v) { return Swap32(v); }
-inline uint64_t HostSwap64(uint64_t v) { return Swap64(v); }
+inline constexpr uint16_t HostSwap16(uint16_t v) { return Swap16(v); }
+inline constexpr uint32_t HostSwap32(uint32_t v) { return Swap32(v); }
+inline constexpr uint64_t HostSwap64(uint64_t v) { return Swap64(v); }
 
 #endif // LITTLE_ENDIAN
 
@@ -267,15 +270,15 @@ namespace LittleEndian {
 
 #if BYTE_ORDER_BIG_ENDIAN
 
-inline uint16_t HostSwap16(uint16_t v) { return Swap16(v); }
-inline uint32_t HostSwap32(uint32_t v) { return Swap32(v); }
-inline uint64_t HostSwap64(uint64_t v) { return Swap64(v); }
+inline constexpr uint16_t HostSwap16(uint16_t v) { return Swap16(v); }
+inline constexpr uint32_t HostSwap32(uint32_t v) { return Swap32(v); }
+inline constexpr uint64_t HostSwap64(uint64_t v) { return Swap64(v); }
 
 #else /* BYTE_ORDER_LITTLE_ENDIAN */
 
-inline uint16_t HostSwap16(uint16_t v) { return v; }
-inline uint32_t HostSwap32(uint32_t v) { return v; }
-inline uint64_t HostSwap64(uint64_t v) { return v; }
+inline constexpr uint16_t HostSwap16(uint16_t v) { return v; }
+inline constexpr uint32_t HostSwap32(uint32_t v) { return v; }
+inline constexpr uint64_t HostSwap64(uint64_t v) { return v; }
 
 #endif
 


### PR DESCRIPTION
This allows their use when defining constant values.