### PR TITLE
[mac] add `CalculateRadioBusTransferTime()` helper method

### DIFF
--- a/src/core/common/time.hpp
+++ b/src/core/common/time.hpp
@@ -64,6 +64,7 @@ public:
     static constexpr uint32_t kOneHourInMsec   = kOneMinuteInMsec * 60; ///< One hour interval in msec.
     static constexpr uint32_t kOneDayInMsec    = kOneHourInMsec * 24;   ///< One day interval in msec.
     static constexpr uint32_t kOneMsecInUsec   = 1000u;                 ///< One millisecond in microseconds.
+    static constexpr uint32_t kOneSecondInUsec = 1000000u;              ///< One second interval in microseconds.
 
     /**
      * This constant defines a maximum time duration ensured to be longer than any other duration.

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2661,5 +2661,20 @@ exit:
 }
 #endif // OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
 
+uint32_t Mac::CalculateRadioBusTransferTime(uint16_t aFrameSize) const
+{
+    uint32_t busSpeed     = Get<Radio>().GetBusSpeed();
+    uint32_t trasnferTime = 0;
+
+    if (busSpeed != 0)
+    {
+        trasnferTime = DivideAndRoundUp<uint32_t>(aFrameSize * kBitsPerByte * Time::kOneSecondInUsec, busSpeed);
+    }
+
+    trasnferTime += Get<Radio>().GetBusLatency();
+
+    return trasnferTime;
+}
+
 } // namespace Mac
 } // namespace ot

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -772,6 +772,16 @@ public:
     bool IsWakeupListenEnabled(void) const { return mWakeupListenEnabled; }
 #endif // OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
 
+    /**
+     * Calculates the radio bus transfer time (in microseconds) for a given frame size based on `Radio::GetBusSpeed()`
+     * and `Radio::GetBusLatency()`.
+     *
+     * @param[in] aFrameSize   The frame size to calculate for, in bytes.
+     *
+     * @returns The calculated radio bus transfer time in microseconds.
+     */
+    uint32_t CalculateRadioBusTransferTime(uint16_t aFrameSize) const;
+
 private:
     static constexpr uint16_t kMaxCcaSampleCount = OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW;
 

--- a/src/core/mac/wakeup_tx_scheduler.cpp
+++ b/src/core/mac/wakeup_tx_scheduler.cpp
@@ -156,18 +156,9 @@ void WakeupTxScheduler::UpdateFrameRequestAhead(void)
 {
     // A rough estimate of the size of data that has to be exchanged with the radio to schedule a wake-up frame TX.
     // This is used to make sure that a wake-up frame is received by the radio early enough to be transmitted on time.
-    constexpr uint32_t kWakeupFrameWeight = 100;
+    constexpr uint32_t kWakeupFrameSize = 100;
 
-    uint32_t busSpeedHz  = Get<Radio>().GetBusSpeed();
-    uint32_t busLatency  = Get<Radio>().GetBusLatency();
-    uint32_t busTxTimeUs = 0;
-
-    if (busSpeedHz != 0)
-    {
-        busSpeedHz = DivideAndRoundUp<uint32_t>(kWakeupFrameWeight * 8 * 1000000, busSpeedHz);
-    }
-
-    mTxRequestAheadTimeUs = Mac::kCslRequestAhead + busTxTimeUs + busLatency;
+    mTxRequestAheadTimeUs = Mac::kCslRequestAhead + Get<Mac::Mac>().CalculateRadioBusTransferTime(kWakeupFrameSize);
 }
 
 } // namespace ot

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -47,22 +47,13 @@ CslTxScheduler::CslTxScheduler(Instance &aInstance)
 
 void CslTxScheduler::UpdateFrameRequestAhead(void)
 {
-    uint32_t busSpeedHz = Get<Radio>().GetBusSpeed();
-    uint32_t busLatency = Get<Radio>().GetBusLatency();
-    uint32_t busTxTime  = 0;
+    // Longest frame on bus is 127 bytes with some metadata, we use
+    // 150 bytes for bus Tx time estimation
+    static constexpr uint16_t kMaxFrameSize = 150;
 
-    if (busSpeedHz != 0)
-    {
-        // Longest frame on bus is 127 bytes with some metadata, we use
-        // 150 bytes for bus Tx time estimation
+    mCslFrameRequestAheadUs = Mac::kCslRequestAhead + Get<Mac::Mac>().CalculateRadioBusTransferTime(kMaxFrameSize);
 
-        busTxTime = DivideAndRoundUp<uint32_t>(150 * 8 * 1000000, busSpeedHz);
-    }
-
-    mCslFrameRequestAheadUs = Mac::kCslRequestAhead + busTxTime + busLatency;
-
-    LogInfo("Bus TX Time: %lu usec, Latency: %lu usec. Calculated CSL Frame Request Ahead: %lu usec",
-            ToUlong(busTxTime), ToUlong(busLatency), ToUlong(mCslFrameRequestAheadUs));
+    LogInfo("Set frame request ahead: %lu usec", ToUlong(mCslFrameRequestAheadUs));
 }
 
 void CslTxScheduler::Update(void)


### PR DESCRIPTION
This commit adds `Mac::CalculateRadioBusTransferTime()`, which calculates the radio bus transfer time (in microseconds) for a given frame size based on `Radio::GetBusSpeed()` & `Radio::GetBusLatency()`. This helper method is used in the `CslTxScheduler` and `WakeupTxScheduler` classes to update frame request-ahead time.
