### PR TITLE
[meshcop] add `LogCertMessage()`

### DIFF
--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -1003,13 +1003,7 @@ void Commissioner::HandleTmf<kUriJoinerFinalize>(Coap::Message &aMessage, const 
     }
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    if (aMessage.GetLength() <= OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE)
-    {
-        uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
-
-        aMessage.ReadBytes(aMessage.GetOffset(), buf, aMessage.GetLength() - aMessage.GetOffset());
-        DumpCert("[THCI] direction=recv | type=JOIN_FIN.req |", buf, aMessage.GetLength() - aMessage.GetOffset());
-    }
+    LogCertMessage("[THCI] direction=recv | type=JOIN_FIN.req |", aMessage);
 #endif
 
     SendJoinFinalizeResponse(aMessage, state);
@@ -1037,11 +1031,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Message &aRequest, State
     joinerMessageInfo.SetPeerPort(mJoinerPort);
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
-
-    VerifyOrExit(message->GetLength() <= sizeof(buf));
-    message->ReadBytes(message->GetOffset(), buf, message->GetLength() - message->GetOffset());
-    DumpCert("[THCI] direction=send | type=JOIN_FIN.rsp |", buf, message->GetLength() - message->GetOffset());
+    LogCertMessage("[THCI] direction=send | type=JOIN_FIN.rsp |", *message);
 #endif
 
     SuccessOrExit(error = Get<Tmf::SecureAgent>().SendMessage(*message, joinerMessageInfo));

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -612,23 +612,6 @@ const char *Joiner::StateToString(State aState)
     return kStateStrings[aState];
 }
 
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-void Joiner::LogCertMessage(const char *aText, const Coap::Message &aMessage) const
-{
-    OT_UNUSED_VARIABLE(aText);
-
-    uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
-
-    VerifyOrExit(aMessage.GetLength() <= sizeof(buf));
-    aMessage.ReadBytes(aMessage.GetOffset(), buf, aMessage.GetLength() - aMessage.GetOffset());
-
-    DumpCert(aText, buf, aMessage.GetLength() - aMessage.GetOffset());
-
-exit:
-    return;
-}
-#endif
-
 // LCOV_EXCL_STOP
 
 } // namespace MeshCoP

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -219,10 +219,6 @@ private:
     void  SendJoinerFinalize(void);
     void  SendJoinerEntrustResponse(const Coap::Message &aRequest, const Ip6::MessageInfo &aRequestInfo);
 
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    void LogCertMessage(const char *aText, const Coap::Message &aMessage) const;
-#endif
-
     using JoinerTimer = TimerMilliIn<Joiner, &Joiner::HandleTimer>;
 
     Mac::ExtAddress mId;

--- a/src/core/meshcop/meshcop.cpp
+++ b/src/core/meshcop/meshcop.cpp
@@ -337,5 +337,25 @@ exit:
 }
 #endif // OPENTHREAD_FTD
 
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+
+void LogCertMessage(const char *aText, const Coap::Message &aMessage)
+{
+    OT_UNUSED_VARIABLE(aText);
+
+    uint8_t  buf[kBufferSize];
+    uint16_t length = aMessage.GetLength() - aMessage.GetOffset();
+
+    VerifyOrExit(length <= sizeof(buf));
+    aMessage.ReadBytes(aMessage.GetOffset(), buf, length);
+
+    DumpCert(aText, buf, length);
+
+exit:
+    return;
+}
+
+#endif
+
 } // namespace MeshCoP
 } // namespace ot

--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -510,6 +510,18 @@ Error GeneratePskc(const char          *aPassPhrase,
  */
 void ComputeJoinerId(const Mac::ExtAddress &aEui64, Mac::ExtAddress &aJoinerId);
 
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+
+/**
+ * Generates a message dump log for certification test.
+ *
+ * @param[in] aText     The title text to include in the log.
+ * @param[in] aMessage  The message to dump the content of.
+ */
+void LogCertMessage(const char *aText, const Coap::Message &aMessage);
+
+#endif
+
 } // namespace MeshCoP
 
 DefineCoreType(otJoinerPskd, MeshCoP::JoinerPskd);


### PR DESCRIPTION
This commit adds `LogCertMessage()` to generate a message dump log for certification test. This function is used by both `Joiner` and `Commissioner`, removing duplicate code.