### PR TITLE
[border-agent] allow setting UDP port at runtime

### DIFF
--- a/include/openthread/border_agent.h
+++ b/include/openthread/border_agent.h
@@ -139,8 +139,25 @@ otBorderAgentState otBorderAgentGetState(otInstance *aInstance);
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  *
  * @returns UDP port of the Border Agent.
+ *
+ * @sa otBorderAgentSetUdpPort
  */
 uint16_t otBorderAgentGetUdpPort(otInstance *aInstance);
+
+/**
+ * Sets the UDP port to listen on.
+ *
+ * If 0 is used, a dynamically-assigned port will be assigned on start.
+ *
+ * @param[in]    aInstance  A pointer to an OpenThread instance.
+ * @param[out]   aUdpPort   UDP port to listen on.
+ *
+ * @retval OT_ERROR_NONE           Successfully set UDP port.
+ * @retval OT_ERROR_INVALID_STATE  Border agent was not stopped.
+ *
+ * @sa otBorderAgentGetUdpPort
+ */
+otError otBorderAgentSetUdpPort(otInstance *aInstance, uint16_t aUdpPort);
 
 /**
  * Gets the randomly generated Border Agent ID.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -412,18 +412,35 @@ template <> otError Interpreter::Process<Cmd("ba")>(Arg aArgs[])
     otError error = OT_ERROR_NONE;
 
     /**
-     * @cli ba port
+     * @cli ba port (get,set)
      * @code
      * ba port
      * 49153
      * Done
      * @endcode
-     * @par api_copy
-     * #otBorderAgentGetUdpPort
+     * @code
+     * ba port 49153
+     * Done
+     * @endcode
+     * @cparam ba port [@ca{border-agent-port}]
+     * Use the optional `border-agent-port` argument to set the Border Agent ID.
+     * @par
+     * Gets or sets the UDP port for the border agent listens on.
+     * @sa otBorderAgentGetUdpPort
+     * @sa otBorderAgentSetUdpPort
      */
     if (aArgs[0] == "port")
     {
-        OutputLine("%hu", otBorderAgentGetUdpPort(GetInstancePtr()));
+        if (aArgs[1].IsEmpty())
+        {
+            OutputLine("%hu", otBorderAgentGetUdpPort(GetInstancePtr()));
+        }
+        else
+        {
+            uint16_t port;
+            SuccessOrExit(error = aArgs[1].ParseAsUint16(port));
+            error = otBorderAgentSetUdpPort(GetInstancePtr(), port);
+        }
     }
     /**
      * @cli ba state

--- a/src/core/api/border_agent_api.cpp
+++ b/src/core/api/border_agent_api.cpp
@@ -79,6 +79,11 @@ uint16_t otBorderAgentGetUdpPort(otInstance *aInstance)
     return AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().GetUdpPort();
 }
 
+otError otBorderAgentSetUdpPort(otInstance *aInstance, uint16_t aUdpPort)
+{
+    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().SetUdpPort(aUdpPort);
+}
+
 #if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
 
 otError otBorderAgentSetEphemeralKey(otInstance *aInstance,

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -50,6 +50,7 @@ BorderAgent::BorderAgent(Instance &aInstance)
     , mState(kStateStopped)
     , mUdpReceiver(BorderAgent::HandleUdpReceive, this)
     , mTimer(aInstance)
+    , mUdpPort(kDefaultUdpPort)
     , mDtlsTransport(aInstance, kNoLinkSecurity)
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
     , mIdInitialized(false)
@@ -181,7 +182,22 @@ exit:
     return;
 }
 
-uint16_t BorderAgent::GetUdpPort(void) const { return mDtlsTransport.GetUdpPort(); }
+uint16_t BorderAgent::GetUdpPort(void) const
+{
+    // mUdpPort is not returned here because it might be 0 for a dynamically-assigned port.
+    return mDtlsTransport.GetUdpPort();
+}
+
+Error BorderAgent::SetUdpPort(const uint16_t &aUdpPort)
+{
+    Error error = kErrorNone;
+
+    VerifyOrExit(mState == kStateStopped, error = kErrorInvalidState);
+    mUdpPort            = aUdpPort;
+
+    exit:
+        return error;
+}
 
 void BorderAgent::HandleNotifierEvents(Events aEvents)
 {

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -139,16 +139,28 @@ public:
 #endif
 
     /**
-     * Gets the UDP port of this service.
+     * Gets the actively-listening UDP port of this service.
+     * Only valid if the service is running.
      *
      * @returns  UDP port number.
      */
     uint16_t GetUdpPort(void) const;
 
     /**
+     * Sets the UDP port of this service.
+     *
+     * The UDP port can only be set while the service is stopped.
+     * If 0 is used, the dynamically-assigned port can be retrieved with GetUdpPort() once started.
+     *
+     * @retval kErrorNone           Successfully set UDP port.
+     * @retval kErrorInvalidState   Service is not stopped.
+     */
+    Error SetUdpPort(const uint16_t &aUdpPort);
+
+    /**
      * Starts the Border Agent service.
      */
-    void Start(void) { IgnoreError(Start(kUdpPort)); }
+    void Start(void) { IgnoreError(Start(mUdpPort)); }
 
     /**
      * Stops the Border Agent service.
@@ -251,7 +263,7 @@ private:
     static_assert(kMaxEphemeralKeyLength <= Dtls::Transport::kPskMaxLength,
                   "Max ephemeral key length is larger than max PSK len");
 
-    static constexpr uint16_t kUdpPort          = OPENTHREAD_CONFIG_BORDER_AGENT_UDP_PORT;
+    static constexpr uint16_t kDefaultUdpPort   = OPENTHREAD_CONFIG_BORDER_AGENT_UDP_PORT;
     static constexpr uint32_t kKeepAliveTimeout = 50 * 1000; // Timeout to reject a commissioner (in msec)
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
@@ -338,6 +350,7 @@ private:
     Ip6::Udp::Receiver         mUdpReceiver;
     Ip6::Netif::UnicastAddress mCommissionerAloc;
     TimeoutTimer               mTimer;
+    uint16_t                   mUdpPort;
     Dtls::Transport            mDtlsTransport;
     OwnedPtr<CoapDtlsSession>  mCoapDtlsSession;
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE


### PR DESCRIPTION
~Make `Start(aUdpPort)` public so that it's possible to explicitly choose the UDP port at runtime rather than only at compile-time.~

EDIT: See latest revision - a `SetUdpPort` setter is exposed instead of making the start method w/ port public per review feedback.

This retains existing compatibility and support for the compile-time `OPENTHREAD_CONFIG_BORDER_AGENT_UDP_PORT` as the "default". Frankly, I'm not sure there's any value in its existence aside from backwards compatibility.

I did change the comment to describe the `0` value for the port as being "dynamically-assigned", which is e.g. how IANA refers to this and avoids confusion with "ephemeral mode" on the agent itself.

My plan for this is to add a `--border-agent-port` CLI flag or similar to `ot-br-posix` in a future Pull Request.

See also:
 * https://github.com/orgs/openthread/discussions/11093