### PR TITLE
[diag] replace diag output buffer with diag output callback

### DIFF
--- a/examples/platforms/simulation/diag.c
+++ b/examples/platforms/simulation/diag.c
@@ -58,6 +58,13 @@ static bool       sGpioValue = false;
 static uint8_t    sRawPowerSetting[OPENTHREAD_CONFIG_POWER_CALIBRATION_RAW_POWER_SETTING_SIZE];
 static uint16_t   sRawPowerSettingLength = 0;
 
+void otPlatDiagSetOutputCallback(otInstance *aInstance, otPlatDiagOutputCallback aCallback, void *aContext)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aCallback);
+    OT_UNUSED_VARIABLE(aContext);
+}
+
 void otPlatDiagModeSet(bool aMode) { sDiagMode = aMode; }
 
 bool otPlatDiagModeGet(void) { return sDiagMode; }

--- a/include/openthread/diag.h
+++ b/include/openthread/diag.h
@@ -36,6 +36,7 @@
 #define OPENTHREAD_DIAG_H_
 
 #include <openthread/instance.h>
+#include <openthread/platform/diag.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,39 +52,38 @@ extern "C" {
  *
  */
 
+/* Represents the pointer to callback to output diag messages. */
+typedef otPlatDiagOutputCallback otDiagOutputCallback;
+
+/**
+ * Sets the diag output callback.
+ *
+ * @param[in]  aInstance   The OpenThread instance structure.
+ * @param[in]  aCallback   A pointer to a function that is called on outputting diag messages.
+ * @param[in]  aContext    A pointer to the user context.
+ *
+ */
+void otDiagSetOutputCallback(otInstance *aInstance, otDiagOutputCallback aCallback, void *aContext);
+
 /**
  * Processes a factory diagnostics command line.
- *
- * The output of this function (the content written to @p aOutput) MUST terminate with `\0` and the `\0` is within the
- * output buffer.
  *
  * @param[in]   aInstance       A pointer to an OpenThread instance.
  * @param[in]   aArgsLength     The number of elements in @p aArgs.
  * @param[in]   aArgs           An array of arguments.
- * @param[out]  aOutput         The diagnostics execution result.
- * @param[in]   aOutputMaxLen   The output buffer size.
  *
  * @retval  OT_ERROR_INVALID_ARGS       The command is supported but invalid arguments provided.
  * @retval  OT_ERROR_NONE               The command is successfully process.
  * @retval  OT_ERROR_NOT_IMPLEMENTED    The command is not supported.
  *
  */
-otError otDiagProcessCmd(otInstance *aInstance,
-                         uint8_t     aArgsLength,
-                         char       *aArgs[],
-                         char       *aOutput,
-                         size_t      aOutputMaxLen);
+otError otDiagProcessCmd(otInstance *aInstance, uint8_t aArgsLength, char *aArgs[]);
 
 /**
  * Processes a factory diagnostics command line.
  *
- * The output of this function (the content written to @p aOutput) MUST terminate with `\0` and the `\0` is within the
- * output buffer.
- *
  * @param[in]   aInstance       A pointer to an OpenThread instance.
  * @param[in]   aString         A NULL-terminated input string.
- * @param[out]  aOutput         The diagnostics execution result.
- * @param[in]   aOutputMaxLen   The output buffer size.
  *
  * @retval  OT_ERROR_NONE               The command is successfully process.
  * @retval  OT_ERROR_INVALID_ARGS       The command is supported but invalid arguments provided.
@@ -91,7 +91,7 @@ otError otDiagProcessCmd(otInstance *aInstance,
  * @retval  OT_ERROR_NO_BUFS            The command string is too long.
  *
  */
-otError otDiagProcessCmdLine(otInstance *aInstance, const char *aString, char *aOutput, size_t aOutputMaxLen);
+otError otDiagProcessCmdLine(otInstance *aInstance, const char *aString);
 
 /**
  * Indicates whether or not the factory diagnostics mode is enabled.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (422)
+#define OPENTHREAD_API_VERSION (423)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/diag.h
+++ b/include/openthread/platform/diag.h
@@ -67,27 +67,38 @@ typedef enum
 } otGpioMode;
 
 /**
- * Processes a factory diagnostics command line.
+ * Pointer to callback to output platform diag messages.
  *
- * The output of this function (the content written to @p aOutput) MUST terminate with `\0` and the `\0` is within the
- * output buffer.
+ * @param[in]  aFormat     The format string.
+ * @param[in]  aArguments  The format string arguments.
+ * @param[out] aContext    A pointer to the user context.
+ *
+ */
+typedef void (*otPlatDiagOutputCallback)(const char *aFormat, va_list aArguments, void *aContext);
+
+/**
+ * Sets the platform diag output callback.
+ *
+ * @param[in]  aInstance   The OpenThread instance structure.
+ * @param[in]  aCallback   A pointer to a function that is called on outputting diag messages.
+ * @param[in]  aContext    A pointer to the user context.
+ *
+ */
+void otPlatDiagSetOutputCallback(otInstance *aInstance, otPlatDiagOutputCallback aCallback, void *aContext);
+
+/**
+ * Processes a factory diagnostics command line.
  *
  * @param[in]   aInstance       The OpenThread instance for current request.
  * @param[in]   aArgsLength     The number of arguments in @p aArgs.
  * @param[in]   aArgs           The arguments of diagnostics command line.
- * @param[out]  aOutput         The diagnostics execution result.
- * @param[in]   aOutputMaxLen   The output buffer size.
  *
  * @retval  OT_ERROR_INVALID_ARGS       The command is supported but invalid arguments provided.
  * @retval  OT_ERROR_NONE               The command is successfully process.
  * @retval  OT_ERROR_INVALID_COMMAND    The command is not valid or not supported.
  *
  */
-otError otPlatDiagProcess(otInstance *aInstance,
-                          uint8_t     aArgsLength,
-                          char       *aArgs[],
-                          char       *aOutput,
-                          size_t      aOutputMaxLen);
+otError otPlatDiagProcess(otInstance *aInstance, uint8_t aArgsLength, char *aArgs[]);
 
 /**
  * Enables/disables the factory diagnostics mode.

--- a/script/check-size
+++ b/script/check-size
@@ -105,9 +105,11 @@ build_nrf52840()
     case "$2" in
         new)
             local sha=${OT_SHA_NEW}
+            local clone_options=("clone")
             ;;
         old)
             local sha=${OT_SHA_OLD}
+            local clone_options=("clone" "no-depend")
             ;;
         *)
             exit 128
@@ -119,7 +121,7 @@ build_nrf52840()
     local config_file="../examples/config/${config_name}"
 
     mkdir -p "${OT_TMP_DIR}/${folder}"
-    script/git-tool clone https://github.com/openthread/ot-nrf528xx.git "${OT_TMP_DIR}/${folder}"
+    script/git-tool "${clone_options[@]}" https://github.com/openthread/ot-nrf528xx.git "${OT_TMP_DIR}/${folder}"
     rm -rf "${OT_TMP_DIR}/${folder}/openthread/*" # replace openthread submodule with latest commit
     git archive "${sha}" | tar x -C "${OT_TMP_DIR}/${folder}/openthread"
 

--- a/script/git-tool
+++ b/script/git-tool
@@ -80,10 +80,15 @@ try_clone()
 {
     local dest_dir
 
-    dest_dir="$(git clone "$@" 2>&1 | tee | cut -d\' -f2)"
+    if [[ $1 == no-depend ]]; then
+        shift
+        git clone "$@" 2>&1
+    else
+        dest_dir="$(git clone "$@" 2>&1 | tee | cut -d\' -f2)"
 
-    cd "${dest_dir}"
-    get_pr_body | apply_dependencies
+        cd "${dest_dir}"
+        get_pr_body | apply_dependencies
+    fi
 }
 
 print_help()

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -339,6 +339,11 @@ private:
 
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD
 
+#if OPENTHREAD_CONFIG_DIAG_ENABLE
+    static void HandleDiagOutput(const char *aFormat, va_list aArguments, void *aContext);
+    void        HandleDiagOutput(const char *aFormat, va_list aArguments);
+#endif
+
     void SetCommandTimeout(uint32_t aTimeoutMilli);
 
     static void HandleTimer(Timer &aTimer);

--- a/src/core/api/diags_api.cpp
+++ b/src/core/api/diags_api.cpp
@@ -42,18 +42,22 @@
 
 using namespace ot;
 
-otError otDiagProcessCmdLine(otInstance *aInstance, const char *aString, char *aOutput, size_t aOutputMaxLen)
+otError otDiagProcessCmdLine(otInstance *aInstance, const char *aString)
 {
     AssertPointerIsNotNull(aString);
 
-    return AsCoreType(aInstance).Get<FactoryDiags::Diags>().ProcessLine(aString, aOutput, aOutputMaxLen);
+    return AsCoreType(aInstance).Get<FactoryDiags::Diags>().ProcessLine(aString);
 }
 
-otError otDiagProcessCmd(otInstance *aInstance, uint8_t aArgsLength, char *aArgs[], char *aOutput, size_t aOutputMaxLen)
+otError otDiagProcessCmd(otInstance *aInstance, uint8_t aArgsLength, char *aArgs[])
 {
-    return AsCoreType(aInstance).Get<FactoryDiags::Diags>().ProcessCmd(aArgsLength, aArgs, aOutput, aOutputMaxLen);
+    return AsCoreType(aInstance).Get<FactoryDiags::Diags>().ProcessCmd(aArgsLength, aArgs);
 }
 
 bool otDiagIsEnabled(otInstance *aInstance) { return AsCoreType(aInstance).Get<FactoryDiags::Diags>().IsEnabled(); }
 
+void otDiagSetOutputCallback(otInstance *aInstance, otDiagOutputCallback aCallback, void *aContext)
+{
+    AsCoreType(aInstance).Get<FactoryDiags::Diags>().SetOutputCallback(aCallback, aContext);
+}
 #endif // OPENTHREAD_CONFIG_DIAG_ENABLE

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -34,6 +34,7 @@
 #ifndef RADIO_SPINEL_HPP_
 #define RADIO_SPINEL_HPP_
 
+#include <openthread/platform/diag.h>
 #include <openthread/platform/radio.h>
 
 #include "openthread-spinel-config.h"
@@ -678,15 +679,22 @@ public:
      * Processes platform diagnostics commands.
      *
      * @param[in]   aString         A null-terminated input string.
-     * @param[out]  aOutput         The diagnostics execution result.
-     * @param[in]   aOutputMaxLen   The output buffer size.
      *
      * @retval  OT_ERROR_NONE               Succeeded.
      * @retval  OT_ERROR_BUSY               Failed due to another operation is on going.
      * @retval  OT_ERROR_RESPONSE_TIMEOUT   Failed due to no response received from the transceiver.
      *
      */
-    otError PlatDiagProcess(const char *aString, char *aOutput, size_t aOutputMaxLen);
+    otError PlatDiagProcess(const char *aString);
+
+    /**
+     * Sets the diag output callback.
+     *
+     * @param[in]  aCallback   A pointer to a function that is called on outputting diag messages.
+     * @param[in]  aContext    A pointer to the user context.
+     *
+     */
+    void SetDiagOutputCallback(otPlatDiagOutputCallback aCallback, void *aContext);
 #endif
 
     /**
@@ -1194,6 +1202,10 @@ private:
     static otError ReadMacKey(const otMacKeyMaterial &aKeyMaterial, otMacKey &aKey);
 #endif
 
+#if OPENTHREAD_CONFIG_DIAG_ENABLE
+    void PlatDiagOutput(const char *aFormat, ...);
+#endif
+
     otInstance *mInstance;
 
     RadioSpinelCallbacks mCallbacks; ///< Callbacks for notifications of higher layer.
@@ -1281,9 +1293,9 @@ private:
 #endif // OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-    bool   mDiagMode;
-    char  *mDiagOutput;
-    size_t mDiagOutputMaxLen;
+    bool                     mDiagMode;
+    otPlatDiagOutputCallback mOutputCallback;
+    void                    *mOutputContext;
 #endif
 
     uint64_t mTxRadioEndUs;

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -549,6 +549,11 @@ protected:
     static uint8_t      ConvertLogLevel(otLogLevel aLogLevel);
     static unsigned int ConvertLogRegion(otLogRegion aLogRegion);
 
+#if OPENTHREAD_CONFIG_DIAG_ENABLE
+    static void HandleDiagOutput_Jump(const char *aFormat, va_list aArguments, void *aContext);
+    void        HandleDiagOutput(const char *aFormat, va_list aArguments);
+#endif
+
 #if OPENTHREAD_ENABLE_NCP_VENDOR_HOOK
     /**
      * Defines a vendor "command handler" hook to process vendor-specific spinel commands.
@@ -734,6 +739,11 @@ protected:
     bool mDidInitialUpdates;
 
     uint64_t mLogTimestampBase; // Timestamp base used for logging
+
+#if OPENTHREAD_CONFIG_DIAG_ENABLE
+    char    *mDiagOutput;
+    uint16_t mDiagOutputLen;
+#endif
 };
 
 } // namespace Ncp

--- a/src/posix/platform/rcp_caps_diag.cpp
+++ b/src/posix/platform/rcp_caps_diag.cpp
@@ -86,14 +86,11 @@ const struct RcpCapsDiag::SpinelEntry RcpCapsDiag::sSpinelEntries[] = {
     SPINEL_ENTRY(kCategoryOptional, SPINEL_CMD_PROP_VALUE_GET, SPINEL_PROP_PHY_CCA_THRESHOLD),
 };
 
-otError RcpCapsDiag::DiagProcess(char *aArgs[], uint8_t aArgsLength, char *aOutput, size_t aOutputMaxLen)
+otError RcpCapsDiag::DiagProcess(char *aArgs[], uint8_t aArgsLength)
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
-
-    mOutputStart = aOutput;
-    mOutputEnd   = aOutput + aOutputMaxLen;
 
     if (strcmp(aArgs[1], "spinel") == 0)
     {
@@ -103,9 +100,6 @@ otError RcpCapsDiag::DiagProcess(char *aArgs[], uint8_t aArgsLength, char *aOutp
     {
         error = OT_ERROR_INVALID_COMMAND;
     }
-
-    mOutputStart = nullptr;
-    mOutputEnd   = nullptr;
 
 exit:
     return error;
@@ -137,6 +131,12 @@ void RcpCapsDiag::TestSpinelCommands(Category aCategory)
     }
 }
 
+void RcpCapsDiag::SetDiagOutputCallback(otPlatDiagOutputCallback aCallback, void *aContext)
+{
+    mOutputCallback = aCallback;
+    mOutputContext  = aContext;
+}
+
 void RcpCapsDiag::OutputResult(const SpinelEntry &aEntry, otError error)
 {
     static constexpr uint8_t  kSpaceLength            = 1;
@@ -161,9 +161,9 @@ void RcpCapsDiag::Output(const char *aFormat, ...)
 
     va_start(args, aFormat);
 
-    if ((mOutputStart != nullptr) && (mOutputEnd != nullptr) && (mOutputStart < mOutputEnd))
+    if (mOutputCallback != nullptr)
     {
-        mOutputStart += vsnprintf(mOutputStart, static_cast<size_t>(mOutputEnd - mOutputStart), aFormat, args);
+        mOutputCallback(aFormat, args, mOutputContext);
     }
 
     va_end(args);

--- a/src/posix/platform/rcp_caps_diag.hpp
+++ b/src/posix/platform/rcp_caps_diag.hpp
@@ -37,6 +37,8 @@
 #include "platform-posix.h"
 
 #if OPENTHREAD_POSIX_CONFIG_RCP_CAPS_DIAG_ENABLE
+#include <openthread/platform/diag.h>
+
 #include "lib/spinel/radio_spinel.hpp"
 #include "lib/spinel/spinel.h"
 
@@ -58,8 +60,8 @@ public:
      */
     explicit RcpCapsDiag(Spinel::RadioSpinel &aRadioSpinel)
         : mRadioSpinel(aRadioSpinel)
-        , mOutputStart(nullptr)
-        , mOutputEnd(nullptr)
+        , mOutputCallback(nullptr)
+        , mOutputContext(nullptr)
     {
     }
 
@@ -68,15 +70,22 @@ public:
      *
      * @param[in]   aArgs           The arguments of diagnostics command line.
      * @param[in]   aArgsLength     The number of arguments in @p aArgs.
-     * @param[out]  aOutput         The diagnostics execution result.
-     * @param[in]   aOutputMaxLen   The output buffer size.
      *
      * @retval  OT_ERROR_INVALID_ARGS       The command is supported but invalid arguments provided.
      * @retval  OT_ERROR_NONE               The command is successfully processed.
      * @retval  OT_ERROR_INVALID_COMMAND    The command is not valid or not supported.
      *
      */
-    otError DiagProcess(char *aArgs[], uint8_t aArgsLength, char *aOutput, size_t aOutputMaxLen);
+    otError DiagProcess(char *aArgs[], uint8_t aArgsLength);
+
+    /**
+     * Sets the diag output callback.
+     *
+     * @param[in]  aCallback   A pointer to a function that is called on outputting diag messages.
+     * @param[in]  aContext    A user context pointer.
+     *
+     */
+    void SetDiagOutputCallback(otPlatDiagOutputCallback aCallback, void *aContext);
 
 private:
     template <uint32_t aCommand, spinel_prop_key_t aKey> otError HandleSpinelCommand(void);
@@ -108,9 +117,9 @@ private:
 
     static const struct SpinelEntry sSpinelEntries[];
 
-    Spinel::RadioSpinel &mRadioSpinel;
-    char                *mOutputStart;
-    char                *mOutputEnd;
+    Spinel::RadioSpinel     &mRadioSpinel;
+    otPlatDiagOutputCallback mOutputCallback;
+    void                    *mOutputContext;
 };
 
 } // namespace Posix

--- a/tests/fuzz/fuzzer_platform.cpp
+++ b/tests/fuzz/fuzzer_platform.cpp
@@ -488,17 +488,18 @@ otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
 
 void otPlatSettingsWipe(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
 
-otError otPlatDiagProcess(otInstance *aInstance,
-                          uint8_t     aArgsLength,
-                          char       *aArgs[],
-                          char       *aOutput,
-                          size_t      aOutputMaxLen)
+void otPlatDiagSetOutputCallback(otInstance *aInstance, otPlatDiagOutputCallback aCallback, void *aContext)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aCallback);
+    OT_UNUSED_VARIABLE(aContext);
+}
+
+otError otPlatDiagProcess(otInstance *aInstance, uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
-    OT_UNUSED_VARIABLE(aOutput);
-    OT_UNUSED_VARIABLE(aOutputMaxLen);
 
     return OT_ERROR_INVALID_COMMAND;
 }

--- a/tests/unit/test_platform.h
+++ b/tests/unit/test_platform.h
@@ -33,6 +33,7 @@
 
 #include <openthread/config.h>
 #include <openthread/platform/alarm-milli.h>
+#include <openthread/platform/diag.h>
 #include <openthread/platform/dns.h>
 #include <openthread/platform/dnssd.h>
 #include <openthread/platform/dso_transport.h>


### PR DESCRIPTION
The length of diag output messages is limited by the diag buffer size. Developers have to change the diag buffer size to allow diag module to output long messages. If diag output messages become longer and longer, developers have to keep changing the diag buffer size.

This commit adds an output callback to diag module to output diag messages. Then the length of diag output messages won't be limited by the diag buffer size.

Depends-On: openthread/ot-nrf528xx#822