### PR TITLE
[netdata] centralize service/server TLV logic in `Service::Manager`

### DIFF
--- a/src/core/backbone_router/bbr_leader.cpp
+++ b/src/core/backbone_router/bbr_leader.cpp
@@ -75,8 +75,7 @@ Error Leader::GetServiceId(uint8_t &aServiceId) const
     Error error = kErrorNone;
 
     VerifyOrExit(HasPrimary(), error = kErrorNotFound);
-    error = Get<NetworkData::Service::Manager>().GetServiceId<NetworkData::Service::BackboneRouter>(
-        /* aServerStable */ true, aServiceId);
+    error = Get<NetworkData::Service::Manager>().GetBackboneRouterServiceId(aServiceId);
 
 exit:
     return error;

--- a/src/core/backbone_router/bbr_local.cpp
+++ b/src/core/backbone_router/bbr_local.cpp
@@ -174,8 +174,7 @@ exit:
 
 Error Local::AddService(RegisterMode aMode)
 {
-    Error                                            error = kErrorInvalidState;
-    NetworkData::Service::BackboneRouter::ServerData serverData;
+    Error error = kErrorInvalidState;
 
     VerifyOrExit(mState != kStateDisabled && Get<Mle::Mle>().IsAttached());
 
@@ -189,11 +188,8 @@ Error Local::AddService(RegisterMode aMode)
         break;
     }
 
-    serverData.SetSequenceNumber(mSequenceNumber);
-    serverData.SetReregistrationDelay(mReregistrationDelay);
-    serverData.SetMlrTimeout(mMlrTimeout);
-
-    SuccessOrExit(error = Get<NetworkData::Service::Manager>().Add<NetworkData::Service::BackboneRouter>(serverData));
+    SuccessOrExit(error = Get<NetworkData::Service::Manager>().AddBackboneRouterService(
+                      mSequenceNumber, mReregistrationDelay, mMlrTimeout));
     Get<NetworkData::Notifier>().HandleServerDataUpdated();
 
     mIsServiceAdded = true;
@@ -207,7 +203,7 @@ void Local::RemoveService(void)
 {
     Error error;
 
-    SuccessOrExit(error = Get<NetworkData::Service::Manager>().Remove<NetworkData::Service::BackboneRouter>());
+    SuccessOrExit(error = Get<NetworkData::Service::Manager>().RemoveBackboneRouterService());
     Get<NetworkData::Notifier>().HandleServerDataUpdated();
     mIsServiceAdded = false;
 

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -2244,11 +2244,11 @@ exit:
 
 void Client::ProcessAutoStart(void)
 {
-    Ip6::SockAddr       serverSockAddr;
-    DnsSrpAnycast::Info anycastInfo;
-    DnsSrpUnicast::Info unicastInfo;
-    AutoStart::State    oldAutoStartState = mAutoStart.GetState();
-    bool                shouldRestart     = false;
+    Ip6::SockAddr     serverSockAddr;
+    DnsSrpAnycastInfo anycastInfo;
+    DnsSrpUnicastInfo unicastInfo;
+    AutoStart::State  oldAutoStartState = mAutoStart.GetState();
+    bool              shouldRestart     = false;
 
     // If auto start mode is enabled, we check the Network Data entries
     // to discover and select the preferred SRP server to register with.
@@ -2274,7 +2274,7 @@ void Client::ProcessAutoStart(void)
 
     serverSockAddr.Clear();
 
-    if (SelectUnicastEntry(DnsSrpUnicast::kFromServiceData, unicastInfo) == kErrorNone)
+    if (SelectUnicastEntry(NetworkData::Service::kAddrInServiceData, unicastInfo) == kErrorNone)
     {
         mAutoStart.SetState(AutoStart::kSelectedUnicastPreferred);
         serverSockAddr = unicastInfo.mSockAddr;
@@ -2299,7 +2299,7 @@ void Client::ProcessAutoStart(void)
 
         mAutoStart.SetState(AutoStart::kSelectedAnycast);
     }
-    else if (SelectUnicastEntry(DnsSrpUnicast::kFromServerData, unicastInfo) == kErrorNone)
+    else if (SelectUnicastEntry(NetworkData::Service::kAddrInServerData, unicastInfo) == kErrorNone)
     {
         mAutoStart.SetState(AutoStart::kSelectedUnicast);
         serverSockAddr = unicastInfo.mSockAddr;
@@ -2378,10 +2378,10 @@ exit:
     return;
 }
 
-Error Client::SelectUnicastEntry(DnsSrpUnicast::Type aType, DnsSrpUnicast::Info &aInfo) const
+Error Client::SelectUnicastEntry(DnsSrpUnicastType aType, DnsSrpUnicastInfo &aInfo) const
 {
     Error                                   error = kErrorNotFound;
-    DnsSrpUnicast::Info                     unicastInfo;
+    DnsSrpUnicastInfo                       unicastInfo;
     NetworkData::Service::Manager::Iterator iterator;
 #if OPENTHREAD_CONFIG_SRP_CLIENT_SAVE_SELECTED_SERVER_ENABLE
     Settings::SrpClientInfo savedInfo;
@@ -2436,9 +2436,9 @@ void Client::SelectNextServer(bool aDisallowSwitchOnRegisteredHost)
     // restarts the client with the new server (keeping the retry wait
     // interval as before).
 
-    Ip6::SockAddr       serverSockAddr;
-    bool                selectNext = false;
-    DnsSrpUnicast::Type type       = DnsSrpUnicast::kFromServiceData;
+    Ip6::SockAddr     serverSockAddr;
+    bool              selectNext = false;
+    DnsSrpUnicastType type       = NetworkData::Service::kAddrInServiceData;
 
     serverSockAddr.Clear();
 
@@ -2450,11 +2450,11 @@ void Client::SelectNextServer(bool aDisallowSwitchOnRegisteredHost)
     switch (mAutoStart.GetState())
     {
     case AutoStart::kSelectedUnicastPreferred:
-        type = DnsSrpUnicast::kFromServiceData;
+        type = NetworkData::Service::kAddrInServiceData;
         break;
 
     case AutoStart::kSelectedUnicast:
-        type = DnsSrpUnicast::kFromServerData;
+        type = NetworkData::Service::kAddrInServerData;
         break;
 
     case AutoStart::kSelectedAnycast:
@@ -2477,7 +2477,7 @@ void Client::SelectNextServer(bool aDisallowSwitchOnRegisteredHost)
 
     do
     {
-        DnsSrpUnicast::Info                     unicastInfo;
+        DnsSrpUnicastInfo                       unicastInfo;
         NetworkData::Service::Manager::Iterator iterator;
 
         while (Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(iterator, type, unicastInfo) == kErrorNone)

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -75,8 +75,9 @@ class Client : public InstanceLocator, private NonCopyable
     friend class ot::Notifier;
     friend class ot::Ip6::Netif;
 
-    using DnsSrpUnicast = NetworkData::Service::DnsSrpUnicast;
-    using DnsSrpAnycast = NetworkData::Service::DnsSrpAnycast;
+    using DnsSrpUnicastInfo = NetworkData::Service::DnsSrpUnicastInfo;
+    using DnsSrpUnicastType = NetworkData::Service::DnsSrpUnicastType;
+    using DnsSrpAnycastInfo = NetworkData::Service::DnsSrpAnycastInfo;
 
 public:
     /**
@@ -1110,7 +1111,7 @@ private:
 #if OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
     void  ApplyAutoStartGuardOnAttach(void);
     void  ProcessAutoStart(void);
-    Error SelectUnicastEntry(DnsSrpUnicast::Type aType, DnsSrpUnicast::Info &aInfo) const;
+    Error SelectUnicastEntry(DnsSrpUnicastType aType, DnsSrpUnicastInfo &aInfo) const;
     void  HandleGuardTimer(void) {}
 #if OPENTHREAD_CONFIG_SRP_CLIENT_SWITCH_SERVER_ON_FAILURE
     void SelectNextServer(bool aDisallowSwitchOnRegisteredHost);

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -599,10 +599,10 @@ Error AddressResolver::ResolveUsingNetDataServices(const Ip6::Address &aEid, uin
     // service entries.  Returns `kErrorNone` and updates `aRloc16`
     // if successful, otherwise returns `kErrorNotFound`.
 
-    Error                                     error = kErrorNotFound;
-    NetworkData::Service::Manager::Iterator   iterator;
-    NetworkData::Service::DnsSrpUnicast::Info unicastInfo;
-    NetworkData::Service::DnsSrpUnicast::Type type = NetworkData::Service::DnsSrpUnicast::kFromServerData;
+    Error                                   error = kErrorNotFound;
+    NetworkData::Service::Manager::Iterator iterator;
+    NetworkData::Service::DnsSrpUnicastInfo unicastInfo;
+    NetworkData::Service::DnsSrpUnicastType type = NetworkData::Service::kAddrInServerData;
 
     VerifyOrExit(Get<Mle::Mle>().GetDeviceMode().GetNetworkDataType() == NetworkData::kFullSet);
 

--- a/src/core/thread/network_data_publisher.hpp
+++ b/src/core/thread/network_data_publisher.hpp
@@ -439,9 +439,9 @@ private:
         void Process(void);
         void CountAnycastEntries(uint8_t &aNumEntries, uint8_t &aNumPreferredEntries) const;
         bool HasAnyAnycastEntry(void) const;
-        void CountUnicastEntries(Service::DnsSrpUnicast::Type aType,
-                                 uint8_t                     &aNumEntries,
-                                 uint8_t                     &aNumPreferredEntries) const;
+        void CountUnicastEntries(Service::DnsSrpUnicastType aType,
+                                 uint8_t                   &aNumEntries,
+                                 uint8_t                   &aNumPreferredEntries) const;
         bool HasAnyServiceDataUnicastEntry(void) const;
 
         Info                            mInfo;

--- a/src/core/thread/network_data_service.hpp
+++ b/src/core/thread/network_data_service.hpp
@@ -52,316 +52,35 @@ namespace Service {
 
 const uint32_t kThreadEnterpriseNumber = ServiceTlv::kThreadEnterpriseNumber; ///< Thread enterprise number.
 
-#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-
 /**
- * Implements Thread Network Data "Backbone Router Service" server data generation and parsing.
+ * Represents information about an DNS/SRP server parsed from related Network Data service entries.
  *
  */
-class BackboneRouter
+struct DnsSrpAnycastInfo
 {
-public:
-    /**
-     * This constant variable represents the Backbone Router service data.
-     *
-     * The service data contains only the service number (THREAD_SERVICE_DATA_BBR) as a single byte.
-     *
-     */
-    static const uint8_t     kServiceData        = 0x01;
-    static constexpr uint8_t kServiceDataMinSize = 1;
-
-    /**
-     * Implements the generation and parsing of "Backbone Router Service" server data.
-     *
-     */
-    OT_TOOL_PACKED_BEGIN
-    class ServerData
-    {
-    public:
-        /**
-         * Returns the length (in bytes) of server data.
-         *
-         * @returns The server data length in bytes.
-         *
-         */
-        uint8_t GetLength(void) const { return sizeof(ServerData); }
-
-        /**
-         * Returns the sequence number of Backbone Router.
-         *
-         * @returns  The sequence number of the Backbone Router.
-         *
-         */
-        uint8_t GetSequenceNumber(void) const { return mSequenceNumber; }
-
-        /**
-         * Sets the sequence number of Backbone Router.
-         *
-         * @param[in]  aSequenceNumber  The sequence number of Backbone Router.
-         *
-         */
-        void SetSequenceNumber(uint8_t aSequenceNumber) { mSequenceNumber = aSequenceNumber; }
-
-        /**
-         * Returns the Registration Delay (in seconds) of Backbone Router.
-         *
-         * @returns The BBR Registration Delay (in seconds) of Backbone Router.
-         *
-         */
-        uint16_t GetReregistrationDelay(void) const { return BigEndian::HostSwap16(mReregistrationDelay); }
-
-        /**
-         * Sets the Registration Delay (in seconds) of Backbone Router.
-         *
-         * @param[in]  aReregistrationDelay  The Registration Delay (in seconds) of Backbone Router.
-         *
-         */
-        void SetReregistrationDelay(uint16_t aReregistrationDelay)
-        {
-            mReregistrationDelay = BigEndian::HostSwap16(aReregistrationDelay);
-        }
-
-        /**
-         * Returns the multicast listener report timeout (in seconds) of Backbone Router.
-         *
-         * @returns The multicast listener report timeout (in seconds) of Backbone Router.
-         *
-         */
-        uint32_t GetMlrTimeout(void) const { return BigEndian::HostSwap32(mMlrTimeout); }
-
-        /**
-         * Sets multicast listener report timeout (in seconds) of Backbone Router.
-         *
-         * @param[in]  aMlrTimeout  The multicast listener report timeout (in seconds) of Backbone Router.
-         *
-         */
-        void SetMlrTimeout(uint32_t aMlrTimeout) { mMlrTimeout = BigEndian::HostSwap32(aMlrTimeout); }
-
-    private:
-        uint8_t  mSequenceNumber;
-        uint16_t mReregistrationDelay;
-        uint32_t mMlrTimeout;
-    } OT_TOOL_PACKED_END;
-
-    BackboneRouter(void) = delete;
-};
-
-#endif // #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-
-/**
- * Implements Thread Network Data "DNS/SRP Service Anycast Address" generation and parsing.
- *
- */
-class DnsSrpAnycast
-{
-public:
-    static constexpr uint8_t kServiceNumber = 0x5c; ///< The service number of a `DnsSrpAnycast` entry.
-
-    /**
-     * This constant variable represents the short version of service data.
-     *
-     * The short version of service data contains only service number as a single byte.
-     *
-     */
-    static const uint8_t kServiceData = kServiceNumber;
-
-    /**
-     * Represents information about an DNS/SRP server parsed from related Network Data service entries.
-     *
-     */
-    struct Info
-    {
-        Ip6::Address mAnycastAddress; ///< The anycast address associated with the DNS/SRP servers.
-        uint8_t      mSequenceNumber; ///< Sequence number used to notify SRP client if they need to re-register.
-        uint16_t     mRloc16;         ///< The RLOC16 of the entry.
-    };
-
-    /**
-     * Represents the "DNS/SRP Service (Anycast)" service data.
-     *
-     */
-    OT_TOOL_PACKED_BEGIN
-    class ServiceData
-    {
-    public:
-        /**
-         * Initializes the `ServiceData` object.
-         *
-         * @param[in] aSequenceNumber   The sequence number of "DNS/SRP server" service.
-         *
-         */
-        explicit ServiceData(uint8_t aSequenceNumber)
-            : mServiceNumber(kServiceNumber)
-            , mSequenceNumber(aSequenceNumber)
-        {
-            OT_UNUSED_VARIABLE(mServiceNumber);
-        }
-
-        /**
-         * Returns the length (in bytes) of service data.
-         *
-         * @returns The data length in bytes.
-         *
-         */
-        uint8_t GetLength(void) const { return sizeof(ServiceData); }
-
-        /**
-         * Returns the sequence number.
-         *
-         * @returns The sequence number.
-         *
-         */
-        uint8_t GetSequenceNumber(void) const { return mSequenceNumber; }
-
-    private:
-        uint8_t mServiceNumber;
-        uint8_t mSequenceNumber;
-    } OT_TOOL_PACKED_END;
-
-    DnsSrpAnycast(void) = delete;
+    Ip6::Address mAnycastAddress; ///< The anycast address associated with the DNS/SRP servers.
+    uint8_t      mSequenceNumber; ///< Sequence number used to notify SRP client if they need to re-register.
+    uint16_t     mRloc16;         ///< The RLOC16 of the entry.
 };
 
 /**
- * Implements Thread Network Data DNS/SRP Service (Unicast Address) generation and parsing.
+ * Represents the `DnsSrpUnicast` entry type.
  *
  */
-class DnsSrpUnicast
+enum DnsSrpUnicastType : uint8_t
 {
-public:
-    static constexpr uint8_t kServiceNumber = 0x5d; ///< The service number of `DnsSrpUnicast` entry.
+    kAddrInServiceData, ///< Socket address is from service data.
+    kAddrInServerData,  ///< Socket address is from server data.
+};
 
-    /**
-     * This constant variable represents the short version of service data.
-     *
-     * The short version of service data contains only service number as a single byte.
-     *
-     */
-    static const uint8_t kServiceData = kServiceNumber;
-
-    /**
-     * Represents the `DnsSrpUnicast` entry type.
-     *
-     */
-    enum Type : uint8_t
-    {
-        kFromServiceData, ///< Socket address is from service data.
-        kFromServerData,  ///< Socket address is from server data.
-    };
-
-    /**
-     * Represents information about an DNS/SRP server parsed from related Network Data service entries.
-     *
-     */
-    struct Info
-    {
-        Ip6::SockAddr mSockAddr; ///< The socket address (IPv6 address and port) of the DNS/SRP server.
-        uint16_t      mRloc16;   ///< The BR RLOC16 adding the entry.
-    };
-
-    /**
-     * Represents long version of "DNS/SRP Service (Unicast)" service data.
-     *
-     */
-    OT_TOOL_PACKED_BEGIN
-    class ServiceData
-    {
-    public:
-        /**
-         * Initializes the `ServiceData` object.
-         *
-         * @param[in] aAddress   The IPv6 address of DNS/SRP server.
-         * @param[in] aPort      The port number of DNS/SRP server.
-         *
-         */
-        explicit ServiceData(const Ip6::Address &aAddress, uint16_t aPort)
-            : mServiceNumber(kServiceNumber)
-            , mAddress(aAddress)
-            , mPort(BigEndian::HostSwap16(aPort))
-        {
-            OT_UNUSED_VARIABLE(mServiceNumber);
-        }
-
-        /**
-         * Returns the length (in bytes) of service data.
-         *
-         * @returns The data length in bytes.
-         *
-         */
-        uint8_t GetLength(void) const { return sizeof(ServiceData); }
-
-        /**
-         * Returns the IPv6 address.
-         *
-         * @returns The IPv6 address
-         *
-         */
-        const Ip6::Address &GetAddress(void) const { return mAddress; }
-
-        /**
-         * Returns the port number.
-         *
-         * @returns The port number.
-         *
-         */
-        uint16_t GetPort(void) const { return BigEndian::HostSwap16(mPort); }
-
-    private:
-        uint8_t      mServiceNumber;
-        Ip6::Address mAddress;
-        uint16_t     mPort;
-    } OT_TOOL_PACKED_END;
-
-    /**
-     * Represents long version of "DNS/SRP Service (Unicast)" server data.
-     *
-     */
-    OT_TOOL_PACKED_BEGIN
-    class ServerData
-    {
-    public:
-        /**
-         * Initializes the `ServerData` object.
-         *
-         * @param[in] aAddress   The IPv6 address of DNS/SRP server.
-         * @param[in] aPort      The port number of DNS/SRP server.
-         *
-         */
-        ServerData(const Ip6::Address &aAddress, uint16_t aPort)
-            : mAddress(aAddress)
-            , mPort(BigEndian::HostSwap16(aPort))
-        {
-        }
-
-        /**
-         * Returns the length (in bytes) of server data.
-         *
-         * @returns The data length in bytes.
-         *
-         */
-        uint8_t GetLength(void) const { return sizeof(ServerData); }
-
-        /**
-         * Returns the IPv6 address.
-         *
-         * @returns The IPv6 address
-         *
-         */
-        const Ip6::Address &GetAddress(void) const { return mAddress; }
-
-        /**
-         * Returns the port number.
-         *
-         * @returns The port number.
-         *
-         */
-        uint16_t GetPort(void) const { return BigEndian::HostSwap16(mPort); }
-
-    private:
-        Ip6::Address mAddress;
-        uint16_t     mPort;
-    } OT_TOOL_PACKED_END;
-
-    DnsSrpUnicast(void) = delete;
+/**
+ * Represents information about an DNS/SRP server parsed from related Network Data service entries.
+ *
+ */
+struct DnsSrpUnicastInfo
+{
+    Ip6::SockAddr mSockAddr; ///< The socket address (IPv6 address and port) of the DNS/SRP server.
+    uint16_t      mRloc16;   ///< The BR RLOC16 adding the entry.
 };
 
 /**
@@ -418,121 +137,116 @@ public:
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     /**
-     * Adds a Thread Service entry to the local Thread Network Data.
+     * Adds a DNS/SRP Anycast Service entry to the local Thread Network Data.
      *
-     * This version of `Add<ServiceType>()` is intended for use with a `ServiceType` that has a constant service data
-     * format with a non-empty and potentially non-const server data format (provided as input parameter).
-     *
-     * The template type `ServiceType` has the following requirements:
-     *   - It MUST have a constant variable `ServiceType::kServiceData` specifying the service data.
-     *   - It MUST define nested type `ServiceType::ServerData` representing the server data (and its format).
-     *   - The `ServiceType::ServerData` MUST provide `GetLength()` method returning the length of server data.
-     *
-     * @tparam    ServiceType    The service type to be added.
-     *
-     * @param[in] aServerData    The server data.
-     * @param[in] aServerStable  The Stable flag value for Server TLV.
+     * @param[in] aSequenceNumber  The anycast sequence number.
      *
      * @retval kErrorNone     Successfully added the Service entry.
      * @retval kErrorNoBufs   Insufficient space to add the Service entry.
      *
      */
-    template <typename ServiceType>
-    Error Add(const typename ServiceType::ServerData &aServerData, bool aServerStable = true)
+    Error AddDnsSrpAnycastService(uint8_t aSequenceNumber)
     {
-        return AddService(&ServiceType::kServiceData, sizeof(ServiceType::kServiceData), aServerStable, &aServerData,
-                          aServerData.GetLength());
+        return AddService(DnsSrpAnycastServiceData(aSequenceNumber));
     }
 
     /**
-     * Adds a Thread Service entry to the local Thread Network Data.
+     * Removes a DNS/SRP Anycast Service entry from local Thread Network Data.
      *
-     * This version of `Add<ServiceType>()` is intended for use with a `ServiceType` that has a non-const service data
-     * format (provided as input parameter) with an empty server data.
+     * @param[in] aSequenceNumber  The anycast sequence number.
      *
-     * The template type `ServiceType` has the following requirements:
-     *   - It MUST define nested type `ServiceType::ServiceData` representing the service data (and its format).
-     *   - The `ServiceType::ServiceData` MUST provide `GetLength()` method returning the length of service data.
+     * @retval kErrorNone       Successfully removed the Service entry.
+     * @retval kErrorNotFound   Could not find the Service entry.
      *
-     * @tparam    ServiceType    The service type to be added.
+     */
+    Error RemoveDnsSrpAnycastService(uint8_t aSequenceNumber)
+    {
+        return RemoveService(DnsSrpAnycastServiceData(aSequenceNumber));
+    }
+
+    /**
+     * Adds a DNS/SRP Unicast Service entry with address in Service Data to the local Thread Network Data.
      *
-     * @param[in] aServiceData   The service data.
-     * @param[in] aServerStable  The Stable flag value for Server TLV.
+     * @param[in] aAddress    The unicast address.
+     * @param[in] aPort       The port number.
      *
      * @retval kErrorNone     Successfully added the Service entry.
      * @retval kErrorNoBufs   Insufficient space to add the Service entry.
      *
      */
-    template <typename ServiceType>
-    Error Add(const typename ServiceType::ServiceData &aServiceData, bool aServerStable = true)
+    Error AddDnsSrpUnicastServiceWithAddrInServiceData(const Ip6::Address &aAddress, uint16_t aPort)
     {
-        return AddService(&aServiceData, aServiceData.GetLength(), aServerStable, nullptr, 0);
+        return AddService(DnsSrpUnicast::ServiceData(aAddress, aPort));
     }
 
     /**
-     * Removes a Thread Service entry from the local Thread Network Data.
+     * Removes a DNS/SRP Unicast Service entry with address in Service Data from the local Thread Network Data.
      *
-     * This version of `Remove<SeviceType>()` is intended for use with a `ServiceType` that has a constant service data
-     * format.
-     *
-     * The template type `ServiceType` has the following requirements:
-     *   - It MUST have a constant variable `ServiceType::kServiceData` specifying the service data.
-     *
-     * @tparam   ServiceType       The service type to be removed.
+     * @param[in] aAddress    The unicast address.
+     * @param[in] aPort       The port number.
      *
      * @retval kErrorNone       Successfully removed the Service entry.
      * @retval kErrorNotFound   Could not find the Service entry.
      *
      */
-    template <typename ServiceType> Error Remove(void)
+    Error RemoveDnsSrpUnicastServiceWithAddrInServiceData(const Ip6::Address &aAddress, uint16_t aPort)
     {
-        return RemoveService(&ServiceType::kServiceData, sizeof(ServiceType::kServiceData));
+        return RemoveService(DnsSrpUnicast::ServiceData(aAddress, aPort));
     }
 
     /**
-     * Removes a Thread Service entry from the local Thread Network Data.
+     * Adds a DNS/SRP Unicast Service entry with address in Server Data to the local Thread Network Data.
      *
-     * This version of `Remove<ServiceType>()` is intended for use with a `ServiceType` that has a non-const service
-     * data format (provided as input parameter).
+     * @param[in] aAddress    The unicast address.
+     * @param[in] aPort       The port number.
      *
-     * The template type `ServiceType` has the following requirements:
-     *   - It MUST define nested type `ServiceType::ServiceData` representing the service data (and its format).
-     *   - The `ServiceType::ServiceData` MUST provide `GetLength()` method returning the length of service data.
+     * @retval kErrorNone     Successfully added the Service entry.
+     * @retval kErrorNoBufs   Insufficient space to add the Service entry.
      *
-     * @tparam   ServiceType       The service type to be removed.
-     *
-     * @param[in] aServiceData     The service data.
+     */
+    Error AddDnsSrpUnicastServiceWithAddrInServerData(const Ip6::Address &aAddress, uint16_t aPort)
+    {
+        return AddService(kDnsSrpUnicastServiceNumber, DnsSrpUnicast::ServerData(aAddress, aPort));
+    }
+
+    /**
+     * Removes a DNS/SRP Unicast Service entry with address in Server Data from the local Thread Network Data.
      *
      * @retval kErrorNone       Successfully removed the Service entry.
      * @retval kErrorNotFound   Could not find the Service entry.
      *
      */
-    template <typename ServiceType> Error Remove(const typename ServiceType::ServiceData &aServiceData)
+    Error RemoveDnsSrpUnicastServiceWithAddrInServerData(void) { return RemoveService(kDnsSrpUnicastServiceNumber); }
+
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
+    /**
+     * Adds a Backbone Router Service entry to the local Thread Network Data.
+     *
+     * @param[in]  aSequenceNumber       The sequence number of Backbone Router.
+     * @param[in]  aReregistrationDelay  The Registration Delay (in seconds) of Backbone Router.
+     * @param[in]  aMlrTimeout           The multicast listener report timeout (in seconds) of Backbone Router.
+     *
+     * @retval kErrorNone     Successfully added the Service entry.
+     * @retval kErrorNoBufs   Insufficient space to add the Service entry.
+     *
+     */
+    Error AddBackboneRouterService(uint8_t aSequenceNumber, uint16_t aReregistrationDelay, uint32_t aMlrTimeout)
     {
-        return RemoveService(&aServiceData, aServiceData.GetLength());
+        return AddService(kBackboneRouterServiceNumber,
+                          BbrServerData(aSequenceNumber, aReregistrationDelay, aMlrTimeout));
     }
+
+    /**
+     * Removes the Backbone Router Service entry from the local Thread Network Data.
+     *
+     * @retval kErrorNone       Successfully removed the Service entry.
+     * @retval kErrorNotFound   Could not find the Service entry.
+     *
+     */
+    Error RemoveBackboneRouterService(void) { return RemoveService(kBackboneRouterServiceNumber); }
+#endif
 
 #endif // OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-
-    /**
-     * Gets the Service ID for the specified service from Thread Network Data.
-     *
-     * The template type `ServiceType` has the following requirements:
-     *   - It MUST have a constant `ServiceType::kServiceNumber` specifying the service number.
-     *
-     * @tparam     ServiceType     The service type to be added.
-     *
-     * @param[in]  aServerStable   The Stable flag value for Server TLV
-     * @param[out] aServiceId      A reference where to put the Service ID.
-     *
-     * @retval kErrorNone       Successfully got the Service ID.
-     * @retval kErrorNotFound   The specified service was not found.
-     *
-     */
-    template <typename ServiceType> Error GetServiceId(bool aServerStable, uint8_t &aServiceId) const
-    {
-        return GetServiceId(&ServiceType::kServiceData, sizeof(ServiceType::kServiceData), aServerStable, aServiceId);
-    }
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
     /**
@@ -542,6 +256,20 @@ public:
      *
      */
     void GetBackboneRouterPrimary(ot::BackboneRouter::Config &aConfig) const;
+
+    /**
+     * Gets the Service ID of Backbone Router service from Thread Network Data.
+     *
+     * @param[out] aServiceId      A reference where to put the Service ID.
+     *
+     * @retval kErrorNone       Successfully got the Service ID.
+     * @retval kErrorNotFound   The specified service was not found.
+     *
+     */
+    Error GetBackboneRouterServiceId(uint8_t &aServiceId) const
+    {
+        return GetServiceId(kBackboneRouterServiceNumber, aServiceId);
+    }
 #endif
 
     /**
@@ -551,13 +279,13 @@ public:
      * method).
      *
      * @param[in,out] aIterator    A reference to an iterator.
-     * @param[out]    aInfo        A reference to `DnsSrpAnycast::Info` to return the info.
+     * @param[out]    aInfo        A reference to `DnsSrpAnycastInfo` to return the info.
      *
      * @retval kErrorNone       Successfully got the next info. @p aInfo and @p aIterator are updated.
      * @retval kErrorNotFound   No more matching entries in the Network Data.
      *
      */
-    Error GetNextDnsSrpAnycastInfo(Iterator &aIterator, DnsSrpAnycast::Info &aInfo) const;
+    Error GetNextDnsSrpAnycastInfo(Iterator &aIterator, DnsSrpAnycastInfo &aInfo) const;
 
     /**
      * Finds the preferred DNS/SRP info among all the Thread Network Data "DNS/SRP Service Anycast Address"
@@ -566,13 +294,13 @@ public:
      * The preferred entry is determined based on the sequence number value where a larger value (in the sense
      * specified by Serial Number Arithmetic logic in RFC-1982) is considered more recent and therefore preferred.
      *
-     * @param[out] aInfo        A reference to `DnsSrpAnycast::Info` to return the info.
+     * @param[out] aInfo        A reference to `DnsSrpAnycastInfo` to return the info.
      *
      * @retval kErrorNone       Successfully found the preferred info. @p aInfo is updated.
      * @retval kErrorNotFound   No "DNS/SRP Service Anycast" entry in Network Data.
      *
      */
-    Error FindPreferredDnsSrpAnycastInfo(DnsSrpAnycast::Info &aInfo) const;
+    Error FindPreferredDnsSrpAnycastInfo(DnsSrpAnycastInfo &aInfo) const;
 
     /**
      * Gets the next DNS/SRP info from the Thread Network Data "DNS/SRP Service Unicast Address" entries.
@@ -581,36 +309,139 @@ public:
      * method).
      *
      * @param[in,out] aIterator    A reference to an iterator.
-     * @param[in]     aType        The entry type, `kFromServiceData` (preferred) or `kFromServerData` (non-preferred).
-     * @param[out]    aInfo        A reference to `DnsSrpUnicast::Info` to return the info.
+     * @param[in]     aType        The entry type, `kAddrInServiceData` or `kAddrInServerData`
+     * @param[out]    aInfo        A reference to `DnsSrpUnicastInfo` to return the info.
      *
      * @retval kErrorNone       Successfully got the next info. @p aInfo and @p aIterator are updated.
      * @retval kErrorNotFound   No more matching entries in the Network Data.
      *
      */
-    Error GetNextDnsSrpUnicastInfo(Iterator &aIterator, DnsSrpUnicast::Type aType, DnsSrpUnicast::Info &aInfo) const;
+    Error GetNextDnsSrpUnicastInfo(Iterator &aIterator, DnsSrpUnicastType aType, DnsSrpUnicastInfo &aInfo) const;
 
 private:
+    static constexpr uint8_t kBackboneRouterServiceNumber = 0x01;
+    static constexpr uint8_t kDnsSrpAnycastServiceNumber  = 0x5c;
+    static constexpr uint8_t kDnsSrpUnicastServiceNumber  = 0x5d;
+
+    OT_TOOL_PACKED_BEGIN
+    class DnsSrpAnycastServiceData
+    {
+    public:
+        explicit DnsSrpAnycastServiceData(uint8_t aSequenceNumber)
+            : mServiceNumber(kDnsSrpAnycastServiceNumber)
+            , mSequenceNumber(aSequenceNumber)
+        {
+            OT_UNUSED_VARIABLE(mServiceNumber);
+        }
+
+        uint8_t GetSequenceNumber(void) const { return mSequenceNumber; }
+
+    private:
+        uint8_t mServiceNumber;
+        uint8_t mSequenceNumber;
+    } OT_TOOL_PACKED_END;
+
+    class DnsSrpUnicast
+    {
+    public:
+        OT_TOOL_PACKED_BEGIN
+        struct ServiceData
+        {
+        public:
+            explicit ServiceData(const Ip6::Address &aAddress, uint16_t aPort)
+                : mServiceNumber(kDnsSrpUnicastServiceNumber)
+                , mAddress(aAddress)
+                , mPort(BigEndian::HostSwap16(aPort))
+            {
+                OT_UNUSED_VARIABLE(mServiceNumber);
+            }
+
+            const Ip6::Address &GetAddress(void) const { return mAddress; }
+            uint16_t            GetPort(void) const { return BigEndian::HostSwap16(mPort); }
+
+        private:
+            uint8_t      mServiceNumber;
+            Ip6::Address mAddress;
+            uint16_t     mPort;
+        } OT_TOOL_PACKED_END;
+
+        OT_TOOL_PACKED_BEGIN
+        class ServerData
+        {
+        public:
+            ServerData(const Ip6::Address &aAddress, uint16_t aPort)
+                : mAddress(aAddress)
+                , mPort(BigEndian::HostSwap16(aPort))
+            {
+            }
+
+            const Ip6::Address &GetAddress(void) const { return mAddress; }
+            uint16_t            GetPort(void) const { return BigEndian::HostSwap16(mPort); }
+
+        private:
+            Ip6::Address mAddress;
+            uint16_t     mPort;
+        } OT_TOOL_PACKED_END;
+
+        DnsSrpUnicast(void) = delete;
+    };
+
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
+    OT_TOOL_PACKED_BEGIN
+    class BbrServerData
+    {
+    public:
+        BbrServerData(uint8_t aSequenceNumber, uint16_t aReregDelay, uint32_t aMlrTimeout)
+            : mSequenceNumber(aSequenceNumber)
+            , mReregDelay(BigEndian::HostSwap16(aReregDelay))
+            , mMlrTimeout(BigEndian::HostSwap32(aMlrTimeout))
+        {
+        }
+
+        uint8_t  GetSequenceNumber(void) const { return mSequenceNumber; }
+        uint16_t GetReregistrationDelay(void) const { return BigEndian::HostSwap16(mReregDelay); }
+        uint32_t GetMlrTimeout(void) const { return BigEndian::HostSwap32(mMlrTimeout); }
+
+    private:
+        uint8_t  mSequenceNumber;
+        uint16_t mReregDelay;
+        uint32_t mMlrTimeout;
+    } OT_TOOL_PACKED_END;
+#endif
+
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+    template <typename ServiceDataType> Error AddService(const ServiceDataType &aServiceData)
+    {
+        return AddService(&aServiceData, sizeof(ServiceDataType), nullptr, 0);
+    }
+
+    template <typename ServerDataType> Error AddService(uint8_t aServiceNumber, const ServerDataType &aServerData)
+    {
+        return AddService(&aServiceNumber, sizeof(uint8_t), &aServerData, sizeof(ServerDataType));
+    }
+
     Error AddService(const void *aServiceData,
                      uint8_t     aServiceDataLength,
-                     bool        aServerStable,
-                     const void *aServerData,
-                     uint8_t     aServerDataLength);
+                     const void *aServerData       = nullptr,
+                     uint8_t     aServerDataLength = 0);
+
+    template <typename ServiceDataType> Error RemoveService(const ServiceDataType &aServiceData)
+    {
+        return RemoveService(&aServiceData, sizeof(ServiceDataType));
+    }
+
+    Error RemoveService(uint8_t aServiceNumber) { return RemoveService(&aServiceNumber, sizeof(uint8_t)); }
     Error RemoveService(const void *aServiceData, uint8_t aServiceDataLength);
 #endif
 
-    Error GetServiceId(const void *aServiceData,
-                       uint8_t     aServiceDataLength,
-                       bool        aServerStable,
-                       uint8_t    &aServiceId) const;
+    Error GetServiceId(uint8_t aServiceNumber, uint8_t &aServiceId) const;
     Error IterateToNextServer(Iterator &aIterator) const;
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-    bool IsBackboneRouterPreferredTo(const ServerTlv                  &aServerTlv,
-                                     const BackboneRouter::ServerData &aServerData,
-                                     const ServerTlv                  &aOtherServerTlv,
-                                     const BackboneRouter::ServerData &aOtherServerData) const;
+    bool IsBackboneRouterPreferredTo(const ServerTlv     &aServerTlv,
+                                     const BbrServerData &aServerData,
+                                     const ServerTlv     &aOtherServerTlv,
+                                     const BbrServerData &aOtherServerData) const;
 #endif
 };
 

--- a/tests/unit/test_network_data.cpp
+++ b/tests/unit/test_network_data.cpp
@@ -637,7 +637,7 @@ void TestNetworkDataDsnSrpServices(void)
             uint8_t  mSequenceNumber;
             uint16_t mRloc16;
 
-            bool Matches(Service::DnsSrpAnycast::Info aInfo) const
+            bool Matches(Service::DnsSrpAnycastInfo aInfo) const
             {
                 VerifyOrQuit(aInfo.mAnycastAddress.GetIid().IsAnycastServiceLocator());
 
@@ -652,7 +652,7 @@ void TestNetworkDataDsnSrpServices(void)
             uint16_t    mPort;
             uint16_t    mRloc16;
 
-            bool Matches(const Service::DnsSrpUnicast::Info &aInfo) const
+            bool Matches(const Service::DnsSrpUnicastInfo &aInfo) const
             {
                 Ip6::SockAddr sockAddr;
 
@@ -699,12 +699,12 @@ void TestNetworkDataDsnSrpServices(void)
 
         const uint8_t kPreferredAnycastEntryIndex = 2;
 
-        Service::Manager            &manager = instance->Get<Service::Manager>();
-        Service::Manager::Iterator   iterator;
-        Service::DnsSrpAnycast::Info anycastInfo;
-        Service::DnsSrpUnicast::Info unicastInfo;
-        Service::DnsSrpUnicast::Type type;
-        Rlocs                        rlocs;
+        Service::Manager          &manager = instance->Get<Service::Manager>();
+        Service::Manager::Iterator iterator;
+        Service::DnsSrpAnycastInfo anycastInfo;
+        Service::DnsSrpUnicastInfo unicastInfo;
+        Service::DnsSrpUnicastType type;
+        Rlocs                      rlocs;
 
         reinterpret_cast<TestLeader &>(instance->Get<Leader>()).Populate(kNetworkData, sizeof(kNetworkData));
 
@@ -756,7 +756,7 @@ void TestNetworkDataDsnSrpServices(void)
         printf("\nDNS/SRP Unicast Service entries (server data)\n");
 
         iterator.Clear();
-        type = Service::DnsSrpUnicast::kFromServerData;
+        type = Service::kAddrInServerData;
 
         for (const UnicastEntry &entry : kUnicastEntriesFromServerData)
         {
@@ -774,7 +774,7 @@ void TestNetworkDataDsnSrpServices(void)
         printf("\nDNS/SRP Unicast Service entries (service data)\n");
 
         iterator.Clear();
-        type = Service::DnsSrpUnicast::kFromServiceData;
+        type = Service::kAddrInServiceData;
 
         for (const UnicastEntry &entry : kUnicastEntriesFromServiceData)
         {
@@ -947,8 +947,8 @@ void TestNetworkDataDsnSrpAnycastSeqNumSelection(void)
 
     for (const TestInfo &test : kTests)
     {
-        Service::Manager::Iterator   iterator;
-        Service::DnsSrpAnycast::Info anycastInfo;
+        Service::Manager::Iterator iterator;
+        Service::DnsSrpAnycastInfo anycastInfo;
 
         reinterpret_cast<TestLeader &>(instance->Get<Leader>()).Populate(test.mNetworkData, test.mNetworkDataLength);
 


### PR DESCRIPTION
This commit updates the `NetworkData::Service::Manager` class to provide helper methods for adding and removing different service types (DNS/SRP anycast or unicast services, backbone router service).

With this change, the definitions of `ServiceData` and `ServerData` formats for different service types are now `private` to the `Service::Manager` class. This centralizes the logic for constructing and parsing the service/server TLVs, making it easier to update and add new fields to these formats in the future.

----

~This PR contains the commit from https://github.com/openthread/openthread/pull/10620. Please check and review the second commit. Thanks.~ 
