### PR TITLE
[udp] remove extra `ShouldUsePlatformUdp()` checks

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -972,9 +972,7 @@ Error Ip6::PassToHost(OwnedPtr<Message> &aMessagePtr,
             Udp::Header udp;
 
             IgnoreError(aMessagePtr->Read(aMessagePtr->GetOffset(), udp));
-            VerifyOrExit(Get<Udp>().ShouldUsePlatformUdp(udp.GetDestinationPort()) &&
-                             !Get<Udp>().IsPortInUse(udp.GetDestinationPort()),
-                         error = kErrorNoRoute);
+            VerifyOrExit(!Get<Udp>().IsPortInUse(udp.GetDestinationPort()), error = kErrorNoRoute);
             break;
         }
 

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -634,16 +634,6 @@ public:
      */
     bool IsPortInUse(uint16_t aPort) const;
 
-    /**
-     * Returns whether a udp port belongs to the platform or the stack.
-     *
-     * @param[in]   aPort       The udp port
-     *
-     * @retval True when the port belongs to the platform.
-     * @retval False when the port belongs to the stack.
-     */
-    bool ShouldUsePlatformUdp(uint16_t aPort) const;
-
 private:
     static constexpr uint16_t kDynamicPortMin = 49152; // Service Name and Transport Protocol Port Number Registry
     static constexpr uint16_t kDynamicPortMax = 65535; // Service Name and Transport Protocol Port Number Registry
@@ -657,6 +647,7 @@ private:
     void AddSocket(SocketHandle &aSocket);
     void RemoveSocket(SocketHandle &aSocket);
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
+    bool ShouldUsePlatformUdp(uint16_t aPort) const;
     bool ShouldUsePlatformUdp(const SocketHandle &aSocket) const;
 #endif
 


### PR DESCRIPTION
This commit removes the `ShouldUsePlatformUdp()` call in `Ip6::PassToHost()` and `Udp::HandleMessage()`.

`ShouldUsePlatformUdp(port)` checks whether the port is NOT one of the port numbers used by the OT stack, such as the MLE port, TMF port, border agent port, or joiner port. This check is already covered by `Udp::IsPortInUse()`, which checks if there is a UDP socket bound to the given port.

Applying such a filter in `Udp::HandleMessage()` seems to have been added by mistake, as it blocks the use of UDP receivers, which should be able to receive and process on any port, not just the ports where we have a socket bound.