### PR TITLE
[mle] rename mesh local address methods to use `Rloc` and `Eid`

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -145,12 +145,12 @@ exit:
 
 const otIp6Address *otThreadGetRloc(otInstance *aInstance)
 {
-    return &AsCoreType(aInstance).Get<Mle::MleRouter>().GetMeshLocal16();
+    return &AsCoreType(aInstance).Get<Mle::MleRouter>().GetMeshLocalRloc();
 }
 
 const otIp6Address *otThreadGetMeshLocalEid(otInstance *aInstance)
 {
-    return &AsCoreType(aInstance).Get<Mle::MleRouter>().GetMeshLocal64();
+    return &AsCoreType(aInstance).Get<Mle::MleRouter>().GetMeshLocalEid();
 }
 
 const otMeshLocalPrefix *otThreadGetMeshLocalPrefix(otInstance *aInstance)

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -98,7 +98,7 @@ void otUdpForwardReceive(otInstance         *aInstance,
 {
     Ip6::MessageInfo messageInfo;
 
-    messageInfo.SetSockAddr(AsCoreType(aInstance).Get<Mle::MleRouter>().GetMeshLocal16());
+    messageInfo.SetSockAddr(AsCoreType(aInstance).Get<Mle::MleRouter>().GetMeshLocalRloc());
     messageInfo.SetSockPort(aSockPort);
     messageInfo.SetPeerAddr(AsCoreType(aPeerAddr));
     messageInfo.SetPeerPort(aPeerPort);

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -954,7 +954,7 @@ template <> void Commissioner::HandleTmf<kUriRelayRx>(Coap::Message &aMessage, c
     aMessage.SetOffset(startOffset);
     SuccessOrExit(error = aMessage.SetLength(endOffset));
 
-    joinerMessageInfo.SetPeerAddr(Get<Mle::MleRouter>().GetMeshLocal64());
+    joinerMessageInfo.SetPeerAddr(Get<Mle::MleRouter>().GetMeshLocalEid());
     joinerMessageInfo.GetPeerAddr().SetIid(mJoinerIid);
     joinerMessageInfo.SetPeerPort(mJoinerPort);
 
@@ -1048,7 +1048,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Message &aRequest, State
 
     SuccessOrExit(error = Tlv::Append<StateTlv>(*message, aState));
 
-    joinerMessageInfo.SetPeerAddr(Get<Mle::MleRouter>().GetMeshLocal64());
+    joinerMessageInfo.SetPeerAddr(Get<Mle::MleRouter>().GetMeshLocalEid());
     joinerMessageInfo.GetPeerAddr().SetIid(mJoinerIid);
     joinerMessageInfo.SetPeerPort(mJoinerPort);
 

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -278,7 +278,7 @@ void Client::Solicit(uint16_t aRloc16)
 #else
     messageInfo.GetPeerAddr().SetToRoutingLocator(Get<Mle::MleRouter>().GetMeshLocalPrefix(), aRloc16);
 #endif
-    messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
+    messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocalRloc());
     messageInfo.mPeerPort = kDhcpServerPort;
 
     SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -76,7 +76,7 @@ void MplOption::Init(SeedIdLength aSeedIdLength)
 
 void Mpl::InitOption(MplOption &aOption, const Address &aAddress)
 {
-    if (aAddress == Get<Mle::Mle>().GetMeshLocal16())
+    if (aAddress == Get<Mle::Mle>().GetMeshLocalRloc())
     {
         // Seed ID can be elided when `aAddress` is RLOC.
         aOption.Init(MplOption::kSeedIdLength0);

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -528,15 +528,15 @@ bool Client::ShouldUpdateHostAutoAddresses(void) const
 {
     bool                        shouldUpdate    = false;
     uint16_t                    registeredCount = 0;
-    Ip6::Netif::UnicastAddress &ml64            = Get<Mle::Mle>().GetMeshLocal64UnicastAddress();
+    Ip6::Netif::UnicastAddress &mlEid           = Get<Mle::Mle>().GetMeshLocalEidUnicastAddress();
 
     VerifyOrExit(mHostInfo.IsAutoAddressEnabled());
 
     // Check all addresses on `ThreadNetif` excluding the mesh local
-    // EID (`ml64`). If any address should be registered but is not,
+    // EID (`mlEid`). If any address should be registered but is not,
     // or if any address was registered earlier but no longer should
     // be, the host information needs to be re-registered to update
-    // the addresses. If there is no eligible address, then `ml64`
+    // the addresses. If there is no eligible address, then `mlEid`
     // should be registered, so its status is checked. Finally, the
     // number of addresses that should be registered is verified
     // against the previous value `mAutoHostAddressCount` to handle
@@ -544,7 +544,7 @@ bool Client::ShouldUpdateHostAutoAddresses(void) const
 
     for (const Ip6::Netif::UnicastAddress &unicastAddress : Get<ThreadNetif>().GetUnicastAddresses())
     {
-        if (&unicastAddress == &ml64)
+        if (&unicastAddress == &mlEid)
         {
             continue;
         }
@@ -562,7 +562,7 @@ bool Client::ShouldUpdateHostAutoAddresses(void) const
 
     if (registeredCount == 0)
     {
-        ExitNow(shouldUpdate = !ml64.mSrpRegistered);
+        ExitNow(shouldUpdate = !mlEid.mSrpRegistered);
     }
 
     shouldUpdate = (registeredCount != mAutoHostAddressCount);
@@ -1350,10 +1350,10 @@ Error Client::AppendHostDescriptionInstruction(Message &aMessage, Info &aInfo)
 
         if (mAutoHostAddressCount == 0)
         {
-            Ip6::Netif::UnicastAddress &ml64 = Get<Mle::Mle>().GetMeshLocal64UnicastAddress();
+            Ip6::Netif::UnicastAddress &mlEid = Get<Mle::Mle>().GetMeshLocalEidUnicastAddress();
 
-            SuccessOrExit(error = AppendAaaaRecord(ml64.GetAddress(), aMessage, aInfo));
-            ml64.mSrpRegistered = true;
+            SuccessOrExit(error = AppendAaaaRecord(mlEid.GetAddress(), aMessage, aInfo));
+            mlEid.mSrpRegistered = true;
             mAutoHostAddressCount++;
         }
     }

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -787,7 +787,7 @@ void AddressResolver::HandleTmf<kUriAddressError>(Coap::Message &aMessage, const
 
     for (Ip6::Netif::UnicastAddress &address : Get<ThreadNetif>().GetUnicastAddresses())
     {
-        if (address.GetAddress() == target && Get<Mle::MleRouter>().GetMeshLocal64().GetIid() != meshLocalIid)
+        if (address.GetAddress() == target && Get<Mle::MleRouter>().GetMeshLocalEid().GetIid() != meshLocalIid)
         {
             // Target EID matches address and Mesh Local EID differs
 #if OPENTHREAD_CONFIG_DUA_ENABLE
@@ -856,7 +856,7 @@ void AddressResolver::HandleTmf<kUriAddressQuery>(Coap::Message &aMessage, const
 
     if (Get<ThreadNetif>().HasUnicastAddress(target))
     {
-        SendAddressQueryResponse(target, Get<Mle::MleRouter>().GetMeshLocal64().GetIid(), nullptr,
+        SendAddressQueryResponse(target, Get<Mle::MleRouter>().GetMeshLocalEid().GetIid(), nullptr,
                                  aMessageInfo.GetPeerAddr());
         ExitNow();
     }

--- a/src/core/thread/anycast_locator.cpp
+++ b/src/core/thread/anycast_locator.cpp
@@ -124,7 +124,7 @@ void AnycastLocator::HandleTmf<kUriAnycastLocate>(Coap::Message &aMessage, const
     message = Get<Tmf::Agent>().NewResponseMessage(aMessage);
     VerifyOrExit(message != nullptr);
 
-    SuccessOrExit(Tlv::Append<ThreadMeshLocalEidTlv>(*message, Get<Mle::Mle>().GetMeshLocal64().GetIid()));
+    SuccessOrExit(Tlv::Append<ThreadMeshLocalEidTlv>(*message, Get<Mle::Mle>().GetMeshLocalEid().GetIid()));
     SuccessOrExit(Tlv::Append<ThreadRloc16Tlv>(*message, Get<Mle::Mle>().GetRloc16()));
 
     SuccessOrExit(Get<Tmf::Agent>().SendMessage(*message, aMessageInfo));

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -472,7 +472,7 @@ void DuaManager::PerformNextRegistration(void)
     {
         dua = GetDomainUnicastAddress();
         SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, dua));
-        SuccessOrExit(error = Tlv::Append<ThreadMeshLocalEidTlv>(*message, mle.GetMeshLocal64().GetIid()));
+        SuccessOrExit(error = Tlv::Append<ThreadMeshLocalEidTlv>(*message, mle.GetMeshLocalEid().GetIid()));
         mDuaState             = kRegistering;
         mLastRegistrationTime = TimerMilli::GetNow();
     }

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -654,7 +654,7 @@ void MeshForwarder::SendDestinationUnreachable(uint16_t aMeshSource, const Ip6::
 {
     Ip6::MessageInfo messageInfo;
 
-    messageInfo.GetPeerAddr() = Get<Mle::MleRouter>().GetMeshLocal16();
+    messageInfo.GetPeerAddr() = Get<Mle::MleRouter>().GetMeshLocalRloc();
     messageInfo.GetPeerAddr().GetIid().SetLocator(aMeshSource);
 
     IgnoreError(Get<Ip6::Icmp>().SendError(Ip6::Icmp::Header::kTypeDstUnreach,

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -390,7 +390,7 @@ public:
      * @returns A reference to the Thread link local address.
      *
      */
-    const Ip6::Address &GetLinkLocalAddress(void) const { return mLinkLocal64.GetAddress(); }
+    const Ip6::Address &GetLinkLocalAddress(void) const { return mLinkLocalAddress.GetAddress(); }
 
     /**
      * Updates the link local address.
@@ -516,20 +516,20 @@ public:
     uint16_t GetRloc16(void) const { return mRloc16; }
 
     /**
-     * Returns a reference to the RLOC assigned to the Thread interface.
+     * Returns the mesh local RLOC IPv6 address assigned to the Thread interface.
      *
-     * @returns A reference to the RLOC assigned to the Thread interface.
+     * @returns The mesh local RLOC IPv6 address.
      *
      */
-    const Ip6::Address &GetMeshLocal16(void) const { return mMeshLocal16.GetAddress(); }
+    const Ip6::Address &GetMeshLocalRloc(void) const { return mMeshLocalRloc.GetAddress(); }
 
     /**
-     * Returns a reference to the ML-EID assigned to the Thread interface.
+     * Returns the mesh local endpoint identifier (ML-EID) IPv6 address assigned to the Thread interface.
      *
-     * @returns A reference to the ML-EID assigned to the Thread interface.
+     * @returns The ML-EID address.
      *
      */
-    const Ip6::Address &GetMeshLocal64(void) const { return mMeshLocal64.GetAddress(); }
+    const Ip6::Address &GetMeshLocalEid(void) const { return mMeshLocalEid.GetAddress(); }
 
     /**
      * Returns a reference to the ML-EID as a `Netif::UnicastAddress`.
@@ -537,7 +537,7 @@ public:
      * @returns A reference to the ML-EID.
      *
      */
-    Ip6::Netif::UnicastAddress &GetMeshLocal64UnicastAddress(void) { return mMeshLocal64; }
+    Ip6::Netif::UnicastAddress &GetMeshLocalEidUnicastAddress(void) { return mMeshLocalEid; }
 
     /**
      * Returns the Router ID of the Leader.
@@ -1448,9 +1448,9 @@ private:
     MsgTxTimer                   mMessageTransmissionTimer;
     DetachGracefullyTimer        mDetachGracefullyTimer;
     Ip6::NetworkPrefix           mMeshLocalPrefix;
-    Ip6::Netif::UnicastAddress   mLinkLocal64;
-    Ip6::Netif::UnicastAddress   mMeshLocal64;
-    Ip6::Netif::UnicastAddress   mMeshLocal16;
+    Ip6::Netif::UnicastAddress   mLinkLocalAddress;
+    Ip6::Netif::UnicastAddress   mMeshLocalEid;
+    Ip6::Netif::UnicastAddress   mMeshLocalRloc;
     Ip6::Netif::MulticastAddress mLinkLocalAllThreadNodes;
     Ip6::Netif::MulticastAddress mRealmLocalAllThreadNodes;
 };

--- a/src/core/thread/network_data_publisher.cpp
+++ b/src/core/thread/network_data_publisher.cpp
@@ -510,7 +510,7 @@ void Publisher::DnsSrpServiceEntry::PublishUnicast(const Ip6::Address &aAddress,
 void Publisher::DnsSrpServiceEntry::PublishUnicast(uint16_t aPort)
 {
     LogInfo("Publishing DNS/SRP service unicast (ml-eid, port:%d)", aPort);
-    Publish(Info::InfoUnicast(kTypeUnicastMeshLocalEid, Get<Mle::Mle>().GetMeshLocal64(), aPort));
+    Publish(Info::InfoUnicast(kTypeUnicastMeshLocalEid, Get<Mle::Mle>().GetMeshLocalEid(), aPort));
 }
 
 void Publisher::DnsSrpServiceEntry::Publish(const Info &aInfo)
@@ -546,7 +546,7 @@ void Publisher::DnsSrpServiceEntry::HandleNotifierEvents(Events aEvents)
 {
     if ((GetType() == kTypeUnicastMeshLocalEid) && aEvents.Contains(kEventThreadMeshLocalAddrChanged))
     {
-        mInfo.SetAddress(Get<Mle::Mle>().GetMeshLocal64());
+        mInfo.SetAddress(Get<Mle::Mle>().GetMeshLocalEid());
 
         if (GetState() == kAdded)
         {

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -42,7 +42,7 @@ namespace Tmf {
 //----------------------------------------------------------------------------------------------------------------------
 // MessageInfo
 
-void MessageInfo::SetSockAddrToRloc(void) { SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16()); }
+void MessageInfo::SetSockAddrToRloc(void) { SetSockAddr(Get<Mle::MleRouter>().GetMeshLocalRloc()); }
 
 Error MessageInfo::SetSockAddrToRlocPeerAddrToLeaderAloc(void)
 {
@@ -65,7 +65,7 @@ void MessageInfo::SetSockAddrToRlocPeerAddrToRealmLocalAllRoutersMulticast(void)
 void MessageInfo::SetSockAddrToRlocPeerAddrTo(uint16_t aRloc16)
 {
     SetSockAddrToRloc();
-    SetPeerAddr(Get<Mle::MleRouter>().GetMeshLocal16());
+    SetPeerAddr(Get<Mle::MleRouter>().GetMeshLocalRloc());
     GetPeerAddr().GetIid().SetLocator(aRloc16);
 }
 

--- a/src/core/utils/mesh_diag.cpp
+++ b/src/core/utils/mesh_diag.cpp
@@ -98,7 +98,7 @@ Error MeshDiag::DiscoverTopology(const DiscoverConfig &aConfig, DiscoverCallback
             continue;
         }
 
-        destination = Get<Mle::MleRouter>().GetMeshLocal16();
+        destination = Get<Mle::MleRouter>().GetMeshLocalRloc();
         destination.GetIid().SetLocator(Mle::Rloc16FromRouterId(routerId));
 
         SuccessOrExit(error = Get<Client>().SendCommand(kUriDiagnosticGetRequest, Message::kPriorityLow, destination,
@@ -176,7 +176,7 @@ Error MeshDiag::SendQuery(uint16_t aRloc16, const uint8_t *aTlvs, uint8_t aTlvsL
     VerifyOrExit(Mle::IsActiveRouter(aRloc16), error = kErrorInvalidArgs);
     VerifyOrExit(Get<RouterTable>().IsAllocated(Mle::RouterIdFromRloc16(aRloc16)), error = kErrorNotFound);
 
-    destination = Get<Mle::MleRouter>().GetMeshLocal16();
+    destination = Get<Mle::MleRouter>().GetMeshLocalRloc();
     destination.GetIid().SetLocator(aRloc16);
 
     SuccessOrExit(error = Get<Client>().SendCommand(kUriDiagnosticGetQuery, Message::kPriorityNormal, destination,

--- a/tests/unit/test_child.cpp
+++ b/tests/unit/test_child.cpp
@@ -214,7 +214,7 @@ void TestChildIp6Address(void)
     numAddresses = 0;
 
     // First addresses uses the mesh local prefix (mesh-local address).
-    addresses[numAddresses] = sInstance->Get<Mle::MleRouter>().GetMeshLocal64();
+    addresses[numAddresses] = sInstance->Get<Mle::MleRouter>().GetMeshLocalEid();
     addresses[numAddresses].SetIid(meshLocalIid);
 
     numAddresses++;

--- a/tests/unit/test_srp_server.cpp
+++ b/tests/unit/test_srp_server.cpp
@@ -1097,7 +1097,7 @@ void TestSrpClientDelayedResponse(void)
             break;
         }
 
-        serverSockAddr.SetAddress(sInstance->Get<Mle::Mle>().GetMeshLocal16());
+        serverSockAddr.SetAddress(sInstance->Get<Mle::Mle>().GetMeshLocalRloc());
         serverSockAddr.SetPort(kServerPort);
         SuccessOrQuit(srpClient->Start(serverSockAddr));
 


### PR DESCRIPTION
This commit renames the methods for retrieving mesh local addresses to `GetMeshLocalRloc()` and `GetMeshLocalEid()` (from `GetMeshLocal16()` and `GetMeshLocal64()`, respectively) to align with the terminology used in the Thread specification. Member and local variables are also renamed accordingly.