### PR TITLE
[mesh-forwarder] restore `FrameData` in `GetForwardFramePriority()`

### DIFF
--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -575,7 +575,7 @@ private:
     Error GetFragmentPriority(Lowpan::FragmentHeader &aFragmentHeader,
                               uint16_t                aSrcRloc16,
                               Message::Priority      &aPriority);
-    void  GetForwardFramePriority(const RxInfo &aRxInfo, Message::Priority &aPriority);
+    void  GetForwardFramePriority(RxInfo &aRxInfo, Message::Priority &aPriority);
 
     bool                CalcIePresent(const Message *aMessage);
     Mac::Frame::Version CalcFrameVersion(const Neighbor *aNeighbor, bool aIePresent) const;


### PR DESCRIPTION
This commit updates `GetForwardFramePriority()` to save the original `aRxInfo.mFrameData` before parsing the fragment header. The header parsing may modify `mFrameData` to skip over the parsed portion. The original `FrameData` is restored before returning, ensuring that forwarded frames include the fragment header and eliminating the need to create a copy of `aRxInfo`.