### PR TITLE
[secure-transport] update mbedtls timer to track finish time

### DIFF
--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -91,7 +91,6 @@ SecureTransport::SecureTransport(Instance &aInstance, LinkSecurityMode aLayerTwo
     , mReceiveMessage(nullptr)
     , mSocket(aInstance, *this)
     , mTimer(aInstance, SecureTransport::HandleTimer, this)
-    , mTimerIntermediate(0)
 #if OPENTHREAD_CONFIG_TLS_API_ENABLE
     , mExtension(nullptr)
 #endif
@@ -567,23 +566,30 @@ int SecureTransport::HandleMbedtlsGetTimer(void *aContext)
 
 int SecureTransport::HandleMbedtlsGetTimer(void)
 {
-    int rval;
+    int rval = 0;
+
+    // `mbedtls_ssl_get_timer_t` return values:
+    //   -1 if cancelled
+    //    0 if none of the delays have passed,
+    //    1 if only the intermediate delay has passed,
+    //    2 if the final delay has passed.
 
     if (!mTimerSet)
     {
         rval = -1;
     }
-    else if (!mTimer.IsRunning())
-    {
-        rval = 2;
-    }
-    else if (mTimerIntermediate <= TimerMilli::GetNow())
-    {
-        rval = 1;
-    }
     else
     {
-        rval = 0;
+        TimeMilli now = TimerMilli::GetNow();
+
+        if (now >= mTimerFinish)
+        {
+            rval = 2;
+        }
+        else if (now >= mTimerIntermediate)
+        {
+            rval = 1;
+        }
     }
 
     return rval;
@@ -603,9 +609,13 @@ void SecureTransport::HandleMbedtlsSetTimer(uint32_t aIntermediate, uint32_t aFi
     }
     else
     {
-        mTimerSet = true;
-        mTimer.Start(aFinish);
-        mTimerIntermediate = TimerMilli::GetNow() + aIntermediate;
+        TimeMilli now = TimerMilli::GetNow();
+
+        mTimerSet          = true;
+        mTimerIntermediate = now + aIntermediate;
+        mTimerFinish       = now + aFinish;
+
+        mTimer.FireAt(mTimerFinish);
     }
 }
 

--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -655,8 +655,9 @@ private:
     Ip6::MessageInfo            mMessageInfo;
     TransportSocket             mSocket;
     uint8_t                     mPsk[kPskMaxLength];
-    TimerMilliContext           mTimer;
     TimeMilli                   mTimerIntermediate;
+    TimeMilli                   mTimerFinish;
+    TimerMilliContext           mTimer;
     Callback<AutoCloseCallback> mAutoCloseCallback;
     Callback<ConnectedHandler>  mConnectedCallback;
     Callback<ReceiveHandler>    mReceiveCallback;


### PR DESCRIPTION
This commit updates how MbedTLS timers are handled, ensuring that both intermediate and finish times are tracked in their own variables. This decouples the intervals from the underlying `TimerMilli` instance, allowing the same timer to be shared to support multiple sessions later.