### PR TITLE
[mle] expedite recovery from temporary router link quality mismatch

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -4529,6 +4529,15 @@ void Mle::DelayedSender::ScheduleParentResponse(const ParentResponseInfo &aInfo,
     AddSchedule(kTypeParentResponse, destination, aDelay, &aInfo, sizeof(aInfo));
 }
 
+void Mle::DelayedSender::ScheduleAdvertisement(const Ip6::Address &aDestination, uint16_t aDelay)
+{
+    VerifyOrExit(!HasMatchingSchedule(kTypeAdvertisement, aDestination));
+    AddSchedule(kTypeAdvertisement, aDestination, aDelay, nullptr, 0);
+
+exit:
+    return;
+}
+
 void Mle::DelayedSender::ScheduleMulticastDataResponse(uint16_t aDelay)
 {
     Ip6::Address destination;
@@ -4663,6 +4672,10 @@ void Mle::DelayedSender::Execute(const Schedule &aSchedule)
         Get<MleRouter>().SendParentResponse(info);
         break;
     }
+
+    case kTypeAdvertisement:
+        Get<MleRouter>().SendAdvertisement(header.mDestination);
+        break;
 
     case kTypeDataResponse:
         Get<MleRouter>().SendMulticastDataResponse();

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1136,6 +1136,7 @@ private:
         void ScheduleChildUpdateRequestToParent(uint16_t aDelay);
 #if OPENTHREAD_FTD
         void ScheduleParentResponse(const ParentResponseInfo &aInfo, uint16_t aDelay);
+        void ScheduleAdvertisement(const Ip6::Address &aDestination, uint16_t aDelay);
         void ScheduleMulticastDataResponse(uint16_t aDelay);
         void ScheduleLinkRequest(const Router &aRouter, uint16_t aDelay);
         void ScheduleLinkAccept(const LinkAcceptInfo &aInfo, uint16_t aDelay);

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -362,6 +362,14 @@ public:
      */
     void FillConnectivityTlv(ConnectivityTlv &aTlv);
 
+    /**
+     * Schedule tx of MLE Advertisement message (unicast) to the given neighboring router after a random delay.
+     *
+     * @param[in] aRouter  The router to send the Advertisement to.
+     *
+     */
+    void ScheduleUnicastAdvertisementTo(const Router &aRouter);
+
 #if OPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE
     /**
      * Sets steering data out of band
@@ -494,6 +502,7 @@ private:
     static constexpr uint32_t kAdvIntervalMaxLogRoutes = 5000;
 #endif
 
+    static constexpr uint32_t kMaxUnicastAdvertisementDelay  = 1000;   // Max random delay for unciast Adv tx
     static constexpr uint32_t kMaxNeighborAge                = 100000; // Max neighbor age (in msec)
     static constexpr uint32_t kMaxLeaderToRouterTimeout      = 90000;  // (in msec)
     static constexpr uint8_t  kMinDowngradeNeighbors         = 7;
@@ -605,7 +614,8 @@ private:
                                         const Router           *aRouter,
                                         const Ip6::MessageInfo &aMessageInfo);
     void     SendAddressRelease(void);
-    void     SendAdvertisement(void);
+    void     SendMulticastAdvertisement(void);
+    void     SendAdvertisement(const Ip6::Address &aDestination);
     void     SendLinkRequest(Router *aRouter);
     Error    SendLinkAccept(const LinkAcceptInfo &aInfo);
     void     SendParentResponse(const ParentResponseInfo &aInfo);

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -596,6 +596,25 @@ void RouterTable::UpdateRoutes(const Mle::RouteTlv &aRouteTlv, uint8_t aNeighbor
                 neighbor->SetLinkQualityOut(linkQuality);
                 SignalTableChanged();
             }
+
+            // If the `aRouteTlv` indicates that the neighboring
+            // router claims to have no link to us (by setting its
+            // `GetLinkQualityOut()` towards us as `kLinkQuality0`),
+            // and we have previously established a link with it, and
+            // our two-way link quality to this router is at least
+            // `kLinkQuality2`, we schedule a unicast Advertisement to
+            // be sent to this neighbor. This helps expedite recovery
+            // from any temporary router link quality mismatch.
+            // Otherwise, the neighboring router will continue to
+            // advertise that it has no link to us until our next
+            // trickle timer-triggered Advertisement transmission
+            // (which can be up to 32 seconds later).
+
+            if (neighbor->IsStateValid() && (aRouteTlv.GetLinkQualityOut(index) == kLinkQuality0) &&
+                (neighbor->GetTwoWayLinkQuality() >= kLinkQuality2))
+            {
+                Get<Mle::MleRouter>().ScheduleUnicastAdvertisementTo(*neighbor);
+            }
         }
 
         break;


### PR DESCRIPTION
This commit adds a mechanism to expedite recovery from temporary router link quality mismatches. If a received `RouteTlv` (from a received Advertisement) indicates that the neighboring router claims no link to us by setting its `GetLinkQualityOut()` towards us as `0`, and our two-way link quality to this router is at least Link Quality 2, we schedule a unicast MLE Advertisement to be sent to this neighbor. This advertisement is sent after a randomly selected delay within a one-second window using `Mle::DelayedSender`.

This helps with link recovery on the neighboring router, which otherwise may take longer due to reliance on the next trickle timer-triggered Advertisement transmission, which can be up to 32 seconds later and, being multicast, may be missed.

---

Related to [SPEC-1308](https://threadgroup.atlassian.net/browse/SPEC-1308)