### PR TITLE
[mesh-forwarder] use `RemoveMessageIfNoPendingTx()` on direct tx fails

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -654,7 +654,7 @@ Message *MeshForwarder::PrepareNextDirectTransmission(void)
 #endif
             LogMessage(kMessageDrop, *curMessage, error);
             FinalizeMessageDirectTx(*curMessage, error);
-            mSendQueue.DequeueAndFree(*curMessage);
+            RemoveMessageIfNoPendingTx(*curMessage);
             continue;
         }
     }


### PR DESCRIPTION
This commit updates `PrepareNextDirectTransmission()` to use `RemoveMessageIfNoPendingTx()` if a message cannot be prepared for direct transmission. This ensures the message is not dequeued and freed if it is also queued for indirect transmission.

---

Should address https://github.com/openthread/openthread/issues/10469