### PR TITLE
[csl] support multiple csl neighbors

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (457)
+#define OPENTHREAD_API_VERSION (458)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -1106,6 +1106,8 @@ otError otPlatRadioGetCoexMetrics(otInstance *aInstance, otRadioCoexMetrics *aCo
  * @param[in]  aExtAddr      The extended source address of CSL receiver's peer.
  *
  * @note Platforms should use CSL peer addresses to include CSL IE when generating enhanced acks.
+ * @note Deprecated by `otPlatRadioEnableMultiCsl`. Platforms may still implement this function for backwards
+ * compatibility. In that case they may expect that if this function is used no multi csl functions will be used.
  *
  * @retval  OT_ERROR_NOT_IMPLEMENTED Radio driver doesn't support CSL.
  * @retval  OT_ERROR_FAILED          Other platform specific errors.
@@ -1117,9 +1119,77 @@ otError otPlatRadioEnableCsl(otInstance         *aInstance,
                              const otExtAddress *aExtAddr);
 
 /**
+ * Returns the maximum number of csl neighbors supported.
+ *
+ * If the multi csl api is not implemented returns 0.
+ *
+ * @param[in]  aInstance   The OpenThread instance structure.
+ *
+ * @retval  The number of supported csl neighbors.
+ */
+uint32_t otPlatRadioGetMaxMultiCslNeighbors(otInstance *aInstance);
+
+/**
+ * Enable or disable CSL receiver.
+ *
+ * Any call to this function automatically clears the csl neighbor table.
+ *
+ * @param[in]  aInstance   The OpenThread instance structure.
+ * @param[in]  aCslPeriod  CSL period, 0 for disabling CSL. In units of 10 symbols.
+ *
+ * @retval  OT_ERROR_NOT_IMPLEMENTED Radio driver doesn't support multi CSL.
+ * @retval  OT_ERROR_FAILED          Other platform specific errors.
+ * @retval  OT_ERROR_NONE            Successfully enabled or disabled CSL.
+ */
+otError otPlatRadioEnableMultiCsl(otInstance *aInstance, uint32_t aCslPeriod);
+
+/**
+ * Adds a entry to the csl neighbor table.
+ *
+ * @param[in]  aInstance      The OpenThread instance structure.
+ * @param[in]  aShortAddress  The short address of the csl neighbor. May be invalid.
+ * @param[in]  aExtAddress    The extended address of the csl neighbor. Must be valid.
+ *
+ * @note To update a entry it must first be cleared. Platforms may consider adding a
+ *       address that already exists in the table as an error.
+ *
+ * @retval  OT_ERROR_NOT_IMPLEMENTED Radio driver doesn't support multi CSL.
+ * @retval  OT_ERROR_NO_BUFS         No available entry in the table.
+ * @retval  OT_ERROR_NONE            Successfully added entry to the table.
+ */
+otError otPlatRadioAddCslEntry(otInstance *aInstance, otShortAddress aShortAddress, const otExtAddress *aExtAddress);
+
+/**
+ * Removes a entry from the csl neighbor table.
+ *
+ * @param[in]  aInstance      The OpenThread instance structure.
+ * @param[in]  aShortAddress  The short address of the csl neighbor.
+ * @param[in]  aExtAddress    The extended address of the csl neighbor.
+ *
+ * @note Both the short and extended address must match the previous call to otPlatRadioAddCslEntry.
+ *       For example it is invalid to only provide the ext address when the entry also contains a short address.
+ *
+ * @retval  OT_ERROR_NOT_IMPLEMENTED Radio driver doesn't support multi CSL.
+ * @retval  OT_ERROR_NO_ADDRESS      The short or extended address is not in the table.
+ * @retval  OT_ERROR_NONE            Successfully removed the addresses from the table.
+ */
+otError otPlatRadioClearCslEntry(otInstance *aInstance, otShortAddress aShortAddress, const otExtAddress *aExtAddress);
+
+/**
+ * Clears the csl neighbor table.
+ *
+ * @param[in]  aInstance  The OpenThread instance structure.
+ *
+ * @retval  OT_ERROR_NOT_IMPLEMENTED Radio driver doesn't support multi CSL.
+ * @retval  OT_ERROR_NONE            Successfully cleared the csl neighbor table.
+ */
+otError otPlatRadioClearCslEntries(otInstance *aInstance);
+
+/**
  * Reset CSL receiver in the platform.
  *
  * @note Defaults to `otPlatRadioEnableCsl(aInstance,0, Mac::kShortAddrInvalid, nullptr);`
+ *       if multi csl is not supported, otherwise `otPlatRadioEnableMultiCsl(aInstance, 0);`.
  *
  * @param[in]  aInstance     The OpenThread instance structure.
  *

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2330,8 +2330,7 @@ void Mac::UpdateCsl(void)
     uint16_t period  = IsCslEnabled() ? GetCslPeriod() : 0;
     uint8_t  channel = GetCslChannel() ? GetCslChannel() : mRadioChannel;
 
-    if (mLinks.UpdateCsl(period, channel, Get<Mle::Mle>().GetParent().GetRloc16(),
-                         &Get<Mle::Mle>().GetParent().GetExtAddress()))
+    if (mLinks.UpdateCsl(period, channel))
     {
         if (Get<Mle::Mle>().IsChild())
         {
@@ -2384,6 +2383,19 @@ bool Mac::IsCslCapable(void) const { return (GetCslPeriod() > 0) && IsCslSupport
 bool Mac::IsCslSupported(void) const
 {
     return Get<Mle::MleRouter>().IsChild() && Get<Mle::Mle>().GetParent().IsEnhancedKeepAliveSupported();
+}
+
+void Mac::UpdateCslParent(void)
+{
+    if (Get<Mle::Mle>().IsChild())
+    {
+        ConfigureCslNeighbor(kCslParentIndex, Get<Mle::Mle>().GetParent().GetRloc16(),
+                             Get<Mle::Mle>().GetParent().GetExtAddress(), Get<Mle::Mle>().GetParent().GetCslAccuracy());
+    }
+    else
+    {
+        ClearCslNeighbor(kCslParentIndex);
+    }
 }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -616,22 +616,19 @@ public:
      */
     bool IsCslSupported(void) const;
 
-    /**
-     * Returns parent CSL accuracy (clock accuracy and uncertainty).
-     *
-     * @returns The parent CSL accuracy.
-     */
-    const CslAccuracy &GetCslParentAccuracy(void) const { return mLinks.GetSubMac().GetCslParentAccuracy(); }
+    uint8_t GetMaxCslNeighbors(void) const { return mLinks.GetSubMac().GetMaxCslNeighbors(); }
 
-    /**
-     * Sets parent CSL accuracy.
-     *
-     * @param[in] aCslAccuracy  The parent CSL accuracy.
-     */
-    void SetCslParentAccuracy(const CslAccuracy &aCslAccuracy)
+    void ConfigureCslNeighbor(uint16_t       aIndex,
+                              otShortAddress aShortAddr,
+                              otExtAddress  &aExtAddr,
+                              CslAccuracy    aCslAccuracy)
     {
-        mLinks.GetSubMac().SetCslParentAccuracy(aCslAccuracy);
+        mLinks.GetSubMac().ConfigureCslNeighbor(aIndex, aShortAddr, aExtAddr, aCslAccuracy);
     }
+
+    void ClearCslNeighbor(uint16_t aIndex) { mLinks.GetSubMac().ClearCslNeighbor(aIndex); }
+
+    void UpdateCslParent(void);
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE && OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
@@ -747,6 +744,10 @@ public:
 
 private:
     static constexpr uint16_t kMaxCcaSampleCount = OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW;
+
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+    static constexpr uint16_t kCslParentIndex = 0;
+#endif
 
     enum Operation : uint8_t
     {

--- a/src/core/mac/mac_links.hpp
+++ b/src/core/mac/mac_links.hpp
@@ -442,16 +442,14 @@ public:
      * @retval  TRUE if CSL Period or CSL Channel changed.
      * @retval  FALSE if CSL Period and CSL Channel did not change.
      */
-    bool UpdateCsl(uint16_t aPeriod, uint8_t aChannel, otShortAddress aShortAddr, const otExtAddress *aExtAddr)
+    bool UpdateCsl(uint16_t aPeriod, uint8_t aChannel)
     {
         bool retval = false;
 
         OT_UNUSED_VARIABLE(aPeriod);
         OT_UNUSED_VARIABLE(aChannel);
-        OT_UNUSED_VARIABLE(aShortAddr);
-        OT_UNUSED_VARIABLE(aExtAddr);
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-        retval = mSubMac.UpdateCsl(aPeriod, aChannel, aShortAddr, aExtAddr);
+        retval = mSubMac.UpdateCsl(aPeriod, aChannel);
 #endif
         return retval;
     }

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -59,10 +59,6 @@ SubMac::SubMac(Instance &aInstance)
     , mWedTimer(aInstance, SubMac::HandleWedTimer)
 #endif
 {
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    mCslParentAccuracy.Init();
-#endif
-
     Init();
 }
 

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -519,6 +519,66 @@ public:
     Error EnableCsl(uint32_t aCslPeriod, otShortAddress aShortAddr, const otExtAddress *aExtAddr);
 
     /**
+     * Returns the maximum number of csl neighbors supported.
+     *
+     * If the multi csl api is not implemented returns 0.
+     *
+     * @retval  The number of supported csl neighbors.
+     */
+    uint32_t GetMaxMultiCslNeighbors(void);
+
+    /**
+     * Enable or disable CSL receiver.
+     *
+     * Any call to this function automatically clears the csl neighbor table.
+     *
+     * @param[in]  aCslPeriod  CSL period, 0 for disabling CSL. In units of 10 symbols.
+     *
+     * @retval  kErrorNotImplemented  Radio driver doesn't support multi CSL.
+     * @retval  kErrorFailed          Other platform specific errors.
+     * @retval  kErrorNone            Successfully enabled or disabled CSL.
+     */
+    Error EnableMultiCsl(uint32_t aCslPeriod);
+
+    /**
+     * Adds a entry to the csl neighbor table.
+     *
+     * @param[in]  aShortAddress  The short address of the csl neighbor. May be invalid.
+     * @param[in]  aExtAddress    The extended address of the csl neighbor. Must be valid.
+     *
+     * @note To update a entry it must first be cleared. Platforms may consider adding a
+     *       address that already exists in the table as an error.
+     *
+     * @retval  kErrorNotImplemented  Radio driver doesn't support multi CSL.
+     * @retval  kErrorNoBufs          No available entry in the table.
+     * @retval  kErrorNone            Successfully added entry to the table.
+     */
+    Error AddCslEntry(otShortAddress aShortAddr, const otExtAddress &aExtAddr);
+
+    /**
+     * Removes a entry from the csl neighbor table.
+     *
+     * @param[in]  aShortAddress  The short address of the csl neighbor.
+     * @param[in]  aExtAddress    The extended address of the csl neighbor.
+     *
+     * @note Both the short and extended address must match the previous call to otPlatRadioAddCslEntry.
+     *       For example it is invalid to only provide the ext address when the entry also contains a short address.
+     *
+     * @retval  kErrorNotImplemented  Radio driver doesn't support multi CSL.
+     * @retval  kErrorNoAddress       The short or extended address is not in the table.
+     * @retval  kErrorNone            Successfully removed the addresses from the table.
+     */
+    Error ClearCslEntry(otShortAddress aShortAddr, const otExtAddress &aExtAddr);
+
+    /**
+     * Clears the csl neighbor table.
+     *
+     * @retval  kErrorNotImplemented  Radio driver doesn't support multi CSL.
+     * @retval  kErrorNone            Successfully cleared the csl neighbor table.
+     */
+    Error ClearCslEntries(void);
+
+    /**
      * Resets CSL receiver in radio.
      *
      * @retval  kErrorNotImplemented Radio driver doesn't support CSL.
@@ -937,6 +997,25 @@ inline Error Radio::EnableCsl(uint32_t aCslPeriod, otShortAddress aShortAddr, co
 {
     return otPlatRadioEnableCsl(GetInstancePtr(), aCslPeriod, aShortAddr, aExtAddr);
 }
+
+inline uint32_t Radio::GetMaxMultiCslNeighbors(void) { return otPlatRadioGetMaxMultiCslNeighbors(GetInstancePtr()); }
+
+inline Error Radio::EnableMultiCsl(uint32_t aCslPeriod)
+{
+    return otPlatRadioEnableMultiCsl(GetInstancePtr(), aCslPeriod);
+}
+
+inline Error Radio::AddCslEntry(otShortAddress aShortAddress, const otExtAddress &aExtAddress)
+{
+    return otPlatRadioAddCslEntry(GetInstancePtr(), aShortAddress, &aExtAddress);
+}
+
+inline Error Radio::ClearCslEntry(otShortAddress aShortAddress, const otExtAddress &aExtAddress)
+{
+    return otPlatRadioClearCslEntry(GetInstancePtr(), aShortAddress, &aExtAddress);
+}
+
+inline Error Radio::ClearCslEntries(void) { return otPlatRadioClearCslEntries(GetInstancePtr()); }
 
 inline Error Radio::ResetCsl(void) { return otPlatRadioResetCsl(GetInstancePtr()); }
 #endif

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -280,9 +280,77 @@ extern "C" OT_TOOL_WEAK uint32_t otPlatRadioGetBusLatency(otInstance *aInstance)
 }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+extern "C" OT_TOOL_WEAK otError otPlatRadioEnableCsl(otInstance         *aInstance,
+                                                     uint32_t            aCslPeriod,
+                                                     otShortAddress      aShortAddr,
+                                                     const otExtAddress *aExtAddr)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aCslPeriod);
+    OT_UNUSED_VARIABLE(aShortAddr);
+    OT_UNUSED_VARIABLE(aExtAddr);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+extern "C" OT_TOOL_WEAK uint32_t otPlatRadioGetMaxMultiCslNeighbors(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    return 0;
+}
+
+extern "C" OT_TOOL_WEAK otError otPlatRadioEnableMultiCsl(otInstance *aInstance, uint32_t aCslPeriod)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aCslPeriod);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+extern "C" OT_TOOL_WEAK otError otPlatRadioAddCslEntry(otInstance         *aInstance,
+                                                       otShortAddress      aShortAddr,
+                                                       const otExtAddress *aExtAddr)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aShortAddr);
+    OT_UNUSED_VARIABLE(aExtAddr);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+extern "C" OT_TOOL_WEAK otError otPlatRadioClearCslEntry(otInstance         *aInstance,
+                                                         otShortAddress      aShortAddr,
+                                                         const otExtAddress *aExtAddr)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aShortAddr);
+    OT_UNUSED_VARIABLE(aExtAddr);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+extern "C" OT_TOOL_WEAK otError otPlatRadioClearCslEntries(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 extern "C" OT_TOOL_WEAK otError otPlatRadioResetCsl(otInstance *aInstance)
 {
-    return otPlatRadioEnableCsl(aInstance, 0, Mac::kShortAddrInvalid, nullptr);
+    otError error;
+
+    if (otPlatRadioGetMaxMultiCslNeighbors(aInstance) == 0)
+    {
+        error = otPlatRadioEnableCsl(aInstance, 0, Mac::kShortAddrInvalid, nullptr);
+    }
+    else
+    {
+        error = otPlatRadioEnableMultiCsl(aInstance, 0);
+    }
+
+    return error;
 }
 #endif
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -697,6 +697,7 @@ void Mle::SetStateDetached(void)
 #endif
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     Get<Mac::Mac>().UpdateCsl();
+    Get<Mac::Mac>().UpdateCslParent();
 #endif
 }
 
@@ -745,6 +746,7 @@ void Mle::SetStateChild(uint16_t aRloc16)
     mPreviousParentRloc = mParent.GetRloc16();
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+    Get<Mac::Mac>().UpdateCslParent();
     Get<Mac::Mac>().UpdateCsl();
 #endif
 }
@@ -3245,10 +3247,6 @@ void Mle::HandleChildIdResponse(RxInfo &aRxInfo)
     mParentCandidate.CopyTo(mParent);
     mParentCandidate.Clear();
 
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    Get<Mac::Mac>().SetCslParentAccuracy(mParent.GetCslAccuracy());
-#endif
-
     mParent.SetRloc16(sourceAddress);
 
     IgnoreError(aRxInfo.mMessage.ReadAndSetNetworkDataTlv(leaderData));
@@ -3515,7 +3513,8 @@ void Mle::HandleChildUpdateResponseOnChild(RxInfo &aRxInfo)
             switch (aRxInfo.mMessage.ReadCslClockAccuracyTlv(cslAccuracy))
             {
             case kErrorNone:
-                Get<Mac::Mac>().SetCslParentAccuracy(cslAccuracy);
+                mParent.SetCslAccuracy(cslAccuracy);
+                Get<Mac::Mac>().UpdateCslParent();
                 break;
             case kErrorNotFound:
                 break;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -447,6 +447,7 @@ void MleRouter::SetStateRouterOrLeader(DeviceRole aRole, uint16_t aRloc16, Leade
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     Get<Mac::Mac>().UpdateCsl();
+    Get<Mac::Mac>().UpdateCslParent();
 #endif
 
     LogNote("Partition ID 0x%lx", ToUlong(mLeaderData.GetPartitionId()));


### PR DESCRIPTION
This PR adds support for multiple csl neighbors.

This arises out of our [child network thread feature proposal](https://threadgroupteam.sharepoint.com/:w:/r/sites/MC/Shared%20Documents/General/Successor%20Specs/Hendrick%27s/New%20Feature%20Documents/Thread%20Child%20Network%20Use%20Case%20New%20Feature%20Request%20.docx?d=w3f1d503b61254e4baf7d3aa9195d01e8&csf=1&web=1&e=hpDNHY). We have working code for this which we want to move towards mergability. Since we require multiple CSL neighbors which requires a change in the platform api we have now created this PR to add support for it.

We also believe that the ability to have multiple CSL neighbors would be very attractive for other future improvements to the thread api including for thread in mobile. However it is not currently a part of thread in mobile. With this in mind the API proposed here has been intentionally kept as flexible as possible to allow these other use cases.

## Implementation
To support multiple csl neighbors the `otPlatRadioEnableCsl` function has been superseded with a new set of functions for configuring csl as well as adding and removing neighbors for which the header IEs should be added. From the platform perspective a neighbor for this api is a pair of an extended address and a short address. It is legal to only provide an extended address but not to only provide a short address.

Internally this is implemented with an array in the sub mac. This array is exposed to upper layers using functions that will call the platform api whenever a entry is updated. The idea is that the index in the array is fixed depending on the type of neighbor. For example the parent is fixed at index 0 which is currently the only implemented entry.

For the ChildNetwork feature the parent candidate could for example be fixed at index 1 and the child table would fill up the remaining slots mapped by child id. If the platform has limited number of available slots for csl neighbors then max number of children would shrink.

The OpenThread code maintains full backwards compatibility with the old csl api and there should be no issues with platforms supporting both either.

## Current Issues:
While implementing the feature for the nrf platform we noticed that it is difficult to separate entires for link metric and csl ie. This is especially problematic for bulk clearing operations. Is this something that should be addressed through book keeping in the platform or an improvement for this api?

As a result of this we also currently have it such that enabling or disabling the csl receiver clears the table. Which is not a very elegant solution. 