### PR TITLE
[mle] fix warning of maybe-uninitialized tlvType

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -34,6 +34,7 @@
 #include "mle.hpp"
 
 #include "instance/instance.hpp"
+#include "openthread/platform/toolchain.h"
 #include "utils/static_counter.hpp"
 
 namespace ot {
@@ -5293,6 +5294,8 @@ Error Mle::TxMessage::AppendDatasetTlv(MeshCoP::Dataset::Type aDatasetType)
         error   = Get<MeshCoP::PendingDatasetManager>().Read(dataset);
         tlvType = Tlv::kPendingDataset;
         break;
+    default:
+        OT_ASSERT(false);
     }
 
     if (error != kErrorNone)


### PR DESCRIPTION
This commit fixes the warning:
```
openthread/src/core/thread/mle.cpp: In member function 'ot::Error ot::Mle::Mle::TxMessage::AppendDatasetTlv(ot::MeshCoP::Dataset::Type)':
src/core/thread/mle.cpp:5312:27: error: 'tlvType' may be used uninitialized in this function [-Werror=maybe-uninitialized]
 5312 |     error = Tlv::AppendTlv(*this, tlvType, dataset.GetBytes(), dataset.GetLength());
      |             ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```