### PR TITLE
[otci] fix the `setDaemon() is deprecated` warning

### DIFF
--- a/tools/otci/otci/command_handlers.py
+++ b/tools/otci/otci/command_handlers.py
@@ -105,8 +105,7 @@ class OtCliCommandRunner(OTCommandHandler):
 
         self.__pending_lines = queue.Queue()
         self.__should_close = threading.Event()
-        self.__otcli_reader = threading.Thread(target=self.__otcli_read_routine)
-        self.__otcli_reader.setDaemon(True)
+        self.__otcli_reader = threading.Thread(target=self.__otcli_read_routine, daemon=True)
         self.__otcli_reader.start()
 
     def __repr__(self):


### PR DESCRIPTION
The otci reports warning `DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead`. This commit updates the otci to fix this warning.