### PR TITLE
[wed] save wake-up parent when receiving a wake-up frame

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -640,6 +640,8 @@ openthread_core_files = [
   "thread/dua_manager.hpp",
   "thread/energy_scan_server.cpp",
   "thread/energy_scan_server.hpp",
+  "thread/enh_csl_neighbor_table.cpp",
+  "thread/enh_csl_neighbor_table.hpp",
   "thread/indirect_sender.cpp",
   "thread/indirect_sender.hpp",
   "thread/indirect_sender_frame_context.hpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -214,6 +214,7 @@ set(COMMON_SOURCES
     thread/discover_scanner.cpp
     thread/dua_manager.cpp
     thread/energy_scan_server.cpp
+    thread/enh_csl_neighbor_table.cpp
     thread/indirect_sender.cpp
     thread/key_manager.cpp
     thread/link_metrics.cpp

--- a/src/core/common/locator.hpp
+++ b/src/core/common/locator.hpp
@@ -81,7 +81,7 @@ public:
      *
      * @returns A reference to the `Type` object of the instance.
      */
-    template <typename Type> inline Type &Get(void) const; // Implemented in `locator_getters.hpp`.
+    template <typename Type> inline Type &Get(void) const;
 
 protected:
     GetProvider(void) = default;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -203,6 +203,9 @@ protected:
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
         bool mTimeSync : 1; // Whether the message is also used for time sync purpose.
 #endif
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+        bool mIsEnhCslNeighbor : 1; // Whether the message is for an enhanced CSL neighbor.
+#endif
         uint8_t mPriority : 2; // The message priority level (higher value is higher priority).
         uint8_t mOrigin : 2;   // The origin of the message.
 #if OPENTHREAD_CONFIG_MULTI_RADIO
@@ -1468,6 +1471,23 @@ public:
     void ClearRadioType(void) { GetMetadata().mIsRadioTypeSet = false; }
 
 #endif // #if OPENTHREAD_CONFIG_MULTI_RADIO
+
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+    /**
+     * Indicates whether the message is destined for an enhanced CSL neighbor.
+     *
+     * @retval TRUE   If the message is destined for an enhanced CSL neighbor.
+     * @retval FALSE  If the message is not destined for an enhanced CSL neighbor.
+     */
+    bool IsForEnhancedCslNeighbor(void) const { return GetMetadata().mIsEnhCslNeighbor; }
+
+    /**
+     * Sets whether the message is destined for an enhanced CSL neighbor.
+     *
+     * @param[in]  aIsEnhCslNeighbor  TRUE if the message is destined for an enhanced CSL neighbor, FALSE otherwise.
+     */
+    void SetForEnhancedCslNeighbor(bool aIsEnhCslNeighbor) { GetMetadata().mIsEnhCslNeighbor = aIsEnhCslNeighbor; }
+#endif
 
 protected:
     class ConstIterator : public ItemPtrIterator<const Message, ConstIterator>

--- a/src/core/config/mac.h
+++ b/src/core/config/mac.h
@@ -559,6 +559,25 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MAC_CSL_WAKEUP_INTERVAL
+ *
+ * Periodicity of wake-up frame transmission by WC (in units of 10 symbols).
+ */
+#ifndef OPENTHREAD_CONFIG_MAC_CSL_WAKEUP_INTERVAL
+#define OPENTHREAD_CONFIG_MAC_CSL_WAKEUP_INTERVAL 47
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_MAC_ENH_CSL_TX_ATTEMPTS
+ *
+ * Maximum number of TX attempts for the enhanced CSL communication before considering the peer de-synchronized.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAC_ENH_CSL_TX_ATTEMPTS
+#define OPENTHREAD_CONFIG_MAC_ENH_CSL_TX_ATTEMPTS 8
+#endif
+
+/**
  * @}
  */
 

--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -255,7 +255,7 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, 
         OT_ASSERT(false);
     }
 
-    Get<IndirectSender>().HandleSentFrameToChild(aFrame, mFrameContext, aError, aChild);
+    Get<IndirectSender>().HandleSentFrameToCslNeighbor(aFrame, mFrameContext, aError, aChild);
 
 exit:
     return;

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1655,7 +1655,8 @@ Error Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Neig
         {
             uint32_t sequence;
 
-            // TODO: Avoid generating a new key if a wake-up frame was recently received already
+            // Avoid generating a new key if a wake-up frame was recently received already
+            VerifyOrExit(!Get<Mle::Mle>().IsWakeupParentPresent(), error = kErrorInvalidState);
 
             IgnoreError(aFrame.GetKeyId(keyid));
             sequence = BigEndian::ReadUint32(aFrame.GetKeySource());
@@ -2472,21 +2473,14 @@ bool Mac::IsCslSupported(void) const
 
 void Mac::ProcessCsl(const RxFrame &aFrame, const Address &aSrcAddr)
 {
-    CslNeighbor *neighbor = nullptr;
+    CslNeighbor *neighbor = Get<Mle::Mle>().FindCslNeighbor(aSrcAddr);
     const CslIe *csl;
 
+    VerifyOrExit(neighbor != nullptr);
     VerifyOrExit(aFrame.IsVersion2015() && aFrame.GetSecurityEnabled());
 
     csl = aFrame.GetCslIe();
     VerifyOrExit(csl != nullptr);
-
-#if OPENTHREAD_FTD
-    neighbor = Get<ChildTable>().FindChild(aSrcAddr, Child::kInStateAnyExceptInvalid);
-#else
-    OT_UNUSED_VARIABLE(aSrcAddr);
-#endif
-
-    VerifyOrExit(neighbor != nullptr);
 
     VerifyOrExit(csl->GetPeriod() >= kMinCslIePeriod);
 
@@ -2620,7 +2614,8 @@ void Mac::UpdateWakeupListening(void)
 
 Error Mac::HandleWakeupFrame(const RxFrame &aFrame)
 {
-    Error               error = kErrorNone;
+    Error               error             = kErrorNone;
+    constexpr uint32_t  kWakeupIntervalUs = kDefaultWakeupInterval * kUsPerTenSymbols;
     const ConnectionIe *connectionIe;
     uint32_t            rvTimeUs;
     uint64_t            rvTimestampUs;
@@ -2628,6 +2623,8 @@ Error Mac::HandleWakeupFrame(const RxFrame &aFrame)
     uint64_t            radioNowUs;
     uint8_t             retryInterval;
     uint8_t             retryCount;
+    Address             parentAddress;
+    CslNeighbor        *parent;
 
     VerifyOrExit(mWakeupListenEnabled && aFrame.IsWakeupFrame());
     connectionIe  = aFrame.GetConnectionIe();
@@ -2662,8 +2659,23 @@ Error Mac::HandleWakeupFrame(const RxFrame &aFrame)
     // Stop receiving more wake up frames
     IgnoreError(SetWakeupListenEnabled(false));
 
-    // TODO: start MLE attach process with the WC
-    OT_UNUSED_VARIABLE(attachDelayMs);
+    IgnoreError(aFrame.GetSrcAddr(parentAddress));
+    Get<Mle::Mle>().AddWakeupParent(parentAddress.GetExtended(), TimerMilli::GetNow() + attachDelayMs,
+                                    kWakeupIntervalUs * retryInterval * retryCount / 1000);
+
+    parent = Get<Mle::Mle>().GetWakeupParent();
+    OT_ASSERT(parent != nullptr);
+    parent->SetCslPeriod(kDefaultWakeupInterval * retryInterval);
+    parent->SetCslPhase(0);
+    parent->SetCslSynchronized(true);
+    parent->SetCslLastHeard(TimerMilli::GetNow());
+    // Rendezvous time is the time when the WC begins listening for the connection request from the awakened WED.
+    // Since EnhCslSender schedules a frame's PHR at `LastRxTimestamp + Phase + n*Period`, increase the timestamp
+    // by SHR length and the CSL uncertainty to make sure SHR begins while the WC is already listening.
+    parent->SetLastRxTimestamp(rvTimestampUs + kRadioHeaderShrDuration + Get<Radio>().GetCslUncertainty() * 10);
+    parent->SetEnhCslMaxTxAttempts(retryCount);
+
+    Get<Mle::Mle>().AttachToWakeupParent();
 
 exit:
     return error;

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -97,6 +97,7 @@ constexpr uint16_t kMinCslIePeriod = OPENTHREAD_CONFIG_MAC_CSL_MIN_PERIOD;
 
 constexpr uint32_t kDefaultWedListenInterval = OPENTHREAD_CONFIG_WED_LISTEN_INTERVAL;
 constexpr uint32_t kDefaultWedListenDuration = OPENTHREAD_CONFIG_WED_LISTEN_DURATION;
+constexpr uint16_t kDefaultWakeupInterval    = OPENTHREAD_CONFIG_MAC_CSL_WAKEUP_INTERVAL;
 
 /**
  * Defines the function pointer called on receiving an IEEE 802.15.4 Beacon during an Active Scan.

--- a/src/core/thread/csl_tx_scheduler.hpp
+++ b/src/core/thread/csl_tx_scheduler.hpp
@@ -64,6 +64,9 @@ class CslTxScheduler : public InstanceLocator, private NonCopyable
 
 public:
     static constexpr uint8_t kMaxCslTriggeredTxAttempts = OPENTHREAD_CONFIG_MAC_MAX_TX_ATTEMPTS_INDIRECT_POLLS;
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+    static constexpr uint8_t kMaxEnhCslTriggeredTxAttempts = OPENTHREAD_CONFIG_MAC_ENH_CSL_TX_ATTEMPTS;
+#endif
 
     /**
      * Defines all the neighbor info required for scheduling CSL transmissions.
@@ -98,13 +101,27 @@ public:
         uint64_t GetLastRxTimestamp(void) const { return mLastRxTimestamp; }
         void     SetLastRxTimestamp(uint64_t aLastRxTimestamp) { mLastRxTimestamp = aLastRxTimestamp; }
 
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+        uint8_t GetEnhCslMaxTxAttempts(void) const
+        {
+            return mCslMaxTxAttempts != 0 ? mCslMaxTxAttempts : kMaxEnhCslTriggeredTxAttempts;
+        }
+        void SetEnhCslMaxTxAttempts(uint8_t txAttempts) { mCslMaxTxAttempts = txAttempts; }
+        void ResetEnhCslMaxTxAttempts() { mCslMaxTxAttempts = 0; }
+#endif
+
     private:
-        uint8_t  mCslTxAttempts : 7;   ///< Number of CSL triggered tx attempts.
-        bool     mCslSynchronized : 1; ///< Indicates whether or not the child is CSL synchronized.
-        uint8_t  mCslChannel;          ///< The channel the device will listen on.
-        uint32_t mCslTimeout;          ///< The sync timeout, in seconds.
-        uint16_t mCslPeriod; ///< CSL sampled listening period between consecutive channel samples in units of 10
-                             ///< symbols (160 microseconds).
+        uint8_t mCslTxAttempts : 7;   ///< Number of CSL triggered tx attempts.
+        bool    mCslSynchronized : 1; ///< Indicates whether or not the child is CSL synchronized.
+        uint8_t mCslChannel;          ///< The channel the device will listen on.
+
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+        uint8_t mCslMaxTxAttempts; ///< Override for the maximum number of enhanced CSL triggered tx attempts.
+#endif
+
+        uint32_t mCslTimeout; ///< The sync timeout, in seconds.
+        uint16_t mCslPeriod;  ///< CSL sampled listening period between consecutive channel samples in units of 10
+                              ///< symbols (160 microseconds).
 
         /**
          * The time in units of 10 symbols from the first symbol of the frame

--- a/src/core/thread/enh_csl_neighbor_table.cpp
+++ b/src/core/thread/enh_csl_neighbor_table.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018, The OpenThread Authors.
+ *  Copyright (c) 2024, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -28,67 +28,29 @@
 
 /**
  * @file
- *   This file implements MTD-specific mesh forwarding of IPv6/6LoWPAN messages.
+ *   This file includes definitions for enhanced CSL neighbor table.
  */
 
-#include "mesh_forwarder.hpp"
+#include "enh_csl_neighbor_table.hpp"
 
-#if OPENTHREAD_MTD
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
 
 #include "instance/instance.hpp"
 
 namespace ot {
 
-void MeshForwarder::SendMessage(OwnedPtr<Message> aMessagePtr)
+CslNeighborTable::CslNeighborTable(Instance &aInstance)
 {
-    Message &message = *aMessagePtr.Release();
-
-#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-    CslNeighbor *cslNeighbor = Get<Mle::Mle>().GetWakeupParent();
-
-    if ((cslNeighbor != nullptr) && cslNeighbor->IsCslSynchronized())
+    for (CslNeighbor &cslNeighbor : mCslNeighbors)
     {
-        mIndirectSender.AddMessageForEnhCslNeighbor(message, *cslNeighbor);
+        cslNeighbor.Init(aInstance);
     }
-    else
-#endif
-    {
-        message.SetDirectTransmission();
-        message.SetOffset(0);
-        message.SetDatagramTag(0);
-        message.SetTimestampToNow();
-    }
-
-    mSendQueue.Enqueue(message);
-    mScheduleTransmissionTask.Post();
-
-#if (OPENTHREAD_CONFIG_MAX_FRAMES_IN_DIRECT_TX_QUEUE > 0)
-    ApplyDirectTxQueueLimit(message);
-#endif
 }
 
-Error MeshForwarder::EvictMessage(Message::Priority aPriority)
-{
-    Error    error = kErrorNotFound;
-    Message *message;
+CslNeighbor *CslNeighborTable::GetNewCslNeighbor(void) { return mCslNeighbors; }
 
-#if OPENTHREAD_CONFIG_DELAY_AWARE_QUEUE_MANAGEMENT_ENABLE
-    error = RemoveAgedMessages();
-    VerifyOrExit(error == kErrorNotFound);
-#endif
-
-    VerifyOrExit((message = mSendQueue.GetTail()) != nullptr);
-
-    if (message->GetPriority() < static_cast<uint8_t>(aPriority))
-    {
-        FinalizeAndRemoveMessage(*message, kErrorNoBufs, kMessageEvict);
-        ExitNow(error = kErrorNone);
-    }
-
-exit:
-    return error;
-}
+CslNeighbor *CslNeighborTable::GetFirstCslNeighbor(void) { return mCslNeighbors; }
 
 } // namespace ot
 
-#endif // OPENTHREAD_MTD
+#endif // OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE

--- a/src/core/thread/enh_csl_neighbor_table.hpp
+++ b/src/core/thread/enh_csl_neighbor_table.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018, The OpenThread Authors.
+ *  Copyright (c) 2024, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -28,67 +28,62 @@
 
 /**
  * @file
- *   This file implements MTD-specific mesh forwarding of IPv6/6LoWPAN messages.
+ *   This file includes definitions for the CSL neighbors table.
  */
 
-#include "mesh_forwarder.hpp"
+#ifndef ENH_CSL_NEIGHBOR_TABLE_HPP_
+#define ENH_CSL_NEIGHBOR_TABLE_HPP_
 
-#if OPENTHREAD_MTD
+#include "openthread-core-config.h"
 
-#include "instance/instance.hpp"
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+
+#include "common/const_cast.hpp"
+#include "common/iterator_utils.hpp"
+#include "common/locator.hpp"
+#include "common/non_copyable.hpp"
+#include "thread/neighbor.hpp"
 
 namespace ot {
 
-void MeshForwarder::SendMessage(OwnedPtr<Message> aMessagePtr)
+/**
+ * Represents the CSL neighbors table.
+ */
+class CslNeighborTable : private NonCopyable
 {
-    Message &message = *aMessagePtr.Release();
+public:
+    /**
+     * Initializes a `CslNeighborTable` instance.
+     *
+     * @param[in]  aInstance     A reference to the OpenThread instance.
+     */
+    explicit CslNeighborTable(Instance &aInstance);
 
-#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-    CslNeighbor *cslNeighbor = Get<Mle::Mle>().GetWakeupParent();
+    /**
+     * Gets a new/unused `CslNeighbor` entry from the enhanced CSL neighbor table.
+     *
+     * @note The returned neighbor entry will be cleared (`memset` to zero).
+     *
+     * @returns A pointer to a new `CslNeighbor` entry, or `nullptr` if all `CslNeighbor` entries are in use.
+     */
+    CslNeighbor *GetNewCslNeighbor(void);
 
-    if ((cslNeighbor != nullptr) && cslNeighbor->IsCslSynchronized())
-    {
-        mIndirectSender.AddMessageForEnhCslNeighbor(message, *cslNeighbor);
-    }
-    else
-#endif
-    {
-        message.SetDirectTransmission();
-        message.SetOffset(0);
-        message.SetDatagramTag(0);
-        message.SetTimestampToNow();
-    }
+    /**
+     * Gets the first `CslNeighbor` entry in the enhanced CSL neighbor table.
+     *
+     * @returns A pointer to the first `CslNeighbor` entry, or `nullptr` if the table is empty.
+     */
+    CslNeighbor *GetFirstCslNeighbor(void);
 
-    mSendQueue.Enqueue(message);
-    mScheduleTransmissionTask.Post();
+private:
+    // static constexpr uint16_t kMaxCslNeighbors = OPENTHREAD_CONFIG_MLE_MAX_ENH_CSL_NEIGHBORS;
+    static constexpr uint16_t kMaxCslNeighbors = 1;
 
-#if (OPENTHREAD_CONFIG_MAX_FRAMES_IN_DIRECT_TX_QUEUE > 0)
-    ApplyDirectTxQueueLimit(message);
-#endif
-}
-
-Error MeshForwarder::EvictMessage(Message::Priority aPriority)
-{
-    Error    error = kErrorNotFound;
-    Message *message;
-
-#if OPENTHREAD_CONFIG_DELAY_AWARE_QUEUE_MANAGEMENT_ENABLE
-    error = RemoveAgedMessages();
-    VerifyOrExit(error == kErrorNotFound);
-#endif
-
-    VerifyOrExit((message = mSendQueue.GetTail()) != nullptr);
-
-    if (message->GetPriority() < static_cast<uint8_t>(aPriority))
-    {
-        FinalizeAndRemoveMessage(*message, kErrorNoBufs, kMessageEvict);
-        ExitNow(error = kErrorNone);
-    }
-
-exit:
-    return error;
-}
+    CslNeighbor mCslNeighbors[kMaxCslNeighbors];
+};
 
 } // namespace ot
 
-#endif // OPENTHREAD_MTD
+#endif // OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+
+#endif // ENH_CSL_NEIGHBOR_TABLE_HPP_

--- a/src/core/thread/indirect_sender.hpp
+++ b/src/core/thread/indirect_sender.hpp
@@ -257,31 +257,49 @@ public:
 
 #endif // OPENTHREAD_FTD
 
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+    /**
+     * Adds a message for indirect transmission to a WED neighbor.
+     *
+     * @param[in] aMessage  The message to add.
+     * @param[in] aNeighbor    The neighbor for indirect transmission.
+     */
+    void AddMessageForEnhCslNeighbor(Message &aMessage, CslNeighbor &aCslNeighbor);
+#endif
+
 private:
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
     // Callbacks from `CslTxScheduler`
     Error PrepareFrameForCslNeighbor(Mac::TxFrame &aFrame, FrameContext &aContext, CslNeighbor &aCslNeighbor);
-    void  HandleSentFrameToCslNeighbor(const Mac::TxFrame &aFrame,
-                                       const FrameContext &aContext,
-                                       Error               aError,
-                                       CslNeighbor        &aCslNeighbor);
 #endif
 
+    uint16_t PrepareDataFrame(Mac::TxFrame &aFrame, CslNeighbor &aNeighbor, Message &aMessage);
+    void     HandleSentFrameToCslNeighbor(const Mac::TxFrame &aFrame,
+                                          const FrameContext &aContext,
+                                          Error               aError,
+                                          CslNeighbor        &aNeighbor);
+    void     UpdateIndirectMessage(CslNeighbor &aNeighbor);
+
 #if OPENTHREAD_FTD
+    bool IsChild(const Neighbor &aNeighbor) const;
+
     // Callbacks from `DataPollHandler`
     Error PrepareFrameForChild(Mac::TxFrame &aFrame, FrameContext &aContext, Child &aChild);
-    void  HandleSentFrameToChild(const Mac::TxFrame &aFrame, const FrameContext &aContext, Error aError, Child &aChild);
     void  HandleFrameChangeDone(Child &aChild);
 
-    void     UpdateIndirectMessage(Child &aChild);
     void     RequestMessageUpdate(Child &aChild);
-    uint16_t PrepareDataFrame(Mac::TxFrame &aFrame, Child &aChild, Message &aMessage);
+    uint16_t PrepareDataFrameForSleepyChild(Mac::TxFrame &aFrame, Child &aChild, Message &aMessage);
     void     PrepareEmptyFrame(Mac::TxFrame &aFrame, Child &aChild, bool aAckRequest);
     void     ClearMessagesForRemovedChildren(void);
 
     static bool AcceptAnyMessage(const Message &aMessage);
     static bool AcceptSupervisionMessage(const Message &aMessage);
 #endif // OPENTHREAD_FTD
+
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+    Error    PrepareFrameForEnhCslNeighbor(Mac::TxFrame &aFrame, FrameContext &aContext, CslNeighbor &aNeighbor);
+    Message *FindQueuedMessageForWedNeighbor(CslNeighbor &aNeighbor);
+#endif
 
     bool mEnabled;
 #if OPENTHREAD_FTD

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -51,6 +51,7 @@
 #include "meshcop/meshcop.hpp"
 #include "net/udp6.hpp"
 #include "thread/child.hpp"
+#include "thread/enh_csl_neighbor_table.hpp"
 #include "thread/link_metrics.hpp"
 #include "thread/link_metrics_tlvs.hpp"
 #include "thread/mle_tlvs.hpp"
@@ -752,6 +753,49 @@ public:
                  WakeupCallback         aCallback,
                  void                  *aCallbackContext);
 #endif // OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
+
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+    /**
+     * Returns whether the Thread interface is currently communicating to a Wake-up Parent.
+     *
+     * @retval TRUE   If the Thread interface is communicating to a Wake-up Parent.
+     * @retval FALSE  If the Thread interface is not communicating to a Wake-up Parent.
+     */
+    bool IsWakeupParentPresent(void) const { return mWakeupParentAttachWindow > 0; }
+
+    /**
+     * Adds a Wake-up Parent to the list of potential parents.
+     *
+     * @param[in] aParent         The extended address of the Wake-up Parent.
+     * @param[in] aAttachTime     The time when the Thread interface attached to the Wake-up Parent.
+     * @param[in] aAttachWindowMs The time window in milliseconds during which the Thread interface can attach to the
+     * Wake-up Parent.
+     */
+    void AddWakeupParent(const Mac::ExtAddress &aParent, TimeMilli aAttachTime, uint32_t aAttachWindowMs);
+
+    /**
+     * Returns the Wake-up Parent that the Thread interface is currently communicating to.
+     *
+     * @returns The Wake-up Parent that the Thread interface is currently communicating to.
+     */
+    CslNeighbor *GetWakeupParent(void);
+
+    /**
+     * Starts the process of attaching to a Wake-up Parent, if previously configured with `AddWakeupParent`.
+     */
+    void AttachToWakeupParent(void);
+#endif
+
+#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+    /**
+     * Returns a CSL Neighbor by its address.
+     *
+     * @param[in] aAddress The address of the CSL Neighbor.
+     *
+     * @returns A pointer to the CSL Neighbor, or NULL if not found.
+     */
+    CslNeighbor *FindCslNeighbor(const Mac::Address &aAddress);
+#endif
 
 private:
     //------------------------------------------------------------------------------------------------------------------
@@ -1519,6 +1563,11 @@ private:
     WedAttachState           mWedAttachState;
     WedAttachTimer           mWedAttachTimer;
     Callback<WakeupCallback> mWakeupCallback;
+#endif
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+    TimeMilli        mWakeupParentAttachTime;
+    uint32_t         mWakeupParentAttachWindow;
+    CslNeighborTable mCslNeighborTable;
 #endif
 };
 

--- a/src/core/thread/neighbor.hpp
+++ b/src/core/thread/neighbor.hpp
@@ -783,6 +783,9 @@ class CslNeighbor : public Neighbor
                     public CslTxScheduler::NeighborInfo
 #endif
 {
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+    friend class CslNeighborTable;
+#endif
 };
 
 } // namespace ot


### PR DESCRIPTION
[wed] save wake-up parent when receiving a wake-up frame

This commit introduces a basic `CslNeighborTable` which currently
assumes a single enhanced CSL capable neighbor: the Wake-up Parent.

When a valid wake-up frame is received the sender's information is
used to add such `CslNeighbor` to the table. `IndirectSender` and
`CslTxScheduler` modules are refactored to be able to enqueue
messages for enhanced CSL neighbors.

Actual link establishment actions are to be added in later commits.