### PR TITLE
[dtls] notify kDisconnectedLocalClosed when disconnect locally

### DIFF
--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -595,6 +595,7 @@ private:
     Error HandleSecureTransportSend(const uint8_t *aBuf, uint16_t aLength, Message::SubType aMessageSubType);
 
     void Process(void);
+    void Disconnect(ConnectEvent aEvent);
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
     static const char *StateToString(State aState);


### PR DESCRIPTION
The PR #10608 added ConnectEvent to notify the coap secure session connection status. It missed to set the event to `kDisconnectedLocalClosed` when the Disconnect() is called outside Process().