### PR TITLE
[wake-up] fix time wrap for wake-up frames

### DIFF
--- a/src/core/mac/wakeup_tx_scheduler.cpp
+++ b/src/core/mac/wakeup_tx_scheduler.cpp
@@ -88,7 +88,7 @@ Mac::TxFrame *WakeupTxScheduler::PrepareWakeupFrame(Mac::TxFrames &aTxFrames)
 
     target.SetExtended(mWedAddress);
     source.SetExtended(Get<Mac::Mac>().GetExtAddress());
-    radioTxUs = static_cast<uint32_t>(Get<Radio>().GetNow()) + (mTxTimeUs - TimerMicro::GetNow());
+    radioTxUs = mTxTimeUs - TimerMicro::GetNow();
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     frame = &aTxFrames.GetTxFrame(Mac::kRadioTypeIeee802154);
@@ -97,7 +97,7 @@ Mac::TxFrame *WakeupTxScheduler::PrepareWakeupFrame(Mac::TxFrames &aTxFrames)
 #endif
 
     VerifyOrExit(frame->GenerateWakeupFrame(Get<Mac::Mac>().GetPanId(), target, source) == kErrorNone, frame = nullptr);
-    frame->SetTxDelayBaseTime(0);
+    frame->SetTxDelayBaseTime(static_cast<uint32_t>(Get<Radio>().GetNow()));
     frame->SetTxDelay(radioTxUs);
     frame->SetCsmaCaEnabled(false);
     frame->SetMaxCsmaBackoffs(0);


### PR DESCRIPTION
This commit fixes the potential issue that mTxDelay becomes 0 around the 32-bit time wrapping.