### PR TITLE
[dataset] move secure storage methods to `DatasetManager`

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -576,45 +576,5 @@ exit:
 
 const char *Dataset::TypeToString(Type aType) { return (aType == kActive) ? "Active" : "Pending"; }
 
-#if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
-
-void Dataset::SaveTlvInSecureStorageAndClearValue(Tlv::Type aTlvType, Crypto::Storage::KeyRef aKeyRef)
-{
-    using namespace ot::Crypto::Storage;
-
-    Tlv *tlv = FindTlv(aTlvType);
-
-    VerifyOrExit(tlv != nullptr);
-    VerifyOrExit(tlv->GetLength() > 0);
-
-    SuccessOrAssert(ImportKey(aKeyRef, kKeyTypeRaw, kKeyAlgorithmVendor, kUsageExport, kTypePersistent, tlv->GetValue(),
-                              tlv->GetLength()));
-
-    memset(tlv->GetValue(), 0, tlv->GetLength());
-
-exit:
-    return;
-}
-
-Error Dataset::ReadTlvFromSecureStorage(Tlv::Type aTlvType, Crypto::Storage::KeyRef aKeyRef)
-{
-    using namespace ot::Crypto::Storage;
-
-    Error  error = kErrorNone;
-    Tlv   *tlv   = FindTlv(aTlvType);
-    size_t readLength;
-
-    VerifyOrExit(tlv != nullptr);
-    VerifyOrExit(tlv->GetLength() > 0);
-
-    SuccessOrExit(error = ExportKey(aKeyRef, tlv->GetValue(), tlv->GetLength(), readLength));
-    VerifyOrExit(readLength == tlv->GetLength(), error = OT_ERROR_FAILED);
-
-exit:
-    return error;
-}
-
-#endif // OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
-
 } // namespace MeshCoP
 } // namespace ot

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -702,35 +702,6 @@ public:
      */
     static const char *TypeToString(Type aType);
 
-#if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
-
-    /**
-     * Saves a given TLV value in secure storage and clears the TLV value by setting all value bytes to zero.
-     *
-     * If the Dataset does not contain the @p aTlvType, no action is performed.
-     *
-     * @param[in] aTlvType    The TLV type.
-     * @param[in] aKeyRef     The `KeyRef` to use with secure storage.
-     *
-     */
-    void SaveTlvInSecureStorageAndClearValue(Tlv::Type aTlvType, Crypto::Storage::KeyRef aKeyRef);
-
-    /**
-     * Reads and updates a given TLV value in Dataset from secure storage.
-     *
-     * If the Dataset does not contain the @p aTlvType, no action is performed and `kErrorNone` is returned.
-     *
-     * @param[in] aTlvType    The TLV type.
-     * @param[in] aKeyRef     The `KeyRef` to use with secure storage.
-     *
-     * @retval kErrorNone    Successfully read the TLV value from secure storage and updated the Dataset.
-     * @retval KErrorFailed  Could not read the @aKeyRef from secure storage.
-     *
-     */
-    Error ReadTlvFromSecureStorage(Tlv::Type aTlvType, Crypto::Storage::KeyRef aKeyRef);
-
-#endif // OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
-
 private:
     void RemoveTlv(Tlv *aTlv);
 

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -233,16 +233,18 @@ private:
     };
 
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
+    using KeyRef = Crypto::Storage::KeyRef;
+
     struct SecurelyStoredTlv
     {
-        Crypto::Storage::KeyRef GetKeyRef(Dataset::Type aType) const
+        KeyRef GetKeyRef(Dataset::Type aType) const
         {
             return (aType == Dataset::kActive) ? mActiveKeyRef : mPendingKeyRef;
         }
 
-        Tlv::Type               mTlvType;
-        Crypto::Storage::KeyRef mActiveKeyRef;
-        Crypto::Storage::KeyRef mPendingKeyRef;
+        Tlv::Type mTlvType;
+        KeyRef    mActiveKeyRef;
+        KeyRef    mPendingKeyRef;
     };
 
     static const SecurelyStoredTlv kSecurelyStoredTlvs[];
@@ -288,9 +290,11 @@ private:
                                       Error                aError);
 
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
-    void MoveKeysToSecureStorage(Dataset &aDataset) const;
-    void DestroySecurelyStoredKeys(void) const;
-    void EmplaceSecurelyStoredKeys(Dataset &aDataset) const;
+    void  MoveKeysToSecureStorage(Dataset &aDataset) const;
+    void  DestroySecurelyStoredKeys(void) const;
+    void  EmplaceSecurelyStoredKeys(Dataset &aDataset) const;
+    void  SaveTlvInSecureStorageAndClearValue(Dataset &aDataset, Tlv::Type aTlvType, KeyRef aKeyRef) const;
+    Error ReadTlvFromSecureStorage(Dataset &aDataset, Tlv::Type aTlvType, KeyRef aKeyRef) const;
 #endif
 
 #if OPENTHREAD_FTD


### PR DESCRIPTION
This commit refactors methods that save or read a specified Dataset TLV in/from secure storage under `PLATFORM_KEY_REFERENCES`. These methods are moved from the `Dataset` class to the `DatasetManager` class, consolidating related functionality and aligning with the responsibilities of each class. The `Dataset` class is focused on appending/parsing TLVs, while the `DatasetManager` class is responsible for managing and saving the Active and Pending Datasets.