### PR TITLE
[mle] add `Mle::RxMessage::ReadAndSave{Active/Pending}Dataset()`

### DIFF
--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -267,22 +267,6 @@ void DatasetManager::Clear(void)
     SignalDatasetChange();
 }
 
-Error DatasetManager::Save(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint16_t aLength)
-{
-    Error   error = kErrorNone;
-    Dataset dataset;
-
-    SuccessOrExit(error = dataset.SetFrom(aMessage, aOffset, aLength));
-    SuccessOrExit(error = dataset.ValidateTlvs());
-
-    SuccessOrExit(error = dataset.WriteTimestamp(mType, aTimestamp));
-
-    error = Save(dataset);
-
-exit:
-    return error;
-}
-
 Error DatasetManager::Save(const Dataset &aDataset, bool aAllowOlderTimestamp)
 {
     Error error = kErrorNone;

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -163,23 +163,6 @@ public:
     Error Save(const Dataset &aDataset) { return Save(aDataset, /* aAllowOlderTimestamp */ false); }
 
     /**
-     * Sets the Operational Dataset for the partition read from a given message.
-     *
-     * Also updates the non-volatile local version if the partition's Operational Dataset is newer. If Active
-     * Operational Dataset is changed, applies the configuration to to Thread interface.
-     *
-     * @param[in]  aTimestamp  The timestamp for the Operational Dataset.
-     * @param[in]  aMessage    The message to read from.
-     * @param[in]  aOffset     The offset where the Operational Dataset begins.
-     * @param[in]  aLength     The length of the Operational Dataset.
-     *
-     * @retval kErrorNone     Successfully parsed the Dataset from the @p aMessage and saved it.
-     * @retval kErrorParse    Could not parse the Dataset from @p aMessage.
-     *
-     */
-    Error Save(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint16_t aLength);
-
-    /**
      * Retrieves the channel mask from local dataset.
      *
      * @param[out]  aChannelMask  A reference to the channel mask.

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1055,7 +1055,7 @@ private:
     private:
         Error AppendCompressedAddressEntry(uint8_t aContextId, const Ip6::Address &aAddress);
         Error AppendAddressEntry(const Ip6::Address &aAddress);
-        Error AppendDatasetTlv(MeshCoP::Dataset::Type mDatasetType);
+        Error AppendDatasetTlv(MeshCoP::Dataset::Type aDatasetType);
     };
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1072,6 +1072,8 @@ private:
         Error ReadFrameCounterTlvs(uint32_t &aLinkFrameCounter, uint32_t &aMleFrameCounter) const;
         Error ReadTlvRequestTlv(TlvList &aTlvList) const;
         Error ReadLeaderDataTlv(LeaderData &aLeaderData) const;
+        Error ReadAndSaveActiveDataset(const MeshCoP::Timestamp &aActiveTimestamp) const;
+        Error ReadAndSavePendingDataset(const MeshCoP::Timestamp &aPendingTimestamp) const;
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
         Error ReadCslClockAccuracyTlv(Mac::CslAccuracy &aCslAccuracy) const;
 #endif
@@ -1081,6 +1083,7 @@ private:
 
     private:
         Error ReadChallengeOrResponse(uint8_t aTlvType, RxChallenge &aRxChallenge) const;
+        Error ReadAndSaveDataset(MeshCoP::Dataset::Type aDatasetType, const MeshCoP::Timestamp &aTimestamp) const;
     };
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This commit adds `ReadAndSave{Active/Pending}Dataset()` helper methods to `Mle::RxMessage` to read the Active or Pending Dataset from a received MLE message and save it in the corresponding `DatasetManager`.

This commit also refactors the code for parsing the MLE TLVs, moving it from `DatasetManager` to the `Mle` class for better alignment of responsibilities.