### PR TITLE
[examples] remove unneeded implementation `otTaskletsSignalPending` in `main.c`

### DIFF
--- a/examples/apps/cli/main.c
+++ b/examples/apps/cli/main.c
@@ -60,8 +60,6 @@ OT_TOOL_WEAK void *otPlatCAlloc(size_t aNum, size_t aSize) { return calloc(aNum,
 OT_TOOL_WEAK void otPlatFree(void *aPtr) { free(aPtr); }
 #endif
 
-void otTaskletsSignalPending(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
-
 #if OPENTHREAD_POSIX && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 static otError ProcessExit(void *aContext, uint8_t aArgsLength, char *aArgs[])
 {

--- a/examples/apps/ncp/main.c
+++ b/examples/apps/ncp/main.c
@@ -66,8 +66,6 @@ OT_TOOL_WEAK void *otPlatCAlloc(size_t aNum, size_t aSize) { return calloc(aNum,
 OT_TOOL_WEAK void otPlatFree(void *aPtr) { free(aPtr); }
 #endif
 
-void otTaskletsSignalPending(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
-
 int main(int argc, char *argv[])
 {
     otInstance *instance;


### PR DESCRIPTION
The implementation of `otTaskletsSignalPending` in `examples/apps/<app>/main.c` is exactly the same as the weak implementation in `tasklet_api.cpp`. No need to repeat it and blocking other implementations of that function