### PR TITLE
[radio] add `Radio::GetNow()`

### DIFF
--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -1004,7 +1004,7 @@ public:
      * 6.9.1 (albeit both unrelated to OT).
      *
      * The time is relative to the local radio clock as defined by
-     * `otPlatRadioGetNow`.
+     * `Radio::GetNow()`.
      *
      * @returns The timestamp in microseconds.
      */

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -388,7 +388,7 @@ void SubMac::StartCsmaBackoff(void)
         {
             static constexpr uint32_t kAheadTime = kCcaSampleInterval + kCslTransmitTimeAhead + kRadioHeaderShrDuration;
             Time                      txStartTime = Time(mTransmitFrame.mInfo.mTxInfo.mTxDelayBaseTime);
-            Time                      radioNow    = Time(static_cast<uint32_t>(otPlatRadioGetNow(&GetInstance())));
+            Time                      radioNow    = Time(static_cast<uint32_t>(Get<Radio>().GetNow()));
 
             txStartTime += (mTransmitFrame.mInfo.mTxInfo.mTxDelay - kAheadTime);
 

--- a/src/core/mac/sub_mac_csl_receiver.cpp
+++ b/src/core/mac/sub_mac_csl_receiver.cpp
@@ -125,7 +125,7 @@ bool SubMac::UpdateCsl(uint16_t aPeriod, uint8_t aChannel, otShortAddress aShort
     mCslTimer.Stop();
     if (mCslPeriod > 0)
     {
-        mCslSampleTime = TimeMicro(static_cast<uint32_t>(otPlatRadioGetNow(&GetInstance())));
+        mCslSampleTime = TimeMicro(static_cast<uint32_t>(Get<Radio>().GetNow()));
         mIsCslSampling = false;
         HandleCslTimer();
     }
@@ -248,7 +248,7 @@ uint32_t SubMac::GetLocalTime(void)
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_LOCAL_TIME_SYNC
     now = TimerMicro::GetNow().GetValue();
 #else
-    now = static_cast<uint32_t>(otPlatRadioGetNow(&GetInstance()));
+    now = static_cast<uint32_t>(Get<Radio>().GetNow());
 #endif
 
     return now;

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -520,6 +520,14 @@ public:
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
     /**
+     * Get the current radio time in microseconds referenced to a continuous monotonic local radio clock (64 bits
+     * width).
+     *
+     * @returns The current radio clock time.
+     */
+    uint64_t GetNow(void);
+
+    /**
      * Get the current accuracy, in units of ± ppm, of the clock used for scheduling CSL operations.
      *
      * @note Platforms may optimize this value based on operational conditions (i.e.: temperature).
@@ -921,10 +929,10 @@ inline Error Radio::ResetCsl(void) { return otPlatRadioResetCsl(GetInstancePtr()
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-inline uint8_t Radio::GetCslAccuracy(void) { return otPlatRadioGetCslAccuracy(GetInstancePtr()); }
-#endif
+inline uint64_t Radio::GetNow(void) { return otPlatRadioGetNow(GetInstancePtr()); }
 
-#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+inline uint8_t Radio::GetCslAccuracy(void) { return otPlatRadioGetCslAccuracy(GetInstancePtr()); }
+
 inline uint8_t Radio::GetCslUncertainty(void) { return otPlatRadioGetCslUncertainty(GetInstancePtr()); }
 #endif
 
@@ -1029,6 +1037,8 @@ inline Error Radio::ResetCsl(void) { return kErrorNotImplemented; }
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+inline uint64_t Radio::GetNow(void) { return NumericLimits<uint64_t>::kMax; }
+
 inline uint8_t Radio::GetCslAccuracy(void) { return NumericLimits<uint8_t>::kMax; }
 
 inline uint8_t Radio::GetCslUncertainty(void) { return NumericLimits<uint8_t>::kMax; }

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -156,7 +156,7 @@ uint32_t CslTxScheduler::GetNextCslTransmissionDelay(const Child &aChild,
                                                      uint32_t    &aDelayFromLastRx,
                                                      uint32_t     aAheadUs) const
 {
-    uint64_t radioNow   = otPlatRadioGetNow(&GetInstance());
+    uint64_t radioNow   = Get<Radio>().GetNow();
     uint32_t periodInUs = aChild.GetCslPeriod() * kUsPerTenSymbols;
 
     /* see CslTxScheduler::ChildInfo::mCslPhase */


### PR DESCRIPTION
This commit adds the `GetNow()` method to the `Radio` class, which maps to `otPlatRadioGetNow()`. This method is used within core modules to avoid calling the `otPlat` API directly, aligning with the practice for all other `otPlatRadio` APIs, which are called through the defined `Radio` class methods.