### PR TITLE
[spinel] MAC security frame counter can be saved / restored incorrectly during RCP recovery (#10633)

### DIFF
--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -700,8 +700,11 @@ otError RadioSpinel::ParseRadioFrame(otRadioFrame   &aFrame,
         aUnpacked += unpacked;
 
 #if OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
-        if (flags & SPINEL_MD_FLAG_ACKED_SEC)
+        if ((flags & SPINEL_MD_FLAG_ACKED_SEC) &&
+            (aFrame.mInfo.mRxInfo.mAckKeyId != 0xFF))
         {
+            LogDebg("ParseRadioFrame: frameCounter=%d",
+                    aFrame.mInfo.mRxInfo.mAckFrameCounter);
             mMacFrameCounterSet = true;
             mMacFrameCounter    = aFrame.mInfo.mRxInfo.mAckFrameCounter;
         }
@@ -926,6 +929,7 @@ otError RadioSpinel::SetMacFrameCounter(uint32_t aMacFrameCounter, bool aSetIfLa
                                 aMacFrameCounter, aSetIfLarger));
 #if OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
     mMacFrameCounterSet = true;
+    LogDebg("SetMacFrameCounter: frameCounter=%d", aMacFrameCounter);
     mMacFrameCounter    = aMacFrameCounter;
 #endif
 
@@ -1577,8 +1581,12 @@ void RadioSpinel::HandleTransmitDone(uint32_t          aCommand,
         static_cast<Mac::TxFrame *>(mTransmitFrame)->SetFrameCounter(frameCounter);
 
 #if OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
-        mMacFrameCounterSet = true;
-        mMacFrameCounter    = frameCounter;
+        LogDebg("HandleTransmitDone: keyId=%02X, frameCounter=%d", keyId, frameCounter);
+        if (keyId != 0xFF)
+        {
+            mMacFrameCounterSet = true;
+            mMacFrameCounter    = frameCounter;
+        }
 #endif
     }
 


### PR DESCRIPTION
[spinel] MAC security frame counter can be saved / restored incorrectly during RCP recovery (#10633)

1. Where possible, check keyId before saving incoming MAC frame counter. keyId == 0xFF is used for Key ID Mode 2, and we don't want to overwrite the global frame counter in this case

2. Add LogDebg trace for MAC security frame counter