### PR TITLE
[nat64-translator] ensure expired mappings are released in timer callback

### DIFF
--- a/src/core/net/nat64_translator.cpp
+++ b/src/core/net/nat64_translator.cpp
@@ -552,8 +552,13 @@ exit:
 
 void Translator::HandleMappingExpirerTimer(void)
 {
-    LogInfo("Released %d expired mappings", ReleaseExpiredMappings());
+    uint16_t numReleased = ReleaseExpiredMappings();
+
+    LogInfo("Released %u expired mappings", numReleased);
+
     mMappingExpirerTimer.Start(kAddressMappingIdleTimeoutMsec);
+
+    OT_UNUSED_VARIABLE(numReleased);
 }
 
 void Translator::InitAddressMappingIterator(AddressMappingIterator &aIterator)


### PR DESCRIPTION
This commit fixes the release of expired mappings by ensuring that `ReleaseExpiredMappings()` is always called from the timer callback `HandleMappingExpirerTimer()`, regardless of the logging level. Previously, `ReleaseExpiredMappings()` was called as an input to `LogInfo()`, which could become an empty macro (ignoring its input) if info-level logs were disabled.

----

Thanks and credit to @marius-preda for finding and fixing this issue. This fix was originally included in #11043. We add this fix as its own smaller PR due to its importance and to allow easier cherry-picking (please see https://github.com/openthread/openthread/pull/11043#discussion_r1907869326)).