### PR TITLE
[spinel] add get iid method

### DIFF
--- a/src/lib/spinel/spinel_driver.hpp
+++ b/src/lib/spinel/spinel_driver.hpp
@@ -210,6 +210,14 @@ public:
      */
     bool CoprocessorHasCap(unsigned int aCapability) { return mCoprocessorCaps.Contains(aCapability); }
 
+    /**
+     * Returns the spinel interface id.
+     *
+     * @returns the spinel interface id.
+     *
+     */
+    spinel_iid_t GetIid(void) { return mIid; }
+
 private:
     static constexpr uint16_t kMaxSpinelFrame    = SPINEL_FRAME_MAX_SIZE;
     static constexpr uint16_t kVersionStringSize = 128;


### PR DESCRIPTION
This PR adds a method to get spinel interface Id in `SpinelDriver`.

This is to enable the user class of `SpinelDriver` can compose the spinel header itself.