### PR TITLE
[posix] support specifying DNS server for resolver

### DIFF
--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -43,6 +43,7 @@
 
 #include <openthread/error.h>
 #include <openthread/instance.h>
+#include <openthread/ip6.h>
 #include <openthread/platform/misc.h>
 
 #include "lib/spinel/coprocessor_type.h"
@@ -310,6 +311,24 @@ bool otSysInfraIfIsRunning(void);
  *
  */
 void otSysCliInitUsingDaemon(otInstance *aInstance);
+
+/**
+ * Sets whether to retrieve upstream DNS servers from "resolv.conf".
+ *
+ * @param[in] aEnabled  TRUE if enable retrieving upstream DNS servers from "resolv.conf", FALSE otherwise.
+ *
+ */
+void otSysUpstreamDnsServerSetResolvConfEnabled(bool aEnabled);
+
+/**
+ * Sets the upstream DNS server list.
+ *
+ * @param[in] aUpstreamDnsServers  A pointer to the list of upstream DNS server addresses. Each address could be an IPv6
+ *                                 address or an IPv4-mapped IPv6 address.
+ * @param[in] aNumServers          The number of upstream DNS servers.
+ *
+ */
+void otSysUpstreamDnsSetServerList(const otIp6Address *aUpstreamDnsServers, int aNumServers);
 
 #ifdef __cplusplus
 } // end of extern "C"

--- a/src/posix/platform/resolver.cpp
+++ b/src/posix/platform/resolver.cpp
@@ -32,6 +32,8 @@
 
 #include <openthread/logging.h>
 #include <openthread/message.h>
+#include <openthread/nat64.h>
+#include <openthread/openthread-system.h>
 #include <openthread/udp.h>
 #include <openthread/platform/dns.h>
 #include <openthread/platform/time.h>
@@ -85,6 +87,8 @@ void Resolver::LoadDnsServerListFromConf(void)
     std::string   line;
     std::ifstream fp;
 
+    VerifyOrExit(mIsResolvConfEnabled);
+
     mUpstreamDnsServerCount = 0;
 
     fp.open(kResolvConfFullPath);
@@ -110,6 +114,8 @@ void Resolver::LoadDnsServerListFromConf(void)
     }
 
     mUpstreamDnsServerListFreshness = otPlatTimeGet();
+exit:
+    return;
 }
 
 void Resolver::Query(otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery)
@@ -290,6 +296,23 @@ void Resolver::Process(const otSysMainloopContext &aContext)
     }
 }
 
+void Resolver::SetUpstreamDnsServers(const otIp6Address *aUpstreamDnsServers, int aNumServers)
+{
+    mUpstreamDnsServerCount = 0;
+
+    for (int i = 0; i < aNumServers && i < kMaxUpstreamServerCount; ++i)
+    {
+        otIp4Address ip4Address;
+
+        // TODO: support DNS servers with IPv6 addresses
+        if (otIp4FromIp4MappedIp6Address(&aUpstreamDnsServers[i], &ip4Address) == OT_ERROR_NONE)
+        {
+            mUpstreamDnsServerList[mUpstreamDnsServerCount] = ip4Address.mFields.m32;
+            mUpstreamDnsServerCount++;
+        }
+    }
+}
+
 } // namespace Posix
 } // namespace ot
 
@@ -311,6 +334,13 @@ void otPlatDnsCancelUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery 
     OT_UNUSED_VARIABLE(aInstance);
 
     gResolver.Cancel(aTxn);
+}
+
+void otSysUpstreamDnsServerSetResolvConfEnabled(bool aEnabled) { gResolver.SetResolvConfEnabled(aEnabled); }
+
+void otSysUpstreamDnsSetServerList(const otIp6Address *aUpstreamDnsServers, int aNumServers)
+{
+    gResolver.SetUpstreamDnsServers(aUpstreamDnsServers, aNumServers);
 }
 
 #endif // OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE

--- a/src/posix/platform/resolver.hpp
+++ b/src/posix/platform/resolver.hpp
@@ -90,6 +90,24 @@ public:
      */
     void Process(const otSysMainloopContext &aContext);
 
+    /**
+     * Sets whether to retrieve upstream DNS servers from "resolv.conf".
+     *
+     * @param[in] aEnabled  TRUE if enable retrieving upstream DNS servers from "resolv.conf", FALSE otherwise.
+     *
+     */
+    void SetResolvConfEnabled(bool aEnabled) { mIsResolvConfEnabled = aEnabled; }
+
+    /**
+     * Sets the upstream DNS servers.
+     *
+     * @param[in] aUpstreamDnsServers  A pointer to the list of upstream DNS server addresses. Each address could be an
+     *                                 IPv6 address or an IPv4-mapped IPv6 address.
+     * @param[in] aNumServers          The number of upstream DNS servers.
+     *
+     */
+    void SetUpstreamDnsServers(const otIp6Address *aUpstreamDnsServers, int aNumServers);
+
 private:
     static constexpr uint64_t kDnsServerListNullCacheTimeoutMs = 1 * 60 * 1000;  // 1 minute
     static constexpr uint64_t kDnsServerListCacheTimeoutMs     = 10 * 60 * 1000; // 10 minutes
@@ -110,6 +128,7 @@ private:
     void TryRefreshDnsServerList(void);
     void LoadDnsServerListFromConf(void);
 
+    bool      mIsResolvConfEnabled    = true;
     int       mUpstreamDnsServerCount = 0;
     in_addr_t mUpstreamDnsServerList[kMaxUpstreamServerCount];
     uint64_t  mUpstreamDnsServerListFreshness = 0;


### PR DESCRIPTION
This PR adds 2 system APIs for resolver for integration on Android platform.
- `otSysUpstreamDnsServerSetResolvConfEnabled` is for enabling/disabling retrieving the DNS servers from `resolve.conf`.
- `otSysUpstreamDnsSetServerList` for specifying the DNS servers on the infra link.