### PR TITLE
[mac-frame] enhance comments regarding PAN ID compression behavior

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -116,6 +116,12 @@ void TxFrame::Info::PrepareHeadersIn(TxFrame &aTxFrame) const
         // | 13 | Extended     | Short        | Present      | Not Present  |      1       |
         // | 14 | Short        | Short        | Present      | Not Present  |      1       |
         // +----+--------------+--------------+--------------+--------------+--------------+
+        //
+        // This table shows the combination of flags allowed in an encoded MAC
+        // header. Regarding rows 9-14, when both Source and Destination
+        // Address fields are present and at least one uses a short address
+        // format, then if the source and destination PAN IDs are equal, PAN
+        // ID compression is set to 1.
 
         if (mAddrs.mDestination.IsNone())
         {


### PR DESCRIPTION
This commit adds an additional note next to the table from the specification text regarding valid combinations of flags within an encoded MAC header and the interpretation of the "PAN ID Compression" flag.