### PR TITLE
[test] relax BR tests that expect a single address on mDNS resolve

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_dnssd_server.py
+++ b/tests/scripts/thread-cert/border_router/test_dnssd_server.py
@@ -268,7 +268,8 @@ class TestDnssdServerOnBr(thread_cert.TestCase):
             self._assert_dig_result_matches(dig_result, {
                 'QUESTION': [(dp_hostname, 'IN', 'AAAA'),],
                 'ANSWER': [(dp_hostname, 'IN', 'AAAA', dp_ip6_address),],
-            })
+            },
+                                            allow_extra_answer=True)
 
     def _config_srp_client_services(self, client, instancename, hostname, port, priority, weight, addrs):
         client.srp_client_enable_auto_start_mode()
@@ -316,7 +317,7 @@ class TestDnssdServerOnBr(thread_cert.TestCase):
 
         return all(a == b or (callable(b) and b(a)) for a, b in zip(record, match))
 
-    def _assert_dig_result_matches(self, dig_result, expected_result):
+    def _assert_dig_result_matches(self, dig_result, expected_result, allow_extra_answer=False):
         self.assertEqual(dig_result['opcode'], expected_result.get('opcode', 'QUERY'), dig_result)
         self.assertEqual(dig_result['status'], expected_result.get('status', 'NOERROR'), dig_result)
 
@@ -327,7 +328,10 @@ class TestDnssdServerOnBr(thread_cert.TestCase):
                 self._assert_have_question(dig_result, question)
 
         if 'ANSWER' in expected_result:
-            self.assertEqual(len(dig_result['ANSWER']), len(expected_result['ANSWER']), dig_result)
+            if allow_extra_answer:
+                self.assertGreaterEqual(len(dig_result['ANSWER']), len(expected_result['ANSWER']), dig_result)
+            else:
+                self.assertEqual(len(dig_result['ANSWER']), len(expected_result['ANSWER']), dig_result)
 
             for record in expected_result['ANSWER']:
                 self._assert_have_answer(dig_result, record, additional=False)

--- a/tests/scripts/thread-cert/border_router/test_dnssd_server_multi_border_routers.py
+++ b/tests/scripts/thread-cert/border_router/test_dnssd_server_multi_border_routers.py
@@ -347,7 +347,8 @@ class TestDnssdServerOnMultiBr(thread_cert.TestCase):
             self._assert_dig_result_matches(dig_result, {
                 'QUESTION': [(dp_hostname, 'IN', 'AAAA'),],
                 'ANSWER': [(dp_hostname, 'IN', 'AAAA', dp_ip6_address),],
-            })
+            },
+                                            allow_extra_answer=True)
 
     def _config_srp_client_services(self, client, instancename, hostname, port, priority, weight, addrs):
         client.srp_client_enable_auto_start_mode()
@@ -396,7 +397,7 @@ class TestDnssdServerOnMultiBr(thread_cert.TestCase):
 
         return all(a == b or (callable(b) and b(a)) for a, b in zip(record, match))
 
-    def _assert_dig_result_matches(self, dig_result, expected_result):
+    def _assert_dig_result_matches(self, dig_result, expected_result, allow_extra_answer=False):
         self.assertEqual(dig_result['opcode'], expected_result.get('opcode', 'QUERY'), dig_result)
         self.assertEqual(dig_result['status'], expected_result.get('status', 'NOERROR'), dig_result)
 
@@ -407,7 +408,10 @@ class TestDnssdServerOnMultiBr(thread_cert.TestCase):
                 self._assert_have_question(dig_result, question)
 
         if 'ANSWER' in expected_result:
-            self.assertEqual(len(dig_result['ANSWER']), len(expected_result['ANSWER']), dig_result)
+            if allow_extra_answer:
+                self.assertGreaterEqual(len(dig_result['ANSWER']), len(expected_result['ANSWER']), dig_result)
+            else:
+                self.assertEqual(len(dig_result['ANSWER']), len(expected_result['ANSWER']), dig_result)
 
             for record in expected_result['ANSWER']:
                 self._assert_have_answer(dig_result, record, additional=False)


### PR DESCRIPTION
This commit relaxes the tests that assume mDNS resolve would provide a single IPv6 answer and explicitly check and require one address. This behavior of the mDNS API is improved/changed in the `ot-br-posix` implementation, allowing multiple addresses to be collected and passed in the "resolved" callback.

 This commit updates the `_assert_dig_result_matches()` function to  have an additional parameter, 
 `allow_extra_answer`, which is then  used in specific test steps.

----

This is related to 
- https://github.com/openthread/ot-br-posix/pull/2712
- https://github.com/openthread/ot-br-posix/issues/2711