### PR TITLE
[dns-client] fix handling of IPv4 resolve failure

### DIFF
--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -1563,7 +1563,7 @@ Error Client::ReplaceWithIp4Query(Query &aQuery)
 
     info.ReadFrom(aQuery);
 
-    VerifyOrExit(info.mQueryType == kIp4AddressQuery);
+    VerifyOrExit(info.mQueryType == kIp6AddressQuery);
     VerifyOrExit(info.mConfig.GetNat64Mode() == QueryConfig::kNat64Allow);
 
     // We send a new query for IPv4 address resolution


### PR DESCRIPTION
This commit fixes an issue in `Client::ReplaceWithIp4Query()` where an IPv6 address resolution query failure could lead to an incorrect IPv4 query being sent. The incorrect query type was being checked in this method, causing `ResolveIp4Address()` to keep sending queries.

----

[test] enhance `test_dns_client` to include addr resolution query (#10766)

This commit updates `test_dns_client` to validate independent address resolution queries (in addition to the existing service resolution tests). Specifically, it adds test cases for `ResolveIp4Address()` and scenarios where the server responds with an error RCODE.

----

Added a second commit that adds a test case. Having two commits makes it easier to cherry-pick the fix.

Addresses #10764 
