### PR TITLE
[border-agent] process Keep Alive messages only for active commissioner

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -493,7 +493,7 @@ template <> void BorderAgent::HandleTmf<kUriPendingGet>(Coap::Message &aMessage,
 template <>
 void BorderAgent::HandleTmf<kUriCommissionerKeepAlive>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    VerifyOrExit(mState != kStateStopped);
+    VerifyOrExit(mState == kStateAccepted);
 
     SuccessOrExit(ForwardToLeader(aMessage, aMessageInfo, kUriLeaderKeepAlive));
     mTimer.Start(kKeepAliveTimeout);
@@ -747,7 +747,7 @@ void BorderAgent::HandleTimeout(void)
     if (Get<Tmf::SecureAgent>().IsConnected())
     {
         Get<Tmf::SecureAgent>().Disconnect();
-        LogWarn("Reset commissioner session");
+        LogWarn("Reset secure session");
     }
 }
 


### PR DESCRIPTION
This commit updates how Keep Alive messages are handled by the Border
Agent. After establishing a secure session, a device has
`TIMEOUT_COMM_PET` (50 seconds) to take any action, including sending
a petition to become an Active Commissioner. This change ensures that
Keep Alive messages are ignored before a device becomes an Active
Commissioner, preventing candidates from extending their sessions.
Keep Alive messages are now processed only for Active Commissioners
(BA in `kStateAccepted` state), aligning the implementation with the
Thread specification. 

Update as clarification in [SPEC-1310](https://threadgroup.atlassian.net/browse/SPEC-1310)