### PR TITLE
[mle] clear queued delayed responses when MLE operation is stopped

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -225,6 +225,9 @@ void Mle::Stop(StopMode aMode)
     Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocalRloc);
     Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocalEid);
 
+    mDelayedResponses.DequeueAndFreeAll();
+    mDelayedResponseTimer.Stop();
+
     SetRole(kRoleDisabled);
 
 exit:


### PR DESCRIPTION
This commit clears queued delayed messages in the `mDelayedResponses` and stops the associated timer when `Mle::Stop()` is called.