### PR TITLE
[mesh-forwarder] use `RemoveMessageIfNoPendingTx()`

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -208,6 +208,8 @@ void MeshForwarder::EvictMessage(Message &aMessage)
 
     OT_ASSERT(queue != nullptr);
 
+    LogMessage(kMessageEvict, aMessage, kErrorNoBufs);
+
     if (queue == &mSendQueue)
     {
 #if OPENTHREAD_FTD
@@ -218,15 +220,12 @@ void MeshForwarder::EvictMessage(Message &aMessage)
 #endif
 
         FinalizeMessageDirectTx(aMessage, kErrorNoBufs);
-
-        if (mSendMessage == &aMessage)
-        {
-            mSendMessage = nullptr;
-        }
+        RemoveMessageIfNoPendingTx(aMessage);
     }
-
-    LogMessage(kMessageEvict, aMessage, kErrorNoBufs);
-    queue->DequeueAndFree(aMessage);
+    else
+    {
+        queue->DequeueAndFree(aMessage);
+    }
 }
 
 void MeshForwarder::ResumeMessageTransmissions(void)

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -166,7 +166,7 @@ void MeshForwarder::HandleResolved(const Ip6::Address &aEid, Error aError)
         {
             LogMessage(kMessageDrop, message, kErrorAddressQuery);
             FinalizeMessageDirectTx(message, kErrorAddressQuery);
-            mSendQueue.DequeueAndFree(message);
+            RemoveMessageIfNoPendingTx(message);
             continue;
         }
 
@@ -337,14 +337,9 @@ void MeshForwarder::RemoveDataResponseMessages(void)
             }
         }
 
-        if (mSendMessage == &message)
-        {
-            mSendMessage = nullptr;
-        }
-
         LogMessage(kMessageDrop, message);
         FinalizeMessageDirectTx(message, kErrorDrop);
-        mSendQueue.DequeueAndFree(message);
+        RemoveMessageIfNoPendingTx(message);
     }
 }
 


### PR DESCRIPTION
This commit replaces direct calls to `DequeueAndFree()` with `RemoveMessageIfNoPendingTx()` in `EvictMessage()`, `HandleResolved()`, and `RemoveDataResponseMessages()`. This promotes consistency in message removal logic and eliminates the need to check if the removed message is `mSendMessage`, as this is already handled by `RemoveMessageIfNoPendingTx()`.

----

In all the above cases, using `DequeueAndFree()` is indeed correct (since we know message has no pending TX). Opted to use `RemoveMessageIfNoPendingTx()` to maintain consistency throughout the codebase. 
