### PR TITLE
[style] use `constexpr` instead of anonymous `enum` for constants

### DIFF
--- a/src/cli/cli_br.hpp
+++ b/src/cli/cli_br.hpp
@@ -77,14 +77,11 @@ public:
     otError Process(Arg aArgs[]);
 
 private:
-    using Command = CommandEntry<Br>;
-
+    using Command    = CommandEntry<Br>;
     using PrefixType = uint8_t;
-    enum : PrefixType
-    {
-        kPrefixTypeLocal   = 1u << 0,
-        kPrefixTypeFavored = 1u << 1,
-    };
+
+    static constexpr PrefixType kPrefixTypeLocal   = 1u << 0;
+    static constexpr PrefixType kPrefixTypeFavored = 1u << 1;
 
     enum RouterOutputMode : uint8_t
     {

--- a/src/core/net/tcp6.hpp
+++ b/src/core/net/tcp6.hpp
@@ -360,14 +360,11 @@ public:
         friend void ::tcplp_sys_set_timer(struct tcpcb *aTcb, uint8_t aTimerFlag, uint32_t aDelay);
         friend void ::tcplp_sys_stop_timer(struct tcpcb *aTcb, uint8_t aTimerFlag);
 
-        enum : uint8_t
-        {
-            kTimerDelack       = 0,
-            kTimerRexmtPersist = 1,
-            kTimerKeep         = 2,
-            kTimer2Msl         = 3,
-            kNumTimers         = 4,
-        };
+        static constexpr uint8_t kTimerDelack       = 0;
+        static constexpr uint8_t kTimerRexmtPersist = 1;
+        static constexpr uint8_t kTimerKeep         = 2;
+        static constexpr uint8_t kTimer2Msl         = 3;
+        static constexpr uint8_t kNumTimers         = 4;
 
         static uint8_t TimerFlagToIndex(uint8_t aTimerFlag);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -4094,10 +4094,7 @@ void Mle::Log(MessageAction aAction, MessageType aType, const Ip6::Address &aAdd
 
 void Mle::Log(MessageAction aAction, MessageType aType, const Ip6::Address &aAddress, uint16_t aRloc)
 {
-    enum : uint8_t
-    {
-        kRlocStringSize = 17,
-    };
+    static constexpr uint16_t kRlocStringSize = 17;
 
     String<kRlocStringSize> rlocString;
 

--- a/src/core/utils/parse_cmdline.cpp
+++ b/src/core/utils/parse_cmdline.cpp
@@ -108,16 +108,13 @@ Error ParseAsUint32(const char *aString, uint32_t &aUint32) { return ParseUint<u
 
 Error ParseAsUint64(const char *aString, uint64_t &aUint64)
 {
+    static constexpr uint64_t kMaxHexBeforeOverflow = (0xffffffffffffffffULL / 16);
+    static constexpr uint64_t kMaxDecBeforeOverflow = (0xffffffffffffffffULL / 10);
+
     Error       error = kErrorNone;
     uint64_t    value = 0;
     const char *cur   = aString;
     bool        isHex = false;
-
-    enum : uint64_t
-    {
-        kMaxHexBeforeOverflow = (0xffffffffffffffffULL / 16),
-        kMaxDecBeforeOverflow = (0xffffffffffffffffULL / 10),
-    };
 
     VerifyOrExit(aString != nullptr, error = kErrorInvalidArgs);
 

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -802,10 +802,7 @@ protected:
     uint32_t mDroppedInboundIpFrameCounter;   // Number of dropped inbound data/IP frames.
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
-    enum : uint8_t
-    {
-        kSrpClientMaxHostAddresses = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRESSES,
-    };
+    static constexpr uint8_t kSrpClientMaxHostAddresses = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRESSES;
 
     otError EncodeSrpClientHostInfo(const otSrpClientHostInfo &aHostInfo);
     otError EncodeSrpClientServices(const otSrpClientService *aServices);

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -39,12 +39,9 @@ namespace ot {
 
 void TestMessage(void)
 {
-    enum : uint16_t
-    {
-        kMaxSize    = (kBufferSize * 3 + 24),
-        kOffsetStep = 101,
-        kLengthStep = 21,
-    };
+    static constexpr uint16_t kMaxSize    = (kBufferSize * 3 + 24);
+    static constexpr uint16_t kOffsetStep = 101;
+    static constexpr uint16_t kLengthStep = 21;
 
     Instance    *instance;
     MessagePool *messagePool;

--- a/tests/unit/test_pool.cpp
+++ b/tests/unit/test_pool.cpp
@@ -58,10 +58,7 @@ private:
     bool mInitWithInstance;
 };
 
-enum : uint16_t
-{
-    kPoolSize = 11,
-};
+constexpr uint16_t kPoolSize = 11;
 
 typedef Pool<Entry, kPoolSize> EntryPool;
 


### PR DESCRIPTION
This commit updates a few remaining places where anonymous enums were used to declare constants, replacing them with `static constexpr`.