### PR TITLE
[netdata] add new API `otNetDataGetBorderRouterCount()`

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (424)
+#define OPENTHREAD_API_VERSION (425)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/netdata.h
+++ b/include/openthread/netdata.h
@@ -253,6 +253,16 @@ otError otNetDataGetNextLowpanContextInfo(otInstance            *aInstance,
 void otNetDataGetCommissioningDataset(otInstance *aInstance, otCommissioningDataset *aDataset);
 
 /**
+ * Get the total number of Border Routers added in network data (including both router and child roles)
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ *
+ * @returns The number of BRs added in network data.
+ *
+ */
+uint8_t otNetDataGetBorderRouterCount(otInstance *aInstance);
+
+/**
  * Get the Network Data Version.
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.

--- a/src/core/api/netdata_api.cpp
+++ b/src/core/api/netdata_api.cpp
@@ -109,6 +109,11 @@ void otNetDataGetCommissioningDataset(otInstance *aInstance, otCommissioningData
     return AsCoreType(aInstance).Get<NetworkData::Leader>().GetCommissioningDataset(AsCoreType(aDataset));
 }
 
+uint8_t otNetDataGetBorderRouterCount(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).Get<NetworkData::Leader>().CountBorderRouters(NetworkData::RoleFilter::kAnyRole);
+}
+
 uint8_t otNetDataGetVersion(otInstance *aInstance)
 {
     return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderData().GetDataVersion(NetworkData::kFullSet);


### PR DESCRIPTION
This API returns the total number of BRs added in network data, including both router and child roles.