### PR TITLE
[thread] move `OT_THREAD_VERSION_*` constants to public header

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (432)
+#define OPENTHREAD_API_VERSION (433)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -53,6 +53,13 @@ extern "C" {
  *
  */
 
+#define OT_THREAD_VERSION_INVALID 0 ///< Invalid Thread version
+#define OT_THREAD_VERSION_1_1 2     ///< Thread Version 1.1
+#define OT_THREAD_VERSION_1_2 3     ///< Thread Version 1.2
+#define OT_THREAD_VERSION_1_3 4     ///< Thread Version 1.3
+#define OT_THREAD_VERSION_1_3_1 5   ///< Thread Version 1.3.1 (alias for 1.4)
+#define OT_THREAD_VERSION_1_4 5     ///< Thread Version 1.4
+
 /**
  * Maximum value length of Thread Base TLV.
  */
@@ -245,6 +252,8 @@ otError otThreadSetEnabled(otInstance *aInstance, bool aEnabled);
 
 /**
  * Gets the Thread protocol version.
+ *
+ * The constants `OT_THREAD_VERSION_*` define the numerical version values.
  *
  * @returns the Thread protocol version.
  *

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -846,7 +846,10 @@ source_set("libopenthread_core_config") {
     ":core_config",
     "../..:openthread_config",
   ]
-  public_deps = [ "../../include/openthread:openthread_config" ]
+  public_deps = [
+    "../../include/openthread:openthread_config",
+    "../../include/openthread",
+  ]
   public_deps += openthread_core_config_deps
 }
 

--- a/src/core/openthread-core-config.h
+++ b/src/core/openthread-core-config.h
@@ -35,15 +35,7 @@
 #define OPENTHREAD_CORE_CONFIG_H_
 
 #include <openthread/config.h>
-
-#define OT_THREAD_VERSION_INVALID 0
-
-#define OT_THREAD_VERSION_1_1 2
-#define OT_THREAD_VERSION_1_2 3
-#define OT_THREAD_VERSION_1_3 4
-// Support projects on legacy "1.3.1" version, which is now "1.4"
-#define OT_THREAD_VERSION_1_3_1 5
-#define OT_THREAD_VERSION_1_4 5
+#include <openthread/thread.h>
 
 #define OPENTHREAD_CORE_CONFIG_H_IN
 


### PR DESCRIPTION
This commit moves the definition of `OT_THREAD_VERSION_*` constants from the config header to the `openthread/thread.h` OT public header file (where `otThreadGetVersion()` is declared). This allows other projects integrating the OT stack to also see and use these constants.