### PR TITLE
[spinel] allow RCP reset if not multipan architecture

### DIFF
--- a/src/lib/spinel/spinel_driver.cpp
+++ b/src/lib/spinel/spinel_driver.cpp
@@ -124,8 +124,10 @@ void SpinelDriver::ResetCoprocessor(bool aSoftwareReset)
     bool hardwareReset;
     bool resetDone = false;
 
+#if OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
     // Avoid resetting the device twice in a row in Multipan RCP architecture
     VerifyOrExit(!mIsCoprocessorReady, resetDone = true);
+#endif
 
     mWaitingKey = SPINEL_PROP_LAST_STATUS;
 


### PR DESCRIPTION
This VerifyOrExit will prevent the RCP recovery process from resetting the RCP. The comment highlights that given a multipan architecture, it is not viable to reset the RCP once it is declared ready. In non-multipan architectures, it is still viable and desirable to reset the RCP as part of recovering it.

See https://github.com/orgs/openthread/discussions/11273