### PR TITLE
[tcplp] fix an issue that occurs when using LTO and TCP is not enabled

### DIFF
--- a/third_party/tcplp/bsdtcp/tcp_subr.c
+++ b/third_party/tcplp/bsdtcp/tcp_subr.c
@@ -92,7 +92,7 @@ tcp_state_change(struct tcpcb *tp, int newstate)
 }
 
  /* samkumar: Based on tcp_newtcb in tcp_subr.c, and tcp_usr_attach in tcp_usrreq.c. */
-__attribute__((used)) void initialize_tcb(struct tcpcb* tp) {
+void initialize_tcb(struct tcpcb* tp) {
 	uint32_t ticks = tcplp_sys_get_ticks();
 
 	/* samkumar: Clear all fields starting laddr; rest are initialized by the host. */


### PR DESCRIPTION
When building and linking with link time optimizations and TCP is not enabled (OPENTHREAD_CONFIG_TCP_ENABLE = 0) the following error occurs:

tcp_subr.c:96: undefined reference to tcplp_sys_get_ticks'

To address the problem we are removing the __attribute__((used)) annotation on the initialize_tcb function which will prevent the function from being retained when no one references it.