### PR TITLE
[spinel] fix little endian in lib

### DIFF
--- a/src/lib/spinel/multi_frame_buffer.hpp
+++ b/src/lib/spinel/multi_frame_buffer.hpp
@@ -464,12 +464,12 @@ private:
     public:
         static uint16_t ReadUint16(const uint8_t *aBuffer)
         {
-            return static_cast<uint16_t>((aBuffer[0] << 8) | aBuffer[1]);
+            return static_cast<uint16_t>((aBuffer[0]) | aBuffer[1] << 8);
         }
         static void WriteUint16(uint16_t aValue, uint8_t *aBuffer)
         {
-            aBuffer[0] = (aValue >> 8) & 0xff;
-            aBuffer[1] = (aValue >> 0) & 0xff;
+            aBuffer[0] = (aValue >> 0) & 0xff;
+            aBuffer[1] = (aValue >> 8) & 0xff;
         }
     };
 

--- a/src/lib/spinel/spi_frame.hpp
+++ b/src/lib/spinel/spi_frame.hpp
@@ -238,12 +238,12 @@ private:
     public:
         static uint16_t ReadUint16(const uint8_t *aBuffer)
         {
-            return static_cast<uint16_t>((aBuffer[0] << 8) | aBuffer[1]);
+            return static_cast<uint16_t>((aBuffer[0]) | aBuffer[1] << 8);
         }
         static void WriteUint16(uint16_t aValue, uint8_t *aBuffer)
         {
-            aBuffer[0] = (aValue >> 8) & 0xff;
-            aBuffer[1] = (aValue >> 0) & 0xff;
+            aBuffer[0] = (aValue >> 0) & 0xff;
+            aBuffer[1] = (aValue >> 8) & 0xff;
         }
     };
 


### PR DESCRIPTION
The order of little endian in lib is incorrect. 