### PR TITLE
[test] add version command to cp-caps

### DIFF
--- a/tools/cp-caps/CHANGE_LOG.md
+++ b/tools/cp-caps/CHANGE_LOG.md
@@ -1,0 +1,19 @@
+# Co-processor capability test change logs (Sorted per date)
+
+## Version 0.1.0 released 2024-09-19
+
+### Features
+
+- Test whether the RCP supports all diag commands.
+- Test whether the RCP supports the CSL transmitter.
+- Test whether the RCP supports data poll.
+- Test whether the RCP supports link metrics.
+- Test Thread network 1-hop throughput.
+
+### Changes
+
+None
+
+### Bugfixes
+
+None

--- a/tools/cp-caps/README.md
+++ b/tools/cp-caps/README.md
@@ -54,7 +54,7 @@ Show help info.
 
 ```bash
 $ python3 ./tools/cp-caps/rcp_caps_test.py -h
-usage: rcp_caps_test.py [-h] [-c] [-d] [-p] [-t] [-v]
+usage: rcp_caps_test.py [-h] [-c] [-d] [-p] [-t] [-v] [-D]
 
 This script is used for testing RCP capabilities.
 
@@ -65,7 +65,8 @@ options:
   -l, --link-metrics   test whether the RCP supports link metrics
   -p, --data-poll      test whether the RCP supports data poll
   -t, --throughput     test the Thread network 1-hop throughput
-  -v, --verbose        output verbose information
+  -v, --version        output version
+  -D, --debug          output debug information
 
 Device Interfaces:
   DUT_SSH=<device_ip>            Connect to the DUT via ssh

--- a/tools/cp-caps/rcp_caps_test.py
+++ b/tools/cp-caps/rcp_caps_test.py
@@ -40,6 +40,8 @@ import otci
 from otci import OTCI
 from otci.types import Ip6Addr
 
+CP_CAPABILITY_VERSION = "0.1.0"
+
 logging.basicConfig(level=logging.WARNING)
 
 
@@ -623,10 +625,18 @@ def parse_arguments():
 
     parser.add_argument(
         '-v',
-        '--verbose',
+        '--version',
         action='store_true',
         default=False,
-        help='output verbose information',
+        help='output version',
+    )
+
+    parser.add_argument(
+        '-D',
+        '--debug',
+        action='store_true',
+        default=False,
+        help='output debug information',
     )
 
     return parser.parse_args()
@@ -635,22 +645,26 @@ def parse_arguments():
 def main():
     arguments = parse_arguments()
 
-    if arguments.verbose is True:
+    if arguments.version:
+        print(f'Version: {CP_CAPABILITY_VERSION}')
+        exit()
+
+    if arguments.debug:
         logger = logging.getLogger()
         logger.setLevel(logging.DEBUG)
 
     rcp_caps = RcpCaps()
 
-    if arguments.diag_commands is True:
+    if arguments.diag_commands:
         rcp_caps.test_diag_commands()
 
-    if arguments.csl is True:
+    if arguments.csl:
         rcp_caps.test_csl()
 
-    if arguments.data_poll is True:
+    if arguments.data_poll:
         rcp_caps.test_data_poll()
 
-    if arguments.link_metrics is True:
+    if arguments.link_metrics:
         rcp_caps.test_link_metrics()
 
     if arguments.throughput:


### PR DESCRIPTION
This commit adds a version command to cp-caps to get the current version. And we release the current version of cp-caps as 0.1.0.