### PR TITLE
[mesh-forwarder] `RemoveMessagesForChild()` to use a predicate fn

### DIFF
--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -241,16 +241,30 @@ public:
     void SetRxOnWhenIdle(bool aRxOnWhenIdle);
 
 #if OPENTHREAD_FTD
+
     /**
-     * Frees any messages queued for an existing child.
+     * Represents a predicate function for checking if a given `Message` meets specific criteria.
      *
-     * @param[in]  aChild    A reference to the child.
-     * @param[in]  aSubType  The message sub-type to remove.
-     *                       Use Message::kSubTypeNone remove all messages for @p aChild.
+     * @param[in] aMessage The message to evaluate.
+     *
+     * @return TRUE   If the @p aMessage satisfies the predicate condition.
+     * @return FALSE  If the @p aMessage does not satisfy the predicate condition.
      *
      */
-    void RemoveMessages(Child &aChild, Message::SubType aSubType);
-#endif
+    typedef bool (&MessageChecker)(const Message &aMessage);
+
+    /**
+     * Removes and frees messages queued for a child, based on a given predicate.
+     *
+     * The `aChild` can be either sleepy or non-sleepy.
+     *
+     * @param[in] aChild            The child whose messages are to be evaluated.
+     * @param[in] aMessageChecker   The predicate function to filter messages.
+     *
+     */
+    void RemoveMessagesForChild(Child &aChild, MessageChecker aMessageChecker);
+
+#endif // OPENTHREAD_FTD
 
     /**
      * Frees unicast/multicast MLE Data Responses from Send Message Queue if any.

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -608,6 +608,9 @@ private:
     void  HandleNetworkDataUpdateRouter(void);
     void  HandleDiscoveryRequest(RxInfo &aRxInfo);
 
+    static bool IsMessageMleSubType(const Message &aMessage);
+    static bool IsMessageChildUpdateRequest(const Message &aMessage);
+
     Error ProcessRouteTlv(const RouteTlv &aRouteTlv, RxInfo &aRxInfo);
     Error ReadAndProcessRouteTlvOnFed(RxInfo &aRxInfo, uint8_t aParentId);
 


### PR DESCRIPTION
This commit updates `RemoveMessagesForChild()` to use a predicate function to determine which messages should be removed. This replaces the `Message::SubType` filtering and allows messages matching multiple sub-types to be removed together.