### PR TITLE
[otci] add network management API to otci

### DIFF
--- a/tools/otci/otci/otci.py
+++ b/tools/otci/otci/otci.py
@@ -1790,6 +1790,11 @@ class OTCI(object):
 
         self.execute_command(cmd)
 
+    def get_dataset_tlvs_bytes(self) -> bytes:
+        """Gets bytes of the Operational Dataset TLVs"""
+        hexstr = self.__parse_str(self.execute_command('dataset tlvs'))
+        return self.__hex_to_bytes(hexstr)
+
     def dataset_set_buffer(self,
                            active_timestamp: Optional[int] = None,
                            channel: Optional[int] = None,
@@ -2534,6 +2539,55 @@ class OTCI(object):
             return False
 
         return True
+
+    #
+    # Network management utilities
+    #
+    def create_dataset(self,
+                       active_timestamp: Optional[int] = None,
+                       channel: Optional[int] = None,
+                       channel_mask: Optional[int] = None,
+                       extpanid: Optional[str] = None,
+                       mesh_local_prefix: Optional[str] = None,
+                       network_key: Optional[str] = None,
+                       network_name: Optional[str] = None,
+                       panid: Optional[int] = None,
+                       pskc: Optional[str] = None,
+                       security_policy: Optional[tuple] = None,
+                       pending_timestamp: Optional[int] = None) -> bytes:
+        """Creates a new Operational Dataset with given parameters."""
+        self.dataset_clear_buffer()
+        self.dataset_init_buffer()
+        self.dataset_set_buffer(active_timestamp, channel, channel_mask, extpanid, mesh_local_prefix, network_key,
+                                network_name, panid, pskc, security_policy, pending_timestamp)
+        return self.get_dataset_tlvs_bytes()
+
+    def join(self, dataset: bytes) -> None:
+        """Joins to a Thread network with given Active Operational Dataset."""
+        self.set_dataset_bytes('active', dataset)
+        self.ifconfig_up()
+        self.thread_start()
+
+    def leave(self) -> None:
+        """Leaves from the Thread network."""
+        self.thread_stop()
+        self.ifconfig_down()
+
+    def wait_for(self, command: str, expect_line: Optional[Union[str, Pattern, Collection[Any]]], timeout: float = 60):
+        """Wait for the expected output by periodically executing the given command."""
+        success = False
+
+        while timeout > 0:
+            output = self.execute_command(command)
+            if any(match_line(line, expect_line) for line in output):
+                success = True
+                break
+
+            self.__otcmd.wait(1)
+            timeout -= 1
+
+        if not success:
+            raise ExpectLineTimeoutError(expect_line)
 
     #
     # Other TODOs


### PR DESCRIPTION
This commit adds high level Thread network management API 'create_dataset()', 'join()', 'leave()' and 'wait_for()' to otci.