### PR TITLE
support platform-specific way to hardware reset RCP

### DIFF
--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -34,6 +34,7 @@
 #include "spi_interface.hpp"
 
 #include "platform-posix.h"
+#include "system.hpp"
 
 #include <assert.h>
 #include <errno.h>
@@ -310,6 +311,12 @@ exit:
 
 void SpiInterface::TriggerReset(void)
 {
+    if (otSysHardwareReset() != OT_ERROR_NOT_IMPLEMENTED)
+    {
+        LogNote("Triggered platform-specific hardware reset");
+        return;
+    }
+
     // Set Reset pin to low level.
     SetGpioValue(mResetGpioValueFd, 0);
 

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -488,6 +488,8 @@ void otSysMainloopProcess(otInstance *aInstance, const otSysMainloopContext *aMa
 #endif
 }
 
+extern "C" OT_TOOL_WEAK otError otSysHardwareReset(void) { return OT_ERROR_NOT_IMPLEMENTED; }
+
 bool IsSystemDryRun(void) { return gDryRun; }
 
 #if OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE && OPENTHREAD_POSIX_CONFIG_DAEMON_CLI_ENABLE

--- a/src/posix/platform/system.hpp
+++ b/src/posix/platform/system.hpp
@@ -26,6 +26,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef OT_POSIX_PLATFORM_SYSTEM_HPP_
+#define OT_POSIX_PLATFORM_SYSTEM_HPP_
+
+#include <openthread/error.h>
+
 /**
  * @file
  * @brief
@@ -38,3 +43,14 @@
  * @returns  If the system runs in dry-run mode.
  */
 bool IsSystemDryRun(void);
+
+/**
+ * @brief Triggers a hardware reset of the radio chip.
+ *
+ * overwrite this to use platform-specific function to trigger hardware reset
+ *
+ * @returns otError OT_ERROR_NOT_IMPLEMENTED means using default implementation
+ */
+extern "C" otError otSysHardwareReset(void);
+
+#endif // OT_POSIX_PLATFORM_SYSTEM_HPP_


### PR DESCRIPTION
Added a weak function `otSysHardwareReset()`, which returns `OT_ERROR_NOT_IMPLEMENTED` directly. For each platform, a platform-specific function can be defined to overwrite.