### PR TITLE
[mle] add RLOC16 related helper methods in `Mle`

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -81,7 +81,7 @@ otError otThreadGetLeaderRloc(otInstance *aInstance, otIp6Address *aLeaderRloc)
 {
     Error error = kErrorNone;
 
-    VerifyOrExit(AsCoreType(aInstance).Get<Mle::Mle>().GetRloc16() != Mle::kInvalidRloc16, error = kErrorDetached);
+    VerifyOrExit(!AsCoreType(aInstance).Get<Mle::Mle>().HasRloc16(Mle::kInvalidRloc16), error = kErrorDetached);
     AsCoreType(aInstance).Get<Mle::Mle>().GetLeaderRloc(AsCoreType(aLeaderRloc));
 
 exit:
@@ -197,7 +197,7 @@ otError otThreadGetServiceAloc(otInstance *aInstance, uint8_t aServiceId, otIp6A
 {
     Error error = kErrorNone;
 
-    VerifyOrExit(AsCoreType(aInstance).Get<Mle::Mle>().GetRloc16() != Mle::kInvalidRloc16, error = kErrorDetached);
+    VerifyOrExit(!AsCoreType(aInstance).Get<Mle::Mle>().HasRloc16(Mle::kInvalidRloc16), error = kErrorDetached);
     AsCoreType(aInstance).Get<Mle::Mle>().GetServiceAloc(aServiceId, AsCoreType(aServiceAloc));
 
 exit:

--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -320,7 +320,7 @@ bool ChildTable::HasMinimalChild(uint16_t aRloc16) const
     bool         hasMinimalChild = false;
     const Child *child;
 
-    VerifyOrExit(Mle::RouterIdMatch(aRloc16, Get<Mle::Mle>().GetRloc16()));
+    VerifyOrExit(Get<Mle::Mle>().HasMatchingRouterIdWith(aRloc16));
 
     child = FindChild(Child::AddressMatcher(aRloc16, Child::kInStateValidOrRestoring));
     VerifyOrExit(child != nullptr);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -432,7 +432,7 @@ void Mle::Restore(void)
         mParent.SetVersion(parentInfo.GetVersion());
         mParent.SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
                                          DeviceMode::kModeFullNetworkData));
-        mParent.SetRloc16(Rloc16FromRouterId(RouterIdFromRloc16(networkInfo.GetRloc16())));
+        mParent.SetRloc16(ParentRloc16ForRloc16(networkInfo.GetRloc16()));
         mParent.SetState(Neighbor::kStateRestored);
 
         mPreviousParentRloc = mParent.GetRloc16();
@@ -3558,7 +3558,7 @@ void Mle::HandleChildUpdateResponse(RxInfo &aRxInfo)
     case kRoleChild:
         SuccessOrExit(error = Tlv::Find<SourceAddressTlv>(aRxInfo.mMessage, sourceAddress));
 
-        if (!RouterIdMatch(sourceAddress, GetRloc16()))
+        if (!HasMatchingRouterIdWith(sourceAddress))
         {
             IgnoreError(BecomeDetached());
             ExitNow();

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -524,6 +524,42 @@ public:
     uint16_t GetRloc16(void) const { return mRloc16; }
 
     /**
+     * Indicates whether or not this device is using a given RLOC16.
+     *
+     * @param[in] aRloc16   The RLOC16 to check.
+     *
+     * @retval TRUE   This device is using @p aRloc16.
+     * @retval FALSE  This device is not using @p aRloc16.
+     *
+     */
+    bool HasRloc16(uint16_t aRloc16) const { return mRloc16 == aRloc16; }
+
+    /**
+     * Indicates whether or not this device RLOC16 matches a given Router ID.
+     *
+     * @param[in] aRouterId   The Router ID to check.
+     *
+     * @retval TRUE   This device's RLOC16 matches the @p aRouterId.
+     * @retval FALSE  This device's RLOC16 does not match the @p aRouterId.
+     *
+     */
+    bool MatchesRouterId(uint8_t aRouterId) const { return RouterIdFromRloc16(mRloc16) == aRouterId; }
+
+    /**
+     * Indicates whether or not this device's RLOC16 shares the same Router ID with a given RLOC16.
+     *
+     * A shared Router ID implies that this device and the @ aRloc16 are either directly related as parent and child,
+     * or are children of the same parent within the Thread network.
+     *
+     * @param[in] aRloc16   The RLOC16 to check.
+     *
+     * @retval TRUE   This device and @p aRloc16 have a matching router ID.
+     * @retval FALSE  This device and @p aRloc16 do not have a matching router ID.
+     *
+     */
+    bool HasMatchingRouterIdWith(uint16_t aRloc16) const { return RouterIdMatch(mRloc16, aRloc16); }
+
+    /**
      * Returns the mesh local RLOC IPv6 address assigned to the Thread interface.
      *
      * @returns The mesh local RLOC IPv6 address.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2775,7 +2775,7 @@ Error MleRouter::SendChildIdResponse(Child &aChild)
     SuccessOrExit(error = message->AppendLeaderDataTlv());
     SuccessOrExit(error = message->AppendActiveAndPendingTimestampTlvs());
 
-    if ((aChild.GetRloc16() == 0) || !RouterIdMatch(aChild.GetRloc16(), GetRloc16()))
+    if ((aChild.GetRloc16() == 0) || !HasMatchingRouterIdWith(aChild.GetRloc16()))
     {
         uint16_t rloc16;
 

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -682,6 +682,18 @@ inline uint16_t CommissionerAloc16FromId(uint16_t aSessionId)
 inline uint16_t Rloc16FromRouterId(uint8_t aRouterId) { return static_cast<uint16_t>(aRouterId << kRouterIdOffset); }
 
 /**
+ * Derives the router RLOC16 corresponding to the parent of a given (child) RLOC16.
+ *
+ * If @p aRloc16 itself refers to a router, then the same RLOC16 value is returned.
+ *
+ * @param[in] aRloc16   An RLOC16.
+ *
+ * @returns The router RLOC16 corresponding to the parent associated with @p aRloc16.
+ *
+ */
+inline uint16_t ParentRloc16ForRloc16(uint16_t aRloc16) { return Rloc16FromRouterId(RouterIdFromRloc16(aRloc16)); }
+
+/**
  * Indicates whether or not @p aRloc16 refers to a router.
  *
  * @param[in]  aRloc16  The RLOC16 value.

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -324,7 +324,7 @@ int Leader::CompareRouteEntries(int8_t   aFirstPreference,
     // On MTD, prefer the BR that is this device itself. This handles
     // the uncommon case where an MTD itself may be acting as BR.
 
-    result = ThreeWayCompare((aFirstRloc == Get<Mle::Mle>().GetRloc16()), (aSecondRloc == Get<Mle::Mle>().GetRloc16()));
+    result = ThreeWayCompare((Get<Mle::Mle>().HasRloc16(aFirstRloc)), Get<Mle::Mle>().HasRloc16(aSecondRloc));
 #endif
 
 #if OPENTHREAD_FTD

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -138,7 +138,7 @@ Error Notifier::RemoveStaleChildEntries(void)
 
     for (uint16_t rloc16 : rlocs)
     {
-        if (Mle::IsChildRloc16(rloc16) && Mle::RouterIdMatch(Get<Mle::MleRouter>().GetRloc16(), rloc16) &&
+        if (Mle::IsChildRloc16(rloc16) && Get<Mle::Mle>().HasMatchingRouterIdWith(rloc16) &&
             Get<ChildTable>().FindChild(rloc16, Child::kInStateValid) == nullptr)
         {
             error = SendServerDataNotification(rloc16);

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -268,7 +268,7 @@ Router *RouterTable::FindNeighbor(uint16_t aRloc16)
 {
     Router *router = nullptr;
 
-    VerifyOrExit(aRloc16 != Get<Mle::MleRouter>().GetRloc16());
+    VerifyOrExit(!Get<Mle::Mle>().HasRloc16(aRloc16));
     router = FindRouter(Router::AddressMatcher(aRloc16, Router::kInStateValid));
 
 exit:
@@ -362,7 +362,7 @@ uint8_t RouterTable::GetLinkCost(const Router &aRouter) const
 {
     uint8_t rval = Mle::kMaxRouteCost;
 
-    VerifyOrExit(aRouter.GetRloc16() != Get<Mle::MleRouter>().GetRloc16() && aRouter.IsStateValid());
+    VerifyOrExit(!Get<Mle::Mle>().HasRloc16(aRouter.GetRloc16()) && aRouter.IsStateValid());
 
     rval = CostForLinkQuality(aRouter.GetTwoWayLinkQuality());
 
@@ -400,7 +400,6 @@ uint8_t RouterTable::GetPathCostToLeader(void) const { return GetPathCost(Get<Ml
 
 void RouterTable::GetNextHopAndPathCost(uint16_t aDestRloc16, uint16_t &aNextHopRloc16, uint8_t &aPathCost) const
 {
-    uint8_t       destRouterId;
     const Router *router;
     const Router *nextHop;
 
@@ -409,7 +408,7 @@ void RouterTable::GetNextHopAndPathCost(uint16_t aDestRloc16, uint16_t &aNextHop
 
     VerifyOrExit(Get<Mle::Mle>().IsAttached());
 
-    if (aDestRloc16 == Get<Mle::Mle>().GetRloc16())
+    if (Get<Mle::Mle>().HasRloc16(aDestRloc16))
     {
         // Destination is this device, return cost as zero.
         aPathCost      = 0;
@@ -417,14 +416,13 @@ void RouterTable::GetNextHopAndPathCost(uint16_t aDestRloc16, uint16_t &aNextHop
         ExitNow();
     }
 
-    destRouterId = Mle::RouterIdFromRloc16(aDestRloc16);
-
-    router  = FindRouterById(destRouterId);
+    router  = FindRouterById(Mle::RouterIdFromRloc16(aDestRloc16));
     nextHop = (router != nullptr) ? FindNextHopOf(*router) : nullptr;
 
     if (Get<Mle::MleRouter>().IsChild())
     {
         const Router &parent = Get<Mle::Mle>().GetParent();
+        bool          destIsParentOrItsChild;
 
         if (parent.IsStateValid())
         {
@@ -436,11 +434,13 @@ void RouterTable::GetNextHopAndPathCost(uint16_t aDestRloc16, uint16_t &aNextHop
         // check if we have a next hop towards the destination and
         // add its cost to the link cost to parent.
 
-        VerifyOrExit((destRouterId == parent.GetRouterId()) || (nextHop != nullptr));
+        destIsParentOrItsChild = Mle::RouterIdMatch(aDestRloc16, parent.GetRloc16());
+
+        VerifyOrExit(destIsParentOrItsChild || (nextHop != nullptr));
 
         aPathCost = CostForLinkQuality(parent.GetLinkQualityIn());
 
-        if (destRouterId != parent.GetRouterId())
+        if (!destIsParentOrItsChild)
         {
             aPathCost += router->GetCost();
         }
@@ -450,7 +450,7 @@ void RouterTable::GetNextHopAndPathCost(uint16_t aDestRloc16, uint16_t &aNextHop
     }
     else // Role is router or leader
     {
-        if (destRouterId == Mle::RouterIdFromRloc16(Get<Mle::Mle>().GetRloc16()))
+        if (Get<Mle::Mle>().HasMatchingRouterIdWith(aDestRloc16))
         {
             // Destination is a one of our children.
 
@@ -590,7 +590,7 @@ void RouterTable::UpdateRoutes(const Mle::RouteTlv &aRouteTlv, uint8_t aNeighbor
     for (uint8_t routerId = 0, index = 0; routerId <= Mle::kMaxRouterId;
          index += aRouteTlv.IsRouterIdSet(routerId) ? 1 : 0, routerId++)
     {
-        if (routerId != Mle::RouterIdFromRloc16(Get<Mle::Mle>().GetRloc16()))
+        if (!Get<Mle::Mle>().MatchesRouterId(routerId))
         {
             continue;
         }
@@ -625,7 +625,7 @@ void RouterTable::UpdateRoutes(const Mle::RouteTlv &aRouteTlv, uint8_t aNeighbor
 
         router = FindRouterById(routerId);
 
-        if (router == nullptr || router->GetRloc16() == Get<Mle::Mle>().GetRloc16() || router == neighbor)
+        if (router == nullptr || Get<Mle::Mle>().HasRloc16(router->GetRloc16()) || router == neighbor)
         {
             continue;
         }
@@ -737,8 +737,8 @@ void RouterTable::FillRouteTlv(Mle::RouteTlv &aRouteTlv, const Neighbor *aNeighb
                     break;
                 }
 
-                if ((routerId == Mle::RouterIdFromRloc16(Get<Mle::Mle>().GetRloc16())) ||
-                    (routerId == aNeighbor->GetRouterId()) || (routerId == Get<Mle::Mle>().GetLeaderId()))
+                if (Get<Mle::Mle>().MatchesRouterId(routerId) || (routerId == aNeighbor->GetRouterId()) ||
+                    (routerId == Get<Mle::Mle>().GetLeaderId()))
                 {
                     // Route64 TLV must contain this device and the
                     // neighboring router to ensure that at least this
@@ -775,7 +775,7 @@ void RouterTable::FillRouteTlv(Mle::RouteTlv &aRouteTlv, const Neighbor *aNeighb
 
         routerRloc16 = Mle::Rloc16FromRouterId(routerId);
 
-        if (routerRloc16 == Get<Mle::Mle>().GetRloc16())
+        if (Get<Mle::Mle>().HasRloc16(routerRloc16))
         {
             aRouteTlv.SetRouteData(routerIndex, kLinkQuality0, kLinkQuality0, 1);
         }
@@ -895,7 +895,7 @@ void RouterTable::LogRouteTable(void) const
 
         string.Append("    %2d 0x%04x", router.GetRouterId(), router.GetRloc16());
 
-        if (router.GetRloc16() == Get<Mle::Mle>().GetRloc16())
+        if (Get<Mle::Mle>().HasRloc16(router.GetRloc16()))
         {
             string.Append(" - me");
         }

--- a/src/core/utils/mesh_diag.cpp
+++ b/src/core/utils/mesh_diag.cpp
@@ -506,7 +506,7 @@ Error MeshDiag::RouterInfo::ParseFrom(const Message &aMessage)
     }
 
     mRouterId           = Mle::RouterIdFromRloc16(mRloc16);
-    mIsThisDevice       = (mRloc16 == mle.GetRloc16());
+    mIsThisDevice       = mle.HasRloc16(mRloc16);
     mIsThisDeviceParent = mle.IsChild() && (mRloc16 == mle.GetParent().GetRloc16());
     mIsLeader           = (mRouterId == mle.GetLeaderId());
     mIsBorderRouter     = aMessage.Get<NetworkData::Leader>().ContainsBorderRouterWithRloc(mRloc16);
@@ -582,7 +582,7 @@ Error MeshDiag::ChildIterator::GetNextChildInfo(ChildInfo &aChildInfo)
     entry.GetMode().Get(aChildInfo.mMode);
     aChildInfo.mLinkQuality = entry.GetLinkQuality();
 
-    aChildInfo.mIsThisDevice   = (aChildInfo.mRloc16 == mMessage->Get<Mle::Mle>().GetRloc16());
+    aChildInfo.mIsThisDevice   = mMessage->Get<Mle::Mle>().HasRloc16(aChildInfo.mRloc16);
     aChildInfo.mIsBorderRouter = mMessage->Get<NetworkData::Leader>().ContainsBorderRouterWithRloc(aChildInfo.mRloc16);
 
 exit:


### PR DESCRIPTION
This commit introduces new helper methods in the `Mle` class:

- `HasRloc16()`: Checks if the device is using a given RLOC16.
- `MatchesRouterId()`: Checks if this device's RLOC16 matches a given Router ID.
- `HasMatchingRouterIdWith()`: Checks if this device's RLOC16 shares the same Router ID with a given RLOC16. This implies that the two devices are either directly related as parent and child or are children of the same parent within the Thread network.
- `ParentRloc16ForRloc16()` derives the router RLOC16 corresponding to the parent of a given (child) RLOC16.

These methods act as syntactic sugar, simplifying code and enhancing readability.