### PR TITLE
[srp-server] fix typo in otSrpServerIsFastStartModeEnabled

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (481)
+#define OPENTHREAD_API_VERSION (482)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/srp_server.h
+++ b/include/openthread/srp_server.h
@@ -321,7 +321,7 @@ otError otSrpServerEnableFastStartMode(otInstance *aInstance);
  * @retval TRUE   The fast-start mode is enabled.
  * @retval FALSE  The fast-start mode is disabled.
  */
-bool otSrpServerIsFastStartmodeEnabled(otInstance *aInstance);
+bool otSrpServerIsFastStartModeEnabled(otInstance *aInstance);
 
 /**
  * Returns SRP server TTL configuration.

--- a/src/cli/cli_srp_server.cpp
+++ b/src/cli/cli_srp_server.cpp
@@ -197,7 +197,7 @@ template <> otError SrpServer::Process<Cmd("domain")>(Arg aArgs[])
  * @par
  * This command requires that `OPENTHREAD_CONFIG_SRP_SERVER_FAST_START_MODE_ENABLE` be enabled.
  * @moreinfo{@srp}.
- * @sa otSrpServerIsFastStartmodeEnabled
+ * @sa otSrpServerIsFastStartModeEnabled
  * @sa otSrpServerEnableFastStartMode
  */
 template <> otError SrpServer::Process<Cmd("faststart")>(Arg aArgs[])
@@ -206,7 +206,7 @@ template <> otError SrpServer::Process<Cmd("faststart")>(Arg aArgs[])
 
     if (aArgs[0].IsEmpty())
     {
-        OutputEnabledDisabledStatus(otSrpServerIsFastStartmodeEnabled(GetInstancePtr()));
+        OutputEnabledDisabledStatus(otSrpServerIsFastStartModeEnabled(GetInstancePtr()));
     }
     else if (aArgs[0] == "enable")
     {

--- a/src/core/api/srp_server_api.cpp
+++ b/src/core/api/srp_server_api.cpp
@@ -96,7 +96,7 @@ otError otSrpServerEnableFastStartMode(otInstance *aInstance)
     return AsCoreType(aInstance).Get<Srp::Server>().EnableFastStartMode();
 }
 
-bool otSrpServerIsFastStartmodeEnabled(otInstance *aInstance)
+bool otSrpServerIsFastStartModeEnabled(otInstance *aInstance)
 {
     return AsCoreType(aInstance).Get<Srp::Server>().IsFastStartModeEnabled();
 }


### PR DESCRIPTION
Rename otSrpServerIsFastStartmodeEnabled to otSrpServerIsFastStartModeEnabled