### PR TITLE
[diag] count the number of packets that are sent succeed and failed

### DIFF
--- a/src/core/diags/README.md
+++ b/src/core/diags/README.md
@@ -345,7 +345,10 @@ Print statistics during diagnostics mode.
 ```bash
 > diag stats
 received packets: 10
-sent packets: 10
+sent success packets: 10
+sent error cca packets: 0
+sent error abort packets: 0
+sent error others packets: 0
 first received packet: rssi=-65, lqi=101
 last received packet: rssi=-64, lqi=98
 Done
@@ -417,7 +420,10 @@ Stop diagnostics mode and print statistics.
 ```bash
 > diag stop
 received packets: 10
-sent packets: 10
+sent success packets: 10
+sent error cca packets: 0
+sent error abort packets: 0
+sent error others packets: 0
 first received packet: rssi=-65, lqi=101
 last received packet: rssi=-61, lqi=98
 

--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -134,7 +134,11 @@ private:
     struct Stats : public Clearable<Stats>
     {
         uint32_t mReceivedPackets;
-        uint32_t mSentPackets;
+        uint32_t mSentSuccessPackets;
+        uint32_t mSentFailedPackets;
+        uint32_t mSentErrorCcaPackets;
+        uint32_t mSentErrorAbortPackets;
+        uint32_t mSentErrorOthersPackets;
         int8_t   mFirstRssi;
         uint8_t  mFirstLqi;
         int8_t   mLastRssi;
@@ -235,6 +239,7 @@ private:
     void Output(const char *aFormat, ...);
     void AppendErrorResult(Error aError);
     void ResetTxPacket(void);
+    void OutputStats(void);
 
     static bool IsChannelValid(uint8_t aChannel);
 

--- a/tests/scripts/expect/cli-diags.exp
+++ b/tests/scripts/expect/cli-diags.exp
@@ -68,7 +68,10 @@ sleep 2
 
 send "diag stats\n"
 expect "received packets: 0"
-expect "sent packets: 10"
+expect "sent success packets: 10"
+expect "sent error cca packets: 0"
+expect "sent error abort packets: 0"
+expect "sent error others packets: 0"
 expect "first received packet: rssi=0, lqi=0"
 expect "last received packet: rssi=0, lqi=0"
 expect_line "Done"
@@ -77,7 +80,10 @@ switch_node 1
 
 send "diag stats\n"
 expect "received packets: 10"
-expect "sent packets: 0"
+expect "sent success packets: 0"
+expect "sent error cca packets: 0"
+expect "sent error abort packets: 0"
+expect "sent error others packets: 0"
 expect "first received packet: rssi=-20, lqi=0"
 expect "last received packet: rssi=-20, lqi=0"
 expect_line "Done"
@@ -100,7 +106,10 @@ switch_node 1
 
 send "diag stats\n"
 expect -r {received packets: \d+}
-expect "sent packets: 0"
+expect "sent success packets: 0"
+expect "sent error cca packets: 0"
+expect "sent error abort packets: 0"
+expect "sent error others packets: 0"
 expect "first received packet: rssi=-20, lqi=0"
 expect "last received packet: rssi=-20, lqi=0"
 expect_line "Done"

--- a/tests/scripts/thread-cert/test_diag.py
+++ b/tests/scripts/thread-cert/test_diag.py
@@ -54,7 +54,11 @@ class TestDiag(thread_cert.TestCase):
             ('diag power', 'tx power: -10 dBm\r\n'),
             (
                 'diag stats',
-                'received packets: 0\r\nsent packets: 0\r\n'
+                'received packets: 0\r\n'
+                'sent success packets: 0\r\n'
+                'sent error cca packets: 0\r\n'
+                'sent error abort packets: 0\r\n'
+                'sent error others packets: 0\r\n'
                 'first received packet: rssi=0, lqi=0\r\n'
                 'last received packet: rssi=0, lqi=0\r\n',
             ),
@@ -76,7 +80,11 @@ class TestDiag(thread_cert.TestCase):
             ),
             (
                 'diag stop',
-                r'received packets: 0\r\nsent packets: ([1-9]\d*)\r\n'
+                'received packets: 0\r\n'
+                r'sent success packets: ([1-9]\d*)\r\n'
+                r'sent error cca packets: ([0-9]\d*)\r\n'
+                r'sent error abort packets: ([0-9]\d*)\r\n'
+                r'sent error others packets: ([0-9]\d*)\r\n'
                 'first received packet: rssi=0, lqi=0\r\n'
                 'last received packet: rssi=0, lqi=0\r\n\n'
                 r'stop diagnostics mode\r\n',

--- a/tools/cp-caps/rcp_caps_test.py
+++ b/tools/cp-caps/rcp_caps_test.py
@@ -549,7 +549,7 @@ class RcpCaps(object):
             dut_stats = self.__dut.diag_get_stats()
             ref_stats = self.__ref.diag_get_stats()
 
-            ret = dut_stats['sent_packets'] == packets and ref_stats['received_packets'] > threshold
+            ret = dut_stats['sent_success_packets'] == packets and ref_stats['received_packets'] > threshold
         else:
             ret = False
 
@@ -578,7 +578,7 @@ class RcpCaps(object):
             dut_stats = self.__dut.diag_get_stats()
             ref_stats = self.__ref.diag_get_stats()
 
-            ret = dut_stats['sent_packets'] > threshold and ref_stats['received_packets'] > threshold
+            ret = dut_stats['sent_success_packets'] > threshold and ref_stats['received_packets'] > threshold
         else:
             ret = False
 
@@ -612,7 +612,7 @@ class RcpCaps(object):
             sender_stats = sender.diag_get_stats()
             receiver_stats = receiver.diag_get_stats()
 
-            ret = sender_stats['sent_packets'] == packets and receiver_stats['received_packets'] > threshold
+            ret = sender_stats['sent_success_packets'] == packets and receiver_stats['received_packets'] > threshold
         else:
             ret = False
 

--- a/tools/otci/otci/otci.py
+++ b/tools/otci/otci/otci.py
@@ -2603,13 +2603,16 @@ class OTCI(object):
         result = {}
 
         result['received_packets'] = int(output[0].split(":")[1])
-        result['sent_packets'] = int(output[1].split(":")[1])
+        result['sent_success_packets'] = int(output[1].split(":")[1])
+        result['sent_error_cca_packets'] = int(output[2].split(":")[1])
+        result['sent_error_abort_packets'] = int(output[3].split(":")[1])
+        result['sent_error_others_packets'] = int(output[4].split(":")[1])
 
-        values = re.findall("\-?\d+", output[2])
+        values = re.findall("\-?\d+", output[5])
         result['first_received_packet_rssi'] = int(values[0])
         result['first_received_packet_lqi'] = int(values[1])
 
-        values = re.findall("\-?\d+", output[3])
+        values = re.findall("\-?\d+", output[6])
         result['last_received_packet_rssi'] = int(values[0])
         result['last_received_packet_lqi'] = int(values[1])
 


### PR DESCRIPTION
When using the `diag frame -c xxxx` command to enable the CSMA-CA for transmitting the frame, the command `diag send` won't output any message when the CCA failure happens. It is difficult for users to know whether the CSMA-CA is actually effective via diag commands.

This commit counts the number of packets that are sent succeed and failed, and do not re-transmit the frame after it fails to send.