### PR TITLE
[ncp] fix get property handler of SRP SERVER

### DIFF
--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -1523,16 +1523,9 @@ exit:
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_SRP_SERVER_ENABLED>(void)
 {
-    otError          error          = OT_ERROR_NONE;
-    uint8_t          header         = SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0;
     otSrpServerState srpServerState = otSrpServerGetState(mInstance);
 
-    SuccessOrExit(error = mEncoder.BeginFrame(header, SPINEL_CMD_PROP_VALUE_IS, SPINEL_PROP_SRP_SERVER_ENABLED));
-    SuccessOrExit(error = mEncoder.WriteBool(srpServerState != OT_SRP_SERVER_STATE_DISABLED));
-    SuccessOrExit(error = mEncoder.EndFrame());
-
-exit:
-    return error;
+    return mEncoder.WriteBool(srpServerState != OT_SRP_SERVER_STATE_DISABLED);
 }
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
@@ -1550,16 +1543,7 @@ exit:
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_SRP_SERVER_AUTO_ENABLE_MODE>(void)
 {
-    otError error  = OT_ERROR_NONE;
-    uint8_t header = SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0;
-
-    SuccessOrExit(error =
-                      mEncoder.BeginFrame(header, SPINEL_CMD_PROP_VALUE_IS, SPINEL_PROP_SRP_SERVER_AUTO_ENABLE_MODE));
-    SuccessOrExit(error = mEncoder.WriteBool(otSrpServerIsAutoEnableMode(mInstance)));
-    SuccessOrExit(error = mEncoder.EndFrame());
-
-exit:
-    return error;
+    return mEncoder.WriteBool(otSrpServerIsAutoEnableMode(mInstance));
 }
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 #endif // OPENTHREAD_CONFIG_SRP_SERVER_ENABLE


### PR DESCRIPTION
This PR fixes the wrong implementation of the GetProperty handler of `SPINEL_PROP_SRP_SERVER_ENABLED` and `SPINEL_PROP_SRP_SERVER_AUTO_ENABLE_MODE`.

In GetProperty handlers only the body should be written. It doesn't need to and shouldn't call `BeginFrame` and `EndFrame`. If using `BeginFrame` here, it will get an error of INVALID_STATE.