### PR TITLE
[thread-cert] support to get link-local address of the infra interface

### DIFF
--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -106,13 +106,14 @@ DEFAULT_NETWORK_KEY = bytearray([
 
 
 class ADDRESS_TYPE(Enum):
-    LINK_LOCAL = 'LINK_LOCAL'
+    LINK_LOCAL = 'LINK_LOCAL'  # For Thread interface link-local only
     GLOBAL = 'GLOBAL'
     RLOC = 'RLOC'
     ALOC = 'ALOC'
     ML_EID = 'ML_EID'
     DUA = 'DUA'
     BACKBONE_GUA = 'BACKBONE_GUA'
+    BACKBONE_LINK_LOCAL = 'BACKBONE_LINK_LOCAL'
     OMR = 'OMR'
     ONLINK_ULA = 'ONLINK_ULA'
     ONLINK_GUA = 'ONLINK_GUA'

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -3792,6 +3792,8 @@ class LinuxHost():
         """
         if address_type == config.ADDRESS_TYPE.BACKBONE_GUA:
             return self._getBackboneGua()
+        elif address_type == config.ADDRESS_TYPE.BACKBONE_LINK_LOCAL:
+            return self._getInfraLinkLocalAddress()
         elif address_type == config.ADDRESS_TYPE.ONLINK_ULA:
             return self._getInfraUla()
         elif address_type == config.ADDRESS_TYPE.ONLINK_GUA:
@@ -3822,6 +3824,15 @@ class LinuxHost():
 
         gua_prefix = config.ONLINK_GUA_PREFIX.split('::/')[0]
         return [addr for addr in self.get_ether_addrs() if addr.startswith(gua_prefix)]
+
+    def _getInfraLinkLocalAddress(self) -> Optional[str]:
+        """ Returns the link-local address autoconfigured on the infra link, which is started with "fe80".
+        """
+        for addr in self.get_ether_addrs():
+            if re.match(config.LINK_LOCAL_REGEX_PATTERN, addr, re.I):
+                return addr
+
+        return None
 
     def ping(self, *args, **kwargs):
         backbone = kwargs.pop('backbone', False)


### PR DESCRIPTION
 This commit targets to support getting infra link-local address of a OtbrNode in docker test, which is usefully for future test cases.

The `test_multi_ail.py` is also updated to test the new method added.