### PR TITLE
[trel] fix crash

### DIFF
--- a/src/posix/platform/trel.cpp
+++ b/src/posix/platform/trel.cpp
@@ -474,9 +474,7 @@ void otPlatTrelEnable(otInstance *aInstance, uint16_t *aUdpPort)
 
     VerifyOrExit(!IsSystemDryRun());
 
-    assert(sInitialized);
-
-    VerifyOrExit(!sEnabled);
+    VerifyOrExit(sInitialized && !sEnabled);
 
     PrepareSocket(*aUdpPort);
     trelDnssdStartBrowse();
@@ -493,8 +491,7 @@ void otPlatTrelDisable(otInstance *aInstance)
 
     VerifyOrExit(!IsSystemDryRun());
 
-    assert(sInitialized);
-    VerifyOrExit(sEnabled);
+    VerifyOrExit(sInitialized && sEnabled);
 
     close(sSocket);
     sSocket = -1;
@@ -540,6 +537,8 @@ void otPlatTrelRegisterService(otInstance *aInstance, uint16_t aPort, const uint
 {
     OT_UNUSED_VARIABLE(aInstance);
     VerifyOrExit(!IsSystemDryRun());
+
+    VerifyOrExit(sEnabled);
 
     trelDnssdRegisterService(aPort, aTxtData, aTxtLength);
 


### PR DESCRIPTION
Started from #10872, platform trel stays un-initialized if no TREL URL is passed in, it also allows deiniting platform TREL with `otSysTrelDeinit`. `otPlatTrelEnable` and `otPlatTrelDisable` asserted for `sInitialized`, and caused crashes when called. 

This PR changes the asserts to VerifyOrExit() to allow otPlatTrelEnable/Disable calls when platform TREL is not initialized, also added check for `sEnabled` when registering service to skip registering any services when uninitialized.