### PR TITLE
[mle] add `Mle::RxMessage::ReadAndSetNetworkDataTlv()`

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1072,6 +1072,7 @@ private:
         Error ReadFrameCounterTlvs(uint32_t &aLinkFrameCounter, uint32_t &aMleFrameCounter) const;
         Error ReadTlvRequestTlv(TlvList &aTlvList) const;
         Error ReadLeaderDataTlv(LeaderData &aLeaderData) const;
+        Error ReadAndSetNetworkDataTlv(const LeaderData &aLeaderData) const;
         Error ReadAndSaveActiveDataset(const MeshCoP::Timestamp &aActiveTimestamp) const;
         Error ReadAndSavePendingDataset(const MeshCoP::Timestamp &aPendingTimestamp) const;
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE


### PR DESCRIPTION
This commit adds `ReadAndSetNetworkDataTlv()` to `Mle::RxMessage` to read the Network Data TLV from a received MLE message and set it in `NetworkData::Leader`.