### PR TITLE
[ot-fct] fix access file from path defined in build parameter

### DIFF
--- a/tools/ot-fct/CMakeLists.txt
+++ b/tools/ot-fct/CMakeLists.txt
@@ -48,3 +48,9 @@ add_executable(ot-fct
     ${OPENTHREAD_DIR}/src/posix/platform/power.cpp
     ${OPENTHREAD_DIR}/src/posix/platform/config_file.cpp
 )
+
+set(OT_POSIX_PRODUCT_CONFIG "" CACHE STRING "OpenThread product config file")
+
+if (OT_POSIX_PRODUCT_CONFIG)
+    target_compile_options(ot-fct PRIVATE -DOPENTHREAD_POSIX_CONFIG_PRODUCT_CONFIG_FILE=\"${OT_POSIX_PRODUCT_CONFIG}\")
+endif()

--- a/tools/ot-fct/cli.cpp
+++ b/tools/ot-fct/cli.cpp
@@ -88,7 +88,6 @@ otError Cli::GetNextDomain(int &aIterator, Power::Domain &aDomain)
         break;
     }
 
-exit:
     return error;
 }
 
@@ -123,8 +122,6 @@ otError Cli::ProcessRegionDomainTable(Utils::CmdLineParser::Arg aArgs[])
     otError error    = OT_ERROR_NONE;
     int     iterator = 0;
     char    value[kMaxValueSize];
-    char   *domain;
-    char   *psave;
 
     VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
 
@@ -277,7 +274,7 @@ exit:
 void Cli::ProcessCommand(Utils::CmdLineParser::Arg aArgs[])
 {
     otError error = OT_ERROR_NOT_FOUND;
-    int     i;
+    size_t  i;
 
     for (i = 0; i < (sizeof(sCommands) / sizeof(sCommands[0])); i++)
     {
@@ -288,7 +285,6 @@ void Cli::ProcessCommand(Utils::CmdLineParser::Arg aArgs[])
         }
     }
 
-exit:
     AppendErrorResult(error);
 }
 


### PR DESCRIPTION

When configuration file defined in build parameter(command line argument), ot-fct is wouldn't take into an account and accessed default path.

This commit fixes to access configuration file from path which is defined from build command line parameter. Also, it fixes some compilation issues while building from ot-br-posix.