### PR TITLE
[tcp] redefine conflicting symbols

### DIFF
--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -657,7 +657,7 @@ Error Tcp::HandleMessage(ot::Ip6::Header &aIp6Header, Message &aMessage, Message
         size_t          priorBacklog = endpoint->GetSendBufferBytes() - endpoint->GetInFlightBytes();
 
         ClearAllBytes(sig);
-        nextAction = tcp_input(ip6Header, tcpHeader, &aMessage, tp, nullptr, &sig);
+        nextAction = tcplp_input(ip6Header, tcpHeader, &aMessage, tp, nullptr, &sig);
         if (nextAction != RELOOKUP_REQUIRED)
         {
             ProcessSignals(*endpoint, priorHead, priorBacklog, sig);
@@ -673,7 +673,7 @@ Error Tcp::HandleMessage(ot::Ip6::Header &aIp6Header, Message &aMessage, Message
         struct tcpcb_listen *tpl = &listener->GetTcbListen();
 
         ClearAllBytes(sig);
-        nextAction = tcp_input(ip6Header, tcpHeader, &aMessage, nullptr, tpl, &sig);
+        nextAction = tcplp_input(ip6Header, tcpHeader, &aMessage, nullptr, tpl, &sig);
         OT_ASSERT(nextAction != RELOOKUP_REQUIRED);
         if (sig.accepted_connection != nullptr)
         {

--- a/third_party/tcplp/bsdtcp/tcp.h
+++ b/third_party/tcplp/bsdtcp/tcp.h
@@ -140,8 +140,8 @@ struct tcphdr {
  *
  * We use explicit numerical definition here to avoid header pollution.
  */
-#define	TCP_MSS		536
-#define	TCP6_MSS	1220
+#define	TCP_MAXSS   536
+#define	TCP6_MAXSS  1220
 
 /*
  * Limit the lowest MSS we accept for path MTU discovery and the TCP SYN MSS

--- a/third_party/tcplp/bsdtcp/tcp_fsm.h
+++ b/third_party/tcplp/bsdtcp/tcp_fsm.h
@@ -80,7 +80,7 @@
 #define	TCPS_HAVERCVDFIN(s)	((s) >= TCPS_TIME_WAIT)
 
  /*
- * Flags used when sending segments in tcp_output.  Basic flags (TH_RST,
+ * Flags used when sending segments in tcplp_output.  Basic flags (TH_RST,
  * TH_ACK,TH_SYN,TH_FIN) are totally determined by state, with the proviso
  * that TH_FIN is sent only if all data queued for output is included in the
  * segment.

--- a/third_party/tcplp/bsdtcp/tcp_output.c
+++ b/third_party/tcplp/bsdtcp/tcp_output.c
@@ -97,7 +97,7 @@ tcp_setpersist(struct tcpcb *tp)
  * Tcp output routine: figure out what should be sent and send it.
  */
 int
-tcp_output(struct tcpcb *tp)
+tcplp_output(struct tcpcb *tp)
 {
 	/*
 	 * samkumar: The biggest change in this function is in how outgoing
@@ -181,7 +181,7 @@ again:
 	 * to send out new data (when sendalot is 1), bypass this function.
 	 * If we retransmit in fast recovery mode, decrement snd_cwnd, since
 	 * we're replacing a (future) new transmission with a retransmission
-	 * now, and we previously incremented snd_cwnd in tcp_input().
+	 * now, and we previously incremented snd_cwnd in tcplp_input().
 	 */
 	/*
 	 * Still in sack recovery , reset rxmit flag to zero.
@@ -647,7 +647,7 @@ dontupdate:
 	    ((tp->t_flags & TF_SENTFIN) == 0 || tp->snd_nxt == tp->snd_una))
 		goto send;
 	/*
-	 * In SACK, it is possible for tcp_output to fail to send a segment
+	 * In SACK, it is possible for tcplp_output to fail to send a segment
 	 * after the retransmission timer has been turned off.  Make sure
 	 * that the retransmission timer is set.
 	 */
@@ -1048,9 +1048,9 @@ send:
 	}
 
 	/*
-	 * samkumar: Make tcp_output reply with ECE flag in the SYN-ACK for
+	 * samkumar: Make tcplp_output reply with ECE flag in the SYN-ACK for
 	 * ECN-enabled connections. The existing code in FreeBSD didn't have to do
-	 * this, because it didn't use tcp_output to send the SYN-ACK; it
+	 * this, because it didn't use tcplp_output to send the SYN-ACK; it
 	 * constructed the SYN-ACK segment manually. Yet another consequnce of
 	 * removing the SYN cache...
 	 */
@@ -1282,7 +1282,7 @@ timer:
 			 * 3) A -> B: ACK for #2, 0 len packet
 			 *
 			 * In this case, A will not activate the persist timer,
-			 * because it chose to send a packet. Unless tcp_output
+			 * because it chose to send a packet. Unless tcplp_output
 			 * is called for some other reason (delayed ack timer,
 			 * another input packet from B, socket syscall), A will
 			 * not send zero window probes.

--- a/third_party/tcplp/bsdtcp/tcp_reass.c
+++ b/third_party/tcplp/bsdtcp/tcp_reass.c
@@ -46,7 +46,7 @@
  * reassembly buffer. I have kept the original code as a comment below this
  * function, for reference.
  *
- * Looking at the usage of this function in tcp_input, this just has to set
+ * Looking at the usage of this function in tcplp_input, this just has to set
  * *tlenp to 0 if the received segment is already completely buffered; it does
  * not need to update it if only part of the segment is trimmed off.
  */

--- a/third_party/tcplp/bsdtcp/tcp_sack.c
+++ b/third_party/tcplp/bsdtcp/tcp_sack.c
@@ -561,7 +561,7 @@ tcp_sack_partialack(struct tcpcb *tp, struct tcphdr *th)
 	if (tp->snd_cwnd > tp->snd_ssthresh)
 		tp->snd_cwnd = tp->snd_ssthresh;
 	tp->t_flags |= TF_ACKNOW;
-	(void) tcp_output(tp);
+	(void) tcplp_output(tp);
 }
 
 /*

--- a/third_party/tcplp/bsdtcp/tcp_subr.c
+++ b/third_party/tcplp/bsdtcp/tcp_subr.c
@@ -179,7 +179,7 @@ tcp_discardcb(struct tcpcb *tp)
  * needed for TCP.
  */
 struct tcpcb *
-tcp_close(struct tcpcb *tp)
+tcp_close_tcb(struct tcpcb *tp)
 {
 	/* samkumar: Eliminate the TFO pending counter. */
 	/*
@@ -353,11 +353,11 @@ tcp_drop(struct tcpcb *tp, int errnum)
 {
 	if (TCPS_HAVERCVDSYN(tp->t_state)) {
 		tcp_state_change(tp, TCPS_CLOSED);
-		(void) tcp_output(tp);
+		(void) tcplp_output(tp);
 	}
 	if (errnum == ETIMEDOUT && tp->t_softerror)
 		errnum = tp->t_softerror;
-	tp = tcp_close(tp);
+	tp = tcp_close_tcb(tp);
 	tcplp_sys_connection_lost(tp, errnum);
 	return tp;
 }

--- a/third_party/tcplp/bsdtcp/tcp_timewait.c
+++ b/third_party/tcplp/bsdtcp/tcp_timewait.c
@@ -212,7 +212,7 @@ tcp_twstart(struct tcpcb *tp)
 			error = in_localip(inp->inp_faddr);
 #endif
 		if (error) {
-			tp = tcp_close(tp);
+			tp = tcp_close_tcb(tp);
 			if (tp != NULL)
 				INP_WUNLOCK(inp);
 			return;
@@ -364,7 +364,7 @@ tcp_twcheck(struct tcpcb* tp, struct tcphdr *th, int tlen)
 		 * do it as below since TCPlp represents TIME-WAIT connects as
 		 * struct tcpcb's.
 		 */
-		tcp_close(tp);
+		tcp_close_tcb(tp);
 		tcplp_sys_connection_lost(tp, CONN_LOST_NORMAL);
 		return (1);
 	}

--- a/third_party/tcplp/bsdtcp/tcp_var.h
+++ b/third_party/tcplp/bsdtcp/tcp_var.h
@@ -381,10 +381,9 @@ void initialize_tcb(struct tcpcb* tp);
 
 /* Copied from the "dead" portions below. */
 
-void	 tcp_init(void);
 void	 tcp_state_change(struct tcpcb *, int);
 tcp_seq tcp_new_isn(struct tcpcb *);
-struct tcpcb *tcp_close(struct tcpcb *);
+struct tcpcb *tcp_close_tcb(struct tcpcb *);
 struct tcpcb *tcp_drop(struct tcpcb *, int);
 void
 tcp_respond(struct tcpcb *tp, otInstance* instance, struct ip6_hdr* ip6gen, struct tcphdr *thgen,
@@ -483,7 +482,7 @@ void tcp_usr_abort(struct tcpcb* tp);
 
 /*
  * Structure to hold TCP options that are only used during segment
- * processing (in tcp_input), but not held in the tcpcb.
+ * processing (in tcplp_input), but not held in the tcpcb.
  * It's basically used to reduce the number of parameters
  * to tcp_dooptions and tcp_addoptions.
  * The binary order of the to_flags is relevant for packing of the
@@ -596,9 +595,9 @@ void	 tcp_twclose(struct tcpcb*, int);
 int	 tcp_twcheck(struct tcpcb*, struct tcphdr *, int);
 void tcp_dropwithreset(struct ip6_hdr* ip6, struct tcphdr *th, struct tcpcb *tp, otInstance* instance,
     int tlen, int rstreason);
-int tcp_input(struct ip6_hdr* ip6, struct tcphdr* th, otMessage* msg, struct tcpcb* tp, struct tcpcb_listen* tpl,
+int tcplp_input(struct ip6_hdr* ip6, struct tcphdr* th, otMessage* msg, struct tcpcb* tp, struct tcpcb_listen* tpl,
           struct tcplp_signals* sig);
-int	 tcp_output(struct tcpcb *);
+int	 tcplp_output(struct tcpcb *);
 void tcpip_maketemplate(struct tcpcb *, struct tcptemp*);
 void	 tcpip_fillheaders(struct tcpcb *, otMessageInfo *, void *);
 uint64_t	 tcp_maxmtu6(struct tcpcb*, struct tcp_ifcap *);


### PR DESCRIPTION
This commit redefines tcplp symbols that conflict with LWIP's TCP implementation:
- tcp_input has been renamed tcplp_input
- tcp_output has be renamed tcplp_output
- tcp_close has been renamed tcp_close_tcb
- tcp_init was already removed but the prototype was still present and was deleted
- TCP_MSS and TCP6_MSS have been renamed to TCP_MAXSS and TCP6_MAXS

This PR fixes issue #10926