### PR TITLE
[core] use RLOC16-related constants and methods consistently across modules

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -81,7 +81,7 @@ otError otThreadGetLeaderRloc(otInstance *aInstance, otIp6Address *aLeaderRloc)
 {
     Error error = kErrorNone;
 
-    VerifyOrExit(AsCoreType(aInstance).Get<Mle::Mle>().GetRloc16() != Mac::kShortAddrInvalid, error = kErrorDetached);
+    VerifyOrExit(AsCoreType(aInstance).Get<Mle::Mle>().GetRloc16() != Mle::kInvalidRloc16, error = kErrorDetached);
     AsCoreType(aInstance).Get<Mle::Mle>().GetLeaderRloc(AsCoreType(aLeaderRloc));
 
 exit:
@@ -197,7 +197,7 @@ otError otThreadGetServiceAloc(otInstance *aInstance, uint8_t aServiceId, otIp6A
 {
     Error error = kErrorNone;
 
-    VerifyOrExit(AsCoreType(aInstance).Get<Mle::Mle>().GetRloc16() != Mac::kShortAddrInvalid, error = kErrorDetached);
+    VerifyOrExit(AsCoreType(aInstance).Get<Mle::Mle>().GetRloc16() != Mle::kInvalidRloc16, error = kErrorDetached);
     AsCoreType(aInstance).Get<Mle::Mle>().GetServiceAloc(aServiceId, AsCoreType(aServiceAloc));
 
 exit:

--- a/src/core/backbone_router/bbr_leader.cpp
+++ b/src/core/backbone_router/bbr_leader.cpp
@@ -52,7 +52,7 @@ Leader::Leader(Instance &aInstance)
 void Leader::Reset(void)
 {
     // Invalid server short address indicates no available Backbone Router service in the Thread Network.
-    mConfig.mServer16 = Mac::kShortAddrInvalid;
+    mConfig.mServer16 = Mle::kInvalidRloc16;
 
     // Domain Prefix Length 0 indicates no available Domain Prefix in the Thread network.
     mDomainPrefix.SetLength(0);
@@ -152,11 +152,11 @@ void Leader::UpdateBackboneRouterPrimary(void)
 
     if (config.mServer16 != mConfig.mServer16)
     {
-        if (config.mServer16 == Mac::kShortAddrInvalid)
+        if (config.mServer16 == Mle::kInvalidRloc16)
         {
             state = kStateRemoved;
         }
-        else if (mConfig.mServer16 == Mac::kShortAddrInvalid)
+        else if (mConfig.mServer16 == Mle::kInvalidRloc16)
         {
             state = kStateAdded;
         }
@@ -166,7 +166,7 @@ void Leader::UpdateBackboneRouterPrimary(void)
             state = kStateToTriggerRereg;
         }
     }
-    else if (config.mServer16 == Mac::kShortAddrInvalid)
+    else if (config.mServer16 == Mle::kInvalidRloc16)
     {
         // If no Primary all the time.
         state = kStateNone;
@@ -185,7 +185,7 @@ void Leader::UpdateBackboneRouterPrimary(void)
     }
 
     // Restrain the range of MLR timeout to be always valid
-    if (config.mServer16 != Mac::kShortAddrInvalid)
+    if (config.mServer16 != Mle::kInvalidRloc16)
     {
         uint32_t origTimeout = config.mMlrTimeout;
 

--- a/src/core/backbone_router/bbr_leader.hpp
+++ b/src/core/backbone_router/bbr_leader.hpp
@@ -143,7 +143,7 @@ public:
     /**
      * Gets the short address of the Primary Backbone Router.
      *
-     * @returns short address of Primary Backbone Router, or Mac::kShortAddrInvalid if no Primary Backbone Router.
+     * @returns short address of Primary Backbone Router, or Mle::kInvalidRloc16 if no Primary Backbone Router.
      *
      */
     uint16_t GetServer16(void) const { return mConfig.mServer16; }
@@ -155,7 +155,7 @@ public:
      * @retval FALSE  If there is no Primary Backbone Router.
      *
      */
-    bool HasPrimary(void) const { return mConfig.mServer16 != Mac::kShortAddrInvalid; }
+    bool HasPrimary(void) const { return mConfig.mServer16 != Mle::kInvalidRloc16; }
 
     /**
      * Gets the Domain Prefix in the Thread Network.

--- a/src/core/backbone_router/bbr_local.cpp
+++ b/src/core/backbone_router/bbr_local.cpp
@@ -254,7 +254,7 @@ void Local::HandleBackboneRouterPrimaryUpdate(Leader::State aState, const Config
     VerifyOrExit(IsEnabled() && Get<Mle::MleRouter>().IsAttached());
 
     // Wait some jitter before trying to Register.
-    if (aConfig.mServer16 == Mac::kShortAddrInvalid)
+    if (aConfig.mServer16 == Mle::kInvalidRloc16)
     {
         mRegistrationTimeout = 1;
 

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -527,7 +527,7 @@ Error Manager::SendBackboneQuery(const Ip6::Address &aDua, uint16_t aRloc16)
 
     SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, aDua));
 
-    if (aRloc16 != Mac::kShortAddrInvalid)
+    if (aRloc16 != Mle::kInvalidRloc16)
     {
         SuccessOrExit(error = Tlv::Append<ThreadRloc16Tlv>(*message, aRloc16));
     }
@@ -550,7 +550,7 @@ template <> void Manager::HandleTmf<kUriBackboneQuery>(Coap::Message &aMessage, 
 {
     Error                  error = kErrorNone;
     Ip6::Address           dua;
-    uint16_t               rloc16 = Mac::kShortAddrInvalid;
+    uint16_t               rloc16 = Mle::kInvalidRloc16;
     NdProxyTable::NdProxy *ndProxy;
 
     VerifyOrExit(aMessageInfo.IsHostInterface(), error = kErrorDrop);
@@ -583,7 +583,7 @@ template <> void Manager::HandleTmf<kUriBackboneAnswer>(Coap::Message &aMessage,
     Ip6::InterfaceIdentifier meshLocalIid;
     uint16_t                 networkNameOffset, networkNameLength;
     uint32_t                 timeSinceLastTransaction;
-    uint16_t                 srcRloc16 = Mac::kShortAddrInvalid;
+    uint16_t                 srcRloc16 = Mle::kInvalidRloc16;
 
     VerifyOrExit(aMessageInfo.IsHostInterface(), error = kErrorDrop);
 
@@ -606,7 +606,7 @@ template <> void Manager::HandleTmf<kUriBackboneAnswer>(Coap::Message &aMessage,
     {
         HandleProactiveBackboneNotification(dua, meshLocalIid, timeSinceLastTransaction);
     }
-    else if (srcRloc16 == Mac::kShortAddrInvalid)
+    else if (srcRloc16 == Mle::kInvalidRloc16)
     {
         HandleDadBackboneAnswer(dua, meshLocalIid);
     }
@@ -626,7 +626,7 @@ Error Manager::SendProactiveBackboneNotification(const Ip6::Address             
                                                  uint32_t                        aTimeSinceLastTransaction)
 {
     return SendBackboneAnswer(Get<Local>().GetAllDomainBackboneRoutersAddress(), aDua, aMeshLocalIid,
-                              aTimeSinceLastTransaction, Mac::kShortAddrInvalid);
+                              aTimeSinceLastTransaction, Mle::kInvalidRloc16);
 }
 
 Error Manager::SendBackboneAnswer(const Ip6::MessageInfo      &aQueryMessageInfo,
@@ -664,7 +664,7 @@ Error Manager::SendBackboneAnswer(const Ip6::Address             &aDstAddr,
     SuccessOrExit(error = Tlv::Append<ThreadNetworkNameTlv>(
                       *message, Get<MeshCoP::NetworkNameManager>().GetNetworkName().GetAsCString()));
 
-    if (aSrcRloc16 != Mac::kShortAddrInvalid)
+    if (aSrcRloc16 != Mle::kInvalidRloc16)
     {
         SuccessOrExit(Tlv::Append<ThreadRloc16Tlv>(*message, aSrcRloc16));
     }

--- a/src/core/backbone_router/bbr_manager.hpp
+++ b/src/core/backbone_router/bbr_manager.hpp
@@ -146,7 +146,7 @@ public:
      * Sends BB.qry on the Backbone link.
      *
      * @param[in]  aDua     The Domain Unicast Address to query.
-     * @param[in]  aRloc16  The short address of the address resolution initiator or `Mac::kShortAddrInvalid` for
+     * @param[in]  aRloc16  The short address of the address resolution initiator or `Mle::kInvalidRloc16` for
      *                      DUA DAD.
      *
      * @retval kErrorNone          Successfully sent BB.qry on backbone link.
@@ -154,7 +154,7 @@ public:
      * @retval kErrorNoBufs        If insufficient message buffers available.
      *
      */
-    Error SendBackboneQuery(const Ip6::Address &aDua, uint16_t aRloc16 = Mac::kShortAddrInvalid);
+    Error SendBackboneQuery(const Ip6::Address &aDua, uint16_t aRloc16 = Mle::kInvalidRloc16);
 
     /**
      * Send a Proactive Backbone Notification (PRO_BB.ntf) on the Backbone link.

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -1783,7 +1783,7 @@ void Server::UpdateAddrResolverCacheTable(const Ip6::MessageInfo &aMessageInfo, 
 
     rloc16 = Get<AddressResolver>().LookUp(aMessageInfo.GetPeerAddr());
 
-    VerifyOrExit(rloc16 != Mac::kShortAddrInvalid);
+    VerifyOrExit(rloc16 != Mle::kInvalidRloc16);
 
     for (const Ip6::Address &address : aHost.mAddresses)
     {

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -139,7 +139,7 @@ public:
      * @param[in]  aRloc16  The RLOC16 address.
      *
      */
-    void RemoveEntriesForRloc16(Mac::ShortAddress aRloc16);
+    void RemoveEntriesForRloc16(uint16_t aRloc16);
 
     /**
      * Removes all EID-to-RLOC cache entries associated with a Router ID.
@@ -177,7 +177,7 @@ public:
      * @param[in] aDest            The short MAC address destination of the received snooped message.
      *
      */
-    void UpdateSnoopedCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16, Mac::ShortAddress aDest);
+    void UpdateSnoopedCacheEntry(const Ip6::Address &aEid, uint16_t aRloc16, uint16_t aDest);
 
     /**
      * Returns the RLOC16 for a given EID, initiates an Address Query if the mapping is not known.
@@ -191,7 +191,7 @@ public:
      * @retval kErrorNoBufs         Insufficient buffer space available to send Address Query.
      *
      */
-    Error Resolve(const Ip6::Address &aEid, Mac::ShortAddress &aRloc16)
+    Error Resolve(const Ip6::Address &aEid, uint16_t &aRloc16)
     {
         return Resolve(aEid, aRloc16, /* aAllowAddressQuery */ true);
     }
@@ -204,10 +204,10 @@ public:
      *
      * @param[in]   aEid   A reference to the EID to lookup.
      *
-     * @returns The RLOC16 mapping to @p aEid or `Mac::kShortAddrInvalid` if it is not found in the address cache.
+     * @returns The RLOC16 mapping to @p aEid or `Mle::kInvalidRloc16` if it is not found in the address cache.
      *
      */
-    Mac::ShortAddress LookUp(const Ip6::Address &aEid);
+    uint16_t LookUp(const Ip6::Address &aEid);
 
     /**
      * Restarts any ongoing address queries.
@@ -267,8 +267,8 @@ private:
         const Ip6::Address &GetTarget(void) const { return mTarget; }
         void                SetTarget(const Ip6::Address &aTarget) { mTarget = aTarget; }
 
-        Mac::ShortAddress GetRloc16(void) const { return mRloc16; }
-        void              SetRloc16(Mac::ShortAddress aRloc16) { mRloc16 = aRloc16; }
+        uint16_t GetRloc16(void) const { return mRloc16; }
+        void     SetRloc16(uint16_t aRloc16) { mRloc16 = aRloc16; }
 
         const Ip6::InterfaceIdentifier &GetMeshLocalIid(void) const { return mInfo.mCached.mMeshLocalIid; }
         void SetMeshLocalIid(const Ip6::InterfaceIdentifier &aIid) { mInfo.mCached.mMeshLocalIid = aIid; }
@@ -298,9 +298,9 @@ private:
         static constexpr uint16_t kNoNextIndex          = 0xffff;     // `mNextIndex` value when at end of list.
         static constexpr uint32_t kInvalidLastTransTime = 0xffffffff; // Value when `mLastTransactionTime` is invalid.
 
-        Ip6::Address      mTarget;
-        Mac::ShortAddress mRloc16;
-        uint16_t          mNextIndex;
+        Ip6::Address mTarget;
+        uint16_t     mRloc16;
+        uint16_t     mNextIndex;
 
         union
         {
@@ -348,16 +348,16 @@ private:
 
     CacheEntryPool &GetCacheEntryPool(void) { return mCacheEntryPool; }
 
-    Error       Resolve(const Ip6::Address &aEid, Mac::ShortAddress &aRloc16, bool aAllowAddressQuery);
-    void        Remove(Mac::ShortAddress aRloc16, bool aMatchRouterId);
+    Error       Resolve(const Ip6::Address &aEid, uint16_t &aRloc16, bool aAllowAddressQuery);
+    void        Remove(uint16_t aRloc16, bool aMatchRouterId);
     void        Remove(const Ip6::Address &aEid, Reason aReason);
     CacheEntry *FindCacheEntry(const Ip6::Address &aEid, CacheEntryList *&aList, CacheEntry *&aPrevEntry);
     CacheEntry *NewCacheEntry(bool aSnoopedEntry);
     void        RemoveCacheEntry(CacheEntry &aEntry, CacheEntryList &aList, CacheEntry *aPrevEntry, Reason aReason);
-    Error       UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16);
+    Error       UpdateCacheEntry(const Ip6::Address &aEid, uint16_t aRloc16);
     Error       SendAddressQuery(const Ip6::Address &aEid);
 #if OPENTHREAD_CONFIG_TMF_ALLOW_ADDRESS_RESOLUTION_USING_NET_DATA_SERVICES
-    Error ResolveUsingNetDataServices(const Ip6::Address &aEid, Mac::ShortAddress &aRloc16);
+    Error ResolveUsingNetDataServices(const Ip6::Address &aEid, uint16_t &aRloc16);
 #endif
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);

--- a/src/core/thread/anycast_locator.cpp
+++ b/src/core/thread/anycast_locator.cpp
@@ -91,7 +91,7 @@ void AnycastLocator::HandleResponse(Coap::Message *aMessage, const Ip6::MessageI
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
-    uint16_t            rloc16  = Mac::kShortAddrInvalid;
+    uint16_t            rloc16  = Mle::kInvalidRloc16;
     const Ip6::Address *address = nullptr;
     Ip6::Address        meshLocalAddress;
 

--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -192,7 +192,7 @@ Error ChildTable::GetChildInfoById(uint16_t aChildId, Child::Info &aChildInfo)
         aChildId = Mle::ChildIdFromRloc16(aChildId);
     }
 
-    rloc16 = Get<Mac::Mac>().GetShortAddress() | aChildId;
+    rloc16 = Get<Mle::Mle>().GetRloc16() | aChildId;
     child  = FindChild(rloc16, Child::kInStateValidOrRestoring);
     VerifyOrExit(child != nullptr, error = kErrorNotFound);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -95,8 +95,8 @@ Mle::Mle(Instance &aInstance)
 #if OPENTHREAD_FTD
     , mLinkRequestAttempts(0)
 #endif
-    , mRloc16(Mac::kShortAddrInvalid)
-    , mPreviousParentRloc(Mac::kShortAddrInvalid)
+    , mRloc16(kInvalidRloc16)
+    , mPreviousParentRloc(kInvalidRloc16)
     , mAttachCounter(0)
     , mAnnounceDelay(kAnnounceTimeout)
     , mAlternatePanId(Mac::kPanIdBroadcast)
@@ -209,7 +209,7 @@ Error Mle::Start(StartMode aMode)
         mReattachState = kReattachStart;
     }
 
-    if ((aMode == kAnnounceAttach) || (GetRloc16() == Mac::kShortAddrInvalid))
+    if ((aMode == kAnnounceAttach) || (GetRloc16() == kInvalidRloc16))
     {
         Attach(kAnyPartition);
     }
@@ -407,7 +407,7 @@ void Mle::Restore(void)
 
     mMeshLocalEid.GetAddress().SetIid(networkInfo.GetMeshLocalIid());
 
-    if (networkInfo.GetRloc16() == Mac::kShortAddrInvalid)
+    if (networkInfo.GetRloc16() == kInvalidRloc16)
     {
         ExitNow();
     }
@@ -540,7 +540,7 @@ Error Mle::BecomeDetached(void)
 
     SetStateDetached();
     mParent.SetState(Neighbor::kStateInvalid);
-    SetRloc16(Mac::kShortAddrInvalid);
+    SetRloc16(kInvalidRloc16);
     Attach(kAnyPartition);
 
 exit:
@@ -749,7 +749,7 @@ void Mle::SetStateChild(uint16_t aRloc16)
     mParentSearch.UpdateState();
 #endif
 
-    if ((mPreviousParentRloc != Mac::kShortAddrInvalid) && (mPreviousParentRloc != mParent.GetRloc16()))
+    if ((mPreviousParentRloc != kInvalidRloc16) && (mPreviousParentRloc != mParent.GetRloc16()))
     {
         mCounters.mParentChanges++;
 
@@ -960,7 +960,7 @@ void Mle::SetRloc16(uint16_t aRloc16)
     Get<Mac::Mac>().SetShortAddress(aRloc16);
     mRloc16 = aRloc16;
 
-    if (aRloc16 != Mac::kShortAddrInvalid)
+    if (aRloc16 != kInvalidRloc16)
     {
         // We can always call `AddUnicastAddress(mMeshLocat16)` and if
         // the address is already added, it will perform no action.
@@ -3948,7 +3948,7 @@ void Mle::ParentSearch::UpdateState(void)
 
     if (mIsInBackoff && !mBackoffWasCanceled && mRecentlyDetached)
     {
-        if ((Get<Mle>().mPreviousParentRloc != Mac::kShortAddrInvalid) &&
+        if ((Get<Mle>().mPreviousParentRloc != kInvalidRloc16) &&
             (Get<Mle>().mPreviousParentRloc != Get<Mle>().mParent.GetRloc16()))
         {
             mIsInBackoff        = false;
@@ -3972,7 +3972,7 @@ void Mle::ParentSearch::UpdateState(void)
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 void Mle::Log(MessageAction aAction, MessageType aType, const Ip6::Address &aAddress)
 {
-    Log(aAction, aType, aAddress, Mac::kShortAddrInvalid);
+    Log(aAction, aType, aAddress, kInvalidRloc16);
 }
 
 void Mle::Log(MessageAction aAction, MessageType aType, const Ip6::Address &aAddress, uint16_t aRloc)
@@ -3984,7 +3984,7 @@ void Mle::Log(MessageAction aAction, MessageType aType, const Ip6::Address &aAdd
 
     String<kRlocStringSize> rlocString;
 
-    if (aRloc != Mac::kShortAddrInvalid)
+    if (aRloc != kInvalidRloc16)
     {
         rlocString.Append(",0x%04x", aRloc);
     }

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1166,7 +1166,7 @@ private:
     class ServiceAloc : public Ip6::Netif::UnicastAddress
     {
     public:
-        static constexpr uint16_t kNotInUse = Mac::kShortAddrInvalid;
+        static constexpr uint16_t kNotInUse = kInvalidRloc16;
 
         ServiceAloc(void);
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1084,7 +1084,7 @@ Error MleRouter::ProcessRouteTlv(const RouteTlv &aRouteTlv, RxInfo &aRxInfo)
     // `RouterTable`).
 
     Error    error          = kErrorNone;
-    uint16_t neighborRloc16 = Mac::kShortAddrInvalid;
+    uint16_t neighborRloc16 = kInvalidRloc16;
 
     if ((aRxInfo.mNeighbor != nullptr) && Get<RouterTable>().Contains(*aRxInfo.mNeighbor))
     {
@@ -1099,7 +1099,7 @@ Error MleRouter::ProcessRouteTlv(const RouteTlv &aRouteTlv, RxInfo &aRxInfo)
         error = kErrorNoRoute;
     }
 
-    if (neighborRloc16 != Mac::kShortAddrInvalid)
+    if (neighborRloc16 != kInvalidRloc16)
     {
         aRxInfo.mNeighbor = Get<NeighborTable>().FindNeighbor(neighborRloc16);
     }
@@ -3415,7 +3415,7 @@ template <> void MleRouter::HandleTmf<kUriAddressSolicit>(Coap::Message &aMessag
     case kErrorNone:
         break;
     case kErrorNotFound:
-        rloc16 = Mac::kShortAddrInvalid;
+        rloc16 = kInvalidRloc16;
         break;
     default:
         ExitNow(error = kErrorParse);
@@ -3464,7 +3464,7 @@ template <> void MleRouter::HandleTmf<kUriAddressSolicit>(Coap::Message &aMessag
         ExitNow();
     }
 
-    if (rloc16 != Mac::kShortAddrInvalid)
+    if (rloc16 != kInvalidRloc16)
     {
         router = mRouterTable.Allocate(RouterIdFromRloc16(rloc16));
 

--- a/src/core/thread/neighbor.hpp
+++ b/src/core/thread/neighbor.hpp
@@ -154,8 +154,7 @@ public:
          */
         AddressMatcher(const Mac::Address &aMacAddress, StateFilter aStateFilter)
             : AddressMatcher(aStateFilter,
-                             aMacAddress.IsShort() ? aMacAddress.GetShort()
-                                                   : static_cast<Mac::ShortAddress>(Mac::kShortAddrInvalid),
+                             aMacAddress.IsShort() ? aMacAddress.GetShort() : Mac::kShortAddrInvalid,
                              aMacAddress.IsExtended() ? &aMacAddress.GetExtended() : nullptr)
         {
         }

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -616,7 +616,7 @@ void Leader::CheckForNetDataGettingFull(const NetworkData &aNetworkData, uint16_
         leaderClone.MarkAsClone();
         SuccessOrAssert(CopyNetworkData(kFullSet, leaderClone));
 
-        if (aOldRloc16 != Mac::kShortAddrInvalid)
+        if (aOldRloc16 != Mle::kInvalidRloc16)
         {
             leaderClone.RemoveBorderRouter(aOldRloc16, kMatchModeRloc16);
         }

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -57,7 +57,7 @@ Notifier::Notifier(Instance &aInstance)
     , mNetDataFullTask(aInstance)
 #endif
     , mNextDelay(0)
-    , mOldRloc(Mac::kShortAddrInvalid)
+    , mOldRloc(Mle::kInvalidRloc16)
     , mWaitingForResponse(false)
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTER_REQUEST_ROUTER_ROLE
     , mDidRequestRouterRoleUpgrade(false)
@@ -177,7 +177,7 @@ Error Notifier::UpdateInconsistentData(void)
 
     if (mOldRloc == deviceRloc)
     {
-        mOldRloc = Mac::kShortAddrInvalid;
+        mOldRloc = Mle::kInvalidRloc16;
     }
 
     SuccessOrExit(error = SendServerDataNotification(mOldRloc, &Get<Local>()));
@@ -211,7 +211,7 @@ Error Notifier::SendServerDataNotification(uint16_t aOldRloc16, const NetworkDat
 #endif
     }
 
-    if (aOldRloc16 != Mac::kShortAddrInvalid)
+    if (aOldRloc16 != Mle::kInvalidRloc16)
     {
         SuccessOrExit(error = Tlv::Append<ThreadRloc16Tlv>(*message, aOldRloc16));
     }

--- a/src/core/thread/network_data_service.cpp
+++ b/src/core/thread/network_data_service.cpp
@@ -103,7 +103,7 @@ void Manager::GetBackboneRouterPrimary(ot::BackboneRouter::Config &aConfig) cons
 
     serviceData.Init(&BackboneRouter::kServiceData, BackboneRouter::kServiceDataMinSize);
 
-    aConfig.mServer16 = Mac::kShortAddrInvalid;
+    aConfig.mServer16 = Mle::kInvalidRloc16;
 
     while ((serviceTlv = Get<Leader>().FindNextThreadService(serviceTlv, serviceData,
                                                              NetworkData::kServicePrefixMatch)) != nullptr)

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -43,6 +43,7 @@
 #include "common/encoding.hpp"
 #include "common/equatable.hpp"
 #include "net/ip6_address.hpp"
+#include "thread/mle_types.hpp"
 #include "thread/network_data_types.hpp"
 
 namespace ot {
@@ -412,7 +413,7 @@ public:
      */
     void Init(void)
     {
-        SetRloc(Mac::kShortAddrInvalid);
+        SetRloc(Mle::kInvalidRloc16);
         mFlags = 0;
     }
 
@@ -923,7 +924,7 @@ public:
      */
     void Init(void)
     {
-        SetRloc(Mac::kShortAddrInvalid);
+        SetRloc(Mle::kInvalidRloc16);
         mFlags = 0;
     }
 

--- a/src/core/utils/history_tracker.hpp
+++ b/src/core/utils/history_tracker.hpp
@@ -292,7 +292,7 @@ private:
     static constexpr AddressEvent kAddressAdded   = OT_HISTORY_TRACKER_ADDRESS_EVENT_ADDED;
     static constexpr AddressEvent kAddressRemoved = OT_HISTORY_TRACKER_ADDRESS_EVENT_REMOVED;
 
-    static constexpr uint16_t kInvalidRloc16 = Mac::kShortAddrInvalid;
+    static constexpr uint16_t kInvalidRloc16 = Mle::kInvalidRloc16;
 
     typedef otHistoryTrackerNeighborEvent NeighborEvent;
 


### PR DESCRIPTION
This commit aims to make the use of RLOC16-related constants and methods consistent across different modules.

- It replaces `Mac::kShortAddrInvalid` with `Mle::kInvalidRloc16` to refer to an invalid RLOC16 value (note that these constants use the same value `0xfffe`).
- It uses `Get<Mle::Mle>().GetRloc16()` to retrieve the device's RLOC16 instead of `Get<Mac::Mac>().GetShortAddress()`.
- It updates `AddressResolver` to consistently use `uint16_t` for RLOC16 (instead of the `Mac::ShortAddress` typedef).