### PR TITLE
[indirect-sender] reset msg timestamp on child mode change to non-sleepy

### DIFF
--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -205,6 +205,7 @@ void IndirectSender::HandleChildModeChange(Child &aChild, Mle::DeviceMode aOldMo
             {
                 message.GetIndirectTxChildMask().Remove(childIndex);
                 message.SetDirectTransmission();
+                message.SetTimestampToNow();
             }
         }
 


### PR DESCRIPTION
This commit resets (to now) the timestamp of queued messages for a previously sleepy child when the child mode changes to non-sleepy. This ensures that delay-aware queue management is correctly applied to these messages and avoids them being dropped immediately.

---

Resolves https://github.com/openthread/openthread/issues/10971