### PR TITLE
[child] update MLR masks when removing registered IPv6 addresses

### DIFF
--- a/src/core/thread/child.cpp
+++ b/src/core/thread/child.cpp
@@ -203,6 +203,23 @@ Error Child::RemoveIp6Address(const Ip6::Address &aAddress)
     entry = mIp6Addresses.Find(aAddress);
     VerifyOrExit(entry != nullptr);
 
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+    {
+        // `Array::Remove()` will replace the removed entry with the
+        // last one in the array. We also update the MLR bit vectors
+        // to reflect this change.
+
+        uint16_t entryIndex = mIp6Addresses.IndexOf(*entry);
+        uint16_t lastIndex  = mIp6Addresses.GetLength() - 1;
+
+        mMlrToRegisterMask.Set(entryIndex, mMlrToRegisterMask.Get(lastIndex));
+        mMlrToRegisterMask.Set(lastIndex, false);
+
+        mMlrRegisteredMask.Set(entryIndex, mMlrRegisteredMask.Get(lastIndex));
+        mMlrRegisteredMask.Set(lastIndex, false);
+    }
+#endif
+
     mIp6Addresses.Remove(*entry);
     error = kErrorNone;
 


### PR DESCRIPTION
This commit modifies `Child::RemoveIp6Address()` to update the `mMlrToRegisterMask` and `mMlrToUnregisterMask` when a registered child IPv6 address entry is removed from the list. These bit-vector masks track the MLR state associated with the entry using its index in the array. Since `Array::Remove()` replaces the deleted entry with the last one in the array, the MLR masks are also updated to reflect this change.

---

~This PR contains the commit from https://github.com/openthread/openthread/pull/10422. Please check and review the last commit. Thanks.~

Fixes the issue mentioned here -> https://github.com/openthread/openthread/pull/10422#discussion_r1649497434
