### PR TITLE
[ncp] initialize diag output callback per instance in `NcpBase`

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -258,6 +258,9 @@ NcpBase::NcpBase(Instance **aInstances, uint8_t aCount)
 
         OT_ASSERT(i + skipped <= SPINEL_HEADER_IID_MAX);
         mInstances[i + skipped] = aInstances[i];
+#if OPENTHREAD_CONFIG_DIAG_ENABLE
+        otDiagSetOutputCallback(mInstances[i + skipped], &NcpBase::HandleDiagOutput_Jump, this);
+#endif
     }
 }
 #endif // OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE  && OPENTHREAD_RADIO


### PR DESCRIPTION
This fixes a bug where diag get output callback was not set properly if we used instance with iid > 1, leading to failure output.