### PR TITLE
[mle] allow appending pending timestamp TLV with zero seconds

### DIFF
--- a/src/core/meshcop/dataset_updater.cpp
+++ b/src/core/meshcop/dataset_updater.cpp
@@ -93,7 +93,6 @@ Error DatasetUpdater::RequestUpdate(Dataset &aDataset, UpdaterCallback aCallback
     if (!pendingTimestamp.IsValid())
     {
         pendingTimestamp.Clear();
-        pendingTimestamp.SetSeconds(1);
     }
 
     pendingTimestamp.AdvanceRandomTicks();

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -4742,7 +4742,7 @@ Error Mle::TxMessage::AppendPendingTimestampTlv(void)
     Error                     error     = kErrorNone;
     const MeshCoP::Timestamp &timestamp = Get<MeshCoP::PendingDatasetManager>().GetTimestamp();
 
-    VerifyOrExit(timestamp.IsValid() && timestamp.GetSeconds() != 0);
+    VerifyOrExit(timestamp.IsValid());
     error = Tlv::Append<PendingTimestampTlv>(*this, timestamp);
 
 exit:


### PR DESCRIPTION
This commit removes the `GetSeconds() != 0` check in `Mle::AppendPendingTimestampTlv()`. This allows `DatasetUpdater` to use a Pending Timestamp with random ticks and a zero seconds value if there is no pending Dataset.

----

~This PR currently contains commits from https://github.com/openthread/openthread/pull/10325 and https://github.com/openthread/openthread/pull/10320. Please check the last commit. Thanks.~