### PR TITLE
[mle] remove now undefined `UpdateChildAddresses()`

### DIFF
--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -643,7 +643,6 @@ private:
     void  StopLeader(void);
     void  SynchronizeChildNetworkData(void);
     Error ProcessAddressRegistrationTlv(RxInfo &aRxInfo, Child &aChild);
-    Error UpdateChildAddresses(const Message &aMessage, uint16_t aOffset, uint16_t aLength, Child &aChild);
     bool  HasNeighborWithGoodLinkQuality(void) const;
 #if OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE
     void SignalDuaAddressEvent(const Child &aChild, const Ip6::Address &aOldDua) const;


### PR DESCRIPTION
This method was refactored in 25fe46d8dd (#8963) but its declaration was not removed.