### PR TITLE
[thread-cert] output docker stdout/stderr only when VERBOSE is non-zero

### DIFF
--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -139,7 +139,10 @@ class OtbrDocker:
             f'trel://{config.BACKBONE_IFNAME}',
         ] + nat64_prefix
         logging.info(' '.join(cmd))
-        self._docker_proc = subprocess.Popen(cmd, stdin=subprocess.DEVNULL, stdout=sys.stdout, stderr=sys.stderr)
+        self._docker_proc = subprocess.Popen(cmd,
+                                             stdin=subprocess.DEVNULL,
+                                             stdout=sys.stdout if self.verbose else subprocess.DEVNULL,
+                                             stderr=sys.stderr if self.verbose else subprocess.DEVNULL)
 
         launch_docker_deadline = time.time() + 300
         launch_ok = False


### PR DESCRIPTION
This commit supresses the docker output unless verbose mode is enabled, which helps preventing unnecessary output from cluttering the console.

docker output is enabled when:
 * env VERBOSE is set to a non-zero value

docker output is suppressed (redirecting to /dev/null) when:
 * VERBOSE is not explicitly set in env, or
 * env VERBOSE is set to 0