### PR TITLE
[border-agent] change meshcop service TXT value after enabling/disabling Epskc

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -560,12 +560,14 @@ void BorderAgent::EphemeralKeyManager::SetEnabled(bool aEnabled)
     {
         VerifyOrExit(mState == kStateDisabled);
         SetState(kStateStopped);
+        Get<BorderAgent>().PostNotifyMeshCoPServiceChangedTask();
     }
     else
     {
         VerifyOrExit(mState != kStateDisabled);
         Stop();
         SetState(kStateDisabled);
+        Get<BorderAgent>().PostNotifyMeshCoPServiceChangedTask();
     }
 
 exit:


### PR DESCRIPTION
This PR posts a MeshCoP service changed task after Epskc feature is enabled/disabled.

After Epskc feature is enabled/disabled, the 'EpskcSupported' bit in the statebitmap in MeshCoP Txt value should change accordingly.

This PR fixes the CI failure of the change in ot-br-posix: https://github.com/openthread/ot-br-posix/pull/2727