### PR TITLE
[routing-manager] simplify `PdPrefixManager::HasPrefix()`

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1470,7 +1470,7 @@ private:
         void               Start(void) { StartStop(/* aStart= */ true); }
         void               Stop(void) { StartStop(/* aStart= */ false); }
         bool               IsRunning(void) const { return GetState() == kDhcp6PdStateRunning; }
-        bool               HasPrefix(void) const { return IsValidOmrPrefix(mPrefix.GetPrefix()); }
+        bool               HasPrefix(void) const { return !mPrefix.IsEmpty(); }
         const Ip6::Prefix &GetPrefix(void) const { return mPrefix.GetPrefix(); }
         State              GetState(void) const;
 


### PR DESCRIPTION
This commit simplifies `PdPrefixManager::HasPrefix()` by simply checking if `mPrefix` is not empty (rather than `IsValidOmrPrefix()`). A favored PD prefix is always validated before it is assigned to `mPrefix`, and when the prefix is removed, `mPrefix` is cleared.