### PR TITLE
[tests] set the number of retry when executing the command

### DIFF
--- a/tools/cp-caps/rcp_caps_test.py
+++ b/tools/cp-caps/rcp_caps_test.py
@@ -880,11 +880,14 @@ class RcpCaps(object):
 
     def __radio_receive_task(self, receiver: OTCI, number: int, result_queue: queue):
         try:
+            receiver.set_execute_command_retry(0)
             result = receiver.diag_radio_receive_number(number)
         except ExpectLineTimeoutError:
             pass
         else:
             result_queue.put(result)
+        finally:
+            receiver.set_execute_command_retry(OTCI.DEFAULT_EXEC_COMMAND_RETRY)
 
     def __test_diag_frame(self):
         frame = self.Frame(name='diag frame 00010203040506070809', tx_frame='00010203040506070809', dst_address='-')

--- a/tools/otci/otci/command_handlers.py
+++ b/tools/otci/otci/command_handlers.py
@@ -330,7 +330,12 @@ class OtbrAdbCommandRunner(OTCommandHandler):
         return self.shell(cmd, timeout=timeout)
 
     def shell(self, cmd: str, timeout: float) -> List[str]:
-        raw_out = self.__adb.shell(cmd, transport_timeout_s=timeout, read_timeout_s=timeout, timeout_s=timeout)
+        from adb_shell.exceptions import UsbReadFailedError, AdbTimeoutError
+
+        try:
+            raw_out = self.__adb.shell(cmd, transport_timeout_s=timeout, read_timeout_s=timeout, timeout_s=timeout)
+        except (UsbReadFailedError, AdbTimeoutError):
+            raise ExpectLineTimeoutError(cmd)
 
         # Normalize ADB shell output for consistent line splitting.
         #   The ADB client may perform automatic newline conversion, potentially replace the '\n' with '\r\n'.


### PR DESCRIPTION
When running the command `diag receive 1 rlp`, the DUT may fail to receive the frame, then the otci will try the command again and again. These retries are useless, and they will take lots of time before timeout.

This commit sets the number of retry to 0 before executing the command, and restore the number of retry after the command is executed. This commit also captures the timeout exception from the adb_shell.
