### PR TITLE
[radio] fix `ClearSrcMatchExtEntry()` Extended Address byte order

### DIFF
--- a/src/core/radio/radio.cpp
+++ b/src/core/radio/radio.cpp
@@ -104,6 +104,15 @@ Error Radio::AddSrcMatchExtEntry(const Mac::ExtAddress &aExtAddress)
     address.Set(aExtAddress.m8, Mac::ExtAddress::kReverseByteOrder);
     return otPlatRadioAddSrcMatchExtEntry(GetInstancePtr(), &address);
 }
+
+Error Radio::ClearSrcMatchExtEntry(const Mac::ExtAddress &aExtAddress)
+{
+    Mac::ExtAddress address;
+
+    address.Set(aExtAddress.m8, Mac::ExtAddress::kReverseByteOrder);
+    return otPlatRadioClearSrcMatchExtEntry(GetInstancePtr(), &address);
+}
+
 Error Radio::Transmit(Mac::TxFrame &aFrame)
 {
 #if (OPENTHREAD_MTD || OPENTHREAD_FTD) && OPENTHREAD_CONFIG_OTNS_ENABLE

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -1021,11 +1021,6 @@ inline Error Radio::ClearSrcMatchShortEntry(Mac::ShortAddress aShortAddress)
     return otPlatRadioClearSrcMatchShortEntry(GetInstancePtr(), aShortAddress);
 }
 
-inline Error Radio::ClearSrcMatchExtEntry(const Mac::ExtAddress &aExtAddress)
-{
-    return otPlatRadioClearSrcMatchExtEntry(GetInstancePtr(), &aExtAddress);
-}
-
 inline void Radio::ClearSrcMatchShortEntries(void) { otPlatRadioClearSrcMatchShortEntries(GetInstancePtr()); }
 
 inline void Radio::ClearSrcMatchExtEntries(void) { otPlatRadioClearSrcMatchExtEntries(GetInstancePtr()); }


### PR DESCRIPTION
This commit addresses an issue introduced in #10892 where the Extended Address byte order was not properly handled when calling `otPlatRadio` APIs. OpenThread core uses big-endian encoding for Extended Addresses, while the `otPlatRadio` APIs expect little-endian, as per documented behavior.

PR #10892 refactored the byte-order reversal code from `SourceMatchController` and `LinkRaw` into the `Radio` class. While `Radio::AddSrcMatchExtEntry()` was updated properly to reverse the byte order, `Radio::ClearSrcMatchExtEntry()` was not. This leads to Extended MAC addresses not being properly removed from the source match table, potentially causing issues with indirect transmission. This commit resolves the issue.

It is strongly recommended to cherry-pick this fix into builds that include #10892.