### PR TITLE
[radio-spinel] separate RCP version check and caps check

### DIFF
--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -124,7 +124,7 @@ RadioSpinel::RadioSpinel(void)
     memset(&mCallbacks, 0, sizeof(mCallbacks));
 }
 
-void RadioSpinel::Init(bool          aSkipRcpCompatibilityCheck,
+void RadioSpinel::Init(bool          aSkipRcpVersionCheck,
                        bool          aSoftwareReset,
                        SpinelDriver *aSpinelDriver,
                        otRadioCaps   aRequiredRadioCaps,
@@ -159,11 +159,12 @@ void RadioSpinel::Init(bool          aSkipRcpCompatibilityCheck,
         EXPECT_NO_ERROR(error = Set(SPINEL_PROP_RCP_LOG_CRASH_DUMP, nullptr));
     }
 
-    if (!aSkipRcpCompatibilityCheck)
+    if (!aSkipRcpVersionCheck)
     {
         SuccessOrDie(CheckRcpApiVersion(supportsRcpApiVersion, supportsRcpMinHostApiVersion));
-        SuccessOrDie(CheckRadioCapabilities(aRequiredRadioCaps));
     }
+
+    SuccessOrDie(CheckRadioCapabilities(aRequiredRadioCaps));
 
     mRxRadioFrame.mPsdu  = mRxPsdu;
     mTxRadioFrame.mPsdu  = mTxPsdu;

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -156,7 +156,7 @@ public:
     /**
      * Initialize this radio transceiver.
      *
-     * @param[in]  aSkipRcpCompatibilityCheck  TRUE to skip RCP compatibility check, FALSE to perform the check.
+     * @param[in]  aSkipRcpVersionCheck        TRUE to skip RCP version check, FALSE to perform the check.
      * @param[in]  aSoftwareReset              When doing RCP recovery, TRUE to try software reset first, FALSE to
      *                                         directly do a hardware reset.
      * @param[in]  aSpinelDriver               A pointer to the spinel driver instance that this object depends on.
@@ -164,7 +164,7 @@ public:
      *                                         the required capabilities during initialization.
      * @param[in]  aEnableRcpTimeSync          TRUE to enable RCP time sync, FALSE to not enable.
      */
-    void Init(bool          aSkipRcpCompatibilityCheck,
+    void Init(bool          aSkipRcpVersionCheck,
               bool          aSoftwareReset,
               SpinelDriver *aSpinelDriver,
               otRadioCaps   aRequiredRadioCaps,

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -99,7 +99,8 @@ void Radio::Init(const char *aUrl)
     skipCompatibilityCheck = mRadioUrl.HasParam("skip-rcp-compatibility-check");
 
     mRadioSpinel.SetCallbacks(callbacks);
-    mRadioSpinel.Init(skipCompatibilityCheck, resetRadio, &GetSpinelDriver(), kRequiredRadioCaps, aEnableRcpTimeSync);
+    mRadioSpinel.Init(skipCompatibilityCheck, resetRadio, &GetSpinelDriver(),
+                      (skipCompatibilityCheck ? 0 : kRequiredRadioCaps), aEnableRcpTimeSync);
 
     ProcessRadioUrl(mRadioUrl);
 }


### PR DESCRIPTION
This commit separates RCP version check and capability check in RadioSpinel so that the RCP caps is guaranteed to be initialized correctly.