### PR TITLE
[mle] add `Mle::TxMessage::AppendDatasetTlv()`

### DIFF
--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -235,18 +235,6 @@ public:
                          const uint8_t             *aTlvTypes,
                          uint8_t                    aLength,
                          const otIp6Address        *aAddress) const;
-#if OPENTHREAD_FTD
-    /**
-     * Appends the MLE Dataset TLV but excluding MeshCoP Sub Timestamp TLV.
-     *
-     * @param[in] aMessage       The message to append the TLV to.
-     *
-     * @retval kErrorNone    Successfully append MLE Dataset TLV without MeshCoP Sub Timestamp TLV.
-     * @retval kErrorNoBufs  Insufficient available buffers to append the message with MLE Dataset TLV.
-     *
-     */
-    Error AppendMleDatasetTlv(Message &aMessage) const;
-#endif
 
 private:
     static constexpr uint8_t  kMaxGetTypes  = 64;   // Max number of types in MGMT_GET.req

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -65,22 +65,6 @@ RegisterLogModule("DatasetManager");
 //----------------------------------------------------------------------------------------------------------------------
 // DatasetManager
 
-Error DatasetManager::AppendMleDatasetTlv(Message &aMessage) const
-{
-    Mle::Tlv::Type mleTlvType = IsActiveDataset() ? Mle::Tlv::kActiveDataset : Mle::Tlv::kPendingDataset;
-    Dataset        dataset;
-
-    IgnoreError(Read(dataset));
-
-    // Remove the Active or Pending Timestamp TLV from Dataset before
-    // appending to the message. The timestamp is appended as its own
-    // MLE TLV to the message.
-
-    dataset.RemoveTimestamp(mType);
-
-    return Tlv::AppendTlv(aMessage, mleTlvType, dataset.GetBytes(), dataset.GetLength());
-}
-
 Error DatasetManager::ProcessSetOrReplaceRequest(MgmtCommand          aCommand,
                                                  const Coap::Message &aMessage,
                                                  RequestInfo         &aInfo) const

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -4895,14 +4895,47 @@ Error Mle::TxMessage::AppendRouteTlv(Neighbor *aNeighbor)
     return tlv.AppendTo(*this);
 }
 
-Error Mle::TxMessage::AppendActiveDatasetTlv(void)
-{
-    return Get<MeshCoP::ActiveDatasetManager>().AppendMleDatasetTlv(*this);
-}
+Error Mle::TxMessage::AppendActiveDatasetTlv(void) { return AppendDatasetTlv(MeshCoP::Dataset::kActive); }
 
-Error Mle::TxMessage::AppendPendingDatasetTlv(void)
+Error Mle::TxMessage::AppendPendingDatasetTlv(void) { return AppendDatasetTlv(MeshCoP::Dataset::kPending); }
+
+Error Mle::TxMessage::AppendDatasetTlv(MeshCoP::Dataset::Type mDatasetType)
 {
-    return Get<MeshCoP::PendingDatasetManager>().AppendMleDatasetTlv(*this);
+    Error            error = kErrorNotFound;
+    Tlv::Type        tlvType;
+    MeshCoP::Dataset dataset;
+
+    switch (mDatasetType)
+    {
+    case MeshCoP::Dataset::kActive:
+        error   = Get<MeshCoP::ActiveDatasetManager>().Read(dataset);
+        tlvType = Tlv::kActiveDataset;
+        break;
+
+    case MeshCoP::Dataset::kPending:
+        error   = Get<MeshCoP::PendingDatasetManager>().Read(dataset);
+        tlvType = Tlv::kPendingDataset;
+        break;
+    }
+
+    if (error != kErrorNone)
+    {
+        // If there's no dataset, no need to append TLV. We'll treat it
+        // as success.
+
+        ExitNow(error = kErrorNone);
+    }
+
+    // Remove the Timestamp TLV from Dataset before appending to the
+    // message. The Timestamp is appended as its own MLE TLV to the
+    // message.
+
+    dataset.RemoveTimestamp(mDatasetType);
+
+    error = Tlv::AppendTlv(*this, tlvType, dataset.GetBytes(), dataset.GetLength());
+
+exit:
+    return error;
 }
 
 Error Mle::TxMessage::AppendSteeringDataTlv(void)

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -45,6 +45,7 @@
 #include "common/timer.hpp"
 #include "crypto/aes_ccm.hpp"
 #include "mac/mac.hpp"
+#include "meshcop/dataset.hpp"
 #include "meshcop/joiner_router.hpp"
 #include "meshcop/meshcop.hpp"
 #include "net/udp6.hpp"
@@ -1053,6 +1054,7 @@ private:
     private:
         Error AppendCompressedAddressEntry(uint8_t aContextId, const Ip6::Address &aAddress);
         Error AppendAddressEntry(const Ip6::Address &aAddress);
+        Error AppendDatasetTlv(MeshCoP::Dataset::Type mDatasetType);
     };
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This commit refactors the code for preparing and appending MLE TLVs, moving it from `DatasetManager` to the `Mle` class for better alignment of responsibilities.

It adds `TxMessage::AppendDatasetTlv()`, which appends an Active or Pending Dataset (if present) to an MLE message following the proper MLE TLV format. This includes removing the corresponding `Timestamp` from the dataset, as MLE messages include timestamps using their own MLE TLVs rather than within the dataset itself.

----------

~This PR currently contains the commit from https://github.com/openthread/openthread/pull/10333. Please check and review the last commit. Thanks.~ 