### PR TITLE
[cli] clarify docs - parameter use `dns config` to change service mode only

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1284,7 +1284,7 @@ Done
 >
 ```
 
-### dns config \[DNS server IP\] \[DNS server port\] \[response timeout (ms)\] \[max tx attempts\] \[recursion desired (boolean)\] \[service mode]
+### dns config \[DNS server IP\] \[DNS server port\] \[response timeout (ms)\] \[max tx attempts\] \[recursion desired (boolean)\] \[service mode] \[protocol]
 
 Set the default query config.
 
@@ -1322,9 +1322,28 @@ Done
 
 > dns config
 Server: [fd00:0:0:0:0:0:0:2]:53
-ResponseTimeout: 3000 ms
+ResponseTimeout: 6000 ms
 MaxTxAttempts: 3
 RecursionDesired: yes
+Nat64Mode: allow
+TransportProtocol: udp
+Done
+```
+
+This final example shows how only 'recursion desired' and the service mode are set, and all other parameters are set to their defaults:
+
+```bash
+> dns config :: 0 0 0 1 srv_txt_sep
+Done
+
+> dns config
+Server: [2001:4860:4860:0:0:0:0:8888]:53
+ResponseTimeout: 6000 ms
+MaxTxAttempts: 3
+RecursionDesired: yes
+ServiceMode: srv_txt_sep
+Nat64Mode: allow
+TransportProtocol: udp
 Done
 ```
 

--- a/src/cli/cli_dns.cpp
+++ b/src/cli/cli_dns.cpp
@@ -161,6 +161,9 @@ template <> otError Dns::Process<Cmd("config")>(Arg aArgs[])
      * ResponseTimeout: 5000 ms
      * MaxTxAttempts: 2
      * RecursionDesired: no
+     * ServiceMode: srv_txt_opt
+     * Nat64Mode: allow
+     * TransportProtocol: udp
      * Done
      * @endcode
      * @code
@@ -170,16 +173,20 @@ template <> otError Dns::Process<Cmd("config")>(Arg aArgs[])
      * @code
      * dns config
      * Server: [fd00:0:0:0:0:0:0:2]:53
-     * ResponseTimeout: 3000 ms
+     * ResponseTimeout: 6000 ms
      * MaxTxAttempts: 3
      * RecursionDesired: yes
+     * ServiceMode: srv_txt_opt
+     * Nat64Mode: allow
+     * TransportProtocol: udp
      * Done
      * @endcode
      * @par api_copy
      * #otDnsClientSetDefaultConfig
      * @cparam dns config [@ca{dns-server-IP}] [@ca{dns-server-port}] <!--
      * -->                [@ca{response-timeout-ms}] [@ca{max-tx-attempts}] <!--
-     * -->                [@ca{recursion-desired-boolean}] [@ca{service-mode}]
+     * -->                [@ca{recursion-desired-boolean}] [@ca{service-mode}] <!--
+     * -->                [@ca{protocol}]
      * @par
      * We can leave some of the fields as unspecified (or use value zero). The
      * unspecified fields are replaced by the corresponding OT config option


### PR DESCRIPTION
Also adds missing CLI outputs in examples.
close #10396  