### PR TITLE
[message] avoid dropping of fragment reassembly queue due to duplicates

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1505,12 +1505,20 @@ void MeshForwarder::HandleFragment(FrameData            &aFrameData,
             // Security Check: only consider reassembly buffers that had the same Security Enabled setting.
             if (msg.GetLength() == fragmentHeader.GetDatagramSize() &&
                 msg.GetDatagramTag() == fragmentHeader.GetDatagramTag() &&
-                msg.GetOffset() == fragmentHeader.GetDatagramOffset() &&
+                msg.GetOffset() <= fragmentHeader.GetDatagramOffset() &&
                 msg.GetOffset() + aFrameData.GetLength() <= fragmentHeader.GetDatagramSize() &&
                 msg.IsLinkSecurityEnabled() == aLinkInfo.IsLinkSecurityEnabled())
             {
-                message = &msg;
-                break;
+                if(msg.GetOffset() < fragmentHeader.GetDatagramOffset())
+                {
+                    LogDebg("Received duplicate fragment with a matching fragmentation offset, tag and security");
+                    ExitNow(error = kErrorDrop);
+                }
+                else
+                {
+                    message = &msg;
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Sometimes duplicate fragments can be received due to conditions like a lost ACK. When such a duplicate fragment is received which doest match the next offset, the whole reassembly queue is dropped. All subsequent fragments are also dropped. This commit avoids fragment drop due to reception of duplicates.