### PR TITLE
[routing-manager] track peer BRs and their age from Network Data

### DIFF
--- a/include/openthread/border_routing.h
+++ b/include/openthread/border_routing.h
@@ -132,6 +132,16 @@ typedef struct otBorderRoutingPrefixTableEntry
 } otBorderRoutingPrefixTableEntry;
 
 /**
+ * Represents information about a peer Border Router found in the Network Data.
+ *
+ */
+typedef struct otBorderRoutingPeerBorderRouterEntry
+{
+    uint16_t mRloc16; ///< The RLOC16 of BR.
+    uint32_t mAge;    ///< Seconds since the BR appeared in the Network Data.
+} otBorderRoutingPeerBorderRouterEntry;
+
+/**
  * Represents a group of data of platform-generated RA messages processed.
  *
  */
@@ -487,6 +497,58 @@ otError otBorderRoutingGetNextPrefixTableEntry(otInstance                       
 otError otBorderRoutingGetNextRouterEntry(otInstance                         *aInstance,
                                           otBorderRoutingPrefixTableIterator *aIterator,
                                           otBorderRoutingRouterEntry         *aEntry);
+
+/**
+ * Iterates over the peer BRs found in the Network Data.
+ *
+ * Requires `OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE`.
+ *
+ * Peer BRs are other devices within the Thread mesh that provide external IP connectivity. A device is considered
+ * to provide external IP connectivity if at least one of the following conditions is met regarding its Network Data
+ * entries:
+ *
+ * - It has added at least one external route entry.
+ * - It has added at least one prefix entry with both the default-route and on-mesh flags set.
+ * - It has added at least one domain prefix (with both the domain and on-mesh flags set).
+ *
+ * The list of peer BRs specifically excludes the current device, even if it is itself acting as a BR.
+ *
+ * @param[in]     aInstance    The OpenThread instance.
+ * @param[in,out] aIterator    A pointer to the iterator.
+ * @param[out]    aEntry       A pointer to the entry to populate.
+ *
+ * @retval OT_ERROR_NONE        Iterated to the next entry, @p aEntry and @p aIterator are updated.
+ * @retval OT_ERROR_NOT_FOUND   No more entries.
+ *
+ */
+otError otBorderRoutingGetNextPeerBrEntry(otInstance                           *aInstance,
+                                          otBorderRoutingPrefixTableIterator   *aIterator,
+                                          otBorderRoutingPeerBorderRouterEntry *aEntry);
+
+/**
+ * Returns the number of peer BRs found in the Network Data.
+ *
+ * Requires `OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE`.
+ *
+ * Peer BRs are other devices within the Thread mesh that provide external IP connectivity. A device is considered
+ * to provide external IP connectivity if at least one of the following conditions is met regarding its Network Data
+ * entries:
+ *
+ * - It has added at least one external route entry.
+ * - It has added at least one prefix entry with both the default-route and on-mesh flags set.
+ * - It has added at least one domain prefix (with both the domain and on-mesh flags set).
+ *
+ * The list of peer BRs specifically excludes the current device, even if it is itself acting as a BR.
+ *
+ * @param[in]  aInstance    The OpenThread instance.
+ * @param[out] aMinAge      Pointer to an `uint32_t` to return the minimum age among all peer BRs.
+ *                          Can be NULL if the caller does not need this information.
+ *                          Age is represented as seconds since appearance of the BR entry in the Network Data.
+ *
+ * @returns The number of peer BRs.
+ *
+ */
+uint16_t otBorderRoutingCountPeerBrs(otInstance *aInstance, uint32_t *aMinAge);
 
 /**
  * Enables / Disables DHCPv6 Prefix Delegation.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (427)
+#define OPENTHREAD_API_VERSION (428)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README_BR.md
+++ b/src/cli/README_BR.md
@@ -13,6 +13,7 @@ Usage : `br [command] ...`
 - [omrprefix](#omrprefix)
 - [onlinkprefix](#onlinkprefix)
 - [pd](#pd)
+- [peers](#peers)
 - [prefixtable](#prefixtable)
 - [rioprf](#rioprf)
 - [routeprf](#routeprf)
@@ -35,6 +36,7 @@ enable
 omrprefix
 onlinkprefix
 pd
+peers
 prefixtable
 raoptions
 rioprf
@@ -218,6 +220,48 @@ Get the DHCPv6 Prefix Delegation (PD) provided off-mesh-routable (OMR) prefix.
 ```bash
 > br pd omrprefix
 2001:db8:cafe:0:0/64 lifetime:1800 preferred:1800
+Done
+```
+
+### peers
+
+Usage: `br peers`
+
+Get the list of peer BRs found in the Network Data.
+
+`OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE` is required.
+
+Peer BRs are other devices within the Thread mesh that provide external IP connectivity. A device is considered to provide external IP connectivity if at least one of the following conditions is met regarding its Network Data entries:
+
+- It has added at least one external route entry.
+- It has added at least one prefix entry with both the default-route and on-mesh flags set.
+- It has added at least one domain prefix (with both the domain and on-mesh flags set).
+
+The list of peer BRs specifically excludes the current device, even if it is itself acting as a BR.
+
+Info per BR entry:
+
+- RLOC16 of the BR
+- Age as the duration interval since this BR appeared in Network Data. It is formatted as `{hh}:{mm}:{ss}` for hours, minutes, seconds, if the duration is less than 24 hours. If the duration is 24 hours or more, the format is `{dd}d.{hh}:{mm}:{ss}` for days, hours, minutes, seconds.
+
+```bash
+> br peers
+rloc16:0x5c00 age:00:00:49
+rloc16:0xf800 age:00:01:51
+Done
+```
+
+Usage: `br peers count`
+
+Gets the number of peer BRs found in the Network Data.
+
+The count does not include the current device, even if it is itself acting as a BR.
+
+The output indicates the minimum age among all peer BRs. Age is formatted as `{hh}:{mm}:{ss}` for hours, minutes, seconds, if the duration is less than 24 hours. If the duration is 24 hours or more, the format is `{dd}d.{hh}:{mm}:{ss}` for days, hours, minutes, seconds.
+
+```bash
+> br peer count
+2 min-age:00:00:49
 Done
 ```
 

--- a/src/core/api/border_routing_api.cpp
+++ b/src/core/api/border_routing_api.cpp
@@ -194,6 +194,28 @@ otError otBorderRoutingGetNextRouterEntry(otInstance                         *aI
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetNextRouterEntry(*aIterator, *aEntry);
 }
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
+
+otError otBorderRoutingGetNextPeerBrEntry(otInstance                           *aInstance,
+                                          otBorderRoutingPrefixTableIterator   *aIterator,
+                                          otBorderRoutingPeerBorderRouterEntry *aEntry)
+{
+    AssertPointerIsNotNull(aIterator);
+    AssertPointerIsNotNull(aEntry);
+
+    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetNextPeerBrEntry(*aIterator, *aEntry);
+}
+
+uint16_t otBorderRoutingCountPeerBrs(otInstance *aInstance, uint32_t *aMinAge)
+{
+    uint32_t minAge;
+
+    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().CountPeerBrs((aMinAge != nullptr) ? *aMinAge
+                                                                                                       : minAge);
+}
+
+#endif
+
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
 void otBorderRoutingDhcp6PdSetEnabled(otInstance *aInstance, bool aEnabled)
 {

--- a/tests/toranj/cli/cli.py
+++ b/tests/toranj/cli/cli.py
@@ -805,6 +805,12 @@ class Node(object):
     def br_get_routers(self):
         return self.cli('br routers')
 
+    def br_get_peer_brs(self):
+        return self.cli('br peers')
+
+    def br_count_peers(self):
+        return self._cli_single_output('br peers count')
+
     # ------------------------------------------------------------------------------------------------------------------
     # Helper methods
 


### PR DESCRIPTION
This commit adds a new mechanism in `RoutingManager` to discover and track peer BRs found in Network Data. The `NetDataPeerBrTracker` class implements this functionality, tracking a list of peer BR RLOC16s and their age (time since appearance in the Network Data).

This commit also implements public OT APIs to iterate over the peer BR list or get the total count, along with corresponding CLI commands (`br peers`), and a test case validating the behavior.

----

~This PR currently contains the commit from the #10453 and #10448. Please check and review the last commit. Thank.~
