### PR TITLE
[routing-manager] simplify `RxRaTracker::HandleRouterTimer()`

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -828,6 +828,7 @@ private:
             };
 
             bool IsReachable(void) const { return mNsProbeCount <= kMaxNsProbes; }
+            bool ShouldCheckReachability(void) const;
             bool Matches(const Ip6::Address &aAddress) const { return aAddress == mAddress; }
             bool Matches(EmptyChecker aChecker) const;
             void CopyInfoTo(RouterEntry &aEntry, TimeMilli aNow) const;
@@ -915,7 +916,6 @@ private:
         void ProcessRouteInfoOption(const RouteInfoOption &aRio, Router &aRouter);
         void ProcessRaFlagsExtOption(const RaFlagsExtOption &aFlagsOption, Router &aRouter);
         bool ContainsOnLinkPrefix(OnLinkPrefix::UlaChecker aUlaChecker) const;
-        void RemoveOrDeprecateEntriesFromUnreachableRouters(void);
         void RemoveRoutersWithNoEntriesOrFlags(void);
         void RemoveExpiredEntries(void);
         void SignalTableChanged(void);


### PR DESCRIPTION
This commit simplifies `RxRaTracker::HandleRouterTimer()`. When all NS probes to a router fail and it is marked as unreachable, `HandleRouterTimer()` now directly removes/deprecates its route/on-link prefixes, replacing a separate method previously used for this purpose.

Additionally, a new helper method, `ShouldCheckReachability()`, is added to check if a reachability check (sending NS probes) is needed. This check is performed only if the router is not already marked as unreachable and is not the local device itself.