### PR TITLE
[mle] enhance neighbor aging & suppress Link Requests on FTD children

### DIFF
--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -503,7 +503,8 @@ private:
 #endif
 
     static constexpr uint32_t kMaxUnicastAdvertisementDelay  = 1000;   // Max random delay for unciast Adv tx
-    static constexpr uint32_t kMaxNeighborAge                = 100000; // Max neighbor age (in msec)
+    static constexpr uint32_t kMaxNeighborAge                = 100000; // Max neighbor age on router (in msec)
+    static constexpr uint32_t kMaxNeighborAgeOnChild         = 150000; // Max neighbor age on FTD child (in msec)
     static constexpr uint32_t kMaxLeaderToRouterTimeout      = 90000;  // (in msec)
     static constexpr uint8_t  kMinDowngradeNeighbors         = 7;
     static constexpr uint8_t  kNetworkIdTimeout              = 120; // (in sec)


### PR DESCRIPTION
This commit updates neighbor aging and recovery on FTD children. An FTD child establishes links with neighboring routers to receive multicast MPL (re)transmissions.

If the device is an FTD child and has more than `mChildRouterLinks` neighbors, it uses a longer neighbor age (`kMaxNeighborAgeOnChild = 150s`) and removes the neighboring router upon expiration without attempting to re-establish the link.

This differs from the existing behavior (which is still used when the device is a router or an FTD child with `mChildRouterLinks` or fewer neighbors), where a 100-second age is used, and the device attempts to re-establish links upon expiration by sending Link Requests.

Link Requests from FTD children are suppressed when a neighboring router becomes unavailable, and the child already has more than `mChildRouterLinks` neighbors. This helps reduce unnecessary network traffic on denser networks, especially when a router device is powered off.

----

Related to [SPEC-1345](https://threadgroup.atlassian.net/browse/SPEC-1345)