### PR TITLE
[core] replace `strcmp()` with `StringMatch()`

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -35,6 +35,7 @@
 #include "common/locator_getters.hpp"
 #include "common/log.hpp"
 #include "common/random.hpp"
+#include "common/string.hpp"
 #include "instance/instance.hpp"
 #include "net/ip6.hpp"
 #include "net/udp6.hpp"
@@ -1360,7 +1361,7 @@ void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo 
 
     for (const ResourceBlockWise &resource : mBlockWiseResources)
     {
-        if (strcmp(resource.GetUriPath(), uriPath) != 0)
+        if (!StringMatch(resource.GetUriPath(), uriPath))
         {
             continue;
         }
@@ -1427,7 +1428,7 @@ void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo 
 
     for (const Resource &resource : mResources)
     {
-        if (strcmp(resource.mUriPath, uriPath) == 0)
+        if (StringMatch(resource.mUriPath, uriPath))
         {
             resource.HandleRequest(aMessage, aMessageInfo);
             error = kErrorNone;

--- a/src/core/common/heap_string.cpp
+++ b/src/core/common/heap_string.cpp
@@ -89,7 +89,7 @@ bool String::operator==(const char *aCString) const
     bool isEqual;
 
     VerifyOrExit((aCString != nullptr) && (mStringBuffer != nullptr), isEqual = (mStringBuffer == aCString));
-    isEqual = (strcmp(mStringBuffer, aCString) == 0);
+    isEqual = StringMatch(mStringBuffer, aCString);
 
 exit:
     return isEqual;

--- a/src/core/common/string.cpp
+++ b/src/core/common/string.cpp
@@ -158,6 +158,11 @@ bool StringEndsWith(const char *aString, const char *aSubString, StringMatchMode
     return (subLen > 0) && (len >= subLen) && (Match(&aString[len - subLen], aSubString, aMode) != kNoMatch);
 }
 
+bool StringMatch(const char *aFirstString, const char *aSecondString)
+{
+    return Match(aFirstString, aSecondString, kStringExactMatch) == kFullMatch;
+}
+
 bool StringMatch(const char *aFirstString, const char *aSecondString, StringMatchMode aMode)
 {
     return Match(aFirstString, aSecondString, aMode) == kFullMatch;

--- a/src/core/common/string.hpp
+++ b/src/core/common/string.hpp
@@ -154,6 +154,18 @@ bool StringEndsWith(const char *aString, char aChar);
 bool StringEndsWith(const char *aString, const char *aSubString, StringMatchMode aMode = kStringExactMatch);
 
 /**
+ * Checks whether or not two null-terminated strings match exactly.
+ *
+ * @param[in] aFirstString   A pointer to the first string.
+ * @param[in] aSecondString  A pointer to the second string.
+ *
+ * @retval TRUE   If @p aFirstString matches @p aSecondString.
+ * @retval FALSE  If @p aFirstString does not match @p aSecondString.
+ *
+ */
+bool StringMatch(const char *aFirstString, const char *aSecondString);
+
+/**
  * Checks whether or not two null-terminated strings match.
  *
  * @param[in] aFirstString   A pointer to the first string.
@@ -164,7 +176,7 @@ bool StringEndsWith(const char *aString, const char *aSubString, StringMatchMode
  * @retval FALSE  If @p aFirstString does not match @p aSecondString using match mode @p aMode.
  *
  */
-bool StringMatch(const char *aFirstString, const char *aSecondString, StringMatchMode aMode = kStringExactMatch);
+bool StringMatch(const char *aFirstString, const char *aSecondString, StringMatchMode aMode);
 
 /**
  * Copies a string into a given target buffer with a given size if it fits.

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -45,6 +45,7 @@
 #include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/locator_getters.hpp"
+#include "common/string.hpp"
 #include "instance/instance.hpp"
 #include "radio/radio.hpp"
 #include "utils/parse_cmdline.hpp"
@@ -125,7 +126,7 @@ Error Diags::ProcessEcho(uint8_t aArgsLength, char *aArgs[])
     {
         Output("%s\r\n", aArgs[0]);
     }
-    else if ((aArgsLength == 2) && (strcmp(aArgs[0], "-n") == 0))
+    else if ((aArgsLength == 2) && StringMatch(aArgs[0], "-n"))
     {
         static constexpr uint8_t  kReservedLen  = 1; // 1 byte '\0'
         static constexpr uint16_t kOutputLen    = OPENTHREAD_CONFIG_DIAG_OUTPUT_BUFFER_SIZE;
@@ -297,7 +298,7 @@ Error Diags::ProcessRepeat(uint8_t aArgsLength, char *aArgs[])
     VerifyOrExit(otPlatDiagModeGet(), error = kErrorInvalidState);
     VerifyOrExit(aArgsLength > 0, error = kErrorInvalidArgs);
 
-    if (strcmp(aArgs[0], "stop") == 0)
+    if (StringMatch(aArgs[0], "stop"))
     {
         otPlatAlarmMilliStop(&GetInstance());
         mRepeatActive = false;
@@ -414,7 +415,7 @@ Error Diags::ProcessStats(uint8_t aArgsLength, char *aArgs[])
 
     VerifyOrExit(otPlatDiagModeGet(), error = kErrorInvalidState);
 
-    if ((aArgsLength == 1) && (strcmp(aArgs[0], "clear") == 0))
+    if ((aArgsLength == 1) && StringMatch(aArgs[0], "clear"))
     {
         mStats.Clear();
         Output("stats cleared\r\n");
@@ -486,12 +487,12 @@ Error Diags::ProcessRadio(uint8_t aArgsLength, char *aArgs[])
     VerifyOrExit(otPlatDiagModeGet(), error = kErrorInvalidState);
     VerifyOrExit(aArgsLength > 0, error = kErrorInvalidArgs);
 
-    if (strcmp(aArgs[0], "sleep") == 0)
+    if (StringMatch(aArgs[0], "sleep"))
     {
         SuccessOrExit(error = Get<Radio>().Sleep());
         Output("set radio from receive to sleep \r\nstatus 0x%02x\r\n", error);
     }
-    else if (strcmp(aArgs[0], "receive") == 0)
+    else if (StringMatch(aArgs[0], "receive"))
     {
         SuccessOrExit(error = Get<Radio>().Receive(mChannel));
         SuccessOrExit(error = Get<Radio>().SetTransmitPower(mTxPower));
@@ -500,7 +501,7 @@ Error Diags::ProcessRadio(uint8_t aArgsLength, char *aArgs[])
 
         Output("set radio from sleep to receive on channel %d\r\nstatus 0x%02x\r\n", mChannel, error);
     }
-    else if (strcmp(aArgs[0], "state") == 0)
+    else if (StringMatch(aArgs[0], "state"))
     {
         otRadioState state = Get<Radio>().GetState();
 
@@ -607,11 +608,11 @@ Error Diags::ProcessContinuousWave(uint8_t aArgsLength, char *aArgs[])
     VerifyOrExit(otPlatDiagModeGet(), error = kErrorInvalidState);
     VerifyOrExit(aArgsLength > 0, error = kErrorInvalidArgs);
 
-    if (strcmp(aArgs[0], "start") == 0)
+    if (StringMatch(aArgs[0], "start"))
     {
         SuccessOrExit(error = otPlatDiagRadioTransmitCarrier(&GetInstance(), true));
     }
-    else if (strcmp(aArgs[0], "stop") == 0)
+    else if (StringMatch(aArgs[0], "stop"))
     {
         SuccessOrExit(error = otPlatDiagRadioTransmitCarrier(&GetInstance(), false));
     }
@@ -628,11 +629,11 @@ Error Diags::ProcessStream(uint8_t aArgsLength, char *aArgs[])
     VerifyOrExit(otPlatDiagModeGet(), error = kErrorInvalidState);
     VerifyOrExit(aArgsLength > 0, error = kErrorInvalidArgs);
 
-    if (strcmp(aArgs[0], "start") == 0)
+    if (StringMatch(aArgs[0], "start"))
     {
         error = otPlatDiagRadioTransmitStream(&GetInstance(), true);
     }
-    else if (strcmp(aArgs[0], "stop") == 0)
+    else if (StringMatch(aArgs[0], "stop"))
     {
         error = otPlatDiagRadioTransmitStream(&GetInstance(), false);
     }
@@ -722,11 +723,11 @@ Error Diags::ProcessRawPowerSetting(uint8_t aArgsLength, char *aArgs[])
         SuccessOrExit(error = GetRawPowerSetting(setting));
         Output("%s\r\n", setting.ToString().AsCString());
     }
-    else if (strcmp(aArgs[0], "enable") == 0)
+    else if (StringMatch(aArgs[0], "enable"))
     {
         SuccessOrExit(error = otPlatDiagRadioRawPowerSettingEnable(&GetInstance(), true));
     }
-    else if (strcmp(aArgs[0], "disable") == 0)
+    else if (StringMatch(aArgs[0], "disable"))
     {
         SuccessOrExit(error = otPlatDiagRadioRawPowerSettingEnable(&GetInstance(), false));
     }
@@ -750,21 +751,21 @@ Error Diags::ProcessGpio(uint8_t aArgsLength, char *aArgs[])
     bool       level;
     otGpioMode mode;
 
-    if ((aArgsLength == 2) && (strcmp(aArgs[0], "get") == 0))
+    if ((aArgsLength == 2) && StringMatch(aArgs[0], "get"))
     {
         SuccessOrExit(error = ParseLong(aArgs[1], value));
         gpio = static_cast<uint32_t>(value);
         SuccessOrExit(error = otPlatDiagGpioGet(gpio, &level));
         Output("%d\r\n", level);
     }
-    else if ((aArgsLength == 3) && (strcmp(aArgs[0], "set") == 0))
+    else if ((aArgsLength == 3) && StringMatch(aArgs[0], "set"))
     {
         SuccessOrExit(error = ParseLong(aArgs[1], value));
         gpio = static_cast<uint32_t>(value);
         SuccessOrExit(error = ParseBool(aArgs[2], level));
         SuccessOrExit(error = otPlatDiagGpioSet(gpio, level));
     }
-    else if ((aArgsLength >= 2) && (strcmp(aArgs[0], "mode") == 0))
+    else if ((aArgsLength >= 2) && StringMatch(aArgs[0], "mode"))
     {
         SuccessOrExit(error = ParseLong(aArgs[1], value));
         gpio = static_cast<uint32_t>(value);
@@ -781,11 +782,11 @@ Error Diags::ProcessGpio(uint8_t aArgsLength, char *aArgs[])
                 Output("out\r\n");
             }
         }
-        else if ((aArgsLength == 3) && (strcmp(aArgs[2], "in") == 0))
+        else if ((aArgsLength == 3) && StringMatch(aArgs[2], "in"))
         {
             SuccessOrExit(error = otPlatDiagGpioSetMode(gpio, OT_GPIO_MODE_INPUT));
         }
-        else if ((aArgsLength == 3) && (strcmp(aArgs[2], "out") == 0))
+        else if ((aArgsLength == 3) && StringMatch(aArgs[2], "out"))
         {
             SuccessOrExit(error = otPlatDiagGpioSetMode(gpio, OT_GPIO_MODE_OUTPUT));
         }
@@ -882,7 +883,7 @@ Error Diags::ProcessCmd(uint8_t aArgsLength, char *aArgs[])
     // This `rcp` command is for debugging and testing only, building only when NDEBUG is not defined
     // so that it will be excluded from release build.
 #if OPENTHREAD_RADIO && !defined(NDEBUG)
-    if (aArgsLength > 0 && !strcmp(aArgs[0], "rcp"))
+    if (aArgsLength > 0 && StringMatch(aArgs[0], "rcp"))
     {
         aArgs++;
         aArgsLength--;
@@ -897,7 +898,7 @@ Error Diags::ProcessCmd(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        if (strcmp(aArgs[0], command.mName) == 0)
+        if (StringMatch(aArgs[0], command.mName))
         {
             error = (this->*command.mCommand)(aArgsLength - 1, (aArgsLength > 1) ? &aArgs[1] : nullptr);
             ExitNow();

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -172,7 +172,7 @@ bool Client::Service::Matches(const Service &aOther) const
     // for use by `LinkedList::FindMatching()` to search within the
     // `mServices` list.
 
-    return (strcmp(GetName(), aOther.GetName()) == 0) && (strcmp(GetInstanceName(), aOther.GetInstanceName()) == 0);
+    return StringMatch(GetName(), aOther.GetName()) && StringMatch(GetInstanceName(), aOther.GetInstanceName());
 }
 
 //---------------------------------------------------------------------

--- a/src/core/radio/trel_interface.cpp
+++ b/src/core/radio/trel_interface.cpp
@@ -271,14 +271,14 @@ Error Interface::ParsePeerInfoTxtData(const Peer::Info       &aInfo,
             continue;
         }
 
-        if (strcmp(entry.mKey, kTxtRecordExtAddressKey) == 0)
+        if (StringMatch(entry.mKey, kTxtRecordExtAddressKey))
         {
             VerifyOrExit(!parsedExtAddress, error = kErrorParse);
             VerifyOrExit(entry.mValueLength == sizeof(Mac::ExtAddress), error = kErrorParse);
             aExtAddress.Set(entry.mValue);
             parsedExtAddress = true;
         }
-        else if (strcmp(entry.mKey, kTxtRecordExtPanIdKey) == 0)
+        else if (StringMatch(entry.mKey, kTxtRecordExtPanIdKey))
         {
             VerifyOrExit(!parsedExtPanId, error = kErrorParse);
             VerifyOrExit(entry.mValueLength == sizeof(MeshCoP::ExtendedPanId), error = kErrorParse);

--- a/src/core/utils/parse_cmdline.cpp
+++ b/src/core/utils/parse_cmdline.cpp
@@ -317,7 +317,7 @@ Error ParseAsHexStringSegment(const char *&aString, uint16_t &aSize, uint8_t *aB
 
 uint16_t Arg::GetLength(void) const { return IsEmpty() ? 0 : static_cast<uint16_t>(strlen(mString)); }
 
-bool Arg::operator==(const char *aString) const { return !IsEmpty() && (strcmp(mString, aString) == 0); }
+bool Arg::operator==(const char *aString) const { return !IsEmpty() && StringMatch(mString, aString); }
 
 void Arg::CopyArgsToStringArray(Arg aArgs[], char *aStrings[])
 {


### PR DESCRIPTION
This commit replaces the use of `strcmp()` with `StringMatch()`, which is an OT-specific internal function for comparing strings. This ensures consistent use of internal helper functions.