### PR TITLE
[radio] add tx timestamp

### DIFF
--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -376,5 +376,6 @@ otError otMacFrameProcessTxSfd(otRadioFrame *aFrame, uint64_t aRadioTime, otRadi
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     otMacFrameUpdateTimeIe(aFrame, aRadioTime, aRadioContext);
 #endif
+    aFrame->mInfo.mTxInfo.mTimestamp = aRadioTime;
     return otMacFrameProcessTransmitSecurity(aFrame, aRadioContext);
 }

--- a/examples/platforms/utils/mac_frame.h
+++ b/examples/platforms/utils/mac_frame.h
@@ -358,6 +358,7 @@ typedef struct otRadioContext
  *
  *  - CSL IE will be populated (if present)
  *  - Time IE will be populated (if present)
+ *  - Tx timestamp will be populated
  *  - Tx security will be performed (including assignment of security frame counter and key id if not assigned)
  *
  * @param[in,out]   aFrame          The target frame. MUST NOT be `NULL`.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (441)
+#define OPENTHREAD_API_VERSION (442)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -361,6 +361,15 @@ typedef struct otRadioFrame
             bool mCsmaCaEnabled : 1;       ///< Set to true to enable CSMA-CA for this packet, false otherwise.
             bool mCslPresent : 1;          ///< Set to true if CSL header IE is present.
             bool mIsSecurityProcessed : 1; ///< True if SubMac should skip the AES processing of this frame.
+
+            /**
+             * The time of the local radio clock in microseconds when the end of
+             * the SFD was present at the local antenna.
+             *
+             * The platform should update this field before otPlatRadioTxStarted() is fired for each transmit attempt.
+             *
+             */
+            uint64_t mTimestamp;
         } mTxInfo;
 
         /**

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -4605,7 +4605,12 @@ void NcpBase::HandlePcapFrame(const otRadioFrame *aFrame, bool aIsTx)
     SuccessOrExit(mEncoder.WriteInt8(-128));    // Noise floor (Currently unused)
     SuccessOrExit(mEncoder.WriteUint16(flags)); // Flags
 
-    SuccessOrExit(mEncoder.OpenStruct()); // PHY-data
+    SuccessOrExit(mEncoder.OpenStruct());                 // PHY-data
+    SuccessOrExit(mEncoder.WriteUint8(aFrame->mChannel)); // Channel
+    SuccessOrExit(
+        mEncoder.WriteUint8(aIsTx ? static_cast<uint8_t>(OT_RADIO_LQI_NONE) : aFrame->mInfo.mRxInfo.mLqi)); // LQI
+    SuccessOrExit(
+        mEncoder.WriteUint64(aIsTx ? aFrame->mInfo.mTxInfo.mTimestamp : aFrame->mInfo.mRxInfo.mTimestamp)); // Timestamp
     // Empty for now
     SuccessOrExit(mEncoder.CloseStruct());
 


### PR DESCRIPTION
This commit adds tx timestamp so that the pcap callback can get the time when a frame was transmitted. This commit also adds channel, LQI and timestamp info in pcap handler in ncp.