### PR TITLE
[cli] fix the issue of overflow when calculating ping statistics

### DIFF
--- a/src/cli/cli_ping.cpp
+++ b/src/cli/cli_ping.cpp
@@ -233,7 +233,8 @@ void PingSender::HandlePingStatistics(const otPingSenderStatistics *aStatistics)
 
     if (aStatistics->mReceivedCount != 0)
     {
-        uint32_t avgRoundTripTime = 1000 * aStatistics->mTotalRoundTripTime / aStatistics->mReceivedCount;
+        uint32_t avgRoundTripTime =
+            1000 * static_cast<uint64_t>(aStatistics->mTotalRoundTripTime) / aStatistics->mReceivedCount;
 
         OutputFormat(" Round-trip min/avg/max = %u/%u.%u/%u ms.", aStatistics->mMinRoundTripTime,
                      static_cast<uint16_t>(avgRoundTripTime / 1000), static_cast<uint16_t>(avgRoundTripTime % 1000),


### PR DESCRIPTION
Fix the overflow issue when `mTotalRoundTripTime` is very large.