### PR TITLE
[simulation] log the exit information when the program exits

### DIFF
--- a/examples/platforms/simulation/alarm.c
+++ b/examples/platforms/simulation/alarm.c
@@ -114,7 +114,7 @@ void platformAlarmInit(uint32_t aSpeedUpFactor)
         if (sigaction(OPENTHREAD_CONFIG_MICRO_TIMER_SIGNAL, &sa, NULL) == -1)
         {
             perror("sigaction");
-            exit(EXIT_FAILURE);
+            DieNow(OT_EXIT_ERROR_ERRNO);
         }
 
         struct sigevent sev;
@@ -126,7 +126,7 @@ void platformAlarmInit(uint32_t aSpeedUpFactor)
         if (-1 == timer_create(CLOCK_MONOTONIC, &sev, &sMicroTimer))
         {
             perror("timer_create");
-            exit(EXIT_FAILURE);
+            DieNow(OT_EXIT_ERROR_ERRNO);
         }
     }
 #endif
@@ -198,7 +198,7 @@ void otPlatAlarmMicroStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
         if (-1 == timer_settime(sMicroTimer, 0, &its, NULL))
         {
             perror("otPlatAlarmMicroStartAt timer_settime()");
-            exit(EXIT_FAILURE);
+            DieNow(OT_EXIT_ERROR_ERRNO);
         }
     }
 #endif // __linux__
@@ -217,7 +217,7 @@ void otPlatAlarmMicroStop(otInstance *aInstance)
         if (-1 == timer_settime(sMicroTimer, 0, &its, NULL))
         {
             perror("otPlatAlarmMicroStop timer_settime()");
-            exit(EXIT_FAILURE);
+            DieNow(OT_EXIT_ERROR_ERRNO);
         }
     }
 #endif // __linux__

--- a/examples/platforms/simulation/ble.c
+++ b/examples/platforms/simulation/ble.c
@@ -37,6 +37,7 @@
 #include <openthread/tcat.h>
 #include <openthread/platform/ble.h>
 
+#include "lib/platform/exit_code.h"
 #include "utils/code_utils.h"
 
 #define PLAT_BLE_MSG_DATA_MAX 2048
@@ -76,7 +77,7 @@ static void initFds(void)
 exit:
     if (sFd == -1)
     {
-        exit(EXIT_FAILURE);
+        DieNow(OT_EXIT_FAILURE);
     }
 }
 
@@ -207,7 +208,7 @@ void platformBleProcess(otInstance *aInstance, const fd_set *aReadFdSet, const f
         else if (errno != EINTR && errno != EAGAIN)
         {
             perror("recvfrom BLE simulation failed");
-            exit(EXIT_FAILURE);
+            DieNow(OT_EXIT_FAILURE);
         }
     }
 exit:

--- a/examples/platforms/simulation/infra_if.c
+++ b/examples/platforms/simulation/infra_if.c
@@ -34,6 +34,7 @@
 #include <openthread/platform/infra_if.h>
 
 #include "simul_utils.h"
+#include "lib/platform/exit_code.h"
 #include "utils/code_utils.h"
 
 #if OPENTHREAD_SIMULATION_IMPLEMENT_INFRA_IF && OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
@@ -252,7 +253,7 @@ void platformInfraIfInit(void)
         if (*endptr != '\0')
         {
             fprintf(stderr, "\r\nInvalid PORT_OFFSET: %s\r\n", str);
-            exit(EXIT_FAILURE);
+            DieNow(OT_EXIT_FAILURE);
         }
 
         sPortOffset *= (MAX_NETWORK_SIZE + 1);
@@ -332,7 +333,7 @@ OT_TOOL_WEAK void otPlatInfraIfRecvIcmp6Nd(otInstance         *aInstance,
     OT_UNUSED_VARIABLE(aBufferLength);
 
     fprintf(stderr, "\n\r Weak otPlatInfraIfRecvIcmp6Nd is being used\n\r");
-    exit(1);
+    DieNow(OT_EXIT_FAILURE);
 }
 
 #endif // OPENTHREAD_SIMULATION_IMPLEMENT_INFRA_IF && OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE

--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -42,6 +42,7 @@
 #include <openthread/platform/time.h>
 
 #include "simul_utils.h"
+#include "lib/platform/exit_code.h"
 #include "utils/code_utils.h"
 #include "utils/link_metrics.h"
 #include "utils/mac_frame.h"
@@ -1231,7 +1232,7 @@ void parseFromEnvAsUint16(const char *aEnvName, uint16_t *aValue)
         if (*endptr != '\0')
         {
             fprintf(stderr, "Invalid %s: %s\n", aEnvName, env);
-            exit(EXIT_FAILURE);
+            DieNow(OT_EXIT_FAILURE);
         }
     }
 }

--- a/examples/platforms/simulation/trel.c
+++ b/examples/platforms/simulation/trel.c
@@ -32,6 +32,7 @@
 #include <openthread/platform/trel.h>
 
 #include "simul_utils.h"
+#include "lib/platform/exit_code.h"
 #include "utils/code_utils.h"
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
@@ -316,7 +317,7 @@ void platformTrelInit(uint32_t aSpeedUpFactor)
         if (*endptr != '\0')
         {
             fprintf(stderr, "\r\nInvalid PORT_OFFSET: %s\r\n", str);
-            exit(EXIT_FAILURE);
+            DieNow(OT_EXIT_FAILURE);
         }
 
         sPortOffset *= (MAX_NETWORK_SIZE + 1);

--- a/examples/platforms/simulation/uart.c
+++ b/examples/platforms/simulation/uart.c
@@ -41,6 +41,7 @@
 #include <openthread/platform/debug_uart.h>
 
 #include "simul_utils.h"
+#include "lib/platform/exit_code.h"
 #include "utils/code_utils.h"
 #include "utils/uart.h"
 
@@ -203,7 +204,7 @@ otError otPlatUartFlush(void)
     else
     {
         perror("write(UART)");
-        exit(EXIT_FAILURE);
+        DieNow(OT_EXIT_ERROR_ERRNO);
     }
 
 exit:
@@ -226,7 +227,7 @@ void platformUartProcess(void)
     if (rval < 0)
     {
         perror("poll");
-        exit(EXIT_FAILURE);
+        DieNow(OT_EXIT_ERROR_ERRNO);
     }
 
     if (rval > 0)
@@ -234,13 +235,13 @@ void platformUartProcess(void)
         if ((pollfd[0].revents & error_flags) != 0)
         {
             perror("s_in_fd");
-            exit(EXIT_FAILURE);
+            DieNow(OT_EXIT_ERROR_ERRNO);
         }
 
         if ((pollfd[1].revents & error_flags) != 0)
         {
             perror("s_out_fd");
-            exit(EXIT_FAILURE);
+            DieNow(OT_EXIT_ERROR_ERRNO);
         }
 
         if (pollfd[0].revents & POLLIN)
@@ -250,7 +251,7 @@ void platformUartProcess(void)
             if (rval <= 0)
             {
                 perror("read");
-                exit(EXIT_FAILURE);
+                DieNow(OT_EXIT_ERROR_ERRNO);
             }
 
             otPlatUartReceived(s_receive_buffer, (uint16_t)rval);
@@ -273,7 +274,7 @@ void platformUartProcess(void)
             else if (errno != EINTR)
             {
                 perror("write");
-                exit(EXIT_FAILURE);
+                DieNow(OT_EXIT_ERROR_ERRNO);
             }
         }
     }

--- a/examples/platforms/simulation/virtual_time/platform-sim.c
+++ b/examples/platforms/simulation/virtual_time/platform-sim.c
@@ -49,6 +49,7 @@
 #include <openthread/tasklet.h>
 #include <openthread/platform/alarm-milli.h>
 
+#include "lib/platform/exit_code.h"
 #include "utils/uart.h"
 
 uint32_t gNodeId = 1;
@@ -87,7 +88,7 @@ void otSimSendEvent(const struct Event *aEvent)
     if (rval < 0)
     {
         perror("sendto");
-        exit(EXIT_FAILURE);
+        DieNow(OT_EXIT_ERROR_ERRNO);
     }
 }
 
@@ -99,7 +100,7 @@ static void receiveEvent(otInstance *aInstance)
     if (rval < 0 || (uint16_t)rval < offsetof(struct Event, mData))
     {
         perror("recvfrom");
-        exit(EXIT_FAILURE);
+        DieNow(OT_EXIT_ERROR_ERRNO);
     }
 
     platformAlarmAdvanceNow(event.mDelay);
@@ -182,13 +183,13 @@ static void socket_init(void)
     if (sSockFd == -1)
     {
         perror("socket");
-        exit(EXIT_FAILURE);
+        DieNow(OT_EXIT_ERROR_ERRNO);
     }
 
     if (bind(sSockFd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) == -1)
     {
         perror("bind");
-        exit(EXIT_FAILURE);
+        DieNow(OT_EXIT_ERROR_ERRNO);
     }
 }
 
@@ -204,7 +205,7 @@ void otSysInit(int argc, char *argv[])
 
     if (argc != 2)
     {
-        exit(EXIT_FAILURE);
+        DieNow(OT_EXIT_FAILURE);
     }
 
     openlog(basename(argv[0]), LOG_PID, LOG_USER);
@@ -218,7 +219,7 @@ void otSysInit(int argc, char *argv[])
     if (*endptr != '\0' || gNodeId < 1 || gNodeId > MAX_NETWORK_SIZE)
     {
         fprintf(stderr, "Invalid NodeId: %s\n", argv[1]);
-        exit(EXIT_FAILURE);
+        DieNow(OT_EXIT_FAILURE);
     }
 
     socket_init();
@@ -268,7 +269,7 @@ void otSysProcessDrivers(otInstance *aInstance)
         if ((rval < 0) && (errno != EINTR))
         {
             perror("select");
-            exit(EXIT_FAILURE);
+            DieNow(OT_EXIT_ERROR_ERRNO);
         }
 
         if (rval > 0 && FD_ISSET(sSockFd, &read_fds))


### PR DESCRIPTION
Sometimes `ot-rcp` will exit without any exit information in the log. It is hard for developers to know what happens on the `ot-rcp` side when the `ot-rcp` exits abnormally. This commit calls functions defined in `lib/platform/exit_code.h` to exit the program and log the exit information.