### PR TITLE
[radio] otPlatRadioGetNow fallback to otPlatTimeGet

### DIFF
--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -253,7 +253,7 @@ OT_TOOL_WEAK uint64_t otPlatRadioGetNow(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    return UINT64_MAX;
+    return otPlatTimeGet();
 }
 
 OT_TOOL_WEAK uint32_t otPlatRadioGetBusSpeed(otInstance *aInstance)


### PR DESCRIPTION
This commit makes the default otPlatRadioGetNow implementation fallback to to otPlatTimeGet so that the default one is a correct implementation in single chip architecture.