### PR TITLE
[test] harden `test_srp_server`

### DIFF
--- a/tests/unit/test_srp_server.cpp
+++ b/tests/unit/test_srp_server.cpp
@@ -533,7 +533,7 @@ void TestSrpServerReject(void)
     srpClient->EnableAutoStartMode(nullptr, nullptr);
     VerifyOrQuit(srpClient->IsAutoStartModeEnabled());
 
-    AdvanceTime(2000);
+    AdvanceTime(15 * 1000);
     VerifyOrQuit(srpClient->IsRunning());
 
     SuccessOrQuit(srpClient->SetHostName(kHostName));
@@ -645,7 +645,7 @@ void TestSrpServerIgnore(void)
     srpClient->EnableAutoStartMode(nullptr, nullptr);
     VerifyOrQuit(srpClient->IsAutoStartModeEnabled());
 
-    AdvanceTime(2000);
+    AdvanceTime(15 * 1000);
     VerifyOrQuit(srpClient->IsRunning());
 
     SuccessOrQuit(srpClient->SetHostName(kHostName));
@@ -759,7 +759,7 @@ void TestSrpServerClientRemove(bool aShouldRemoveKeyLease)
     srpClient->EnableAutoStartMode(nullptr, nullptr);
     VerifyOrQuit(srpClient->IsAutoStartModeEnabled());
 
-    AdvanceTime(2000);
+    AdvanceTime(15 * 1000);
     VerifyOrQuit(srpClient->IsRunning());
 
     SuccessOrQuit(srpClient->SetHostName(kHostName));


### PR DESCRIPTION
This commit updates `test_srp_server` to wait longer after the start of the SRP client before performing the test steps. This makes the test more robust against random jitter which may be applied by the client when registering.

---

Should help address failures like [link](https://github.com/openthread/openthread/actions/runs/9831798497/job/27139692103).