### PR TITLE
[ip6] do not report an error for disabled host loopback

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -935,7 +935,7 @@ Error Ip6::PassToHost(OwnedPtr<Message> &aMessagePtr,
     Error             error = kErrorNone;
     OwnedPtr<Message> messagePtr;
 
-    VerifyOrExit(aMessagePtr->IsLoopbackToHostAllowed(), error = kErrorNoRoute);
+    VerifyOrExit(aMessagePtr->IsLoopbackToHostAllowed());
 
     VerifyOrExit(mReceiveIp6DatagramCallback.IsSet(), error = kErrorNoRoute);
 


### PR DESCRIPTION
Currently, sending an IPv6 multicast destined packet encoded in otMessage with the otIp6Send() function reports an error kErrorNoRoute if "host loopback allowed" flag is disabled (despite of packet being properly passed to Mesh Forwarder). This commit changes a flag checking statement to return kErrorNone instead.