### PR TITLE
[radio] fix ACK frame counter using previous key

### DIFF
--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -1144,8 +1144,11 @@ void otPlatRadioSetMacKey(otInstance             *aInstance,
 
     otEXPECT(aPrevKey != NULL && aCurrKey != NULL && aNextKey != NULL);
 
-    sRadioContext.mKeyId   = aKeyId;
-    sRadioContext.mKeyType = aKeyType;
+    sRadioContext.mKeyId               = aKeyId;
+    sRadioContext.mKeyType             = aKeyType;
+    sRadioContext.mPrevMacFrameCounter = sRadioContext.mMacFrameCounter;
+    sRadioContext.mMacFrameCounter     = 0;
+
     memcpy(&sRadioContext.mPrevKey, aPrevKey, sizeof(otMacKeyMaterial));
     memcpy(&sRadioContext.mCurrKey, aCurrKey, sizeof(otMacKeyMaterial));
     memcpy(&sRadioContext.mNextKey, aNextKey, sizeof(otMacKeyMaterial));

--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -294,6 +294,7 @@ otError otMacFrameProcessTransmitSecurity(otRadioFrame *aFrame, otRadioContext *
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
     otMacKeyMaterial *key = nullptr;
     uint8_t           keyId;
+    uint32_t          frameCounter;
 
     VerifyOrExit(otMacFrameIsSecurityEnabled(aFrame) && otMacFrameIsKeyIdMode1(aFrame) &&
                  !aFrame->mInfo.mTxInfo.mIsSecurityProcessed);
@@ -306,15 +307,18 @@ otError otMacFrameProcessTransmitSecurity(otRadioFrame *aFrame, otRadioContext *
 
         if (keyId == aRadioContext->mKeyId)
         {
-            key = &aRadioContext->mCurrKey;
+            key          = &aRadioContext->mCurrKey;
+            frameCounter = aRadioContext->mMacFrameCounter++;
         }
         else if (keyId == aRadioContext->mKeyId - 1)
         {
-            key = &aRadioContext->mPrevKey;
+            key          = &aRadioContext->mPrevKey;
+            frameCounter = aRadioContext->mPrevMacFrameCounter++;
         }
         else if (keyId == aRadioContext->mKeyId + 1)
         {
-            key = &aRadioContext->mNextKey;
+            key          = &aRadioContext->mNextKey;
+            frameCounter = 0;
         }
         else
         {
@@ -323,8 +327,9 @@ otError otMacFrameProcessTransmitSecurity(otRadioFrame *aFrame, otRadioContext *
     }
     else if (!aFrame->mInfo.mTxInfo.mIsHeaderUpdated)
     {
-        key   = &aRadioContext->mCurrKey;
-        keyId = aRadioContext->mKeyId;
+        key          = &aRadioContext->mCurrKey;
+        keyId        = aRadioContext->mKeyId;
+        frameCounter = aRadioContext->mMacFrameCounter++;
     }
 
     if (key != nullptr)
@@ -332,7 +337,7 @@ otError otMacFrameProcessTransmitSecurity(otRadioFrame *aFrame, otRadioContext *
         aFrame->mInfo.mTxInfo.mAesKey = key;
 
         otMacFrameSetKeyId(aFrame, keyId);
-        otMacFrameSetFrameCounter(aFrame, aRadioContext->mMacFrameCounter++);
+        otMacFrameSetFrameCounter(aFrame, frameCounter);
         aFrame->mInfo.mTxInfo.mIsHeaderUpdated = true;
     }
 #else

--- a/examples/platforms/utils/mac_frame.h
+++ b/examples/platforms/utils/mac_frame.h
@@ -315,6 +315,7 @@ typedef struct otRadioContext
 {
     otExtAddress     mExtAddress; ///< In little-endian byte order.
     uint32_t         mMacFrameCounter;
+    uint32_t         mPrevMacFrameCounter;
     uint32_t         mCslSampleTime; ///< The sample time based on the microsecond timer.
     uint16_t         mCslPeriod;     ///< In unit of 10 symbols.
     otShortAddress   mShortAddress;


### PR DESCRIPTION
This commit tracks the frame counter used for the previous key index and use it for the ACK frame to a frame still using previous key index.