### PR TITLE
[posix] add a method to set the radio url

### DIFF
--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -320,6 +320,14 @@ void otSysTrelInit(const char *aInterfaceName);
  */
 void otSysTrelDeinit(void);
 
+/**
+ * Sets the radio url to configure the radio related parameters.
+ *
+ * @param[in] aRadioUrl  A pointer to the radio url string.
+ *
+ */
+void otSysSetRadioUrl(const char *aRadioUrl);
+
 #ifdef __cplusplus
 } // end of extern "C"
 #endif

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -225,6 +225,17 @@ void platformRadioHandleStateChange(otInstance *aInstance, otChangedFlags aFlags
     }
 }
 
+void otSysSetRadioUrl(const char *aRadioUrl)
+{
+    ot::Posix::RadioUrl radioUrl(aRadioUrl);
+
+    VerifyOrExit((aRadioUrl != nullptr) && (radioUrl.GetPath() != nullptr));
+    sRadio.ProcessRadioUrl(radioUrl);
+
+exit:
+    return;
+}
+
 void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
 {
     OT_UNUSED_VARIABLE(aInstance);

--- a/src/posix/platform/radio.hpp
+++ b/src/posix/platform/radio.hpp
@@ -91,8 +91,15 @@ public:
     RcpCapsDiag &GetRcpCapsDiag(void) { return mRcpCapsDiag; }
 #endif
 
-private:
+    /**
+     * Processes the radio url to set the radio related parameters
+     *
+     * @param[in] aRadioUrl  A reference to the radio url string.
+     *
+     */
     void ProcessRadioUrl(const RadioUrl &aRadioUrl);
+
+private:
     void ProcessMaxPowerTable(const RadioUrl &aRadioUrl);
 
 #if OPENTHREAD_POSIX_CONFIG_SPINEL_HDLC_INTERFACE_ENABLE && OPENTHREAD_POSIX_CONFIG_SPINEL_SPI_INTERFACE_ENABLE


### PR DESCRIPTION
The Thread stack is located in mainline module of AOSP. The radio url of the Thread stack is hard-coded in mainline module, developers can not change it.

This commit adds a method to posix platform for the Android framework of Thead stack to set the radio related parameters.