### PR TITLE
[settings] reset the platform settings file descriptor once closed

### DIFF
--- a/src/posix/platform/settings.cpp
+++ b/src/posix/platform/settings.cpp
@@ -232,6 +232,7 @@ void otPlatSettingsDeinit(otInstance *aInstance)
 
     VerifyOrExit(sSettingsFd != -1);
     VerifyOrDie(close(sSettingsFd) == 0, OT_EXIT_ERROR_ERRNO);
+    sSettingsFd = -1;
 
 exit:
     return;


### PR DESCRIPTION
On platform settings deinit, the file descriptor is closed but the variable is not reset, which can lead to calling close on a stale fd leading to bad file descriptor error in case the API is invoked multiple times