### PR TITLE
[indirect-sender] remove callbacks to its sub-components

### DIFF
--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -36,34 +36,11 @@ namespace ot {
 
 RegisterLogModule("CslTxScheduler");
 
-CslTxScheduler::Callbacks::Callbacks(Instance &aInstance)
-    : InstanceLocator(aInstance)
-{
-}
-
-inline Error CslTxScheduler::Callbacks::PrepareFrameForChild(Mac::TxFrame &aFrame,
-                                                             FrameContext &aContext,
-                                                             Child        &aChild)
-{
-    return Get<IndirectSender>().PrepareFrameForChild(aFrame, aContext, aChild);
-}
-
-inline void CslTxScheduler::Callbacks::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
-                                                              const FrameContext &aContext,
-                                                              Error               aError,
-                                                              Child              &aChild)
-{
-    Get<IndirectSender>().HandleSentFrameToChild(aFrame, aContext, aError, aChild);
-}
-
-//---------------------------------------------------------
-
 CslTxScheduler::CslTxScheduler(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mCslTxChild(nullptr)
     , mCslTxMessage(nullptr)
     , mFrameContext()
-    , mCallbacks(aInstance)
 {
     UpdateFrameRequestAhead();
 }
@@ -190,7 +167,8 @@ Mac::TxFrame *CslTxScheduler::HandleFrameRequest(Mac::TxFrames &aTxFrames)
     frame = &aTxFrames.GetTxFrame();
 #endif
 
-    VerifyOrExit(mCallbacks.PrepareFrameForChild(*frame, mFrameContext, *mCslTxChild) == kErrorNone, frame = nullptr);
+    VerifyOrExit(Get<IndirectSender>().PrepareFrameForChild(*frame, mFrameContext, *mCslTxChild) == kErrorNone,
+                 frame = nullptr);
     mCslTxMessage = mCslTxChild->GetIndirectMessage();
     VerifyOrExit(mCslTxMessage != nullptr, frame = nullptr);
 
@@ -328,7 +306,7 @@ void CslTxScheduler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, C
         OT_UNREACHABLE_CODE(break);
     }
 
-    mCallbacks.HandleSentFrameToChild(aFrame, mFrameContext, aError, aChild);
+    Get<IndirectSender>().HandleSentFrameToChild(aFrame, mFrameContext, aError, aChild);
 
 exit:
     return;

--- a/src/core/thread/csl_tx_scheduler.hpp
+++ b/src/core/thread/csl_tx_scheduler.hpp
@@ -157,51 +157,6 @@ public:
     };
 
     /**
-     * Defines the callbacks used by the `CslTxScheduler`.
-     */
-    class Callbacks : public InstanceLocator
-    {
-        friend class CslTxScheduler;
-
-    private:
-        typedef IndirectSenderBase::FrameContext FrameContext;
-
-        /**
-         * Initializes the callbacks object.
-         *
-         * @param[in]  aInstance   A reference to the OpenThread instance.
-         */
-        explicit Callbacks(Instance &aInstance);
-
-        /**
-         * This callback method requests a frame to be prepared for CSL transmission to a given SSED.
-         *
-         * @param[out] aFrame    A reference to a MAC frame where the new frame would be placed.
-         * @param[out] aContext  A reference to a `FrameContext` where the context for the new frame would be placed.
-         * @param[in]  aChild    The child for which to prepare the frame.
-         *
-         * @retval kErrorNone   Frame was prepared successfully.
-         * @retval kErrorAbort  CSL transmission should be aborted (no frame for the child).
-         */
-        Error PrepareFrameForChild(Mac::TxFrame &aFrame, FrameContext &aContext, Child &aChild);
-
-        /**
-         * This callback method notifies the end of CSL frame transmission to a child.
-         *
-         * @param[in]  aFrame     The transmitted frame.
-         * @param[in]  aContext   The context associated with the frame when it was prepared.
-         * @param[in]  aError     kErrorNone when the frame was transmitted successfully,
-         *                        kErrorNoAck when the frame was transmitted but no ACK was received,
-         *                        kErrorChannelAccessFailure tx failed due to activity on the channel,
-         *                        kErrorAbort when transmission was aborted for other reasons.
-         * @param[in]  aChild     The child to which the frame was transmitted.
-         */
-        void HandleSentFrameToChild(const Mac::TxFrame &aFrame,
-                                    const FrameContext &aContext,
-                                    Error               aError,
-                                    Child              &aChild);
-    };
-    /**
      * Initializes the CSL tx scheduler object.
      *
      * @param[in]  aInstance   A reference to the OpenThread instance.
@@ -232,6 +187,8 @@ private:
     // Guard time in usec to add when checking delay while preparing the CSL frame for tx.
     static constexpr uint32_t kFramePreparationGuardInterval = 1500;
 
+    typedef IndirectSenderBase::FrameContext FrameContext;
+
     void RescheduleCslTx(void);
 
     uint32_t GetNextCslTransmissionDelay(const Child &aChild, uint32_t &aDelayFromLastRx, uint32_t aAheadUs) const;
@@ -242,11 +199,10 @@ private:
 
     void HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, Child &aChild);
 
-    uint32_t                mCslFrameRequestAheadUs;
-    Child                  *mCslTxChild;
-    Message                *mCslTxMessage;
-    Callbacks::FrameContext mFrameContext;
-    Callbacks               mCallbacks;
+    uint32_t     mCslFrameRequestAheadUs;
+    Child       *mCslTxChild;
+    Message     *mCslTxMessage;
+    FrameContext mFrameContext;
 };
 
 /**

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -310,8 +310,6 @@ void IndirectSender::UpdateIndirectMessage(Child &aChild)
     {
         Mac::Address childAddress;
 
-        mDataPollHandler.HandleNewFrame(aChild);
-
         aChild.GetMacAddress(childAddress);
         Get<MeshForwarder>().LogMessage(MeshForwarder::kMessagePrepareIndirect, *message, kErrorNone, &childAddress);
     }
@@ -460,7 +458,6 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
     if ((message != nullptr) && (nextOffset < message->GetLength()))
     {
         aChild.SetIndirectFragmentOffset(nextOffset);
-        mDataPollHandler.HandleNewFrame(aChild);
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
         mCslTxScheduler.Update();
 #endif

--- a/src/core/thread/indirect_sender.hpp
+++ b/src/core/thread/indirect_sender.hpp
@@ -67,9 +67,9 @@ class Child;
 class IndirectSender : public InstanceLocator, public IndirectSenderBase, private NonCopyable
 {
     friend class Instance;
-    friend class DataPollHandler::Callbacks;
+    friend class DataPollHandler;
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-    friend class CslTxScheduler::Callbacks;
+    friend class CslTxScheduler;
 #endif
 
 public:
@@ -248,7 +248,7 @@ public:
     void HandleChildModeChange(Child &aChild, Mle::DeviceMode aOldMode);
 
 private:
-    // Callbacks from DataPollHandler
+    // Callbacks from `DataPollHandler` or `CslTxScheduler`
     Error PrepareFrameForChild(Mac::TxFrame &aFrame, FrameContext &aContext, Child &aChild);
     void  HandleSentFrameToChild(const Mac::TxFrame &aFrame, const FrameContext &aContext, Error aError, Child &aChild);
     void  HandleFrameChangeDone(Child &aChild);


### PR DESCRIPTION
This commit removes the `Callbacks` class defined for use between `IndirectSender` and its underlying `DataPollHandler` and `CslTxScheduler` components. This model was added earlier in #3952 to make all interactions between these modules asynchronous (callback-based). The objective was to move the handling of data polls and indirect transmissions closer to the MAC layer and allow `DataPollHandler` logic to be moved to RCP in an host and RCP architecture. With the introduction of CSL, this approach is no longer viable, but the callback style was still used. This commit removes this and simplifies the code.