### PR TITLE
[routing-manager] advertise deprecating RIO prefixes with low preference

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1302,7 +1302,10 @@ private:
 
         void  SetPreferenceBasedOnRole(void);
         void  UpdatePreference(RoutePreference aPreference);
-        Error AppendRio(const Ip6::Prefix &aPrefix, uint32_t aRouteLifetime, RouterAdvert::TxMessage &aRaMessage);
+        Error AppendRio(const Ip6::Prefix       &aPrefix,
+                        uint32_t                 aRouteLifetime,
+                        RoutePreference          aPreference,
+                        RouterAdvert::TxMessage &aRaMessage);
 
         using RioTimer = TimerMilliIn<RoutingManager, &RoutingManager::HandleRioAdvertiserimer>;
 

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -183,6 +183,8 @@ Array<DeprecatingPrefix, kMaxDeprecatingPrefixes> sDeprecatingPrefixes;
 
 static constexpr uint16_t kMaxRioPrefixes = 10;
 
+using NetworkData::RoutePreference;
+
 struct RioPrefix
 {
     RioPrefix(void) = default;
@@ -191,12 +193,14 @@ struct RioPrefix
         : mSawInRa(false)
         , mPrefix(aPrefix)
         , mLifetime(0)
+        , mPreference(NetworkData::kRoutePreferenceMedium)
     {
     }
 
-    bool        mSawInRa;  // Indicate whether or not this prefix was seen in the emitted RA (as RIO).
-    Ip6::Prefix mPrefix;   // The RIO prefix.
-    uint32_t    mLifetime; // The RIO prefix lifetime - only valid when `mSawInRa`
+    bool            mSawInRa;    // Indicate whether or not this prefix was seen in the emitted RA (as RIO).
+    Ip6::Prefix     mPrefix;     // The RIO prefix.
+    uint32_t        mLifetime;   // The RIO prefix lifetime - only valid when `mSawInRa`
+    RoutePreference mPreference; // The RIO preference - only valid when `mSawInRa`
 };
 
 class ExpectedRios : public Array<RioPrefix, kMaxRioPrefixes>
@@ -531,8 +535,9 @@ void ValidateRouterAdvert(const Icmp6Packet &aPacket)
             {
                 if (prefix == rioPrefix.mPrefix)
                 {
-                    rioPrefix.mSawInRa  = true;
-                    rioPrefix.mLifetime = rio.GetRouteLifetime();
+                    rioPrefix.mSawInRa    = true;
+                    rioPrefix.mLifetime   = rio.GetRouteLifetime();
+                    rioPrefix.mPreference = rio.GetPreference();
                 }
             }
 
@@ -740,8 +745,6 @@ void VerifyNoOmrPrefixInNetData(void)
     Log("VerifyNoOmrPrefixInNetData()");
     VerifyOrQuit(otNetDataGetNextOnMeshPrefix(sInstance, &iterator, &prefixConfig) != kErrorNone);
 }
-
-using NetworkData::RoutePreference;
 
 enum ExternalRouteMode : uint8_t
 {
@@ -1419,6 +1422,7 @@ void TestOmrSelection(void)
     VerifyOrQuit(sRaValidated);
     VerifyOrQuit(sExpectedRios.SawAll());
     VerifyOrQuit(sExpectedRios[0].mLifetime == kRioValidLifetime);
+    VerifyOrQuit(sExpectedRios[0].mPreference == NetworkData::kRoutePreferenceMedium);
 
     Log("Received RA was validated");
 
@@ -1460,7 +1464,9 @@ void TestOmrSelection(void)
     VerifyOrQuit(sRaValidated);
     VerifyOrQuit(sExpectedRios.SawAll());
     VerifyOrQuit(sExpectedRios[0].mLifetime == kRioValidLifetime);
+    VerifyOrQuit(sExpectedRios[0].mPreference == NetworkData::kRoutePreferenceMedium);
     VerifyOrQuit(sExpectedRios[1].mLifetime <= kRioDeprecatingLifetime);
+    VerifyOrQuit(sExpectedRios[1].mPreference == NetworkData::kRoutePreferenceLow);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Check Network Data. We should now see that the local OMR prefix
@@ -1491,7 +1497,9 @@ void TestOmrSelection(void)
     VerifyOrQuit(sRaValidated);
     VerifyOrQuit(sExpectedRios.SawAll());
     VerifyOrQuit(sExpectedRios[0].mLifetime <= kRioDeprecatingLifetime);
+    VerifyOrQuit(sExpectedRios[0].mPreference == NetworkData::kRoutePreferenceLow);
     VerifyOrQuit(sExpectedRios[1].mLifetime == kRioValidLifetime);
+    VerifyOrQuit(sExpectedRios[1].mPreference == NetworkData::kRoutePreferenceMedium);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Check Network Data. We should see that the local OMR prefix is
@@ -1514,6 +1522,7 @@ void TestOmrSelection(void)
     VerifyOrQuit(sExpectedRios.SawAll());
     VerifyOrQuit(sExpectedRios[0].mLifetime == 0);
     VerifyOrQuit(sExpectedRios[1].mLifetime == kRioValidLifetime);
+    VerifyOrQuit(sExpectedRios[0].mPreference == NetworkData::kRoutePreferenceLow);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -2202,6 +2211,7 @@ void TestDomainPrefixAsOmr(void)
     VerifyOrQuit(sExpectedRios[1].mPrefix == localOmr);
     VerifyOrQuit(sExpectedRios[1].mSawInRa);
     VerifyOrQuit(sExpectedRios[1].mLifetime <= kRioDeprecatingLifetime);
+    VerifyOrQuit(sExpectedRios[1].mPreference == NetworkData::kRoutePreferenceLow);
 
     // Wait long enough for deprecating RIO prefix to expire
     AdvanceTime(3200000);


### PR DESCRIPTION
This commit updates `RoutingManager::RioAdvertiser` to advertise deprecating prefixes with `NetworkData::kkRoutePreferenceLow`. `test_routing_manager` is updated to validate this new behavior.

-----

Related to [SPEC-1272](https://threadgroup.atlassian.net/browse/SPEC-1272).