### PR TITLE
[netdata] update `GetNextDnsSrpUnicastInfo()` to use `Type`

### DIFF
--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -2378,7 +2378,7 @@ exit:
     return;
 }
 
-Error Client::SelectUnicastEntry(DnsSrpUnicast::Origin aOrigin, DnsSrpUnicast::Info &aInfo) const
+Error Client::SelectUnicastEntry(DnsSrpUnicast::Type aType, DnsSrpUnicast::Info &aInfo) const
 {
     Error                                   error = kErrorNotFound;
     DnsSrpUnicast::Info                     unicastInfo;
@@ -2393,13 +2393,8 @@ Error Client::SelectUnicastEntry(DnsSrpUnicast::Origin aOrigin, DnsSrpUnicast::I
     }
 #endif
 
-    while (Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(iterator, unicastInfo) == kErrorNone)
+    while (Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(iterator, aType, unicastInfo) == kErrorNone)
     {
-        if (unicastInfo.mOrigin != aOrigin)
-        {
-            continue;
-        }
-
         if (mAutoStart.HasSelectedServer() && (GetServerAddress() == unicastInfo.mSockAddr))
         {
             aInfo = unicastInfo;
@@ -2441,9 +2436,9 @@ void Client::SelectNextServer(bool aDisallowSwitchOnRegisteredHost)
     // restarts the client with the new server (keeping the retry wait
     // interval as before).
 
-    Ip6::SockAddr         serverSockAddr;
-    bool                  selectNext = false;
-    DnsSrpUnicast::Origin origin     = DnsSrpUnicast::kFromServiceData;
+    Ip6::SockAddr       serverSockAddr;
+    bool                selectNext = false;
+    DnsSrpUnicast::Type type       = DnsSrpUnicast::kFromServiceData;
 
     serverSockAddr.Clear();
 
@@ -2455,11 +2450,11 @@ void Client::SelectNextServer(bool aDisallowSwitchOnRegisteredHost)
     switch (mAutoStart.GetState())
     {
     case AutoStart::kSelectedUnicastPreferred:
-        origin = DnsSrpUnicast::kFromServiceData;
+        type = DnsSrpUnicast::kFromServiceData;
         break;
 
     case AutoStart::kSelectedUnicast:
-        origin = DnsSrpUnicast::kFromServerData;
+        type = DnsSrpUnicast::kFromServerData;
         break;
 
     case AutoStart::kSelectedAnycast:
@@ -2485,13 +2480,8 @@ void Client::SelectNextServer(bool aDisallowSwitchOnRegisteredHost)
         DnsSrpUnicast::Info                     unicastInfo;
         NetworkData::Service::Manager::Iterator iterator;
 
-        while (Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(iterator, unicastInfo) == kErrorNone)
+        while (Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(iterator, type, unicastInfo) == kErrorNone)
         {
-            if (unicastInfo.mOrigin != origin)
-            {
-                continue;
-            }
-
             if (selectNext)
             {
                 serverSockAddr = unicastInfo.mSockAddr;

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -1110,7 +1110,7 @@ private:
 #if OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
     void  ApplyAutoStartGuardOnAttach(void);
     void  ProcessAutoStart(void);
-    Error SelectUnicastEntry(DnsSrpUnicast::Origin aOrigin, DnsSrpUnicast::Info &aInfo) const;
+    Error SelectUnicastEntry(DnsSrpUnicast::Type aType, DnsSrpUnicast::Info &aInfo) const;
     void  HandleGuardTimer(void) {}
 #if OPENTHREAD_CONFIG_SRP_CLIENT_SWITCH_SERVER_ON_FAILURE
     void SelectNextServer(bool aDisallowSwitchOnRegisteredHost);

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -602,16 +602,12 @@ Error AddressResolver::ResolveUsingNetDataServices(const Ip6::Address &aEid, uin
     Error                                     error = kErrorNotFound;
     NetworkData::Service::Manager::Iterator   iterator;
     NetworkData::Service::DnsSrpUnicast::Info unicastInfo;
+    NetworkData::Service::DnsSrpUnicast::Type type = NetworkData::Service::DnsSrpUnicast::kFromServerData;
 
     VerifyOrExit(Get<Mle::Mle>().GetDeviceMode().GetNetworkDataType() == NetworkData::kFullSet);
 
-    while (Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(iterator, unicastInfo) == kErrorNone)
+    while (Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(iterator, type, unicastInfo) == kErrorNone)
     {
-        if (unicastInfo.mOrigin != NetworkData::Service::DnsSrpUnicast::kFromServerData)
-        {
-            continue;
-        }
-
         if (aEid == unicastInfo.mSockAddr.GetAddress())
         {
             aRloc16 = unicastInfo.mRloc16;

--- a/src/core/thread/network_data_publisher.hpp
+++ b/src/core/thread/network_data_publisher.hpp
@@ -56,6 +56,7 @@
 #include "common/string.hpp"
 #include "common/timer.hpp"
 #include "net/ip6_address.hpp"
+#include "thread/network_data_service.hpp"
 #include "thread/network_data_types.hpp"
 
 namespace ot {
@@ -437,10 +438,10 @@ private:
         void Notify(Event aEvent) const;
         void Process(void);
         void CountAnycastEntries(uint8_t &aNumEntries, uint8_t &aNumPreferredEntries) const;
-        void CountServiceDataUnicastEntries(uint8_t &aNumEntries, uint8_t &aNumPreferredEntries) const;
-        void CountServerDataUnicastEntries(uint8_t &aNumEntries,
-                                           uint8_t &aNumPreferredEntries,
-                                           bool    &aHasServiceDataEntry) const;
+        void CountUnicastEntries(Service::DnsSrpUnicast::Type aType,
+                                 uint8_t                     &aNumEntries,
+                                 uint8_t                     &aNumPreferredEntries) const;
+        bool HasAnyServiceDataUnicastEntry(void) const;
 
         Info                            mInfo;
         Callback<DnsSrpServiceCallback> mCallback;

--- a/src/core/thread/network_data_service.hpp
+++ b/src/core/thread/network_data_service.hpp
@@ -238,10 +238,10 @@ public:
     static const uint8_t kServiceData = kServiceNumber;
 
     /**
-     * Represents the origin a `DnsSrpUnicast` entry.
+     * Represents the `DnsSrpUnicast` entry type.
      *
      */
-    enum Origin : uint8_t
+    enum Type : uint8_t
     {
         kFromServiceData, ///< Socket address is from service data.
         kFromServerData,  ///< Socket address is from server data.
@@ -254,8 +254,7 @@ public:
     struct Info
     {
         Ip6::SockAddr mSockAddr; ///< The socket address (IPv6 address and port) of the DNS/SRP server.
-        Origin        mOrigin;   ///< The origin of the socket address (whether from service or server data).
-        uint16_t      mRloc16;   ///< The BR RLOC16 adding the entry (only used when `mOrigin == kFromServerData`).
+        uint16_t      mRloc16;   ///< The BR RLOC16 adding the entry.
     };
 
     /**
@@ -581,13 +580,14 @@ public:
      * method).
      *
      * @param[in,out] aIterator    A reference to an iterator.
+     * @param[in]     aType        The entry type, `kFromServiceData` (preferred) or `kFromServerData` (non-preferred).
      * @param[out]    aInfo        A reference to `DnsSrpUnicast::Info` to return the info.
      *
      * @retval kErrorNone       Successfully got the next info. @p aInfo and @p aIterator are updated.
      * @retval kErrorNotFound   No more matching entries in the Network Data.
      *
      */
-    Error GetNextDnsSrpUnicastInfo(Iterator &aIterator, DnsSrpUnicast::Info &aInfo) const;
+    Error GetNextDnsSrpUnicastInfo(Iterator &aIterator, DnsSrpUnicast::Type aType, DnsSrpUnicast::Info &aInfo) const;
 
 private:
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE


### PR DESCRIPTION
This commit updates `Service::Manager::GetNextDnsSrpUnicastInfo()` to accept a `DnsSrpUnicast::Type`, indicating the desired entry type (either `kFromServiceData` or `kFromServerData`). This simplifies the code, which previously iterated over all types and performed type checks. Additionally, this change simplifies the `Publisher` methods used for counting existing DNS/SRP unicast entries of different types.