### PR TITLE
[spinel] allow custom config file for lib spinel

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -26,6 +26,14 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+add_library(ot-lib-config INTERFACE)
+
+set(OT_LIB_CONFIG "" CACHE STRING "Lib project-specific config header file")
+if (OT_LIB_CONFIG)
+    target_compile_definitions(ot-lib-config INTERFACE "OPENTHREAD_PROJECT_LIB_CONFIG_FILE=\"${OT_LIB_CONFIG}\"")
+    message(STATUS "OT_LIB_CONFIG=\"${OT_LIB_CONFIG}\"")
+endif()
+
 add_subdirectory(hdlc)
 add_subdirectory(platform)
 add_subdirectory(spinel)

--- a/src/lib/spinel/CMakeLists.txt
+++ b/src/lib/spinel/CMakeLists.txt
@@ -99,17 +99,23 @@ target_sources(openthread-spinel-ncp PRIVATE ${COMMON_SOURCES})
 target_sources(openthread-spinel-rcp PRIVATE ${COMMON_SOURCES})
 
 target_link_libraries(openthread-radio-spinel
+    INTERFACE
+        ot-lib-config
     PRIVATE
         ot-config
 )
 
 target_link_libraries(openthread-spinel-ncp
+    INTERFACE
+        ot-lib-config
     PRIVATE
         ot-config-ftd
         ot-config
 )
 
 target_link_libraries(openthread-spinel-rcp
+    INTERFACE
+        ot-lib-config
     PRIVATE
         ot-config-radio
         ot-config

--- a/src/lib/spinel/openthread-spinel-config.h
+++ b/src/lib/spinel/openthread-spinel-config.h
@@ -35,6 +35,14 @@
 #define OPENTHREAD_SPINEL_CONFIG_H_
 
 /**
+ * Include project specific lib config file if defined.
+ *
+ */
+#ifdef OPENTHREAD_PROJECT_LIB_CONFIG_FILE
+#include OPENTHREAD_PROJECT_LIB_CONFIG_FILE
+#endif
+
+/**
  * @def OPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE
  *
  * Define 1 to enable feeding an OpenThread message to encoder/decoder.


### PR DESCRIPTION
This PR allows user projects to override the ot lib configs by using
a customized lib config file, by setting `OT_LIB_CONFIG`.