### PR TITLE
[routing-manager] add `OnLinkPrefix::IsFavoredOver()`

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -702,8 +702,11 @@ private:
         TimeMilli GetStaleTime(void) const;
         void      AdoptValidAndPreferredLifetimesFrom(const OnLinkPrefix &aPrefix);
         void      CopyInfoTo(PrefixTableEntry &aEntry, TimeMilli aNow) const;
+        bool      IsFavoredOver(const Ip6::Prefix &aPrefix) const;
 
     private:
+        static constexpr uint32_t kFavoredMinPreferredLifetime = 1800; // In sec.
+
         uint32_t mPreferredLifetime;
     };
 
@@ -782,8 +785,6 @@ private:
         void HandleRouterTimer(void);
 
     private:
-        static constexpr uint32_t kFavoredOnLinkPrefixMinPreferredLifetime = 1800; // In sec.
-
         //-  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 
         template <class Type>


### PR DESCRIPTION
This commit adds the `OnLinkPrefix::IsFavoredOver()` method to determine if an on-link prefix is eligible to be considered as a favored prefix, and if so, is favored over another prefix. A numerically smaller prefix is considered favored.

Additionally, a new test case is added to `test_routing_manager` to validate the selection of favored on-link prefixes, including the the requirement of a minimum preferred lifetime of 1800 seconds for a prefix to be considered eligible.