### PR TITLE
[tlv] use `OffsetRange` and make `ParsedInfo` public

### DIFF
--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -56,20 +56,6 @@ const uint8_t *Tlv::GetValue(void) const
 
 Error Tlv::AppendTo(Message &aMessage) const { return aMessage.AppendBytes(this, static_cast<uint16_t>(GetSize())); }
 
-Error Tlv::ParseAndSkipTlv(const Message &aMessage, OffsetRange &aOffsetRange)
-{
-    Error      error;
-    ParsedInfo info;
-
-    SuccessOrExit(error = info.ParseFrom(aMessage, aOffsetRange.GetOffset()));
-
-    VerifyOrExit(aOffsetRange.Contains(info.mSize), error = kErrorParse);
-    aOffsetRange.AdvanceOffset(info.mSize);
-
-exit:
-    return error;
-}
-
 Error Tlv::FindTlv(const Message &aMessage, uint8_t aType, uint16_t aMaxSize, Tlv &aTlv)
 {
     uint16_t offset;
@@ -84,13 +70,9 @@ Error Tlv::FindTlv(const Message &aMessage, uint8_t aType, uint16_t aMaxSize, Tl
 
     SuccessOrExit(error = info.FindIn(aMessage, aType));
 
-    if (aMaxSize > info.mSize)
-    {
-        aMaxSize = info.mSize;
-    }
-
-    aMessage.ReadBytes(info.mOffset, &aTlv, aMaxSize);
-    aOffset = info.mOffset;
+    info.mTlvOffsetRange.ShrinkLength(aMaxSize);
+    aMessage.ReadBytes(info.mTlvOffsetRange, &aTlv);
+    aOffset = info.mTlvOffsetRange.GetOffset();
 
 exit:
     return error;
@@ -102,8 +84,7 @@ Error Tlv::FindTlvValueOffsetRange(const Message &aMessage, uint8_t aType, Offse
     ParsedInfo info;
 
     SuccessOrExit(error = info.FindIn(aMessage, aType));
-
-    aOffsetRange.Init(info.mValueOffset, info.mLength);
+    aOffsetRange = info.mValueOffsetRange;
 
 exit:
     return error;
@@ -111,49 +92,47 @@ exit:
 
 Error Tlv::ParsedInfo::ParseFrom(const Message &aMessage, uint16_t aOffset)
 {
-    // This method reads and parses the TLV info from `aMessage` at
-    // `aOffset`. This can be used independent of whether the TLV is
-    // extended or not. It validates that the entire TLV can be read
-    // from `aMessage`.  Returns `kErrorNone` when successfully parsed,
-    // otherwise `kErrorParse`.
+    OffsetRange offsetRange;
 
+    offsetRange.InitFromRange(aOffset, aMessage.GetLength());
+    return ParseFrom(aMessage, offsetRange);
+}
+
+Error Tlv::ParsedInfo::ParseFrom(const Message &aMessage, const OffsetRange &aOffsetRange)
+{
     Error       error;
     Tlv         tlv;
     ExtendedTlv extTlv;
-    uint16_t    headerSize;
+    uint32_t    headerSize;
+    uint32_t    size;
 
-    SuccessOrExit(error = aMessage.Read(aOffset, tlv));
+    SuccessOrExit(error = aMessage.Read(aOffsetRange, tlv));
+
+    mType = tlv.GetType();
 
     if (!tlv.IsExtended())
     {
-        mType      = tlv.GetType();
-        mLength    = tlv.GetLength();
-        headerSize = sizeof(Tlv);
+        mIsExtended = false;
+        headerSize  = sizeof(Tlv);
+        size        = headerSize + tlv.GetLength();
     }
     else
     {
-        SuccessOrExit(error = aMessage.Read(aOffset, extTlv));
+        SuccessOrExit(error = aMessage.Read(aOffsetRange, extTlv));
 
-        mType      = extTlv.GetType();
-        mLength    = extTlv.GetLength();
-        headerSize = sizeof(ExtendedTlv);
+        mIsExtended = true;
+        headerSize  = sizeof(ExtendedTlv);
+        size        = headerSize + extTlv.GetLength();
     }
 
-    // We know that we could successfully read `tlv` or `extTlv`
-    // (`headerSize` bytes) from the message, so the calculation of the
-    // remaining length as `aMessage.GetLength() - aOffset - headerSize`
-    // cannot underflow.
+    mTlvOffsetRange = aOffsetRange;
+    VerifyOrExit(mTlvOffsetRange.Contains(size), error = kErrorParse);
+    mTlvOffsetRange.ShrinkLength(static_cast<uint16_t>(size));
 
-    VerifyOrExit(mLength <= aMessage.GetLength() - aOffset - headerSize, error = kErrorParse);
+    VerifyOrExit(mTlvOffsetRange.GetEndOffset() <= aMessage.GetLength(), error = kErrorParse);
 
-    // Now that we know the entire TLV is contained within the
-    // `aMessage`, we can safely calculate `mValueOffset` and `mSize`
-    // as `uint16_t` and know that there will be no overflow.
-
-    mType        = tlv.GetType();
-    mOffset      = aOffset;
-    mValueOffset = aOffset + headerSize;
-    mSize        = mLength + headerSize;
+    mValueOffsetRange = mTlvOffsetRange;
+    mValueOffsetRange.AdvanceOffset(headerSize);
 
 exit:
     return error;
@@ -161,18 +140,14 @@ exit:
 
 Error Tlv::ParsedInfo::FindIn(const Message &aMessage, uint8_t aType)
 {
-    // This  method searches within `aMessage` starting from
-    // `aMessage.GetOffset()` for a TLV type `aType` and parsed its
-    // info and validates that the entire TLV can be read from
-    // `aMessage`. Returns `kErrorNone` when found, otherwise
-    // `kErrorNotFound`.
+    Error       error = kErrorNotFound;
+    OffsetRange offsetRange;
 
-    Error    error  = kErrorNotFound;
-    uint16_t offset = aMessage.GetOffset();
+    offsetRange.InitFromMessageOffsetToEnd(aMessage);
 
     while (true)
     {
-        SuccessOrExit(ParseFrom(aMessage, offset));
+        SuccessOrExit(ParseFrom(aMessage, offsetRange));
 
         if (mType == aType)
         {
@@ -180,11 +155,7 @@ Error Tlv::ParsedInfo::FindIn(const Message &aMessage, uint8_t aType)
             ExitNow();
         }
 
-        // `ParseFrom()` already validated that `offset + mSize` is
-        // less than `aMessage.GetLength()` and therefore we can not
-        // have an overflow here.
-
-        offset += mSize;
+        offsetRange.AdvanceOffset(mTlvOffsetRange.GetLength());
     }
 
 exit:
@@ -195,14 +166,12 @@ Error Tlv::ReadStringTlv(const Message &aMessage, uint16_t aOffset, uint8_t aMax
 {
     Error      error = kErrorNone;
     ParsedInfo info;
-    uint16_t   length;
 
     SuccessOrExit(error = info.ParseFrom(aMessage, aOffset));
 
-    length = Min(info.mLength, static_cast<uint16_t>(aMaxStringLength));
-
-    aMessage.ReadBytes(info.mValueOffset, aValue, length);
-    aValue[length] = '\0';
+    info.mValueOffsetRange.ShrinkLength(aMaxStringLength);
+    aMessage.ReadBytes(info.mValueOffsetRange, aValue);
+    aValue[info.mValueOffsetRange.GetLength()] = kNullChar;
 
 exit:
     return error;
@@ -231,9 +200,10 @@ Error Tlv::ReadTlvValue(const Message &aMessage, uint16_t aOffset, void *aValue,
 
     SuccessOrExit(error = info.ParseFrom(aMessage, aOffset));
 
-    VerifyOrExit(info.mLength >= aMinLength, error = kErrorParse);
+    VerifyOrExit(info.mValueOffsetRange.Contains(aMinLength), error = kErrorParse);
+    info.mValueOffsetRange.ShrinkLength(aMinLength);
 
-    aMessage.ReadBytes(info.mValueOffset, aValue, aMinLength);
+    aMessage.ReadBytes(info.mValueOffsetRange, aValue);
 
 exit:
     return error;
@@ -245,7 +215,7 @@ Error Tlv::FindStringTlv(const Message &aMessage, uint8_t aType, uint8_t aMaxStr
     ParsedInfo info;
 
     SuccessOrExit(error = info.FindIn(aMessage, aType));
-    error = ReadStringTlv(aMessage, info.mOffset, aMaxStringLength, aValue);
+    error = ReadStringTlv(aMessage, info.mTlvOffsetRange.GetOffset(), aMaxStringLength, aValue);
 
 exit:
     return error;
@@ -257,7 +227,7 @@ template <typename UintType> Error Tlv::FindUintTlv(const Message &aMessage, uin
     ParsedInfo info;
 
     SuccessOrExit(error = info.FindIn(aMessage, aType));
-    error = ReadUintTlv<UintType>(aMessage, info.mOffset, aValue);
+    error = ReadUintTlv<UintType>(aMessage, info.mTlvOffsetRange.GetOffset(), aValue);
 
 exit:
     return error;

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -246,19 +246,69 @@ public:
     // Static methods for reading/finding/appending TLVs in a `Message`.
 
     /**
-     * Parses a TLV in a message from a given offset range, validating that it is fully contained within the offset
-     * range and the message, and then updating the offset range to skip over the entire parsed TLV.
-     *
-     * Can be used independent of whether the read TLV (from the message) is an Extended TLV or not.
-     *
-     * @param[in]       aMessage      The message to read from.
-     * @param[in,out]   aOffsetRange  The offset range to read from. On success, it is updated to skip the TLV.
-     *
-     * @retval kErrorNone    Successfully parsed a TLV from @p aMessage. @p aOffsetRange is updated.
-     * @retval kErrorParse   The TLV was not well-formed or was not fully contained in @p aMessage.
+     * Represents information for a parsed TLV from a message.
      *
      */
-    static Error ParseAndSkipTlv(const Message &aMessage, OffsetRange &aOffsetRange);
+    struct ParsedInfo
+    {
+        /**
+         * Parses the TLV from a given message at given offset, ensures the TLV is well-formed and its header and
+         * value are fully contained in the message.
+         *
+         * Can be used independent of whether the TLV is an Extended TLV or not.
+         *
+         * @param[in] aMessage      The message to read from.
+         * @param[in] aOffset       The offset in @p aMessage.
+         *
+         * @retval kErrorNone   Successfully parsed the TLV.
+         * @retval kErrorParse  The TLV was not well-formed or not fully contained in @p aMessage.
+         *
+         */
+        Error ParseFrom(const Message &aMessage, uint16_t aOffset);
+
+        /**
+         * Parses the TLV from a given message for a given offset range, ensures the TLV is well-formed and its header
+         * and value are fully contained in the offset range and the message.
+         *
+         * Can be used independent of whether the TLV is an Extended TLV or not.
+         *
+         * @param[in] aMessage      The message to read from.
+         * @param[in] aOffsetRange  The offset range in @p aMessage.
+         *
+         * @retval kErrorNone   Successfully parsed the TLV.
+         * @retval kErrorParse  The TLV was not well-formed or not contained in @p aOffsetRange or @p aMessage.
+         *
+         */
+        Error ParseFrom(const Message &aMessage, const OffsetRange &aOffsetRange);
+
+        /**
+         * Searches in a given message starting from message offset for a TLV of given type and if found, parses
+         * the TLV and validates that the entire TLV is present in the message.
+         *
+         * Can be used independent of whether the TLV is an Extended TLV or not.
+         *
+         * @param[in] aMessage  The message to search in.
+         * @param[in] aType     The TLV type to search for.
+         *
+         * @retval kErrorNone      Successfully found and parsed the TLV.
+         * @retval kErrorNotFound  Could not find the TLV, or the TLV was not well-formed.
+         *
+         */
+        Error FindIn(const Message &aMessage, uint8_t aType);
+
+        /**
+         * Returns the full TLV size in bytes.
+         *
+         * @returns The TLV size in bytes.
+         *
+         */
+        uint16_t GetSize(void) const { return mTlvOffsetRange.GetLength(); }
+
+        uint8_t     mType;             ///< The TLV type
+        bool        mIsExtended;       ///< Whether the TLV is extended or not.
+        OffsetRange mTlvOffsetRange;   ///< Offset range containing the full TLV.
+        OffsetRange mValueOffsetRange; ///< Offset range containing the TLV's value.
+    };
 
     /**
      * Reads a TLV's value in a message at a given offset expecting a minimum length for the value.
@@ -686,18 +736,6 @@ protected:
     static const uint8_t kExtendedLength = 255; // Extended Length value.
 
 private:
-    struct ParsedInfo
-    {
-        Error ParseFrom(const Message &aMessage, uint16_t aOffset);
-        Error FindIn(const Message &aMessage, uint8_t aType);
-
-        uint8_t  mType;
-        uint16_t mLength;
-        uint16_t mOffset;
-        uint16_t mValueOffset;
-        uint16_t mSize;
-    };
-
     static Error FindTlv(const Message &aMessage, uint8_t aType, void *aValue, uint16_t aLength);
     static Error ReadStringTlv(const Message &aMessage, uint16_t aOffset, uint8_t aMaxStringLength, char *aValue);
     static Error FindStringTlv(const Message &aMessage, uint8_t aType, uint8_t aMaxStringLength, char *aValue);

--- a/src/core/thread/link_metrics.hpp
+++ b/src/core/thread/link_metrics.hpp
@@ -341,7 +341,7 @@ private:
     static constexpr uint16_t kMaxSeriesSupported = OPENTHREAD_CONFIG_MLE_LINK_METRICS_SERIES_MTD;
 #endif
 
-    static Error ReadTypeIdsFromMessage(const Message &aMessage, OffsetRange &aOffsetRange, Metrics &aMetrics);
+    static Error ReadTypeIdsFromMessage(const Message &aMessage, const OffsetRange &aOffsetRange, Metrics &aMetrics);
     static Error AppendReportSubTlvToMessage(Message &aMessage, const MetricsValues &aValues);
 
     Status ConfigureForwardTrackingSeries(uint8_t        aSeriesId,


### PR DESCRIPTION
This commit updates `Tlv` helper methods to use `OffsetRange` in their implementation. It also makes the `Tlv::ParsedInfo` type public. This struct represents information about a parsed TLV in a message, including the TLV type, the `OffsetRange` for the full TLV, and the `OffsetRange` where the TLV's value resides in the message. This replaces and enhances the `ParseAndSkipTlv()` method.

The `ParsedInfo` provides two methods:

- `ParseFrom()`: Parses a TLV at a given offset or offset range.
- `FindIn()`: Searches for a given TLV type in a message.

These methods handle both extended and regular TLV formats, validating that the parsed TLV is well-formed and fully contained within the message and the given `OffsetRange`.

Modules that iterate over a sequence of TLVs in a message are updated to use `ParsedInfo` and its methods, simplifying the code.