### PR TITLE
[mle] add `GetLeaderRloc16()` helper method

### DIFF
--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -522,7 +522,7 @@ Error MeshForwarder::UpdateIp6RouteFtd(const Ip6::Header &aIp6Header, Message &a
 
         if (aloc16 == Mle::kAloc16Leader)
         {
-            mMeshDest = Mle::Rloc16FromRouterId(mle.GetLeaderId());
+            mMeshDest = mle.GetLeaderRloc16();
         }
         else if (aloc16 <= Mle::kAloc16DhcpAgentEnd)
         {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1004,7 +1004,7 @@ Error Mle::GetLeaderAddress(Ip6::Address &aAddress) const
 
     VerifyOrExit(GetRloc16() != Mac::kShortAddrInvalid, error = kErrorDetached);
 
-    aAddress.SetToRoutingLocator(mMeshLocalPrefix, Rloc16FromRouterId(mLeaderData.GetLeaderRouterId()));
+    aAddress.SetToRoutingLocator(mMeshLocalPrefix, GetLeaderRloc16());
 
 exit:
     return error;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -548,6 +548,14 @@ public:
     uint8_t GetLeaderId(void) const { return mLeaderData.GetLeaderRouterId(); }
 
     /**
+     * Returns the RLOC16 of the Leader.
+     *
+     * @returns The RLOC16 of the Leader.
+     *
+     */
+    uint16_t GetLeaderRloc16(void) const { return Rloc16FromRouterId(GetLeaderId()); }
+
+    /**
      * Retrieves the Leader's RLOC.
      *
      * @param[out]  aAddress  A reference to the Leader's RLOC.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -959,7 +959,7 @@ Error MleRouter::HandleLinkAccept(RxInfo &aRxInfo, bool aRequest)
         router = mRouterTable.FindRouterById(routerId);
         VerifyOrExit(router != nullptr);
 
-        if (mLeaderData.GetLeaderRouterId() == RouterIdFromRloc16(GetRloc16()))
+        if (GetLeaderRloc16() == GetRloc16())
         {
             SetStateLeader(GetRloc16(), kRestoringLeaderRoleAfterReset);
         }

--- a/src/core/thread/network_data_service.cpp
+++ b/src/core/thread/network_data_service.cpp
@@ -152,7 +152,7 @@ bool Manager::IsBackboneRouterPreferredTo(const ServerTlv                  &aSer
                                           const BackboneRouter::ServerData &aOtherServerData) const
 {
     bool     isPreferred;
-    uint16_t leaderRloc16 = Mle::Rloc16FromRouterId(Get<Mle::MleRouter>().GetLeaderId());
+    uint16_t leaderRloc16 = Get<Mle::MleRouter>().GetLeaderRloc16();
 
     VerifyOrExit(aServerTlv.GetServer16() != leaderRloc16, isPreferred = true);
     VerifyOrExit(aOtherServerTlv.GetServer16() != leaderRloc16, isPreferred = false);

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -396,10 +396,7 @@ uint8_t RouterTable::GetPathCost(uint16_t aDestRloc16) const
     return pathCost;
 }
 
-uint8_t RouterTable::GetPathCostToLeader(void) const
-{
-    return GetPathCost(Mle::Rloc16FromRouterId(Get<Mle::Mle>().GetLeaderId()));
-}
+uint8_t RouterTable::GetPathCostToLeader(void) const { return GetPathCost(Get<Mle::Mle>().GetLeaderRloc16()); }
 
 void RouterTable::GetNextHopAndPathCost(uint16_t aDestRloc16, uint16_t &aNextHopRloc16, uint8_t &aPathCost) const
 {


### PR DESCRIPTION
This commit adds the `Mle::GetLeaderRloc16()` method, which returns the RLOC16 of the Leader. This simplifies code that previously used `GetLeaderId()` followed by a conversion to RLOC16.