### PR TITLE
[border-agent] update interactions with native `Commissioner`

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -185,12 +185,8 @@ uint16_t BorderAgent::GetUdpPort(void) const { return mDtlsTransport.GetUdpPort(
 
 void BorderAgent::HandleNotifierEvents(Events aEvents)
 {
-    if ((aEvents.ContainsAny(kEventThreadRoleChanged | kEventCommissionerStateChanged)))
+    if (aEvents.Contains(kEventThreadRoleChanged))
     {
-#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-        VerifyOrExit(Get<Commissioner>().IsDisabled());
-#endif
-
         if (Get<Mle::MleRouter>().IsAttached())
         {
             Start();

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -146,16 +146,6 @@ public:
     uint16_t GetUdpPort(void) const;
 
     /**
-     * Starts the Border Agent service.
-     */
-    void Start(void) { IgnoreError(Start(kUdpPort)); }
-
-    /**
-     * Stops the Border Agent service.
-     */
-    void Stop(void);
-
-    /**
      * Gets the state of the Border Agent service.
      *
      * @returns The state of the Border Agent service.
@@ -293,8 +283,10 @@ private:
         uint8_t  mToken[Coap::Message::kMaxTokenLength]; // The CoAP Token of the original request.
     };
 
+    void  Start(void) { IgnoreError(Start(kUdpPort)); }
     Error Start(uint16_t aUdpPort);
     Error Start(uint16_t aUdpPort, const uint8_t *aPsk, uint8_t aPskLength);
+    void  Stop(void);
     void  HandleNotifierEvents(Events aEvents);
     void  HandleTimeout(void);
     Error ForwardToLeader(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, Uri aUri);

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -268,10 +268,6 @@ Error Commissioner::Start(StateCallback aStateCallback, JoinerCallback aJoinerCa
     VerifyOrExit(Get<Mle::MleRouter>().IsAttached(), error = kErrorInvalidState);
     VerifyOrExit(mState == kStateDisabled, error = kErrorAlready);
 
-#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    Get<BorderAgent>().Stop();
-#endif
-
     SuccessOrExit(error = Get<Tmf::SecureAgent>().Open());
     SuccessOrExit(error = Get<Tmf::SecureAgent>().Bind(SendRelayTransmit, this));
 
@@ -325,10 +321,6 @@ Error Commissioner::Stop(ResignMode aResignMode)
     {
         SendKeepAlive();
     }
-
-#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    Get<BorderAgent>().Start();
-#endif
 
 exit:
     if (error != kErrorAlready)


### PR DESCRIPTION
This commit updates the interaction between `BorderAgent` and the native `Commissioner`, removing the unnecessary mechanism to stop and restart the Border Agent when the commissioner is enabled and disabled.

This was previously required because both modules shared the same underlying `Tmf::SecureAgent` and DTLS transport. This has been changed recently so that `BorderAgent` uses its own DTLS transport and sessions.
