### PR TITLE
[radio] move required radio caps from radio spinel into posix platform

### DIFF
--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -163,9 +163,14 @@ public:
      * @param[in]  aSoftwareReset              When doing RCP recovery, TRUE to try software reset first, FALSE to
      *                                         directly do a hardware reset.
      * @param[in]  aSpinelDriver               A pointer to the spinel driver instance that this object depends on.
+     * @param[in]  aRequiredRadioCaps          The required radio capabilities. RadioSpinel will check if RCP has
+     *                                         the required capabilities during initiailization.
      *
      */
-    void Init(bool aSkipRcpCompatibilityCheck, bool aSoftwareReset, SpinelDriver *aSpinelDriver);
+    void Init(bool          aSkipRcpCompatibilityCheck,
+              bool          aSoftwareReset,
+              SpinelDriver *aSpinelDriver,
+              otRadioCaps   aRequiredRadioCaps);
 
     /**
      * This method sets the notification callbacks.
@@ -1115,7 +1120,7 @@ private:
     SpinelDriver &GetSpinelDriver(void) const;
 
     otError CheckSpinelVersion(void);
-    otError CheckRadioCapabilities(void);
+    otError CheckRadioCapabilities(otRadioCaps aRequiredRadioCaps);
     otError CheckRcpApiVersion(bool aSupportsRcpApiVersion, bool aSupportsRcpMinHostApiVersion);
     void    InitializeCaps(bool &aSupportsRcpApiVersion, bool &aSupportsRcpMinHostApiVersion);
 

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -93,7 +93,7 @@ void Radio::Init(const char *aUrl)
     skipCompatibilityCheck = mRadioUrl.HasParam("skip-rcp-compatibility-check");
 
     mRadioSpinel.SetCallbacks(callbacks);
-    mRadioSpinel.Init(skipCompatibilityCheck, resetRadio, &GetSpinelDriver());
+    mRadioSpinel.Init(skipCompatibilityCheck, resetRadio, &GetSpinelDriver(), kRequiredRadioCaps);
 
     ProcessRadioUrl(mRadioUrl);
 }

--- a/src/posix/platform/radio.hpp
+++ b/src/posix/platform/radio.hpp
@@ -115,6 +115,12 @@ private:
 #error "No Spinel interface is specified!"
 #endif
 
+    static constexpr otRadioCaps kRequiredRadioCaps =
+#if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
+        OT_RADIO_CAPS_TRANSMIT_SEC | OT_RADIO_CAPS_TRANSMIT_TIMING |
+#endif
+        OT_RADIO_CAPS_ACK_TIMEOUT | OT_RADIO_CAPS_TRANSMIT_RETRIES | OT_RADIO_CAPS_CSMA_BACKOFF;
+
     RadioUrl mRadioUrl;
 #if OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_ENABLE
     Spinel::VendorRadioSpinel mRadioSpinel;


### PR DESCRIPTION
This PR moves the definition of the 'RequiredRadioCaps' from `RadioSpinel` to posix `Radio` class. Because this definition depends on `OPENTHREAD_CONFIG_THREAD_VERSION`. And we want to remove lib's dependency on OT core. And lib as a tool should be able to decide what caps to check at runtime.