### PR TITLE
[mle] update `DelayedSender` to keep the tx schedule

### DIFF
--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -616,22 +616,19 @@ private:
                                         const Ip6::MessageInfo &aMessageInfo);
     void     SendAddressRelease(void);
     void     SendAdvertisement(void);
-    Error    SendLinkAccept(const RxInfo      &aRxInfo,
-                            Neighbor          *aNeighbor,
-                            const TlvList     &aRequestedTlvList,
-                            const RxChallenge &aChallenge);
-    void     SendParentResponse(Child &aChild, const RxChallenge &aChallenge, bool aRoutersOnlyRequest);
+    Error    SendLinkAccept(const LinkAcceptInfo &aInfo);
+    void     SendParentResponse(const ParentResponseInfo &aInfo);
     Error    SendChildIdResponse(Child &aChild);
     Error    SendChildUpdateRequest(Child &aChild);
     void     SendChildUpdateResponse(Child                  *aChild,
                                      const Ip6::MessageInfo &aMessageInfo,
                                      const TlvList          &aTlvList,
                                      const RxChallenge      &aChallenge);
+    void     SendMulticastDataResponse(void);
     void     SendDataResponse(const Ip6::Address &aDestination,
                               const TlvList      &aTlvList,
-                              uint16_t            aDelay,
                               const Message      *aRequestMessage = nullptr);
-    Error    SendDiscoveryResponse(const Ip6::Address &aDestination, const Message &aDiscoverRequestMessage);
+    Error    SendDiscoveryResponse(const Ip6::Address &aDestination, const DiscoveryResponseInfo &aInfo);
     void     SetStateRouter(uint16_t aRloc16);
     void     SetStateLeader(uint16_t aRloc16, LeaderStartMode aStartMode);
     void     SetStateRouterOrLeader(DeviceRole aRole, uint16_t aRloc16, LeaderStartMode aStartMode);

--- a/tests/unit/test_dns_client.cpp
+++ b/tests/unit/test_dns_client.cpp
@@ -225,6 +225,8 @@ void InitTest(void)
 
 void FinalizeTest(void)
 {
+    AdvanceTime(30 * 1000);
+
     SuccessOrQuit(otIp6SetEnabled(sInstance, false));
     SuccessOrQuit(otThreadSetEnabled(sInstance, false));
     // Make sure there is no message/buffer leak


### PR DESCRIPTION
This commit updates how `Mle::DelayedSender` sends MLE messages after a delay.

Previously, a delayed message was fully prepared and placed in a queue, waiting for its delay duration to expire. In the new model, a delayed message is prepared when the requested delay time expires and the message transmission time is reached. The message is constructed right before transmission. This ensures that the delayed message includes the most up-to-date information and simplifies the methods that prepare and send different types of MLE messages.

`DelayedSender` now keeps track of the message type and the specific information required to construct the message later. For example, for a delayed Parent Response to a Parent Request, the extended address and the `RxChallenge` of the child are saved.

This new model makes it easier to implement the desired behavior when similar messages are already scheduled to the same destination. For example:
-   For Data Request, if one is already scheduled, a new request can be skipped, as the earlier Data Request will be valid.
-   For Parent Response, Link Accept, and Data Response, a new schedule request replaces an earlier one.
-   For Discovery Response, multiple schedules are allowed.