### PR TITLE
[mesh-forwarder] anycast forwarding to use a child RLOC16 dest

### DIFF
--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -424,7 +424,6 @@ Error MeshForwarder::AnycastRouteLookup(uint8_t aServiceId, AnycastType aType, u
     NetworkData::Iterator iterator = NetworkData::kIteratorInit;
     uint8_t               bestCost = Mle::kMaxRouteCost;
     uint16_t              bestDest = Mac::kShortAddrInvalid;
-    uint8_t               routerId;
 
     switch (aType)
     {
@@ -483,15 +482,6 @@ Error MeshForwarder::AnycastRouteLookup(uint8_t aServiceId, AnycastType aType, u
 
         break;
     }
-    }
-
-    routerId = Mle::RouterIdFromRloc16(bestDest);
-
-    if (!(Mle::IsActiveRouter(bestDest) || Mle::Rloc16FromRouterId(routerId) == Get<Mle::MleRouter>().GetRloc16()))
-    {
-        // if agent is neither active router nor child of this device
-        // use the parent of the ED Agent as Dest
-        bestDest = Mle::Rloc16FromRouterId(routerId);
     }
 
     aMeshDest = bestDest;


### PR DESCRIPTION
This commit updates `AnycastRouteLookup()` to always select the best RLOC16 destination for service ALOCs or DHCPv6/ND agent ALOCs, as discovered from Network Data entries. It removes previous logic that could choose the parent of a child device as the destination if the child was selected as the best RLOC16.