### PR TITLE
[mle] apply random delay when sending Link Request on Adv rx

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -766,6 +766,9 @@ private:
     static constexpr uint32_t kParentResponseMaxDelayRouters = 500;  // Max response delay for Parent Req to routers
     static constexpr uint32_t kParentResponseMaxDelayAll     = 1000; // Max response delay for Parent Req to all
     static constexpr uint32_t kChildUpdateRequestDelay       = 100;  // Delay for aggregating Child Update Req
+    static constexpr uint32_t kMaxLinkRequestDelayOnRouter   = 1000; // Max delay to tx Link Request on Adv rx
+    static constexpr uint32_t kMinLinkRequestDelayOnChild    = 1500; // Min delay to tx Link Request on Adv rx (child)
+    static constexpr uint32_t kMaxLinkRequestDelayOnChild    = 3000; // Max delay to tx Link Request on Adv rx (child)
     static constexpr uint32_t kMaxLinkAcceptDelay            = 1000; // Max delay to tx Link Accept for multicast Req
     static constexpr uint32_t kChildIdRequestTimeout         = 5000; // Max delay to rx a Child ID Req after Parent Res
     static constexpr uint32_t kLinkRequestTimeout            = 2000; // Max delay to rx a Link Accept
@@ -1134,6 +1137,7 @@ private:
 #if OPENTHREAD_FTD
         void ScheduleParentResponse(const ParentResponseInfo &aInfo, uint16_t aDelay);
         void ScheduleMulticastDataResponse(uint16_t aDelay);
+        void ScheduleLinkRequest(const Router &aRouter, uint16_t aDelay);
         void ScheduleLinkAccept(const LinkAcceptInfo &aInfo, uint16_t aDelay);
         void ScheduleDiscoveryResponse(const Ip6::Address          &aDestination,
                                        const DiscoveryResponseInfo &aInfo,


### PR DESCRIPTION
This commit updates `DelayedSender` to allow scheduling of delayed MLE Link Request messages. This is then used to apply a random delay to send a Link Request when processing a MLE Advertisement from a neighbor.
    
Advertisement messages are multicast transmissions and can be received by multiple nodes, which could create a synchronized generation of Link Requests from all. This change helps distribute this time over a random window (of one second if the requester is itself a router or [1-2.5] seconds if it is a child).
    
This aligns the implementation with the Thread specification and can help improve situations where a new router is added (e.g., single device reboot or network-wide reboot due to power shutdown, etc).

----

~Builds on top of commit from https://github.com/openthread/openthread/pull/10846. Please check and review the second commit in this PR.~