### PR TITLE
[mle] simplify handling of Link Accept variants

### DIFF
--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -587,8 +587,8 @@ private:
     void     HandleSecurityPolicyChanged(void);
     void     HandleLinkRequest(RxInfo &aRxInfo);
     void     HandleLinkAccept(RxInfo &aRxInfo);
-    Error    HandleLinkAccept(RxInfo &aRxInfo, bool aRequest);
     void     HandleLinkAcceptAndRequest(RxInfo &aRxInfo);
+    void     HandleLinkAcceptVariant(RxInfo &aRxInfo, MessageType aMessageType);
     Error    HandleAdvertisementOnFtd(RxInfo &aRxInfo, uint16_t aSourceAddress, const LeaderData &aLeaderData);
     void     HandleParentRequest(RxInfo &aRxInfo);
     void     HandleChildIdRequest(RxInfo &aRxInfo);


### PR DESCRIPTION
This commit renames and updates `HandleLinkAcceptVariant()` used to handle an MLE "Link Accept" or "Link Accept And Request". The method now takes the `MessageType` directly as an input parameter.