### PR TITLE
[spinel] extract SpinelStatusToOtError method from RadioSpinel into a helper module

### DIFF
--- a/src/lib/spinel/BUILD.gn
+++ b/src/lib/spinel/BUILD.gn
@@ -49,6 +49,8 @@ spinel_sources = [
   "spinel_driver.hpp",
   "spinel_encoder.cpp",
   "spinel_encoder.hpp",
+  "spinel_helper.cpp",
+  "spinel_helper.hpp",
   "spinel_platform.h",
 ]
 

--- a/src/lib/spinel/CMakeLists.txt
+++ b/src/lib/spinel/CMakeLists.txt
@@ -72,6 +72,7 @@ set(COMMON_SOURCES
     spinel_buffer.cpp
     spinel_decoder.cpp
     spinel_encoder.cpp
+    spinel_helper.cpp
 )
 
 set(OT_SPINEL_VENDOR_HOOK_SOURCE "" CACHE STRING "set vendor hook source file for Spinel")

--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -46,6 +46,7 @@
 #include "lib/spinel/logger.hpp"
 #include "lib/spinel/spinel_decoder.hpp"
 #include "lib/spinel/spinel_driver.hpp"
+#include "lib/spinel/spinel_helper.hpp"
 #include "lib/utils/utils.hpp"
 
 namespace ot {
@@ -2334,83 +2335,6 @@ exit:
     return error;
 }
 #endif // OPENTHREAD_CONFIG_PLATFORM_POWER_CALIBRATION_ENABLE
-
-otError RadioSpinel::SpinelStatusToOtError(spinel_status_t aStatus)
-{
-    otError ret;
-
-    switch (aStatus)
-    {
-    case SPINEL_STATUS_OK:
-        ret = OT_ERROR_NONE;
-        break;
-
-    case SPINEL_STATUS_FAILURE:
-        ret = OT_ERROR_FAILED;
-        break;
-
-    case SPINEL_STATUS_DROPPED:
-        ret = OT_ERROR_DROP;
-        break;
-
-    case SPINEL_STATUS_NOMEM:
-        ret = OT_ERROR_NO_BUFS;
-        break;
-
-    case SPINEL_STATUS_BUSY:
-        ret = OT_ERROR_BUSY;
-        break;
-
-    case SPINEL_STATUS_PARSE_ERROR:
-        ret = OT_ERROR_PARSE;
-        break;
-
-    case SPINEL_STATUS_INVALID_ARGUMENT:
-        ret = OT_ERROR_INVALID_ARGS;
-        break;
-
-    case SPINEL_STATUS_UNIMPLEMENTED:
-        ret = OT_ERROR_NOT_IMPLEMENTED;
-        break;
-
-    case SPINEL_STATUS_INVALID_STATE:
-        ret = OT_ERROR_INVALID_STATE;
-        break;
-
-    case SPINEL_STATUS_NO_ACK:
-        ret = OT_ERROR_NO_ACK;
-        break;
-
-    case SPINEL_STATUS_CCA_FAILURE:
-        ret = OT_ERROR_CHANNEL_ACCESS_FAILURE;
-        break;
-
-    case SPINEL_STATUS_ALREADY:
-        ret = OT_ERROR_ALREADY;
-        break;
-
-    case SPINEL_STATUS_PROP_NOT_FOUND:
-        ret = OT_ERROR_NOT_IMPLEMENTED;
-        break;
-
-    case SPINEL_STATUS_ITEM_NOT_FOUND:
-        ret = OT_ERROR_NOT_FOUND;
-        break;
-
-    default:
-        if (aStatus >= SPINEL_STATUS_STACK_NATIVE__BEGIN && aStatus <= SPINEL_STATUS_STACK_NATIVE__END)
-        {
-            ret = static_cast<otError>(aStatus - SPINEL_STATUS_STACK_NATIVE__BEGIN);
-        }
-        else
-        {
-            ret = OT_ERROR_FAILED;
-        }
-        break;
-    }
-
-    return ret;
-}
 
 } // namespace Spinel
 } // namespace ot

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -1022,28 +1022,6 @@ public:
     otError SetChannelTargetPower(uint8_t aChannel, int16_t aTargetPower);
 #endif
 
-    /**
-     * Convert the Spinel status code to OpenThread error code.
-     *
-     * @param[in]  aStatus  The Spinel status code.
-     *
-     * @retval  OT_ERROR_NONE                    The operation has completed successfully.
-     * @retval  OT_ERROR_DROP                    The packet was dropped.
-     * @retval  OT_ERROR_NO_BUFS                 The operation has been prevented due to memory pressure.
-     * @retval  OT_ERROR_BUSY                    The device is currently performing a mutuallyexclusive operation.
-     * @retval  OT_ERROR_PARSE                   An error has occurred while parsing the command.
-     * @retval  OT_ERROR_INVALID_ARGS            An argument to the given operation is invalid.
-     * @retval  OT_ERROR_NOT_IMPLEMENTED         The given operation has not been implemented.
-     * @retval  OT_ERROR_INVALID_STATE           The given operation is invalid for the current state of the device.
-     * @retval  OT_ERROR_NO_ACK                  The packet was not acknowledged.
-     * @retval  OT_ERROR_NOT_FOUND               The given property is not recognized.
-     * @retval  OT_ERROR_FAILED                  The given operation has failed for some undefined reason.
-     * @retval  OT_ERROR_CHANNEL_ACCESS_FAILURE  The packet was not sent due to a CCA failure.
-     * @retval  OT_ERROR_ALREADY                 The operation is already in progress or the property was already set
-     *                                           to the given value.
-     */
-    static otError SpinelStatusToOtError(spinel_status_t aStatus);
-
 #if OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
     /**
      * Restore the properties of Radio Co-processor (RCP).

--- a/src/lib/spinel/spinel_helper.cpp
+++ b/src/lib/spinel/spinel_helper.cpp
@@ -1,0 +1,117 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "lib/spinel/spinel_helper.hpp"
+
+/**
+ * @file This file implements the spinel helper methods.
+ *
+ */
+
+namespace ot {
+namespace Spinel {
+
+otError SpinelStatusToOtError(spinel_status_t aStatus)
+{
+    otError ret;
+
+    switch (aStatus)
+    {
+    case SPINEL_STATUS_OK:
+        ret = OT_ERROR_NONE;
+        break;
+
+    case SPINEL_STATUS_FAILURE:
+        ret = OT_ERROR_FAILED;
+        break;
+
+    case SPINEL_STATUS_DROPPED:
+        ret = OT_ERROR_DROP;
+        break;
+
+    case SPINEL_STATUS_NOMEM:
+        ret = OT_ERROR_NO_BUFS;
+        break;
+
+    case SPINEL_STATUS_BUSY:
+        ret = OT_ERROR_BUSY;
+        break;
+
+    case SPINEL_STATUS_PARSE_ERROR:
+        ret = OT_ERROR_PARSE;
+        break;
+
+    case SPINEL_STATUS_INVALID_ARGUMENT:
+        ret = OT_ERROR_INVALID_ARGS;
+        break;
+
+    case SPINEL_STATUS_UNIMPLEMENTED:
+        ret = OT_ERROR_NOT_IMPLEMENTED;
+        break;
+
+    case SPINEL_STATUS_INVALID_STATE:
+        ret = OT_ERROR_INVALID_STATE;
+        break;
+
+    case SPINEL_STATUS_NO_ACK:
+        ret = OT_ERROR_NO_ACK;
+        break;
+
+    case SPINEL_STATUS_CCA_FAILURE:
+        ret = OT_ERROR_CHANNEL_ACCESS_FAILURE;
+        break;
+
+    case SPINEL_STATUS_ALREADY:
+        ret = OT_ERROR_ALREADY;
+        break;
+
+    case SPINEL_STATUS_PROP_NOT_FOUND:
+        ret = OT_ERROR_NOT_IMPLEMENTED;
+        break;
+
+    case SPINEL_STATUS_ITEM_NOT_FOUND:
+        ret = OT_ERROR_NOT_FOUND;
+        break;
+
+    default:
+        if (aStatus >= SPINEL_STATUS_STACK_NATIVE__BEGIN && aStatus <= SPINEL_STATUS_STACK_NATIVE__END)
+        {
+            ret = static_cast<otError>(aStatus - SPINEL_STATUS_STACK_NATIVE__BEGIN);
+        }
+        else
+        {
+            ret = OT_ERROR_FAILED;
+        }
+        break;
+    }
+
+    return ret;
+}
+
+} // namespace Spinel
+} // namespace ot

--- a/src/lib/spinel/spinel_helper.hpp
+++ b/src/lib/spinel/spinel_helper.hpp
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file This file includes definitions for spinel helper methods.
+ *
+ */
+
+#ifndef SPINEL_HELPER_HPP_
+#define SPINEL_HELPER_HPP_
+
+#include <openthread/error.h>
+
+#include "lib/spinel/spinel.h"
+
+namespace ot {
+namespace Spinel {
+
+/**
+ * Convert the Spinel status code to OpenThread error code.
+ *
+ * @param[in]  aStatus  The Spinel status code.
+ *
+ * @retval  OT_ERROR_NONE                    The operation has completed successfully.
+ * @retval  OT_ERROR_DROP                    The packet was dropped.
+ * @retval  OT_ERROR_NO_BUFS                 The operation has been prevented due to memory pressure.
+ * @retval  OT_ERROR_BUSY                    The device is currently performing a mutuallyexclusive operation.
+ * @retval  OT_ERROR_PARSE                   An error has occurred while parsing the command.
+ * @retval  OT_ERROR_INVALID_ARGS            An argument to the given operation is invalid.
+ * @retval  OT_ERROR_NOT_IMPLEMENTED         The given operation has not been implemented.
+ * @retval  OT_ERROR_INVALID_STATE           The given operation is invalid for the current state of the device.
+ * @retval  OT_ERROR_NO_ACK                  The packet was not acknowledged.
+ * @retval  OT_ERROR_NOT_FOUND               The given property is not recognized.
+ * @retval  OT_ERROR_FAILED                  The given operation has failed for some undefined reason.
+ * @retval  OT_ERROR_CHANNEL_ACCESS_FAILURE  The packet was not sent due to a CCA failure.
+ * @retval  OT_ERROR_ALREADY                 The operation is already in progress or the property was already set
+ *                                           to the given value.
+ */
+otError SpinelStatusToOtError(spinel_status_t aStatus);
+
+} // namespace Spinel
+} // namespace ot
+
+#endif // SPINEL_HELPER_HPP_


### PR DESCRIPTION
This PR moves `RadioSpinel::SpinelStatusToOtError` to a seperate header `spinel_header.hpp` so that this method can be used externally. (For example, in `ot-br-posix`.