### PR TITLE
[trel] fix missing ie field in TREL link

### DIFF
--- a/src/core/radio/trel_link.cpp
+++ b/src/core/radio/trel_link.cpp
@@ -62,6 +62,11 @@ Link::Link(Instance &aInstance)
     mTxFrame.mPsdu = &mTxPacketBuffer[kMaxHeaderSize];
     mTxFrame.SetLength(0);
 
+#if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
+    memset(&mTxIeInfo, 0, sizeof(otRadioIeInfo));
+    mTxFrame.mInfo.mTxInfo.mIeInfo = &mTxIeInfo;
+#endif
+
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     mTxFrame.SetRadioType(Mac::kRadioTypeTrel);
     mRxFrame.SetRadioType(Mac::kRadioTypeTrel);

--- a/src/core/radio/trel_link.hpp
+++ b/src/core/radio/trel_link.hpp
@@ -191,6 +191,11 @@ private:
     Interface    mInterface;
     Mac::RxFrame mRxFrame;
     Mac::TxFrame mTxFrame;
+
+    #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
+    otRadioIeInfo mTxIeInfo;
+    #endif
+
     uint8_t      mTxPacketBuffer[kMaxHeaderSize + kMtuSize];
     uint8_t      mAckPacketBuffer[kMaxHeaderSize];
     uint8_t      mAckFrameBuffer[k154AckFrameSize];


### PR DESCRIPTION
Fixes #10426 

In #10426 , turning on any IE fields with TREL enabled (for example, when `OPENTHREAD_CONFIG_TIME_SYNC` is set), will result in a segfault because the`mIeInfo` is NULL, and will result in a null pointer dereference. This PR fixes this by allocating a instance of `otRadioIeInfo` on trel::Link and setting the `mIeInfo` field of the `txFrame` to the instance.

