### PR TITLE
[version] add thread version string

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -713,6 +713,7 @@ openthread_core_files = [
   "thread/tmf.hpp",
   "thread/uri_paths.cpp",
   "thread/uri_paths.hpp",
+  "thread/version.cpp",
   "thread/version.hpp",
   "utils/channel_manager.cpp",
   "utils/channel_manager.hpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -250,6 +250,7 @@ set(COMMON_SOURCES
     thread/time_sync_service.cpp
     thread/tmf.cpp
     thread/uri_paths.cpp
+    thread/version.cpp
     utils/channel_manager.cpp
     utils/channel_monitor.cpp
     utils/flash.cpp

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -371,18 +371,6 @@ template <> Error BorderAgent::MeshCoPTxtEncoder::AppendTxtEntry<NameData>(const
 
 Error BorderAgent::MeshCoPTxtEncoder::EncodeTxtData(void)
 {
-#if OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_1
-    static const char kThreadVersionString[] = "1.1.1";
-#elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_2
-    static const char kThreadVersionString[] = "1.2.0";
-#elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_3
-    static const char kThreadVersionString[] = "1.3.0";
-#elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_3_1
-    static const char kThreadVersionString[] = "1.3.1";
-#elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_4
-    static const char kThreadVersionString[] = "1.4.0";
-#endif
-
     Error error = kErrorNone;
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
     Id id;
@@ -397,7 +385,7 @@ Error BorderAgent::MeshCoPTxtEncoder::EncodeTxtData(void)
 #endif
     SuccessOrExit(error = AppendTxtEntry("nn", Get<NetworkNameManager>().GetNetworkName().GetAsData()));
     SuccessOrExit(error = AppendTxtEntry("xp", Get<ExtendedPanIdManager>().GetExtPanId()));
-    SuccessOrExit(error = AppendTxtEntry("tv", NameData(kThreadVersionString, sizeof(kThreadVersionString) - 1)));
+    SuccessOrExit(error = AppendTxtEntry("tv", NameData(kThreadVersionString, strlen(kThreadVersionString))));
     SuccessOrExit(error = AppendTxtEntry("xa", Get<Mac::Mac>().GetExtAddress()));
 
     state = GetStateBitmap();

--- a/src/core/thread/version.cpp
+++ b/src/core/thread/version.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022, The OpenThread Authors.
+ *  Copyright (c) 2025, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -28,29 +28,26 @@
 
 /**
  * @file
- *   This file includes definitions for Thread Version.
+ *   This file implements Thread Version.
  */
 
-#ifndef VERSION_HPP_
-#define VERSION_HPP_
-
-#include "openthread-core-config.h"
-
-#include <stdint.h>
+#include "version.hpp"
 
 namespace ot {
 
-constexpr uint16_t kThreadVersion = OPENTHREAD_CONFIG_THREAD_VERSION; ///< Thread Version of this device.
-
-constexpr uint16_t kThreadVersion1p1 = OT_THREAD_VERSION_1_1; ///< Thread Version 1.1
-constexpr uint16_t kThreadVersion1p2 = OT_THREAD_VERSION_1_2; ///< Thread Version 1.2
-constexpr uint16_t kThreadVersion1p3 = OT_THREAD_VERSION_1_3; ///< Thread Version 1.3
+#if OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_1
+const char kThreadVersionString[] = "1.1.1";
+#elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_2
+const char kThreadVersionString[] = "1.2.0";
+#elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_3
+const char kThreadVersionString[] = "1.3.0";
+#elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_3_1
 // Support projects on legacy "1.3.1" version, which is now "1.4"
-constexpr uint16_t kThreadVersion1p3p1 = OT_THREAD_VERSION_1_3_1; ///< Thread Version 1.3.1
-constexpr uint16_t kThreadVersion1p4   = OT_THREAD_VERSION_1_4;   ///< Thread Version 1.4
-
-extern const char kThreadVersionString[]; ///< Thread version as human-readable string.
+const char kThreadVersionString[] = "1.4.0";
+#elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_4
+const char kThreadVersionString[] = "1.4.0";
+#else
+#error "The `OPENTHREAD_CONFIG_THREAD_VERSION` is not valid or supported"
+#endif
 
 } // namespace ot
-
-#endif // VERSION_HPP_

--- a/tests/nexus/test_border_agent.cpp
+++ b/tests/nexus/test_border_agent.cpp
@@ -808,18 +808,6 @@ template <> bool CheckObjectSameAsTxtEntryData<NameData>(const TxtEntry &aTxtEnt
            memcmp(aTxtEntry.mValue, aNameData.GetBuffer(), aNameData.GetLength()) == 0;
 }
 
-#if OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_1
-static const char kThreadVersionString[] = "1.1.1";
-#elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_2
-static const char kThreadVersionString[] = "1.2.0";
-#elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_3
-static const char kThreadVersionString[] = "1.3.0";
-#elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_3_1
-static const char kThreadVersionString[] = "1.3.1";
-#elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_4
-static const char kThreadVersionString[] = "1.4.0";
-#endif
-
 void TestBorderAgentMeshCoPServiceChangedCallback(void)
 {
     Core  nexus;
@@ -850,8 +838,7 @@ void TestBorderAgentMeshCoPServiceChangedCallback(void)
     VerifyOrQuit(meshCoPServiceTester.FindTxtEntry("xp", txtEntry));
     VerifyOrQuit(CheckObjectSameAsTxtEntryData(txtEntry, node0.Get<ExtendedPanIdManager>().GetExtPanId()));
     VerifyOrQuit(meshCoPServiceTester.FindTxtEntry("tv", txtEntry));
-    VerifyOrQuit(
-        CheckObjectSameAsTxtEntryData(txtEntry, NameData(kThreadVersionString, sizeof(kThreadVersionString) - 1)));
+    VerifyOrQuit(CheckObjectSameAsTxtEntryData(txtEntry, NameData(kThreadVersionString, strlen(kThreadVersionString))));
     VerifyOrQuit(meshCoPServiceTester.FindTxtEntry("xa", txtEntry));
     VerifyOrQuit(CheckObjectSameAsTxtEntryData(txtEntry, node0.Get<Mac::Mac>().GetExtAddress()));
     VerifyOrQuit(meshCoPServiceTester.FindTxtEntry("sb", txtEntry));
@@ -880,8 +867,7 @@ void TestBorderAgentMeshCoPServiceChangedCallback(void)
     VerifyOrQuit(meshCoPServiceTester.FindTxtEntry("xp", txtEntry));
     VerifyOrQuit(CheckObjectSameAsTxtEntryData(txtEntry, node0.Get<ExtendedPanIdManager>().GetExtPanId()));
     VerifyOrQuit(meshCoPServiceTester.FindTxtEntry("tv", txtEntry));
-    VerifyOrQuit(
-        CheckObjectSameAsTxtEntryData(txtEntry, NameData(kThreadVersionString, sizeof(kThreadVersionString) - 1)));
+    VerifyOrQuit(CheckObjectSameAsTxtEntryData(txtEntry, NameData(kThreadVersionString, strlen(kThreadVersionString))));
     VerifyOrQuit(meshCoPServiceTester.FindTxtEntry("xa", txtEntry));
     VerifyOrQuit(CheckObjectSameAsTxtEntryData(txtEntry, node0.Get<Mac::Mac>().GetExtAddress()));
     VerifyOrQuit(meshCoPServiceTester.FindTxtEntry("sb", txtEntry));


### PR DESCRIPTION
This PR adds thread version string for the "tv" entry in border agent MeshCoP TXT records.

The PR also replaces "1.3.1" with "1.4.0". 