### PR TITLE
[tests] add more test case in test_multi_ail.py

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_multi_ail.py
+++ b/tests/scripts/thread-cert/border_router/test_multi_ail.py
@@ -38,7 +38,126 @@ from node import OtbrNode
 IPV4_CIDR_ADDR_CMD = f'ip addr show {config.BACKBONE_IFNAME} | grep -w inet | grep -Eo "[0-9.]+/[0-9]+"'
 
 
-class TwoBorderRoutersOnTwoInfrastructures(thread_cert.TestCase):
+class SevenBRs_ThreePartitions_ThreeInfra(thread_cert.TestCase):
+    """
+    Topology:
+        ****************(backbone0.0)******************
+                |                |              |
+              BR2_0            BR0_0          BR1_0
+                |                               |
+              BR2_1 ---- BR2_2 ---- BR2_3     BR1_1
+                |          |         |          |
+        *****(backbone0.1)****   *****(backbone0.2)****
+    """
+    USE_MESSAGE_FACTORY = False
+    BR0_0, BR1_0, BR1_1, BR2_0, BR2_1, BR2_2, BR2_3 = range(1, 8)
+
+    TOPOLOGY = {
+        BR0_0: {
+            'name': 'BR0_0',
+            'backbone_network_id': 0,
+            'allowlist': [],
+            'is_otbr': True,
+            'version': '1.3',
+        },
+        BR1_0: {
+            'name': 'BR1_1',
+            'backbone_network_id': 0,
+            'allowlist': [BR1_1],
+            'is_otbr': True,
+            'version': '1.3',
+        },
+        BR1_1: {
+            'name': 'BR1_2',
+            'backbone_network_id': 2,
+            'allowlist': [BR1_0],
+            'is_otbr': True,
+            'version': '1.3',
+        },
+        BR2_0: {
+            'name': 'BR2_0',
+            'backbone_network_id': 0,
+            'allowlist': [BR2_1],
+            'is_otbr': True,
+            'version': '1.3',
+        },
+        BR2_1: {
+            'name': 'BR2_1',
+            'backbone_network_id': 1,
+            'allowlist': [BR2_0, BR2_2],
+            'is_otbr': True,
+            'version': '1.3',
+        },
+        BR2_2: {
+            'name': 'BR2_2',
+            'backbone_network_id': 1,
+            'allowlist': [BR2_1, BR2_3],
+            'is_otbr': True,
+            'version': '1.3',
+        },
+        BR2_3: {
+            'name': 'BR2_4',
+            'backbone_network_id': 2,
+            'allowlist': [BR2_2],
+            'is_otbr': True,
+            'version': '1.3',
+        }
+    }
+
+    def test(self):
+        """ This test verify "br peers" and "br routers" commands work as expected.
+        """
+        br0_0: OtbrNode = self.nodes[self.BR0_0]
+        br1_0: OtbrNode = self.nodes[self.BR1_0]
+        br1_1: OtbrNode = self.nodes[self.BR1_1]
+        br2_0: OtbrNode = self.nodes[self.BR2_0]
+        br2_1: OtbrNode = self.nodes[self.BR2_1]
+        br2_2: OtbrNode = self.nodes[self.BR2_2]
+        br2_3: OtbrNode = self.nodes[self.BR2_3]
+
+        border_routers = [br0_0, br1_0, br1_1, br2_0, br2_1, br2_2, br2_3]
+
+        for br in border_routers:
+            br.start()
+
+        # sleep some time more to ensure every BR gets the network data, otherwise the test can fail sometimes.
+        self.simulator.go(config.BORDER_ROUTER_STARTUP_DELAY + 3)
+
+        # ---------------------------------------
+        # br peers
+        _, br1_0_rloc16, br1_1_rloc16, br2_0_rloc16, br2_1_rloc16, br2_2_rloc16, br2_3_rloc16 = [
+            br.get_addr16() for br in border_routers
+        ]
+
+        self.assertCountEqual(br0_0.get_br_peers_rloc16s(), [])
+        self.assertCountEqual(br1_0.get_br_peers_rloc16s(), [br1_1_rloc16])
+        self.assertCountEqual(br1_1.get_br_peers_rloc16s(), [br1_0_rloc16])
+        self.assertCountEqual(br2_0.get_br_peers_rloc16s(), [br2_1_rloc16, br2_2_rloc16, br2_3_rloc16])
+        self.assertCountEqual(br2_1.get_br_peers_rloc16s(), [br2_0_rloc16, br2_2_rloc16, br2_3_rloc16])
+        self.assertCountEqual(br2_2.get_br_peers_rloc16s(), [br2_0_rloc16, br2_1_rloc16, br2_3_rloc16])
+        self.assertCountEqual(br2_3.get_br_peers_rloc16s(), [br2_0_rloc16, br2_1_rloc16, br2_2_rloc16])
+
+        # ---------------------------------------
+        # br routers
+        br0_0_addr = ipaddress.IPv6Address(br0_0.get_ip6_address(config.ADDRESS_TYPE.BACKBONE_LINK_LOCAL))
+        br1_0_addr = ipaddress.IPv6Address(br1_0.get_ip6_address(config.ADDRESS_TYPE.BACKBONE_LINK_LOCAL))
+        br1_1_addr = ipaddress.IPv6Address(br1_1.get_ip6_address(config.ADDRESS_TYPE.BACKBONE_LINK_LOCAL))
+        br2_0_addr = ipaddress.IPv6Address(br2_0.get_ip6_address(config.ADDRESS_TYPE.BACKBONE_LINK_LOCAL))
+        br2_1_addr = ipaddress.IPv6Address(br2_1.get_ip6_address(config.ADDRESS_TYPE.BACKBONE_LINK_LOCAL))
+        br2_2_addr = ipaddress.IPv6Address(br2_2.get_ip6_address(config.ADDRESS_TYPE.BACKBONE_LINK_LOCAL))
+        br2_3_addr = ipaddress.IPv6Address(br2_3.get_ip6_address(config.ADDRESS_TYPE.BACKBONE_LINK_LOCAL))
+
+        self.assertCountEqual(br0_0.get_br_routers_ip_addresses(), [br2_0_addr, br1_0_addr])
+        self.assertCountEqual(br1_0.get_br_routers_ip_addresses(), [br2_0_addr, br0_0_addr])
+        self.assertCountEqual(br1_1.get_br_routers_ip_addresses(), [br2_3_addr])
+        self.assertCountEqual(br2_0.get_br_routers_ip_addresses(), [br0_0_addr, br1_0_addr])
+        self.assertCountEqual(br2_1.get_br_routers_ip_addresses(), [br2_2_addr])
+        self.assertCountEqual(br2_2.get_br_routers_ip_addresses(), [br2_1_addr])
+        self.assertCountEqual(br2_3.get_br_routers_ip_addresses(), [br1_1_addr])
+
+
+@unittest.skip("This is just an example")
+class ExampleTest(thread_cert.TestCase):
     """
     Test that two border routers on different infrastructures can ping each other via Thread interface.
 


### PR DESCRIPTION
 The new test cases is testing 7 BRs (in 3 partitions) on 3 infra link. The target is to verify the following number and content are expected:
1. The number of BRs on infra link (link-local address is also verified)
2. The number of BRs in the Thread network partition (rloc16 is also verified)

The previous test case in test_multi_ail.py is kept as an example test case, but is skipped when running.
