### PR TITLE
[diag] support send security processed frames

### DIFF
--- a/src/core/diags/README.md
+++ b/src/core/diags/README.md
@@ -80,7 +80,7 @@ Done
 
 ### diag frame
 
-Usage: `diag [-s] frame <frame>`
+Usage: `diag frame [-s] <frame>`
 
 Set the frame (hex encoded) to be used by `diag send` and `diag repeat`. The frame may be overwritten by `diag send` and `diag repeat`.
 

--- a/src/core/diags/README.md
+++ b/src/core/diags/README.md
@@ -10,6 +10,7 @@ The diagnostics module supports common diagnostics features that are listed belo
 - [diag start](#diag-start)
 - [diag channel](#diag-channel)
 - [diag cw](#diag-cw-start)
+- [diag frame] (#diag-frame)
 - [diag stream](#diag-stream-start)
 - [diag power](#diag-power)
 - [diag powersettings](#diag-powersettings)
@@ -77,9 +78,13 @@ Stop transmitting continuous carrier wave.
 Done
 ```
 
-### diag frame \<frame\>
+### diag frame
+
+Usage: `diag [-s] frame <frame>`
 
 Set the frame (hex encoded) to be used by `diag send` and `diag repeat`. The frame may be overwritten by `diag send` and `diag repeat`.
+
+Specify `-s` to skip security process in radio layer.
 
 ```bash
 > diag frame 11223344

--- a/src/core/diags/README.md
+++ b/src/core/diags/README.md
@@ -84,7 +84,7 @@ Usage: `diag frame [-s] <frame>`
 
 Set the frame (hex encoded) to be used by `diag send` and `diag repeat`. The frame may be overwritten by `diag send` and `diag repeat`.
 
-Specify `-s` to skip security process in radio layer.
+Specify `-s` to skip security processing in radio layer.
 
 ```bash
 > diag frame 11223344

--- a/src/core/diags/README.md
+++ b/src/core/diags/README.md
@@ -10,7 +10,7 @@ The diagnostics module supports common diagnostics features that are listed belo
 - [diag start](#diag-start)
 - [diag channel](#diag-channel)
 - [diag cw](#diag-cw-start)
-- [diag frame] (#diag-frame)
+- [diag frame](#diag-frame)
 - [diag stream](#diag-stream-start)
 - [diag power](#diag-power)
 - [diag powersettings](#diag-powersettings)

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -234,16 +234,15 @@ void Diags::ResetTxPacket(void)
 
 Error Diags::ProcessFrame(uint8_t aArgsLength, char *aArgs[])
 {
-    Error    error = kErrorNone;
-    uint16_t size  = OT_RADIO_FRAME_MAX_SIZE;
-
-    ResetTxPacket();
+    Error    error             = kErrorNone;
+    uint16_t size              = OT_RADIO_FRAME_MAX_SIZE;
+    bool     securityProcessed = false;
 
     if (aArgsLength >= 1)
     {
         if (StringMatch(aArgs[0], "-s"))
         {
-            mTxPacket->mInfo.mTxInfo.mIsSecurityProcessed = true;
+            securityProcessed = true;
             aArgs++;
             aArgsLength--;
         }
@@ -254,8 +253,11 @@ Error Diags::ProcessFrame(uint8_t aArgsLength, char *aArgs[])
     SuccessOrExit(error = Utils::CmdLineParser::ParseAsHexString(aArgs[0], size, mTxPacket->mPsdu));
     VerifyOrExit(size <= OT_RADIO_FRAME_MAX_SIZE, error = kErrorInvalidArgs);
     VerifyOrExit(size >= OT_RADIO_FRAME_MIN_SIZE, error = kErrorInvalidArgs);
-    mTxPacket->mLength = size;
-    mIsTxPacketSet     = true;
+
+    ResetTxPacket();
+    mTxPacket->mInfo.mTxInfo.mIsSecurityProcessed = securityProcessed;
+    mTxPacket->mLength                            = size;
+    mIsTxPacketSet                                = true;
 
 exit:
     AppendErrorResult(error);

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -33,6 +33,7 @@
 
 #include "factory_diags.hpp"
 #include "common/error.hpp"
+#include "openthread/platform/radio.h"
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
 
@@ -216,14 +217,29 @@ Diags::Diags(Instance &aInstance)
     mStats.Clear();
 }
 
+void Diags::ResetTxPacket(void)
+{
+    mTxPacket->mInfo.mTxInfo.mTxDelayBaseTime      = 0;
+    mTxPacket->mInfo.mTxInfo.mTxDelay              = 0;
+    mTxPacket->mInfo.mTxInfo.mMaxCsmaBackoffs      = 0;
+    mTxPacket->mInfo.mTxInfo.mMaxFrameRetries      = 0;
+    mTxPacket->mInfo.mTxInfo.mRxChannelAfterTxDone = mChannel;
+    mTxPacket->mInfo.mTxInfo.mTxPower              = OT_RADIO_POWER_INVALID;
+    mTxPacket->mInfo.mTxInfo.mIsHeaderUpdated      = false;
+    mTxPacket->mInfo.mTxInfo.mIsARetx              = false;
+    mTxPacket->mInfo.mTxInfo.mCsmaCaEnabled        = false;
+    mTxPacket->mInfo.mTxInfo.mCslPresent           = false;
+    mTxPacket->mInfo.mTxInfo.mIsSecurityProcessed  = false;
+}
+
 Error Diags::ProcessFrame(uint8_t aArgsLength, char *aArgs[])
 {
     Error    error = kErrorNone;
     uint16_t size  = OT_RADIO_FRAME_MAX_SIZE;
 
-    ClearAllBytes(mTxPacket->mInfo);
+    ResetTxPacket();
 
-    if (aArgsLength > 1)
+    if (aArgsLength >= 1)
     {
         if (StringMatch(aArgs[0], "-s"))
         {
@@ -480,7 +496,7 @@ void Diags::TransmitPacket(void)
 
     if (!mIsTxPacketSet)
     {
-        ClearAllBytes(mTxPacket->mInfo);
+        ResetTxPacket();
         mTxPacket->mLength = mTxLen;
 
         for (uint8_t i = 0; i < mTxLen; i++)

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -485,7 +485,7 @@ void Diags::TransmitPacket(void)
 
     if (!mIsTxPacketSet)
     {
-        memset(&mTxPacket->mInfo, 0, sizeof(mTxPacket->mInfo));
+        ClearAllBytes(mTxPacket->mInfo);
         mTxPacket->mLength = mTxLen;
 
         for (uint8_t i = 0; i < mTxLen; i++)

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -223,19 +223,14 @@ Error Diags::ProcessFrame(uint8_t aArgsLength, char *aArgs[])
 
     ClearAllBytes(mTxPacket->mInfo);
 
-    while (aArgsLength > 1)
+    if (aArgsLength > 1)
     {
         if (StringMatch(aArgs[0], "-s"))
         {
             mTxPacket->mInfo.mTxInfo.mIsSecurityProcessed = true;
+            aArgs++;
+            aArgsLength--;
         }
-        else
-        {
-            break;
-        }
-
-        aArgs++;
-        aArgsLength--;
     }
 
     VerifyOrExit(aArgsLength == 1, error = kErrorInvalidArgs);

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -221,7 +221,7 @@ Error Diags::ProcessFrame(uint8_t aArgsLength, char *aArgs[])
     Error    error = kErrorNone;
     uint16_t size  = OT_RADIO_FRAME_MAX_SIZE;
 
-    memset(&mTxPacket->mInfo, 0, sizeof(mTxPacket->mInfo));
+    ClearAllBytes(mTxPacket->mInfo);
 
     while (aArgsLength > 1)
     {

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -238,7 +238,7 @@ Error Diags::ProcessFrame(uint8_t aArgsLength, char *aArgs[])
         aArgsLength--;
     }
 
-    VerifyOrExit(aArgsLength >= 1, error = kErrorInvalidArgs);
+    VerifyOrExit(aArgsLength == 1, error = kErrorInvalidArgs);
 
     SuccessOrExit(error = Utils::CmdLineParser::ParseAsHexString(aArgs[0], size, mTxPacket->mPsdu));
     VerifyOrExit(size <= OT_RADIO_FRAME_MAX_SIZE, error = kErrorInvalidArgs);

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -225,7 +225,7 @@ Error Diags::ProcessFrame(uint8_t aArgsLength, char *aArgs[])
 
     while (aArgsLength > 1)
     {
-        if (!strcmp(aArgs[0], "-s"))
+        if (StringMatch(aArgs[0], "-s"))
         {
             mTxPacket->mInfo.mTxInfo.mIsSecurityProcessed = true;
         }

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -221,7 +221,24 @@ Error Diags::ProcessFrame(uint8_t aArgsLength, char *aArgs[])
     Error    error = kErrorNone;
     uint16_t size  = OT_RADIO_FRAME_MAX_SIZE;
 
-    VerifyOrExit(aArgsLength == 1, error = kErrorInvalidArgs);
+    memset(&mTxPacket->mInfo, 0, sizeof(mTxPacket->mInfo));
+
+    while (aArgsLength > 1)
+    {
+        if (!strcmp(aArgs[0], "-s"))
+        {
+            mTxPacket->mInfo.mTxInfo.mIsSecurityProcessed = true;
+        }
+        else
+        {
+            break;
+        }
+
+        aArgs++;
+        aArgsLength--;
+    }
+
+    VerifyOrExit(aArgsLength >= 1, error = kErrorInvalidArgs);
 
     SuccessOrExit(error = Utils::CmdLineParser::ParseAsHexString(aArgs[0], size, mTxPacket->mPsdu));
     VerifyOrExit(size <= OT_RADIO_FRAME_MAX_SIZE, error = kErrorInvalidArgs);
@@ -468,6 +485,7 @@ void Diags::TransmitPacket(void)
 
     if (!mIsTxPacketSet)
     {
+        memset(&mTxPacket->mInfo, 0, sizeof(mTxPacket->mInfo));
         mTxPacket->mLength = mTxLen;
 
         for (uint8_t i = 0; i < mTxLen; i++)

--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -210,6 +210,7 @@ private:
     void TransmitPacket(void);
     void Output(const char *aFormat, ...);
     void AppendErrorResult(Error aError);
+    void ResetTxPacket(void);
 
     static Error ParseLong(char *aString, long &aLong);
     static Error ParseBool(char *aString, bool &aBool);

--- a/tests/scripts/expect/cli-diags.exp
+++ b/tests/scripts/expect/cli-diags.exp
@@ -152,6 +152,13 @@ send "diag repeat 1\n"
 expect "length 0x7f"
 expect "Done"
 
+send_user "send frame with security processed\n"
+send "diag frame -s 112233\n"
+expect "Done"
+send "diag send 1\n"
+expect "length 0x3"
+expect "Done"
+
 send "diag repeat stop\n"
 expect "Done"
 


### PR DESCRIPTION
This commit extends the `diag frame` command by adding an argument `-s` to indicate whether the frame has been encrypted or not, so that the diag commands can be used to test frames having security processed in the host.