### PR TITLE
[secure-transport] support multiple sessions on the same transport

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -53,10 +53,11 @@ CoapBase::CoapBase(Instance &aInstance, Sender aSender)
 {
 }
 
-void CoapBase::ClearRequestsAndResponses(void)
+void CoapBase::ClearAllRequestsAndResponses(void)
 {
     ClearRequests(nullptr); // Clear requests matching any address.
     mResponsesQueue.DequeueAllResponses();
+    mRetransmissionTimer.Stop();
 }
 
 void CoapBase::ClearRequests(const Ip6::Address &aAddress) { ClearRequests(&aAddress); }
@@ -1553,7 +1554,11 @@ void ResponsesQueue::UpdateQueue(void)
 
 void ResponsesQueue::DequeueResponse(Message &aMessage) { mQueue.DequeueAndFree(aMessage); }
 
-void ResponsesQueue::DequeueAllResponses(void) { mQueue.DequeueAndFreeAll(); }
+void ResponsesQueue::DequeueAllResponses(void)
+{
+    mQueue.DequeueAndFreeAll();
+    mTimer.Stop();
+}
 
 void ResponsesQueue::HandleTimer(Timer &aTimer)
 {
@@ -1693,7 +1698,7 @@ Error Coap::Stop(void)
     VerifyOrExit(mSocket.IsBound());
 
     SuccessOrExit(error = mSocket.Close());
-    ClearRequestsAndResponses();
+    ClearAllRequestsAndResponses();
 
 exit:
     return error;

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -358,9 +358,9 @@ public:
     typedef Error (*Interceptor)(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext);
 
     /**
-     * Clears requests and responses used by this CoAP agent.
+     * Clears all requests and responses used by this CoAP agent and stops all timers.
      */
-    void ClearRequestsAndResponses(void);
+    void ClearAllRequestsAndResponses(void);
 
     /**
      * Clears requests with specified source address used by this CoAP agent.

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -61,6 +61,11 @@ class SecureSession : public CoapBase, public Dtls::Session
 {
 public:
     /**
+     * Dequeues and frees all queued messages (requests and responses) and stops all timers and tasklets.
+     */
+    void Cleanup(void);
+
+    /**
      * Sets the connection event callback.
      *
      * @param[in]  aHandler   A pointer to a function that is called when connected or disconnected.
@@ -148,8 +153,13 @@ public:
         , Dtls::Transport::Extension(static_cast<Dtls::Transport &>(*this))
         , SecureSession(aInstance, static_cast<Dtls::Transport &>(*this))
     {
+        Dtls::Transport::SetAcceptCallback(HandleDtlsAccept, this);
         Dtls::Transport::SetExtension(static_cast<Dtls::Transport::Extension &>(*this));
     }
+
+private:
+    static MeshCoP::SecureSession *HandleDtlsAccept(void *aContext, const Ip6::MessageInfo &aMessageInfo);
+    SecureSession                 *HandleDtlsAccept(void);
 };
 
 #endif // OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -51,6 +51,7 @@ BorderAgent::BorderAgent(Instance &aInstance)
     , mUdpReceiver(BorderAgent::HandleUdpReceive, this)
     , mTimer(aInstance)
     , mDtlsTransport(aInstance, kNoLinkSecurity)
+    , mCoapDtlsSession(nullptr)
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
     , mIdInitialized(false)
 #endif
@@ -129,15 +130,13 @@ Error BorderAgent::Start(uint16_t aUdpPort, const uint8_t *aPsk, uint8_t aPskLen
     }
 #endif
 
-    mCoapDtlsSession.Reset(CoapDtlsSession::Allocate(GetInstance(), mDtlsTransport));
-    VerifyOrExit(mCoapDtlsSession != nullptr, error = kErrorNoBufs);
+    mDtlsTransport.SetAcceptCallback(HandleAcceptSession, this);
+    mDtlsTransport.SetRemoveSessionCallback(HandleRemoveSession, this);
 
     SuccessOrExit(error = mDtlsTransport.Open());
     SuccessOrExit(error = mDtlsTransport.Bind(aUdpPort));
 
     SuccessOrExit(error = mDtlsTransport.SetPsk(aPsk, aPskLength));
-
-    mCoapDtlsSession->SetConnectCallback(HandleConnected, this);
 
     mState = kStateStarted;
 
@@ -163,7 +162,6 @@ void BorderAgent::Stop(void)
 
     mTimer.Stop();
     mDtlsTransport.Close();
-    mCoapDtlsSession.Free();
 
     mState = kStateStopped;
     LogInfo("Border Agent stopped");
@@ -175,6 +173,7 @@ exit:
 void BorderAgent::Disconnect(void)
 {
     VerifyOrExit(mState == kStateConnected || mState == kStateAccepted);
+    VerifyOrExit(mCoapDtlsSession != nullptr);
 
     mCoapDtlsSession->Disconnect();
 
@@ -225,11 +224,51 @@ exit:
 
 void BorderAgent::HandleTimeout(void)
 {
-    if (mCoapDtlsSession->IsConnected())
-    {
-        mCoapDtlsSession->Disconnect();
-        LogWarn("Reset secure session");
-    }
+    VerifyOrExit(mCoapDtlsSession != nullptr);
+    VerifyOrExit(mCoapDtlsSession->IsConnected());
+
+    mCoapDtlsSession->Disconnect();
+    LogWarn("Reset secure session");
+
+exit:
+    return;
+}
+
+SecureSession *BorderAgent::HandleAcceptSession(void *aContext, const Ip6::MessageInfo &aMessageInfo)
+{
+    OT_UNUSED_VARIABLE(aMessageInfo);
+
+    return static_cast<BorderAgent *>(aContext)->HandleAcceptSession();
+}
+
+BorderAgent::CoapDtlsSession *BorderAgent::HandleAcceptSession(void)
+{
+    CoapDtlsSession *session = nullptr;
+
+    VerifyOrExit(mCoapDtlsSession == nullptr);
+
+    session = CoapDtlsSession::Allocate(GetInstance(), mDtlsTransport);
+    VerifyOrExit(session != nullptr);
+
+    session->SetConnectCallback(HandleConnected, this);
+    mCoapDtlsSession = session;
+
+exit:
+    return session;
+}
+
+void BorderAgent::HandleRemoveSession(void *aContext, SecureSession &aSesssion)
+{
+    static_cast<BorderAgent *>(aContext)->HandleRemoveSession(aSesssion);
+}
+
+void BorderAgent::HandleRemoveSession(SecureSession &aSesssion)
+{
+    CoapDtlsSession &coapSession = static_cast<CoapDtlsSession &>(aSesssion);
+
+    coapSession.Cleanup();
+    coapSession.Free();
+    mCoapDtlsSession = nullptr;
 }
 
 void BorderAgent::HandleConnected(Dtls::Session::ConnectEvent aEvent, void *aContext)
@@ -315,6 +354,7 @@ Error BorderAgent::ForwardToLeader(const Coap::Message &aMessage, const Ip6::Mes
     OffsetRange              offsetRange;
 
     VerifyOrExit(mState != kStateStopped);
+    VerifyOrExit(mCoapDtlsSession != nullptr);
 
     switch (aUri)
     {
@@ -389,6 +429,7 @@ void BorderAgent::HandleCoapResponse(const ForwardContext &aForwardContext,
     Error          error;
 
     SuccessOrExit(error = aResult);
+    VerifyOrExit(mCoapDtlsSession != nullptr);
     VerifyOrExit((message = mCoapDtlsSession->NewPriorityMessage()) != nullptr, error = kErrorNoBufs);
 
     if (aForwardContext.IsPetition() && aResponse->GetCode() == Coap::kCodeChanged)
@@ -464,6 +505,7 @@ bool BorderAgent::HandleUdpReceive(const Message &aMessage, const Ip6::MessageIn
     OffsetRange               offsetRange;
 
     VerifyOrExit(aMessageInfo.GetSockAddr() == mCommissionerAloc.GetAddress());
+    VerifyOrExit(mCoapDtlsSession != nullptr);
 
     didHandle = true;
 
@@ -499,8 +541,10 @@ exit:
 
 Error BorderAgent::ForwardToCommissioner(Coap::Message &aForwardMessage, const Message &aMessage)
 {
-    Error       error;
+    Error       error = kErrorNone;
     OffsetRange offsetRange;
+
+    VerifyOrExit(mCoapDtlsSession != nullptr);
 
     offsetRange.InitFromMessageOffsetToEnd(aMessage);
     SuccessOrExit(error = aForwardMessage.AppendBytesFromMessage(aMessage, offsetRange));
@@ -519,6 +563,8 @@ void BorderAgent::SendErrorMessage(const ForwardContext &aForwardContext, Error 
     Error          error   = kErrorNone;
     Coap::Message *message = nullptr;
 
+    VerifyOrExit(mCoapDtlsSession != nullptr);
+
     VerifyOrExit((message = mCoapDtlsSession->NewPriorityMessage()) != nullptr, error = kErrorNoBufs);
     SuccessOrExit(error = aForwardContext.ToHeader(*message, CoapCodeFromError(aError)));
     SuccessOrExit(error = mCoapDtlsSession->SendMessage(*message));
@@ -532,6 +578,8 @@ void BorderAgent::SendErrorMessage(const Coap::Message &aRequest, bool aSeparate
 {
     Error          error   = kErrorNone;
     Coap::Message *message = nullptr;
+
+    VerifyOrExit(mCoapDtlsSession != nullptr);
 
     VerifyOrExit((message = mCoapDtlsSession->NewPriorityMessage()) != nullptr, error = kErrorNoBufs);
 
@@ -592,6 +640,8 @@ template <> void BorderAgent::HandleTmf<kUriRelayRx>(Coap::Message &aMessage, co
     VerifyOrExit(mState != kStateStopped);
 
     VerifyOrExit(aMessage.IsNonConfirmablePostRequest(), error = kErrorDrop);
+
+    VerifyOrExit(mCoapDtlsSession != nullptr);
 
     message = mCoapDtlsSession->NewPriorityNonConfirmablePostMessage(kUriRelayRx);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
@@ -680,6 +730,8 @@ void BorderAgent::HandleTmfDatasetGet(Coap::Message &aMessage, const Ip6::Messag
 
     Error          error    = kErrorNone;
     Coap::Message *response = nullptr;
+
+    VerifyOrExit(mCoapDtlsSession != nullptr);
 
     // When processing `MGMT_GET` request directly on Border Agent,
     // the Security Policy flags (O-bit) should be ignored to allow

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -300,6 +300,11 @@ private:
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
+    static SecureSession *HandleAcceptSession(void *aContext, const Ip6::MessageInfo &aMessageInfo);
+    CoapDtlsSession      *HandleAcceptSession(void);
+    static void           HandleRemoveSession(void *aContext, SecureSession &aSesssion);
+    void                  HandleRemoveSession(SecureSession &aSesssion);
+
     static void HandleConnected(Dtls::Session::ConnectEvent aEvent, void *aContext);
     void        HandleConnected(Dtls::Session::ConnectEvent aEvent);
     static void HandleCoapResponse(void                *aContext,
@@ -331,7 +336,7 @@ private:
     Ip6::Netif::UnicastAddress mCommissionerAloc;
     TimeoutTimer               mTimer;
     Dtls::Transport            mDtlsTransport;
-    OwnedPtr<CoapDtlsSession>  mCoapDtlsSession;
+    CoapDtlsSession           *mCoapDtlsSession;
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
     Id   mId;
     bool mIdInitialized;

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -276,9 +276,23 @@ SecureAgent::SecureAgent(Instance &aInstance)
     : Coap::Dtls::Transport(aInstance, kNoLinkSecurity)
     , Coap::SecureSession(aInstance, static_cast<Coap::Dtls::Transport &>(*this))
 {
+    SetAcceptCallback(&HandleDtlsAccept, this);
+
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
     SetResourceHandler(&HandleResource);
 #endif
+}
+
+MeshCoP::SecureSession *SecureAgent::HandleDtlsAccept(void *aContext, const Ip6::MessageInfo &aMessageInfo)
+{
+    OT_UNUSED_VARIABLE(aMessageInfo);
+
+    return static_cast<SecureAgent *>(aContext)->HandleDtlsAccept();
+}
+
+Coap::SecureSession *SecureAgent::HandleDtlsAccept(void)
+{
+    return IsSessionInUse() ? nullptr : static_cast<Coap::SecureSession *>(this);
 }
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE

--- a/src/core/thread/tmf.hpp
+++ b/src/core/thread/tmf.hpp
@@ -208,6 +208,9 @@ public:
     explicit SecureAgent(Instance &aInstance);
 
 private:
+    static MeshCoP::SecureSession *HandleDtlsAccept(void *aContext, const Ip6::MessageInfo &aMessageInfo);
+    Coap::SecureSession           *HandleDtlsAccept(void);
+
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
     static bool HandleResource(CoapBase               &aCoapBase,
                                const char             *aUriPath,

--- a/tests/nexus/test_dtls.cpp
+++ b/tests/nexus/test_dtls.cpp
@@ -48,6 +48,7 @@ static const uint8_t kPsk[] = {0x10, 0x20, 0x03, 0x15, 0x10, 0x00, 0x60, 0x16};
 static Dtls::Session::ConnectEvent  sDtlsEvent[kMaxNodes];
 static Array<uint8_t, kMessageSize> sDtlsLastReceive[kMaxNodes];
 static bool                         sDtlsAutoClosed[kMaxNodes];
+static uint32_t                     sHeapSessionsAllocated = 0;
 
 const char *ConnectEventToString(Dtls::Session::ConnectEvent aEvent)
 {
@@ -131,23 +132,112 @@ OwnedPtr<Message> PrepareMessage(Node &aNode)
     return OwnedPtr<Message>(message);
 }
 
-class DtlsTransportAndSession : public InstanceLocator, public Dtls::Transport, public Dtls::Session
+class DtlsTransportAndSingleSession : public InstanceLocator, public Dtls::Transport, public Dtls::Session
 {
+    // A DTLS transport and single session
 public:
-    explicit DtlsTransportAndSession(Node &aNode)
+    explicit DtlsTransportAndSingleSession(Node &aNode)
         : InstanceLocator(aNode.GetInstance())
         , Dtls::Transport(aNode.GetInstance(), kWithLinkSecurity)
         , Dtls::Session(static_cast<Dtls::Transport &>(*this))
+        , mNode(aNode)
     {
+        SetAcceptCallback(HandleAccept, this);
+
+        VerifyOrQuit(!IsSessionInUse());
     }
+
+private:
+    static MeshCoP::SecureSession *HandleAccept(void *aContext, const Ip6::MessageInfo &aMessageInfo)
+    {
+        return static_cast<DtlsTransportAndSingleSession *>(aContext)->HandleAccept();
+    }
+
+    Dtls::Session *HandleAccept(void)
+    {
+        Dtls::Session *session = IsSessionInUse() ? nullptr : static_cast<Dtls::Session *>(this);
+
+        Log("   node%u: HandleAccept(), %s", mNode.GetId(), (session != nullptr) ? "accepted" : "rejected");
+        return session;
+    }
+
+    Node &mNode;
 };
 
-void TestDtls(void)
+class DtlsTransportAndHeapSession : public InstanceLocator, public Dtls::Transport
+{
+    // A DTLS session with heap allocated sessions.
+
+public:
+    explicit DtlsTransportAndHeapSession(Node &aNode)
+        : InstanceLocator(aNode.GetInstance())
+        , Dtls::Transport(aNode.GetInstance(), kWithLinkSecurity)
+        , mNode(aNode)
+    {
+        SetAcceptCallback(HandleAccept, this);
+        SetRemoveSessionCallback(HandleRemoveSession, this);
+    }
+
+private:
+    class HeapDtlsSession : public Dtls::Session, public Heap::Allocatable<HeapDtlsSession>
+    {
+        friend Heap::Allocatable<HeapDtlsSession>;
+
+    private:
+        HeapDtlsSession(Dtls::Transport &aTransport)
+            : Dtls::Session(aTransport)
+        {
+            sHeapSessionsAllocated++;
+        }
+    };
+
+    static MeshCoP::SecureSession *HandleAccept(void *aContext, const Ip6::MessageInfo &aMessageInfo)
+    {
+        DtlsTransportAndHeapSession *transport;
+        HeapDtlsSession             *session;
+
+        VerifyOrQuit(aContext != nullptr);
+        transport = static_cast<DtlsTransportAndHeapSession *>(aContext);
+
+        Log("   node%u: HandleAccept()", transport->mNode.GetId());
+
+        session = HeapDtlsSession::Allocate(*transport);
+        VerifyOrQuit(session != nullptr);
+
+        session->SetReceiveCallback(&ot::Nexus::HandleReceive, &transport->mNode);
+        session->SetConnectCallback(&ot::Nexus::HandleConnectEvent, &transport->mNode);
+
+        return session;
+    }
+
+    static void HandleRemoveSession(void *aContext, MeshCoP::SecureSession &aSesssion)
+    {
+        DtlsTransportAndHeapSession *transport;
+
+        VerifyOrQuit(aContext != nullptr);
+        transport = static_cast<DtlsTransportAndHeapSession *>(aContext);
+
+        Log("   node%u: HandleRemoveSession()", transport->mNode.GetId());
+
+        VerifyOrQuit(sHeapSessionsAllocated > 0);
+
+        static_cast<HeapDtlsSession &>(aSesssion).Free();
+        sHeapSessionsAllocated--;
+    }
+
+private:
+    Node &mNode;
+};
+
+void TestDtlsSingleSession(void)
 {
     Core  nexus;
     Node &node0 = nexus.CreateNode();
     Node &node1 = nexus.CreateNode();
     Node &node2 = nexus.CreateNode();
+
+    Log("------------------------------------------------------------------------------------------------------");
+    Log("TestDtlsSingleSession");
 
     nexus.AdvanceTime(0);
 
@@ -167,13 +257,11 @@ void TestDtls(void)
     nexus.AdvanceTime(20 * Time::kOneSecondInMsec);
     VerifyOrQuit(node2.Get<Mle::Mle>().IsChild());
 
-    Log("------------------------------------------------------------------------------------------------------");
-
     {
-        DtlsTransportAndSession dtls0(node0);
-        DtlsTransportAndSession dtls1(node1);
-        DtlsTransportAndSession dtls2(node2);
-        Ip6::SockAddr           sockAddr;
+        DtlsTransportAndSingleSession dtls0(node0);
+        DtlsTransportAndSingleSession dtls1(node1);
+        DtlsTransportAndSingleSession dtls2(node2);
+        Ip6::SockAddr                 sockAddr;
 
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         Log("Start DTLS (server) on node0 bound to port %u", kUdpPort);
@@ -370,7 +458,7 @@ void TestDtls(void)
         SuccessOrQuit(dtls1.Connect(sockAddr));
         nexus.AdvanceTime(3 * Time::kOneSecondInMsec);
 
-        VerifyOrQuit(sDtlsEvent[node0.GetId()] == Dtls::Session::kDisconnectedMaxAttempts);
+        VerifyOrQuit(sDtlsEvent[node0.GetId()] == Dtls::Session::kDisconnectedError);
         VerifyOrQuit(sDtlsEvent[node1.GetId()] == Dtls::Session::kDisconnectedError);
 
         VerifyOrQuit(sDtlsAutoClosed[node0.GetId()]);
@@ -383,12 +471,190 @@ void TestDtls(void)
     }
 }
 
+void TestDtlsMultiSession(void)
+{
+    Core  nexus;
+    Node &node0 = nexus.CreateNode();
+    Node &node1 = nexus.CreateNode();
+    Node &node2 = nexus.CreateNode();
+
+    Log("------------------------------------------------------------------------------------------------------");
+    Log("TestDtlsMultiSession");
+
+    nexus.AdvanceTime(0);
+
+    // Form the topology: node0 leader, with node1 & node2 as its FTD children
+
+    node0.Form();
+    nexus.AdvanceTime(50 * Time::kOneSecondInMsec);
+    VerifyOrQuit(node0.Get<Mle::Mle>().IsLeader());
+
+    SuccessOrQuit(node1.Get<Mle::MleRouter>().SetRouterEligible(false));
+    node1.Join(node0);
+    nexus.AdvanceTime(20 * Time::kOneSecondInMsec);
+    VerifyOrQuit(node1.Get<Mle::Mle>().IsChild());
+
+    SuccessOrQuit(node2.Get<Mle::MleRouter>().SetRouterEligible(false));
+    node2.Join(node0);
+    nexus.AdvanceTime(20 * Time::kOneSecondInMsec);
+    VerifyOrQuit(node2.Get<Mle::Mle>().IsChild());
+
+    {
+        DtlsTransportAndHeapSession   dtls0(node0);
+        DtlsTransportAndSingleSession dtls1(node1);
+        DtlsTransportAndSingleSession dtls2(node2);
+        Ip6::SockAddr                 sockAddr;
+        uint16_t                      numSessions;
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        Log("Start DTLS (server) on node0 bound to port %u", kUdpPort);
+
+        SuccessOrQuit(dtls0.SetPsk(kPsk, sizeof(kPsk)));
+        SuccessOrQuit(dtls0.Open());
+        SuccessOrQuit(dtls0.Bind(kUdpPort));
+
+        nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
+
+        VerifyOrQuit(dtls0.GetUdpPort() == kUdpPort);
+
+        sockAddr.SetAddress(node0.Get<Mle::Mle>().GetMeshLocalRloc());
+        sockAddr.SetPort(kUdpPort);
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        Log("Establish a DTLS connection with node 0 from node1");
+
+        memset(sDtlsEvent, Dtls::Session::kDisconnectedError, sizeof(sDtlsEvent));
+
+        SuccessOrQuit(dtls1.SetPsk(kPsk, sizeof(kPsk)));
+        dtls1.SetReceiveCallback(HandleReceive, &node1);
+        dtls1.SetConnectCallback(HandleConnectEvent, &node1);
+        SuccessOrQuit(dtls1.Open());
+        SuccessOrQuit(dtls1.Connect(sockAddr));
+
+        nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
+
+        VerifyOrQuit(dtls1.IsConnected());
+
+        VerifyOrQuit(sDtlsEvent[node0.GetId()] == Dtls::Session::kConnected);
+        VerifyOrQuit(sDtlsEvent[node1.GetId()] == Dtls::Session::kConnected);
+
+        numSessions = 0;
+
+        for (MeshCoP::SecureSession &session : dtls0.GetSessions())
+        {
+            VerifyOrQuit(session.IsConnected());
+            numSessions++;
+        }
+
+        VerifyOrQuit(numSessions == 1);
+        VerifyOrQuit(sHeapSessionsAllocated == 1);
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        Log("Establish a second DTLS connection with node0 from node2");
+
+        memset(sDtlsEvent, Dtls::Session::kDisconnectedError, sizeof(sDtlsEvent));
+
+        SuccessOrQuit(dtls2.SetPsk(kPsk, sizeof(kPsk)));
+        dtls2.SetReceiveCallback(HandleReceive, &node2);
+        dtls2.SetConnectCallback(HandleConnectEvent, &node2);
+        SuccessOrQuit(dtls2.Open());
+        SuccessOrQuit(dtls2.Connect(sockAddr));
+
+        nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
+
+        VerifyOrQuit(dtls2.IsConnected());
+
+        VerifyOrQuit(sDtlsEvent[node0.GetId()] == Dtls::Session::kConnected);
+        VerifyOrQuit(sDtlsEvent[node2.GetId()] == Dtls::Session::kConnected);
+
+        numSessions = 0;
+
+        for (MeshCoP::SecureSession &session : dtls0.GetSessions())
+        {
+            VerifyOrQuit(session.IsConnected());
+            numSessions++;
+        }
+
+        VerifyOrQuit(numSessions == 2);
+        VerifyOrQuit(sHeapSessionsAllocated == 2);
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        Log("Disconnect from node1 - validate the disconnect events");
+
+        dtls1.Disconnect();
+
+        nexus.AdvanceTime(3 * Time::kOneSecondInMsec);
+
+        VerifyOrQuit(!dtls1.IsConnected());
+
+        VerifyOrQuit(sDtlsEvent[node0.GetId()] == Dtls::Session::kDisconnectedPeerClosed);
+        VerifyOrQuit(sDtlsEvent[node1.GetId()] == Dtls::Session::kDisconnectedLocalClosed);
+
+        numSessions = 0;
+
+        for (MeshCoP::SecureSession &session : dtls0.GetSessions())
+        {
+            VerifyOrQuit(session.IsConnected());
+            numSessions++;
+        }
+
+        VerifyOrQuit(numSessions == 1);
+        VerifyOrQuit(sHeapSessionsAllocated == 1);
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        Log("Disconnect session with node2 from node0 (server) - validate the disconnect events");
+
+        memset(sDtlsEvent, Dtls::Session::kConnected, sizeof(sDtlsEvent));
+
+        dtls0.GetSessions().GetHead()->Disconnect();
+
+        nexus.AdvanceTime(3 * Time::kOneSecondInMsec);
+
+        VerifyOrQuit(!dtls2.IsConnected());
+
+        VerifyOrQuit(sDtlsEvent[node0.GetId()] == Dtls::Session::kDisconnectedLocalClosed);
+        VerifyOrQuit(sDtlsEvent[node2.GetId()] == Dtls::Session::kDisconnectedPeerClosed);
+
+        VerifyOrQuit(dtls0.GetSessions().IsEmpty());
+        VerifyOrQuit(sHeapSessionsAllocated == 0);
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        Log("Establish two DTLS connections from node1 and node2 at the same time");
+
+        memset(sDtlsEvent, Dtls::Session::kDisconnectedError, sizeof(sDtlsEvent));
+
+        SuccessOrQuit(dtls1.Connect(sockAddr));
+        SuccessOrQuit(dtls2.Connect(sockAddr));
+
+        nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
+
+        VerifyOrQuit(dtls1.IsConnected());
+        VerifyOrQuit(dtls2.IsConnected());
+
+        VerifyOrQuit(sDtlsEvent[node0.GetId()] == Dtls::Session::kConnected);
+        VerifyOrQuit(sDtlsEvent[node1.GetId()] == Dtls::Session::kConnected);
+        VerifyOrQuit(sDtlsEvent[node2.GetId()] == Dtls::Session::kConnected);
+
+        numSessions = 0;
+
+        for (MeshCoP::SecureSession &session : dtls0.GetSessions())
+        {
+            VerifyOrQuit(session.IsConnected());
+            numSessions++;
+        }
+
+        VerifyOrQuit(numSessions == 2);
+        VerifyOrQuit(sHeapSessionsAllocated == 2);
+    }
+}
+
 } // namespace Nexus
 } // namespace ot
 
 int main(void)
 {
-    ot::Nexus::TestDtls();
+    ot::Nexus::TestDtlsSingleSession();
+    ot::Nexus::TestDtlsMultiSession();
     printf("All tests passed\n");
     return 0;
 }


### PR DESCRIPTION
This commit updates `SecureTransport` to support multiple `SecureSession`s on the same transport. The transport tracks a list of sessions that it owns and manages. Two new callbacks are introduced:
- `AcceptCallback`: Used to accept a new connection request, providing
  the `SecureSession` instance to use (passing ownership of the
  session to the transport).
- `RemoveSessionCallback`: Signals that a session is removed,
  releasing ownership of the session.

`BorderAgent`, `Tmf::SecureAgent`, and `ApplicationCoapSecure` are updated to adopt the new model.

This commit also updates the Nexus `test_dtls`, adding `TestDtlsMultiSession` to validate multiple session support behavior.

----

~This PR currently contains the commit from https://github.com/openthread/openthread/pull/11101. Please check and review the last commit. Thanks.~ 
