### PR TITLE
[channel monitor] make scan duration configurable

### DIFF
--- a/src/core/config/channel_monitor.h
+++ b/src/core/config/channel_monitor.h
@@ -71,8 +71,8 @@
  *
  * The sample interval in milliseconds used by Channel Monitoring feature.
 
- * When enabled, a zero-duration Energy Scan is performed, collecting a single RSSI sample per channel during each
- * interval.
+ * When enabled, an Energy Scan is performed during each interval with a duration defined by
+ * `OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENERGY_SCAN_DURATION`.
  *
  * Applicable only if Channel Monitoring feature is enabled (i.e., `OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE` is set).
  */
@@ -110,6 +110,17 @@
 #define OPENTHREAD_CONFIG_CHANNEL_MONITOR_SAMPLE_WINDOW 960
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENERGY_SCAN_DURATION
+ *
+ * The scan duration to use when performing an Energy Scan while monitoring channels. When set to 0, collect a
+ * single RSSI sample per channel.
+ *
+ * Applicable only if Channel Monitoring feature is enabled (i.e., `OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE` is set).
+ */
+#ifndef OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENERGY_SCAN_DURATION
+#define OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENERGY_SCAN_DURATION 0
+#endif
 /**
  * @}
  */

--- a/src/core/utils/channel_monitor.cpp
+++ b/src/core/utils/channel_monitor.cpp
@@ -113,7 +113,7 @@ exit:
 
 void ChannelMonitor::HandleTimer(void)
 {
-    IgnoreError(Get<Mac::Mac>().EnergyScan(mScanChannelMasks[mChannelMaskIndex], 0,
+    IgnoreError(Get<Mac::Mac>().EnergyScan(mScanChannelMasks[mChannelMaskIndex], kScanDuration,
                                            &ChannelMonitor::HandleEnergyScanResult, this));
 
     mTimer.StartAt(mTimer.GetFireTime(), Random::NonCrypto::AddJitter(kTimerInterval, kMaxJitterInterval));

--- a/src/core/utils/channel_monitor.hpp
+++ b/src/core/utils/channel_monitor.hpp
@@ -64,9 +64,9 @@ namespace Utils {
  * Channel Monitoring will periodically monitor all channels to help determine the cleaner channels (channels
  * with less interference).
  *
- * When Channel Monitoring is active, every `kSampleInterval`, a zero-duration Energy Scan is performed on every
- * channel collecting a single RSSI  sample per channel. The RSSI samples are compared with a pre-specified RSSI
- * threshold `kRssiThreshold`. As an indicator of channel quality, the `ChannelMonitor` maintains and provides the
+ * When Channel Monitoring is active, every `kSampleInterval`, an `kScanDuration`-duration Energy Scan
+ * is performed on every channel. The RSSI samples are compared with a pre-specified RSSI threshold 
+ * `kRssiThreshold`. As an indicator of channel quality, the `ChannelMonitor` maintains and provides the
  * average rate/percentage of RSSI samples that are above the threshold within (approximately) a specified sample
  * window (referred to as "channel occupancy").
  */
@@ -90,6 +90,10 @@ public:
      */
     static constexpr uint32_t kSampleWindow = OPENTHREAD_CONFIG_CHANNEL_MONITOR_SAMPLE_WINDOW;
 
+    /**
+     * The duration to request when conducting an Energy Scan.
+     */
+    static constexpr uint32_t kScanDuration = OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENERGY_SCAN_DURATION;
     /**
      * Initializes the object.
      *


### PR DESCRIPTION
This allows the scan duration of the Channel Monitor to be configurable in order to support radios/RCPs that do not provide the channel-specific RSSI when a zero-duration energy scan is conducted.

An example is the Espressif ESP32H2 radio co-processor, which provides the last received RSSI regardless of channel, despite the energy scan logic of setting the receive channel, then asking for the last RSSI, that is executed when a zero-duration scan is requested from Mac::EnergyScan. The Channel Monitor in the case of this RCP will report the same last RSSI received from a Thread transmitter for every channel, which breaks the utility of the Channel Monitor.