### PR TITLE
[test] test whether the RCP support CSL transmitter

### DIFF
--- a/tools/cp-caps/README.md
+++ b/tools/cp-caps/README.md
@@ -41,7 +41,7 @@ $ git clone git@github.com:openthread/ot-nrf528xx.git
 $ cd ot-nrf528xx/
 $ git submodule update --init
 $ ./script/bootstrap
-$ ./script/build nrf52840 UART_trans -DOT_DIAGNOSTIC=ON
+$ ./script/build nrf52840 UART_trans -DOT_DIAGNOSTIC=ON -DOT_CSL_RECEIVER=ON
 $ arm-none-eabi-objcopy -O ihex build/bin/ot-cli-ftd ot-cli-ftd.hex
 $ nrfjprog -f nrf52 --chiperase --program ot-cli-ftd.hex --reset
 ```
@@ -54,12 +54,13 @@ Show help info.
 
 ```bash
 $ python3 ./tools/cp-caps/rcp_caps_test.py -h
-usage: rcp_caps_test.py [-h] [-d] [-v]
+usage: rcp_caps_test.py [-h] [-c] [-d] [-v]
 
 This script is used for testing RCP capabilities.
 
 options:
   -h, --help           show this help message and exit
+  -c, --csl            test whether the RCP supports CSL transmitter
   -d, --diag-commands  test whether the RCP supports all diag commands
   -v, --verbose        output verbose information
 
@@ -122,4 +123,13 @@ diag gpio mode 2 out ------------------------------------- NotSupported
 diag gpio get 2 ------------------------------------------ NotSupported
 diag gpio set 2 0 ---------------------------------------- NotSupported
 diag gpio set 2 1 ---------------------------------------- NotSupported
+```
+
+### Test CSL Transmitter
+
+The parameter `-c` or `--csl` starts to test whether the RCP supports the CSL transmitter.
+
+```bash
+$ DUT_ADB_USB=TW69UCKFZTGM95OR REF_CLI_SERIAL=/dev/ttyACM0 python3 ./tools/cp-caps/rcp_caps_test.py -c
+CSL Transmitter ------------------------------------------ OK
 ```

--- a/tools/cp-caps/rcp_caps_test.py
+++ b/tools/cp-caps/rcp_caps_test.py
@@ -79,9 +79,44 @@ class RcpCaps(object):
         self.__ref.diag_stop()
         self.__dut.diag_stop()
 
+    def test_csl(self):
+        self.__dataset = self.__get_default_dataset()
+        self.__test_csl_transmitter()
+
     #
     # Private methods
     #
+    def __get_default_dataset(self):
+        return self.__dut.create_dataset(channel=20, network_key='00112233445566778899aabbccddcafe')
+
+    def __test_csl_transmitter(self):
+        packets = 10
+
+        self.__dut.factory_reset()
+        self.__ref.factory_reset()
+
+        self.__dut.join(self.__dataset)
+        self.__dut.wait_for('state', 'leader')
+
+        # Set the reference device as an SSED
+        self.__ref.set_mode('-')
+        self.__ref.config_csl(channel=15, period=320000, timeout=100)
+        self.__ref.join(self.__dataset)
+        self.__ref.wait_for('state', 'child')
+
+        child_table = self.__dut.get_child_table()
+        ret = len(child_table) == 1 and child_table[1]['csl']
+
+        if ret:
+            ref_mleid = self.__ref.get_ipaddr_mleid()
+            result = self.__dut.ping(ref_mleid, count=packets, interval=1)
+            ret = result['transmitted_packets'] == result['received_packets'] == packets
+
+        self.__dut.leave()
+        self.__ref.leave()
+
+        self.__output_format_bool('CSL Transmitter', ret)
+
     def __test_diag_channel(self):
         channel = 20
         commands = ['diag channel', f'diag channel {channel}']
@@ -379,6 +414,14 @@ def parse_arguments():
                                      epilog=epilog_msg)
 
     parser.add_argument(
+        '-c',
+        '--csl',
+        action='store_true',
+        default=False,
+        help='test whether the RCP supports CSL transmitter',
+    )
+
+    parser.add_argument(
         '-d',
         '--diag-commands',
         action='store_true',
@@ -408,6 +451,9 @@ def main():
 
     if arguments.diag_commands is True:
         rcp_caps.test_diag_commands()
+
+    if arguments.csl is True:
+        rcp_caps.test_csl()
 
 
 if __name__ == '__main__':

--- a/tools/otci/otci/otci.py
+++ b/tools/otci/otci/otci.py
@@ -746,7 +746,16 @@ class OTCI(object):
 
             id = int(col("ID"))
             r, d, n = int(col("R")), int(col("D")), int(col("N"))
-            mode = DeviceMode(f'{"r" if r else ""}{"d" if d else ""}{"n" if n else ""}')
+
+            #
+            # Device mode flags:
+            #
+            # r: rx-on-when-idle
+            # d: Full Thread Device
+            # n: Full Network Data
+            # -: no flags set (rx-off-when-idle, minimal Thread device, stable network data)
+            mode = DeviceMode(
+                f'{"r" if r else ""}{"d" if d else ""}{"n" if n else ""}{"-" if r == d == n == 0 else ""}')
 
             child = {
                 'id': ChildId(id),
@@ -767,6 +776,9 @@ class OTCI(object):
 
             if 'QMsgCnt' in headers:
                 child['qmsgcnt'] = int(col('QMsgCnt'))
+
+            if 'Suprvsn' in headers:
+                child['suprvsn'] = int(col('Suprvsn'))
 
             table[ChildId(id)] = child
 


### PR DESCRIPTION
This commit adds a test case to `cp-tests` to test whether the RCP supports the CSL transmitter.