### PR TITLE
[srp-client] apply short random jitter to lease renew time

### DIFF
--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -1857,12 +1857,14 @@ void Client::ProcessResponse(Message &aMessage)
     // and the lease time. `kLeaseRenewGuardInterval` is used to
     // ensure that we renew the lease before server expires it. In the
     // unlikely (but maybe useful for testing) case where the accepted
-    // lease interval is too short (shorter than the guard time) we
-    // just use half of the accepted lease interval.
+    // lease interval is too short (shorter than twice the guard time)
+    // we just use half of the accepted lease interval.
 
-    if (mLease > kLeaseRenewGuardInterval)
+    if (mLease > 2 * kLeaseRenewGuardInterval)
     {
-        mLeaseRenewTime += Time::SecToMsec(mLease - kLeaseRenewGuardInterval);
+        uint32_t interval = Time::SecToMsec(mLease - kLeaseRenewGuardInterval);
+
+        mLeaseRenewTime += Random::NonCrypto::AddJitter(interval, kLeaseRenewJitter);
     }
     else
     {

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -829,6 +829,9 @@ private:
     // to renew the lease. Value is in seconds.
     static constexpr uint32_t kLeaseRenewGuardInterval = OPENTHREAD_CONFIG_SRP_CLIENT_LEASE_RENEW_GUARD_INTERVAL;
 
+    // Lease renew time jitter (in msec).
+    static constexpr uint16_t kLeaseRenewJitter = 15 * 1000; // 15 second
+
     // Max allowed lease time to avoid timer roll-over (~24.8 days).
     static constexpr uint32_t kMaxLease = (Timer::kMaxDelay / 1000) - 1;
 


### PR DESCRIPTION
This commit updates `Srp::Client` to apply a short random jitter (15 seconds) when calculating the lease renew time. The lease is renewed close to its expiration, using a guard interval of 120 seconds (renewing 120 seconds before expiration). The jitter is added to distribute client refreshes, in case many clients registered their services around the same time.