### PR TITLE
[continuous-integration] fix the path for uploading artifacts when the BR fails

### DIFF
--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -85,7 +85,7 @@ jobs:
       run: |
         export CI_ENV="$(bash <(curl -s https://codecov.io/env)) -e GITHUB_ACTIONS -e COVERAGE"
         echo "CI_ENV=${CI_ENV}"
-        sudo -E ./script/test cert_suite ./tests/scripts/thread-cert/backbone/*.py || (sudo chmod a+r *.log *.json *.pcap && false)
+        sudo -E ./script/test cert_suite ./tests/scripts/thread-cert/backbone/*.py || (sudo chmod a+r ot_testing/* && false)
     - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: cov-thread-1-3-backbone-docker
@@ -96,11 +96,11 @@ jobs:
       with:
         name: thread-1-3-backbone-results
         path: |
-          *.pcap
-          *.json
-          *.log
-          coredump_*
-          otbr-agent_*
+          ot_testing/*.pcap
+          ot_testing/*.json
+          ot_testing/*.log
+          ot_testing/coredump_*
+          ot_testing/otbr-agent_*
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage gcc
@@ -207,7 +207,7 @@ jobs:
       run: |
         export CI_ENV="$(bash <(curl -s https://codecov.io/env)) -e GITHUB_ACTIONS -e COVERAGE"
         echo "CI_ENV=${CI_ENV}"
-        sudo -E ./script/test cert_suite ${{ matrix.cert_scripts }} || (sudo chmod a+r *.log *.json *.pcap && false)
+        sudo -E ./script/test cert_suite ${{ matrix.cert_scripts }} || (sudo chmod a+r ot_testing/* && false)
     - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: cov-br-docker-${{ matrix.description }}-${{ matrix.otbr_mdns }}-${{matrix.otbr_trel}}
@@ -218,11 +218,11 @@ jobs:
       with:
         name: br-results-${{ matrix.description }}-${{ matrix.otbr_mdns }}-${{matrix.otbr_trel}}
         path: |
-          *.pcap
-          *.json
-          *.log
-          coredump_*
-          otbr-agent_*
+          ot_testing/*.pcap
+          ot_testing/*.json
+          ot_testing/*.log
+          ot_testing/coredump_*
+          ot_testing/otbr-agent_*
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage gcc


### PR DESCRIPTION
The OTBR testing artifacts used to be at the root directory but they are now at `ot_testing/`.