### PR TITLE
[radio-spinel] fix tracking of current MAC frame counter

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (437)
+#define OPENTHREAD_API_VERSION (438)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -691,6 +691,16 @@ uint8_t otLinkGetMaxFrameRetriesIndirect(otInstance *aInstance);
 void otLinkSetMaxFrameRetriesIndirect(otInstance *aInstance, uint8_t aMaxFrameRetriesIndirect);
 
 /**
+ * Gets the current MAC frame counter value.
+ *
+ * @param[in] aInstance    A pointer to the OpenThread instance.
+ *
+ * @returns The current MAC frame counter value.
+ *
+ */
+uint32_t otLinkGetFrameCounter(otInstance *aInstance);
+
+/**
  * Gets the address mode of MAC filter.
  *
  * Is available when `OPENTHREAD_CONFIG_MAC_FILTER_ENABLE` configuration is enabled.

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -188,6 +188,11 @@ void otLinkSetMaxFrameRetriesIndirect(otInstance *aInstance, uint8_t aMaxFrameRe
 
 #endif // OPENTHREAD_FTD
 
+uint32_t otLinkGetFrameCounter(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).Get<Mac::SubMac>().GetFrameCounter();
+}
+
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
 
 otMacFilterAddressMode otLinkFilterGetAddressMode(otInstance *aInstance)

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -1316,7 +1316,6 @@ private:
     int8_t       mCcaEnergyDetectThreshold;
     int8_t       mTransmitPower;
     int8_t       mFemLnaGain;
-    uint32_t     mMacFrameCounter;
     bool         mCoexEnabled : 1;
     bool         mSrcMatchEnabled : 1;
 


### PR DESCRIPTION
This commit fixes an issue in `RadioSpinel` related to the tracking of the MAC frame counter used during RCP restoration. Previously, `RadioSpinel` tracked the last seen counter on any secured received/transmitted frame. However, the frame counter should only be tracked for frames that use Key ID Mode 1 and where the included Key ID in the frame matches the current Key ID being used. The `SubMac` module also tracks the current MAC frame counter, and it does perform Key ID Mode and Key ID checks.

This commit adds a new public API `otLinkGetFrameCounter()` to get the current frame counter. This is used by `RadioSpinel` to get the frame counter instead of having `RadioSpinel` track the frame counter itself.


---------

- Should resolve #10633