### PR TITLE
[utils] check whether `mInfo.mTxInfo.mIeInfo` is null before using it

### DIFF
--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -420,6 +420,7 @@ void platformRadioInit(void)
 #else
     sTransmitFrame.mInfo.mTxInfo.mIeInfo = NULL;
 #endif
+    sAckFrame.mInfo.mTxInfo.mIeInfo = NULL;
 
     for (size_t i = 0; i <= kMaxChannel - kMinChannel; i++)
     {

--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -380,20 +380,24 @@ exit:
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 void otMacFrameUpdateTimeIe(otRadioFrame *aFrame, uint64_t aRadioTime, otRadioContext *aRadioContext)
 {
-    if (aFrame->mInfo.mTxInfo.mIeInfo->mTimeIeOffset != 0)
+    uint8_t *timeIe;
+    uint64_t time;
+
+    VerifyOrExit((aFrame->mInfo.mTxInfo.mIeInfo != nullptr) && (aFrame->mInfo.mTxInfo.mIeInfo->mTimeIeOffset != 0));
+
+    timeIe  = aFrame->mPsdu + aFrame->mInfo.mTxInfo.mIeInfo->mTimeIeOffset;
+    time    = aRadioTime + aFrame->mInfo.mTxInfo.mIeInfo->mNetworkTimeOffset;
+    *timeIe = aFrame->mInfo.mTxInfo.mIeInfo->mTimeSyncSeq;
+
+    *(++timeIe) = static_cast<uint8_t>(time & 0xff);
+    for (uint8_t i = 1; i < sizeof(uint64_t); i++)
     {
-        uint8_t *timeIe = aFrame->mPsdu + aFrame->mInfo.mTxInfo.mIeInfo->mTimeIeOffset;
-        uint64_t time   = aRadioTime + aFrame->mInfo.mTxInfo.mIeInfo->mNetworkTimeOffset;
-
-        *timeIe = aFrame->mInfo.mTxInfo.mIeInfo->mTimeSyncSeq;
-
+        time        = time >> 8;
         *(++timeIe) = static_cast<uint8_t>(time & 0xff);
-        for (uint8_t i = 1; i < sizeof(uint64_t); i++)
-        {
-            time        = time >> 8;
-            *(++timeIe) = static_cast<uint8_t>(time & 0xff);
-        }
     }
+
+exit:
+    return;
 }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 


### PR DESCRIPTION
The simulation platform radio driver doesn't set the 'mInfo.mTxInfo.mIeInfo' field of the ACK frame. And the function 'otMacFrameUpdateTimeIe()' directly use the 'mInfo.mTxInfo.mIeInfo' field, this may cause the program crash.

This commit checks whether 'mInfo.mTxInfo.mIeInfo' is null before using it and sets the 'mInfo.mTxInfo.mIeInfo' field of the ACK frame to null in simulation platform.