### PR TITLE
[spinel] set mState when mRxOnWhenIdle

### DIFF
--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -785,7 +785,7 @@ void RadioSpinel::ProcessRadioStateMachine(void)
 {
     if (mState == kStateTransmitDone)
     {
-        mState        = kStateReceive;
+        mState        = mRxOnWhenIdle ? kStateReceive : kStateSleep;
         mTxRadioEndUs = UINT64_MAX;
 
         TransmitDone(mTransmitFrame, (mAckRadioFrame.mLength != 0) ? &mAckRadioFrame : nullptr, mTxError);


### PR DESCRIPTION
This PR fixes an issue related to https://github.com/openthread/openthread/pull/9554. In PR https://github.com/openthread/openthread/pull/9554, a new radio capability is introduced: RX_ON_WHEN_IDLE.

In this PR, we set `mState` to be `kStateSleep` instead of defaulting to `kStateReceive` if `mRxOnWhenIdle = false`. 

This fix ensures that packets can be received upon subsequent calls of `RadioSpinel::Receive()` for devices configured as rx_off_when_idle. 