### PR TITLE
[diag] add 'diag send async' command support

### DIFF
--- a/src/core/diags/README.md
+++ b/src/core/diags/README.md
@@ -14,7 +14,7 @@ The diagnostics module supports common diagnostics features that are listed belo
 - [diag stream](#diag-stream-start)
 - [diag power](#diag-power)
 - [diag powersettings](#diag-powersettings)
-- [diag send](#diag-send-packets-length)
+- [diag send](#diag-send-async-packets-length)
 - [diag repeat](#diag-repeat-delay-length)
 - [diag radio](#diag-radio-sleep)
 - [diag rawpowersetting](#diag-rawpowersetting)
@@ -166,14 +166,21 @@ RawPowerSetting: 223344
 Done
 ```
 
-### diag send \<packets\> [length]
+### diag send [async] \<packets\> [length]
 
 Transmit a fixed number of packets.
+
+- async: Use the non-blocking mode.
+- packets: The number of packets to be sent.
+- length: The length of the packet.
 
 Send the frame set by `diag frame` if length is omitted. Otherwise overwrite the frame set by `diag frame` and send a frame of the given length(MUST be in range [3, 127]).
 
 ```bash
 > diag send 20 100
+sending 0x14 packet(s), length 0x64
+Done
+> diag send async 20 100
 sending 0x14 packet(s), length 0x64
 Done
 ```

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -199,6 +199,7 @@ Diags::Diags(Instance &aInstance)
     , mTxPower(0)
     , mTxLen(0)
     , mIsTxPacketSet(false)
+    , mIsAsyncSend(false)
     , mRepeatActive(false)
     , mDiagSendOn(false)
     , mOutputCallback(nullptr)
@@ -436,6 +437,18 @@ Error Diags::ProcessSend(uint8_t aArgsLength, char *aArgs[])
 
     VerifyOrExit(aArgsLength >= 1, error = kErrorInvalidArgs);
 
+    if (StringMatch(aArgs[0], "async"))
+    {
+        aArgs++;
+        aArgsLength--;
+        VerifyOrExit(aArgsLength >= 1, error = kErrorInvalidArgs);
+        mIsAsyncSend = true;
+    }
+    else
+    {
+        mIsAsyncSend = false;
+    }
+
     SuccessOrExit(error = Utils::CmdLineParser::ParseAsUint32(aArgs[0], txPackets));
     mTxPackets = txPackets;
 
@@ -459,6 +472,11 @@ Error Diags::ProcessSend(uint8_t aArgsLength, char *aArgs[])
 
     Output("sending %#x packet(s), length %#x\r\n", static_cast<int>(mTxPackets), static_cast<int>(mTxLen));
     TransmitPacket();
+
+    if (!mIsAsyncSend)
+    {
+        error = kErrorPending;
+    }
 
 exit:
     return error;
@@ -854,6 +872,12 @@ void Diags::TransmitDone(Error aError)
         }
         else
         {
+            if (!mRepeatActive && !mIsAsyncSend)
+            {
+                mIsAsyncSend = true;
+                Output("OT_ERROR_NONE");
+            }
+
             ExitNow();
         }
     }

--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -251,6 +251,7 @@ private:
     uint8_t       mTxLen;
     bool          mIsHeaderUpdated : 1;
     bool          mIsTxPacketSet : 1;
+    bool          mIsAsyncSend : 1;
     bool          mRepeatActive : 1;
     bool          mDiagSendOn : 1;
 #endif

--- a/tests/scripts/expect/cli-diags.exp
+++ b/tests/scripts/expect/cli-diags.exp
@@ -64,8 +64,6 @@ send "diag send 10 100\n"
 expect "sending 0xa packet(s), length 0x64"
 expect_line "Done"
 
-sleep 2
-
 send "diag stats\n"
 expect "received packets: 0"
 expect "sent packets: 10"
@@ -73,10 +71,23 @@ expect "first received packet: rssi=0, lqi=0"
 expect "last received packet: rssi=0, lqi=0"
 expect_line "Done"
 
+send "diag send async 10 100\n"
+expect "sending 0xa packet(s), length 0x64"
+expect_line "Done"
+
+sleep 2
+
+send "diag stats\n"
+expect "received packets: 0"
+expect "sent packets: 20"
+expect "first received packet: rssi=0, lqi=0"
+expect "last received packet: rssi=0, lqi=0"
+expect_line "Done"
+
 switch_node 1
 
 send "diag stats\n"
-expect "received packets: 10"
+expect "received packets: 20"
 expect "sent packets: 0"
 expect "first received packet: rssi=-20, lqi=0"
 expect "last received packet: rssi=-20, lqi=0"
@@ -142,6 +153,9 @@ send "diag frame 112233445566778899001122334455667788990011223344556677889900112
 expect "Done"
 send "diag repeat 1\n"
 expect "length 0x7f"
+expect "Done"
+
+send "diag repeat stop\n"
 expect "Done"
 
 send_user "send frame with security processed\n"

--- a/tools/otci/otci/otci.py
+++ b/tools/otci/otci/otci.py
@@ -2562,12 +2562,13 @@ class OTCI(object):
         """Stop transmitting a stream of characters."""
         self.execute_command('diag stream stop')
 
-    def diag_send(self, packets: int, length: Optional[int] = None):
+    def diag_send(self, packets: int, length: Optional[int] = None, is_async: bool = True):
         """Transmit a fixed number of packets."""
-        if length is None:
-            command = f'diag send {packets}'
-        else:
-            command = f'diag send {packets} {length}'
+        command = 'diag send '
+        command += 'async ' if is_async else ''
+        command += f'{packets} '
+        command += f'{length}' if length is not None else ''
+
         self.execute_command(command)
 
     def diag_repeat(self, delay: int, length: Optional[int] = None):


### PR DESCRIPTION
The original `diag send` command is an asynchronous command. Users must wait for a certain period of time and then run the `diag stats` command to query how many packets have been sent to know whether all packets have been sent. This is very inefficient, and it is not convenient for scripts to process this command.

This commit changes the command `diag send` from an asynchronous command to a synchronous command, and add the asynchronous command `diag send async`. 