### PR TITLE
[posix] check the RCP supported short and extended source match table sizes

### DIFF
--- a/src/posix/platform/README_RCP_CAPS_DIAG.md
+++ b/src/posix/platform/README_RCP_CAPS_DIAG.md
@@ -8,6 +8,7 @@ This module provides diag commands for checking RCP capabilities.
 
 - [capflags](#capflags)
 - [spinel](#spinel)
+- [srcmatchtable](#srcmatchtable)
 
 ## Command Details
 
@@ -110,5 +111,16 @@ PROP_VALUE_SET PHY_FEM_LNA_GAIN --------------------------- OK
 PROP_VALUE_SET PHY_REGION_CODE ---------------------------- OK
 PROP_VALUE_SET PHY_TX_POWER ------------------------------- OK
 PROP_VALUE_SET RADIO_COEX_ENABLE -------------------------- OK
+Done
+```
+
+### srcmatchtable
+
+Check the source match table size supported by the RCP.
+
+```bash
+> diag rcpcaps srcmatchtable
+ShortSrcMatchTableSize ------------------------------------ 128
+ExtendedSrcMatchTableSize --------------------------------- 128
 Done
 ```

--- a/src/posix/platform/rcp_caps_diag.hpp
+++ b/src/posix/platform/rcp_caps_diag.hpp
@@ -108,8 +108,11 @@ private:
         RcpCapsDiag::SpinelCommandHandler mHandler;
     };
 
+    static constexpr uint16_t kMaxNumChildren = 512;
+
     void ProcessSpinel(void);
     void ProcessCapabilityFlags(void);
+    void ProcessSrcMatchTable(void);
     void TestSpinelCommands(Category aCategory);
     void TestRadioCapbilityFlags(void);
     void OutputRadioCapFlags(Category aCategory, uint32_t aRadioCaps, const uint32_t *aFlags, uint16_t aNumbFlags);
@@ -120,7 +123,10 @@ private:
                               const uint32_t *aFlags,
                               uint16_t        aNumbFlags);
     bool IsSpinelCapabilitySupported(const uint8_t *aCapsData, spinel_size_t aCapsLength, uint32_t aCapability);
+    void OutputExtendedSrcMatchTableSize(void);
+    void OutputShortSrcMatchTableSize(void);
     void OutputFormat(const char *aName, const char *aValue);
+    void OutputFormat(const char *aName, uint32_t aValue);
     void OutputResult(const SpinelEntry &aEntry, otError error);
     void Output(const char *aFormat, ...);
 


### PR DESCRIPTION
This commit adds a diag command to rcp capability diag module to check the  short and extended source match table size of the RCP.