### PR TITLE
[api] adds new APIs for Border Agent MeshCoP service publishing

### DIFF
--- a/include/openthread/border_agent.h
+++ b/include/openthread/border_agent.h
@@ -327,6 +327,59 @@ void otBorderAgentSetEphemeralKeyCallback(otInstance                       *aIns
 void otBorderAgentDisconnect(otInstance *aInstance);
 
 /**
+ * Enables/Disables the MeshCoP service publisher.
+ *
+ * Requires `OPENTHREAD_CONFIG_PLATFORM_DNSSD_ENABLE`.
+ *
+ * When this is enabled and the state of platform Dnssd is ready, the MeshCoP service will be published. When this is
+ * disabled, the existing MeshCoP service will be unpublished. By default, the service publisher is disabled.
+ *
+ * @param[in] aInstance     The OpenThread instance.
+ * @param[in] aIsEnabled    Whether to enable the service publisher.
+ */
+void otBorderAgentSetServicePublisherEnabled(otInstance *aInstance, bool aIsEnabled);
+
+/**
+ * Defines the vendor TXT entry in the MeshCoP service.
+ */
+typedef struct otBorderAgentVendorTxtEntry
+{
+    const char    *mKey;    ///< A pointer to the key.
+    const uint8_t *mValue;  ///< A pointer to the value.
+    uint16_t       mLength; ///< The length of the value.
+} otBorderAgentVendorTxtEntry;
+
+/**
+ * Sets the value of the MeshCoP service.
+ *
+ * Requires `OPENTHREAD_CONFIG_PLATFORM_DNSSD_ENABLE`.
+ *
+ * This method allows the user to set the values displayed in the MeshCoP service, including the basic service instance
+ * name, the product name and vendor specific values like "vn" (vendor name) or "vo" (vendor oui).
+ *
+ * This API allows the user to only set part of the values while keeping other values unchanged by passing a nullptr in
+ * the parameter. For example, passing nullptr to @p aBaseServiceInstanceName and @p aProductName and a valid pointer
+ * to @p aVendorTxtEntries will only update the vendor TXT entries.
+ *
+ * The key of any vendor TXT entries MUST start with 'v'. And the value length of key "vo" MUST be 3. The total length
+ * of the encoded vendor txt entries SHALL NOT exceed 256 bytes.
+ *
+ * @param[in] aInstance                   The OpenThread instance.
+ * @param[in] aBaseServiceInstanceName    A pointer to the basic service instance name.
+ * @param[in] aProductName                A pointer to the product name.
+ * @param[in] aVendorTxtEntries           A pointer to the array of the vendor TXT entries.
+ * @param[in] aLength                     Then length of the vendor TXT entries.
+ *
+ * @retval OT_ERROR_NONE            If successfully set the MeshCoP Service values.
+ * @retval OT_ERROR_INVALID_ARGS    Some parameters passed are invalid.
+ * @retval OT_ERROR_NO_BUFS         The vendor TXT entries passed are too long.
+ */
+otError otBorderAgentSetMeshCopServiceValues(otInstance                        *aInstance,
+                                             const char                        *aBaseServiceInstanceName,
+                                             const char                        *aProductName,
+                                             const otBorderAgentVendorTxtEntry *aVendorTxtEntries,
+                                             uint8_t                            aLength);
+/**
  * @}
  */
 

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (471)
+#define OPENTHREAD_API_VERSION (472)
 
 /**
  * @addtogroup api-instance


### PR DESCRIPTION
This PR adds OT APIs to enable/disable the MeshCoP Service Publisher and the values of the MeshCoP service.

This PR is part of the effort to move the BorderAgent MeshCoP Service Publisher into OT core: https://github.com/openthread/ot-br-posix/issues/2658

This PR only defines the APIs and doesn't implement them. 

There are a few key considerations why the API is designed in this way and a little different from the [method](https://github.com/openthread/ot-br-posix/blob/main/src/border_agent/border_agent.hpp#L112) in ot-br-posix to set the MeshCoP values.
```
    /**
     * ot-br-posix method
     */
    otbrError SetMeshCopServiceValues(const std::string              &aServiceInstanceName,
                                      const std::string              &aProductName,
                                      const std::string              &aVendorName,
                                      const std::vector<uint8_t>     &aVendorOui             = {},
                                      const Mdns::Publisher::TxtList &aNonStandardTxtEntries = {});

     /**
      * new OT API
      */
    typedef struct otBorderAgentVendorTxtEntry
    {
        const char    *mKey;    ///< A pointer to the key.
        const uint8_t *mValue;  ///< A pointer to the value.
        uint16_t       mLength; ///< The length of the value.
    } otBorderAgentVendorTxtEntry;

    otError otBorderAgentSetMeshCopServiceValues(otInstance                        *aInstance,
                                                 const char                        *aBaseServiceInstanceName,
                                                 const char                        *aProductName,
                                                 const otBorderAgentVendorTxtEntry *aVendorTxtEntries,
                                                 uint8_t                            aLength);
```
* The vendor name and vendor oui are removed from the parameters and should be set via `aVendorTxtEntries` together with other vendor txt entries. This helps avoiding the override issue. In this way, we are sure that the txt entry key passed in `aVendorTxtEntries` won't conflict with the existing keys in the service. The vendor should ensure that there are no duplicate keys in `aVendorTxtEntries`. But unless delibrately, it's not possible to have duplicate keys when defining a list of Vendor Txt entries. Otherwise, the implementation to check conflict entry keys would be complex and cost many resources in OT core.
* By having this new API, we can still have a default VENDOR_NAME in openthread. Even this API is not called, the service can still be published using the default VENDOR_NAME.
* The new API allows to only set part of the values by passing `nullptr` to parameters that we don't want to change. This makes it easier to implement the existing DBUS method in ot-br-posix that only changes the vendor txt entries.