### PR TITLE
[udp] update `Socket::Open()` to include `NetifId`

### DIFF
--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -44,7 +44,7 @@ otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSett
 
 otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aContext)
 {
-    return AsCoreType(aInstance).Get<Ip6::Udp>().Open(AsCoreType(aSocket), aCallback, aContext);
+    return AsCoreType(aInstance).Get<Ip6::Udp>().Open(AsCoreType(aSocket), Ip6::kNetifThread, aCallback, aContext);
 }
 
 bool otUdpIsOpen(otInstance *aInstance, const otUdpSocket *aSocket)
@@ -59,7 +59,9 @@ otError otUdpClose(otInstance *aInstance, otUdpSocket *aSocket)
 
 otError otUdpBind(otInstance *aInstance, otUdpSocket *aSocket, const otSockAddr *aSockName, otNetifIdentifier aNetif)
 {
-    return AsCoreType(aInstance).Get<Ip6::Udp>().Bind(AsCoreType(aSocket), AsCoreType(aSockName), MapEnum(aNetif));
+    AsCoreType(aSocket).SetNetifId(MapEnum(aNetif));
+
+    return AsCoreType(aInstance).Get<Ip6::Udp>().Bind(AsCoreType(aSocket), AsCoreType(aSockName));
 }
 
 otError otUdpConnect(otInstance *aInstance, otUdpSocket *aSocket, const otSockAddr *aSockName)

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1672,10 +1672,10 @@ Error Coap::Start(uint16_t aPort, Ip6::NetifIdentifier aNetifIdentifier)
 
     VerifyOrExit(!mSocket.IsBound());
 
-    SuccessOrExit(error = mSocket.Open());
+    SuccessOrExit(error = mSocket.Open(aNetifIdentifier));
     socketOpened = true;
 
-    SuccessOrExit(error = mSocket.Bind(aPort, aNetifIdentifier));
+    SuccessOrExit(error = mSocket.Bind(aPort));
 
 exit:
     if (error != kErrorNone && socketOpened)

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -69,7 +69,7 @@ void JoinerRouter::Start(void)
 
         VerifyOrExit(!mSocket.IsBound());
 
-        IgnoreError(mSocket.Open());
+        IgnoreError(mSocket.Open(Ip6::kNetifThread));
         IgnoreError(mSocket.Bind(port));
         IgnoreError(Get<Ip6::Filter>().AddUnsecurePort(port));
         LogInfo("Joiner Router: start");

--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -131,7 +131,7 @@ Error SecureTransport::Open(ReceiveHandler aReceiveHandler, ConnectedHandler aCo
 
     VerifyOrExit(IsStateClosed(), error = kErrorAlready);
 
-    SuccessOrExit(error = mSocket.Open());
+    SuccessOrExit(error = mSocket.Open(Ip6::kNetifUnspecified));
 
     mConnectedCallback.Set(aConnectedHandler, aContext);
     mReceiveCallback.Set(aReceiveHandler, aContext);
@@ -225,7 +225,7 @@ Error SecureTransport::Bind(uint16_t aPort)
     VerifyOrExit(IsStateOpen(), error = kErrorInvalidState);
     VerifyOrExit(!mTransportCallback.IsSet(), error = kErrorAlready);
 
-    SuccessOrExit(error = mSocket.Bind(aPort, Ip6::kNetifUnspecified));
+    SuccessOrExit(error = mSocket.Bind(aPort));
 
 exit:
     return error;

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -162,7 +162,7 @@ void Client::Start(void)
 {
     VerifyOrExit(!mSocket.IsBound());
 
-    IgnoreError(mSocket.Open());
+    IgnoreError(mSocket.Open(Ip6::kNetifThread));
     IgnoreError(mSocket.Bind(kDhcpClientPort));
 
     ProcessNextIdentityAssociation();

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -130,7 +130,7 @@ void Server::Start(void)
 {
     VerifyOrExit(!mSocket.IsOpen());
 
-    IgnoreError(mSocket.Open());
+    IgnoreError(mSocket.Open(Ip6::kNetifThread));
     IgnoreError(mSocket.Bind(kDhcpServerPort));
 
 exit:

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -764,8 +764,8 @@ Error Client::Start(void)
 {
     Error error;
 
-    SuccessOrExit(error = mSocket.Open());
-    SuccessOrExit(error = mSocket.Bind(0, Ip6::kNetifUnspecified));
+    SuccessOrExit(error = mSocket.Open(Ip6::kNetifUnspecified));
+    SuccessOrExit(error = mSocket.Bind(0));
 
 exit:
     return error;

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -71,8 +71,8 @@ Error Server::Start(void)
 
     VerifyOrExit(!IsRunning());
 
-    SuccessOrExit(error = mSocket.Open());
-    SuccessOrExit(error = mSocket.Bind(kPort, kBindUnspecifiedNetif ? Ip6::kNetifUnspecified : Ip6::kNetifThread));
+    SuccessOrExit(error = mSocket.Open(kBindUnspecifiedNetif ? Ip6::kNetifUnspecified : Ip6::kNetifThread));
+    SuccessOrExit(error = mSocket.Bind(kPort));
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
     Get<Srp::Server>().HandleDnssdServerStateChange();

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -54,8 +54,8 @@ Error Client::Start(void)
 {
     Error error;
 
-    SuccessOrExit(error = mSocket.Open());
-    SuccessOrExit(error = mSocket.Bind(0, Ip6::kNetifUnspecified));
+    SuccessOrExit(error = mSocket.Open(Ip6::kNetifUnspecified));
+    SuccessOrExit(error = mSocket.Bind(0));
 
 exit:
     return error;

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -400,9 +400,10 @@ Error Client::Start(const Ip6::SockAddr &aServerSockAddr, Requester aRequester)
     VerifyOrExit(GetState() == kStateStopped,
                  error = (aServerSockAddr == GetServerAddress()) ? kErrorNone : kErrorBusy);
 
-    SuccessOrExit(error = mSocket.Open());
+    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThread));
 
     error = mSocket.Connect(aServerSockAddr);
+
     if (error != kErrorNone)
     {
         LogInfo("Failed to connect to server %s: %s", aServerSockAddr.GetAddress().ToString().AsCString(),

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -658,8 +658,8 @@ Error Server::PrepareSocket(void)
 #endif
 
     VerifyOrExit(!mSocket.IsOpen());
-    SuccessOrExit(error = mSocket.Open());
-    error = mSocket.Bind(mPort, Ip6::kNetifThread);
+    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThread));
+    error = mSocket.Bind(mPort);
 
 exit:
     if (error != kErrorNone)

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -135,6 +135,13 @@ public:
          */
         NetifIdentifier GetNetifId(void) const { return static_cast<NetifIdentifier>(mNetifId); }
 
+        /**
+         * Sets the network interface identifier.
+         *
+         * @param[in] aNetifId   The network interface identifier.
+         */
+        void SetNetifId(NetifIdentifier aNetifId) { mNetifId = static_cast<otNetifIdentifier>(aNetifId); }
+
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
         /**
          * Indicate whether or not the socket is bound to the backbone network interface.
@@ -200,10 +207,12 @@ public:
         /**
          * Opens the UDP socket.
          *
+         * @param[in]  aNetifId   The network interface identifier.
+         *
          * @retval kErrorNone     Successfully opened the socket.
          * @retval kErrorFailed   Failed to open the socket.
          */
-        Error Open(void);
+        Error Open(NetifIdentifier aNetifId);
 
         /**
          * Returns if the UDP socket is open.
@@ -215,25 +224,23 @@ public:
         /**
          * Binds the UDP socket.
          *
-         * @param[in]  aSockAddr            A reference to the socket address.
-         * @param[in]  aNetifIdentifier     The network interface identifier.
+         * @param[in]  aSockAddr         A reference to the socket address.
          *
          * @retval kErrorNone            Successfully bound the socket.
          * @retval kErrorInvalidArgs     Unable to bind to Thread network interface with the given address.
          * @retval kErrorFailed          Failed to bind UDP Socket.
          */
-        Error Bind(const SockAddr &aSockAddr, NetifIdentifier aNetifIdentifier = kNetifThread);
+        Error Bind(const SockAddr &aSockAddr);
 
         /**
          * Binds the UDP socket.
          *
-         * @param[in]  aPort                A port number.
-         * @param[in]  aNetifIdentifier     The network interface identifier.
+         * @param[in]  aPort             A port number.
          *
          * @retval kErrorNone            Successfully bound the socket.
          * @retval kErrorFailed          Failed to bind UDP Socket.
          */
-        Error Bind(uint16_t aPort, NetifIdentifier aNetifIdentifier = kNetifThread);
+        Error Bind(uint16_t aPort);
 
         /**
          * Binds the UDP socket.
@@ -479,13 +486,14 @@ public:
      * Opens a UDP socket.
      *
      * @param[in]  aSocket   A reference to the socket.
+     * @param[in]  aNetifId  A network interface identifier.
      * @param[in]  aHandler  A pointer to a function that is called when receiving UDP messages.
      * @param[in]  aContext  A pointer to arbitrary context information.
      *
      * @retval kErrorNone     Successfully opened the socket.
      * @retval kErrorFailed   Failed to open the socket.
      */
-    Error Open(SocketHandle &aSocket, ReceiveHandler aHandler, void *aContext);
+    Error Open(SocketHandle &aSocket, NetifIdentifier aNetifId, ReceiveHandler aHandler, void *aContext);
 
     /**
      * Returns if a UDP socket is open.
@@ -501,13 +509,12 @@ public:
      *
      * @param[in]  aSocket          A reference to the socket.
      * @param[in]  aSockAddr        A reference to the socket address.
-     * @param[in]  aNetifIdentifier The network interface identifier.
      *
      * @retval kErrorNone            Successfully bound the socket.
      * @retval kErrorInvalidArgs     Unable to bind to Thread network interface with the given address.
      * @retval kErrorFailed          Failed to bind UDP Socket.
      */
-    Error Bind(SocketHandle &aSocket, const SockAddr &aSockAddr, NetifIdentifier aNetifIdentifier);
+    Error Bind(SocketHandle &aSocket, const SockAddr &aSockAddr);
 
     /**
      * Connects a UDP socket.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -127,7 +127,7 @@ Error Mle::Enable(void)
     Error error = kErrorNone;
 
     UpdateLinkLocalAddress();
-    SuccessOrExit(error = mSocket.Open());
+    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThread));
     SuccessOrExit(error = mSocket.Bind(kUdpPort));
 
 #if OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE

--- a/tests/unit/test_srp_server.cpp
+++ b/tests/unit/test_srp_server.cpp
@@ -1076,8 +1076,8 @@ void TestSrpClientDelayedResponse(void)
 
         sServerRxCount = 0;
 
-        SuccessOrQuit(udpSocket.Open());
-        SuccessOrQuit(udpSocket.Bind(kServerPort, Ip6::kNetifThread));
+        SuccessOrQuit(udpSocket.Open(Ip6::kNetifThread));
+        SuccessOrQuit(udpSocket.Bind(kServerPort));
 
         //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         // Manually start the client with a message ID based on `testIter`


### PR DESCRIPTION
This commit updates how the `NetifId` is set on a `Udp::Socket`. It is now specified as a parameter in the `Open()` call instead of `Bind()`.

This change makes the socket more flexible by allowing the `NetifId` to be known earlier (which can be used for future optimizations). It also allows the desired `NetifId` to be set even when `Bind()` is not explicitly called, such as when `Connect()` or `SendTo()` are used on a socket that is not yet bound. Previously, `kNetifThread` was assumed by default in these situations.

The public `otUdp` APIs are left unchanged to ensure backward compatibility.