### PR TITLE
[border-agent] keep alive enhancements

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -486,9 +486,17 @@ template <> void BorderAgent::HandleTmf<kUriPendingGet>(Coap::Message &aMessage,
 template <>
 void BorderAgent::HandleTmf<kUriCommissionerKeepAlive>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    VerifyOrExit(mState != kStateStopped);
+    VerifyOrExit(mState == kStateAccepted || mState == kStateConnected);
 
-    SuccessOrExit(ForwardToLeader(aMessage, aMessageInfo, kUriLeaderKeepAlive));
+    if (mState == kStateAccepted)
+    {
+        SuccessOrExit(ForwardToLeader(aMessage, aMessageInfo, kUriLeaderKeepAlive));
+    }
+    else
+    {
+        SuccessOrExit(Get<Tmf::SecureAgent>().SendAck(aMessage, aMessageInfo));
+    }
+
     mTimer.Start(kKeepAliveTimeout);
 
 exit:
@@ -738,7 +746,7 @@ void BorderAgent::HandleTimeout(void)
     if (Get<Tmf::SecureAgent>().IsConnected())
     {
         Get<Tmf::SecureAgent>().Disconnect();
-        LogWarn("Reset commissioner session");
+        LogWarn("Reset secure session");
     }
 }
 


### PR DESCRIPTION
This commit only forwards keep alive to leader from active commissioner, otherwise locally reset the 50s lifetime if recieved over secure session.