### PR TITLE
[ip6] simplify `PassToHost()` to directly use `Ip6::Header`

### DIFF
--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -153,7 +153,7 @@ exit:
     return error;
 }
 
-bool Icmp::ShouldHandleEchoRequest(const MessageInfo &aMessageInfo)
+bool Icmp::ShouldHandleEchoRequest(const Address &aAddress)
 {
     bool rval = false;
 
@@ -163,16 +163,16 @@ bool Icmp::ShouldHandleEchoRequest(const MessageInfo &aMessageInfo)
         rval = false;
         break;
     case OT_ICMP6_ECHO_HANDLER_UNICAST_ONLY:
-        rval = !aMessageInfo.GetSockAddr().IsMulticast();
+        rval = !aAddress.IsMulticast();
         break;
     case OT_ICMP6_ECHO_HANDLER_MULTICAST_ONLY:
-        rval = aMessageInfo.GetSockAddr().IsMulticast();
+        rval = aAddress.IsMulticast();
         break;
     case OT_ICMP6_ECHO_HANDLER_ALL:
         rval = true;
         break;
     case OT_ICMP6_ECHO_HANDLER_RLOC_ALOC_ONLY:
-        rval = aMessageInfo.GetSockAddr().GetIid().IsLocator();
+        rval = aAddress.GetIid().IsLocator();
         break;
     }
 
@@ -187,7 +187,7 @@ Error Icmp::HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMess
     MessageInfo replyMessageInfo;
     uint16_t    dataOffset;
 
-    VerifyOrExit(ShouldHandleEchoRequest(aMessageInfo));
+    VerifyOrExit(ShouldHandleEchoRequest(aMessageInfo.GetSockAddr()));
 
     LogInfo("Received Echo Request");
 

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -331,11 +331,13 @@ public:
     /**
      * Indicates whether or not the ICMPv6 Echo Request should be handled.
      *
+     * @param[in] aAddress    The ICMPv6 destination IPv6 address.
+     *
      * @retval TRUE if OpenThread should respond with an ICMPv6 Echo Reply.
      * @retval FALSE if OpenThread should not respond with an ICMPv6 Echo Reply.
      *
      */
-    bool ShouldHandleEchoRequest(const MessageInfo &aMessageInfo);
+    bool ShouldHandleEchoRequest(const Address &aAddress);
 
     /**
      * Returns the ICMPv6 Echo sequence number.

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -384,14 +384,13 @@ private:
     void  EnqueueDatagram(Message &aMessage);
     void  HandleSendQueue(void);
     Error PassToHost(OwnedPtr<Message> &aMessagePtr,
-                     const MessageInfo &aMessageInfo,
+                     const Header      &aHeader,
                      uint8_t            aIpProto,
                      bool               aApplyFilter,
                      bool               aReceive,
                      Message::Ownership aMessageOwnership);
     Error HandleExtensionHeaders(OwnedPtr<Message> &aMessagePtr,
-                                 MessageInfo       &aMessageInfo,
-                                 Header            &aHeader,
+                                 const Header      &aHeader,
                                  uint8_t           &aNextHeader,
                                  bool              &aReceive);
     Error FragmentDatagram(Message &aMessage, uint8_t aIpProto);
@@ -407,12 +406,11 @@ private:
     Error PrepareMulticastToLargerThanRealmLocal(Message &aMessage, const Header &aHeader);
     Error InsertMplOption(Message &aMessage, Header &aHeader);
     Error RemoveMplOption(Message &aMessage);
-    Error HandleOptions(Message &aMessage, Header &aHeader, bool &aReceive);
-    Error HandlePayload(Header            &aIp6Header,
-                        OwnedPtr<Message> &aMessagePtr,
-                        MessageInfo       &aMessageInfo,
-                        uint8_t            aIpProto,
-                        Message::Ownership aMessageOwnership);
+    Error HandleOptions(Message &aMessage, const Header &aHeader, bool &aReceive);
+    Error Receive(Header            &aIp6Header,
+                  OwnedPtr<Message> &aMessagePtr,
+                  uint8_t            aIpProto,
+                  Message::Ownership aMessageOwnership);
     bool  IsOnLink(const Address &aAddress) const;
     Error RouteLookup(const Address &aSource, const Address &aDestination) const;
 #if OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE


### PR DESCRIPTION
This commit updates `PassToHost()` to directly use the `Ip6::Header` and its `GetSource()` and `GetDestination()` methods when applying filter rules. This replaces the previous model where a `MessageInfo` was constructed from the received IPv6 header and passed to `PassToHost()`. The previous model indirectly assumed that the message was received, with the `MessageInfo` sock/peer addresses mapped accordingly. However, `HandleDatagram()` can also process messages originating from the device itself, where the notion of peer and sock addresses would be reversed. Using `Ip6::Header` directly makes the rules clearer and simplifies the logic of `PassToHost()`.

Additionally, this change simplifies the code by moving the construction of `MessageInfo` to the `Receive()` method, where the message is received.