### PR TITLE
[git-tool] explicit disable rebase

### DIFF
--- a/script/git-tool
+++ b/script/git-tool
@@ -46,7 +46,7 @@ apply_dependencies()
         echo "${dependency}"
         depends_on_pr="$(echo "${dependency}" | tr -d '\r\n' | cut -d# -f2)"
         echo "pr: #${depends_on_pr}"
-        git pull --no-edit origin "pull/${depends_on_pr}/merge"
+        git pull --no-edit --no-rebase origin "pull/${depends_on_pr}/merge"
     done < <(grep -E "^Depends-On: *${project_name}" || true)
 }
 


### PR DESCRIPTION
This commit adds the `--no-rebase` flag to `git` command when applying dependencies because recent git versions doesn't have a default rebase strategy anymore.

Without this flag, if the dependency may fail to be pulled when a merge is required.