### PR TITLE
[spinel] replace otLinkxxx with otPlatRadioxxx in radio spinel

### DIFF
--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -734,6 +734,8 @@ void otPlatRadioSetMacFrameCounterIfLarger(otInstance *aInstance, uint32_t aMacF
  */
 uint64_t otPlatRadioGetNow(otInstance *aInstance);
 
+uint32_t otPlatRadioGetFrameCounter(otInstance *aInstance);
+
 /**
  * Get the bus speed in bits/second between the host and the radio chip.
  *

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -268,6 +268,11 @@ extern "C" OT_TOOL_WEAK uint64_t otPlatRadioGetNow(otInstance *aInstance)
     return otPlatTimeGet();
 }
 
+extern "C" OT_TOOL_WEAK uint32_t otPlatRadioGetFrameCounter(otInstance *aInstance)
+{
+    return otLinkGetFrameCounter(aInstance);
+}
+
 extern "C" OT_TOOL_WEAK uint32_t otPlatRadioGetBusSpeed(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);

--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -2181,7 +2181,7 @@ void RadioSpinel::RestoreProperties(void)
         static constexpr uint16_t kFrameCounterGuard = 1000;
 
         SuccessOrDie(Set(SPINEL_PROP_RCP_MAC_FRAME_COUNTER, SPINEL_DATATYPE_UINT32_S,
-                         otLinkGetFrameCounter(mInstance) + kFrameCounterGuard));
+                         otPlatRadioGetFrameCounter(mInstance) + kFrameCounterGuard));
     }
 
     for (int i = 0; i < mSrcMatchShortEntryCount; ++i)


### PR DESCRIPTION
To ensure the general applicability of `radio spinel` (for example, sometimes we need to provide radio spinel for use with the `Zigbee` protocol), we should avoid using `otLinkxxx` in radio_spinel.cpp and instead use `otPlatRadioxxx`. The `otPlatRadioxxx` functions can be implemented by the platform and override the weak symbols in the OpenThread source code.

This PR currently looks a bit odd because `otLinkGetFrameCounter` is called in `otPlatRadioGetFrameCounter` , but I think it's worth considering separating otLinkxxx from radio spinel.