### PR TITLE
[mle] use `RouterIdMatch()` to compare Router IDs of two RLOC16 values

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3583,7 +3583,7 @@ void Mle::HandleChildUpdateResponse(RxInfo &aRxInfo)
     case kRoleChild:
         SuccessOrExit(error = Tlv::Find<SourceAddressTlv>(aRxInfo.mMessage, sourceAddress));
 
-        if (RouterIdFromRloc16(sourceAddress) != RouterIdFromRloc16(GetRloc16()))
+        if (!RouterIdMatch(sourceAddress, GetRloc16()))
         {
             IgnoreError(BecomeDetached());
             ExitNow();

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3111,18 +3111,18 @@ exit:
 
 bool MleRouter::IsMinimalChild(uint16_t aRloc16)
 {
-    bool rval = false;
+    bool      isMinimalChild = false;
+    Neighbor *neighbor;
 
-    if (RouterIdFromRloc16(aRloc16) == RouterIdFromRloc16(Get<Mac::Mac>().GetShortAddress()))
-    {
-        Neighbor *neighbor;
+    VerifyOrExit(RouterIdMatch(aRloc16, GetRloc16()));
 
-        neighbor = mNeighborTable.FindNeighbor(aRloc16);
+    neighbor = mNeighborTable.FindNeighbor(aRloc16);
+    VerifyOrExit(neighbor != nullptr);
 
-        rval = (neighbor != nullptr) && (!neighbor->IsFullThreadDevice());
-    }
+    isMinimalChild = !neighbor->IsFullThreadDevice();
 
-    return rval;
+exit:
+    return isMinimalChild;
 }
 
 void MleRouter::RemoveRouterLink(Router &aRouter)


### PR DESCRIPTION
This commit updates the code to use `RouterIdMatch()` for comparing the Router IDs of two given RLOC16 values. Additionally, it simplifies the `IsMinimalChild()` method.