### PR TITLE
[csl] set the `SubMac` to handle the `CslSample()` method

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -586,13 +586,6 @@ void Mac::UpdateIdleMode(void)
 
     if (shouldSleep)
     {
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-        if (IsCslEnabled())
-        {
-            mLinks.CslSample();
-            ExitNow();
-        }
-#endif
         mLinks.Sleep();
         LogDebg("Idle mode: Radio sleeping");
     }

--- a/src/core/mac/mac_links.hpp
+++ b/src/core/mac/mac_links.hpp
@@ -484,22 +484,6 @@ public:
 #endif
         return retval;
     }
-
-    /**
-     * Transitions all radios link to CSL sample state, given that a non-zero CSL period is configured.
-     *
-     * CSL sample state is only applicable and used for 15.4 radio link. Other link are transitioned to sleep state
-     * when CSL period is non-zero.
-     */
-    void CslSample(void)
-    {
-#if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-        mSubMac.CslSample();
-#endif
-#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-        mTrel.Sleep();
-#endif
-    }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
 #if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -240,6 +240,24 @@ Error SubMac::Sleep(void)
 {
     Error error = kErrorNone;
 
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+    if (IsCslEnabled())
+    {
+        CslSample();
+    }
+    else
+#endif
+    {
+        error = RadioSleep();
+    }
+
+    return error;
+}
+
+Error SubMac::RadioSleep(void)
+{
+    Error error = kErrorNone;
+
     VerifyOrExit(ShouldHandleTransitionToSleep());
 
     error = Get<Radio>().Sleep();

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -389,13 +389,6 @@ public:
     bool UpdateCsl(uint16_t aPeriod, uint8_t aChannel, otShortAddress aShortAddr, const otExtAddress *aExtAddr);
 
     /**
-     * Lets `SubMac` start CSL sample mode given a configured non-zero CSL period.
-     *
-     * `SubMac` would switch the radio state between `Receive` and `Sleep` according the CSL timer.
-     */
-    void CslSample(void);
-
-    /**
      * Returns parent CSL accuracy (clock accuracy and uncertainty).
      *
      * @returns The parent CSL accuracy.
@@ -509,12 +502,14 @@ public:
 private:
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     void        CslInit(void);
+    void        CslSample(void);
     void        UpdateCslLastSyncTimestamp(TxFrame &aFrame, RxFrame *aAckFrame);
     void        UpdateCslLastSyncTimestamp(RxFrame *aFrame, Error aError);
     static void HandleCslTimer(Timer &aTimer);
     void        HandleCslTimer(void);
     void        GetCslWindowEdges(uint32_t &aAhead, uint32_t &aAfter);
     uint32_t    GetLocalTime(void);
+    bool        IsCslEnabled(void) const { return mCslPeriod > 0; }
 #if OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
     void LogReceived(RxFrame *aFrame);
 #endif
@@ -625,6 +620,8 @@ private:
     void SignalFrameCounterUsedOnTxDone(const TxFrame &aFrame);
     void HandleEnergyScanDone(int8_t aMaxRssi);
     void HandleTimer(void);
+
+    Error RadioSleep(void);
 
     void               SetState(State aState);
     static const char *StateToString(State aState);


### PR DESCRIPTION
This commit moves the calling `CslSample()` logic from `Mac` to the `SubMac`. It will make it easier for us to move CSL receiver to RCP in the future.