### PR TITLE
[doc] instruct to build nexus test in a directory

### DIFF
--- a/tests/nexus/README.md
+++ b/tests/nexus/README.md
@@ -19,11 +19,12 @@ Nexus is a test framework for OpenThread testing.
 To build Nexus test cases, the `build.sh` script can be used:
 
 ```bash
-./tests/nexus/build.sh
+mkdir nexus_test
+top_builddir=nexus_test ./tests/nexus/build.sh
 ```
 
 Afterwards, each test can be run directly:
 
 ```bash
-./tests/nexus/nexus_form_join
+./nexus_test/tests/nexus/nexus_form_join
 ```


### PR DESCRIPTION
Putting all build caches in the default directory makes it less clear when we do 'ls'.