### PR TITLE
[udp] clear all properties in `SocketHandle` from `Udp::Open()`

### DIFF
--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -175,8 +175,7 @@ Error Udp::Open(SocketHandle &aSocket, otUdpReceive aHandler, void *aContext)
 
     OT_ASSERT(!IsOpen(aSocket));
 
-    aSocket.GetSockName().Clear();
-    aSocket.GetPeerName().Clear();
+    aSocket.Clear();
     aSocket.mHandler = aHandler;
     aSocket.mContext = aContext;
 


### PR DESCRIPTION
This commit modifies `Udp::Open()` to clear all properties of the passed-in `aSocket` using the `Clear()` method. This replaces the existing code, which only cleared the socket and peer address and port numbers. This change ensures that `void *mHandle` member variable in `otUdpSocket` is also set to `nullptr` before invoking platform UDP `otPlatUdpSocket()`.