### PR TITLE
[num-utils] add `DivideAndRoundUp()` helper

### DIFF
--- a/src/core/common/num_utils.hpp
+++ b/src/core/common/num_utils.hpp
@@ -196,6 +196,21 @@ template <typename IntType> inline IntType DivideAndRoundToClosest(IntType aDivi
 }
 
 /**
+ * This template function divides two numbers and always rounds the result up.
+ *
+ * @tparam IntType   The integer type.
+ *
+ * @param[in] aDividend   The dividend value.
+ * @param[in] aDivisor    The divisor value.
+ *
+ * @return The result of division and rounding up.
+ */
+template <typename IntType> inline IntType DivideAndRoundUp(IntType aDividend, IntType aDivisor)
+{
+    return (aDividend + (aDivisor - 1)) / aDivisor;
+}
+
+/**
  * Casts a given `uint32_t` to `unsigned long`.
  *
  * @param[in] aUint32   A `uint32_t` value.

--- a/src/core/mac/wakeup_tx_scheduler.cpp
+++ b/src/core/mac/wakeup_tx_scheduler.cpp
@@ -160,7 +160,12 @@ void WakeupTxScheduler::UpdateFrameRequestAhead(void)
 
     uint32_t busSpeedHz  = Get<Radio>().GetBusSpeed();
     uint32_t busLatency  = Get<Radio>().GetBusLatency();
-    uint32_t busTxTimeUs = ((busSpeedHz == 0) ? 0 : (kWakeupFrameWeight * 8 * 1000000 + busSpeedHz - 1) / busSpeedHz);
+    uint32_t busTxTimeUs = 0;
+
+    if (busSpeedHz != 0)
+    {
+        busSpeedHz = DivideAndRoundUp<uint32_t>(kWakeupFrameWeight * 8 * 1000000, busSpeedHz);
+    }
 
     mTxRequestAheadTimeUs = OPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US + busTxTimeUs + busLatency;
 }

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -204,7 +204,7 @@ void Prefix::ToString(char *aBuffer, uint16_t aSize) const
 
 void Prefix::ToString(StringWriter &aWriter) const
 {
-    uint8_t sizeInUint16 = (GetBytesSize() + sizeof(uint16_t) - 1) / sizeof(uint16_t);
+    uint8_t sizeInUint16 = DivideAndRoundUp<uint8_t>(GetBytesSize(), sizeof(uint16_t));
     Prefix  tidyPrefix   = *this;
 
     tidyPrefix.Tidy();

--- a/src/core/net/nd6.hpp
+++ b/src/core/net/nd6.hpp
@@ -108,7 +108,7 @@ public:
      *
      * @param[in]  aSize  The size of option in bytes.
      */
-    void SetSize(uint16_t aSize) { mLength = static_cast<uint8_t>((aSize + kLengthUnit - 1) / kLengthUnit); }
+    void SetSize(uint16_t aSize) { mLength = static_cast<uint8_t>(DivideAndRoundUp(aSize, kLengthUnit)); }
 
     /**
      * Returns the size of the option in bytes.

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -49,13 +49,20 @@ void CslTxScheduler::UpdateFrameRequestAhead(void)
 {
     uint32_t busSpeedHz = Get<Radio>().GetBusSpeed();
     uint32_t busLatency = Get<Radio>().GetBusLatency();
+    uint32_t busTxTime  = 0;
 
-    // longest frame on bus is 127 bytes with some metadata, use 150 bytes for bus Tx time estimation
-    uint32_t busTxTimeUs = ((busSpeedHz == 0) ? 0 : (150 * 8 * 1000000 + busSpeedHz - 1) / busSpeedHz);
+    if (busSpeedHz != 0)
+    {
+        // Longest frame on bus is 127 bytes with some metadata, we use
+        // 150 bytes for bus Tx time estimation
 
-    mCslFrameRequestAheadUs = OPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US + busTxTimeUs + busLatency;
+        busTxTime = DivideAndRoundUp<uint32_t>(150 * 8 * 1000000, busSpeedHz);
+    }
+
+    mCslFrameRequestAheadUs = OPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US + busTxTime + busLatency;
+
     LogInfo("Bus TX Time: %lu usec, Latency: %lu usec. Calculated CSL Frame Request Ahead: %lu usec",
-            ToUlong(busTxTimeUs), ToUlong(busLatency), ToUlong(mCslFrameRequestAheadUs));
+            ToUlong(busTxTime), ToUlong(busLatency), ToUlong(mCslFrameRequestAheadUs));
 }
 
 void CslTxScheduler::Update(void)

--- a/tests/unit/test_serial_number.cpp
+++ b/tests/unit/test_serial_number.cpp
@@ -132,6 +132,20 @@ void TestNumUtils(void)
     VerifyOrQuit(DivideAndRoundToClosest<uint8_t>(9, 10) == 1);
     VerifyOrQuit(DivideAndRoundToClosest<uint8_t>(10, 10) == 1);
 
+    VerifyOrQuit(DivideAndRoundUp<uint8_t>(2, 1) == 2);
+    VerifyOrQuit(DivideAndRoundUp<uint8_t>(1, 3) == 1);
+    VerifyOrQuit(DivideAndRoundUp<uint8_t>(1, 2) == 1);
+    VerifyOrQuit(DivideAndRoundUp<uint8_t>(2, 3) == 1);
+    VerifyOrQuit(DivideAndRoundUp<uint8_t>(3, 2) == 2);
+    VerifyOrQuit(DivideAndRoundUp<uint8_t>(4, 2) == 2);
+
+    VerifyOrQuit(DivideAndRoundUp<uint8_t>(0, 10) == 0);
+    VerifyOrQuit(DivideAndRoundUp<uint8_t>(4, 10) == 1);
+    VerifyOrQuit(DivideAndRoundUp<uint8_t>(5, 10) == 1);
+    VerifyOrQuit(DivideAndRoundUp<uint8_t>(9, 10) == 1);
+    VerifyOrQuit(DivideAndRoundUp<uint8_t>(10, 10) == 1);
+    VerifyOrQuit(DivideAndRoundUp<uint8_t>(11, 10) == 2);
+
     VerifyOrQuit(CountBitsInMask<uint8_t>(0) == 0);
     VerifyOrQuit(CountBitsInMask<uint8_t>(1) == 1);
     VerifyOrQuit(CountBitsInMask<uint8_t>(2) == 1);


### PR DESCRIPTION
This commit introduces the `DivideAndRoundUp()` method, which divides two given unsigned integers and always rounds the result up.