### PR TITLE
[mle] do not request link when not recognized

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1348,7 +1348,8 @@ Error MleRouter::HandleAdvertisementOnFtd(RxInfo &aRxInfo, uint16_t aSourceAddre
     // Send unicast link request if no link to router and no
     // unicast/multicast link request in progress
 
-    if (!router->IsStateValid() && !router->IsStateLinkRequest() && (linkMargin >= kLinkRequestMinMargin))
+    if (!router->IsStateValid() && !router->IsStateLinkRequest() && (linkMargin >= kLinkRequestMinMargin) &&
+        routeTlv.IsRouterIdSet(mRouterId))
     {
         InitNeighbor(*router, aRxInfo);
         router->SetState(Neighbor::kStateLinkRequest);


### PR DESCRIPTION
If the new router is not in peer's route TLV, the link request would be ignored, causing the link establishment stuck at the Link Request stage until timeout when a new attempt could proceed. This commit adds a check on the initiator to make sure the peer router's Route TLV contains the initiator's router id before sending the link request, otherwise it refrains from initiating the link establishment.