### PR TITLE
[spinel] fix cmake source list for spinel_helper.cpp

### DIFF
--- a/src/lib/spinel/CMakeLists.txt
+++ b/src/lib/spinel/CMakeLists.txt
@@ -95,6 +95,7 @@ target_sources(openthread-radio-spinel
         logger.cpp
         radio_spinel.cpp
         spinel_driver.cpp
+        spinel_helper.cpp
 )
 target_sources(openthread-spinel-ncp PRIVATE ${COMMON_SOURCES})
 target_sources(openthread-spinel-rcp PRIVATE ${COMMON_SOURCES})


### PR DESCRIPTION
This PR adds `spinel_helper.cpp` in the target source list of `openthread-radio-spinel`.

When `openthread-radio-spinel` is used in external projects, there may be link issues (`SpinelStatusToError` cannot be found). Because currently `spinel_helper.cpp` is not in the target source list. 

This issue isn't found when the PR was submitted because `spinel_helper.cpp` is added in `COMMON_SOURCES` which is used to build `openthread-rcp-spinel` and ot-daemon also links this lib.