### PR TITLE
[mac] support frames without sequence number

### DIFF
--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -606,7 +606,11 @@ static void radioReceive(otInstance *aInstance)
     {
         if (otMacFrameIsAckRequested(&sTransmitFrame))
         {
-            isTxDone = isAck && otMacFrameGetSequence(&sReceiveFrame) == otMacFrameGetSequence(&sTransmitFrame);
+            uint8_t rxSeq;
+            uint8_t txSeq;
+
+            isTxDone = isAck && otMacFrameGetSequence(&sReceiveFrame, &rxSeq) == OT_ERROR_NONE &&
+                       otMacFrameGetSequence(&sTransmitFrame, &txSeq) == OT_ERROR_NONE && rxSeq == txSeq;
         }
 #if OPENTHREAD_SIMULATION_VIRTUAL_TIME
         // Simulate tx done when receiving the echo frame.

--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -139,9 +139,21 @@ exit:
     return error;
 }
 
-uint8_t otMacFrameGetSequence(const otRadioFrame *aFrame)
+otError otMacFrameGetSequence(const otRadioFrame *aFrame, uint8_t *aSequence)
 {
-    return static_cast<const Mac::Frame *>(aFrame)->GetSequence();
+    otError error;
+
+    if (static_cast<const Mac::Frame *>(aFrame)->IsSequencePresent())
+    {
+        *aSequence = static_cast<const Mac::Frame *>(aFrame)->GetSequence();
+        error      = kErrorNone;
+    }
+    else
+    {
+        error = kErrorParse;
+    }
+
+    return error;
 }
 
 void otMacFrameProcessTransmitAesCcm(otRadioFrame *aFrame, const otExtAddress *aExtAddress)

--- a/examples/platforms/utils/mac_frame.h
+++ b/examples/platforms/utils/mac_frame.h
@@ -169,11 +169,13 @@ otError otMacFrameGetDstAddr(const otRadioFrame *aFrame, otMacAddress *aMacAddre
  * Get the sequence of @p aFrame.
  *
  * @param[in]   aFrame          A pointer to the frame.
+ * @param[out]  aSequence       A pointer to the sequence.
  *
- * @returns The sequence of the frame.
+ * @retval  OT_ERROR_NONE   Successfully got the sequence.
+ * @retval  OT_ERROR_PARSE  Failed to parse the sequence.
  *
  */
-uint8_t otMacFrameGetSequence(const otRadioFrame *aFrame);
+otError otMacFrameGetSequence(const otRadioFrame *aFrame, uint8_t *aSequence);
 
 /**
  * Performs AES CCM on the frame which is going to be sent.

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -205,6 +205,7 @@ void TestMacHeader(void)
         Mac::Frame::KeyIdMode     mKeyIdMode;
         uint8_t                   mHeaderLength;
         uint8_t                   mFooterLength;
+        bool                      mSuppressSequence;
     };
 
     static constexpr Mac::Frame::Version kVer2006 = Mac::Frame::kVersion2006;
@@ -265,6 +266,7 @@ void TestMacHeader(void)
         {kVer2015, kExtdAddr, kNoPanId, kNoneAddr, kNoPanId, kMic32, kModeId1, 17, 6},
         {kVer2015, kExtdAddr, kNoPanId, kExtdAddr, kNoPanId, kNoSec, kModeId1, 19, 2},
         {kVer2015, kExtdAddr, kNoPanId, kExtdAddr, kNoPanId, kMic32, kModeId1, 25, 6},
+        {kVer2015, kExtdAddr, kNoPanId, kExtdAddr, kNoPanId, kMic32, kModeId1, 24, 6, true},
     };
 
     const uint16_t kPanId1     = 0xbaba;
@@ -285,7 +287,9 @@ void TestMacHeader(void)
 
     for (const TestCase &testCase : kTestCases)
     {
-        uint8_t        psdu[OT_RADIO_FRAME_MAX_SIZE];
+        uint8_t psdu[OT_RADIO_FRAME_MAX_SIZE];
+        uint8_t offset;
+
         Mac::TxFrame   frame;
         Mac::Addresses addresses;
         Mac::Address   address;
@@ -352,7 +356,7 @@ void TestMacHeader(void)
         }
 
         frame.InitMacHeader(Mac::Frame::kTypeData, testCase.mVersion, addresses, panIds, testCase.mSecurity,
-                            testCase.mKeyIdMode);
+                            testCase.mKeyIdMode, testCase.mSuppressSequence);
 
         VerifyOrQuit(frame.GetHeaderLength() == testCase.mHeaderLength);
         VerifyOrQuit(frame.GetFooterLength() == testCase.mFooterLength);
@@ -401,11 +405,20 @@ void TestMacHeader(void)
             VerifyOrQuit(keyIdMode == testCase.mKeyIdMode);
         }
 
-        snprintf(string, sizeof(string), "\nver:%s, src[addr:%s, pan:%s], dst[addr:%s, pan:%s], sec:%s",
-                 (testCase.mVersion == kVer2006) ? "2006" : "2015", kAddrTypeStrings[testCase.mSrcAddrType],
-                 kPanIdModeStrings[testCase.mSrcPanIdMode], kAddrTypeStrings[testCase.mDstAddrType],
-                 kPanIdModeStrings[testCase.mDstPanIdMode], testCase.mSecurity == kNoSec ? "no" : "mic32");
+        offset = snprintf(string, sizeof(string), "\nver:%s, src[addr:%s, pan:%s], dst[addr:%s, pan:%s], sec:%s",
+                          (testCase.mVersion == kVer2006) ? "2006" : "2015", kAddrTypeStrings[testCase.mSrcAddrType],
+                          kPanIdModeStrings[testCase.mSrcPanIdMode], kAddrTypeStrings[testCase.mDstAddrType],
+                          kPanIdModeStrings[testCase.mDstPanIdMode], testCase.mSecurity == kNoSec ? "no" : "mic32");
 
+        if (!testCase.mSuppressSequence)
+        {
+            VerifyOrQuit(frame.IsSequencePresent());
+            offset += snprintf(string + offset, sizeof(string) - offset, ", seq:%u", frame.GetSequence());
+        }
+        else
+        {
+            VerifyOrQuit(!frame.IsSequencePresent());
+        }
         DumpBuffer(string, frame.GetPsdu(), frame.GetLength());
     }
 }
@@ -590,6 +603,7 @@ void TestMacFrameApi(void)
     VerifyOrQuit(!frame.IsDstAddrPresent());
     VerifyOrQuit(frame.GetVersion() == Mac::Frame::kVersion2006);
     VerifyOrQuit(!frame.IsSrcAddrPresent());
+    VerifyOrQuit(frame.IsSequencePresent());
     VerifyOrQuit(frame.GetSequence() == 94);
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
@@ -619,6 +633,7 @@ void TestMacFrameApi(void)
     uint8_t commandId;
     frame.mPsdu   = mac_cmd_psdu1;
     frame.mLength = sizeof(mac_cmd_psdu1);
+    VerifyOrQuit(frame.IsSequencePresent());
     VerifyOrQuit(frame.GetSequence() == 133);
     VerifyOrQuit(frame.GetVersion() == Mac::Frame::kVersion2006);
     VerifyOrQuit(frame.GetType() == Mac::Frame::kTypeMacCmd);
@@ -637,6 +652,7 @@ void TestMacFrameApi(void)
     //   Command Identifier: Data Request (0x04)
     frame.mPsdu   = mac_cmd_psdu2;
     frame.mLength = sizeof(mac_cmd_psdu2);
+    VerifyOrQuit(frame.IsSequencePresent());
     VerifyOrQuit(frame.GetSequence() == 141);
     VerifyOrQuit(frame.IsVersion2015());
     VerifyOrQuit(frame.GetType() == Mac::Frame::kTypeMacCmd);
@@ -700,6 +716,7 @@ void TestMacFrameAckGeneration(void)
     VerifyOrQuit(!ackFrame.IsDstAddrPresent());
     VerifyOrQuit(!ackFrame.IsSrcAddrPresent());
     VerifyOrQuit(ackFrame.GetVersion() == Mac::Frame::kVersion2006);
+    VerifyOrQuit(ackFrame.IsSequencePresent());
     VerifyOrQuit(ackFrame.GetSequence() == 189);
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
@@ -758,6 +775,7 @@ void TestMacFrameAckGeneration(void)
     VerifyOrQuit(ackFrame.IsDstAddrPresent());
     VerifyOrQuit(!ackFrame.IsSrcAddrPresent());
     VerifyOrQuit(ackFrame.GetVersion() == Mac::Frame::kVersion2015);
+    VerifyOrQuit(ackFrame.IsSequencePresent());
     VerifyOrQuit(ackFrame.GetSequence() == 142);
     VerifyOrQuit(csl->GetPeriod() == 3125 && csl->GetPhase() == 3105);
 


### PR DESCRIPTION
This commit adds the capability to support frames without sequence number.