### PR TITLE
[gitignore] ignore nexus unit test binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ CTestTestfile.cmake
 ot-test-*
 ot_testing/
 Testing/
+tests/nexus/nexus_*
 
 # Misc
 DartConfiguration.tcl


### PR DESCRIPTION
Ignore unit test binaries. For example, 'tests/nexus/nexus_border_agent'.