### PR TITLE
[mac-frame] set `mCslPresent` on `TxFrame` when CSL IE is added

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -232,6 +232,7 @@ void TxFrame::Info::PrepareHeadersIn(TxFrame &aTxFrame) const
     {
         builder.Append<HeaderIe>()->Init(CslIe::kHeaderIeId, sizeof(CslIe));
         builder.Append<CslIe>();
+        aTxFrame.SetCslIePresent(true);
     }
 #endif
 


### PR DESCRIPTION
This commit ensures that the `mCslPresent` flag is set on `TxFrame` when the CSL IE header is appended to the frame. This addresses an issue introduced in #10692 where this flag can remain unset.


---

Resolves #10938 