### PR TITLE
[tlv] ensure handling of extended TLVs when iterating over sub-TLVs

### DIFF
--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -56,6 +56,24 @@ const uint8_t *Tlv::GetValue(void) const
 
 Error Tlv::AppendTo(Message &aMessage) const { return aMessage.AppendBytes(this, static_cast<uint16_t>(GetSize())); }
 
+Error Tlv::ParseAndSkipTlv(const Message &aMessage, uint16_t &aOffset)
+{
+    Error      error;
+    ParsedInfo info;
+
+    SuccessOrExit(error = info.ParseFrom(aMessage, aOffset));
+
+    // `ParseFrom()` has already validated that the entire TLV is
+    // present within `aMessage`. This ensures that `aOffset + mSize`
+    // is less than `aMessage.GetLength()`, and therefore we cannot
+    // have an overflow here.
+
+    aOffset += info.mSize;
+
+exit:
+    return error;
+}
+
 Error Tlv::FindTlv(const Message &aMessage, uint8_t aType, uint16_t aMaxSize, Tlv &aTlv)
 {
     uint16_t offset;

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -245,6 +245,21 @@ public:
     // Static methods for reading/finding/appending TLVs in a `Message`.
 
     /**
+     * Parses a TLV in a message at a given offset, validating that it is fully contained within the message and then
+     * updating the offset to skip over the entire parsed TLV.
+     *
+     * Can be used independent of whether the read TLV (from the message) is an Extended TLV or not.
+     *
+     * @param[in]       aMessage    The message to read from.
+     * @param[in,out]   aOffset     The offset to read from. On success, it is updated to point after the parsed TLV.
+     *
+     * @retval kErrorNone    Successfully parsed a TLV from @p aMessage. @p aOffset is updated.
+     * @retval kErrorParse   The TLV was not well-formed or was not fully contained in @p aMessage.
+     *
+     */
+    static Error ParseAndSkipTlv(const Message &aMessage, uint16_t &aOffset);
+
+    /**
      * Reads a TLV's value in a message at a given offset expecting a minimum length for the value.
      *
      * Can be used independent of whether the read TLV (from the message) is an Extended TLV or not.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2637,12 +2637,21 @@ void MleRouter::HandleDiscoveryRequest(RxInfo &aRxInfo)
 
     while (offset < end)
     {
-        IgnoreError(aRxInfo.mMessage.Read(offset, meshcopTlv));
+        SuccessOrExit(error = aRxInfo.mMessage.Read(offset, meshcopTlv));
+
+        if (meshcopTlv.IsExtended())
+        {
+            SuccessOrExit(error = Tlv::ParseAndSkipTlv(aRxInfo.mMessage, offset));
+            VerifyOrExit(offset <= end, error = kErrorParse);
+            continue;
+        }
+
+        VerifyOrExit(meshcopTlv.GetSize() + offset <= aRxInfo.mMessage.GetLength(), error = kErrorParse);
 
         switch (meshcopTlv.GetType())
         {
         case MeshCoP::Tlv::kDiscoveryRequest:
-            IgnoreError(aRxInfo.mMessage.Read(offset, discoveryRequestTlv));
+            SuccessOrExit(error = aRxInfo.mMessage.Read(offset, discoveryRequestTlv));
             VerifyOrExit(discoveryRequestTlv.IsValid(), error = kErrorParse);
 
             break;


### PR DESCRIPTION
This commit adds the `Tlv::ParseAndSkipTlv()` static method, which parses a TLV (regular or extended) in a message at a given offset. It validates that the TLV is fully contained within the message and updates the offset to skip over the entire parsed TLV.

This helper method is used in various modules where manual iteration over a sequence of TLVs is performed, specifically to skip over extended TLVs. The following methods are updated to utilize this new method and perform additional TLV checks:

- `DiscoverScanner::HandleDiscoveryResponse()`
- `MleRouter::HandleDiscoveryRequest()`
- `LinkMetrics::SubJect::AppendReport()`
- `LinkMetrics::Subject::HandleManagementRequest()`
- `LinkMetrics::Initiator::HandleReport()`

-----

- Should help address:https://github.com/openthread/openthread/issues/10438
- This change introduces repeated code patterns.  In a future PR (following #10436), we can implement a new mechanism for iterating over TLVs which should help simplify the code and eliminate these repetitive patterns.