### PR TITLE
[cli] update `ping` output to use comma after IPv6 address

### DIFF
--- a/examples/apps/cli/README.md
+++ b/examples/apps/cli/README.md
@@ -116,7 +116,7 @@ Done
 
 ```bash
 > ping fd3d:b50b:f96d:722d:7a73:bff6:9093:9117
-16 bytes from fd3d:b50b:f96d:722d:558:f56b:d688:799: icmp_seq=1 hlim=64 time=24ms
+16 bytes from fd3d:b50b:f96d:722d:558:f56b:d688:799, icmp_seq=1 hlim=64 time=24ms
 ```
 
 ## 4. Explore More

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -2903,12 +2903,12 @@ Send an ICMPv6 Echo Request.
 
 ```bash
 > ping fd00:db8:0:0:76b:6a05:3ae9:a61a
-> 16 bytes from fd00:db8:0:0:76b:6a05:3ae9:a61a: icmp_seq=5 hlim=64 time=0ms
+> 16 bytes from fd00:db8:0:0:76b:6a05:3ae9:a61a, icmp_seq=5 hlim=64 time=0ms
 1 packets transmitted, 1 packets received. Packet loss = 0.0%. Round-trip min/avg/max = 0/0.0/0 ms.
 Done
 
 > ping -I fd00:db8:0:0:76b:6a05:3ae9:a61a ff02::1 100 1 1 1
-> 108 bytes from fd00:db8:0:0:f605:fb4b:d429:d59a: icmp_seq=4 hlim=64 time=7ms
+> 108 bytes from fd00:db8:0:0:f605:fb4b:d429:d59a, icmp_seq=4 hlim=64 time=7ms
 1 packets transmitted, 1 packets received. Round-trip min/avg/max = 7/7.0/7 ms.
 Done
 ```
@@ -2920,7 +2920,7 @@ The address can be an IPv4 address, which will be synthesized to an IPv6 address
 ```bash
 > ping 172.17.0.1
 Pinging synthesized IPv6 address: fdde:ad00:beef:2:0:0:ac11:1
-> 16 bytes from fdde:ad00:beef:2:0:0:ac11:1: icmp_seq=5 hlim=64 time=0ms
+> 16 bytes from fdde:ad00:beef:2:0:0:ac11:1, icmp_seq=5 hlim=64 time=0ms
 1 packets transmitted, 1 packets received. Packet loss = 0.0%. Round-trip min/avg/max = 0/0.0/0 ms.
 Done
 ```

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -5513,20 +5513,20 @@ exit:
  * @cli ping
  * @code
  * ping fd00:db8:0:0:76b:6a05:3ae9:a61a
- * 16 bytes from fd00:db8:0:0:76b:6a05:3ae9:a61a: icmp_seq=5 hlim=64 time=0ms
+ * 16 bytes from fd00:db8:0:0:76b:6a05:3ae9:a61a, icmp_seq=5 hlim=64 time=0ms
  * 1 packets transmitted, 1 packets received. Packet loss = 0.0%. Round-trip min/avg/max = 0/0.0/0 ms.
  * Done
  * @endcode
  * @code
  * ping -I fd00:db8:0:0:76b:6a05:3ae9:a61a ff02::1 100 1 1 1
- * 108 bytes from fd00:db8:0:0:f605:fb4b:d429:d59a: icmp_seq=4 hlim=64 time=7ms
+ * 108 bytes from fd00:db8:0:0:f605:fb4b:d429:d59a, icmp_seq=4 hlim=64 time=7ms
  * 1 packets transmitted, 1 packets received. Round-trip min/avg/max = 7/7.0/7 ms.
  * Done
  * @endcode
  * @code
  * ping 172.17.0.1
  * Pinging synthesized IPv6 address: fdde:ad00:beef:2:0:0:ac11:1
- * 16 bytes from fdde:ad00:beef:2:0:0:ac11:1: icmp_seq=5 hlim=64 time=0ms
+ * 16 bytes from fdde:ad00:beef:2:0:0:ac11:1, icmp_seq=5 hlim=64 time=0ms
  * 1 packets transmitted, 1 packets received. Packet loss = 0.0%. Round-trip min/avg/max = 0/0.0/0 ms.
  * Done
  * @endcode

--- a/src/cli/cli_ping.cpp
+++ b/src/cli/cli_ping.cpp
@@ -209,7 +209,7 @@ void PingSender::HandlePingReply(const otPingSenderReply *aReply)
 {
     OutputFormat("%u bytes from ", static_cast<uint16_t>(aReply->mSize + sizeof(otIcmp6Header)));
     OutputIp6Address(aReply->mSenderAddress);
-    OutputLine(": icmp_seq=%u hlim=%u time=%ums", aReply->mSequenceNumber, aReply->mHopLimit, aReply->mRoundTripTime);
+    OutputLine(", icmp_seq=%u hlim=%u time=%ums", aReply->mSequenceNumber, aReply->mHopLimit, aReply->mRoundTripTime);
 }
 
 void PingSender::HandlePingStatistics(const otPingSenderStatistics *aStatistics, void *aContext)

--- a/tests/scripts/expect/cli-ipmaddr.exp
+++ b/tests/scripts/expect/cli-ipmaddr.exp
@@ -51,7 +51,7 @@ expect_line "Done"
 
 switch_node 2
 send "ping ff0e::1\n"
-expect "16 bytes from $addr: icmp_seq=1"
+expect "16 bytes from $addr, icmp_seq=1"
 expect_line "Done"
 
 switch_node 1

--- a/tests/scripts/expect/cli-ping.exp
+++ b/tests/scripts/expect/cli-ping.exp
@@ -54,10 +54,10 @@ set addr [get_ipaddr mleid]
 
 switch_node 1
 send "ping $addr\n"
-expect "16 bytes from $addr: icmp_seq=1"
+expect "16 bytes from $addr, icmp_seq=1"
 send "ping $addr 20 10 0.00123456 255\n"
 for {set i 2} {$i <= 11} {incr i} {
-    expect "28 bytes from $addr: icmp_seq=$i"
+    expect "28 bytes from $addr, icmp_seq=$i"
 }
 
 dispose_all

--- a/tests/scripts/expect/cli-promiscuous.exp
+++ b/tests/scripts/expect/cli-promiscuous.exp
@@ -72,7 +72,7 @@ expect_line "Done"
 
 switch_node 1
 send "ping $addr\n"
-expect "16 bytes from $addr: icmp_seq=1"
+expect "16 bytes from $addr, icmp_seq=1"
 expect_line "Done"
 
 switch_node 3

--- a/tests/scripts/expect/cli_non_rcp-radiostats.exp
+++ b/tests/scripts/expect/cli_non_rcp-radiostats.exp
@@ -43,7 +43,7 @@ switch_node 1
 for {set i 1} {$i <= 10} {incr i} {
     send "ping $addr\n"
     sleep 3
-    expect "16 bytes from $addr: icmp_seq="
+    expect "16 bytes from $addr, icmp_seq="
 }
 
 switch_node 2

--- a/tests/scripts/expect/posix-rcp-stack-reset.exp
+++ b/tests/scripts/expect/posix-rcp-stack-reset.exp
@@ -62,7 +62,7 @@ try {
 
     switch_node 1
     send "ping $addr\n"
-    expect "16 bytes from $addr: icmp_seq=1"
+    expect "16 bytes from $addr, icmp_seq=1"
     expect_line "Done"
     send "reset\n"
     wait_for "state" "disabled"
@@ -72,7 +72,7 @@ try {
     send "thread start\n"
     expect_line "Done"
     wait_for "state" "leader"
-    wait_for "ping $addr" "16 bytes from $addr: icmp_seq=\\d+"
+    wait_for "ping $addr" "16 bytes from $addr, icmp_seq=\\d+"
     expect_line "Done"
 } finally {
     exec kill $rcp_pid

--- a/tests/scripts/expect/tun-realm-local-multicast.exp
+++ b/tests/scripts/expect/tun-realm-local-multicast.exp
@@ -84,7 +84,7 @@ set mleid4 [get_ipaddr "mleid"]
 switch_node 1
 
 send "ping ${mleid4}\n"
-expect "16 bytes from $mleid4: icmp_seq=1"
+expect "16 bytes from $mleid4, icmp_seq=1"
 expect_line "Done"
 
 dispose_all

--- a/tests/scripts/expect/v1_2-linkmetricsmgr.exp
+++ b/tests/scripts/expect/v1_2-linkmetricsmgr.exp
@@ -46,7 +46,7 @@ set addr [get_ipaddr mleid]
 
 switch_node 1
 send "ping $addr\n"
-expect "16 bytes from $addr: icmp_seq=1"
+expect "16 bytes from $addr, icmp_seq=1"
 send "linkmetricsmgr show\n"
 expect -re {ExtAddr:([0-9a-f]){16}, LinkMargin:\d+, Rssi:\-?\d+}
 expect "Done"
@@ -75,12 +75,12 @@ expect_line "Enabled"
 expect_line "Done"
 
 send "ping $addr\n"
-expect "16 bytes from $addr: icmp_seq="
+expect "16 bytes from $addr, icmp_seq="
 
 sleep 10
 
 send "ping $addr\n"
-expect "16 bytes from $addr: icmp_seq="
+expect "16 bytes from $addr, icmp_seq="
 
 send "linkmetricsmgr show\n"
 expect -re {ExtAddr:([0-9a-f]){16}, LinkMargin:\d+, Rssi:\-?\d+}
@@ -98,12 +98,12 @@ expect_line "Disabled"
 expect_line "Done"
 
 send "ping $addr\n"
-expect "16 bytes from $addr: icmp_seq="
+expect "16 bytes from $addr, icmp_seq="
 
 sleep 10
 
 send "ping $addr\n"
-expect "16 bytes from $addr: icmp_seq="
+expect "16 bytes from $addr, icmp_seq="
 
 send "linkmetricsmgr show\n"
 expect_line "Done"
@@ -120,12 +120,12 @@ expect_line "Enabled"
 expect_line "Done"
 
 send "ping $addr\n"
-expect "16 bytes from $addr: icmp_seq="
+expect "16 bytes from $addr, icmp_seq="
 
 sleep 10
 
 send "ping $addr\n"
-expect "16 bytes from $addr: icmp_seq="
+expect "16 bytes from $addr, icmp_seq="
 
 send "linkmetricsmgr show\n"
 expect -re {ExtAddr:([0-9a-f]){16}, LinkMargin:\d+, Rssi:\-?\d+}
@@ -142,12 +142,12 @@ expect_line "Disabled"
 expect_line "Done"
 
 send "ping $addr\n"
-expect "16 bytes from $addr: icmp_seq="
+expect "16 bytes from $addr, icmp_seq="
 
 sleep 10
 
 send "ping $addr\n"
-expect "16 bytes from $addr: icmp_seq="
+expect "16 bytes from $addr, icmp_seq="
 
 send "linkmetricsmgr show\n"
 expect_line "Done"

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -2547,7 +2547,7 @@ class NodeImpl:
         while len(responders) < num_responses or not done:
             self.simulator.go(1)
             try:
-                i = self._expect([r'from (\S+):', r'Done'], timeout=0.1)
+                i = self._expect([r'from (\S+),', r'Done'], timeout=0.1)
             except (pexpect.TIMEOUT, socket.timeout):
                 if self.simulator.now() < end:
                     continue


### PR DESCRIPTION
This commit updates the CLI `ping` command output. When information about a received echo response is outputted, a comma (`,`) is now used after the sender's IPv6 address instead of a colon (`:`). This change aligns the output with common `ping` outputs (e.g., on Linux) and avoids ambiguity in parsing the IPv6 address, which itself contains colons.