### PR TITLE
[thread-cert] relax TLV type checks in `pktverify`

### DIFF
--- a/tests/scripts/thread-cert/Cert_5_1_01_RouterAttach.py
+++ b/tests/scripts/thread-cert/Cert_5_1_01_RouterAttach.py
@@ -245,7 +245,7 @@ class Cert_5_1_01_RouterAttach(thread_cert.TestCase):
             filter(lambda p: {
                               NL_MAC_EXTENDED_ADDRESS_TLV,
                               NL_STATUS_TLV
-                              } == set(p.coap.tlv.type)\
+                              } <= set(p.coap.tlv.type)\
                    ).\
            must_next()
 
@@ -265,7 +265,7 @@ class Cert_5_1_01_RouterAttach(thread_cert.TestCase):
                               NL_STATUS_TLV,
                               NL_RLOC16_TLV,
                               NL_ROUTER_MASK_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.coap.code == COAP_CODE_ACK and\
                    p.thread_address.tlv.status == 0\
                    ).\
@@ -289,7 +289,7 @@ class Cert_5_1_01_RouterAttach(thread_cert.TestCase):
                               LEADER_DATA_TLV,
                               ROUTE64_TLV,
                               SOURCE_ADDRESS_TLV
-                              } == set(p.mle.tlv.type) and\
+                              } <= set(p.mle.tlv.type) and\
                    p.ipv6.hlim == 255).\
             must_next()
 

--- a/tests/scripts/thread-cert/Cert_5_1_04_RouterAddressReallocation.py
+++ b/tests/scripts/thread-cert/Cert_5_1_04_RouterAddressReallocation.py
@@ -256,7 +256,7 @@ class Cert_5_1_04_RouterAddressReallocation(thread_cert.TestCase):
                               NL_STATUS_TLV,
                               NL_RLOC16_TLV,
                               NL_ROUTER_MASK_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.coap.code == COAP_CODE_ACK and\
                    p.thread_address.tlv.rloc16 ==
                    _pkt_as.thread_address.tlv.rloc16 and\

--- a/tests/scripts/thread-cert/Cert_5_1_05_RouterAddressTimeout.py
+++ b/tests/scripts/thread-cert/Cert_5_1_05_RouterAddressTimeout.py
@@ -117,7 +117,7 @@ class Cert_5_1_05_RouterAddressTimeout(thread_cert.TestCase):
                               NL_STATUS_TLV,
                               NL_RLOC16_TLV,
                               NL_ROUTER_MASK_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.coap.code == COAP_CODE_ACK and\
                    p.thread_address.tlv.status == 0
                    ).\
@@ -196,7 +196,7 @@ class Cert_5_1_05_RouterAddressTimeout(thread_cert.TestCase):
                               NL_MAC_EXTENDED_ADDRESS_TLV,
                               NL_RLOC16_TLV,
                               NL_STATUS_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.coap.code == COAP_CODE_POST and\
                    p.thread_address.tlv.rloc16 ==
                    _pkt_as.thread_address.tlv.rloc16
@@ -209,7 +209,7 @@ class Cert_5_1_05_RouterAddressTimeout(thread_cert.TestCase):
                               NL_STATUS_TLV,
                               NL_RLOC16_TLV,
                               NL_ROUTER_MASK_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.coap.code == COAP_CODE_ACK and\
                    p.thread_address.tlv.rloc16 !=
                    _pkt_as2.thread_address.tlv.rloc16 and\
@@ -288,7 +288,7 @@ class Cert_5_1_05_RouterAddressTimeout(thread_cert.TestCase):
                               NL_MAC_EXTENDED_ADDRESS_TLV,
                               NL_RLOC16_TLV,
                               NL_STATUS_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.coap.code == COAP_CODE_POST and\
                    p.thread_address.tlv.rloc16 ==
                    _pkt_as3.thread_address.tlv.rloc16
@@ -301,7 +301,7 @@ class Cert_5_1_05_RouterAddressTimeout(thread_cert.TestCase):
                               NL_STATUS_TLV,
                               NL_RLOC16_TLV,
                               NL_ROUTER_MASK_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.coap.code == COAP_CODE_ACK and\
                    p.thread_address.tlv.rloc16 ==
                    _pkt_as3.thread_address.tlv.rloc16 and\

--- a/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
+++ b/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
@@ -111,7 +111,7 @@ class Cert_5_1_06_RemoveRouterId(thread_cert.TestCase):
                               NL_STATUS_TLV,
                               NL_RLOC16_TLV,
                               NL_ROUTER_MASK_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.coap.code == COAP_CODE_ACK and\
                    p.thread_address.tlv.status == 0
                    ).\
@@ -162,7 +162,7 @@ class Cert_5_1_06_RemoveRouterId(thread_cert.TestCase):
                               NL_MAC_EXTENDED_ADDRESS_TLV,
                               NL_RLOC16_TLV,
                               NL_STATUS_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.coap.code == COAP_CODE_POST and\
                    p.thread_address.tlv.rloc16 ==
                    _pkt_as.thread_address.tlv.rloc16
@@ -175,7 +175,7 @@ class Cert_5_1_06_RemoveRouterId(thread_cert.TestCase):
                               NL_STATUS_TLV,
                               NL_RLOC16_TLV,
                               NL_ROUTER_MASK_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.coap.code == COAP_CODE_ACK and\
                    p.thread_address.tlv.rloc16 !=
                    _pkt_as.thread_address.tlv.rloc16 and\

--- a/tests/scripts/thread-cert/Cert_5_1_12_NewRouterNeighborSync.py
+++ b/tests/scripts/thread-cert/Cert_5_1_12_NewRouterNeighborSync.py
@@ -122,7 +122,7 @@ class Cert_5_1_12_NewRouterSync(thread_cert.TestCase):
                               LEADER_DATA_TLV,
                               ROUTE64_TLV,
                               SOURCE_ADDRESS_TLV
-                              } == set(p.mle.tlv.type) and\
+                              } <= set(p.mle.tlv.type) and\
                    p.ipv6.hlim == 255).\
             must_next()
 
@@ -134,7 +134,7 @@ class Cert_5_1_12_NewRouterSync(thread_cert.TestCase):
                               LEADER_DATA_TLV,
                               ROUTE64_TLV,
                               SOURCE_ADDRESS_TLV
-                              } == set(p.mle.tlv.type) and\
+                              } <= set(p.mle.tlv.type) and\
                    p.ipv6.hlim == 255).\
             must_next()
 

--- a/tests/scripts/thread-cert/Cert_5_1_13_RouterReset.py
+++ b/tests/scripts/thread-cert/Cert_5_1_13_RouterReset.py
@@ -122,7 +122,7 @@ class Cert_5_1_13_RouterReset(thread_cert.TestCase):
                               LEADER_DATA_TLV,
                               ROUTE64_TLV,
                               SOURCE_ADDRESS_TLV
-                              } == set(p.mle.tlv.type) and\
+                              } <= set(p.mle.tlv.type) and\
                    p.ipv6.hlim == 255
                    ).\
             must_next()
@@ -133,7 +133,7 @@ class Cert_5_1_13_RouterReset(thread_cert.TestCase):
                               LEADER_DATA_TLV,
                               ROUTE64_TLV,
                               SOURCE_ADDRESS_TLV
-                              } == set(p.mle.tlv.type) and\
+                              } <= set(p.mle.tlv.type) and\
                    p.ipv6.hlim == 255
                    ).\
             must_next()

--- a/tests/scripts/thread-cert/Cert_5_2_01_REEDAttach.py
+++ b/tests/scripts/thread-cert/Cert_5_2_01_REEDAttach.py
@@ -144,7 +144,7 @@ class Cert_5_2_01_REEDAttach(thread_cert.TestCase):
                               LEADER_DATA_TLV,
                               ROUTE64_TLV,
                               SOURCE_ADDRESS_TLV
-                              } == set(p.mle.tlv.type) and\
+                              } <= set(p.mle.tlv.type) and\
                    p.ipv6.hlim == 255
                    ).\
             must_next()
@@ -243,7 +243,7 @@ class Cert_5_2_01_REEDAttach(thread_cert.TestCase):
             filter(lambda p: {
                               NL_MAC_EXTENDED_ADDRESS_TLV,
                               NL_STATUS_TLV
-                              } == set(p.coap.tlv.type)\
+                              } <= set(p.coap.tlv.type)\
                    ).\
            must_next()
 
@@ -263,7 +263,7 @@ class Cert_5_2_01_REEDAttach(thread_cert.TestCase):
             filter(lambda p: {
                               NL_MAC_EXTENDED_ADDRESS_TLV,
                               NL_STATUS_TLV
-                              } == set(p.coap.tlv.type)\
+                              } <= set(p.coap.tlv.type)\
                    ).\
            must_next()
 
@@ -274,7 +274,7 @@ class Cert_5_2_01_REEDAttach(thread_cert.TestCase):
                               NL_STATUS_TLV,
                               NL_RLOC16_TLV,
                               NL_ROUTER_MASK_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.coap.code == COAP_CODE_ACK and\
                    p.thread_address.tlv.status == 0\
                    ).\
@@ -286,7 +286,7 @@ class Cert_5_2_01_REEDAttach(thread_cert.TestCase):
                               NL_STATUS_TLV,
                               NL_RLOC16_TLV,
                               NL_ROUTER_MASK_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.coap.code == COAP_CODE_ACK and\
                    p.thread_address.tlv.status == 0\
                    ).\

--- a/tests/scripts/thread-cert/Cert_5_2_03_LeaderReject2Hops.py
+++ b/tests/scripts/thread-cert/Cert_5_2_03_LeaderReject2Hops.py
@@ -350,7 +350,7 @@ class Cert_5_2_3_LeaderReject2Hops(thread_cert.TestCase):
             filter(lambda p: {
                               NL_MAC_EXTENDED_ADDRESS_TLV,
                               NL_STATUS_TLV
-                              } == set(p.coap.tlv.type)
+                              } <= set(p.coap.tlv.type)
                   ).\
             must_next()
 
@@ -370,7 +370,7 @@ class Cert_5_2_3_LeaderReject2Hops(thread_cert.TestCase):
                               NL_STATUS_TLV,
                               NL_RLOC16_TLV,
                               NL_ROUTER_MASK_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.coap.code == COAP_CODE_ACK and\
                    p.thread_address.tlv.status == ADDR_SOL_SUCCESS\
                    ).\
@@ -387,7 +387,7 @@ class Cert_5_2_3_LeaderReject2Hops(thread_cert.TestCase):
                               LEADER_DATA_TLV,
                               ROUTE64_TLV,
                               SOURCE_ADDRESS_TLV
-                              } == set(p.mle.tlv.type) and\
+                              } <= set(p.mle.tlv.type) and\
                    len(p.mle.tlv.route64.cost) == 32 and\
                    p.ipv6.hlim == 255
                   ).\
@@ -403,7 +403,7 @@ class Cert_5_2_3_LeaderReject2Hops(thread_cert.TestCase):
             filter(lambda p: {
                               NL_MAC_EXTENDED_ADDRESS_TLV,
                               NL_STATUS_TLV
-                              } == set(p.coap.tlv.type)
+                              } <= set(p.coap.tlv.type)
                   ).\
            must_next()
 

--- a/tests/scripts/thread-cert/Cert_5_2_04_REEDUpgrade.py
+++ b/tests/scripts/thread-cert/Cert_5_2_04_REEDUpgrade.py
@@ -238,7 +238,7 @@ class Cert_5_2_4_REEDUpgrade(thread_cert.TestCase):
             filter(lambda p: {
                               NL_MAC_EXTENDED_ADDRESS_TLV,
                               NL_STATUS_TLV
-                              } == set(p.coap.tlv.type)
+                              } <= set(p.coap.tlv.type)
                   ).\
             must_not_next()
 

--- a/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
@@ -302,7 +302,7 @@ class Cert_5_2_5_AddressQuery(thread_cert.TestCase):
                               NL_TARGET_EID_TLV,
                               NL_RLOC16_TLV,
                               NL_ML_EID_TLV
-                             } == set(p.thread_address.tlv.type)
+                             } <= set(p.thread_address.tlv.type)
                    ).\
             must_next()
         pkts.filter_ipv6_src_dst(REED_MLEID, MED_MLEID).\
@@ -330,7 +330,7 @@ class Cert_5_2_5_AddressQuery(thread_cert.TestCase):
                               NL_TARGET_EID_TLV,
                               NL_RLOC16_TLV,
                               NL_ML_EID_TLV
-                             } == set(p.thread_address.tlv.type)
+                             } <= set(p.thread_address.tlv.type)
                    ).\
             must_next()
         pkts.filter_ipv6_src_dst(REED2001, MED2001).\
@@ -358,7 +358,7 @@ class Cert_5_2_5_AddressQuery(thread_cert.TestCase):
                               NL_TARGET_EID_TLV,
                               NL_RLOC16_TLV,
                               NL_ML_EID_TLV
-                             } == set(p.thread_address.tlv.type)
+                             } <= set(p.thread_address.tlv.type)
                    ).\
             must_next()
         pkts.filter_ipv6_src_dst(REED2002, MED2002).\

--- a/tests/scripts/thread-cert/Cert_5_2_06_RouterDowngrade.py
+++ b/tests/scripts/thread-cert/Cert_5_2_06_RouterDowngrade.py
@@ -301,7 +301,7 @@ class Cert_5_2_06_RouterDowngrade(thread_cert.TestCase):
             filter(lambda p: {
                               NL_MAC_EXTENDED_ADDRESS_TLV,
                               NL_RLOC16_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.thread_address.tlv.rloc16 == ROUTER_1_RLOC16
                    ).\
            must_next()

--- a/tests/scripts/thread-cert/Cert_5_2_07_REEDSynchronization.py
+++ b/tests/scripts/thread-cert/Cert_5_2_07_REEDSynchronization.py
@@ -198,7 +198,7 @@ class Cert_5_2_7_REEDSynchronization_Base(thread_cert.TestCase):
             filter(lambda p: {
                               NL_MAC_EXTENDED_ADDRESS_TLV,
                               NL_STATUS_TLV
-                              } == set(p.coap.tlv.type)
+                              } <= set(p.coap.tlv.type)
                   ).\
             must_not_next()
 

--- a/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
@@ -212,7 +212,7 @@ class Cert_5_3_3_AddressQuery(thread_cert.TestCase):
                               NL_ML_EID_TLV,
                               NL_RLOC16_TLV,
                               NL_TARGET_EID_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.thread_address.tlv.target_eid == ROUTER_3_MLEID and\
                    p.coap.code == COAP_CODE_POST
                    ).\

--- a/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
+++ b/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
@@ -208,7 +208,7 @@ class Cert_5_3_7_DuplicateAddress(thread_cert.TestCase):
             filter(lambda p: {
                               NL_ML_EID_TLV,
                               NL_TARGET_EID_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.thread_address.tlv.target_eid == IPV6_ADDR
                    ).\
             must_next()

--- a/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
+++ b/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
@@ -105,24 +105,24 @@ class Cert_5_5_2_LeaderReboot(thread_cert.TestCase):
         _rpkts.filter_mle_cmd(MLE_CHILD_ID_RESPONSE).must_next()
         _lpkts = leader_pkts.range(_rpkts.index)
         _lpkts.filter_mle_cmd(MLE_ADVERTISEMENT).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} == set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} <= set(p.mle.tlv.type))
 
         _rpkts.filter_mle_cmd(MLE_ADVERTISEMENT).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} == set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} <= set(p.mle.tlv.type))
 
         # Step 4: Router_1 MUST attempt to reattach to its original partition by
         # sending MLE Parent Requests to the All-Routers multicast
         # address (FFxx::xx) with a hop limit of 255. MUST make two separate attempts
         for i in range(1, 3):
             _rpkts.filter_mle_cmd(MLE_PARENT_REQUEST).must_next().must_verify(
-                lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(
+                lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(
                     p.mle.tlv.type) and p.mle.tlv.scan_mask.r == 1 and p.mle.tlv.scan_mask.e == 1)
         lreset_start = _rpkts.index
 
         # Step 6:Router_1 MUST attempt to attach to any other Partition
         # within range by sending a MLE Parent Request.
         _rpkts.filter_mle_cmd(MLE_PARENT_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(p.mle.tlv.type))
+            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(p.mle.tlv.type))
         lreset_stop = _rpkts.index
 
         # Step 3: The Leader MUST stop sending MLE advertisements.
@@ -135,35 +135,35 @@ class Cert_5_5_2_LeaderReboot(thread_cert.TestCase):
         # begin transmitting MLE Advertisements
         with _rpkts.save_index():
             _rpkts.filter_mle_cmd(MLE_ADVERTISEMENT).must_next().must_verify(
-                lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} == set(p.mle.tlv.type))
+                lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} <= set(p.mle.tlv.type))
 
         # Step 8: Router_1 MUST respond with an MLE Child Update Response,
         # with the updated TLVs of the new partition
         _rpkts.filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type))
 
         # Step 9: The Leader MUST send properly formatted MLE Parent
         # Requests to the All-Routers multicast address
         _lpkts.range(lreset_stop).filter_mle_cmd(MLE_PARENT_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(p.mle.tlv.type))
+            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(p.mle.tlv.type))
 
         # Step 10: Router_1 MUST send an MLE Parent Response
         _rpkts.filter_mle_cmd(MLE_PARENT_RESPONSE).must_next().must_verify(
             lambda p: {
                 SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, LINK_LAYER_FRAME_COUNTER_TLV, RESPONSE_TLV, CHALLENGE_TLV,
                 LINK_MARGIN_TLV, CONNECTIVITY_TLV, VERSION_TLV
-            } < set(p.mle.tlv.type))
+            } <= set(p.mle.tlv.type))
 
         # Step 11: Leader send MLE Child ID Request
         _lpkts.filter_mle_cmd(MLE_CHILD_ID_REQUEST).must_next().must_verify(
             lambda p: {
                 RESPONSE_TLV, LINK_LAYER_FRAME_COUNTER_TLV, MODE_TLV, TIMEOUT_TLV, VERSION_TLV, TLV_REQUEST_TLV,
                 ADDRESS16_TLV, NETWORK_DATA_TLV, ROUTE64_TLV, ACTIVE_TIMESTAMP_TLV
-            } < set(p.mle.tlv.type))
+            } <= set(p.mle.tlv.type))
 
         #Step 12: Router_1 send MLE Child ID Response
         _rpkts.filter_mle_cmd(MLE_CHILD_ID_RESPONSE).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ADDRESS16_TLV, NETWORK_DATA_TLV, ROUTE64_TLV} < set(
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ADDRESS16_TLV, NETWORK_DATA_TLV, ROUTE64_TLV} <= set(
                 p.mle.tlv.type))
 
         #Step 13: Leader send an Address Solicit Request

--- a/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
+++ b/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
@@ -143,15 +143,15 @@ class Cert_5_5_3_SplitMergeChildren(thread_cert.TestCase):
 
         # Step 2: The Leader and Router_1 MUST send properly formatted MLE Advertisements
         pkts.filter_wpan_src64(LEADER).filter_LLANMA().filter_mle_cmd(MLE_ADVERTISEMENT).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} == set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} <= set(p.mle.tlv.type))
         _pkt = pkts.filter_wpan_src64(ROUTER_1).filter_LLANMA().filter_mle_cmd(MLE_ADVERTISEMENT).must_next()
         _pkt.must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} == set(p.mle.tlv.type) and p.ipv6.hlim == 255)
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} <= set(p.mle.tlv.type) and p.ipv6.hlim == 255)
 
         # Step 4: Router_1 MUST attempt to reattach to its original partition by
         # sending MLE Parent Requests to the All-Routers multicast address
         _router1_pkts.range(pkts.index).filter_LLARMA().filter_mle_cmd(MLE_PARENT_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(
+            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(
                 p.mle.tlv.type) and p.mle.tlv.scan_mask.r == 1 and p.mle.tlv.scan_mask.e == 1 and p.ipv6.hlim == 255)
         lreset_start = _router1_pkts.index
 
@@ -159,7 +159,7 @@ class Cert_5_5_3_SplitMergeChildren(thread_cert.TestCase):
         # within range by sending a MLE Parent Request.
         _router1_pkts.filter_LLARMA().filter_mle_cmd(MLE_PARENT_REQUEST).filter(
             lambda p: p.mle.tlv.scan_mask.r == 1 and p.mle.tlv.scan_mask.e == 0).must_next().must_verify(
-                lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(p.mle.tlv.type
+                lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(p.mle.tlv.type
                                                                                       ) and p.ipv6.hlim == 255)
         lreset_stop = _router1_pkts.index
 
@@ -174,7 +174,7 @@ class Cert_5_5_3_SplitMergeChildren(thread_cert.TestCase):
         # begin transmitting MLE Advertisements
         with _router1_pkts.save_index():
             _router1_pkts.filter_LLANMA().filter_mle_cmd(MLE_ADVERTISEMENT).filter(
-                lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} == set(p.mle.tlv.type) and p.mle.tlv.
+                lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} <= set(p.mle.tlv.type) and p.mle.tlv.
                 leader_data.partition_id != _pkt.mle.tlv.leader_data.partition_id and p.mle.tlv.leader_data.
                 data_version != _pkt.mle.tlv.leader_data.data_version and p.mle.tlv.leader_data.stable_data_version !=
                 _pkt.mle.tlv.leader_data.stable_data_version and p.ipv6.hlim == 255).must_next()
@@ -182,12 +182,12 @@ class Cert_5_5_3_SplitMergeChildren(thread_cert.TestCase):
         # Step 9: Router_1 MUST respond with an MLE Child Update Response,
         # with the updated TLVs of the new partition
         _router1_pkts.filter_wpan_dst64(MED_2).filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type))
 
         # Step 10: The Leader MUST send properly formatted MLE Parent
         # Requests to the All-Routers multicast address
         _lpkts.filter_LLARMA().filter_mle_cmd(MLE_PARENT_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(p.mle.tlv.type
+            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(p.mle.tlv.type
                                                                                   ) and p.ipv6.hlim == 255)
 
         # Step 11: Leader send MLE Child ID Request to Router_2
@@ -195,11 +195,11 @@ class Cert_5_5_3_SplitMergeChildren(thread_cert.TestCase):
             lambda p: {
                 RESPONSE_TLV, LINK_LAYER_FRAME_COUNTER_TLV, MODE_TLV, TIMEOUT_TLV, VERSION_TLV, TLV_REQUEST_TLV,
                 ADDRESS16_TLV, NETWORK_DATA_TLV, ROUTE64_TLV, ACTIVE_TIMESTAMP_TLV
-            } < set(p.mle.tlv.type))
+            } <= set(p.mle.tlv.type))
 
         # Step 12: Leader send MLE ADVERTISEMENT
         _lpkts.filter_mle_cmd(MLE_ADVERTISEMENT).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} == set(p.mle.tlv.type) and p.ipv6.hlim == 255)
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} <= set(p.mle.tlv.type) and p.ipv6.hlim == 255)
 
         # Step 13: Router_1 send an Address Solicit Request
         _router1_pkts.filter_coap_request(ADDR_SOL_URI).must_next().must_verify(

--- a/tests/scripts/thread-cert/Cert_5_5_04_SplitMergeRouters.py
+++ b/tests/scripts/thread-cert/Cert_5_5_04_SplitMergeRouters.py
@@ -126,7 +126,7 @@ class Cert_5_5_4_SplitMergeRouters(thread_cert.TestCase):
         # Step 2: The Leader  MUST send properly formatted MLE Advertisements
         router1_pkts.filter_mle_cmd(MLE_CHILD_ID_RESPONSE).must_next()
         leader_pkts.range(router1_pkts.index).filter_mle_cmd(MLE_ADVERTISEMENT).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, ROUTE64_TLV, LEADER_DATA_TLV} == set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, ROUTE64_TLV, LEADER_DATA_TLV} <= set(p.mle.tlv.type))
 
         router1_pkts.filter_mle_cmd(MLE_PARENT_REQUEST).must_next()
         lreset_start = router1_pkts.index

--- a/tests/scripts/thread-cert/Cert_5_5_07_SplitMergeThreeWay.py
+++ b/tests/scripts/thread-cert/Cert_5_5_07_SplitMergeThreeWay.py
@@ -127,25 +127,25 @@ class Cert_5_5_7_SplitMergeThreeWay(thread_cert.TestCase):
         leader_pkts.filter_mle_cmd(MLE_CHILD_ID_RESPONSE).must_next()
         _lpkts = leader_pkts.copy()
         _lpkts.filter_mle_cmd(MLE_ADVERTISEMENT).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} == set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} <= set(p.mle.tlv.type))
 
         router1_pkts.range(leader_pkts.index).filter_mle_cmd(MLE_ADVERTISEMENT).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} == set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} <= set(p.mle.tlv.type))
 
         # Step 4: Each router forms a partition with the lowest possible partition ID
         # Step 5: Router_1 MUST send MLE Parent Requests and MUST make two separate attempts
         router1_pkts.filter_mle_cmd(MLE_PARENT_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(
+            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(
                 p.mle.tlv.type) and p.mle.tlv.scan_mask.r == 1 and p.mle.tlv.scan_mask.e == 1)
         lreset_start = router1_pkts.index
         router1_pkts.filter_mle_cmd(MLE_PARENT_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(
+            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(
                 p.mle.tlv.type) and p.mle.tlv.scan_mask.r == 1 and p.mle.tlv.scan_mask.e == 1)
 
         # Step 7: Router_1 MUST attempt to attach to any other Partition
         # within range by sending a MLE Parent Request.
         router1_pkts.filter_mle_cmd(MLE_PARENT_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(p.mle.tlv.type))
+            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(p.mle.tlv.type))
         lreset_stop = router1_pkts.index
 
         # Step 3: The Leader MUST stop sending MLE advertisements.
@@ -157,12 +157,12 @@ class Cert_5_5_7_SplitMergeThreeWay(thread_cert.TestCase):
         # Step 8: Router_1 take over leader role of a new Partition and begin transmitting
         # MLE Advertisements
         router1_pkts.copy().filter_mle_cmd(MLE_ADVERTISEMENT).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} == set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} <= set(p.mle.tlv.type))
 
         # Step 9: The Leader MUST send properly formatted MLE Parent Requests to the
         # All-Routers multicast address
         _lpkts.filter_mle_cmd(MLE_PARENT_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(p.mle.tlv.type))
+            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(p.mle.tlv.type))
 
         # Step 10: Router_1 MUST send an MLE Parent Response
         router1_pkts.filter_mle_cmd(MLE_PARENT_RESPONSE).must_next().must_verify(

--- a/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
@@ -129,14 +129,14 @@ class Cert_5_6_1_NetworkDataLeaderAsBr(thread_cert.TestCase):
             lambda p: {
                 RESPONSE_TLV, LINK_LAYER_FRAME_COUNTER_TLV, MODE_TLV, TIMEOUT_TLV, VERSION_TLV, TLV_REQUEST_TLV,
                 ADDRESS16_TLV, NETWORK_DATA_TLV, ROUTE64_TLV
-            } < set(p.mle.tlv.type))
+            } <= set(p.mle.tlv.type))
         _rpkts_med = _rpkts.copy()
         _rpkts_sed = _rpkts.copy()
 
         # Step 6: The DUT MUST send an MLE Child ID Response to SED_1,
         # containing only stable Network Data
         _rpkts_sed.filter_mle_cmd(MLE_CHILD_ID_RESPONSE).filter_wpan_dst64(SED).must_next().must_verify(
-            lambda p: {MODE_TLV, TIMEOUT_TLV, CHALLENGE_TLV} == set(p.thread_nwd.tlv.type) and
+            lambda p: {MODE_TLV, TIMEOUT_TLV, CHALLENGE_TLV} <= set(p.thread_nwd.tlv.type) and
             {Ipv6Addr('2001:2:0:1::')} == set(p.thread_nwd.tlv.prefix) and p.thread_nwd.tlv.border_router.flag.p ==
             [1] and p.thread_nwd.tlv.border_router.flag.s == [1] and p.thread_nwd.tlv.border_router.flag.r == [1] and p
             .thread_nwd.tlv.border_router.flag.o == [1] and p.thread_nwd.tlv.stable == [1, 1, 1])
@@ -153,10 +153,10 @@ class Cert_5_6_1_NetworkDataLeaderAsBr(thread_cert.TestCase):
         # Response to each of MED_1 and SED_1
         _rpkts_med.filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).must_next().must_verify(
             lambda p: p.wpan.dst64 == MED and
-            {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type))
+            {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type))
         _rpkts_sed.filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).must_next().must_verify(
             lambda p: p.wpan.dst64 == SED and
-            {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type))
+            {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type))
 
         # Step 11: MED_1 and SED_1 MUST respond to each ICMPv6 Echo Request
         # with an ICMPv6 Echo Reply

--- a/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
@@ -121,14 +121,14 @@ class Cert_5_6_2_NetworkDataRouterAsBr(thread_cert.TestCase):
 
         # Step 1: The DUT MUST send properly formatted MLE Advertisements
         _lpkts.filter_mle_cmd(MLE_ADVERTISEMENT).must_next().must_verify(
-            lambda p: {LEADER_DATA_TLV, ROUTE64_TLV, SOURCE_ADDRESS_TLV} == set(p.mle.tlv.type))
+            lambda p: {LEADER_DATA_TLV, ROUTE64_TLV, SOURCE_ADDRESS_TLV} <= set(p.mle.tlv.type))
 
         # Step 3: The DUT MUST properly attach Router_1 device to the network,
         # and transmit Network Data during the attach phase in the
         # Child ID Response frame of the Network Data TLV
         _lpkts.filter_mle_cmd(MLE_CHILD_ID_RESPONSE).must_next().must_verify(lambda p: p.wpan.dst64 == ROUTER and {
             SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ACTIVE_TIMESTAMP_TLV, ADDRESS16_TLV, NETWORK_DATA_TLV
-        } < set(p.mle.tlv.type))
+        } <= set(p.mle.tlv.type))
 
         # Step 5: The DUT Automatically sends a CoAP Response frame and
         # MLE Data Response message
@@ -159,9 +159,9 @@ class Cert_5_6_2_NetworkDataRouterAsBr(thread_cert.TestCase):
         # Step 10: The DUT MUST send a unicast MLE Child Update
         # Response to each of MED_1 and SED_1
         _lpkts_med.filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).filter_wpan_dst64(MED).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type))
         _lpkts_sed.filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).filter_wpan_dst64(SED).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type))
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
@@ -134,12 +134,12 @@ class Cert_5_6_3_NetworkDataRegisterAfterAttachLeader(thread_cert.TestCase):
         # Step 5: The DUT MUST send a unicast MLE Child Update
         # Response to MED_1
         _rpkts_med.filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).filter_wpan_dst64(MED).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type))
 
         # Step 6: The DUT MUST send a unicast MLE Child Update
         # Request to SED_1
         _rpkts_sed.filter_mle_cmd(MLE_CHILD_UPDATE_REQUEST).filter_wpan_dst64(SED).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} == set(
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} <= set(
                 p.mle.tlv.type) and {Ipv6Addr('2001:2:0:1::')} == set(p.thread_nwd.tlv.prefix) and p.thread_nwd.tlv.
             border_router.flag.p == [1] and p.thread_nwd.tlv.border_router.flag.s == [1] and p.thread_nwd.tlv.
             border_router.flag.r == [1] and p.thread_nwd.tlv.border_router.flag.o == [1] and p.thread_nwd.tlv.stable ==
@@ -148,7 +148,7 @@ class Cert_5_6_3_NetworkDataRegisterAfterAttachLeader(thread_cert.TestCase):
         # Step 8: The DUT MUST send a unicast MLE Child Update
         # Response to SED_1
         _rpkts_sed.filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).filter_wpan_dst64(SED).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type))
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
@@ -141,12 +141,12 @@ class Cert_5_6_4_NetworkDataRegisterAfterAttachRouter(thread_cert.TestCase):
         # Step 7: The DUT MUST send a unicast MLE Child Update
         # Response to MED_1
         _lpkts_med.filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).filter_wpan_dst64(MED).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type))
 
         # Step 9: The DUT MUST send a unicast MLE Child Update
         # Request to SED_1
         _lpkts_sed.filter_mle_cmd(MLE_CHILD_UPDATE_REQUEST).filter_wpan_dst64(SED).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} == set(
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} <= set(
                 p.mle.tlv.type) and {Ipv6Addr('2001:2:0:1::')} == set(p.thread_nwd.tlv.prefix) and p.thread_nwd.tlv.
             border_router.flag.p == [1] and p.thread_nwd.tlv.border_router.flag.s == [1] and p.thread_nwd.tlv.
             border_router.flag.r == [1] and p.thread_nwd.tlv.border_router.flag.o == [1] and p.thread_nwd.tlv.stable ==
@@ -155,7 +155,7 @@ class Cert_5_6_4_NetworkDataRegisterAfterAttachRouter(thread_cert.TestCase):
         # Step 11: The DUT MUST send a unicast MLE Child Update
         # Response to SED_1
         _lpkts_sed.filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).filter_wpan_dst64(SED).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type))
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
@@ -147,12 +147,12 @@ class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(thread_cert.TestCase):
         # Step 7: The DUT MUST send a unicast MLE Child Update
         # Response to MED_1
         _lpkts_med.filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).filter_wpan_dst64(MED).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type))
 
         # Step 8: The DUT MUST send a unicast MLE Child Update
         # Request to SED_1
         _lpkts_sed.filter_mle_cmd(MLE_CHILD_UPDATE_REQUEST).filter_wpan_dst64(SED).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} == set(
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} <= set(
                 p.mle.tlv.type) and {Ipv6Addr('2001:2:0:1::'), Ipv6Addr('2001:2:0:3::')} == set(
                     p.thread_nwd.tlv.prefix) and p.thread_nwd.tlv.border_router.flag.p == [1, 1] and p.thread_nwd.tlv.
             border_router.flag.s == [1, 1] and p.thread_nwd.tlv.border_router.flag.r == [1, 0] and p.thread_nwd.tlv.
@@ -161,7 +161,7 @@ class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(thread_cert.TestCase):
         # Step 10: The DUT MUST send a unicast MLE Child Update
         # Response to SED_1
         _lpkts_sed.filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).filter_wpan_dst64(SED).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type))
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
+++ b/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
@@ -163,29 +163,29 @@ class Cert_5_6_6_NetworkDataExpiration(thread_cert.TestCase):
             lambda p: {
                 NWD_COMMISSIONING_DATA_TLV, NWD_PREFIX_TLV, NWD_BORDER_ROUTER_TLV, NWD_6LOWPAN_ID_TLV, NWD_PREFIX_TLV,
                 NWD_BORDER_ROUTER_TLV, NWD_6LOWPAN_ID_TLV, NWD_PREFIX_TLV, NWD_BORDER_ROUTER_TLV, NWD_6LOWPAN_ID_TLV
-            } == set(p.thread_nwd.tlv.type) and {
+            } <= set(p.thread_nwd.tlv.type) and {
                 Ipv6Addr('2001:2:0:1::'), Ipv6Addr('2001:2:0:2::'),
                 Ipv6Addr('2001:2:0:3::')
             } == set(p.thread_nwd.tlv.prefix) and p.thread_nwd.tlv.stable == [0, 1, 1, 1, 0, 0, 0, 1, 1, 1])
 
         # Step 7: The DUT MUST send a unicast MLE Child Update Response to MED_1
         _lpkts_med.filter_wpan_dst64(MED).filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type))
 
         # Step 8: The DUT MUST send a unicast MLE Child Update Request to SED_1
         _lpkts_sed.filter_wpan_dst64(SED).filter_mle_cmd(MLE_CHILD_UPDATE_REQUEST).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} == set(
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} <= set(
                 p.mle.tlv.type) and {
                     NWD_PREFIX_TLV, NWD_BORDER_ROUTER_TLV, NWD_6LOWPAN_ID_TLV, NWD_PREFIX_TLV, NWD_BORDER_ROUTER_TLV,
                     NWD_6LOWPAN_ID_TLV
-                } == set(p.thread_nwd.tlv.type) and {
+                } <= set(p.thread_nwd.tlv.type) and {
                     Ipv6Addr('2001:2:0:1::'), Ipv6Addr('2001:2:0:3::')
                 } == set(p.thread_nwd.tlv.prefix) and {0xFFFE, 0xFFFE} == set(p.thread_nwd.tlv.border_router_16))
 
         # Step 10: The DUT MUST send a unicast MLE Child Update Response to SED_1
         _pkt = _lpkts_sed.filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).filter_wpan_dst64(SED).must_next()
         _pkt.must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type))
 
         # Step 12: The DUT updates Router ID Set and removes Router_1
         # from Network Data TLV after Router_1 power off
@@ -197,7 +197,7 @@ class Cert_5_6_6_NetworkDataExpiration(thread_cert.TestCase):
             lambda p: {
                 NWD_COMMISSIONING_DATA_TLV, NWD_PREFIX_TLV, NWD_BORDER_ROUTER_TLV, NWD_6LOWPAN_ID_TLV, NWD_PREFIX_TLV,
                 NWD_BORDER_ROUTER_TLV, NWD_6LOWPAN_ID_TLV, NWD_PREFIX_TLV, NWD_BORDER_ROUTER_TLV, NWD_6LOWPAN_ID_TLV
-            } == set(p.thread_nwd.tlv.type) and
+            } <= set(p.thread_nwd.tlv.type) and
             {Ipv6Addr('2001:2:0:1::'), Ipv6Addr('2001:2:0:2::'),
              Ipv6Addr('2001:2:0:3::')} == set(p.thread_nwd.tlv.prefix) and p.mle.tlv.leader_data.data_version ==
             (_pkt.mle.tlv.leader_data.data_version + 1) % 256 and p.mle.tlv.leader_data.stable_data_version ==
@@ -205,20 +205,20 @@ class Cert_5_6_6_NetworkDataExpiration(thread_cert.TestCase):
 
         # Step 15: The DUT MUST send a unicast MLE Child Update Response to MED_1
         _lpkts_med.filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).filter_wpan_dst64(MED).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type)
+            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type)
             and p.mle.tlv.leader_data.data_version == (_pkt.mle.tlv.leader_data.data_version + 1) % 256 and p.mle.tlv.
             leader_data.stable_data_version == (_pkt.mle.tlv.leader_data.stable_data_version + 1) % 256)
 
         # Step 16: The DUT MUST send a unicast MLE Child Update Request to SED_1
         _lpkts_sed.filter_mle_cmd(MLE_CHILD_UPDATE_REQUEST).filter_wpan_dst64(SED).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} == set(
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} <= set(
                 p.mle.tlv.type) and p.mle.tlv.leader_data.data_version ==
             (_pkt.mle.tlv.leader_data.data_version + 1) % 256 and p.mle.tlv.leader_data.stable_data_version ==
             (_pkt.mle.tlv.leader_data.stable_data_version + 1) % 256)
 
         # Step 18: The DUT MUST send a unicast MLE Child Update Response to SED_1
         _lpkts_sed.filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).filter_wpan_dst64(SED).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} < set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, MODE_TLV, LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV} <= set(p.mle.tlv.type))
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
+++ b/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
@@ -154,9 +154,9 @@ class Cert_5_6_9_NetworkDataForwarding(thread_cert.TestCase):
         # Step 5: The DUT MUST send a unicast MLE Child Update
         # Request to SED_1
         _rpkts.filter_mle_cmd(MLE_CHILD_UPDATE_REQUEST).filter_wpan_dst64(SED).must_next(
-        ).must_verify(lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} == set(
+        ).must_verify(lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} <= set(
             p.mle.tlv.type
-        ) and {NWD_PREFIX_TLV, NWD_BORDER_ROUTER_TLV, NWD_6LOWPAN_ID_TLV, NWD_PREFIX_TLV, NWD_HAS_ROUTER_TLV} == set(
+        ) and {NWD_PREFIX_TLV, NWD_BORDER_ROUTER_TLV, NWD_6LOWPAN_ID_TLV, NWD_PREFIX_TLV, NWD_HAS_ROUTER_TLV} <= set(
             p.thread_nwd.tlv.type) and {Ipv6Addr('2001:2:0:1::'), Ipv6Addr('2001:2:0:2::')} == set(
                 p.thread_nwd.tlv.prefix) and {0xFFFE, 0xFFFE} == set(p.thread_nwd.tlv.border_router_16))
 
@@ -179,7 +179,7 @@ class Cert_5_6_9_NetworkDataForwarding(thread_cert.TestCase):
                 lambda p: {
                     NWD_COMMISSIONING_DATA_TLV, NWD_PREFIX_TLV, NWD_BORDER_ROUTER_TLV, NWD_6LOWPAN_ID_TLV,
                     NWD_PREFIX_TLV, NWD_HAS_ROUTER_TLV
-                } == set(p.thread_nwd.tlv.type) and {
+                } <= set(p.thread_nwd.tlv.type) and {
                     Ipv6Addr('2001:2:0:1::'), Ipv6Addr('2001:2:0:2::')
                 } == set(p.thread_nwd.tlv.prefix) and p.thread_nwd.tlv.border_router.flag.p == [0, 1] and p.thread_nwd.
                 tlv.border_router.flag.s == [1, 1] and p.thread_nwd.tlv.border_router.flag.r == [1, 1] and p.thread_nwd
@@ -187,9 +187,9 @@ class Cert_5_6_9_NetworkDataForwarding(thread_cert.TestCase):
 
         # Step 10: The DUT MUST send a unicast MLE Child Update Request to SED_1
         _rpkts.filter_mle_cmd(MLE_CHILD_UPDATE_REQUEST).filter_wpan_dst64(SED).must_next(
-        ).must_verify(lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} == set(
+        ).must_verify(lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} <= set(
             p.mle.tlv.type
-        ) and {NWD_PREFIX_TLV, NWD_BORDER_ROUTER_TLV, NWD_6LOWPAN_ID_TLV, NWD_PREFIX_TLV, NWD_HAS_ROUTER_TLV} == set(
+        ) and {NWD_PREFIX_TLV, NWD_BORDER_ROUTER_TLV, NWD_6LOWPAN_ID_TLV, NWD_PREFIX_TLV, NWD_HAS_ROUTER_TLV} <= set(
             p.thread_nwd.tlv.type) and {Ipv6Addr('2001:2:0:1::'), Ipv6Addr('2001:2:0:2::')} == set(
                 p.thread_nwd.tlv.prefix) and {0xFFFE, 0xFFFE} == set(p.thread_nwd.tlv.border_router_16))
 
@@ -205,14 +205,14 @@ class Cert_5_6_9_NetworkDataForwarding(thread_cert.TestCase):
                 lambda p: {
                     NWD_COMMISSIONING_DATA_TLV, NWD_PREFIX_TLV, NWD_BORDER_ROUTER_TLV, NWD_6LOWPAN_ID_TLV,
                     NWD_PREFIX_TLV, NWD_HAS_ROUTER_TLV
-                } == set(p.thread_nwd.tlv.type) and {Ipv6Addr('2001:2:0:1::'),
+                } <= set(p.thread_nwd.tlv.type) and {Ipv6Addr('2001:2:0:1::'),
                                                      Ipv6Addr('2001:2:0:2::')} == set(p.thread_nwd.tlv.prefix))
 
         # Step 14: The DUT MUST send a unicast MLE Child Update Request to SED_1
         _rpkts.filter_mle_cmd(MLE_CHILD_UPDATE_REQUEST).filter_wpan_dst64(SED).must_next(
-        ).must_verify(lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} == set(
+        ).must_verify(lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} <= set(
             p.mle.tlv.type
-        ) and {NWD_PREFIX_TLV, NWD_BORDER_ROUTER_TLV, NWD_6LOWPAN_ID_TLV, NWD_PREFIX_TLV, NWD_HAS_ROUTER_TLV} == set(
+        ) and {NWD_PREFIX_TLV, NWD_BORDER_ROUTER_TLV, NWD_6LOWPAN_ID_TLV, NWD_PREFIX_TLV, NWD_HAS_ROUTER_TLV} <= set(
             p.thread_nwd.tlv.type) and {Ipv6Addr('2001:2:0:1::'), Ipv6Addr('2001:2:0:2::')} == set(
                 p.thread_nwd.tlv.prefix) and {0xFFFE, 0xFFFE} == set(p.thread_nwd.tlv.border_router_16))
 

--- a/tests/scripts/thread-cert/Cert_5_7_01_CoapDiagCommands.py
+++ b/tests/scripts/thread-cert/Cert_5_7_01_CoapDiagCommands.py
@@ -230,7 +230,7 @@ class Cert_5_7_01_CoapDiagCommands_Base(thread_cert.TestCase):
                               DG_NETWORK_DATA_TLV,
                               DG_IPV6_ADDRESS_LIST_TLV,
                               DG_CHANNEL_PAGES_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
         pkts.filter_wpan_src64(DUT).\
@@ -246,7 +246,7 @@ class Cert_5_7_01_CoapDiagCommands_Base(thread_cert.TestCase):
                               DG_NETWORK_DATA_TLV,
                               DG_IPV6_ADDRESS_LIST_TLV,
                               DG_CHANNEL_PAGES_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
 
@@ -263,7 +263,7 @@ class Cert_5_7_01_CoapDiagCommands_Base(thread_cert.TestCase):
             filter(lambda p: {
                               DG_TYPE_LIST_TLV,
                               DG_MAC_COUNTERS_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
         pkts.filter_wpan_src64(DUT).\
@@ -271,7 +271,7 @@ class Cert_5_7_01_CoapDiagCommands_Base(thread_cert.TestCase):
             filter_coap_ack(DIAG_GET_URI).\
             filter(lambda p: {
                               DG_MAC_COUNTERS_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
 
@@ -288,7 +288,7 @@ class Cert_5_7_01_CoapDiagCommands_Base(thread_cert.TestCase):
             filter(lambda p: {
                               DG_TYPE_LIST_TLV,
                               DG_TIMEOUT_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
         pkts.filter_wpan_src64(DUT).\
@@ -311,7 +311,7 @@ class Cert_5_7_01_CoapDiagCommands_Base(thread_cert.TestCase):
                               DG_TYPE_LIST_TLV,
                               DG_BATTERY_LEVEL_TLV,
                               DG_SUPPLY_VOLTAGE_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
         pkts.filter_wpan_src64(DUT).\
@@ -334,7 +334,7 @@ class Cert_5_7_01_CoapDiagCommands_Base(thread_cert.TestCase):
             filter(lambda p: {
                               DG_TYPE_LIST_TLV,
                               DG_CHILD_TABLE_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
 
@@ -344,7 +344,7 @@ class Cert_5_7_01_CoapDiagCommands_Base(thread_cert.TestCase):
                 filter_coap_ack(DIAG_GET_URI).\
                 filter(lambda p: {
                                   DG_CHILD_TABLE_TLV
-                                  } == set(p.thread_diagnostic.tlv.type)
+                                  } <= set(p.thread_diagnostic.tlv.type)
                        ).\
                 must_next()
         else:
@@ -366,7 +366,7 @@ class Cert_5_7_01_CoapDiagCommands_Base(thread_cert.TestCase):
             filter(lambda p: {
                               DG_TYPE_LIST_TLV,
                               DG_MAC_COUNTERS_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
         pkts.filter_wpan_src64(DUT).\
@@ -389,7 +389,7 @@ class Cert_5_7_01_CoapDiagCommands_Base(thread_cert.TestCase):
             filter(lambda p: {
                               DG_TYPE_LIST_TLV,
                               DG_MAC_COUNTERS_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
         pkts.filter_wpan_src64(DUT).\
@@ -397,7 +397,7 @@ class Cert_5_7_01_CoapDiagCommands_Base(thread_cert.TestCase):
             filter_coap_ack(DIAG_GET_URI).\
             filter(lambda p: {
                               DG_MAC_COUNTERS_TLV
-                              } == set(p.thread_diagnostic.tlv.type)
+                              } <= set(p.thread_diagnostic.tlv.type)
                    ).\
             must_next()
 

--- a/tests/scripts/thread-cert/Cert_5_8_04_SecurityPolicyTLV.py
+++ b/tests/scripts/thread-cert/Cert_5_8_04_SecurityPolicyTLV.py
@@ -236,7 +236,7 @@ class Cert_5_8_04_SecurityPolicyTLV(thread_cert.TestCase):
                               NM_COMMISSIONER_SESSION_ID_TLV,
                               NM_ACTIVE_TIMESTAMP_TLV,
                               NM_SECURITY_POLICY_TLV
-                             }  == set(p.thread_meshcop.tlv.type) and\
+                             }  <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.active_tstamp == 15 and\
                    (p.thread_meshcop.tlv.sec_policy_o == 0 or
                     p.thread_meshcop.tlv.unknown == '0e1077')).\
@@ -289,7 +289,7 @@ class Cert_5_8_04_SecurityPolicyTLV(thread_cert.TestCase):
                               NM_COMMISSIONER_SESSION_ID_TLV,
                               NM_ACTIVE_TIMESTAMP_TLV,
                               NM_SECURITY_POLICY_TLV
-                             }  == set(p.thread_meshcop.tlv.type) and\
+                             }  <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.active_tstamp == 20 and\
                    (p.thread_meshcop.tlv.sec_policy_n == 0 or
                     p.thread_meshcop.tlv.unknown == '0e10b7')).\
@@ -327,7 +327,7 @@ class Cert_5_8_04_SecurityPolicyTLV(thread_cert.TestCase):
                               NM_COMMISSIONER_SESSION_ID_TLV,
                               NM_ACTIVE_TIMESTAMP_TLV,
                               NM_SECURITY_POLICY_TLV
-                             }  == set(p.thread_meshcop.tlv.type) and\
+                             }  <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.active_tstamp == 25 and\
                    (p.thread_meshcop.tlv.sec_policy_b == 0 or
                     p.thread_meshcop.tlv.unknown == '0e10f7')).\
@@ -373,7 +373,7 @@ class Cert_5_8_04_SecurityPolicyTLV(thread_cert.TestCase):
                               NM_COMMISSIONER_SESSION_ID_TLV,
                               NM_ACTIVE_TIMESTAMP_TLV,
                               NM_SECURITY_POLICY_TLV
-                             }  == set(p.thread_meshcop.tlv.type) and\
+                             }  <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.active_tstamp == 30 and\
                    (p.thread_meshcop.tlv.sec_policy_r == 0 or
                     p.thread_meshcop.tlv.unknown == '0e10d7')).\

--- a/tests/scripts/thread-cert/Cert_6_1_02_REEDAttach.py
+++ b/tests/scripts/thread-cert/Cert_6_1_02_REEDAttach.py
@@ -272,7 +272,7 @@ class Cert_6_1_2_REEDAttach_Base(thread_cert.TestCase):
                               NL_STATUS_TLV,
                               NL_RLOC16_TLV,
                               NL_ROUTER_MASK_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.coap.code == COAP_CODE_ACK and\
                    p.thread_address.tlv.status == 0\
                    ).\
@@ -305,7 +305,7 @@ class Cert_6_1_2_REEDAttach_Base(thread_cert.TestCase):
                                   SOURCE_ADDRESS_TLV,
                                   MODE_TLV,
                                   LEADER_DATA_TLV
-                                 } < set(p.mle.tlv.type)
+                                 } <= set(p.mle.tlv.type)
                        ).\
                 must_next()
 
@@ -318,7 +318,7 @@ class Cert_6_1_2_REEDAttach_Base(thread_cert.TestCase):
                                   SOURCE_ADDRESS_TLV,
                                   MODE_TLV,
                                   LEADER_DATA_TLV
-                                 } < set(p.mle.tlv.type)
+                                 } <= set(p.mle.tlv.type)
                        ).\
                 must_next()
 

--- a/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
@@ -108,7 +108,7 @@ class Cert_6_1_3_RouterAttachConnectivity(thread_cert.TestCase):
         # All-Routers multicast address
         _ed_pkts.filter_mle_cmd(MLE_PARENT_REQUEST).filter_ipv6_dst(
             LINK_LOCAL_ALL_ROUTERS_MULTICAST_ADDRESS).must_next().must_verify(
-                lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(p.mle.tlv.type
+                lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(p.mle.tlv.type
                                                                                       ) and p.mle.tlv.scan_mask.r == 1)
 
         # Step 3: Router_2, Router_3 Respond with MLE Parent Response

--- a/tests/scripts/thread-cert/Cert_6_1_04_REEDAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_04_REEDAttachConnectivity.py
@@ -276,7 +276,7 @@ class Cert_6_1_4_REEDAttachConnectivity_Base(thread_cert.TestCase):
                               NL_STATUS_TLV,
                               NL_RLOC16_TLV,
                               NL_ROUTER_MASK_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.thread_address.tlv.status == 0
                    ).\
             must_next()

--- a/tests/scripts/thread-cert/Cert_6_1_05_REEDAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_05_REEDAttachConnectivity.py
@@ -117,13 +117,13 @@ class Cert_6_1_5_REEDAttachConnectivity(thread_cert.TestCase):
         for num in range(self.num_parent_requests):
             _ed_pkts.filter_mle_cmd(MLE_PARENT_REQUEST).filter_ipv6_dst(
                 LINK_LOCAL_ALL_ROUTERS_MULTICAST_ADDRESS).must_next().must_verify(
-                    lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(
+                    lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(
                         p.mle.tlv.type) and p.mle.tlv.scan_mask.r == 1)
 
         # Step 3: REED_1 and REED_2 No response to Parent Request
         # Step 4: DUT Send MLE Parent Request with Scan Mask set to Routers AND REEDs
         _ed_pkts.filter_mle_cmd(MLE_PARENT_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(
+            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(
                 p.mle.tlv.type) and p.mle.tlv.scan_mask.r == 1 and p.mle.tlv.scan_mask.e == 1)
 
         # Step 5: The DUT MUST send a MLE Child ID Request

--- a/tests/scripts/thread-cert/Cert_6_1_07_RouterAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_6_1_07_RouterAttachLinkQuality.py
@@ -99,7 +99,7 @@ class Cert_6_1_7_RouterAttachLinkQuality(thread_cert.TestCase):
         # All-Routers multicast address
         _ed_pkts.filter_mle_cmd(MLE_PARENT_REQUEST).filter_ipv6_dst(
             LINK_LOCAL_ALL_ROUTERS_MULTICAST_ADDRESS).must_next().must_verify(
-                lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(
+                lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(
                     p.mle.tlv.type) and p.mle.tlv.scan_mask.r == 1 and p.mle.tlv.scan_mask.e == 0)
 
         # Step 5: The DUT MUST send a MLE Child ID Request to Router_1

--- a/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
+++ b/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
@@ -111,7 +111,7 @@ class Cert_6_2_2_NewPartition(thread_cert.TestCase):
         _ed_pkts.filter_mle_cmd(MLE_ADVERTISEMENT).must_not_next()
         _ed_pkts.filter_mle_cmd(MLE_CHILD_ID_REQUEST).must_not_next()
         _ed_pkts.filter_wpan_dst64(ROUTER_1).filter_mle_cmd(MLE_CHILD_UPDATE_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV, SOURCE_ADDRESS_TLV, LEADER_DATA_TLV} < set(p.mle.tlv.type))
+            lambda p: {MODE_TLV, SOURCE_ADDRESS_TLV, LEADER_DATA_TLV} <= set(p.mle.tlv.type))
 
         # Step 8: The DUT MUST respond with ICMPv6 Echo Reply
         _ed_pkts.filter('ipv6.dst == {ROUTER_1_MLEID} and ipv6.src == {ED_MLEID}',

--- a/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
+++ b/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
@@ -113,16 +113,16 @@ class Cert_6_3_2_NetworkDataUpdate(thread_cert.TestCase):
         # Step 3: The DUT MUST send a MLE Child Update Request to the Leader
         _epkts.range(pkts.index).filter_mle_cmd(MLE_CHILD_UPDATE_REQUEST).must_next().must_verify(
             lambda p: p.wpan.dst64 == LEADER and {LEADER_DATA_TLV, ADDRESS_REGISTRATION_TLV, MODE_TLV, TIMEOUT_TLV
-                                                 } < set(p.mle.tlv.type))
+                                                 } <= set(p.mle.tlv.type))
 
         # Step 10: The DUT MUST send a MLE Data Request frame to
         # request the updated Network Data
         _epkts.filter_mle_cmd(MLE_DATA_REQUEST).must_next().must_verify(
-            lambda p: {TLV_REQUEST_TLV, NETWORK_DATA_TLV} < set(p.mle.tlv.type))
+            lambda p: {TLV_REQUEST_TLV, NETWORK_DATA_TLV} <= set(p.mle.tlv.type))
 
         # Step 12: The DUT MUST send a MLE Child Update Request to the Leader
         _epkts.filter_mle_cmd(MLE_CHILD_UPDATE_REQUEST).filter_wpan_dst64(LEADER).must_next().must_verify(
-            lambda p: {ADDRESS_REGISTRATION_TLV, MODE_TLV, TIMEOUT_TLV} < set(p.mle.tlv.type))
+            lambda p: {ADDRESS_REGISTRATION_TLV, MODE_TLV, TIMEOUT_TLV} <= set(p.mle.tlv.type))
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_6_5_01_ChildResetReattach.py
+++ b/tests/scripts/thread-cert/Cert_6_5_01_ChildResetReattach.py
@@ -97,7 +97,7 @@ class Cert_6_5_1_ChildResetReattach(thread_cert.TestCase):
         # Step 3: Send MLE Child Update Request to Leader
         _ed_pkts.filter_mle_cmd(MLE_CHILD_ID_REQUEST).must_next()
         _ed_pkts.filter_mle_cmd(MLE_CHILD_UPDATE_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV} < set(p.mle.tlv.type))
+            lambda p: {MODE_TLV} <= set(p.mle.tlv.type))
 
         # Step 5: DUT reattaches to Leader
         _ed_pkts.filter_mle_cmd(MLE_CHILD_ID_REQUEST).must_next().must_verify(

--- a/tests/scripts/thread-cert/Cert_6_5_02_ChildResetReattach.py
+++ b/tests/scripts/thread-cert/Cert_6_5_02_ChildResetReattach.py
@@ -150,7 +150,7 @@ class Cert_6_5_2_ChildResetReattach_Base(thread_cert.TestCase):
             filter_mle_cmd(MLE_CHILD_UPDATE_REQUEST).\
             filter(lambda p: {
                               MODE_TLV
-                             } < set(p.mle.tlv.type)
+                             } <= set(p.mle.tlv.type)
                    ).\
             must_next()
         if self.TOPOLOGY[MTD]['mode'] == '-':

--- a/tests/scripts/thread-cert/Cert_6_5_03_ChildResetSynchronize.py
+++ b/tests/scripts/thread-cert/Cert_6_5_03_ChildResetSynchronize.py
@@ -95,7 +95,7 @@ class Cert_6_5_3_ChildResetSynchronize(thread_cert.TestCase):
         _ed_pkts.filter_mle_cmd(MLE_CHILD_ID_REQUEST).must_next()
         _leader_pkts.range(_ed_pkts.index).filter_mle_cmd(MLE_CHILD_ID_RESPONSE).must_next()
         _ed_pkts.filter_mle_cmd(MLE_CHILD_UPDATE_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV} < set(p.mle.tlv.type))
+            lambda p: {MODE_TLV} <= set(p.mle.tlv.type))
 
         # Step 4: Leader send an MLE Child Update Response
         _leader_pkts.range(_ed_pkts.index).filter_mle_cmd(MLE_CHILD_UPDATE_RESPONSE).must_next()

--- a/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
@@ -146,7 +146,7 @@ class Cert_7_1_1_BorderRouterAsLeader(thread_cert.TestCase):
                               ADDRESS16_TLV,
                               NETWORK_DATA_TLV,
                               ROUTE64_TLV
-                             } < set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                    p.mle.tlv.mode.network_data == 1
                    ).\
             must_next()
@@ -208,7 +208,7 @@ class Cert_7_1_1_BorderRouterAsLeader(thread_cert.TestCase):
                               MODE_TLV,
                               TIMEOUT_TLV,
                               CHALLENGE_TLV
-                             } == set(p.thread_nwd.tlv.type) and\
+                             } <= set(p.thread_nwd.tlv.type) and\
                    [Ipv6Addr(PREFIX_2001[:-3])] == p.thread_nwd.tlv.prefix and\
                    p.thread_nwd.tlv.border_router.flag.p == [1] and\
                    p.thread_nwd.tlv.border_router.flag.s == [1] and\
@@ -235,7 +235,7 @@ class Cert_7_1_1_BorderRouterAsLeader(thread_cert.TestCase):
                               ADDRESS16_TLV,
                               NETWORK_DATA_TLV,
                               ADDRESS_REGISTRATION_TLV
-                             } < set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                    p.mle.tlv.mode.network_data == 1
                    ).\
             must_next()
@@ -286,7 +286,7 @@ class Cert_7_1_1_BorderRouterAsLeader(thread_cert.TestCase):
                                   SOURCE_ADDRESS_TLV,
                                   MODE_TLV,
                                   ADDRESS_REGISTRATION_TLV
-                                 } < set(p.mle.tlv.type) and\
+                                 } <= set(p.mle.tlv.type) and\
                        set(p.mle.tlv.addr_reg_iid) < set(_pkt.mle.tlv.addr_reg_iid)
                        ).\
                 must_next()

--- a/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
@@ -125,7 +125,7 @@ class Cert_7_1_2_BorderRouterAsRouter(thread_cert.TestCase):
         # with the server’s information (Prefix, Border Router) to the Leader
         _rpkts.filter_mle_cmd(MLE_CHILD_ID_REQUEST).must_next()
         _rpkts.filter_mle_cmd(MLE_ADVERTISEMENT).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} == set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} <= set(p.mle.tlv.type))
         _rpkts.filter_coap_request(SVR_DATA_URI).must_next().must_verify(
             lambda p: p.wpan.dst16 == pv.vars['LEADER_RLOC16'] and {
                 Ipv6Addr('2001:2:0:1::'), Ipv6Addr('2001:2:0:2::')
@@ -136,7 +136,7 @@ class Cert_7_1_2_BorderRouterAsRouter(thread_cert.TestCase):
         # Step 3: Automatically transmits a 2.04 Changed CoAP response to the DUT
         # Step 4: The DUT MUST multicast the MLE Data Response message sent by the Leader
         _rpkts.filter_mle_cmd(MLE_DATA_RESPONSE).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} == set(p.mle.tlv.
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} <= set(p.mle.tlv.
                                                                                                            type))
 
         # Step 5: MED_1 to attach to DUT and request complete network data

--- a/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
@@ -177,7 +177,7 @@ class Cert_7_1_3_BorderRouterAsLeader(thread_cert.TestCase):
                                   SOURCE_ADDRESS_TLV,
                                   MODE_TLV,
                                   ADDRESS_REGISTRATION_TLV
-                                 } < set(p.mle.tlv.type) and\
+                                 } <= set(p.mle.tlv.type) and\
                        p.mle.tlv.addr_reg_iid is not nullField and\
                        set(_pkt.mle.tlv.addr_reg_iid) > set(p.mle.tlv.addr_reg_iid)
                        ).\
@@ -197,7 +197,7 @@ class Cert_7_1_3_BorderRouterAsLeader(thread_cert.TestCase):
                               SOURCE_ADDRESS_TLV,
                               LEADER_DATA_TLV,
                               ACTIVE_TIMESTAMP_TLV
-                             } == set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                    [Ipv6Addr(PREFIX_2001[:-3])] == p.thread_nwd.tlv.prefix and\
                    p.thread_nwd.tlv.border_router.flag.p == [1] and\
                    p.thread_nwd.tlv.border_router.flag.s == [1] and\
@@ -228,7 +228,7 @@ class Cert_7_1_3_BorderRouterAsLeader(thread_cert.TestCase):
                               SOURCE_ADDRESS_TLV,
                               MODE_TLV,
                               ADDRESS_REGISTRATION_TLV
-                             } < set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                    p.mle.tlv.addr_reg_iid is not nullField and\
                    set(_pkt.mle.tlv.addr_reg_iid) > set(p.mle.tlv.addr_reg_iid)
                    ).\

--- a/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
@@ -125,7 +125,7 @@ class Cert_7_1_4_BorderRouterAsRouter(thread_cert.TestCase):
         # with the server’s information (Prefix, Border Router) to the Leader
         _rpkts.filter_mle_cmd(MLE_CHILD_ID_REQUEST).must_next()
         _rpkts.filter_mle_cmd(MLE_ADVERTISEMENT).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} == set(p.mle.tlv.type))
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, ROUTE64_TLV} <= set(p.mle.tlv.type))
         _pkt = _rpkts.filter_coap_request(SVR_DATA_URI).must_next()
         _pkt.must_verify(lambda p: p.wpan.dst16 == pv.vars['LEADER_RLOC16'] and {
             Ipv6Addr('2001:2:0:1::'), Ipv6Addr('2001:2:0:2::')
@@ -138,7 +138,7 @@ class Cert_7_1_4_BorderRouterAsRouter(thread_cert.TestCase):
         # Step 4: Automatically transmits a 2.04 Changed CoAP response to the DUT
         # Step 5: The DUT MUST send a multicast MLE Data Response
         _rpkts.filter_mle_cmd(MLE_DATA_RESPONSE).must_next().must_verify(
-            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} == set(
+            lambda p: {SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV} <= set(
                 p.mle.tlv.type) and {Ipv6Addr('2001:2:0:1::'), Ipv6Addr('2001:2:0:2::')} == set(
                     p.thread_nwd.tlv.prefix) and p.thread_nwd.tlv.border_router.flag.p == [1, 1] and p.thread_nwd.tlv.
             border_router.flag.s == [1, 1] and p.thread_nwd.tlv.border_router.flag.r == [1, 1] and p.thread_nwd.tlv.

--- a/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
@@ -188,7 +188,7 @@ class Cert_7_1_5_BorderRouterAsRouter(thread_cert.TestCase):
                               SOURCE_ADDRESS_TLV,
                               MODE_TLV,
                               ADDRESS_REGISTRATION_TLV
-                             } < set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                    len(p.mle.tlv.addr_reg_iid) >= 3 and\
                    set(p.mle.tlv.addr_reg_iid) < set(_pkt.mle.tlv.addr_reg_iid)
                    ).\
@@ -214,7 +214,7 @@ class Cert_7_1_5_BorderRouterAsRouter(thread_cert.TestCase):
                               SOURCE_ADDRESS_TLV,
                               LEADER_DATA_TLV,
                               ACTIVE_TIMESTAMP_TLV
-                             } == set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                              {
                               Ipv6Addr(PREFIX_2001[:-3]),
                               Ipv6Addr(PREFIX_2003[:-3])
@@ -246,7 +246,7 @@ class Cert_7_1_5_BorderRouterAsRouter(thread_cert.TestCase):
                               SOURCE_ADDRESS_TLV,
                               MODE_TLV,
                               ADDRESS_REGISTRATION_TLV
-                             } < set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                    len(p.mle.tlv.addr_reg_iid) >= 2 and\
                    set(p.mle.tlv.addr_reg_iid) < set(_pkt.mle.tlv.addr_reg_iid)
                    ).\

--- a/tests/scripts/thread-cert/Cert_7_1_06_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_06_BorderRouterAsLeader.py
@@ -287,7 +287,7 @@ class Cert_7_1_6_BorderRouterAsLeader(thread_cert.TestCase):
                               SOURCE_ADDRESS_TLV,
                               LEADER_DATA_TLV,
                               ACTIVE_TIMESTAMP_TLV
-                             } == set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                    [Ipv6Addr(PREFIX_2001[:-3])] ==
                    p.thread_nwd.tlv.prefix and\
                    p.thread_nwd.tlv.stable == [1, 1, 1] and\
@@ -459,7 +459,7 @@ class Cert_7_1_6_BorderRouterAsLeader(thread_cert.TestCase):
                               SOURCE_ADDRESS_TLV,
                               LEADER_DATA_TLV,
                               ACTIVE_TIMESTAMP_TLV
-                             } == set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                    [Ipv6Addr(PREFIX_2001[:-3])] ==
                    p.thread_nwd.tlv.prefix and\
                    p.mle.tlv.leader_data.data_version  ==

--- a/tests/scripts/thread-cert/Cert_7_1_07_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_07_BorderRouterAsLeader.py
@@ -313,7 +313,7 @@ class Cert_7_1_7_BorderRouterAsLeader(thread_cert.TestCase):
                               SOURCE_ADDRESS_TLV,
                               LEADER_DATA_TLV,
                               ACTIVE_TIMESTAMP_TLV
-                             } == set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                    is_sublist([Ipv6Addr(PREFIX_1[:-3])], p.thread_nwd.tlv.prefix) and\
                    is_sublist([1, 1, 1], p.thread_nwd.tlv.stable) and\
                    is_sublist([1], getattr(p.thread_nwd.tlv, '6co').flag.c) and\
@@ -429,7 +429,7 @@ class Cert_7_1_7_BorderRouterAsLeader(thread_cert.TestCase):
                                   SOURCE_ADDRESS_TLV,
                                   LEADER_DATA_TLV,
                                   ACTIVE_TIMESTAMP_TLV
-                                 } == set(p.mle.tlv.type) and\
+                                 } <= set(p.mle.tlv.type) and\
                        is_sublist([1, 1, 1, 1, 1, 1],
                                p.thread_nwd.tlv.stable) and\
                        is_sublist([1, 1], getattr(p.thread_nwd.tlv, '6co').flag.c) and\
@@ -548,7 +548,7 @@ class Cert_7_1_7_BorderRouterAsLeader(thread_cert.TestCase):
                               SOURCE_ADDRESS_TLV,
                               LEADER_DATA_TLV,
                               ACTIVE_TIMESTAMP_TLV
-                             } == set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                    is_sublist([Ipv6Addr(PREFIX_1[:-3]), Ipv6Addr(PREFIX_2[:-3])],
                            p.thread_nwd.tlv.prefix) and\
                    is_sublist([1, 1, 1, 1, 1], p.thread_nwd.tlv.stable) and\

--- a/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
@@ -82,7 +82,7 @@ class Cert_8_1_02_Commissioning(thread_cert.TestCase):
             lambda p: {
                 NM_EXTENDED_PAN_ID_TLV, NM_NETWORK_NAME_TLV, NM_STEERING_DATA_TLV, NM_COMMISSIONER_UDP_PORT_TLV,
                 NM_JOINER_UDP_PORT_TLV, NM_DISCOVERY_RESPONSE_TLV
-            } == set(p.thread_meshcop.tlv.type))
+            } <= set(p.thread_meshcop.tlv.type))
 
         # 2. Joiner_1 sends an initial DTLS-ClientHello handshake record to the Commissioner
         _cpkts2.range(_cpkts.index).filter(lambda p: p.dtls.handshake.type == [HANDSHAKE_CLIENT_HELLO]).must_next()

--- a/tests/scripts/thread-cert/Cert_8_1_06_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_06_Commissioning.py
@@ -123,7 +123,7 @@ class Cert_8_1_06_Commissioning(thread_cert.TestCase):
                               NM_COMMISSIONER_UDP_PORT_TLV,
                               NM_JOINER_UDP_PORT_TLV,
                               NM_DISCOVERY_RESPONSE_TLV
-                            } == set(p.thread_meshcop.tlv.type) and\
+                            } <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.discovery_rsp_ver ==
                    COMMISSIONER_VERSION
                   ).\

--- a/tests/scripts/thread-cert/Cert_8_2_01_JoinerRouter.py
+++ b/tests/scripts/thread-cert/Cert_8_2_01_JoinerRouter.py
@@ -119,7 +119,7 @@ class Cert_8_2_01_JoinerRouter(thread_cert.TestCase):
             lambda p: {
                 NM_EXTENDED_PAN_ID_TLV, NM_NETWORK_NAME_TLV, NM_STEERING_DATA_TLV, NM_COMMISSIONER_UDP_PORT_TLV,
                 NM_JOINER_UDP_PORT_TLV, NM_DISCOVERY_RESPONSE_TLV
-            } == set(p.thread_meshcop.tlv.type))
+            } <= set(p.thread_meshcop.tlv.type))
 
         # 2. Joiner_1 sends an initial DTLS-ClientHello handshake record to the Commissioner
         pkts.filter(lambda p: p.dtls.handshake.type == [HANDSHAKE_CLIENT_HELLO]).must_next()

--- a/tests/scripts/thread-cert/Cert_8_2_02_JoinerRouter.py
+++ b/tests/scripts/thread-cert/Cert_8_2_02_JoinerRouter.py
@@ -111,7 +111,7 @@ class Cert_8_2_02_JoinerRouter(thread_cert.TestCase):
             lambda p: {
                 NM_EXTENDED_PAN_ID_TLV, NM_NETWORK_NAME_TLV, NM_STEERING_DATA_TLV, NM_COMMISSIONER_UDP_PORT_TLV,
                 NM_JOINER_UDP_PORT_TLV, NM_DISCOVERY_RESPONSE_TLV
-            } == set(p.thread_meshcop.tlv.type))
+            } <= set(p.thread_meshcop.tlv.type))
 
         # 2. Joiner_1 sends an initial DTLS-ClientHello handshake record to the Commissioner
         pkts.filter(lambda p: p.dtls.handshake.type == [HANDSHAKE_CLIENT_HELLO]).must_next()

--- a/tests/scripts/thread-cert/Cert_8_2_05_JoinerRouter.py
+++ b/tests/scripts/thread-cert/Cert_8_2_05_JoinerRouter.py
@@ -161,7 +161,7 @@ class Cert_8_2_05_JoinerRouter(thread_cert.TestCase):
                               NM_COMMISSIONER_UDP_PORT_TLV,
                               NM_JOINER_UDP_PORT_TLV,
                               NM_DISCOVERY_RESPONSE_TLV
-                            } == set(p.thread_meshcop.tlv.type)
+                            } <= set(p.thread_meshcop.tlv.type)
                   ).\
             must_next()
 
@@ -198,7 +198,7 @@ class Cert_8_2_05_JoinerRouter(thread_cert.TestCase):
                               NM_JOINER_UDP_PORT_TLV,
                               NM_JOINER_IID_TLV,
                               NM_JOINER_ROUTER_LOCATOR_TLV
-                             } == set(p.thread_meshcop.tlv.type) and\
+                             } <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.udp_port == [_ch_pkt.udp.dstport] and\
                    p.thread_meshcop.tlv.jr_locator == JOINER_ROUTER_RLOC16
                    ).\
@@ -223,7 +223,7 @@ class Cert_8_2_05_JoinerRouter(thread_cert.TestCase):
                               NM_JOINER_IID_TLV,
                               NM_JOINER_ROUTER_LOCATOR_TLV,
                               NM_JOINER_ROUTER_KEK_TLV
-                             } == set(p.thread_meshcop.tlv.type) and\
+                             } <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.udp_port == [_ch_pkt.udp.dstport] and\
                    p.thread_meshcop.tlv.jr_locator == JOINER_ROUTER_RLOC16
                    ).\

--- a/tests/scripts/thread-cert/Cert_8_3_01_CommissionerPetition.py
+++ b/tests/scripts/thread-cert/Cert_8_3_01_CommissionerPetition.py
@@ -122,7 +122,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
             filter_coap_request(LEAD_PET_URI).\
             filter(lambda p: {
                               NM_COMMISSIONER_ID_TLV
-                              } == set(p.coap.tlv.type)\
+                              } <= set(p.coap.tlv.type)\
                    ).\
            must_next()
 
@@ -159,15 +159,15 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
                               SOURCE_ADDRESS_TLV,
                               ACTIVE_TIMESTAMP_TLV,
                               LEADER_DATA_TLV
-                             } == set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                              {
                               NWD_COMMISSIONING_DATA_TLV
-                             } == set(p.thread_nwd.tlv.type) and\
+                             } <= set(p.thread_nwd.tlv.type) and\
                              {
                               NM_BORDER_AGENT_LOCATOR_TLV,
                               NM_COMMISSIONER_SESSION_ID_TLV,
                               NM_STEERING_DATA_TLV
-                             } == set(p.thread_meshcop.tlv.type) and\
+                             } <= set(p.thread_meshcop.tlv.type) and\
                    p.mle.tlv.leader_data.data_version ==
                    (_pkt.mle.tlv.leader_data.data_version + 1) % 256 and\
                    p.thread_nwd.tlv.stable == [0]
@@ -186,7 +186,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
             filter(lambda p: {
                               NM_STATE_TLV,
                               NM_COMMISSIONER_SESSION_ID_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.thread_meshcop.tlv.state == MESHCOP_ACCEPT
                    ).\
            must_next()
@@ -218,7 +218,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
             filter(lambda p: {
                               NM_STEERING_DATA_TLV,
                               NM_COMMISSIONER_SESSION_ID_TLV
-                              } == set(p.coap.tlv.type)
+                              } <= set(p.coap.tlv.type)
                    ).\
            must_next()
 
@@ -252,15 +252,15 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
                               SOURCE_ADDRESS_TLV,
                               ACTIVE_TIMESTAMP_TLV,
                               LEADER_DATA_TLV
-                             } == set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                              {
                               NWD_COMMISSIONING_DATA_TLV
-                             } == set(p.thread_nwd.tlv.type) and\
+                             } <= set(p.thread_nwd.tlv.type) and\
                              {
                               NM_BORDER_AGENT_LOCATOR_TLV,
                               NM_COMMISSIONER_SESSION_ID_TLV,
                               NM_STEERING_DATA_TLV
-                             } == set(p.thread_meshcop.tlv.type) and\
+                             } <= set(p.thread_meshcop.tlv.type) and\
                    p.mle.tlv.leader_data.data_version ==
                    (_dr_pkt.mle.tlv.leader_data.data_version + 1) % 256 and\
                    p.thread_nwd.tlv.stable == [0]
@@ -280,7 +280,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
             filter(lambda p: {
                               NM_STATE_TLV,
                               NM_COMMISSIONER_SESSION_ID_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.thread_meshcop.tlv.state == MESHCOP_REJECT
                    ).\
            must_next()
@@ -302,7 +302,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
             filter_coap_ack(LEAD_KA_URI).\
             filter(lambda p: {
                               NM_STATE_TLV
-                              } == set(p.coap.tlv.type) and\
+                              } <= set(p.coap.tlv.type) and\
                    p.thread_meshcop.tlv.state == MESHCOP_REJECT
                    ).\
            must_next()
@@ -314,13 +314,13 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
                               SOURCE_ADDRESS_TLV,
                               ACTIVE_TIMESTAMP_TLV,
                               LEADER_DATA_TLV
-                             } == set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                              {
                               NWD_COMMISSIONING_DATA_TLV
-                             } == set(p.thread_nwd.tlv.type) and\
+                             } <= set(p.thread_nwd.tlv.type) and\
                              {
                               NM_COMMISSIONER_SESSION_ID_TLV
-                             } == set(p.thread_meshcop.tlv.type) and\
+                             } <= set(p.thread_meshcop.tlv.type) and\
                    (p.mle.tlv.leader_data.data_version -
                    _dr_pkt2.mle.tlv.leader_data.data_version) % 256 <= 127 and\
                    p.thread_nwd.tlv.stable == [0]
@@ -337,7 +337,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
             filter_coap_request(LEAD_PET_URI).\
             filter(lambda p: {
                               NM_COMMISSIONER_ID_TLV
-                              } == set(p.coap.tlv.type)\
+                              } <= set(p.coap.tlv.type)\
                    ).\
            must_next()
 

--- a/tests/scripts/thread-cert/Cert_9_2_01_MGMTCommissionerGet.py
+++ b/tests/scripts/thread-cert/Cert_9_2_01_MGMTCommissionerGet.py
@@ -146,7 +146,7 @@ class Cert_9_2_01_MGMTCommissionerGet(thread_cert.TestCase):
                               NM_COMMISSIONER_SESSION_ID_TLV,
                               NM_BORDER_AGENT_LOCATOR_TLV,
                               NM_STEERING_DATA_TLV
-                             } == set(p.thread_meshcop.tlv.type) and\
+                             } <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.ba_locator is not nullField and\
                    p.thread_meshcop.tlv.commissioner_sess_id is not nullField and\
                    p.thread_meshcop.tlv.steering_data is not nullField
@@ -183,7 +183,7 @@ class Cert_9_2_01_MGMTCommissionerGet(thread_cert.TestCase):
             filter(lambda p: {
                               NM_COMMISSIONER_SESSION_ID_TLV,
                               NM_STEERING_DATA_TLV
-                             } == set(p.thread_meshcop.tlv.type) and\
+                             } <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.commissioner_sess_id is not nullField and\
                    p.thread_meshcop.tlv.steering_data is not nullField
                    ).\
@@ -218,7 +218,7 @@ class Cert_9_2_01_MGMTCommissionerGet(thread_cert.TestCase):
             filter_coap_ack(MGMT_COMMISSIONER_GET_URI).\
             filter(lambda p: {
                               NM_COMMISSIONER_SESSION_ID_TLV
-                             } == set(p.thread_meshcop.tlv.type) and\
+                             } <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.commissioner_sess_id is not nullField and\
                    p.thread_meshcop.tlv.pan_id is nullField
                    ).\
@@ -253,7 +253,7 @@ class Cert_9_2_01_MGMTCommissionerGet(thread_cert.TestCase):
             filter_coap_ack(MGMT_COMMISSIONER_GET_URI).\
             filter(lambda p: {
                               NM_BORDER_AGENT_LOCATOR_TLV
-                             } == set(p.thread_meshcop.tlv.type) and\
+                             } <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.ba_locator is not nullField and\
                    p.thread_meshcop.tlv.net_name is nullField
                    ).\

--- a/tests/scripts/thread-cert/Cert_9_2_02_MGMTCommissionerSet.py
+++ b/tests/scripts/thread-cert/Cert_9_2_02_MGMTCommissionerSet.py
@@ -185,7 +185,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
             filter(lambda p: {
                               NM_COMMISSIONER_SESSION_ID_TLV,
                               NM_STEERING_DATA_TLV
-                             } == set(p.thread_meshcop.tlv.type) and\
+                             } <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.steering_data == Bytes('ff')
                    ).\
            must_next()
@@ -218,15 +218,15 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
                               SOURCE_ADDRESS_TLV,
                               ACTIVE_TIMESTAMP_TLV,
                               LEADER_DATA_TLV
-                             } == set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                              {
                               NWD_COMMISSIONING_DATA_TLV
-                             } == set(p.thread_nwd.tlv.type) and\
+                             } <= set(p.thread_nwd.tlv.type) and\
                              {
                               NM_BORDER_AGENT_LOCATOR_TLV,
                               NM_COMMISSIONER_SESSION_ID_TLV,
                               NM_STEERING_DATA_TLV
-                             } == set(p.thread_meshcop.tlv.type) and\
+                             } <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_nwd.tlv.stable == [0]
                    ).\
             must_next()
@@ -244,7 +244,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
             filter(lambda p: {
                               NM_COMMISSIONER_SESSION_ID_TLV,
                               NM_BORDER_AGENT_LOCATOR_TLV
-                             } == set(p.thread_meshcop.tlv.type) and\
+                             } <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.ba_locator == 0x0400
                    ).\
            must_next()
@@ -278,7 +278,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
                               NM_COMMISSIONER_SESSION_ID_TLV,
                               NM_STEERING_DATA_TLV,
                               NM_BORDER_AGENT_LOCATOR_TLV
-                             } == set(p.thread_meshcop.tlv.type) and\
+                             } <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.ba_locator == 0x0400 and\
                    p.thread_meshcop.tlv.steering_data == Bytes('ff')
                    ).\
@@ -311,7 +311,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
             filter(lambda p: {
                               NM_COMMISSIONER_SESSION_ID_TLV,
                               NM_STEERING_DATA_TLV
-                             } == set(p.thread_meshcop.tlv.type) and\
+                             } <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.commissioner_sess_id == 0xFFFF and\
                    p.thread_meshcop.tlv.steering_data == Bytes('ff')
                    ).\
@@ -346,7 +346,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
                               NM_COMMISSIONER_SESSION_ID_TLV,
                               NM_STEERING_DATA_TLV,
                               NM_CHANNEL_TLV
-                             } == set(p.thread_meshcop.tlv.type) and\
+                             } <= set(p.thread_meshcop.tlv.type) and\
                    p.thread_meshcop.tlv.steering_data == Bytes('ff')
                    ).\
            must_next()

--- a/tests/scripts/thread-cert/Cert_9_2_03_ActiveDatasetGet.py
+++ b/tests/scripts/thread-cert/Cert_9_2_03_ActiveDatasetGet.py
@@ -162,7 +162,7 @@ class Cert_9_2_03_ActiveDatasetGet(thread_cert.TestCase):
                               NM_PAN_ID_TLV,
                               NM_PSKC_TLV,
                               NM_SECURITY_POLICY_TLV
-                             } == set(p.thread_meshcop.tlv.type)
+                             } <= set(p.thread_meshcop.tlv.type)
                    ).\
            must_next()
 
@@ -199,7 +199,7 @@ class Cert_9_2_03_ActiveDatasetGet(thread_cert.TestCase):
                               NM_CHANNEL_MASK_TLV,
                               NM_NETWORK_MESH_LOCAL_PREFIX_TLV,
                               NM_NETWORK_NAME_TLV
-                             } == set(p.thread_meshcop.tlv.type)
+                             } <= set(p.thread_meshcop.tlv.type)
                    ).\
            must_next()
 
@@ -240,7 +240,7 @@ class Cert_9_2_03_ActiveDatasetGet(thread_cert.TestCase):
                               NM_CHANNEL_TLV,
                               NM_NETWORK_MESH_LOCAL_PREFIX_TLV,
                               NM_NETWORK_NAME_TLV,
-                             } == set(p.thread_meshcop.tlv.type)
+                             } <= set(p.thread_meshcop.tlv.type)
                    ).\
            must_next()
 

--- a/tests/scripts/thread-cert/Cert_9_2_07_DelayTimer.py
+++ b/tests/scripts/thread-cert/Cert_9_2_07_DelayTimer.py
@@ -159,7 +159,7 @@ class Cert_9_2_7_DelayTimer(thread_cert.TestCase):
 
         # Step 4: Leader MUST send a unicast MLE Child ID Response to the Router
         _lpkts.filter_wpan_dst64(ROUTER).filter_mle_cmd(MLE_CHILD_ID_RESPONSE).must_next(
-        ).must_verify(lambda p: {ACTIVE_OPERATION_DATASET_TLV, ACTIVE_TIMESTAMP_TLV} < set(p.mle.tlv.type) and {
+        ).must_verify(lambda p: {ACTIVE_OPERATION_DATASET_TLV, ACTIVE_TIMESTAMP_TLV} <= set(p.mle.tlv.type) and {
             NM_CHANNEL_TLV, NM_CHANNEL_MASK_TLV, NM_EXTENDED_PAN_ID_TLV, NM_NETWORK_KEY_TLV,
             NM_NETWORK_MESH_LOCAL_PREFIX_TLV, NM_NETWORK_NAME_TLV, NM_PAN_ID_TLV, NM_PSKC_TLV, NM_SECURITY_POLICY_TLV
         } <= set(p.thread_meshcop.tlv.type) and p.mle.tlv.active_tstamp == LEADER_ACTIVE_TIMESTAMP)
@@ -177,7 +177,7 @@ class Cert_9_2_7_DelayTimer(thread_cert.TestCase):
 
         # Step 10: Leader MUST send a unicast MLE Data Response to the Router
         _lpkts.filter_wpan_dst64(ROUTER).filter_mle_cmd(MLE_DATA_RESPONSE).must_next(
-        ).must_verify(lambda p: {ACTIVE_OPERATION_DATASET_TLV, ACTIVE_TIMESTAMP_TLV} < set(p.mle.tlv.type) and {
+        ).must_verify(lambda p: {ACTIVE_OPERATION_DATASET_TLV, ACTIVE_TIMESTAMP_TLV} <= set(p.mle.tlv.type) and {
             NM_CHANNEL_TLV, NM_CHANNEL_MASK_TLV, NM_EXTENDED_PAN_ID_TLV, NM_NETWORK_KEY_TLV,
             NM_NETWORK_MESH_LOCAL_PREFIX_TLV, NM_NETWORK_NAME_TLV, NM_PAN_ID_TLV, NM_PSKC_TLV, NM_SECURITY_POLICY_TLV
         } <= set(p.thread_meshcop.tlv.type) and p.mle.tlv.active_tstamp == ROUTER_ACTIVE_TIMESTAMP)
@@ -198,7 +198,7 @@ class Cert_9_2_7_DelayTimer(thread_cert.TestCase):
 
         # Step 16: Leader MUST send a unicast MLE Data Response to the Router
         _lpkts.filter_wpan_dst64(ROUTER).filter_mle_cmd(MLE_DATA_RESPONSE).must_next().must_verify(
-            lambda p: {ACTIVE_TIMESTAMP_TLV, PENDING_TIMESTAMP_TLV} < set(p.mle.tlv.type) and p.mle.tlv.active_tstamp
+            lambda p: {ACTIVE_TIMESTAMP_TLV, PENDING_TIMESTAMP_TLV} <= set(p.mle.tlv.type) and p.mle.tlv.active_tstamp
             == ROUTER_ACTIVE_TIMESTAMP and p.mle.tlv.pending_tstamp == ROUTER_PENDING_TIMESTAMP)
 
         # Step 18: The DUT MUST send MGMT_PENDING_SET.rsp to the Commissioner

--- a/tests/scripts/thread-cert/Cert_9_2_08_PersistentDatasets.py
+++ b/tests/scripts/thread-cert/Cert_9_2_08_PersistentDatasets.py
@@ -285,7 +285,7 @@ class Cert_9_2_8_PersistentDatasets_Base(thread_cert.TestCase):
             filter(lambda p: {
                               TLV_REQUEST_TLV,
                               NETWORK_DATA_TLV
-                             } < set(p.mle.tlv.type) and\
+                             } <= set(p.mle.tlv.type) and\
                    p.thread_nwd.tlv.type is nullField and\
                    p.mle.tlv.active_tstamp == LEADER_ACTIVE_TIMESTAMP
                   ).\
@@ -302,7 +302,7 @@ class Cert_9_2_8_PersistentDatasets_Base(thread_cert.TestCase):
                               ACTIVE_TIMESTAMP_TLV,
                               PENDING_TIMESTAMP_TLV,
                               PENDING_OPERATION_DATASET_TLV
-                              } < set(p.mle.tlv.type)
+                              } <= set(p.mle.tlv.type)
                    ).\
             must_next()
 

--- a/tests/scripts/thread-cert/Cert_9_2_12_Announce.py
+++ b/tests/scripts/thread-cert/Cert_9_2_12_Announce.py
@@ -152,7 +152,7 @@ class Cert_9_2_12_Announce(thread_cert.TestCase):
 
         pkts.filter_wpan_src64(LEADER_2).filter_ipv6_dst(LINK_LOCAL_ALL_NODES_MULTICAST_ADDRESS).filter_mle_cmd(
             MLE_ANNOUNCE).must_next().must_verify(
-                lambda p: {CHANNEL_TLV, PAN_ID_TLV, ACTIVE_TIMESTAMP_TLV} == set(p.mle.tlv.type) and p.wpan.dst_pan ==
+                lambda p: {CHANNEL_TLV, PAN_ID_TLV, ACTIVE_TIMESTAMP_TLV} <= set(p.mle.tlv.type) and p.wpan.dst_pan ==
                 0xffff and p.wpan.aux_sec.key_id_mode == 0x2 and p.wpan.aux_sec.key_source == 0x00000000ffffffff)
 
         # Step 5: MED MUST send a MLE Child ID Request on its new channel
@@ -163,7 +163,7 @@ class Cert_9_2_12_Announce(thread_cert.TestCase):
 
         pkts.filter_wpan_src64(MED).filter_ipv6_dst(LINK_LOCAL_ALL_NODES_MULTICAST_ADDRESS).filter_mle_cmd(
             MLE_ANNOUNCE).must_next().must_verify(
-                lambda p: {CHANNEL_TLV, PAN_ID_TLV, ACTIVE_TIMESTAMP_TLV} == set(p.mle.tlv.type) and p.wpan.dst_pan ==
+                lambda p: {CHANNEL_TLV, PAN_ID_TLV, ACTIVE_TIMESTAMP_TLV} <= set(p.mle.tlv.type) and p.wpan.dst_pan ==
                 0xffff and p.wpan.aux_sec.key_id_mode == 0x2 and p.wpan.aux_sec.key_source == 0x00000000ffffffff)
 
         # Step 6: MED MUST respond with an ICMPv6 Echo Reply

--- a/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
@@ -112,12 +112,12 @@ class Cert_9_2_13_EnergyScan_Base(thread_cert.TestCase):
 
         # Step 3: The DUT MUST send MGMT_ED_REPORT.ans to the Commissioner and report energy measurements
         _pkts.filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_request(MGMT_ED_REPORT).must_next().must_verify(
-            lambda p: {NM_CHANNEL_MASK_TLV, NM_ENERGY_LIST_TLV} == set(p.thread_meshcop.tlv.type) and p.thread_meshcop.
+            lambda p: {NM_CHANNEL_MASK_TLV, NM_ENERGY_LIST_TLV} <= set(p.thread_meshcop.tlv.type) and p.thread_meshcop.
             tlv.chan_mask_mask == '0000a000' and len(p.thread_meshcop.tlv.energy_list) == 2)
 
         # Step 5: The DUT MUST send MGMT_ED_REPORT.ans to the Commissioner and report energy measurements
         _pkts.filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_request(MGMT_ED_REPORT).must_next().must_verify(
-            lambda p: {NM_CHANNEL_MASK_TLV, NM_ENERGY_LIST_TLV} == set(p.thread_meshcop.tlv.type) and p.thread_meshcop.
+            lambda p: {NM_CHANNEL_MASK_TLV, NM_ENERGY_LIST_TLV} <= set(p.thread_meshcop.tlv.type) and p.thread_meshcop.
             tlv.chan_mask_mask == '0000a000' and len(p.thread_meshcop.tlv.energy_list) == 2)
 
         # Step 6: The DUT MUST respond with ICMPv6 Echo Reply

--- a/tests/scripts/thread-cert/Cert_9_2_15_PendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_15_PendingPartition.py
@@ -174,24 +174,24 @@ class Cert_9_2_15_PendingPartition(thread_cert.TestCase):
         # Step 5: Router_2 begins attach process by sending a multicast MLE Parent Request
         # The first MLE Parent Request sent MUST NOT be sent to all routers and REEDS
         _router2_pkts.range(pkts.index).filter_mle_cmd(MLE_PARENT_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(
+            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(
                 p.mle.tlv.type) and p.mle.tlv.scan_mask.r == 1 and p.mle.tlv.scan_mask.e == 0)
 
         # Step 7: Router_2  MUST send a MLE Child ID Request to Router_1
         _router2_pkts.filter_mle_cmd(MLE_CHILD_ID_REQUEST).must_next().must_verify(lambda p: {
             RESPONSE_TLV, LINK_LAYER_FRAME_COUNTER_TLV, MODE_TLV, TIMEOUT_TLV, VERSION_TLV, TLV_REQUEST_TLV
-        } < set(p.mle.tlv.type) and ADDRESS_REGISTRATION_TLV not in p.mle.tlv.type)
+        } <= set(p.mle.tlv.type) and ADDRESS_REGISTRATION_TLV not in p.mle.tlv.type)
 
         # Step 14: Router_2 begins attach process by sending a multicast MLE Parent Request
         # The first MLE Parent Request sent MUST NOT be sent to all routers and REEDS
         _router2_pkts.filter_mle_cmd(MLE_PARENT_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(
+            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(
                 p.mle.tlv.type) and p.mle.tlv.scan_mask.r == 1 and p.mle.tlv.scan_mask.e == 0)
 
         # Step 16: Router_2 MUST send a MLE Child ID Request to Router_1
         _router2_pkts.filter_mle_cmd(MLE_CHILD_ID_REQUEST).must_next().must_verify(lambda p: {
             RESPONSE_TLV, LINK_LAYER_FRAME_COUNTER_TLV, MODE_TLV, TIMEOUT_TLV, VERSION_TLV, TLV_REQUEST_TLV
-        } < set(p.mle.tlv.type) and ADDRESS_REGISTRATION_TLV not in p.mle.tlv.type)
+        } <= set(p.mle.tlv.type) and ADDRESS_REGISTRATION_TLV not in p.mle.tlv.type)
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_9_2_16_ActivePendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_16_ActivePendingPartition.py
@@ -184,24 +184,24 @@ class Cert_9_2_16_ActivePendingPartition(thread_cert.TestCase):
         # Step 5: Router_2 begins attach process by sending a multicast MLE Parent Request
         # The first MLE Parent Request sent MUST NOT be sent to all routers and REEDS
         _router2_pkts.range(pkts.index).filter_mle_cmd(MLE_PARENT_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(
+            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(
                 p.mle.tlv.type) and p.mle.tlv.scan_mask.r == 1 and p.mle.tlv.scan_mask.e == 0)
 
         # Step 7: Router_2  MUST send a MLE Child ID Request to Router_1
         _router2_pkts.filter_mle_cmd(MLE_CHILD_ID_REQUEST).must_next().must_verify(lambda p: {
             RESPONSE_TLV, LINK_LAYER_FRAME_COUNTER_TLV, MODE_TLV, TIMEOUT_TLV, VERSION_TLV, TLV_REQUEST_TLV
-        } < set(p.mle.tlv.type) and ADDRESS_REGISTRATION_TLV not in p.mle.tlv.type)
+        } <= set(p.mle.tlv.type) and ADDRESS_REGISTRATION_TLV not in p.mle.tlv.type)
 
         # Step 14: Router_2 begins attach process by sending a multicast MLE Parent Request
         # The first MLE Parent Request sent MUST NOT be sent to all routers and REEDS
         _router2_pkts.filter_mle_cmd(MLE_PARENT_REQUEST).must_next().must_verify(
-            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} == set(
+            lambda p: {MODE_TLV, CHALLENGE_TLV, SCAN_MASK_TLV, VERSION_TLV} <= set(
                 p.mle.tlv.type) and p.mle.tlv.scan_mask.r == 1 and p.mle.tlv.scan_mask.e == 0)
 
         # Step 16: Router_2 MUST send a MLE Child ID Request to Router_1
         _router2_pkts.filter_mle_cmd(MLE_CHILD_ID_REQUEST).must_next().must_verify(lambda p: {
             RESPONSE_TLV, LINK_LAYER_FRAME_COUNTER_TLV, MODE_TLV, TIMEOUT_TLV, VERSION_TLV, TLV_REQUEST_TLV
-        } < set(p.mle.tlv.type) and ADDRESS_REGISTRATION_TLV not in p.mle.tlv.type)
+        } <= set(p.mle.tlv.type) and ADDRESS_REGISTRATION_TLV not in p.mle.tlv.type)
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_9_2_17_Orphan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_17_Orphan.py
@@ -129,7 +129,7 @@ class Cert_9_2_17_Orphan(thread_cert.TestCase):
         # Step 6: ED MUST send a MLE Announce Message
         # The Destination PAN ID (0xFFFF) in the IEEE 802.15.4 MAC and MUST be secured using Key ID Mode 2.
         _epkts.filter_mle_cmd(MLE_ANNOUNCE).must_next().must_verify(
-            lambda p: {CHANNEL_TLV, PAN_ID_TLV, ACTIVE_TIMESTAMP_TLV} == set(
+            lambda p: {CHANNEL_TLV, PAN_ID_TLV, ACTIVE_TIMESTAMP_TLV} <= set(
                 p.mle.tlv.type) and p.wpan.dst_pan == 0xffff and p.wpan.aux_sec.key_id_mode == 0x2)
 
         # Step 8: ED MUST attempt to attach on the Secondary channel,

--- a/tests/scripts/thread-cert/Cert_9_2_18_RollBackActiveTimestamp.py
+++ b/tests/scripts/thread-cert/Cert_9_2_18_RollBackActiveTimestamp.py
@@ -196,7 +196,7 @@ class Cert_9_2_18_RollBackActiveTimestamp(thread_cert.TestCase):
             MLE_DATA_RESPONSE).must_next()
         _pkt.must_verify(lambda p: {
             SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV, PENDING_TIMESTAMP_TLV
-        } == set(p.mle.tlv.type) and {NM_COMMISSIONER_SESSION_ID_TLV, NM_BORDER_AGENT_LOCATOR_TLV} <= set(
+        } <= set(p.mle.tlv.type) and {NM_COMMISSIONER_SESSION_ID_TLV, NM_BORDER_AGENT_LOCATOR_TLV} <= set(
             p.thread_meshcop.tlv.type) and p.thread_nwd.tlv.stable == [0])
 
         # Step 9: Router MUST send a unicast MLE Data Request to the Leader
@@ -209,7 +209,7 @@ class Cert_9_2_18_RollBackActiveTimestamp(thread_cert.TestCase):
                 lambda p: {
                     SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV, PENDING_TIMESTAMP_TLV,
                     PENDING_OPERATION_DATASET_TLV
-                } == set(p.mle.tlv.type) and {
+                } <= set(p.mle.tlv.type) and {
                     NM_COMMISSIONER_SESSION_ID_TLV, NM_BORDER_AGENT_LOCATOR_TLV, NM_ACTIVE_TIMESTAMP_TLV,
                     NM_NETWORK_NAME_TLV, NM_NETWORK_KEY_TLV
                 } <= set(p.thread_meshcop.tlv.type) and p.thread_nwd.tlv.stable == [0])
@@ -222,7 +222,7 @@ class Cert_9_2_18_RollBackActiveTimestamp(thread_cert.TestCase):
             MLE_DATA_RESPONSE).must_next().must_verify(
                 lambda p: {
                     SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV, PENDING_TIMESTAMP_TLV
-                } == set(p.mle.tlv.type) and p.mle.tlv.leader_data.data_version == _pkt.mle.tlv.leader_data.
+                } <= set(p.mle.tlv.type) and p.mle.tlv.leader_data.data_version == _pkt.mle.tlv.leader_data.
                 data_version and p.mle.tlv.leader_data.stable_data_version == _pkt.mle.tlv.leader_data.
                 stable_data_version and {NM_COMMISSIONER_SESSION_ID_TLV, NM_BORDER_AGENT_LOCATOR_TLV} <= set(
                     p.thread_meshcop.tlv.type) and p.thread_nwd.tlv.stable == [0])
@@ -231,7 +231,7 @@ class Cert_9_2_18_RollBackActiveTimestamp(thread_cert.TestCase):
         pkts.filter_wpan_src64(ROUTER_1).filter_wpan_dst64(SED).filter_mle_cmd(
             MLE_CHILD_UPDATE_REQUEST).must_next().must_verify(lambda p: {
                 SOURCE_ADDRESS_TLV, LEADER_DATA_TLV, NETWORK_DATA_TLV, ACTIVE_TIMESTAMP_TLV, PENDING_TIMESTAMP_TLV
-            } == set(p.mle.tlv.type) and p.mle.tlv.leader_data.data_version == _pkt.mle.tlv.leader_data.data_version)
+            } <= set(p.mle.tlv.type) and p.mle.tlv.leader_data.data_version == _pkt.mle.tlv.leader_data.data_version)
 
         # Step 13: SED MUST send a unicast MLE Data Request to Router_1
         _pkts_sed.filter_wpan_src64(SED).filter_wpan_dst64(ROUTER_1).filter_mle_cmd(MLE_DATA_REQUEST).must_next(

--- a/tests/scripts/thread-cert/Cert_9_2_19_PendingDatasetGet.py
+++ b/tests/scripts/thread-cert/Cert_9_2_19_PendingDatasetGet.py
@@ -228,7 +228,7 @@ class Cert_9_2_19_PendingDatasetGet(thread_cert.TestCase):
                               NM_PENDING_TIMESTAMP_TLV,
                               NM_PSKC_TLV,
                               NM_SECURITY_POLICY_TLV
-                             } == set(p.thread_meshcop.tlv.type)
+                             } <= set(p.thread_meshcop.tlv.type)
                    ).\
            must_next()
 
@@ -259,7 +259,7 @@ class Cert_9_2_19_PendingDatasetGet(thread_cert.TestCase):
             filter(lambda p: {
                               NM_DELAY_TIMER_TLV,
                               NM_PAN_ID_TLV
-                             } == set(p.coap.tlv.type) and\
+                             } <= set(p.coap.tlv.type) and\
                    p.thread_meshcop.tlv.pan_id == [0xafce] and\
                    p.thread_meshcop.tlv.delay_timer < 60000
                    ).\

--- a/tests/scripts/thread-cert/pktverify/packet_filter.py
+++ b/tests/scripts/thread-cert/pktverify/packet_filter.py
@@ -363,7 +363,7 @@ class PacketFilter(object):
 
         return self.filter_LLANMA(). \
             filter_mle_cmd(consts.MLE_ADVERTISEMENT). \
-            filter(lambda p: tlv_set ==
+            filter(lambda p: tlv_set <=
                              set(p.mle.tlv.type) and \
                              p.ipv6.hlim == 255, **kwargs
                    )


### PR DESCRIPTION
This commit modifies thread-cert scripts utilizing `pktverify` to adopt a more flexible approach to TLV type checking. Specifically, it replaces strict equality (`==`) or strict subset (`<`) checks with a subset or equal check (`<=`) when verifying the presence of TLVs in a message. This adjustment ensures that test scripts adhere to the principle of ignoring extra or unknown TLVs, thereby future-proofing them against potential protocol updates that might introduce new TLVs.