### PR TITLE
[mle] use `DelayedSender` to delay & aggregate Child Update Requests

### DIFF
--- a/src/core/thread/child_supervision.cpp
+++ b/src/core/thread/child_supervision.cpp
@@ -160,7 +160,7 @@ void SupervisionListener::SetInterval(uint16_t aInterval)
 
     if (Get<Mle::Mle>().IsChild())
     {
-        IgnoreError(Get<Mle::Mle>().SendChildUpdateRequest());
+        IgnoreError(Get<Mle::Mle>().SendChildUpdateRequestToParent());
     }
 
 exit:
@@ -210,7 +210,7 @@ void SupervisionListener::HandleTimer(void)
     LogWarn("Supervision timeout. No frame from parent in %u sec", mTimeout);
     mCounter++;
 
-    IgnoreError(Get<Mle::MleRouter>().SendChildUpdateRequest());
+    IgnoreError(Get<Mle::Mle>().SendChildUpdateRequestToParent());
 
 exit:
     RestartTimer();

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -200,7 +200,7 @@ Error Mle::Start(StartMode aMode)
     else
     {
         mChildUpdateAttempts = 0;
-        IgnoreError(SendChildUpdateRequest());
+        IgnoreError(SendChildUpdateRequestToParent());
     }
 
 exit:
@@ -786,7 +786,7 @@ void Mle::SetTimeout(uint32_t aTimeout)
 
     if (IsChild())
     {
-        IgnoreError(SendChildUpdateRequest());
+        IgnoreError(SendChildUpdateRequestToParent());
     }
 
 exit:
@@ -864,7 +864,7 @@ Error Mle::SetDeviceMode(DeviceMode aDeviceMode)
     else if (IsChild())
     {
         SetStateChild(GetRloc16());
-        IgnoreError(SendChildUpdateRequest());
+        IgnoreError(SendChildUpdateRequestToParent());
     }
 
 exit:
@@ -1909,7 +1909,7 @@ void Mle::HandleMessageTransmissionTimer(void)
 
     VerifyOrExit(mChildUpdateAttempts < kMaxChildKeepAliveAttempts, IgnoreError(BecomeDetached()));
 
-    if (SendChildUpdateRequest() == kErrorNone)
+    if (SendChildUpdateRequestToParent() == kErrorNone)
     {
         mChildUpdateAttempts++;
     }
@@ -1918,9 +1918,9 @@ exit:
     return;
 }
 
-Error Mle::SendChildUpdateRequest(void) { return SendChildUpdateRequest(kNormalChildUpdateRequest); }
+Error Mle::SendChildUpdateRequestToParent(void) { return SendChildUpdateRequestToParent(kNormalChildUpdateRequest); }
 
-Error Mle::SendChildUpdateRequest(ChildUpdateRequestMode aMode)
+Error Mle::SendChildUpdateRequestToParent(ChildUpdateRequestMode aMode)
 {
     Error                   error = kErrorNone;
     Ip6::Address            destination;
@@ -2077,7 +2077,7 @@ Error Mle::SendChildUpdateResponse(const TlvList      &aTlvList,
 
     if (checkAddress && HasUnregisteredAddress())
     {
-        IgnoreError(SendChildUpdateRequest());
+        IgnoreError(SendChildUpdateRequestToParent());
     }
 
 exit:
@@ -2629,7 +2629,7 @@ void Mle::ReestablishLinkWithNeighbor(Neighbor &aNeighbor)
 
     if (IsChild() && (&aNeighbor == &mParent))
     {
-        IgnoreError(SendChildUpdateRequest(kAppendChallengeTlv));
+        IgnoreError(SendChildUpdateRequestToParent(kAppendChallengeTlv));
         ExitNow();
     }
 
@@ -2645,7 +2645,7 @@ void Mle::ReestablishLinkWithNeighbor(Neighbor &aNeighbor)
         Child &child = static_cast<Child &>(aNeighbor);
 
         child.SetState(Child::kStateChildUpdateRequest);
-        IgnoreError(Get<MleRouter>().SendChildUpdateRequest(child));
+        IgnoreError(Get<MleRouter>().SendChildUpdateRequestToChild(child));
     }
 #endif
 
@@ -4263,7 +4263,7 @@ Error Mle::DetachGracefully(DetachCallback aCallback, void *aContext)
         break;
 
     case kRoleChild:
-        IgnoreError(SendChildUpdateRequest(kAppendZeroTimeout));
+        IgnoreError(SendChildUpdateRequestToParent(kAppendZeroTimeout));
         break;
 
     case kRoleDisabled:

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -641,6 +641,14 @@ public:
      */
     void ScheduleChildUpdateRequest(void);
 
+    /**
+     * Sends a Child Update Request to the parent.
+     *
+     * @retval kErrorNone     Successfully prepared and sent an MLE Child Update Request message.
+     * @retval kErrorNoBufs   Insufficient buffers to construct the MLE Child Update Request message.
+     */
+    Error SendChildUpdateRequestToParent(void);
+
     /*
      * Indicates whether or not the device has restored the network information from
      * non-volatile settings after boot.
@@ -1262,8 +1270,7 @@ private:
     void       HandleNotifierEvents(Events aEvents);
     void       HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void       ReestablishLinkWithNeighbor(Neighbor &aNeighbor);
-    Error      SendChildUpdateRequest(ChildUpdateRequestMode aMode);
-    Error      SendChildUpdateRequest(void);
+    Error      SendChildUpdateRequestToParent(ChildUpdateRequestMode aMode);
     Error      SendChildUpdateResponse(const TlvList      &aTlvList,
                                        const RxChallenge  &aChallenge,
                                        const Ip6::Address &aDestination);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1628,7 +1628,7 @@ void MleRouter::HandleTimeTick(void)
         }
         else if (IsRouterOrLeader() && child.IsStateRestored())
         {
-            IgnoreError(SendChildUpdateRequest(child));
+            IgnoreError(SendChildUpdateRequestToChild(child));
         }
     }
 
@@ -2180,7 +2180,7 @@ void MleRouter::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
         if (mode.IsRxOnWhenIdle())
         {
             tlvList.Add(Tlv::kStatus);
-            SendChildUpdateResponse(nullptr, aRxInfo.mMessageInfo, tlvList, challenge);
+            SendChildUpdateResponseToChild(nullptr, aRxInfo.mMessageInfo, tlvList, challenge);
         }
 
         ExitNow();
@@ -2347,7 +2347,7 @@ void MleRouter::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
     }
 #endif
 
-    SendChildUpdateResponse(child, aRxInfo.mMessageInfo, tlvList, challenge);
+    SendChildUpdateResponseToChild(child, aRxInfo.mMessageInfo, tlvList, challenge);
 
     aRxInfo.mClass = RxInfo::kPeerMessage;
 
@@ -2595,7 +2595,7 @@ void MleRouter::SynchronizeChildNetworkData(void)
             continue;
         }
 
-        SuccessOrExit(SendChildUpdateRequest(child));
+        SuccessOrExit(SendChildUpdateRequestToChild(child));
     }
 
 exit:
@@ -2886,7 +2886,7 @@ exit:
     return error;
 }
 
-Error MleRouter::SendChildUpdateRequest(Child &aChild)
+Error MleRouter::SendChildUpdateRequestToChild(Child &aChild)
 {
     static const uint8_t kTlvs[] = {Tlv::kTimeout, Tlv::kAddressRegistration};
 
@@ -2955,10 +2955,10 @@ exit:
     return error;
 }
 
-void MleRouter::SendChildUpdateResponse(Child                  *aChild,
-                                        const Ip6::MessageInfo &aMessageInfo,
-                                        const TlvList          &aTlvList,
-                                        const RxChallenge      &aChallenge)
+void MleRouter::SendChildUpdateResponseToChild(Child                  *aChild,
+                                               const Ip6::MessageInfo &aMessageInfo,
+                                               const TlvList          &aTlvList,
+                                               const RxChallenge      &aChallenge)
 {
     Error      error = kErrorNone;
     TxMessage *message;

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -362,14 +362,6 @@ public:
      */
     void FillConnectivityTlv(ConnectivityTlv &aTlv);
 
-    /**
-     * Generates an MLE Child Update Request message to be sent to the parent.
-     *
-     * @retval kErrorNone     Successfully generated an MLE Child Update Request message.
-     * @retval kErrorNoBufs   Insufficient buffers to generate the MLE Child Update Request message.
-     */
-    Error SendChildUpdateRequest(void) { return Mle::SendChildUpdateRequest(); }
-
     Error SendLinkRequest(Neighbor *aNeighbor);
 
 #if OPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE
@@ -619,11 +611,11 @@ private:
     Error    SendLinkAccept(const LinkAcceptInfo &aInfo);
     void     SendParentResponse(const ParentResponseInfo &aInfo);
     Error    SendChildIdResponse(Child &aChild);
-    Error    SendChildUpdateRequest(Child &aChild);
-    void     SendChildUpdateResponse(Child                  *aChild,
-                                     const Ip6::MessageInfo &aMessageInfo,
-                                     const TlvList          &aTlvList,
-                                     const RxChallenge      &aChallenge);
+    Error    SendChildUpdateRequestToChild(Child &aChild);
+    void     SendChildUpdateResponseToChild(Child                  *aChild,
+                                            const Ip6::MessageInfo &aMessageInfo,
+                                            const TlvList          &aTlvList,
+                                            const RxChallenge      &aChallenge);
     void     SendMulticastDataResponse(void);
     void     SendDataResponse(const Ip6::Address &aDestination,
                               const TlvList      &aTlvList,


### PR DESCRIPTION
This commit refines the Child Update Request mechanism within the MLE module. The `DelayedSender` class is now used to schedule these requests, enabling the aggregation of multiple updates into a single transmission.
    
The previous implementation, which relied on `mMessageTransmissionTimer` and a state variable, has been replaced
with the `DelayedSender` mechanism. This change aligns the Child Update Request process with the scheduling of other MLE messages,
ensuring consistency.
    
Additionally, the `mMessageTransmissionTimer` is now exclusively dedicated to retransmission handling, simplifying the logic and improving code readability. The introduction of two boolean variables, `mWaitingForChildUpdateResponse` and `mWaitingForDataResponse`, further streamlines retransmission handling by clearly tracking the waiting state for specific responses.


----

Second commit:

**[mle] rename `SendChildUpdateRequest/Response()` methods**
    
This commit renames the `SendChildUpdateRequest/Response()`  methods to distinguish between those sending (from a child) to its parent and those sending (from a parent node) to a child. This improves the readability of the code.    


-----


~Currently contains commit from https://github.com/openthread/openthread/pull/10846, please check and review the last two commits in this PR. Thanks.~