### PR TITLE
[test] fix socat version to 1.7.4.4

### DIFF
--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -73,7 +73,8 @@ jobs:
     - name: Bootstrap
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
-        sudo apt-get --no-install-recommends install -y python3-setuptools python3-wheel ninja-build socat lcov
+        sudo apt-get --no-install-recommends install -y python3-setuptools python3-wheel ninja-build lcov
+        sudo bash script/install_socat
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build
       run: |
@@ -195,7 +196,8 @@ jobs:
     - name: Bootstrap
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
-        sudo apt-get --no-install-recommends install -y python3-setuptools python3-wheel ninja-build socat lcov
+        sudo apt-get --no-install-recommends install -y python3-setuptools python3-wheel ninja-build lcov
+        sudo bash script/install_socat
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build
       run: |

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -63,7 +63,8 @@ jobs:
         cache: pip
     - name: Bootstrap
       run: |
-        sudo apt-get --no-install-recommends install -y expect ninja-build lcov socat
+        sudo apt-get --no-install-recommends install -y expect ninja-build lcov
+        sudo bash script/install_socat
         pip install bleak 'cryptography==43.0.0'
     - name: Run RCP Mode
       run: |
@@ -98,7 +99,8 @@ jobs:
       run: |
         sudo apt-get update
         echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
-        sudo apt-get install --no-install-recommends -y bind9-host ntp socat
+        sudo apt-get install --no-install-recommends -y bind9-host ntp
+        sudo bash script/install_socat
         sudo systemctl restart ntp
         sudo socat 'UDP6-LISTEN:53,fork,reuseaddr,bind=[::1]' UDP:127.0.0.53:53 &
         socat 'TCP6-LISTEN:2000,fork,reuseaddr' TCP:127.0.0.53:53 &
@@ -198,7 +200,8 @@ jobs:
     - name: Bootstrap
       run: |
         sudo apt-get update
-        sudo apt-get --no-install-recommends install -y socat expect lcov libreadline-dev net-tools ninja-build
+        sudo apt-get --no-install-recommends install -y expect lcov libreadline-dev net-tools ninja-build
+        sudo bash script/install_socat
         cd /tmp
         wget https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz
         tar xvf bsd-licensed.tar.gz
@@ -258,7 +261,8 @@ jobs:
         rm -f /usr/local/bin/python3-config
         rm -f /usr/local/bin/python3.11-config
         brew update
-        brew install ninja socat
+        brew install ninja
+        sudo bash script/install_socat
     - name: Build
       run: |
         script/check-posix-pty build
@@ -279,7 +283,8 @@ jobs:
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       run: |
-        sudo apt-get --no-install-recommends install -y expect ninja-build lcov socat
+        sudo apt-get --no-install-recommends install -y expect ninja-build lcov
+        sudo bash script/install_socat
         sudo python3 -m pip install git+https://github.com/openthread/pyspinel
     - name: Build
       run: |

--- a/.github/workflows/simulation-1.1.yml
+++ b/.github/workflows/simulation-1.1.yml
@@ -266,7 +266,8 @@ jobs:
         cache: pip
     - name: Bootstrap
       run: |
-        sudo apt-get --no-install-recommends install -y expect ninja-build lcov socat
+        sudo apt-get --no-install-recommends install -y expect ninja-build lcov
+        sudo bash script/install_socat
         pip install bleak 'cryptography==43.0.0'
     - name: Run
       run: |

--- a/.github/workflows/simulation-1.4.yml
+++ b/.github/workflows/simulation-1.4.yml
@@ -317,7 +317,8 @@ jobs:
         cache: pip
     - name: Bootstrap
       run: |
-        sudo apt-get --no-install-recommends install -y expect ninja-build lcov socat
+        sudo apt-get --no-install-recommends install -y expect ninja-build lcov
+        sudo bash script/install_socat
         pip install bleak 'cryptography==43.0.0'
     - name: Run RCP Mode
       run: |

--- a/script/install_socat
+++ b/script/install_socat
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+#  Copyright (c) 2025, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -euxo pipefail
+
+TEMP_PATH=$(mktemp -d)
+SOCAT="socat-1.7.4.4"
+SOCAT_TAR="$SOCAT.tar.gz"
+
+INSTALL_PREFIX="--prefix=/usr"
+if command -v brew; then
+    INSTALL_PREFIX="" # On MacOS, it's not allowed to install to /usr/bin due to System Integrity Protection
+fi
+
+cd "$TEMP_PATH"
+[[ -f $SOCAT_TAR ]] || wget http://www.dest-unreach.org/socat/download/"$SOCAT_TAR"
+tar -xvzf "$SOCAT_TAR"
+cd "$SOCAT" && ./configure "$INSTALL_PREFIX" && make && sudo make install


### PR DESCRIPTION
This PR changes the installation of socat from using 'apt' to manual installation.

We found the latest socat version 1.8.0.3 has an issue when running with OTBR docker. To avoid the error caused by version and facilitate local development, the PR provides a script to install socat of version 1.7.4.4 and replaces the installation in CI and scripts..

We add the install script in openthread and ot-br-posix will use the script in openthread to install socat.

Fixes: https://github.com/openthread/ot-br-posix/issues/2719