### PR TITLE
[mle] avoid link dead lock

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -707,7 +707,6 @@ void MleRouter::HandleLinkRequest(RxInfo &aRxInfo)
         {
             neighbor = mRouterTable.FindRouterByRloc16(sourceAddress);
             VerifyOrExit(neighbor != nullptr, error = kErrorParse);
-            VerifyOrExit(!neighbor->IsStateLinkRequest(), error = kErrorAlready);
 
             if (!neighbor->IsStateValid())
             {


### PR DESCRIPTION
The current MLE Link Request handler would result in dead lock if two routers sends Link Request to each other at very close time points, when either node tracks the other node in LinkRequest state, so rejects the request until timeout.

This commit changes the handler so that a node will accept the Link Request even if the peer is in LinkRequest state.