### PR TITLE
[posix] update the max size of file path to PATH_MAX

### DIFF
--- a/src/posix/platform/config_file.cpp
+++ b/src/posix/platform/config_file.cpp
@@ -47,7 +47,7 @@ ConfigFile::ConfigFile(const char *aFilePath)
     : mFilePath(aFilePath)
 {
     assert(mFilePath != nullptr);
-    VerifyOrDie(strlen(mFilePath) + strlen(kSwapSuffix) < kFileNameMaxSize, OT_EXIT_FAILURE);
+    VerifyOrDie(strlen(mFilePath) + strlen(kSwapSuffix) < kFilePathMaxSize, OT_EXIT_FAILURE);
 }
 
 bool ConfigFile::HasKey(const char *aKey) const
@@ -163,7 +163,7 @@ exit:
 otError ConfigFile::Clear(const char *aKey)
 {
     otError error = OT_ERROR_NONE;
-    char    swapFile[kFileNameMaxSize];
+    char    swapFile[kFilePathMaxSize];
     char    line[kLineMaxSize];
     FILE   *fp     = nullptr;
     FILE   *fpSwap = nullptr;

--- a/src/posix/platform/config_file.hpp
+++ b/src/posix/platform/config_file.hpp
@@ -30,6 +30,7 @@
 #define OT_POSIX_PLATFORM_CONFIG_FILE_HPP_
 
 #include <assert.h>
+#include <limits.h>
 #include <stdint.h>
 #include <openthread/error.h>
 
@@ -115,7 +116,7 @@ private:
     const char               *kCommentDelimiter = "#";
     const char               *kSwapSuffix       = ".swap";
     static constexpr uint16_t kLineMaxSize      = 512;
-    static constexpr uint16_t kFileNameMaxSize  = 255;
+    static constexpr uint16_t kFilePathMaxSize  = PATH_MAX;
 
     void Strip(char *aString) const;
 


### PR DESCRIPTION
The length of the configuration file path may exceed the default defined max length 255.

This commit changes the name of file path max length from `kFileNameMaxSize` to `kFilePathMaxSize`, and sets the value of `kFilePathMaxSize` to the PATH_MAX.

Related issue: https://github.com/openthread/ot-br-posix/issues/2445