### PR TITLE
[mesh-forwarder] move `CheckReachability()` to `MeshForwarder`

### DIFF
--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -501,6 +501,7 @@ private:
 
     void     SendIcmpErrorIfDstUnreach(const Message &aMessage, const Mac::Addresses &aMacAddrs);
     Error    CheckReachability(const FrameData &aFrameData, const Mac::Addresses &aMeshAddrs);
+    Error    CheckReachability(uint16_t aMeshDest, const Ip6::Header &aIp6Header);
     void     UpdateRoutes(const FrameData &aFrameData, const Mac::Addresses &aMeshAddrs);
     Error    FrameToMessage(const FrameData      &aFrameData,
                             uint16_t              aDatagramSize,
@@ -510,6 +511,7 @@ private:
     void     GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr);
     Message *PrepareNextDirectTransmission(void);
     void     HandleMesh(FrameData &aFrameData, const Mac::Address &aMacSource, const ThreadLinkInfo &aLinkInfo);
+    void     ResolveRoutingLoops(uint16_t aSourceRloc16, uint16_t aDestRloc16);
     void     HandleFragment(FrameData &aFrameData, const Mac::Addresses &aMacAddrs, const ThreadLinkInfo &aLinkInfo);
     void HandleLowpanHC(const FrameData &aFrameData, const Mac::Addresses &aMacAddrs, const ThreadLinkInfo &aLinkInfo);
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3213,62 +3213,6 @@ void MleRouter::SetRouterId(uint8_t aRouterId)
     mPreviousRouterId = mRouterId;
 }
 
-void MleRouter::ResolveRoutingLoops(uint16_t aSourceMac, uint16_t aDestRloc16)
-{
-    Router *router;
-
-    if (aSourceMac != mRouterTable.GetNextHop(aDestRloc16))
-    {
-        ExitNow();
-    }
-
-    router = mRouterTable.FindRouterByRloc16(aDestRloc16);
-    VerifyOrExit(router != nullptr);
-
-    router->SetNextHopToInvalid();
-    ResetAdvertiseInterval();
-
-exit:
-    return;
-}
-
-Error MleRouter::CheckReachability(uint16_t aMeshDest, const Ip6::Header &aIp6Header)
-{
-    bool isReachable = false;
-
-    if (IsChild())
-    {
-        if (aMeshDest == GetRloc16())
-        {
-            isReachable = Get<ThreadNetif>().HasUnicastAddress(aIp6Header.GetDestination());
-        }
-        else
-        {
-            isReachable = true;
-        }
-
-        ExitNow();
-    }
-
-    if (aMeshDest == GetRloc16())
-    {
-        isReachable = Get<ThreadNetif>().HasUnicastAddress(aIp6Header.GetDestination()) ||
-                      (mNeighborTable.FindNeighbor(aIp6Header.GetDestination()) != nullptr);
-        ExitNow();
-    }
-
-    if (RouterIdFromRloc16(aMeshDest) == mRouterId)
-    {
-        isReachable = (mChildTable.FindChild(aMeshDest, Child::kInStateValidOrRestoring) != nullptr);
-        ExitNow();
-    }
-
-    isReachable = (mRouterTable.GetNextHop(aMeshDest) != Mac::kShortAddrInvalid);
-
-exit:
-    return isReachable ? kErrorNone : kErrorNoRoute;
-}
-
 Error MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
 {
     Error            error = kErrorNone;

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -391,27 +391,6 @@ public:
                                  const LeaderData &aLeaderDataB);
 
     /**
-     * Checks if the destination is reachable.
-     *
-     * @param[in]  aMeshDest   The RLOC16 of the destination.
-     * @param[in]  aIp6Header  A reference to the IPv6 header of the message.
-     *
-     * @retval kErrorNone      The destination is reachable.
-     * @retval kErrorNoRoute   The destination is not reachable and the message should be dropped.
-     *
-     */
-    Error CheckReachability(uint16_t aMeshDest, const Ip6::Header &aIp6Header);
-
-    /**
-     * Resolves 2-hop routing loops.
-     *
-     * @param[in]  aSourceMac   The RLOC16 of the previous hop.
-     * @param[in]  aDestRloc16  The RLOC16 of the final destination.
-     *
-     */
-    void ResolveRoutingLoops(uint16_t aSourceMac, uint16_t aDestRloc16);
-
-    /**
      * Fills an ConnectivityTlv.
      *
      * @param[out]  aTlv  A reference to the tlv to be filled.


### PR DESCRIPTION
This commit moves the `CheckReachability()` & `ResolveRoutingLoops()` methods from the `MleRouter` class to the `MeshForwarder` class now as `private` methods. This consolidates all `CheckReachability()` overloads within the `MeshForwarder` class.