### PR TITLE
[mac-frame] process key id mode 2 only when WC is enabled

### DIFF
--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -319,7 +319,7 @@ otError otMacFrameProcessTransmitSecurity(otRadioFrame *aFrame, otRadioContext *
     bool              processKeyId;
 
     processKeyId =
-#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+#if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
         otMacFrameIsKeyIdMode2(aFrame) ||
 #endif
         otMacFrameIsKeyIdMode1(aFrame);


### PR DESCRIPTION
The wakeup frame is sent from the wakeup coordinator rather than the wakeup end device. Current code processes the key id mode 2 only when the device is the wakeup end device. This commit corrects this issue.