### PR TITLE
[mle] introduce `TxMessage::AppendAddressRegistrationEntry()`

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1032,8 +1032,7 @@ private:
         Error SendTo(const Ip6::Address &aDestination);
 
     private:
-        Error AppendCompressedAddressEntry(uint8_t aContextId, const Ip6::Address &aAddress);
-        Error AppendAddressEntry(const Ip6::Address &aAddress);
+        Error AppendAddressRegistrationEntry(const Ip6::Address &aAddress);
         Error AppendDatasetTlv(MeshCoP::Dataset::Type aDatasetType);
     };
 


### PR DESCRIPTION
This commit introduces `TxMessage::AppendAddressRegistrationEntry()` which appends an address entry in an MLE Address Registration TLV. The new helper method determines whether a given address can be appended as a compressed (using a lowpan context ID) or as an uncompressed entry. This simplifies the code by moving all checks into a common method. It also adds an explicit check to ensure the associated Context TLV has the "compress" flag set before using the compressed format.