### PR TITLE
[secure-transport] apply style fixes and renames

### DIFF
--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -48,16 +48,16 @@ namespace MeshCoP {
 RegisterLogModule("SecTransport");
 
 #if (MBEDTLS_VERSION_NUMBER >= 0x03010000)
-const uint16_t SecureTransport::sGroups[] = {MBEDTLS_SSL_IANA_TLS_GROUP_SECP256R1, MBEDTLS_SSL_IANA_TLS_GROUP_NONE};
+const uint16_t SecureTransport::kGroups[] = {MBEDTLS_SSL_IANA_TLS_GROUP_SECP256R1, MBEDTLS_SSL_IANA_TLS_GROUP_NONE};
 #else
-const mbedtls_ecp_group_id SecureTransport::sCurves[] = {MBEDTLS_ECP_DP_SECP256R1, MBEDTLS_ECP_DP_NONE};
+const mbedtls_ecp_group_id SecureTransport::kCurves[] = {MBEDTLS_ECP_DP_SECP256R1, MBEDTLS_ECP_DP_NONE};
 #endif
 
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED) || defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
 #if (MBEDTLS_VERSION_NUMBER >= 0x03020000)
-const uint16_t SecureTransport::sSignatures[] = {MBEDTLS_TLS1_3_SIG_ECDSA_SECP256R1_SHA256, MBEDTLS_TLS1_3_SIG_NONE};
+const uint16_t SecureTransport::kSignatures[] = {MBEDTLS_TLS1_3_SIG_ECDSA_SECP256R1_SHA256, MBEDTLS_TLS1_3_SIG_NONE};
 #else
-const int SecureTransport::sHashes[] = {MBEDTLS_MD_SHA256, MBEDTLS_MD_NONE};
+const int SecureTransport::kHashes[] = {MBEDTLS_MD_SHA256, MBEDTLS_MD_NONE};
 #endif
 #endif
 
@@ -318,15 +318,15 @@ Error SecureTransport::Setup(bool aClient)
     if (mCipherSuites[0] == MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8)
     {
 #if (MBEDTLS_VERSION_NUMBER >= 0x03010000)
-        mbedtls_ssl_conf_groups(&mConf, sGroups);
+        mbedtls_ssl_conf_groups(&mConf, kGroups);
 #else
-        mbedtls_ssl_conf_curves(&mConf, sCurves);
+        mbedtls_ssl_conf_curves(&mConf, kCurves);
 #endif
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED) || defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
 #if (MBEDTLS_VERSION_NUMBER >= 0x03020000)
-        mbedtls_ssl_conf_sig_algs(&mConf, sSignatures);
+        mbedtls_ssl_conf_sig_algs(&mConf, kSignatures);
 #else
-        mbedtls_ssl_conf_sig_hashes(&mConf, sHashes);
+        mbedtls_ssl_conf_sig_hashes(&mConf, kHashes);
 #endif
 #endif
     }

--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -107,15 +107,6 @@ public:
     typedef otHandleCoapSecureClientConnect ConnectedHandler;
 
     /**
-     * Initializes the SecureTransport object.
-     *
-     * @param[in]  aInstance            A reference to the OpenThread instance.
-     * @param[in]  aLayerTwoSecurity    Specifies whether to use layer two security or not.
-     * @param[in]  aDatagramTransport   Specifies if dtls of tls connection should be used.
-     */
-    explicit SecureTransport(Instance &aInstance, bool aLayerTwoSecurity, bool aDatagramTransport = true);
-
-    /**
      * Pointer is called when data is received from the session.
      *
      * @param[in]  aContext  A pointer to application-specific context.
@@ -140,6 +131,15 @@ public:
      * @param[in] aContext    A pointer to arbitrary context information.
      */
     typedef void (*AutoCloseCallback)(void *aContext);
+
+    /**
+     * Initializes the SecureTransport object.
+     *
+     * @param[in]  aInstance            A reference to the OpenThread instance.
+     * @param[in]  aLayerTwoSecurity    Specifies whether to use layer two security or not.
+     * @param[in]  aDatagramTransport   Specifies if dtls of tls connection should be used.
+     */
+    explicit SecureTransport(Instance &aInstance, bool aLayerTwoSecurity, bool aDatagramTransport = true);
 
     /**
      * Opens the socket.
@@ -581,25 +581,25 @@ private:
 
     using TransportSocket = Ip6::Udp::SocketIn<SecureTransport, &SecureTransport::HandleReceive>;
 
+#if (MBEDTLS_VERSION_NUMBER >= 0x03010000)
+    static const uint16_t kGroups[];
+#else
+    static const mbedtls_ecp_group_id kCurves[];
+#endif
+
+#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED) || defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
+#if (MBEDTLS_VERSION_NUMBER >= 0x03020000)
+    static const uint16_t kSignatures[];
+#else
+    static const int kHashes[];
+#endif
+#endif
+
     State mState;
 
     int     mCipherSuites[2];
     uint8_t mPsk[kPskMaxLength];
     uint8_t mPskLength;
-
-#if (MBEDTLS_VERSION_NUMBER >= 0x03010000)
-    static const uint16_t sGroups[];
-#else
-    static const mbedtls_ecp_group_id sCurves[];
-#endif
-
-#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED) || defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
-#if (MBEDTLS_VERSION_NUMBER >= 0x03020000)
-    static const uint16_t sSignatures[];
-#else
-    static const int sHashes[];
-#endif
-#endif
 
 #if OPENTHREAD_CONFIG_TLS_API_ENABLE
 #ifdef MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
@@ -646,7 +646,6 @@ private:
 
     Callback<ConnectedHandler> mConnectedCallback;
     Callback<ReceiveHandler>   mReceiveCallback;
-    void                      *mContext;
 
     Ip6::MessageInfo mMessageInfo;
     TransportSocket  mSocket;


### PR DESCRIPTION
This commit applies style fixes and renames in the `SecureTransport` class, including using the `k` prefix for constants and removing unused member variables.