### PR TITLE
[test] fix uploading code coverage

### DIFF
--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -256,8 +256,7 @@ jobs:
     - name: Upload Coverage
       continue-on-error: true
       uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: final.info
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -324,8 +324,7 @@ jobs:
         script/test combine_coverage
     - name: Upload Coverage
       uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: final.info
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/simulation-1.1.yml
+++ b/.github/workflows/simulation-1.1.yml
@@ -451,8 +451,7 @@ jobs:
         script/test combine_coverage
     - name: Upload Coverage
       uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: final.info
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/simulation-1.4.yml
+++ b/.github/workflows/simulation-1.4.yml
@@ -443,8 +443,7 @@ jobs:
         script/test combine_coverage
     - name: Upload Coverage
       uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: final.info
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -240,8 +240,7 @@ jobs:
         script/test combine_coverage
     - name: Upload Coverage
       uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: final.info
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -129,8 +129,7 @@ jobs:
         script/test combine_coverage
     - name: Upload Coverage
       uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: final.info
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This commit changes the codecov action to avoid using the token from the environment which seems to be causing failures.