### PR TITLE
[spinel] move definition of new

### DIFF
--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -48,6 +48,7 @@
 #include "lib/spinel/spinel_decoder.hpp"
 #include "lib/spinel/spinel_driver.hpp"
 #include "lib/spinel/spinel_helper.hpp"
+#include "lib/utils/new.hpp"
 #include "lib/utils/utils.hpp"
 
 namespace ot {

--- a/src/lib/spinel/spinel_driver.cpp
+++ b/src/lib/spinel/spinel_driver.cpp
@@ -35,6 +35,7 @@
 #include "lib/platform/exit_code.h"
 #include "lib/spinel/spinel.h"
 #include "lib/utils/math.hpp"
+#include "lib/utils/new.hpp"
 #include "lib/utils/utils.hpp"
 
 namespace ot {

--- a/src/lib/utils/new.hpp
+++ b/src/lib/utils/new.hpp
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef LIB_UTILS_NEW_HPP_
+#define LIB_UTILS_NEW_HPP_
+
+#include <cstddef>
+
+/**
+ * Overload the new operator to new an object at a specific address.
+ *
+ * @param[in]  p  The pointer of the address.
+ */
+inline void *operator new(size_t, void *p) throw() { return p; }
+
+#endif // LIB_UTILS_NEW_HPP_

--- a/src/lib/utils/utils.hpp
+++ b/src/lib/utils/utils.hpp
@@ -109,11 +109,4 @@
         }                         \
     } while (false)
 
-/**
- * Overload the new operator to new an object at a specific address.
- *
- * @param[in]  p  The pointer of the address.
- */
-inline void *operator new(size_t, void *p) throw() { return p; }
-
 #endif // LIB_UTILS_CODE_UTILS_HPP_


### PR DESCRIPTION
This PR moves the definition of `new` in `lib/spinel`.

The PR moves it from `lib/spinel/utils/utils.hpp` to `lib/spinel/utils/new.hpp`. The purpose is to make `lib/spinel/utils/utils.hpp` be safely included by any hpp header in `lib/spinel`. Currently only cpps in `lib/spinel` can include `lib/spinel/utils/utils.hpp` because when hpps in `lib/spinel` are included by OT source files, the source files may also include `src/core/common/new.hpp` and will have a conflict definition of `new`. With this PR, the util functions can be used in the hpp headers in `lib/spinel`.