### PR TITLE
[gtest] fix build error when building posix

### DIFF
--- a/tests/gtest/fake_platform.cpp
+++ b/tests/gtest/fake_platform.cpp
@@ -536,6 +536,13 @@ bool otPlatBleSupportsMultiRadio(otInstance *) { return false; }
 
 otError otPlatBleGapAdvSetData(otInstance *, uint8_t *, uint16_t) { return OT_ERROR_NONE; }
 
+OT_TOOL_WEAK otError otPlatRadioAddCalibratedPower(otInstance *, uint8_t, int16_t, const uint8_t *, uint16_t)
+{
+    return OT_ERROR_NONE;
+}
+
+OT_TOOL_WEAK otError otPlatRadioClearCalibratedPowers(otInstance *) { return OT_ERROR_NONE; }
+
 void otPlatSettingsInit(otInstance *, const uint16_t *, uint16_t) {}
 
 void otPlatSettingsDeinit(otInstance *) {}


### PR DESCRIPTION
This commit fix build error when running `./script/cmake-build posix -DOT_BUILD_GTEST=ON`