### PR TITLE
[secure-transport] introduce `Extension` class 

### DIFF
--- a/src/core/api/ble_secure_api.cpp
+++ b/src/core/api/ble_secure_api.cpp
@@ -85,9 +85,15 @@ void otBleSecureSetPsk(otInstance    *aInstance,
 #if defined(MBEDTLS_BASE64_C) && defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
 otError otBleSecureGetPeerCertificateBase64(otInstance *aInstance, unsigned char *aPeerCert, size_t *aCertLength)
 {
-    return AsCoreType(aInstance).Get<Ble::BleSecure>().GetPeerCertificateBase64(aPeerCert, aCertLength);
+    Error error;
+
+    VerifyOrExit(aCertLength != nullptr, error = kErrorInvalidArgs);
+    error = AsCoreType(aInstance).Get<Ble::BleSecure>().GetPeerCertificateBase64(aPeerCert, aCertLength, *aCertLength);
+
+exit:
+    return error;
 }
-#endif // defined(MBEDTLS_BASE64_C) && defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
+#endif
 
 #if defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
 otError otBleSecureGetPeerSubjectAttributeByOid(otInstance *aInstance,

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -42,9 +42,9 @@ namespace Coap {
 
 RegisterLogModule("CoapSecure");
 
-CoapSecureBase::CoapSecureBase(Instance &aInstance, LinkSecurityMode aLayerTwoSecurity)
+CoapSecureBase::CoapSecureBase(Instance &aInstance, MeshCoP::Dtls &aDtls)
     : CoapBase(aInstance, Send)
-    , mDtls(aInstance, aLayerTwoSecurity)
+    , mDtls(aDtls)
     , mTransmitTask(aInstance, HandleTransmit, this)
 {
 }
@@ -62,7 +62,7 @@ exit:
     return error;
 }
 
-Error CoapSecureBase::Start(MeshCoP::SecureTransport::TransportCallback aCallback, void *aContext)
+Error CoapSecureBase::Start(MeshCoP::Dtls::TransportCallback aCallback, void *aContext)
 {
     Error error;
 
@@ -106,7 +106,7 @@ Error CoapSecureBase::Connect(const Ip6::SockAddr &aSockAddr, ConnectEventCallba
 void CoapSecureBase::SetPsk(const MeshCoP::JoinerPskd &aPskd)
 {
     static_assert(static_cast<uint16_t>(MeshCoP::JoinerPskd::kMaxLength) <=
-                      static_cast<uint16_t>(MeshCoP::SecureTransport::kPskMaxLength),
+                      static_cast<uint16_t>(MeshCoP::Dtls::kPskMaxLength),
                   "The maximum length of DTLS PSK is smaller than joiner PSKd");
 
     SuccessOrAssert(mDtls.SetPsk(reinterpret_cast<const uint8_t *>(aPskd.GetAsCString()), aPskd.GetLength()));
@@ -172,12 +172,12 @@ Error CoapSecureBase::Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessa
     return kErrorNone;
 }
 
-void CoapSecureBase::HandleDtlsConnectEvent(MeshCoP::SecureTransport::ConnectEvent aEvent, void *aContext)
+void CoapSecureBase::HandleDtlsConnectEvent(MeshCoP::Dtls::ConnectEvent aEvent, void *aContext)
 {
     return static_cast<CoapSecureBase *>(aContext)->HandleDtlsConnectEvent(aEvent);
 }
 
-void CoapSecureBase::HandleDtlsConnectEvent(MeshCoP::SecureTransport::ConnectEvent aEvent)
+void CoapSecureBase::HandleDtlsConnectEvent(MeshCoP::Dtls::ConnectEvent aEvent)
 {
     mConnectEventCallback.InvokeIfSet(aEvent);
 }

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -96,7 +96,7 @@ public:
      * @retval kErrorNone        Successfully started the CoAP agent.
      * @retval kErrorAlready     Already started.
      */
-    Error Start(MeshCoP::SecureTransport::TransportCallback aCallback, void *aContext);
+    Error Start(MeshCoP::Dtls::TransportCallback aCallback, void *aContext);
 
     /**
      * Sets connected callback of this secure CoAP agent.
@@ -159,7 +159,7 @@ public:
      *
      * @returns  A reference to the DTLS object.
      */
-    MeshCoP::SecureTransport &GetDtls(void) { return mDtls; }
+    MeshCoP::Dtls &GetDtls(void) { return mDtls; }
 
     /**
      * Gets the UDP port of this agent.
@@ -293,7 +293,7 @@ public:
     const Ip6::MessageInfo &GetMessageInfo(void) const { return mDtls.GetMessageInfo(); }
 
 protected:
-    CoapSecureBase(Instance &aInstance, LinkSecurityMode aLayerTwoSecurity);
+    CoapSecureBase(Instance &aInstance, MeshCoP::Dtls &aDtls);
 
     Error Open(uint16_t aMaxAttempts, AutoStopCallback aCallback, void *aContext);
 
@@ -304,8 +304,8 @@ protected:
 
     Error Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleDtlsConnectEvent(MeshCoP::SecureTransport::ConnectEvent aEvent, void *aContext);
-    void        HandleDtlsConnectEvent(MeshCoP::SecureTransport::ConnectEvent aEvent);
+    static void HandleDtlsConnectEvent(MeshCoP::Dtls::ConnectEvent aEvent, void *aContext);
+    void        HandleDtlsConnectEvent(MeshCoP::Dtls::ConnectEvent aEvent);
 
     static void HandleDtlsAutoClose(void *aContext);
     void        HandleDtlsAutoClose(void);
@@ -316,7 +316,7 @@ protected:
     static void HandleTransmit(Tasklet &aTasklet);
     void        HandleTransmit(void);
 
-    MeshCoP::SecureTransport       mDtls;
+    MeshCoP::Dtls                 &mDtls;
     Callback<ConnectEventCallback> mConnectEventCallback;
     Callback<AutoStopCallback>     mAutoStopCallback;
     ot::MessageQueue               mTransmitQueue;
@@ -328,7 +328,7 @@ protected:
 /**
  * Represents an Application CoAPS.
  */
-class ApplicationCoapSecure : public CoapSecureBase
+class ApplicationCoapSecure : public CoapSecureBase, public MeshCoP::Dtls::Extension
 {
 public:
     /**
@@ -338,86 +338,14 @@ public:
      * @param[in]  aLayerTwoSecurity   Specifies whether to use layer two security or not.
      */
     ApplicationCoapSecure(Instance &aInstance, LinkSecurityMode aLayerTwoSecurity)
-        : CoapSecureBase(aInstance, aLayerTwoSecurity)
+        : CoapSecureBase(aInstance, mDtls)
+        , MeshCoP::Dtls::Extension(mDtls)
+        , mDtls(aInstance, aLayerTwoSecurity, *this)
     {
     }
 
-#ifdef MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
-    /**
-     * Sets the Pre-Shared Key (PSK) for DTLS sessions identified by a PSK.
-     *
-     * DTLS mode "TLS with AES 128 CCM 8" for Application CoAPS.
-     *
-     * @param[in]  aPsk          A pointer to the PSK.
-     * @param[in]  aPskLength    The PSK char length.
-     * @param[in]  aPskIdentity  The Identity Name for the PSK.
-     * @param[in]  aPskIdLength  The PSK Identity Length.
-     */
-    void SetPreSharedKey(const uint8_t *aPsk, uint16_t aPskLength, const uint8_t *aPskIdentity, uint16_t aPskIdLength)
-    {
-        mDtls.SetPreSharedKey(aPsk, aPskLength, aPskIdentity, aPskIdLength);
-    }
-#endif // MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
-
-#ifdef MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
-    /**
-     * Sets a X509 certificate with corresponding private key for DTLS session.
-     *
-     * DTLS mode "ECDHE ECDSA with AES 128 CCM 8" for Application CoAPS.
-     *
-     * @param[in]  aX509Cert          A pointer to the PEM formatted X509 PEM certificate.
-     * @param[in]  aX509Length        The length of certificate.
-     * @param[in]  aPrivateKey        A pointer to the PEM formatted private key.
-     * @param[in]  aPrivateKeyLength  The length of the private key.
-     */
-    void SetCertificate(const uint8_t *aX509Cert,
-                        uint32_t       aX509Length,
-                        const uint8_t *aPrivateKey,
-                        uint32_t       aPrivateKeyLength)
-    {
-        mDtls.SetCertificate(aX509Cert, aX509Length, aPrivateKey, aPrivateKeyLength);
-    }
-
-    /**
-     * Sets the trusted top level CAs. It is needed for validate the certificate of the peer.
-     *
-     * DTLS mode "ECDHE ECDSA with AES 128 CCM 8" for Application CoAPS.
-     *
-     * @param[in]  aX509CaCertificateChain  A pointer to the PEM formatted X509 CA chain.
-     * @param[in]  aX509CaCertChainLength   The length of chain.
-     */
-    void SetCaCertificateChain(const uint8_t *aX509CaCertificateChain, uint32_t aX509CaCertChainLength)
-    {
-        mDtls.SetCaCertificateChain(aX509CaCertificateChain, aX509CaCertChainLength);
-    }
-#endif // MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
-
-#if defined(MBEDTLS_BASE64_C) && defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
-    /**
-     * Returns the peer x509 certificate base64 encoded.
-     *
-     * DTLS mode "ECDHE ECDSA with AES 128 CCM 8" for Application CoAPS.
-     *
-     * @param[out]  aPeerCert        A pointer to the base64 encoded certificate buffer.
-     * @param[out]  aCertLength      The length of the base64 encoded peer certificate.
-     * @param[in]   aCertBufferSize  The buffer size of aPeerCert.
-     *
-     * @retval kErrorNone    Successfully get the peer certificate.
-     * @retval kErrorNoBufs  Can't allocate memory for certificate.
-     */
-    Error GetPeerCertificateBase64(unsigned char *aPeerCert, size_t *aCertLength, size_t aCertBufferSize)
-    {
-        return mDtls.GetPeerCertificateBase64(aPeerCert, aCertLength, aCertBufferSize);
-    }
-#endif // defined(MBEDTLS_BASE64_C) && defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
-
-    /**
-     * Sets the authentication mode for the CoAP secure connection. It disables or enables the verification
-     * of peer certificate.
-     *
-     * @param[in]  aVerifyPeerCertificate  true, if the peer certificate should be verified
-     */
-    void SetSslAuthMode(bool aVerifyPeerCertificate) { mDtls.SetSslAuthMode(aVerifyPeerCertificate); }
+private:
+    MeshCoP::DtlsExtended mDtls;
 };
 
 #endif // OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -639,14 +639,14 @@ exit:
     FreeMessageOnError(response, error);
 }
 
-void BorderAgent::HandleConnected(SecureTransport::ConnectEvent aEvent, void *aContext)
+void BorderAgent::HandleConnected(Dtls::ConnectEvent aEvent, void *aContext)
 {
     static_cast<BorderAgent *>(aContext)->HandleConnected(aEvent);
 }
 
-void BorderAgent::HandleConnected(SecureTransport::ConnectEvent aEvent)
+void BorderAgent::HandleConnected(Dtls::ConnectEvent aEvent)
 {
-    if (aEvent == SecureTransport::kConnected)
+    if (aEvent == Dtls::kConnected)
     {
         LogInfo("SecureSession connected");
         mState = kStateConnected;
@@ -674,11 +674,11 @@ void BorderAgent::HandleConnected(SecureTransport::ConnectEvent aEvent)
         {
             RestartAfterRemovingEphemeralKey();
 
-            if (aEvent == SecureTransport::kDisconnectedError)
+            if (aEvent == Dtls::kDisconnectedError)
             {
                 mCounters.mEpskcSecureSessionFailures++;
             }
-            else if (aEvent == SecureTransport::kDisconnectedPeerClosed)
+            else if (aEvent == Dtls::kDisconnectedPeerClosed)
             {
                 mCounters.mEpskcDeactivationDisconnects++;
             }
@@ -689,7 +689,7 @@ void BorderAgent::HandleConnected(SecureTransport::ConnectEvent aEvent)
             mState        = kStateStarted;
             mUdpProxyPort = 0;
 
-            if (aEvent == SecureTransport::kDisconnectedError)
+            if (aEvent == Dtls::kDisconnectedError)
             {
                 mCounters.mPskcSecureSessionFailures++;
             }

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -251,8 +251,7 @@ public:
     uint16_t GetUdpProxyPort(void) const { return mUdpProxyPort; }
 
 private:
-    static_assert(kMaxEphemeralKeyLength <= SecureTransport::kPskMaxLength,
-                  "Max ephemeral key length is larger than max PSK len");
+    static_assert(kMaxEphemeralKeyLength <= Dtls::kPskMaxLength, "Max ephemeral key length is larger than max PSK len");
 
     static constexpr uint16_t kUdpPort          = OPENTHREAD_CONFIG_BORDER_AGENT_UDP_PORT;
     static constexpr uint32_t kKeepAliveTimeout = 50 * 1000; // Timeout to reject a commissioner (in msec)
@@ -288,8 +287,8 @@ private:
     void                SendErrorMessage(const ForwardContext &aForwardContext, Error aError);
     void                SendErrorMessage(const Coap::Message &aRequest, bool aSeparate, Error aError);
 
-    static void HandleConnected(SecureTransport::ConnectEvent aEvent, void *aContext);
-    void        HandleConnected(SecureTransport::ConnectEvent aEvent);
+    static void HandleConnected(Dtls::ConnectEvent aEvent, void *aContext);
+    void        HandleConnected(Dtls::ConnectEvent aEvent);
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -112,14 +112,14 @@ exit:
     return;
 }
 
-void Commissioner::HandleSecureAgentConnectEvent(SecureTransport::ConnectEvent aEvent, void *aContext)
+void Commissioner::HandleSecureAgentConnectEvent(Dtls::ConnectEvent aEvent, void *aContext)
 {
     static_cast<Commissioner *>(aContext)->HandleSecureAgentConnectEvent(aEvent);
 }
 
-void Commissioner::HandleSecureAgentConnectEvent(SecureTransport::ConnectEvent aEvent)
+void Commissioner::HandleSecureAgentConnectEvent(Dtls::ConnectEvent aEvent)
 {
-    bool isConnected = (aEvent == SecureTransport::kConnected);
+    bool isConnected = (aEvent == Dtls::kConnected);
     if (!isConnected)
     {
         mJoinerSessionTimer.Stop();

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -414,8 +414,8 @@ private:
                                               Error                aResult);
     void HandleLeaderKeepAliveResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
 
-    static void HandleSecureAgentConnectEvent(SecureTransport::ConnectEvent aEvent, void *aContext);
-    void        HandleSecureAgentConnectEvent(SecureTransport::ConnectEvent aEvent);
+    static void HandleSecureAgentConnectEvent(Dtls::ConnectEvent aEvent, void *aContext);
+    void        HandleSecureAgentConnectEvent(Dtls::ConnectEvent aEvent);
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -367,16 +367,16 @@ exit:
     return error;
 }
 
-void Joiner::HandleSecureCoapClientConnect(SecureTransport::ConnectEvent aEvent, void *aContext)
+void Joiner::HandleSecureCoapClientConnect(Dtls::ConnectEvent aEvent, void *aContext)
 {
     static_cast<Joiner *>(aContext)->HandleSecureCoapClientConnect(aEvent);
 }
 
-void Joiner::HandleSecureCoapClientConnect(SecureTransport::ConnectEvent aEvent)
+void Joiner::HandleSecureCoapClientConnect(Dtls::ConnectEvent aEvent)
 {
     VerifyOrExit(mState == kStateConnect);
 
-    if (aEvent == SecureTransport::kConnected)
+    if (aEvent == Dtls::kConnected)
     {
         SetState(kStateConnected);
         SendJoinerFinalize();

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -189,8 +189,8 @@ private:
     static void HandleDiscoverResult(Mle::DiscoverScanner::ScanResult *aResult, void *aContext);
     void        HandleDiscoverResult(Mle::DiscoverScanner::ScanResult *aResult);
 
-    static void HandleSecureCoapClientConnect(SecureTransport::ConnectEvent aEvent, void *aContext);
-    void        HandleSecureCoapClientConnect(SecureTransport::ConnectEvent aEvent);
+    static void HandleSecureCoapClientConnect(Dtls::ConnectEvent aEvent, void *aContext);
+    void        HandleSecureCoapClientConnect(Dtls::ConnectEvent aEvent);
 
     static void HandleJoinerFinalizeResponse(void                *aContext,
                                              otMessage           *aMessage,

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -112,7 +112,7 @@ exit:
     return error;
 }
 
-Error TcatAgent::Connected(MeshCoP::SecureTransport &aTlsContext)
+Error TcatAgent::Connected(MeshCoP::Tls::Extension &aTls)
 {
     size_t len;
     Error  error;
@@ -120,13 +120,13 @@ Error TcatAgent::Connected(MeshCoP::SecureTransport &aTlsContext)
     VerifyOrExit(IsEnabled(), error = kErrorInvalidState);
     len = sizeof(mCommissionerAuthorizationField);
     SuccessOrExit(
-        error = aTlsContext.GetThreadAttributeFromPeerCertificate(
+        error = aTls.GetThreadAttributeFromPeerCertificate(
             kCertificateAuthorizationField, reinterpret_cast<uint8_t *>(&mCommissionerAuthorizationField), &len));
     VerifyOrExit(len == sizeof(mCommissionerAuthorizationField), error = kErrorParse);
     VerifyOrExit((mCommissionerAuthorizationField.mHeader & kCommissionerFlag) == 1, error = kErrorParse);
 
     len = sizeof(mDeviceAuthorizationField);
-    SuccessOrExit(error = aTlsContext.GetThreadAttributeFromOwnCertificate(
+    SuccessOrExit(error = aTls.GetThreadAttributeFromOwnCertificate(
                       kCertificateAuthorizationField, reinterpret_cast<uint8_t *>(&mDeviceAuthorizationField), &len));
     VerifyOrExit(len == sizeof(mDeviceAuthorizationField), error = kErrorParse);
     VerifyOrExit((mDeviceAuthorizationField.mHeader & kCommissionerFlag) == 0, error = kErrorParse);
@@ -136,7 +136,7 @@ Error TcatAgent::Connected(MeshCoP::SecureTransport &aTlsContext)
     mCommissionerHasExtendedPanId = false;
 
     len = sizeof(mCommissionerDomainName) - 1;
-    if (aTlsContext.GetThreadAttributeFromPeerCertificate(
+    if (aTls.GetThreadAttributeFromPeerCertificate(
             kCertificateDomainName, reinterpret_cast<uint8_t *>(&mCommissionerDomainName), &len) == kErrorNone)
     {
         mCommissionerDomainName.m8[len] = '\0';
@@ -144,7 +144,7 @@ Error TcatAgent::Connected(MeshCoP::SecureTransport &aTlsContext)
     }
 
     len = sizeof(mCommissionerNetworkName) - 1;
-    if (aTlsContext.GetThreadAttributeFromPeerCertificate(
+    if (aTls.GetThreadAttributeFromPeerCertificate(
             kCertificateNetworkName, reinterpret_cast<uint8_t *>(&mCommissionerNetworkName), &len) == kErrorNone)
     {
         mCommissionerNetworkName.m8[len] = '\0';
@@ -152,7 +152,7 @@ Error TcatAgent::Connected(MeshCoP::SecureTransport &aTlsContext)
     }
 
     len = sizeof(mCommissionerExtendedPanId);
-    if (aTlsContext.GetThreadAttributeFromPeerCertificate(
+    if (aTls.GetThreadAttributeFromPeerCertificate(
             kCertificateExtendedPanId, reinterpret_cast<uint8_t *>(&mCommissionerExtendedPanId), &len) == kErrorNone)
     {
         if (len == sizeof(mCommissionerExtendedPanId))

--- a/src/core/meshcop/tcat_agent.hpp
+++ b/src/core/meshcop/tcat_agent.hpp
@@ -334,7 +334,7 @@ public:
     bool GetInstallCodeVerifyStatus(void) const { return mInstallCodeVerified; }
 
 private:
-    Error Connected(MeshCoP::SecureTransport &aTlsContext);
+    Error Connected(MeshCoP::Tls::Extension &aTls);
     void  Disconnected(void);
 
     Error HandleSingleTlv(const Message &aIncomingMessage, Message &aOutgoingMessage);

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -273,7 +273,8 @@ Message::Priority Agent::DscpToPriority(uint8_t aDscp)
 #if OPENTHREAD_CONFIG_SECURE_TRANSPORT_ENABLE
 
 SecureAgent::SecureAgent(Instance &aInstance)
-    : Coap::CoapSecureBase(aInstance, kNoLinkSecurity)
+    : Coap::CoapSecureBase(aInstance, mDtls)
+    , mDtls(aInstance, kNoLinkSecurity)
 {
     SetResourceHandler(&HandleResource);
 }

--- a/src/core/thread/tmf.hpp
+++ b/src/core/thread/tmf.hpp
@@ -213,6 +213,8 @@ private:
                                Message                &aMessage,
                                const Ip6::MessageInfo &aMessageInfo);
     bool        HandleResource(const char *aUriPath, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+
+    MeshCoP::Dtls mDtls;
 };
 
 #endif


### PR DESCRIPTION
This commit updates `SecureTransport`. It introduces the `Extension` class within `SecureTransport`, providing support for additional cipher suites and related methods to configure the ciphers (e.g., `SetPreSharedKey()`, `SetCertificate()`).

This class decouples this functionality from the common `SecureTransport` object, allowing it to be added to any class. Classes like `ApplicationCoapSecure` or `BleSecure` can inherit from `Extension` to provide these methods. An `Extension` is then associated with a `SecureTransport` (or any of its subclasses). This approach ensures that only instances requiring extended cipher suite support incur the associated memory cost and avoid repeated code.

This commit also introduces `Dtls`, `DtlsExtended`, and `Tls` as subclasses of `SecureTransport` for easier use by other modules.

-----

Added a new second commit which re-arranges the method:

**[secure-transport] rearrange method definitions**

This commit rearranges the method definitions in the `SecureTransport` source file to place the `SecureTransport::Extension` class methods next to each other and after the `SecureTransport` methods.

