### PR TITLE
[nd6] add `CONFIG_BORDER_ROUTING_ENABLE` guard check

### DIFF
--- a/src/core/net/nd6.cpp
+++ b/src/core/net/nd6.cpp
@@ -33,6 +33,8 @@
 
 #include "nd6.hpp"
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+
 #include "instance/instance.hpp"
 
 namespace ot {
@@ -323,3 +325,5 @@ NeighborAdvertMessage::NeighborAdvertMessage(void)
 } // namespace Nd
 } // namespace Ip6
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE

--- a/src/core/net/nd6.hpp
+++ b/src/core/net/nd6.hpp
@@ -38,6 +38,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+
 #include <stdint.h>
 
 #include <openthread/netdata.h>
@@ -972,5 +974,7 @@ static_assert(sizeof(NeighborAdvertMessage) == 24, "Invalid NeighborAdvertMessag
 } // namespace Nd
 } // namespace Ip6
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 
 #endif // ND6_HPP_


### PR DESCRIPTION
This commit adds `CONFIG_BORDER_ROUTING_ENABLE` guard checks to `nd6.hpp` and `nd6.cpp` source files, as the definitions in these files are only used when the `BORDER_ROUTING` feature is enabled.