### PR TITLE
[udp] add `kNetifThreadInternal` which disallows platform UDP use

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (464)
+#define OPENTHREAD_API_VERSION (465)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/udp.h
+++ b/include/openthread/udp.h
@@ -115,7 +115,8 @@ typedef void (*otUdpReceive)(void *aContext, otMessage *aMessage, const otMessag
 typedef enum otNetifIdentifier
 {
     OT_NETIF_UNSPECIFIED = 0, ///< Unspecified network interface.
-    OT_NETIF_THREAD,          ///< The Thread interface.
+    OT_NETIF_THREAD_HOST,     ///< The host Thread interface - allow use of platform UDP.
+    OT_NETIF_THREAD_INTERNAL, ///< The internal Thread interface (within OpenThread) - do not use platform UDP.
     OT_NETIF_BACKBONE,        ///< The Backbone interface.
 } otNetifIdentifier;
 

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -83,7 +83,7 @@ template <> otError UdpExample::Process<Cmd("bind")>(Arg aArgs[])
 {
     otError           error;
     otSockAddr        sockaddr;
-    otNetifIdentifier netif = OT_NETIF_THREAD;
+    otNetifIdentifier netif = OT_NETIF_THREAD_HOST;
 
     if (aArgs[0] == "-u")
     {

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -44,7 +44,7 @@ otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSett
 
 otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aContext)
 {
-    return AsCoreType(aInstance).Get<Ip6::Udp>().Open(AsCoreType(aSocket), Ip6::kNetifThread, aCallback, aContext);
+    return AsCoreType(aInstance).Get<Ip6::Udp>().Open(AsCoreType(aSocket), Ip6::kNetifThreadHost, aCallback, aContext);
 }
 
 bool otUdpIsOpen(otInstance *aInstance, const otUdpSocket *aSocket)

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -69,7 +69,7 @@ void JoinerRouter::Start(void)
 
         VerifyOrExit(!mSocket.IsBound());
 
-        IgnoreError(mSocket.Open(Ip6::kNetifThread));
+        IgnoreError(mSocket.Open(Ip6::kNetifThreadInternal));
         IgnoreError(mSocket.Bind(port));
         IgnoreError(Get<Ip6::Filter>().AddUnsecurePort(port));
         LogInfo("Joiner Router: start");

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -162,7 +162,7 @@ void Client::Start(void)
 {
     VerifyOrExit(!mSocket.IsBound());
 
-    IgnoreError(mSocket.Open(Ip6::kNetifThread));
+    IgnoreError(mSocket.Open(Ip6::kNetifThreadInternal));
     IgnoreError(mSocket.Bind(kDhcpClientPort));
 
     ProcessNextIdentityAssociation();

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -130,7 +130,7 @@ void Server::Start(void)
 {
     VerifyOrExit(!mSocket.IsOpen());
 
-    IgnoreError(mSocket.Open(Ip6::kNetifThread));
+    IgnoreError(mSocket.Open(Ip6::kNetifThreadInternal));
     IgnoreError(mSocket.Bind(kDhcpServerPort));
 
 exit:

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -71,7 +71,7 @@ Error Server::Start(void)
 
     VerifyOrExit(!IsRunning());
 
-    SuccessOrExit(error = mSocket.Open(kBindUnspecifiedNetif ? Ip6::kNetifUnspecified : Ip6::kNetifThread));
+    SuccessOrExit(error = mSocket.Open(kBindUnspecifiedNetif ? Ip6::kNetifUnspecified : Ip6::kNetifThreadInternal));
     SuccessOrExit(error = mSocket.Bind(kPort));
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -400,7 +400,7 @@ Error Client::Start(const Ip6::SockAddr &aServerSockAddr, Requester aRequester)
     VerifyOrExit(GetState() == kStateStopped,
                  error = (aServerSockAddr == GetServerAddress()) ? kErrorNone : kErrorBusy);
 
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThread));
+    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThreadInternal));
 
     error = mSocket.Connect(aServerSockAddr);
 

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -658,7 +658,7 @@ Error Server::PrepareSocket(void)
 #endif
 
     VerifyOrExit(!mSocket.IsOpen());
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThread));
+    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThreadHost));
     error = mSocket.Bind(mPort);
 
 exit:

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -127,7 +127,7 @@ Error Mle::Enable(void)
     Error error = kErrorNone;
 
     UpdateLinkLocalAddress();
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThread));
+    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThreadInternal));
     SuccessOrExit(error = mSocket.Bind(kUdpPort));
 
 #if OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -83,7 +83,7 @@ Agent::Agent(Instance &aInstance)
     SetResourceHandler(&HandleResource);
 }
 
-Error Agent::Start(void) { return Coap::Start(kUdpPort, Ip6::kNetifThread); }
+Error Agent::Start(void) { return Coap::Start(kUdpPort, Ip6::kNetifThreadInternal); }
 
 template <> void Agent::HandleTmf<kUriRelayRx>(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -305,7 +305,7 @@ otError otPlatUdpBindToNetif(otUdpSocket *aUdpSocket, otNetifIdentifier aNetifId
 #endif // __linux__
         break;
     }
-    case OT_NETIF_THREAD:
+    case OT_NETIF_THREAD_HOST:
     {
 #ifdef __linux__
         VerifyOrExit(setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, &gNetifName, strlen(gNetifName)) == 0,
@@ -341,6 +341,9 @@ otError otPlatUdpBindToNetif(otUdpSocket *aUdpSocket, otNetifIdentifier aNetifId
 
         break;
     }
+
+    case OT_NETIF_THREAD_INTERNAL:
+        assert(false);
     }
 
     VerifyOrExit(setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, &zero, sizeof(zero)) == 0, error = OT_ERROR_FAILED);
@@ -471,7 +474,7 @@ otError otPlatUdpJoinMulticastGroup(otUdpSocket        *aUdpSocket,
     {
     case OT_NETIF_UNSPECIFIED:
         break;
-    case OT_NETIF_THREAD:
+    case OT_NETIF_THREAD_HOST:
         mreq.ipv6mr_interface = gNetifIndex;
         break;
     case OT_NETIF_BACKBONE:
@@ -481,6 +484,8 @@ otError otPlatUdpJoinMulticastGroup(otUdpSocket        *aUdpSocket,
         ExitNow(error = OT_ERROR_NOT_IMPLEMENTED);
 #endif
         break;
+    case OT_NETIF_THREAD_INTERNAL:
+        assert(false);
     }
 
     VerifyOrExit(setsockopt(fd, IPPROTO_IPV6, IPV6_JOIN_GROUP, &mreq, sizeof(mreq)) == 0 || errno == EADDRINUSE,
@@ -512,7 +517,7 @@ otError otPlatUdpLeaveMulticastGroup(otUdpSocket        *aUdpSocket,
     {
     case OT_NETIF_UNSPECIFIED:
         break;
-    case OT_NETIF_THREAD:
+    case OT_NETIF_THREAD_HOST:
         mreq.ipv6mr_interface = gNetifIndex;
         break;
     case OT_NETIF_BACKBONE:
@@ -522,6 +527,9 @@ otError otPlatUdpLeaveMulticastGroup(otUdpSocket        *aUdpSocket,
         ExitNow(error = OT_ERROR_NOT_IMPLEMENTED);
 #endif
         break;
+
+    case OT_NETIF_THREAD_INTERNAL:
+        assert(false);
     }
 
     VerifyOrExit(setsockopt(fd, IPPROTO_IPV6, IPV6_LEAVE_GROUP, &mreq, sizeof(mreq)) == 0 || errno == EADDRINUSE,

--- a/tests/unit/test_srp_server.cpp
+++ b/tests/unit/test_srp_server.cpp
@@ -1076,7 +1076,7 @@ void TestSrpClientDelayedResponse(void)
 
         sServerRxCount = 0;
 
-        SuccessOrQuit(udpSocket.Open(Ip6::kNetifThread));
+        SuccessOrQuit(udpSocket.Open(Ip6::kNetifThreadHost));
         SuccessOrQuit(udpSocket.Bind(kServerPort));
 
         //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This commit introduces `kNetifThreadInternal` as a network interface option for UDP sockets. Unlike other options, this disallows the use of platform UDP for the socket, indicating that the socket should use the OpenThread internal Thread network interface only.

This model replaces the previous approach where `ShouldUsePlatformUdp()` would check the socket port against a set of port numbers used by different modules (such as MLE, TMF, Joiner Router, etc) to determine whether platform UDP APIs should be used. With the new model, each module decides whether to associate its socket with the 
`kNetifThreadInternal`.

This is a more flexible and extensible model, ensuring that sockets that should not use the platform do not waste resources (they will not be created or opened/closed on the platform). This also help avoid edge cases where platform UDP operations may unintentionally fail when the platform socket is not actually needed.
