### PR TITLE
[diag] add new command to factory diags

### DIFF
--- a/src/core/diags/README.md
+++ b/src/core/diags/README.md
@@ -226,6 +226,24 @@ Return the state of the radio.
 sleep
 ```
 
+### diag radio enable
+
+Enable radio interface and put it in receive mode.
+
+```bash
+> diag radio enable
+Done
+```
+
+### diag radio disable
+
+Disable radio interface.
+
+```bash
+> diag radio disable
+Done
+```
+
 ### diag rawpowersetting
 
 Show the raw power setting for diagnostics module.

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -621,6 +621,14 @@ Error Diags::ProcessRadio(uint8_t aArgsLength, char *aArgs[])
             break;
         }
     }
+    else if (StringMatch(aArgs[0], "enable"))
+    {
+        SuccessOrExit(error = Get<Radio>().Enable());
+    }
+    else if (StringMatch(aArgs[0], "disable"))
+    {
+        SuccessOrExit(error = Get<Radio>().Disable());
+    }
 
 exit:
     AppendErrorResult(error);


### PR DESCRIPTION
Commit adds new command to factory diag called `radio`.
        - `enable` for enabling the interface to dfault mode,
        - `disable` for disabling the interface
