### PR TITLE
[api] add error code

### DIFF
--- a/include/openthread/error.h
+++ b/include/openthread/error.h
@@ -237,6 +237,21 @@ typedef enum OT_MUST_USE_RESULT otError
     OT_ERROR_REJECTED = 37,
 
     /**
+     * The channel provided is not supported.
+     */
+    OT_ERROR_UNSUPPORTED_CHANNEL = 38,
+
+    /**
+     * The action didn't succeed because Thread is in Disabled state.
+     */
+    OT_ERROR_THREAD_DISABLED = 39,
+
+    /*
+     * The action didn't succeed because some precondition isn't satisfied.
+     */
+    OT_ERROR_FAILED_PRECONDITION = 40,
+
+    /**
      * The number of defined errors.
      */
     OT_NUM_ERRORS,

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (465)
+#define OPENTHREAD_API_VERSION (466)
 
 /**
  * @addtogroup api-instance


### PR DESCRIPTION
This PR adds 3 new error code.

The 3 error code are not directly used inside OT core. They will be used in ThreadHost [methods](https://github.com/openthread/ot-br-posix/blob/main/src/ncp/rcp_host.cpp#L491) in ot-br-posix so that on android platform these error code can raise specific exception.