### PR TITLE
[test] fix address list comparison in `spinel_prop_codec`

### DIFF
--- a/tests/unit/test_spinel_prop_codec.cpp
+++ b/tests/unit/test_spinel_prop_codec.cpp
@@ -84,8 +84,8 @@ void TestDnssd(void)
     SuccessOrQuit(error = DecodeDnssdHost(decoder, dnssdHostDecode, requestId, callbackData, callbackDataLen));
     VerifyOrQuit(strcmp(dnssdHostDecode.mHostName, dnssdHostEncode.mHostName) == 0);
     VerifyOrQuit(dnssdHostDecode.mAddressesLength == dnssdHostEncode.mAddressesLength);
-    VerifyOrQuit(memcmp(dnssdHostDecode.mAddresses, dnssdHostEncode.mAddresses, sizeof(dnssdHostEncode.mAddresses)) ==
-                 0);
+    VerifyOrQuit(memcmp(dnssdHostDecode.mAddresses, dnssdHostEncode.mAddresses,
+                        dnssdHostDecode.mAddressesLength * sizeof(otIp6Address)) == 0);
     VerifyOrQuit(requestId == 1);
     VerifyOrQuit(callbackDataLen == sizeof(otPlatDnssdRegisterCallback));
     VerifyOrQuit(*reinterpret_cast<const otPlatDnssdRegisterCallback *>(callbackData) == DnssdFakeCallback);


### PR DESCRIPTION
This commit updates how address lists are compared in the unit test `spinel_prop_codec`, ensuring that the correct size based on the array length is passed to `memcmp()`.