### PR TITLE
[diag] correct usage of "diag frame"

### DIFF
--- a/src/core/diags/README.md
+++ b/src/core/diags/README.md
@@ -93,7 +93,7 @@ Set the frame (hex encoded) to be used by `diag send` and `diag repeat`. The fra
 - Specify `-u` to specify the `mInfo.mTxInfo.mIsHeaderUpdated` field for this frame.
 
 ```bash
-> diag frame 11223344
+> diag frame 0200ffc0ba
 Done
 ```
 


### PR DESCRIPTION
The example for the "diag frame" command uses an invalid 802.15.4 frame while not bypassing the header and security processing with "-s" flag.
In such a case, it cannot be guaranteed that the underlying platform will send such a frame if it can't parse the frame IEs to check if any dynamic data is to be injected.

Switch to using a correct ACK frame.