### PR TITLE
[sub-mac] use relative time when starting CSL TX delay

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -396,12 +396,13 @@ void SubMac::StartCsmaBackoff(void)
         {
             static constexpr uint32_t kAheadTime = kCcaSampleInterval + kCslTransmitTimeAhead + kRadioHeaderShrDuration;
             Time                      txStartTime = Time(mTransmitFrame.mInfo.mTxInfo.mTxDelayBaseTime);
+            Time                      radioNow    = Time(static_cast<uint32_t>(otPlatRadioGetNow(&GetInstance())));
 
             txStartTime += (mTransmitFrame.mInfo.mTxInfo.mTxDelay - kAheadTime);
 
-            if (Time(static_cast<uint32_t>(otPlatRadioGetNow(&GetInstance()))) < txStartTime)
+            if (radioNow < txStartTime)
             {
-                mTimer.FireAt(txStartTime);
+                StartTimer(txStartTime - radioNow);
             }
             else // Transmit without delay
             {


### PR DESCRIPTION
The original code uses the absolute time when staring the CSL TX delay in `SubMac`. The timer is a `MicroTimer` and the absolute time comes from the `mTxDelayBaseTime`. The `mTxDelayBaseTime` comes from the radio time `otPlatRadioGetNow ()`, the time of `MicroTimer` should come from `otPlatAlarmMicroGetNow()`. If the `MicroTimer` and the radio are using different timer sources, it will cause the unexpected issue.

This commit use the relative time when starting CSL TX delay to fix this issue.