### PR TITLE
[tcat] feat: add dataset clear command

### DIFF
--- a/tools/tcat_ble_client/cli/dataset_commands.py
+++ b/tools/tcat_ble_client/cli/dataset_commands.py
@@ -42,6 +42,17 @@ def handle_dataset_entry_command(type: MeshcopTlvType, args, context):
     return CommandResultNone()
 
 
+class DatasetClearCommand(Command):
+
+    def get_help_string(self) -> str:
+        return 'Clear dataset.'
+
+    async def execute_default(self, args, context):
+        ds: ThreadDataset = context['dataset']
+        ds.clear()
+        return CommandResultNone()
+
+
 class DatasetHelpCommand(Command):
 
     def get_help_string(self) -> str:
@@ -194,6 +205,7 @@ class DatasetCommand(Command):
 
     def __init__(self):
         self._subcommands = {
+            'clear': DatasetClearCommand(),
             'help': DatasetHelpCommand(),
             'hex': PrintDatasetHexCommand(),
             'reload': ReloadDatasetCommand(),

--- a/tools/tcat_ble_client/dataset/dataset.py
+++ b/tools/tcat_ble_client/dataset/dataset.py
@@ -62,3 +62,6 @@ class ThreadDataset:
             self.entries[type].set(args)
             return
         raise KeyError(f'Key {type} not available in the dataset.')
+
+    def clear(self):
+        self.entries.clear()


### PR DESCRIPTION
Added 'clear' command to the 'dataset' command tree. This allows to remove all entries in the 'ThreadDataset' object used by the script to store the dataset values.

The reason behind this feature is that in the current implementation of the script, the 'ThreadDataset' object entries are always initialized by 'initial_dataset' when running the script. No command allows to clear/remove the particular entry, which makes this script unable to send an active dataset to the target device without specific dataset values(custom dataset). To make this possible, the 'clear' command has been added to the 'dataset' command tree, which removes all entries from the 'ThreadDataset' object and, by using existing commands, sets the desired entries in the 'ThreadDataset' object from scratch. This enables the script to send custom active dataset values to the target device.