### PR TITLE
[border-agent] try getting coap dtls session from ephemeral key manager

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -280,6 +280,14 @@ BorderAgent::CoapDtlsSession *BorderAgent::FindActiveCommissionerSession(void)
         }
     }
 
+#if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+    if ((mEphemeralKeyManager.mCoapDtlsSession != nullptr) &&
+        mEphemeralKeyManager.mCoapDtlsSession->IsActiveCommissioner())
+    {
+        commissionerSession = mEphemeralKeyManager.mCoapDtlsSession;
+    }
+#endif
+
     return commissionerSession;
 }
 


### PR DESCRIPTION
If the EphemeralKey Manager is enabled, when no active CoAP DTLS session is found in the Border Agent's mDtlsTransport, it should attempt to retrieve one managed by the EphemeralKey Manager.

This issue was discovered when using Thread devices, a Border Router , and `ot-commissioner` for commissioning with an ephemeral key. The process is as follows:

Using `ot-commissioner` commit: `8fffd186b28809257bad73eab2459c97240fe535`
Using `openthread` commit: `36a8f71d0693bfb1407fc48444c4da6e7f2d32d6`

1. Using the ephemeral key, the BR and `ot-commissioner` established a DTLS connection over the Wi-Fi link. This process worked as expected, and the Border Agent successfully created `mCoapDtlsSession` in the EphemeralKey Manager.
2. The `ot-commissioner` executed the command `joiner enableall meshcop J01NU5` to allow joiners to connect.
3. When a Thread node attempted to join the network using `joiner start J01NU5`, it failed. 

The root cause was that when the `BorderAgent` received a CoAP message from the Thread device and attempted to forward it to `ot-commissioner` via `HandleTmf<kUriRelayRx>`, it could not find an active CoAP DTLS session through `FindActiveCommissionerSession`. Because the `mCoapDtlsSession` in the EphemeralKey Manager was not managed by the Border Agent’s `mDtlsTransport`.