### PR TITLE
[mac-frame] remove unused `Set{Src/Dst}{Addr/PanId}()` methods

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -450,14 +450,6 @@ exit:
     return error;
 }
 
-void Frame::SetDstPanId(PanId aPanId)
-{
-    uint8_t index = FindDstPanIdIndex();
-
-    OT_ASSERT(index != kInvalidIndex);
-    LittleEndian::WriteUint16(aPanId, &mPsdu[index]);
-}
-
 uint8_t Frame::GetSequence(void) const
 {
     OT_ASSERT(IsSequencePresent());
@@ -498,40 +490,6 @@ Error Frame::GetDstAddr(Address &aAddress) const
 
 exit:
     return error;
-}
-
-void Frame::SetDstAddr(ShortAddress aShortAddress)
-{
-    OT_ASSERT(GetFcfDstAddr(GetFrameControlField()) == kFcfAddrShort);
-    LittleEndian::WriteUint16(aShortAddress, &mPsdu[FindDstAddrIndex()]);
-}
-
-void Frame::SetDstAddr(const ExtAddress &aExtAddress)
-{
-    uint8_t index = FindDstAddrIndex();
-
-    OT_ASSERT(GetFcfDstAddr(GetFrameControlField()) == kFcfAddrExt);
-    OT_ASSERT(index != kInvalidIndex);
-
-    aExtAddress.CopyTo(&mPsdu[index], ExtAddress::kReverseByteOrder);
-}
-
-void Frame::SetDstAddr(const Address &aAddress)
-{
-    switch (aAddress.GetType())
-    {
-    case Address::kTypeShort:
-        SetDstAddr(aAddress.GetShort());
-        break;
-
-    case Address::kTypeExtended:
-        SetDstAddr(aAddress.GetExtended());
-        break;
-
-    default:
-        OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
-    }
 }
 
 uint8_t Frame::FindSrcPanIdIndex(void) const
@@ -627,18 +585,6 @@ exit:
     return error;
 }
 
-Error Frame::SetSrcPanId(PanId aPanId)
-{
-    Error   error = kErrorNone;
-    uint8_t index = FindSrcPanIdIndex();
-
-    VerifyOrExit(index != kInvalidIndex, error = kErrorParse);
-    LittleEndian::WriteUint16(aPanId, &mPsdu[index]);
-
-exit:
-    return error;
-}
-
 uint8_t Frame::FindSrcAddrIndex(void) const
 {
     uint16_t fcf   = GetFrameControlField();
@@ -700,43 +646,6 @@ exit:
     return error;
 }
 
-void Frame::SetSrcAddr(ShortAddress aShortAddress)
-{
-    uint8_t index = FindSrcAddrIndex();
-
-    OT_ASSERT(GetFcfSrcAddr(GetFrameControlField()) == kFcfAddrShort);
-    OT_ASSERT(index != kInvalidIndex);
-
-    LittleEndian::WriteUint16(aShortAddress, &mPsdu[index]);
-}
-
-void Frame::SetSrcAddr(const ExtAddress &aExtAddress)
-{
-    uint8_t index = FindSrcAddrIndex();
-
-    OT_ASSERT(GetFcfSrcAddr(GetFrameControlField()) == kFcfAddrExt);
-    OT_ASSERT(index != kInvalidIndex);
-
-    aExtAddress.CopyTo(&mPsdu[index], ExtAddress::kReverseByteOrder);
-}
-
-void Frame::SetSrcAddr(const Address &aAddress)
-{
-    switch (aAddress.GetType())
-    {
-    case Address::kTypeShort:
-        SetSrcAddr(aAddress.GetShort());
-        break;
-
-    case Address::kTypeExtended:
-        SetSrcAddr(aAddress.GetExtended());
-        break;
-
-    default:
-        OT_ASSERT(false);
-    }
-}
-
 Error Frame::GetSecurityControlField(uint8_t &aSecurityControlField) const
 {
     Error   error = kErrorNone;
@@ -748,15 +657,6 @@ Error Frame::GetSecurityControlField(uint8_t &aSecurityControlField) const
 
 exit:
     return error;
-}
-
-void Frame::SetSecurityControlField(uint8_t aSecurityControlField)
-{
-    uint8_t index = FindSecurityHeaderIndex();
-
-    OT_ASSERT(index != kInvalidIndex);
-
-    mPsdu[index] = aSecurityControlField;
 }
 
 uint8_t Frame::FindSecurityHeaderIndex(void) const

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -348,13 +348,6 @@ public:
     Error GetDstPanId(PanId &aPanId) const;
 
     /**
-     * Sets the Destination PAN Identifier.
-     *
-     * @param[in]  aPanId  The Destination PAN Identifier.
-     */
-    void SetDstPanId(PanId aPanId);
-
-    /**
      * Indicates whether or not the Destination Address is present for this object.
      *
      * @retval TRUE   If the Destination Address is present.
@@ -370,27 +363,6 @@ public:
      * @retval kErrorNone  Successfully retrieved the Destination Address.
      */
     Error GetDstAddr(Address &aAddress) const;
-
-    /**
-     * Sets the Destination Address.
-     *
-     * @param[in]  aShortAddress  The Destination Address.
-     */
-    void SetDstAddr(ShortAddress aShortAddress);
-
-    /**
-     * Sets the Destination Address.
-     *
-     * @param[in]  aExtAddress  The Destination Address.
-     */
-    void SetDstAddr(const ExtAddress &aExtAddress);
-
-    /**
-     * Sets the Destination Address.
-     *
-     * @param[in]  aAddress  The Destination Address.
-     */
-    void SetDstAddr(const Address &aAddress);
 
     /**
      * Indicates whether or not the Source Address is present for this object.
@@ -410,15 +382,6 @@ public:
     Error GetSrcPanId(PanId &aPanId) const;
 
     /**
-     * Sets the Source PAN Identifier.
-     *
-     * @param[in]  aPanId  The Source PAN Identifier.
-     *
-     * @retval kErrorNone   Successfully set the Source PAN Identifier.
-     */
-    Error SetSrcPanId(PanId aPanId);
-
-    /**
      * Indicates whether or not the Source Address is present for this object.
      *
      * @retval TRUE   If the Source Address is present.
@@ -436,27 +399,6 @@ public:
     Error GetSrcAddr(Address &aAddress) const;
 
     /**
-     * Sets the Source Address.
-     *
-     * @param[in]  aShortAddress  The Source Address.
-     */
-    void SetSrcAddr(ShortAddress aShortAddress);
-
-    /**
-     * Sets the Source Address.
-     *
-     * @param[in]  aExtAddress  The Source Address.
-     */
-    void SetSrcAddr(const ExtAddress &aExtAddress);
-
-    /**
-     * Sets the Source Address.
-     *
-     * @param[in]  aAddress  The Source Address.
-     */
-    void SetSrcAddr(const Address &aAddress);
-
-    /**
      * Gets the Security Control Field.
      *
      * @param[out]  aSecurityControlField  The Security Control Field.
@@ -465,13 +407,6 @@ public:
      * @retval kErrorParse  Failed to find the security control field in the frame.
      */
     Error GetSecurityControlField(uint8_t &aSecurityControlField) const;
-
-    /**
-     * Sets the Security Control Field.
-     *
-     * @param[in]  aSecurityControlField  The Security Control Field.
-     */
-    void SetSecurityControlField(uint8_t aSecurityControlField);
 
     /**
      * Gets the Security Level Identifier.

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -626,9 +626,6 @@ void TestMacFrameApi(void)
     VerifyOrQuit(frame.IsSrcAddrPresent());
     SuccessOrQuit(frame.GetSecurityControlField(scf));
     VerifyOrQuit(scf == 0x0d);
-    frame.SetSecurityControlField(0xff);
-    SuccessOrQuit(frame.GetSecurityControlField(scf));
-    VerifyOrQuit(scf == 0xff);
 #endif // OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
 
     // IEEE 802.15.4-2006 Mac Command


### PR DESCRIPTION
Recent changes updated `Mac::Frame` to use `FrameBuilder` for preparing frame headers. With the adoption of this model, the previously defined `Set` methods for setting source/destination address or PAN ID are no longer used or needed. This commit removes them.