### PR TITLE
[cli] set `mUseTls` to false after de-initializing TCP session

### DIFF
--- a/src/cli/cli_tcp.cpp
+++ b/src/cli/cli_tcp.cpp
@@ -304,6 +304,8 @@ template <> otError TcpExample::Process<Cmd("deinit")>(Arg aArgs[])
 
         mbedtls_pk_free(&mPKey);
         mbedtls_x509_crt_free(&mSrvCert);
+
+        mUseTls = false;
     }
 #endif
 


### PR DESCRIPTION
Avoid SSL context operations in TCP callbacks (for eg. `HandleTcpDisconnected`) when the context could have already been de-allocated after de-initialization.

In local testing, we found out after issuing `"deinit"`, which [frees the existing SSL context](https://github.com/openthread/openthread/blob/main/src/cli/cli_tcp.cpp#L300), we could hit a `HandleTcpDisconnected` callback late that [tries to perform operations on the SSL context](https://github.com/openthread/openthread/blob/main/src/cli/cli_tcp.cpp#L1022) and hits a fault.