### PR TITLE
[indirect-sender] add `HasQueuedMessageForSleepyChild()`

### DIFF
--- a/src/core/thread/indirect_sender.hpp
+++ b/src/core/thread/indirect_sender.hpp
@@ -131,6 +131,16 @@ public:
     };
 
     /**
+     * Represents a predicate function for checking if a given `Message` meets specific criteria.
+     *
+     * @param[in] aMessage The message to evaluate.
+     *
+     * @retval TRUE   If the @p aMessage satisfies the predicate condition.
+     * @retval FALSE  If the @p aMessage does not satisfy the predicate condition.
+     */
+    typedef bool (&MessageChecker)(const Message &aMessage);
+
+    /**
      * Initializes the object.
      *
      * @param[in]  aInstance  A reference to the OpenThread instance.
@@ -176,6 +186,52 @@ public:
     void ClearAllMessagesForSleepyChild(Child &aChild);
 
     /**
+     * Finds the first queued message for a given sleepy child that also satisfies the conditions of a given
+     * `MessageChecker`.
+     *
+     * The caller MUST ensure that @p aChild is sleepy.
+     *
+     * @param[in] aChild     The sleepy child to check.
+     * @param[in] aChecker   The predicate function to apply.
+     *
+     * @returns A pointer to the matching queued message, or `nullptr` if none is found.
+     */
+    Message *FindQueuedMessageForSleepyChild(const Child &aChild, MessageChecker aChecker)
+    {
+        return AsNonConst(AsConst(this)->FindQueuedMessageForSleepyChild(aChild, aChecker));
+    }
+
+    /**
+     * Finds the first queued message for a given sleepy child that also satisfies the conditions of a given
+     * `MessageChecker`.
+     *
+     * The caller MUST ensure that @p aChild is sleepy.
+     *
+     * @param[in] aChild     The sleepy child to check.
+     * @param[in] aChecker   The predicate function to apply.
+     *
+     * @returns A pointer to the matching queued message, or `nullptr` if none is found.
+     */
+    const Message *FindQueuedMessageForSleepyChild(const Child &aChild, MessageChecker aChecker) const;
+
+    /**
+     * Indicates whether there is any queued message for a given sleepy child that also satisfies the conditions of a
+     * given `MessageChecker`.
+     *
+     * The caller MUST ensure that @p aChild is sleepy.
+     *
+     * @param[in] aChild    The sleepy child to check for.
+     * @param[in] aChecker  The predicate function to apply.
+     *
+     * @retval TRUE   There is a queued message satisfying @p aChecker for sleepy child @p aChild.
+     * @retval FALSE  There is no queued message satisfying @p aChecker for sleepy child @p aChild.
+     */
+    bool HasQueuedMessageForSleepyChild(const Child &aChild, MessageChecker aChecker) const
+    {
+        return (FindQueuedMessageForSleepyChild(aChild, aChecker) != nullptr);
+    }
+
+    /**
      * Sets whether to use the extended or short address for a child.
      *
      * @param[in] aChild            A reference to the child.
@@ -198,11 +254,13 @@ private:
     void  HandleFrameChangeDone(Child &aChild);
 
     void     UpdateIndirectMessage(Child &aChild);
-    Message *FindIndirectMessage(Child &aChild, bool aSupervisionTypeOnly = false);
     void     RequestMessageUpdate(Child &aChild);
     uint16_t PrepareDataFrame(Mac::TxFrame &aFrame, Child &aChild, Message &aMessage);
     void     PrepareEmptyFrame(Mac::TxFrame &aFrame, Child &aChild, bool aAckRequest);
     void     ClearMessagesForRemovedChildren(void);
+
+    static bool AcceptAnyMessage(const Message &aMessage);
+    static bool AcceptSupervisionMessage(const Message &aMessage);
 
     bool                  mEnabled;
     SourceMatchController mSourceMatchController;

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -222,16 +222,7 @@ public:
     void SetRxOnWhenIdle(bool aRxOnWhenIdle);
 
 #if OPENTHREAD_FTD
-
-    /**
-     * Represents a predicate function for checking if a given `Message` meets specific criteria.
-     *
-     * @param[in] aMessage The message to evaluate.
-     *
-     * @return TRUE   If the @p aMessage satisfies the predicate condition.
-     * @return FALSE  If the @p aMessage does not satisfy the predicate condition.
-     */
-    typedef bool (&MessageChecker)(const Message &aMessage);
+    typedef IndirectSender::MessageChecker MessageChecker; ///< General predicate function checking a message.
 
     /**
      * Removes and frees messages queued for a child, based on a given predicate.
@@ -242,8 +233,7 @@ public:
      * @param[in] aMessageChecker   The predicate function to filter messages.
      */
     void RemoveMessagesForChild(Child &aChild, MessageChecker aMessageChecker);
-
-#endif // OPENTHREAD_FTD
+#endif
 
     /**
      * Frees unicast/multicast MLE Data Responses from Send Message Queue if any.


### PR DESCRIPTION
This commit adds new helper methods in `IndirectSender` to find a queued message for transmission to a given sleepy child that also satisfies a certain condition (using a general-purpose predicate `MessageChecker` function pointer).

These helpers are then used in `IndirectSender` and `MleRouter` to simplify the code, particularly in `SendChildUpdateRequest()`, where sending multiple "Child Update Request" messages to a sleepy child being restored (after a parent restart/reboot) should be avoided.