### PR TITLE
[tests] reduce waiting time in the test of registering 500 SRP services

### DIFF
--- a/tests/scripts/thread-cert/test_srp_register_500_services.py
+++ b/tests/scripts/thread-cert/test_srp_register_500_services.py
@@ -119,7 +119,7 @@ class SrpRegister500Services(thread_cert.TestCase):
         for router in routers():
             router.srp_server_set_enabled(False)
             router.start()
-            self.simulator.go(config.ROUTER_STARTUP_DELAY)
+        self.simulator.go(config.ROUTER_STARTUP_DELAY)
 
         for router in routers():
             self.assertEqual(router.get_state(), 'router')
@@ -127,7 +127,7 @@ class SrpRegister500Services(thread_cert.TestCase):
         for fed in feds():
             fed.srp_server_set_enabled(False)
             fed.start()
-            self.simulator.go(3)
+        self.simulator.go(3)
 
         for fed in feds():
             self.assertEqual(fed.get_state(), 'child')


### PR DESCRIPTION
Previously there's a delay for every router (10 seconds) and child (3 seconds) for it to start. The serialized waiting times are unnecessary. This PR removes such waitings to speed up the test case. This is especially useful in the BR test `test_srp_register_500_services_br.py` which uses non-virtual time.