### PR TITLE
[test] cover src match handling

### DIFF
--- a/tests/gtest/fake_platform.cpp
+++ b/tests/gtest/fake_platform.cpp
@@ -51,6 +51,11 @@
 
 using namespace ot;
 
+bool operator<(const otExtAddress &aLeft, const otExtAddress &aRight)
+{
+    return memcmp(&aLeft, &aRight, sizeof(aLeft)) < 0;
+}
+
 namespace ot {
 
 FakePlatform *FakePlatform::sPlatform = nullptr;
@@ -396,19 +401,38 @@ otRadioCaps otPlatRadioGetCaps(otInstance *) { return OT_RADIO_CAPS_NONE; }
 
 bool otPlatRadioGetPromiscuous(otInstance *) { return false; }
 
-void otPlatRadioEnableSrcMatch(otInstance *, bool) {}
+void otPlatRadioEnableSrcMatch(otInstance *, bool aEnabled)
+{
+    FakePlatform::CurrentPlatform().SrcMatchEnable(aEnabled);
+}
 
-otError otPlatRadioAddSrcMatchShortEntry(otInstance *, uint16_t) { return OT_ERROR_NONE; }
+otError otPlatRadioAddSrcMatchShortEntry(otInstance *, uint16_t aShortAddr)
+{
+    FakePlatform::CurrentPlatform().SrcMatchAddShortEntry(aShortAddr);
+    return OT_ERROR_NONE;
+}
 
-otError otPlatRadioAddSrcMatchExtEntry(otInstance *, const otExtAddress *) { return OT_ERROR_NONE; }
+otError otPlatRadioAddSrcMatchExtEntry(otInstance *, const otExtAddress *aExtAddr)
+{
+    FakePlatform::CurrentPlatform().SrcMatchAddExtEntry(*aExtAddr);
+    return OT_ERROR_NONE;
+}
 
-otError otPlatRadioClearSrcMatchShortEntry(otInstance *, uint16_t) { return OT_ERROR_NONE; }
+otError otPlatRadioClearSrcMatchShortEntry(otInstance *, uint16_t aShortAddr)
+{
+    FakePlatform::CurrentPlatform().SrcMatchClearShortEntry(aShortAddr);
+    return OT_ERROR_NONE;
+}
 
-otError otPlatRadioClearSrcMatchExtEntry(otInstance *, const otExtAddress *) { return OT_ERROR_NONE; }
+otError otPlatRadioClearSrcMatchExtEntry(otInstance *, const otExtAddress *aExtAddr)
+{
+    FakePlatform::CurrentPlatform().SrcMatchClearExtEntry(*aExtAddr);
+    return OT_ERROR_NONE;
+}
 
-void otPlatRadioClearSrcMatchShortEntries(otInstance *) {}
+void otPlatRadioClearSrcMatchShortEntries(otInstance *) { FakePlatform::CurrentPlatform().SrcMatchClearShortEntries(); }
 
-void otPlatRadioClearSrcMatchExtEntries(otInstance *) {}
+void otPlatRadioClearSrcMatchExtEntries(otInstance *) { FakePlatform::CurrentPlatform().SrcMatchClearExtEntries(); }
 
 otError otPlatRadioEnergyScan(otInstance *, uint8_t, uint16_t) { return OT_ERROR_NOT_IMPLEMENTED; }
 

--- a/tests/gtest/fake_platform.hpp
+++ b/tests/gtest/fake_platform.hpp
@@ -32,6 +32,7 @@
 #include "openthread-core-config.h"
 
 #include <map>
+#include <set>
 #include <vector>
 
 #include <inttypes.h>
@@ -42,6 +43,8 @@
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/radio.h>
 #include <openthread/platform/time.h>
+
+bool operator<(const otExtAddress &aLeft, const otExtAddress &aRight);
 
 namespace ot {
 
@@ -108,6 +111,22 @@ public:
 
     virtual uint64_t GetEui64() const { return 0; }
 
+    virtual void SrcMatchEnable(bool aEnabled) { mSrcMatchEnabled = aEnabled; }
+    virtual bool SrcMatchIsEnabled() const { return mSrcMatchEnabled; }
+    virtual void SrcMatchAddShortEntry(uint16_t aShortAddr) { mSrcMatchShortAddrs.insert(aShortAddr); }
+    virtual void SrcMatchClearShortEntry(uint16_t aShortAddr) { mSrcMatchShortAddrs.erase(aShortAddr); }
+    virtual bool SrcMatchHasShortEntry(uint16_t aShortAddr) const { return mSrcMatchShortAddrs.count(aShortAddr) != 0; }
+    virtual void SrcMatchAddExtEntry(const otExtAddress &aExtAddr) { mSrcMatchExtAddrs.insert(aExtAddr); }
+    virtual void SrcMatchClearExtEntry(const otExtAddress &aExtAddr) { mSrcMatchExtAddrs.erase(aExtAddr); }
+    virtual bool SrcMatchHasExtEntry(const otExtAddress &aExtAddr) const
+    {
+        return mSrcMatchExtAddrs.count(aExtAddr) != 0;
+    }
+    virtual void   SrcMatchClearShortEntries(void) { mSrcMatchShortAddrs.clear(); }
+    virtual size_t SrcMatchCountShortEntries(void) const { return mSrcMatchShortAddrs.size(); }
+    virtual void   SrcMatchClearExtEntries(void) { mSrcMatchExtAddrs.clear(); }
+    virtual size_t SrcMatchCountExtEntries(void) const { return mSrcMatchExtAddrs.size(); }
+
 protected:
     void ProcessSchedules(uint64_t &aTimeout);
 
@@ -139,6 +158,10 @@ protected:
     uint8_t mFlash[kFlashSwapSize * kFlashSwapNum];
 
     std::map<uint32_t, std::vector<std::vector<uint8_t>>> mSettings;
+
+    bool                   mSrcMatchEnabled = false;
+    std::set<uint16_t>     mSrcMatchShortAddrs;
+    std::set<otExtAddress> mSrcMatchExtAddrs;
 };
 
 template <> inline void FakePlatform::HandleSchedule<&FakePlatform::mMilliAlarmStart>()

--- a/tests/gtest/radio_spinel_rcp_test.cpp
+++ b/tests/gtest/radio_spinel_rcp_test.cpp
@@ -371,3 +371,122 @@ TEST(RadioSpinelTransmit, shouldSkipCsmaBackoffWhenCsmaCaIsEnabledAndMaxBackoffs
 
     platform.GoInMs(1000);
 }
+
+TEST(RadioSpinelSrcMatch, shouldBeAbleToEnableRadioSrcMatch)
+{
+    FakeCoprocessorPlatform platform;
+
+    platform.SrcMatchEnable(false);
+    ASSERT_EQ(platform.mRadioSpinel.Enable(FakePlatform::CurrentInstance()), kErrorNone);
+    ASSERT_EQ(platform.mRadioSpinel.EnableSrcMatch(true), kErrorNone);
+    ASSERT_EQ(platform.SrcMatchIsEnabled(), true);
+}
+
+TEST(RadioSpinelSrcMatch, shouldBeAbleToDisableRadioSrcMatch)
+{
+    FakeCoprocessorPlatform platform;
+
+    platform.SrcMatchEnable(true);
+    ASSERT_EQ(platform.mRadioSpinel.Enable(FakePlatform::CurrentInstance()), kErrorNone);
+    ASSERT_EQ(platform.mRadioSpinel.EnableSrcMatch(false), kErrorNone);
+    ASSERT_EQ(platform.SrcMatchIsEnabled(), false);
+}
+
+TEST(RadioSpinelSrcMatch, shouldBeAbleToAddRadioSrcMatchShortEntry)
+{
+    constexpr uint16_t      kTestShortAddr = 0x1234;
+    FakeCoprocessorPlatform platform;
+
+    platform.SrcMatchEnable(true);
+
+    ASSERT_EQ(platform.SrcMatchHasShortEntry(kTestShortAddr), 0);
+
+    ASSERT_EQ(platform.mRadioSpinel.Enable(FakePlatform::CurrentInstance()), kErrorNone);
+    ASSERT_EQ(platform.mRadioSpinel.AddSrcMatchShortEntry(kTestShortAddr), kErrorNone);
+
+    ASSERT_EQ(platform.SrcMatchHasShortEntry(kTestShortAddr), 1);
+}
+
+TEST(RadioSpinelSrcMatch, shouldBeAbleToClearRadioSrcMatchShortEntry)
+{
+    constexpr uint16_t      kTestShortAddr = 0x1234;
+    FakeCoprocessorPlatform platform;
+
+    platform.SrcMatchEnable(true);
+    platform.SrcMatchAddShortEntry(kTestShortAddr);
+
+    ASSERT_EQ(platform.SrcMatchHasShortEntry(kTestShortAddr), 1);
+
+    ASSERT_EQ(platform.mRadioSpinel.Enable(FakePlatform::CurrentInstance()), kErrorNone);
+    ASSERT_EQ(platform.mRadioSpinel.ClearSrcMatchShortEntry(kTestShortAddr), kErrorNone);
+
+    ASSERT_EQ(platform.SrcMatchHasShortEntry(kTestShortAddr), 0);
+}
+
+TEST(RadioSpinelSrcMatch, shouldBeAbleToAddRadioSrcMatchExtEntry)
+{
+    constexpr otExtAddress  kTestExtAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
+    constexpr otExtAddress  kTestExtAddrReversed{0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11};
+    FakeCoprocessorPlatform platform;
+
+    platform.SrcMatchEnable(true);
+    platform.SrcMatchClearExtEntries();
+
+    ASSERT_EQ(platform.SrcMatchHasExtEntry(kTestExtAddr), 0);
+    ASSERT_EQ(platform.SrcMatchHasExtEntry(kTestExtAddrReversed), 0);
+
+    ASSERT_EQ(platform.mRadioSpinel.Enable(FakePlatform::CurrentInstance()), kErrorNone);
+    ASSERT_EQ(platform.mRadioSpinel.AddSrcMatchExtEntry(kTestExtAddr), kErrorNone);
+
+    ASSERT_EQ(platform.SrcMatchHasExtEntry(kTestExtAddr), 0);
+    ASSERT_EQ(platform.SrcMatchHasExtEntry(kTestExtAddrReversed), 1);
+}
+
+TEST(RadioSpinelSrcMatch, shouldBeAbleToClearRadioSrcMatchExtEntry)
+{
+    constexpr otExtAddress  kTestExtAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
+    constexpr otExtAddress  kTestExtAddrReversed{0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11};
+    FakeCoprocessorPlatform platform;
+
+    platform.SrcMatchEnable(true);
+    platform.SrcMatchAddExtEntry(kTestExtAddrReversed);
+
+    ASSERT_EQ(platform.SrcMatchHasExtEntry(kTestExtAddrReversed), 1);
+
+    ASSERT_EQ(platform.mRadioSpinel.Enable(FakePlatform::CurrentInstance()), kErrorNone);
+    ASSERT_EQ(platform.mRadioSpinel.ClearSrcMatchExtEntry(kTestExtAddr), kErrorNone);
+
+    ASSERT_EQ(platform.SrcMatchHasExtEntry(kTestExtAddrReversed), 0);
+}
+
+TEST(RadioSpinelSrcMatch, shouldBeAbleToClearAllRadioSrcMatchShortEntres)
+{
+    constexpr uint16_t      kTestShortAddr = 0x1234;
+    FakeCoprocessorPlatform platform;
+
+    platform.SrcMatchEnable(true);
+    platform.SrcMatchAddShortEntry(kTestShortAddr);
+
+    ASSERT_EQ(platform.SrcMatchHasShortEntry(kTestShortAddr), 1);
+
+    ASSERT_EQ(platform.mRadioSpinel.Enable(FakePlatform::CurrentInstance()), kErrorNone);
+    ASSERT_EQ(platform.mRadioSpinel.ClearSrcMatchShortEntries(), kErrorNone);
+
+    ASSERT_EQ(platform.SrcMatchCountShortEntries(), 0);
+}
+
+TEST(RadioSpinelSrcMatch, shouldBeAbleToClearAllRadioSrcMatchExtEntres)
+{
+    constexpr otExtAddress  kTestExtAddrReversed{0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11};
+    FakeCoprocessorPlatform platform;
+
+    platform.SrcMatchEnable(true);
+    platform.SrcMatchAddExtEntry(kTestExtAddrReversed);
+
+    ASSERT_EQ(platform.SrcMatchHasExtEntry(kTestExtAddrReversed), 1);
+
+    ASSERT_EQ(platform.mRadioSpinel.Enable(FakePlatform::CurrentInstance()), kErrorNone);
+    ASSERT_EQ(platform.mRadioSpinel.ClearSrcMatchExtEntries(), kErrorNone);
+
+    ASSERT_EQ(platform.SrcMatchCountExtEntries(), 0);
+}


### PR DESCRIPTION
This commit adds tests to cover the handling of Src Match entries, including adding, removing and clearing of short addr entries and extended addr entries.