### PR TITLE
[ncp] add border routing InfraIf send ICMP6 ND

### DIFF
--- a/src/lib/spinel/spinel.h
+++ b/src/lib/spinel/spinel.h
@@ -603,13 +603,6 @@ typedef enum
     SPINEL_IPV6_ICMP_PING_OFFLOAD_RLOC_ALOC_ONLY = 4,
 } spinel_ipv6_icmp_ping_offload_mode_t;
 
-typedef uint8_t spinel_ipv6_icmp_type_t;
-
-enum
-{
-    SPINEL_IPV6_ICMP_TYPE_ND = 0,
-};
-
 typedef enum
 {
     SPINEL_SCAN_STATE_IDLE     = 0,
@@ -4769,6 +4762,16 @@ enum
      * `d`: The data of the ICMPv6 packet. The host MUST ensure the hoplimit is 255.
      */
     SPINEL_PROP_INFRA_IF_RECV_ICMP6 = SPINEL_PROP_INFRA_IF__BEGIN + 2,
+
+    /// ICMP6 message sent by NCP and needs to be sent on the infrastructure interface.
+    /** Format: `L6d`
+     * Type: Unsolicited notifications only
+     *
+     * `L`: The infrastructure interface index.
+     * `6`: The IP6 destination address of the message to send.
+     * `d`: The data of the message to send.
+     */
+    SPINEL_PROP_INFRA_IF_SEND_ICMP6 = SPINEL_PROP_INFRA_IF__BEGIN + 3,
 
     SPINEL_PROP_INFRA_IF__END = 0x920,
 

--- a/src/lib/spinel/spinel.h
+++ b/src/lib/spinel/spinel.h
@@ -603,6 +603,13 @@ typedef enum
     SPINEL_IPV6_ICMP_PING_OFFLOAD_RLOC_ALOC_ONLY = 4,
 } spinel_ipv6_icmp_ping_offload_mode_t;
 
+typedef uint8_t spinel_ipv6_icmp_type_t;
+
+enum
+{
+    SPINEL_IPV6_ICMP_TYPE_ND = 0,
+};
+
 typedef enum
 {
     SPINEL_SCAN_STATE_IDLE     = 0,

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -224,6 +224,26 @@ public:
      */
     bool InfraIfHasAddress(uint32_t aInfraIfIndex, const otIp6Address *aAddress);
 
+    /**
+     * Send a ICMP6 ND message through the Infrastructure interface on the host.
+     *
+     * @param[in]  aInfraIfIndex  The index of the infrastructure interface this message is sent to.
+     * @param[in]  aDestAddress   The destination address this message is sent to.
+     * @param[in]  aBuffer        The ICMPv6 message buffer. The ICMPv6 checksum is left zero and the
+     *                            platform should do the checksum calculate.
+     * @param[in]  aBufferLength  The length of the message buffer.
+     *
+     * @note  Per RFC 4861, the implementation should send the message with IPv6 link-local source address
+     *        of interface @p aInfraIfIndex and IP Hop Limit 255.
+     *
+     * @retval OT_ERROR_NONE    Successfully sent the ICMPv6 message.
+     * @retval OT_ERROR_FAILED  Failed to send the ICMPv6 message.
+     */
+    otError InfraIfSendIcmp6Nd(uint32_t            aInfraIfIndex,
+                               const otIp6Address *aDestAddress,
+                               const uint8_t      *aBuffer,
+                               uint16_t            aBufferLength);
+
 protected:
     static constexpr uint8_t kBitsPerByte = 8; ///< Number of bits in a byte.
 

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -1488,6 +1488,24 @@ bool NcpBase::InfraIfHasAddress(uint32_t aInfraIfIndex, const otIp6Address *aAdd
     return aInfraIfIndex == mInfraIfIndex && InfraIfContainsAddress(*aAddress);
 }
 
+otError NcpBase::InfraIfSendIcmp6Nd(uint32_t            aInfraIfIndex,
+                                    const otIp6Address *aDestAddress,
+                                    const uint8_t      *aBuffer,
+                                    uint16_t            aBufferLength)
+{
+    otError error  = OT_ERROR_NONE;
+    uint8_t header = SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0;
+
+    SuccessOrExit(error = mEncoder.BeginFrame(header, SPINEL_CMD_PROP_VALUE_IS, SPINEL_PROP_INFRA_IF_SEND_ICMP6));
+    SuccessOrExit(error = mEncoder.WriteUint32(aInfraIfIndex));
+    SuccessOrExit(error = mEncoder.WriteIp6Address(*aDestAddress));
+    SuccessOrExit(error = mEncoder.WriteDataWithLen(aBuffer, aBufferLength));
+    SuccessOrExit(error = mEncoder.EndFrame());
+
+exit:
+    return error;
+}
+
 #endif // OPENTHREAD_CONFIG_NCP_INFRA_IF_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 
 } // namespace Ncp

--- a/src/ncp/platform/infra_if.cpp
+++ b/src/ncp/platform/infra_if.cpp
@@ -41,12 +41,9 @@ otError otPlatInfraIfSendIcmp6Nd(uint32_t            aInfraIfIndex,
                                  const uint8_t      *aBuffer,
                                  uint16_t            aBufferLength)
 {
-    OT_UNUSED_VARIABLE(aInfraIfIndex);
-    OT_UNUSED_VARIABLE(aDestAddress);
-    OT_UNUSED_VARIABLE(aBuffer);
-    OT_UNUSED_VARIABLE(aBufferLength);
+    ot::Ncp::NcpBase *ncp = ot::Ncp::NcpBase::GetNcpInstance();
 
-    return OT_ERROR_NOT_IMPLEMENTED;
+    return ncp->InfraIfSendIcmp6Nd(aInfraIfIndex, aDestAddress, aBuffer, aBufferLength);
 }
 
 otError otPlatInfraIfDiscoverNat64Prefix(uint32_t aInfraIfIndex)


### PR DESCRIPTION
This PR implements sending InfraIf Icmp6 Nd messages on NCP.

This is to support border routing for NCP case. See this https://github.com/openthread/ot-br-posix/issues/2398#issuecomment-2348518919 for the whole picture of this series of changes.

In this PR, a new spinel property SPINEL_PROP_INFRA_IF_SEND_ICMP6 is added for the NCP to send the ICMP6 messages to the host.