### PR TITLE
[posix] fix build with custom netif prefix route set

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -483,7 +483,7 @@ static void UpdateUnicastLinux(otInstance *aInstance, const otIp6AddressInfo &aA
 #endif
     {
 #if OPENTHREAD_POSIX_CONFIG_NETIF_PREFIX_ROUTE_METRIC > 0
-        static constexpr kLinkLocalScope = 2;
+        static constexpr uint8_t kLinkLocalScope = 2;
 
         if (aAddressInfo.mScope > kLinkLocalScope)
         {


### PR DESCRIPTION
This fixes a build error when the pre-processor define `OPENTHREAD_POSIX_CONFIG_NETIF_PREFIX_ROUTE_METRIC` is set:

```
/usr/src/ot-br-posix/third_party/openthread/repo/src/posix/platform/netif.cpp:486:26: error: ‘kLinkLocalScope’ does not name a type
  486 |         static constexpr kLinkLocalScope = 2;
      |                          ^~~~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
```