### PR TITLE
[mle] add helper methods for constructing RLOC and ALOC addresses

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -79,7 +79,7 @@ exit:
 
 otError otThreadGetLeaderRloc(otInstance *aInstance, otIp6Address *aLeaderRloc)
 {
-    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderAddress(AsCoreType(aLeaderRloc));
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderRloc(AsCoreType(aLeaderRloc));
 }
 
 otLinkModeConfig otThreadGetLinkMode(otInstance *aInstance)
@@ -189,7 +189,7 @@ const otIp6Address *otThreadGetRealmLocalAllThreadNodesMulticastAddress(otInstan
 
 otError otThreadGetServiceAloc(otInstance *aInstance, uint8_t aServiceId, otIp6Address *aServiceAloc)
 {
-    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetServiceAloc(aServiceId, AsCoreType(aServiceAloc));
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().ConstructServiceAloc(aServiceId, AsCoreType(aServiceAloc));
 }
 
 const char *otThreadGetNetworkName(otInstance *aInstance)

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -701,7 +701,7 @@ void Manager::HandleDadBackboneAnswer(const Ip6::Address &aDua, const Ip6::Inter
     {
         Ip6::Address dest;
 
-        dest.SetToRoutingLocator(Get<Mle::MleRouter>().GetMeshLocalPrefix(), ndProxy->GetRloc16());
+        IgnoreError(Get<Mle::Mle>().ConstructRloc(ndProxy->GetRloc16(), dest));
         Get<AddressResolver>().SendAddressError(aDua, aMeshLocalIid, &dest);
     }
 
@@ -719,7 +719,8 @@ void Manager::HandleExtendedBackboneAnswer(const Ip6::Address             &aDua,
 {
     Ip6::Address dest;
 
-    dest.SetToRoutingLocator(Get<Mle::MleRouter>().GetMeshLocalPrefix(), aSrcRloc16);
+    IgnoreError(Get<Mle::Mle>().ConstructRloc(aSrcRloc16, dest));
+
     Get<AddressResolver>().SendAddressQueryResponse(aDua, aMeshLocalIid, &aTimeSinceLastTransaction, dest);
 
     LogInfo("HandleExtendedBackboneAnswer: target=%s, mliid=%s, LTT=%lus, rloc16=%04x", aDua.ToString().AsCString(),

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -200,7 +200,7 @@ void BorderAgent::HandleCoapResponse(const ForwardContext &aForwardContext,
 
             SuccessOrExit(error = Tlv::Find<CommissionerSessionIdTlv>(*aResponse, sessionId));
 
-            IgnoreError(Get<Mle::MleRouter>().GetCommissionerAloc(mCommissionerAloc.GetAddress(), sessionId));
+            IgnoreError(Get<Mle::MleRouter>().ConstructCommissionerAloc(sessionId, mCommissionerAloc.GetAddress()));
             Get<ThreadNetif>().AddUnicastAddress(mCommissionerAloc);
             IgnoreError(Get<Ip6::Udp>().AddReceiver(mUdpReceiver));
 

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -811,7 +811,7 @@ void Commissioner::HandleLeaderPetitionResponse(Coap::Message          *aMessage
         ExitNow();
     }
 
-    IgnoreError(Get<Mle::MleRouter>().GetCommissionerAloc(mCommissionerAloc.GetAddress(), mSessionId));
+    IgnoreError(Get<Mle::MleRouter>().ConstructCommissionerAloc(mSessionId, mCommissionerAloc.GetAddress()));
     Get<ThreadNetif>().AddUnicastAddress(mCommissionerAloc);
 
     SetState(kStateActive);

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -241,7 +241,7 @@ Error DatasetManager::HandleSetOrReplace(MgmtCommand             aCommand,
         Ip6::Address destination;
 
         SuccessOrExit(Get<NetworkData::Leader>().FindCommissioningSessionId(localSessionId));
-        SuccessOrExit(Get<Mle::MleRouter>().GetCommissionerAloc(destination, localSessionId));
+        SuccessOrExit(Get<Mle::MleRouter>().ConstructCommissionerAloc(localSessionId, destination));
         Get<Leader>().SendDatasetChanged(destination);
     }
 

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -276,7 +276,7 @@ void Client::Solicit(uint16_t aRloc16)
 #if OPENTHREAD_ENABLE_DHCP6_MULTICAST_SOLICIT
     messageInfo.GetPeerAddr().SetToRealmLocalAllRoutersMulticast();
 #else
-    messageInfo.GetPeerAddr().SetToRoutingLocator(Get<Mle::MleRouter>().GetMeshLocalPrefix(), aRloc16);
+    IgnoreError(Get<Mle::Mle>().ConstructRloc(aRloc16, messageInfo.GetPeerAddr()));
 #endif
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocalRloc());
     messageInfo.mPeerPort = kDhcpServerPort;

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -166,7 +166,7 @@ private:
             mPrefix = aPrefix;
 
             mAloc.InitAsThreadOrigin();
-            mAloc.GetAddress().SetToAnycastLocator(aMeshLocalPrefix, (Ip6::Address::kAloc16Mask << 8) + aContextId);
+            mAloc.GetAddress().SetToLocator(aMeshLocalPrefix, (Ip6::Address::kAloc16Mask << 8) + aContextId);
             mAloc.mMeshLocal = true;
         }
 

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -783,30 +783,14 @@ public:
     bool IsMulticastLargerThanRealmLocal(void) const;
 
     /**
-     * Sets the IPv6 address to a Routing Locator (RLOC) IPv6 address with a given Network Prefix and
-     * RLOC16 value.
+     * Sets the IPv6 address to a Locator (RLOC or ALOC) IPv6 address with a given Network Prefix and locator (RLOC16
+     * or ALOC16) value.
      *
      * @param[in]  aNetworkPrefix    A Network Prefix.
-     * @param[in]  aRloc16           A RLOC16 value.
+     * @param[in]  aLocator          A locator value (RLOC16 or ALOC16).
      *
      */
-    void SetToRoutingLocator(const NetworkPrefix &aNetworkPrefix, uint16_t aRloc16)
-    {
-        SetToLocator(aNetworkPrefix, aRloc16);
-    }
-
-    /**
-     * Sets the IPv6 address to a Anycast Locator (ALOC) IPv6 address with a given Network Prefix and
-     * ALOC16 value.
-     *
-     * @param[in]  aNetworkPrefix    A Network Prefix.
-     * @param[in]  aAloc16           A ALOC16 value.
-     *
-     */
-    void SetToAnycastLocator(const NetworkPrefix &aNetworkPrefix, uint16_t aAloc16)
-    {
-        SetToLocator(aNetworkPrefix, aAloc16);
-    }
+    void SetToLocator(const NetworkPrefix &aNetworkPrefix, uint16_t aLocator);
 
     /**
      * Indicates whether or not the IPv6 address follows the IPv4-mapped format.
@@ -1053,7 +1037,6 @@ private:
     static constexpr uint8_t kMulticastNetworkPrefixLengthOffset = 3; // Prefix-Based Multicast Address (RFC3306)
     static constexpr uint8_t kMulticastNetworkPrefixOffset       = 4; // Prefix-Based Multicast Address (RFC3306)
 
-    void SetToLocator(const NetworkPrefix &aNetworkPrefix, uint16_t aLocator);
     void ToString(StringWriter &aWriter) const;
     void AppendHexWords(StringWriter &aWriter, uint8_t aLength) const;
 

--- a/src/core/net/nd_agent.cpp
+++ b/src/core/net/nd_agent.cpp
@@ -101,10 +101,10 @@ void Agent::UpdateService(void)
 
         if (error == kErrorNone)
         {
-            uint16_t rloc = Mle::kAloc16NeighborDiscoveryAgentStart + lowpanContext.mContextId - 1;
+            uint16_t aloc = Mle::kAloc16NeighborDiscoveryAgentStart + lowpanContext.mContextId - 1;
 
             mAloc.InitAsThreadOrigin();
-            mAloc.GetAddress().SetToAnycastLocator(Get<Mle::MleRouter>().GetMeshLocalPrefix(), rloc);
+            IgnoreError(Get<Mle::Mle>().ConstructAloc(aloc, mAloc.GetAddress()));
             mAloc.mMeshLocal = true;
             Get<ThreadNetif>().AddUnicastAddress(mAloc);
             ExitNow();

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -822,7 +822,7 @@ void AddressResolver::HandleTmf<kUriAddressError>(Coap::Message &aMessage, const
 
             if (child.RemoveIp6Address(target) == kErrorNone)
             {
-                SuccessOrExit(error = Get<Mle::Mle>().GetLocatorAddress(destination, child.GetRloc16()));
+                SuccessOrExit(error = Get<Mle::Mle>().ConstructRloc(child.GetRloc16(), destination));
 
                 SendAddressError(target, meshLocalIid, &destination);
                 ExitNow();

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -511,16 +511,15 @@ void DuaManager::PerformNextRegistration(void)
     {
         uint8_t pbbrServiceId;
 
+        messageInfo.SetSockAddrToRloc();
+
         SuccessOrExit(error = Get<BackboneRouter::Leader>().GetServiceId(pbbrServiceId));
-        SuccessOrExit(error = mle.GetServiceAloc(pbbrServiceId, messageInfo.GetPeerAddr()));
+        SuccessOrExit(error = mle.ConstructServiceAloc(pbbrServiceId, messageInfo.GetPeerAddr()));
     }
     else
     {
-        messageInfo.GetPeerAddr().SetToRoutingLocator(mle.GetMeshLocalPrefix(),
-                                                      Get<BackboneRouter::Leader>().GetServer16());
+        messageInfo.SetSockAddrToRlocPeerAddrTo(Get<BackboneRouter::Leader>().GetServer16());
     }
-
-    messageInfo.SetSockAddrToRloc();
 
     SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo, &DuaManager::HandleDuaResponse, this));
 

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -654,8 +654,7 @@ void MeshForwarder::SendDestinationUnreachable(uint16_t aMeshSource, const Ip6::
 {
     Ip6::MessageInfo messageInfo;
 
-    messageInfo.GetPeerAddr() = Get<Mle::MleRouter>().GetMeshLocalRloc();
-    messageInfo.GetPeerAddr().GetIid().SetLocator(aMeshSource);
+    IgnoreError(Get<Mle::Mle>().ConstructRloc(aMeshSource, messageInfo.GetPeerAddr()));
 
     IgnoreError(Get<Ip6::Icmp>().SendError(Ip6::Icmp::Header::kTypeDstUnreach,
                                            Ip6::Icmp::Header::kCodeDstUnreachNoRoute, messageInfo, aIp6Headers));

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -558,51 +558,72 @@ public:
     /**
      * Retrieves the Leader's RLOC.
      *
-     * @param[out]  aAddress  A reference to the Leader's RLOC.
+     * @param[out]  aAddress  A reference to an address to return the Leader's RLOC.
      *
-     * @retval kErrorNone      Successfully retrieved the Leader's RLOC.
+     * @retval kErrorNone      Successfully retrieved the Leader's RLOC. @p aAddress is updated.
      * @retval kErrorDetached  The Thread interface is not currently attached to a Thread Partition.
      *
      */
-    Error GetLeaderAddress(Ip6::Address &aAddress) const;
+    Error GetLeaderRloc(Ip6::Address &aAddress) const;
 
     /**
      * Retrieves the Leader's ALOC.
      *
-     * @param[out]  aAddress  A reference to the Leader's ALOC.
+     * @param[out]  aAddress  A reference to an address to return the Leader's ALOC.
      *
-     * @retval kErrorNone      Successfully retrieved the Leader's ALOC.
-     * @retval kErrorDetached  The Thread interface is not currently attached to a Thread Partition.
+     * @retval kErrorNone      Successfully retrieved the Leader's ALOC. @p aAddress is updated.
+     * @retval kErrorDetached  Device has not attached yet.
      *
      */
-    Error GetLeaderAloc(Ip6::Address &aAddress) const { return GetLocatorAddress(aAddress, kAloc16Leader); }
+    Error GetLeaderAloc(Ip6::Address &aAddress) const;
 
     /**
-     * Computes the Commissioner's ALOC.
+     * Constructs a Commissioner's ALOC IPv6 address for a given commissioner session ID.
      *
-     * @param[out]  aAddress        A reference to the Commissioner's ALOC.
-     * @param[in]   aSessionId      Commissioner session id.
+     * @param[in]  aSessionId  Commissioner session ID to construct ALOC for.
+     * @param[out] aAddress    A reference to an address to return the Commissioner ALOC.
      *
-     * @retval kErrorNone      Successfully retrieved the Commissioner's ALOC.
-     * @retval kErrorDetached  The Thread interface is not currently attached to a Thread Partition.
+     * @retval kErrorNone      Successfully constructed the Commissioner's ALOC. @p aAddress is updated.
+     * @retval kErrorDetached  Device has not attached yet.
      *
      */
-    Error GetCommissionerAloc(Ip6::Address &aAddress, uint16_t aSessionId) const
-    {
-        return GetLocatorAddress(aAddress, CommissionerAloc16FromId(aSessionId));
-    }
+    Error ConstructCommissionerAloc(uint16_t aSessionId, Ip6::Address &aAddress) const;
 
     /**
-     * Retrieves the Service ALOC for given Service ID.
+     * Constructs a Service ALOC IPv6 address for given Service ID.
      *
-     * @param[in]   aServiceId Service ID to get ALOC for.
-     * @param[out]  aAddress   A reference to the Service ALOC.
+     * @param[in]  aServiceId   Service ID to construct ALOC for.
+     * @param[out] aAddress     A reference to an address to return the Service ALOC.
      *
-     * @retval kErrorNone      Successfully retrieved the Service ALOC.
-     * @retval kErrorDetached  The Thread interface is not currently attached to a Thread Partition.
+     * @retval kErrorNone      Successfully constructed the Service ALOC. @p aAddress is updated.
+     * @retval kErrorDetached  Device has not attached yet.
      *
      */
-    Error GetServiceAloc(uint8_t aServiceId, Ip6::Address &aAddress) const;
+    Error ConstructServiceAloc(uint8_t aServiceId, Ip6::Address &aAddress) const;
+
+    /**
+     * Constructs an RLOC IPv6 address for a given RLOC16.
+     *
+     * @param[in]  aRloc16   An RLOC16 value.
+     * @param[out] aAddress  A reference to an address to return the RLOC.
+     *
+     * @retval kErrorNone      Successfully constructed RLOC. @p aAddress is updated
+     * @retval kErrorDetached  Device has not attached yet.
+     *
+     */
+    Error ConstructRloc(uint16_t aRloc16, Ip6::Address &aAddress) const;
+
+    /**
+     * Constructs an ALOC IPv6 address for a given ALOC16
+     *
+     * @param[in]  aAloc16   An ALOC16 value.
+     * @param[out] aAddress  A reference to an address to return the ALOC.
+     *
+     * @retval kErrorNone      Successfully constructed ALOC. @p aAddress is updated
+     * @retval kErrorDetached  Device has not attached yet.
+     *
+     */
+    Error ConstructAloc(uint16_t aAloc16, Ip6::Address &aAddress) const { return ConstructRloc(aAloc16, aAddress); }
 
     /**
      * Returns the most recently received Leader Data.
@@ -676,18 +697,6 @@ public:
      *
      */
     void RequestShorterChildIdRequest(void);
-
-    /**
-     * Gets the RLOC or ALOC of a given RLOC16 or ALOC16.
-     *
-     * @param[out]  aAddress  A reference to the RLOC or ALOC.
-     * @param[in]   aLocator  RLOC16 or ALOC16.
-     *
-     * @retval kErrorNone      If got the RLOC or ALOC successfully.
-     * @retval kErrorDetached  If device is detached.
-     *
-     */
-    Error GetLocatorAddress(Ip6::Address &aAddress, uint16_t aLocator) const;
 
     /**
      * Schedules a Child Update Request.

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -400,16 +400,15 @@ Error MlrManager::SendMlrMessage(const Ip6::Address   *aAddresses,
     {
         uint8_t pbbrServiceId;
 
+        messageInfo.SetSockAddrToRloc();
+
         SuccessOrExit(error = Get<BackboneRouter::Leader>().GetServiceId(pbbrServiceId));
-        SuccessOrExit(error = mle.GetServiceAloc(pbbrServiceId, messageInfo.GetPeerAddr()));
+        SuccessOrExit(error = mle.ConstructServiceAloc(pbbrServiceId, messageInfo.GetPeerAddr()));
     }
     else
     {
-        messageInfo.GetPeerAddr().SetToRoutingLocator(mle.GetMeshLocalPrefix(),
-                                                      Get<BackboneRouter::Leader>().GetServer16());
+        messageInfo.SetSockAddrToRlocPeerAddrTo(Get<BackboneRouter::Leader>().GetServer16());
     }
-
-    messageInfo.SetSockAddrToRloc();
 
     error = Get<Tmf::Agent>().SendMessage(*message, messageInfo, aResponseHandler, aResponseContext);
 

--- a/src/core/thread/network_data_service.cpp
+++ b/src/core/thread/network_data_service.cpp
@@ -182,8 +182,9 @@ Error Manager::GetNextDnsSrpAnycastInfo(Iterator &aIterator, DnsSrpAnycast::Info
     } while (tlv->GetServiceDataLength() < sizeof(DnsSrpAnycast::ServiceData));
 
     tlv->GetServiceData(serviceData);
-    aInfo.mAnycastAddress.SetToAnycastLocator(Get<Mle::Mle>().GetMeshLocalPrefix(),
-                                              Mle::ServiceAlocFromId(tlv->GetServiceId()));
+
+    IgnoreError(Get<Mle::Mle>().ConstructServiceAloc(tlv->GetServiceId(), aInfo.mAnycastAddress));
+
     aInfo.mSequenceNumber =
         reinterpret_cast<const DnsSrpAnycast::ServiceData *>(serviceData.GetBytes())->GetSequenceNumber();
 
@@ -297,8 +298,10 @@ Error Manager::GetNextDnsSrpUnicastInfo(Iterator &aIterator, DnsSrpUnicast::Info
                 // Handle the case where the server TLV data only
                 // contains a port number and use the RLOC as the
                 // IPv6 address.
-                aInfo.mSockAddr.GetAddress().SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(),
-                                                                 aIterator.mServerSubTlv->GetServer16());
+
+                uint16_t rloc16 = aIterator.mServerSubTlv->GetServer16();
+
+                IgnoreError(Get<Mle::Mle>().ConstructRloc(rloc16, aInfo.mSockAddr.GetAddress()));
                 aInfo.mSockAddr.SetPort(BigEndian::ReadUint16(data.GetBytes()));
                 aInfo.mOrigin = DnsSrpUnicast::kFromServerData;
                 aInfo.mRloc16 = aIterator.mServerSubTlv->GetServer16();

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -53,7 +53,7 @@ Error MessageInfo::SetSockAddrToRlocPeerAddrToLeaderAloc(void)
 Error MessageInfo::SetSockAddrToRlocPeerAddrToLeaderRloc(void)
 {
     SetSockAddrToRloc();
-    return Get<Mle::MleRouter>().GetLeaderAddress(GetPeerAddr());
+    return Get<Mle::MleRouter>().GetLeaderRloc(GetPeerAddr());
 }
 
 void MessageInfo::SetSockAddrToRlocPeerAddrToRealmLocalAllRoutersMulticast(void)
@@ -65,8 +65,7 @@ void MessageInfo::SetSockAddrToRlocPeerAddrToRealmLocalAllRoutersMulticast(void)
 void MessageInfo::SetSockAddrToRlocPeerAddrTo(uint16_t aRloc16)
 {
     SetSockAddrToRloc();
-    SetPeerAddr(Get<Mle::MleRouter>().GetMeshLocalRloc());
-    GetPeerAddr().GetIid().SetLocator(aRloc16);
+    IgnoreError(Get<Mle::Mle>().ConstructRloc(aRloc16, GetPeerAddr()));
 }
 
 void MessageInfo::SetSockAddrToRlocPeerAddrTo(const Ip6::Address &aPeerAddress)

--- a/src/core/utils/mesh_diag.cpp
+++ b/src/core/utils/mesh_diag.cpp
@@ -98,8 +98,7 @@ Error MeshDiag::DiscoverTopology(const DiscoverConfig &aConfig, DiscoverCallback
             continue;
         }
 
-        destination = Get<Mle::MleRouter>().GetMeshLocalRloc();
-        destination.GetIid().SetLocator(Mle::Rloc16FromRouterId(routerId));
+        IgnoreError(Get<Mle::Mle>().ConstructRloc(Mle::RouterIdFromRloc16(routerId), destination));
 
         SuccessOrExit(error = Get<Client>().SendCommand(kUriDiagnosticGetRequest, Message::kPriorityLow, destination,
                                                         tlvs, tlvsLength, HandleDiagGetResponse, this));
@@ -176,8 +175,7 @@ Error MeshDiag::SendQuery(uint16_t aRloc16, const uint8_t *aTlvs, uint8_t aTlvsL
     VerifyOrExit(Mle::IsActiveRouter(aRloc16), error = kErrorInvalidArgs);
     VerifyOrExit(Get<RouterTable>().IsAllocated(Mle::RouterIdFromRloc16(aRloc16)), error = kErrorNotFound);
 
-    destination = Get<Mle::MleRouter>().GetMeshLocalRloc();
-    destination.GetIid().SetLocator(aRloc16);
+    IgnoreError(Get<Mle::Mle>().ConstructRloc(aRloc16, destination));
 
     SuccessOrExit(error = Get<Client>().SendCommand(kUriDiagnosticGetQuery, Message::kPriorityNormal, destination,
                                                     aTlvs, aTlvsLength));


### PR DESCRIPTION
This commit adds `ConstructRloc()` and `ConstructAloc()` helper methods to the `Mle` class for constructing RLOC and ALOC IPv6 addresses from given RLOC16/ALOC16 values. These methods are now used in other modules where RLOC or ALOC addresses are needed.

Related methods are renamed to use the `Construct` term (e.g., `ConstructServiceAloc()`) to harmonize the naming style. Additionally, the `SetToRoutingLocator()` and `SetToAnycastLocator()` methods in the `Ip6` class are replaced with a common `SetLocator()` method.