### PR TITLE
[logging] aling define guards on `RegisterLogModule` and `LogAt`

### DIFF
--- a/src/core/common/log.hpp
+++ b/src/core/common/log.hpp
@@ -77,7 +77,7 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 
 constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max size of log string
 
-#if OT_SHOULD_LOG && (OPENTHREAD_CONFIG_LOG_LEVEL != OT_LOG_LEVEL_NONE)
+#if OT_SHOULD_LOG
 /**
  * Registers log module name.
  *


### PR DESCRIPTION
Commit aligns define guards on `LogAt` macto and `RegisterLogModule` to match. Previuosly `OT_SHOULD_LOG` was getting default value set as platform defined and log level was buy default set to none which caused misalignment.