### PR TITLE
[secure-transport] fix Send() method to send entire message

### DIFF
--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -229,18 +229,12 @@ void CoapSecureBase::HandleTransmit(void)
         mTransmitTask.Post();
     }
 
-    SuccessOrExit(error = mDtls.Send(*message, message->GetLength()));
+    SuccessOrExit(error = mDtls.Send(*message));
+    LogDebg("Transmit");
 
 exit:
-    if (error != kErrorNone)
-    {
-        LogNote("Transmit: %s", ErrorToString(error));
-        message->Free();
-    }
-    else
-    {
-        LogDebg("Transmit: %s", ErrorToString(error));
-    }
+    FreeMessageOnError(message, error);
+    LogWarnOnError(error, "transmit");
 }
 
 } // namespace Coap

--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -470,22 +470,18 @@ exit:
     return error;
 }
 
-Error SecureTransport::Send(Message &aMessage, uint16_t aLength)
+Error SecureTransport::Send(Message &aMessage)
 {
-    Error   error = kErrorNone;
-    uint8_t buffer[kApplicationDataMaxLength];
+    Error    error  = kErrorNone;
+    uint16_t length = aMessage.GetLength();
+    uint8_t  buffer[kApplicationDataMaxLength];
 
-    VerifyOrExit(aLength <= kApplicationDataMaxLength, error = kErrorNoBufs);
+    VerifyOrExit(length <= sizeof(buffer), error = kErrorNoBufs);
 
-    // Store message specific sub type.
-    if (aMessage.GetSubType() != Message::kSubTypeNone)
-    {
-        mMessageSubType = aMessage.GetSubType();
-    }
+    mMessageSubType = aMessage.GetSubType();
+    aMessage.ReadBytes(0, buffer, length);
 
-    aMessage.ReadBytes(0, buffer, aLength);
-
-    SuccessOrExit(error = Crypto::MbedTls::MapError(mbedtls_ssl_write(&mSsl, buffer, aLength)));
+    SuccessOrExit(error = Crypto::MbedTls::MapError(mbedtls_ssl_write(&mSsl, buffer, length)));
 
     aMessage.Free();
 

--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -481,15 +481,17 @@ public:
     Error SetPsk(const uint8_t *aPsk, uint8_t aPskLength);
 
     /**
-     * Sends data within the session.
+     * Sends message to the secure session.
      *
-     * @param[in]  aMessage  A message to send via connection.
-     * @param[in]  aLength   Number of bytes in the data buffer.
+     * When successful (returning `kErrorNone`), this method takes over the ownership of @p aMessage and will free it
+     * after transmission. Otherwise, the caller keeps the ownership of @p aMessage.
      *
-     * @retval kErrorNone     Successfully sent the data via the session.
-     * @retval kErrorNoBufs   A message is too long.
+     * @param[in]  aMessage   A message to send.
+     *
+     * @retval kErrorNone     Successfully sent the message.
+     * @retval kErrorNoBufs   @p aMessage is too long.
      */
-    Error Send(Message &aMessage, uint16_t aLength);
+    Error Send(Message &aMessage);
 
     /**
      * Returns the session's peer address.

--- a/src/core/radio/ble_secure.cpp
+++ b/src/core/radio/ble_secure.cpp
@@ -468,18 +468,12 @@ void BleSecure::HandleTransmit(void)
         mTransmitTask.Post();
     }
 
-    SuccessOrExit(error = mTls.Send(*message, message->GetLength()));
+    SuccessOrExit(error = mTls.Send(*message));
+    LogDebg("Transmit");
 
 exit:
-    if (error != kErrorNone)
-    {
-        LogNote("Transmit: %s", ErrorToString(error));
-        message->Free();
-    }
-    else
-    {
-        LogDebg("Transmit: %s", ErrorToString(error));
-    }
+    FreeMessageOnError(message, error);
+    LogWarnOnError(error, "transmit");
 }
 
 Error BleSecure::HandleTransport(void *aContext, ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/tests/nexus/test_dtls.cpp
+++ b/tests/nexus/test_dtls.cpp
@@ -223,7 +223,7 @@ void TestDtls(void)
         {
             OwnedPtr<Message> msg(PrepareMessage(node0));
 
-            SuccessOrQuit(dtls0.Send(*msg->Clone(), msg->GetLength()));
+            SuccessOrQuit(dtls0.Send(*msg->Clone()));
             nexus.AdvanceTime(100);
 
             VerifyOrQuit(sDtlsLastReceive[node1.GetId()].GetLength() == msg->GetLength());
@@ -237,7 +237,7 @@ void TestDtls(void)
         {
             OwnedPtr<Message> msg(PrepareMessage(node1));
 
-            SuccessOrQuit(dtls1.Send(*msg->Clone(), msg->GetLength()));
+            SuccessOrQuit(dtls1.Send(*msg->Clone()));
             nexus.AdvanceTime(100);
 
             VerifyOrQuit(sDtlsLastReceive[node0.GetId()].GetLength() == msg->GetLength());


### PR DESCRIPTION
This commit simplifies and fixes the `Send()` method by sending the entire `aMessage` content and removing the extra `aLength` input parameter. In all calls, the input `aLength` was set to the message's length. The previous implementation of `Send()` did not correctly handle cases where the passed-in length was longer than the available bytes in the given message.

This commit also updates the documentation of `Send()` to clarify the behavior regarding the transfer of ownership of `aMessage`.

Additionally, this commit simplifies `CoapSecure` and `BleSecure` where `Send()` is called.