### PR TITLE
[tests] fix `test_upstream_dns.py` 

### DIFF
--- a/tests/scripts/thread-cert/border_router/internet/test_upstream_dns.py
+++ b/tests/scripts/thread-cert/border_router/internet/test_upstream_dns.py
@@ -91,8 +91,11 @@ class UpstreamDns(thread_cert.TestCase):
         self._start_dns_server(dns_server)
         dns_server_addr = dns_server.get_ether_addrs(ipv4=True, ipv6=False)[0]
 
+        # Disable the bind9 service on the BR otherwise bind9 may respond to Thread devices' DNS queries
+        br.bash('service bind9 stop')
+
         # Update BR's /etc/resolv.conf and force BR to reload it
-        br.bash(shlex.join(['echo', 'nameserver ' + dns_server_addr]) + ' >> /etc/resolv.conf')
+        br.bash(shlex.join(['echo', 'nameserver ' + dns_server_addr]) + ' > /etc/resolv.conf')
         br.stop_otbr_service()
         br.start_otbr_service()
 


### PR DESCRIPTION
There's a [CI failure](https://github.com/openthread/ot-br-posix/actions/runs/11590671688/job/32317956417?pr=2571) that the BR sends the query to 8.8.8.8 as the upstream DNS server and responded to the DNS client. This is undesired behavior. We want the BR to query our test DNS server instead.

The issue happened because 8.8.8.8 is already an entry in `/etc/resolv.conf`. To avoid querying it, we should fully overwrite the `/etc/resolv.conf` to ensure the BR queries the test DNS server.

There's another issue that `bind9` service was also running on the BR node which taken over all incoming DNS queries. `bind9` should only run on the upstream DNS server node. I'll try fix this in a more generic way later.