### PR TITLE
[posix] extract co-processor init out of otSysInit

### DIFF
--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -275,12 +275,14 @@ static void ParseArg(int aArgCount, char *aArgVector[], PosixConfig *aConfig)
 
     for (; optind < aArgCount; optind++)
     {
-        VerifyOrDie(aConfig->mPlatformConfig.mRadioUrlNum < OT_ARRAY_LENGTH(aConfig->mPlatformConfig.mRadioUrls),
+        VerifyOrDie(aConfig->mPlatformConfig.mCoprocessorUrls.mNum <
+                        OT_ARRAY_LENGTH(aConfig->mPlatformConfig.mCoprocessorUrls.mUrls),
                     OT_EXIT_INVALID_ARGUMENTS);
-        aConfig->mPlatformConfig.mRadioUrls[aConfig->mPlatformConfig.mRadioUrlNum++] = aArgVector[optind];
+        aConfig->mPlatformConfig.mCoprocessorUrls.mUrls[aConfig->mPlatformConfig.mCoprocessorUrls.mNum++] =
+            aArgVector[optind];
     }
 
-    if (aConfig->mPlatformConfig.mRadioUrlNum == 0)
+    if (aConfig->mPlatformConfig.mCoprocessorUrls.mNum == 0)
     {
         PrintUsage(aArgVector[0], stderr, OT_EXIT_INVALID_ARGUMENTS);
     }

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -70,23 +70,47 @@ enum
 };
 
 /**
+ * Represents the Co-processor URLs.
+ *
+ */
+typedef struct otPlatformCoprocessorUrls
+{
+    const char *mUrls[OT_PLATFORM_CONFIG_MAX_RADIO_URLS]; ///< Co-processor URLs.
+    uint8_t     mNum;                                     ///< Number of Co-processor URLs.
+} otPlatformCoprocessorUrls;
+
+/**
  * Represents platform specific configurations.
  *
  */
 typedef struct otPlatformConfig
 {
-    const char *mBackboneInterfaceName;                        ///< Backbone network interface name.
-    const char *mInterfaceName;                                ///< Thread network interface name.
-    const char *mRadioUrls[OT_PLATFORM_CONFIG_MAX_RADIO_URLS]; ///< Radio URLs.
-    uint8_t     mRadioUrlNum;                                  ///< Number of Radio URLs.
-    int         mRealTimeSignal;                               ///< The real-time signal for microsecond timer.
-    uint32_t    mSpeedUpFactor;                                ///< Speed up factor.
-    bool        mPersistentInterface;                          ///< Whether persistent the interface
-    bool        mDryRun;                                       ///< If 'DryRun' is set, the posix daemon will exit
-                                                               ///< directly after initialization.
-    CoprocessorType mCoprocessorType;                          ///< The co-processor type. This field is used to pass
-                                                               ///< the type to the app layer.
+    const char               *mBackboneInterfaceName; ///< Backbone network interface name.
+    const char               *mInterfaceName;         ///< Thread network interface name.
+    otPlatformCoprocessorUrls mCoprocessorUrls;       ///< Coprocessor URLs.
+    int                       mRealTimeSignal;        ///< The real-time signal for microsecond timer.
+    uint32_t                  mSpeedUpFactor;         ///< Speed up factor.
+    bool                      mPersistentInterface;   ///< Whether persistent the interface
+    bool                      mDryRun;                ///< If 'DryRun' is set, the posix daemon will exit
+                                                      ///< directly after initialization.
+    CoprocessorType mCoprocessorType;                 ///< The co-processor type. This field is used to pass
+                                                      ///< the type to the app layer.
 } otPlatformConfig;
+
+/**
+ * Initializes the co-processor and the spinel driver.
+ *
+ * @note This API will initialize the co-processor by resetting it and return the co-processor type.
+ *       If this API is called, the upcoming call of `otSysInit` won't initialize the co-processor
+ *       and the spinel driver again, unless `otSysDeinit` is called. This API is used to get the
+ *       co-processor type without calling `otSysInit`.
+ *
+ * @param[in]  aUrls  The URLs to initialize the co-processor.
+ *
+ * @returns The co-processor type.
+ *
+ */
+CoprocessorType otSysInitCoprocessor(otPlatformCoprocessorUrls *aUrls);
 
 /**
  * Performs all platform-specific initialization of OpenThread's drivers and initializes the OpenThread


### PR DESCRIPTION
This PR adds a new posix sys API `otSysInitCoprocessor` which only
initializes the platform spinel component. (Reset the co-processor
and get the type)

The intention is to let the app to get the co-processor type without
creating the otInstance. Currently only `otSysInit` can be called
which creates the otInstance. However in some cases, we don't want to
create the instance at the early stage. For example, in this [PR](https://github.com/openthread/ot-br-posix/pull/2309/),
after knowing the co-processor type, `otSysInit` will be again called.
If using `otSysInit` to get the co-processor type at first, otInstance 
will be created twice.

This PR doesn't break the existing usage of `otSysInit`. `otSysInitCoprocessor`
isn't required to be called at first.

Depends-On: openthread/ot-br-posix#2318