### PR TITLE
[key-manager] update how the "Key Switch Guard Timer" is reset

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -275,7 +275,8 @@ uint32_t otThreadGetKeySequenceCounter(otInstance *aInstance)
 
 void otThreadSetKeySequenceCounter(otInstance *aInstance, uint32_t aKeySequenceCounter)
 {
-    AsCoreType(aInstance).Get<KeyManager>().SetCurrentKeySequence(aKeySequenceCounter, KeyManager::kForceUpdate);
+    AsCoreType(aInstance).Get<KeyManager>().SetCurrentKeySequence(
+        aKeySequenceCounter, KeyManager::kForceUpdate | KeyManager::kGuardTimerUnchanged);
 }
 
 uint16_t otThreadGetKeySwitchGuardTime(otInstance *aInstance)

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1641,7 +1641,7 @@ Error Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Neig
 
         if (keySequence > keyManager.GetCurrentKeySequence())
         {
-            keyManager.SetCurrentKeySequence(keySequence, KeyManager::kApplyKeySwitchGuard);
+            keyManager.SetCurrentKeySequence(keySequence, KeyManager::kApplySwitchGuard | KeyManager::kResetGuardTimer);
         }
     }
 

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -368,11 +368,11 @@ void KeyManager::UpdateKeyMaterial(void)
 #endif
 }
 
-void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence, KeySequenceUpdateMode aUpdateMode)
+void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence, KeySeqUpdateFlags aFlags)
 {
     VerifyOrExit(aKeySequence != mKeySequence, Get<Notifier>().SignalIfFirst(kEventThreadKeySeqCounterChanged));
 
-    if (aUpdateMode == kApplyKeySwitchGuard)
+    if (aFlags & kApplySwitchGuard)
     {
         VerifyOrExit(mKeySwitchGuardTimer == 0);
     }
@@ -384,7 +384,11 @@ void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence, KeySequenceUpdateM
     mMleFrameCounter = 0;
 
     ResetKeyRotationTimer();
-    mKeySwitchGuardTimer = mKeySwitchGuardTime;
+
+    if (aFlags & kResetGuardTimer)
+    {
+        mKeySwitchGuardTimer = mKeySwitchGuardTime;
+    }
 
     Get<Notifier>().Signal(kEventThreadKeySeqCounterChanged);
 
@@ -528,7 +532,7 @@ void KeyManager::CheckForKeyRotation(void)
 {
     if (mHoursSinceKeyRotation >= mSecurityPolicy.mRotationTime)
     {
-        SetCurrentKeySequence(mKeySequence + 1, kForceUpdate);
+        SetCurrentKeySequence(mKeySequence + 1, kForceUpdate | kResetGuardTimer);
     }
 }
 

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -221,16 +221,24 @@ class KeyManager : public InstanceLocator, private NonCopyable
 {
 public:
     /**
-     * Determines whether to apply or ignore key switch guard when updating the key sequence.
+     * Defines bit-flag constants specifying how to handle key sequence update used in `KeySeqUpdateFlags`.
+     *
+     */
+    enum KeySeqUpdateFlag : uint8_t
+    {
+        kApplySwitchGuard    = (1 << 0), ///< Apply key switch guard check.
+        kForceUpdate         = (0 << 0), ///< Ignore key switch guard check and forcibly update.
+        kResetGuardTimer     = (1 << 1), ///< On key seq change, reset the guard timer.
+        kGuardTimerUnchanged = (0 << 1), ///< On key seq change, leave guard timer unchanged.
+    };
+
+    /**
+     * Represents a combination of `KeySeqUpdateFlag` bits.
      *
      * Used as input by `SetCurrentKeySequence()`.
      *
      */
-    enum KeySequenceUpdateMode : uint8_t
-    {
-        kApplyKeySwitchGuard, ///< Apply key switch guard check before setting the new key sequence.
-        kForceUpdate,         ///< Ignore key switch guard check and forcibly update the key sequence to new value.
-    };
+    typedef uint8_t KeySeqUpdateFlags;
 
     /**
      * Initializes the object.
@@ -342,14 +350,12 @@ public:
     /**
      * Sets the current key sequence value.
      *
-     * If @p aMode is `kApplyKeySwitchGuard`, the current key switch guard timer is checked and only if it is zero, key
-     * sequence will be updated.
-     *
      * @param[in]  aKeySequence    The key sequence value.
-     * @param[in]  aUpdateMode     Whether or not to apply the key switch guard.
+     * @param[in]  aFlags          Specify behavior when updating the key sequence, i.e., whether or not to apply the
+     *                             key switch guard or reset guard timer upon change.
      *
      */
-    void SetCurrentKeySequence(uint32_t aKeySequence, KeySequenceUpdateMode aUpdateMode);
+    void SetCurrentKeySequence(uint32_t aKeySequence, KeySeqUpdateFlags aFlags);
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
     /**

--- a/tests/scripts/thread-cert/Cert_5_8_02_KeyIncrement.py
+++ b/tests/scripts/thread-cert/Cert_5_8_02_KeyIncrement.py
@@ -42,13 +42,11 @@ class Cert_5_8_2_KeyIncrement(thread_cert.TestCase):
     TOPOLOGY = {
         LEADER: {
             'name': 'LEADER',
-            'key_switch_guardtime': 0,
             'mode': 'rdn',
             'allowlist': [ROUTER]
         },
         ROUTER: {
             'name': 'ROUTER',
-            'key_switch_guardtime': 0,
             'mode': 'rdn',
             'allowlist': [LEADER]
         },

--- a/tests/scripts/thread-cert/Cert_5_8_03_KeyIncrementRollOver.py
+++ b/tests/scripts/thread-cert/Cert_5_8_03_KeyIncrementRollOver.py
@@ -43,13 +43,11 @@ class Cert_5_8_3_KeyIncrementRollOver(thread_cert.TestCase):
         LEADER: {
             'name': 'LEADER',
             'key_sequence_counter': 127,
-            'key_switch_guardtime': 0,
             'mode': 'rdn',
             'allowlist': [ROUTER]
         },
         ROUTER: {
             'name': 'ROUTER',
-            'key_switch_guardtime': 0,
             'mode': 'rdn',
             'allowlist': [LEADER]
         },

--- a/tests/scripts/thread-cert/Cert_6_6_01_KeyIncrement.py
+++ b/tests/scripts/thread-cert/Cert_6_6_01_KeyIncrement.py
@@ -42,14 +42,12 @@ class Cert_6_6_1_KeyIncrement(thread_cert.TestCase):
     TOPOLOGY = {
         LEADER: {
             'name': 'LEADER',
-            'key_switch_guardtime': 0,
             'mode': 'rdn',
             'allowlist': [ED]
         },
         ED: {
             'name': 'ED',
             'is_mtd': True,
-            'key_switch_guardtime': 0,
             'mode': 'rn',
             'allowlist': [LEADER]
         },

--- a/tests/scripts/thread-cert/Cert_6_6_02_KeyIncrementRollOver.py
+++ b/tests/scripts/thread-cert/Cert_6_6_02_KeyIncrementRollOver.py
@@ -43,14 +43,12 @@ class Cert_6_6_2_KeyIncrement1(thread_cert.TestCase):
         LEADER: {
             'name': 'LEADER',
             'key_sequence_counter': 127,
-            'key_switch_guardtime': 0,
             'mode': 'rdn',
             'allowlist': [ED]
         },
         ED: {
             'name': 'ED',
             'is_mtd': True,
-            'key_switch_guardtime': 0,
             'mode': 'rn',
             'allowlist': [LEADER]
         },

--- a/tests/scripts/thread-cert/thread_cert.py
+++ b/tests/scripts/thread-cert/thread_cert.py
@@ -207,8 +207,6 @@ class TestCase(NcpSupportMixin, unittest.TestCase):
                                                   channel=params['pending_dataset'].get('channel'),
                                                   delay=params['pending_dataset'].get('delay'))
 
-            if 'key_switch_guardtime' in params:
-                self.nodes[i].set_key_switch_guardtime(params['key_switch_guardtime'])
             if 'key_sequence_counter' in params:
                 self.nodes[i].set_key_sequence_counter(params['key_sequence_counter'])
 


### PR DESCRIPTION
This commit updates the resetting of the Key Switch Guard Timer. It is now reset under two conditions:

- The device itself triggers a key rotation and moves to the next key sequence after the rotation time has passed since the last switch.
- The device receives a MAC or MLE message with an incoming key index matching the next key index. Regarding MLE messages, this rule is applied regardless of the message being classified as Authoritative or Peer.

---


Relates to [SPEC-1293](https://threadgroup.atlassian.net/browse/SPEC-1293)