### PR TITLE
[cli] add '-x' flag to tcp client to send hexadecimal data

### DIFF
--- a/src/cli/cli_tcp.cpp
+++ b/src/cli/cli_tcp.cpp
@@ -493,14 +493,14 @@ template <> otError TcpExample::Process<Cmd("send")>(Arg aArgs[])
     {
         // Binary hex data payload
         dataLen = sizeof(buf);
-        data = &buf[0];
+        data    = &buf[0];
         SuccessOrExit(error = aArgs[1].ParseAsHexString(dataLen, buf));
     }
     else
     {
         VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
         dataLen = aArgs[0].GetLength();
-        data = reinterpret_cast<uint8_t *>(aArgs[0].GetCString());
+        data    = reinterpret_cast<uint8_t *>(aArgs[0].GetCString());
     }
 
     if (mUseCircularSendBuffer)
@@ -522,8 +522,7 @@ template <> otError TcpExample::Process<Cmd("send")>(Arg aArgs[])
         {
             size_t written;
 
-            SuccessOrExit(error = otTcpCircularSendBufferWrite(&mEndpoint, &mSendBuffer, data,
-                                                               dataLen, &written, 0));
+            SuccessOrExit(error = otTcpCircularSendBufferWrite(&mEndpoint, &mSendBuffer, data, dataLen, &written, 0));
         }
     }
     else

--- a/src/cli/cli_tcp.cpp
+++ b/src/cli/cli_tcp.cpp
@@ -470,8 +470,8 @@ exit:
  * @cparam tcp send [@ca{type}] @ca{message}
  * The `message` parameter contains the message you want to send to the
  * remote TCP endpoint.
- * If `type` is `-x`:
- * Binary data in hexadecimal representation is given in the `message` parameter.
+ * If `type` is `-x`, then
+ * binary data in hexadecimal representation is given in the `message` parameter.
  * @par
  * Sends data over the TCP connection associated with the example TCP endpoint
  * that is provided with the `tcp` CLI. @moreinfo{@tcp}.

--- a/src/cli/cli_tcp.cpp
+++ b/src/cli/cli_tcp.cpp
@@ -480,7 +480,7 @@ template <> otError TcpExample::Process<Cmd("send")>(Arg aArgs[])
 {
     static constexpr uint16_t kBufferSizeForHexData = 128;
 
-    otError error;
+    otError  error;
     uint16_t dataLen;
     uint8_t *data;
     uint8_t  buf[kBufferSizeForHexData];
@@ -494,13 +494,13 @@ template <> otError TcpExample::Process<Cmd("send")>(Arg aArgs[])
         // Binary hex data payload
         dataLen = sizeof(buf);
         data = &buf[0];
-        SuccessOrExit(error  = ot::Utils::CmdLineParser::ParseAsHexString(aArgs[1].GetCString(), dataLen, buf));
+        SuccessOrExit(error = aArgs[1].ParseAsHexString(dataLen, buf));
     }
     else
     {
         VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
-        data = reinterpret_cast<unsigned char *>(aArgs[0].GetCString());
         dataLen = aArgs[0].GetLength();
+        data = reinterpret_cast<uint8_t *>(aArgs[0].GetCString());
     }
 
     if (mUseCircularSendBuffer)

--- a/tests/scripts/expect/cli-tcp.exp
+++ b/tests/scripts/expect/cli-tcp.exp
@@ -80,11 +80,11 @@ expect_line "Done"
 
 switch_node 1
 expect "TCP: Received 5 bytes: world"
-send "tcp send -x 546573745c725c6e4865785c725c6e\n"
+send "tcp send -x 546573740d0a4865780d0a\n"
 expect_line "Done"
 
 switch_node 2
-expect "TCP: Received 15 bytes: Test\r\nHex\r\n"
+expect "TCP: Received 11 bytes: Test\r\nHex\r\n"
 
 switch_node 1
 send "tcp sendend\n"

--- a/tests/scripts/expect/cli-tcp.exp
+++ b/tests/scripts/expect/cli-tcp.exp
@@ -80,6 +80,13 @@ expect_line "Done"
 
 switch_node 1
 expect "TCP: Received 5 bytes: world"
+send "tcp send -x 546573745c725c6e4865785c725c6e\n"
+expect_line "Done"
+
+switch_node 2
+expect "TCP: Received 15 bytes: Test\r\nHex\r\n"
+
+switch_node 1
 send "tcp sendend\n"
 expect_line "Done"
 send "tcp send more\n"


### PR DESCRIPTION
This adds the `-x` flag to the `tcp send` command so send specific data defined by a hexadecimal string.
The purpose is to use this in testing, for example to emulate HTTP GET requests.