### PR TITLE
[cmake] add build option OT_BUILD_UTEST

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,9 +27,12 @@
 #
 
 option(OT_BUILD_GTEST "enable gtest")
+option(OT_BUILD_UTEST "enable unit test" ON)
 
 if(OT_FTD AND BUILD_TESTING AND (NOT OT_PLATFORM STREQUAL "nexus"))
-    add_subdirectory(unit)
+    if(OT_BUILD_UTEST)
+        add_subdirectory(unit)
+    endif()
     if(OT_BUILD_GTEST)
         add_subdirectory(gtest)
     endif()


### PR DESCRIPTION
Repeated unit test compilation during local simulation platform debug builds slows down development. This commit adds the OT_BUILD_UTEST build option, allowing users to skip unit test compilation.