### PR TITLE
[mle] prioritize equivalent pending dataset update over MLE announce

### DIFF
--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -897,11 +897,8 @@ Error PendingDatasetManager::GetActiveTimestamp(Timestamp &aTimestamp)
 
     SuccessOrExit(Read(dataset));
 
-    if (dataset.Read<ActiveTimestampTlv>()->IsValid())
-    {
-        error = kErrorNone;
-        aTimestamp = dataset.Read<ActiveTimestampTlv>()->GetTimestamp();
-    }
+    SuccessOrExit(dataset.Read<ActiveTimestampTlv>(aTimestamp));
+    error = kErrorNone;
 
 exit:
     return error;

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -885,7 +885,6 @@ PendingDatasetManager::PendingDatasetManager(Instance &aInstance)
 {
 }
 
-
 Error PendingDatasetManager::GetActiveTimestamp(Timestamp &aTimestamp)
 {
     Error   error = kErrorInvalidState;

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -899,17 +899,16 @@ exit:
     return error;
 }
 
-Error PendingDatasetManager::ReadRemainingDelay(uint32_t &aRemainingDelay)
+Error PendingDatasetManager::ReadRemainingDelay(uint32_t &aRemainingDelay) const
 {
-    Error   error = kErrorNotFound;
-    Dataset dataset;
+    Error     error = kErrorNone;
+    TimeMilli now   = TimerMilli::GetNow();
+
+    aRemainingDelay = 0;
 
     VerifyOrExit(mDelayTimer.IsRunning(), error = kErrorInvalidState);
-
-    SuccessOrExit(Read(dataset));
-
-    SuccessOrExit(dataset.Read<DelayTimerTlv>(aRemainingDelay));
-    error = kErrorNone;
+    VerifyOrExit(mDelayTimer.GetFireTime() > now);
+    aRemainingDelay = mDelayTimer.GetFireTime() - now;
 
 exit:
     return error;

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -885,6 +885,28 @@ PendingDatasetManager::PendingDatasetManager(Instance &aInstance)
 {
 }
 
+
+Error PendingDatasetManager::GetActiveTimestamp(Timestamp &aTimestamp)
+{
+    Error   error = kErrorInvalidState;
+    Dataset dataset;
+
+    // If the delay timer is not running, then the pending dataset is not valid, avoid
+    // reading from nonvolatile memory if there's no point.
+    VerifyOrExit(mDelayTimer.IsRunning());
+
+    SuccessOrExit(Read(dataset));
+
+    if (dataset.Read<ActiveTimestampTlv>()->IsValid())
+    {
+        error = kErrorNone;
+        aTimestamp = dataset.Read<ActiveTimestampTlv>()->GetTimestamp();
+    }
+
+exit:
+    return error;
+}
+
 void PendingDatasetManager::StartDelayTimer(void)
 {
     Dataset dataset;

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -901,8 +901,8 @@ exit:
 
 Error PendingDatasetManager::ReadRemainingDelay(uint32_t &aRemainingDelay)
 {
-    Error    error = kErrorNotFound;
-    Dataset  dataset;
+    Error   error = kErrorNotFound;
+    Dataset dataset;
 
     VerifyOrExit(mDelayTimer.IsRunning(), error = kErrorInvalidState);
 

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -885,9 +885,9 @@ PendingDatasetManager::PendingDatasetManager(Instance &aInstance)
 {
 }
 
-Error PendingDatasetManager::GetActiveTimestamp(Timestamp &aTimestamp)
+Error PendingDatasetManager::ReadActiveTimestamp(Timestamp &aTimestamp) const
 {
-    Error   error = kErrorInvalidState;
+    Error   error = kErrorNotFound;
     Dataset dataset;
 
     // If the delay timer is not running, then the pending dataset is not valid, avoid

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -906,7 +906,7 @@ Error PendingDatasetManager::ReadRemainingDelay(uint32_t &aRemainingDelay) const
 
     aRemainingDelay = 0;
 
-    VerifyOrExit(mDelayTimer.IsRunning(), error = kErrorInvalidState);
+    VerifyOrExit(mDelayTimer.IsRunning(), error = kErrorNotFound);
     VerifyOrExit(mDelayTimer.GetFireTime() > now);
     aRemainingDelay = mDelayTimer.GetFireTime() - now;
 

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -890,13 +890,25 @@ Error PendingDatasetManager::ReadActiveTimestamp(Timestamp &aTimestamp) const
     Error   error = kErrorNotFound;
     Dataset dataset;
 
-    // If the delay timer is not running, then the pending dataset is not valid, avoid
-    // reading from nonvolatile memory if there's no point.
-    VerifyOrExit(mDelayTimer.IsRunning());
-
     SuccessOrExit(Read(dataset));
 
     SuccessOrExit(dataset.Read<ActiveTimestampTlv>(aTimestamp));
+    error = kErrorNone;
+
+exit:
+    return error;
+}
+
+Error PendingDatasetManager::ReadRemainingDelay(uint32_t &aRemainingDelay)
+{
+    Error    error = kErrorNotFound;
+    Dataset  dataset;
+
+    VerifyOrExit(mDelayTimer.IsRunning(), error = kErrorInvalidState);
+
+    SuccessOrExit(Read(dataset));
+
+    SuccessOrExit(dataset.Read<DelayTimerTlv>(aRemainingDelay));
     error = kErrorNone;
 
 exit:

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -445,7 +445,8 @@ public:
      * This method fetches the Active Timestamp contained in the Pending Operational Dataset, or an error
      * if it does not exist.
      *
-     * @param[out] aTimestamp The active timestamp contained in the pending dataset. Only valid if kErrorNone is returned.
+     * @param[out] aTimestamp The active timestamp contained in the pending dataset. Only valid if kErrorNone is
+     * returned.
      * 
      * @retval kErrorNone         The active timestamp was successfully fetched.
      * @retval kErrorInvalidState The pending dataset is not currently valid.

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -447,7 +447,7 @@ public:
      *
      * @param[out] aTimestamp The active timestamp contained in the pending dataset. Only valid if kErrorNone is
      * returned.
-     * 
+     *
      * @retval kErrorNone         The active timestamp was successfully fetched.
      * @retval kErrorInvalidState The pending dataset is not currently valid.
      *

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -452,6 +452,17 @@ public:
      */
     Error ReadActiveTimestamp(Timestamp &aTimestamp) const;
 
+    /**
+     * Reads the remaining delay time in ms.
+     *
+     * @param[out] aRemainingDelay A reference to return the remaining delay time.
+     *
+     * @retval kErrorNone     The remaining delay time was successfully fetched.
+     * @retval kErrorNotFound The pending dataset is not currently valid.
+     *
+     */
+    Error ReadRemainingDelay(uint32_t &aRemainingDelay);
+
 #if OPENTHREAD_FTD
     /**
      * Starts the Leader functions for maintaining the Active Operational Dataset.

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -441,6 +441,18 @@ public:
      */
     explicit PendingDatasetManager(Instance &aInstance);
 
+    /**
+     * This method fetches the Active Timestamp contained in the Pending Operational Dataset, or an error
+     * if it does not exist.
+     *
+     * @param[out] aTimestamp The active timestamp contained in the pending dataset. Only valid if kErrorNone is returned.
+     * 
+     * @retval kErrorNone         The active timestamp was successfully fetched.
+     * @retval kErrorInvalidState The pending dataset is not currently valid.
+     *
+     */
+    Error GetActiveTimestamp(Timestamp &aTimestamp);
+
 #if OPENTHREAD_FTD
     /**
      * Starts the Leader functions for maintaining the Active Operational Dataset.

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -461,7 +461,7 @@ public:
      * @retval kErrorNotFound The pending dataset is not currently valid.
      *
      */
-    Error ReadRemainingDelay(uint32_t &aRemainingDelay);
+    Error ReadRemainingDelay(uint32_t &aRemainingDelay) const;
 
 #if OPENTHREAD_FTD
     /**

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -442,17 +442,15 @@ public:
     explicit PendingDatasetManager(Instance &aInstance);
 
     /**
-     * This method fetches the Active Timestamp contained in the Pending Operational Dataset, or an error
-     * if it does not exist.
+     * Reads the Active Timestamp in the Pending Operational Dataset.
      *
-     * @param[out] aTimestamp The active timestamp contained in the pending dataset. Only valid if kErrorNone is
-     * returned.
+     * @param[out] aTimestamp A reference to return the read timestamp.
      *
-     * @retval kErrorNone         The active timestamp was successfully fetched.
-     * @retval kErrorInvalidState The pending dataset is not currently valid.
+     * @retval kErrorNone     The active timestamp was successfully fetched.
+     * @retval kErrorNotFound The pending dataset is not currently valid.
      *
      */
-    Error GetActiveTimestamp(Timestamp &aTimestamp);
+    Error ReadActiveTimestamp(Timestamp &aTimestamp) const;
 
 #if OPENTHREAD_FTD
     /**

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3644,6 +3644,7 @@ void Mle::HandleAnnounce(RxInfo &aRxInfo)
     bool               isFromOrphan;
     bool               channelAndPanIdMatch;
     int                timestampCompare;
+    uint32_t           pendingRemainingDelay;
 
     Log(kMessageReceive, kTypeAnnounce, aRxInfo.mMessageInfo.GetPeerAddr());
 
@@ -3683,9 +3684,11 @@ void Mle::HandleAnnounce(RxInfo &aRxInfo)
             VerifyOrExit(!channelAndPanIdMatch);
         }
 
-        if (Get<MeshCoP::PendingDatasetManager>().ReadActiveTimestamp(pendingActiveTimestamp) == kErrorNone)
+        if (Get<MeshCoP::PendingDatasetManager>().ReadRemainingDelay(pendingRemainingDelay) == kErrorNone &&
+            Get<MeshCoP::PendingDatasetManager>().ReadActiveTimestamp(pendingActiveTimestamp) == kErrorNone)
         {
-            VerifyOrExit(timestamp > pendingActiveTimestamp);
+            VerifyOrExit(pendingRemainingDelay < kAnnounceBackoffForPendingDataset &&
+                timestamp > pendingActiveTimestamp);
         }
 
         if (mAttachState == kAttachStateProcessAnnounce)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3661,7 +3661,7 @@ void Mle::HandleAnnounce(RxInfo &aRxInfo)
     timestampCompare     = MeshCoP::Timestamp::Compare(timestamp, Get<MeshCoP::ActiveDatasetManager>().GetTimestamp());
     channelAndPanIdMatch = (channel == Get<Mac::Mac>().GetPanChannel()) && (panId == Get<Mac::Mac>().GetPanId());
 
-    pendingDatasetValid  =
+    pendingDatasetValid =
         (kErrorNone == Get<MeshCoP::PendingDatasetManager>().GetActiveTimestamp(pendingActiveTimestamp));
     pendingTimestampCompare = MeshCoP::Timestamp::Compare(timestamp, pendingActiveTimestamp);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3660,7 +3660,9 @@ void Mle::HandleAnnounce(RxInfo &aRxInfo)
     isFromOrphan         = timestamp.IsOrphanAnnounce();
     timestampCompare     = MeshCoP::Timestamp::Compare(timestamp, Get<MeshCoP::ActiveDatasetManager>().GetTimestamp());
     channelAndPanIdMatch = (channel == Get<Mac::Mac>().GetPanChannel()) && (panId == Get<Mac::Mac>().GetPanId());
-    pendingDatasetValid  = (kErrorNone == Get<MeshCoP::PendingDatasetManager>().GetActiveTimestamp(pendingActiveTimestamp));
+
+    pendingDatasetValid  =
+        (kErrorNone == Get<MeshCoP::PendingDatasetManager>().GetActiveTimestamp(pendingActiveTimestamp));
     pendingTimestampCompare = MeshCoP::Timestamp::Compare(timestamp, pendingActiveTimestamp);
 
     if (isFromOrphan || (timestampCompare < 0))

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3688,7 +3688,7 @@ void Mle::HandleAnnounce(RxInfo &aRxInfo)
             Get<MeshCoP::PendingDatasetManager>().ReadActiveTimestamp(pendingActiveTimestamp) == kErrorNone)
         {
             VerifyOrExit(pendingRemainingDelay < kAnnounceBackoffForPendingDataset &&
-                timestamp > pendingActiveTimestamp);
+                         timestamp > pendingActiveTimestamp);
         }
 
         if (mAttachState == kAttachStateProcessAnnounce)

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -771,25 +771,26 @@ private:
     // Constants
 
     // All time intervals are in milliseconds
-    static constexpr uint32_t kParentRequestRouterTimeout     = 750;  // Wait time after tx of Parent Req to routers
-    static constexpr uint32_t kParentRequestReedTimeout       = 1250; // Wait timer after tx of Parent Req to REEDs
-    static constexpr uint32_t kParentRequestDuplicateMargin   = 50;   // Margin to detect duplicate received Parent Req
-    static constexpr uint32_t kChildIdResponseTimeout         = 1250; // Wait time to receive Child ID Response
-    static constexpr uint32_t kAttachStartJitter              = 50;   // Max jitter time added to start of attach
-    static constexpr uint32_t kAnnounceProcessTimeout         = 250;  // Delay after Announce rx before processing
-    static constexpr uint32_t kAnnounceTimeout                = 1400; // Total timeout for sending Announce messages
-    static constexpr uint16_t kMinAnnounceDelay               = 80;   // Min delay between Announcement messages
-    static constexpr uint32_t kParentResponseMaxDelayRouters  = 500;  // Max response delay for Parent Req to routers
-    static constexpr uint32_t kParentResponseMaxDelayAll      = 1000; // Max response delay for Parent Req to all
-    static constexpr uint32_t kChildUpdateRequestPendingDelay = 100;  // Delay for aggregating Child Update Req
-    static constexpr uint32_t kMaxLinkAcceptDelay             = 1000; // Max delay to tx Link Accept for multicast Req
-    static constexpr uint32_t kChildIdRequestTimeout          = 5000; // Max delay to rx a Child ID Req after Parent Res
-    static constexpr uint32_t kLinkRequestTimeout             = 2000; // Max delay to rx a Link Accept
-    static constexpr uint32_t kDetachGracefullyTimeout        = 1000; // Timeout for graceful detach
-    static constexpr uint32_t kUnicastRetxDelay               = 1000; // Base delay for MLE unicast retx
-    static constexpr uint32_t kMulticastRetxDelay             = 5000; // Base delay for MLE multicast retx
-    static constexpr uint32_t kMulticastRetxDelayMin          = kMulticastRetxDelay * 9 / 10;  // 0.9 * base delay
-    static constexpr uint32_t kMulticastRetxDelayMax          = kMulticastRetxDelay * 11 / 10; // 1.1 * base delay
+    static constexpr uint32_t kParentRequestRouterTimeout       = 750;  // Wait time after tx of Parent Req to routers
+    static constexpr uint32_t kParentRequestReedTimeout         = 1250; // Wait timer after tx of Parent Req to REEDs
+    static constexpr uint32_t kParentRequestDuplicateMargin     = 50;   // Margin to detect duplicate received Parent Req
+    static constexpr uint32_t kChildIdResponseTimeout           = 1250; // Wait time to receive Child ID Response
+    static constexpr uint32_t kAttachStartJitter                = 50;   // Max jitter time added to start of attach
+    static constexpr uint32_t kAnnounceProcessTimeout           = 250;  // Delay after Announce rx before processing
+    static constexpr uint32_t kAnnounceTimeout                  = 1400; // Total timeout for sending Announce messages
+    static constexpr uint16_t kMinAnnounceDelay                 = 80;   // Min delay between Announcement messages
+    static constexpr uint32_t kParentResponseMaxDelayRouters    = 500;  // Max response delay for Parent Req to routers
+    static constexpr uint32_t kParentResponseMaxDelayAll        = 1000; // Max response delay for Parent Req to all
+    static constexpr uint32_t kChildUpdateRequestPendingDelay   = 100;  // Delay for aggregating Child Update Req
+    static constexpr uint32_t kMaxLinkAcceptDelay               = 1000; // Max delay to tx Link Accept for multicast Req
+    static constexpr uint32_t kChildIdRequestTimeout            = 5000; // Max delay to rx a Child ID Req after Parent Res
+    static constexpr uint32_t kLinkRequestTimeout               = 2000; // Max delay to rx a Link Accept
+    static constexpr uint32_t kDetachGracefullyTimeout          = 1000; // Timeout for graceful detach
+    static constexpr uint32_t kUnicastRetxDelay                 = 1000; // Base delay for MLE unicast retx
+    static constexpr uint32_t kMulticastRetxDelay               = 5000; // Base delay for MLE multicast retx
+    static constexpr uint32_t kMulticastRetxDelayMin            = kMulticastRetxDelay * 9 / 10;  // 0.9 * base delay
+    static constexpr uint32_t kMulticastRetxDelayMax            = kMulticastRetxDelay * 11 / 10; // 1.1 * base delay
+    static constexpr uint32_t kAnnounceBackoffForPendingDataset = 60000; // Max delay left to block Announce processing.
 
     static constexpr uint8_t kMaxTxCount                = 3; // Max tx count for MLE message
     static constexpr uint8_t kMaxCriticalTxCount        = 6; // Max tx count for critical MLE message

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -771,25 +771,25 @@ private:
     // Constants
 
     // All time intervals are in milliseconds
-    static constexpr uint32_t kParentRequestRouterTimeout       = 750;  // Wait time after tx of Parent Req to routers
-    static constexpr uint32_t kParentRequestReedTimeout         = 1250; // Wait timer after tx of Parent Req to REEDs
-    static constexpr uint32_t kParentRequestDuplicateMargin     = 50;   // Margin to detect duplicate received Parent Req
-    static constexpr uint32_t kChildIdResponseTimeout           = 1250; // Wait time to receive Child ID Response
-    static constexpr uint32_t kAttachStartJitter                = 50;   // Max jitter time added to start of attach
-    static constexpr uint32_t kAnnounceProcessTimeout           = 250;  // Delay after Announce rx before processing
-    static constexpr uint32_t kAnnounceTimeout                  = 1400; // Total timeout for sending Announce messages
-    static constexpr uint16_t kMinAnnounceDelay                 = 80;   // Min delay between Announcement messages
-    static constexpr uint32_t kParentResponseMaxDelayRouters    = 500;  // Max response delay for Parent Req to routers
-    static constexpr uint32_t kParentResponseMaxDelayAll        = 1000; // Max response delay for Parent Req to all
-    static constexpr uint32_t kChildUpdateRequestPendingDelay   = 100;  // Delay for aggregating Child Update Req
-    static constexpr uint32_t kMaxLinkAcceptDelay               = 1000; // Max delay to tx Link Accept for multicast Req
-    static constexpr uint32_t kChildIdRequestTimeout            = 5000; // Max delay to rx a Child ID Req after Parent Res
-    static constexpr uint32_t kLinkRequestTimeout               = 2000; // Max delay to rx a Link Accept
-    static constexpr uint32_t kDetachGracefullyTimeout          = 1000; // Timeout for graceful detach
-    static constexpr uint32_t kUnicastRetxDelay                 = 1000; // Base delay for MLE unicast retx
-    static constexpr uint32_t kMulticastRetxDelay               = 5000; // Base delay for MLE multicast retx
-    static constexpr uint32_t kMulticastRetxDelayMin            = kMulticastRetxDelay * 9 / 10;  // 0.9 * base delay
-    static constexpr uint32_t kMulticastRetxDelayMax            = kMulticastRetxDelay * 11 / 10; // 1.1 * base delay
+    static constexpr uint32_t kParentRequestRouterTimeout     = 750;  // Wait time after tx of Parent Req to routers
+    static constexpr uint32_t kParentRequestReedTimeout       = 1250; // Wait timer after tx of Parent Req to REEDs
+    static constexpr uint32_t kParentRequestDuplicateMargin   = 50;   // Margin to detect duplicate received Parent Req
+    static constexpr uint32_t kChildIdResponseTimeout         = 1250; // Wait time to receive Child ID Response
+    static constexpr uint32_t kAttachStartJitter              = 50;   // Max jitter time added to start of attach
+    static constexpr uint32_t kAnnounceProcessTimeout         = 250;  // Delay after Announce rx before processing
+    static constexpr uint32_t kAnnounceTimeout                = 1400; // Total timeout for sending Announce messages
+    static constexpr uint16_t kMinAnnounceDelay               = 80;   // Min delay between Announcement messages
+    static constexpr uint32_t kParentResponseMaxDelayRouters  = 500;  // Max response delay for Parent Req to routers
+    static constexpr uint32_t kParentResponseMaxDelayAll      = 1000; // Max response delay for Parent Req to all
+    static constexpr uint32_t kChildUpdateRequestPendingDelay = 100;  // Delay for aggregating Child Update Req
+    static constexpr uint32_t kMaxLinkAcceptDelay             = 1000; // Max delay to tx Link Accept for multicast Req
+    static constexpr uint32_t kChildIdRequestTimeout          = 5000; // Max delay to rx a Child ID Req after Parent Res
+    static constexpr uint32_t kLinkRequestTimeout             = 2000; // Max delay to rx a Link Accept
+    static constexpr uint32_t kDetachGracefullyTimeout        = 1000; // Timeout for graceful detach
+    static constexpr uint32_t kUnicastRetxDelay               = 1000; // Base delay for MLE unicast retx
+    static constexpr uint32_t kMulticastRetxDelay             = 5000; // Base delay for MLE multicast retx
+    static constexpr uint32_t kMulticastRetxDelayMin          = kMulticastRetxDelay * 9 / 10;  // 0.9 * base delay
+    static constexpr uint32_t kMulticastRetxDelayMax          = kMulticastRetxDelay * 11 / 10; // 1.1 * base delay
     static constexpr uint32_t kAnnounceBackoffForPendingDataset = 60000; // Max delay left to block Announce processing.
 
     static constexpr uint8_t kMaxTxCount                = 3; // Max tx count for MLE message


### PR DESCRIPTION
Avoid processing announce messages with equivalent data that is stored in a pending dataset update.
Implements changes that support proposed spec text update in [SPEC-1311.](https://threadgroup.atlassian.net/browse/SPEC-1311)