### PR TITLE
[diag] go back to sleep after transmission

### DIFF
--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -259,6 +259,7 @@ private:
     bool          mIsAsyncSend : 1;
     bool          mRepeatActive : 1;
     bool          mDiagSendOn : 1;
+    bool          mIsSleepOn : 1;
 #endif
 
     ReceiveConfig        mReceiveConfig;


### PR DESCRIPTION
When "diag radio sleep" is followed by "diag send" or "diag repeat", the radio switches to and stays in the receive mode after a transmission. Normally, the MAC layer is responsible for putting the radio back to sleep but the MAC layer is  bypassed when using the diag commands.

Make sure that the radio goes back to sleep after a transmission when the sleep mode is on. This helps command like "diag repeat" work more reliably as the transmission is less likely to be interferred with the accidental frame reception.