### PR TITLE
[test] use ubuntu 22.04 for otci workflow

### DIFF
--- a/.github/workflows/otci.yml
+++ b/.github/workflows/otci.yml
@@ -47,7 +47,7 @@ jobs:
 
   cli-sim:
     name: cli-sim VIRTUAL_TIME=${{ matrix.virtual_time }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This commit update the otci workflow to use ubuntu-22.04 because some dependency fails to build on ubuntu-20.04