### PR TITLE
[posix] add OT sys API to get the spinel driver

### DIFF
--- a/src/lib/spinel/spinel_driver.hpp
+++ b/src/lib/spinel/spinel_driver.hpp
@@ -36,6 +36,14 @@
 #include "lib/spinel/spinel.h"
 #include "lib/spinel/spinel_interface.hpp"
 
+/**
+ * Represents an opaque (and empty) type corresponding to a SpinelDriver object.
+ *
+ */
+struct otSpinelDriver
+{
+};
+
 namespace ot {
 namespace Spinel {
 
@@ -49,7 +57,7 @@ static constexpr uint8_t kSpinelHeaderMaxNumIid = 4;
 static constexpr uint8_t kSpinelHeaderMaxNumIid = 1;
 #endif
 
-class SpinelDriver : public Logger
+class SpinelDriver : public otSpinelDriver, public Logger
 {
 public:
     typedef void (

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -98,6 +98,23 @@ typedef struct otPlatformConfig
 } otPlatformConfig;
 
 /**
+ * Represents the platform spinel driver structure.
+ *
+ */
+typedef struct otSpinelDriver otSpinelDriver;
+
+/**
+ * Gets the instance of the spinel driver;
+ *
+ * @note This API is used for external projects to get the instance of `SpinelDriver` to customize
+ *       different spinel handlings.
+ *
+ * @returns A pointer to the spinel driver instance.
+ *
+ */
+otSpinelDriver *otSysGetSpinelDriver(void);
+
+/**
  * Initializes the co-processor and the spinel driver.
  *
  * @note This API will initialize the co-processor by resetting it and return the co-processor type.

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -57,6 +57,7 @@
 #include "posix/platform/mainloop.hpp"
 #include "posix/platform/mdns_socket.hpp"
 #include "posix/platform/radio_url.hpp"
+#include "posix/platform/spinel_driver_getter.hpp"
 #include "posix/platform/udp.hpp"
 
 otInstance *gInstance = nullptr;
@@ -257,6 +258,8 @@ CoprocessorType otSysInitCoprocessor(otPlatformCoprocessorUrls *aUrls)
     sCoprocessorType = platformSpinelManagerInit(get802154RadioUrl(*aUrls));
     return sCoprocessorType;
 }
+
+otSpinelDriver *otSysGetSpinelDriver(void) { return &ot::Posix::GetSpinelDriver(); }
 
 otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
 {


### PR DESCRIPTION
This PR adds a new posix openthread system API `otSysGetSpinelDriver`
to get the instance of spinel driver.

As discussed in [here](https://github.com/openthread/ot-br-posix/pull/2329#discussion_r1639576181), we should not access posix headers from
external 
procjects. So we add a openthread system API with opaque class to make
`SpinelDriver` accessible.