### PR TITLE
[trel] align trel_interface and platform layer with the initialized state

### DIFF
--- a/examples/platforms/simulation/trel.c
+++ b/examples/platforms/simulation/trel.c
@@ -377,6 +377,12 @@ void otPlatTrelResetCounters(otInstance *aInstance)
     memset(&sCounters, 0, sizeof(sCounters));
 }
 
+bool otPlatTrelIsInitialized(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return true;
+}
+
 //---------------------------------------------------------------------------------------------------------------------
 
 // This is added for RCP build to be built ok

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (462)
+#define OPENTHREAD_API_VERSION (463)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/trel.h
+++ b/include/openthread/platform/trel.h
@@ -94,6 +94,11 @@ void otPlatTrelEnable(otInstance *aInstance, uint16_t *aUdpPort);
 void otPlatTrelDisable(otInstance *aInstance);
 
 /**
+ * Returns if the TREL is initialized in the platform layer.
+ */
+bool otPlatTrelIsInitialized(otInstance *aInstance);
+
+/**
  * Represents a TREL peer info discovered using DNS-SD browse on the service name "_trel._udp".
  */
 typedef struct otPlatTrelPeerInfo

--- a/src/posix/platform/trel.cpp
+++ b/src/posix/platform/trel.cpp
@@ -474,9 +474,7 @@ void otPlatTrelEnable(otInstance *aInstance, uint16_t *aUdpPort)
 
     VerifyOrExit(!IsSystemDryRun());
 
-    assert(sInitialized);
-
-    VerifyOrExit(!sEnabled);
+    VerifyOrExit(sInitialized && !sEnabled);
 
     PrepareSocket(*aUdpPort);
     trelDnssdStartBrowse();
@@ -560,6 +558,12 @@ void otPlatTrelResetCounters(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
     ResetCounters();
+}
+
+bool otPlatTrelIsInitialized(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sInitialized;
 }
 
 void otSysTrelInit(const char *aInterfaceName)

--- a/tests/gtest/fake_platform.cpp
+++ b/tests/gtest/fake_platform.cpp
@@ -533,6 +533,7 @@ void                      otPlatTrelRegisterService(otInstance *, uint16_t, cons
 void                      otPlatTrelSend(otInstance *, const uint8_t *, uint16_t, const otSockAddr *) {}
 const otPlatTrelCounters *otPlatTrelGetCounters(otInstance *) { return nullptr; }
 void                      otPlatTrelResetCounters(otInstance *) {}
+bool                      otPlatTrelIsInitialized(otInstance *) { return true; }
 
 otError otPlatUdpSocket(otUdpSocket *) { return OT_ERROR_NOT_IMPLEMENTED; }
 otError otPlatUdpClose(otUdpSocket *) { return OT_ERROR_NOT_IMPLEMENTED; }

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -455,6 +455,8 @@ OT_TOOL_WEAK void otPlatTrelRegisterService(otInstance *, uint16_t, const uint8_
 OT_TOOL_WEAK const otPlatTrelCounters *otPlatTrelGetCounters(otInstance *) { return nullptr; }
 
 OT_TOOL_WEAK void otPlatTrelResetCounters(otInstance *) {}
+
+OT_TOOL_WEAK bool otPlatTrelIsInitialized(otInstance *) { return true; }
 #endif
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE


### PR DESCRIPTION
Currently Trel::Interface has a `mInitialized` state that is set to true after the ot instance is initialized. The platform layer trel can be initiated and deinitiated at runtimes now after https://github.com/openthread/openthread/pull/10872. This means the Trel::Interface can have a different init state than the platform layer.

This PR adds a otPlatTrelIsInitialized() method for the Trel::Interface to get the platform's status, this is used instead of the Trel::Interface::mInitialized to avoid out of sync. Also changed the check of (mInitialized && mEnabled) to only (mEnabled) because the trel interface can't be enabled unless it's initiated.