### PR TITLE
[dataset] validate Active/Pending Timestamp and Delay Timer TLVs

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -130,6 +130,15 @@ bool Dataset::IsTlvValid(const Tlv &aTlv)
 
     switch (aTlv.GetType())
     {
+    case Tlv::kActiveTimestamp:
+        minLength = sizeof(ActiveTimestampTlv::ValueType);
+        break;
+    case Tlv::kPendingTimestamp:
+        minLength = sizeof(PendingTimestampTlv::ValueType);
+        break;
+    case Tlv::kDelayTimer:
+        minLength = sizeof(DelayTimerTlv::UintValueType);
+        break;
     case Tlv::kPanId:
         minLength = sizeof(PanIdTlv::UintValueType);
         break;


### PR DESCRIPTION
This commit updates the `Dataset::IsTlvValid()` method to also validate the Active/Pending Timestamp and Delay Timer TLVs, ensuring they have the minimum required length. This ensures that a dataset with invalid TLVs is correctly rejected when set on a device.