### PR TITLE
[secure-transport] smaller enhancements in `SecureTransport`

### DIFF
--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -186,7 +186,7 @@ public:
      *
      * @returns  UDP port number.
      */
-    uint16_t GetUdpPort(void) const;
+    uint16_t GetUdpPort(void) const { return mSocket.GetSockName().GetPort(); }
 
     /**
      * Binds with a transport callback.
@@ -241,7 +241,7 @@ public:
     /**
      * Disconnects the session.
      */
-    void Disconnect(void);
+    void Disconnect(void) { Disconnect(kDisconnectedLocalClosed); }
 
     /**
      * Closes the socket.
@@ -413,18 +413,6 @@ public:
 
 #endif // OPENTHREAD_CONFIG_TLS_API_ENABLE
 
-#ifdef MBEDTLS_SSL_SRV_C
-    /**
-     * Sets the Client ID used for generating the Hello Cookie.
-     *
-     * @param[in]  aClientId  A pointer to the Client ID.
-     * @param[in]  aLength    Number of bytes in the Client ID.
-     *
-     * @retval kErrorNone  Successfully set the Client ID.
-     */
-    Error SetClientId(const uint8_t *aClientId, uint8_t aLength);
-#endif
-
     /**
      * Sends data within the session.
      *
@@ -591,9 +579,6 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
-    Error HandleSecureTransportSend(const uint8_t *aBuf, uint16_t aLength, Message::SubType aMessageSubType);
-
-    void Receive(Message &aMessage);
     void Process(void);
     void Disconnect(ConnectEvent aEvent);
 


### PR DESCRIPTION
This commit contains changes to `SecureTransport`:

- Inlines simple methods (`Disconnect()` and `GetUdpPort()`).
- Removes/refactors simpler methods, such as `Receive()` and `HandleSecureTransportSend()`, which are now directly moved into `HandleMbedtlsTransmit()` and `HandleReceive()`.
- Removes unused `SetClientId()` and inlines its implementation.
- Removes extra `LogDebug` line (can be tracked by logging `State` changes).
- Simplifies `HandleMbedtlsReceive()` and how data is read from `mReceiveMessage`.
- Uses a consistent style to refer to function pointers.