### PR TITLE
[secure-transport] remove extra `mbedtls_ssl_close_notify()` calls

### DIFF
--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -1048,7 +1048,6 @@ void SecureTransport::Process(void)
             break;
 
         case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY:
-            mbedtls_ssl_close_notify(&mSsl);
             disconnectEvent = kDisconnectedPeerClosed;
             break;
 
@@ -1056,7 +1055,6 @@ void SecureTransport::Process(void)
             break;
 
         case MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE:
-            mbedtls_ssl_close_notify(&mSsl);
             disconnectEvent = kDisconnectedError;
             break;
 


### PR DESCRIPTION
This commit removes the calls to `mbedtls_ssl_close_notify()` in `SecureTransport::Process()` when, based on `rval`, it is determined that `Disconnect()` should be called, as the `Disconnect()` method itself will call `mbedtls_ssl_close_notify()`.