### PR TITLE
[trel] add cli to get TREL UDP port

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (440)
+#define OPENTHREAD_API_VERSION (441)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/trel.h
+++ b/include/openthread/trel.h
@@ -185,6 +185,16 @@ const otTrelCounters *otTrelGetCounters(otInstance *aInstance);
 void otTrelResetCounters(otInstance *aInstance);
 
 /**
+ * Gets the UDP port of the TREL interface.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ *
+ * @returns UDP port of the TREL interface.
+ *
+ */
+uint16_t otTrelGetUdpPort(otInstance *aInstance);
+
+/**
  * @}
  *
  */

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -3948,6 +3948,16 @@ Done
 Done
 ```
 
+### trel port
+
+Get the TREL UDP port number.
+
+```bash
+> trel port
+49154
+Done
+```
+
 ### tvcheck enable
 
 Enable thread version check when upgrading to router or leader.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -7577,6 +7577,20 @@ template <> otError Interpreter::Process<Cmd("trel")>(Arg aArgs[])
             error = OT_ERROR_INVALID_ARGS;
         }
     }
+    /**
+     * @cli trel port
+     * @code
+     * trel port
+     * 49153
+     * Done
+     * @endcode
+     * @par api_copy
+     * #otTrelGetUdpPort
+     */
+    else if (aArgs[0] == "port")
+    {
+        OutputLine("%hu", otTrelGetUdpPort(GetInstancePtr()));
+    }
     else
     {
         error = OT_ERROR_INVALID_ARGS;

--- a/src/core/api/trel_api.cpp
+++ b/src/core/api/trel_api.cpp
@@ -82,4 +82,6 @@ const otTrelCounters *otTrelGetCounters(otInstance *aInstance)
 
 void otTrelResetCounters(otInstance *aInstance) { AsCoreType(aInstance).Get<Trel::Interface>().ResetCounters(); }
 
+uint16_t otTrelGetUdpPort(otInstance *aInstance) { return AsCoreType(aInstance).Get<Trel::Interface>().GetUdpPort(); }
+
 #endif // OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE

--- a/src/core/radio/trel_interface.hpp
+++ b/src/core/radio/trel_interface.hpp
@@ -256,6 +256,14 @@ public:
      */
     void ResetCounters(void);
 
+    /**
+     * Returns the TREL UDP port.
+     *
+     * @returns The TREL UDP port.
+     *
+     */
+    uint16_t GetUdpPort(void) const { return mUdpPort; }
+
 private:
 #if OPENTHREAD_CONFIG_TREL_PEER_TABLE_SIZE != 0
     static constexpr uint16_t kPeerTableSize = OPENTHREAD_CONFIG_TREL_PEER_TABLE_SIZE;

--- a/tests/scripts/thread-cert/border_router/test_trel_connectivity.py
+++ b/tests/scripts/thread-cert/border_router/test_trel_connectivity.py
@@ -160,6 +160,8 @@ class TestTrelConnectivity(thread_cert.TestCase):
         self.assertTrue(counters['Outbound']['bytes'] == 0)
         self.assertTrue(counters['Outbound']['failures'] == 0)
 
+        self.assertGreater(br1.get_trel_port(), 0)
+
     def verify(self, pv: PacketVerifier):
         pkts: PacketFilter = pv.pkts
         BR1_RLOC16 = pv.vars['BR1_RLOC16']

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1451,6 +1451,11 @@ class NodeImpl:
         self.send_command(cmd)
         self._expect_done()
 
+    def get_trel_port(self):
+        cmd = 'trel port'
+        self.send_command(cmd)
+        return int(self._expect_command_output()[0])
+
     def set_epskc(self, keystring: str, timeout=120000, port=0):
         cmd = 'ba ephemeralkey set ' + keystring + ' ' + str(timeout) + ' ' + str(port)
         self.send_command(cmd)


### PR DESCRIPTION
The test software for certification currently uses the mDNS packets of trel service responses to find out the trel port, and then use the port number to determine which packets in a capture should be decoded as TREL packets. However this may not be reliable since it depends on when the capture starts. Added a cli to get trel port, so this can be used by a THCI function.