### PR TITLE
[tests] deal with the `No Such Record` lines in the output of `dns-sd` 

### DIFF
--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -4040,6 +4040,8 @@ class LinuxHost():
         for line in self.bash(f'cat {host_name_file}', encoding='raw_unicode_escape'):
             elements = line.split()
             fullname = f'{host_name}.local.'
+            if 'No Such Record' in line:
+                continue
             if fullname not in elements:
                 continue
             if 'Add' not in elements:


### PR DESCRIPTION
https://github.com/openthread/ot-br-posix/actions/runs/13192276355/job/36827304346?pr=2677

When resolving a hostname, `dns-sd` may output a line saying `No Such Record` with an all-zero address which should be discarded.
```
2025-02-07 03:15:14,335 - INFO - Host<3> $ 'DATE: ---Fri 07 Feb 2025---'
2025-02-07 03:15:14,335 - INFO - Host<3> $ ' 3:15:12.260  ...STARTING...'
2025-02-07 03:15:14,335 - INFO - Host<3> $ 'Timestamp     A/R  Flags         IF  Hostname                               Address                                      TTL'
2025-02-07 03:15:14,335 - INFO - Host<3> $ ' 3:15:12.260  Add  40000003     105  my-host.local.                         0000:0000:0000:0000:0000:0000:0000:0000%<0>  1   No Such Record'
2025-02-07 03:15:14,335 - INFO - Host<3> $ ' 3:15:12.260  Add  40000002     105  my-host.local.                         2001:0000:0000:0000:0000:0000:0000:0001%<0>  120'
```