### PR TITLE
[diag] do not allow running `diag send` and `diag repeat` concurrently

### DIFF
--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -240,12 +240,20 @@ private:
     void Output(const char *aFormat, ...);
     void ResetTxPacket(void);
     void OutputStats(void);
+    void UpdateTxStats(Error aError);
 
     static bool IsChannelValid(uint8_t aChannel);
 
     static const struct Command sCommands[];
 
 #if OPENTHREAD_FTD || OPENTHREAD_MTD || (OPENTHREAD_RADIO && OPENTHREAD_RADIO_CLI)
+    enum TxCmd : uint8_t
+    {
+        kTxCmdNone,
+        kTxCmdRepeat,
+        kTxCmdSend,
+    };
+
     Stats mStats;
 
     otRadioFrame *mTxPacket;
@@ -254,10 +262,10 @@ private:
     uint8_t       mChannel;
     int8_t        mTxPower;
     uint8_t       mTxLen;
+    TxCmd         mCurTxCmd;
     bool          mIsHeaderUpdated : 1;
     bool          mIsTxPacketSet : 1;
     bool          mIsAsyncSend : 1;
-    bool          mRepeatActive : 1;
     bool          mDiagSendOn : 1;
     bool          mIsSleepOn : 1;
 #endif

--- a/tests/scripts/expect/cli-diags.exp
+++ b/tests/scripts/expect/cli-diags.exp
@@ -158,6 +158,18 @@ expect_line "Done"
 send "diag radio receive\n"
 expect_line "Done"
 
+send "diag repeat 100 100\n"
+expect "Done"
+
+send "diag send 1 10\n"
+expect "Error 13: InvalidState"
+
+send "diag repeat stop\n"
+expect "Done"
+
+send "diag send 1 10\n"
+expect "Done"
+
 send_user "shortest frame test\n"
 send "diag frame 112233\n"
 expect "Done"


### PR DESCRIPTION
The current diag module allows users running the 'diag send' and 'diag repeat' concurrently. The command run later will change the settings of the command run earlier, which will cause unexpected test results.

This commit does not allow running 'diag send' and 'diag repeat' concurrently.