### PR TITLE
[border-agent] directly respond to MGMT_GET from non-active commissioner

### DIFF
--- a/src/core/api/border_agent_api.cpp
+++ b/src/core/api/border_agent_api.cpp
@@ -56,7 +56,22 @@ otError otBorderAgentSetId(otInstance *aInstance, const otBorderAgentId *aId)
 
 otBorderAgentState otBorderAgentGetState(otInstance *aInstance)
 {
-    return MapEnum(AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().GetState());
+    otBorderAgentState state = OT_BORDER_AGENT_STATE_STOPPED;
+
+    switch (AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().GetState())
+    {
+    case MeshCoP::BorderAgent::kStateStopped:
+        break;
+    case MeshCoP::BorderAgent::kStateStarted:
+        state = OT_BORDER_AGENT_STATE_STARTED;
+        break;
+    case MeshCoP::BorderAgent::kStateConnected:
+    case MeshCoP::BorderAgent::kStateAccepted:
+        state = OT_BORDER_AGENT_STATE_ACTIVE;
+        break;
+    }
+
+    return state;
 }
 
 uint16_t otBorderAgentGetUdpPort(otInstance *aInstance)

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -46,6 +46,7 @@
 #include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/tasklet.hpp"
+#include "meshcop/dataset.hpp"
 #include "meshcop/secure_transport.hpp"
 #include "net/udp6.hpp"
 #include "thread/tmf.hpp"
@@ -94,9 +95,10 @@ public:
      */
     enum State : uint8_t
     {
-        kStateStopped = OT_BORDER_AGENT_STATE_STOPPED, ///< Border agent is stopped/disabled.
-        kStateStarted = OT_BORDER_AGENT_STATE_STARTED, ///< Border agent is started.
-        kStateActive  = OT_BORDER_AGENT_STATE_ACTIVE,  ///< Border agent is connected with external commissioner.
+        kStateStopped,   ///< Stopped/disabled.
+        kStateStarted,   ///< Started and listening for connections.
+        kStateConnected, ///< Connected to an external commissioner candidate, petition pending.
+        kStateAccepted,  ///< Connected to and accepted an external commissioner.
     };
 
     /**
@@ -288,6 +290,7 @@ private:
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
+    void HandleTmfDatasetGet(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, Dataset::Type aType);
     void HandleTimeout(void);
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
@@ -346,7 +349,6 @@ DeclareTmfHandler(BorderAgent, kUriProxyTx);
 
 } // namespace MeshCoP
 
-DefineMapEnum(otBorderAgentState, MeshCoP::BorderAgent::State);
 DefineCoreType(otBorderAgentId, MeshCoP::BorderAgent::Id);
 
 } // namespace ot

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -66,6 +66,18 @@ public:
     typedef otDatasetMgmtSetCallback MgmtSetCallback;
 
     /**
+     * Indicates whether to check or ignore Security Policy flag when processing an MGMT_GET request message.
+     *
+     * This is used as input in `ProcessGetRequest().
+     *
+     */
+    enum SecurityPolicyCheckMode : uint8_t
+    {
+        kCheckSecurityPolicyFlags,  ///< Check Security Policy flags.
+        kIgnoreSecurityPolicyFlags, ///< Ignore Security Policy flags.
+    };
+
+    /**
      * Returns the network Timestamp.
      *
      * @returns The network Timestamp.
@@ -219,6 +231,17 @@ public:
                          uint8_t                    aLength,
                          const otIp6Address        *aAddress) const;
 
+    /**
+     * Processes a MGMT_GET request message and prepares the response.
+     *
+     * @param[in] aRequest   The MGMT_GET request message.
+     * @param[in] aCheckMode Indicates whether to check or ignore the Security Policy flags.
+     *
+     * @returns The prepared response, or `nullptr` if fails to parse the request or cannot allocate message.
+     *
+     */
+    Coap::Message *ProcessGetRequest(const Coap::Message &aRequest, SecurityPolicyCheckMode aCheckMode) const;
+
 private:
     static constexpr uint8_t  kMaxGetTypes  = 64;   // Max number of types in MGMT_GET.req
     static constexpr uint32_t kSendSetDelay = 5000; // in msec.
@@ -279,9 +302,6 @@ private:
     void  SignalDatasetChange(void) const;
     void  SyncLocalWithLeader(const Dataset &aDataset);
     Error SendSetRequest(const Dataset &aDataset);
-    void  SendGetResponse(const Coap::Message    &aRequest,
-                          const Ip6::MessageInfo &aMessageInfo,
-                          const TlvList          &aTlvList) const;
     void  HandleMgmtSetResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aError);
 
     static void HandleMgmtSetResponse(void                *aContext,


### PR DESCRIPTION
This commit updates the `BorderAgent` to directly respond to `MGMT_ACTIVE_GET` and `MGMT_PENDING_GET` requests from a non-active commissioner. Requests from an active commissioner are still forwarded to the leader. This aligns the implementation with Thread 1.4 requirements (ephemeral PSKc use case).

To achieve this, the following changes are made:

- New `State` values are added to distinguish between when a commissioner candidate is connected and when its petition to become the active commissioner is accepted. This determines whether the `MGMT_GET` request should be handled directly or forwarded to the leader.
- This state is tracked locally by `BorderAgent` instead of monitoring Network Data to determine whether an active commissioner exists. This ensures correct behavior even when Network Data updates are delayed.
- The `DatasetManager` is updated to provide `ProcessGetRequest()` to process an `MGMT_GET` request and prepare the response. This is then used in `DatasetManager` itself and by `BorderAgent`.

---

Related to [SPEC-1216](https://threadgroup.atlassian.net/browse/SPEC-1216).