### PR TITLE
[radio] add `GetBusSpeed()` and `GetBusLatency()` methods

### DIFF
--- a/src/core/mac/wakeup_tx_scheduler.cpp
+++ b/src/core/mac/wakeup_tx_scheduler.cpp
@@ -158,8 +158,8 @@ void WakeupTxScheduler::UpdateFrameRequestAhead(void)
     // This is used to make sure that a wake-up frame is received by the radio early enough to be transmitted on time.
     constexpr uint32_t kWakeupFrameWeight = 100;
 
-    uint32_t busSpeedHz  = otPlatRadioGetBusSpeed(&GetInstance());
-    uint32_t busLatency  = otPlatRadioGetBusLatency(&GetInstance());
+    uint32_t busSpeedHz  = Get<Radio>().GetBusSpeed();
+    uint32_t busLatency  = Get<Radio>().GetBusLatency();
     uint32_t busTxTimeUs = ((busSpeedHz == 0) ? 0 : (kWakeupFrameWeight * 8 * 1000000 + busSpeedHz - 1) / busSpeedHz);
 
     mTxRequestAheadTimeUs = OPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US + busTxTimeUs + busLatency;

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -812,6 +812,24 @@ public:
         return mask;
     }
 
+    /**
+     * Get the bus speed in bits/second between the host and the radio chip.
+     *
+     * @returns The bus speed in bits/second between the host and the radio chip.
+     *          Return 0 when the MAC and above layer and Radio layer resides on the same chip.
+     */
+    uint32_t GetBusSpeed(void);
+
+    /**
+     * Get the bus latency in microseconds between the host and the radio chip.
+     *
+     * @param[in]   aInstance    A pointer to an OpenThread instance.
+     *
+     * @returns The bus latency in microseconds between the host and the radio chip.
+     *          Return 0 when the MAC and above layer and Radio layer resides on the same chip.
+     */
+    uint32_t GetBusLatency(void);
+
 private:
     otInstance *GetInstancePtr(void) const { return reinterpret_cast<otInstance *>(&InstanceLocator::GetInstance()); }
 
@@ -995,6 +1013,10 @@ inline void Radio::ClearSrcMatchShortEntries(void) { otPlatRadioClearSrcMatchSho
 
 inline void Radio::ClearSrcMatchExtEntries(void) { otPlatRadioClearSrcMatchExtEntries(GetInstancePtr()); }
 
+inline uint32_t Radio::GetBusSpeed(void) { return otPlatRadioGetBusSpeed(GetInstancePtr()); }
+
+inline uint32_t Radio::GetBusLatency(void) { return otPlatRadioGetBusLatency(GetInstancePtr()); }
+
 #else //----------------------------------------------------------------------------------------------------------------
 
 inline otRadioCaps Radio::GetCaps(void)
@@ -1094,6 +1116,10 @@ inline Error Radio::ClearSrcMatchExtEntry(const Mac::ExtAddress &) { return kErr
 inline void Radio::ClearSrcMatchShortEntries(void) {}
 
 inline void Radio::ClearSrcMatchExtEntries(void) {}
+
+inline uint32_t Radio::GetBusSpeed(void) { return 0; }
+
+inline uint32_t Radio::GetBusLatency(void) { return 0; }
 
 #endif // #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -47,8 +47,8 @@ CslTxScheduler::CslTxScheduler(Instance &aInstance)
 
 void CslTxScheduler::UpdateFrameRequestAhead(void)
 {
-    uint32_t busSpeedHz = otPlatRadioGetBusSpeed(&GetInstance());
-    uint32_t busLatency = otPlatRadioGetBusLatency(&GetInstance());
+    uint32_t busSpeedHz = Get<Radio>().GetBusSpeed();
+    uint32_t busLatency = Get<Radio>().GetBusLatency();
 
     // longest frame on bus is 127 bytes with some metadata, use 150 bytes for bus Tx time estimation
     uint32_t busTxTimeUs = ((busSpeedHz == 0) ? 0 : (150 * 8 * 1000000 + busSpeedHz - 1) / busSpeedHz);


### PR DESCRIPTION
This commit adds `GetBusSpeed()` and `GetBusLatency()` methods to the `Radio` class, which map to the corresponding `otPlatRadio` platform APIs.