### PR TITLE
[linked-list] remove unused method & rename FindMatchingWithPrev()

### DIFF
--- a/src/core/common/linked_list.hpp
+++ b/src/core/common/linked_list.hpp
@@ -338,7 +338,7 @@ public:
     template <typename Indicator> Type *RemoveMatching(const Indicator &aIndicator)
     {
         Type *prev;
-        Type *entry = FindMatching(aIndicator, prev);
+        Type *entry = FindMatchingWithPrev(prev, aIndicator);
 
         if (entry != nullptr)
         {
@@ -432,73 +432,6 @@ public:
     }
 
     /**
-     * Searches within a given range of the linked list to find an entry matching a given
-     * indicator.
-     *
-     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
-     * in the list. To check that an entry matches the given indicator, the `Matches()` method is invoked on each
-     * `Type` entry in the list. The `Matches()` method should be provided by `Type` class accordingly:
-     *
-     *     bool Type::Matches(const Indicator &aIndicator) const
-     *
-     * @param[in]  aBegin      A pointer to the begin of the range.
-     * @param[in]  aEnd        A pointer to the end of the range, or `nullptr` to search all entries after @p aBegin.
-     * @param[in]  aIndicator  An indicator to match with entries in the list.
-     * @param[out] aPrevEntry  A pointer to output the previous entry on success (when a match is found in the list).
-     *                         @p aPrevEntry is set to `nullptr` if the matching entry is the head of the list.
-     *                         Otherwise it is updated to point to the previous entry before the matching entry in the
-     *                         list.
-     *
-     * @returns A pointer to the matching entry if one is found, or `nullptr` if no matching entry was found.
-     */
-    template <typename Indicator>
-    const Type *FindMatching(const Type      *aBegin,
-                             const Type      *aEnd,
-                             const Indicator &aIndicator,
-                             const Type     *&aPrevEntry) const
-    {
-        const Type *entry;
-
-        aPrevEntry = nullptr;
-
-        for (entry = aBegin; entry != aEnd; aPrevEntry = entry, entry = entry->GetNext())
-        {
-            if (entry->Matches(aIndicator))
-            {
-                break;
-            }
-        }
-
-        return entry;
-    }
-
-    /**
-     * Searches within a given range of the linked list to find an entry matching a given
-     * indicator.
-     *
-     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
-     * in the list. To check that an entry matches the given indicator, the `Matches()` method is invoked on each
-     * `Type` entry in the list. The `Matches()` method should be provided by `Type` class accordingly:
-     *
-     *     bool Type::Matches(const Indicator &aIndicator) const
-     *
-     * @param[in]  aBegin      A pointer to the begin of the range.
-     * @param[in]  aEnd        A pointer to the end of the range, or `nullptr` to search all entries after @p aBegin.
-     * @param[in]  aIndicator  An indicator to match with entries in the list.
-     * @param[out] aPrevEntry  A pointer to output the previous entry on success (when a match is found in the list).
-     *                         @p aPrevEntry is set to `nullptr` if the matching entry is the head of the list.
-     *                         Otherwise it is updated to point to the previous entry before the matching entry in the
-     *                         list.
-     *
-     * @returns A pointer to the matching entry if one is found, or `nullptr` if no matching entry was found.
-     */
-    template <typename Indicator>
-    Type *FindMatching(const Type *aBegin, const Type *aEnd, const Indicator &aIndicator, Type *&aPrevEntry)
-    {
-        return AsNonConst(FindMatching(aBegin, aEnd, aIndicator, const_cast<const Type *&>(aPrevEntry)));
-    }
-
-    /**
      * Searches within the linked list to find an entry matching a given indicator.
      *
      * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
@@ -507,17 +440,30 @@ public:
      *
      *     bool Type::Matches(const Indicator &aIndicator) const
      *
-     * @param[in]  aIndicator  An indicator to match with entries in the list.
      * @param[out] aPrevEntry  A pointer to output the previous entry on success (when a match is found in the list).
      *                         @p aPrevEntry is set to `nullptr` if the matching entry is the head of the list.
      *                         Otherwise it is updated to point to the previous entry before the matching entry in the
      *                         list.
+     * @param[in]  aIndicator  An indicator to match with entries in the list.
      *
      * @returns A pointer to the matching entry if one is found, or `nullptr` if no matching entry was found.
      */
-    template <typename Indicator> const Type *FindMatching(const Indicator &aIndicator, const Type *&aPrevEntry) const
+    template <typename Indicator>
+    const Type *FindMatchingWithPrev(const Type *&aPrevEntry, const Indicator &aIndicator) const
     {
-        return FindMatching(mHead, nullptr, aIndicator, aPrevEntry);
+        const Type *entry;
+
+        aPrevEntry = nullptr;
+
+        for (entry = mHead; entry != nullptr; aPrevEntry = entry, entry = entry->GetNext())
+        {
+            if (entry->Matches(aIndicator))
+            {
+                break;
+            }
+        }
+
+        return entry;
     }
 
     /**
@@ -530,17 +476,17 @@ public:
      *
      *     bool Type::Matches(const Indicator &aIndicator) const
      *
-     * @param[in]  aIndicator  An indicator to match with entries in the list.
      * @param[out] aPrevEntry  A pointer to output the previous entry on success (when a match is found in the list).
      *                         @p aPrevEntry is set to `nullptr` if the matching entry is the head of the list.
      *                         Otherwise it is updated to point to the previous entry before the matching entry in the
      *                         list.
+     * @param[in]  aIndicator  An indicator to match with entries in the list.
      *
      * @returns A pointer to the matching entry if one is found, or `nullptr` if no matching entry was found.
      */
-    template <typename Indicator> Type *FindMatching(const Indicator &aIndicator, Type *&aPrevEntry)
+    template <typename Indicator> Type *FindMatchingWithPrev(Type *&aPrevEntry, const Indicator &aIndicator)
     {
-        return AsNonConst(AsConst(this)->FindMatching(aIndicator, const_cast<const Type *&>(aPrevEntry)));
+        return AsNonConst(AsConst(this)->FindMatchingWithPrev(const_cast<const Type *&>(aPrevEntry), aIndicator));
     }
 
     /**
@@ -560,7 +506,7 @@ public:
     {
         const Type *prev;
 
-        return FindMatching(aIndicator, prev);
+        return FindMatchingWithPrev(prev, aIndicator);
     }
 
     /**

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -327,7 +327,7 @@ Error Netif::UnsubscribeExternalMulticast(const Address &aAddress)
     MulticastAddress *entry;
     MulticastAddress *prev;
 
-    entry = mMulticastAddresses.FindMatching(aAddress, prev);
+    entry = mMulticastAddresses.FindMatchingWithPrev(prev, aAddress);
     VerifyOrExit(entry != nullptr, error = kErrorNotFound);
 
     VerifyOrExit(IsMulticastAddressExternal(*entry), error = kErrorRejected);
@@ -474,7 +474,7 @@ Error Netif::RemoveExternalUnicastAddress(const Address &aAddress)
     UnicastAddress *entry;
     UnicastAddress *prev;
 
-    entry = mUnicastAddresses.FindMatching(aAddress, prev);
+    entry = mUnicastAddresses.FindMatchingWithPrev(prev, aAddress);
     VerifyOrExit(entry != nullptr, error = kErrorNotFound);
 
     VerifyOrExit(IsUnicastAddressExternal(*entry), error = kErrorRejected);

--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -625,10 +625,7 @@ Error Tcp::HandleMessage(ot::Ip6::Header &aIp6Header, Message &aMessage, Message
     struct tcphdr  *tcpHeader;
 
     Endpoint *endpoint;
-    Endpoint *endpointPrev;
-
     Listener *listener;
-    Listener *listenerPrev;
 
     struct tcplp_signals sig;
     int                  nextAction;
@@ -650,7 +647,8 @@ Error Tcp::HandleMessage(ot::Ip6::Header &aIp6Header, Message &aMessage, Message
     aMessageInfo.mPeerPort = BigEndian::HostSwap16(tcpHeader->th_sport);
     aMessageInfo.mSockPort = BigEndian::HostSwap16(tcpHeader->th_dport);
 
-    endpoint = mEndpoints.FindMatching(aMessageInfo, endpointPrev);
+    endpoint = mEndpoints.FindMatching(aMessageInfo);
+
     if (endpoint != nullptr)
     {
         struct tcpcb *tp = &endpoint->GetTcb();
@@ -668,7 +666,8 @@ Error Tcp::HandleMessage(ot::Ip6::Header &aIp6Header, Message &aMessage, Message
         /* If the matching socket was in the TIME-WAIT state, then we try passive sockets. */
     }
 
-    listener = mListeners.FindMatching(aMessageInfo, listenerPrev);
+    listener = mListeners.FindMatching(aMessageInfo);
+
     if (listener != nullptr)
     {
         struct tcpcb_listen *tpl = &listener->GetTcbListen();

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -201,7 +201,7 @@ AddressResolver::CacheEntry *AddressResolver::FindCacheEntry(const Ip6::Address 
     for (CacheEntryList *list : lists)
     {
         aList = list;
-        entry = aList->FindMatching(aEid, aPrevEntry);
+        entry = aList->FindMatchingWithPrev(aPrevEntry, aEid);
         VerifyOrExit(entry == nullptr);
     }
 

--- a/tests/unit/test_linked_list.cpp
+++ b/tests/unit/test_linked_list.cpp
@@ -107,10 +107,10 @@ void VerifyLinkedListContent(const LinkedList<Entry> *aList, ...)
         SuccessOrQuit(aList->Find(*argEntry, prev));
         VerifyOrQuit(prev == argPrev, "List::Find() returned prev entry is incorrect");
 
-        VerifyOrQuit(aList->FindMatching(argEntry->GetName(), prev) == argEntry);
+        VerifyOrQuit(aList->FindMatchingWithPrev(prev, argEntry->GetName()) == argEntry);
         VerifyOrQuit(prev == argPrev, "List::FindMatching() returned prev entry is incorrect");
 
-        VerifyOrQuit(aList->FindMatching(argEntry->GetId(), prev) == argEntry);
+        VerifyOrQuit(aList->FindMatchingWithPrev(prev, argEntry->GetId()) == argEntry);
         VerifyOrQuit(prev == argPrev, "List::FindMatching() returned prev entry is incorrect");
 
         VerifyOrQuit(!argEntry->WasFreed());
@@ -126,8 +126,8 @@ void VerifyLinkedListContent(const LinkedList<Entry> *aList, ...)
     VerifyOrQuit(!aList->ContainsMatching("none"), "succeeded for a missing entry");
     VerifyOrQuit(!aList->ContainsMatching(unusedId), "succeeded for a missing entry");
 
-    VerifyOrQuit(aList->FindMatching("none", prev) == nullptr, "succeeded for a missing entry");
-    VerifyOrQuit(aList->FindMatching(unusedId, prev) == nullptr, "succeeded for a missing entry");
+    VerifyOrQuit(aList->FindMatching("none") == nullptr, "succeeded for a missing entry");
+    VerifyOrQuit(aList->FindMatching(unusedId) == nullptr, "succeeded for a missing entry");
 }
 
 void TestLinkedList(void)
@@ -174,16 +174,16 @@ void TestLinkedList(void)
     VerifyLinkedListContent(&list, &d, &c, &b, &a, nullptr);
     VerifyOrQuit(list.Find(e, prev) == kErrorNotFound, "succeeded for a missing entry");
 
-    VerifyOrQuit(list.FindMatching(d.GetName(), prev) == &d);
+    VerifyOrQuit(list.FindMatchingWithPrev(prev, d.GetName()) == &d);
     VerifyOrQuit(prev == nullptr);
-    VerifyOrQuit(list.FindMatching(c.GetId(), prev) == &c);
+    VerifyOrQuit(list.FindMatchingWithPrev(prev, c.GetId()) == &c);
     VerifyOrQuit(prev == &d);
-    VerifyOrQuit(list.FindMatching(b.GetName(), prev) == &b);
+    VerifyOrQuit(list.FindMatchingWithPrev(prev, b.GetName()) == &b);
     VerifyOrQuit(prev == &c);
-    VerifyOrQuit(list.FindMatching(a.GetId(), prev) == &a);
+    VerifyOrQuit(list.FindMatchingWithPrev(prev, a.GetId()) == &a);
     VerifyOrQuit(prev == &b);
-    VerifyOrQuit(list.FindMatching(e.GetId(), prev) == nullptr, "succeeded for a missing entry");
-    VerifyOrQuit(list.FindMatching(e.GetName(), prev) == nullptr, "succeeded for a missing entry");
+    VerifyOrQuit(list.FindMatchingWithPrev(prev, e.GetId()) == nullptr, "succeeded for a missing entry");
+    VerifyOrQuit(list.FindMatchingWithPrev(prev, e.GetName()) == nullptr, "succeeded for a missing entry");
 
     list.SetHead(&e);
     VerifyLinkedListContent(&list, &e, &d, &c, &b, &a, nullptr);
@@ -250,8 +250,8 @@ void TestLinkedList(void)
     VerifyOrQuit(list.PopAfter(nullptr) == nullptr);
     VerifyLinkedListContent(&list, nullptr);
     VerifyOrQuit(list.Find(a, prev) == kErrorNotFound, "succeeded for a missing entry");
-    VerifyOrQuit(list.FindMatching(b.GetName(), prev) == nullptr, "succeeded when empty");
-    VerifyOrQuit(list.FindMatching(c.GetId(), prev) == nullptr, "succeeded when empty");
+    VerifyOrQuit(list.FindMatching(b.GetName()) == nullptr, "succeeded when empty");
+    VerifyOrQuit(list.FindMatching(c.GetId()) == nullptr, "succeeded when empty");
     VerifyOrQuit(list.RemoveMatching(a.GetName()) == nullptr, "succeeded when empty");
     VerifyOrQuit(list.Remove(a) == kErrorNotFound, "succeeded when empty");
 


### PR DESCRIPTION
This commit contains the following changes to `LinkedList`:

- Removes the `FindMatching()` version that searches within a given sub-section of the list, as this method is no longer needed.
- Renames the method that finds a matching entry and also returns the `prev` entry in the list to `FindMatchingWithPrev()`. This distinguishes it from other `FindMatching()` overloads and clarifies its purpose. This method is often used when the caller wants to find the matching entry and later remove it from the list.