### PR TITLE
Include the "openthread-core-config.h" in spinel headers.

### DIFF
--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -37,6 +37,7 @@
 #include <openthread/platform/diag.h>
 #include <openthread/platform/radio.h>
 
+#include "openthread-core-config.h"
 #include "openthread-spinel-config.h"
 #include "core/radio/max_power_table.hpp"
 #include "lib/spinel/logger.hpp"

--- a/src/lib/spinel/spinel_decoder.hpp
+++ b/src/lib/spinel/spinel_decoder.hpp
@@ -33,6 +33,7 @@
 #ifndef SPINEL_DECODER_HPP_
 #define SPINEL_DECODER_HPP_
 
+#include "openthread-core-config.h"
 #include "openthread-spinel-config.h"
 
 #include <openthread/ip6.h>


### PR DESCRIPTION
To avoid macro redefined errors.