### PR TITLE
[posix] introduce `OT_EXIT_RCP_RESET_REQUIRED` for platform reset requests

### DIFF
--- a/src/lib/platform/exit_code.c
+++ b/src/lib/platform/exit_code.c
@@ -75,6 +75,10 @@ const char *otExitCodeToString(uint8_t aExitCode)
 #endif
         break;
 
+    case OT_EXIT_INVALID_STATE:
+        retval = "InvalidState";
+        break;
+
     default:
         assert(false);
         retval = "UnknownExitCode";

--- a/src/lib/platform/exit_code.c
+++ b/src/lib/platform/exit_code.c
@@ -79,6 +79,10 @@ const char *otExitCodeToString(uint8_t aExitCode)
         retval = "InvalidState";
         break;
 
+    case OT_EXIT_RCP_RESET_REQUIRED:
+        retval = "RcpResetRequired";
+        break;
+
     default:
         assert(false);
         retval = "UnknownExitCode";

--- a/src/lib/platform/exit_code.h
+++ b/src/lib/platform/exit_code.h
@@ -88,6 +88,10 @@ enum
      */
     OT_EXIT_INVALID_STATE = 7,
 
+    /**
+     * RCP chip reset is not able to be done by OT
+     */
+    OT_EXIT_RCP_RESET_REQUIRED = 8,
 };
 
 /**

--- a/src/posix/platform/radio_url.cpp
+++ b/src/posix/platform/radio_url.cpp
@@ -43,28 +43,30 @@ const char *otSysGetRadioUrlHelpString(void)
     "\n"
 
 #if OPENTHREAD_POSIX_CONFIG_SPINEL_SPI_INTERFACE_ENABLE
-#define OT_SPINEL_SPI_RADIO_URL_HELP_BUS                                                                       \
-    "Protocol=[spinel+spi*]           Specify the Spinel interface as the Spinel SPI interface\n"              \
-    "    spinel+spi://${PATH_TO_SPI_DEVICE}?${Parameters}\n"                                                   \
-    "Parameters:\n"                                                                                            \
-    "    gpio-int-device[=gpio-device-path]\n"                                                                 \
-    "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"       \
-    "                                  `I̅N̅T̅` pin.\n"                                                     \
-    "    gpio-int-line[=line-offset]\n"                                                                        \
-    "                                  The offset index of `I̅N̅T̅` pin for the associated GPIO device.\n"  \
-    "    gpio-reset-device[=gpio-device-path]\n"                                                               \
-    "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"       \
-    "                                  `R̅E̅S̅` pin.\n"                                                     \
-    "    gpio-reset-line[=line-offset]"                                                                        \
-    "                                  The offset index of `R̅E̅S̅` pin for the associated GPIO device.\n"  \
-    "    spi-mode[=mode]               Specify the SPI mode to use (0-3).\n"                                   \
-    "    spi-speed[=hertz]             Specify the SPI speed in hertz.\n"                                      \
-    "    spi-cs-delay[=usec]           Specify the delay after C̅S̅ assertion, in µsec.\n"                  \
-    "    spi-reset-delay[=ms]          Specify the delay after R̅E̅S̅E̅T̅ assertion, in milliseconds.\n"  \
-    "    spi-align-allowance[=n]       Specify the maximum number of 0xFF bytes to clip from start of\n"       \
-    "                                  MISO frame. Max value is 16.\n"                                         \
-    "    spi-small-packet=[n]          Specify the smallest packet we can receive in a single transaction.\n"  \
-    "                                  (larger packets will require two transactions). Default value is 32.\n" \
+#define OT_SPINEL_SPI_RADIO_URL_HELP_BUS                                                                           \
+    "Protocol=[spinel+spi*]           Specify the Spinel interface as the Spinel SPI interface\n"                  \
+    "    spinel+spi://${PATH_TO_SPI_DEVICE}?${Parameters}\n"                                                       \
+    "Parameters:\n"                                                                                                \
+    "    gpio-int-device[=gpio-device-path]\n"                                                                     \
+    "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"           \
+    "                                  `I̅N̅T̅` pin.\n"                                                         \
+    "    gpio-int-line[=line-offset]\n"                                                                            \
+    "                                  The offset index of `I̅N̅T̅` pin for the associated GPIO device.\n"      \
+    "    gpio-reset-device[=gpio-device-path]\n"                                                                   \
+    "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"           \
+    "                                  `R̅E̅S̅` pin. If not specified, the process will direct exist when an\n" \
+    "                                  RCP reset is required.\n"                                                   \
+    "    gpio-reset-line[=line-offset]\n"                                                                          \
+    "                                  The offset index of `R̅E̅S̅` pin for the associated GPIO device. This\n" \
+    "                                  is required if `gpio-reset-device` is specified.\n"                         \
+    "    spi-mode[=mode]               Specify the SPI mode to use (0-3).\n"                                       \
+    "    spi-speed[=hertz]             Specify the SPI speed in hertz.\n"                                          \
+    "    spi-cs-delay[=usec]           Specify the delay after C̅S̅ assertion, in µsec.\n"                      \
+    "    spi-reset-delay[=ms]          Specify the delay after R̅E̅S̅E̅T̅ assertion, in milliseconds.\n"      \
+    "    spi-align-allowance[=n]       Specify the maximum number of 0xFF bytes to clip from start of\n"           \
+    "                                  MISO frame. Max value is 16.\n"                                             \
+    "    spi-small-packet=[n]          Specify the smallest packet we can receive in a single transaction.\n"      \
+    "                                  (larger packets will require two transactions). Default value is 32.\n"     \
     "\n"
 #else
 #define OT_SPINEL_SPI_RADIO_URL_HELP_BUS

--- a/src/posix/platform/radio_url.cpp
+++ b/src/posix/platform/radio_url.cpp
@@ -52,7 +52,7 @@ const char *otSysGetRadioUrlHelpString(void)
     "                                  `I̅N̅T̅` pin.\n"                                                     \
     "    gpio-int-line[=line-offset]\n"                                                                        \
     "                                  The offset index of `I̅N̅T̅` pin for the associated GPIO device.\n"  \
-    "    gpio-reset-dev[=gpio-device-path]\n"                                                                  \
+    "    gpio-reset-device[=gpio-device-path]\n"                                                               \
     "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"       \
     "                                  `R̅E̅S̅` pin.\n"                                                     \
     "    gpio-reset-line[=line-offset]"                                                                        \


### PR DESCRIPTION
This commit modifies the process exit behavior to introduce a new exit code, `OT_EXIT_RCP_RESET_REQUIRED`. This code signals that a hardware reset is required by the POSIX platform, rather than being initiated directly by OpenThread itself.

This change is necessary to accommodate scenarios where the platform or a separate stack (e.g., Wifi/BT) is responsible for managing hardware resets of integrated chips (like Wifi/BT/Thread combo chips).  Previously, OpenThread might have attempted to handle resets directly, which is not always appropriate in these integrated environments.

This commit includes the following changes:

- **Adds a new exit code:** `OT_EXIT_RCP_RESET_REQUIRED` is now defined to indicate a platform-requested hardware reset.
- **Makes reset parameters optional:** The `gpio-reset-device` and `gpio-reset-line` parameters for reset functionality are now optional.
- **Exit if no rest device/pin:** process dies if gpio-reset-device is not given when TriggerReset().