### PR TITLE
[thread-cert] fix bug that docker network is not removed

### DIFF
--- a/tests/scripts/thread-cert/thread_cert.py
+++ b/tests/scripts/thread-cert/thread_cert.py
@@ -296,10 +296,12 @@ class TestCase(NcpSupportMixin, unittest.TestCase):
 
         self.simulator.stop()
 
+        if self._has_backbone_traffic():
+            self._remove_backbone_network()
+
         if self._do_packet_verification:
 
             if self._has_backbone_traffic():
-                self._remove_backbone_network()
                 pcap_filename = self._merge_thread_backbone_pcaps()
             else:
                 pcap_filename = self._get_thread_pcap_filename()


### PR DESCRIPTION
In some cases that `_do_packet_verification` is False (e.g. verify() is not defined), the docker network is not correctly removed.

docker network interface should always be removed at the end of the test if it was created at the begin of the test