### PR TITLE
[doc] fix typos in comments

### DIFF
--- a/.code-spell-ignore
+++ b/.code-spell-ignore
@@ -1,10 +1,12 @@
+aafter
 aanother
 acount
 addrss
 afile
 aline
-anumber
+alocator
 ans
+anumber
 aother
 aparent
 apending
@@ -14,6 +16,7 @@ ect
 intialize
 nd
 ot
+re-use
 shashes
 ue
 unknwn

--- a/include/openthread/ble_secure.h
+++ b/include/openthread/ble_secure.h
@@ -334,7 +334,7 @@ otError otBleSecureConnect(otInstance *aInstance);
 void otBleSecureDisconnect(otInstance *aInstance);
 
 /**
- * Indicates whether or not the TLS session is active (connected or conneting).
+ * Indicates whether or not the TLS session is active (connected or connecting).
  *
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  *

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (438)
+#define OPENTHREAD_API_VERSION (439)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/multipan.h
+++ b/include/openthread/platform/multipan.h
@@ -36,7 +36,7 @@
  *   Currently we support two types of multipan RCP:
  *   - Full multipan: RCP operates in parallel on both networks (for example using more than one transceiver)
  *   - Switching RCP: RCP can communicate only with one network at a time and requires network switching mechanism.
- *                    Switching can be automatic (for example time based, radio sleep based) or manually contolled by
+ *                    Switching can be automatic (for example time based, radio sleep based) or manually controlled by
  *                    the host.
  *
  *   Full multipan RCP and Automatic Switching RCP do not require any special care from the host side.

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -91,7 +91,7 @@ class TxParameters : public otCoapTxParameters
 
 public:
     /**
-     * Coverts a pointer to `otCoapTxParameters` to `Coap::TxParamters`
+     * Converts a pointer to `otCoapTxParameters` to `Coap::TxParamters`
      *
      * If the pointer is `nullptr`, the default parameters are used instead.
      *

--- a/src/core/common/heap_string.hpp
+++ b/src/core/common/heap_string.hpp
@@ -46,7 +46,7 @@ namespace Heap {
 /**
  * Represents a heap allocated string.
  *
- * The buffer to store the string is allocated from heap and is manged by the `Heap::String` class itself, e.g., it may
+ * The buffer to store the string is allocated from heap and is managed by the `Heap::String` class itself, e.g., it may
  * be reused and/or freed and reallocated when the string is set. The `Heap::String` destructor will always free the
  * allocated buffer.
  *

--- a/src/core/common/string.hpp
+++ b/src/core/common/string.hpp
@@ -352,7 +352,7 @@ Error ParseDigit(char aDigitChar, uint8_t &aValue);
 Error ParseHexDigit(char aHexChar, uint8_t &aValue);
 
 /**
- * Coverts a boolean to "yes" or "no" string.
+ * Converts a boolean to "yes" or "no" string.
  *
  * @param[in] aBool  A boolean value to convert.
  *

--- a/src/core/radio/ble_secure.hpp
+++ b/src/core/radio/ble_secure.hpp
@@ -142,7 +142,7 @@ public:
     void Disconnect(void);
 
     /**
-     * Indicates whether or not the TLS session is active (connected or conneting).
+     * Indicates whether or not the TLS session is active (connected or connecting).
      *
      * @retval TRUE  If TLS session is active.
      * @retval FALSE If TLS session is not active.

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -77,7 +77,7 @@ static constexpr uint64_t kMaxCslTimeout = OPENTHREAD_CONFIG_MAC_CSL_MAX_TIMEOUT
  * Implements the radio statistics logic.
  *
  * The radio statistics are the time when the radio in TX/RX/radio state.
- * Since this class collects these statistics from pure software level and no platform API is involved, a simplied
+ * Since this class collects these statistics from pure software level and no platform API is involved, a simplified
  * model is used to calculate the time of different radio states. The data may not be very accurate, but it's
  * sufficient to provide a general understanding of the proportion of time a device is in different radio states.
  *

--- a/src/core/thread/link_metrics.hpp
+++ b/src/core/thread/link_metrics.hpp
@@ -270,7 +270,7 @@ private:
 /**
  * Implements the Thread Link Metrics Subject.
  *
- * The Subject reponds queries with reports, handles Link Metrics Management Requests and Link Probe Messages.
+ * The Subject responds queries with reports, handles Link Metrics Management Requests and Link Probe Messages.
  *
  */
 class Subject : public InstanceLocator, private NonCopyable

--- a/src/core/thread/network_data_types.hpp
+++ b/src/core/thread/network_data_types.hpp
@@ -153,7 +153,7 @@ typedef Array<uint16_t, kMaxRlocs> Rlocs;
 inline bool IsRoutePreferenceValid(int8_t aPref) { return Preference::IsValid(aPref); }
 
 /**
- * Coverts a route preference to a 2-bit unsigned value.
+ * Converts a route preference to a 2-bit unsigned value.
  *
  * The @p aPref MUST be valid (value from `RoutePreference` enumeration), or the behavior is undefined.
  *
@@ -165,7 +165,7 @@ inline bool IsRoutePreferenceValid(int8_t aPref) { return Preference::IsValid(aP
 inline uint8_t RoutePreferenceToValue(int8_t aPref) { return Preference::To2BitUint(aPref); }
 
 /**
- * Coverts a 2-bit unsigned value to a route preference.
+ * Converts a 2-bit unsigned value to a route preference.
  *
  * @param[in] aValue   The 2-bit unsigned value to convert from. Note that only the first two bits of @p aValue
  *                     are used and the rest of bits are ignored.

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -172,7 +172,7 @@ public:
      *                                         directly do a hardware reset.
      * @param[in]  aSpinelDriver               A pointer to the spinel driver instance that this object depends on.
      * @param[in]  aRequiredRadioCaps          The required radio capabilities. RadioSpinel will check if RCP has
-     *                                         the required capabilities during initiailization.
+     *                                         the required capabilities during initialization.
      * @param[in]  aEnableRcpTimeSync          TRUE to enable RCP time sync, FALSE to not enable.
      *
      */

--- a/src/lib/spinel/spinel.h
+++ b/src/lib/spinel/spinel.h
@@ -522,7 +522,7 @@ enum
 
     /// Generic failure to associate with other peers.
     /**
-     *  This status error should not be used by implementors if
+     *  This status error should not be used by implementers if
      *  enough information is available to determine that one of the
      *  later join failure status codes would be more accurate.
      *

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -226,7 +226,7 @@ ot::Posix::Resolver gResolver;
 #else
 // on some platforms (Linux, but others might be made to work), we do not get information about multicast
 // group joining via AF_NETLINK or AF_ROUTE sockets.  on those platform, we must listen for IPv6 ICMP
-// MLDv2 messages to know when mulicast memberships change
+// MLDv2 messages to know when multicast memberships change
 // 		https://stackoverflow.com/questions/37346289/using-netlink-is-it-possible-to-listen-whenever-multicast-group-membership-is-ch
 #define OPENTHREAD_POSIX_USE_MLD_MONITOR 1
 #endif // defined(RTM_NEWMADDR) || defined(__NetBSD__)

--- a/tests/scripts/thread-cert/command.py
+++ b/tests/scripts/thread-cert/command.py
@@ -559,7 +559,7 @@ def check_compressed_address_registration_tlv(command_msg, cid, iid, cid_present
             command_msg (MleMessage) : The Mle message to check.
             cid (int): The context id of the domain prefix.
             iid (string): The Interface Identifier.
-            cid_present_once(boolean): True if cid entry should apprear only once in AR Tlv.
+            cid_present_once(boolean): True if cid entry should appear only once in AR Tlv.
                                        False otherwise.
     '''
     found = False

--- a/tests/scripts/thread-cert/test_crypto.py
+++ b/tests/scripts/thread-cert/test_crypto.py
@@ -195,7 +195,7 @@ class TestCryptoEngine(unittest.TestCase):
 
 
 class TestCryptoMaterialCreator(unittest.TestCase):
-    """ Key generaion was described in Thread specification.
+    """ Key generation was described in Thread specification.
 
     Read more: Thread 1.1.0 Specification Candidate Final - 7.1.4 Key Generation
 


### PR DESCRIPTION
This PR is done by `script/code-spell` with some manual fixes. 