### PR TITLE
[dataset-manager] apply partial dataset config on channel set failure

### DIFF
--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -199,8 +199,7 @@ Error DatasetManager::ApplyConfiguration(const Dataset &aDataset) const
 
             if (error != kErrorNone)
             {
-                LogWarn("ApplyConfiguration() Failed to set channel to %d (%s)", channel, ErrorToString(error));
-                ExitNow();
+                LogCrit("Failed to set channel to %u when applying dataset: %s", channel, ErrorToString(error));
             }
 
             break;


### PR DESCRIPTION
This commit updates `DatasetManager::ApplyConfiguration()` to apply the rest of the parameters in the Dataset even if setting the channel fails.