### PR TITLE
[routing-manager] map `otBorderRoutingDhcp6PdState` to core type

### DIFF
--- a/src/core/api/border_routing_api.cpp
+++ b/src/core/api/border_routing_api.cpp
@@ -221,8 +221,7 @@ void otBorderRoutingDhcp6PdSetEnabled(otInstance *aInstance, bool aEnabled)
 
 otBorderRoutingDhcp6PdState otBorderRoutingDhcp6PdGetState(otInstance *aInstance)
 {
-    return static_cast<otBorderRoutingDhcp6PdState>(
-        AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetDhcp6PdState());
+    return MapEnum(AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetDhcp6PdState());
 }
 
 void otBorderRoutingDhcp6PdSetRequestCallback(otInstance                           *aInstance,

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -3990,7 +3990,7 @@ void RoutingManager::PdPrefixManager::EvaluateStateChange(Dhcp6PdState aOldState
     // manager will refuse to request the prefix.
     // TODO: Either update the comment for the state callback or add a random delay when notifing the upper layer for
     // state change.
-    mStateCallback.InvokeIfSet(static_cast<otBorderRoutingDhcp6PdState>(newState));
+    mStateCallback.InvokeIfSet(MapEnum(newState));
 
 exit:
     return;

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1636,6 +1636,7 @@ template <> void RoutingManager::RxRaTracker::Entry<RoutingManager::RxRaTracker:
 } // namespace BorderRouter
 
 DefineMapEnum(otBorderRoutingState, BorderRouter::RoutingManager::State);
+DefineMapEnum(otBorderRoutingDhcp6PdState, BorderRouter::RoutingManager::Dhcp6PdState);
 
 } // namespace ot
 


### PR DESCRIPTION
This commit updates `otBorderRoutingDhcp6PdState` to be properly mapped using `DefineMapEnum()` to its related core-internal `enum` definition. This avoids the use of `static_cast` for conversion and ensures only associated `enum` types can be mapped to each other.