### PR TITLE
[ncp] update ncp prop IP6_ADDRESS_TABLE

### DIFF
--- a/src/lib/spinel/spinel.h
+++ b/src/lib/spinel/spinel.h
@@ -3416,7 +3416,7 @@ enum
     SPINEL_PROP_IPV6_ML_PREFIX = SPINEL_PROP_IPV6__BEGIN + 2,
 
     /// IPv6 (Unicast) Address Table
-    /** Format: `A(t(6CLLC))`
+    /** Format: `A(t(6CCbb))`
      *
      * This property provides all unicast addresses.
      *
@@ -3424,8 +3424,9 @@ enum
      *
      *  `6`: IPv6 Address
      *  `C`: Network Prefix Length (in bits)
-     *  `L`: Valid Lifetime
-     *  `L`: Preferred Lifetime
+     *  `C`: Scope
+     *  `b`: Is Preferred
+     *  `b`: Is Mesh Local
      *
      */
     SPINEL_PROP_IPV6_ADDRESS_TABLE = SPINEL_PROP_IPV6__BEGIN + 3,

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -68,6 +68,7 @@
 #include <openthread/trel.h>
 #endif
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/string.hpp"
@@ -1925,8 +1926,11 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_IPV6_ADDRESS_TABLE>(v
 
         SuccessOrExit(error = mEncoder.WriteIp6Address(address->mAddress));
         SuccessOrExit(error = mEncoder.WriteUint8(address->mPrefixLength));
-        SuccessOrExit(error = mEncoder.WriteUint32(address->mPreferred ? 0xffffffff : 0));
-        SuccessOrExit(error = mEncoder.WriteUint32(address->mValid ? 0xffffffff : 0));
+        SuccessOrExit(error = mEncoder.WriteUint8(address->mScopeOverrideValid
+                                                      ? address->mScopeOverride
+                                                      : AsCoreType(&address->mAddress).GetScope()));
+        SuccessOrExit(error = mEncoder.WriteBool(address->mPreferred));
+        SuccessOrExit(error = mEncoder.WriteBool(address->mMeshLocal));
 
         SuccessOrExit(error = mEncoder.CloseStruct());
     }


### PR DESCRIPTION
This PR updates the content of the spinel property `SPINEL_PROP_IPV6_ADDRESS_TABLE`. The address information is used to update the addresses of network interface (wpan0) on the posix host. Currently the required information are: prefix length, scope, preferred and meshlocal.