### PR TITLE
[mdns] implement response aggregation

### DIFF
--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -53,6 +53,14 @@ NextFireTime::NextFireTime(Time aNow)
 
 void NextFireTime::UpdateIfEarlier(Time aTime) { mNextTime = Min(mNextTime, Max(mNow, aTime)); }
 
+void NextFireTime::UpdateIfEarlierAndInFuture(Time aTime)
+{
+    if (aTime > mNow)
+    {
+        mNextTime = Min(mNextTime, aTime);
+    }
+}
+
 //---------------------------------------------------------------------------------------------------------------------
 // `Timer`
 

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -96,6 +96,21 @@ public:
     void UpdateIfEarlier(Time aTime);
 
     /**
+     * Updates the tracked next fire time with a new given time, but only if it is earlier than the current
+     * fire time and in the future relative to `GetNow()`.
+     *
+     * If the given @p aTime is not in the future relative to `GetNow()`, it is ignored. This is unlike
+     * `UpdateIfEarlier()`, which allows all `aTime` values, including ones that are in the past (where it uses
+     * `GetNow()`).
+     *
+     * This method can be used to track the next fire time among non-expired times, ensuring the tracked next fire time
+     * will be in the future relative to `GetNow()`.
+     *
+     * @param[in] aTime     The new time.
+     */
+    void UpdateIfEarlierAndInFuture(Time aTime);
+
+    /**
      * Indicates whether or not next fire time is set.
      *
      * @retval TRUE   The next fire time is set.


### PR DESCRIPTION
This commit implements response aggregation (RFC 6762 section 6.4) in the mDNS module. If multiple responses are scheduled to be sent, each delayed by a different interval, earlier responses are further delayed to allow aggregation with other responses scheduled to go out a little later.

Before preparing a response, we determine the next multicast transmission time that is explicitly after the current time. This is used for response aggregation. As the response is being prepared, different entries can decide whether to extend their answer delay duration if allowed (e.g., probe question answer delay cannot be extended) and possible (not extending the delay beyond the maximum allowed delay).

To realize this, the way we track the `AnswerTime` of records is changed. It is now tracked by two variables: `mQueryRxTime` (the receive time of the question triggering the answer) and `mAnswerDelay`.

This commit also adds `TestResponseAggregation()` to the `test_mdns` unit test to validate the response aggregation behavior.