### PR TITLE
[trel] add otSys API to init/deinit TREL

### DIFF
--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -304,6 +304,22 @@ void otSysUpstreamDnsServerSetResolvConfEnabled(bool aEnabled);
  */
 void otSysUpstreamDnsSetServerList(const otIp6Address *aUpstreamDnsServers, int aNumServers);
 
+/**
+ * Initializes TREL on the given interface.
+ *
+ * After this call, TREL is ready to be enabled on the interface. Callers need to make sure TREL is disabled prior
+ * to this call.
+ */
+void otSysTrelInit(const char *aInterfaceName);
+
+/**
+ * Deinitializes TREL.
+ *
+ * After this call, TREL is deinitialized. It's ready to be initialized on any given interface. Callers need to
+ * make sure TREL is disabled prior to this call.
+ */
+void otSysTrelDeinit(void);
+
 #ifdef __cplusplus
 } // end of extern "C"
 #endif

--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -416,4 +416,13 @@
 #define OPENTHREAD_POSIX_CONFIG_UPSTREAM_DNS_BIND_TO_INFRA_NETIF 1
 #endif
 
+/**
+ * @def OPENTHREAD_POSIX_CONFIG_TREL_SELECT_INFRA_IF
+ *
+ * Define to 1 to let TREL select the infrastructure interface, otherwise use the interface in the TREL URL.
+ */
+#ifndef OPENTHREAD_POSIX_CONFIG_TREL_SELECT_INFRA_IF
+#define OPENTHREAD_POSIX_CONFIG_TREL_SELECT_INFRA_IF 0
+#endif
+
 #endif // OPENTHREAD_PLATFORM_POSIX_CONFIG_H_

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -43,6 +43,7 @@
 #include <openthread/cli.h>
 #include <openthread/heap.h>
 #include <openthread/tasklet.h>
+#include <openthread/trel.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/infra_if.h>
 #include <openthread/platform/logging.h>
@@ -138,7 +139,7 @@ void platformInitRcpMode(otPlatformConfig *aPlatformConfig)
     // For Dry-Run option, only init the co-processor.
     VerifyOrExit(!aPlatformConfig->mDryRun);
 
-#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE && !OPENTHREAD_POSIX_CONFIG_TREL_SELECT_INFRA_IF
     platformTrelInit(getTrelRadioUrl(aPlatformConfig));
 #endif
     platformRandomInit();
@@ -326,7 +327,8 @@ void platformDeinitRcpMode(void)
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
     platformNetifDeinit();
 #endif
-#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE && !OPENTHREAD_POSIX_CONFIG_TREL_SELECT_INFRA_IF
+    otPlatTrelDisable(/* aInstance */ nullptr);
     platformTrelDeinit();
 #endif
 

--- a/src/posix/platform/trel.cpp
+++ b/src/posix/platform/trel.cpp
@@ -43,6 +43,7 @@
 #include <unistd.h>
 
 #include <openthread/logging.h>
+#include <openthread/openthread-system.h>
 #include <openthread/platform/trel.h>
 
 #include "logger.hpp"
@@ -561,10 +562,7 @@ void otPlatTrelResetCounters(otInstance *aInstance)
     ResetCounters();
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-// platformTrel system
-
-void platformTrelInit(const char *aTrelUrl)
+void otSysTrelInit(const char *aInterfaceName)
 {
     // To silence "unused function" warning.
     (void)LogCrit;
@@ -573,17 +571,12 @@ void platformTrelInit(const char *aTrelUrl)
     (void)LogNote;
     (void)LogDebg;
 
-    LogDebg("platformTrelInit(aTrelUrl:\"%s\")", aTrelUrl != nullptr ? aTrelUrl : "");
+    LogDebg("otSysTrelInit(aInterfaceName:\"%s\")", aInterfaceName != nullptr ? aInterfaceName : "");
 
-    assert(!sInitialized);
+    VerifyOrExit(!sInitialized && !sEnabled && aInterfaceName != nullptr);
 
-    if (aTrelUrl != nullptr)
-    {
-        ot::Posix::RadioUrl url(aTrelUrl);
-
-        strncpy(sInterfaceName, url.GetPath(), sizeof(sInterfaceName) - 1);
-        sInterfaceName[sizeof(sInterfaceName) - 1] = '\0';
-    }
+    strncpy(sInterfaceName, aInterfaceName, sizeof(sInterfaceName) - 1);
+    sInterfaceName[sizeof(sInterfaceName) - 1] = '\0';
 
     trelDnssdInitialize(sInterfaceName);
 
@@ -591,13 +584,32 @@ void platformTrelInit(const char *aTrelUrl)
     sInitialized = true;
 
     ResetCounters();
+
+exit:
+    return;
+}
+
+void otSysTrelDeinit(void) { platformTrelDeinit(); }
+
+//---------------------------------------------------------------------------------------------------------------------
+// platformTrel system
+
+void platformTrelInit(const char *aTrelUrl)
+{
+    LogDebg("platformTrelInit(aTrelUrl:\"%s\")", aTrelUrl != nullptr ? aTrelUrl : "");
+
+    if (aTrelUrl != nullptr)
+    {
+        ot::Posix::RadioUrl url(aTrelUrl);
+
+        otSysTrelInit(url.GetPath());
+    }
 }
 
 void platformTrelDeinit(void)
 {
-    VerifyOrExit(sInitialized);
+    VerifyOrExit(sInitialized && !sEnabled);
 
-    otPlatTrelDisable(nullptr);
     sInterfaceName[0] = '\0';
     sInitialized      = false;
     LogDebg("platformTrelDeinit()");


### PR DESCRIPTION
The current TREL implementation uses TREL URL to pass in the TREL interface at system start. This works for devices that have a fixed interface for TREL.

There are devices that can dynamically switch infrastructure link, for those devices it's possible that infra link changes from ethernet to wifi and TREL should be re-configured on the new interface.