### PR TITLE
[routing-manager] append source link-layer option in ND6 message

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (453)
+#define OPENTHREAD_API_VERSION (454)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/infra_if.h
+++ b/include/openthread/platform/infra_if.h
@@ -49,7 +49,6 @@ extern "C" {
 
 /**
  * Represents an InfraIf Link-Layer Address.
- *
  */
 typedef struct otPlatInfraIfLinkLayerAddress
 {
@@ -178,7 +177,6 @@ extern void otPlatInfraIfDiscoverNat64PrefixDone(otInstance        *aInstance,
  *
  * @retval  OT_ERROR_NONE    Successfully get the infrastructure interface link-layer address.
  * @retval  OT_ERROR_FAILED  Failed to get the infrastructure interface link-layer address.
- *
  */
 otError otPlatGetInfraIfLinkLayerAddress(otInstance                    *aInstance,
                                          uint32_t                       aIfIndex,

--- a/include/openthread/platform/infra_if.h
+++ b/include/openthread/platform/infra_if.h
@@ -45,6 +45,18 @@
 extern "C" {
 #endif
 
+#define OT_PLAT_INFRA_IF_MAX_LINK_LAYER_ADDR_LENGTH 16 ///< Maximum InfraIf Link-layer address length.
+
+/**
+ * Represents an InfraIf Link-Layer Address.
+ *
+ */
+typedef struct otPlatInfraIfLinkLayerAddress
+{
+    uint8_t mAddress[OT_PLAT_INFRA_IF_MAX_LINK_LAYER_ADDR_LENGTH]; ///< The link-layer address bytes.
+    uint8_t mLength;                                               ///< The address length (number of bytes).
+} otPlatInfraIfLinkLayerAddress;
+
 /**
  * @addtogroup plat-infra-if
  *
@@ -153,6 +165,24 @@ otError otPlatInfraIfDiscoverNat64Prefix(uint32_t aInfraIfIndex);
 extern void otPlatInfraIfDiscoverNat64PrefixDone(otInstance        *aInstance,
                                                  uint32_t           aInfraIfIndex,
                                                  const otIp6Prefix *aIp6Prefix);
+
+/**
+ * Get the link-layer address of the infrastructure interface.
+ *
+ * OpenThread invokes this method when the address is required, for example: when generating an ND6 message
+ * which includes a source link-layer address option.
+ *
+ * @param[in]  aInstance                    The OpenThread instance structure.
+ * @param[in]  aInfraIfIndex                The index of the infrastructure interface.
+ * @param[out] aInfraIfLinkLayerAddress     A pointer to infrastructure interface link-layer address.
+ *
+ * @retval  OT_ERROR_NONE    Successfully get the infrastructure interface link-layer address.
+ * @retval  OT_ERROR_FAILED  Failed to get the infrastructure interface link-layer address.
+ *
+ */
+otError otPlatGetInfraIfLinkLayerAddress(otInstance                    *aInstance,
+                                         uint32_t                       aIfIndex,
+                                         otPlatInfraIfLinkLayerAddress *aInfraIfLinkLayerAddress);
 
 /**
  * @}

--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -137,6 +137,11 @@ exit:
     }
 }
 
+Error InfraIf::GetLinkLayerAddress(LinkLayerAddress &aLinkLayerAddress)
+{
+    return otPlatGetInfraIfLinkLayerAddress(&GetInstance(), mIfIndex, &aLinkLayerAddress);
+}
+
 Error InfraIf::HandleStateChanged(uint32_t aIfIndex, bool aIsRunning)
 {
     Error error = kErrorNone;
@@ -216,5 +221,12 @@ OT_TOOL_WEAK otError otPlatInfraIfSendIcmp6Nd(uint32_t, const otIp6Address *, co
 
 OT_TOOL_WEAK otError otPlatInfraIfDiscoverNat64Prefix(uint32_t) { return OT_ERROR_FAILED; }
 #endif
+
+extern "C" OT_TOOL_WEAK otError otPlatGetInfraIfLinkLayerAddress(otInstance *,
+                                                                 uint32_t,
+                                                                 otPlatInfraIfLinkLayerAddress *)
+{
+    return OT_ERROR_FAILED;
+}
 
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE

--- a/src/core/border_router/infra_if.hpp
+++ b/src/core/border_router/infra_if.hpp
@@ -57,8 +57,9 @@ class InfraIf : public InstanceLocator
 public:
     static constexpr uint16_t kInfoStringSize = 20; ///< Max chars for the info string (`ToString()`).
 
-    typedef String<kInfoStringSize> InfoString;  ///< String type returned from `ToString()`.
-    typedef Data<kWithUint16Length> Icmp6Packet; ///< An IMCPv6 packet (data containing the IP payload)
+    typedef String<kInfoStringSize>       InfoString;       ///< String type returned from `ToString()`.
+    typedef Data<kWithUint16Length>       Icmp6Packet;      ///< An IMCPv6 packet (data containing the IP payload)
+    typedef otPlatInfraIfLinkLayerAddress LinkLayerAddress; ///< A link-layer address
 
     /**
      * Initializes the `InfraIf`.
@@ -112,6 +113,17 @@ public:
      * @param[in]  aIfIndex        The infrastructure interface index.
      */
     void SetIfIndex(uint32_t aIfIndex) { mIfIndex = aIfIndex; }
+
+    /**
+     * Gets the infrastructure interface link-layer address.
+     *
+     * @param[out]  aLinkLayerAddress     A reference to return the interface link-layer address.
+     *
+     * @retval  kErrorNone    Successfully get the infrastructure interface link-layer address.
+     * @retval  kErrorFailed  Failed to get the infrastructure interface link-layer address.
+     *
+     */
+    Error GetLinkLayerAddress(LinkLayerAddress &aLinkLayerAddress);
 
     /**
      * Indicates whether or not the infra interface has the given IPv6 address assigned.

--- a/src/core/border_router/infra_if.hpp
+++ b/src/core/border_router/infra_if.hpp
@@ -121,7 +121,6 @@ public:
      *
      * @retval  kErrorNone    Successfully get the infrastructure interface link-layer address.
      * @retval  kErrorFailed  Failed to get the infrastructure interface link-layer address.
-     *
      */
     Error GetLinkLayerAddress(LinkLayerAddress &aLinkLayerAddress);
 

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -642,13 +642,16 @@ private:
     //------------------------------------------------------------------------------------------------------------------
     // Typedefs
 
-    using Option                 = Ip6::Nd::Option;
-    using PrefixInfoOption       = Ip6::Nd::PrefixInfoOption;
-    using RouteInfoOption        = Ip6::Nd::RouteInfoOption;
-    using RouterAdvert           = Ip6::Nd::RouterAdvert;
-    using NeighborAdvertMessage  = Ip6::Nd::NeighborAdvertMessage;
-    using NeighborSolicitMessage = Ip6::Nd::NeighborSolicitMessage;
-    using RouterSolicitMessage   = Ip6::Nd::RouterSolicitMessage;
+    using Option                = Ip6::Nd::Option;
+    using PrefixInfoOption      = Ip6::Nd::PrefixInfoOption;
+    using RouteInfoOption       = Ip6::Nd::RouteInfoOption;
+    using RaFlagsExtOption      = Ip6::Nd::RaFlagsExtOption;
+    using RouterAdvert          = Ip6::Nd::RouterAdvert;
+    using NeighborAdvertMessage = Ip6::Nd::NeighborAdvertMessage;
+    using TxMessage             = Ip6::Nd::TxMessage;
+    using NeighborSolicitHeader = Ip6::Nd::NeighborSolicitHeader;
+    using RouterSolicitHeader   = Ip6::Nd::RouterSolicitHeader;
+    using LinkLayerAddress      = InfraIf::LinkLayerAddress;
 
     //------------------------------------------------------------------------------------------------------------------
     // Enumerations
@@ -1488,7 +1491,7 @@ private:
             bool IsFavoredOver(const PrefixEntry &aOther) const;
         };
 
-        void Process(const RouterAdvert::Icmp6Packet *aRaPacket, const PrefixTableEntry *aPrefixTableEntry);
+        void Process(const InfraIf::Icmp6Packet *aRaPacket, const PrefixTableEntry *aPrefixTableEntry);
         bool ProcessPrefixEntry(PrefixEntry &aEntry, PrefixEntry &aFavoredEntry);
         void EvaluateStateChange(State aOldState);
         void WithdrawPrefix(void);

--- a/src/core/net/nd6.hpp
+++ b/src/core/net/nd6.hpp
@@ -43,21 +43,26 @@
 #include <stdint.h>
 
 #include <openthread/netdata.h>
+#include <openthread/platform/infra_if.h>
 #include <openthread/platform/toolchain.h>
 
+#include "border_router/infra_if.hpp"
 #include "common/const_cast.hpp"
 #include "common/encoding.hpp"
 #include "common/equatable.hpp"
 #include "common/heap_array.hpp"
 #include "net/icmp6.hpp"
 #include "net/ip6.hpp"
+#include "net/ip6_headers.hpp"
 #include "thread/network_data_types.hpp"
 
 namespace ot {
 namespace Ip6 {
 namespace Nd {
 
-typedef NetworkData::RoutePreference RoutePreference; ///< Route Preference
+typedef NetworkData::RoutePreference  RoutePreference;  ///< Route Preference
+typedef Data<kWithUint16Length>       Icmp6Packet;      ///< A data buffer for an ICMPv6 packet.
+typedef otPlatInfraIfLinkLayerAddress LinkLayerAddress; ///< An infra-if link-layer address.
 
 /**
  * Represents the variable length options in Neighbor Discovery messages.
@@ -73,6 +78,8 @@ class Option
 public:
     enum Type : uint8_t
     {
+        kSourceLinkLayerAddr  = 1,  ///< Source Link Layer Address Option.
+        kTargetLinkLayerAddr  = 2,  ///< Target Link Layer Address Option.
         kTypePrefixInfo       = 3,  ///< Prefix Information Option.
         kTypeRouteInfo        = 24, ///< Route Information Option.
         kTypeRaFlagsExtension = 26, ///< RA Flags Extension Option.
@@ -482,6 +489,71 @@ private:
 static_assert(sizeof(RaFlagsExtOption) == 8, "invalid RaFlagsExtOption structure");
 
 /**
+ * Defines the ND6 Tx Message.
+ *
+ */
+class TxMessage
+{
+public:
+    /**
+     * Gets the prepared ND6 message as an `Icmp6Packet`.
+     *
+     * @param[out] aPacket   A reference to an `Icmp6Packet`.
+     *
+     */
+    void GetAsPacket(Icmp6Packet &aPacket) const { aPacket.Init(mArray.AsCArray(), mArray.GetLength()); }
+
+    /**
+     * Appends bytes from a given buffer to the ND6 message.
+     *
+     * @param[in] aBytes     A pointer to the buffer containing the bytes to append.
+     * @param[in] aLength    The buffer length.
+     *
+     * @retval kErrorNone    Bytes are appended successfully.
+     * @retval kErrorNoBufs  Insufficient available buffers to grow the message.
+     *
+     */
+    Error AppendBytes(const uint8_t *aBytes, uint16_t aLength);
+
+    /**
+     * Appends a Source/Target Link Layer Address Option to the ND6 message.
+     *
+     * @param[in] aLinkLayerAddress    The AIL Layer Address.
+     * @param[in] aType                The type of Link Layer Address Option, Source or Target
+     *
+     * @retval kErrorNone    Option is appended successfully.
+     * @retval kErrorNoBufs  Insufficient available buffers to grow the message.
+     *
+     */
+    Error AppendLinkLayerOption(LinkLayerAddress &aLinkLayerAddress, Option::Type aType);
+
+    /**
+     * Appends an object to the ND6 message.
+     *
+     * @tparam    ObjectType   The object type to append to the message.
+     *
+     * @param[in] aObject      A reference to the object to append to the message.
+     *
+     * @retval kErrorNone      Successfully appended the object.
+     * @retval kErrorNoBufs  Insufficient available buffers to grow the message.
+     *
+     */
+    template <typename ObjectType> Error Append(const ObjectType &aObject)
+    {
+        static_assert(!TypeTraits::IsPointer<ObjectType>::kValue, "ObjectType must not be a pointer");
+
+        return AppendBytes(reinterpret_cast<const uint8_t *>(&aObject), sizeof(ObjectType));
+    }
+
+protected:
+    static constexpr uint16_t kCapacityIncrement = 256;
+
+    Option *AppendOption(uint16_t aOptionSize);
+
+    Heap::Array<uint8_t, kCapacityIncrement> mArray;
+};
+
+/**
  * Defines Router Advertisement components.
  */
 class RouterAdvert
@@ -635,8 +707,6 @@ public:
 
     static_assert(sizeof(Header) == 16, "Invalid RA `Header`");
 
-    typedef Data<kWithUint16Length> Icmp6Packet; ///< A data buffer containing an ICMPv6 packet.
-
     /**
      * Represents a received RA message.
      */
@@ -716,26 +786,9 @@ public:
     /**
      * Represents an RA message to be sent.
      */
-    class TxMessage
+    class TxMessage : public ot::Ip6::Nd::TxMessage
     {
     public:
-        /**
-         * Gets the prepared RA message as an `Icmp6Packet`.
-         *
-         * @param[out] aPacket   A reference to an `Icmp6Packet`.
-         */
-        void GetAsPacket(Icmp6Packet &aPacket) const { aPacket.Init(mArray.AsCArray(), mArray.GetLength()); }
-
-        /**
-         * Appends the RA header.
-         *
-         * @param[in] aHeader  The RA header.
-         *
-         * @retval kErrorNone    Header is written successfully.
-         * @retval kErrorNoBufs  Insufficient available buffers to grow the message.
-         */
-        Error AppendHeader(const Header &aHeader);
-
         /**
          * Appends a Prefix Info Option to the RA message.
          *
@@ -764,30 +817,12 @@ public:
         Error AppendRouteInfoOption(const Prefix &aPrefix, uint32_t aRouteLifetime, RoutePreference aPreference);
 
         /**
-         * Appends bytes from a given buffer to the RA message.
-         *
-         * @param[in] aBytes     A pointer to the buffer containing the bytes to append.
-         * @param[in] aLength    The buffer length.
-         *
-         * @retval kErrorNone    Bytes are appended successfully.
-         * @retval kErrorNoBufs  Insufficient available buffers to grow the message.
-         */
-        Error AppendBytes(const uint8_t *aBytes, uint16_t aLength);
-
-        /**
          * Indicates whether or not the received RA message contains any options.
          *
          * @retval TRUE   If the RA message contains at least one option.
          * @retval FALSE  If the RA message contains no options.
          */
         bool ContainsAnyOptions(void) const { return (mArray.GetLength() > sizeof(Header)); }
-
-    private:
-        static constexpr uint16_t kCapacityIncrement = 256;
-
-        Option *AppendOption(uint16_t aOptionSize);
-
-        Heap::Array<uint8_t, kCapacityIncrement> mArray;
     };
 
     RouterAdvert(void) = delete;
@@ -800,37 +835,38 @@ public:
  * https://tools.ietf.org/html/rfc4861#section-4.1
  */
 OT_TOOL_PACKED_BEGIN
-class RouterSolicitMessage
+class RouterSolicitHeader
 {
 public:
     /**
      * Initializes the Router Solicitation message.
      */
-    RouterSolicitMessage(void);
+    RouterSolicitHeader(void);
 
 private:
     Icmp::Header mHeader; // The common ICMPv6 header.
 } OT_TOOL_PACKED_END;
 
-static_assert(sizeof(RouterSolicitMessage) == 8, "invalid RouterSolicitMessage structure");
-
+static_assert(sizeof(RouterSolicitHeader) == 8, "invalid RouterSolicitHeader structure");
 /**
  * Represents a Neighbor Solicitation (NS) message.
  */
 OT_TOOL_PACKED_BEGIN
-class NeighborSolicitMessage : public Clearable<NeighborSolicitMessage>
+class NeighborSolicitHeader : public Clearable<NeighborSolicitHeader>
 {
 public:
     /**
-     * Initializes the Neighbor Solicitation message.
+     * Initializes the Neighbor Solicitation message header.
+     *
      */
-    NeighborSolicitMessage(void);
+    NeighborSolicitHeader(void);
 
     /**
      * Indicates whether the Neighbor Solicitation message is valid (proper Type and Code).
      *
-     * @retval TRUE  If the message is valid.
-     * @retval FALSE If the message is not valid.
+     * @retval TRUE  If the message header is valid.
+     * @retval FALSE If the message header is not valid.
+     *
      */
     bool IsValid(void) const { return (mType == Icmp::Header::kTypeNeighborSolicit) && (mCode == 0); }
 
@@ -876,7 +912,7 @@ private:
     Address  mTargetAddress;
 } OT_TOOL_PACKED_END;
 
-static_assert(sizeof(NeighborSolicitMessage) == 24, "Invalid NeighborSolicitMessage definition");
+static_assert(sizeof(NeighborSolicitHeader) == 24, "Invalid NeighborSolicitHeader definition");
 
 /**
  * Represents a Neighbor Advertisement (NA) message.

--- a/src/core/net/nd6.hpp
+++ b/src/core/net/nd6.hpp
@@ -490,7 +490,6 @@ static_assert(sizeof(RaFlagsExtOption) == 8, "invalid RaFlagsExtOption structure
 
 /**
  * Defines the ND6 Tx Message.
- *
  */
 class TxMessage
 {
@@ -499,7 +498,6 @@ public:
      * Gets the prepared ND6 message as an `Icmp6Packet`.
      *
      * @param[out] aPacket   A reference to an `Icmp6Packet`.
-     *
      */
     void GetAsPacket(Icmp6Packet &aPacket) const { aPacket.Init(mArray.AsCArray(), mArray.GetLength()); }
 
@@ -511,7 +509,6 @@ public:
      *
      * @retval kErrorNone    Bytes are appended successfully.
      * @retval kErrorNoBufs  Insufficient available buffers to grow the message.
-     *
      */
     Error AppendBytes(const uint8_t *aBytes, uint16_t aLength);
 
@@ -523,7 +520,6 @@ public:
      *
      * @retval kErrorNone    Option is appended successfully.
      * @retval kErrorNoBufs  Insufficient available buffers to grow the message.
-     *
      */
     Error AppendLinkLayerOption(LinkLayerAddress &aLinkLayerAddress, Option::Type aType);
 
@@ -535,8 +531,7 @@ public:
      * @param[in] aObject      A reference to the object to append to the message.
      *
      * @retval kErrorNone      Successfully appended the object.
-     * @retval kErrorNoBufs  Insufficient available buffers to grow the message.
-     *
+     * @retval kErrorNoBufs    Insufficient available buffers to grow the message.
      */
     template <typename ObjectType> Error Append(const ObjectType &aObject)
     {
@@ -866,7 +861,6 @@ public:
      *
      * @retval TRUE  If the message header is valid.
      * @retval FALSE If the message header is not valid.
-     *
      */
     bool IsValid(void) const { return (mType == Icmp::Header::kTypeNeighborSolicit) && (mCode == 0); }
 

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -126,7 +126,7 @@ static otRadioFrame sRadioTxFrame;
 static uint8_t      sRadioTxFramePsdu[OT_RADIO_FRAME_MAX_SIZE];
 static bool         sRadioTxOngoing = false;
 
-using Icmp6Packet = Ip6::Nd::RouterAdvert::Icmp6Packet;
+using Icmp6Packet = Ip6::Nd::Icmp6Packet;
 
 enum ExpectedPio
 {
@@ -332,12 +332,12 @@ otError otPlatInfraIfSendIcmp6Nd(uint32_t            aInfraIfIndex,
 
     case Ip6::Icmp::Header::kTypeNeighborSolicit:
     {
-        const Ip6::Nd::NeighborSolicitMessage *nsMsg =
-            reinterpret_cast<const Ip6::Nd::NeighborSolicitMessage *>(packet.GetBytes());
+        const Ip6::Nd::NeighborSolicitHeader *nsMsg =
+            reinterpret_cast<const Ip6::Nd::NeighborSolicitHeader *>(packet.GetBytes());
 
         Log("  Neighbor Solicit message");
 
-        VerifyOrQuit(packet.GetLength() >= sizeof(Ip6::Nd::NeighborSolicitMessage));
+        VerifyOrQuit(packet.GetLength() >= sizeof(Ip6::Nd::NeighborSolicitHeader));
         VerifyOrQuit(nsMsg->IsValid());
         sNsEmitted = true;
 
@@ -875,7 +875,7 @@ void BuildRouterAdvert(Ip6::Nd::RouterAdvert::TxMessage &aRaMsg,
         header.SetSnacRouterFlag();
     }
 
-    SuccessOrQuit(aRaMsg.AppendHeader(header));
+    SuccessOrQuit(aRaMsg.Append(header));
 
     for (; aNumPios > 0; aPios++, aNumPios--)
     {


### PR DESCRIPTION
This PR introduces a platform API to get the InfraIf link-layer address. And add the source link-layer address option to all ND6 messages generated from Openthread.

Related Issue: [Unicast NS sent from should contain source link-layer address option. #10588](https://github.com/openthread/openthread/issues/10588)