### PR TITLE
[dns-client] enhance logic for following up with IPv4 address query

### DIFF
--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -805,7 +805,7 @@ private:
     void        HandleTimer(void);
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_NAT64_ENABLE
-    Error ReplaceWithIp4Query(Query &aQuery);
+    Error ReplaceWithIp4Query(Query &aQuery, const Message &aResponseMessage);
 #endif
 #if OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE
     Error Resolve(const char        *aInstanceLabel,

--- a/tests/unit/test_dnssd_discovery_proxy.cpp
+++ b/tests/unit/test_dnssd_discovery_proxy.cpp
@@ -1696,6 +1696,7 @@ void TestProxyTimeout(void)
 
     config.Clear();
     config.mResponseTimeout = 120 * 1000; // 2 minutes (in msec)
+    config.mNat64Mode       = OT_DNS_NAT64_DISALLOW;
     dnsClient->SetDefaultConfig(config);
 
     Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");


### PR DESCRIPTION
This commit updates the `ReplaceWithIp4Query()` method, which determines whether an unsuccessful IPv6 address query should be followed up with an IPv4 query.

The logic is changed as follows:

- If the response code to the IPv6 query indicates success but the answer section is empty (meaning the name exists but has no IPv6 address), or the response code indicates an error other than `NameError`, the query is replaced with an IPv4 address resolution query for the same name.
- If the server responds with `NameError` (RCode=3), indicating that the name doesn't exist, an IPv4 query is not attempted.

This replaces the previous behavior where a follow-up query was attempted for any error response code.