### PR TITLE
[posix] decouple `resolver.cpp` from `netif.cpp`

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -215,10 +215,6 @@ static otIp6Prefix        sAddedExternalRoutes[kMaxExternalRoutesNum];
 static constexpr uint32_t kNat64RoutePriority = 100; ///< Priority for route to NAT64 CIDR, 100 means a high priority.
 #endif
 
-#if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE
-ot::Posix::Resolver gResolver;
-#endif
-
 #if defined(RTM_NEWMADDR) || defined(__NetBSD__)
 // on some BSDs (mac OS, FreeBSD), we get RTM_NEWMADDR/RTM_DELMADDR messages, so we don't need to monitor using MLD
 // on NetBSD, MLD monitoring simply doesn't work
@@ -2285,9 +2281,6 @@ void platformNetifSetUp(void)
 #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
     nat64Init();
 #endif
-#if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE
-    gResolver.Init();
-#endif
 }
 
 void platformNetifTearDown(void) {}
@@ -2343,10 +2336,6 @@ void platformNetifUpdateFdSet(otSysMainloopContext *aContext)
 #if OPENTHREAD_POSIX_USE_MLD_MONITOR
     FD_SET(sMLDMonitorFd, &aContext->mReadFdSet);
     FD_SET(sMLDMonitorFd, &aContext->mErrorFdSet);
-#endif
-
-#if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE
-    gResolver.UpdateFdSet(*aContext);
 #endif
 
     if (sTunFd > aContext->mMaxFd)
@@ -2409,10 +2398,6 @@ void platformNetifProcess(const otSysMainloopContext *aContext)
     {
         processMLDEvent(gInstance);
     }
-#endif
-
-#if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE
-    gResolver.Process(*aContext);
 #endif
 
 exit:

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -461,6 +461,28 @@ void platformSpinelManagerProcess(otInstance *aInstance, const otSysMainloopCont
  */
 void platformSpinelManagerUpdateFdSet(otSysMainloopContext *aContext);
 
+/**
+ * Initializes the resolver used by OpenThread.
+ *
+ */
+void platformResolverInit(void);
+
+/**
+ * Updates the file descriptor sets with file descriptors used by the resolver.
+ *
+ * @param[in]   aContext    A pointer to the mainloop context.
+ *
+ */
+void platformResolverUpdateFdSet(otSysMainloopContext *aContext);
+
+/**
+ * Performs the resolver processing.
+ *
+ * @param[in]  aContext  A pointer to the mainloop context.
+ *
+ */
+void platformResolverProcess(const otSysMainloopContext *aContext);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/posix/platform/resolver.cpp
+++ b/src/posix/platform/resolver.cpp
@@ -56,7 +56,7 @@ constexpr char kResolvConfFullPath[] = "/etc/resolv.conf";
 constexpr char kNameserverItem[]     = "nameserver";
 } // namespace
 
-extern ot::Posix::Resolver gResolver;
+ot::Posix::Resolver gResolver;
 
 namespace ot {
 namespace Posix {
@@ -292,6 +292,12 @@ void Resolver::Process(const otSysMainloopContext &aContext)
 
 } // namespace Posix
 } // namespace ot
+
+void platformResolverProcess(const otSysMainloopContext *aContext) { gResolver.Process(*aContext); }
+
+void platformResolverUpdateFdSet(otSysMainloopContext *aContext) { gResolver.UpdateFdSet(*aContext); }
+
+void platformResolverInit(void) { gResolver.Init(); }
 
 void otPlatDnsStartUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery)
 {

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -156,6 +156,9 @@ void platformInitRcpMode(otPlatformConfig *aPlatformConfig)
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
     platformNetifInit(aPlatformConfig);
 #endif
+#if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE
+    platformResolverInit();
+#endif
 
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
@@ -408,6 +411,9 @@ void otSysMainloopUpdate(otInstance *aInstance, otSysMainloopContext *aMainloop)
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
     platformTrelUpdateFdSet(aMainloop);
 #endif
+#if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE
+    platformResolverUpdateFdSet(aMainloop);
+#endif
 
     if (otTaskletsArePending(aInstance))
     {
@@ -475,6 +481,9 @@ void otSysMainloopProcess(otInstance *aInstance, const otSysMainloopContext *aMa
     platformAlarmProcess(aInstance);
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
     platformNetifProcess(aMainloop);
+#endif
+#if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE
+    platformResolverProcess(aMainloop);
 #endif
 }
 


### PR DESCRIPTION
This PR introduces `platformResolver*` APIs so that `system.cpp` can treat resolver as an independent module. 

Reasons for this refactor:
- Simplify the integration on Android platform.
- The functionality of resolver is not related to the functionality of netif.