### PR TITLE
[border-agent] remove unnecessary state checks in `CoapDtlsSession` methods

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -610,8 +610,6 @@ Error BorderAgent::CoapDtlsSession::ForwardToLeader(const Coap::Message    &aMes
     bool                     separate = false;
     OffsetRange              offsetRange;
 
-    VerifyOrExit(Get<BorderAgent>().mState != kStateStopped);
-
     switch (aUri)
     {
     case kUriLeaderPetition:
@@ -854,8 +852,6 @@ void BorderAgent::CoapDtlsSession::HandleTmfProxyTx(Coap::Message &aMessage)
     OffsetRange               offsetRange;
     UdpEncapsulationTlvHeader udpEncapHeader;
 
-    VerifyOrExit(Get<BorderAgent>().mState != kStateStopped);
-
     SuccessOrExit(error = Tlv::FindTlvValueOffsetRange(aMessage, Tlv::kUdpEncapsulation, offsetRange));
 
     SuccessOrExit(error = aMessage.Read(offsetRange, udpEncapHeader));
@@ -888,8 +884,6 @@ void BorderAgent::CoapDtlsSession::HandleTmfRelayTx(Coap::Message &aMessage)
     Coap::Message   *message = nullptr;
     Tmf::MessageInfo messageInfo(GetInstance());
     OffsetRange      offsetRange;
-
-    VerifyOrExit(Get<BorderAgent>().mState != kStateStopped);
 
     VerifyOrExit(aMessage.IsNonConfirmablePostRequest());
 


### PR DESCRIPTION
This commit removes unnecessary Border Agent state checks in `CoapDtlsSession` methods. When the Border Agent is stopped, the DTLS transport is closed, and all associated sessions are cleared and removed.