### PR TITLE
[posix] allow custom implementation of `otPlatInfraIfDiscoverNat64Prefix`

### DIFF
--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -115,7 +115,11 @@ Error InfraIf::DiscoverNat64Prefix(void) const
 {
     OT_ASSERT(mInitialized);
 
+#if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
     return otPlatInfraIfDiscoverNat64Prefix(mIfIndex);
+#else
+    return kErrorNotImplemented;
+#endif
 }
 
 void InfraIf::DiscoverNat64PrefixDone(uint32_t aIfIndex, const Ip6::Prefix &aPrefix)

--- a/src/posix/platform/infra_if.hpp
+++ b/src/posix/platform/infra_if.hpp
@@ -174,6 +174,7 @@ public:
                         const uint8_t      *aBuffer,
                         uint16_t            aBufferLength);
 
+#if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE && OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE
     /**
      * Sends an asynchronous address lookup for the well-known host name "ipv4only.arpa"
      * to discover the NAT64 prefix.
@@ -185,6 +186,7 @@ public:
      *
      */
     otError DiscoverNat64Prefix(uint32_t aInfraIfIndex);
+#endif
 
     /**
      * Gets the infrastructure network interface name.
@@ -240,12 +242,18 @@ private:
     MulticastRoutingManager mMulticastRoutingManager;
 #endif
 
+    bool HasLinkLocalAddress(void) const;
+
 #ifdef __linux__
     void ReceiveNetLinkMessage(void);
 #endif
 
-    bool        HasLinkLocalAddress(void) const;
+#if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE && OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE
+#ifdef __linux__
     static void DiscoverNat64PrefixDone(union sigval sv);
+#endif // #ifdef __linux__
+#endif
+
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
     void SetInfraNetifIcmp6SocketForBorderRouting(int aIcmp6Socket);
     void ReceiveIcmp6Message(void);

--- a/tests/toranj/openthread-core-toranj-config-posix.h
+++ b/tests/toranj/openthread-core-toranj-config-posix.h
@@ -65,6 +65,8 @@
 
 #define OPENTHREAD_POSIX_CONFIG_SPINEL_HDLC_INTERFACE_ENABLE 1
 
+#define OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE 1
+
 // Disabled explicitly on posix `toranj` to validate the build with this config
 #define OPENTHREAD_CONFIG_BORDER_ROUTING_USE_HEAP_ENABLE 0
 


### PR DESCRIPTION
This PR moves the macro guard `OPENTHREAD_POSIX_CONFIG_INFRA_IF_ENABLE` in the code so that it can allow custom implementation of `otPlatInfraIfDiscoverNat64Prefix` when `OPENTHREAD_POSIX_CONFIG_INFRA_IF_ENABLE` is disabled.

The use case is on Android platform. We'll not let `ot-daemon` proactively discover the prefixes by DNS. Instead, System Server will do the discovery of NAT64 prefix on AIL and it will notify `ot-daemon` when the AIL NAT64 prefix is discovered/removed.