### PR TITLE
[diag] set rx_on_when_idle mode when diag start/stop

### DIFF
--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -487,6 +487,7 @@ Error Diags::ProcessStart(uint8_t aArgsLength, char *aArgs[])
 
     IgnoreError(Get<Radio>().Enable());
     Get<Radio>().SetPromiscuous(true);
+    Get<Mac::SubMac>().SetRxOnWhenIdle(true);
     otPlatAlarmMilliStop(&GetInstance());
     SuccessOrExit(error = Get<Radio>().Receive(mChannel));
     SuccessOrExit(error = Get<Radio>().SetTransmitPower(mTxPower));
@@ -538,6 +539,7 @@ Error Diags::ProcessStop(uint8_t aArgsLength, char *aArgs[])
     otPlatAlarmMilliStop(&GetInstance());
     otPlatDiagModeSet(false);
     Get<Radio>().SetPromiscuous(false);
+    Get<Mac::SubMac>().SetRxOnWhenIdle(false);
 
     Output("received packets: %d\r\nsent packets: %d\r\n"
            "first received packet: rssi=%d, lqi=%d\r\n"


### PR DESCRIPTION
This PR fixes an issue related to https://github.com/openthread/openthread/pull/9554. In PR https://github.com/openthread/openthread/pull/9554, a new radio capability is introduced: RX_ON_WHEN_IDLE.

In this PR, we set `rx_on_when_idle` to be true when calling `diag start`, and false when calling `diag stop` for devices which support `rx_on_when_idle`. 

This fix ensures that packets can still be received if `diag` is used after `ifconfig down`.

