### PR TITLE
[mle] remove `GetNextHop()` and directly use `RouterTable` method

### DIFF
--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -374,7 +374,7 @@ Error MeshForwarder::UpdateMeshRoute(Message &aMessage)
 
     IgnoreError(meshHeader.ParseFrom(aMessage));
 
-    nextHop = Get<Mle::MleRouter>().GetNextHop(meshHeader.GetDestination());
+    nextHop = Get<RouterTable>().GetNextHop(meshHeader.GetDestination());
 
     if (nextHop != Mac::kShortAddrInvalid)
     {
@@ -577,7 +577,7 @@ Error MeshForwarder::UpdateIp6RouteFtd(const Ip6::Header &aIp6Header, Message &a
 
     SuccessOrExit(error = mle.CheckReachability(mMeshDest, aIp6Header));
     aMessage.SetMeshDest(mMeshDest);
-    mMacAddrs.mDestination.SetShort(mle.GetNextHop(mMeshDest));
+    mMacAddrs.mDestination.SetShort(Get<RouterTable>().GetNextHop(mMeshDest));
 
     if (mMacAddrs.mDestination.GetShort() != mMeshDest)
     {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3217,7 +3217,7 @@ void MleRouter::ResolveRoutingLoops(uint16_t aSourceMac, uint16_t aDestRloc16)
 {
     Router *router;
 
-    if (aSourceMac != GetNextHop(aDestRloc16))
+    if (aSourceMac != mRouterTable.GetNextHop(aDestRloc16))
     {
         ExitNow();
     }
@@ -3263,7 +3263,7 @@ Error MleRouter::CheckReachability(uint16_t aMeshDest, const Ip6::Header &aIp6He
         ExitNow();
     }
 
-    isReachable = (GetNextHop(aMeshDest) != Mac::kShortAddrInvalid);
+    isReachable = (mRouterTable.GetNextHop(aMeshDest) != Mac::kShortAddrInvalid);
 
 exit:
     return isReachable ? kErrorNone : kErrorNoRoute;

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -237,16 +237,6 @@ public:
     void SetRouterId(uint8_t aRouterId);
 
     /**
-     * Returns the next hop towards an RLOC16 destination.
-     *
-     * @param[in]  aDestination  The RLOC16 of the destination.
-     *
-     * @returns A RLOC16 of the next hop if a route is known, kInvalidRloc16 otherwise.
-     *
-     */
-    uint16_t GetNextHop(uint16_t aDestination) { return mRouterTable.GetNextHop(aDestination); }
-
-    /**
      * Returns the NETWORK_ID_TIMEOUT value.
      *
      * @returns The NETWORK_ID_TIMEOUT value.


### PR DESCRIPTION
This commit removes the `MleRouter::GetNextHop()` method and instead directly uses `RouterTable::GetNextHop()`. This improves consistency across all modules.