### PR TITLE
[srp-server] use `kNetifThreadInternal` for UDP socket

### DIFF
--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -658,7 +658,7 @@ Error Server::PrepareSocket(void)
 #endif
 
     VerifyOrExit(!mSocket.IsOpen());
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThreadHost));
+    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThreadInternal));
     error = mSocket.Bind(mPort);
 
 exit:

--- a/tests/scripts/thread-cert/border_router/test_advertising_proxy.py
+++ b/tests/scripts/thread-cert/border_router/test_advertising_proxy.py
@@ -80,12 +80,6 @@ class SingleHostAndService(thread_cert.TestCase):
         host.start(start_radvd=False)
         self.simulator.go(5)
 
-        # Reserve UDP ports to verify that SRP server can skip the unavailable
-        # ports correctly
-        server.reserve_udp_port(53535)
-        server.reserve_udp_port(53536)
-        server.reserve_udp_port(53537)
-
         self.assertEqual(server.srp_server_get_state(), 'disabled')
         server.srp_server_set_enabled(True)
         server.srp_server_set_lease_range(LEASE, LEASE, KEY_LEASE, KEY_LEASE)
@@ -93,7 +87,6 @@ class SingleHostAndService(thread_cert.TestCase):
         self.simulator.go(config.BORDER_ROUTER_STARTUP_DELAY)
         self.assertEqual('leader', server.get_state())
         self.assertEqual(server.srp_server_get_state(), 'running')
-        self.assertNotIn(server.get_srp_server_port(), [53535, 53536, 53537])
 
         client.start()
         self.simulator.go(config.ROUTER_STARTUP_DELAY)

--- a/tests/unit/test_srp_server.cpp
+++ b/tests/unit/test_srp_server.cpp
@@ -1076,7 +1076,7 @@ void TestSrpClientDelayedResponse(void)
 
         sServerRxCount = 0;
 
-        SuccessOrQuit(udpSocket.Open(Ip6::kNetifThreadHost));
+        SuccessOrQuit(udpSocket.Open(Ip6::kNetifThreadInternal));
         SuccessOrQuit(udpSocket.Bind(kServerPort));
 
         //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This commit updates `Srp::Server` to associate its UDP socket with `kNetifThreadInternal`, ensuring that received messages are from the internal Thread network interface (i.e., from devices within the Thread mesh).