### PR TITLE
[routing-manager] add `mIsReachable` to `otBorderRoutingRouterEntry`

### DIFF
--- a/include/openthread/border_routing.h
+++ b/include/openthread/border_routing.h
@@ -102,6 +102,7 @@ typedef struct otBorderRoutingRouterEntry
     bool         mOtherConfigFlag : 1;          ///< The router's Other Config flag (`O` flag).
     bool         mStubRouterFlag : 1;           ///< The router's Stub Router flag.
     bool         mIsLocalDevice : 1;            ///< This router is the local device (this BR).
+    bool         mIsReachable : 1;              ///< This router is reachable.
 } otBorderRoutingRouterEntry;
 
 /**

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (421)
+#define OPENTHREAD_API_VERSION (422)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README_BR.md
+++ b/src/cli/README_BR.md
@@ -352,9 +352,11 @@ Info per router:
   - O: Other Config flag
   - Stub: Stub Router flag (indicates whether the router is a stub router)
 - Milliseconds since last received message from this router
+- Reachability flag: A router is marked as unreachable if it fails to respond to multiple Neighbor Solicitation probes.
+- `(this BR)` is appended when the router is the local device itself.
 
 ```bash
 > br routers
-ff02:0:0:0:0:0:0:1 (M:0 O:0 Stub:1) ms-since-rx:1505
+ff02:0:0:0:0:0:0:1 (M:0 O:0 Stub:1) ms-since-rx:1505 reachable:yes
 Done
 ```

--- a/src/cli/cli_br.cpp
+++ b/src/cli/cli_br.cpp
@@ -518,7 +518,7 @@ exit:
  * @cli br routers
  * @code
  * br routers
- * ff02:0:0:0:0:0:0:1 (M:0 O:0 Stub:1) ms-since-rx:1505
+ * ff02:0:0:0:0:0:0:1 (M:0 O:0 Stub:1) ms-since-rx:1505 reachable:yes
  * Done
  * @endcode
  * @par
@@ -530,6 +530,9 @@ exit:
  *   - O: Other Config flag
  *   - Stub: Stub Router flag (indicates whether the router is a stub router)
  * - Milliseconds since last received message from this router
+ * - Reachability flag: A router is marked as unreachable if it fails to respond to multiple Neighbor Solicitation
+ *   probes.
+ * - `(this BR)` is appended when the router is the local device itself.
  * @sa otBorderRoutingGetNextRouterEntry
  */
 template <> otError Br::Process<Cmd("routers")>(Arg aArgs[])
@@ -559,7 +562,8 @@ void Br::OutputRouterInfo(const otBorderRoutingRouterEntry &aEntry, RouterOutput
 
     if (aMode == kLongVersion)
     {
-        OutputFormat(" ms-since-rx:%lu", ToUlong(aEntry.mMsecSinceLastUpdate));
+        OutputFormat(" ms-since-rx:%lu reachable:%s", ToUlong(aEntry.mMsecSinceLastUpdate),
+                     aEntry.mIsReachable ? "yes" : "no");
 
         if (aEntry.mIsLocalDevice)
         {

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1969,6 +1969,7 @@ void RoutingManager::RxRaTracker::Router::CopyInfoTo(RouterEntry &aEntry, TimeMi
     aEntry.mOtherConfigFlag          = mOtherConfigFlag;
     aEntry.mStubRouterFlag           = mStubRouterFlag;
     aEntry.mIsLocalDevice            = mIsLocalDevice;
+    aEntry.mIsReachable              = IsReachable();
 }
 
 //---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This commit adds `mIsReachable` to the `otBorderRoutingRouterEntry` structure to indicate whether a router is reachable. A router is marked unreachable after it fails to respond to multiple Neighbor Solicitation (NS) probes. Additionally, the `br` CLI commands are updated to display this information.