### PR TITLE
[dns-client] Initialize mSendLink structure in Client constructor

### DIFF
--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -753,6 +753,9 @@ Client::Client(Instance &aInstance)
     static_assert(kServiceQuerySrv == 3, "kServiceQuerySrv value is not correct");
     static_assert(kServiceQueryTxt == 4, "kServiceQuerySrv value is not correct");
 #endif
+#if OPENTHREAD_CONFIG_DNS_CLIENT_OVER_TCP_ENABLE
+    ClearAllBytes(mSendLink);
+#endif
 }
 
 Error Client::Start(void)


### PR DESCRIPTION
This commit fixes an issue in `Client::SendQuery` where `mSendLink.mLength` being uninitialized on hardware platform can lead to a `kErrorNoBuffs` error and `InitTcpSocket()` will never get to run due to a possible high value.
https://github.com/openthread/openthread/blob/7ec2c31816eaca343a1916f139b35ad327537b55/src/core/net/dns_client.cpp#L1136 