### PR TITLE
[mle] clamp child timeout to min/max range

### DIFF
--- a/src/core/common/time.hpp
+++ b/src/core/common/time.hpp
@@ -59,12 +59,17 @@ namespace ot {
 class Time : public Unequatable<Time>
 {
 public:
-    static constexpr uint32_t kOneSecondInMsec = 1000u;                 ///< One second interval in msec.
-    static constexpr uint32_t kOneMinuteInMsec = kOneSecondInMsec * 60; ///< One minute interval in msec.
-    static constexpr uint32_t kOneHourInMsec   = kOneMinuteInMsec * 60; ///< One hour interval in msec.
-    static constexpr uint32_t kOneDayInMsec    = kOneHourInMsec * 24;   ///< One day interval in msec.
-    static constexpr uint32_t kOneMsecInUsec   = 1000u;                 ///< One millisecond in microseconds.
-    static constexpr uint32_t kOneSecondInUsec = 1000000u;              ///< One second interval in microseconds.
+    static constexpr uint32_t kOneMinuteInSec = 60;                   ///< One minute interval in sec.
+    static constexpr uint32_t kOneHourInSec   = 60 * kOneMinuteInSec; ///< One hour interval in sec.
+    static constexpr uint32_t kOneDayInSec    = 24 * kOneHourInSec;   ///< One day interval in sec.
+
+    static constexpr uint32_t kOneSecondInMsec = 1000u;                              ///< One second interval in msec.
+    static constexpr uint32_t kOneMinuteInMsec = kOneMinuteInSec * kOneSecondInMsec; ///< One minute interval in msec.
+    static constexpr uint32_t kOneHourInMsec   = kOneHourInSec * kOneSecondInMsec;   ///< One hour interval in msec.
+    static constexpr uint32_t kOneDayInMsec    = kOneDayInSec * kOneSecondInMsec;    ///< One day interval in msec.
+
+    static constexpr uint32_t kOneMsecInUsec   = 1000u;    ///< One millisecond in microseconds.
+    static constexpr uint32_t kOneSecondInUsec = 1000000u; ///< One second interval in microseconds.
 
     /**
      * This constant defines a maximum time duration ensured to be longer than any other duration.

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -472,7 +472,7 @@ public:
      *
      * @param[in]  aTimeout  The Timeout value in seconds.
      */
-    void SetTimeout(uint32_t aTimeout);
+    void SetTimeout(uint32_t aTimeout) { SetTimeout(aTimeout, kSendChildUpdateToParent); }
 
     /**
      * Returns the RLOC16 assigned to the Thread interface.
@@ -904,6 +904,12 @@ private:
         kNoSecurity  = 255, // Security suite value indicating that MLE message is secured.
     };
 
+    enum TimeoutAction : uint8_t // Used as input in `SetTimeout()` to determine whether or not to update the parent.
+    {
+        kSendChildUpdateToParent,
+        kDoNotSendChildUpdateToParent,
+    };
+
     enum MessageAction : uint8_t
     {
         kMessageSend,
@@ -1330,6 +1336,7 @@ private:
     void       SetStateChild(uint16_t aRloc16);
     void       SetLeaderData(uint32_t aPartitionId, uint8_t aWeighting, uint8_t aLeaderRouterId);
     void       SetLeaderData(const LeaderData &aLeaderData);
+    void       SetTimeout(uint32_t aTimeout, TimeoutAction aAction);
     void       InformPreviousChannel(void);
     bool       IsAnnounceAttach(void) const { return mAlternatePanId != Mac::kPanIdBroadcast; }
     void       ScheduleMessageTransmissionTimer(void);


### PR DESCRIPTION
This commit updates `SetTimeout()` to ensure the child timeout remains within the minimum and maximum allowed values (per the specification, the maximum value of 8 hours is used).

These limits are also enforced when the parent requests a different timeout value in an MLE Child Update Response to the child's request.