### PR TITLE
[cli] update default bind interface

### DIFF
--- a/src/cli/README_UDP.md
+++ b/src/cli/README_UDP.md
@@ -68,11 +68,14 @@ Done
 Assigns a name (i.e. IPv6 address and port) to the example socket.
 
 - netif: the network interface to bind to.
-  - not specified: Thread network interface.
+  - not specified: Thread stack network interface.
   - `-u`: unspecified network interface.
   - `-b`: Backbone network interface.
+  - `-h`: Host Thread network interface.
 - ip: the unicast IPv6 address or the unspecified IPv6 address (`::`).
 - port: the UDP port
+
+> Note: the netif parameter values (-u, -b, -h) are only valid if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE is set.
 
 ```bash
 > udp bind :: 1234
@@ -80,6 +83,8 @@ Done
 > udp bind -u :: 1234
 Done
 > udp bind -b :: 1234
+Done
+> udp bind -h :: 1234
 Done
 ```
 

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -64,12 +64,17 @@ UdpExample::UdpExample(otInstance *aInstance, OutputImplementer &aOutputImplemen
  * udp bind -b :: 1234
  * Done
  * @endcode
+ * @code
+ * udp bind -h :: 1234
+ * Done
+ * @endcode
  * @cparam udp bind [@ca{netif}] @ca{ip} @ca{port}
  * - `netif`: The binding network interface, which is determined as follows:
- *   - No value (leaving out this parameter from the command): Thread network interface is used.
- *   - `-u`: Unspecified network interface, which means that the UDP/IPv6 stack determines which
- *   network interface to bind the socket to.
- *   - `-b`: Backbone network interface is used.
+ *   - No value (leaving out this parameter from the command): Thread stack network interface is used.
+ *   - `-u`: Unspecified network interface, which means that the Host UDP/IPv6 stack determines which
+ *   network interface to bind the socket to. Valid if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE is set.
+ *   - `-b`: Backbone network interface is used. Valid if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE is set.
+ *   - `-h`: Host Thread network interface is used. Valid if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE is set.
  * - `ip`: Unicast IPv6 address to bind to. If you wish to have the UDP/IPv6 stack assign the binding
  *   IPv6 address, or if you wish to bind to multicast IPv6 addresses, then you can use the following
  *   value to use the unspecified IPv6 address: `::`. Each example uses the unspecified IPv6 address.
@@ -83,7 +88,7 @@ template <> otError UdpExample::Process<Cmd("bind")>(Arg aArgs[])
 {
     otError           error;
     otSockAddr        sockaddr;
-    otNetifIdentifier netif = OT_NETIF_THREAD_HOST;
+    otNetifIdentifier netif = OT_NETIF_THREAD_INTERNAL;
 
     if (aArgs[0] == "-u")
     {
@@ -93,6 +98,11 @@ template <> otError UdpExample::Process<Cmd("bind")>(Arg aArgs[])
     else if (aArgs[0] == "-b")
     {
         netif = OT_NETIF_BACKBONE;
+        aArgs++;
+    }
+    else if (aArgs[0] == "-h")
+    {
+        netif = OT_NETIF_THREAD_HOST;
         aArgs++;
     }
 


### PR DESCRIPTION
This commit updates the default CLI bind interface to be consistent with the description. The default behavior should apply to all Thread nodes, not just devices that define UDP platform layer. For Thread nodes that only use the Open Thread Stack, netif type OT_NETIF_THREAD_HOST has no meaning.

Support for OT_NETIF_THREAD_HOST has been kept using the -h option.

Updated the CLI bind command readme to make it clear when the netif options are valid and what is the default behavior.