### PR TITLE
[mesh-forwarder] lower log level on missing priority

### DIFF
--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -827,7 +827,7 @@ void MeshForwarder::GetForwardFramePriority(RxInfo &aRxInfo, Message::Priority &
     error = GetFramePriority(aRxInfo, aPriority);
 
 exit:
-    LogInfoOnError(error, "get forwarded frame priority %s", aRxInfo.ToString().AsCString());
+    LogDebgOnError(error, "get forwarded frame priority %s", aRxInfo.ToString().AsCString());
 
     if ((error == kErrorNone) && isFragment)
     {


### PR DESCRIPTION
It seems that frames which are received through TREL do not have a priority field. This creates quite some log noise when having notice log level enabled. Print a more clear message when priority is missing specifically and lower that log entry to info level.