### PR TITLE
[udp6] simplify handling of backbone sockets

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (420)
+#define OPENTHREAD_API_VERSION (421)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/udp.h
+++ b/include/openthread/udp.h
@@ -129,6 +129,7 @@ typedef struct otUdpSocket
     void               *mContext;  ///< A pointer to application-specific context.
     void               *mHandle;   ///< A handle to platform's UDP.
     struct otUdpSocket *mNext;     ///< A pointer to the next UDP socket (internal use only).
+    uint8_t             mType;     ///< For OT internal use.
 } otUdpSocket;
 
 /**

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -135,6 +135,31 @@ public:
          */
         const SockAddr &GetPeerName(void) const { return AsCoreType(&mPeerName); }
 
+        /**
+         * Gets the socket's network interface identifier.
+         *
+         * @returns The socket's network interface identifiers.
+         *
+         */
+        NetifIdentifier GetNetifId(void) const { return static_cast<NetifIdentifier>(mType); }
+
+        /**
+         * Sets the socket's network interface identifier.
+         *
+         * @param[in] aNetifId  The network interface identifier to use.
+         *
+         */
+        void SetNetifId(NetifIdentifier aNetifId) { mType = aNetifId; }
+
+        /**
+         * Indicates whether the socket is a backbone socket.
+         *
+         * @retval TRUE  This is a backbone socket.
+         * @retval FALSE This is not a backbone sockect.
+         *
+         */
+        bool IsBackboneSocket(void) const { return GetNetifId() == kNetifBackbone; }
+
     private:
         bool Matches(const MessageInfo &aMessageInfo) const;
 
@@ -671,18 +696,9 @@ private:
     bool ShouldUsePlatformUdp(const SocketHandle &aSocket) const;
 #endif
 
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    void                SetBackboneSocket(SocketHandle &aSocket);
-    const SocketHandle *GetBackboneSockets(void) const;
-    bool                IsBackboneSocket(const SocketHandle &aSocket) const;
-#endif
-
     uint16_t                 mEphemeralPort;
     LinkedList<Receiver>     mReceivers;
     LinkedList<SocketHandle> mSockets;
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    SocketHandle *mPrevBackboneSockets;
-#endif
 #if OPENTHREAD_CONFIG_UDP_FORWARD_ENABLE
     Callback<otUdpForwarder> mUdpForwarder;
 #endif


### PR DESCRIPTION
This commit updates how backbone sockets are tracked. The `SocketHandle` now tracks the associated `NetifIdentifier`, which is used to determine if the socket is a backbone socket. The `SocketHandle::Matches(const MessageInfo &aMessageInfo)` method now selects backbone or other sockets based on the result of `aMessageInfo.IsHostInterface()`.

This simplifies the maintenance of backbone sockets in the linked list, eliminating the need to track multiple heads into the list and ensuring backbone sockets are always at the end of the list.