### PR TITLE
[ip-utils] extend and improve ip4/ip6 headers

### DIFF
--- a/src/core/net/ip4_types.cpp
+++ b/src/core/net/ip4_types.cpp
@@ -214,5 +214,121 @@ exit:
     return error;
 }
 
+//---------------------------------------------------------------------------------------------------------------------
+// Headers
+
+Error Headers::ParseFrom(const Message &aMessage)
+{
+    Error error = kErrorParse;
+
+    Clear();
+
+    SuccessOrExit(mIp4Header.ParseFrom(aMessage));
+
+    switch (mIp4Header.GetProtocol())
+    {
+    case kProtoUdp:
+        SuccessOrExit(aMessage.Read(sizeof(Header), mHeader.mUdp));
+        break;
+    case kProtoTcp:
+        SuccessOrExit(aMessage.Read(sizeof(Header), mHeader.mTcp));
+        break;
+    case kProtoIcmp:
+        SuccessOrExit(aMessage.Read(sizeof(Header), mHeader.mIcmp));
+        break;
+    default:
+        break;
+    }
+
+    error = kErrorNone;
+
+exit:
+    return error;
+}
+
+uint16_t Headers::GetSourcePort(void) const
+{
+    uint16_t port = 0;
+
+    switch (GetIpProto())
+    {
+    case kProtoUdp:
+        port = mHeader.mUdp.GetSourcePort();
+        break;
+
+    case kProtoTcp:
+        port = mHeader.mTcp.GetSourcePort();
+        break;
+
+    default:
+        break;
+    }
+
+    return port;
+}
+
+uint16_t Headers::GetDestinationPort(void) const
+{
+    uint16_t port = 0;
+
+    switch (GetIpProto())
+    {
+    case kProtoUdp:
+        port = mHeader.mUdp.GetDestinationPort();
+        break;
+
+    case kProtoTcp:
+        port = mHeader.mTcp.GetDestinationPort();
+        break;
+
+    default:
+        break;
+    }
+
+    return port;
+}
+
+void Headers::SetDestinationPort(uint16_t aDstPort)
+{
+    switch (GetIpProto())
+    {
+    case kProtoUdp:
+        mHeader.mUdp.SetDestinationPort(aDstPort);
+        break;
+
+    case kProtoTcp:
+        mHeader.mTcp.SetDestinationPort(aDstPort);
+        break;
+
+    default:
+        break;
+    }
+}
+
+uint16_t Headers::GetChecksum(void) const
+{
+    uint16_t checksum = 0;
+
+    switch (GetIpProto())
+    {
+    case kProtoUdp:
+        checksum = mHeader.mUdp.GetChecksum();
+        break;
+
+    case kProtoTcp:
+        checksum = mHeader.mTcp.GetChecksum();
+        break;
+
+    case kProtoIcmp:
+        checksum = mHeader.mIcmp.GetChecksum();
+        break;
+
+    default:
+        break;
+    }
+
+    return checksum;
+}
+
 } // namespace Ip4
 } // namespace ot

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1619,6 +1619,23 @@ uint16_t Headers::GetSourcePort(void) const
     return port;
 }
 
+void Headers::SetSourcePort(uint16_t aSrcPort)
+{
+    switch (GetIpProto())
+    {
+    case kProtoUdp:
+        mHeader.mUdp.SetSourcePort(aSrcPort);
+        break;
+
+    case kProtoTcp:
+        mHeader.mTcp.SetSourcePort(aSrcPort);
+        break;
+
+    default:
+        break;
+    }
+}
+
 uint16_t Headers::GetDestinationPort(void) const
 {
     uint16_t port = 0;

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -467,6 +467,20 @@ public:
     uint8_t GetIpProto(void) const { return mIp6Header.GetNextHeader(); }
 
     /**
+     * Returns the IPv6 Payload Length value.
+     *
+     * @returns The IPv6 Payload Length value.
+     */
+    uint8_t GetIpLength(void) const { return mIp6Header.GetPayloadLength(); }
+
+    /**
+     * Returns the IPv6 Hop Limit value.
+     *
+     * @returns The IPv6 Hop Limit value.
+     */
+    uint8_t GetIpHopLimit(void) const { return mIp6Header.GetHopLimit(); }
+
+    /**
      * Returns the 2-bit Explicit Congestion Notification (ECN) from Traffic Class field from IPv6 header.
      *
      * @returns The ECN value.
@@ -544,6 +558,13 @@ public:
      * @returns The source port number under UDP / TCP or zero.
      */
     uint16_t GetSourcePort(void) const;
+
+    /**
+     * Sets the source port number if the header is UDP or TCP, does nothing otherwise
+     *
+     * @param[in]  aSrcPort  The UDP / TCP source Port.
+     */
+    void SetSourcePort(uint16_t aSrcPort);
 
     /**
      * Returns the destination port number if header is UDP or TCP, or zero otherwise.

--- a/src/core/net/tcp6.hpp
+++ b/src/core/net/tcp6.hpp
@@ -534,6 +534,20 @@ public:
         uint16_t GetDestinationPort(void) const { return BigEndian::HostSwap16(mDestination); }
 
         /**
+         * Sets the TCP Source Port.
+         *
+         * @param[in]  aPort  The TCP Source Port.
+         */
+        void SetSourcePort(uint16_t aPort) { mSource = BigEndian::HostSwap16(aPort); }
+
+        /**
+         * Sets the TCP Destination Port.
+         *
+         * @param[in]  aPort  The TCP Destination Port.
+         */
+        void SetDestinationPort(uint16_t aPort) { mDestination = BigEndian::HostSwap16(aPort); }
+
+        /**
          * Returns the TCP Sequence Number.
          *
          * @returns The TCP Sequence Number.


### PR DESCRIPTION
This commit adds a new class, Ip4::Headers that offers support for
managing an IPv4 header along with UDP/TCP/ICMP4 headers from a received
message/frame. This functionality is equivalent to the one already
present for IPv6.

Added GetId() and SetId() methods to ICMP4 class.

Improved the Ip6::Headers functionality:
- added SetSourcePort() method to allow easier translation of ports in NAT64.
- added GetIpLength() and GetIpHopLimit() methods.

Added SetSourcePort() and SetDestinationPort() methods for TCP.