### PR TITLE
[mac] define `Mac::kCslRequestAhead` constant

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2629,9 +2629,10 @@ Error Mac::HandleWakeupFrame(const RxFrame &aFrame)
     radioNowUs    = otPlatRadioGetNow(&GetInstance());
     rvTimeUs      = aFrame.GetRendezvousTimeIe()->GetRendezvousTime() * kUsPerTenSymbols;
     rvTimestampUs = aFrame.GetTimestamp() + kRadioHeaderPhrDuration + aFrame.GetLength() * kOctetDuration + rvTimeUs;
-    if (rvTimestampUs > radioNowUs + OPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US)
+
+    if (rvTimestampUs > radioNowUs + kCslRequestAhead)
     {
-        attachDelayMs = static_cast<uint32_t>(rvTimestampUs - radioNowUs - OPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US);
+        attachDelayMs = static_cast<uint32_t>(rvTimestampUs - radioNowUs - kCslRequestAhead);
         attachDelayMs = attachDelayMs / 1000;
     }
     else

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -87,6 +87,12 @@ constexpr uint8_t kMaxFrameRetriesCsl             = 0;
 
 constexpr uint8_t kTxNumBcast = OPENTHREAD_CONFIG_MAC_TX_NUM_BCAST; ///< Num of times broadcast frame is tx.
 
+/**
+ * Specifies the number of microseconds ahead of time that the MAC layer should deliver a CSL frame to the sub-MAC
+ * layer.
+ */
+constexpr uint16_t kCslRequestAhead = OPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US;
+
 constexpr uint16_t kMinCslIePeriod = OPENTHREAD_CONFIG_MAC_CSL_MIN_PERIOD;
 
 constexpr uint32_t kDefaultWedListenInterval = OPENTHREAD_CONFIG_WED_LISTEN_INTERVAL;

--- a/src/core/mac/wakeup_tx_scheduler.cpp
+++ b/src/core/mac/wakeup_tx_scheduler.cpp
@@ -167,7 +167,7 @@ void WakeupTxScheduler::UpdateFrameRequestAhead(void)
         busSpeedHz = DivideAndRoundUp<uint32_t>(kWakeupFrameWeight * 8 * 1000000, busSpeedHz);
     }
 
-    mTxRequestAheadTimeUs = OPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US + busTxTimeUs + busLatency;
+    mTxRequestAheadTimeUs = Mac::kCslRequestAhead + busTxTimeUs + busLatency;
 }
 
 } // namespace ot

--- a/src/core/mac/wakeup_tx_scheduler.hpp
+++ b/src/core/mac/wakeup_tx_scheduler.hpp
@@ -95,8 +95,7 @@ public:
     void Stop(void);
 
     /**
-     * Updates the value of `mTxRequestAheadTimeUs`, based on bus speed, bus latency and
-     * `OPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US`.
+     * Updates the value of `mTxRequestAheadTimeUs`, based on bus speed, bus latency and `Mac::kCslRequestAhead`.
      */
     void UpdateFrameRequestAhead(void);
 

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -59,7 +59,7 @@ void CslTxScheduler::UpdateFrameRequestAhead(void)
         busTxTime = DivideAndRoundUp<uint32_t>(150 * 8 * 1000000, busSpeedHz);
     }
 
-    mCslFrameRequestAheadUs = OPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US + busTxTime + busLatency;
+    mCslFrameRequestAheadUs = Mac::kCslRequestAhead + busTxTime + busLatency;
 
     LogInfo("Bus TX Time: %lu usec, Latency: %lu usec. Calculated CSL Frame Request Ahead: %lu usec",
             ToUlong(busTxTime), ToUlong(busLatency), ToUlong(mCslFrameRequestAheadUs));

--- a/src/core/thread/csl_tx_scheduler.hpp
+++ b/src/core/thread/csl_tx_scheduler.hpp
@@ -178,8 +178,7 @@ public:
     void Clear(void);
 
     /**
-     * Updates the value of `mCslFrameRequestAheadUs`, based on bus speed, bus latency
-     * and `OPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US`.
+     * Updates the value of `mCslFrameRequestAheadUs`, based on bus speed, bus latency and `Mac::kCslRequestAhead`.
      */
     void UpdateFrameRequestAhead(void);
 


### PR DESCRIPTION
This commit defines the `Mac::kCslRequestAhead` constant, which maps to `OPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US`. This constant is used within the core modules.