### PR TITLE
[mesh-forwarder] simplify logging messages

### DIFF
--- a/src/core/common/log.hpp
+++ b/src/core/common/log.hpp
@@ -78,6 +78,8 @@ enum LogLevel : uint8_t
 
 constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 
+constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max size of log string
+
 #if OT_SHOULD_LOG && (OPENTHREAD_CONFIG_LOG_LEVEL != OT_LOG_LEVEL_NONE)
 /**
  * Registers log module name.

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -638,12 +638,20 @@ private:
                          Error               aError,
                          LogLevel            aLogLevel);
 #endif
+#if OPENTHREAD_CONFIG_LOG_SRC_DST_IP_ADDRESSES
+    void LogIp6AddressAndPort(const char *aLabel, const Ip6::Address &aAddress, uint16_t aPort, LogLevel aLogLevel);
+#endif
     void LogIp6SourceDestAddresses(const Ip6::Headers &aHeaders, LogLevel aLogLevel);
     void LogIp6Message(MessageAction       aAction,
                        const Message      &aMessage,
                        const Mac::Address *aAddress,
                        Error               aError,
                        LogLevel            aLogLevel);
+    void AppendSecErrorPrioRssRadioLabelsToLogString(StringWriter  &aString,
+                                                     MessageAction  aAction,
+                                                     const Message &aMessage,
+                                                     Error          aError);
+    void AppendMacAddrToLogString(StringWriter &aString, MessageAction aAction, const Mac::Address *aMacAddress);
 #endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
 
     using TxTask = TaskletIn<MeshForwarder, &MeshForwarder::ScheduleTransmissionTask>;

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -874,14 +874,12 @@ Error MeshForwarder::LogMeshFragmentHeader(MessageAction       aAction,
                                            Mac::Addresses     &aMeshAddrs,
                                            LogLevel            aLogLevel)
 {
-    Error                  error             = kErrorFailed;
-    bool                   hasFragmentHeader = false;
-    bool                   shouldLogRss;
-    Lowpan::MeshHeader     meshHeader;
-    Lowpan::FragmentHeader fragmentHeader;
-    uint16_t               headerLength;
-    bool                   shouldLogRadio = false;
-    const char            *radioString    = "";
+    Error                     error             = kErrorFailed;
+    bool                      hasFragmentHeader = false;
+    Lowpan::MeshHeader        meshHeader;
+    Lowpan::FragmentHeader    fragmentHeader;
+    uint16_t                  headerLength;
+    String<kMaxLogStringSize> string;
 
     SuccessOrExit(meshHeader.ParseFrom(aMessage, headerLength));
 
@@ -896,23 +894,17 @@ Error MeshForwarder::LogMeshFragmentHeader(MessageAction       aAction,
         aOffset += headerLength;
     }
 
-    shouldLogRss = (aAction == kMessageReceive) || (aAction == kMessageReassemblyDrop);
+    string.Append("%s mesh frame, len:%u, ", MessageActionToString(aAction, aError), aMessage.GetLength());
 
-#if OPENTHREAD_CONFIG_MULTI_RADIO
-    shouldLogRadio = true;
-    radioString    = aMessage.IsRadioTypeSet() ? RadioTypeToString(aMessage.GetRadioType()) : "all";
-#endif
+    AppendMacAddrToLogString(string, aAction, aMacAddress);
 
-    LogAt(aLogLevel, "%s mesh frame, len:%d%s%s, msrc:%s, mdst:%s, hops:%d, frag:%s, sec:%s%s%s%s%s%s%s",
-          MessageActionToString(aAction, aError), aMessage.GetLength(),
-          (aMacAddress == nullptr) ? "" : ((aAction == kMessageReceive) ? ", from:" : ", to:"),
-          (aMacAddress == nullptr) ? "" : aMacAddress->ToString().AsCString(),
-          aMeshAddrs.mSource.ToString().AsCString(), aMeshAddrs.mDestination.ToString().AsCString(),
-          meshHeader.GetHopsLeft() + ((aAction == kMessageReceive) ? 1 : 0), ToYesNo(hasFragmentHeader),
-          ToYesNo(aMessage.IsLinkSecurityEnabled()),
-          (aError == kErrorNone) ? "" : ", error:", (aError == kErrorNone) ? "" : ErrorToString(aError),
-          shouldLogRss ? ", rss:" : "", shouldLogRss ? aMessage.GetRssAverager().ToString().AsCString() : "",
-          shouldLogRadio ? ", radio:" : "", radioString);
+    string.Append("msrc:%s, mdst:%s, hops:%d, frag:%s, ", aMeshAddrs.mSource.ToString().AsCString(),
+                  aMeshAddrs.mDestination.ToString().AsCString(),
+                  meshHeader.GetHopsLeft() + ((aAction == kMessageReceive) ? 1 : 0), ToYesNo(hasFragmentHeader));
+
+    AppendSecErrorPrioRssRadioLabelsToLogString(string, aAction, aMessage, aError);
+
+    LogAt(aLogLevel, "%s", string.AsCString());
 
     if (hasFragmentHeader)
     {


### PR DESCRIPTION
This commit simplifies logging methods (e.g., `LogIp6Message()`) in the `MeshForwarder` class:
- Log lines are prepared in a `String`, allowing new fields to be added conditionally. This simplifies the code and avoids complex `printf`-style formats for handling optional fields.
- New helper methods are added to prepare common labels in a log line (e.g., adding MAC address, adding security/error/priority fields).
- Logging IPv6 source/destination addresses is simplified by defining a new helper to log an address/port.