### PR TITLE
[test] add implementation of otPlatRadioSetChannelTargetPower in FakePlatform

### DIFF
--- a/tests/gtest/fake_platform.cpp
+++ b/tests/gtest/fake_platform.cpp
@@ -406,6 +406,8 @@ otError otPlatRadioConfigureEnhAckProbing(otInstance *, otLinkMetrics, otShortAd
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
+otError otPlatRadioSetChannelTargetPower(otInstance *, uint8_t, int16_t) { return OT_ERROR_NONE; }
+
 void otPlatReset(otInstance *) {}
 
 otPlatResetReason otPlatGetResetReason(otInstance *) { return OT_PLAT_RESET_REASON_POWER_ON; }


### PR DESCRIPTION
This PR adds implementation of otPlatRadioSetChannelTargetPower in FakePlatform.

This method is required in unit test in otbr.