### PR TITLE
[test] add wait time for reliablity of test_advertising_proxy

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_advertising_proxy.py
+++ b/tests/scripts/thread-cert/border_router/test_advertising_proxy.py
@@ -174,7 +174,7 @@ class SingleHostAndService(thread_cert.TestCase):
         self.assertIsNone(host.discover_mdns_service('my-service-1', '_ipps._tcp', 'my-host'))
 
         server.srp_server_set_enabled(True)
-        self.simulator.go(LEASE)
+        self.simulator.go(LEASE + 5)
 
         self.check_host_and_service(server, client, '2001::2', 'my-service')
         self.check_host_and_service(server, client, '2001::2', 'my-service-1')


### PR DESCRIPTION
1 failing out of 3 runs before this change with the same signature as https://github.com/openthread/openthread/issues/10478
All 3 runs pass with the extra wait time as in this PR.