### PR TITLE
[mac-frame] add `TxFrame::Info` and simplify mac header preparation

### DIFF
--- a/src/core/common/frame_builder.cpp
+++ b/src/core/common/frame_builder.cpp
@@ -45,11 +45,11 @@
 
 namespace ot {
 
-void FrameBuilder::Init(void *aBuffer, uint16_t aLength)
+void FrameBuilder::Init(void *aBuffer, uint16_t aMaxLength)
 {
     mBuffer    = static_cast<uint8_t *>(aBuffer);
     mLength    = 0;
-    mMaxLength = aLength;
+    mMaxLength = aMaxLength;
 }
 
 Error FrameBuilder::AppendUint8(uint8_t aUint8) { return Append<uint8_t>(aUint8); }
@@ -117,6 +117,18 @@ exit:
     return error;
 }
 #endif
+
+void *FrameBuilder::AppendLength(uint16_t aLength)
+{
+    void *buffer = nullptr;
+
+    VerifyOrExit(CanAppend(aLength));
+    buffer = &mBuffer[mLength];
+    mLength += aLength;
+
+exit:
+    return buffer;
+}
 
 void FrameBuilder::WriteBytes(uint16_t aOffset, const void *aBuffer, uint16_t aLength)
 {

--- a/src/core/common/frame_builder.hpp
+++ b/src/core/common/frame_builder.hpp
@@ -55,9 +55,9 @@ public:
      * `FrameBuilder` MUST be initialized before its other methods are used.
      *
      * @param[in] aBuffer   A pointer to a buffer.
-     * @param[in] aLength   The data length (number of bytes in @p aBuffer).
+     * @param[in] aLength   The max data length (number of bytes in @p aBuffer).
      */
-    void Init(void *aBuffer, uint16_t aLength);
+    void Init(void *aBuffer, uint16_t aMaxLength);
 
     /**
      * Returns a pointer to the start of `FrameBuilder` buffer.
@@ -209,6 +209,38 @@ public:
         static_assert(!TypeTraits::IsPointer<ObjectType>::kValue, "ObjectType must not be a pointer");
 
         return AppendBytes(&aObject, sizeof(ObjectType));
+    }
+
+    /**
+     * Appends the given number of bytes to the `FrameBuilder`.
+     *
+     * This method reserves @p aLength bytes at the current position of the `FrameBuilder` and returns a pointer to the
+     * start of this reserved buffer if successful. The reserved bytes are left uninitialized. The caller is
+     * responsible for initializing them.
+     *
+     * @param[in] aLength  The number of bytes to append.
+     *
+     * @returns A pointer to the start of the appended bytes if successful, or `nullptr` if there are not enough
+     *          remaining bytes to append @p aLength bytes.
+     */
+    void *AppendLength(uint16_t aLength);
+
+    /**
+     * Appends an object to the `FrameBuilder`.
+     *
+     * @tparam ObjectType  The object type to append.
+     *
+     * This method reserves bytes in `FrameBuilder`  to accommodate an `ObjectType` and returns a pointer to the
+     * appended `ObjectType`. The `ObjectType` bytes are left uninitialized. Caller is responsible to initialize them.
+     *
+     * @returns A pointer the appended `ObjectType` if successful, or `nullptr` if there are not enough remaining
+     *          bytes to append an `ObjectType`.
+     */
+    template <typename ObjectType> ObjectType *Append(void)
+    {
+        static_assert(!TypeTraits::IsPointer<ObjectType>::kValue, "ObjectType must not be a pointer");
+
+        return static_cast<ObjectType *>(AppendLength(sizeof(ObjectType)));
     }
 
     /**

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -722,15 +722,17 @@ void Mac::FinishOperation(void)
 
 TxFrame *Mac::PrepareBeaconRequest(void)
 {
-    TxFrame  &frame = mLinks.GetTxFrames().GetBroadcastTxFrame();
-    Addresses addrs;
-    PanIds    panIds;
+    TxFrame      &frame = mLinks.GetTxFrames().GetBroadcastTxFrame();
+    TxFrame::Info frameInfo;
 
-    addrs.mSource.SetNone();
-    addrs.mDestination.SetShort(kShortAddrBroadcast);
-    panIds.SetDestination(kShortAddrBroadcast);
+    frameInfo.mAddrs.mSource.SetNone();
+    frameInfo.mAddrs.mDestination.SetShort(kShortAddrBroadcast);
+    frameInfo.mPanIds.SetDestination(kShortAddrBroadcast);
 
-    frame.InitMacHeader(Frame::kTypeMacCmd, Frame::kVersion2003, addrs, panIds, Frame::kSecurityNone);
+    frameInfo.mType    = Frame::kTypeMacCmd;
+    frameInfo.mVersion = Frame::kVersion2003;
+
+    frameInfo.PrepareHeadersIn(frame);
 
     IgnoreError(frame.SetCommandId(Frame::kMacCmdBeaconRequest));
 
@@ -741,10 +743,9 @@ TxFrame *Mac::PrepareBeaconRequest(void)
 
 TxFrame *Mac::PrepareBeacon(void)
 {
-    TxFrame  *frame;
-    Beacon   *beacon = nullptr;
-    Addresses addrs;
-    PanIds    panIds;
+    TxFrame      *frame;
+    TxFrame::Info frameInfo;
+    Beacon       *beacon = nullptr;
 #if OPENTHREAD_CONFIG_MAC_OUTGOING_BEACON_PAYLOAD_ENABLE
     uint8_t        beaconLength;
     BeaconPayload *beaconPayload = nullptr;
@@ -758,11 +759,14 @@ TxFrame *Mac::PrepareBeacon(void)
     frame = &mLinks.GetTxFrames().GetBroadcastTxFrame();
 #endif
 
-    addrs.mSource.SetExtended(GetExtAddress());
-    panIds.SetSource(mPanId);
-    addrs.mDestination.SetNone();
+    frameInfo.mAddrs.mSource.SetExtended(GetExtAddress());
+    frameInfo.mPanIds.SetSource(mPanId);
+    frameInfo.mAddrs.mDestination.SetNone();
 
-    frame->InitMacHeader(Frame::kTypeBeacon, Frame::kVersion2003, addrs, panIds, Frame::kSecurityNone);
+    frameInfo.mType    = Frame::kTypeBeacon;
+    frameInfo.mVersion = Frame::kVersion2003;
+
+    frameInfo.PrepareHeadersIn(*frame);
 
     beacon = reinterpret_cast<Beacon *>(frame->GetPayload());
     beacon->Init();

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -48,20 +48,15 @@
 namespace ot {
 namespace Mac {
 
-void Frame::InitMacHeader(Type             aType,
-                          Version          aVersion,
-                          const Addresses &aAddrs,
-                          const PanIds    &aPanIds,
-                          SecurityLevel    aSecurityLevel,
-                          KeyIdMode        aKeyIdMode,
-                          bool             aSuppressSequence)
+void TxFrame::Info::PrepareHeadersIn(TxFrame &aTxFrame) const
 {
     uint16_t     fcf;
     FrameBuilder builder;
+    uint8_t      micSize = 0;
 
-    fcf = static_cast<uint16_t>(aType) | static_cast<uint16_t>(aVersion);
+    fcf = static_cast<uint16_t>(mType) | static_cast<uint16_t>(mVersion);
 
-    switch (aAddrs.mSource.GetType())
+    switch (mAddrs.mSource.GetType())
     {
     case Address::kTypeNone:
         fcf |= kFcfSrcAddrNone;
@@ -74,30 +69,30 @@ void Frame::InitMacHeader(Type             aType,
         break;
     }
 
-    switch (aAddrs.mDestination.GetType())
+    switch (mAddrs.mDestination.GetType())
     {
     case Address::kTypeNone:
         fcf |= kFcfDstAddrNone;
         break;
     case Address::kTypeShort:
         fcf |= kFcfDstAddrShort;
-        fcf |= ((aAddrs.mDestination.GetShort() == kShortAddrBroadcast) ? 0 : kFcfAckRequest);
+        fcf |= ((mAddrs.mDestination.GetShort() == kShortAddrBroadcast) ? 0 : kFcfAckRequest);
         break;
     case Address::kTypeExtended:
         fcf |= (kFcfDstAddrExt | kFcfAckRequest);
         break;
     }
 
-    if (aType == kTypeAck)
+    if (mType == kTypeAck)
     {
         fcf &= ~kFcfAckRequest;
     }
 
-    fcf |= (aSecurityLevel != kSecurityNone) ? kFcfSecurityEnabled : 0;
+    fcf |= (mSecurityLevel != kSecurityNone) ? kFcfSecurityEnabled : 0;
 
     // PAN ID compression
 
-    switch (aVersion)
+    switch (mVersion)
     {
     case kVersion2003:
     case kVersion2006:
@@ -114,14 +109,14 @@ void Frame::InitMacHeader(Type             aType,
         //   PAN ID Compression field shall be set to zero, and both Destination PAN ID
         //   field and Source PAN ID fields shall be included in the transmitted frame.
 
-        if (!aAddrs.mSource.IsNone() && !aAddrs.mDestination.IsNone() &&
-            (aPanIds.GetSource() == aPanIds.GetDestination()))
+        if (!mAddrs.mSource.IsNone() && !mAddrs.mDestination.IsNone() &&
+            (mPanIds.GetSource() == mPanIds.GetDestination()))
         {
             fcf |= kFcfPanidCompression;
         }
 
         // Sequence Number Suppression bit was reserved, and must not be set on initialization.
-        OT_ASSERT(!aSuppressSequence);
+        OT_ASSERT(!mSuppressSequence);
         break;
 
     case kVersion2015:
@@ -146,12 +141,12 @@ void Frame::InitMacHeader(Type             aType,
         // | 14 | Short        | Short        | Present      | Not Present  |      1       |
         // +----+--------------+--------------+--------------+--------------+--------------+
 
-        if (aAddrs.mDestination.IsNone())
+        if (mAddrs.mDestination.IsNone())
         {
             // Dst addr not present - rows 1,2,5,6.
 
-            if ((aAddrs.mSource.IsNone() && aPanIds.IsDestinationPresent()) ||                               // Row 2.
-                (!aAddrs.mSource.IsNone() && !aPanIds.IsDestinationPresent() && !aPanIds.IsSourcePresent())) // Row 6.
+            if ((mAddrs.mSource.IsNone() && mPanIds.IsDestinationPresent()) ||                               // Row 2.
+                (!mAddrs.mSource.IsNone() && !mPanIds.IsDestinationPresent() && !mPanIds.IsSourcePresent())) // Row 6.
             {
                 fcf |= kFcfPanidCompression;
             }
@@ -159,11 +154,11 @@ void Frame::InitMacHeader(Type             aType,
             break;
         }
 
-        if (aAddrs.mSource.IsNone())
+        if (mAddrs.mSource.IsNone())
         {
             // Dst addr present, Src addr not present - rows 3,4.
 
-            if (!aPanIds.IsDestinationPresent()) // Row 4.
+            if (!mPanIds.IsDestinationPresent()) // Row 4.
             {
                 fcf |= kFcfPanidCompression;
             }
@@ -173,16 +168,16 @@ void Frame::InitMacHeader(Type             aType,
 
         // Both addresses are present - rows 7 to 14.
 
-        if (aAddrs.mSource.IsExtended() && aAddrs.mDestination.IsExtended())
+        if (mAddrs.mSource.IsExtended() && mAddrs.mDestination.IsExtended())
         {
             // Both addresses are extended - rows 7,8.
 
-            if (aPanIds.IsDestinationPresent()) // Row 7.
+            if (mPanIds.IsDestinationPresent()) // Row 7.
             {
                 break;
             }
         }
-        else if (aPanIds.GetSource() != aPanIds.GetDestination()) // Rows 9-14.
+        else if (mPanIds.GetSource() != mPanIds.GetDestination()) // Rows 9-14.
         {
             break;
         }
@@ -192,51 +187,53 @@ void Frame::InitMacHeader(Type             aType,
         break;
     }
 
-    if (aSuppressSequence)
+    if (mSuppressSequence)
     {
         fcf |= kFcfSequenceSuppression;
     }
 
-    builder.Init(mPsdu, GetMtu());
+    builder.Init(aTxFrame.mPsdu, aTxFrame.GetMtu());
     IgnoreError(builder.AppendLittleEndianUint16(fcf));
 
     if (IsSequencePresent(fcf))
     {
-        IgnoreError(builder.AppendUint8(0)); // Seq number
+        builder.Append<uint8_t>(); // Place holder for seq number
     }
 
     if (IsDstPanIdPresent(fcf))
     {
-        IgnoreError(builder.AppendLittleEndianUint16(aPanIds.GetDestination()));
+        IgnoreError(builder.AppendLittleEndianUint16(mPanIds.GetDestination()));
     }
 
-    IgnoreError(builder.AppendMacAddress(aAddrs.mDestination));
+    IgnoreError(builder.AppendMacAddress(mAddrs.mDestination));
 
     if (IsSrcPanIdPresent(fcf))
     {
-        IgnoreError(builder.AppendLittleEndianUint16(aPanIds.GetSource()));
+        IgnoreError(builder.AppendLittleEndianUint16(mPanIds.GetSource()));
     }
 
-    IgnoreError(builder.AppendMacAddress(aAddrs.mSource));
+    IgnoreError(builder.AppendMacAddress(mAddrs.mSource));
 
-    mLength = builder.GetLength();
+    aTxFrame.mLength = builder.GetLength();
 
-    if (aSecurityLevel != kSecurityNone)
+    if (mSecurityLevel != kSecurityNone)
     {
-        uint8_t secCtl = static_cast<uint8_t>(aSecurityLevel) | static_cast<uint8_t>(aKeyIdMode);
+        uint8_t secCtl = static_cast<uint8_t>(mSecurityLevel) | static_cast<uint8_t>(mKeyIdMode);
 
         IgnoreError(builder.AppendUint8(secCtl));
+        builder.AppendLength(CalculateSecurityHeaderSize(secCtl) - sizeof(secCtl));
 
-        mLength += CalculateSecurityHeaderSize(secCtl);
-        mLength += CalculateMicSize(secCtl);
+        micSize = CalculateMicSize(secCtl);
     }
 
-    if (aType == kTypeMacCmd)
+    if (mType == kTypeMacCmd)
     {
-        mLength += kCommandIdSize;
+        builder.Append<uint8_t>(); // Placeholder for Command ID
     }
 
-    mLength += GetFcsSize();
+    builder.AppendLength(micSize + aTxFrame.GetFcsSize());
+
+    aTxFrame.mLength = builder.GetLength();
 }
 
 void Frame::SetFrameControlField(uint16_t aFcf)
@@ -1546,13 +1543,12 @@ void TxFrame::GenerateImmAck(const RxFrame &aFrame, bool aIsFramePending)
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
 Error TxFrame::GenerateEnhAck(const RxFrame &aRxFrame, bool aIsFramePending, const uint8_t *aIeData, uint8_t aIeLength)
 {
-    Error     error = kErrorNone;
-    Address   address;
-    PanId     panId;
-    Addresses addrs;
-    PanIds    panIds;
-    uint8_t   securityLevel = kSecurityNone;
-    uint8_t   keyIdMode     = kKeyIdMode0;
+    Error   error = kErrorNone;
+    Info    frameInfo;
+    Address address;
+    PanId   panId;
+    uint8_t securityLevel = kSecurityNone;
+    uint8_t keyIdMode     = kKeyIdMode0;
 
     // Validate the received frame.
 
@@ -1569,8 +1565,8 @@ Error TxFrame::GenerateEnhAck(const RxFrame &aRxFrame, bool aIsFramePending, con
     // Check `aRxFrame` has a valid source, which is then used as
     // ack frames destination.
 
-    SuccessOrExit(error = aRxFrame.GetSrcAddr(addrs.mDestination));
-    VerifyOrExit(!addrs.mDestination.IsNone(), error = kErrorParse);
+    SuccessOrExit(error = aRxFrame.GetSrcAddr(frameInfo.mAddrs.mDestination));
+    VerifyOrExit(!frameInfo.mAddrs.mDestination.IsNone(), error = kErrorParse);
 
     if (aRxFrame.GetSecurityEnabled())
     {
@@ -1583,12 +1579,12 @@ Error TxFrame::GenerateEnhAck(const RxFrame &aRxFrame, bool aIsFramePending, con
     if (aRxFrame.IsSrcPanIdPresent())
     {
         SuccessOrExit(error = aRxFrame.GetSrcPanId(panId));
-        panIds.SetDestination(panId);
+        frameInfo.mPanIds.SetDestination(panId);
     }
     else if (aRxFrame.IsDstPanIdPresent())
     {
         SuccessOrExit(error = aRxFrame.GetDstPanId(panId));
-        panIds.SetDestination(panId);
+        frameInfo.mPanIds.SetDestination(panId);
     }
 
     // Prepare the ack frame
@@ -1596,8 +1592,12 @@ Error TxFrame::GenerateEnhAck(const RxFrame &aRxFrame, bool aIsFramePending, con
     mChannel = aRxFrame.mChannel;
     ClearAllBytes(mInfo.mTxInfo);
 
-    InitMacHeader(kTypeAck, kVersion2015, addrs, panIds, static_cast<SecurityLevel>(securityLevel),
-                  static_cast<KeyIdMode>(keyIdMode));
+    frameInfo.mType          = kTypeAck;
+    frameInfo.mVersion       = kVersion2015;
+    frameInfo.mSecurityLevel = static_cast<SecurityLevel>(securityLevel);
+    frameInfo.mKeyIdMode     = static_cast<KeyIdMode>(keyIdMode);
+
+    frameInfo.PrepareHeadersIn(*this);
 
     SetFramePending(aIsFramePending);
     SetIePresent(aIeLength != 0);

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -156,31 +156,6 @@ public:
     bool IsEmpty(void) const { return (mLength == 0); }
 
     /**
-     * Initializes the MAC header.
-     *
-     * Determines and writes the Frame Control Field (FCF) and Security Control in the frame along with
-     * given source and destination addresses and PAN IDs.
-     *
-     * The Ack Request bit in FCF is set if there is destination and it is not broadcast and frame type @p aType is not
-     * ACK. The Frame Pending and IE Present bits are not set.
-     *
-     * @param[in] aType          Frame type.
-     * @param[in] aVersion       Frame version.
-     * @param[in] aAddrs         Frame source and destination addresses (each can be none, short, or extended).
-     * @param[in] aPanIds        Source and destination PAN IDs.
-     * @param[in] aSecurityLevel Frame security level.
-     * @param[in] aKeyIdMode     Frame security key ID mode.
-     * @param[in] aSuppressSequence     Whether to suppress sequence number.
-     */
-    void InitMacHeader(Type             aType,
-                       Version          aVersion,
-                       const Addresses &aAddrs,
-                       const PanIds    &aPanIds,
-                       SecurityLevel    aSecurityLevel,
-                       KeyIdMode        aKeyIdMode        = kKeyIdMode0,
-                       bool             aSuppressSequence = false);
-
-    /**
      * Validates the frame.
      *
      * @retval kErrorNone    Successfully parsed the MAC header.
@@ -1136,6 +1111,45 @@ public:
 class TxFrame : public Frame
 {
 public:
+    /**
+     * Represents header information.
+     */
+    struct Info : public Clearable<Info>
+    {
+        /**
+         * Initializes the `Info` by clearing all its fields (setting all bytes to zero).
+         */
+        Info(void) { Clear(); }
+
+        /**
+         * Prepares MAC headers based on `Info` fields in a given `TxFrame`.
+         *
+         * This method uses the `Info` structure to construct the MAC address and security headers in @p aTxFrame.
+         * It determines the Frame Control Field (FCF), including setting the appropriate frame type, security level,
+         * and addressing mode flags. It populates the source and destination addresses and PAN IDs within the MAC
+         * header based on the information provided in the `Info` structure.
+         *
+         * It sets the Ack Request bit in the FCF if the following criteria are met:
+         *   - A destination address is present
+         *   - The destination address is not the broadcast address
+         *   - The frame type is not an ACK frame
+         *
+         * The Frame Pending and IE Present flags in the FCF are not set. They may need to be set separately depending
+         * on the specific requirements of the frame being transmitted.
+         *
+         * @param[in,out] aTxFrame  The `TxFrame` instance in which to prepare and append the MAC headers.
+         */
+        void PrepareHeadersIn(TxFrame &aTxFrame) const;
+
+        Type          mType;                 ///< Frame type.
+        Version       mVersion;              ///< Frame version.
+        Addresses     mAddrs;                ///< Frame source and destination addresses.
+        PanIds        mPanIds;               ///< Source and destination PAN Ids.
+        SecurityLevel mSecurityLevel;        ///< Frame security level.
+        KeyIdMode     mKeyIdMode;            ///< Frame security key ID mode.
+        bool          mSuppressSequence : 1; ///< Whether to suppress seq number.
+    };
+
     /**
      * Sets the channel on which to send the frame.
      *

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -509,13 +509,7 @@ private:
     void     HandleFragment(RxInfo &aRxInfo);
     void     HandleLowpanHc(RxInfo &aRxInfo);
 
-    void     PrepareMacHeaders(Mac::TxFrame             &aFrame,
-                               Mac::Frame::Type          aFrameType,
-                               const Mac::Addresses     &aMacAddr,
-                               const Mac::PanIds        &aPanIds,
-                               Mac::Frame::SecurityLevel aSecurityLevel,
-                               Mac::Frame::KeyIdMode     aKeyIdMode,
-                               const Message            *aMessage);
+    void     PrepareMacHeaders(Mac::TxFrame &aTxFrame, Mac::TxFrame::Info &aTxFrameInfo, const Message *aMessage);
     uint16_t PrepareDataFrame(Mac::TxFrame         &aFrame,
                               Message              &aMessage,
                               const Mac::Addresses &aMacAddrs,

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -328,12 +328,15 @@ void MeshForwarder::RemoveDataResponseMessages(void)
 
 void MeshForwarder::SendMesh(Message &aMessage, Mac::TxFrame &aFrame)
 {
-    Mac::PanIds panIds;
+    Mac::TxFrame::Info frameInfo;
 
-    panIds.SetBothSourceDestination(Get<Mac::Mac>().GetPanId());
+    frameInfo.mType          = Mac::Frame::kTypeData;
+    frameInfo.mAddrs         = mMacAddrs;
+    frameInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
+    frameInfo.mKeyIdMode     = Mac::Frame::kKeyIdMode1;
+    frameInfo.mPanIds.SetBothSourceDestination(Get<Mac::Mac>().GetPanId());
 
-    PrepareMacHeaders(aFrame, Mac::Frame::kTypeData, mMacAddrs, panIds, Mac::Frame::kSecurityEncMic32,
-                      Mac::Frame::kKeyIdMode1, &aMessage);
+    PrepareMacHeaders(aFrame, frameInfo, &aMessage);
 
     // write payload
     OT_ASSERT(aMessage.GetLength() <= aFrame.GetMaxPayloadLength());


### PR DESCRIPTION
This commit simplifies the preparation of MAC and security frames. It introduces a `TxFrame::Info` structure that provides information about the frame, such as its type, version, source and destination addresses, PAN IDs, security level, and key ID mode. A new method `PrepareHeadersIn()` is added, which uses the `Info` structure to construct the MAC address and security headers in a given `TxFrame`.

This approach replaces the earlier `Mac::Frame::InitMacHeader()` where all the information was passed as a list of input arguments. The `TxFrame::Info` approach simplifies the code and allows for future extension to accommodate other parameters (e.g., Header IE entries).