### PR TITLE
[mdns] introduce `RecordQuerier` for continuous record queries

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (484)
+#define OPENTHREAD_API_VERSION (485)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/cli_mdns.cpp
+++ b/src/cli/cli_mdns.cpp
@@ -879,6 +879,64 @@ void Mdns::HandleIp4AddressResult(otInstance *aInstance, const otMdnsAddressResu
     Interpreter::GetInterpreter().mMdns.HandleAddressResult(*aResult, kIp4Address);
 }
 
+template <> otError Mdns::Process<Cmd("recordquerier")>(Arg aArgs[])
+{
+    // mdns recordquerier start|stop <record-type> <first-label> [<next-labels>]
+
+    otError             error;
+    otMdnsRecordQuerier querier;
+    bool                isStart;
+
+    ClearAllBytes(querier);
+
+    SuccessOrExit(error = ParseStartOrStop(aArgs[0], isStart));
+
+    SuccessOrExit(error = aArgs[1].ParseAsUint16(querier.mRecordType));
+
+    VerifyOrExit(!aArgs[2].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+    querier.mFirstLabel = aArgs[2].GetCString();
+
+    if (!aArgs[3].IsEmpty())
+    {
+        querier.mNextLabels = aArgs[3].GetCString();
+        VerifyOrExit(aArgs[4].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+    }
+
+    querier.mInfraIfIndex = mInfraIfIndex;
+    querier.mCallback     = HandleRecordResult;
+
+    if (isStart)
+    {
+        error = otMdnsStartRecordQuerier(GetInstancePtr(), &querier);
+    }
+    else
+    {
+        error = otMdnsStopRecordQuerier(GetInstancePtr(), &querier);
+    }
+
+exit:
+    return error;
+}
+
+void Mdns::HandleRecordResult(otInstance *aInstance, const otMdnsRecordResult *aResult)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    Interpreter::GetInterpreter().mMdns.HandleRecordResult(*aResult);
+}
+
+void Mdns::HandleRecordResult(const otMdnsRecordResult &aResult)
+{
+    OutputLine("mDNS result for record %u and name %s %s", aResult.mRecordType, aResult.mFirstLabel,
+               aResult.mNextLabels == nullptr ? "" : aResult.mNextLabels);
+
+    OutputFormat(kIndentSize, "data: ");
+    OutputBytesLine(aResult.mRecordData, aResult.mRecordDataLength);
+
+    OutputLine(kIndentSize, "ttl: %lu", ToUlong(aResult.mTtl));
+    OutputLine(kIndentSize, "if-index: %lu", ToUlong(aResult.mInfraIfIndex));
+}
+
 #if OPENTHREAD_CONFIG_MULTICAST_DNS_ENTRY_ITERATION_API_ENABLE
 
 template <> otError Mdns::Process<Cmd("browsers")>(Arg aArgs[])
@@ -1083,6 +1141,46 @@ exit:
     return error;
 }
 
+template <> otError Mdns::Process<Cmd("recordqueriers")>(Arg aArgs[])
+{
+    // mdns recordqueriers
+
+    otError             error;
+    otMdnsIterator     *iterator = nullptr;
+    otMdnsCacheInfo     info;
+    otMdnsRecordQuerier querier;
+
+    VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+
+    iterator = otMdnsAllocateIterator(GetInstancePtr());
+    VerifyOrExit(iterator != nullptr, error = OT_ERROR_NO_BUFS);
+
+    while (true)
+    {
+        error = otMdnsGetNextRecordQuerier(GetInstancePtr(), iterator, &querier, &info);
+
+        if (error == OT_ERROR_NOT_FOUND)
+        {
+            error = OT_ERROR_NONE;
+            ExitNow();
+        }
+
+        SuccessOrExit(error);
+
+        OutputLine("Record querier for type %u and name %s %s", querier.mRecordType, querier.mFirstLabel,
+                   querier.mNextLabels == nullptr ? "" : querier.mNextLabels);
+        OutputCacheInfo(info);
+    }
+
+exit:
+    if (iterator != nullptr)
+    {
+        otMdnsFreeIterator(GetInstancePtr(), iterator);
+    }
+
+    return error;
+}
+
 #endif // OPENTHREAD_CONFIG_MULTICAST_DNS_ENTRY_ITERATION_API_ENABLE
 
 otError Mdns::Process(Arg aArgs[])
@@ -1110,6 +1208,10 @@ otError Mdns::Process(Arg aArgs[])
 #if OPENTHREAD_CONFIG_MULTICAST_DNS_ENTRY_ITERATION_API_ENABLE
         CmdEntry("ip6resolvers"),
         CmdEntry("keys"),
+#endif
+        CmdEntry("recordquerier"),
+#if OPENTHREAD_CONFIG_MULTICAST_DNS_ENTRY_ITERATION_API_ENABLE
+        CmdEntry("recordqueriers"),
 #endif
         CmdEntry("register"),
 #if OPENTHREAD_CONFIG_MULTICAST_DNS_ENTRY_ITERATION_API_ENABLE

--- a/src/cli/cli_mdns.hpp
+++ b/src/cli/cli_mdns.hpp
@@ -117,6 +117,7 @@ private:
     void    HandleSrvResult(const otMdnsSrvResult &aResult);
     void    HandleTxtResult(const otMdnsTxtResult &aResult);
     void    HandleAddressResult(const otMdnsAddressResult &aResult, IpAddressType aType);
+    void    HandleRecordResult(const otMdnsRecordResult &aResult);
 
     static otError ParseStartOrStop(const Arg &aArg, bool &aIsStart);
     static void    HandleRegisterationDone(otInstance *aInstance, otMdnsRequestId aRequestId, otError aError);
@@ -125,6 +126,7 @@ private:
     static void    HandleTxtResult(otInstance *aInstance, const otMdnsTxtResult *aResult);
     static void    HandleIp6AddressResult(otInstance *aInstance, const otMdnsAddressResult *aResult);
     static void    HandleIp4AddressResult(otInstance *aInstance, const otMdnsAddressResult *aResult);
+    static void    HandleRecordResult(otInstance *aInstance, const otMdnsRecordResult *aResult);
 
     static otError ParseServiceArgs(Arg aArgs[], otMdnsService &aService, Buffers &aBuffers);
 

--- a/src/core/api/mdns_api.cpp
+++ b/src/core/api/mdns_api.cpp
@@ -228,6 +228,20 @@ otError otMdnsStopIp4AddressResolver(otInstance *aInstance, const otMdnsAddressR
     return AsCoreType(aInstance).Get<Dns::Multicast::Core>().StopIp4AddressResolver(*aResolver);
 }
 
+otError otMdnsStartRecordQuerier(otInstance *aInstance, const otMdnsRecordQuerier *aQuerier)
+{
+    AssertPointerIsNotNull(aQuerier);
+
+    return AsCoreType(aInstance).Get<Dns::Multicast::Core>().StartRecordQuerier(*aQuerier);
+}
+
+otError otMdnsStopRecordQuerier(otInstance *aInstance, const otMdnsRecordQuerier *aQuerier)
+{
+    AssertPointerIsNotNull(aQuerier);
+
+    return AsCoreType(aInstance).Get<Dns::Multicast::Core>().StopRecordQuerier(*aQuerier);
+}
+
 #if OPENTHREAD_CONFIG_MULTICAST_DNS_ENTRY_ITERATION_API_ENABLE
 
 otError otMdnsGetNextBrowser(otInstance      *aInstance,
@@ -288,6 +302,18 @@ otError otMdnsGetNextIp4AddressResolver(otInstance            *aInstance,
     AssertPointerIsNotNull(aInfo);
 
     return AsCoreType(aInstance).Get<Dns::Multicast::Core>().GetNextIp4AddressResolver(*aIterator, *aResolver, *aInfo);
+}
+
+otError otMdnsGetNextRecordQuerier(otInstance          *aInstance,
+                                   otMdnsIterator      *aIterator,
+                                   otMdnsRecordQuerier *aQuerier,
+                                   otMdnsCacheInfo     *aInfo)
+{
+    AssertPointerIsNotNull(aIterator);
+    AssertPointerIsNotNull(aQuerier);
+    AssertPointerIsNotNull(aInfo);
+
+    return AsCoreType(aInstance).Get<Dns::Multicast::Core>().GetNextRecordQuerier(*aIterator, *aQuerier, *aInfo);
 }
 
 #endif // OPENTHREAD_CONFIG_MULTICAST_DNS_ENTRY_ITERATION_API_ENABLE

--- a/src/core/net/dns_types.cpp
+++ b/src/core/net/dns_types.cpp
@@ -111,8 +111,11 @@ bool Name::Matches(const char *aFirstLabel, const char *aLabels, const char *aDo
             VerifyOrExit(matches);
         }
 
-        matches = CompareAndSkipLabels(namePtr, aLabels, kLabelSeparatorChar);
-        VerifyOrExit(matches);
+        if (aLabels != nullptr)
+        {
+            matches = CompareAndSkipLabels(namePtr, aLabels, kLabelSeparatorChar);
+            VerifyOrExit(matches);
+        }
 
         matches = CompareAndSkipLabels(namePtr, aDomain, kNullChar);
     }
@@ -125,7 +128,11 @@ bool Name::Matches(const char *aFirstLabel, const char *aLabels, const char *aDo
             SuccessOrExit(CompareLabel(*mMessage, offset, aFirstLabel));
         }
 
-        SuccessOrExit(CompareMultipleLabels(*mMessage, offset, aLabels));
+        if (aLabels != nullptr)
+        {
+            SuccessOrExit(CompareMultipleLabels(*mMessage, offset, aLabels));
+        }
+
         SuccessOrExit(CompareName(*mMessage, offset, aDomain));
         matches = true;
     }

--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -606,15 +606,15 @@ public:
      * @p aFirstLabel can be `nullptr` if not needed. But if non-null, it is treated as a single label and can itself
      * include dot `.` character.
      *
-     * The @p aLabels MUST NOT be `nullptr` and MUST follow  "<label1>.<label2>.<label3>", i.e., a sequence of one or
-     * more labels separated by dot '.' char, and it MUST NOT end with dot `.`.
+     * The @p aLabels can be `nullptr`. If it is provided it MUST follow  "<label1>.<label2>.<label3>", i.e., a
+     * sequence of one or more labels separated by dot '.' char, and it MUST NOT end with dot `.`.
      *
      * @p aDomain MUST NOT be `nullptr` and MUST have at least one label and MUST always end with a dot `.` character.
      *
      * If the above conditions are not satisfied, the behavior of this method is undefined.
      *
      * @param[in] aFirstLabel     A first label to check. Can be `nullptr`.
-     * @param[in] aLabels         A string of dot separated labels, MUST NOT end with dot.
+     * @param[in] aLabels         A string of dot separated labels, MUST NOT end with dot. Can be `nullptr`
      * @param[in] aDomain         Domain name. MUST end with dot.
      *
      * @retval TRUE   The name matches the given components.


### PR DESCRIPTION
This commit enhances the native mDNS implementation by adding `RecordQuerier`, which enables continuous queries for arbitrary record types and query names. The `RecordQuerier` follows a pattern similar to service/address browsers and resolvers, allowing multiple queriers to be started for the same record type and name (provided they use different callbacks).

Record results are cached, and the cache correctly handles and reports when new records are added or removed (either explicitly or due to timeouts), including when the "cache-flush" flag is used in a response.

Public OpenThread APIs and corresponding CLI commands are added for `RecordQuerier` functionality.

The `test_mdns` unit test is updated with a detailed test case covering the newly added `RecordQuerier` functions.
