### PR TITLE
[submac] WED performs periodic sampling by calling `Sleep()` and `Receive()`

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -240,10 +240,10 @@ Error SubMac::Sleep(void)
 {
     Error error = kErrorNone;
 
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    if (IsCslEnabled())
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+    if (IsRadioSampleEnabled())
     {
-        CslSample();
+        RadioSample();
     }
     else
 #endif
@@ -343,8 +343,8 @@ Error SubMac::Send(void)
 #endif
     case kStateSleep:
     case kStateReceive:
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    case kStateCslSample:
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+    case kStateRadioSample:
 #endif
         break;
 
@@ -721,8 +721,8 @@ Error SubMac::EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration)
 
     case kStateReceive:
     case kStateSleep:
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    case kStateCslSample:
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+    case kStateRadioSample:
 #endif
         break;
     }
@@ -1029,6 +1029,145 @@ void SubMac::StartTimerAt(Time aStartTime, uint32_t aDelayUs)
 #endif
 }
 
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+void SubMac::RadioSample(void)
+{
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+    VerifyOrExit(!mRadioFilterEnabled, IgnoreError(Get<Radio>().Sleep()));
+#endif
+
+    SetState(kStateRadioSample);
+
+    if (RadioSupportsReceiveTiming() || !RequestSample())
+    {
+#if !OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
+        IgnoreError(Get<Radio>().Sleep()); // Don't actually sleep for debugging
+#endif
+    }
+
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+exit:
+#endif
+    return;
+}
+
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE && OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+bool SubMac::IsRadioSampleEnabled(void) const { return IsCslEnabled() || mIsWedEnabled; }
+
+/*
+ * The radio state (receive/sleep) is determined by the request from both CSL and WED:
+ * <1> If both CSL and WED request to enter sleep state, the radio is set to sleep state.
+ * <2> If either CSL or WED requests to enter the receive state and the other requests to enter sleep state, the radio
+ *     is set to receive state using the channel that is requested to enter the receive state.
+ * <3> If both CSL and WED request to enter the receive state, the radio is set to the receive state using the CSL
+ *     channel.
+ *
+ * The diagram below illustrates how to set the radio state based on the request of WED and CSL.
+ *
+ * CSL   ------========------------========------------========------------========---
+ *             ^       ^
+ *             |       |
+ *             | RequestSleep(Csl)
+ *     RequestReceive(Csl)
+ *
+ * WED   -----------++++++++----------------++++++++----------------++++++++----------
+ *                  ^       ^
+ *                  |       |
+ *                  | RequestSleep(Wed)
+ *         RequestReceive(Wed)
+ *
+ * Radio ------========+++++-------========-++++++++---========-----+++++++========---
+ *             ^       ^    ^
+ *             |       |    |
+ *             |       | Radio::Sleep()
+ *             |  Radio::Receive(WedCh)
+ *      Radio::Receive(CslCh)
+ */
+void SubMac::RequestSleep(Requester aRequester)
+{
+    if (IsCslEnabled() && mIsWedEnabled)
+    {
+        if ((aRequester == kRequesterCsl) && mIsWedSampling)
+        {
+            IgnoreError(Get<Radio>().Receive(mWakeupChannel));
+        }
+        else if ((aRequester == kRequesterWed) && mIsCslSampling)
+        {
+            // When the CSL is in the receive state and the WED enters the sleep state, the radio should have entered
+            // receive state using CSL channel. Do nothing here.
+        }
+        else
+        {
+            IgnoreError(Get<Radio>().Sleep());
+        }
+    }
+    else if (IsCslEnabled() || mIsWedEnabled)
+    {
+        IgnoreError(Get<Radio>().Sleep());
+    }
+}
+
+void SubMac::RequestReceive(Requester aRequester)
+{
+    if (aRequester == kRequesterCsl)
+    {
+        IgnoreError(Get<Radio>().Receive(mCslChannel));
+    }
+    else if ((aRequester == kRequesterWed) && ((IsCslEnabled() && !mIsCslSampling) || !IsCslEnabled()))
+    {
+        IgnoreError(Get<Radio>().Receive(mWakeupChannel));
+    }
+}
+
+bool SubMac::RequestSample(void)
+{
+    bool ret = false;
+
+    if (mIsCslSampling && IsCslEnabled())
+    {
+        IgnoreError(Get<Radio>().Receive(mCslChannel));
+        ret = true;
+    }
+    else if (mIsWedSampling && mIsWedEnabled)
+    {
+        IgnoreError(Get<Radio>().Receive(mWakeupChannel));
+        ret = true;
+    }
+
+    return ret;
+}
+
+#elif OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+bool SubMac::IsRadioSampleEnabled(void) const { return IsCslEnabled(); }
+void SubMac::RequestSleep(Requester) { IgnoreError(Get<Radio>().Sleep()); }
+void SubMac::RequestReceive(Requester) { IgnoreError(Get<Radio>().Receive(mCslChannel)); }
+
+bool SubMac::RequestSample(void)
+{
+    if (mIsCslSampling)
+    {
+        IgnoreError(Get<Radio>().Receive(mCslChannel));
+    }
+
+    return mIsCslSampling;
+}
+#elif OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+bool SubMac::IsRadioSampleEnabled(void) const { return mIsWedEnabled; }
+void SubMac::RequestSleep(Requester) { IgnoreError(Get<Radio>().Sleep()); }
+void SubMac::RequestReceive(Requester) { IgnoreError(Get<Radio>().Receive(mWakeupChannel)); }
+
+bool SubMac::RequestSample(void)
+{
+    if (mIsWedSampling)
+    {
+        IgnoreError(Get<Radio>().Receive(mWakeupChannel));
+    }
+
+    return mIsWedSampling;
+}
+#endif
+#endif
+
 // LCOV_EXCL_START
 
 const char *SubMac::StateToString(State aState)
@@ -1046,8 +1185,8 @@ const char *SubMac::StateToString(State aState)
 #if !OPENTHREAD_MTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
         "CslTransmit", // (7) kStateCslTransmit
 #endif
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-        "CslSample", // (8) kStateCslSample
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+        "RadioSample", // (8) kStateRadioSample
 #endif
     };
 
@@ -1067,8 +1206,8 @@ const char *SubMac::StateToString(State aState)
 #if !OPENTHREAD_MTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
         ValidateNextEnum(kStateCslTransmit);
 #endif
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-        ValidateNextEnum(kStateCslSample);
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+        ValidateNextEnum(kStateRadioSample);
 #endif
     };
 

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -518,6 +518,8 @@ private:
     void        WedInit(void);
     static void HandleWedTimer(Timer &aTimer);
     void        HandleWedTimer(void);
+    void        HandleWedReceiveAt(void);
+    void        HandleWedReceiveOrSleep(void);
 #endif
 
     static constexpr uint8_t  kCsmaMinBe         = 3;                  // macMinBE (IEEE 802.15.4-2006).
@@ -551,8 +553,9 @@ private:
 #if !OPENTHREAD_MTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
         kStateCslTransmit, // CSL transmission.
 #endif
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-        kStateCslSample, // CSL receive.
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+        kStateRadioSample, // Mac layer has requested the SubMac to enter sleep state, but the SubMac is in the periodic
+                           // sample state.
 #endif
     };
 
@@ -564,6 +567,11 @@ private:
     // CSL/wake-up listening receivers would wake up `kCslReceiveTimeAhead` earlier
     // than expected sample window. The value is in usec.
     static constexpr uint32_t kCslReceiveTimeAhead = OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD;
+
+    enum Requester : uint8_t{
+        kRequesterCsl, // The CSL receiver requester.
+        kRequesterWed, // The Wake-up listener requester.
+    };
 #endif
 
 #if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
@@ -626,6 +634,14 @@ private:
     void               SetState(State aState);
     static const char *StateToString(State aState);
 
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+    void RequestReceive(Requester aRequester);
+    void RequestSleep(Requester aRequester);
+    bool RequestSample(void);
+    void RadioSample(void);
+    bool IsRadioSampleEnabled(void) const;
+#endif
+
     using SubMacTimer =
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
         TimerMicroIn<SubMac, &SubMac::HandleTimer>;
@@ -672,6 +688,9 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+    bool mIsWedSampling : 1;      // Indicates that the radio is requested to enter WED receive state for platforms not
+                                  // supporting delayed reception.
+    bool       mIsWedEnabled : 1; // Indicates if the WED is enabled.
     uint32_t   mWakeupListenInterval; // The wake-up listen interval, in microseconds.
     uint32_t   mWakeupListenDuration; // The wake-up listen duration, in microseconds.
     uint8_t    mWakeupChannel;        // The wake-up sample channel.

--- a/src/core/mac/sub_mac_csl_receiver.cpp
+++ b/src/core/mac/sub_mac_csl_receiver.cpp
@@ -91,7 +91,7 @@ void SubMac::CslSample(void)
     VerifyOrExit(!mRadioFilterEnabled, IgnoreError(Get<Radio>().Sleep()));
 #endif
 
-    SetState(kStateCslSample);
+    SetState(kStateRadioSample);
 
     if (mIsCslSampling && !RadioSupportsReceiveTiming())
     {
@@ -129,6 +129,13 @@ bool SubMac::UpdateCsl(uint16_t aPeriod, uint8_t aChannel, ShortAddress aShortAd
         mIsCslSampling = false;
         HandleCslTimer();
     }
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+    else if ((mState == kStateRadioSample) && (!RadioSupportsReceiveTiming()))
+    {
+        // Give WED a chance to enter receive state.
+        RequestSleep(kRequesterCsl);
+    }
+#endif
 
 exit:
     return retval;
@@ -181,10 +188,10 @@ void SubMac::HandleCslTimer(void)
     {
         mIsCslSampling = false;
         mCslTimer.FireAt(mCslSampleTime - timeAhead);
-        if (mState == kStateCslSample)
+        if (mState == kStateRadioSample)
         {
 #if !OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
-            IgnoreError(Get<Radio>().Sleep()); // Don't actually sleep for debugging
+            RequestSleep(kRequesterCsl); // Don't actually sleep for debugging
 #endif
             LogDebg("CSL sleep %lu", ToUlong(mCslTimer.GetNow().GetValue()));
         }
@@ -215,9 +222,9 @@ void SubMac::HandleCslTimer(void)
         {
             IgnoreError(Get<Radio>().ReceiveAt(mCslChannel, winStart, winDuration));
         }
-        else if (mState == kStateCslSample)
+        else if (mState == kStateRadioSample)
         {
-            IgnoreError(Get<Radio>().Receive(mCslChannel));
+            RequestReceive(kRequesterCsl);
         }
 
         LogDebg("CSL window start %lu, duration %lu", ToUlong(winStart), ToUlong(winDuration));
@@ -273,7 +280,7 @@ void SubMac::LogReceived(RxFrame *aFrame)
             mIsCslSampling ? "CslSample" : "CslSleep",
             ToUlong(static_cast<uint32_t>(aFrame->mInfo.mRxInfo.mTimestamp)));
 
-    VerifyOrExit(mState == kStateCslSample);
+    VerifyOrExit(mState == kStateRadioSample);
 
     GetCslWindowEdges(ahead, after);
     ahead -= kMinReceiveOnAhead + kCslReceiveTimeAhead;

--- a/src/core/mac/sub_mac_wed.cpp
+++ b/src/core/mac/sub_mac_wed.cpp
@@ -44,34 +44,39 @@ RegisterLogModule("SubMac");
 
 void SubMac::WedInit(void)
 {
+    mIsWedSampling        = false;
+    mIsWedEnabled         = false;
     mWakeupListenInterval = 0;
     mWedTimer.Stop();
 }
 
 void SubMac::UpdateWakeupListening(bool aEnable, uint32_t aInterval, uint32_t aDuration, uint8_t aChannel)
 {
-    VerifyOrExit(RadioSupportsReceiveTiming());
-
     mWakeupListenInterval = aInterval;
     mWakeupListenDuration = aDuration;
     mWakeupChannel        = aChannel;
+    mIsWedEnabled         = aEnable;
     mWedTimer.Stop();
 
     if (aEnable)
     {
+        mIsWedSampling      = true;
         mWedSampleTime      = TimerMicro::GetNow() + kCslReceiveTimeAhead - mWakeupListenInterval;
         mWedSampleTimeRadio = Get<Radio>().GetNow() + kCslReceiveTimeAhead - mWakeupListenInterval;
 
         HandleWedTimer();
     }
-
-exit:
-    return;
+    else if ((mState == kStateRadioSample) && (!RadioSupportsReceiveTiming()))
+    {
+        // `mState == kStateRadioSample` means that the Mac layer has called the `Sleep()` to request the radio to
+        // enter the sleep state. Here, sets the radio to enter sleep state after the WED is disabled.
+        RequestSleep(kRequesterWed);
+    }
 }
 
 void SubMac::HandleWedTimer(Timer &aTimer) { aTimer.Get<SubMac>().HandleWedTimer(); }
 
-void SubMac::HandleWedTimer(void)
+void SubMac::HandleWedReceiveAt(void)
 {
     mWedSampleTime += mWakeupListenInterval;
     mWedSampleTimeRadio += mWakeupListenInterval;
@@ -81,6 +86,41 @@ void SubMac::HandleWedTimer(void)
     {
         IgnoreError(
             Get<Radio>().ReceiveAt(mWakeupChannel, static_cast<uint32_t>(mWedSampleTimeRadio), mWakeupListenDuration));
+    }
+}
+
+void SubMac::HandleWedReceiveOrSleep(void)
+{
+    uint32_t interval = mIsWedSampling ? mWakeupListenDuration : (mWakeupListenInterval - mWakeupListenDuration);
+    int32_t  delay    = mIsWedSampling ? kMinReceiveOnAfter : -kMinReceiveOnAhead;
+
+    mWedSampleTime += interval;
+    mWedTimer.FireAt(mWedSampleTime + delay);
+
+    if (mState == kStateRadioSample)
+    {
+        if (mIsWedSampling)
+        {
+            RequestReceive(kRequesterWed);
+        }
+        else
+        {
+            RequestSleep(kRequesterWed);
+        }
+    }
+
+    mIsWedSampling = !mIsWedSampling;
+}
+
+void SubMac::HandleWedTimer(void)
+{
+    if (RadioSupportsReceiveTiming())
+    {
+        HandleWedReceiveAt();
+    }
+    else
+    {
+        HandleWedReceiveOrSleep();
     }
 }
 


### PR DESCRIPTION
The WED listener only supports calling the `Radio::ReceiveAt()` for periodic sampling. And the radio platform API `otPlatRadioReceiveAt()` is an optional API. Not all platforms support `Radio::ReceiveAt()`.

This commit adds support for the WED to perform periodic sampling by calling `Radio::Sleep()` and `Radio::Receive()`.