### PR TITLE
[ip6] add `Ip6::Address::IsLinkLocalUnicastOrMulticast()`

### DIFF
--- a/src/core/backbone_router/backbone_tmf.cpp
+++ b/src/core/backbone_router/backbone_tmf.cpp
@@ -120,8 +120,8 @@ bool BackboneTmfAgent::IsBackboneTmfMessage(const Ip6::MessageInfo &aMessageInfo
     //     2. All Domain BBRs (Link-Local scope)
     //     3. A Backbone Link-Local address
     // The source must be a Backbone Link-local address.
-    return (Get<BackboneRouter::Local>().IsEnabled() && src.IsLinkLocal() &&
-            (dst.IsLinkLocal() || dst == Get<BackboneRouter::Local>().GetAllNetworkBackboneRoutersAddress() ||
+    return (Get<BackboneRouter::Local>().IsEnabled() && src.IsLinkLocalUnicast() &&
+            (dst.IsLinkLocalUnicast() || dst == Get<BackboneRouter::Local>().GetAllNetworkBackboneRoutersAddress() ||
              dst == Get<BackboneRouter::Local>().GetAllDomainBackboneRoutersAddress()));
 }
 

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -2103,7 +2103,8 @@ exit:
 
 bool Server::IsProxyAddressValid(const Ip6::Address &aAddress)
 {
-    return !aAddress.IsLinkLocal() && !aAddress.IsMulticast() && !aAddress.IsUnspecified() && !aAddress.IsLoopback();
+    return !aAddress.IsLinkLocalUnicast() && !aAddress.IsMulticast() && !aAddress.IsUnspecified() &&
+           !aAddress.IsLoopback();
 }
 
 #endif // OPENTHREAD_CONFIG_DNSSD_DISCOVERY_PROXY_ENABLE

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1025,7 +1025,8 @@ Error Ip6::PassToHost(OwnedPtr<Message> &aMessagePtr,
     // than realm-local, set the hop limit to 1 before sending to host, so this packet
     // will not be forwarded by host.
     if (aMessageInfo.GetSockAddr().IsMulticastLargerThanRealmLocal() &&
-        (aMessageInfo.GetPeerAddr().IsLinkLocal() || (Get<Mle::Mle>().IsMeshLocalAddress(aMessageInfo.GetPeerAddr()))))
+        (aMessageInfo.GetPeerAddr().IsLinkLocalUnicast() ||
+         (Get<Mle::Mle>().IsMeshLocalAddress(aMessageInfo.GetPeerAddr()))))
     {
         messagePtr->Write<uint8_t>(Header::kHopLimitFieldOffset, 1);
     }
@@ -1131,9 +1132,9 @@ Error Ip6::HandleDatagram(OwnedPtr<Message> aMessagePtr, bool aIsReassembled)
         {
             receive = true;
         }
-        else if (!aMessagePtr->IsOriginThreadNetif() || !header.GetDestination().IsLinkLocal())
+        else if (!aMessagePtr->IsOriginThreadNetif() || !header.GetDestination().IsLinkLocalUnicast())
         {
-            if (header.GetDestination().IsLinkLocal())
+            if (header.GetDestination().IsLinkLocalUnicast())
             {
                 forwardThread = true;
             }
@@ -1430,8 +1431,8 @@ void Ip6::UpdateBorderRoutingCounters(const Header &aHeader, uint16_t aMessageLe
     otPacketsAndBytes       *counter         = nullptr;
     otPacketsAndBytes       *internetCounter = nullptr;
 
-    VerifyOrExit(!aHeader.GetSource().IsLinkLocal());
-    VerifyOrExit(!aHeader.GetDestination().IsLinkLocal());
+    VerifyOrExit(!aHeader.GetSource().IsLinkLocalUnicast());
+    VerifyOrExit(!aHeader.GetDestination().IsLinkLocalUnicast());
     VerifyOrExit(aHeader.GetSource().GetPrefix() != Get<Mle::Mle>().GetMeshLocalPrefix());
     VerifyOrExit(aHeader.GetDestination().GetPrefix() != Get<Mle::Mle>().GetMeshLocalPrefix());
 

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -343,7 +343,7 @@ bool Address::IsLoopback(void) const
             mFields.m32[3] == BigEndian::HostSwap32(1));
 }
 
-bool Address::IsLinkLocal(void) const
+bool Address::IsLinkLocalUnicast(void) const
 {
     return (mFields.m16[0] & BigEndian::HostSwap16(0xffc0)) == BigEndian::HostSwap16(0xfe80);
 }
@@ -363,6 +363,8 @@ void Address::SetToLinkLocalAddress(const InterfaceIdentifier &aIid)
 }
 
 bool Address::IsLinkLocalMulticast(void) const { return IsMulticast() && (GetScope() == kLinkLocalScope); }
+
+bool Address::IsLinkLocalUnicastOrMulticast(void) const { return IsLinkLocalUnicast() || IsLinkLocalMulticast(); }
 
 bool Address::IsLinkLocalAllNodesMulticast(void) const { return (*this == GetLinkLocalAllNodesMulticast()); }
 
@@ -458,7 +460,7 @@ uint8_t Address::GetScope(void) const
     {
         rval = mFields.m8[1] & 0xf;
     }
-    else if (IsLinkLocal())
+    else if (IsLinkLocalUnicast())
     {
         rval = kLinkLocalScope;
     }

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -646,13 +646,13 @@ public:
     bool IsLoopback(void) const;
 
     /**
-     * Indicates whether or not the IPv6 address scope is Link-Local.
+     * Indicates whether or not the IPv6 address is a Link-Local unicast address.
      *
-     * @retval TRUE   If the IPv6 address scope is Link-Local.
-     * @retval FALSE  If the IPv6 address scope is not Link-Local.
+     * @retval TRUE   If the IPv6 address is a Link-Local unicast address.
+     * @retval FALSE  If the IPv6 address is not a Link-Local unicast address.
      *
      */
-    bool IsLinkLocal(void) const;
+    bool IsLinkLocalUnicast(void) const;
 
     /**
      * Sets the IPv6 address to a Link-Local address with Interface Identifier generated from a given
@@ -688,6 +688,15 @@ public:
      *
      */
     bool IsLinkLocalMulticast(void) const;
+
+    /**
+     * Indicates whether or not the IPv6 address is a link-local unicast or a link-local multicast address.
+     *
+     * @retval TRUE   If the IPv6 address is a link-local unicast or multicast address.
+     * @retval FALSE  If the IPv6 address is not a link-local unicast and not a link-local multicast address.
+     *
+     */
+    bool IsLinkLocalUnicastOrMulticast(void) const;
 
     /**
      * Indicates whether or not the IPv6 address is a link-local all nodes multicast address (ff02::01).

--- a/src/core/net/ip6_filter.cpp
+++ b/src/core/net/ip6_filter.cpp
@@ -64,9 +64,7 @@ bool Filter::Accept(Message &aMessage) const
 
     SuccessOrExit(headers.ParseFrom(aMessage));
 
-    // Allow only link-local unicast or multicast
-    VerifyOrExit(headers.GetDestinationAddress().IsLinkLocal() ||
-                 headers.GetDestinationAddress().IsLinkLocalMulticast());
+    VerifyOrExit(headers.GetDestinationAddress().IsLinkLocalUnicastOrMulticast());
 
     // Allow all link-local IPv6 datagrams when Thread is not enabled
     if (Get<Mle::MleRouter>().GetRole() == Mle::kRoleDisabled)

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -453,7 +453,7 @@ Error Netif::AddExternalUnicastAddress(const UnicastAddress &aAddress)
         ExitNow();
     }
 
-    VerifyOrExit(!aAddress.GetAddress().IsLinkLocal(), error = kErrorInvalidArgs);
+    VerifyOrExit(!aAddress.GetAddress().IsLinkLocalUnicast(), error = kErrorInvalidArgs);
 
     entry = mExtUnicastAddressPool.Allocate();
     VerifyOrExit(entry != nullptr, error = kErrorNoBufs);

--- a/src/core/net/srp_advertising_proxy.cpp
+++ b/src/core/net/srp_advertising_proxy.cpp
@@ -944,7 +944,7 @@ void AdvertisingProxy::RegisterHost(Host &aHost)
 
     for (const Ip6::Address &address : aHost.mAddresses)
     {
-        if (!address.IsLinkLocal() && !Get<Mle::Mle>().IsMeshLocalAddress(address))
+        if (!address.IsLinkLocalUnicast() && !Get<Mle::Mle>().IsMeshLocalAddress(address))
         {
             IgnoreError(hostAddresses.PushBack(address));
         }

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -577,7 +577,7 @@ bool Client::ShouldHostAutoAddressRegister(const Ip6::Netif::UnicastAddress &aUn
 
     VerifyOrExit(aUnicastAddress.mValid);
     VerifyOrExit(aUnicastAddress.mPreferred);
-    VerifyOrExit(!aUnicastAddress.GetAddress().IsLinkLocal());
+    VerifyOrExit(!aUnicastAddress.GetAddress().IsLinkLocalUnicast());
     VerifyOrExit(!Get<Mle::Mle>().IsMeshLocalAddress(aUnicastAddress.GetAddress()));
 
     shouldRegister = true;

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -370,7 +370,7 @@ uint16_t IndirectSender::PrepareDataFrame(Mac::TxFrame &aFrame, Child &aChild, M
 
     Get<MeshForwarder>().GetMacSourceAddress(ip6Header.GetSource(), macAddrs.mSource);
 
-    if (ip6Header.GetDestination().IsLinkLocal())
+    if (ip6Header.GetDestination().IsLinkLocalUnicast())
     {
         Get<MeshForwarder>().GetMacDestinationAddress(ip6Header.GetDestination(), macAddrs.mDestination);
     }

--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -395,7 +395,7 @@ Error Initiator::FindNeighbor(const Ip6::Address &aDestination, Neighbor *&aNeig
 
     aNeighbor = nullptr;
 
-    VerifyOrExit(aDestination.IsLinkLocal());
+    VerifyOrExit(aDestination.IsLinkLocalUnicast());
     aDestination.GetIid().ConvertToMacAddress(macAddress);
 
     aNeighbor = Get<NeighborTable>().FindNeighbor(macAddress);

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -345,7 +345,7 @@ Error Lowpan::Compress(Message              &aMessage,
     {
         hcCtl |= kHcSrcAddrContext;
     }
-    else if (ip6Header.GetSource().IsLinkLocal())
+    else if (ip6Header.GetSource().IsLinkLocalUnicast())
     {
         SuccessOrExit(
             error = CompressSourceIid(aMacAddrs.mSource, ip6Header.GetSource(), srcContext, hcCtl, aFrameBuilder));
@@ -366,7 +366,7 @@ Error Lowpan::Compress(Message              &aMessage,
     {
         SuccessOrExit(error = CompressMulticast(ip6Header.GetDestination(), hcCtl, aFrameBuilder));
     }
-    else if (ip6Header.GetDestination().IsLinkLocal())
+    else if (ip6Header.GetDestination().IsLinkLocalUnicast())
     {
         SuccessOrExit(error = CompressDestinationIid(aMacAddrs.mDestination, ip6Header.GetDestination(), dstContext,
                                                      hcCtl, aFrameBuilder));

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -670,7 +670,7 @@ Error MeshForwarder::UpdateIp6Route(Message &aMessage)
 
     if (mle.IsDisabled() || mle.IsDetached())
     {
-        if (ip6Header.GetDestination().IsLinkLocal() || ip6Header.GetDestination().IsLinkLocalMulticast())
+        if (ip6Header.GetDestination().IsLinkLocalUnicastOrMulticast())
         {
             GetMacDestinationAddress(ip6Header.GetDestination(), mMacAddrs.mDestination);
         }
@@ -697,7 +697,7 @@ Error MeshForwarder::UpdateIp6Route(Message &aMessage)
             mMacAddrs.mDestination.SetShort(Mac::kShortAddrBroadcast);
         }
     }
-    else if (ip6Header.GetDestination().IsLinkLocal())
+    else if (ip6Header.GetDestination().IsLinkLocalUnicast())
     {
         GetMacDestinationAddress(ip6Header.GetDestination(), mMacAddrs.mDestination);
     }

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1032,7 +1032,7 @@ bool Mle::HasUnregisteredAddress(void)
 
     for (const Ip6::Netif::UnicastAddress &addr : Get<ThreadNetif>().GetUnicastAddresses())
     {
-        if (!addr.GetAddress().IsLinkLocal() && !IsRoutingLocator(addr.GetAddress()) &&
+        if (!addr.GetAddress().IsLinkLocalUnicast() && !IsRoutingLocator(addr.GetAddress()) &&
             !IsAnycastLocator(addr.GetAddress()) && addr.GetAddress() != GetMeshLocalEid())
         {
             ExitNow(retval = true);
@@ -4575,7 +4575,7 @@ Error Mle::TxMessage::AppendAddressRegistrationTlv(AddressRegistrationMode aMode
 
     for (const Ip6::Netif::UnicastAddress &addr : Get<ThreadNetif>().GetUnicastAddresses())
     {
-        if (addr.GetAddress().IsLinkLocal() || Get<Mle>().IsRoutingLocator(addr.GetAddress()) ||
+        if (addr.GetAddress().IsLinkLocalUnicast() || Get<Mle>().IsRoutingLocator(addr.GetAddress()) ||
             Get<Mle>().IsAnycastLocator(addr.GetAddress()) || addr.GetAddress() == Get<Mle>().GetMeshLocalEid())
         {
             continue;

--- a/src/core/thread/neighbor_table.cpp
+++ b/src/core/thread/neighbor_table.cpp
@@ -139,7 +139,7 @@ Neighbor *NeighborTable::FindNeighbor(const Ip6::Address &aIp6Address, Neighbor:
     Neighbor    *neighbor = nullptr;
     Mac::Address macAddress;
 
-    if (aIp6Address.IsLinkLocal())
+    if (aIp6Address.IsLinkLocalUnicast())
     {
         aIp6Address.GetIid().ConvertToMacAddress(macAddress);
     }

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -113,7 +113,7 @@ void Server::PrepareMessageInfoForDest(const Ip6::Address &aDestination, Tmf::Me
         aMessageInfo.SetMulticastLoop(true);
     }
 
-    if (aDestination.IsLinkLocal() || aDestination.IsLinkLocalMulticast())
+    if (aDestination.IsLinkLocalUnicastOrMulticast())
     {
         aMessageInfo.SetSockAddr(Get<Mle::MleRouter>().GetLinkLocalAddress());
     }

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -208,9 +208,9 @@ bool Agent::IsTmfMessage(const Ip6::Address &aSourceAddress, const Ip6::Address 
 
     VerifyOrExit(aDestPort == kUdpPort);
 
-    if (aSourceAddress.IsLinkLocal())
+    if (aSourceAddress.IsLinkLocalUnicast())
     {
-        isTmf = aDestAddress.IsLinkLocal() || aDestAddress.IsLinkLocalMulticast();
+        isTmf = aDestAddress.IsLinkLocalUnicastOrMulticast();
         ExitNow();
     }
 

--- a/src/posix/platform/multicast_routing.cpp
+++ b/src/posix/platform/multicast_routing.cpp
@@ -310,7 +310,7 @@ otError MulticastRoutingManager::AddMulticastForwardingCache(const Ip6::Address 
     }
     else
     {
-        VerifyOrExit(!aSrcAddr.IsLinkLocal(), error = OT_ERROR_NONE);
+        VerifyOrExit(!aSrcAddr.IsLinkLocalUnicast(), error = OT_ERROR_NONE);
         VerifyOrExit(aSrcAddr.GetPrefix() != AsCoreType(otThreadGetMeshLocalPrefix(gInstance)), error = OT_ERROR_NONE);
         // Forward multicast traffic from Thread to Backbone if multicast scope > kRealmLocalScope
         // TODO: (MLR) allow scope configuration of outbound multicast routing


### PR DESCRIPTION
This commit adds `IsLinkLocalUnicastOrMulticast()` to `Ip6::Address` to indicate whether the address is either a link-local unicast or a link-local multicast address.

The existing `IsLinkLocal()` is renamed to `IsLinkLocalUnicast()` to clarify its purpose and align its name with `IsLinkLocalMulticast()` and the new method.