### PR TITLE
[child-supervision] Support Short Supervision Interval TLV

### DIFF
--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -67,7 +67,7 @@ typedef struct
     uint16_t     mFrameErrorRate;       ///< Frame error rate (0xffff->100%). Requires error tracking feature.
     uint16_t     mMessageErrorRate;     ///< (IPv6) msg error rate (0xffff->100%). Requires error tracking feature.
     uint16_t     mQueuedMessageCnt;     ///< Number of queued messages for the child.
-    uint16_t     mSupervisionInterval;  ///< Supervision interval (in seconds).
+    uint16_t     mSupervisionInterval;  ///< Supervision interval (in seconds or 100 ms).
     uint8_t      mVersion;              ///< MLE version
     bool         mRxOnWhenIdle : 1;     ///< rx-on-when-idle
     bool         mFullThreadDevice : 1; ///< Full Thread Device

--- a/src/core/config/child_supervision.h
+++ b/src/core/config/child_supervision.h
@@ -74,6 +74,35 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_CHILD_SUPERVISION_INTERVAL_WED
+ *
+ * The supervision interval in the units of 100 milliseconds to use in a Wake-up End Device when it is attached to
+ * a Wake-up Parent.
+ *
+ * Child supervision feature provides a mechanism for parent to ensure that a message is sent to each sleepy child
+ * within the supervision interval. If there is no transmission to the child within the supervision interval, child
+ * supervisor will enqueue and send a supervision message (a data message with empty payload) to the child.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CHILD_SUPERVISION_INTERVAL_WED
+#define OPENTHREAD_CONFIG_CHILD_SUPERVISION_INTERVAL_WED 2
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT
+ *
+ * The supervision check timeout in the units of 100 milliseconds to use in a Wake-up End Device when it is attached to
+ * a Wake-up Parent.
+ *
+ * If the WED does not hear from the Wake-up Parent within the specified timeout interval, it tears down the current
+ * link and it may restart listening for wake-up frames.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT_WED
+#define OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT_WED 20
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_CHILD_SUPERVISION_OLDER_VERSION_CHILD_DEFAULT_INTERVAL
  *
  * Specifies the default supervision interval to use on parent for children that do not explicitly indicate their

--- a/src/core/thread/child.hpp
+++ b/src/core/thread/child.hpp
@@ -312,35 +312,51 @@ public:
     void SetRequestTlv(uint8_t aIndex, uint8_t aType) { mRequestTlvs[aIndex] = aType; }
 
     /**
-     * Returns the supervision interval (in seconds).
+     * Returns the supervision interval.
      *
-     * @returns The supervision interval (in seconds).
+     * @returns The supervision interval in seconds or units of 100 ms (if the child uses a short supervision interval).
      */
     uint16_t GetSupervisionInterval(void) const { return mSupervisionInterval; }
 
     /**
      * Sets the supervision interval.
      *
-     * @param[in] aInterval  The supervision interval (in seconds).
+     * @param[in] aInterval  The supervision interval in seconds or units of 100 ms (if the child uses a short
+     *                       supervision interval).
      */
     void SetSupervisionInterval(uint16_t aInterval) { mSupervisionInterval = aInterval; }
 
     /**
-     * Increments the number of seconds since last supervision of the child.
-     */
-    void IncrementSecondsSinceLastSupervision(void) { mSecondsSinceSupervision++; }
-
-    /**
-     * Returns the number of seconds since last supervision of the child (last message to the child)
+     * Returns whether the child uses a short supervision interval.
      *
-     * @returns Number of seconds since last supervision of the child.
+     * @retval true  The child uses a short supervision interval, defined in units of 100 ms.
+     * @retval false The child uses a normal supervision interval, defined in seconds.
      */
-    uint16_t GetSecondsSinceLastSupervision(void) const { return mSecondsSinceSupervision; }
+    bool IsShortSupervisionInterval(void) const { return mIsShortSupervisionInterval; }
 
     /**
-     * Resets the number of seconds since last supervision of the child to zero.
+     * Sets whether the child uses a short supervision interval.
+     *
+     * @param[in] aIsShort Indicates whether the child uses a short supervision interval.
      */
-    void ResetSecondsSinceLastSupervision(void) { mSecondsSinceSupervision = 0; }
+    void SetIsShortSupervisionInterval(bool aIsShort) { mIsShortSupervisionInterval = aIsShort; }
+
+    /**
+     * Increments the number of supervision time units since last supervision of the child.
+     */
+    void IncrementUnitsSinceLastSupervision(void) { mUnitsSinceSupervision++; }
+
+    /**
+     * Returns the number of supervision time units since last supervision of the child (last message to the child)
+     *
+     * @returns The supervision time units (seconds or 100ms) since last supervision of the child.
+     */
+    uint16_t GetUnitsSinceLastSupervision(void) const { return mUnitsSinceSupervision; }
+
+    /**
+     * Resets the number of supervision time units since last supervision of the child to zero.
+     */
+    void ResetUnitsSinceLastSupervision(void) { mUnitsSinceSupervision = 0; }
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     /**
@@ -391,7 +407,8 @@ private:
     };
 
     uint16_t mSupervisionInterval;
-    uint16_t mSecondsSinceSupervision;
+    uint16_t mUnitsSinceSupervision;
+    bool     mIsShortSupervisionInterval : 1;
 };
 
 DefineCoreType(otChildInfo, Child::Info);

--- a/src/core/thread/child_supervision.hpp
+++ b/src/core/thread/child_supervision.hpp
@@ -120,11 +120,18 @@ public:
 
 private:
     static constexpr uint16_t kDefaultSupervisionInterval = OPENTHREAD_CONFIG_CHILD_SUPERVISION_INTERVAL; // (seconds)
+    static constexpr uint32_t kShortSupervisionUnitMs     = 100;
 
     void SendMessage(Child &aChild);
     void CheckState(void);
     void HandleTimeTick(void);
+    void HandleShortIntervalTimer(void);
+    void UpdateUnitsSinceLastSupervision(bool aShortInterval);
     void HandleNotifierEvents(Events aEvents);
+
+    using ShortIntervalTimer = TimerMilliIn<ChildSupervisor, &ChildSupervisor::HandleShortIntervalTimer>;
+
+    ShortIntervalTimer mShortIntervalTimer;
 };
 
 #endif // #if OPENTHREAD_FTD
@@ -209,8 +216,10 @@ public:
     void UpdateOnReceive(const Mac::Address &aSourceAddress, bool aIsSecure);
 
 private:
-    static constexpr uint16_t kDefaultTimeout  = OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT; // (seconds)
-    static constexpr uint16_t kDefaultInterval = OPENTHREAD_CONFIG_CHILD_SUPERVISION_INTERVAL;      // (seconds)
+    static constexpr uint16_t kDefaultTimeout  = OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT;     // (seconds)
+    static constexpr uint16_t kDefaultInterval = OPENTHREAD_CONFIG_CHILD_SUPERVISION_INTERVAL;          // (seconds)
+    static constexpr uint16_t kWedTimeout      = OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT_WED; // (100 ms);
+    static constexpr uint16_t kWedInterval     = OPENTHREAD_CONFIG_CHILD_SUPERVISION_INTERVAL_WED;      // (100 ms);
 
     void RestartTimer(void);
     void HandleTimer(void);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -5021,15 +5021,16 @@ Error Mle::TxMessage::AppendSupervisionIntervalTlvIfSleepyChild(void)
     Error error = kErrorNone;
 
     VerifyOrExit(!Get<Mle>().IsRxOnWhenIdle());
-    error = AppendSupervisionIntervalTlv(Get<SupervisionListener>().GetInterval());
+    error = AppendSupervisionIntervalTlv(Get<SupervisionListener>().GetInterval(), false);
 
 exit:
     return error;
 }
 
-Error Mle::TxMessage::AppendSupervisionIntervalTlv(uint16_t aInterval)
+Error Mle::TxMessage::AppendSupervisionIntervalTlv(uint16_t aInterval, bool aIsShortInterval)
 {
-    return Tlv::Append<SupervisionIntervalTlv>(*this, aInterval);
+    return aIsShortInterval ? Tlv::Append<ShortSupervisionIntervalTlv>(*this, aInterval)
+                            : Tlv::Append<SupervisionIntervalTlv>(*this, aInterval);
 }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -997,7 +997,7 @@ private:
         Error AppendVersionTlv(void);
         Error AppendAddressRegistrationTlv(AddressRegistrationMode aMode = kAppendAllAddresses);
         Error AppendSupervisionIntervalTlvIfSleepyChild(void);
-        Error AppendSupervisionIntervalTlv(uint16_t aInterval);
+        Error AppendSupervisionIntervalTlv(uint16_t aInterval, bool aIsShortInterval);
         Error AppendXtalAccuracyTlv(void);
         Error AppendActiveTimestampTlv(void);
         Error AppendPendingTimestampTlv(void);

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -643,13 +643,14 @@ private:
     void SignalDuaAddressEvent(const Child &aChild, const Ip6::Address &aOldDua) const;
 #endif
 
-    static bool IsMessageMleSubType(const Message &aMessage);
-    static bool IsMessageChildUpdateRequest(const Message &aMessage);
-    static void HandleAdvertiseTrickleTimer(TrickleTimer &aTimer);
-    static void HandleAddressSolicitResponse(void                *aContext,
-                                             otMessage           *aMessage,
-                                             const otMessageInfo *aMessageInfo,
-                                             Error                aResult);
+    static bool  IsMessageMleSubType(const Message &aMessage);
+    static bool  IsMessageChildUpdateRequest(const Message &aMessage);
+    static void  HandleAdvertiseTrickleTimer(TrickleTimer &aTimer);
+    static void  HandleAddressSolicitResponse(void                *aContext,
+                                              otMessage           *aMessage,
+                                              const otMessageInfo *aMessageInfo,
+                                              Error                aResult);
+    static Error ParseSupervisionInterval(const Message &aMessage, uint16_t &aInterval, bool &aIsShort);
 
     //------------------------------------------------------------------------------------------------------------------
     // Variables

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -70,42 +70,43 @@ public:
      */
     enum Type : uint8_t
     {
-        kSourceAddress         = 0,  ///< Source Address TLV
-        kMode                  = 1,  ///< Mode TLV
-        kTimeout               = 2,  ///< Timeout TLV
-        kChallenge             = 3,  ///< Challenge TLV
-        kResponse              = 4,  ///< Response TLV
-        kLinkFrameCounter      = 5,  ///< Link-Layer Frame Counter TLV
-        kLinkQuality           = 6,  ///< Link Quality TLV
-        kNetworkParameter      = 7,  ///< Network Parameter TLV
-        kMleFrameCounter       = 8,  ///< MLE Frame Counter TLV
-        kRoute                 = 9,  ///< Route64 TLV
-        kAddress16             = 10, ///< Address16 TLV
-        kLeaderData            = 11, ///< Leader Data TLV
-        kNetworkData           = 12, ///< Network Data TLV
-        kTlvRequest            = 13, ///< TLV Request TLV
-        kScanMask              = 14, ///< Scan Mask TLV
-        kConnectivity          = 15, ///< Connectivity TLV
-        kLinkMargin            = 16, ///< Link Margin TLV
-        kStatus                = 17, ///< Status TLV
-        kVersion               = 18, ///< Version TLV
-        kAddressRegistration   = 19, ///< Address Registration TLV
-        kChannel               = 20, ///< Channel TLV
-        kPanId                 = 21, ///< PAN ID TLV
-        kActiveTimestamp       = 22, ///< Active Timestamp TLV
-        kPendingTimestamp      = 23, ///< Pending Timestamp TLV
-        kActiveDataset         = 24, ///< Active Operational Dataset TLV
-        kPendingDataset        = 25, ///< Pending Operational Dataset TLV
-        kDiscovery             = 26, ///< Thread Discovery TLV
-        kSupervisionInterval   = 27, ///< Supervision Interval TLV
-        kWakeupChannel         = 74, ///< Wakeup Channel TLV
-        kCslChannel            = 80, ///< CSL Channel TLV
-        kCslTimeout            = 85, ///< CSL Timeout TLV
-        kCslClockAccuracy      = 86, ///< CSL Clock Accuracy TLV
-        kLinkMetricsQuery      = 87, ///< Link Metrics Query TLV
-        kLinkMetricsManagement = 88, ///< Link Metrics Management TLV
-        kLinkMetricsReport     = 89, ///< Link Metrics Report TLV
-        kLinkProbe             = 90, ///< Link Probe TLV
+        kSourceAddress            = 0,  ///< Source Address TLV
+        kMode                     = 1,  ///< Mode TLV
+        kTimeout                  = 2,  ///< Timeout TLV
+        kChallenge                = 3,  ///< Challenge TLV
+        kResponse                 = 4,  ///< Response TLV
+        kLinkFrameCounter         = 5,  ///< Link-Layer Frame Counter TLV
+        kLinkQuality              = 6,  ///< Link Quality TLV
+        kNetworkParameter         = 7,  ///< Network Parameter TLV
+        kMleFrameCounter          = 8,  ///< MLE Frame Counter TLV
+        kRoute                    = 9,  ///< Route64 TLV
+        kAddress16                = 10, ///< Address16 TLV
+        kLeaderData               = 11, ///< Leader Data TLV
+        kNetworkData              = 12, ///< Network Data TLV
+        kTlvRequest               = 13, ///< TLV Request TLV
+        kScanMask                 = 14, ///< Scan Mask TLV
+        kConnectivity             = 15, ///< Connectivity TLV
+        kLinkMargin               = 16, ///< Link Margin TLV
+        kStatus                   = 17, ///< Status TLV
+        kVersion                  = 18, ///< Version TLV
+        kAddressRegistration      = 19, ///< Address Registration TLV
+        kChannel                  = 20, ///< Channel TLV
+        kPanId                    = 21, ///< PAN ID TLV
+        kActiveTimestamp          = 22, ///< Active Timestamp TLV
+        kPendingTimestamp         = 23, ///< Pending Timestamp TLV
+        kActiveDataset            = 24, ///< Active Operational Dataset TLV
+        kPendingDataset           = 25, ///< Pending Operational Dataset TLV
+        kDiscovery                = 26, ///< Thread Discovery TLV
+        kSupervisionInterval      = 27, ///< Supervision Interval TLV
+        kShortSupervisionInterval = 28, ///< Short Supervision Interval TLV
+        kWakeupChannel            = 74, ///< Wakeup Channel TLV
+        kCslChannel               = 80, ///< CSL Channel TLV
+        kCslTimeout               = 85, ///< CSL Timeout TLV
+        kCslClockAccuracy         = 86, ///< CSL Clock Accuracy TLV
+        kLinkMetricsQuery         = 87, ///< Link Metrics Query TLV
+        kLinkMetricsManagement    = 88, ///< Link Metrics Management TLV
+        kLinkMetricsReport        = 89, ///< Link Metrics Report TLV
+        kLinkProbe                = 90, ///< Link Probe TLV
 
         /**
          * Applicable/Required only when time synchronization service
@@ -210,9 +211,14 @@ typedef SimpleTlvInfo<Tlv::kActiveTimestamp, MeshCoP::Timestamp> ActiveTimestamp
 typedef SimpleTlvInfo<Tlv::kPendingTimestamp, MeshCoP::Timestamp> PendingTimestampTlv;
 
 /**
- * Defines Timeout TLV constants and types.
+ * Defines Supervision Interval TLV constants and types.
  */
 typedef UintTlvInfo<Tlv::kSupervisionInterval, uint16_t> SupervisionIntervalTlv;
+
+/**
+ * Defines Short Supervision Interval TLV constants and types.
+ */
+typedef UintTlvInfo<Tlv::kShortSupervisionInterval, uint16_t> ShortSupervisionIntervalTlv;
 
 /**
  * Defines CSL Timeout TLV constants and types.


### PR DESCRIPTION
A Wake-up End Device uses the child supervision mechanism to assure a proper time synchronization of the enhanced CSL link, and to quickly react on the link loss in order to return to wake-up frame sniffing, and be able to recover the connection with no delay.

To achieve the above goals, the WED needs to use the child supervision interval shorter than 1s that is currently the minimum value possible to encode in Supervision Interval TLV. To overcome this limitation, the Short Supervision Interval TLV element is being introduced, which has the same meaning as Supervision Interval TLV, except that it carries the interval in units of 100ms, instead of seconds.

Implement handling Short Supervision Interval TLV in Thread routers. Subsequent commits will add support for the short supervision interval on WEDs being attached to Wake-up Parents.

Related to #10725