### PR TITLE
[epskc] return error from otBorderAgentClearEphemeralKey api

### DIFF
--- a/include/openthread/border_agent.h
+++ b/include/openthread/border_agent.h
@@ -248,16 +248,19 @@ otError otBorderAgentSetEphemeralKey(otInstance *aInstance,
  * Requires `OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE`.
  *
  * Can be used to cancel a previously set ephemeral key before it times out. If the Border Agent is not running or
- * there is no ephemeral key in use, calling this function has no effect.
+ * there is no ephemeral key in use, calling this function has no effect and returns `OT_ERROR_NONE`.
  *
  * If a commissioner is connected using the ephemeral key and is currently active, calling this function does not
- * change its state. In this case the `otBorderAgentIsEphemeralKeyActive()` will continue to return `TRUE` until the
- * commissioner disconnects.
+ * change its state, and `OT_ERROR_INVALID_STATE` is returned. In this case the `otBorderAgentIsEphemeralKeyActive()`
+ * will continue to return `TRUE` until the commissioner disconnects.
  *
  * @param[in] aInstance    The OpenThread instance.
  *
+ * @retval OT_ERROR_NONE           Successfully cleared the ephemeral key.
+ * @retval OT_ERROR_INVALID_STATE  Border Agent is connected to an external commissioner.
+ *
  */
-void otBorderAgentClearEphemeralKey(otInstance *aInstance);
+otError otBorderAgentClearEphemeralKey(otInstance *aInstance);
 
 /**
  * Indicates whether or not an ephemeral key is currently active.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (439)
+#define OPENTHREAD_API_VERSION (440)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -505,7 +505,7 @@ template <> otError Interpreter::Process<Cmd("ba")>(Arg aArgs[])
          */
         else if (aArgs[1] == "clear")
         {
-            otBorderAgentClearEphemeralKey(GetInstancePtr());
+            error = otBorderAgentClearEphemeralKey(GetInstancePtr());
         }
         /**
          * @cli ba ephemeralkey callback (enable, disable)

--- a/src/core/api/border_agent_api.cpp
+++ b/src/core/api/border_agent_api.cpp
@@ -91,9 +91,9 @@ otError otBorderAgentSetEphemeralKey(otInstance *aInstance,
     return AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().SetEphemeralKey(aKeyString, aTimeout, aUdpPort);
 }
 
-void otBorderAgentClearEphemeralKey(otInstance *aInstance)
+otError otBorderAgentClearEphemeralKey(otInstance *aInstance)
 {
-    AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().ClearEphemeralKey();
+    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().ClearEphemeralKey();
 }
 
 bool otBorderAgentIsEphemeralKeyActive(otInstance *aInstance)

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -851,8 +851,10 @@ exit:
     return error;
 }
 
-void BorderAgent::ClearEphemeralKey(void)
+Error BorderAgent::ClearEphemeralKey(void)
 {
+    Error error = kErrorNone;
+
     VerifyOrExit(mUsingEphemeralKey);
 
     LogInfo("Clearing ephemeral key");
@@ -875,22 +877,24 @@ void BorderAgent::ClearEphemeralKey(void)
         break;
 
     case kStateStopped:
+        break;
     case kStateConnected:
     case kStateAccepted:
         // If there is an active commissioner connection, we wait till
         // it gets disconnected before removing ephemeral key and
         // restarting the agent.
+        error = kErrorInvalidState;
         break;
     }
 
 exit:
-    return;
+    return error;
 }
 
 void BorderAgent::HandleEphemeralKeyTimeout(void)
 {
     LogInfo("Ephemeral key timed out");
-    ClearEphemeralKey();
+    IgnoreError(ClearEphemeralKey());
 }
 
 void BorderAgent::InvokeEphemeralKeyCallback(void) { mEphemeralKeyCallback.InvokeIfSet(); }

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -212,8 +212,11 @@ public:
      * change its state. In this case the `IsEphemeralKeyActive()` will continue to return `true` until the commissioner
      * disconnects.
      *
+     * @retval kErrorNone            Successfully cleared the ephemeral key.
+     * @retval kErrorInvalidState    Border Agent is connected to an external commissioner.
+     *
      */
-    void ClearEphemeralKey(void);
+    Error ClearEphemeralKey(void);
 
     /**
      * Indicates whether or not an ephemeral key is currently active.


### PR DESCRIPTION
Adding return error to the `otBorderAgentClearEphemeralKey` api function, so that callers will know if epskc has been cleared without having to call `otBorderAgentIsEphemeralKeyActive` afterwards. It also aligns with the `otBorderAgentSetEphemeralKey` which returns errors to indicate the results.