### PR TITLE
[network-data] refactor anycast dest lookup to `NetworkData::Leader`

### DIFF
--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -404,13 +404,6 @@ private:
 #endif
     };
 
-    enum AnycastType : uint8_t
-    {
-        kAnycastDhcp6Agent,
-        kAnycastNeighborDiscoveryAgent,
-        kAnycastService,
-    };
-
     struct RxInfo : public InstanceLocator
     {
         static constexpr uint16_t kInfoStringSize = 70;
@@ -557,8 +550,6 @@ private:
     void  SendDestinationUnreachable(uint16_t aMeshSource, const Ip6::Headers &aIp6Headers);
     Error UpdateIp6Route(Message &aMessage);
     Error UpdateIp6RouteFtd(const Ip6::Header &aIp6Header, Message &aMessage);
-    void  EvaluateRoutingCost(uint16_t aDest, uint8_t &aBestCost, uint16_t &aBestDest) const;
-    Error AnycastRouteLookup(uint8_t aServiceId, AnycastType aType, uint16_t &aMeshDest) const;
     Error UpdateMeshRoute(Message &aMessage);
     bool  UpdateReassemblyList(void);
     void  UpdateFragmentPriority(Lowpan::FragmentHeader &aFragmentHeader,

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -364,6 +364,19 @@ public:
     void IncrementVersionAndStableVersion(void);
 
     /**
+     * Performs anycast ALOC route lookup using the Network Data.
+     *
+     * @param[in]   aAloc16     The ALOC16 destination to lookup.
+     * @param[out]  aRloc16     A reference to return the RLOC16 for the selected route.
+     *
+     * @retval kErrorNone      Successfully lookup best option for @p aAloc16. @p aRloc16 is updated.
+     * @retval kErrorNoRoute   No valid route was found.
+     * @retval kErrorDrop      The @p aAloc16 is not valid.
+     *
+     */
+    Error AnycastLookup(uint16_t aAloc16, uint16_t &aRloc16) const;
+
+    /**
      * Returns CONTEXT_ID_RESUSE_DELAY value.
      *
      * @returns The CONTEXT_ID_REUSE_DELAY value (in seconds).
@@ -467,6 +480,13 @@ private:
     static constexpr uint8_t  kMinServiceId       = 0x00;
     static constexpr uint8_t  kMaxServiceId       = 0x0f;
 
+    enum AnycastType : uint8_t
+    {
+        kAnycastDhcp6Agent,
+        kAnycastNdAgent,
+        kAnycastService,
+    };
+
     class ChangedFlags
     {
     public:
@@ -550,6 +570,9 @@ private:
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     void HandleTimer(void);
+
+    Error AnycastLookup(uint8_t aServiceId, AnycastType aType, uint16_t &aRloc16) const;
+    void  EvaluateRoutingCost(uint16_t aDest, uint8_t &aBestCost, uint16_t &aBestDest) const;
 
     void RegisterNetworkData(uint16_t aRloc16, const NetworkData &aNetworkData);
 


### PR DESCRIPTION
This commit refactors the code and methods responsible for looking up anycast destination, moving them from the `MeshForwarder` class to the more appropriate `NetworkData::Leader` class. This better aligns the responsibilities of each module (e.g. `RouteLookup()` is provided by `NetworkData::Leader). This is a pure refactor with no changes or enhancements to the existing implementation.

---

I kept this as a pure refactor with no logic changes. In future PRs we can include enhancements (e.g., reusing existing methods in `NetworkData::Leader` for comparing network data entries when selecting a destination).


