### PR TITLE
[border-agent] not forward MGMT_GET/SET commands directly to leader

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -471,32 +471,16 @@ void BorderAgent::HandleTmf<kUriCommissionerGet>(Coap::Message &aMessage, const 
     HandleTmfDatasetGet(aMessage, aMessageInfo, kUriCommissionerGet);
 }
 
-template <>
-void BorderAgent::HandleTmf<kUriCommissionerSet>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
-{
-    IgnoreError(ForwardToLeader(aMessage, aMessageInfo, kUriCommissionerSet));
-}
-
 template <> void BorderAgent::HandleTmf<kUriActiveGet>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     HandleTmfDatasetGet(aMessage, aMessageInfo, kUriActiveGet);
     mCounters.mMgmtActiveGets++;
 }
 
-template <> void BorderAgent::HandleTmf<kUriActiveSet>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
-{
-    IgnoreError(ForwardToLeader(aMessage, aMessageInfo, kUriActiveSet));
-}
-
 template <> void BorderAgent::HandleTmf<kUriPendingGet>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     HandleTmfDatasetGet(aMessage, aMessageInfo, kUriPendingGet);
     mCounters.mMgmtPendingGets++;
-}
-
-template <> void BorderAgent::HandleTmf<kUriPendingSet>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
-{
-    IgnoreError(ForwardToLeader(aMessage, aMessageInfo, kUriPendingSet));
 }
 
 template <>
@@ -614,12 +598,6 @@ void BorderAgent::HandleTmfDatasetGet(Coap::Message &aMessage, const Ip6::Messag
 {
     Error          error    = kErrorNone;
     Coap::Message *response = nullptr;
-
-    if (mState == kStateAccepted)
-    {
-        IgnoreError(ForwardToLeader(aMessage, aMessageInfo, aUri));
-        ExitNow();
-    }
 
     // When processing `MGMT_GET` request directly on Border Agent,
     // the Security Policy flags (O-bit) should be ignore to allow

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -349,11 +349,8 @@ DeclareTmfHandler(BorderAgent, kUriCommissionerPetition);
 DeclareTmfHandler(BorderAgent, kUriCommissionerKeepAlive);
 DeclareTmfHandler(BorderAgent, kUriRelayTx);
 DeclareTmfHandler(BorderAgent, kUriCommissionerGet);
-DeclareTmfHandler(BorderAgent, kUriCommissionerSet);
 DeclareTmfHandler(BorderAgent, kUriActiveGet);
-DeclareTmfHandler(BorderAgent, kUriActiveSet);
 DeclareTmfHandler(BorderAgent, kUriPendingGet);
-DeclareTmfHandler(BorderAgent, kUriPendingSet);
 DeclareTmfHandler(BorderAgent, kUriProxyTx);
 
 } // namespace MeshCoP

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -311,11 +311,8 @@ bool SecureAgent::HandleResource(const char *aUriPath, Message &aMessage, const 
         Case(kUriCommissionerKeepAlive, MeshCoP::BorderAgent);
         Case(kUriRelayTx, MeshCoP::BorderAgent);
         Case(kUriCommissionerGet, MeshCoP::BorderAgent);
-        Case(kUriCommissionerSet, MeshCoP::BorderAgent);
         Case(kUriActiveGet, MeshCoP::BorderAgent);
-        Case(kUriActiveSet, MeshCoP::BorderAgent);
         Case(kUriPendingGet, MeshCoP::BorderAgent);
-        Case(kUriPendingSet, MeshCoP::BorderAgent);
         Case(kUriProxyTx, MeshCoP::BorderAgent);
 #endif
 


### PR DESCRIPTION
This commit doesn't forward the MGMT*GET/SET commands directly to leader any more, and enforces the use of UDP Proxy for Thread Management Commands if needed for external commissioner

[SPEC-1316](https://threadgroup.atlassian.net/browse/SPEC-1316)