### PR TITLE
[udp] track netif ID in socket and simplify handling of backbone sockets

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (461)
+#define OPENTHREAD_API_VERSION (462)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/udp.h
+++ b/include/openthread/udp.h
@@ -110,6 +110,16 @@ otError otUdpSendDatagram(otInstance *aInstance, otMessage *aMessage, otMessageI
 typedef void (*otUdpReceive)(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 
 /**
+ * Defines the OpenThread network interface identifiers.
+ */
+typedef enum otNetifIdentifier
+{
+    OT_NETIF_UNSPECIFIED = 0, ///< Unspecified network interface.
+    OT_NETIF_THREAD,          ///< The Thread interface.
+    OT_NETIF_BACKBONE,        ///< The Backbone interface.
+} otNetifIdentifier;
+
+/**
  * Represents a UDP socket.
  */
 typedef struct otUdpSocket
@@ -120,17 +130,8 @@ typedef struct otUdpSocket
     void               *mContext;  ///< A pointer to application-specific context.
     void               *mHandle;   ///< A handle to platform's UDP.
     struct otUdpSocket *mNext;     ///< A pointer to the next UDP socket (internal use only).
+    otNetifIdentifier   mNetifId;  ///< The network interface identifier.
 } otUdpSocket;
-
-/**
- * Defines the OpenThread network interface identifiers.
- */
-typedef enum otNetifIdentifier
-{
-    OT_NETIF_UNSPECIFIED = 0, ///< Unspecified network interface.
-    OT_NETIF_THREAD,          ///< The Thread interface.
-    OT_NETIF_BACKBONE,        ///< The Backbone interface.
-} otNetifIdentifier;
 
 /**
  * Allocate a new message buffer for sending a UDP message.

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -45,6 +45,10 @@ bool Udp::SocketHandle::Matches(const MessageInfo &aMessageInfo) const
 {
     bool matches = false;
 
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+    VerifyOrExit(IsBackbone() == aMessageInfo.IsHostInterface());
+#endif
+
     VerifyOrExit(GetSockName().mPort == aMessageInfo.GetSockPort());
 
     VerifyOrExit(aMessageInfo.GetSockAddr().IsMulticast() || GetSockName().GetAddress().IsUnspecified() ||
@@ -152,9 +156,6 @@ exit:
 Udp::Udp(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mEphemeralPort(kDynamicPortMin)
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    , mPrevBackboneSockets(nullptr)
-#endif
 {
 }
 
@@ -194,20 +195,13 @@ exit:
 
 Error Udp::Bind(SocketHandle &aSocket, const SockAddr &aSockAddr, NetifIdentifier aNetifIdentifier)
 {
-    OT_UNUSED_VARIABLE(aNetifIdentifier);
-
     Error error = kErrorNone;
 
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
     SuccessOrExit(error = otPlatUdpBindToNetif(&aSocket, MapEnum(aNetifIdentifier)));
 #endif
 
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    if (aNetifIdentifier == kNetifBackbone)
-    {
-        SetBackboneSocket(aSocket);
-    }
-#endif
+    aSocket.mNetifId = MapEnum(aNetifIdentifier);
 
     VerifyOrExit(aSockAddr.GetAddress().IsUnspecified() || Get<ThreadNetif>().HasUnicastAddress(aSockAddr.GetAddress()),
                  error = kErrorInvalidArgs);
@@ -234,43 +228,6 @@ Error Udp::Bind(SocketHandle &aSocket, const SockAddr &aSockAddr, NetifIdentifie
 exit:
     return error;
 }
-
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-void Udp::SetBackboneSocket(SocketHandle &aSocket)
-{
-    RemoveSocket(aSocket);
-
-    if (mPrevBackboneSockets != nullptr)
-    {
-        mSockets.PushAfter(aSocket, *mPrevBackboneSockets);
-    }
-    else
-    {
-        mSockets.Push(aSocket);
-    }
-}
-
-const Udp::SocketHandle *Udp::GetBackboneSockets(void) const
-{
-    return mPrevBackboneSockets != nullptr ? mPrevBackboneSockets->GetNext() : mSockets.GetHead();
-}
-
-bool Udp::IsBackboneSocket(const SocketHandle &aSocket) const
-{
-    bool retval = false;
-
-    for (const SocketHandle *sock = GetBackboneSockets(); sock != nullptr; sock = sock->GetNext())
-    {
-        if (sock == &aSocket)
-        {
-            ExitNow(retval = true);
-        }
-    }
-
-exit:
-    return retval;
-}
-#endif
 
 Error Udp::Connect(SocketHandle &aSocket, const SockAddr &aSockAddr)
 {
@@ -368,19 +325,7 @@ bool Udp::IsPortReserved(uint16_t aPort)
     return aPort == Tmf::kUdpPort || (kSrpServerPortMin <= aPort && aPort <= kSrpServerPortMax);
 }
 
-void Udp::AddSocket(SocketHandle &aSocket)
-{
-    SuccessOrExit(mSockets.Add(aSocket));
-
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    if (mPrevBackboneSockets == nullptr)
-    {
-        mPrevBackboneSockets = &aSocket;
-    }
-#endif
-exit:
-    return;
-}
+void Udp::AddSocket(SocketHandle &aSocket) { IgnoreError(mSockets.Add(aSocket)); }
 
 void Udp::RemoveSocket(SocketHandle &aSocket)
 {
@@ -390,13 +335,6 @@ void Udp::RemoveSocket(SocketHandle &aSocket)
 
     mSockets.PopAfter(prev);
     aSocket.SetNext(nullptr);
-
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    if (&aSocket == mPrevBackboneSockets)
-    {
-        mPrevBackboneSockets = prev;
-    }
-#endif
 
 exit:
     return;
@@ -492,29 +430,8 @@ exit:
 void Udp::HandlePayload(Message &aMessage, MessageInfo &aMessageInfo)
 {
     SocketHandle *socket;
-    SocketHandle *prev;
 
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    {
-        const SocketHandle *socketsBegin, *socketsEnd;
-
-        if (!aMessageInfo.IsHostInterface())
-        {
-            socketsBegin = mSockets.GetHead();
-            socketsEnd   = GetBackboneSockets();
-        }
-        else
-        {
-            socketsBegin = GetBackboneSockets();
-            socketsEnd   = nullptr;
-        }
-
-        socket = mSockets.FindMatching(socketsBegin, socketsEnd, aMessageInfo, prev);
-    }
-#else
-    socket = mSockets.FindMatching(aMessageInfo, prev);
-#endif
-
+    socket = mSockets.FindMatching(aMessageInfo);
     VerifyOrExit(socket != nullptr);
 
     aMessage.RemoveHeader(aMessage.GetOffset());
@@ -567,7 +484,7 @@ bool Udp::ShouldUsePlatformUdp(const Udp::SocketHandle &aSocket) const
 {
     return (ShouldUsePlatformUdp(aSocket.mSockName.mPort)
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-            || IsBackboneSocket(aSocket)
+            || aSocket.IsBackbone()
 #endif
     );
 }

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -128,6 +128,23 @@ public:
          */
         const SockAddr &GetPeerName(void) const { return AsCoreType(&mPeerName); }
 
+        /**
+         * Returns the network interface identifier.
+         *
+         * @returns The network interface identifier.
+         */
+        NetifIdentifier GetNetifId(void) const { return static_cast<NetifIdentifier>(mNetifId); }
+
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+        /**
+         * Indicate whether or not the socket is bound to the backbone network interface.
+         *
+         * @retval TRUE    This is a backbone socket.
+         * @retval FALSE   This is not a backbone socket.
+         */
+        bool IsBackbone(void) const { return (GetNetifId() == kNetifBackbone); }
+#endif
+
     private:
         bool Matches(const MessageInfo &aMessageInfo) const;
 
@@ -643,18 +660,9 @@ private:
     bool ShouldUsePlatformUdp(const SocketHandle &aSocket) const;
 #endif
 
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    void                SetBackboneSocket(SocketHandle &aSocket);
-    const SocketHandle *GetBackboneSockets(void) const;
-    bool                IsBackboneSocket(const SocketHandle &aSocket) const;
-#endif
-
     uint16_t                 mEphemeralPort;
     LinkedList<Receiver>     mReceivers;
     LinkedList<SocketHandle> mSockets;
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    SocketHandle *mPrevBackboneSockets;
-#endif
 #if OPENTHREAD_CONFIG_UDP_FORWARD_ENABLE
     Callback<otUdpForwarder> mUdpForwarder;
 #endif


### PR DESCRIPTION
This commit updates `otUdpSocket` to track the associated network interface identifier to which the socket is bound. This simplifies the code for tracking backbone sockets, particularly how `Udp::HandlePayload()` finds a matching socket.

Previously, backbone sockets were placed at the end of the `mSockets` linked-list. The code tracked and updated a pointer to the entry before the first backbone socket in the list. This commit removes the need for this additional tracking and simplifies the implementation.