### PR TITLE
[instance] add `otInstanceGetIndex()`

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (485)
+#define OPENTHREAD_API_VERSION (486)
 
 /**
  * @addtogroup api-instance
@@ -113,6 +113,18 @@ otInstance *otInstanceInitSingle(void);
  * @returns  A pointer to the new OpenThread instance.
  */
 otInstance *otInstanceInitMultiple(uint8_t aIdx);
+
+/**
+ * Gets the index of the OpenThread instance when multiple instance is in use.
+ *
+ * This function is available when both `OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE` and
+ * `OPENTHREAD_CONFIG_MULTIPLE_STATIC_INSTANCE_ENABLE` are enabled.
+ *
+ * @param[in] aInstance The reference of the OpenThread instance to get index.
+ *
+ * @returns The index of the OpenThread instance.
+ */
+uint8_t otInstanceGetIndex(otInstance *aInstance);
 
 /**
  * Gets the instance identifier.

--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -65,6 +65,7 @@ otInstance *otInstanceInitMultiple(uint8_t aIdx)
 
     return instance;
 }
+uint8_t otInstanceGetIndex(otInstance *aInstance) { return Instance::GetIdx(AsCoreTypePtr(aInstance)); }
 #endif // OPENTHREAD_CONFIG_MULTIPLE_STATIC_INSTANCE_ENABLE
 otInstance *otInstanceInit(void *aInstanceBuffer, size_t *aInstanceBufferSize)
 {


### PR DESCRIPTION
Add otInstanceGetIdx function that can be useful in multi-instance context at platform level.