### PR TITLE
[include] fix `#include` style for public OT headers

### DIFF
--- a/examples/platforms/simulation/ble.c
+++ b/examples/platforms/simulation/ble.c
@@ -32,10 +32,11 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+
+#include <openthread/error.h>
+#include <openthread/tcat.h>
 #include <openthread/platform/ble.h>
 
-#include "openthread/error.h"
-#include "openthread/tcat.h"
 #include "utils/code_utils.h"
 
 #define PLAT_BLE_MSG_DATA_MAX 2048

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (444)
+#define OPENTHREAD_API_VERSION (445)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/trel.h
+++ b/include/openthread/trel.h
@@ -39,7 +39,7 @@
 #include <openthread/dataset.h>
 #include <openthread/ip6.h>
 #include <openthread/platform/radio.h>
-#include "openthread/platform/trel.h"
+#include <openthread/platform/trel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/core/common/debug.hpp
+++ b/src/core/common/debug.hpp
@@ -43,7 +43,7 @@
 
 #if OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT
 
-#include "openthread/platform/misc.h"
+#include <openthread/platform/misc.h>
 
 /**
  * Allow the build system to provide a custom file name.

--- a/src/core/crypto/context_size.hpp
+++ b/src/core/crypto/context_size.hpp
@@ -30,7 +30,8 @@
 #define CRYPTO_CONTEXT_HPP_
 
 #include "openthread-core-config.h"
-#include "openthread/crypto.h"
+
+#include <openthread/crypto.h>
 
 #if OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS
 #include <mbedtls/aes.h>

--- a/src/core/crypto/hkdf_sha256.cpp
+++ b/src/core/crypto/hkdf_sha256.cpp
@@ -38,7 +38,6 @@
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/error.hpp"
-#include "openthread/platform/crypto.h"
 
 namespace ot {
 namespace Crypto {

--- a/src/core/crypto/hkdf_sha256.hpp
+++ b/src/core/crypto/hkdf_sha256.hpp
@@ -37,10 +37,11 @@
 
 #include "openthread-core-config.h"
 
+#include <openthread/platform/crypto.h>
+
 #include "common/code_utils.hpp"
 #include "crypto/context_size.hpp"
 #include "crypto/hmac_sha256.hpp"
-#include "openthread/platform/crypto.h"
 
 namespace ot {
 namespace Crypto {

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -32,8 +32,6 @@
  */
 
 #include "factory_diags.hpp"
-#include "common/error.hpp"
-#include "openthread/platform/radio.h"
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
 
@@ -42,9 +40,11 @@
 
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
+#include <openthread/platform/radio.h>
 
 #include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
+#include "common/error.hpp"
 #include "common/string.hpp"
 #include "instance/instance.hpp"
 #include "radio/radio.hpp"

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -49,7 +49,6 @@
 #include "net/nat64_translator.hpp"
 #include "net/netif.hpp"
 #include "net/udp6.hpp"
-#include "openthread/ip6.h"
 #include "thread/mle.hpp"
 
 using IcmpType = ot::Ip6::Icmp::Header::Type;

--- a/src/core/radio/max_power_table.hpp
+++ b/src/core/radio/max_power_table.hpp
@@ -29,8 +29,7 @@
 #ifndef OT_CORE_RADIO_MAX_POWER_TABLE_HPP_
 #define OT_CORE_RADIO_MAX_POWER_TABLE_HPP_
 
-#include "core/radio/radio.hpp"
-#include "openthread/platform/radio.h"
+#include "radio/radio.hpp"
 
 namespace ot {
 

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -59,7 +59,7 @@
 #include <openthread/server.h>
 #endif
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-#include "openthread/backbone_router.h"
+#include <openthread/backbone_router.h>
 #endif
 #if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
 #include <openthread/srp_client_buffers.h>

--- a/src/posix/platform/firewall.hpp
+++ b/src/posix/platform/firewall.hpp
@@ -33,7 +33,7 @@
 
 #if OPENTHREAD_POSIX_CONFIG_FIREWALL_ENABLE
 
-#include "openthread/thread.h"
+#include <openthread/thread.h>
 
 namespace ot {
 namespace Posix {

--- a/src/posix/platform/utils.hpp
+++ b/src/posix/platform/utils.hpp
@@ -29,7 +29,7 @@
 #ifndef OT_POSIX_PLATFORM_UTILS_HPP_
 #define OT_POSIX_PLATFORM_UTILS_HPP_
 
-#include "openthread/error.h"
+#include <openthread/error.h>
 
 namespace ot {
 namespace Posix {

--- a/tests/unit/test_multipan_rcp_instances.cpp
+++ b/tests/unit/test_multipan_rcp_instances.cpp
@@ -27,13 +27,13 @@
  */
 
 #include <openthread/config.h>
+#include <openthread/link_raw.h>
 
 #include "common/array.hpp"
 #include "common/code_utils.hpp"
 #include "instance/instance.hpp"
 
 #include "ncp/ncp_base.hpp"
-#include "openthread/link_raw.h"
 
 #include "test_platform.h"
 #include "test_util.hpp"


### PR DESCRIPTION
This commit updates `#include` of public OT headers to follow the OT style guide and use brace (`<`) and (`>`) style.