### PR TITLE
SetSockOpt(TCP_NODELAY)

### DIFF
--- a/include/openthread/tcp.h
+++ b/include/openthread/tcp.h
@@ -396,6 +396,7 @@ otError otTcpBind(otTcpEndpoint *aEndpoint, const otSockAddr *aSockName);
 enum
 {
     OT_TCP_CONNECT_NO_FAST_OPEN = 1 << 0,
+    OT_TCP_NODELAY = 1 << 1,
 };
 
 /**
@@ -421,6 +422,18 @@ enum
  *
  */
 otError otTcpConnect(otTcpEndpoint *aEndpoint, const otSockAddr *aSockName, uint32_t aFlags);
+
+/**
+ * Sets the TCP endpoint's options.
+ *
+ * @param[in]  aEndpoint  A pointer to the TCP endpoint structure to connect.
+ * @param[in]  aFlags     Flags specifying options for this operation (see enumeration above).
+ *
+ * @retval OT_ERROR_NONE    Successfully completed the operation.
+ * @retval OT_ERROR_FAILED  Failed to complete the operation.
+ *
+ */
+otError otTcpSetSockOpt(otTcpEndpoint *aEndpoint, uint32_t aFlags);
 
 /**
  * Defines flags passed to @p otTcpSendByReference.

--- a/src/core/api/tcp_api.cpp
+++ b/src/core/api/tcp_api.cpp
@@ -73,6 +73,11 @@ otError otTcpConnect(otTcpEndpoint *aEndpoint, const otSockAddr *aSockName, uint
     return AsCoreType(aEndpoint).Connect(AsCoreType(aSockName), aFlags);
 }
 
+otError otTcpSetSockOpt(otTcpEndpoint *aEndpoint, uint32_t aFlags)
+{
+    return AsCoreType(aEndpoint).SetSockOpt(aFlags);
+}
+
 otError otTcpSendByReference(otTcpEndpoint *aEndpoint, otLinkedBuffer *aBuffer, uint32_t aFlags)
 {
     return AsCoreType(aEndpoint).SendByReference(*aBuffer, aFlags);

--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -188,6 +188,36 @@ Error Tcp::Endpoint::Connect(const SockAddr &aSockName, uint32_t aFlags)
         tp.fport = BigEndian::HostSwap16(aSockName.mPort);
     }
 
+    if (aFlags & OT_TCP_NODELAY)
+    {
+        tp.t_flags |= TF_NODELAY;
+    }
+    else
+    {
+        tp.t_flags &= ~TF_NODELAY;
+    }
+
+exit:
+    return error;
+}
+
+Error Tcp::Endpoint::SetSockOpt(uint32_t aFlags)
+{
+    Error         error = kErrorNone;
+    struct tcpcb &tp    = GetTcb();
+
+    VerifyOrExit((tp.t_state == TCP6S_CLOSED) || (tp.t_state == TCP6S_LISTEN), error = kErrorInvalidState);
+
+    if (aFlags & OT_TCP_NODELAY)
+    {
+        tp.t_flags |= TF_NODELAY;
+    }
+    else
+    {
+        tp.t_flags &= ~TF_NODELAY;
+    }
+
+
 exit:
     return error;
 }

--- a/src/core/net/tcp6.hpp
+++ b/src/core/net/tcp6.hpp
@@ -563,7 +563,7 @@ public:
          * @returns The TCP Source Port.
          *
          */
-        uint16_t GetSourcePort(void) const { return HostSwap16(mSource); }
+        uint16_t GetSourcePort(void) const { return BigEndian::HostSwap16(mSource); }
 
         /**
          * Returns the TCP Destination Port.
@@ -571,7 +571,7 @@ public:
          * @returns The TCP Destination Port.
          *
          */
-        uint16_t GetDestinationPort(void) const { return HostSwap16(mDestination); }
+        uint16_t GetDestinationPort(void) const { return BigEndian::HostSwap16(mDestination); }
 
         /**
          * Returns the TCP Sequence Number.
@@ -579,7 +579,7 @@ public:
          * @returns The TCP Sequence Number.
          *
          */
-        uint32_t GetSequenceNumber(void) const { return HostSwap32(mSequenceNumber); }
+        uint32_t GetSequenceNumber(void) const { return BigEndian::HostSwap32(mSequenceNumber); }
 
         /**
          * Returns the TCP Acknowledgment Sequence Number.
@@ -587,7 +587,7 @@ public:
          * @returns The TCP Acknowledgment Sequence Number.
          *
          */
-        uint32_t GetAcknowledgmentNumber(void) const { return HostSwap32(mAckNumber); }
+        uint32_t GetAcknowledgmentNumber(void) const { return BigEndian::HostSwap32(mAckNumber); }
 
         /**
          * Returns the TCP Flags.
@@ -595,7 +595,7 @@ public:
          * @returns The TCP Flags.
          *
          */
-        uint16_t GetFlags(void) const { return HostSwap16(mFlags); }
+        uint16_t GetFlags(void) const { return BigEndian::HostSwap16(mFlags); }
 
         /**
          * Returns the TCP Window.
@@ -603,7 +603,7 @@ public:
          * @returns The TCP Window.
          *
          */
-        uint16_t GetWindow(void) const { return HostSwap16(mWindow); }
+        uint16_t GetWindow(void) const { return BigEndian::HostSwap16(mWindow); }
 
         /**
          * Returns the TCP Checksum.
@@ -611,7 +611,7 @@ public:
          * @returns The TCP Checksum.
          *
          */
-        uint16_t GetChecksum(void) const { return HostSwap16(mChecksum); }
+        uint16_t GetChecksum(void) const { return BigEndian::HostSwap16(mChecksum); }
 
         /**
          * Returns the TCP Urgent Pointer.
@@ -619,7 +619,7 @@ public:
          * @returns The TCP Urgent Pointer.
          *
          */
-        uint16_t GetUrgentPointer(void) const { return HostSwap16(mUrgentPointer); }
+        uint16_t GetUrgentPointer(void) const { return BigEndian::HostSwap16(mUrgentPointer); }
 
     private:
         uint16_t mSource;

--- a/src/core/net/tcp6.hpp
+++ b/src/core/net/tcp6.hpp
@@ -200,6 +200,19 @@ public:
         Error Connect(const SockAddr &aSockName, uint32_t aFlags);
 
         /**
+         * Sets the TCP endpoint's options.
+         *
+         * @sa otTcpSetSockOpt
+         *
+         * @param[in]  aFlags     Flags specifying options for this operation (see enumeration above).
+         *
+         * @retval kErrorNone    Successfully completed the operation.
+         * @retval kErrorFailed  Failed to complete the operation.
+         *
+         */
+        Error SetSockOpt(uint32_t aFlags);
+
+        /**
          * Adds data referenced by the linked buffer pointed to by @p aBuffer to the
          * send buffer.
          *
@@ -550,7 +563,7 @@ public:
          * @returns The TCP Source Port.
          *
          */
-        uint16_t GetSourcePort(void) const { return BigEndian::HostSwap16(mSource); }
+        uint16_t GetSourcePort(void) const { return HostSwap16(mSource); }
 
         /**
          * Returns the TCP Destination Port.
@@ -558,7 +571,7 @@ public:
          * @returns The TCP Destination Port.
          *
          */
-        uint16_t GetDestinationPort(void) const { return BigEndian::HostSwap16(mDestination); }
+        uint16_t GetDestinationPort(void) const { return HostSwap16(mDestination); }
 
         /**
          * Returns the TCP Sequence Number.
@@ -566,7 +579,7 @@ public:
          * @returns The TCP Sequence Number.
          *
          */
-        uint32_t GetSequenceNumber(void) const { return BigEndian::HostSwap32(mSequenceNumber); }
+        uint32_t GetSequenceNumber(void) const { return HostSwap32(mSequenceNumber); }
 
         /**
          * Returns the TCP Acknowledgment Sequence Number.
@@ -574,7 +587,7 @@ public:
          * @returns The TCP Acknowledgment Sequence Number.
          *
          */
-        uint32_t GetAcknowledgmentNumber(void) const { return BigEndian::HostSwap32(mAckNumber); }
+        uint32_t GetAcknowledgmentNumber(void) const { return HostSwap32(mAckNumber); }
 
         /**
          * Returns the TCP Flags.
@@ -582,7 +595,7 @@ public:
          * @returns The TCP Flags.
          *
          */
-        uint16_t GetFlags(void) const { return BigEndian::HostSwap16(mFlags); }
+        uint16_t GetFlags(void) const { return HostSwap16(mFlags); }
 
         /**
          * Returns the TCP Window.
@@ -590,7 +603,7 @@ public:
          * @returns The TCP Window.
          *
          */
-        uint16_t GetWindow(void) const { return BigEndian::HostSwap16(mWindow); }
+        uint16_t GetWindow(void) const { return HostSwap16(mWindow); }
 
         /**
          * Returns the TCP Checksum.
@@ -598,7 +611,7 @@ public:
          * @returns The TCP Checksum.
          *
          */
-        uint16_t GetChecksum(void) const { return BigEndian::HostSwap16(mChecksum); }
+        uint16_t GetChecksum(void) const { return HostSwap16(mChecksum); }
 
         /**
          * Returns the TCP Urgent Pointer.
@@ -606,7 +619,7 @@ public:
          * @returns The TCP Urgent Pointer.
          *
          */
-        uint16_t GetUrgentPointer(void) const { return BigEndian::HostSwap16(mUrgentPointer); }
+        uint16_t GetUrgentPointer(void) const { return HostSwap16(mUrgentPointer); }
 
     private:
         uint16_t mSource;

--- a/third_party/tcplp/bsdtcp/tcp_input.c
+++ b/third_party/tcplp/bsdtcp/tcp_input.c
@@ -317,8 +317,8 @@ cc_post_recovery(struct tcpcb *tp, struct tcphdr *th)
 #define DELAY_ACK(tp, tlen)						\
 	((!tcp_timer_active(tp, TT_DELACK) &&				\
 	    (tp->t_flags & TF_RXWIN0SENT) == 0) &&			\
-	    (tlen <= tp->t_maxopd) &&					\
-	    (V_tcp_delack_enabled || (tp->t_flags & TF_NEEDSYN)))
+	    (tlen <= tp->t_maxopd) &&					    \
+	    ((V_tcp_delack_enabled && !(tp->t_flags & TF_NODELAY)) || (tp->t_flags & TF_NEEDSYN)))
 
 static inline void
 cc_ecnpkt_handler(struct tcpcb *tp, struct tcphdr *th, uint8_t iptos)


### PR DESCRIPTION
Add a common API to configure the socket options to be able to use TCP_NODELAY.
For incomming connections: SetSockOpt(OT_TCP_NODELAY).
For outgoing connections combine it with the connect function: otTcpConnect(&mEtnTcpEndpoint, &socket, OT_TCP_CONNECT_NO_FAST_OPEN | OT_TCP_NODELAY).
Within the TCP stack sources the NO_DELAY option already exists, because it is used within BSD.
For TCPlp it wasn't imlemented up to now.