### PR TITLE
[border-agent] track successful connection with ephemeral key

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -56,6 +56,7 @@ BorderAgent::BorderAgent(Instance &aInstance)
 #endif
 #if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
     , mUsingEphemeralKey(false)
+    , mDidConnectWithEphemeralKey(false)
     , mOldUdpPort(0)
     , mEphemeralKeyTimer(aInstance)
     , mEphemeralKeyTask(aInstance)
@@ -250,6 +251,7 @@ void BorderAgent::HandleConnected(Dtls::Session::ConnectEvent aEvent)
 #if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
         if (mUsingEphemeralKey)
         {
+            mDidConnectWithEphemeralKey = true;
             mCounters.mEpskcSecureSessionSuccesses++;
             mEphemeralKeyTask.Post();
         }
@@ -268,7 +270,10 @@ void BorderAgent::HandleConnected(Dtls::Session::ConnectEvent aEvent)
 #if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
         if (mUsingEphemeralKey)
         {
-            RestartAfterRemovingEphemeralKey();
+            if (mDidConnectWithEphemeralKey)
+            {
+                RestartAfterRemovingEphemeralKey();
+            }
 
             if (aEvent == Dtls::Session::kDisconnectedError)
             {
@@ -739,7 +744,8 @@ Error BorderAgent::SetEphemeralKey(const char *aKeyString, uint32_t aTimeout, ui
     // callbacks (like `HandleConnected()`) may be invoked from
     // `Start()` itself.
 
-    mUsingEphemeralKey = true;
+    mUsingEphemeralKey          = true;
+    mDidConnectWithEphemeralKey = false;
 
     error = Start(aUdpPort, reinterpret_cast<const uint8_t *>(aKeyString), static_cast<uint8_t>(length));
 

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -345,7 +345,8 @@ private:
     bool mIdInitialized;
 #endif
 #if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
-    bool                           mUsingEphemeralKey;
+    bool                           mUsingEphemeralKey : 1;
+    bool                           mDidConnectWithEphemeralKey : 1;
     uint16_t                       mOldUdpPort;
     EphemeralKeyTimer              mEphemeralKeyTimer;
     EphemeralKeyTask               mEphemeralKeyTask;


### PR DESCRIPTION
This commit adds a new variable, `mDidConnectWithEphemeralKey`, which tracks whether a successful secure session is established using the ephemeral key. This variable is used in `HandleConnected()` to determine whether to stop using the ephemeral key when the Border Agent is notified that the secure session is disconnected.

This change ensures that ephemeral key use is not stopped after a failed connection attempt, while still guaranteeing that an ephemeral key can only be used once.

Without this fix, a failed connection attempt would immediately stop the use of the ephemeral key. With this change, the intended `kMaxEphemeralKeyConnectionAttempts` will be applied.