### PR TITLE
[core] consolidate standard C header includes in `toolchain.h`

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (447)
+#define OPENTHREAD_API_VERSION (448)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/toolchain.h
+++ b/include/openthread/platform/toolchain.h
@@ -56,8 +56,14 @@
 #ifndef OPENTHREAD_PLATFORM_TOOLCHAIN_H_
 #define OPENTHREAD_PLATFORM_TOOLCHAIN_H_
 
+#include <ctype.h>
+#include <stdarg.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -35,8 +35,6 @@
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 
-#include <string.h>
-
 #include <openthread/border_router.h>
 #include <openthread/platform/border_routing.h>
 #include <openthread/platform/infra_if.h>

--- a/src/core/common/binary_search.hpp
+++ b/src/core/common/binary_search.hpp
@@ -36,7 +36,7 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
+#include <openthread/platform/toolchain.h>
 
 namespace ot {
 

--- a/src/core/common/callback.hpp
+++ b/src/core/common/callback.hpp
@@ -36,7 +36,7 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
+#include <openthread/platform/toolchain.h>
 
 #include "common/type_traits.hpp"
 

--- a/src/core/common/clearable.hpp
+++ b/src/core/common/clearable.hpp
@@ -36,8 +36,7 @@
 
 #include "openthread-core-config.h"
 
-#include <string.h>
-
+#include "common/error.hpp"
 #include "common/type_traits.hpp"
 
 namespace ot {

--- a/src/core/common/code_utils.hpp
+++ b/src/core/common/code_utils.hpp
@@ -34,8 +34,6 @@
 #ifndef CODE_UTILS_HPP_
 #define CODE_UTILS_HPP_
 
-#include <stdbool.h>
-
 #include <openthread/error.h>
 
 #include "common/arg_macros.hpp"

--- a/src/core/common/crc16.hpp
+++ b/src/core/common/crc16.hpp
@@ -36,7 +36,7 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
+#include <openthread/platform/toolchain.h>
 
 namespace ot {
 

--- a/src/core/common/data.hpp
+++ b/src/core/common/data.hpp
@@ -36,9 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
-#include <string.h>
-
 #include "common/clearable.hpp"
 #include "common/code_utils.hpp"
 #include "common/const_cast.hpp"

--- a/src/core/common/debug.hpp
+++ b/src/core/common/debug.hpp
@@ -36,8 +36,7 @@
 
 #include "openthread-core-config.h"
 
-#include <ctype.h>
-#include <stdio.h>
+#include <openthread/platform/toolchain.h>
 
 #if OPENTHREAD_CONFIG_ASSERT_ENABLE
 

--- a/src/core/common/encoding.hpp
+++ b/src/core/common/encoding.hpp
@@ -45,7 +45,7 @@
 #endif
 #endif
 
-#include <stdint.h>
+#include <openthread/platform/toolchain.h>
 
 namespace ot {
 

--- a/src/core/common/equatable.hpp
+++ b/src/core/common/equatable.hpp
@@ -36,7 +36,7 @@
 
 #include "openthread-core-config.h"
 
-#include <string.h>
+#include "common/error.hpp"
 
 namespace ot {
 

--- a/src/core/common/error.hpp
+++ b/src/core/common/error.hpp
@@ -38,8 +38,6 @@
 
 #include <openthread/error.h>
 
-#include <stdint.h>
-
 namespace ot {
 
 /**

--- a/src/core/common/frame_builder.cpp
+++ b/src/core/common/frame_builder.cpp
@@ -33,8 +33,6 @@
 
 #include "frame_builder.hpp"
 
-#include <string.h>
-
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/encoding.hpp"

--- a/src/core/common/heap.hpp
+++ b/src/core/common/heap.hpp
@@ -36,8 +36,7 @@
 
 #include "openthread-core-config.h"
 
-#include <stddef.h>
-#include <string.h>
+#include <openthread/platform/toolchain.h>
 
 namespace ot {
 namespace Heap {

--- a/src/core/common/heap_array.hpp
+++ b/src/core/common/heap_array.hpp
@@ -36,9 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
-#include <stdio.h>
-
 #include "common/array.hpp"
 #include "common/code_utils.hpp"
 #include "common/error.hpp"

--- a/src/core/common/linked_list.hpp
+++ b/src/core/common/linked_list.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdio.h>
-
 #include "common/const_cast.hpp"
 #include "common/error.hpp"
 #include "common/iterator_utils.hpp"

--- a/src/core/common/locator.hpp
+++ b/src/core/common/locator.hpp
@@ -38,8 +38,6 @@
 
 #include <openthread/platform/toolchain.h>
 
-#include <stdint.h>
-
 namespace ot {
 
 class Instance;

--- a/src/core/common/log.cpp
+++ b/src/core/common/log.cpp
@@ -33,8 +33,6 @@
 
 #include "log.hpp"
 
-#include <ctype.h>
-
 #include <openthread/platform/logging.h>
 
 #include "common/code_utils.hpp"

--- a/src/core/common/log.hpp
+++ b/src/core/common/log.hpp
@@ -38,7 +38,6 @@
 
 #include <openthread/logging.h>
 #include <openthread/platform/logging.h>
-#include <openthread/platform/toolchain.h>
 
 #include "common/error.hpp"
 

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
-
 #include <openthread/message.h>
 #include <openthread/nat64.h>
 #include <openthread/platform/messagepool.h>

--- a/src/core/common/new.hpp
+++ b/src/core/common/new.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stddef.h>
-
 #include <openthread/platform/toolchain.h>
 
 inline void *operator new(size_t, void *p) throw() { return p; }

--- a/src/core/common/notifier.hpp
+++ b/src/core/common/notifier.hpp
@@ -36,11 +36,7 @@
 
 #include "openthread-core-config.h"
 
-#include <stdbool.h>
-#include <stdint.h>
-
 #include <openthread/instance.h>
-#include <openthread/platform/toolchain.h>
 
 #include "common/callback.hpp"
 #include "common/error.hpp"

--- a/src/core/common/numeric_limits.hpp
+++ b/src/core/common/numeric_limits.hpp
@@ -34,7 +34,7 @@
 #ifndef NUMERIC_LIMITS_HPP_
 #define NUMERIC_LIMITS_HPP_
 
-#include <stdint.h>
+#include <openthread/platform/toolchain.h>
 
 namespace ot {
 

--- a/src/core/common/offset_range.hpp
+++ b/src/core/common/offset_range.hpp
@@ -36,9 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdbool.h>
-#include <stdint.h>
-
 #include "common/clearable.hpp"
 
 namespace ot {

--- a/src/core/common/ptr_wrapper.hpp
+++ b/src/core/common/ptr_wrapper.hpp
@@ -36,8 +36,7 @@
 
 #include "openthread-core-config.h"
 
-#include <stdbool.h>
-#include <stdint.h>
+#include <openthread/platform/toolchain.h>
 
 namespace ot {
 

--- a/src/core/common/random.hpp
+++ b/src/core/common/random.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
-
 #include <openthread/platform/crypto.h>
 
 #include "common/debug.hpp"

--- a/src/core/common/serial_number.hpp
+++ b/src/core/common/serial_number.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
-
 #include "common/numeric_limits.hpp"
 #include "common/type_traits.hpp"
 

--- a/src/core/common/string.cpp
+++ b/src/core/common/string.cpp
@@ -34,8 +34,6 @@
 #include "string.hpp"
 #include "debug.hpp"
 
-#include <string.h>
-
 namespace ot {
 
 namespace {

--- a/src/core/common/string.hpp
+++ b/src/core/common/string.hpp
@@ -36,10 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-
 #include "common/binary_search.hpp"
 #include "common/code_utils.hpp"
 #include "common/error.hpp"

--- a/src/core/common/tasklet.hpp
+++ b/src/core/common/tasklet.hpp
@@ -36,9 +36,8 @@
 
 #include "openthread-core-config.h"
 
-#include <stdio.h>
-
 #include <openthread/tasklet.h>
+#include <openthread/platform/toolchain.h>
 
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"

--- a/src/core/common/time.hpp
+++ b/src/core/common/time.hpp
@@ -36,8 +36,7 @@
 
 #include "openthread-core-config.h"
 
-#include <stddef.h>
-#include <stdint.h>
+#include <openthread/platform/toolchain.h>
 
 #include "common/equatable.hpp"
 #include "common/serial_number.hpp"

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -36,9 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stddef.h>
-#include <stdint.h>
-
 #include <openthread/platform/alarm-micro.h>
 #include <openthread/platform/alarm-milli.h>
 

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -37,7 +37,6 @@
 #include "openthread-core-config.h"
 
 #include <openthread/thread.h>
-#include <openthread/platform/toolchain.h>
 
 #include "common/const_cast.hpp"
 #include "common/encoding.hpp"

--- a/src/core/crypto/aes_ccm.hpp
+++ b/src/core/crypto/aes_ccm.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
-
 #include <openthread/platform/crypto.h>
 #include "common/error.hpp"
 #include "common/message.hpp"

--- a/src/core/crypto/crypto_platform.cpp
+++ b/src/core/crypto/crypto_platform.cpp
@@ -32,8 +32,6 @@
 
 #include "openthread-core-config.h"
 
-#include <string.h>
-
 #include <mbedtls/aes.h>
 #include <mbedtls/cmac.h>
 #include <mbedtls/ctr_drbg.h>

--- a/src/core/crypto/ecdsa.hpp
+++ b/src/core/crypto/ecdsa.hpp
@@ -38,9 +38,6 @@
 
 #if OPENTHREAD_CONFIG_ECDSA_ENABLE
 
-#include <stdint.h>
-#include <stdlib.h>
-
 #include <openthread/crypto.h>
 #include <openthread/platform/crypto.h>
 

--- a/src/core/crypto/hkdf_sha256.cpp
+++ b/src/core/crypto/hkdf_sha256.cpp
@@ -33,8 +33,6 @@
 
 #include "hkdf_sha256.hpp"
 
-#include <string.h>
-
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/error.hpp"

--- a/src/core/crypto/hmac_sha256.hpp
+++ b/src/core/crypto/hmac_sha256.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
-
 #include <openthread/platform/crypto.h>
 
 #include "common/code_utils.hpp"

--- a/src/core/crypto/sha256.hpp
+++ b/src/core/crypto/sha256.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
-
 #include <openthread/crypto.h>
 #include <openthread/platform/crypto.h>
 

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -35,9 +35,6 @@
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
 
-#include <stdio.h>
-#include <stdlib.h>
-
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
 #include <openthread/platform/radio.h>

--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -38,8 +38,6 @@
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
 
-#include <string.h>
-
 #include <openthread/diag.h>
 #include <openthread/platform/radio.h>
 

--- a/src/core/instance/extension_example.cpp
+++ b/src/core/instance/extension_example.cpp
@@ -33,9 +33,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdbool.h>
-#include <stdint.h>
-
 #include "common/code_utils.hpp"
 #include "common/new.hpp"
 #include "instance/extension.hpp"

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -36,9 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdbool.h>
-#include <stdint.h>
-
 #include <openthread/heap.h>
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 #include <openthread/platform/memory.h>

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -33,8 +33,6 @@
 
 #include "mac.hpp"
 
-#include <stdio.h>
-
 #include "crypto/aes_ccm.hpp"
 #include "crypto/sha256.hpp"
 #include "instance/instance.hpp"

--- a/src/core/mac/mac_filter.hpp
+++ b/src/core/mac/mac_filter.hpp
@@ -38,8 +38,6 @@
 
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
 
-#include <stdint.h>
-
 #include "common/as_core_type.hpp"
 #include "common/const_cast.hpp"
 #include "common/non_copyable.hpp"

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -33,8 +33,6 @@
 
 #include "mac_frame.hpp"
 
-#include <stdio.h>
-
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/frame_builder.hpp"

--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -33,8 +33,6 @@
 
 #include "mac_types.hpp"
 
-#include <stdio.h>
-
 #include "common/code_utils.hpp"
 #include "common/random.hpp"
 #include "common/string.hpp"

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -36,9 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
-#include <string.h>
-
 #include <openthread/link.h>
 #include <openthread/thread.h>
 

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -33,8 +33,6 @@
 
 #include "sub_mac.hpp"
 
-#include <stdio.h>
-
 #include <openthread/platform/time.h>
 
 #include "instance/instance.hpp"

--- a/src/core/meshcop/timestamp.hpp
+++ b/src/core/meshcop/timestamp.hpp
@@ -36,13 +36,11 @@
 
 #include "openthread-core-config.h"
 
-#include <string.h>
-
 #include <openthread/dataset.h>
-#include <openthread/platform/toolchain.h>
 
 #include "common/clearable.hpp"
 #include "common/encoding.hpp"
+#include "common/error.hpp"
 #include "common/random.hpp"
 
 namespace ot {

--- a/src/core/net/checksum.hpp
+++ b/src/core/net/checksum.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
-
 #include "common/message.hpp"
 #include "net/ip4_types.hpp"
 #include "net/ip6_address.hpp"

--- a/src/core/net/ip4_types.hpp
+++ b/src/core/net/ip4_types.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stddef.h>
-
 #include <openthread/nat64.h>
 
 #include "common/clearable.hpp"

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stddef.h>
-
 #include <openthread/ip6.h>
 #include <openthread/nat64.h>
 #include <openthread/udp.h>

--- a/src/core/net/ip6_headers.hpp
+++ b/src/core/net/ip6_headers.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stddef.h>
-
 #include "common/clearable.hpp"
 #include "common/encoding.hpp"
 #include "common/message.hpp"

--- a/src/core/net/ip6_types.hpp
+++ b/src/core/net/ip6_types.hpp
@@ -36,9 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stddef.h>
-#include <stdint.h>
-
 namespace ot {
 namespace Ip6 {
 

--- a/src/core/net/nd6.hpp
+++ b/src/core/net/nd6.hpp
@@ -38,10 +38,7 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
-
 #include <openthread/netdata.h>
-#include <openthread/platform/toolchain.h>
 
 #include "common/const_cast.hpp"
 #include "common/encoding.hpp"

--- a/src/core/thread/child_supervision.hpp
+++ b/src/core/thread/child_supervision.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
-
 #include <openthread/child_supervision.h>
 
 #include "common/locator.hpp"

--- a/src/core/thread/indirect_sender_frame_context.hpp
+++ b/src/core/thread/indirect_sender_frame_context.hpp
@@ -36,7 +36,7 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
+#include <openthread/platform/toolchain.h>
 
 namespace ot {
 

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
-
 #include <openthread/dataset.h>
 #include <openthread/platform/crypto.h>
 

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -36,9 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
-#include <string.h>
-
 #include <openthread/thread.h>
 #if OPENTHREAD_FTD
 #include <openthread/thread_ftd.h>

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
-
 #include "coap/coap.hpp"
 #include "common/const_cast.hpp"
 #include "common/non_copyable.hpp"

--- a/src/core/thread/version.hpp
+++ b/src/core/thread/version.hpp
@@ -36,7 +36,7 @@
 
 #include "openthread-core-config.h"
 
-#include <stdint.h>
+#include <openthread/platform/toolchain.h>
 
 namespace ot {
 

--- a/src/core/utils/flash.hpp
+++ b/src/core/utils/flash.hpp
@@ -33,11 +33,6 @@
 
 #if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
 
-#include <stdint.h>
-#include <string.h>
-
-#include <openthread/platform/toolchain.h>
-
 #include "common/debug.hpp"
 #include "common/error.hpp"
 #include "common/locator.hpp"

--- a/src/core/utils/heap.cpp
+++ b/src/core/utils/heap.cpp
@@ -35,7 +35,7 @@
 
 #if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 
-#include <string.h>
+#include <openthread/platform/toolchain.h>
 
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"

--- a/src/core/utils/heap.hpp
+++ b/src/core/utils/heap.hpp
@@ -38,8 +38,7 @@
 
 #if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 
-#include <stddef.h>
-#include <stdint.h>
+#include <openthread/platform/toolchain.h>
 
 #include "common/const_cast.hpp"
 #include "common/non_copyable.hpp"

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -38,8 +38,6 @@
 
 #if OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
 
-#include <stdint.h>
-
 #include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"

--- a/src/core/utils/parse_cmdline.cpp
+++ b/src/core/utils/parse_cmdline.cpp
@@ -33,8 +33,6 @@
 
 #include "parse_cmdline.hpp"
 
-#include <string.h>
-
 #include "common/code_utils.hpp"
 #include "common/numeric_limits.hpp"
 #include "common/string.hpp"

--- a/src/core/utils/parse_cmdline.hpp
+++ b/src/core/utils/parse_cmdline.hpp
@@ -34,9 +34,6 @@
 #ifndef PARSE_CMD_LINE_HPP_
 #define PARSE_CMD_LINE_HPP_
 
-#include <stdint.h>
-#include <string.h>
-
 #include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>


### PR DESCRIPTION
This commit centralizes all standard C header includes(e.g., `#include <stdint.h>`) within `platform/toolchain.h`, removing them from individual core source files. This improves OpenThread's portability across different platforms and toolchains, simplifying updates and handling cases where toolchain-specific headers are required.