### PR TITLE
[tcp] send RST and clear send buffer on abort

### DIFF
--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -1089,13 +1089,6 @@ void tcplp_sys_connection_lost(struct tcpcb *aTcb, uint8_t aErrNum)
 
 void tcplp_sys_on_state_change(struct tcpcb *aTcb, int aNewState)
 {
-    if (aNewState == TCP6S_CLOSED)
-    {
-        /* Re-initialize the TCB. */
-        cbuf_pop(&aTcb->recvbuf, cbuf_used_space(&aTcb->recvbuf));
-        aTcb->accepted_from = nullptr;
-        initialize_tcb(aTcb);
-    }
     /* Any adaptive changes to the sleep interval would go here. */
 }
 

--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -1089,6 +1089,9 @@ void tcplp_sys_connection_lost(struct tcpcb *aTcb, uint8_t aErrNum)
 
 void tcplp_sys_on_state_change(struct tcpcb *aTcb, int aNewState)
 {
+    OT_UNUSED_VARIABLE(aTcb);
+    OT_UNUSED_VARIABLE(aNewState);
+
     /* Any adaptive changes to the sleep interval would go here. */
 }
 

--- a/third_party/tcplp/bsdtcp/tcp_subr.c
+++ b/third_party/tcplp/bsdtcp/tcp_subr.c
@@ -169,8 +169,6 @@ static void reinitialize_tcb(struct tcpcb* tp)
 void
 tcp_discardcb(struct tcpcb *tp)
 {
-	reinitialize_tcb(tp);
-
 	tcp_cancel_timers(tp);
 
 	/* Allow the CC algorithm to clean up after itself. */
@@ -178,6 +176,8 @@ tcp_discardcb(struct tcpcb *tp)
 		CC_ALGO(tp)->cb_destroy(tp->ccv);
 
 	tcp_free_sackholes(tp);
+
+	reinitialize_tcb(tp);
 }
 
 

--- a/third_party/tcplp/bsdtcp/tcp_usrreq.c
+++ b/third_party/tcplp/bsdtcp/tcp_usrreq.c
@@ -522,7 +522,7 @@ tcp_usr_abort(struct tcpcb* tp)
 	if (tp->t_state != TCP6S_TIME_WAIT &&
 		tp->t_state != TCP6S_CLOSED) {
 		tcp_drop(tp, ECONNABORTED);
-	} else if (tp->t_state == TCPS_TIME_WAIT) { // samkumar: I added this clause
+	} else if (tp->t_state == TCP6S_TIME_WAIT) { // samkumar: I added this clause
 		tp = tcp_close_tcb(tp);
 		tcplp_sys_connection_lost(tp, CONN_LOST_NORMAL);
 	}


### PR DESCRIPTION
Temporary solution for #11255?

---

Why is `(void) tcplp_output(tp)` called *after* `tcp_state_change(tp, TCPS_CLOSED)`? Shouldn't `tcplp_output(tp)` be called *first* to send any remaining data or to send a RST/FIN, *before* calling `tcp_state_change(tp, TCPS_CLOSED)`?

```
struct tcpcb *
tcp_drop(struct tcpcb *tp, int errnum)
{
	if (TCPS_HAVERCVDSYN(tp->t_state)) {
		tcp_state_change(tp, TCPS_CLOSED);
		(void) tcplp_output(tp);
	}
	if (errnum == ETIMEDOUT && tp->t_softerror)
		errnum = tp->t_softerror;
	tp = tcp_close_tcb(tp);
	tcplp_sys_connection_lost(tp, errnum);
	return tp;
}
```