### PR TITLE
[spinel] support per-frame TX power in coprocessor

### DIFF
--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -1643,26 +1643,30 @@ otError RadioSpinel::Transmit(otRadioFrame &aFrame)
 #endif // OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT && OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
     // `otPlatRadioTxStarted()` is triggered immediately for now, which may be earlier than real started time.
-    mCallbacks.mTxStarted(mInstance, mTransmitFrame);
+    if (mCallbacks.mTxStarted != nullptr)
+    {
+        mCallbacks.mTxStarted(mInstance, mTransmitFrame);
+    }
 
     error = Request(SPINEL_CMD_PROP_VALUE_SET, SPINEL_PROP_STREAM_RAW,
-                    SPINEL_DATATYPE_DATA_WLEN_S                                      // Frame data
-                        SPINEL_DATATYPE_UINT8_S                                      // Channel
-                            SPINEL_DATATYPE_UINT8_S                                  // MaxCsmaBackoffs
-                                SPINEL_DATATYPE_UINT8_S                              // MaxFrameRetries
-                                    SPINEL_DATATYPE_BOOL_S                           // CsmaCaEnabled
-                                        SPINEL_DATATYPE_BOOL_S                       // IsHeaderUpdated
-                                            SPINEL_DATATYPE_BOOL_S                   // IsARetx
-                                                SPINEL_DATATYPE_BOOL_S               // IsSecurityProcessed
-                                                    SPINEL_DATATYPE_UINT32_S         // TxDelay
-                                                        SPINEL_DATATYPE_UINT32_S     // TxDelayBaseTime
-                                                            SPINEL_DATATYPE_UINT8_S, // RxChannelAfterTxDone
+                    SPINEL_DATATYPE_DATA_WLEN_S                                         // Frame data
+                        SPINEL_DATATYPE_UINT8_S                                         // Channel
+                            SPINEL_DATATYPE_UINT8_S                                     // MaxCsmaBackoffs
+                                SPINEL_DATATYPE_UINT8_S                                 // MaxFrameRetries
+                                    SPINEL_DATATYPE_BOOL_S                              // CsmaCaEnabled
+                                        SPINEL_DATATYPE_BOOL_S                          // IsHeaderUpdated
+                                            SPINEL_DATATYPE_BOOL_S                      // IsARetx
+                                                SPINEL_DATATYPE_BOOL_S                  // IsSecurityProcessed
+                                                    SPINEL_DATATYPE_UINT32_S            // TxDelay
+                                                        SPINEL_DATATYPE_UINT32_S        // TxDelayBaseTime
+                                                            SPINEL_DATATYPE_UINT8_S     // RxChannelAfterTxDone
+                                                                SPINEL_DATATYPE_INT8_S, // TxPower
                     mTransmitFrame->mPsdu, mTransmitFrame->mLength, mTransmitFrame->mChannel,
                     mTransmitFrame->mInfo.mTxInfo.mMaxCsmaBackoffs, mTransmitFrame->mInfo.mTxInfo.mMaxFrameRetries,
                     mTransmitFrame->mInfo.mTxInfo.mCsmaCaEnabled, mTransmitFrame->mInfo.mTxInfo.mIsHeaderUpdated,
                     mTransmitFrame->mInfo.mTxInfo.mIsARetx, mTransmitFrame->mInfo.mTxInfo.mIsSecurityProcessed,
                     mTransmitFrame->mInfo.mTxInfo.mTxDelay, mTransmitFrame->mInfo.mTxInfo.mTxDelayBaseTime,
-                    mTransmitFrame->mInfo.mTxInfo.mRxChannelAfterTxDone);
+                    mTransmitFrame->mInfo.mTxInfo.mRxChannelAfterTxDone, mTransmitFrame->mInfo.mTxInfo.mTxPower);
 
     if (error == OT_ERROR_NONE)
     {

--- a/src/ncp/ncp_base_radio.cpp
+++ b/src/ncp/ncp_base_radio.cpp
@@ -457,6 +457,7 @@ otError NcpBase::DecodeStreamRawTxRequest(otRadioFrame &aFrame)
     aFrame.mInfo.mTxInfo.mIsSecurityProcessed  = false;
     aFrame.mInfo.mTxInfo.mTxDelay              = 0;
     aFrame.mInfo.mTxInfo.mTxDelayBaseTime      = 0;
+    aFrame.mInfo.mTxInfo.mTxPower              = OT_RADIO_POWER_INVALID;
 
     // All the next parameters are optional. Note that even if the
     // decoder fails to parse any of optional parameters we still want to
@@ -481,6 +482,7 @@ otError NcpBase::DecodeStreamRawTxRequest(otRadioFrame &aFrame)
     SuccessOrExit(mDecoder.ReadUint32(aFrame.mInfo.mTxInfo.mTxDelay));
     SuccessOrExit(mDecoder.ReadUint32(aFrame.mInfo.mTxInfo.mTxDelayBaseTime));
     SuccessOrExit(mDecoder.ReadUint8(aFrame.mInfo.mTxInfo.mRxChannelAfterTxDone));
+    SuccessOrExit(mDecoder.ReadInt8(aFrame.mInfo.mTxInfo.mTxPower));
 
 exit:
     return error;

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -65,3 +65,24 @@ target_link_libraries(ot-ftd-gtest
     GTest::gmock_main
 )
 gtest_discover_tests(ot-ftd-gtest)
+
+add_library(ot-fake-rcp
+    fake_coprocessor_platform.cpp
+)
+target_link_libraries(ot-fake-rcp
+    openthread-hdlc
+    openthread-rcp
+    openthread-radio-spinel
+    openthread-radio
+    ot-fake-platform
+)
+
+add_executable(ot-radio-spinel-rcp-gtest
+    radio_spinel_rcp_test.cpp
+)
+target_link_libraries(ot-radio-spinel-rcp-gtest
+    ot-fake-rcp
+    GTest::gmock_main
+)
+
+gtest_discover_tests(ot-radio-spinel-rcp-gtest)

--- a/tests/gtest/fake_coprocessor_platform.cpp
+++ b/tests/gtest/fake_coprocessor_platform.cpp
@@ -28,12 +28,19 @@
 
 #include "fake_coprocessor_platform.hpp"
 
+#include <openthread/instance.h>
+#include <openthread/link.h>
 #include <openthread/ncp.h>
+#include <openthread/platform/toolchain.h>
 
 #include "common/code_utils.hpp"
 #include "lib/hdlc/hdlc.hpp"
 #include "lib/spinel/spinel.h"
 #include "lib/spinel/spinel_interface.hpp"
+
+// Currently radio spinel depends on this OpenThread user API
+// TODO remove this dependency in future.
+OT_TOOL_WEAK uint32_t otLinkGetFrameCounter(otInstance *) { return 0; }
 
 namespace ot {
 

--- a/tests/gtest/fake_coprocessor_platform.cpp
+++ b/tests/gtest/fake_coprocessor_platform.cpp
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fake_coprocessor_platform.hpp"
+
+#include <openthread/ncp.h>
+
+#include "common/code_utils.hpp"
+#include "lib/hdlc/hdlc.hpp"
+#include "lib/spinel/spinel.h"
+#include "lib/spinel/spinel_interface.hpp"
+
+namespace ot {
+
+otError DirectSpinelInterface::SendFrame(const uint8_t *aFrame, uint16_t aLength)
+{
+    otError                            error = OT_ERROR_NONE;
+    Spinel::FrameBuffer<kMaxFrameSize> encoderBuffer;
+    Hdlc::Encoder                      hdlcEncoder(encoderBuffer);
+
+    SuccessOrExit(error = hdlcEncoder.BeginFrame());
+    SuccessOrExit(error = hdlcEncoder.Encode(aFrame, aLength));
+    SuccessOrExit(error = hdlcEncoder.EndFrame());
+
+    otNcpHdlcReceive(encoderBuffer.GetFrame(), encoderBuffer.GetLength());
+
+exit:
+    return error;
+}
+
+otError DirectSpinelInterface::WaitForFrame(uint64_t aTimeoutUs)
+{
+    while (!mReceived && (aTimeoutUs = FakePlatform::CurrentPlatform().Run(aTimeoutUs)))
+    {
+        // Empty
+    }
+
+    Error error = mReceived ? kErrorNone : kErrorResponseTimeout;
+    mReceived   = false;
+    return error;
+}
+
+int DirectSpinelInterface::Receive(const uint8_t *aBuffer, uint16_t aLength)
+{
+    Hdlc::Decoder hdlcDecoder;
+
+    hdlcDecoder.Init(*mDecoderBuffer, &DirectSpinelInterface::OnReceived, this);
+    hdlcDecoder.Decode(aBuffer, aLength);
+
+    return aLength;
+}
+
+FakeCoprocessorPlatform::FakeCoprocessorPlatform()
+{
+    spinel_iid_t iids[]{
+        0,
+    };
+
+    otNcpHdlcInit(mInstance, [](const uint8_t *aBuf, uint16_t aLength) -> int {
+        int rval = static_cast<FakeCoprocessorPlatform &>(FakePlatform::CurrentPlatform())
+                       .mSpinelInterface.Receive(aBuf, aLength);
+        otNcpHdlcSendDone();
+        return rval;
+    });
+
+    mSpinelDriver.Init(mSpinelInterface, false, iids, OT_ARRAY_LENGTH(iids));
+
+    mRadioSpinel.Init(true, false, &mSpinelDriver, 0, false);
+}
+
+} // namespace ot

--- a/tests/gtest/fake_coprocessor_platform.hpp
+++ b/tests/gtest/fake_coprocessor_platform.hpp
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OT_GTEST_FAKE_COPROCESSOR_PLATFORM_HPP_
+#define OT_GTEST_FAKE_COPROCESSOR_PLATFORM_HPP_
+
+#include <openthread/config.h>
+
+#include "fake_platform.hpp"
+
+#include "lib/spinel/radio_spinel.hpp"
+
+namespace ot {
+
+/**
+ * This spinel interface directly connects to the coprocessor with function calls.
+ */
+class DirectSpinelInterface : public Spinel::SpinelInterface
+{
+public:
+    virtual otError Init(ReceiveFrameCallback aCallback, void *aCallbackContext, RxFrameBuffer &aFrameBuffer) override
+    {
+        mDecoderBuffer        = &aFrameBuffer;
+        mReceiveFrameCallback = aCallback;
+        mReceiveFrameContext  = aCallbackContext;
+        return kErrorNone;
+    }
+
+    virtual void Deinit(void) override {}
+
+    virtual otError SendFrame(const uint8_t *aFrame, uint16_t aLength) override;
+
+    virtual otError WaitForFrame(uint64_t aTimeoutUs) override;
+
+    virtual void UpdateFdSet(void *aMainloopContext) override {}
+    virtual void Process(const void *aMainloopContext) override {}
+
+    virtual uint32_t GetBusSpeed(void) const override { return 0; }
+
+    virtual otError HardwareReset(void) override { return kErrorNone; }
+
+    virtual const otRcpInterfaceMetrics *GetRcpInterfaceMetrics(void) const override { return nullptr; }
+
+    static void OnReceived(void *aContext, otError aError)
+    {
+        static_cast<DirectSpinelInterface *>(aContext)->OnReceived(aError);
+    }
+
+    void OnReceived(otError aError)
+    {
+        mReceived = true;
+        if (aError == kErrorNone)
+        {
+            mReceiveFrameCallback(mReceiveFrameContext);
+        }
+    }
+
+    int Receive(const uint8_t *aBuffer, uint16_t aLength);
+
+private:
+    ReceiveFrameCallback            mReceiveFrameCallback = nullptr;
+    void                           *mReceiveFrameContext  = nullptr;
+    SpinelInterface::RxFrameBuffer *mDecoderBuffer        = nullptr;
+    bool                            mReceived             = false;
+};
+
+class FakeCoprocessorPlatform : public FakePlatform
+{
+public:
+    FakeCoprocessorPlatform();
+    virtual ~FakeCoprocessorPlatform() = default;
+
+    Spinel::RadioSpinel   mRadioSpinel;
+    Spinel::SpinelDriver  mSpinelDriver;
+    DirectSpinelInterface mSpinelInterface;
+};
+
+} // namespace ot
+#endif // OT_GTEST_FAKE_COPROCESSOR_PLATFORM_HPP_

--- a/tests/gtest/radio_spinel_rcp_test.cpp
+++ b/tests/gtest/radio_spinel_rcp_test.cpp
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <openthread/platform/radio.h>
+
+#include "common/error.hpp"
+#include "mac/mac_frame.hpp"
+#include "mac/mac_types.hpp"
+
+#include "fake_coprocessor_platform.hpp"
+#include "fake_platform.hpp"
+
+using namespace ot;
+
+using ::testing::Truly;
+
+class MockPlatform : public FakeCoprocessorPlatform
+{
+public:
+    MOCK_METHOD(otError, Transmit, (otRadioFrame * aFrame), (override));
+};
+
+TEST(RadioSpinelTransmit, shouldPassDesiredTxPowerToRadioPlatform)
+{
+    MockPlatform platform;
+
+    constexpr Mac::PanId kSrcPanId  = 0x1234;
+    constexpr Mac::PanId kDstPanId  = 0x4321;
+    constexpr uint8_t    kDstAddr[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
+    constexpr uint16_t   kSrcAddr   = 0xac00;
+    constexpr int8_t     kTxPower   = 100;
+
+    uint8_t      frameBuffer[OT_RADIO_FRAME_MAX_SIZE];
+    Mac::TxFrame txFrame;
+
+    txFrame.mPsdu = frameBuffer;
+
+    {
+        Mac::TxFrame::Info frameInfo;
+
+        frameInfo.mType    = Mac::Frame::kTypeData;
+        frameInfo.mVersion = Mac::Frame::kVersion2006;
+        frameInfo.mAddrs.mSource.SetShort(kSrcAddr);
+        frameInfo.mAddrs.mDestination.SetExtended(kDstAddr);
+        frameInfo.mPanIds.SetSource(kSrcPanId);
+        frameInfo.mPanIds.SetDestination(kDstPanId);
+        frameInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
+
+        frameInfo.PrepareHeadersIn(txFrame);
+    }
+
+    txFrame.mInfo.mTxInfo.mTxPower = kTxPower;
+    txFrame.mChannel               = 11;
+
+    EXPECT_CALL(platform, Transmit(Truly([](otRadioFrame *aFrame) -> bool {
+                    Mac::Frame &frame = *static_cast<Mac::Frame *>(aFrame);
+                    return frame.mInfo.mTxInfo.mTxPower == kTxPower;
+                })))
+        .Times(1);
+
+    ASSERT_EQ(platform.mRadioSpinel.Enable(FakePlatform::CurrentInstance()), kErrorNone);
+    ASSERT_EQ(platform.mRadioSpinel.Receive(11), kErrorNone);
+    ASSERT_EQ(platform.mRadioSpinel.Transmit(txFrame), kErrorNone);
+
+    platform.GoInMs(1000);
+}


### PR DESCRIPTION
This commit passes the tx power from host to coprocessor. This commit also adds a new fake platform for coprocessor to cover the changes in RadioSpinel and coprocess.