### PR TITLE
[mbedtls] remove `-Wno-unused-but-set-variable`

### DIFF
--- a/third_party/mbedtls/BUILD.gn
+++ b/third_party/mbedtls/BUILD.gn
@@ -43,7 +43,6 @@ config("mbedtls_config") {
   defines = [ "MBEDTLS_CONFIG_FILE=\"${mbedtls_config_file}\"" ]
   cflags = [
     "-Wno-conversion",
-    "-Wno-unused-but-set-variable"
   ]
 }
 

--- a/third_party/mbedtls/CMakeLists.txt
+++ b/third_party/mbedtls/CMakeLists.txt
@@ -42,7 +42,6 @@ if(UNIFDEF_EXE)
 endif()
 find_program(SED_EXE sed)
 
-string(APPEND CMAKE_C_FLAGS " -Wno-unused-but-set-variable")
 string(REPLACE "-Wconversion" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 string(REPLACE "-Wconversion" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 


### PR DESCRIPTION
To resolve this build error:

```
fatal error: unknown warning option '-Wno-unused-but-set-variable'; did you mean '-Wno-unused-const-variable'? [-Wunknown-warning-option]
[298/511] Building CXX object third_party/openthread/repo/src/core/CMakeFiles/openthread-ftd.dir/utils/slaac_address.cpp.o
ninja: build stopped: subcommand failed.
```

https://github.com/openthread/ot-br-posix/actions/runs/9359945142/job/25764511252?pr=2311