### PR TITLE
[dsnsd-server] support handling of "A record" queries

### DIFF
--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -326,12 +326,19 @@ private:
         kTxtQuery,
         kSrvTxtQuery,
         kAaaaQuery,
+        kAQuery,
     };
 
     enum Section : uint8_t
     {
         kAnswerSection,
         kAdditionalDataSection,
+    };
+
+    enum AddrType : uint8_t
+    {
+        kIp6AddrType,
+        kIp4AddrType,
     };
 
 #if OPENTHREAD_CONFIG_DNSSD_DISCOVERY_PROXY_ENABLE
@@ -342,6 +349,7 @@ private:
         kResolvingSrv,
         kResolvingTxt,
         kResolvingIp6Address,
+        kResolvingIp4Address
     };
 #endif
 
@@ -384,33 +392,35 @@ private:
     {
     public:
         explicit Response(Instance &aInstance);
-        Error        AllocateAndInitFrom(const Request &aRequest);
-        void         InitFrom(ProxyQuery &aQuery, const ProxyQueryInfo &aInfo);
-        void         SetResponseCode(ResponseCode aResponseCode) { mHeader.SetResponseCode(aResponseCode); }
         ResponseCode AddQuestionsFrom(const Request &aRequest);
-        Error        ParseQueryName(void);
-        void         ReadQueryName(Name::Buffer &aName) const;
-        bool         QueryNameMatches(const char *aName) const;
-        Error        AppendQueryName(void);
-        Error        AppendPtrRecord(const char *aInstanceLabel, uint32_t aTtl);
-        Error        AppendSrvRecord(const ServiceInstanceInfo &aInstanceInfo);
-        Error        AppendSrvRecord(const char *aHostName,
-                                     uint32_t    aTtl,
-                                     uint16_t    aPriority,
-                                     uint16_t    aWeight,
-                                     uint16_t    aPort);
-        Error        AppendTxtRecord(const ServiceInstanceInfo &aInstanceInfo);
-        Error        AppendTxtRecord(const void *aTxtData, uint16_t aTxtLength, uint32_t aTtl);
-        Error        AppendHostAddresses(const HostInfo &aHostInfo);
-        Error        AppendHostAddresses(const ServiceInstanceInfo &aInstanceInfo);
-        Error        AppendHostAddresses(const Ip6::Address *aAddrs, uint16_t aAddrsLength, uint32_t aTtl);
-        Error        AppendAaaaRecord(const Ip6::Address &aAddress, uint32_t aTtl);
-        void         UpdateRecordLength(ResourceRecord &aRecord, uint16_t aOffset);
-        void         IncResourceRecordCount(void);
-        void         Send(const Ip6::MessageInfo &aMessageInfo);
-        void         Answer(const HostInfo &aHostInfo, const Ip6::MessageInfo &aMessageInfo);
-        void         Answer(const ServiceInstanceInfo &aInstanceInfo, const Ip6::MessageInfo &aMessageInfo);
-        Error        ExtractServiceInstanceLabel(const char *aInstanceName, Name::LabelBuffer &aLabel);
+
+        Error AllocateAndInitFrom(const Request &aRequest);
+        void  InitFrom(ProxyQuery &aQuery, const ProxyQueryInfo &aInfo);
+        void  SetResponseCode(ResponseCode aResponseCode) { mHeader.SetResponseCode(aResponseCode); }
+        Error ParseQueryName(void);
+        void  ReadQueryName(Name::Buffer &aName) const;
+        bool  QueryNameMatches(const char *aName) const;
+        Error AppendQueryName(void);
+        Error AppendPtrRecord(const char *aInstanceLabel, uint32_t aTtl);
+        Error AppendSrvRecord(const ServiceInstanceInfo &aInstanceInfo);
+        Error AppendSrvRecord(const char *aHostName,
+                              uint32_t    aTtl,
+                              uint16_t    aPriority,
+                              uint16_t    aWeight,
+                              uint16_t    aPort);
+        Error AppendTxtRecord(const ServiceInstanceInfo &aInstanceInfo);
+        Error AppendTxtRecord(const void *aTxtData, uint16_t aTxtLength, uint32_t aTtl);
+        Error AppendHostAddresses(AddrType aAddrType, const HostInfo &aHostInfo);
+        Error AppendHostAddresses(const ServiceInstanceInfo &aInstanceInfo);
+        Error AppendHostAddresses(AddrType aAddrType, const Ip6::Address *aAddrs, uint16_t aAddrsLength, uint32_t aTtl);
+        Error AppendAaaaRecord(const Ip6::Address &aAddress, uint32_t aTtl);
+        Error AppendARecord(const Ip6::Address &aAddress, uint32_t aTtl);
+        void  UpdateRecordLength(ResourceRecord &aRecord, uint16_t aOffset);
+        void  IncResourceRecordCount(void);
+        void  Send(const Ip6::MessageInfo &aMessageInfo);
+        void  Answer(const HostInfo &aHostInfo, const Ip6::MessageInfo &aMessageInfo);
+        void  Answer(const ServiceInstanceInfo &aInstanceInfo, const Ip6::MessageInfo &aMessageInfo);
+        Error ExtractServiceInstanceLabel(const char *aInstanceName, Name::LabelBuffer &aLabel);
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
         Error ResolveBySrp(void);
         bool  QueryNameMatchesService(const Srp::Server::Service &aService) const;
@@ -422,8 +432,8 @@ private:
         Error AppendPtrRecord(const ProxyResult &aResult);
         Error AppendSrvRecord(const ProxyResult &aResult);
         Error AppendTxtRecord(const ProxyResult &aResult);
-
-        Error AppendHostAddresses(const ProxyResult &aResult);
+        Error AppendHostIp6Addresses(const ProxyResult &aResult);
+        Error AppendHostIp4Addresses(const ProxyResult &aResult);
 #endif
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
@@ -493,16 +503,19 @@ private:
         void StartOrStopSrvResolver(Command aCommand, const ProxyQuery &aQuery, const ProxyQueryInfo &aInfo);
         void StartOrStopTxtResolver(Command aCommand, const ProxyQuery &aQuery, const ProxyQueryInfo &aInfo);
         void StartOrStopIp6Resolver(Command aCommand, Name::Buffer &aHostName);
+        void StartOrStopIp4Resolver(Command aCommand, Name::Buffer &aHostName);
 
         static void HandleBrowseResult(otInstance *aInstance, const otPlatDnssdBrowseResult *aResult);
         static void HandleSrvResult(otInstance *aInstance, const otPlatDnssdSrvResult *aResult);
         static void HandleTxtResult(otInstance *aInstance, const otPlatDnssdTxtResult *aResult);
         static void HandleIp6AddressResult(otInstance *aInstance, const otPlatDnssdAddressResult *aResult);
+        static void HandleIp4AddressResult(otInstance *aInstance, const otPlatDnssdAddressResult *aResult);
 
         void HandleBrowseResult(const Dnssd::BrowseResult &aResult);
         void HandleSrvResult(const Dnssd::SrvResult &aResult);
         void HandleTxtResult(const Dnssd::TxtResult &aResult);
         void HandleIp6AddressResult(const Dnssd::AddressResult &aResult);
+        void HandleIp4AddressResult(const Dnssd::AddressResult &aResult);
         void HandleResult(ProxyAction         aAction,
                           const Name::Buffer &aName,
                           ResponseAppender    aAppender,

--- a/tests/scripts/thread-cert/border_router/test_dnssd_server.py
+++ b/tests/scripts/thread-cert/border_router/test_dnssd_server.py
@@ -196,7 +196,7 @@ class TestDnssdServerOnBr(thread_cert.TestCase):
             })
 
         # check some invalid queries
-        for qtype in ['A', 'CNAME']:
+        for qtype in ['CNAME']:
             dig_result = digger.dns_dig(server_addr, host1_full_name, qtype)
             self._assert_dig_result_matches(dig_result, {
                 'status': 'NOTIMP',

--- a/tests/scripts/thread-cert/border_router/test_dnssd_server_multi_border_routers.py
+++ b/tests/scripts/thread-cert/border_router/test_dnssd_server_multi_border_routers.py
@@ -278,7 +278,7 @@ class TestDnssdServerOnMultiBr(thread_cert.TestCase):
         self._verify_discovery_proxy_meshcop(br2_addr, br2.get_network_name(), host)
 
         # 4. Check some invalid queries
-        for qtype in ['A', 'CNAME']:
+        for qtype in ['CNAME']:
             dig_result = host.dns_dig(br2_addr, host1_full_name, qtype)
             self._assert_dig_result_matches(dig_result, {
                 'status': 'NOTIMP',


### PR DESCRIPTION
This commit adds support for responding to "A record" queries in the DNS-SD server and discovery proxy.

If the query matches a host registered with the SRP server, the host's IPv6 addresses are returned in the Additional Data section of the response. If the query is resolved by the proxy, the `otPlatDnssd` APIs are used to start/stop IPv4 address resolvers for the hostname on the infrastructure network.

The `test_dnssd_discovery_proxy` unit test is updated to validate the new functionality.