### PR TITLE
[time] unify macros for time unit conversion

### DIFF
--- a/examples/platforms/simulation/alarm.c
+++ b/examples/platforms/simulation/alarm.c
@@ -51,13 +51,9 @@ timer_t sMicroTimer;
 #include <openthread/platform/alarm-micro.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
+#include <openthread/platform/time.h>
 
 #include "lib/platform/exit_code.h"
-
-#define MS_PER_S 1000
-#define NS_PER_US 1000
-#define US_PER_MS 1000
-#define US_PER_S 1000000
 
 #define DEFAULT_TIMEOUT_IN_SEC 10 // seconds
 
@@ -146,7 +142,7 @@ uint64_t platformGetNow(void)
 
     VerifyOrDie(err == 0, OT_EXIT_ERROR_ERRNO);
 
-    return (uint64_t)now.tv_sec * sSpeedUpFactor * US_PER_S + (uint64_t)now.tv_nsec * sSpeedUpFactor / NS_PER_US;
+    return (uint64_t)now.tv_sec * sSpeedUpFactor * OT_US_PER_S + (uint64_t)now.tv_nsec * sSpeedUpFactor / OT_NS_PER_US;
 }
 #else
 uint64_t platformGetNow(void)
@@ -158,11 +154,11 @@ uint64_t platformGetNow(void)
 
     assert(err == 0);
 
-    return (uint64_t)tv.tv_sec * sSpeedUpFactor * US_PER_S + (uint64_t)tv.tv_usec * sSpeedUpFactor;
+    return (uint64_t)tv.tv_sec * sSpeedUpFactor * OT_US_PER_S + (uint64_t)tv.tv_usec * sSpeedUpFactor;
 }
 #endif // defined(CLOCK_MONOTONIC_RAW) || defined(CLOCK_MONOTONIC)
 
-uint32_t otPlatAlarmMilliGetNow(void) { return (uint32_t)(platformGetNow() / US_PER_MS); }
+uint32_t otPlatAlarmMilliGetNow(void) { return (uint32_t)(platformGetNow() / OT_US_PER_MS); }
 
 void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
@@ -193,8 +189,8 @@ void otPlatAlarmMicroStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
         struct itimerspec its;
         uint32_t          diff = sUsAlarm - otPlatAlarmMicroGetNow();
 
-        its.it_value.tv_sec  = diff / US_PER_S;
-        its.it_value.tv_nsec = (diff % US_PER_S) * NS_PER_US;
+        its.it_value.tv_sec  = diff / OT_US_PER_S;
+        its.it_value.tv_nsec = (diff % OT_US_PER_S) * OT_NS_PER_US;
 
         its.it_interval.tv_sec  = 0;
         its.it_interval.tv_nsec = 0;
@@ -229,7 +225,7 @@ void otPlatAlarmMicroStop(otInstance *aInstance)
 
 void platformAlarmUpdateTimeout(struct timeval *aTimeout)
 {
-    uint64_t remaining = DEFAULT_TIMEOUT_IN_SEC * US_PER_S; // in usec.
+    uint64_t remaining = DEFAULT_TIMEOUT_IN_SEC * OT_US_PER_S; // in usec.
 
     assert(aTimeout != NULL);
 
@@ -237,7 +233,7 @@ void platformAlarmUpdateTimeout(struct timeval *aTimeout)
     {
         uint32_t msRemaining = calculateDuration(sMsAlarm, otPlatAlarmMilliGetNow());
 
-        remaining = ((uint64_t)msRemaining) * US_PER_MS;
+        remaining = ((uint64_t)msRemaining) * OT_US_PER_MS;
     }
 
     if (sIsUsRunning)
@@ -264,8 +260,8 @@ void platformAlarmUpdateTimeout(struct timeval *aTimeout)
             remaining = 1;
         }
 
-        aTimeout->tv_sec  = (time_t)(remaining / US_PER_S);
-        aTimeout->tv_usec = remaining % US_PER_S;
+        aTimeout->tv_sec  = (time_t)(remaining / OT_US_PER_S);
+        aTimeout->tv_usec = remaining % OT_US_PER_S;
     }
 }
 

--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -47,9 +47,6 @@
 #include "utils/mac_frame.h"
 #include "utils/soft_source_match_table.h"
 
-#define MS_PER_S 1000
-#define US_PER_MS 1000
-
 enum
 {
     IEEE802154_ACK_LENGTH = 5,
@@ -814,8 +811,8 @@ void platformRadioUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, struct ti
         {
             uint32_t remaining = sEnergyScanEndTime - now;
 
-            tv.tv_sec  = remaining / MS_PER_S;
-            tv.tv_usec = (remaining % MS_PER_S) * US_PER_MS;
+            tv.tv_sec  = remaining / OT_MS_PER_S;
+            tv.tv_usec = (remaining % OT_MS_PER_S) * OT_US_PER_MS;
         }
 
         if (timercmp(&tv, aTimeout, <))

--- a/examples/platforms/simulation/virtual_time/alarm-sim.c
+++ b/examples/platforms/simulation/virtual_time/alarm-sim.c
@@ -37,8 +37,7 @@
 #include <openthread/platform/alarm-micro.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
-
-#define US_PER_MS 1000
+#include <openthread/platform/time.h>
 
 extern uint64_t sNow; // microseconds
 
@@ -59,7 +58,7 @@ uint64_t platformAlarmGetNow(void) { return sNow; }
 
 void platformAlarmAdvanceNow(uint64_t aDelta) { sNow += aDelta; }
 
-uint32_t otPlatAlarmMilliGetNow(void) { return (uint32_t)(sNow / US_PER_MS); }
+uint32_t otPlatAlarmMilliGetNow(void) { return (uint32_t)(sNow / OT_US_PER_MS); }
 
 void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
@@ -108,7 +107,7 @@ uint64_t platformAlarmGetNext(void)
         else
         {
             remaining = (uint64_t)milli;
-            remaining *= US_PER_MS;
+            remaining *= OT_US_PER_MS;
         }
     }
 

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (436)
+#define OPENTHREAD_API_VERSION (437)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/time.h
+++ b/include/openthread/platform/time.h
@@ -41,6 +41,11 @@
 extern "C" {
 #endif
 
+#define OT_MS_PER_S 1000    ///< Number of milliseconds per second
+#define OT_NS_PER_US 1000   ///< Number of nanoseconds per microsecond
+#define OT_US_PER_MS 1000   ///< Number of microseconds per millisecond
+#define OT_US_PER_S 1000000 ///< Number of microseconds per second
+
 /**
  * @addtogroup plat-time
  *

--- a/include/openthread/platform/time.h
+++ b/include/openthread/platform/time.h
@@ -42,9 +42,9 @@ extern "C" {
 #endif
 
 #define OT_MS_PER_S 1000    ///< Number of milliseconds per second
-#define OT_NS_PER_US 1000   ///< Number of nanoseconds per microsecond
 #define OT_US_PER_MS 1000   ///< Number of microseconds per millisecond
 #define OT_US_PER_S 1000000 ///< Number of microseconds per second
+#define OT_NS_PER_US 1000   ///< Number of nanoseconds per microsecond
 
 /**
  * @addtogroup plat-time

--- a/src/posix/platform/alarm.cpp
+++ b/src/posix/platform/alarm.cpp
@@ -83,7 +83,7 @@ uint64_t otPlatTimeGet(void)
 
     VerifyOrDie(clock_gettime(OT_POSIX_CLOCK_ID, &now) == 0, OT_EXIT_FAILURE);
 
-    return static_cast<uint64_t>(now.tv_sec) * US_PER_S + static_cast<uint64_t>(now.tv_nsec) / NS_PER_US;
+    return static_cast<uint64_t>(now.tv_sec) * OT_US_PER_S + static_cast<uint64_t>(now.tv_nsec) / OT_NS_PER_US;
 }
 #endif // !OPENTHREAD_POSIX_VIRTUAL_TIME
 
@@ -128,7 +128,7 @@ void platformAlarmInit(uint32_t aSpeedUpFactor, int aRealTimeSignal)
     }
 }
 
-uint32_t otPlatAlarmMilliGetNow(void) { return (uint32_t)(platformAlarmGetNow() / US_PER_MS); }
+uint32_t otPlatAlarmMilliGetNow(void) { return (uint32_t)(platformAlarmGetNow() / OT_US_PER_MS); }
 
 void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
@@ -161,8 +161,8 @@ void otPlatAlarmMicroStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
         struct itimerspec its;
         uint32_t          diff = sUsAlarm - otPlatAlarmMicroGetNow();
 
-        its.it_value.tv_sec  = diff / US_PER_S;
-        its.it_value.tv_nsec = (diff % US_PER_S) * NS_PER_US;
+        its.it_value.tv_sec  = diff / OT_US_PER_S;
+        its.it_value.tv_nsec = (diff % OT_US_PER_S) * OT_NS_PER_US;
 
         its.it_interval.tv_sec  = 0;
         its.it_interval.tv_nsec = 0;
@@ -204,10 +204,10 @@ void platformAlarmUpdateTimeout(struct timeval *aTimeout)
 
     if (sIsMsRunning)
     {
-        remaining = (int32_t)(sMsAlarm - (uint32_t)(now / US_PER_MS));
+        remaining = (int32_t)(sMsAlarm - (uint32_t)(now / OT_US_PER_MS));
         VerifyOrExit(remaining > 0);
-        remaining *= US_PER_MS;
-        remaining -= (now % US_PER_MS);
+        remaining *= OT_US_PER_MS;
+        remaining -= (now % OT_US_PER_MS);
     }
 
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
@@ -237,10 +237,10 @@ exit:
             remaining = 1;
         }
 
-        if (remaining < static_cast<int64_t>(aTimeout->tv_sec) * US_PER_S + static_cast<int64_t>(aTimeout->tv_usec))
+        if (remaining < static_cast<int64_t>(aTimeout->tv_sec) * OT_US_PER_S + static_cast<int64_t>(aTimeout->tv_usec))
         {
-            aTimeout->tv_sec  = static_cast<time_t>(remaining / US_PER_S);
-            aTimeout->tv_usec = static_cast<suseconds_t>(remaining % US_PER_S);
+            aTimeout->tv_sec  = static_cast<time_t>(remaining / OT_US_PER_S);
+            aTimeout->tv_usec = static_cast<suseconds_t>(remaining % OT_US_PER_S);
         }
     }
 }

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -283,8 +283,8 @@ otError HdlcInterface::WaitForFrame(uint64_t aTimeoutUs)
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
     struct VirtualTimeEvent event;
 
-    timeout.tv_sec  = static_cast<time_t>(aTimeoutUs / US_PER_S);
-    timeout.tv_usec = static_cast<suseconds_t>(aTimeoutUs % US_PER_S);
+    timeout.tv_sec  = static_cast<time_t>(aTimeoutUs / OT_US_PER_S);
+    timeout.tv_usec = static_cast<suseconds_t>(aTimeoutUs % OT_US_PER_S);
 
     virtualTimeSendSleepEvent(&timeout);
     virtualTimeReceiveEvent(&event);
@@ -304,8 +304,8 @@ otError HdlcInterface::WaitForFrame(uint64_t aTimeoutUs)
         break;
     }
 #else  // OPENTHREAD_POSIX_VIRTUAL_TIME
-    timeout.tv_sec = static_cast<time_t>(aTimeoutUs / US_PER_S);
-    timeout.tv_usec = static_cast<suseconds_t>(aTimeoutUs % US_PER_S);
+    timeout.tv_sec = static_cast<time_t>(aTimeoutUs / OT_US_PER_S);
+    timeout.tv_usec = static_cast<suseconds_t>(aTimeoutUs % OT_US_PER_S);
 
     fd_set read_fds;
     fd_set error_fds;
@@ -392,7 +392,7 @@ otError HdlcInterface::WaitForWritable(void)
     otError        error   = OT_ERROR_NONE;
     struct timeval timeout = {kMaxWaitTime / 1000, (kMaxWaitTime % 1000) * 1000};
     uint64_t       now     = otPlatTimeGet();
-    uint64_t       end     = now + kMaxWaitTime * US_PER_MS;
+    uint64_t       end     = now + kMaxWaitTime * OT_US_PER_MS;
     fd_set         writeFds;
     fd_set         errorFds;
     int            rval;
@@ -432,8 +432,8 @@ otError HdlcInterface::WaitForWritable(void)
         {
             uint64_t remain = end - now;
 
-            timeout.tv_sec  = static_cast<time_t>(remain / US_PER_S);
-            timeout.tv_usec = static_cast<suseconds_t>(remain % US_PER_S);
+            timeout.tv_sec  = static_cast<time_t>(remain / OT_US_PER_S);
+            timeout.tv_usec = static_cast<suseconds_t>(remain % OT_US_PER_S);
         }
         else
         {
@@ -744,10 +744,10 @@ otError HdlcInterface::ResetConnection(void)
 
     if (mRadioUrl.HasParam("uart-reset"))
     {
-        usleep(static_cast<useconds_t>(kRemoveRcpDelay) * US_PER_MS);
+        usleep(static_cast<useconds_t>(kRemoveRcpDelay) * OT_US_PER_MS);
         CloseFile();
 
-        end = otPlatTimeGet() + kResetTimeout * US_PER_MS;
+        end = otPlatTimeGet() + kResetTimeout * OT_US_PER_MS;
         do
         {
             mSockFd = OpenFile(mRadioUrl);
@@ -755,7 +755,7 @@ otError HdlcInterface::ResetConnection(void)
             {
                 ExitNow();
             }
-            usleep(static_cast<useconds_t>(kOpenFileDelay) * US_PER_MS);
+            usleep(static_cast<useconds_t>(kOpenFileDelay) * OT_US_PER_MS);
         } while (end > otPlatTimeGet());
 
         LogCrit("Failed to reopen UART connection after resetting the RCP device.");

--- a/src/posix/platform/multicast_routing.cpp
+++ b/src/posix/platform/multicast_routing.cpp
@@ -400,7 +400,7 @@ void MulticastRoutingManager::ExpireMulticastForwardingCache(void)
     uint64_t            now = otPlatTimeGet();
     struct mf6cctl      mf6cctl;
 
-    VerifyOrExit(now >= mLastExpireTime + kMulticastForwardingCacheExpiringInterval * US_PER_S);
+    VerifyOrExit(now >= mLastExpireTime + kMulticastForwardingCacheExpiringInterval * OT_US_PER_S);
 
     mLastExpireTime = now;
 
@@ -409,7 +409,7 @@ void MulticastRoutingManager::ExpireMulticastForwardingCache(void)
 
     for (MulticastForwardingCache &mfc : mMulticastForwardingCacheTable)
     {
-        if (mfc.IsValid() && mfc.mLastUseTime + kMulticastForwardingCacheExpireTimeout * US_PER_S < now)
+        if (mfc.IsValid() && mfc.mLastUseTime + kMulticastForwardingCacheExpireTimeout * OT_US_PER_S < now)
         {
             if (!UpdateMulticastRouteInfo(mfc))
             {

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -127,19 +127,6 @@ void platformAlarmProcess(otInstance *aInstance);
  */
 int32_t platformAlarmGetNext(void);
 
-#ifndef MS_PER_S
-#define MS_PER_S 1000
-#endif
-#ifndef US_PER_MS
-#define US_PER_MS 1000
-#endif
-#ifndef US_PER_S
-#define US_PER_S (MS_PER_S * US_PER_MS)
-#endif
-#ifndef NS_PER_US
-#define NS_PER_US 1000
-#endif
-
 /**
  * Advances the alarm time by @p aDelta.
  *

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -348,11 +348,11 @@ void platformRadioUpdateFdSet(otSysMainloopContext *aContext)
     {
         uint64_t remain = deadline - now;
 
-        if (remain < (static_cast<uint64_t>(aContext->mTimeout.tv_sec) * US_PER_S +
+        if (remain < (static_cast<uint64_t>(aContext->mTimeout.tv_sec) * OT_US_PER_S +
                       static_cast<uint64_t>(aContext->mTimeout.tv_usec)))
         {
-            aContext->mTimeout.tv_sec  = static_cast<time_t>(remain / US_PER_S);
-            aContext->mTimeout.tv_usec = static_cast<suseconds_t>(remain % US_PER_S);
+            aContext->mTimeout.tv_sec  = static_cast<time_t>(remain / OT_US_PER_S);
+            aContext->mTimeout.tv_usec = static_cast<suseconds_t>(remain % OT_US_PER_S);
         }
     }
     else

--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -748,8 +748,8 @@ otError SpiInterface::WaitForFrame(uint64_t aTimeoutUs)
         int                  ret;
 
         context.mMaxFd           = -1;
-        context.mTimeout.tv_sec  = static_cast<time_t>((end - now) / US_PER_S);
-        context.mTimeout.tv_usec = static_cast<suseconds_t>((end - now) % US_PER_S);
+        context.mTimeout.tv_sec  = static_cast<time_t>((end - now) / OT_US_PER_S);
+        context.mTimeout.tv_usec = static_cast<suseconds_t>((end - now) % OT_US_PER_S);
 
         FD_ZERO(&context.mReadFdSet);
         FD_ZERO(&context.mWriteFdSet);


### PR DESCRIPTION
This commit unifies macros used for time unit conversion so that we don't need to define them on different components.