### PR TITLE
[core] add destructors for `Timer`, `Tasklet`, and `MessageQueue`

### DIFF
--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -1589,6 +1589,11 @@ public:
     MessageQueue(void) { SetTail(nullptr); }
 
     /**
+     * Destructor for `MessageQueue`.
+     */
+    ~MessageQueue(void) { DequeueAndFreeAll(); }
+
+    /**
      * Returns a pointer to the first message.
      *
      * @returns A pointer to the first message.
@@ -1682,6 +1687,11 @@ public:
      * Initializes the priority queue.
      */
     PriorityQueue(void) { Clear(); }
+
+    /**
+     * Destructor for `PriorityQueue`.
+     */
+    ~PriorityQueue(void) { DequeueAndFreeAll(); }
 
     /**
      * Returns a pointer to the first message.

--- a/src/core/common/tasklet.cpp
+++ b/src/core/common/tasklet.cpp
@@ -38,6 +38,14 @@
 
 namespace ot {
 
+Tasklet::~Tasklet(void)
+{
+    if (IsPosted())
+    {
+        Get<Scheduler>().RemoveTasklet(*this);
+    }
+}
+
 void Tasklet::Post(void)
 {
     if (!IsPosted())
@@ -61,6 +69,24 @@ void Tasklet::Scheduler::PostTasklet(Tasklet &aTasklet)
         aTasklet.mNext = mTail->mNext;
         mTail->mNext   = &aTasklet;
         mTail          = &aTasklet;
+    }
+}
+
+void Tasklet::Scheduler::RemoveTasklet(Tasklet &aTasklet)
+{
+    Tasklet *prev = mTail;
+
+    while (prev->mNext != &aTasklet)
+    {
+        prev = prev->mNext;
+    }
+
+    prev->mNext    = aTasklet.mNext;
+    aTasklet.mNext = nullptr;
+
+    if (mTail == &aTasklet)
+    {
+        mTail = prev;
     }
 }
 

--- a/src/core/common/tasklet.hpp
+++ b/src/core/common/tasklet.hpp
@@ -91,6 +91,7 @@ public:
 
     private:
         void PostTasklet(Tasklet &aTasklet);
+        void RemoveTasklet(Tasklet &aTasklet);
 
         Tasklet *mTail; // A circular singly linked-list
     };
@@ -114,6 +115,11 @@ public:
         , mNext(nullptr)
     {
     }
+
+    /**
+     * Destructor for `Tasklet`.
+     */
+    ~Tasklet(void);
 
     /**
      * Puts the tasklet on the tasklet scheduler run queue.

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -257,6 +257,11 @@ public:
     }
 
     /**
+     * Destructor for `TimerMilli`
+     */
+    ~TimerMilli(void) { Stop(); }
+
+    /**
      * Schedules the timer to fire after a given delay (in milliseconds) from now.
      *
      * @param[in]  aDelay   The delay in milliseconds. It must not be longer than `kMaxDelay`.
@@ -427,6 +432,11 @@ public:
         : Timer(aInstance, aHandler)
     {
     }
+
+    /**
+     * Destructor for `TimerMicro`
+     */
+    ~TimerMicro(void) { Stop(); }
 
     /**
      * Schedules the timer to fire after a given delay (in microseconds) from now.


### PR DESCRIPTION
This commit adds destructors to the `Timer{Milli/Micro}`, `Tasklet`, and `{Message/Priority}Queue` classes.

- For the `Timer` classes, the timer is stopped, removing it from the underlying `Scheduler`.
- For `Tasklet`, a new `Scheduler::RemoveTasklet()` method is added to remove the tasklet (if `IsPosted()`) from the linked list.
- For `MessageQueue` and `PriorityQueue`, the messages in the queue are all dequeued and freed.

Adding destructors ensures that if any of these basic types are used as member variables in a more complex class that is heap-allocated, resources are properly cleaned up when the allocated object is freed.