### PR TITLE
[dataset-manager] enhance starting of Pending Dataset delay timer

### DIFF
--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -295,12 +295,7 @@ Error DatasetManager::Save(const Timestamp &aTimestamp, const Message &aMessage,
         SuccessOrExit(error = dataset.Write<PendingTimestampTlv>(aTimestamp));
     }
 
-    SuccessOrExit(error = Save(dataset));
-
-    if (IsPendingDataset())
-    {
-        Get<PendingDatasetManager>().StartDelayTimer(dataset);
-    }
+    error = Save(dataset);
 
 exit:
     return error;
@@ -368,11 +363,6 @@ void DatasetManager::SaveLocal(const Dataset &aDataset)
 {
     LocalSave(aDataset);
 
-    if (IsPendingDataset())
-    {
-        Get<PendingDatasetManager>().StartDelayTimer(aDataset);
-    }
-
     switch (Get<Mle::MleRouter>().GetRole())
     {
     case Mle::kRoleDisabled:
@@ -431,6 +421,11 @@ void DatasetManager::LocalSave(const Dataset &aDataset)
 
     mLocalTimestampValid = (aDataset.ReadTimestamp(mType, mLocalTimestamp) == kErrorNone);
     mLocalUpdateTime     = TimerMilli::GetNow();
+
+    if (IsPendingDataset())
+    {
+        Get<PendingDatasetManager>().StartDelayTimer(aDataset);
+    }
 }
 
 void DatasetManager::SignalDatasetChange(void) const


### PR DESCRIPTION
This commit updates and fixes how the Pending Dataset delay timer is started. It is now started only after the timestamps are checked and the local Pending Dataset is updated and saved to non-volatile storage from the `LocalSave()` method.

In particular, we no longer start the delay timer from the `Save()` method, which reads the `Dataset` from a received `Message`. This is because we may receive a Pending Dataset with a timestamp that is older than the currently saved local Pending Dataset. In this case, the local Dataset is correctly not updated but without this change, we could start the delay timer for the received stale Pending Dataset.

