### PR TITLE
[posix] add radio URL parameter `uart-init-deassert` to deassert DTR and RTS on init when flow control is disabled

### DIFF
--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -600,8 +600,9 @@ int HdlcInterface::OpenFile(const Url::Url &aRadioUrl)
         {
             tios.c_cflag |= CRTSCTS;
         }
-        else
+        else if (aRadioUrl.HasParam("uart-init-deassert"))
         {
+            // When flow control is disabled, deassert DTR and RTS on init
 #ifndef __APPLE__
             int flags;
 #endif

--- a/src/posix/platform/radio_url.cpp
+++ b/src/posix/platform/radio_url.cpp
@@ -84,6 +84,7 @@ const char *otSysGetRadioUrlHelpString(void)
     "    uart-stop[=number-of-bits]     Uart stop bit, default is 1.\n"                              \
     "    uart-baudrate[=baudrate]       Uart baud rate, default is 115200.\n"                        \
     "    uart-flow-control              Enable flow control, disabled by default.\n"                 \
+    "    uart-init-deassert             Deassert lines on init when flow control is disabled.\n"     \
     "    uart-reset                     Reset connection after hard resetting RCP(USB CDC ACM).\n"   \
     "\n"
 #else


### PR DESCRIPTION
This lets us preserve legacy behavior where "`uart-flow-control`" was not required in radio URL parameters even with hardware flow control enabled.