### PR TITLE
[otci] remove the last element if it's an empty string in command output list

### DIFF
--- a/tools/otci/otci/otci.py
+++ b/tools/otci/otci/otci.py
@@ -122,6 +122,9 @@ class OTCI(object):
             self.log('info', '> %s', cmd)
 
         output = self.__otcmd.execute_command(cmd, timeout)
+        # remove the last element if the last element is an empty string
+        if output and output[-1] == '':
+            output = output[:-1]
 
         if not silent:
             for line in output:


### PR DESCRIPTION
In some cases, `self.__otcmd.execute_command` returns a list, of which the last element is '' instead of 'Done', this causes the `__execute_command` in class OTCI cannot returns correctly, but raise an exception.