### PR TITLE
[mle] add Thread Domain Name TLV (59) to MLE Discovery Response

### DIFF
--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -292,6 +292,7 @@ typedef enum otMeshcopTlvType
     OT_MESHCOP_TLV_PERIOD                   = 55,  ///< meshcop Period TLV
     OT_MESHCOP_TLV_SCAN_DURATION            = 56,  ///< meshcop Scan Duration TLV
     OT_MESHCOP_TLV_ENERGY_LIST              = 57,  ///< meshcop Energy List TLV
+    OT_MESHCOP_TLV_THREAD_DOMAIN_NAME       = 59,  ///< meshcop Thread Domain Name TLV
     OT_MESHCOP_TLV_DISCOVERYREQUEST         = 128, ///< meshcop Discovery Request TLV
     OT_MESHCOP_TLV_DISCOVERYRESPONSE        = 129, ///< meshcop Discovery Response TLV
     OT_MESHCOP_TLV_JOINERADVERTISEMENT      = 241, ///< meshcop Joiner Advertisement TLV

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (448)
+#define OPENTHREAD_API_VERSION (449)
 
 /**
  * @addtogroup api-instance

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -108,6 +108,7 @@ public:
         kPeriod                  = OT_MESHCOP_TLV_PERIOD,                   ///< Period TLV
         kScanDuration            = OT_MESHCOP_TLV_SCAN_DURATION,            ///< Scan Duration TLV
         kEnergyList              = OT_MESHCOP_TLV_ENERGY_LIST,              ///< Energy List TLV
+        kThreadDomainName        = OT_MESHCOP_TLV_THREAD_DOMAIN_NAME,       ///< Thread Domain Name TLV
         kDiscoveryRequest        = OT_MESHCOP_TLV_DISCOVERYREQUEST,         ///< Discovery Request TLV
         kDiscoveryResponse       = OT_MESHCOP_TLV_DISCOVERYRESPONSE,        ///< Discovery Response TLV
         kJoinerAdvertisement     = OT_MESHCOP_TLV_JOINERADVERTISEMENT,      ///< Joiner Advertisement TLV
@@ -118,11 +119,12 @@ public:
      */
     static constexpr uint8_t kMaxProvisioningUrlLength = OT_PROVISIONING_URL_MAX_SIZE;
 
-    static constexpr uint8_t kMaxCommissionerIdLength  = 64; ///< Max length of Commissioner ID TLV.
-    static constexpr uint8_t kMaxVendorNameLength      = 32; ///< Max length of Vendor Name TLV.
-    static constexpr uint8_t kMaxVendorModelLength     = 32; ///< Max length of Vendor Model TLV.
-    static constexpr uint8_t kMaxVendorSwVersionLength = 16; ///< Max length of Vendor SW Version TLV.
-    static constexpr uint8_t kMaxVendorDataLength      = 64; ///< Max length of Vendor Data TLV.
+    static constexpr uint8_t kMaxCommissionerIdLength   = 64; ///< Max length of Commissioner ID TLV.
+    static constexpr uint8_t kMaxVendorNameLength       = 32; ///< Max length of Vendor Name TLV.
+    static constexpr uint8_t kMaxVendorModelLength      = 32; ///< Max length of Vendor Model TLV.
+    static constexpr uint8_t kMaxVendorSwVersionLength  = 16; ///< Max length of Vendor SW Version TLV.
+    static constexpr uint8_t kMaxVendorDataLength       = 64; ///< Max length of Vendor Data TLV.
+    static constexpr uint8_t kMaxThreadDomainNameLength = 16; ///< Max length of Thread Domain Name TLV.
 
     /**
      * Returns the Type value.
@@ -936,6 +938,11 @@ private:
     uint16_t mDestinationPort;
     // Followed by the UDP Payload.
 } OT_TOOL_PACKED_END;
+
+/**
+ * Implements Thread Domain Name TLV type.
+ */
+typedef StringTlvInfo<Tlv::kThreadDomainName, Tlv::kMaxThreadDomainNameLength> ThreadDomainNameTlv;
 
 /**
  * Implements Discovery Request TLV generation and parsing.

--- a/src/core/meshcop/network_name.cpp
+++ b/src/core/meshcop/network_name.cpp
@@ -157,6 +157,11 @@ Error NetworkNameManager::SetDomainName(const NameData &aNameData)
 
     return (error == kErrorAlready) ? kErrorNone : error;
 }
+
+bool NetworkNameManager::IsDefaultDomainNameSet(void) const
+{
+    return StringMatch(mDomainName.GetAsCString(), NetworkName::kDomainNameInit);
+}
 #endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 
 } // namespace MeshCoP

--- a/src/core/meshcop/network_name.hpp
+++ b/src/core/meshcop/network_name.hpp
@@ -101,7 +101,7 @@ class NetworkName : public otNetworkName, public Unequatable<NetworkName>
 {
 public:
     static constexpr const char *kNetworkNameInit = "OpenThread";
-    static constexpr const char *kDomainNameInit  = "DefaultDomain";
+    static constexpr const char *kDomainNameInit  = "DefaultDomain"; // Section 5.22 Thread spec, MUST NOT change.
 
     /**
      * This constant specified the maximum number of chars in Network Name (excludes null char).
@@ -237,6 +237,14 @@ public:
      * @retval kErrorInvalidArgs   Given name is too long.
      */
     Error SetDomainName(const NameData &aNameData);
+
+    /**
+     * Checks whether the Thread Domain Name is currently set to the default name.
+     *
+     * @returns true if Thread Domain Name equals "DefaultDomain", false otherwise.
+     */
+    bool IsDefaultDomainNameSet(void) const;
+
 #endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 
 private:

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2758,6 +2758,14 @@ Error MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, const M
     SuccessOrExit(
         error = Tlv::Append<MeshCoP::JoinerUdpPortTlv>(*message, Get<MeshCoP::JoinerRouter>().GetJoinerUdpPort()));
 
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_4)
+    if (!Get<MeshCoP::NetworkNameManager>().IsDefaultDomainNameSet())
+    {
+        SuccessOrExit(error = Tlv::Append<MeshCoP::ThreadDomainNameTlv>(
+                          *message, Get<MeshCoP::NetworkNameManager>().GetDomainName().GetAsCString()));
+    }
+#endif
+
     tlv.SetLength(static_cast<uint8_t>(message->GetLength() - startOffset));
     message->Write(startOffset - sizeof(tlv), tlv);
 


### PR DESCRIPTION
This commit adds the Thread Domain Name TLV (59) to the MLE Discovery Response message. The TLV is only included if not equal to 'DefaultDomain', as per Thread 1.4 spec Section 8.4.4.1.1.2.
Also, the TLV is only included for Thread 1.4 or higher builds.  This is because for Thread < 1.4 the inclusion of this TLV was only specified for CCM devices. Thread 1.4 changed this: the TLV is now included if the domain name is not equal to the default name "DefaultDomain" specified in Section 5.22. 

The purpose of including the domain name is to allow discovery of Thread Networks that belong to the same domain that the Joiner is part of. This is used by any commissioning methods where the Thread device can roam e.g. CCM/CCM-light or other (future) methods.

Related JIRA: [SPEC-1276](https://threadgroup.atlassian.net/browse/SPEC-1276)