### PR TITLE
[settings] simplify saving of Border Agent ID

### DIFF
--- a/include/openthread/border_agent.h
+++ b/include/openthread/border_agent.h
@@ -82,22 +82,13 @@ extern "C" {
 #define OT_BORDER_AGENT_MAX_EPHEMERAL_KEY_TIMEOUT (10 * 60 * 1000u)
 
 /**
- * @struct otBorderAgentId
- *
- * Represents a Border Agent ID.
+ * Represents a Border Agent Identifier.
  *
  */
-OT_TOOL_PACKED_BEGIN
-struct otBorderAgentId
+typedef struct otBorderAgentId
 {
-    uint8_t mId[OT_BORDER_AGENT_ID_LENGTH];
-} OT_TOOL_PACKED_END;
-
-/**
- * Represents a Border Agent ID.
- *
- */
-typedef struct otBorderAgentId otBorderAgentId;
+    uint8_t mId[OT_BORDER_AGENT_ID_LENGTH]; ///< Border Agent ID bytes.
+} otBorderAgentId;
 
 /**
  * Defines the Border Agent state.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (445)
+#define OPENTHREAD_API_VERSION (446)
 
 /**
  * @addtogroup api-instance

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -107,15 +107,16 @@ void SettingsBase::SrpServerInfo::Log(Action aAction) const
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
-void SettingsBase::BorderAgentId::Log(Action aAction) const
+void SettingsBase::BorderAgentId::Log(Action aAction, const MeshCoP::BorderAgent::Id &aId)
 {
-    char         buffer[sizeof(BorderAgentId) * 2 + 1];
-    StringWriter sw(buffer, sizeof(buffer));
+    static constexpr uint8_t kStringSize = sizeof(MeshCoP::BorderAgent::Id) * 2 + 1;
 
-    sw.AppendHexBytes(GetId().mId, sizeof(BorderAgentId));
-    LogInfo("%s BorderAgentId {id:%s}", ActionToString(aAction), buffer);
+    String<kStringSize> string;
+
+    string.AppendHexBytes(aId.mId, sizeof(aId));
+    LogInfo("%s BorderAgentId {id:%s}", ActionToString(aAction), string.AsCString());
 }
-#endif // OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
+#endif
 
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
@@ -533,7 +534,7 @@ void Settings::Log(Action aAction, Error aError, Key aKey, const void *aValue)
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
         case kKeyBorderAgentId:
-            reinterpret_cast<const BorderAgentId *>(aValue)->Log(aAction);
+            BorderAgentId::Log(aAction, *reinterpret_cast<const MeshCoP::BorderAgent::Id *>(aValue));
             break;
 #endif
 

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -772,7 +772,6 @@ public:
      * Represents the Border Agent ID.
      *
      */
-    OT_TOOL_PACKED_BEGIN
     class BorderAgentId
     {
         friend class Settings;
@@ -780,40 +779,14 @@ public:
     public:
         static constexpr Key kKey = kKeyBorderAgentId; ///< The associated key.
 
-        /**
-         * Initializes the `BorderAgentId` object.
-         *
-         */
-        void Init(void) { ClearAllBytes(mId); }
-
-        /**
-         * Returns the Border Agent ID.
-         *
-         * @returns The Border Agent ID.
-         *
-         */
-        const MeshCoP::BorderAgent::Id &GetId(void) const { return mId; }
-
-        /**
-         * Returns the Border Agent ID.
-         *
-         * @returns The Border Agent ID.
-         *
-         */
-        MeshCoP::BorderAgent::Id &GetId(void) { return mId; }
-
-        /**
-         * Sets the Border Agent ID.
-         *
-         */
-        void SetId(const MeshCoP::BorderAgent::Id &aId) { mId = aId; }
+        typedef MeshCoP::BorderAgent::Id ValueType; ///< The associated value type.
 
     private:
-        void Log(Action aAction) const;
+        static void Log(Action aAction, const MeshCoP::BorderAgent::Id &aId);
 
-        MeshCoP::BorderAgent::Id mId;
-    } OT_TOOL_PACKED_END;
-#endif // OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
+        BorderAgentId(void) = delete;
+    };
+#endif
 
 protected:
     explicit SettingsBase(Instance &aInstance)

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -268,35 +268,32 @@ BorderAgent::BorderAgent(Instance &aInstance)
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
 Error BorderAgent::GetId(Id &aId)
 {
-    Error                   error = kErrorNone;
-    Settings::BorderAgentId id;
+    Error error = kErrorNone;
 
-    VerifyOrExit(!mIdInitialized, error = kErrorNone);
-
-    if (Get<Settings>().Read(id) != kErrorNone)
-    {
-        Random::NonCrypto::Fill(id.GetId());
-        SuccessOrExit(error = Get<Settings>().Save(id));
-    }
-
-    mId            = id.GetId();
-    mIdInitialized = true;
-
-exit:
-    if (error == kErrorNone)
+    if (mIdInitialized)
     {
         aId = mId;
+        ExitNow();
     }
+
+    if (Get<Settings>().Read<Settings::BorderAgentId>(mId) != kErrorNone)
+    {
+        Random::NonCrypto::Fill(mId);
+        SuccessOrExit(error = Get<Settings>().Save<Settings::BorderAgentId>(mId));
+    }
+
+    mIdInitialized = true;
+    aId            = mId;
+
+exit:
     return error;
 }
 
 Error BorderAgent::SetId(const Id &aId)
 {
-    Error                   error = kErrorNone;
-    Settings::BorderAgentId id;
+    Error error = kErrorNone;
 
-    id.SetId(aId);
-    SuccessOrExit(error = Get<Settings>().Save(id));
+    SuccessOrExit(error = Get<Settings>().Save<Settings::BorderAgentId>(aId));
     mId            = aId;
     mIdInitialized = true;
 


### PR DESCRIPTION
This commit simplifies how Border Agent ID is saved in non-volatile `Settings` by utilizing generic methods designed for single-value setting entries. As a result, `Settings::BorderAgentId` now only needs to define the key and the associated entry value type. This eliminates the need for `otBorderAgentId` to be defined as packed, thereby simplifying this structure.