### PR TITLE
[core] replace `#if !OPENTHREAD_RADIO` with explicit FTD or MTD check

### DIFF
--- a/src/core/common/random.cpp
+++ b/src/core/common/random.cpp
@@ -52,7 +52,7 @@ Manager::Manager(void)
 
     VerifyOrExit(sInitCount == 0);
 
-#if !OPENTHREAD_RADIO
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
     otPlatCryptoRandomInit();
     SuccessOrAssert(Random::Crypto::Fill(seed));
 #else
@@ -72,7 +72,7 @@ Manager::~Manager(void)
     sInitCount--;
     VerifyOrExit(sInitCount == 0);
 
-#if !OPENTHREAD_RADIO
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
     otPlatCryptoRandomDeinit();
 #endif
 

--- a/src/core/common/random.hpp
+++ b/src/core/common/random.hpp
@@ -71,7 +71,7 @@ public:
      */
     static uint32_t NonCryptoGetUint32(void);
 
-#if !OPENTHREAD_RADIO
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
     /**
      * Fills a given buffer with cryptographically secure random bytes.
      *
@@ -189,7 +189,7 @@ uint32_t AddJitter(uint32_t aValue, uint16_t aJitter);
 
 } // namespace NonCrypto
 
-#if !OPENTHREAD_RADIO
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
 
 namespace Crypto {
 
@@ -222,7 +222,7 @@ template <typename ObjectType> Error Fill(ObjectType &aObject)
 
 } // namespace Crypto
 
-#endif // !OPENTHREAD_RADIO
+#endif // OPENTHREAD_FTD || OPENTHREAD_MTD
 
 } // namespace Random
 } // namespace ot

--- a/src/core/crypto/aes_ccm.cpp
+++ b/src/core/crypto/aes_ccm.cpp
@@ -246,7 +246,7 @@ void AesCcm::Payload(void *aPlainText, void *aCipherText, uint32_t aLength, Mode
     }
 }
 
-#if !OPENTHREAD_RADIO
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
 void AesCcm::Payload(Message &aMessage, uint16_t aOffset, uint16_t aLength, Mode aMode)
 {
     Message::MutableChunk chunk;

--- a/src/core/crypto/aes_ccm.hpp
+++ b/src/core/crypto/aes_ccm.hpp
@@ -143,7 +143,7 @@ public:
      */
     void Payload(void *aPlainText, void *aCipherText, uint32_t aLength, Mode aMode);
 
-#if !OPENTHREAD_RADIO
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
     /**
      * Processes the payload within a given message.
      *

--- a/src/core/crypto/crypto_platform.cpp
+++ b/src/core/crypto/crypto_platform.cpp
@@ -71,7 +71,7 @@ using namespace Crypto;
 #define OT_MBEDTLS_STRONG_DEFAULT_ENTROPY_PRESENT
 #endif
 
-#if !OPENTHREAD_RADIO
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
 static mbedtls_ctr_drbg_context sCtrDrbgContext;
 static mbedtls_entropy_context  sEntropyContext;
 #ifndef OT_MBEDTLS_STRONG_DEFAULT_ENTROPY_PRESENT
@@ -147,7 +147,7 @@ exit:
     return error;
 }
 
-#if !OPENTHREAD_RADIO
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
 
 // HMAC implementations
 OT_TOOL_WEAK otError otPlatCryptoHmacSha256Init(otCryptoContext *aContext)
@@ -660,7 +660,7 @@ exit:
 
 #endif // #if OPENTHREAD_CONFIG_ECDSA_ENABLE
 
-#endif // #if !OPENTHREAD_RADIO
+#endif // #if OPENTHREAD_FTD || OPENTHREAD_MTD
 
 #if OPENTHREAD_FTD
 
@@ -752,7 +752,7 @@ exit:
 
 #elif OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_PSA
 
-#if !OPENTHREAD_RADIO
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
 #if OPENTHREAD_CONFIG_ECDSA_ENABLE
 
 OT_TOOL_WEAK otError otPlatCryptoEcdsaGenerateKey(otPlatCryptoEcdsaKeyPair *aKeyPair)
@@ -795,7 +795,7 @@ OT_TOOL_WEAK otError otPlatCryptoEcdsaVerify(const otPlatCryptoEcdsaPublicKey *a
 }
 #endif // #if OPENTHREAD_CONFIG_ECDSA_ENABLE
 
-#endif // #if !OPENTHREAD_RADIO
+#endif // #if OPENTHREAD_FTD || OPENTHREAD_MTD
 
 #if OPENTHREAD_FTD
 

--- a/src/core/crypto/mbedtls.cpp
+++ b/src/core/crypto/mbedtls.cpp
@@ -170,7 +170,7 @@ Error MbedTls::MapError(int aMbedTlsError)
     return error;
 }
 
-#if !OPENTHREAD_RADIO
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
 
 int MbedTls::CryptoSecurePrng(void *, unsigned char *aBuffer, size_t aSize)
 {
@@ -179,7 +179,7 @@ int MbedTls::CryptoSecurePrng(void *, unsigned char *aBuffer, size_t aSize)
     return 0;
 }
 
-#endif // !OPENTHREAD_RADIO
+#endif // OPENTHREAD_FTD || OPENTHREAD_MTD
 
 } // namespace Crypto
 } // namespace ot

--- a/src/core/crypto/mbedtls.hpp
+++ b/src/core/crypto/mbedtls.hpp
@@ -86,7 +86,7 @@ public:
      */
     static Error MapError(int aMbedTlsError);
 
-#if !OPENTHREAD_RADIO
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
     /**
      * Fills a given buffer with cryptographically secure random bytes.
      *

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -41,7 +41,7 @@
 #include "common/log.hpp"
 #include "common/num_utils.hpp"
 #include "radio/trel_link.hpp"
-#if !OPENTHREAD_RADIO || OPENTHREAD_CONFIG_MAC_SOFTWARE_TX_SECURITY_ENABLE
+#if OPENTHREAD_FTD || OPENTHREAD_MTD || OPENTHREAD_CONFIG_MAC_SOFTWARE_TX_SECURITY_ENABLE
 #include "crypto/aes_ccm.hpp"
 #endif
 

--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -54,7 +54,7 @@ PanId GenerateRandomPanId(void)
     return panId;
 }
 
-#if !OPENTHREAD_RADIO
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
 void ExtAddress::GenerateRandom(void)
 {
     IgnoreError(Random::Crypto::Fill(*this));

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -110,10 +110,12 @@ public:
      */
     void Fill(uint8_t aByte) { memset(this, aByte, sizeof(*this)); }
 
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
     /**
      * Generates a random IEEE 802.15.4 Extended Address.
      */
     void GenerateRandom(void);
+#endif
 
     /**
      * Sets the Extended Address from a given byte array.

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -140,7 +140,7 @@ class NetworkKey : public otNetworkKey, public Equatable<NetworkKey>, public Cle
 public:
     static constexpr uint8_t kSize = OT_NETWORK_KEY_SIZE; ///< Size of the Thread Network Key (in bytes).
 
-#if !OPENTHREAD_RADIO
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
     /**
      * Generates a cryptographically secure random sequence to populate the Thread Network Key.
      *
@@ -168,7 +168,7 @@ class Pskc : public otPskc, public Equatable<Pskc>, public Clearable<Pskc>
 public:
     static constexpr uint8_t kSize = OT_PSKC_MAX_SIZE; ///< Size (number of bytes) of the PSKc.
 
-#if !OPENTHREAD_RADIO
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
     /**
      * Generates a cryptographically secure random sequence to populate the Thread PSKc.
      *


### PR DESCRIPTION
This commit replaces the `#if !OPENTHREAD_RADIO` checks with explicit `#if OPENTHREAD_FTD || OPENTHREAD_MTD` checks.

The existing check relied on the assumption that exactly one of the three options `FTD`, `MTD`, or `RADIO` will be set, and therefore `#if !RADIO`  was used indirectly as a check for `FTD` or `MTD`. This change improves clarity and allows for future addition of new configurations (where this assumption may no longer hold true).