### PR TITLE
[ip6] style fixes and minor enhancements

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -228,7 +228,7 @@ Error Ip6::PrepareMulticastToLargerThanRealmLocal(Message &aMessage, const Heade
 
     // Use IP-in-IP encapsulation (RFC2473) and ALL_MPL_FORWARDERS address.
     tunnelHeader.InitVersionTrafficClassFlow();
-    tunnelHeader.SetHopLimit(static_cast<uint8_t>(kDefaultHopLimit));
+    tunnelHeader.SetHopLimit(kDefaultHopLimit);
     tunnelHeader.SetPayloadLength(aHeader.GetPayloadLength() + sizeof(tunnelHeader));
     tunnelHeader.GetDestination().SetToRealmLocalAllMplForwarders();
     tunnelHeader.SetNextHeader(kProtoIp6);
@@ -451,7 +451,7 @@ Error Ip6::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aI
     }
     else
     {
-        header.SetHopLimit(static_cast<uint8_t>(kDefaultHopLimit));
+        header.SetHopLimit(kDefaultHopLimit);
     }
 
     if (aMessageInfo.GetSockAddr().IsUnspecified() || aMessageInfo.GetSockAddr().IsMulticast())
@@ -828,8 +828,7 @@ Error Ip6::HandleExtensionHeaders(OwnedPtr<Message> &aMessagePtr,
                                   uint8_t           &aNextHeader,
                                   bool              &aReceive)
 {
-    Error error = kErrorNone;
-
+    Error           error = kErrorNone;
     ExtensionHeader extHeader;
 
     while (aReceive || aNextHeader == kProtoHopOpts)
@@ -839,6 +838,7 @@ Error Ip6::HandleExtensionHeaders(OwnedPtr<Message> &aMessagePtr,
         switch (aNextHeader)
         {
         case kProtoHopOpts:
+        case kProtoDstOpts:
             SuccessOrExit(error = HandleOptions(*aMessagePtr, aHeader, aReceive));
             break;
 
@@ -846,10 +846,6 @@ Error Ip6::HandleExtensionHeaders(OwnedPtr<Message> &aMessagePtr,
             IgnoreError(PassToHost(aMessagePtr, aHeader, aNextHeader,
                                    /* aApplyFilter */ false, aReceive, Message::kCopyToUse));
             SuccessOrExit(error = HandleFragment(*aMessagePtr));
-            break;
-
-        case kProtoDstOpts:
-            SuccessOrExit(error = HandleOptions(*aMessagePtr, aHeader, aReceive));
             break;
 
         case kProtoIp6:
@@ -863,7 +859,7 @@ Error Ip6::HandleExtensionHeaders(OwnedPtr<Message> &aMessagePtr,
             ExitNow();
         }
 
-        aNextHeader = static_cast<uint8_t>(extHeader.GetNextHeader());
+        aNextHeader = extHeader.GetNextHeader();
     }
 
 exit:
@@ -1173,7 +1169,7 @@ Error Ip6::HandleDatagram(OwnedPtr<Message> aMessagePtr, bool aIsReassembled)
     aMessagePtr->SetOffset(sizeof(header));
 
     // Process IPv6 Extension Headers
-    nextHeader = static_cast<uint8_t>(header.GetNextHeader());
+    nextHeader = header.GetNextHeader();
     SuccessOrExit(error = HandleExtensionHeaders(aMessagePtr, header, nextHeader, receive));
 
     if (receive && (nextHeader == kProtoIp6))
@@ -1422,49 +1418,55 @@ Error Ip6::RouteLookup(const Address &aSource, const Address &aDestination) cons
 }
 
 #if OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
+
 void Ip6::UpdateBorderRoutingCounters(const Header &aHeader, uint16_t aMessageLength, bool aIsInbound)
 {
-    static constexpr uint8_t kPrefixLength   = 48;
-    otPacketsAndBytes       *counter         = nullptr;
-    otPacketsAndBytes       *internetCounter = nullptr;
+    static constexpr uint8_t kPrefixLength = 48;
+
+    otPacketsAndBytes *counter         = nullptr;
+    otPacketsAndBytes *internetCounter = nullptr;
 
     VerifyOrExit(!aHeader.GetSource().IsLinkLocalUnicast());
     VerifyOrExit(!aHeader.GetDestination().IsLinkLocalUnicast());
-    VerifyOrExit(aHeader.GetSource().GetPrefix() != Get<Mle::Mle>().GetMeshLocalPrefix());
-    VerifyOrExit(aHeader.GetDestination().GetPrefix() != Get<Mle::Mle>().GetMeshLocalPrefix());
+    VerifyOrExit(!Get<Mle::Mle>().IsMeshLocalAddress(aHeader.GetSource()));
+    VerifyOrExit(!Get<Mle::Mle>().IsMeshLocalAddress(aHeader.GetDestination()));
 
     if (aIsInbound)
     {
         VerifyOrExit(!Get<Netif>().HasUnicastAddress(aHeader.GetSource()));
+
         if (!aHeader.GetSource().MatchesPrefix(aHeader.GetDestination().GetPrefix().m8, kPrefixLength))
         {
-            internetCounter = &mBorderRoutingCounters.mInboundInternet;
+            internetCounter = &mBrCounters.mInboundInternet;
         }
+
         if (aHeader.GetDestination().IsMulticast())
         {
             VerifyOrExit(aHeader.GetDestination().IsMulticastLargerThanRealmLocal());
-            counter = &mBorderRoutingCounters.mInboundMulticast;
+            counter = &mBrCounters.mInboundMulticast;
         }
         else
         {
-            counter = &mBorderRoutingCounters.mInboundUnicast;
+            counter = &mBrCounters.mInboundUnicast;
         }
     }
     else
     {
         VerifyOrExit(!Get<Netif>().HasUnicastAddress(aHeader.GetDestination()));
+
         if (!aHeader.GetSource().MatchesPrefix(aHeader.GetDestination().GetPrefix().m8, kPrefixLength))
         {
-            internetCounter = &mBorderRoutingCounters.mOutboundInternet;
+            internetCounter = &mBrCounters.mOutboundInternet;
         }
+
         if (aHeader.GetDestination().IsMulticast())
         {
             VerifyOrExit(aHeader.GetDestination().IsMulticastLargerThanRealmLocal());
-            counter = &mBorderRoutingCounters.mOutboundMulticast;
+            counter = &mBrCounters.mOutboundMulticast;
         }
         else
         {
-            counter = &mBorderRoutingCounters.mOutboundUnicast;
+            counter = &mBrCounters.mOutboundUnicast;
         }
     }
 
@@ -1481,7 +1483,8 @@ exit:
         internetCounter->mBytes += aMessageLength;
     }
 }
-#endif
+
+#endif // OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
 
 // LCOV_EXCL_START
 

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -327,13 +327,8 @@ public:
     static const char *EcnToString(Ecn aEcn);
 
 #if OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
-    /**
-     * Returns a reference to the Border Routing counters.
-     *
-     * @returns A reference to the Border Routing counters.
-     *
-     */
-    const otBorderRoutingCounters &GetBorderRoutingCounters(void) const { return mBorderRoutingCounters; }
+
+    typedef otBorderRoutingCounters BrCounters; ///< Border Routing counters.
 
     /**
      * Returns a reference to the Border Routing counters.
@@ -341,14 +336,23 @@ public:
      * @returns A reference to the Border Routing counters.
      *
      */
-    otBorderRoutingCounters &GetBorderRoutingCounters(void) { return mBorderRoutingCounters; }
+    const BrCounters &GetBorderRoutingCounters(void) const { return mBrCounters; }
+
+    /**
+     * Returns a reference to the Border Routing counters.
+     *
+     * @returns A reference to the Border Routing counters.
+     *
+     */
+    BrCounters &GetBorderRoutingCounters(void) { return mBrCounters; }
 
     /**
      * Resets the Border Routing counters.
      *
      */
-    void ResetBorderRoutingCounters(void) { ClearAllBytes(mBorderRoutingCounters); }
-#endif
+    void ResetBorderRoutingCounters(void) { ClearAllBytes(mBrCounters); }
+
+#endif // OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 
@@ -447,7 +451,7 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
-    otBorderRoutingCounters mBorderRoutingCounters;
+    BrCounters mBrCounters;
 #endif
 };
 


### PR DESCRIPTION
This commit contains minor enhancements in the `Ip6` class:

- Removes unnecessary `static_cast<uint8>()` use,
- Combines repeated `case` statements,
- Use shorter variable/type names,
- Style fixes.