### PR TITLE
[core] remove redundant namespace usage

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -736,7 +736,7 @@ void Frame::SetFrameCounter(uint32_t aFrameCounter)
 
     LittleEndian::WriteUint32(aFrameCounter, &mPsdu[index]);
 
-    static_cast<Mac::TxFrame *>(this)->SetIsHeaderUpdated(true);
+    static_cast<TxFrame *>(this)->SetIsHeaderUpdated(true);
 }
 
 const uint8_t *Frame::GetKeySource(void) const

--- a/src/core/thread/mle_tlvs.cpp
+++ b/src/core/thread/mle_tlvs.cpp
@@ -59,7 +59,7 @@ bool RouteTlv::IsValid(void) const
     VerifyOrExit(GetLength() >= sizeof(mRouterIdSequence) + sizeof(mRouterIdMask));
 
     numAllocatedIds = mRouterIdMask.GetNumberOfAllocatedIds();
-    VerifyOrExit(numAllocatedIds <= Mle::kMaxRouters);
+    VerifyOrExit(numAllocatedIds <= kMaxRouters);
 
     isValid = (GetRouteDataLength() >= numAllocatedIds);
 


### PR DESCRIPTION
This commit removes redundant namespace qualifiers from two instances within core modules, preventing potential build warnings with certain toolchains.