### PR TITLE
[mesh-forwarder] add `RxInfo::ToString()` to simplify logging

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -2017,18 +2017,24 @@ void MeshForwarder::LogFragmentFrameDrop(Error                         aError,
                                          const RxInfo                 &aRxInfo,
                                          const Lowpan::FragmentHeader &aFragmentHeader)
 {
-    LogNote("Dropping rx frag frame, error:%s, len:%d, src:%s, dst:%s, tag:%d, offset:%d, dglen:%d, sec:%s",
-            ErrorToString(aError), aRxInfo.mFrameData.GetLength(), aRxInfo.GetSrcAddr().ToString().AsCString(),
-            aRxInfo.GetDstAddr().ToString().AsCString(), aFragmentHeader.GetDatagramTag(),
-            aFragmentHeader.GetDatagramOffset(), aFragmentHeader.GetDatagramSize(),
-            ToYesNo(aRxInfo.IsLinkSecurityEnabled()));
+    LogNote("Dropping rx frag frame, error:%s, %s, tag:%d, offset:%d, dglen:%d", ErrorToString(aError),
+            aRxInfo.ToString().AsCString(), aFragmentHeader.GetDatagramTag(), aFragmentHeader.GetDatagramOffset(),
+            aFragmentHeader.GetDatagramSize());
 }
 
 void MeshForwarder::LogLowpanHcFrameDrop(Error aError, const RxInfo &aRxInfo)
 {
-    LogNote("Dropping rx lowpan HC frame, error:%s, len:%d, src:%s, dst:%s, sec:%s", ErrorToString(aError),
-            aRxInfo.mFrameData.GetLength(), aRxInfo.GetSrcAddr().ToString().AsCString(),
-            aRxInfo.GetDstAddr().ToString().AsCString(), ToYesNo(aRxInfo.IsLinkSecurityEnabled()));
+    LogNote("Dropping rx lowpan HC frame, error:%s, %s", ErrorToString(aError), aRxInfo.ToString().AsCString());
+}
+
+MeshForwarder::RxInfo::InfoString MeshForwarder::RxInfo::ToString(void) const
+{
+    InfoString string;
+
+    string.Append("len:%d, src:%s, dst:%s, sec:%s", mFrameData.GetLength(), GetSrcAddr().ToString().AsCString(),
+                  GetDstAddr().ToString().AsCString(), ToYesNo(IsLinkSecurityEnabled()));
+
+    return string;
 }
 
 #else // #if OT_SHOULD_LOG_AT( OT_LOG_LEVEL_NOTE)

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -413,9 +413,14 @@ private:
 
     struct RxInfo
     {
+        static constexpr uint16_t kInfoStringSize = 70;
+
+        typedef String<kInfoStringSize> InfoString;
+
         const Mac::Address &GetSrcAddr(void) const { return mMacAddrs.mSource; }
         const Mac::Address &GetDstAddr(void) const { return mMacAddrs.mDestination; }
         bool                IsLinkSecurityEnabled(void) const { return mLinkInfo.IsLinkSecurityEnabled(); }
+        InfoString          ToString(void) const;
 
         FrameData      mFrameData;
         ThreadLinkInfo mLinkInfo;

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -1000,9 +1000,8 @@ void MeshForwarder::GetForwardFramePriority(RxInfo &aRxInfo, Message::Priority &
 exit:
     if (error != kErrorNone)
     {
-        LogNote("Failed to get forwarded frame priority, error:%s, len:%d, src:%s, dst:%s", ErrorToString(error),
-                aRxInfo.mFrameData.GetLength(), aRxInfo.GetSrcAddr().ToString().AsCString(),
-                aRxInfo.GetDstAddr().ToString().AsCString());
+        LogNote("Failed to get forwarded frame priority, error:%s, %s", ErrorToString(error),
+                aRxInfo.ToString().AsCString());
     }
     else if (isFragment)
     {


### PR DESCRIPTION
This commit adds `RxInfo::ToString()`, which generates a common log string about an `RxInfo` using the "len:%d, src:%s, dst:%s, sec:%s" format, providing frame length, source and destination addresses, and whether link security is used. This is then used in different logging methods, simplifying the code.