### PR TITLE
[border-agent] invoke ephemeral key callback on session connection

### DIFF
--- a/include/openthread/border_agent.h
+++ b/include/openthread/border_agent.h
@@ -257,6 +257,9 @@ bool otBorderAgentIsEphemeralKeyActive(otInstance *aInstance);
  *
  * - The Border Agent starts using an ephemeral key.
  * - Any parameter related to the ephemeral key, such as the port number, changes.
+ * - A commissioner candidate successfully establishes a secure session with the Border Agent using the ephemeral key.
+ *   This situation can be identified by `otBorderAgentGetState()` being `OT_BORDER_AGENT_STATE_ACTIVE` (this event
+ *   can be used to stop advertising the mDNS service "_meshcop-e._udp").
  * - The Border Agent stops using the ephemeral key due to:
  *   - A direct call to `otBorderAgentClearEphemeralKey()`.
  *   - The ephemeral key timing out.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (459)
+#define OPENTHREAD_API_VERSION (460)
 
 /**
  * @addtogroup api-instance

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -655,6 +655,7 @@ void BorderAgent::HandleConnected(SecureTransport::ConnectEvent aEvent)
         if (mUsingEphemeralKey)
         {
             mCounters.mEpskcSecureSessionSuccesses++;
+            mEphemeralKeyTask.Post();
         }
         else
 #endif


### PR DESCRIPTION
This commit updates the Border Agent to invoke the ephemeral key callback when a commissioner candidate successfully establishes a secure session using the ephemeral key. This can be identified by checking the state `otBorderAgentGetState()` and matching it with `OT_BORDER_AGENT_STATE_ACTIVE`. This new signal can be used to stop advertising the mDNS service "_meshcop-e._udp" earlier (since the ephemeral key is one-time use).