### PR TITLE
[coaps] use `LinkSecurityMode` to determine layer two security usage

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -109,7 +109,7 @@ Message *CoapBase::NewMessage(void) { return NewMessage(Message::Settings::GetDe
 
 Message *CoapBase::NewPriorityMessage(void)
 {
-    return NewMessage(Message::Settings(Message::kWithLinkSecurity, Message::kPriorityNet));
+    return NewMessage(Message::Settings(kWithLinkSecurity, Message::kPriorityNet));
 }
 
 Message *CoapBase::NewPriorityConfirmablePostMessage(Uri aUri)

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -42,7 +42,7 @@ namespace Coap {
 
 RegisterLogModule("CoapSecure");
 
-CoapSecure::CoapSecure(Instance &aInstance, bool aLayerTwoSecurity)
+CoapSecure::CoapSecure(Instance &aInstance, LinkSecurityMode aLayerTwoSecurity)
     : CoapBase(aInstance, &CoapSecure::Send)
     , mDtls(aInstance, aLayerTwoSecurity)
     , mTransmitTask(aInstance, CoapSecure::HandleTransmit, this)

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -69,7 +69,7 @@ public:
      * @param[in]  aInstance           A reference to the OpenThread instance.
      * @param[in]  aLayerTwoSecurity   Specifies whether to use layer two security or not.
      */
-    explicit CoapSecure(Instance &aInstance, bool aLayerTwoSecurity = false);
+    explicit CoapSecure(Instance &aInstance, LinkSecurityMode aLayerTwoSecurity);
 
     /**
      * Starts the secure CoAP agent.

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -148,6 +148,15 @@ class PriorityQueue;
 class ThreadLinkInfo;
 
 /**
+ * Represents the link security mode indicating whether to use MAC (layer two) security.
+ */
+enum LinkSecurityMode : bool
+{
+    kNoLinkSecurity   = false, ///< Link security disabled (no link security).
+    kWithLinkSecurity = true,  ///< Link security enabled.
+};
+
+/**
  * Represents a Message buffer.
  */
 class Buffer : public otMessageBuffer, public LinkedListEntry<Buffer>
@@ -307,15 +316,6 @@ public:
     };
 
     static constexpr uint8_t kNumPriorities = 4; ///< Number of priority levels.
-
-    /**
-     * Represents the link security mode (used by `Settings` constructor).
-     */
-    enum LinkSecurityMode : bool
-    {
-        kNoLinkSecurity   = false, ///< Link security disabled (no link security).
-        kWithLinkSecurity = true,  ///< Link security enabled.
-    };
 
     /**
      * Represents the message ownership model when a `Message` instance is passed to a method/function.

--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -221,7 +221,7 @@ Instance::Instance(void)
     , mApplicationCoap(*this)
 #endif
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-    , mApplicationCoapSecure(*this, /* aLayerTwoSecurity */ true)
+    , mApplicationCoapSecure(*this, kWithLinkSecurity)
 #endif
 #if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
     , mApplicationBleSecure(*this)

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -161,7 +161,7 @@ template <> void JoinerRouter::HandleTmf<kUriRelayTx>(Coap::Message &aMessage, c
     Kek                      kek;
     OffsetRange              offsetRange;
     Message                 *message = nullptr;
-    Message::Settings        settings(Message::kNoLinkSecurity, Message::kPriorityNet);
+    Message::Settings        settings(kNoLinkSecurity, Message::kPriorityNet);
     Ip6::MessageInfo         messageInfo;
 
     VerifyOrExit(aMessage.IsNonConfirmablePostRequest(), error = kErrorDrop);

--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -61,7 +61,7 @@ const int SecureTransport::kHashes[] = {MBEDTLS_MD_SHA256, MBEDTLS_MD_NONE};
 #endif
 #endif
 
-SecureTransport::SecureTransport(Instance &aInstance, bool aLayerTwoSecurity, bool aDatagramTransport)
+SecureTransport::SecureTransport(Instance &aInstance, LinkSecurityMode aLayerTwoSecurity, bool aDatagramTransport)
     : InstanceLocator(aInstance)
     , mState(kStateClosed)
     , mPskLength(0)

--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -139,7 +139,7 @@ public:
      * @param[in]  aLayerTwoSecurity    Specifies whether to use layer two security or not.
      * @param[in]  aDatagramTransport   Specifies if dtls of tls connection should be used.
      */
-    explicit SecureTransport(Instance &aInstance, bool aLayerTwoSecurity, bool aDatagramTransport = true);
+    explicit SecureTransport(Instance &aInstance, LinkSecurityMode aLayerTwoSecurity, bool aDatagramTransport = true);
 
     /**
      * Opens the socket.

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -92,7 +92,7 @@ Error Icmp::SendError(Header::Type aType, Header::Code aCode, const MessageInfo 
     MessageInfo       messageInfoLocal;
     Message          *message = nullptr;
     Header            icmp6Header;
-    Message::Settings settings(Message::kWithLinkSecurity, Message::kPriorityNet);
+    Message::Settings settings(kWithLinkSecurity, Message::kPriorityNet);
 
     if (aHeaders.GetIpProto() == kProtoIcmp6)
     {

--- a/src/core/radio/ble_secure.cpp
+++ b/src/core/radio/ble_secure.cpp
@@ -48,7 +48,7 @@ RegisterLogModule("BleSecure");
 
 BleSecure::BleSecure(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mTls(aInstance, false, false)
+    , mTls(aInstance, kNoLinkSecurity, /* aDatagramTransport */ false)
     , mTcatAgent(aInstance)
     , mTlvMode(false)
     , mReceivedMessage(nullptr)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -4531,7 +4531,7 @@ Mle::TxMessage *Mle::NewMleMessage(Command aCommand)
 {
     Error             error = kErrorNone;
     TxMessage        *message;
-    Message::Settings settings(Message::kNoLinkSecurity, Message::kPriorityNet);
+    Message::Settings settings(kNoLinkSecurity, Message::kPriorityNet);
     uint8_t           securitySuite;
 
     message = static_cast<TxMessage *>(mSocket.NewMessage(0, settings));

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -273,7 +273,7 @@ Message::Priority Agent::DscpToPriority(uint8_t aDscp)
 #if OPENTHREAD_CONFIG_SECURE_TRANSPORT_ENABLE
 
 SecureAgent::SecureAgent(Instance &aInstance)
-    : Coap::CoapSecure(aInstance)
+    : Coap::CoapSecure(aInstance, kNoLinkSecurity)
 {
     SetResourceHandler(&HandleResource);
 }

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -67,7 +67,7 @@ void TestMessage(void)
     Random::NonCrypto::FillBuffer(writeBuffer, kMaxSize);
 
     VerifyOrQuit((message = messagePool->Allocate(Message::kTypeIp6)) != nullptr);
-    message->SetLinkSecurityEnabled(Message::kWithLinkSecurity);
+    message->SetLinkSecurityEnabled(kWithLinkSecurity);
     SuccessOrQuit(message->SetPriority(Message::Priority::kPriorityNet));
     message->SetType(Message::Type::kType6lowpan);
     message->SetSubType(Message::SubType::kSubTypeJoinerEntrust);


### PR DESCRIPTION
This commit updates the `CoapSecure`, `Tmf`, and `SecureTransport` modules to use the `LinkSecurityMode` enum and its defined constants to indicate whether or not layer two security should be used. This replaces the use of boolean input parameters with `kWithLinkSecurity` or `kNoLinkSecurity` constants, improving code readability.