### PR TITLE
[ip6] use `OffsetRange` for parsing options in extension headers

### DIFF
--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -402,6 +402,7 @@ private:
     void UpdateReassemblyList(void);
     void SendIcmpError(Message &aMessage, Icmp::Header::Type aIcmpType, Icmp::Header::Code aIcmpCode);
 #endif
+    Error ReadHopByHopHeader(const Message &aMessage, OffsetRange &aOffsetRange, HopByHopHeader &aHbhHeader) const;
     Error AddMplOption(Message &aMessage, Header &aHeader);
     Error PrepareMulticastToLargerThanRealmLocal(Message &aMessage, const Header &aHeader);
     Error InsertMplOption(Message &aMessage, Header &aHeader);

--- a/src/core/net/ip6_headers.cpp
+++ b/src/core/net/ip6_headers.cpp
@@ -69,14 +69,14 @@ bool Header::IsValid(void) const
 //---------------------------------------------------------------------------------------------------------------------
 // Option
 
-Error Option::ParseFrom(const Message &aMessage, uint16_t aOffset, uint16_t aEndOffset)
+Error Option::ParseFrom(const Message &aMessage, const OffsetRange &aOffsetRange)
 {
     Error error;
 
     // Read the Type first to check for the Pad1 Option.
     // If it is not, then we read the full `Option` header.
 
-    SuccessOrExit(error = aMessage.Read(aOffset, this, sizeof(mType)));
+    SuccessOrExit(error = aMessage.Read(aOffsetRange, this, sizeof(mType)));
 
     if (mType == kTypePad1)
     {
@@ -84,9 +84,8 @@ Error Option::ParseFrom(const Message &aMessage, uint16_t aOffset, uint16_t aEnd
         ExitNow();
     }
 
-    SuccessOrExit(error = aMessage.Read(aOffset, *this));
-
-    VerifyOrExit(aOffset + GetSize() <= aEndOffset, error = kErrorParse);
+    SuccessOrExit(error = aMessage.Read(aOffsetRange, *this));
+    VerifyOrExit(aOffsetRange.Contains(GetSize()), error = kErrorParse);
 
 exit:
     return error;

--- a/src/core/net/ip6_headers.hpp
+++ b/src/core/net/ip6_headers.hpp
@@ -517,17 +517,16 @@ public:
      * Parses and validates the IPv6 Option from a given message.
      *
      * The Option is read from @p aOffset in @p aMessage. This method then checks that the entire Option is present
-     * in @p aMessage before the @p aEndOffset.
+     * within @p aOffsetRange.
      *
-     * @param[in]  aMessage    The IPv6 message.
-     * @param[in]  aOffset     The offset in @p aMessage to read the IPv6 Option.
-     * @param[in]  aEndOffset  The end offset in @p aMessage.
+     * @param[in]  aMessage      The IPv6 message.
+     * @param[in]  aOffsetRange  The offset range in @p aMessage to read the IPv6 Option.
      *
      * @retval kErrorNone   Successfully parsed the IPv6 option from @p aMessage.
-     * @retval kErrorParse  Malformed IPv6 Option or Option is not contained within @p aMessage by @p aEndOffset.
+     * @retval kErrorParse  Malformed IPv6 Option or Option is not contained within @p aMessage and @p aOffsetRange.
      *
      */
-    Error ParseFrom(const Message &aMessage, uint16_t aOffset, uint16_t aEndOffset);
+    Error ParseFrom(const Message &aMessage, const OffsetRange &aOffsetRange);
 
 protected:
     static constexpr uint8_t kTypePad1 = 0x00; ///< Pad1 Option Type.

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -90,14 +90,14 @@ void Mpl::InitOption(MplOption &aOption, const Address &aAddress)
     aOption.SetSequence(mSequence++);
 }
 
-Error Mpl::ProcessOption(Message &aMessage, uint16_t aOffset, const Address &aAddress, bool &aReceive)
+Error Mpl::ProcessOption(Message &aMessage, const OffsetRange &aOffsetRange, const Address &aAddress, bool &aReceive)
 {
     Error     error;
     MplOption option;
 
     // Read the min size bytes first, then check the expected
     // `SeedIdLength` and read the full `MplOption` if needed.
-    SuccessOrExit(error = aMessage.Read(aOffset, &option, MplOption::kMinSize));
+    SuccessOrExit(error = aMessage.Read(aOffsetRange, &option, MplOption::kMinSize));
 
     switch (option.GetSeedIdLength())
     {
@@ -108,7 +108,7 @@ Error Mpl::ProcessOption(Message &aMessage, uint16_t aOffset, const Address &aAd
         break;
 
     case MplOption::kSeedIdLength2:
-        SuccessOrExit(error = aMessage.Read(aOffset, option));
+        SuccessOrExit(error = aMessage.Read(aOffsetRange, option));
         break;
 
     case MplOption::kSeedIdLength8:

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -191,17 +191,17 @@ public:
      * MPL Seed it allows to send the first MPL Data Message directly, then sets up Trickle
      * timer expirations for subsequent retransmissions.
      *
-     * @param[in]  aMessage    A reference to the message.
-     * @param[in]  aOffset     The offset in @p aMessage to read the MPL option.
-     * @param[in]  aAddress    A reference to the IPv6 Source Address.
-     * @param[out] aReceive    Set to FALSE if the MPL message is a duplicate and must not
-     *                         go through the receiving process again, untouched otherwise.
+     * @param[in]  aMessage      A reference to the message.
+     * @param[in]  aOffsetRange  The offset range in @p aMessage to read the MPL option.
+     * @param[in]  aAddress      A reference to the IPv6 Source Address.
+     * @param[out] aReceive      Set to FALSE if the MPL message is a duplicate and must not
+     *                           go through the receiving process again, untouched otherwise.
      *
      * @retval kErrorNone  Successfully processed the MPL option.
      * @retval kErrorDrop  The MPL message is a duplicate and should be dropped.
      *
      */
-    Error ProcessOption(Message &aMessage, uint16_t aOffset, const Address &aAddress, bool &aReceive);
+    Error ProcessOption(Message &aMessage, const OffsetRange &aOffsetRange, const Address &aAddress, bool &aReceive);
 
 #if OPENTHREAD_FTD
     /**

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -470,14 +470,15 @@ Error Lowpan::CompressExtensionHeader(Message &aMessage, FrameBuilder &aFrameBui
     // Pad1 or PadN option MAY be elided by the compressor."
     if (aNextHeader == Ip6::kProtoHopOpts || aNextHeader == Ip6::kProtoDstOpts)
     {
-        uint16_t    offset    = aMessage.GetOffset();
-        uint16_t    endOffset = offset + len;
+        OffsetRange offsetRange;
         bool        hasOption = false;
         Ip6::Option option;
 
-        for (; offset < endOffset; offset += option.GetSize())
+        offsetRange.Init(aMessage.GetOffset(), len);
+
+        for (; !offsetRange.IsEmpty(); offsetRange.AdvanceOffset(option.GetSize()))
         {
-            SuccessOrExit(error = option.ParseFrom(aMessage, offset, endOffset));
+            SuccessOrExit(error = option.ParseFrom(aMessage, offsetRange));
             hasOption = true;
         }
 


### PR DESCRIPTION
This commit updates `Ip6` and `Lowpan` to use `OffsetRange` when iterating and parsing options in an HBH extension header. It also simplifies the `RemoveMplOption()` method by adding an `Action` enum, which determines how to remove the MPL option: whether to shrink the HBH header, fully remove the HBH header (if it contains no other options), or replace MPL option with padding.