### PR TITLE
[github-actions] run `packet-verification` tests once

### DIFF
--- a/.github/workflows/simulation-1.1.yml
+++ b/.github/workflows/simulation-1.1.yml
@@ -52,7 +52,7 @@ jobs:
       REFERENCE_DEVICE: 1
       THREAD_VERSION: 1.1
       VIRTUAL_TIME: 1
-      MULTIPLY: 3
+      MULTIPLY: 1
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1

--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -196,7 +196,7 @@ jobs:
       PACKET_VERIFICATION: 1
       THREAD_VERSION: 1.3
       INTER_OP_BBR: 1
-      MULTIPLY: 3
+      MULTIPLY: 1
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1


### PR DESCRIPTION
This commit updates the `MULTIPLY` config to `1` from `3` for the `packet-verification` test jobs in `simulation-1.*` workflows. This ensures that the tests are run only once instead of three times. This helps reduce the chance of occasional CI failures.