### PR TITLE
[mle] replace `Mle::GetNextHop()` with `GetParentRloc16()`

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -690,7 +690,7 @@ Error MeshForwarder::UpdateIp6Route(Message &aMessage)
 
         if (mle.IsChild() && aMessage.IsLinkSecurityEnabled() && !aMessage.IsSubTypeMle())
         {
-            mMacAddrs.mDestination.SetShort(mle.GetNextHop(Mac::kShortAddrBroadcast));
+            mMacAddrs.mDestination.SetShort(mle.GetParentRloc16());
         }
         else
         {
@@ -703,7 +703,7 @@ Error MeshForwarder::UpdateIp6Route(Message &aMessage)
     }
     else if (mle.IsMinimalEndDevice())
     {
-        mMacAddrs.mDestination.SetShort(mle.GetNextHop(Mac::kShortAddrBroadcast));
+        mMacAddrs.mDestination.SetShort(mle.GetParentRloc16());
     }
     else
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3813,11 +3813,7 @@ void Mle::ProcessAnnounce(void)
     IgnoreError(Start(kAnnounceAttach));
 }
 
-uint16_t Mle::GetNextHop(uint16_t aDestination) const
-{
-    OT_UNUSED_VARIABLE(aDestination);
-    return (mParent.IsStateValid()) ? mParent.GetRloc16() : static_cast<uint16_t>(Mac::kShortAddrInvalid);
-}
+uint16_t Mle::GetParentRloc16(void) const { return (mParent.IsStateValid() ? mParent.GetRloc16() : kInvalidRloc16); }
 
 Error Mle::GetParentInfo(Router::Info &aParentInfo) const
 {

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -420,6 +420,14 @@ public:
     }
 
     /**
+     * Gets the parent's RLOC16.
+     *
+     * @returns  The parent's RLOC16, or `kInvalidRloc16` if parent's state is not valid.
+     *
+     */
+    uint16_t GetParentRloc16(void) const;
+
+    /**
      * Gets the parent when operating in End Device mode.
      *
      * @returns A reference to the parent.
@@ -692,16 +700,6 @@ public:
     {
         return (&aAddress == &mLinkLocalAllThreadNodes) || (&aAddress == &mRealmLocalAllThreadNodes);
     }
-
-    /**
-     * Determines the next hop towards an RLOC16 destination.
-     *
-     * @param[in]  aDestination  The RLOC16 of the destination.
-     *
-     * @returns A RLOC16 of the next hop if a route is known, kInvalidRloc16 otherwise.
-     *
-     */
-    uint16_t GetNextHop(uint16_t aDestination) const;
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     /**


### PR DESCRIPTION
This commit removes the `Mle::GetNextHop()` method, which returned the parent RLOC16 (when the parent state was valid) irrespective of a given destination.

The `Mle::GetNextHop()` method was only used on MTD builds and from `MeshForwarder::UpdateIp6Route()` method, where
`mle.GetNextHop(Mac::kShortAddrBroadcast)` served as an indirect way to get the parent RLOC16. This is now replaced with a direct `GetParentRloc16()` call, clarifying the intended purpose.

On FTD builds, the `MleRouter::GetNextHop()` is used instead of `Mle::GetNextHop()`. The `MleRouter` method remains unchanged. Since it would also return the parent's RLOC16 when the device is acting as a child, using `GetParentRloc16()` covers this case as well.