### PR TITLE
[srp-client] improve Client::Start error handling

### DIFF
--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -26,6 +26,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <string.h>
+#include <errno.h>
+
 #include "srp_client.hpp"
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
@@ -403,6 +406,11 @@ Error Client::Start(const Ip6::SockAddr &aServerSockAddr, Requester aRequester)
 #endif
 
 exit:
+    if(error != kErrorNone && mSocket.IsOpen())
+    {
+        LogInfo("cannot connect to server %s port %d: %s", aServerSockAddr.GetAddress().ToString().AsCString(), aServerSockAddr.GetPort(), strerror(errno));
+        IgnoreError(mSocket.Close());
+    }
     return error;
 }
 


### PR DESCRIPTION
SRPClient close socket on connect error to avoid to fail the next time:
on Client::Start, if an error occured (connect error: Network unreachable), close the socket to avoid an assert socket already opened on a ReStart.