### PR TITLE
[posix] skip 0x00 bytes at the start of the received SPI frame

### DIFF
--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -326,7 +326,7 @@ uint8_t *SpiInterface::GetRealRxFrameStart(uint8_t *aSpiRxFrameBuffer, uint8_t a
     uint8_t       *start = aSpiRxFrameBuffer;
     const uint8_t *end   = aSpiRxFrameBuffer + aAlignAllowance;
 
-    for (; start != end && start[0] == 0xff; start++)
+    for (; start != end && ((start[0] == 0xff) || (start[0] == 0x00)); start++)
         ;
 
     aSkipLength = static_cast<uint16_t>(start - aSpiRxFrameBuffer);
@@ -469,7 +469,7 @@ otError SpiInterface::PushPullSpi(void)
         DieNow(OT_EXIT_FAILURE);
     }
 
-    // Account for misalignment (0xFF bytes at the start)
+    // Account for misalignment (0xFF or 0x00 bytes at the start)
     spiRxFrame = GetRealRxFrameStart(spiRxFrameBuffer, mSpiAlignAllowance, skipAlignAllowanceLength);
 
     {


### PR DESCRIPTION
The SPI interface may receive the garbage bytes 0xff or 0x00 at the start of the received SPI frame. This commit skips the 0x00 bytes at the start of the received SPI frame.