### PR TITLE
[pd] update of PD prefix deprecation strategy

### DIFF
--- a/include/openthread/platform/border_routing.h
+++ b/include/openthread/platform/border_routing.h
@@ -71,8 +71,12 @@ extern void otPlatBorderRoutingProcessIcmp6Ra(otInstance *aInstance, const uint8
  *
  * The prefix lifetime can be updated by calling the function again with updated time values.
  * If the preferred lifetime of the prefix is set to 0, the prefix becomes deprecated.
- * When this function is called multiple times, the smallest prefix is preferred as this rule allows
- * choosing a GUA instead of a ULA.
+ * When multiple prefixes are available, one is selected based on the following
+ * rules:
+ *
+ * 1. A GUA prefix is always preferred over a ULA prefix.
+ * 2. Among prefixes of the same type (GUA or ULA), the one with the most recent
+ *    update time is preferred.
  *
  * Requires `OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE`.
  *

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -4180,6 +4180,13 @@ bool RoutingManager::PdPrefixManager::PrefixEntry::IsValidPdPrefix(void) const
            !GetPrefix().IsMulticast();
 }
 
+bool RoutingManager::PdPrefixManager::PrefixEntry::IsValidGUAPrefix(void) const
+{
+    // Check if the prefix falls within the GUA range (2000::/3).
+
+    return (GetPrefix().mPrefix.mFields.m16[0] >= 0x2000) && (GetPrefix().mPrefix.mFields.m16[0] <= 0x3fff);
+}
+
 bool RoutingManager::PdPrefixManager::PrefixEntry::IsFavoredOver(const PrefixEntry &aOther) const
 {
     bool isFavored;
@@ -4199,9 +4206,16 @@ bool RoutingManager::PdPrefixManager::PrefixEntry::IsFavoredOver(const PrefixEnt
         ExitNow();
     }
 
-    // Numerically smaller prefix is favored.
-
-    isFavored = GetPrefix() < aOther.GetPrefix();
+    // If one is GUA prefix and the other is ULA prefix, GUA is always favored;
+    // otherwise, the new prefix is favored
+    if (IsValidGUAPrefix() != aOther.IsValidGUAPrefix())
+    {
+        isFavored = GetPrefix() < aOther.GetPrefix();
+    }
+    else
+    {
+        isFavored = GetLastUpdateTime() > aOther.GetLastUpdateTime();
+    }
 
 exit:
     return isFavored;

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1489,6 +1489,7 @@ private:
             PrefixEntry(void) { Clear(); }
             bool IsEmpty(void) const { return (GetPrefix().GetLength() == 0); }
             bool IsValidPdPrefix(void) const;
+            bool IsValidGUAPrefix(void) const;
             bool IsFavoredOver(const PrefixEntry &aOther) const;
         };
 


### PR DESCRIPTION
This PR implements a new PD prefix deprecation strategy in the RoutingManager based on the following rules:

GUA Prioritization: GUA prefixes are always preferred over ULA prefixes.

Recency: Among prefixes of the same type (GUA or ULA), the most recently updated prefix is preferred.

The strategy change is to align with Thread 1.4.0 Section 9.6.1.3
```
If an OMR prefix obtained by DHCPv6-PD becomes deprecated for any reason (for example, if the preferred lifetime of the prefix expires, or if the DHCPv6 server does not include the prefix in response to a Renew request), the BR MUST either withdraw this OMR prefix from the Thread Network Data or mark it as deprecated by setting the P_preferred flag for the prefix to 'false'.
```