### PR TITLE
[mac] fix the compile error of wakeup_tx_scheduler.cpp on Android

### DIFF
--- a/src/core/mac/wakeup_tx_scheduler.cpp
+++ b/src/core/mac/wakeup_tx_scheduler.cpp
@@ -31,10 +31,11 @@
 #if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
 
 #include "common/code_utils.hpp"
+#include "common/locator_getters.hpp"
 #include "common/log.hpp"
 #include "common/num_utils.hpp"
 #include "common/time.hpp"
-#include "core/instance/instance.hpp"
+#include "instance/instance.hpp"
 #include "radio/radio.hpp"
 
 namespace ot {


### PR DESCRIPTION
When compiling the WC role on Android, the compiler reports an error: "error: inline function 'ot::GetProvider<ot::InstanceLocator>::Get<ot::Mac::Mac>' is not defined".

This commit adds "common/locator_getters.hpp" to
"wakeup_tx_scheduler.cpp" to resolve the compile error.