### PR TITLE
[posix] deassert DTR and RTS if flow control is disabled

### DIFF
--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -600,6 +600,20 @@ int HdlcInterface::OpenFile(const Url::Url &aRadioUrl)
         {
             tios.c_cflag |= CRTSCTS;
         }
+        else
+        {
+#ifndef __APPLE__
+            int flags;
+#endif
+
+            tios.c_cflag &= ~(CRTSCTS);
+
+#ifndef __APPLE__
+            // Deassert DTR and RTS
+            flags = TIOCM_DTR | TIOCM_RTS;
+            VerifyOrExit(ioctl(fd, TIOCMBIC, &flags) != -1, perror("tiocmbic"));
+#endif
+        }
 
         VerifyOrExit((rval = cfsetspeed(&tios, static_cast<speed_t>(speed))) == 0, perror("cfsetspeed"));
         rval = tcsetattr(fd, TCSANOW, &tios);


### PR DESCRIPTION
Many USB radio devices (particularly those based on TI CC2652) have reset and bootloader activation directly connected to DTR/RTS lines. These devices will fail to start, in the default state where both DTR/RTS are asserted on connection.

This patch ensures flow control is disabled and both DTR and RTS are deasserted on startup while configuring the terminal. There is no impact on devices using hw flow control.