### PR TITLE
[cli] `udp bind` doc update to clarify that multicast address cannot be used as argument

### DIFF
--- a/src/cli/README_UDP.md
+++ b/src/cli/README_UDP.md
@@ -71,7 +71,7 @@ Assigns a name (i.e. IPv6 address and port) to the example socket.
   - not specified: Thread network interface.
   - `-u`: unspecified network interface.
   - `-b`: Backbone network interface.
-- ip: the IPv6 address or the unspecified IPv6 address (`::`).
+- ip: the unicast IPv6 address or the unspecified IPv6 address (`::`).
 - port: the UDP port
 
 ```bash
@@ -82,6 +82,8 @@ Done
 > udp bind -b :: 1234
 Done
 ```
+
+> Note: to receive datagrams sent to a multicast IPv6 address, the unspecified IPv6 address must be used. Using a multicast address for the \<ip\> argument is not supported. Also, the node must subscribe to the multicast group using `ipmaddr add` before it can receive UDP multicast.
 
 ### close
 

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -70,9 +70,9 @@ UdpExample::UdpExample(otInstance *aInstance, OutputImplementer &aOutputImplemen
  *   - `-u`: Unspecified network interface, which means that the UDP/IPv6 stack determines which
  *   network interface to bind the socket to.
  *   - `-b`: Backbone network interface is used.
- * - `ip`: IPv6 address to bind to. If you wish to have the UDP/IPv6 stack assign the binding
- *   IPv6 address, then you can use the following value to use the unspecified
- *   IPv6 address: `::`. Each example uses the unspecified IPv6 address.
+ * - `ip`: unicast IPv6 address to bind to. If you wish to have the UDP/IPv6 stack assign the binding
+ *   IPv6 address, or if you wish to bind to multicast IPv6 addresses, then you can use the following
+ *   value to use the unspecified IPv6 address: `::`. Each example uses the unspecified IPv6 address.
  * - `port`: UDP port number to bind to. Each of the examples is using port number 1234.
  * @par
  * Assigns an IPv6 address and a port to an open socket, which binds the socket for communication.

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -70,7 +70,7 @@ UdpExample::UdpExample(otInstance *aInstance, OutputImplementer &aOutputImplemen
  *   - `-u`: Unspecified network interface, which means that the UDP/IPv6 stack determines which
  *   network interface to bind the socket to.
  *   - `-b`: Backbone network interface is used.
- * - `ip`: unicast IPv6 address to bind to. If you wish to have the UDP/IPv6 stack assign the binding
+ * - `ip`: Unicast IPv6 address to bind to. If you wish to have the UDP/IPv6 stack assign the binding
  *   IPv6 address, or if you wish to bind to multicast IPv6 addresses, then you can use the following
  *   value to use the unspecified IPv6 address: `::`. Each example uses the unspecified IPv6 address.
  * - `port`: UDP port number to bind to. Each of the examples is using port number 1234.


### PR DESCRIPTION
close #10315 