### PR TITLE
[address-resolver] add new API `otThreadUpdateSnoopedCacheEntry()`

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (470)
+#define OPENTHREAD_API_VERSION (471)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -619,6 +619,18 @@ otError otThreadGetRouterInfo(otInstance *aInstance, uint16_t aRouterId, otRoute
 otError otThreadGetNextCacheEntry(otInstance *aInstance, otCacheEntryInfo *aEntryInfo, otCacheEntryIterator *aIterator);
 
 /**
+ * Adds or updates a snooped EID cache entry into address cache table.
+ *
+ * This function allows an application-specific mechanism to determine the RLOC16 and add/update a snoop optimization
+ * entry in address (by inspecting a received message to create a cache entry that maps an EID to an RLOC).
+ *
+ * @param[in]  aInstance   A pointer to an OpenThread instance.
+ * @param[in]  aEid        The EID IPv6 address.
+ * @param[in]  aRloc16     The RLOC16 corresponding to @p aEid.
+ */
+void otThreadUpdateSnoopedCacheEntry(otInstance *aInstance, const otIp6Address *aEid, uint16_t aRloc16);
+
+/**
  * Get the Thread PSKc
  *
  * @param[in]   aInstance   A pointer to an OpenThread instance.

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -257,6 +257,13 @@ otError otThreadGetNextCacheEntry(otInstance *aInstance, otCacheEntryInfo *aEntr
                                                                           AsCoreType(aIterator));
 }
 
+void otThreadUpdateSnoopedCacheEntry(otInstance *aInstance, const otIp6Address *aEid, uint16_t aRloc16)
+{
+    uint16_t devRloc16 = AsCoreType(aInstance).Get<Mle::Mle>().GetRloc16();
+
+    return AsCoreType(aInstance).Get<AddressResolver>().UpdateSnoopedCacheEntry(AsCoreType(aEid), aRloc16, devRloc16);
+}
+
 #if OPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE
 void otThreadSetSteeringData(otInstance *aInstance, const otExtAddress *aExtAddress)
 {


### PR DESCRIPTION
This commit adds a new public API to add/update a snoop optimization entry in the address cache table. This is done by inspecting a received message and using an application-specific mechanism to determine the RLOC16 of the sender.