### PR TITLE
[csl] simplify calculating CSL phase

### DIFF
--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -436,11 +436,9 @@ void platformRadioInit(void)
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 static uint16_t getCslPhase(void)
 {
-    uint32_t curTime       = otPlatAlarmMicroGetNow();
-    uint32_t cslPeriodInUs = sCslPeriod * OT_US_PER_TEN_SYMBOLS;
-    uint32_t diff = ((sCslSampleTime % cslPeriodInUs) - (curTime % cslPeriodInUs) + cslPeriodInUs) % cslPeriodInUs;
-
-    return (uint16_t)(diff / OT_US_PER_TEN_SYMBOLS);
+    uint32_t diff = (sCslSampleTime - otPlatAlarmMicroGetNow()) / OT_US_PER_TEN_SYMBOLS;
+    assert(diff < sCslPeriod);
+    return (uint16_t)diff;
 }
 #endif
 


### PR DESCRIPTION
This commit simplifies the calculation of CSL phase. The previous expression is only correct if the CSL phase is smaller than the CSL period, which may not be true when the CSL period is updated and the new CSL sample time is not updated yet, this can happen because the CSL IE is supposed to be filled in an ISR handler.