### PR TITLE
[ip6] add `MessageInfo::HasSamePeerAddrAndPort()`

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1483,8 +1483,7 @@ const Message *ResponsesQueue::FindMatchedResponse(const Message &aRequest, cons
 
             metadata.ReadFrom(message);
 
-            if ((metadata.mMessageInfo.GetPeerPort() == aMessageInfo.GetPeerPort()) &&
-                (metadata.mMessageInfo.GetPeerAddr() == aMessageInfo.GetPeerAddr()))
+            if (metadata.mMessageInfo.HasSamePeerAddrAndPort(aMessageInfo))
             {
                 response = &message;
                 break;

--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -199,8 +199,7 @@ void SecureTransport::HandleReceive(Message &aMessage, const Ip6::MessageInfo &a
     else
     {
         // Once DTLS session is started, communicate only with a single peer.
-        VerifyOrExit((mMessageInfo.GetPeerAddr() == aMessageInfo.GetPeerAddr()) &&
-                     (mMessageInfo.GetPeerPort() == aMessageInfo.GetPeerPort()));
+        VerifyOrExit(mMessageInfo.HasSamePeerAddrAndPort(aMessageInfo));
     }
 
 #ifdef MBEDTLS_SSL_SRV_C

--- a/src/core/net/socket.cpp
+++ b/src/core/net/socket.cpp
@@ -36,6 +36,11 @@
 namespace ot {
 namespace Ip6 {
 
+bool MessageInfo::HasSamePeerAddrAndPort(const MessageInfo &aOther) const
+{
+    return (GetPeerPort() == aOther.GetPeerPort()) && (GetPeerAddr() == aOther.GetPeerAddr());
+}
+
 SockAddr::InfoString SockAddr::ToString(void) const
 {
     InfoString string;

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -199,6 +199,16 @@ public:
      * @param[in]  aIsHost  TRUE if the peer is via the host interface, FALSE otherwise.
      */
     void SetIsHostInterface(bool aIsHost) { mIsHostInterface = aIsHost; }
+
+    /**
+     * Checks if the peer address and port match those of another `MessageInfo`.
+     *
+     * @param[in] aOther  The other `MessageInfo` to compare with.
+     *
+     * @retval TRUE   The peer address and port of the two `MessageInfo` objects match.
+     * @retval FALSE  The peer address and port of the two `MessageInfo` objects do not match.
+     */
+    bool HasSamePeerAddrAndPort(const MessageInfo &aOther) const;
 };
 
 /**

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -778,8 +778,7 @@ const Server::UpdateMetadata *Server::FindOutstandingUpdate(const MessageMetadat
     for (const UpdateMetadata &update : mOutstandingUpdates)
     {
         if (aMessageMetadata.mDnsHeader.GetMessageId() == update.GetDnsHeader().GetMessageId() &&
-            aMessageMetadata.mMessageInfo->GetPeerAddr() == update.GetMessageInfo().GetPeerAddr() &&
-            aMessageMetadata.mMessageInfo->GetPeerPort() == update.GetMessageInfo().GetPeerPort())
+            aMessageMetadata.mMessageInfo->HasSamePeerAddrAndPort(update.GetMessageInfo()))
         {
             ExitNow(ret = &update);
         }


### PR DESCRIPTION
This commit adds `Ip6::MessageInfo::HasSamePeerAddrAndPort()` which checks if the peer address and port of two `MessageInfo` objects match. This method is used in different modules (`Coap`, `Srp::Server`, `SecureTransport`) to simplify the code.