### PR TITLE
[spinel] correct `SPINEL_PROP_IPV6_ADDRESS_TABLE` documentation

### DIFF
--- a/src/lib/spinel/spinel.h
+++ b/src/lib/spinel/spinel.h
@@ -3467,8 +3467,8 @@ enum
      *
      *  `6`: IPv6 Address
      *  `C`: Network Prefix Length (in bits)
-     *  `L`: Valid Lifetime
      *  `L`: Preferred Lifetime
+     *  `L`: Valid Lifetime
      *
      */
     SPINEL_PROP_IPV6_ADDRESS_TABLE = SPINEL_PROP_IPV6__BEGIN + 3,


### PR DESCRIPTION
This commit aligns the documentation in `spinel.h` with the implementation for `SPINEL_PROP_IPV6_ADDRESS_TABLE` regarding the order of valid/preferred lifetime fields.