### PR TITLE
[border-router] persist ULA prefix when adding it to avoid it being invalid after a power cycle (#11089)

### DIFF
--- a/include/openthread/border_router.h
+++ b/include/openthread/border_router.h
@@ -53,6 +53,11 @@ extern "C" {
  */
 
 /**
+ * The length of Border Router ULA prefix in bits.
+ */
+#define OT_BR_ULA_PREFIX_LENGTH 48
+
+/**
  * Provides a full or stable copy of the local Thread Network Data.
  *
  * @param[in]      aInstance    A pointer to an OpenThread instance.

--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -61,6 +61,13 @@ otError otBorderRouterAddOnMeshPrefix(otInstance *aInstance, const otBorderRoute
     {
         error = AsCoreType(aInstance).Get<NetworkData::Local>().AddOnMeshPrefix(AsCoreType(aConfig));
     }
+    
+    Ip6::Prefix brUlaPrefix;
+    brUlaPrefix.Set(aConfig->mPrefix.mPrefix.mFields.m8, OT_IP6_PREFIX_BITSIZE);
+    brUlaPrefix.SetSubnetId(0);
+    brUlaPrefix.SetLength(OT_BR_ULA_PREFIX_LENGTH);
+
+    IgnoreError(AsCoreType(aInstance).Get<Settings>().Save<Settings::BrUlaPrefix>(brUlaPrefix));
 
     return error;
 }


### PR DESCRIPTION
Facing the issue here: [[border-router] BrUlaPrefix not persisted when cli prefix add <prefix> or otBorderRouterAddOnMeshPrefix() invoked #11089](https://github.com/openthread/openthread/issues/11089), I create a solution.

It works well for single TBR replacing case. I am not sure about the `OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE` part.

And I did not see the need to remove the `BrUlaPrefix` separately, when `factoryreset` could deal with it, right? 
