### PR TITLE
[config] define uptime feature for MTDs

### DIFF
--- a/src/core/config/misc.h
+++ b/src/core/config/misc.h
@@ -119,7 +119,7 @@
  * Define to 1 to enable tracking the uptime of OpenThread instance.
  */
 #ifndef OPENTHREAD_CONFIG_UPTIME_ENABLE
-#define OPENTHREAD_CONFIG_UPTIME_ENABLE OPENTHREAD_FTD
+#define OPENTHREAD_CONFIG_UPTIME_ENABLE (OPENTHREAD_FTD || OPENTHREAD_MTD)
 #endif
 
 /**


### PR DESCRIPTION
MTDs built out of the OpenThread stack fail a 1.4 network diagnostics test that tracks connection time and role time in MLE counter TLVs (test case 4.2). We can workaround manually defining UPTIME for MTDs, but it's better to make it the default behavior.