### PR TITLE
[meshcop] update `ChannelMaskTlv` to use `OffsetRange`

### DIFF
--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -136,8 +136,8 @@ Error ChannelMaskTlv::ReadChannelMask(uint32_t &aChannelMask) const
     EntriesData entriesData;
 
     entriesData.Clear();
-    entriesData.mData   = &mEntriesStart;
-    entriesData.mLength = GetLength();
+    entriesData.mData = &mEntriesStart;
+    entriesData.mOffsetRange.Init(0, GetLength());
 
     return entriesData.Parse(aChannelMask);
 }
@@ -152,9 +152,8 @@ Error ChannelMaskTlv::FindIn(const Message &aMessage, uint32_t &aChannelMask)
     entriesData.mMessage = &aMessage;
 
     SuccessOrExit(error = FindTlvValueOffsetRange(aMessage, Tlv::kChannelMask, offsetRange));
-    entriesData.mOffset = offsetRange.GetOffset();
-    entriesData.mLength = offsetRange.GetLength();
-    error               = entriesData.Parse(aChannelMask);
+    entriesData.mOffsetRange = offsetRange;
+    error                    = entriesData.Parse(aChannelMask);
 
 exit:
     return error;
@@ -165,9 +164,8 @@ Error ChannelMaskTlv::EntriesData::Parse(uint32_t &aChannelMask)
     // Validates and parses the Channel Mask TLV entries for each
     // channel page and if successful updates `aChannelMask` to
     // return the combined mask for all channel pages supported by
-    // radio. The entries can be either contained in `mMessage` from
-    // `mOffset` (when `mMessage` is non-null) or be in a buffer
-    // `mData`. `mLength` gives the number of bytes for all entries.
+    // radio. The entries can be either contained in `mMessage`
+    // (when `mMessage` is non-null) or be in a buffer `mData`.
 
     Error        error = kErrorParse;
     Entry        readEntry;
@@ -176,11 +174,11 @@ Error ChannelMaskTlv::EntriesData::Parse(uint32_t &aChannelMask)
 
     aChannelMask = 0;
 
-    VerifyOrExit(mLength > 0); // At least one entry.
+    VerifyOrExit(!mOffsetRange.IsEmpty()); // At least one entry.
 
-    while (mLength > 0)
+    while (!mOffsetRange.IsEmpty())
     {
-        VerifyOrExit(mLength > kEntryHeaderSize);
+        VerifyOrExit(mOffsetRange.Contains(kEntryHeaderSize));
 
         if (mMessage != nullptr)
         {
@@ -188,17 +186,17 @@ Error ChannelMaskTlv::EntriesData::Parse(uint32_t &aChannelMask)
             // validating the entry and that the entry's channel page
             // is supported by radio, we read the full `Entry`.
 
-            mMessage->ReadBytes(mOffset, &readEntry, kEntryHeaderSize);
+            mMessage->ReadBytes(mOffsetRange.GetOffset(), &readEntry, kEntryHeaderSize);
             entry = &readEntry;
         }
         else
         {
-            entry = reinterpret_cast<const Entry *>(mData);
+            entry = reinterpret_cast<const Entry *>(&mData[mOffsetRange.GetOffset()]);
         }
 
         size = kEntryHeaderSize + entry->GetMaskLength();
 
-        VerifyOrExit(size <= mLength);
+        VerifyOrExit(mOffsetRange.Contains(size));
 
         if (Radio::SupportsChannelPage(entry->GetChannelPage()))
         {
@@ -209,22 +207,13 @@ Error ChannelMaskTlv::EntriesData::Parse(uint32_t &aChannelMask)
 
             if (mMessage != nullptr)
             {
-                IgnoreError(mMessage->Read(mOffset, readEntry));
+                IgnoreError(mMessage->Read(mOffsetRange, readEntry));
             }
 
             aChannelMask |= (entry->GetMask() & Radio::ChannelMaskForPage(entry->GetChannelPage()));
         }
 
-        mLength -= size;
-
-        if (mMessage != nullptr)
-        {
-            mOffset += size;
-        }
-        else
-        {
-            mData += size;
-        }
+        mOffsetRange.AdvanceOffset(size);
     }
 
     error = kErrorNone;

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -753,8 +753,7 @@ private:
 
         const uint8_t *mData;
         const Message *mMessage;
-        uint16_t       mOffset;
-        uint16_t       mLength;
+        OffsetRange    mOffsetRange;
     };
 
     uint8_t mEntriesStart;


### PR DESCRIPTION
This commit updates `ChannelMaskTlv` to use `OffsetRange` when iterating over and parsing the list of entries contained in the TLV.