### PR TITLE
[test] test whether the RCP supports data poll

### DIFF
--- a/tools/cp-caps/README.md
+++ b/tools/cp-caps/README.md
@@ -54,7 +54,7 @@ Show help info.
 
 ```bash
 $ python3 ./tools/cp-caps/rcp_caps_test.py -h
-usage: rcp_caps_test.py [-h] [-c] [-d] [-v]
+usage: rcp_caps_test.py [-h] [-c] [-d] [-p] [-v]
 
 This script is used for testing RCP capabilities.
 
@@ -62,6 +62,7 @@ options:
   -h, --help           show this help message and exit
   -c, --csl            test whether the RCP supports CSL transmitter
   -d, --diag-commands  test whether the RCP supports all diag commands
+  -p, --data-poll      test whether the RCP supports data poll
   -v, --verbose        output verbose information
 
 Device Interfaces:
@@ -132,4 +133,14 @@ The parameter `-c` or `--csl` starts to test whether the RCP supports the CSL tr
 ```bash
 $ DUT_ADB_USB=TW69UCKFZTGM95OR REF_CLI_SERIAL=/dev/ttyACM0 python3 ./tools/cp-caps/rcp_caps_test.py -c
 CSL Transmitter ------------------------------------------ OK
+```
+
+### Test Data Poll
+
+The parameter `-p` or `--data-poll` starts to test whether the RCP supports data poll.
+
+```bash
+$ DUT_ADB_USB=1269UCKFZTAM95OR REF_CLI_SERIAL=/dev/ttyACM0 python3 ./tools/cp-caps/rcp_caps_test.py -p
+Data Poll Parent ----------------------------------------- OK
+Data Poll Child ------------------------------------------ OK
 ```


### PR DESCRIPTION
This commit adds a test case to the `cp-tests` to test whether the RCP supports data poll transmitter and receiver.