### PR TITLE
[secure-transport] simplify how `Connect/Receive` callbacks are set

### DIFF
--- a/src/core/api/coap_secure_api.cpp
+++ b/src/core/api/coap_secure_api.cpp
@@ -110,7 +110,9 @@ otError otCoapSecureConnect(otInstance                     *aInstance,
                             otHandleCoapSecureClientConnect aHandler,
                             void                           *aContext)
 {
-    return AsCoreType(aInstance).GetApplicationCoapSecure().Connect(AsCoreType(aSockAddr), aHandler, aContext);
+    AsCoreType(aInstance).GetApplicationCoapSecure().SetConnectCallback(aHandler, aContext);
+
+    return AsCoreType(aInstance).GetApplicationCoapSecure().Connect(AsCoreType(aSockAddr));
 }
 
 void otCoapSecureDisconnect(otInstance *aInstance) { AsCoreType(aInstance).GetApplicationCoapSecure().Disconnect(); }
@@ -176,7 +178,7 @@ void otCoapSecureSetClientConnectEventCallback(otInstance                     *a
                                                otHandleCoapSecureClientConnect aHandler,
                                                void                           *aContext)
 {
-    AsCoreType(aInstance).GetApplicationCoapSecure().SetConnectEventCallback(aHandler, aContext);
+    AsCoreType(aInstance).GetApplicationCoapSecure().SetConnectCallback(aHandler, aContext);
 }
 
 void otCoapSecureSetDefaultHandler(otInstance *aInstance, otCoapRequestHandler aHandler, void *aContext)

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -79,8 +79,8 @@ Error CoapSecureBase::Open(uint16_t aMaxAttempts, AutoStopCallback aCallback, vo
 
     SuccessOrExit(mDtls.SetMaxConnectionAttempts(aMaxAttempts, HandleDtlsAutoClose, this));
     mAutoStopCallback.Set(aCallback, aContext);
-    mConnectEventCallback.Clear();
-    SuccessOrExit(mDtls.Open(HandleDtlsReceive, HandleDtlsConnectEvent, this));
+    SuccessOrExit(mDtls.Open());
+    mDtls.SetReceiveCallback(HandleDtlsReceive, this);
 
     error = kErrorNone;
 
@@ -94,13 +94,6 @@ void CoapSecureBase::Stop(void)
 
     mTransmitQueue.DequeueAndFreeAll();
     ClearRequestsAndResponses();
-}
-
-Error CoapSecureBase::Connect(const Ip6::SockAddr &aSockAddr, ConnectEventCallback aCallback, void *aContext)
-{
-    mConnectEventCallback.Set(aCallback, aContext);
-
-    return mDtls.Connect(aSockAddr);
 }
 
 void CoapSecureBase::SetPsk(const MeshCoP::JoinerPskd &aPskd)
@@ -170,16 +163,6 @@ Error CoapSecureBase::Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessa
     mTransmitTask.Post();
 
     return kErrorNone;
-}
-
-void CoapSecureBase::HandleDtlsConnectEvent(MeshCoP::Dtls::ConnectEvent aEvent, void *aContext)
-{
-    return static_cast<CoapSecureBase *>(aContext)->HandleDtlsConnectEvent(aEvent);
-}
-
-void CoapSecureBase::HandleDtlsConnectEvent(MeshCoP::Dtls::ConnectEvent aEvent)
-{
-    mConnectEventCallback.InvokeIfSet(aEvent);
 }
 
 void CoapSecureBase::HandleDtlsAutoClose(void *aContext)

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -55,7 +55,7 @@ public:
     /**
      * Function pointer which is called reporting a connection event (when connection established or disconnected)
      */
-    typedef otHandleCoapSecureClientConnect ConnectEventCallback;
+    typedef MeshCoP::SecureSession::ConnectHandler ConnectHandler;
 
     /**
      * Callback to notify when the agent is automatically stopped due to reaching the maximum number of connection
@@ -104,10 +104,7 @@ public:
      * @param[in]  aCallback  A pointer to a function to get called when connection state changes.
      * @param[in]  aContext   A pointer to arbitrary context information.
      */
-    void SetConnectEventCallback(ConnectEventCallback aCallback, void *aContext)
-    {
-        mConnectEventCallback.Set(aCallback, aContext);
-    }
+    void SetConnectCallback(ConnectHandler aCallback, void *aContext) { mDtls.SetConnectCallback(aCallback, aContext); }
 
     /**
      * Stops the secure CoAP agent.
@@ -118,12 +115,11 @@ public:
      * Initializes DTLS session with a peer.
      *
      * @param[in]  aSockAddr               A reference to the remote socket address,
-     * @param[in]  aCallback               A pointer to a function that will be called once DTLS connection is
-     * established.
      *
-     * @retval kErrorNone  Successfully started DTLS connection.
+     * @retval kErrorNone          Successfully started DTLS connection.
+     * @retval kErrorInvalidState  DTLS transport is not ready.
      */
-    Error Connect(const Ip6::SockAddr &aSockAddr, ConnectEventCallback aCallback, void *aContext);
+    Error Connect(const Ip6::SockAddr &aSockAddr) { return mDtls.Connect(aSockAddr); }
 
     /**
      * Indicates whether or not the DTLS session is active.
@@ -316,11 +312,10 @@ protected:
     static void HandleTransmit(Tasklet &aTasklet);
     void        HandleTransmit(void);
 
-    MeshCoP::Dtls                 &mDtls;
-    Callback<ConnectEventCallback> mConnectEventCallback;
-    Callback<AutoStopCallback>     mAutoStopCallback;
-    ot::MessageQueue               mTransmitQueue;
-    TaskletContext                 mTransmitTask;
+    MeshCoP::Dtls             &mDtls;
+    Callback<AutoStopCallback> mAutoStopCallback;
+    ot::MessageQueue           mTransmitQueue;
+    TaskletContext             mTransmitTask;
 };
 
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -731,7 +731,7 @@ Error BorderAgent::Start(uint16_t aUdpPort, const uint8_t *aPsk, uint8_t aPskLen
 
     SuccessOrExit(error = Get<Tmf::SecureAgent>().SetPsk(aPsk, aPskLength));
 
-    Get<Tmf::SecureAgent>().SetConnectEventCallback(HandleConnected, this);
+    Get<Tmf::SecureAgent>().SetConnectCallback(HandleConnected, this);
 
     mState        = kStateStarted;
     mUdpProxyPort = 0;

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -273,7 +273,7 @@ Error Commissioner::Start(StateCallback aStateCallback, JoinerCallback aJoinerCa
 #endif
 
     SuccessOrExit(error = Get<Tmf::SecureAgent>().Start(SendRelayTransmit, this));
-    Get<Tmf::SecureAgent>().SetConnectEventCallback(&Commissioner::HandleSecureAgentConnectEvent, this);
+    Get<Tmf::SecureAgent>().SetConnectCallback(HandleSecureAgentConnectEvent, this);
 
     mStateCallback.Set(aStateCallback, aCallbackContext);
     mJoinerCallback.Set(aJoinerCallback, aCallbackContext);

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -138,6 +138,7 @@ Error Joiner::Start(const char      *aPskd,
     Get<Mle::MleRouter>().UpdateLinkLocalAddress();
 
     SuccessOrExit(error = Get<Tmf::SecureAgent>().Start(kJoinerUdpPort));
+    Get<Tmf::SecureAgent>().SetConnectCallback(HandleSecureCoapClientConnect, this);
     Get<Tmf::SecureAgent>().SetPsk(joinerPskd);
 
     for (JoinerRouter &router : mJoinerRouters)
@@ -358,7 +359,7 @@ Error Joiner::Connect(JoinerRouter &aRouter)
 
     sockAddr.GetAddress().SetToLinkLocalAddress(aRouter.mExtAddr);
 
-    SuccessOrExit(error = Get<Tmf::SecureAgent>().Connect(sockAddr, Joiner::HandleSecureCoapClientConnect, this));
+    SuccessOrExit(error = Get<Tmf::SecureAgent>().Connect(sockAddr));
 
     SetState(kStateConnect);
 

--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -141,20 +141,14 @@ exit:
     return;
 }
 
-Error SecureTransport::Open(SecureSession::ReceiveHandler   aReceiveHandler,
-                            SecureSession::ConnectedHandler aConnectedHandler,
-                            void                           *aContext)
+Error SecureTransport::Open(void)
 {
     Error error;
 
     VerifyOrExit(!mIsOpen, error = kErrorAlready);
 
     SuccessOrExit(error = mSocket.Open(Ip6::kNetifUnspecified));
-
-    mIsOpen = true;
-    mSession->SetConnectedCallback(aConnectedHandler, aContext);
-    mSession->SetReceiveCallback(aReceiveHandler, aContext);
-
+    mIsOpen                      = true;
     mRemainingConnectionAttempts = mMaxConnectionAttempts;
 
 exit:

--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -116,10 +116,9 @@ public:
     static constexpr ConnectEvent kDisconnectedError       = OT_COAP_SECURE_DISCONNECTED_ERROR;
 
     /**
-     * Function pointer which is called reporting a session connection event (when connection established or
-     * disconnected).
+     * Function pointer which is called reporting a session connection event.
      */
-    typedef otHandleCoapSecureClientConnect ConnectedHandler;
+    typedef otHandleCoapSecureClientConnect ConnectHandler;
 
     /**
      * Pointer is called when data is received from the session.
@@ -133,12 +132,12 @@ public:
     /**
      * Sets the connection event callback.
      *
-     * @param[in]  aConnectedHandler    A pointer to a function that is called when connected or disconnected.
-     * @param[in]  aContext             A pointer to arbitrary context information.
+     * @param[in]  aConnectHandler   A pointer to a function that is called when connected or disconnected.
+     * @param[in]  aContext          A pointer to arbitrary context information.
      */
-    void SetConnectedCallback(ConnectedHandler aConnectedHandler, void *aContext)
+    void SetConnectCallback(ConnectHandler aConnectHandler, void *aContext)
     {
-        mConnectedCallback.Set(aConnectedHandler, aContext);
+        mConnectedCallback.Set(aConnectHandler, aContext);
     }
 
     /**
@@ -253,19 +252,19 @@ private:
     static const char *StateToString(State aState);
 #endif
 
-    bool                       mTimerSet : 1;
-    State                      mState;
-    Message::SubType           mMessageSubType;
-    ConnectEvent               mConnectEvent;
-    TimeMilli                  mTimerIntermediate;
-    TimeMilli                  mTimerFinish;
-    SecureTransport           &mTransport;
-    Message                   *mReceiveMessage;
-    Ip6::MessageInfo           mMessageInfo;
-    Callback<ConnectedHandler> mConnectedCallback;
-    Callback<ReceiveHandler>   mReceiveCallback;
-    mbedtls_ssl_config         mConf;
-    mbedtls_ssl_context        mSsl;
+    bool                     mTimerSet : 1;
+    State                    mState;
+    Message::SubType         mMessageSubType;
+    ConnectEvent             mConnectEvent;
+    TimeMilli                mTimerIntermediate;
+    TimeMilli                mTimerFinish;
+    SecureTransport         &mTransport;
+    Message                 *mReceiveMessage;
+    Ip6::MessageInfo         mMessageInfo;
+    Callback<ConnectHandler> mConnectedCallback;
+    Callback<ReceiveHandler> mReceiveCallback;
+    mbedtls_ssl_config       mConf;
+    mbedtls_ssl_context      mSsl;
 #if defined(MBEDTLS_SSL_SRV_C) && defined(MBEDTLS_SSL_COOKIE_C)
     mbedtls_ssl_cookie_ctx mCookieCtx;
 #endif
@@ -528,18 +527,12 @@ public:
 #endif // OPENTHREAD_CONFIG_TLS_API_ENABLE
 
     /**
-     * Opens the socket.
-     *
-     * @param[in]  aReceiveHandler      A pointer to a function that is called to receive payload.
-     * @param[in]  aConnectedHandler    A pointer to a function that is called when connected or disconnected.
-     * @param[in]  aContext             A pointer to arbitrary context information.
+     * Opens the transport.
      *
      * @retval kErrorNone     Successfully opened the socket.
      * @retval kErrorAlready  The connection is already open.
      */
-    Error Open(SecureSession::ReceiveHandler   aReceiveHandler,
-               SecureSession::ConnectedHandler aConnectedHandler,
-               void                           *aContext);
+    Error Open(void);
 
     /**
      * Sets the maximum number of allowed connection requests before socket is automatically closed.

--- a/src/core/radio/ble_secure.cpp
+++ b/src/core/radio/ble_secure.cpp
@@ -81,7 +81,9 @@ Error BleSecure::Start(ConnectCallback aConnectHandler, ReceiveCallback aReceive
     SuccessOrExit(error = otPlatBleGapAdvSetData(&GetInstance(), advertisementData, advertisementLen));
     SuccessOrExit(error = otPlatBleGapAdvStart(&GetInstance(), OT_BLE_ADV_INTERVAL_DEFAULT));
 
-    SuccessOrExit(error = mTls.Open(&BleSecure::HandleTlsReceive, &BleSecure::HandleTlsConnectEvent, this));
+    SuccessOrExit(error = mTls.Open());
+    mTls.SetReceiveCallback(HandleTlsReceive, this);
+    mTls.SetConnectCallback(HandleTlsConnectEvent, this);
     SuccessOrExit(error = mTls.Bind(HandleTransport, this));
 
 exit:

--- a/tests/nexus/test_dtls.cpp
+++ b/tests/nexus/test_dtls.cpp
@@ -161,14 +161,16 @@ void TestDtls(void)
     {
         Dtls          dtls0(node0.GetInstance(), kWithLinkSecurity);
         Dtls          dtls1(node1.GetInstance(), kWithLinkSecurity);
-        Dtls          dtsl2(node2.GetInstance(), kWithLinkSecurity);
+        Dtls          dtls2(node2.GetInstance(), kWithLinkSecurity);
         Ip6::SockAddr sockAddr;
 
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         Log("Start DTLS (server) on node0 bound to port %u", kUdpPort);
 
         SuccessOrQuit(dtls0.SetPsk(kPsk, sizeof(kPsk)));
-        SuccessOrQuit(dtls0.Open(HandleReceive, HandleConnectEvent, &node0));
+        dtls0.SetReceiveCallback(HandleReceive, &node0);
+        dtls0.SetConnectCallback(HandleConnectEvent, &node0);
+        SuccessOrQuit(dtls0.Open());
         SuccessOrQuit(dtls0.Bind(kUdpPort));
 
         nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
@@ -183,7 +185,9 @@ void TestDtls(void)
         Log("Try to establish a DTLS connection from node 1 using a wrong PSK multiple times");
 
         SuccessOrQuit(dtls1.SetPsk(kPsk, sizeof(kPsk) - 1));
-        SuccessOrQuit(dtls1.Open(HandleReceive, HandleConnectEvent, &node1));
+        dtls1.SetReceiveCallback(HandleReceive, &node1);
+        dtls1.SetConnectCallback(HandleConnectEvent, &node1);
+        SuccessOrQuit(dtls1.Open());
 
         for (uint16_t iter = 0; iter <= kMaxAttempts + 1; iter++)
         {
@@ -205,7 +209,9 @@ void TestDtls(void)
         dtls1.Close();
 
         SuccessOrQuit(dtls1.SetPsk(kPsk, sizeof(kPsk)));
-        SuccessOrQuit(dtls1.Open(HandleReceive, HandleConnectEvent, &node1));
+        dtls1.SetReceiveCallback(HandleReceive, &node1);
+        dtls1.SetConnectCallback(HandleConnectEvent, &node1);
+        SuccessOrQuit(dtls1.Open());
         SuccessOrQuit(dtls1.Connect(sockAddr));
 
         nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
@@ -273,15 +279,17 @@ void TestDtls(void)
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         Log("Try to connect from node2 - validate that it fails to connect since already connected");
 
-        SuccessOrQuit(dtsl2.SetPsk(kPsk, sizeof(kPsk)));
-        SuccessOrQuit(dtsl2.Open(HandleReceive, HandleConnectEvent, &node2));
-        SuccessOrQuit(dtsl2.Connect(sockAddr));
+        SuccessOrQuit(dtls2.SetPsk(kPsk, sizeof(kPsk)));
+        dtls2.SetReceiveCallback(HandleReceive, &node2);
+        dtls2.SetReceiveCallback(HandleReceive, &node2);
+        SuccessOrQuit(dtls2.Open());
+        SuccessOrQuit(dtls2.Connect(sockAddr));
 
         nexus.AdvanceTime(20 * Time::kOneSecondInMsec);
 
         VerifyOrQuit(dtls0.IsConnected());
         VerifyOrQuit(dtls1.IsConnected());
-        VerifyOrQuit(!dtsl2.IsConnected());
+        VerifyOrQuit(!dtls2.IsConnected());
 
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         Log("Disconnect from node0 - validate the disconnect events");
@@ -292,7 +300,7 @@ void TestDtls(void)
 
         VerifyOrQuit(!dtls0.IsConnected());
         VerifyOrQuit(!dtls1.IsConnected());
-        VerifyOrQuit(!dtsl2.IsConnected());
+        VerifyOrQuit(!dtls2.IsConnected());
 
         VerifyOrQuit(sDtlsEvent[node0.GetId()] == Dtls::kDisconnectedLocalClosed);
         VerifyOrQuit(sDtlsEvent[node1.GetId()] == Dtls::kDisconnectedPeerClosed);
@@ -301,7 +309,7 @@ void TestDtls(void)
 
         dtls0.Close();
         dtls1.Close();
-        dtsl2.Close();
+        dtls2.Close();
 
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -311,7 +319,9 @@ void TestDtls(void)
 
         SuccessOrQuit(dtls0.SetMaxConnectionAttempts(kMaxAttempts, HandleAutoClose, &node0));
         SuccessOrQuit(dtls0.SetPsk(kPsk, sizeof(kPsk)));
-        SuccessOrQuit(dtls0.Open(HandleReceive, HandleConnectEvent, &node0));
+        dtls0.SetReceiveCallback(HandleReceive, &node0);
+        dtls0.SetConnectCallback(HandleConnectEvent, &node0);
+        SuccessOrQuit(dtls0.Open());
         SuccessOrQuit(dtls0.Bind(kUdpPort));
 
         nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
@@ -323,7 +333,9 @@ void TestDtls(void)
         Log("Using wrong PSK try to establish DTLS connection with node0 %u times", kMaxAttempts - 1);
 
         SuccessOrQuit(dtls1.SetPsk(kPsk, sizeof(kPsk) - 1));
-        SuccessOrQuit(dtls1.Open(HandleReceive, HandleConnectEvent, &node1));
+        dtls1.SetReceiveCallback(HandleReceive, &node1);
+        dtls1.SetConnectCallback(HandleConnectEvent, &node1);
+        SuccessOrQuit(dtls1.Open());
 
         for (uint16_t iter = 0; iter < kMaxAttempts - 1; iter++)
         {
@@ -356,7 +368,7 @@ void TestDtls(void)
 
         dtls0.Close();
         dtls1.Close();
-        dtsl2.Close();
+        dtls2.Close();
     }
 }
 


### PR DESCRIPTION
This commit updates and simplifies how `Connect` and `Receive` callbacks are set on `SecureTransport` and `CoapSecure`. Instead of using the `Open()` method to set these, they are now directly set using the corresponding `SecureSession` methods. This commit also harmonizes the method name for setting the "connect" callback, ensuring the same name is used by different classes.

----

~This PR currently contains the commit from https://github.com/openthread/openthread/pull/11044 and https://github.com/openthread/openthread/pull/11046. Please check and review the last commit. Thanks.~
