### PR TITLE
[dns-client] switch to separate SRV/TXT queries on response timeout

### DIFF
--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -291,8 +291,9 @@ public:
      */
     enum TestModeFlags : uint8_t
     {
-        kTestModeSingleQuestionOnly     = 1 << 0, ///< Allow single question in query, send `FormatError` otherwise.
-        kTestModeEmptyAdditionalSection = 1 << 1, ///< Do not include any RR in additional section.
+        kTestModeRejectMultiQuestionQuery = 1 << 0, ///< Send `FormatError` for a query with multiple questions.
+        kTestModeIgnoreMultiQuestionQuery = 1 << 1, ///< Ignore a query with multiple questions (send no response).
+        kTestModeEmptyAdditionalSection   = 1 << 2, ///< Do not include any RR in additional section.
     };
 
     static constexpr uint8_t kTestModeDisabled = 0; ///< Test mode is disabled (no flags).
@@ -346,7 +347,7 @@ private:
 
     struct Request
     {
-        ResponseCode ParseQuestions(uint8_t aTestMode);
+        ResponseCode ParseQuestions(uint8_t aTestMode, bool &aShouldRespond);
 
         const Message          *mMessage;
         const Ip6::MessageInfo *mMessageInfo;


### PR DESCRIPTION
This commit updates `Dns::Client` so that when resolving a service using `kServiceModeSrvTxtOptimize`, it switches to single-question query mode and sends separate parallel SRV and TXT queries upon the first response timeout. This is in addition to the existing behavior of switching to separate queries upon receiving a response with an error rcode from the server.

The `test_dns_client` unit test is also updated to validate this scenario. New `TestMode` configurations are added to server to control its behavior, allowing it to either reject multi-question queries (by sending a "FormatError" rcode) or ignore them (sending no response).