### PR TITLE
[mle] track Link Accept timeout in `Router` entry

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2662,7 +2662,7 @@ void Mle::ReestablishLinkWithNeighbor(Neighbor &aNeighbor)
 
     if (IsRouterRloc16(aNeighbor.GetRloc16()))
     {
-        IgnoreError(Get<MleRouter>().SendLinkRequest(&aNeighbor));
+        Get<MleRouter>().SendLinkRequest(static_cast<Router *>(&aNeighbor));
     }
     else if (Get<ChildTable>().Contains(aNeighbor))
     {
@@ -3928,7 +3928,7 @@ Error Mle::ParentSearch::SelectBetterParent(void)
     }
 
     VerifyOrExit(mSelectedParent != nullptr, error = kErrorNotFound);
-    mSelectedParent->SetParentReselectTimeout(kParentReselectTimeout);
+    mSelectedParent->RestartParentReselectTimeout();
 
     LogInfo("PeriodicParentSearch: Selected router 0x%04x as parent with RSS %d", mSelectedParent->GetRloc16(),
             mSelectedParent->GetLinkInfo().GetAverageRss());

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1243,8 +1243,7 @@ private:
         static constexpr int8_t   kRssThreshold    = OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD;
 
 #if OPENTHREAD_FTD
-        static constexpr int8_t   kRssMarginOverParent   = OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_MARGIN;
-        static constexpr uint16_t kParentReselectTimeout = OPENTHREAD_CONFIG_PARENT_SEARCH_RESELECT_TIMEOUT; // in sec
+        static constexpr int8_t kRssMarginOverParent = OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_MARGIN;
 
         Error SelectBetterParent(void);
         void  CompareAndUpdateSelectedParent(Router &aRouter);

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -362,8 +362,6 @@ public:
      */
     void FillConnectivityTlv(ConnectivityTlv &aTlv);
 
-    Error SendLinkRequest(Neighbor *aNeighbor);
-
 #if OPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE
     /**
      * Sets steering data out of band
@@ -608,6 +606,7 @@ private:
                                         const Ip6::MessageInfo &aMessageInfo);
     void     SendAddressRelease(void);
     void     SendAdvertisement(void);
+    void     SendLinkRequest(Router *aRouter);
     Error    SendLinkAccept(const LinkAcceptInfo &aInfo);
     void     SendParentResponse(const ParentResponseInfo &aInfo);
     Error    SendChildIdResponse(Child &aChild);

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -91,6 +91,15 @@ constexpr uint8_t kMaxRouteCost = 16; ///< Maximum path cost
 #endif
 
 constexpr uint8_t kMeshLocalPrefixContextId = 0; ///< Reserved 6lowpan context ID for Mesh Local Prefix
+constexpr uint8_t kLinkAcceptTimeout        = 3; ///< Timeout in seconds to rx Link Accept after Link Request tx.
+
+/**
+ * Specifies parent reselect timeout duration in seconds used on FTD child devices.
+ *
+ * When an attach attempt to a neighboring router selected as a potential new parent fails, the same router
+ * cannot be selected again until this timeout expires.
+ */
+constexpr uint16_t kParentReselectTimeout = OPENTHREAD_CONFIG_PARENT_SEARCH_RESELECT_TIMEOUT;
 
 /**
  * Number of consecutive tx failures to child (with no-ack error) to consider child-parent link broken.


### PR DESCRIPTION
This commit updates how the Link Accept response timeout is tracked. It is now directly tracked in a `Router` entry using a new member variable, `mLinkAcceptTimeout`, which stores the remaining timeout in seconds. This value is decremented from `HandleTimeTick()` every second.

This model replaces the previous approach, which indirectly used `SetLastHeard()` for this purpose. The earlier method had shortcomings; primarily, `SetLastHeard()` could be called again on receiving a new advertisement, inadvertently pushing back the Link Accept timeout. This model also became problematic when a random delay was introduced before the transmission of Link Requests (e.g., after receiving an advertisement).

This commit also enhances the process for restoring a link when a router is aged (i.e., no advertisements are received from it). In the new model, once the router age expires, Link Requests are sent every time tick (every second) up to `kMaxTxCount = 3` attempts. The main change is that after the last attempt, the code waits for the Link Accept timeout (~3 seconds) before the router is removed.

---

~This PR contains the commit from the PR below. Please check and review the second commit. Thanks.~
~- https://github.com/openthread/openthread/pull/10915~