### PR TITLE
[mle] include Link Margin TLV in Child Update messages

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2211,6 +2211,7 @@ void MleRouter::HandleChildUpdateRequest(RxInfo &aRxInfo)
     child->SetDeviceMode(mode);
 
     tlvList.Add(Tlv::kMode);
+    tlvList.Add(Tlv::kLinkMargin);
 
     // Parent MUST include Leader Data TLV in Child Update Response
     tlvList.Add(Tlv::kLeaderData);
@@ -2921,7 +2922,11 @@ Error MleRouter::SendChildUpdateRequest(Child &aChild)
     SuccessOrExit(error = message->AppendNetworkDataTlv(aChild.GetNetworkDataType()));
     SuccessOrExit(error = message->AppendActiveAndPendingTimestampTlvs());
 
-    if (!aChild.IsStateValid())
+    if (aChild.IsStateValid())
+    {
+        SuccessOrExit(error = message->AppendLinkMarginTlv(aChild.GetLinkInfo().GetLinkMargin()));
+    }
+    else
     {
         SuccessOrExit(error = message->AppendTlvRequestTlv(kTlvs));
 
@@ -3027,6 +3032,10 @@ void MleRouter::SendChildUpdateResponse(Child                  *aChild,
 
         case Tlv::kTimeout:
             SuccessOrExit(error = message->AppendTimeoutTlv(aChild->GetTimeout()));
+            break;
+
+        case Tlv::kLinkMargin:
+            SuccessOrExit(error = message->AppendLinkMarginTlv(aChild->GetLinkInfo().GetLinkMargin()));
             break;
 
         case Tlv::kSupervisionInterval:


### PR DESCRIPTION
This commit adds code to include the Link Margin TLV in MLE Child Update Request or Response messages sent by a parent to a child. This allows the child to learn and update its "link quality out" to its parent.

The change is designed to be backward compatible. Child devices running older firmware will simply disregard this additional TLV. When processing the message, the presence of the Link Margin TLV is checked (it is optional).

---

Related to [SPEC-1245](https://threadgroup.atlassian.net/browse/SPEC-1245).

~This PR currently contains the commit from https://github.com/openthread/openthread/pull/10627. Please review the last commit. Thanks.~