### PR TITLE
[spinel] define a new spinel-specific configuration value for source match table size

### DIFF
--- a/src/lib/spinel/openthread-spinel-config.h
+++ b/src/lib/spinel/openthread-spinel-config.h
@@ -89,6 +89,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_SPINEL_CONFIG_MAX_SRC_MATCH_ENTRIES
+ *
+ * Defines size of the local source match table used by RadioSpinel
+ * when OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT is used.
+ */
+#ifndef OPENTHREAD_SPINEL_CONFIG_MAX_SRC_MATCH_ENTRIES
+#define OPENTHREAD_SPINEL_CONFIG_MAX_SRC_MATCH_ENTRIES OPENTHREAD_CONFIG_MLE_MAX_CHILDREN
+#endif
+
+/**
  * @def OPENTHREAD_SPINEL_CONFIG_ABORT_ON_UNEXPECTED_RCP_RESET_ENABLE
  *
  * Define 1 to abort the host when receiving unexpected reset from RCP.

--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -984,7 +984,7 @@ otError RadioSpinel::AddSrcMatchShortEntry(uint16_t aShortAddress)
     EXPECT_NO_ERROR(error = Insert(SPINEL_PROP_MAC_SRC_MATCH_SHORT_ADDRESSES, SPINEL_DATATYPE_UINT16_S, aShortAddress));
 
 #if OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
-    assert(mSrcMatchShortEntryCount < OPENTHREAD_CONFIG_MLE_MAX_CHILDREN);
+    assert(mSrcMatchShortEntryCount < OPENTHREAD_SPINEL_CONFIG_MAX_SRC_MATCH_ENTRIES);
 
     for (int i = 0; i < mSrcMatchShortEntryCount; ++i)
     {
@@ -1009,7 +1009,7 @@ otError RadioSpinel::AddSrcMatchExtEntry(const otExtAddress &aExtAddress)
                         Insert(SPINEL_PROP_MAC_SRC_MATCH_EXTENDED_ADDRESSES, SPINEL_DATATYPE_EUI64_S, aExtAddress.m8));
 
 #if OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
-    assert(mSrcMatchExtEntryCount < OPENTHREAD_CONFIG_MLE_MAX_CHILDREN);
+    assert(mSrcMatchExtEntryCount < OPENTHREAD_SPINEL_CONFIG_MAX_SRC_MATCH_ENTRIES);
 
     for (int i = 0; i < mSrcMatchExtEntryCount; ++i)
     {

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -1213,14 +1213,16 @@ private:
     uint8_t mRcpFailure : 2;          ///< RCP failure reason, should recover and retry operation.
 
     // Properties set by core.
-    uint8_t      mKeyIdMode;
-    uint8_t      mKeyId;
-    otMacKey     mPrevKey;
-    otMacKey     mCurrKey;
-    otMacKey     mNextKey;
-    uint16_t     mSrcMatchShortEntries[OPENTHREAD_CONFIG_MLE_MAX_CHILDREN];
+    uint8_t  mKeyIdMode;
+    uint8_t  mKeyId;
+    otMacKey mPrevKey;
+    otMacKey mCurrKey;
+    otMacKey mNextKey;
+    static_assert(OPENTHREAD_SPINEL_CONFIG_MAX_SRC_MATCH_ENTRIES >= OPENTHREAD_CONFIG_MLE_MAX_CHILDREN,
+                  "SPINEL_CONFIG_MAX_SRC_MATCH_ENTRIES is not large enough to cover MLE_MAX_CHILDREN");
+    uint16_t     mSrcMatchShortEntries[OPENTHREAD_SPINEL_CONFIG_MAX_SRC_MATCH_ENTRIES];
     int16_t      mSrcMatchShortEntryCount;
-    otExtAddress mSrcMatchExtEntries[OPENTHREAD_CONFIG_MLE_MAX_CHILDREN];
+    otExtAddress mSrcMatchExtEntries[OPENTHREAD_SPINEL_CONFIG_MAX_SRC_MATCH_ENTRIES];
     int16_t      mSrcMatchExtEntryCount;
     uint8_t      mScanChannel;
     uint16_t     mScanDuration;


### PR DESCRIPTION
Avoids any confusion with `OPENTHREAD_CONFIG_MLE_MAX_CHILDREN`:

* `OPENTHREAD_SPINEL_CONFIG_MAX_SRC_MATCH_ENTRIES` in `openthread-spinel-config.h` defines size of the local source match table used by RadioSpinel when `OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT` is used.
* For OpenThread, the default value of this config is `OPENTHREAD_CONFIG_MLE_MAX_CHILDREN`.
* Other protocols (in case of MultiPAN with spinel) can define whatever value they want for the size of the table using this config.

See previous discussion / suggestions here: https://github.com/openthread/openthread/pull/9047#discussion_r1194533293