### PR TITLE
[ncp] fix implementation of NCP get dataset tlvs

### DIFF
--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -1372,26 +1372,24 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_PENDING_DATASE
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_ACTIVE_DATASET_TLVS>(void)
 {
-    otError                  error = OT_ERROR_NONE;
     otOperationalDatasetTlvs dataset;
 
-    SuccessOrExit(error = otDatasetGetActiveTlvs(mInstance, &dataset));
-    SuccessOrExit(error = mEncoder.WriteData(dataset.mTlvs, dataset.mLength));
-
-exit:
-    return error;
+    if (otDatasetGetActiveTlvs(mInstance, &dataset) != OT_ERROR_NONE)
+    {
+        dataset.mLength = 0;
+    }
+    return mEncoder.WriteData(dataset.mTlvs, dataset.mLength);
 }
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_PENDING_DATASET_TLVS>(void)
 {
-    otError                  error = OT_ERROR_NONE;
     otOperationalDatasetTlvs dataset;
 
-    SuccessOrExit(error = otDatasetGetPendingTlvs(mInstance, &dataset));
-    SuccessOrExit(error = mEncoder.WriteData(dataset.mTlvs, dataset.mLength));
-
-exit:
-    return error;
+    if (otDatasetGetPendingTlvs(mInstance, &dataset) != OT_ERROR_NONE)
+    {
+        dataset.mLength = 0;
+    }
+    return mEncoder.WriteData(dataset.mTlvs, dataset.mLength);
 }
 
 otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,


### PR DESCRIPTION
This PR fixes the bug in NCP Get `SPINEL_PROP_THREAD_ACTIVE_DATASET_TLVS` and `SPINEL_PROP_THREAD_PENDING_DATASET_TLVS`.

There are cases where dataset doesn't exist and `otDatasetGetActiveTlvs` returns `OT_ERROR_NOT_FOUND`. This will cause that the NCP doesn't send any responses to the host. This PR lets the implementation ignore the NOT_FOUND error and will encode empty data in this case.