### PR TITLE
[srp-client] use sequential message IDs & allow older response IDs

### DIFF
--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -167,7 +167,7 @@ public:
 
     private:
         void SetName(const char *aName) { mName = aName; }
-        void SetState(ItemState aState);
+        bool SetState(ItemState aState);
         void SetAddresses(const Ip6::Address *aAddresses, uint8_t aNumAddresses);
         void EnableAutoAddress(void);
     };
@@ -303,7 +303,7 @@ public:
         static constexpr uint32_t kAppendedInMsgFlag = (1U << 31);
         static constexpr uint32_t kLeaseMask         = ~kAppendedInMsgFlag;
 
-        void      SetState(ItemState aState);
+        bool      SetState(ItemState aState);
         TimeMilli GetLeaseRenewTime(void) const { return TimeMilli(mData); }
         void      SetLeaseRenewTime(TimeMilli aTime) { mData = aTime.GetValue(); }
         bool      IsAppendedInMessage(void) const { return mLease & kAppendedInMsgFlag; }
@@ -788,6 +788,17 @@ public:
      *
      */
     bool GetUseShortLeaseOption(void) const { return mUseShortLeaseOption; }
+
+    /**
+     * Set the next DNS message ID for client to use.
+     *
+     * This is intended for testing only.
+     *
+     * @pram[in] aMessageId  A message ID.
+     *
+     */
+    void SetNextMessageId(uint16_t aMessageId) { mNextMessageId = aMessageId; }
+
 #endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 
 private:
@@ -1007,7 +1018,7 @@ private:
     void  UpdateServiceStateToRemove(Service &aService);
     State GetState(void) const { return mState; }
     void  SetState(State aState);
-    void  ChangeHostAndServiceStates(const ItemState *aNewStates, ServiceStateChangeMode aMode);
+    bool  ChangeHostAndServiceStates(const ItemState *aNewStates, ServiceStateChangeMode aMode);
     void  InvokeCallback(Error aError) const;
     void  InvokeCallback(Error aError, const HostInfo &aHostInfo, const Service *aRemovedServices) const;
     void  HandleHostInfoOrServiceChange(void);
@@ -1031,6 +1042,7 @@ private:
     void         UpdateRecordLengthInMessage(Dns::ResourceRecord &aRecord, uint16_t aOffset, Message &aMessage) const;
     static void  HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void         ProcessResponse(Message &aMessage);
+    bool         IsResponseMessageIdValid(uint16_t aId) const;
     void         HandleUpdateDone(void);
     void         GetRemovedServices(LinkedList<Service> &aRemovedServices);
     static Error ReadResourceRecord(const Message &aMessage, uint16_t &aOffset, Dns::ResourceRecord &aRecord);
@@ -1073,7 +1085,8 @@ private:
     bool mUseShortLeaseOption : 1;
 #endif
 
-    uint16_t mUpdateMessageId;
+    uint16_t mNextMessageId;
+    uint16_t mResponseMessageId;
     uint16_t mAutoHostAddressCount;
     uint32_t mRetryWaitInterval;
 


### PR DESCRIPTION
This commit updates `Srp::Client` to use sequential message IDs, replacing the previous model where message IDs were generated randomly.

When processing responses from the server, older message IDs are accepted as long as the corresponding older message was identical to the latest one. This helps in situations where the server's response may be delayed  (e.g., due to network congestion) and the client retry mechanism is retransmitting the same update message.

This commit also adds a unit test `TestSrpClientDelayedResponse()` to validate the new behavior.

----

Relates to [SPEC-1290](https://threadgroup.atlassian.net/browse/SPEC-1290)