### PR TITLE
[thread-netif] do not close `Tmf::SecureAgent` on `Down()`

### DIFF
--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -87,9 +87,6 @@ void ThreadNetif::Down(void)
 #if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
     Get<Dns::ServiceDiscovery::Server>().Stop();
 #endif
-#if OPENTHREAD_CONFIG_SECURE_TRANSPORT_ENABLE
-    Get<Tmf::SecureAgent>().Close();
-#endif
     IgnoreError(Get<Tmf::Agent>().Stop());
     IgnoreError(Get<Mle::MleRouter>().Disable());
     RemoveAllExternalUnicastAddresses();


### PR DESCRIPTION
This commit updates the code so that `Tmf::SecureAgent` is not closed when the Thread network interface is brought down. The `SecureAgent` is directly controlled and used by either the `BorderAgent` or `Commissioner` during network operation, which may continue to function even if the Thread network interface is offline. It may also be used by the `Joiner`, but in that case, it will be closed by the `Joiner` itself upon finishing the join attempt.

----

~This PR currently contains the commit from #11056. Please check and review the last commit. Thanks.~ 
