### PR TITLE
[nat64] enhancements for `Translator::UpdateState`

### DIFF
--- a/src/core/net/nat64_translator.cpp
+++ b/src/core/net/nat64_translator.cpp
@@ -509,8 +509,10 @@ Error Translator::SetIp4Cidr(const Ip4::Cidr &aCidr)
             ToUlong(numberOfHosts));
     mIp4Cidr = aCidr;
 
-    // Always notify the platform when the CIDR is changed.
-    UpdateState(true /* aAlwaysNotify */);
+    UpdateState();
+
+    // Notify the platform when the CIDR is changed.
+    Get<Notifier>().Signal(kEventNat64TranslatorStateChanged);
 
 exit:
     return err;
@@ -634,7 +636,7 @@ void Translator::ProtocolCounters::Count4To6Packet(uint8_t aProtocol, uint64_t a
     mTotal.m4To6Bytes += aPacketSize;
 }
 
-void Translator::UpdateState(bool aAlwaysNotify)
+void Translator::UpdateState(void)
 {
     State newState;
 
@@ -654,14 +656,7 @@ void Translator::UpdateState(bool aAlwaysNotify)
         newState = kStateDisabled;
     }
 
-    if (aAlwaysNotify)
-    {
-        Get<Notifier>().Signal(kEventNat64TranslatorStateChanged);
-    }
-    else
-    {
-        SuccessOrExit(Get<Notifier>().Update(mState, newState, kEventNat64TranslatorStateChanged));
-    }
+    SuccessOrExit(Get<Notifier>().Update(mState, newState, kEventNat64TranslatorStateChanged));
     LogInfo("NAT64 translator is now %s", StateToString(mState));
 
 exit:

--- a/src/core/net/nat64_translator.hpp
+++ b/src/core/net/nat64_translator.hpp
@@ -380,7 +380,7 @@ private:
 
     using MappingTimer = TimerMilliIn<Translator, &Translator::HandleMappingExpirerTimer>;
 
-    void UpdateState(bool aAlwaysNotify = false);
+    void UpdateState(void);
 
     bool  mEnabled;
     State mState;


### PR DESCRIPTION
This PR applies following enhancements to the `Translator::UpdateState`:
- Remove the `aAlwaysNotify` parameter to simplify its logic.
- Fix an issue that `mState` may not be updated when setting a CIDR.