### PR TITLE
[ip6] update `PassToHost` to use `aReceive` for applying RX filter

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -843,8 +843,7 @@ Error Ip6::HandleExtensionHeaders(OwnedPtr<Message> &aMessagePtr,
             break;
 
         case kProtoFragment:
-            IgnoreError(PassToHost(aMessagePtr, aHeader, aNextHeader,
-                                   /* aApplyFilter */ false, aReceive, Message::kCopyToUse));
+            IgnoreError(PassToHost(aMessagePtr, aHeader, aNextHeader, aReceive, Message::kCopyToUse));
             SuccessOrExit(error = HandleFragment(*aMessagePtr));
             break;
 
@@ -945,7 +944,6 @@ exit:
 Error Ip6::PassToHost(OwnedPtr<Message> &aMessagePtr,
                       const Header      &aHeader,
                       uint8_t            aIpProto,
-                      bool               aApplyFilter,
                       bool               aReceive,
                       Message::Ownership aMessageOwnership)
 {
@@ -971,7 +969,7 @@ Error Ip6::PassToHost(OwnedPtr<Message> &aMessagePtr,
         VerifyOrExit(aReceive, error = kErrorDrop);
     }
 
-    if (mIsReceiveIp6FilterEnabled && aApplyFilter)
+    if (mIsReceiveIp6FilterEnabled && aReceive)
     {
         switch (aIpProto)
         {
@@ -1202,8 +1200,7 @@ Error Ip6::HandleDatagram(OwnedPtr<Message> aMessagePtr, bool aIsReassembled)
 
     if ((forwardHost || receive) && !aIsReassembled)
     {
-        error = PassToHost(aMessagePtr, header, nextHeader,
-                           /* aApplyFilter */ !forwardHost, receive,
+        error = PassToHost(aMessagePtr, header, nextHeader, receive,
                            (receive || forwardThread) ? Message::kCopyToUse : Message::kTakeCustody);
     }
 

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -386,7 +386,6 @@ private:
     Error PassToHost(OwnedPtr<Message> &aMessagePtr,
                      const Header      &aHeader,
                      uint8_t            aIpProto,
-                     bool               aApplyFilter,
                      bool               aReceive,
                      Message::Ownership aMessageOwnership);
     Error HandleExtensionHeaders(OwnedPtr<Message> &aMessagePtr,


### PR DESCRIPTION
This commit updates `PassToHost()`, removing the `aApplyFilter` input and using `aReceive` to determine whether or not to apply the RX filter. The filter serves multiple purposes:

- Ensure Thread control UDP traffic (e.g., MLE, TMF, etc.) is filtered out when delivering IPv6 datagrams to the host.
- Apply ICMPv6 echo requests filtering, based on the configured mode (whether the OT stack should respond to pings for specific address types or they should be passed to the next layer).
- Filter TCP traffic when the native OT TCP stack is used.

In all cases, the filter should be applied only if the IPv6 message is supposed to be received by the device itself (i.e., the destination matches the device's address), which is indicated by the `aReceive` input.

The `aApplyFilter` input was previously set to `!forwardHost`, indirectly assuming that `forwardHost` and `receive` would be exclusive. While this remains true for unicast destinations, recent changes updated the code so that all multicast traffic is forwarded to the host regardless of whether it is also marked for `receive`. This caused multicast MLE/TMF traffic to be passed to the host even though it should be filtered. This issue is now addressed by this change.

This commit also ensures that RX filter rules are consistently applied to fragmented IPv6 messages. Previously, the filter would not apply when fragmented IPv6 messages were passed to the host, but with this change, the filter is applied when the message should be received by the device.