### PR TITLE
[srp-server] add new `otSrpServerAddressMode` for faster start up

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (479)
+#define OPENTHREAD_API_VERSION (480)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/srp_server.h
+++ b/include/openthread/srp_server.h
@@ -84,11 +84,17 @@ typedef enum
  *
  * Address mode specifies how the address and port number are determined by the SRP server and how this info is
  * published in the Thread Network Data.
+ *
+ * @warning Using the `OT_SRP_SERVER_ADDRESS_MODE_UNICAST_FORCE_ADD` option will make the implementation
+ * non-compliant with the Thread specification. This option is intended for testing and specific use-cases.
+ * When selected, the SRP server, upon being enabled, will bypass the Network Data publisher and always add the
+ * "SRP/DNS unicast" entry directly to the Network Data, regardless of how many other similar entries are present.
  */
 typedef enum otSrpServerAddressMode
 {
-    OT_SRP_SERVER_ADDRESS_MODE_UNICAST = 0, ///< Unicast address mode.
-    OT_SRP_SERVER_ADDRESS_MODE_ANYCAST = 1, ///< Anycast address mode.
+    OT_SRP_SERVER_ADDRESS_MODE_UNICAST           = 0, ///< Unicast address mode. Use Network Data publisher.
+    OT_SRP_SERVER_ADDRESS_MODE_ANYCAST           = 1, ///< Anycast address mode. Use Network Data publisher
+    OT_SRP_SERVER_ADDRESS_MODE_UNICAST_FORCE_ADD = 2, ///< Unicast address mode. Immediately force add to Network Data.
 } otSrpServerAddressMode;
 
 /**

--- a/src/cli/cli_srp_server.cpp
+++ b/src/cli/cli_srp_server.cpp
@@ -54,7 +54,7 @@ namespace Cli {
  * anycast
  * Done
  * @endcode
- * @cparam srp server addrmode [@ca{anycast}|@ca{unicast}]
+ * @cparam srp server addrmode [@ca{anycast}|@ca{unicast}|@ca{unicast-force-add}]
  * @par
  * Gets or sets the address mode used by the SRP server.
  * @par
@@ -78,6 +78,10 @@ template <> otError SrpServer::Process<Cmd("addrmode")>(Arg aArgs[])
         case OT_SRP_SERVER_ADDRESS_MODE_ANYCAST:
             OutputLine("anycast");
             break;
+
+        case OT_SRP_SERVER_ADDRESS_MODE_UNICAST_FORCE_ADD:
+            OutputLine("unicast-force-add");
+            break;
         }
 
         error = OT_ERROR_NONE;
@@ -89,6 +93,10 @@ template <> otError SrpServer::Process<Cmd("addrmode")>(Arg aArgs[])
     else if (aArgs[0] == "anycast")
     {
         error = otSrpServerSetAddressMode(GetInstancePtr(), OT_SRP_SERVER_ADDRESS_MODE_ANYCAST);
+    }
+    else if (aArgs[0] == "unicast-force-add")
+    {
+        error = otSrpServerSetAddressMode(GetInstancePtr(), OT_SRP_SERVER_ADDRESS_MODE_UNICAST_FORCE_ADD);
     }
 
     return error;

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -159,8 +159,9 @@ public:
      */
     enum AddressMode : uint8_t
     {
-        kAddressModeUnicast = OT_SRP_SERVER_ADDRESS_MODE_UNICAST, ///< Unicast address mode.
-        kAddressModeAnycast = OT_SRP_SERVER_ADDRESS_MODE_ANYCAST, ///< Anycast address mode.
+        kAddressModeUnicast         = OT_SRP_SERVER_ADDRESS_MODE_UNICAST,          ///< Unicast mode with publisher.
+        kAddressModeAnycast         = OT_SRP_SERVER_ADDRESS_MODE_ANYCAST,          ///< Anycast mode with publisher.
+        kAddressModeUnicastForceAdd = OT_SRP_SERVER_ADDRESS_MODE_UNICAST_FORCE_ADD ///< Unicast - force add.
     };
 
     class Host;

--- a/tests/toranj/cli/cli.py
+++ b/tests/toranj/cli/cli.py
@@ -676,7 +676,8 @@ class Node(object):
         return self._cli_single_output('srp server state', expected_outputs=['disabled', 'running', 'stopped'])
 
     def srp_server_get_addr_mode(self):
-        return self._cli_single_output('srp server addrmode', expected_outputs=['unicast', 'anycast'])
+        return self._cli_single_output('srp server addrmode',
+                                       expected_outputs=['unicast', 'anycast', 'unicast-force-add'])
 
     def srp_server_set_addr_mode(self, mode):
         self._cli_no_output('srp server addrmode', mode)


### PR DESCRIPTION
This commit adds a new option in `otSrpServerAddressMode` as `OT_SRP_SERVER_ADDRESS_MODE_UNICAST_FORCE_ADD`. This allows faster SRP server start up by bypassing the Network Data publisher and adding the "SRP/DNS unicast" entry directly to Network Data upon enabling of the SRP server, regardless of how many other similar entries are present.

This option is intended for testing and specific situations. A warning is added to indicate that using this option will make the device non-compliant with the Thread specification.

The unit test `test_srp_server` is updated with a new test case to validate the new `AddressMode` and its related behavior.