### PR TITLE
[routing-manager] update stale time constant to 10 minute

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -887,7 +887,7 @@ TimeMilli RoutingManager::OnLinkPrefix::GetDeprecationTime(void) const
 
 TimeMilli RoutingManager::OnLinkPrefix::GetStaleTime(void) const
 {
-    return CalculateExpirationTime(Min(kRtrAdvStaleTime, mPreferredLifetime));
+    return CalculateExpirationTime(Min(kStaleTime, mPreferredLifetime));
 }
 
 void RoutingManager::OnLinkPrefix::AdoptValidAndPreferredLifetimesFrom(const OnLinkPrefix &aPrefix)
@@ -948,7 +948,7 @@ void RoutingManager::RoutePrefix::SetFrom(const RouterAdvert::Header &aRaHeader)
 
 TimeMilli RoutingManager::RoutePrefix::GetStaleTime(void) const
 {
-    return CalculateExpirationTime(Min(kRtrAdvStaleTime, mValidLifetime));
+    return CalculateExpirationTime(Min(kStaleTime, mValidLifetime));
 }
 
 void RoutingManager::RoutePrefix::CopyInfoTo(PrefixTableEntry &aEntry, TimeMilli aNow) const
@@ -1538,7 +1538,7 @@ void RoutingManager::RxRaTracker::ScheduleStaleTimer(void)
 
     if (mLocalRaHeader.IsValid())
     {
-        uint16_t interval = kRtrAdvStaleTime;
+        uint16_t interval = kStaleTime;
 
         if (mLocalRaHeader.GetRouterLifetime() > 0)
         {

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -582,6 +582,19 @@ private:
     static constexpr uint32_t kDefaultOnLinkPrefixLifetime = 1800;
     static constexpr uint32_t kDefaultNat64PrefixLifetime  = 300;
 
+    // The entry stale time in seconds.
+    //
+    // The amount of time that can pass after the last time an RA from
+    // a particular router has been received advertising an on-link
+    // or route prefix before we assume the prefix entry is stale.
+    //
+    // If multiple routers advertise the same on-link or route prefix,
+    // the stale time for the prefix is determined by the latest
+    // stale time among all corresponding entries. Stale time
+    // expiration triggers tx of Router Solicitation (RS) messages
+
+    static constexpr uint32_t kStaleTime = 600; // 10 minutes.
+
     // RA transmission constants (in milliseconds). Initially, three
     // RAs are sent with a short interval of 16 seconds (± 2 seconds
     // jitter). Subsequently, a longer, regular RA beacon interval of
@@ -599,14 +612,6 @@ private:
     static constexpr uint16_t kRsReplyJitter      = 250;
     static constexpr uint32_t kEvaluationInterval = Time::kOneSecondInMsec * 3;
     static constexpr uint16_t kEvaluationJitter   = Time::kOneSecondInMsec * 1;
-
-    // The STALE_RA_TIME in seconds. The Routing Manager will consider the prefixes
-    // and learned RA parameters STALE when they are not refreshed in STALE_RA_TIME
-    // seconds. The Routing Manager will then start Router Solicitation to verify
-    // that the STALE prefix is not being advertised anymore and remove the STALE
-    // prefix.
-    // The value is chosen in range of [`kMaxRtrAdvInterval` upper bound (1800s), `kDefaultOnLinkPrefixLifetime`].
-    static constexpr uint32_t kRtrAdvStaleTime = 1800;
 
     //------------------------------------------------------------------------------------------------------------------
     // Typedefs

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -1848,7 +1848,7 @@ void TestAdvNonUlaRoute(void)
 
 void TestLocalOnLinkPrefixDeprecation(void)
 {
-    static constexpr uint32_t kMaxRaTxInterval = 601; // In seconds
+    static constexpr uint32_t kMaxRaTxInterval = 196; // In seconds
 
     Ip6::Prefix  localOnLink;
     Ip6::Prefix  localOmr;
@@ -2142,7 +2142,7 @@ void TestDomainPrefixAsOmr(void)
 
 void TestExtPanIdChange(void)
 {
-    static constexpr uint32_t kMaxRaTxInterval = 601; // In seconds
+    static constexpr uint32_t kMaxRaTxInterval = 196; // In seconds
 
     static const otExtendedPanId kExtPanId1 = {{0x01, 0x02, 0x03, 0x04, 0x05, 0x6, 0x7, 0x08}};
     static const otExtendedPanId kExtPanId2 = {{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x99, 0x88}};
@@ -2996,7 +2996,7 @@ void TestLearningAndCopyingOfFlags(void)
     sRaValidated           = false;
     sExpectedRaHeaderFlags = kRaHeaderFlagsOnlyM;
 
-    AdvanceTime(610 * 1000);
+    AdvanceTime(310 * 1000);
     VerifyOrQuit(sRaValidated);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3013,7 +3013,7 @@ void TestLearningAndCopyingOfFlags(void)
     AdvanceTime(1);
     VerifyDiscoveredRoutersIsEmpty();
 
-    AdvanceTime(610 * 1000);
+    AdvanceTime(310 * 1000);
     VerifyOrQuit(sRaValidated);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3033,7 +3033,7 @@ void TestLearningAndCopyingOfFlags(void)
     sRaValidated           = false;
     sExpectedRaHeaderFlags = kRaHeaderFlagsNone;
 
-    AdvanceTime(610 * 1000);
+    AdvanceTime(310 * 1000);
     VerifyOrQuit(sRaValidated);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3052,7 +3052,7 @@ void TestLearningAndCopyingOfFlags(void)
     sRaValidated           = false;
     sExpectedRaHeaderFlags = kRaHeaderFlagsOnlyO;
 
-    AdvanceTime(610 * 1000);
+    AdvanceTime(310 * 1000);
     VerifyOrQuit(sRaValidated);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3074,7 +3074,7 @@ void TestLearningAndCopyingOfFlags(void)
     sExpectedPio           = kPioDeprecatingLocalOnLink;
     sExpectedRaHeaderFlags = kRaHeaderFlagsBothMAndO;
 
-    AdvanceTime(610 * 1000);
+    AdvanceTime(310 * 1000);
     VerifyOrQuit(sRaValidated);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3257,7 +3257,7 @@ void TestConflictingPrefix(void)
     // Check that the local on-link prefix is still being advertised.
 
     sRaValidated = false;
-    AdvanceTime(610000);
+    AdvanceTime(310000);
     VerifyOrQuit(sRaValidated);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3282,7 +3282,7 @@ void TestConflictingPrefix(void)
     // Check that the local on-link prefix is still being advertised.
 
     sRaValidated = false;
-    AdvanceTime(610000);
+    AdvanceTime(310000);
     VerifyOrQuit(sRaValidated);
 
     VerifyExternalRouteInNetData(kUlaRoute, kWithAdvPioFlagSet);
@@ -3321,7 +3321,7 @@ void TestConflictingPrefix(void)
     // Check that the local on-link prefix is still being deprecated.
 
     sRaValidated = false;
-    AdvanceTime(610000);
+    AdvanceTime(310000);
     VerifyOrQuit(sRaValidated);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This commit renames the entry stale time constant to `kStaleTime` and sets it to 10 minutes (from 30 minutes). This change aligns the `RoutingManager` with the recommended value in the latest stub router RFC draft (`STALE_RA_TIME`).

The unit test `test_routing_manager` is also updated to reflect this new constant.