### PR TITLE
[test] set default paths of expect scripts

### DIFF
--- a/script/check-simulation-local-host
+++ b/script/check-simulation-local-host
@@ -30,7 +30,7 @@
 set -euxo pipefail
 
 IFACE_NAME="dummy116"
-EXPECT_TEST=tests/scripts/expect/cli-ping.exp
+EXPECT_TEST=./tests/scripts/expect/cli-ping.exp
 
 cleanup()
 {
@@ -59,24 +59,27 @@ setup_dummy116()
 test_ipv6()
 {
     setup_dummy116
-    OT_SIMULATION_LOCAL_HOST=$IFACE_NAME ./script/test build expect $EXPECT_TEST
-    OT_SIMULATION_LOCAL_HOST=$IP6ADDR ./script/test build expect $EXPECT_TEST
+    OT_SIMULATION_LOCAL_HOST=$IFACE_NAME $EXPECT_TEST
+    OT_SIMULATION_LOCAL_HOST=$IP6ADDR $EXPECT_TEST
 
-    OT_NODE_TYPE=rcp OT_SIMULATION_LOCAL_HOST=$IFACE_NAME ./script/test build expect $EXPECT_TEST
-    OT_NODE_TYPE=rcp OT_SIMULATION_LOCAL_HOST=$IP6ADDR ./script/test build expect $EXPECT_TEST
+    OT_NODE_TYPE=rcp OT_SIMULATION_LOCAL_HOST=$IFACE_NAME $EXPECT_TEST
+    OT_NODE_TYPE=rcp OT_SIMULATION_LOCAL_HOST=$IP6ADDR $EXPECT_TEST
 }
 
 test_ipv4()
 {
-    OT_SIMULATION_LOCAL_HOST=lo ./script/test build expect $EXPECT_TEST
-    OT_SIMULATION_LOCAL_HOST=127.0.0.1 ./script/test build expect $EXPECT_TEST
+    OT_SIMULATION_LOCAL_HOST=lo $EXPECT_TEST
+    OT_SIMULATION_LOCAL_HOST=127.0.0.1 $EXPECT_TEST
 
-    OT_NODE_TYPE=rcp OT_SIMULATION_LOCAL_HOST=lo ./script/test build expect $EXPECT_TEST
-    OT_NODE_TYPE=rcp OT_SIMULATION_LOCAL_HOST=127.0.0.1 ./script/test build expect $EXPECT_TEST
+    OT_NODE_TYPE=rcp OT_SIMULATION_LOCAL_HOST=lo $EXPECT_TEST
+    OT_NODE_TYPE=rcp OT_SIMULATION_LOCAL_HOST=127.0.0.1 $EXPECT_TEST
 }
 
 main()
 {
+    ./script/cmake-build posix
+    ./script/cmake-build simulation
+
     test_ipv4
     test_ipv6
 }

--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -69,11 +69,27 @@ proc spawn_node {id {type ""} {radio_url ""}} {
     global argv0
 
     if {${type} == ""} {
-        set type $::env(OT_NODE_TYPE)
+        if {[info exists ::env(OT_NODE_TYPE)]} {
+            set type $::env(OT_NODE_TYPE)
+        } else {
+            set type "cli"
+        }
+    }
+
+    if {[info exists ::env(OT_POSIX_APPS)]} {
+        set ot_posix_apps $::env(OT_POSIX_APPS)
+    } else {
+        set ot_posix_apps "build/posix/src/posix"
+    }
+
+    if {[info exists ::env(OT_SIMULATION_APPS)]} {
+        set ot_simulation_apps $::env(OT_SIMULATION_APPS)
+    } else {
+        set ot_simulation_apps "build/simulation/examples/apps"
     }
 
     if {${radio_url} == ""} {
-        set radio_url "spinel+hdlc+uart://$::env(OT_SIMULATION_APPS)/ncp/ot-rcp?forkpty-arg=$id"
+        set radio_url "spinel+hdlc+uart://$ot_simulation_apps/ncp/ot-rcp?forkpty-arg=$id"
     }
 
     send_user "\n# ${id} ${type}\n"
@@ -96,7 +112,7 @@ proc spawn_node {id {type ""} {radio_url ""}} {
             # Sleep 0.2 seconds to ensure that the ot-rcp in the previous test has exited to
             # avoid the error: "bind(sTxFd): Address already in use"
             sleep 0.2
-            spawn /usr/bin/env GCOV_PREFIX=$gcov_prefix $::env(OT_POSIX_APPS)/ot-cli $radio_url
+            spawn /usr/bin/env GCOV_PREFIX=$gcov_prefix $ot_posix_apps/ot-cli $radio_url
             send "factoryreset\n"
             wait_for "state" "disabled"
             expect_line "Done"
@@ -104,7 +120,7 @@ proc spawn_node {id {type ""} {radio_url ""}} {
             expect_line "Done"
         }
         cli {
-            spawn /usr/bin/env GCOV_PREFIX=$gcov_prefix $::env(OT_SIMULATION_APPS)/cli/ot-cli-ftd \
+            spawn /usr/bin/env GCOV_PREFIX=$gcov_prefix $ot_simulation_apps/cli/ot-cli-ftd \
                 -L$ot_simulation_local_host $id
             send "factoryreset\n"
             wait_for "state" "disabled"
@@ -113,7 +129,7 @@ proc spawn_node {id {type ""} {radio_url ""}} {
             expect_line "Done"
         }
         mtd {
-            spawn /usr/bin/env GCOV_PREFIX=$gcov_prefix $::env(OT_SIMULATION_APPS)/cli/ot-cli-mtd \
+            spawn /usr/bin/env GCOV_PREFIX=$gcov_prefix $ot_simulation_apps/cli/ot-cli-mtd \
                 -L$ot_simulation_local_host $id
             send "factoryreset\n"
             wait_for "state" "disabled"


### PR DESCRIPTION
This commit adds default paths for expect scripts to make it easier for running expect scripts. With this change, we can run expect tests as follows:

```bash
./script/cmake-build simulation
./script/cmake-build posix
./tests/scripts/expect/cli-ping.exp
OT_NODE_TYPE=rcp ./tests/scripts/expect/cli-ping.exp
```

This commit also updates an existing test to cover the change.