### PR TITLE
[tcat] implement get diagnostic tlvs in command class commissioning

### DIFF
--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -37,6 +37,7 @@
 #if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
 
 #include "instance/instance.hpp"
+#include "thread/network_diagnostic.hpp"
 
 namespace ot {
 namespace MeshCoP {
@@ -408,6 +409,10 @@ Error TcatAgent::HandleSingleTlv(const Message &aIncomingMessage, Message &aOutg
             error = HandleGetActiveOperationalDataset(aOutgoingMessage, response);
             break;
 
+        case kTlvGetDiagnosticTlvs:
+            error = HandleGetDiagnosticTlvs(aIncomingMessage, aOutgoingMessage, offset, length, response);
+            break;
+
         case kTlvStartThreadInterface:
             error = HandleStartThreadInterface();
             break;
@@ -579,6 +584,65 @@ Error TcatAgent::HandleGetCommissionerCertificate(Message &aOutgoingMessage, boo
                  error = kErrorInvalidState);
     SuccessOrExit(error = Tlv::AppendTlv(aOutgoingMessage, kTlvResponseWithPayload, buf, bufLen));
     aResponse = true;
+
+exit:
+    return error;
+}
+
+Error TcatAgent::HandleGetDiagnosticTlvs(const Message &aIncomingMessage,
+                                         Message       &aOutgoingMessage,
+                                         uint16_t       aOffset,
+                                         uint16_t       aLength,
+                                         bool          &aResponse)
+{
+    Error           error = kErrorNone;
+    OffsetRange     offsetRange;
+    ot::ExtendedTlv extTlv;
+    uint16_t        initialLength;
+    uint16_t        length;
+
+    if (!CheckCommandClassAuthorizationFlags(mCommissionerAuthorizationField.mCommissioningFlags,
+                                             mDeviceAuthorizationField.mCommissioningFlags, nullptr))
+    {
+        error = kErrorRejected;
+        ExitNow();
+    }
+
+    offsetRange.Init(aOffset, aLength);
+    initialLength = aOutgoingMessage.GetLength();
+
+    // Start with extTlv to avoid the need for a temporary message buffer to calucalate reply length
+    extTlv.SetType(kTlvResponseWithPayload);
+    extTlv.SetLength(0);
+    SuccessOrExit(error = aOutgoingMessage.Append(extTlv));
+
+    error =
+        Get<NetworkDiagnostic::Server>().AppendRequestedTlvsForTcat(aIncomingMessage, aOutgoingMessage, offsetRange);
+
+    // Ensure enough message buffers are left for transmission of the result. Report error otherwise.
+    if (Get<MessagePool>().GetFreeBufferCount() < kBufferReserve)
+    {
+        error = kErrorNoBufs;
+    }
+
+    if (error != kErrorNone)
+    {
+        IgnoreError(aOutgoingMessage.SetLength(initialLength));
+        ExitNow();
+    }
+
+    length = aOutgoingMessage.GetLength() - initialLength - sizeof(extTlv);
+
+    if (length > 0)
+    {
+        extTlv.SetLength(length);
+        aOutgoingMessage.WriteBytes(initialLength, &extTlv, sizeof(extTlv));
+        aResponse = true;
+    }
+    else
+    {
+        IgnoreError(aOutgoingMessage.SetLength(initialLength));
+    }
 
 exit:
     return error;

--- a/src/core/meshcop/tcat_agent.hpp
+++ b/src/core/meshcop/tcat_agent.hpp
@@ -340,6 +340,11 @@ private:
     Error HandleSingleTlv(const Message &aIncomingMessage, Message &aOutgoingMessage);
     Error HandleSetActiveOperationalDataset(const Message &aIncomingMessage, uint16_t aOffset, uint16_t aLength);
     Error HandleGetActiveOperationalDataset(Message &aOutgoingMessage, bool &aResponse);
+    Error HandleGetDiagnosticTlvs(const Message &aIncomingMessage,
+                                  Message       &aOutgoingMessage,
+                                  uint16_t       aOffset,
+                                  uint16_t       aLength,
+                                  bool          &response);
     Error HandleDecomission(void);
     Error HandlePing(const Message &aIncomingMessage,
                      Message       &aOutgoingMessage,
@@ -383,6 +388,7 @@ private:
     static constexpr uint16_t kTcatMaxDeviceIdSize       = OT_TCAT_MAX_DEVICEID_SIZE;
     static constexpr uint16_t kInstallCodeMaxSize        = 255;
     static constexpr uint16_t kCommissionerCertMaxLength = 1024;
+    static constexpr uint16_t kBufferReserve             = 2048 / (kBufferSize - sizeof(otMessageBuffer)) + 1;
 
     JoinerPskd                       mJoinerPskd;
     const VendorInfo                *mVendorInfo;

--- a/src/core/radio/ble_secure.hpp
+++ b/src/core/radio/ble_secure.hpp
@@ -287,7 +287,8 @@ private:
     static constexpr uint8_t  kInitialMtuSize   = 23; // ATT_MTU
     static constexpr uint8_t  kGattOverhead     = 3;  // BLE GATT payload fits MTU size - 3 bytes
     static constexpr uint8_t  kPacketBufferSize = OT_BLE_ATT_MTU_MAX - kGattOverhead;
-    static constexpr uint16_t kTxBleHandle      = 0; // Characteristics Handle for TX (not used)
+    static constexpr uint16_t kTxBleHandle      = 0;   // Characteristics Handle for TX (not used)
+    static constexpr uint16_t kTlsDataMaxSize   = 800; // Maximum size of data chunks sent with mTls.Send(..)
 
     static void HandleTlsConnectEvent(MeshCoP::Tls::ConnectEvent aEvent, void *aContext);
     void        HandleTlsConnectEvent(MeshCoP::Tls::ConnectEvent aEvent);

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -52,6 +52,10 @@ namespace Utils {
 class MeshDiag;
 }
 
+namespace MeshCoP {
+class TcatAgent;
+}
+
 namespace NetworkDiagnostic {
 
 /**
@@ -71,6 +75,7 @@ class Client;
 class Server : public InstanceLocator, private NonCopyable
 {
     friend class Tmf::Agent;
+    friend class MeshCoP::TcatAgent;
     friend class Client;
 
 public:
@@ -221,6 +226,10 @@ private:
     Error AppendRequestedTlvs(const Message &aRequest, Message &aResponse);
     void  PrepareMessageInfoForDest(const Ip6::Address &aDestination, Tmf::MessageInfo &aMessageInfo) const;
 
+#if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
+    Error AppendRequestedTlvsForTcat(const Message &aRequest, Message &aResponse, OffsetRange &aOffsetRange);
+#endif
+
 #if OPENTHREAD_MTD
     void SendAnswer(const Ip6::Address &aDestination, const Message &aRequest);
 #elif OPENTHREAD_FTD
@@ -234,8 +243,14 @@ private:
     Error       AppendChildTableAsChildTlvs(Coap::Message *&aAnswer, AnswerInfo &aInfo);
     Error       AppendRouterNeighborTlvs(Coap::Message *&aAnswer, AnswerInfo &aInfo);
     Error       AppendChildTableIp6AddressList(Coap::Message *&aAnswer, AnswerInfo &aInfo);
-    Error       AppendChildIp6AddressListTlv(Coap::Message &aAnswer, const Child &aChild);
+    Error       AppendChildIp6AddressListTlv(Message &aAnswer, const Child &aChild);
     Error       AppendEnhancedRoute(Message &aMessage);
+
+#if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
+    Error       AppendChildTableAsChildTlvs(Message &aMessage);
+    Error       AppendRouterNeighborTlvs(Message &aMessage);
+    Error       AppendChildTableIp6AddressList(Message &aMessage);
+#endif
 
     static void HandleAnswerResponse(void                *aContext,
                                      otMessage           *aMessage,

--- a/tests/scripts/expect/cli-tcat-diagnostics.exp
+++ b/tests/scripts/expect/cli-tcat-diagnostics.exp
@@ -1,0 +1,98 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2025, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+source "tests/scripts/expect/_common.exp"
+source "tests/scripts/expect/_multinode.exp"
+
+spawn_node 2 "cli"
+spawn_node 1 "cli"
+setup_leader
+setup_node 2
+
+switch_node 1
+
+spawn_tcat_client_for_node 1
+
+send "diagnostic_tlvs extaddr\n"
+expect_line "\tTYPE:\tRESPONSE_W_PAYLOAD"
+expect_line "\tLEN:\t10"
+expect -re {\tVALUE:\t0x0008([0-9a-fA-F]{16})}
+
+send "diagnostic_tlvs macaddr\n"
+expect_line "\tTYPE:\tRESPONSE_W_PAYLOAD"
+expect_line "\tLEN:\t4"
+expect -re {\tVALUE:\t0x0102([0-9a-fA-F]{4})}
+
+send "diagnostic_tlvs mode timeout connectivity\n"
+expect_line "\tTYPE:\tRESPONSE_W_PAYLOAD"
+expect_line "\tLEN:\t15"
+expect -re {\tVALUE:\t0x0201([0-9a-fA-F]{2})040a([0-9a-fA-F]{20})}
+
+send "diagnostic_tlvs route64 leaderdata\n"
+expect_line "\tTYPE:\tRESPONSE_W_PAYLOAD"
+expect_line "\tLEN:\t22"
+expect -re {\tVALUE:\t0x050a([0-9a-fA-F]{20})0608([0-9a-fA-F]{16})}
+
+send "diagnostic_tlvs ipaddr\n"
+expect_line "\tTYPE:\tRESPONSE_W_PAYLOAD"
+expect -re {\tLEN:\t([0-9]{2,3})}
+expect -re {\tVALUE:\t0x08([0-9a-fA-F]{33,197})}
+
+send "diagnostic_tlvs mlecounters\n"
+expect_line "\tTYPE:\tRESPONSE_W_PAYLOAD"
+expect_line "\tLEN:\t68"
+expect -re {\tVALUE:\t0x2242([0-9a-fA-F]{132})}
+
+send "diagnostic_tlvs channelpages maxchildtimeout eui64 vendorname vendormodel vendorswversion vendorappurl\n"
+expect_line "\tTYPE:\tRESPONSE_W_PAYLOAD"
+expect_line "\tLEN:\t27"
+expect_line "\tVALUE:\t0x1101001304000000f0170818b430000000000119001a001b002300"
+
+send "diagnostic_tlvs childtable\n"
+expect_line "\tTYPE:\tRESPONSE_W_PAYLOAD"
+expect_line "\tLEN:\t5"
+expect -re {\tVALUE:\t0x1003([0-9a-fA-F]{6})}
+
+send "diagnostic_tlvs child\n"
+expect_line "\tTYPE:\tRESPONSE_W_PAYLOAD"
+expect_line "\tLEN:\t47"
+expect -re {\tVALUE:\t0x1d2b([0-9a-fA-F]{86})1d00}
+
+send "diagnostic_tlvs childipv6list routerneighbor\n"
+expect_line "\tTYPE:\tRESPONSE_W_PAYLOAD"
+expect -re {\tLEN:\t([0-9]{2})}
+expect -re {\tVALUE:\t0x1e([0-9a-fA-F]{6,69})1e001f00}
+
+dispose_tcat_client 1
+
+switch_node 1
+send "tcat stop\n"
+expect_line "Done"
+
+dispose_all

--- a/tools/tcat_ble_client/cli/base_commands.py
+++ b/tools/tcat_ble_client/cli/base_commands.py
@@ -33,6 +33,7 @@ from ble.ble_stream import BleStream
 from ble.ble_stream_secure import BleStreamSecure
 from ble import ble_scanner
 from tlv.tlv import TLV
+from tlv.diagnostic_tlv import DiagnosticTLVType
 from tlv.tcat_tlv import TcatTLVType
 from cli.command import Command, CommandResultNone, CommandResultTLV
 from dataset.dataset import ThreadDataset
@@ -384,6 +385,31 @@ class ScanCommand(Command):
             print('Secure channel not established.')
             await ble_stream.disconnect()
         return CommandResultNone()
+
+
+class DiagnosticTlvsCommand(BleCommand):
+
+    def get_log_string(self) -> str:
+        return 'Retrieving diagnostic information.'
+
+    def get_help_string(self) -> str:
+        return 'Get diagnostic TLVs from the TCAT device.'
+
+    def prepare_data(self, args, context):
+        num_args = DiagnosticTLVType.names_to_numbers(args)
+        try:
+            if not num_args:
+                raise ValueError()
+            vals = [int(x) for x in num_args]
+            tlvs = bytes(vals)
+        except ValueError:
+            print('Please provide a list of diagnostic TLV types as names or numbers')
+            print('TLV Types:')
+            for key, value in DiagnosticTLVType.get_dict().items():
+                print(f'{key} = {value},')
+            raise DataNotPrepared()
+
+        return TLV(TcatTLVType.GET_DIAGNOSTIC_TLVS.value, tlvs).to_bytes()
 
 
 class ThreadStartCommand(BleCommand):

--- a/tools/tcat_ble_client/cli/cli.py
+++ b/tools/tcat_ble_client/cli/cli.py
@@ -32,7 +32,8 @@ from ble.ble_stream_secure import BleStreamSecure
 from cli.base_commands import (DisconnectCommand, HelpCommand, HelloCommand, CommissionCommand, DecommissionCommand,
                                ExtractDatasetCommand, GetCommissionerCertificate, GetDeviceIdCommand, GetPskdHash,
                                GetExtPanIDCommand, GetNetworkNameCommand, GetProvisioningUrlCommand, PingCommand,
-                               GetRandomNumberChallenge, ThreadStateCommand, ScanCommand, PresentHash)
+                               GetRandomNumberChallenge, ThreadStateCommand, ScanCommand, PresentHash,
+                               DiagnosticTlvsCommand)
 from .tlv_commands import TlvCommand
 from cli.dataset_commands import (DatasetCommand)
 from dataset.dataset import ThreadDataset
@@ -65,6 +66,7 @@ class CLI:
             'peer_pskd_hash': GetPskdHash(),
             'tlv': TlvCommand(),
             'get_comm_cert': GetCommissionerCertificate(),
+            'diagnostic_tlvs': DiagnosticTlvsCommand()
         }
         self._context = {
             'ble_sstream': ble_sstream,

--- a/tools/tcat_ble_client/tlv/diagnostic_tlv.py
+++ b/tools/tcat_ble_client/tlv/diagnostic_tlv.py
@@ -1,5 +1,5 @@
 """
-  Copyright (c) 2024, The OpenThread Authors.
+  Copyright (c) 2025, The OpenThread Authors.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -25,35 +25,47 @@
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
 """
-from enum import Enum
 
 
-class TcatTLVType(Enum):
-    RESPONSE_W_STATUS = 0x01
-    RESPONSE_W_PAYLOAD = 0x02
-    GET_NETWORK_NAME = 0x08
-    DISCONNECT = 0x09
-    PING = 0x0A
-    GET_DEVICE_ID = 0x0B
-    GET_EXT_PAN_ID = 0x0C
-    GET_PROVISIONING_URL = 0x0D
-    PRESENT_PSKD_HASH = 0x10
-    PRESENT_PSKC_HASH = 0x11
-    PRESENT_INSTALL_CODE_HASH = 0x12
-    GET_RANDOM_NUMBER_CHALLENGE = 0x13
-    GET_PSKD_HASH = 0x14
-    ACTIVE_DATASET = 0x20
-    GET_COMMISSIONER_CERTIFICATE = 0x25
-    GET_ACTIVE_DATASET = 0x40
-    GET_DIAGNOSTIC_TLVS = 0x26
-    DECOMMISSION = 0x60
-    APPLICATION = 0x82
-    THREAD_START = 0x27
-    THREAD_STOP = 0x28
+class DiagnosticTLVType:
 
-    @classmethod
-    def from_value(cls, value: int):
-        return cls._value2member_map_.get(value)
+    def __init__(self):
+        self._tlv_dict = {
+            'extaddr': '0',
+            'macaddr': '1',
+            'mode': '2',
+            'timeout': '3',
+            'connectivity': '4',
+            'route64': '5',
+            'leaderdata': '6',
+            'networkdata': '7',
+            'ipaddr': '8',
+            'maccounters': '9',
+            'batterylevel': '14',
+            'supplyvoltage': '15',
+            'childtable': '16',
+            'channelpages': '17',
+            'maxchildtimeout': '19',
+            'eui64': '23',
+            'version': '24',
+            'vendorname': '25',
+            'vendormodel': '26',
+            'vendorswversion': '27',
+            'threadstackversion': '28',
+            'child': '29',
+            'childipv6list': '30',
+            'routerneighbor': '31',
+            'mlecounters': '34',
+            'vendorappurl': '35',
+            'channeldenylist': '36'
+        }
 
-    def to_bytes(self):
-        return bytes([self.value])
+    @staticmethod
+    def names_to_numbers(args):
+        res = DiagnosticTLVType()
+        return [x if x not in res._tlv_dict else res._tlv_dict[x] for x in args]
+
+    @staticmethod
+    def get_dict():
+        res = DiagnosticTLVType()
+        return res._tlv_dict


### PR DESCRIPTION
Adds implementation of Tcat TLV 0x26 Get Diagnostic TLVs.
It also adds support for long BleSecure messages >1280 bytes in BleSecure::Flush(void).