### PR TITLE
[diag] add `diag radio receive filter` command support

### DIFF
--- a/src/core/diags/README.md
+++ b/src/core/diags/README.md
@@ -240,6 +240,39 @@ Set the radio to receive mode and receive a specified number of frames.
 Done
 ```
 
+### diag radio receive filter enable
+
+Enable the diag filter module to only receive frames with a specified destination address.
+
+```bash
+> diag radio receive filter enable
+Done
+```
+
+### diag radio receive filter disable
+
+Disable the diag filter module from only receiving frames with a specified destination address.
+
+```bash
+> diag radio receive filter disable
+Done
+```
+
+### diag radio receive filter \<destaddress\>
+
+Set the destination address of the radio receive filter.
+
+- destaddress: The destination mac address. It can be a short, extended or none. Use '-' to specify none.
+
+```bash
+> diag radio receive filter -
+Done
+> diag radio receive filter 0x0a17
+Done
+> diag radio receive filter dead00beef00cafe
+Done
+```
+
 ### diag radio state
 
 Return the state of the radio.

--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -48,6 +48,7 @@
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/string.hpp"
+#include "mac/mac_types.hpp"
 
 namespace ot {
 namespace FactoryDiags {
@@ -185,18 +186,23 @@ private:
             , mShowRssi(true)
             , mShowLqi(true)
             , mShowPsdu(false)
+            , mIsFilterEnabled(false)
             , mReceiveCount(0)
             , mNumFrames(0)
+            , mFilterAddress()
         {
         }
 
-        bool     mIsEnabled : 1;
-        bool     mIsAsyncCommand : 1;
-        bool     mShowRssi : 1;
-        bool     mShowLqi : 1;
-        bool     mShowPsdu : 1;
-        uint16_t mReceiveCount;
-        uint16_t mNumFrames;
+        bool mIsEnabled : 1;
+        bool mIsAsyncCommand : 1;
+        bool mShowRssi : 1;
+        bool mShowLqi : 1;
+        bool mShowPsdu : 1;
+        bool mIsFilterEnabled : 1;
+
+        uint16_t     mReceiveCount;
+        uint16_t     mNumFrames;
+        Mac::Address mFilterAddress;
     };
 
     Error ParseCmd(char *aString, uint8_t &aArgsLength, char *aArgs[]);
@@ -223,6 +229,7 @@ private:
     Error ParseReceiveConfigFormat(const char *aFormat, ReceiveConfig &aConfig);
     Error RadioReceive(void);
     void  OutputReceivedFrame(const otRadioFrame *aFrame);
+    bool  ShouldHandleReceivedFrame(const otRadioFrame &aFrame) const;
 
     void TransmitPacket(void);
     void Output(const char *aFormat, ...);

--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -63,6 +63,8 @@ void ExtAddress::GenerateRandom(void)
 }
 #endif
 
+bool ExtAddress::operator==(const ExtAddress &aOther) const { return (memcmp(m8, aOther.m8, sizeof(m8)) == 0); }
+
 ExtAddress::InfoString ExtAddress::ToString(void) const
 {
     InfoString string;
@@ -88,6 +90,35 @@ void ExtAddress::CopyAddress(uint8_t *aDst, const uint8_t *aSrc, CopyByteOrder a
         }
         break;
     }
+}
+
+bool Address::operator==(const Address &aOther) const
+{
+    bool ret = false;
+
+    VerifyOrExit(GetType() == aOther.GetType());
+
+    switch (GetType())
+    {
+    case kTypeNone:
+        ret = true;
+        break;
+
+    case kTypeShort:
+        ret = (GetShort() == aOther.GetShort());
+        break;
+
+    case kTypeExtended:
+        ret = (GetExtended() == aOther.GetExtended());
+        break;
+
+    default:
+        OT_ASSERT(false);
+        break;
+    }
+
+exit:
+    return ret;
 }
 
 Address::InfoString Address::ToString(void) const

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -199,6 +199,16 @@ public:
     }
 
     /**
+     * Overloads operator `==` to evaluate whether or not two `ExtAddress` instances are equal.
+     *
+     * @param[in]  aOther  The other `ExtAddress` instance to compare with.
+     *
+     * @retval TRUE   If the two `ExtAddress` instances are equal.
+     * @retval FALSE  If the two `ExtAddress` instances are not equal.
+     */
+    bool operator==(const ExtAddress &aOther) const;
+
+    /**
      * Converts an address to a string.
      *
      * @returns An `InfoString` containing the string representation of the Extended Address.
@@ -357,6 +367,16 @@ public:
      * @returns TRUE if address is Short Invalid Address, FALSE otherwise.
      */
     bool IsShortAddrInvalid(void) const { return ((mType == kTypeShort) && (GetShort() == kShortAddrInvalid)); }
+
+    /**
+     * Overloads operator `==` to evaluate whether or not two `Address` instances are equal.
+     *
+     * @param[in]  aOther  The other `Address` instance to compare with.
+     *
+     * @retval TRUE   If the two `Address` instances are equal.
+     * @retval FALSE  If the two `Address` instances are not equal.
+     */
+    bool operator==(const Address &aOther) const;
 
     /**
      * Converts an address to a null-terminated string


### PR DESCRIPTION
The current diag module will count any packets received. This commit adds the command 'diag radio receive filter` to allow the diag module receives only frames with the specified destination mac address.