### PR TITLE
[child-table] add `HasMinimalChild()` and move logic from `MleRouter`

### DIFF
--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -397,12 +397,12 @@ void AddressResolver::UpdateSnoopedCacheEntry(const Ip6::Address &aEid,
     // is this device or an MTD (minimal) child of the device itself.
 
     macAddress = Get<Mac::Mac>().GetShortAddress();
-    VerifyOrExit((aRloc16 != macAddress) && !Get<Mle::MleRouter>().IsMinimalChild(aRloc16));
+    VerifyOrExit((aRloc16 != macAddress) && !Get<ChildTable>().HasMinimalChild(aRloc16));
 
     // Ensure that the destination of the snooped message is this device
     // or a minimal child of this device.
 
-    VerifyOrExit((aDest == macAddress) || Get<Mle::MleRouter>().IsMinimalChild(aDest));
+    VerifyOrExit((aDest == macAddress) || Get<ChildTable>().HasMinimalChild(aDest));
 
     entry = NewCacheEntry(/* aSnoopedEntry */ true);
     VerifyOrExit(entry != nullptr);

--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -315,6 +315,22 @@ exit:
     return;
 }
 
+bool ChildTable::HasMinimalChild(uint16_t aRloc16) const
+{
+    bool         hasMinimalChild = false;
+    const Child *child;
+
+    VerifyOrExit(Mle::RouterIdMatch(aRloc16, Get<Mle::Mle>().GetRloc16()));
+
+    child = FindChild(Child::AddressMatcher(aRloc16, Child::kInStateValidOrRestoring));
+    VerifyOrExit(child != nullptr);
+
+    hasMinimalChild = !child->IsFullThreadDevice();
+
+exit:
+    return hasMinimalChild;
+}
+
 bool ChildTable::HasSleepyChildWithAddress(const Ip6::Address &aIp6Address) const
 {
     bool         hasChild = false;

--- a/src/core/thread/child_table.hpp
+++ b/src/core/thread/child_table.hpp
@@ -293,6 +293,19 @@ public:
     Error StoreChild(const Child &aChild);
 
     /**
+     * Indicates whether or not the child table contains an MTD child with a given @p aRloc16.
+     *
+     * Only children in `kInStateValidOrRestoring` are considered.
+     *
+     * @param[in]  aRloc16  The RLOC16 to check.
+     *
+     * @retval TRUE  If the child table contains an MTD child with @p aRloc16.
+     * @retval FALSE If the child table does not contain an MTD child with @p aRloc16.
+     *
+     */
+    bool HasMinimalChild(uint16_t aRloc16) const;
+
+    /**
      * Indicates whether the child table contains any sleepy child (in states valid or restoring) with a
      * given IPv6 address.
      *

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -677,7 +677,7 @@ void MeshForwarder::HandleMesh(FrameData &aFrameData, const Mac::Address &aMacSo
     UpdateRoutes(aFrameData, meshAddrs);
 
     if (meshAddrs.mDestination.GetShort() == Get<Mac::Mac>().GetShortAddress() ||
-        Get<Mle::MleRouter>().IsMinimalChild(meshAddrs.mDestination.GetShort()))
+        Get<ChildTable>().HasMinimalChild(meshAddrs.mDestination.GetShort()))
     {
         if (Lowpan::FragmentHeader::IsFragmentHeader(aFrameData))
         {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3107,22 +3107,6 @@ exit:
     LogSendError(kTypeDataResponse, error);
 }
 
-bool MleRouter::IsMinimalChild(uint16_t aRloc16)
-{
-    bool      isMinimalChild = false;
-    Neighbor *neighbor;
-
-    VerifyOrExit(RouterIdMatch(aRloc16, GetRloc16()));
-
-    neighbor = mNeighborTable.FindNeighbor(aRloc16);
-    VerifyOrExit(neighbor != nullptr);
-
-    isMinimalChild = !neighbor->IsFullThreadDevice();
-
-exit:
-    return isMinimalChild;
-}
-
 void MleRouter::RemoveRouterLink(Router &aRouter)
 {
     switch (mRole)

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -362,17 +362,6 @@ public:
     void RemoveRouterLink(Router &aRouter);
 
     /**
-     * Indicates whether or not the RLOC16 is an MTD child of this device.
-     *
-     * @param[in]  aRloc16  The RLOC16.
-     *
-     * @retval TRUE if @p aRloc16 is an MTD child of this device.
-     * @retval FALSE if @p aRloc16 is not an MTD child of this device.
-     *
-     */
-    bool IsMinimalChild(uint16_t aRloc16);
-
-    /**
      * Indicates whether or not the given Thread partition attributes are preferred.
      *
      * @param[in]  aSingletonA   Whether or not the Thread Partition A has a single router.


### PR DESCRIPTION
This commit adds the `HasMinimalChild()` method to the `ChildTable` class and moves the logic for checking if a device has an MTD child with a given RLOC16 from the `MleRouter` class to `ChildTable`. This aligns better with the `ChildTable` class's responsibility of managing all children and providing methods to search and find child entries in the table.