### PR TITLE
[mle] remove redundant checks in otThreadBecomeRouter

### DIFF
--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -176,25 +176,7 @@ exit:
 
 otError otThreadBecomeRouter(otInstance *aInstance)
 {
-    Error error = kErrorInvalidState;
-
-    switch (AsCoreType(aInstance).Get<Mle::MleRouter>().GetRole())
-    {
-    case Mle::kRoleDisabled:
-    case Mle::kRoleDetached:
-        break;
-
-    case Mle::kRoleChild:
-        error = AsCoreType(aInstance).Get<Mle::MleRouter>().BecomeRouter(ThreadStatusTlv::kHaveChildIdRequest);
-        break;
-
-    case Mle::kRoleRouter:
-    case Mle::kRoleLeader:
-        error = kErrorNone;
-        break;
-    }
-
-    return error;
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().BecomeRouter(ThreadStatusTlv::kHaveChildIdRequest);
 }
 
 otError otThreadBecomeLeader(otInstance *aInstance)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -238,7 +238,7 @@ Error MleRouter::BecomeRouter(ThreadStatusTlv::Status aStatus)
     Error error = kErrorNone;
 
     VerifyOrExit(!IsDisabled(), error = kErrorInvalidState);
-    VerifyOrExit(!IsRouter(), error = kErrorNone);
+    VerifyOrExit(!IsRouter() && !IsLeader(), error = kErrorNone);
     VerifyOrExit(IsRouterEligible(), error = kErrorNotCapable);
 
     LogInfo("Attempt to become router");

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -238,7 +238,7 @@ Error MleRouter::BecomeRouter(ThreadStatusTlv::Status aStatus)
     Error error = kErrorNone;
 
     VerifyOrExit(!IsDisabled(), error = kErrorInvalidState);
-    VerifyOrExit(!IsRouter() && !IsLeader(), error = kErrorNone);
+    VerifyOrExit(!IsRouterOrLeader(), error = kErrorNone);
     VerifyOrExit(IsRouterEligible(), error = kErrorNotCapable);
 
     LogInfo("Attempt to become router");


### PR DESCRIPTION
The MleRouter::BecomeRouter already checks the device role and the API claims only return OT_ERROR_INVALID_STATE when the role is disabled.

This commit consolidates the device role check in
MleRouter::BecomeRouter.