### PR TITLE
[routing-manager] check local on-link prefix in `IsAddressOnLink()`

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1845,7 +1845,9 @@ void RoutingManager::RxRaTracker::SetHeaderFlagsOn(RouterAdvert::Header &aHeader
 
 bool RoutingManager::RxRaTracker::IsAddressOnLink(const Ip6::Address &aAddress) const
 {
-    bool isOnLink = false;
+    bool isOnLink = Get<RoutingManager>().mOnLinkPrefixManager.AddressMatchesLocalPrefix(aAddress);
+
+    VerifyOrExit(!isOnLink);
 
     for (const Router &router : mRouters)
     {
@@ -2621,6 +2623,17 @@ void RoutingManager::OnLinkPrefixManager::Stop(void)
         SetState(kDeprecating);
         break;
     }
+}
+
+bool RoutingManager::OnLinkPrefixManager::AddressMatchesLocalPrefix(const Ip6::Address &aAddress) const
+{
+    bool matches = false;
+
+    VerifyOrExit(GetState() != kIdle);
+    matches = aAddress.MatchesPrefix(mLocalPrefix);
+
+exit:
+    return matches;
 }
 
 void RoutingManager::OnLinkPrefixManager::Evaluate(void)

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1160,6 +1160,7 @@ private:
         void               Evaluate(void);
         const Ip6::Prefix &GetLocalPrefix(void) const { return mLocalPrefix; }
         const Ip6::Prefix &GetFavoredDiscoveredPrefix(void) const { return mFavoredDiscoveredPrefix; }
+        bool               AddressMatchesLocalPrefix(const Ip6::Address &aAddress) const;
         bool               IsInitalEvaluationDone(void) const;
         void               HandleRaPrefixTableChanged(void);
         bool               ShouldPublishUlaRoute(void) const;


### PR DESCRIPTION
This commit adds `OnLinkPrefixManager::AddressMatchesLocalPrefix()` method, which checks whether a given address matches the current local on-link prefix only when the prefix is valid (being published, advertised, or deprecated by the BR). This method is used in `RxRaTracker::IsAddressOnLink()`, ensuring that the local prefix is always explicitly checked. This makes the check more robust and independent of whether `RxRaTracker` receives and tracks self-generated RAs.