### PR TITLE
[link-quality] track "link quality out" in `LinkQualityInfo`

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2167,7 +2167,7 @@ exit:
 
 void Mac::UpdateNeighborLinkInfo(Neighbor &aNeighbor, const RxFrame &aRxFrame)
 {
-    LinkQuality oldLinkQuality = aNeighbor.GetLinkInfo().GetLinkQuality();
+    LinkQuality oldLinkQuality = aNeighbor.GetLinkInfo().GetLinkQualityIn();
 
     aNeighbor.GetLinkInfo().AddRss(aRxFrame.GetRssi());
 
@@ -2179,7 +2179,7 @@ void Mac::UpdateNeighborLinkInfo(Neighbor &aNeighbor, const RxFrame &aRxFrame)
     // quality gets changed.
 
     VerifyOrExit(Get<Mle::Mle>().IsChild() && (&aNeighbor == &Get<Mle::Mle>().GetParent()));
-    VerifyOrExit(aNeighbor.GetLinkInfo().GetLinkQuality() != oldLinkQuality);
+    VerifyOrExit(aNeighbor.GetLinkInfo().GetLinkQualityIn() != oldLinkQuality);
     Get<Notifier>().Signal(kEventParentLinkQualityChanged);
 
 exit:

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -130,7 +130,8 @@ void LqiAverager::Add(uint8_t aLqi)
 void LinkQualityInfo::Clear(void)
 {
     mRssAverager.Clear();
-    SetLinkQuality(kLinkQuality0);
+    SetLinkQualityIn(kLinkQuality0);
+    SetLinkQualityOut(kLinkQuality0);
     mLastRss = Radio::kInvalidRssi;
 
     mFrameErrorRate.Clear();
@@ -147,12 +148,12 @@ void LinkQualityInfo::AddRss(int8_t aRss)
 
     if (mRssAverager.HasAverage())
     {
-        oldLinkQuality = GetLinkQuality();
+        oldLinkQuality = GetLinkQualityIn();
     }
 
     SuccessOrExit(mRssAverager.Add(aRss));
 
-    SetLinkQuality(CalculateLinkQuality(GetLinkMargin(), oldLinkQuality));
+    SetLinkQualityIn(CalculateLinkQuality(GetLinkMargin(), oldLinkQuality));
 
 exit:
     return;
@@ -168,7 +169,7 @@ LinkQualityInfo::InfoString LinkQualityInfo::ToInfoString(void) const
     InfoString string;
 
     string.Append("aveRss:%s, lastRss:%d, linkQuality:%d", mRssAverager.ToString().AsCString(), GetLastRss(),
-                  GetLinkQuality());
+                  GetLinkQualityIn());
 
     return string;
 }

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -352,7 +352,7 @@ public:
      *
      * @returns The current link quality value (value 0-3 as per Thread specification).
      */
-    LinkQuality GetLinkQuality(void) const { return mLinkQuality; }
+    LinkQuality GetLinkQualityIn(void) const { return static_cast<LinkQuality>(mLinkQualityIn); }
 
     /**
      * Returns the most recent RSS value.
@@ -407,6 +407,22 @@ public:
      */
     uint16_t GetMessageErrorRate(void) const { return mMessageErrorRate.GetFailureRate(); }
 
+    /**
+     * Gets the link quality out value.
+     *
+     * This indicates the Link Quality from the perspective of the neighbor.
+     *
+     * @returns The link quality out value.
+     */
+    LinkQuality GetLinkQualityOut(void) const { return static_cast<LinkQuality>(mLinkQualityOut); }
+
+    /**
+     * Sets the link quality out value.
+     *
+     * @param[in]  aLinkQuality  The link quality out value.
+     */
+    void SetLinkQualityOut(LinkQuality aLinkQuality) { mLinkQualityOut = aLinkQuality; }
+
 private:
     // Constants for obtaining link quality from link margin:
 
@@ -422,14 +438,14 @@ private:
 
     static constexpr uint8_t kNoLinkQuality = 0xff; // Indicate that there is no previous/last link quality.
 
-    void SetLinkQuality(LinkQuality aLinkQuality) { mLinkQuality = aLinkQuality; }
+    void SetLinkQualityIn(LinkQuality aLinkQuality) { mLinkQualityIn = aLinkQuality; }
 
     static LinkQuality CalculateLinkQuality(uint8_t aLinkMargin, uint8_t aLastLinkQuality);
 
-    RssAverager mRssAverager;
-    LinkQuality mLinkQuality;
-    int8_t      mLastRss;
-
+    RssAverager        mRssAverager;
+    uint8_t            mLinkQualityIn : 2;
+    uint8_t            mLinkQualityOut : 2;
+    int8_t             mLastRss;
     SuccessRateTracker mFrameErrorRate;
     SuccessRateTracker mMessageErrorRate;
 };

--- a/src/core/thread/neighbor.hpp
+++ b/src/core/thread/neighbor.hpp
@@ -583,7 +583,7 @@ public:
      *
      * @returns The link quality in value.
      */
-    LinkQuality GetLinkQualityIn(void) const { return GetLinkInfo().GetLinkQuality(); }
+    LinkQuality GetLinkQualityIn(void) const { return GetLinkInfo().GetLinkQualityIn(); }
 
     /**
      * Generates a new challenge value for MLE Link Request/Response exchanges.

--- a/src/core/thread/router.hpp
+++ b/src/core/thread/router.hpp
@@ -130,14 +130,14 @@ public:
      *
      * @returns The link quality out value for this router.
      */
-    LinkQuality GetLinkQualityOut(void) const { return static_cast<LinkQuality>(mLinkQualityOut); }
+    LinkQuality GetLinkQualityOut(void) const { return GetLinkInfo().GetLinkQualityOut(); }
 
     /**
      * Sets the link quality out value for this router.
      *
      * @param[in]  aLinkQuality  The link quality out value for this router.
      */
-    void SetLinkQualityOut(LinkQuality aLinkQuality) { mLinkQualityOut = aLinkQuality; }
+    void SetLinkQualityOut(LinkQuality aLinkQuality) { GetLinkInfo().SetLinkQualityOut(aLinkQuality); }
 
     /**
      * Gets the two-way link quality value (minimum of link quality in and out).
@@ -216,7 +216,6 @@ private:
 
     uint8_t mNextHop;               // The next hop towards this router
     uint8_t mLinkAcceptTimeout : 2; // Timeout (in seconds) after sending Link Request waiting for Link Accept
-    uint8_t mLinkQualityOut : 2;    // The link quality out for this router (learned from received Route TLV)
 #if !OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
     uint8_t mCost : 4; // The cost to this router via neighbor router
 #else

--- a/tests/unit/test_link_quality.cpp
+++ b/tests/unit/test_link_quality.cpp
@@ -114,7 +114,7 @@ void TestLinkQualityData(RssTestData aRssData)
         PrintOutcome(linkInfo);
     }
 
-    VerifyOrQuit(linkInfo.GetLinkQuality() == aRssData.mExpectedLinkQuality);
+    VerifyOrQuit(linkInfo.GetLinkQualityIn() == aRssData.mExpectedLinkQuality);
 }
 
 // Check and verify the raw average RSS value to match the value from GetAverage().


### PR DESCRIPTION
This commit updates `LinkQualityInfo` to track the "link quality out", which is the link quality from the neighbor's perspective. This value is currently tracked by the `Router` class. The existing methods in `LinkQualityInfo` that return the "link quality in" are renamed to use `LinkQualityIn` to clarify and distinguish them.

This change uses existing bits in `LinkQualityInfo`, freeing up bit fields in the `Router` class to be used for other information.
