### PR TITLE
[netdiag] add support for Enhanced Route TLV

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (489)
+#define OPENTHREAD_API_VERSION (490)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -7555,6 +7555,7 @@ template <> otError Interpreter::Process<Cmd("networkdiagnostic")>(Arg aArgs[])
      * - `29`: Child TLV
      * - `34`: MLE Counters TLV
      * - `35`: Vendor App URL TLV
+     * - `37`: Enhanced Route TLV
      * @par
      * Sends a network diagnostic request to retrieve specified Type Length Values (TLVs)
      * for the specified addresses(es).
@@ -7663,6 +7664,10 @@ void Interpreter::HandleDiagnosticGetResponse(otError                 aError,
             OutputLine("Route:");
             OutputRoute(kIndentSize, diagTlv.mData.mRoute);
             break;
+        case OT_NETWORK_DIAGNOSTIC_TLV_ENHANCED_ROUTE:
+            OutputLine("EnhRoute:");
+            OutputEnhRoute(kIndentSize, diagTlv.mData.mEnhRoute);
+            break;
         case OT_NETWORK_DIAGNOSTIC_TLV_LEADER_DATA:
             OutputLine("Leader Data:");
             OutputLeaderData(kIndentSize, diagTlv.mData.mLeaderData);
@@ -7756,6 +7761,7 @@ void Interpreter::OutputConnectivity(uint8_t aIndentSize, const otNetworkDiagCon
     OutputLine(aIndentSize, "SedBufferSize: %u", aConnectivity.mSedBufferSize);
     OutputLine(aIndentSize, "SedDatagramCount: %u", aConnectivity.mSedDatagramCount);
 }
+
 void Interpreter::OutputRoute(uint8_t aIndentSize, const otNetworkDiagRoute &aRoute)
 {
     OutputLine(aIndentSize, "IdSequence: %u", aRoute.mIdSequence);
@@ -7776,6 +7782,36 @@ void Interpreter::OutputRouteData(uint8_t aIndentSize, const otNetworkDiagRouteD
     OutputLine(aIndentSize, "LinkQualityOut: %u", aRouteData.mLinkQualityOut);
     OutputLine(aIndentSize, "LinkQualityIn: %u", aRouteData.mLinkQualityIn);
     OutputLine(aIndentSize, "RouteCost: %u", aRouteData.mRouteCost);
+}
+
+void Interpreter::OutputEnhRoute(uint8_t aIndentSize, const otNetworkDiagEnhRoute &aEnhRoute)
+{
+    static constexpr uint8_t kInvalidRouterId = OT_NETWORK_MAX_ROUTER_ID + 1;
+
+    for (uint8_t index = 0; index < aEnhRoute.mRouteCount; index++)
+    {
+        const otNetworkDiagEnhRouteData &routeData = aEnhRoute.mRouteData[index];
+
+        OutputFormat(aIndentSize, "- RouterId:%-2u", routeData.mRouterId);
+
+        if (routeData.mIsSelf)
+        {
+            OutputLine(" The queried device");
+            continue;
+        }
+
+        OutputFormat(" HasLink:%-3s LinkQualityOut:%u LinkQualityIn:%u ", routeData.mHasLink ? "yes" : "no",
+                     routeData.mLinkQualityOut, routeData.mLinkQualityIn);
+
+        if (routeData.mNextHop == kInvalidRouterId)
+        {
+            OutputLine("NextHop:na NextHopCost:na");
+        }
+        else
+        {
+            OutputLine("NextHop:%-2u NextHopCost:%u", routeData.mNextHop, routeData.mNextHopCost);
+        }
+    }
 }
 
 void Interpreter::OutputLeaderData(uint8_t aIndentSize, const otLeaderData &aLeaderData)

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -262,6 +262,7 @@ private:
     void OutputConnectivity(uint8_t aIndentSize, const otNetworkDiagConnectivity &aConnectivity);
     void OutputRoute(uint8_t aIndentSize, const otNetworkDiagRoute &aRoute);
     void OutputRouteData(uint8_t aIndentSize, const otNetworkDiagRouteData &aRouteData);
+    void OutputEnhRoute(uint8_t aIndentSize, const otNetworkDiagEnhRoute &aEnhRoute);
     void OutputLeaderData(uint8_t aIndentSize, const otLeaderData &aLeaderData);
     void OutputNetworkDiagMacCounters(uint8_t aIndentSize, const otNetworkDiagMacCounters &aMacCounters);
     void OutputNetworkDiagMleCounters(uint8_t aIndentSize, const otNetworkDiagMleCounters &aMleCounters);

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -205,6 +205,7 @@ private:
     Error       AppendRouterNeighborTlvs(Coap::Message *&aAnswer, AnswerInfo &aInfo);
     Error       AppendChildTableIp6AddressList(Coap::Message *&aAnswer, AnswerInfo &aInfo);
     Error       AppendChildIp6AddressListTlv(Coap::Message &aAnswer, const Child &aChild);
+    Error       AppendEnhancedRoute(Message &aMessage);
 
     static void HandleAnswerResponse(void                *aContext,
                                      otMessage           *aMessage,

--- a/src/core/thread/network_diagnostic_tlvs.cpp
+++ b/src/core/thread/network_diagnostic_tlvs.cpp
@@ -38,6 +38,35 @@
 namespace ot {
 namespace NetworkDiagnostic {
 
+void EnhancedRouteTlvEntry::InitFrom(const Router &aRouter)
+{
+    uint16_t data = 0;
+
+    if (aRouter.IsStateValid())
+    {
+        data |= kLinkFlag;
+        data |= (static_cast<uint16_t>(aRouter.GetLinkQualityOut()) << kLinkQualityOutOffset);
+        data |= (static_cast<uint16_t>(aRouter.GetLinkQualityIn()) << kLinkQualityInOffset);
+    }
+
+    data |= ((static_cast<uint16_t>(aRouter.GetNextHop()) & kNextHopMask) << kNextHopOffset);
+    data |= ((static_cast<uint16_t>(aRouter.GetCost()) & kCostMask) << kNextHopCostOffset);
+
+    SetRouteData(data);
+}
+
+void EnhancedRouteTlvEntry::Parse(ParseInfo &aParseInfo) const
+{
+    uint16_t data = GetRouteData();
+
+    aParseInfo.mIsSelf         = (data & kSelfFlag);
+    aParseInfo.mHasLink        = (data & kLinkFlag);
+    aParseInfo.mLinkQualityOut = static_cast<uint8_t>((data >> kLinkQualityOutOffset) & kLinkQualityMask);
+    aParseInfo.mLinkQualityIn  = static_cast<uint8_t>((data >> kLinkQualityInOffset) & kLinkQualityMask);
+    aParseInfo.mNextHop        = static_cast<uint8_t>((data >> kNextHopOffset) & kNextHopMask);
+    aParseInfo.mNextHopCost    = static_cast<uint8_t>((data >> kNextHopCostOffset) & kCostMask);
+}
+
 #if OPENTHREAD_FTD
 
 void ChildTlv::InitFrom(const Child &aChild)

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -95,6 +95,7 @@ public:
         kQueryId             = OT_NETWORK_DIAGNOSTIC_TLV_QUERY_ID,
         kMleCounters         = OT_NETWORK_DIAGNOSTIC_TLV_MLE_COUNTERS,
         kVendorAppUrl        = OT_NETWORK_DIAGNOSTIC_TLV_VENDOR_APP_URL,
+        kEnhancedRoute       = OT_NETWORK_DIAGNOSTIC_TLV_ENHANCED_ROUTE,
     };
 
     /**
@@ -953,6 +954,59 @@ private:
 } OT_TOOL_PACKED_END;
 
 #endif // OPENTHREAD_FTD
+
+/**
+ * Represents an Enhanced Route TLV Entry
+ */
+OT_TOOL_PACKED_BEGIN
+class EnhancedRouteTlvEntry
+{
+public:
+    typedef otNetworkDiagEnhRouteData ParseInfo; ///< Parse entry info
+
+    /**
+     * Initializes the entry as self (associated with device itself).
+     */
+    void InitAsSelf(void) { SetRouteData(kSelfFlag); }
+
+    /**
+     * Initializes the entry from given `router`.
+     *
+     * @param[in] aRouter  Router entry to use for initialization.
+     */
+    void InitFrom(const Router &aRouter);
+
+    /**
+     * Parses the entry and populate the information in given `ParseInfo` struct.
+     *
+     * @parma[out] aParseInfo   The `ParseInfo` structure to populate.
+     */
+    void Parse(ParseInfo &aParseInfo) const;
+
+private:
+    // Format:
+    //
+    //  15  14  13   12  11  10  9   8   7   6   5   4   3   2   1   0
+    // +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    // | S | L | LQOut | LQIn  |     NextHop (6-bit)   | NHCost(4 bits)|
+    // +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+
+    static constexpr uint16_t kSelfFlag             = 1 << 15;
+    static constexpr uint16_t kLinkFlag             = 1 << 14;
+    static constexpr uint8_t  kLinkQualityOutOffset = 12;
+    static constexpr uint8_t  kLinkQualityInOffset  = 10;
+    static constexpr uint8_t  kNextHopOffset        = 4;
+    static constexpr uint8_t  kNextHopCostOffset    = 0;
+
+    static constexpr uint16_t kLinkQualityMask = 0x3;
+    static constexpr uint16_t kNextHopMask     = 0x3f;
+    static constexpr uint16_t kCostMask        = 0xf;
+
+    uint16_t GetRouteData(void) const { return BigEndian::HostSwap16(mRouteData); }
+    void     SetRouteData(uint16_t aRouteData) { mRouteData = BigEndian::HostSwap16(aRouteData); }
+
+    uint16_t mRouteData;
+} OT_TOOL_PACKED_END;
 
 /**
  * Implements Answer TLV generation and parsing.

--- a/tests/toranj/cli/test-023-mesh-diag.py
+++ b/tests/toranj/cli/test-023-mesh-diag.py
@@ -160,6 +160,50 @@ verify(len([line for line in neightable if line.startswith('rloc16')]) == 2)
 neightable = r3.cli('meshdiag routerneighbortable', r1_rloc)
 verify(len([line for line in neightable if line.startswith('rloc16')]) == 1)
 
+# Validate network diagnostics enhanced route TLV
+
+r1_router_id = int(r1_rloc / 1024)
+r2_router_id = int(r2_rloc / 1024)
+r3_router_id = int(r3_rloc / 1024)
+
+enh_routes = r1.cli('networkdiagnostic get', r3.get_rloc_ip_addr(), 37)
+
+verify(enh_routes[1] == 'EnhRoute:')
+verify(len(enh_routes) == 5)
+
+for line in enh_routes[2:]:
+    line = line.strip()
+    verify(line.startswith('- RouterId:'))
+    rid = int(line[11:].split()[0])
+    if (rid == r1_router_id):
+        verify('HasLink:no' in line)
+        verify(f'NextHop:{r2_router_id}' in line)
+    elif (rid == r2_router_id):
+        verify('HasLink:yes' in line)
+        verify('NextHop:na' in line)
+    elif (rid == r3_router_id):
+        verify('The queried device' in line)
+    else:
+        verify(False)
+
+enh_routes = r3.cli('networkdiagnostic get', r2.get_rloc_ip_addr(), 37)
+
+verify(enh_routes[1] == 'EnhRoute:')
+verify(len(enh_routes) == 5)
+
+for line in enh_routes[2:]:
+    line = line.strip()
+    verify(line.startswith('- RouterId:'))
+    rid = int(line[11:].split()[0])
+    if (rid == r1_router_id):
+        verify('HasLink:yes' in line)
+    elif (rid == r2_router_id):
+        verify('The queried device' in line)
+    elif (rid == r3_router_id):
+        verify('HasLink:yes' in line)
+    else:
+        verify(False)
+
 # -----------------------------------------------------------------------------------------------------------------------
 # Test finished
 


### PR DESCRIPTION
This commit adds support for the Network Diagnostics Enhanced Route TLV (TLV number 37). This TLV provides information about established links between routers, including the next hop and associated cost for routes to all routers. This commit also adds CLI support and test coverage for the new TLV.

---

Related to [SPEC-1361](https://threadgroup.atlassian.net/browse/SPEC-1361).