### PR TITLE
[routing-manager] add support for tracking peer BRs

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -677,12 +677,16 @@ private:
         void SetStaleTimeCalculated(bool aFlag) { mStaleTimeCalculated = aFlag; }
         bool IsStaleTimeCalculated(void) const { return mStaleTimeCalculated; }
 
+        void SetDisregardFlag(bool aFlag) { mDisregard = aFlag; }
+        bool ShouldDisregard(void) const { return mDisregard; }
+
     protected:
         LifetimedPrefix(void) = default;
 
         TimeMilli CalculateExpirationTime(uint32_t aLifetime) const;
 
         Ip6::Prefix mPrefix;
+        bool        mDisregard : 1;
         bool        mStaleTimeCalculated : 1;
         uint32_t    mValidLifetime;
         TimeMilli   mLastUpdateTime;
@@ -807,9 +811,15 @@ private:
 
         struct Router : public Clearable<Router>
         {
-            // The timeout (in msec) for router to be considered reachable
-            // before starting the Neighbor Solicitation (NS) probes.
-            static constexpr uint32_t kReachableTimeout = OPENTHREAD_CONFIG_BORDER_ROUTING_ROUTER_ACTIVE_CHECK_TIMEOUT;
+            // Reachability timeout intervals before starting Neighbor
+            // Solicitation (NS) probes. Generally 60 seconds (± 2
+            // seconds jitter) is used. For peer BRs a longer timeout
+            // of 200 seconds (3 min and 20 seconds) is used. This is
+            // selected to be longer than regular RA beacon interval
+            // of 3 minutes (± 15 seconds jitter).
+
+            static constexpr uint32_t kReachableInterval = OPENTHREAD_CONFIG_BORDER_ROUTING_ROUTER_ACTIVE_CHECK_TIMEOUT;
+            static constexpr uint32_t kPeerBrReachableInterval = Time::kOneSecondInMsec * 200;
 
             static constexpr uint8_t  kMaxNsProbes          = 5;    // Max number of NS probe attempts.
             static constexpr uint32_t kNsProbeRetryInterval = 1000; // In msec. Time between NS probe attempts.
@@ -823,6 +833,7 @@ private:
             bool IsReachable(void) const { return mNsProbeCount <= kMaxNsProbes; }
             bool ShouldCheckReachability(void) const;
             void ResetReachabilityState(void);
+            void DetermineReachabilityTimeout(void);
             bool Matches(const Ip6::Address &aAddress) const { return aAddress == mAddress; }
             bool Matches(const EmptyChecker &aChecker);
             void CopyInfoTo(RouterEntry &aEntry, TimeMilli aNow) const;
@@ -834,12 +845,13 @@ private:
             OnLinkPrefixList mOnLinkPrefixes;
             RoutePrefixList  mRoutePrefixes;
             TimeMilli        mLastUpdateTime;
-            TimeMilli        mTimeout;
+            TimeMilli        mTimeoutTime;
             uint8_t          mNsProbeCount;
             bool             mManagedAddressConfigFlag : 1;
             bool             mOtherConfigFlag : 1;
             bool             mStubRouterFlag : 1;
             bool             mIsLocalDevice : 1;
+            bool             mAllEntriesDisregarded : 1;
         };
 
         //-  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -

--- a/src/core/config/border_routing.h
+++ b/src/core/config/border_routing.h
@@ -72,6 +72,23 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
+ *
+ * Define to 1 to allow the Routing Manager to track information (e.g., advertised prefixes) about peer Thread
+ * Border Routers that are connected to the same Thread network.
+ *
+ * When enabled, the Routing Manager will maintain a record of advertised RIO/PIO prefixes discovered from received
+ * Router Advertisements of peer BRs. These entries are disregarded in decision-making (e.g., selecting favored
+ * on-link prefix or determining which route to publish in the Thread Network Data).
+ *
+ * It is recommended to enable this feature alongside `OPENTHREAD_CONFIG_BORDER_ROUTING_USE_HEAP_ENABLE`.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE OPENTHREAD_CONFIG_BORDER_ROUTING_USE_HEAP_ENABLE
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_ROUTERS
  *
  * Specifies maximum number of routers (on infra link) to track by routing manager.


### PR DESCRIPTION
This commit adds a new feature to the `RoutingManager` to enable tracking information about peer Thread Border Routers that are connected to the same Thread network.

When enabled, the `RoutingManager` will maintain a record of advertised RIO/PIO prefixes discovered from received Router Advertisement (RA) messages of peer BRs. When disabled (the existing behavior), such entries are not tracked.

When tracked, these entries are marked to be disregarded and are not considered in any decision-making processes, such as selecting favored on-link prefixes or determining routes to publish in the Thread Network Data. They are primarily intended for debugging and telemetry (information gathering) purposes.