### PR TITLE
[cli] simplify parsing dataset TLVs

### DIFF
--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -118,6 +118,8 @@ private:
     otError ParsePskc(Arg *&aArgs, otOperationalDataset &aDataset);
     otError ParseSecurityPolicy(Arg *&aArgs, otOperationalDataset &aDataset);
 
+    otError ParseTlvs(Arg &aArg, otOperationalDatasetTlvs &aDatasetTlvs);
+
     otError ProcessCommand(const ComponentMapper &aMapper, Arg aArgs[]);
 
     template <CommandId kCommandId> otError Process(Arg aArgs[]);


### PR DESCRIPTION
This commit adds the `ParseTlvs()` helper method in the `Cli::Dataset` class, which parses TLVs (as hex strings) from an input argument. This is used in multiple methods to simplify the code.

The `Process<Cmd("set")>()` method is updated to avoid extra conversion and use of core-internal types.