### PR TITLE
[epskc] add API for ePSKc telemetry

### DIFF
--- a/include/openthread/border_agent.h
+++ b/include/openthread/border_agent.h
@@ -112,26 +112,34 @@ typedef enum otBorderAgentState
 
 typedef struct otBorderAgentCounters
 {
-    uint64_t mEpskcActivations;
-    uint64_t mEpskcDeactivationClears;
-    uint64_t mEpskcDeactivationTimeouts;
-    uint64_t mEpskcDeactivationMaxAttempts;
-    uint64_t mEpskcDeactivationDisconnects;
-    uint64_t mEpskcInvalidBaStateErrors;
-    uint64_t mEpskcInvalidArgsErrors;
-    uint64_t mEpskcStartSecureSessionErrors;
-    uint64_t mEpskcSecureSessionSuccesses;
-    uint64_t mEpskcSecureSessionFailures;
-    uint64_t mEpskcCommissionerPetitions;
+    uint32_t mEpskcActivations;              ///< The number of ePSKc activations
+    uint32_t mEpskcDeactivationClears;       ///< The number of ePSKc deactivations via API
+    uint32_t mEpskcDeactivationTimeouts;     ///< The number of ePSKc deactivations due to timeout
+    uint32_t mEpskcDeactivationMaxAttempts;  ///< The number of ePSKc deactivations due to reached max attempts
+    uint32_t mEpskcDeactivationDisconnects;  ///< The number of ePSKc deactivations due to commissioner disconnected
+    uint32_t mEpskcInvalidBaStateErrors;     ///< The number of invalid border agent state errors at ePSKc activation
+    uint32_t mEpskcInvalidArgsErrors;        ///< The number of invalid args errors at ePSKc activation
+    uint32_t mEpskcStartSecureSessionErrors; ///< The number of start secure session errors at ePSKc activation
+    uint32_t mEpskcSecureSessionSuccesses;   ///< The number of established secure sessions with ePSKc
+    uint32_t mEpskcSecureSessionFailures;    ///< The number of failed secure sessions with ePSKc
+    uint32_t mEpskcCommissionerPetitions;    ///< The number of successful commissioner petitions with ePSKc
 
-    uint64_t mPskcSecureSessionSuccesses;
-    uint64_t mPskcSecureSessionFailures;
-    uint64_t mPskcCommissionerPetitions;
+    uint32_t mPskcSecureSessionSuccesses; ///< The number of established secure sessions with PSKc
+    uint32_t mPskcSecureSessionFailures;  ///< The number of failed secure sessions with PSKc
+    uint32_t mPskcCommissionerPetitions;  ///< The number of successful commissioner petitions with PSKc
 
-    uint64_t mMgmtActiveGets;
-    uint64_t mMgmtPendingGets;
+    uint32_t mMgmtActiveGets;  ///< The number of MGMT_ACTIVE_GET.req sent over secure sessions
+    uint32_t mMgmtPendingGets; ///< The number of MGMT_PENDING_GET.req sent over secure sessions
 } otBorderAgentCounters;
 
+/**
+ * Gets the counters of the Thread Border Agent.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ *
+ * @returns A pointer to the Border Agent counters.
+ *
+ */
 const otBorderAgentCounters *otBorderAgentGetCounters(otInstance *aInstance);
 
 /**

--- a/include/openthread/border_agent.h
+++ b/include/openthread/border_agent.h
@@ -110,6 +110,30 @@ typedef enum otBorderAgentState
     OT_BORDER_AGENT_STATE_ACTIVE  = 2, ///< Border agent is connected with external commissioner.
 } otBorderAgentState;
 
+typedef struct otBorderAgentCounters
+{
+    uint64_t mEpskcActivations;
+    uint64_t mEpskcDeactivationClears;
+    uint64_t mEpskcDeactivationTimeouts;
+    uint64_t mEpskcDeactivationMaxAttempts;
+    uint64_t mEpskcDeactivationDisconnects;
+    uint64_t mEpskcInvalidBaStateErrors;
+    uint64_t mEpskcInvalidArgsErrors;
+    uint64_t mEpskcStartSecureSessionErrors;
+    uint64_t mEpskcSecureSessionSuccesses;
+    uint64_t mEpskcSecureSessionFailures;
+    uint64_t mEpskcCommissionerPetitions;
+
+    uint64_t mPskcSecureSessionSuccesses;
+    uint64_t mPskcSecureSessionFailures;
+    uint64_t mPskcCommissionerPetitions;
+
+    uint64_t mMgmtActiveGets;
+    uint64_t mMgmtPendingGets;
+} otBorderAgentCounters;
+
+const otBorderAgentCounters *otBorderAgentGetCounters(otInstance *aInstance);
+
 /**
  * Gets the #otBorderAgentState of the Thread Border Agent role.
  *

--- a/include/openthread/coap_secure.h
+++ b/include/openthread/coap_secure.h
@@ -68,13 +68,26 @@ extern "C" {
 #define OT_DEFAULT_COAP_SECURE_PORT 5684 ///< Default CoAP Secure port, as specified in RFC 7252
 
 /**
+ * CoAP secure connection event types.
+ *
+ */
+typedef enum otCoapSecureConnectEvent
+{
+    OT_COAP_SECURE_CONNECTED = 0,             ///< Connection established
+    OT_COAP_SECURE_DISCONNECTED_PEER_CLOSED,  ///< Disconnected by peer
+    OT_COAP_SECURE_DISCONNECTED_LOCAL_CLOSED, ///< Disconnected locally
+    OT_COAP_SECURE_DISCONNECTED_MAX_ATTEMPTS, ///< Disconnected due to reaching the max connection attempts
+    OT_COAP_SECURE_DISCONNECTED_ERROR,        ///< Disconnected due to an error
+} otCoapSecureConnectEvent;
+
+/**
  * Pointer is called when the DTLS connection state changes.
  *
- * @param[in]  aConnected  true, if a connection was established, false otherwise.
+ * @param[in]  aEvent      The connection event.
  * @param[in]  aContext    A pointer to arbitrary context information.
  *
  */
-typedef void (*otHandleCoapSecureClientConnect)(bool aConnected, void *aContext);
+typedef void (*otHandleCoapSecureClientConnect)(otCoapSecureConnectEvent aEvent, void *aContext);
 
 /**
  * Callback function pointer to notify when the CoAP secure agent is automatically stopped due to reaching the maximum
@@ -368,17 +381,17 @@ void otCoapSecureRemoveBlockWiseResource(otInstance *aInstance, otCoapBlockwiseR
 void otCoapSecureSetDefaultHandler(otInstance *aInstance, otCoapRequestHandler aHandler, void *aContext);
 
 /**
- * Sets the connected callback to indicate, when
- * a Client connect to the CoAP Secure server.
+ * Sets the connect event callback to indicate when
+ * a Client connection to the CoAP Secure server has changed.
  *
  * @param[in]  aInstance     A pointer to an OpenThread instance.
- * @param[in]  aHandler      A pointer to a function that will be called once DTLS connection is established.
+ * @param[in]  aHandler      A pointer to a function that will be called once DTLS connection has changed.
  * @param[in]  aContext      A pointer to arbitrary context information. May be NULL if not used.
  *
  */
-void otCoapSecureSetClientConnectedCallback(otInstance                     *aInstance,
-                                            otHandleCoapSecureClientConnect aHandler,
-                                            void                           *aContext);
+void otCoapSecureSetClientConnectEventCallback(otInstance                     *aInstance,
+                                               otHandleCoapSecureClientConnect aHandler,
+                                               void                           *aContext);
 
 /**
  * Sends a CoAP response block-wise from the CoAP Secure server.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (435)
+#define OPENTHREAD_API_VERSION (436)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -453,6 +453,33 @@ Disables callback from Border Agent for ephemeral key state changes.
 Done
 ```
 
+### ba counters
+
+Get the border agent counter values.
+
+Note that it requires `OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE` to output the ePSKc counters.
+
+```bash
+> ba counters
+epskcActivation: 2
+epskcApiDeactivation: 1
+epskcTimeoutDeactivation: 1
+epskcMaxAttemptDeactivation: 0
+epskcDisconnectDeactivation: 0
+epskcInvalidBaStateError: 1
+epskcInvalidArgsError: 1
+epskcStartSecureSessionError: 0
+epskcSecureSessionSuccess: 0
+epskcSecureSessionFailure: 0
+epskcCommissionerPetition: 0
+pskcSecureSessionSuccess: 0
+pskcSecureSessionFailure: 0
+pskcCommissionerPetition: 0
+mgmtActiveGet: 0
+mgmtPendingGet: 0
+Done
+```
+
 ### bufferinfo
 
 Show the current message buffer information.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -540,6 +540,26 @@ template <> otError Interpreter::Process<Cmd("ba")>(Arg aArgs[])
             error = OT_ERROR_INVALID_ARGS;
         }
     }
+    /**
+     * @cli ba counters
+     * @code
+     * border agent counters
+     * ePSKc: activations 2 api_deactivations 1 timeout_deactivations 1 max_attempt_deactivations 0
+     *        disconnect_deactivations 0
+     * ePSKc: invalid_ba_state_errors 0 invalid_args_errors 1 start_secure_session_errors 0
+     * ePSKc: secure_session_successes 0 secure_session_failures 0 commissioner_petitions 0
+     * PSKc: secure_session_successes 0 secure_session_failures 0 commissioner_petitions 0
+     * coap: MGMT_ACTIVE_GET 0 MGMT_PENDING_GET 0
+     * Done
+     * @endcode
+     * @par
+     * Gets the border agent counters.
+     * @sa otBorderAgentGetCounters
+     */
+    else if (aArgs[0] == "counters")
+    {
+        OutputBorderAgentCounters(*otBorderAgentGetCounters(GetInstancePtr()));
+    }
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
     else
     {
@@ -551,6 +571,36 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+void Interpreter::OutputBorderAgentCounters(const otBorderAgentCounters &aCounters)
+{
+    Uint64StringBuffer u64StringBuffer;
+
+    OutputFormat("ePSKc: activations %s ", Uint64ToString(aCounters.mEpskcActivations, u64StringBuffer));
+    OutputFormat("api_deactivations %s ", Uint64ToString(aCounters.mEpskcDeactivationClears, u64StringBuffer));
+    OutputFormat("timeout_deactivations %s ", Uint64ToString(aCounters.mEpskcDeactivationTimeouts, u64StringBuffer));
+    OutputFormat("max_attempt_deactivations %s ",
+                 Uint64ToString(aCounters.mEpskcDeactivationMaxAttempts, u64StringBuffer));
+    OutputLine("disconnect_deactivations %s ",
+               Uint64ToString(aCounters.mEpskcDeactivationDisconnects, u64StringBuffer));
+    OutputFormat("ePSKc: invalid_ba_state_errors %s ",
+                 Uint64ToString(aCounters.mEpskcInvalidBaStateErrors, u64StringBuffer));
+    OutputFormat("invalid_args_errors %s ", Uint64ToString(aCounters.mEpskcInvalidArgsErrors, u64StringBuffer));
+    OutputLine("start_secure_session_errors %s ",
+               Uint64ToString(aCounters.mEpskcStartSecureSessionErrors, u64StringBuffer));
+    OutputFormat("ePSKc: secure_session_successes %s ",
+                 Uint64ToString(aCounters.mEpskcSecureSessionSuccesses, u64StringBuffer));
+    OutputFormat("secure_session_failures %s ", Uint64ToString(aCounters.mEpskcSecureSessionFailures, u64StringBuffer));
+    OutputLine("commissioner_petitions %s ", Uint64ToString(aCounters.mEpskcCommissionerPetitions, u64StringBuffer));
+
+    OutputFormat("PSKc: secure_session_successes %s ",
+                 Uint64ToString(aCounters.mPskcSecureSessionSuccesses, u64StringBuffer));
+    OutputFormat("secure_session_failures %s ", Uint64ToString(aCounters.mPskcSecureSessionFailures, u64StringBuffer));
+    OutputLine("commissioner_petitions %s ", Uint64ToString(aCounters.mPskcCommissionerPetitions, u64StringBuffer));
+
+    OutputFormat("coap: MGMT_ACTIVE_GET %s ", Uint64ToString(aCounters.mMgmtActiveGets, u64StringBuffer));
+    OutputLine("MGMT_PENDING_GET %s", Uint64ToString(aCounters.mMgmtPendingGets, u64StringBuffer));
+}
+
 void Interpreter::HandleBorderAgentEphemeralKeyStateChange(void *aContext)
 {
     reinterpret_cast<Interpreter *>(aContext)->HandleBorderAgentEphemeralKeyStateChange();

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -540,16 +540,27 @@ template <> otError Interpreter::Process<Cmd("ba")>(Arg aArgs[])
             error = OT_ERROR_INVALID_ARGS;
         }
     }
+#endif // OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
     /**
      * @cli ba counters
      * @code
-     * border agent counters
-     * ePSKc: activations 2 api_deactivations 1 timeout_deactivations 1 max_attempt_deactivations 0
-     *        disconnect_deactivations 0
-     * ePSKc: invalid_ba_state_errors 0 invalid_args_errors 1 start_secure_session_errors 0
-     * ePSKc: secure_session_successes 0 secure_session_failures 0 commissioner_petitions 0
-     * PSKc: secure_session_successes 0 secure_session_failures 0 commissioner_petitions 0
-     * coap: MGMT_ACTIVE_GET 0 MGMT_PENDING_GET 0
+     * ba counters
+     * epskcActivation: 0
+     * epskcApiDeactivation: 0
+     * epskcTimeoutDeactivation: 0
+     * epskcMaxAttemptDeactivation: 0
+     * epskcDisconnectDeactivation: 0
+     * epskcInvalidBaStateError: 0
+     * epskcInvalidArgsError: 0
+     * epskcStartSecureSessionError: 0
+     * epskcSecureSessionSuccess: 0
+     * epskcSecureSessionFailure: 0
+     * epskcCommissionerPetition: 0
+     * pskcSecureSessionSuccess: 0
+     * pskcSecureSessionFailure: 0
+     * pskcCommissionerPetition: 0
+     * mgmtActiveGet: 0
+     * mgmtPendingGet: 0
      * Done
      * @endcode
      * @par
@@ -560,7 +571,6 @@ template <> otError Interpreter::Process<Cmd("ba")>(Arg aArgs[])
     {
         OutputBorderAgentCounters(*otBorderAgentGetCounters(GetInstancePtr()));
     }
-#endif // OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
     else
     {
         ExitNow(error = OT_ERROR_INVALID_COMMAND);
@@ -570,37 +580,29 @@ exit:
     return error;
 }
 
-#if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
 void Interpreter::OutputBorderAgentCounters(const otBorderAgentCounters &aCounters)
 {
-    Uint64StringBuffer u64StringBuffer;
-
-    OutputFormat("ePSKc: activations %s ", Uint64ToString(aCounters.mEpskcActivations, u64StringBuffer));
-    OutputFormat("api_deactivations %s ", Uint64ToString(aCounters.mEpskcDeactivationClears, u64StringBuffer));
-    OutputFormat("timeout_deactivations %s ", Uint64ToString(aCounters.mEpskcDeactivationTimeouts, u64StringBuffer));
-    OutputFormat("max_attempt_deactivations %s ",
-                 Uint64ToString(aCounters.mEpskcDeactivationMaxAttempts, u64StringBuffer));
-    OutputLine("disconnect_deactivations %s ",
-               Uint64ToString(aCounters.mEpskcDeactivationDisconnects, u64StringBuffer));
-    OutputFormat("ePSKc: invalid_ba_state_errors %s ",
-                 Uint64ToString(aCounters.mEpskcInvalidBaStateErrors, u64StringBuffer));
-    OutputFormat("invalid_args_errors %s ", Uint64ToString(aCounters.mEpskcInvalidArgsErrors, u64StringBuffer));
-    OutputLine("start_secure_session_errors %s ",
-               Uint64ToString(aCounters.mEpskcStartSecureSessionErrors, u64StringBuffer));
-    OutputFormat("ePSKc: secure_session_successes %s ",
-                 Uint64ToString(aCounters.mEpskcSecureSessionSuccesses, u64StringBuffer));
-    OutputFormat("secure_session_failures %s ", Uint64ToString(aCounters.mEpskcSecureSessionFailures, u64StringBuffer));
-    OutputLine("commissioner_petitions %s ", Uint64ToString(aCounters.mEpskcCommissionerPetitions, u64StringBuffer));
-
-    OutputFormat("PSKc: secure_session_successes %s ",
-                 Uint64ToString(aCounters.mPskcSecureSessionSuccesses, u64StringBuffer));
-    OutputFormat("secure_session_failures %s ", Uint64ToString(aCounters.mPskcSecureSessionFailures, u64StringBuffer));
-    OutputLine("commissioner_petitions %s ", Uint64ToString(aCounters.mPskcCommissionerPetitions, u64StringBuffer));
-
-    OutputFormat("coap: MGMT_ACTIVE_GET %s ", Uint64ToString(aCounters.mMgmtActiveGets, u64StringBuffer));
-    OutputLine("MGMT_PENDING_GET %s", Uint64ToString(aCounters.mMgmtPendingGets, u64StringBuffer));
+#if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+    OutputLine("epskcActivation: %lu ", ToUlong(aCounters.mEpskcActivations));
+    OutputLine("epskcApiDeactivation: %lu ", ToUlong(aCounters.mEpskcDeactivationClears));
+    OutputLine("epskcTimeoutDeactivation: %lu ", ToUlong(aCounters.mEpskcDeactivationTimeouts));
+    OutputLine("epskcMaxAttemptDeactivation: %lu ", ToUlong(aCounters.mEpskcDeactivationMaxAttempts));
+    OutputLine("epskcDisconnectDeactivation: %lu ", ToUlong(aCounters.mEpskcDeactivationDisconnects));
+    OutputLine("epskcInvalidBaStateError: %lu ", ToUlong(aCounters.mEpskcInvalidBaStateErrors));
+    OutputLine("epskcInvalidArgsError: %lu ", ToUlong(aCounters.mEpskcInvalidArgsErrors));
+    OutputLine("epskcStartSecureSessionError: %lu ", ToUlong(aCounters.mEpskcStartSecureSessionErrors));
+    OutputLine("epskcSecureSessionSuccess: %lu ", ToUlong(aCounters.mEpskcSecureSessionSuccesses));
+    OutputLine("epskcSecureSessionFailure: %lu ", ToUlong(aCounters.mEpskcSecureSessionFailures));
+    OutputLine("epskcCommissionerPetition: %lu ", ToUlong(aCounters.mEpskcCommissionerPetitions));
+#endif
+    OutputLine("pskcSecureSessionSuccess: %lu ", ToUlong(aCounters.mPskcSecureSessionSuccesses));
+    OutputLine("pskcSecureSessionFailure: %lu ", ToUlong(aCounters.mPskcSecureSessionFailures));
+    OutputLine("pskcCommissionerPetition: %lu ", ToUlong(aCounters.mPskcCommissionerPetitions));
+    OutputLine("mgmtActiveGet: %lu ", ToUlong(aCounters.mMgmtActiveGets));
+    OutputLine("mgmtPendingGet: %lu", ToUlong(aCounters.mMgmtPendingGets));
 }
 
+#if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
 void Interpreter::HandleBorderAgentEphemeralKeyStateChange(void *aContext)
 {
     reinterpret_cast<Interpreter *>(aContext)->HandleBorderAgentEphemeralKeyStateChange();

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -40,6 +40,7 @@
 
 #include <stdarg.h>
 
+#include <openthread/border_agent.h>
 #include <openthread/cli.h>
 #include <openthread/dataset.h>
 #include <openthread/dns_client.h>
@@ -317,6 +318,7 @@ private:
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
     static void HandleBorderAgentEphemeralKeyStateChange(void *aContext);
     void        HandleBorderAgentEphemeralKeyStateChange(void);
+    void        OutputBorderAgentCounters(const otBorderAgentCounters &aCounters);
 #endif
 
     static void HandleDetachGracefullyResult(void *aContext);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -315,10 +315,12 @@ private:
     void HandleSntpResponse(uint64_t aTime, otError aResult);
 #endif
 
-#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
+    void OutputBorderAgentCounters(const otBorderAgentCounters &aCounters);
+#if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
     static void HandleBorderAgentEphemeralKeyStateChange(void *aContext);
     void        HandleBorderAgentEphemeralKeyStateChange(void);
-    void        OutputBorderAgentCounters(const otBorderAgentCounters &aCounters);
+#endif
 #endif
 
     static void HandleDetachGracefullyResult(void *aContext);

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -210,7 +210,7 @@ exit:
  * Starts the CoAP Secure service. @moreinfo{@coaps}.
  * @sa otCoapSecureStart
  * @sa otCoapSecureSetSslAuthMode
- * @sa otCoapSecureSetClientConnectedCallback
+ * @sa otCoapSecureSetClientConnectEventCallback
  */
 template <> otError CoapSecure::Process<Cmd("start")>(Arg aArgs[])
 {
@@ -235,7 +235,7 @@ template <> otError CoapSecure::Process<Cmd("start")>(Arg aArgs[])
     }
 
     otCoapSecureSetSslAuthMode(GetInstancePtr(), verifyPeerCert);
-    otCoapSecureSetClientConnectedCallback(GetInstancePtr(), &CoapSecure::HandleConnected, this);
+    otCoapSecureSetClientConnectEventCallback(GetInstancePtr(), &CoapSecure::HandleConnectEvent, this);
 
 #if CLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER
     otCoapSecureSetDefaultHandler(GetInstancePtr(), &CoapSecure::DefaultHandler, this);
@@ -629,7 +629,7 @@ template <> otError CoapSecure::Process<Cmd("connect")>(Arg aArgs[])
         SuccessOrExit(error = aArgs[1].ParseAsUint16(sockaddr.mPort));
     }
 
-    SuccessOrExit(error = otCoapSecureConnect(GetInstancePtr(), &sockaddr, &CoapSecure::HandleConnected, this));
+    SuccessOrExit(error = otCoapSecureConnect(GetInstancePtr(), &sockaddr, &CoapSecure::HandleConnectEvent, this));
 
 exit:
     return error;
@@ -783,14 +783,14 @@ void CoapSecure::Stop(void)
     otCoapSecureStop(GetInstancePtr());
 }
 
-void CoapSecure::HandleConnected(bool aConnected, void *aContext)
+void CoapSecure::HandleConnectEvent(otCoapSecureConnectEvent aEvent, void *aContext)
 {
-    static_cast<CoapSecure *>(aContext)->HandleConnected(aConnected);
+    static_cast<CoapSecure *>(aContext)->HandleConnectEvent(aEvent);
 }
 
-void CoapSecure::HandleConnected(bool aConnected)
+void CoapSecure::HandleConnectEvent(otCoapSecureConnectEvent aEvent)
 {
-    if (aConnected)
+    if (aEvent == OT_COAP_SECURE_CONNECTED)
     {
         OutputLine("coaps connected");
     }

--- a/src/cli/cli_coap_secure.hpp
+++ b/src/cli/cli_coap_secure.hpp
@@ -137,8 +137,8 @@ private:
     void        DefaultHandler(otMessage *aMessage, const otMessageInfo *aMessageInfo);
 #endif // CLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER
 
-    static void HandleConnected(bool aConnected, void *aContext);
-    void        HandleConnected(bool aConnected);
+    static void HandleConnectEvent(otCoapSecureConnectEvent aEvent, void *aContext);
+    void        HandleConnectEvent(otCoapSecureConnectEvent aEvent);
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
     otCoapBlockwiseResource mResource;

--- a/src/core/api/border_agent_api.cpp
+++ b/src/core/api/border_agent_api.cpp
@@ -108,11 +108,11 @@ void otBorderAgentSetEphemeralKeyCallback(otInstance                       *aIns
     AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().SetEphemeralKeyCallback(aCallback, aContext);
 }
 
+#endif // OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+
 const otBorderAgentCounters *otBorderAgentGetCounters(otInstance *aInstance)
 {
     return AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().GetCounters();
 }
-
-#endif // OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
 
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE

--- a/src/core/api/border_agent_api.cpp
+++ b/src/core/api/border_agent_api.cpp
@@ -108,6 +108,11 @@ void otBorderAgentSetEphemeralKeyCallback(otInstance                       *aIns
     AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().SetEphemeralKeyCallback(aCallback, aContext);
 }
 
+const otBorderAgentCounters *otBorderAgentGetCounters(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().GetCounters();
+}
+
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
 
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE

--- a/src/core/api/coap_secure_api.cpp
+++ b/src/core/api/coap_secure_api.cpp
@@ -178,11 +178,11 @@ void otCoapSecureRemoveResource(otInstance *aInstance, otCoapResource *aResource
     AsCoreType(aInstance).GetApplicationCoapSecure().RemoveResource(AsCoreType(aResource));
 }
 
-void otCoapSecureSetClientConnectedCallback(otInstance                     *aInstance,
-                                            otHandleCoapSecureClientConnect aHandler,
-                                            void                           *aContext)
+void otCoapSecureSetClientConnectEventCallback(otInstance                     *aInstance,
+                                               otHandleCoapSecureClientConnect aHandler,
+                                               void                           *aContext)
 {
-    AsCoreType(aInstance).GetApplicationCoapSecure().SetConnectedCallback(aHandler, aContext);
+    AsCoreType(aInstance).GetApplicationCoapSecure().SetConnectEventCallback(aHandler, aContext);
 }
 
 void otCoapSecureSetDefaultHandler(otInstance *aInstance, otCoapRequestHandler aHandler, void *aContext)

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -85,9 +85,8 @@ Error CoapSecure::Open(uint16_t aMaxAttempts, AutoStopCallback aCallback, void *
 
     SuccessOrExit(mDtls.SetMaxConnectionAttempts(aMaxAttempts, HandleDtlsAutoClose, this));
     mAutoStopCallback.Set(aCallback, aContext);
-    mConnectedCallback.Clear();
-    mExtendedConnectedCallback.Clear();
-    SuccessOrExit(mDtls.Open(HandleDtlsReceive, HandleDtlsConnected, this));
+    mConnectEventCallback.Clear();
+    SuccessOrExit(mDtls.Open(HandleDtlsReceive, HandleDtlsConnectEvent, this));
 
     error = kErrorNone;
 
@@ -103,9 +102,9 @@ void CoapSecure::Stop(void)
     ClearRequestsAndResponses();
 }
 
-Error CoapSecure::Connect(const Ip6::SockAddr &aSockAddr, ConnectedCallback aCallback, void *aContext)
+Error CoapSecure::Connect(const Ip6::SockAddr &aSockAddr, ConnectEventCallback aCallback, void *aContext)
 {
-    mConnectedCallback.Set(aCallback, aContext);
+    mConnectEventCallback.Set(aCallback, aContext);
 
     return mDtls.Connect(aSockAddr);
 }
@@ -179,15 +178,14 @@ Error CoapSecure::Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageIn
     return kErrorNone;
 }
 
-void CoapSecure::HandleDtlsConnected(void *aContext, bool aConnected, bool aWithError)
+void CoapSecure::HandleDtlsConnectEvent(MeshCoP::SecureTransport::ConnectEvent aEvent, void *aContext)
 {
-    return static_cast<CoapSecure *>(aContext)->HandleDtlsConnected(aConnected, aWithError);
+    return static_cast<CoapSecure *>(aContext)->HandleDtlsConnectEvent(aEvent);
 }
 
-void CoapSecure::HandleDtlsConnected(bool aConnected, bool aWithError)
+void CoapSecure::HandleDtlsConnectEvent(MeshCoP::SecureTransport::ConnectEvent aEvent)
 {
-    mConnectedCallback.InvokeIfSet(aConnected);
-    mExtendedConnectedCallback.InvokeIfSet(aConnected, aWithError);
+    mConnectEventCallback.InvokeIfSet(aEvent);
 }
 
 void CoapSecure::HandleDtlsAutoClose(void *aContext)

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -86,6 +86,7 @@ Error CoapSecure::Open(uint16_t aMaxAttempts, AutoStopCallback aCallback, void *
     SuccessOrExit(mDtls.SetMaxConnectionAttempts(aMaxAttempts, HandleDtlsAutoClose, this));
     mAutoStopCallback.Set(aCallback, aContext);
     mConnectedCallback.Clear();
+    mExtendedConnectedCallback.Clear();
     SuccessOrExit(mDtls.Open(HandleDtlsReceive, HandleDtlsConnected, this));
 
     error = kErrorNone;
@@ -178,12 +179,16 @@ Error CoapSecure::Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageIn
     return kErrorNone;
 }
 
-void CoapSecure::HandleDtlsConnected(void *aContext, bool aConnected)
+void CoapSecure::HandleDtlsConnected(void *aContext, bool aConnected, bool aWithError)
 {
-    return static_cast<CoapSecure *>(aContext)->HandleDtlsConnected(aConnected);
+    return static_cast<CoapSecure *>(aContext)->HandleDtlsConnected(aConnected, aWithError);
 }
 
-void CoapSecure::HandleDtlsConnected(bool aConnected) { mConnectedCallback.InvokeIfSet(aConnected); }
+void CoapSecure::HandleDtlsConnected(bool aConnected, bool aWithError)
+{
+    mConnectedCallback.InvokeIfSet(aConnected);
+    mExtendedConnectedCallback.InvokeIfSet(aConnected, aWithError);
+}
 
 void CoapSecure::HandleDtlsAutoClose(void *aContext)
 {

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -62,6 +62,16 @@ public:
     typedef void (*ConnectedCallback)(bool aConnected, void *aContext);
 
     /**
+     * Pointer is called once DTLS connection is established or closed.
+     *
+     * @param[in]  aConnected  TRUE if a connection was established, FALSE otherwise.
+     * @param[in]  aWithError  TRUE if the connection was closed due to an error.
+     * @param[in]  aContext    A pointer to arbitrary context information.
+     *
+     */
+    typedef void (*ExtendedConnectedCallback)(bool aConnected, bool aWithError, void *aContext);
+
+    /**
      * Callback to notify when the agent is automatically stopped due to reaching the maximum number of connection
      * attempts.
      *
@@ -125,6 +135,18 @@ public:
     void SetConnectedCallback(ConnectedCallback aCallback, void *aContext)
     {
         mConnectedCallback.Set(aCallback, aContext);
+    }
+
+    /**
+     * Sets extended connected callback of this secure CoAP agent.
+     *
+     * @param[in]  aCallback  A pointer to a function to get called when connection state changes.
+     * @param[in]  aContext   A pointer to arbitrary context information.
+     *
+     */
+    void SetExtendedConnectedCallback(ExtendedConnectedCallback aCallback, void *aContext)
+    {
+        mExtendedConnectedCallback.Set(aCallback, aContext);
     }
 
     /**
@@ -421,8 +443,8 @@ private:
     }
     Error Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleDtlsConnected(void *aContext, bool aConnected);
-    void        HandleDtlsConnected(bool aConnected);
+    static void HandleDtlsConnected(void *aContext, bool aConnected, bool aWithError);
+    void        HandleDtlsConnected(bool aConnected, bool aWithError);
 
     static void HandleDtlsAutoClose(void *aContext);
     void        HandleDtlsAutoClose(void);
@@ -433,11 +455,12 @@ private:
     static void HandleTransmit(Tasklet &aTasklet);
     void        HandleTransmit(void);
 
-    MeshCoP::SecureTransport    mDtls;
-    Callback<ConnectedCallback> mConnectedCallback;
-    Callback<AutoStopCallback>  mAutoStopCallback;
-    ot::MessageQueue            mTransmitQueue;
-    TaskletContext              mTransmitTask;
+    MeshCoP::SecureTransport            mDtls;
+    Callback<ConnectedCallback>         mConnectedCallback;
+    Callback<ExtendedConnectedCallback> mExtendedConnectedCallback;
+    Callback<AutoStopCallback>          mAutoStopCallback;
+    ot::MessageQueue                    mTransmitQueue;
+    TaskletContext                      mTransmitTask;
 };
 
 } // namespace Coap

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -238,7 +238,13 @@ public:
 
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
 
-    const otBorderAgentCounters *GetCounters() { return &mCounters; }
+    /**
+     * Gets the set of border agent counters.
+     *
+     * @returns The border agent counters.
+     *
+     */
+    const otBorderAgentCounters *GetCounters(void) { return &mCounters; }
 
     /**
      * Returns the UDP Proxy port to which the commissioner is currently
@@ -255,7 +261,6 @@ private:
 
     static constexpr uint16_t kUdpPort          = OPENTHREAD_CONFIG_BORDER_AGENT_UDP_PORT;
     static constexpr uint32_t kKeepAliveTimeout = 50 * 1000; // Timeout to reject a commissioner (in msec)
-    otBorderAgentCounters     mCounters;
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
     static constexpr uint16_t kMaxEphemeralKeyConnectionAttempts = 10;
@@ -288,11 +293,8 @@ private:
     void                SendErrorMessage(const ForwardContext &aForwardContext, Error aError);
     void                SendErrorMessage(const Coap::Message &aRequest, bool aSeparate, Error aError);
 
-    static void HandleConnected(bool aConnected, bool aWithError, void *aContext);
-    void        HandleConnected(bool aConnected, bool aWithError);
-
-    static void HandleDisconnected(bool aWithError, void *aContext);
-    void        HandleDisconnected(bool aWithError);
+    static void HandleConnected(SecureTransport::ConnectEvent aEvent, void *aContext);
+    void        HandleConnected(SecureTransport::ConnectEvent aEvent);
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
@@ -339,6 +341,7 @@ private:
     EphemeralKeyTask               mEphemeralKeyTask;
     Callback<EphemeralKeyCallback> mEphemeralKeyCallback;
 #endif
+    otBorderAgentCounters mCounters;
 };
 
 DeclareTmfHandler(BorderAgent, kUriRelayRx);

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -238,6 +238,8 @@ public:
 
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
 
+    const otBorderAgentCounters *GetCounters() { return &mCounters; }
+
     /**
      * Returns the UDP Proxy port to which the commissioner is currently
      * bound.
@@ -253,6 +255,7 @@ private:
 
     static constexpr uint16_t kUdpPort          = OPENTHREAD_CONFIG_BORDER_AGENT_UDP_PORT;
     static constexpr uint32_t kKeepAliveTimeout = 50 * 1000; // Timeout to reject a commissioner (in msec)
+    otBorderAgentCounters     mCounters;
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
     static constexpr uint16_t kMaxEphemeralKeyConnectionAttempts = 10;

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -288,8 +288,11 @@ private:
     void                SendErrorMessage(const ForwardContext &aForwardContext, Error aError);
     void                SendErrorMessage(const Coap::Message &aRequest, bool aSeparate, Error aError);
 
-    static void HandleConnected(bool aConnected, void *aContext);
-    void        HandleConnected(bool aConnected);
+    static void HandleConnected(bool aConnected, bool aWithError, void *aContext);
+    void        HandleConnected(bool aConnected, bool aWithError);
+
+    static void HandleDisconnected(bool aWithError, void *aContext);
+    void        HandleDisconnected(bool aWithError);
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -127,19 +127,20 @@ exit:
     return;
 }
 
-void Commissioner::HandleSecureAgentConnected(bool aConnected, void *aContext)
+void Commissioner::HandleSecureAgentConnectEvent(SecureTransport::ConnectEvent aEvent, void *aContext)
 {
-    static_cast<Commissioner *>(aContext)->HandleSecureAgentConnected(aConnected);
+    static_cast<Commissioner *>(aContext)->HandleSecureAgentConnectEvent(aEvent);
 }
 
-void Commissioner::HandleSecureAgentConnected(bool aConnected)
+void Commissioner::HandleSecureAgentConnectEvent(SecureTransport::ConnectEvent aEvent)
 {
-    if (!aConnected)
+    bool isConnected = (aEvent == SecureTransport::kConnected);
+    if (!isConnected)
     {
         mJoinerSessionTimer.Stop();
     }
 
-    SignalJoinerEvent(aConnected ? kJoinerEventConnected : kJoinerEventEnd, mActiveJoiner);
+    SignalJoinerEvent(isConnected ? kJoinerEventConnected : kJoinerEventEnd, mActiveJoiner);
 }
 
 Commissioner::Joiner *Commissioner::GetUnusedJoinerEntry(void)
@@ -287,7 +288,7 @@ Error Commissioner::Start(StateCallback aStateCallback, JoinerCallback aJoinerCa
 #endif
 
     SuccessOrExit(error = Get<Tmf::SecureAgent>().Start(SendRelayTransmit, this));
-    Get<Tmf::SecureAgent>().SetConnectedCallback(&Commissioner::HandleSecureAgentConnected, this);
+    Get<Tmf::SecureAgent>().SetConnectEventCallback(&Commissioner::HandleSecureAgentConnectEvent, this);
 
     mStateCallback.Set(aStateCallback, aCallbackContext);
     mJoinerCallback.Set(aJoinerCallback, aCallbackContext);

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -440,8 +440,8 @@ private:
                                               Error                aResult);
     void HandleLeaderKeepAliveResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
 
-    static void HandleSecureAgentConnected(bool aConnected, void *aContext);
-    void        HandleSecureAgentConnected(bool aConnected);
+    static void HandleSecureAgentConnectEvent(SecureTransport::ConnectEvent aEvent, void *aContext);
+    void        HandleSecureAgentConnectEvent(SecureTransport::ConnectEvent aEvent);
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -382,16 +382,16 @@ exit:
     return error;
 }
 
-void Joiner::HandleSecureCoapClientConnect(bool aConnected, void *aContext)
+void Joiner::HandleSecureCoapClientConnect(SecureTransport::ConnectEvent aEvent, void *aContext)
 {
-    static_cast<Joiner *>(aContext)->HandleSecureCoapClientConnect(aConnected);
+    static_cast<Joiner *>(aContext)->HandleSecureCoapClientConnect(aEvent);
 }
 
-void Joiner::HandleSecureCoapClientConnect(bool aConnected)
+void Joiner::HandleSecureCoapClientConnect(SecureTransport::ConnectEvent aEvent)
 {
     VerifyOrExit(mState == kStateConnect);
 
-    if (aConnected)
+    if (aEvent == SecureTransport::kConnected)
     {
         SetState(kStateConnected);
         SendJoinerFinalize();

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -199,8 +199,8 @@ private:
     static void HandleDiscoverResult(Mle::DiscoverScanner::ScanResult *aResult, void *aContext);
     void        HandleDiscoverResult(Mle::DiscoverScanner::ScanResult *aResult);
 
-    static void HandleSecureCoapClientConnect(bool aConnected, void *aContext);
-    void        HandleSecureCoapClientConnect(bool aConnected);
+    static void HandleSecureCoapClientConnect(SecureTransport::ConnectEvent aEvent, void *aContext);
+    void        HandleSecureCoapClientConnect(SecureTransport::ConnectEvent aEvent);
 
     static void HandleJoinerFinalizeResponse(void                *aContext,
                                              otMessage           *aMessage,

--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -1043,16 +1043,15 @@ void SecureTransport::HandleTimer(void)
         if ((mMaxConnectionAttempts > 0) && (mRemainingConnectionAttempts == 0))
         {
             Close();
-            mConnectedCallback.InvokeIfSet(false, mDisconnectedWithError);
+            mConnectEvent = kDisconnectedMaxAttempts;
             mAutoCloseCallback.InvokeIfSet();
         }
         else
         {
             SetState(kStateOpen);
             mTimer.Stop();
-            mConnectedCallback.InvokeIfSet(false, mDisconnectedWithError);
         }
-        mDisconnectedWithError = false;
+        mConnectedCallback.InvokeIfSet(mConnectEvent);
     }
 }
 
@@ -1071,7 +1070,8 @@ void SecureTransport::Process(void)
             if (mSsl.MBEDTLS_PRIVATE(state) == MBEDTLS_SSL_HANDSHAKE_OVER)
             {
                 SetState(kStateConnected);
-                mConnectedCallback.InvokeIfSet(true, false);
+                mConnectEvent = kConnected;
+                mConnectedCallback.InvokeIfSet(mConnectEvent);
             }
         }
         else
@@ -1093,6 +1093,7 @@ void SecureTransport::Process(void)
             {
             case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY:
                 mbedtls_ssl_close_notify(&mSsl);
+                mConnectEvent = kDisconnectedPeerClosed;
                 ExitNow(shouldDisconnect = true);
                 OT_UNREACHABLE_CODE(break);
 
@@ -1101,6 +1102,7 @@ void SecureTransport::Process(void)
 
             case MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE:
                 mbedtls_ssl_close_notify(&mSsl);
+                mConnectEvent = kDisconnectedError;
                 ExitNow(shouldDisconnect = true);
                 OT_UNREACHABLE_CODE(break);
 
@@ -1109,6 +1111,7 @@ void SecureTransport::Process(void)
                 {
                     mbedtls_ssl_send_alert_message(&mSsl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
                                                    MBEDTLS_SSL_ALERT_MSG_BAD_RECORD_MAC);
+                    mConnectEvent = kDisconnectedError;
                     ExitNow(shouldDisconnect = true);
                 }
 
@@ -1119,6 +1122,7 @@ void SecureTransport::Process(void)
                 {
                     mbedtls_ssl_send_alert_message(&mSsl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
                                                    MBEDTLS_SSL_ALERT_MSG_HANDSHAKE_FAILURE);
+                    mConnectEvent = kDisconnectedError;
                     ExitNow(shouldDisconnect = true);
                 }
 
@@ -1138,10 +1142,6 @@ exit:
 
     if (shouldDisconnect)
     {
-        if (rval != MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY)
-        {
-            mDisconnectedWithError = true;
-        }
         Disconnect();
     }
 }

--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -104,9 +104,10 @@ public:
      *
      * @param[in]  aContext    A pointer to application-specific context.
      * @param[in]  aConnected  TRUE if a connection was established, FALSE otherwise.
+     * @param[in]  aWithError  TRUE if a connection was torn down due to an error.
      *
      */
-    typedef void (*ConnectedHandler)(void *aContext, bool aConnected);
+    typedef void (*ConnectedHandler)(void *aContext, bool aConnected, bool aWithError);
 
     /**
      * Pointer is called when data is received from the session.
@@ -670,6 +671,8 @@ private:
 
     Message::SubType mMessageSubType;
     Message::SubType mMessageDefaultSubType;
+
+    bool mDisconnectedWithError;
 };
 
 } // namespace MeshCoP

--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -69,6 +69,8 @@
 #endif
 #endif
 
+#include <openthread/coap_secure.h>
+
 #include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/log.hpp"
@@ -87,7 +89,21 @@ namespace MeshCoP {
 class SecureTransport : public InstanceLocator
 {
 public:
+    typedef otCoapSecureConnectEvent ConnectEvent; ///< A connect event.
+
+    static constexpr ConnectEvent kConnected               = OT_COAP_SECURE_CONNECTED;
+    static constexpr ConnectEvent kDisconnectedPeerClosed  = OT_COAP_SECURE_DISCONNECTED_PEER_CLOSED;
+    static constexpr ConnectEvent kDisconnectedLocalClosed = OT_COAP_SECURE_DISCONNECTED_LOCAL_CLOSED;
+    static constexpr ConnectEvent kDisconnectedMaxAttempts = OT_COAP_SECURE_DISCONNECTED_MAX_ATTEMPTS;
+    static constexpr ConnectEvent kDisconnectedError       = OT_COAP_SECURE_DISCONNECTED_ERROR;
+
     static constexpr uint8_t kPskMaxLength = 32; ///< Maximum PSK length.
+
+    /**
+     * Function pointer which is called reporting a connection event (when connection established or disconnected)
+     *
+     */
+    typedef otHandleCoapSecureClientConnect ConnectedHandler;
 
     /**
      * Initializes the SecureTransport object.
@@ -98,16 +114,6 @@ public:
      *
      */
     explicit SecureTransport(Instance &aInstance, bool aLayerTwoSecurity, bool aDatagramTransport = true);
-
-    /**
-     * Pointer is called when a connection is established or torn down.
-     *
-     * @param[in]  aContext    A pointer to application-specific context.
-     * @param[in]  aConnected  TRUE if a connection was established, FALSE otherwise.
-     * @param[in]  aWithError  TRUE if a connection was torn down due to an error.
-     *
-     */
-    typedef void (*ConnectedHandler)(void *aContext, bool aConnected, bool aWithError);
 
     /**
      * Pointer is called when data is received from the session.
@@ -672,7 +678,7 @@ private:
     Message::SubType mMessageSubType;
     Message::SubType mMessageDefaultSubType;
 
-    bool mDisconnectedWithError;
+    ConnectEvent mConnectEvent;
 };
 
 } // namespace MeshCoP

--- a/src/core/radio/ble_secure.cpp
+++ b/src/core/radio/ble_secure.cpp
@@ -321,8 +321,9 @@ Error BleSecure::HandleBleMtuUpdate(uint16_t aMtu)
     return error;
 }
 
-void BleSecure::HandleTlsConnected(void *aContext, bool aConnected)
+void BleSecure::HandleTlsConnected(void *aContext, bool aConnected, bool aWithError)
 {
+    OT_UNUSED_VARIABLE(aWithError);
     return static_cast<BleSecure *>(aContext)->HandleTlsConnected(aConnected);
 }
 

--- a/src/core/radio/ble_secure.cpp
+++ b/src/core/radio/ble_secure.cpp
@@ -83,7 +83,7 @@ Error BleSecure::Start(ConnectCallback aConnectHandler, ReceiveCallback aReceive
     SuccessOrExit(error = otPlatBleGapAdvSetData(&GetInstance(), advertisementData, advertisementLen));
     SuccessOrExit(error = otPlatBleGapAdvStart(&GetInstance(), OT_BLE_ADV_INTERVAL_DEFAULT));
 
-    SuccessOrExit(error = mTls.Open(&BleSecure::HandleTlsReceive, &BleSecure::HandleTlsConnected, this));
+    SuccessOrExit(error = mTls.Open(&BleSecure::HandleTlsReceive, &BleSecure::HandleTlsConnectEvent, this));
     SuccessOrExit(error = mTls.Bind(HandleTransport, this));
 
 exit:
@@ -321,15 +321,14 @@ Error BleSecure::HandleBleMtuUpdate(uint16_t aMtu)
     return error;
 }
 
-void BleSecure::HandleTlsConnected(void *aContext, bool aConnected, bool aWithError)
+void BleSecure::HandleTlsConnectEvent(MeshCoP::SecureTransport::ConnectEvent aEvent, void *aContext)
 {
-    OT_UNUSED_VARIABLE(aWithError);
-    return static_cast<BleSecure *>(aContext)->HandleTlsConnected(aConnected);
+    return static_cast<BleSecure *>(aContext)->HandleTlsConnectEvent(aEvent);
 }
 
-void BleSecure::HandleTlsConnected(bool aConnected)
+void BleSecure::HandleTlsConnectEvent(MeshCoP::SecureTransport::ConnectEvent aEvent)
 {
-    if (aConnected)
+    if (aEvent == MeshCoP::SecureTransport::kConnected)
     {
         if (mReceivedMessage == nullptr)
         {
@@ -359,7 +358,7 @@ void BleSecure::HandleTlsConnected(bool aConnected)
         }
     }
 
-    mConnectCallback.InvokeIfSet(&GetInstance(), aConnected, true);
+    mConnectCallback.InvokeIfSet(&GetInstance(), aEvent == MeshCoP::SecureTransport::kConnected, true);
 
 exit:
     return;

--- a/src/core/radio/ble_secure.hpp
+++ b/src/core/radio/ble_secure.hpp
@@ -464,7 +464,7 @@ private:
     static constexpr uint8_t  kPacketBufferSize = OT_BLE_ATT_MTU_MAX - kGattOverhead;
     static constexpr uint16_t kTxBleHandle      = 0; // Characteristics Handle for TX (not used)
 
-    static void HandleTlsConnected(void *aContext, bool aConnected);
+    static void HandleTlsConnected(void *aContext, bool aConnected, bool aWithError);
     void        HandleTlsConnected(bool aConnected);
 
     static void HandleTlsReceive(void *aContext, uint8_t *aBuf, uint16_t aLength);

--- a/src/core/radio/ble_secure.hpp
+++ b/src/core/radio/ble_secure.hpp
@@ -464,8 +464,8 @@ private:
     static constexpr uint8_t  kPacketBufferSize = OT_BLE_ATT_MTU_MAX - kGattOverhead;
     static constexpr uint16_t kTxBleHandle      = 0; // Characteristics Handle for TX (not used)
 
-    static void HandleTlsConnected(void *aContext, bool aConnected, bool aWithError);
-    void        HandleTlsConnected(bool aConnected);
+    static void HandleTlsConnectEvent(MeshCoP::SecureTransport::ConnectEvent aEvent, void *aContext);
+    void        HandleTlsConnectEvent(MeshCoP::SecureTransport::ConnectEvent aEvent);
 
     static void HandleTlsReceive(void *aContext, uint8_t *aBuf, uint16_t aLength);
     void        HandleTlsReceive(uint8_t *aBuf, uint16_t aLength);

--- a/tests/scripts/thread-cert/border_router/test_ephemeral_key.py
+++ b/tests/scripts/thread-cert/border_router/test_ephemeral_key.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2024, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+import logging
+import unittest
+
+import config
+import thread_cert
+
+# Test description:
+#   This test verifies that ephemeral key can be activated and deactivated.
+#
+# Topology:
+#    --------------
+#           |
+#          BR1
+#
+
+BR1 = 1
+
+
+class EphemeralKeyTest(thread_cert.TestCase):
+    USE_MESSAGE_FACTORY = False
+
+    TOPOLOGY = {
+        BR1: {
+            'name': 'BR_1',
+            'allowlist': [],
+            'is_otbr': True,
+            'version': '1.2',
+            'network_name': 'ot-br1',
+            'boot_delay': 5,
+        },
+    }
+
+    def test(self):
+        br1 = self.nodes[BR1]
+
+        counters = br1.get_border_agent_counters()
+        print('br1 ba counters', counters)
+        self.assertTrue(counters['ePSKc']['activations'] == 0)
+        self.assertTrue(counters['ePSKc']['api_deactivations'] == 0)
+        self.assertTrue(counters['ePSKc']['timeout_deactivations'] == 0)
+        self.assertTrue(counters['ePSKc']['max_attempt_deactivations'] == 0)
+        self.assertTrue(counters['ePSKc']['disconnect_deactivations'] == 0)
+        self.assertTrue(counters['ePSKc']['invalid_ba_state_errors'] == 0)
+        self.assertTrue(counters['ePSKc']['invalid_args_errors'] == 0)
+        self.assertTrue(counters['ePSKc']['start_secure_session_errors'] == 0)
+        self.assertTrue(counters['ePSKc']['secure_session_successes'] == 0)
+        self.assertTrue(counters['ePSKc']['secure_session_failures'] == 0)
+        self.assertTrue(counters['ePSKc']['commissioner_petitions'] == 0)
+        self.assertTrue(counters['PSKc']['secure_session_successes'] == 0)
+        self.assertTrue(counters['PSKc']['secure_session_failures'] == 0)
+        self.assertTrue(counters['PSKc']['commissioner_petitions'] == 0)
+        self.assertTrue(counters['coap']['MGMT_ACTIVE_GET'] == 0)
+        self.assertTrue(counters['coap']['MGMT_PENDING_GET'] == 0)
+
+        # activate epskc before border agent is up
+        br1.set_epskc('123456789', 10)
+
+        counters = br1.get_border_agent_counters()
+        print('br1 ba counters', counters)
+        self.assertTrue(counters['ePSKc']['activations'] == 0)
+        self.assertTrue(counters['ePSKc']['invalid_ba_state_errors'] == 1)
+
+        br1.set_active_dataset(updateExisting=True, network_name='ot-br1')
+        br1.start()
+        self.simulator.go(config.BORDER_ROUTER_STARTUP_DELAY)
+        self.assertEqual('leader', br1.get_state())
+
+        # activate epskc and let it timeout
+        br1.set_epskc('123456789', 10)
+        self.simulator.go(1)
+
+        counters = br1.get_border_agent_counters()
+        print('br1 ba counters', counters)
+        self.assertTrue(counters['ePSKc']['activations'] == 1)
+        self.assertTrue(counters['ePSKc']['api_deactivations'] == 0)
+        self.assertTrue(counters['ePSKc']['timeout_deactivations'] == 1)
+
+        # activate epskc and clear it
+        br1.set_epskc('123456789', 10000)
+        self.simulator.go(1)
+        br1.clear_epskc()
+
+        counters = br1.get_border_agent_counters()
+        print('br1 ba counters', counters)
+        self.assertTrue(counters['ePSKc']['activations'] == 2)
+        self.assertTrue(counters['ePSKc']['api_deactivations'] == 1)
+        self.assertTrue(counters['ePSKc']['timeout_deactivations'] == 1)
+
+        # set epskc with invalid passcode
+        br1.set_epskc('123', 1000)
+        self.simulator.go(1)
+
+        counters = br1.get_border_agent_counters()
+        print('br1 ba counters', counters)
+        self.assertTrue(counters['ePSKc']['activations'] == 2)
+        self.assertTrue(counters['ePSKc']['api_deactivations'] == 1)
+        self.assertTrue(counters['ePSKc']['timeout_deactivations'] == 1)
+        self.assertTrue(counters['ePSKc']['invalid_args_errors'] == 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/scripts/thread-cert/border_router/test_ephemeral_key_counters.py
+++ b/tests/scripts/thread-cert/border_router/test_ephemeral_key_counters.py
@@ -33,7 +33,7 @@ import config
 import thread_cert
 
 # Test description:
-#   This test verifies that ephemeral key can be activated and deactivated.
+#   This test verifies the counters of ephemeral key activations/deactivations.
 #
 # Topology:
 #    --------------
@@ -44,17 +44,15 @@ import thread_cert
 BR1 = 1
 
 
-class EphemeralKeyTest(thread_cert.TestCase):
+class EphemeralKeyCountersTest(thread_cert.TestCase):
     USE_MESSAGE_FACTORY = False
 
     TOPOLOGY = {
         BR1: {
             'name': 'BR_1',
-            'allowlist': [],
             'is_otbr': True,
-            'version': '1.2',
+            'version': '1.4',
             'network_name': 'ot-br1',
-            'boot_delay': 5,
         },
     }
 
@@ -62,31 +60,29 @@ class EphemeralKeyTest(thread_cert.TestCase):
         br1 = self.nodes[BR1]
 
         counters = br1.get_border_agent_counters()
-        print('br1 ba counters', counters)
-        self.assertTrue(counters['ePSKc']['activations'] == 0)
-        self.assertTrue(counters['ePSKc']['api_deactivations'] == 0)
-        self.assertTrue(counters['ePSKc']['timeout_deactivations'] == 0)
-        self.assertTrue(counters['ePSKc']['max_attempt_deactivations'] == 0)
-        self.assertTrue(counters['ePSKc']['disconnect_deactivations'] == 0)
-        self.assertTrue(counters['ePSKc']['invalid_ba_state_errors'] == 0)
-        self.assertTrue(counters['ePSKc']['invalid_args_errors'] == 0)
-        self.assertTrue(counters['ePSKc']['start_secure_session_errors'] == 0)
-        self.assertTrue(counters['ePSKc']['secure_session_successes'] == 0)
-        self.assertTrue(counters['ePSKc']['secure_session_failures'] == 0)
-        self.assertTrue(counters['ePSKc']['commissioner_petitions'] == 0)
-        self.assertTrue(counters['PSKc']['secure_session_successes'] == 0)
-        self.assertTrue(counters['PSKc']['secure_session_failures'] == 0)
-        self.assertTrue(counters['PSKc']['commissioner_petitions'] == 0)
-        self.assertTrue(counters['coap']['MGMT_ACTIVE_GET'] == 0)
-        self.assertTrue(counters['coap']['MGMT_PENDING_GET'] == 0)
+        self.assertEqual(counters['epskcActivation'], 0)
+        self.assertEqual(counters['epskcApiDeactivation'], 0)
+        self.assertEqual(counters['epskcTimeoutDeactivation'], 0)
+        self.assertEqual(counters['epskcMaxAttemptDeactivation'], 0)
+        self.assertEqual(counters['epskcDisconnectDeactivation'], 0)
+        self.assertEqual(counters['epskcInvalidBaStateError'], 0)
+        self.assertEqual(counters['epskcInvalidArgsError'], 0)
+        self.assertEqual(counters['epskcStartSecureSessionError'], 0)
+        self.assertEqual(counters['epskcSecureSessionSuccess'], 0)
+        self.assertEqual(counters['epskcSecureSessionFailure'], 0)
+        self.assertEqual(counters['epskcCommissionerPetition'], 0)
+        self.assertEqual(counters['pskcSecureSessionSuccess'], 0)
+        self.assertEqual(counters['pskcSecureSessionFailure'], 0)
+        self.assertEqual(counters['pskcCommissionerPetition'], 0)
+        self.assertEqual(counters['mgmtActiveGet'], 0)
+        self.assertEqual(counters['mgmtPendingGet'], 0)
 
-        # activate epskc before border agent is up
-        br1.set_epskc('123456789', 10)
+        # activate epskc before border agent is up returns an error
+        br1.set_epskc('123456789')
 
         counters = br1.get_border_agent_counters()
-        print('br1 ba counters', counters)
-        self.assertTrue(counters['ePSKc']['activations'] == 0)
-        self.assertTrue(counters['ePSKc']['invalid_ba_state_errors'] == 1)
+        self.assertEqual(counters['epskcActivation'], 0)
+        self.assertEqual(counters['epskcInvalidBaStateError'], 1)
 
         br1.set_active_dataset(updateExisting=True, network_name='ot-br1')
         br1.start()
@@ -98,10 +94,9 @@ class EphemeralKeyTest(thread_cert.TestCase):
         self.simulator.go(1)
 
         counters = br1.get_border_agent_counters()
-        print('br1 ba counters', counters)
-        self.assertTrue(counters['ePSKc']['activations'] == 1)
-        self.assertTrue(counters['ePSKc']['api_deactivations'] == 0)
-        self.assertTrue(counters['ePSKc']['timeout_deactivations'] == 1)
+        self.assertEqual(counters['epskcActivation'], 1)
+        self.assertEqual(counters['epskcApiDeactivation'], 0)
+        self.assertEqual(counters['epskcTimeoutDeactivation'], 1)
 
         # activate epskc and clear it
         br1.set_epskc('123456789', 10000)
@@ -109,21 +104,19 @@ class EphemeralKeyTest(thread_cert.TestCase):
         br1.clear_epskc()
 
         counters = br1.get_border_agent_counters()
-        print('br1 ba counters', counters)
-        self.assertTrue(counters['ePSKc']['activations'] == 2)
-        self.assertTrue(counters['ePSKc']['api_deactivations'] == 1)
-        self.assertTrue(counters['ePSKc']['timeout_deactivations'] == 1)
+        self.assertEqual(counters['epskcActivation'], 2)
+        self.assertEqual(counters['epskcApiDeactivation'], 1)
+        self.assertEqual(counters['epskcTimeoutDeactivation'], 1)
 
         # set epskc with invalid passcode
-        br1.set_epskc('123', 1000)
+        br1.set_epskc('123')
         self.simulator.go(1)
 
         counters = br1.get_border_agent_counters()
-        print('br1 ba counters', counters)
-        self.assertTrue(counters['ePSKc']['activations'] == 2)
-        self.assertTrue(counters['ePSKc']['api_deactivations'] == 1)
-        self.assertTrue(counters['ePSKc']['timeout_deactivations'] == 1)
-        self.assertTrue(counters['ePSKc']['invalid_args_errors'] == 1)
+        self.assertEqual(counters['epskcActivation'], 2)
+        self.assertEqual(counters['epskcApiDeactivation'], 1)
+        self.assertEqual(counters['epskcTimeoutDeactivation'], 1)
+        self.assertEqual(counters['epskcInvalidArgsError'], 1)
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1451,8 +1451,8 @@ class NodeImpl:
         self.send_command(cmd)
         self._expect_done()
 
-    def set_epskc(self, passcode: str, lifetime: int):
-        cmd = 'ba ephemeralkey set ' + passcode + ' ' + str(lifetime)
+    def set_epskc(self, keystring: str, timeout=120000, port=0):
+        cmd = 'ba ephemeralkey set ' + keystring + ' ' + str(timeout) + ' ' + str(port)
         self.send_command(cmd)
         self._expect(r"(Done|Error .*)")
 
@@ -1468,15 +1468,12 @@ class NodeImpl:
 
         counters = {}
         for line in result:
-            m = re.match(r'(\w+)\:', line)
+            m = re.match(r'(\w+)\: (\d+)', line)
             if m:
-                group_name = m.group(1)
-                if group_name not in counters:
-                    counters[group_name] = {}
+                counter_name = m.group(1)
+                counter_value = m.group(2)
 
-                counter_matches = re.findall(r"(\w+) (\d+)", line)
-                for counter_name, counter_value in counter_matches:
-                    counters[group_name][counter_name] = int(counter_value)
+                counters[counter_name] = int(counter_value)
         return counters
 
     def _encode_txt_entry(self, entry):

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1451,6 +1451,34 @@ class NodeImpl:
         self.send_command(cmd)
         self._expect_done()
 
+    def set_epskc(self, passcode: str, lifetime: int):
+        cmd = 'ba ephemeralkey set ' + passcode + ' ' + str(lifetime)
+        self.send_command(cmd)
+        self._expect(r"(Done|Error .*)")
+
+    def clear_epskc(self):
+        cmd = 'ba ephemeralkey clear'
+        self.send_command(cmd)
+        self._expect_done()
+
+    def get_border_agent_counters(self):
+        cmd = 'ba counters'
+        self.send_command(cmd)
+        result = self._expect_command_output()
+
+        counters = {}
+        for line in result:
+            m = re.match(r'(\w+)\:', line)
+            if m:
+                group_name = m.group(1)
+                if group_name not in counters:
+                    counters[group_name] = {}
+
+                counter_matches = re.findall(r"(\w+) (\d+)", line)
+                for counter_name, counter_value in counter_matches:
+                    counters[group_name][counter_name] = int(counter_value)
+        return counters
+
     def _encode_txt_entry(self, entry):
         """Encodes the TXT entry to the DNS-SD TXT record format as a HEX string.
 


### PR DESCRIPTION
Adds API to get border agent counters which include counters for ePSKc, PSKc and coap messages.