### PR TITLE
[ip6] remove UDP port check for messages with `HostTrusted` origin

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1271,22 +1271,6 @@ Error Ip6::HandleDatagram(OwnedPtr<Message> aMessagePtr, bool aIsReassembled)
             }
         }
 
-#if !OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-        if (aMessagePtr->IsOriginHostTrusted() && !aMessagePtr->IsLoopbackToHostAllowed() && (nextHeader == kProtoUdp))
-        {
-            uint16_t destPort;
-
-            SuccessOrExit(
-                error = aMessagePtr->Read(aMessagePtr->GetOffset() + Udp::Header::kDestPortFieldOffset, destPort));
-            destPort = BigEndian::HostSwap16(destPort);
-
-            if (nextHeader == kProtoUdp)
-            {
-                VerifyOrExit(Get<Udp>().ShouldUsePlatformUdp(destPort), error = kErrorDrop);
-            }
-        }
-#endif
-
 #if OPENTHREAD_CONFIG_MULTI_RADIO
         // Since the message will be forwarded, we clear the radio
         // type on the message to allow the radio type for tx to be


### PR DESCRIPTION
This commit removes the checks previously performed on messages with the origin `HostTrusted` that are to be forwarded to the Thread mesh. This origin is used for messages generated by the OpenThread stack itself. These checks were unnecessarily restricting such messages from using Thread Control UDP port numbers (like TMF, MLE, etc.). The additional check `!IsLoopbackToHostAllowed()` (which is set to `true` by default on such messages) bypassed the entire block, preventing any functional impact.

Recent related changes (in #9437) added similar guard checks for messages with `HostUntrusted` origins.

---

Related to #10543 