### PR TITLE
[border-agent] remove unused `GetUdpProxyPort()` method

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -48,7 +48,6 @@ RegisterLogModule("BorderAgent");
 BorderAgent::BorderAgent(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mState(kStateStopped)
-    , mUdpProxyPort(0)
     , mUdpReceiver(BorderAgent::HandleUdpReceive, this)
     , mTimer(aInstance)
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
@@ -136,8 +135,7 @@ Error BorderAgent::Start(uint16_t aUdpPort, const uint8_t *aPsk, uint8_t aPskLen
 
     Get<Tmf::SecureAgent>().SetConnectCallback(HandleConnected, this);
 
-    mState        = kStateStarted;
-    mUdpProxyPort = 0;
+    mState = kStateStarted;
 
     LogInfo("Border Agent start listening on port %u", GetUdpPort());
 
@@ -162,8 +160,7 @@ void BorderAgent::Stop(void)
     mTimer.Stop();
     Get<Tmf::SecureAgent>().Stop();
 
-    mState        = kStateStopped;
-    mUdpProxyPort = 0;
+    mState = kStateStopped;
     LogInfo("Border Agent stopped");
 
 exit:
@@ -281,8 +278,7 @@ void BorderAgent::HandleConnected(Dtls::ConnectEvent aEvent)
         else
 #endif
         {
-            mState        = kStateStarted;
-            mUdpProxyPort = 0;
+            mState = kStateStarted;
 
             if (aEvent == Dtls::kDisconnectedError)
             {
@@ -643,7 +639,6 @@ template <> void BorderAgent::HandleTmf<kUriProxyTx>(Coap::Message &aMessage, co
     SuccessOrExit(error = Tlv::Find<Ip6AddressTlv>(aMessage, messageInfo.GetPeerAddr()));
 
     SuccessOrExit(error = Get<Ip6::Udp>().SendDatagram(*message, messageInfo));
-    mUdpProxyPort = udpEncapHeader.GetSourcePort();
 
     LogInfo("Proxy transmit sent to %s", messageInfo.GetPeerAddr().ToString().AsCString());
 

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -247,14 +247,6 @@ public:
      */
     const Counters &GetCounters(void) { return mCounters; }
 
-    /**
-     * Returns the UDP Proxy port to which the commissioner is currently
-     * bound.
-     *
-     * @returns  The current UDP Proxy port or 0 if no Proxy Transmit has been received yet.
-     */
-    uint16_t GetUdpProxyPort(void) const { return mUdpProxyPort; }
-
 private:
     static_assert(kMaxEphemeralKeyLength <= Dtls::kPskMaxLength, "Max ephemeral key length is larger than max PSK len");
 
@@ -322,7 +314,6 @@ private:
 #endif
 
     State                      mState;
-    uint16_t                   mUdpProxyPort;
     Ip6::Udp::Receiver         mUdpReceiver;
     Ip6::Netif::UnicastAddress mCommissionerAloc;
     TimeoutTimer               mTimer;


### PR DESCRIPTION
This commit removes the unused `GetUdpProxyPort()` method and the related code tracking the proxy port in `BorderAgent`.