### PR TITLE
[mle_router] send unicast MLE advertisement to recover assymetric links

### DIFF
--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -606,6 +606,7 @@ private:
     void     HandleNetworkDataUpdateRouter(void);
     void     HandleDiscoveryRequest(RxInfo &aRxInfo);
     Error    ProcessRouteTlv(const RouteTlv &aRouteTlv, RxInfo &aRxInfo);
+    bool     DetectAsymmetricLinks(const RouteTlv &aRouteTlv, RxInfo &aRxInfo);
     Error    ReadAndProcessRouteTlvOnFtdChild(RxInfo &aRxInfo, uint8_t aParentId);
     void     StopAdvertiseTrickleTimer(void);
     uint32_t DetermineAdvertiseIntervalMax(void) const;
@@ -615,7 +616,7 @@ private:
                                         const Router           *aRouter,
                                         const Ip6::MessageInfo &aMessageInfo);
     void     SendAddressRelease(void);
-    void     SendAdvertisement(void);
+    void     SendAdvertisement(Neighbor *aNeighbor = nullptr);
     Error    SendLinkAccept(const LinkAcceptInfo &aInfo);
     void     SendParentResponse(const ParentResponseInfo &aInfo);
     Error    SendChildIdResponse(Child &aChild);


### PR DESCRIPTION
This is related to [SPEC-1308](https://threadgroup.atlassian.net/browse/SPEC-1308) where unicast MLE advertisement is sent when an incoming advertisement indicates no outgoing link to the current node, but the incoming link quality and the router table's outgoing link quality indicates good link. This would expedite the recovery of such asymmetric links