### PR TITLE
[routing-manager] use `IsInfrastructureDerived()` in `PdPrefixManager`

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -3961,9 +3961,7 @@ RoutingManager::PdPrefixManager::State RoutingManager::PdPrefixManager::GetState
 void RoutingManager::PdPrefixManager::Evaluate(void)
 {
     const FavoredOmrPrefix &favoredPrefix = Get<RoutingManager>().mOmrPrefixManager.GetFavoredPrefix();
-
-    bool shouldPause = !favoredPrefix.IsEmpty() && favoredPrefix.GetPrefix() != mPrefix.GetPrefix() &&
-                       favoredPrefix.GetPreference() >= kPdRoutePreference;
+    bool shouldPause = favoredPrefix.IsInfrastructureDerived() && (favoredPrefix.GetPrefix() != mPrefix.GetPrefix());
 
     PauseResume(/* aPause */ shouldPause);
 }


### PR DESCRIPTION
This commit updates `PdPrefixManager::Evaluate()` to directly use the helper method `FavoredOmrPrefix::IsInfrastructureDerived()` when deciding to pause and change to `kDhcp6PdStateIdle`. This helps improve code readability.