### PR TITLE
[border-agent] update ephemeral key connection timeout handling

### DIFF
--- a/include/openthread/border_agent.h
+++ b/include/openthread/border_agent.h
@@ -195,9 +195,10 @@ otError otBorderAgentSetId(otInstance *aInstance, const otBorderAgentId *aId);
  * Setting the ephemeral key again before a previously set key has timed out will replace the previously set key and
  * reset the timeout.
  *
- * While the timeout interval is in effect, the ephemeral key can be used only once by an external commissioner to
- * connect. Once the commissioner disconnects, the ephemeral key is cleared, and the Border Agent reverts to using
- * PSKc.
+ * During the timeout interval, the ephemeral key can be used only once by an external commissioner to establish a
+ * connection. After the commissioner disconnects, the ephemeral key is cleared, and the Border Agent reverts to
+ * using PSKc. If the timeout expires while a commissioner is still connected, the session will be terminated, and the
+ * Border Agent will cease using the ephemeral key and revert to PSKc.
  *
  * @param[in] aInstance    The OpenThread instance.
  * @param[in] aKeyString   The ephemeral key string (used as PSK excluding the trailing null `\0` character).
@@ -229,7 +230,7 @@ otError otBorderAgentSetEphemeralKey(otInstance *aInstance,
  *
  * If a commissioner is connected using the ephemeral key and is currently active, calling this function does not
  * change its state. In this case the `otBorderAgentIsEphemeralKeyActive()` will continue to return `TRUE` until the
- * commissioner disconnects.
+ * commissioner disconnects, or the ephemeral key timeout expires.
  *
  * @param[in] aInstance    The OpenThread instance.
  */

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (447)
+#define OPENTHREAD_API_VERSION (448)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -407,7 +407,7 @@ The `port` specifies the UDP port to use with the ephemeral key. If UDP port is 
 
 Setting the ephemeral key again before a previously set one is timed out, will replace the previous one.
 
-While the timeout interval is in effect, the ephemeral key can be used only once by an external commissioner to connect. Once the commissioner disconnects, the ephemeral key is cleared, and Border Agent reverts to using PSKc.
+During the timeout interval, the ephemeral key can be used only once by an external commissioner to establish a connection. After the commissioner disconnects, the ephemeral key is cleared, and the Border Agent reverts to using PSKc. If the timeout expires while a commissioner is still connected, the session will be terminated, and the Border Agent will cease using the ephemeral key and revert to PSKc.
 
 ```bash
 > ba ephemeralkey set Z10X20g3J15w1000P60m16 5000 1234

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -170,9 +170,10 @@ public:
      * Setting the ephemeral key again before a previously set one is timed out will replace the previous one and will
      * reset the timeout.
      *
-     * While the timeout interval is in effect, the ephemeral key can be used only once by an external commissioner to
-     * connect. Once the commissioner disconnects, the ephemeral key is cleared, and Border Agent reverts to using
-     * PSKc.
+     * During the timeout interval, the ephemeral key can be used only once by an external commissioner to establish a
+     * connection. After the commissioner disconnects, the ephemeral key is cleared, and the Border Agent reverts to
+     * using PSKc. If the timeout expires while a commissioner is still connected, the session will be terminated, and
+     * the Border Agent will cease using the ephemeral key and revert to PSKc.
      *
      * @param[in] aKeyString   The ephemeral key.
      * @param[in] aTimeout     The timeout duration in milliseconds to use the ephemeral key.
@@ -197,7 +198,7 @@ public:
      *
      * If a commissioner is connected using the ephemeral key and is currently active, calling this method does not
      * change its state. In this case the `IsEphemeralKeyActive()` will continue to return `true` until the commissioner
-     * disconnects.
+     * disconnects, or the ephemeral key timeout expires.
      */
     void ClearEphemeralKey(void);
 


### PR DESCRIPTION
This commit enhances how ephemeral key timeout is used. If the timeout expires while a commissioner or commissioner candidate is connected, the session will be terminated. The Border Agent (BA) will then stop using the ephemeral key and revert to using PSKc.

The ephemeral key timeout timer starts when the ephemeral key is set on the BA. During this timeout interval, the ephemeral key can be used only once by an external commissioner to establish a secure connection.

---

Related to [SPEC-1310](https://threadgroup.atlassian.net/browse/SPEC-1310)