### PR TITLE
[mac-frame] process security of the wakeup frame

### DIFF
--- a/examples/platforms/utils/mac_frame.h
+++ b/examples/platforms/utils/mac_frame.h
@@ -260,6 +260,16 @@ bool otMacFrameIsSecurityEnabled(otRadioFrame *aFrame);
 bool otMacFrameIsKeyIdMode1(otRadioFrame *aFrame);
 
 /**
+ * Tell if the key ID mode of @p aFrame is 2.
+ *
+ * @param[in]   aFrame          A pointer to the frame.
+ *
+ * @retval  true    The frame key ID mode is 2.
+ * @retval  false   The frame security is not enabled or key ID mode is not 2.
+ */
+bool otMacFrameIsKeyIdMode2(otRadioFrame *aFrame);
+
+/**
  * Get the key ID of @p aFrame.
  *
  * @param[in]   aFrame          A pointer to the frame.


### PR DESCRIPTION
If the radio driver supports the radio capability `OT_RADIO_CAPS_TRANSMIT_SEC`, the radio driver should process the security of the send frame if the security is enabled and the frame security is not processed. The wakeup frame uses the KeyIdMode2, but the current method `otMacFrameProcessTransmitSecurity()` only process the frame with the KeyIdMode1. Which causes sent wakeup frame is not encrypted.

This commit enables the method `otMacFrameProcessTransmitSecurity()` to process the security of the wakeup frame.