### PR TITLE
[tcat] TCAT documentation cleanup

### DIFF
--- a/include/openthread/ble_secure.h
+++ b/include/openthread/ble_secure.h
@@ -124,8 +124,6 @@ otError otBleSecureSetTcatVendorInfo(otInstance *aInstance, const otTcatVendorIn
  * Enables the TCAT protocol over BLE Secure.
  *
  * @param[in]  aInstance         A pointer to an OpenThread instance.
- * @param[in]  aVendorInfo       A pointer to the Vendor Information (must remain valid after the method call, may be
- *                               NULL).
  * @param[in]  aHandler          A pointer to a function that is called when the join operation completes.
  *
  * @retval OT_ERROR_NONE              Successfully started the BLE Secure Joiner role.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (443)
+#define OPENTHREAD_API_VERSION (444)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/cli_tcat.cpp
+++ b/src/cli/cli_tcat.cpp
@@ -137,6 +137,23 @@ static void HandleBleSecureReceive(otInstance               *aInstance,
     IgnoreReturnValue(otBleSecureFlush(aInstance));
 }
 
+/**
+ * @cli tcat advid
+ * @code
+ * tcat advid ianapen f378aabb
+ * Done
+ * @endcode
+ * @cparam tcat advid [@ca{id_type}] [@ca{value}]
+ * * The `id_type` has five possible values:
+ *   * `clear` - removes all previously set advertised IDs.
+ *   * `oui24` - sets OUI24 ID type.
+ *   * `oui36` - sets OUI36 ID type.
+ *   * `discriminator` - sets discriminator ID type.
+ *   * `ianapen` - sets IANA PEN ID type.
+ * * The `value` hexstring value of the ID.
+ * @par
+ * Sets/clears advertised ID type and value.
+ */
 template <> otError Tcat::Process<Cmd("advid")>(Arg aArgs[])
 {
     otError                  error = OT_ERROR_NONE;
@@ -212,6 +229,17 @@ exit:
     return error;
 }
 
+/**
+ * @cli tcat devid
+ * @code
+ * tcat devid ianapen f378aabb
+ * Done
+ * @endcode
+ * @cparam tcat devid [@ca{value}|clear]
+ * * The `value` hexstring value of the ID. `clear` is a special value removing previously set ID.
+ * @par
+ * Sets/clears vendor specific device ID.
+ */
 template <> otError Tcat::Process<Cmd("devid")>(Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
@@ -241,6 +269,21 @@ exit:
     return error;
 }
 
+/**
+ * @cli tcat start
+ * @code
+ * tcat start
+ * Done
+ * @endcode
+ * @par
+ * Starts TCAT operation.
+ * @sa otBleSecureSetCertificate
+ * @sa otBleSecureSetCaCertificateChain
+ * @sa otBleSecureSetSslAuthMode
+ * @sa otBleSecureSetTcatVendorInfo
+ * @sa otBleSecureStart
+ * @sa otBleSecureTcatStart
+ */
 template <> otError Tcat::Process<Cmd("start")>(Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);
@@ -279,6 +322,16 @@ exit:
     return error;
 }
 
+/**
+ * @cli tcat stop
+ * @code
+ * tcat stop
+ * Done
+ * @endcode
+ * @par
+ * Stops TCAT operation.
+ * @sa otBleSecureStop
+ */
 template <> otError Tcat::Process<Cmd("stop")>(Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);


### PR DESCRIPTION
Commit adds documentation to tcat CLi commands, also removes incorrect parameter form `otBleSecureTcatStart`.