### PR TITLE
[mle] remove scheduled Link Request to a router if a link is established

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -4576,6 +4576,14 @@ exit:
     return;
 }
 
+void Mle::DelayedSender::RemoveScheduledLinkRequest(const Router &aRouter)
+{
+    Ip6::Address destination;
+
+    destination.SetToLinkLocalAddress(aRouter.GetExtAddress());
+    RemoveMatchingSchedules(kTypeLinkRequest, destination);
+}
+
 void Mle::DelayedSender::ScheduleLinkAccept(const LinkAcceptInfo &aInfo, uint16_t aDelay)
 {
     Ip6::Address destination;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1145,6 +1145,7 @@ private:
         void ScheduleDiscoveryResponse(const Ip6::Address          &aDestination,
                                        const DiscoveryResponseInfo &aInfo,
                                        uint16_t                     aDelay);
+        void RemoveScheduledLinkRequest(const Router &aRouter);
 #endif
         void RemoveScheduledChildUpdateRequestToParent(void);
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1042,6 +1042,8 @@ void MleRouter::HandleLinkAcceptVariant(RxInfo &aRxInfo, MessageType aMessageTyp
 
     mNeighborTable.Signal(NeighborTable::kRouterAdded, *router);
 
+    mDelayedSender.RemoveScheduledLinkRequest(*router);
+
     if (shouldUpdateRoutes)
     {
         mRouterTable.UpdateRoutes(routeTlv, routerId);


### PR DESCRIPTION
This commit adds a mechanism to remove any scheduled (delayed) Link Request transmissions to a neighboring router when a link is established with it.


----

Background:

- We set the state to `kStateLinkRequest` when scheduling a Link Request transmission to a neighboring router (from which we receive an Advertisement).
- Currently, this state change blocks replies to "link requests" from the neighbor itself, which can create a deadlock situation (resolved after time out and next advertisment tx).
- https://github.com/openthread/openthread/pull/11030 addresses this by relaxing the state check.
- This change prepares for this update to ensure that the scheduled "Link Request" transmission is canceled if the link is already established, avoiding extra message exchanges between the routers.