### PR TITLE
[spinel] make `SendCommand` public to allow calling without variable arguments

### DIFF
--- a/src/lib/spinel/spinel_driver.hpp
+++ b/src/lib/spinel/spinel_driver.hpp
@@ -181,6 +181,20 @@ public:
                         va_list           aArgs);
 
     /*
+     * Sends a spinel command without arguments to the co-processor.
+     *
+     * @param[in] aCommand    The spinel command.
+     * @param[in] aKey        The spinel property key.
+     * @param[in] aTid        The spinel transaction id.
+     *
+     * @retval  OT_ERROR_NONE           Successfully sent the command through spinel interface.
+     * @retval  OT_ERROR_INVALID_STATE  The spinel interface is in an invalid state.
+     * @retval  OT_ERROR_NO_BUFS        The spinel interface doesn't have enough buffer.
+     *
+     */
+    otError SendCommand(uint32_t aCommand, spinel_prop_key_t aKey, spinel_tid_t aTid);
+
+    /*
      * Sets the handler to process the received spinel frame.
      *
      * @param[in] aReceivedFrameHandler  The handler to process received spinel frames.
@@ -290,8 +304,6 @@ private:
                                    bool          &aSave,
                                    void          *aContext);
     void        HandleInitialFrame(const uint8_t *aFrame, uint16_t aLength, uint8_t aHeader, bool &aSave);
-
-    otError SendCommand(uint32_t aCommand, spinel_prop_key_t aKey, spinel_tid_t aTid);
 
     otError         CheckSpinelVersion(void);
     otError         GetCoprocessorVersion(void);


### PR DESCRIPTION
Changed access of SendCommand to public to allow calling without variable arguments. This is to address compilation error in ot-br-posix repo NcpSpinel::ThreadErasePersistentInfo (while building for OpenWrt v23.05.4 for a mips target)(error: 'args' may be used uninitialized [-Werror=maybe-uninitialized])