### PR TITLE
[posix] check if the RCP supports specified diag commands

### DIFF
--- a/src/posix/platform/README_RCP_CAPS_DIAG.md
+++ b/src/posix/platform/README_RCP_CAPS_DIAG.md
@@ -6,9 +6,34 @@ This module provides diag commands for checking RCP capabilities.
 
 ## Command List
 
+- [diagcmd](#diagcmd)
 - [spinel](#spinel)
 
 ## Command Details
+
+### diagcmd
+
+Check which diag commands RCP supports.
+
+```bash
+> diag rcpcaps diagcmd
+
+Diag Commands :
+diag channel 20 ------------------------------------------- OK
+diag cw start --------------------------------------------- OK
+diag cw stop ---------------------------------------------- OK
+diag power 10 --------------------------------------------- OK
+diag echo 112233 ------------------------------------------ OK
+diag echo -n 200 ------------------------------------------ OK
+diag stream start ----------------------------------------- OK
+diag stream stop ------------------------------------------ OK
+diag rawpowersetting enable ------------------------------- OK
+diag rawpowersetting 112233 ------------------------------- OK
+diag rawpowersetting -------------------------------------- OK
+diag powersettings 20 ------------------------------------- NotFound
+diag rawpowersetting disable ------------------------------ OK
+Done
+```
 
 ### spinel
 

--- a/src/posix/platform/rcp_caps_diag.hpp
+++ b/src/posix/platform/rcp_caps_diag.hpp
@@ -100,7 +100,10 @@ private:
     };
 
     void ProcessSpinel(void);
+    void ProcessDiagCommands(void);
     void TestSpinelCommands(Category aCategory);
+    void TestDiagCommand(const char *aCommand);
+    void OutputFormat(const char *aName, const char *aValue);
     void OutputResult(const SpinelEntry &aEntry, otError error);
     void Output(const char *aFormat, ...);
 


### PR DESCRIPTION
This commit adds a diag command `diag rcpcaps diagcmd` to check whether the RCP supports specified diag commands.