### PR TITLE
[coap] ensure CoAP header and token length are validated

### DIFF
--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -373,7 +373,8 @@ exit:
 
 Error Message::ParseHeader(void)
 {
-    Error            error = kErrorNone;
+    Error            error  = kErrorNone;
+    uint16_t         offset = GetOffset();
     Option::Iterator iterator;
 
     OT_ASSERT(GetReserved() >=
@@ -381,10 +382,13 @@ Error Message::ParseHeader(void)
 
     GetHelpData().Clear();
 
-    GetHelpData().mHeaderOffset = GetOffset();
-    IgnoreError(Read(GetHelpData().mHeaderOffset, GetHelpData().mHeader));
+    GetHelpData().mHeaderOffset = offset;
+
+    SuccessOrExit(error = Read(offset, &GetHelpData().mHeader, kMinHeaderLength));
+    offset += kMinHeaderLength;
 
     VerifyOrExit(GetTokenLength() <= kMaxTokenLength, error = kErrorParse);
+    SuccessOrExit(error = Read(offset, GetHelpData().mHeader.mToken, GetTokenLength()));
 
     SuccessOrExit(error = iterator.Init(*this));
 


### PR DESCRIPTION
This commit updates `Coap::Message::ParseHeader()` to perform two crucial validations:
- It now checks if the message contains sufficient bytes to read the minimum 4-byte CoAP header.
- Afterwards, determines the CoAP token length from the read header, and then validates that the message has enough bytes to read the token.

These validations prevent the parsing and misinterpretation of a malformed or incomplete CoAP message as a valid one,