### PR TITLE
[csl] use correct time basis for CSL sample time

### DIFF
--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -663,14 +663,15 @@ private:
     SubMacTimer mTimer;
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    uint16_t mCslPeriod;            // The CSL sample period, in units of 10 symbols (160 microseconds).
-    uint8_t  mCslChannel : 7;       // The CSL sample channel.
-    bool     mIsCslSampling : 1;    // Indicates that the radio is receiving in CSL state for platforms not supporting
-                                    // delayed reception.
-    uint16_t    mCslPeerShort;      // The CSL peer short address.
-    TimeMicro   mCslSampleTime;     // The CSL sample time of the current period relative to the local radio clock.
-    TimeMicro   mCslLastSync;       // The timestamp of the last successful CSL synchronization.
-    CslAccuracy mCslParentAccuracy; // The parent's CSL accuracy (clock accuracy and uncertainty).
+    uint16_t mCslPeriod;             // The CSL sample period, in units of 10 symbols (160 microseconds).
+    uint8_t  mCslChannel : 7;        // The CSL sample channel.
+    bool     mIsCslSampling : 1;     // Indicates that the radio is receiving in CSL state for platforms not supporting
+                                     // delayed reception.
+    uint16_t    mCslPeerShort;       // The CSL peer short address.
+    uint32_t    mCslSampleTimeRadio; // The CSL sample time of the current period based on radio time (lower 32-bit).
+    TimeMicro   mCslSampleTimeLocal; // The CSL sample time of the current period based on local time.
+    TimeMicro   mCslLastSync;        // The timestamp of the last successful CSL synchronization.
+    CslAccuracy mCslParentAccuracy;  // The parent's CSL accuracy (clock accuracy and uncertainty).
     TimerMicro  mCslTimer;
 #endif
 


### PR DESCRIPTION
This commit updates how the CSL sample time is tracked in `SubMac`, ensuring that it is tracked using both radio time based on `otPlatRadioGetNow()` and the local time (`TimeMicro::GetNow()`). These two time sources may not necessarily be the same.

This change addresses the issue where the same time value was used for both scheduling `mCslTimer` (which should be based on local time) and for calls to the radio APIs (which should use radio time).