### PR TITLE
Use non-perl grep for version number extraction

### DIFF
--- a/script/check-api-version
+++ b/script/check-api-version
@@ -61,8 +61,8 @@ main()
 
     [[ $line_count == 2 ]] || die 'Multiple OPENTHREAD_API_VERSION definitions found!'
 
-    old_version=$(grep '\-\#define OPENTHREAD_API_VERSION' "${OT_VERSIONS_FILE}" | grep -o '[0-9]..') || die 'Failed to find old version!'
-    new_version=$(grep '\+\#define OPENTHREAD_API_VERSION' "${OT_VERSIONS_FILE}" | grep -o '[0-9]..') || die 'Failed to find new version!'
+    old_version=$(grep '\-\#define OPENTHREAD_API_VERSION' "${OT_VERSIONS_FILE}" | grep -o '[1-9][0-9]*') || die 'Failed to find old version!'
+    new_version=$(grep '\+\#define OPENTHREAD_API_VERSION' "${OT_VERSIONS_FILE}" | grep -o '[1-9][0-9]*') || die 'Failed to find new version!'
 
     echo -e '\n--------------------------\n'
 

--- a/script/check-api-version
+++ b/script/check-api-version
@@ -54,19 +54,19 @@ main()
         exit 0
     fi
 
-    git diff "${OT_SHA_OLD}" -- include/openthread | tee >(cat >&2) | grep -aP '[-+]#define OPENTHREAD_API_VERSION (.+)' >"${OT_VERSIONS_FILE}" || die 'Version number is not updated!'
+    git diff "${OT_SHA_OLD}" -- include/openthread | tee >(cat >&2) | grep '[-+]#define OPENTHREAD_API_VERSION' >"${OT_VERSIONS_FILE}" || die 'Version number is not updated!'
 
-    [[ $(wc -l <"${OT_VERSIONS_FILE}") == 2 ]] || die 'Multiple OPENTHREAD_API_VERSION definitions found!'
+    [ $(wc -l <"${OT_VERSIONS_FILE}") == 2 ] || die 'Multiple OPENTHREAD_API_VERSION definitions found!'
 
-    old_version=$(grep -aoP '(?<=-#define OPENTHREAD_API_VERSION ).+' "${OT_VERSIONS_FILE}") || die 'Failed to find old version!'
-    new_version=$(grep -aoP '(?<=\+#define OPENTHREAD_API_VERSION ).+' "${OT_VERSIONS_FILE}") || die 'Failed to find new version!'
+    old_version=$(grep '\-\#define OPENTHREAD_API_VERSION' "${OT_VERSIONS_FILE}" | grep -o '[0-9]..') || die 'Failed to find old version!'
+    new_version=$(grep '\+\#define OPENTHREAD_API_VERSION' "${OT_VERSIONS_FILE}" | grep -o '[0-9]..') || die 'Failed to find new version!'
 
     echo -e '\n--------------------------\n'
 
     echo "Old version: ${old_version}"
     echo "New version: ${new_version}"
 
-    [[ $((new_version - old_version)) -gt 0 ]] || die 'Version is not increased!'
+    [ $((new_version - old_version)) -gt 0 ] || die 'Version is not increased!'
 
     echo -e '\n--------------------------\n'
 

--- a/script/check-api-version
+++ b/script/check-api-version
@@ -56,7 +56,7 @@ main()
 
     git diff "${OT_SHA_OLD}" -- include/openthread | tee >(cat >&2) | grep '[-+]#define OPENTHREAD_API_VERSION' >"${OT_VERSIONS_FILE}" || die 'Version number is not updated!'
 
-    line_count="$(wc -l < ${OT_VERSIONS_FILE})"
+    line_count="$(wc -l <${OT_VERSIONS_FILE})"
     line_count="${line_count// /}"
 
     [[ $line_count == 2 ]] || die 'Multiple OPENTHREAD_API_VERSION definitions found!'

--- a/script/check-api-version
+++ b/script/check-api-version
@@ -56,7 +56,10 @@ main()
 
     git diff "${OT_SHA_OLD}" -- include/openthread | tee >(cat >&2) | grep '[-+]#define OPENTHREAD_API_VERSION' >"${OT_VERSIONS_FILE}" || die 'Version number is not updated!'
 
-    [ $(wc -l <"${OT_VERSIONS_FILE}") == 2 ] || die 'Multiple OPENTHREAD_API_VERSION definitions found!'
+    line_count="$(wc -l < ${OT_VERSIONS_FILE})"
+    line_count="${line_count// /}"
+
+    [[ $line_count == 2 ]] || die 'Multiple OPENTHREAD_API_VERSION definitions found!'
 
     old_version=$(grep '\-\#define OPENTHREAD_API_VERSION' "${OT_VERSIONS_FILE}" | grep -o '[0-9]..') || die 'Failed to find old version!'
     new_version=$(grep '\+\#define OPENTHREAD_API_VERSION' "${OT_VERSIONS_FILE}" | grep -o '[0-9]..') || die 'Failed to find new version!'
@@ -66,7 +69,7 @@ main()
     echo "Old version: ${old_version}"
     echo "New version: ${new_version}"
 
-    [ $((new_version - old_version)) -gt 0 ] || die 'Version is not increased!'
+    [[ $((new_version - old_version)) -gt 0 ]] || die 'Version is not increased!'
 
     echo -e '\n--------------------------\n'
 


### PR DESCRIPTION
Mac platform is becoming more locked down and grep installed from XCode for example is BSD grep not GNU grep so "-P" doesn't work.

This changes the grep in check-api-version script to extract the version numbers without needing perl patterns.

Also, on Mac platform, the [[ ]] syntax for checking the line count in the version file doesn't work because "wc -" prepends spaces on the count and [[ leaves spaces in.   Using the [ ] syntax works for Mac and other platforms as well but doesn't pass shellcheck, so manually stripping spaces is used.
