### PR TITLE
[wakeup] encrypt the wakeup frame in mac layer

### DIFF
--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -316,15 +316,9 @@ otError otMacFrameProcessTransmitSecurity(otRadioFrame *aFrame, otRadioContext *
     otMacKeyMaterial *key = nullptr;
     uint8_t           keyId;
     uint32_t          frameCounter;
-    bool              processKeyId;
 
-    processKeyId =
-#if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
-        otMacFrameIsKeyIdMode2(aFrame) ||
-#endif
-        otMacFrameIsKeyIdMode1(aFrame);
-
-    VerifyOrExit(otMacFrameIsSecurityEnabled(aFrame) && processKeyId && !aFrame->mInfo.mTxInfo.mIsSecurityProcessed);
+    VerifyOrExit(otMacFrameIsSecurityEnabled(aFrame) && otMacFrameIsKeyIdMode1(aFrame) &&
+                 !aFrame->mInfo.mTxInfo.mIsSecurityProcessed);
 
     if (otMacFrameIsAck(aFrame))
     {

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -924,24 +924,36 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame)
 
     case Frame::kKeyIdMode2:
     {
-        uint8_t keySource[] = {0xff, 0xff, 0xff, 0xff};
+        uint8_t            keySource[] = {0xff, 0xff, 0xff, 0xff};
+        uint8_t            keyId;
+        const KeyMaterial *macKey;
 
 #if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
         if (aFrame.IsWakeupFrame())
         {
-            // Just set the key source here, further security processing will happen in SubMac
-            BigEndian::WriteUint32(keyManager.GetCurrentKeySequence(), keySource);
-            aFrame.SetKeySource(keySource);
-            ExitNow();
+            uint32_t keySequence = keyManager.GetCurrentKeySequence();
+
+            BigEndian::WriteUint32(keySequence, keySource);
+
+            macKey     = mLinks.GetCurrentMacKey(aFrame);
+            extAddress = &GetExtAddress();
+            keyId      = static_cast<uint8_t>((keySequence & 0x7f) + 1);
         }
+        else
 #endif
-        aFrame.SetAesKey(mMode2KeyMaterial);
+        {
+            macKey     = &mMode2KeyMaterial;
+            extAddress = &AsCoreType(&sMode2ExtAddress);
+            keyId      = 0xff;
+        }
+
+        aFrame.SetAesKey(*macKey);
 
         mKeyIdMode2FrameCounter++;
         aFrame.SetFrameCounter(mKeyIdMode2FrameCounter);
         aFrame.SetKeySource(keySource);
-        aFrame.SetKeyId(0xff);
-        extAddress = &AsCoreType(&sMode2ExtAddress);
+        aFrame.SetKeyId(keyId);
+
         break;
     }
 

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -373,17 +373,7 @@ void SubMac::ProcessTransmitSecurity(void)
     }
 
     VerifyOrExit(ShouldHandleTransmitSecurity());
-
-#if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
-    if (mTransmitFrame.GetType() == Frame::kTypeMultipurpose)
-    {
-        VerifyOrExit(keyIdMode == Frame::kKeyIdMode2);
-    }
-    else
-#endif
-    {
-        VerifyOrExit(keyIdMode == Frame::kKeyIdMode1);
-    }
+    VerifyOrExit(keyIdMode == Frame::kKeyIdMode1);
 
     mTransmitFrame.SetAesKey(GetCurrentMacKey());
 


### PR DESCRIPTION
The wake-up frame is already prepared at the `Mac` layer, and the `SubMac` layer and the radio driver won't update any IE fields of wake-up frame. The current code relies on the radio driver to encrypt the wake-up frame when the `OT_RADIO_CAPS_TRANSMIT_SEC` is supported. Which requires every radio driver to change the code to support this requirement.

This commit encrypts the wake-up frame in `Mac` layer to avoid code changes in the radio driver.