### PR TITLE
[dns-client] track limited query (one question) servers

### DIFF
--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -770,7 +770,8 @@ public:
 #endif // OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE
 
 private:
-    static constexpr uint16_t kMaxCnameAliasNameChanges = 40;
+    static constexpr uint16_t kMaxCnameAliasNameChanges     = 40;
+    static constexpr uint8_t  kLimitedQueryServersArraySize = 3;
 
     enum QueryType : uint8_t
     {
@@ -858,6 +859,9 @@ private:
                   void              *aContext,
                   const QueryConfig *aConfig,
                   bool               aShouldResolveHostAddr);
+    void  CheckAndUpdateServiceMode(QueryConfig &aConfig, const QueryConfig *aRequestConfig) const;
+    void  RecordServerAsLimitedToSingleQuestion(const Ip6::Address &aServerAddress);
+    void  RecordServerAsCapableOfMultiQuestions(const Ip6::Address &aServerAddress);
     Error ReplaceWithSeparateSrvTxtQueries(Query &aQuery);
     void  ResolveHostAddressIfNeeded(Query &aQuery, const Message &aResponseMessage);
 #endif
@@ -925,6 +929,7 @@ private:
 #if OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_SERVER_ADDRESS_AUTO_SET_ENABLE
     bool mUserDidSetDefaultAddress;
 #endif
+    Array<Ip6::Address, kLimitedQueryServersArraySize> mLimitedQueryServers;
 };
 
 } // namespace Dns

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -49,6 +49,7 @@
 #include "border_router/infra_if.hpp"
 #include "common/as_core_type.hpp"
 #include "common/callback.hpp"
+#include "common/equatable.hpp"
 #include "common/message.hpp"
 #include "common/non_copyable.hpp"
 #include "common/owned_ptr.hpp"
@@ -96,6 +97,26 @@ public:
      */
     class Counters : public otDnssdCounters, public Clearable<Counters>
     {
+    public:
+        /**
+         * Returns the total number of processed queries (successful or failed responses).
+         *
+         * @return The total number of queries.
+         *
+         */
+        uint32_t GetTotalQueries(void) const { return mSuccessResponse + GetTotalFailedQueries(); }
+
+        /**
+         * Returns the total number of failed queries (any error response code).
+         *
+         * @return The total number of failed queries.
+         *
+         */
+        uint32_t GetTotalFailedQueries(void) const
+        {
+            return mServerFailureResponse + mFormatErrorResponse + mNameErrorResponse + mNotImplementedResponse +
+                   mOtherResponse;
+        }
     };
 
 #if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE


### PR DESCRIPTION
This commit updates `Dns::Client` to remember servers/resolvers that are known to have trouble with multiple-question queries. This information is learned from earlier interactions with the server.

When `ResolveService()` is requested, if the user explicitly requests "optimize" service mode, the request is honored. Otherwise, if "optimize" service mode is chosen from the default configuration and the DNS server is known to have trouble with multiple-question queries, "separate" service mode is used instead.

This commit also updates the `test_dns_client.cpp` unit test to validate the newly added behavior.