### PR TITLE
[srp-server] allow disabling "Fast Start Mode" via auto-enable

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (482)
+#define OPENTHREAD_API_VERSION (483)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/srp_server.h
+++ b/include/openthread/srp_server.h
@@ -301,8 +301,12 @@ bool otSrpServerIsAutoEnableMode(otInstance *aInstance);
  * The Fast Start Mode can be enabled when the device is in the detached or disabled state, the SRP server is currently
  * disabled, and "auto-enable mode" is not in use (i.e., `otSrpServerIsAutoEnableMode()` returns `false`).
  *
- * After successfully enabling Fast Start Mode, it can be disabled by a direct call to `otSrpServerSetEnabled()`,
- * explicitly enabling or disabling the SRP server function.
+ * After successfully enabling Fast Start Mode, it can be disabled either by a call to `otSrpServerSetEnabled()`,
+ * explicitly enabling or disabling the SRP server, or by a call to `otSrpServerSetAutoEnableMode()`, enabling or
+ * disabling the auto-enable mode. If the Fast Start Mode (while active) enables the SRP server, upon disabling
+ * Fast Start Mode (regardless of how it is done), the SRP server will also be stopped, and the use of the
+ * `OT_SRP_SERVER_ADDRESS_MODE_UNICAST_FORCE_ADD` address mode will be stopped, and the address mode will be
+ * automatically reverted back to its previous setting before Fast Start Mode was enabled.
  *
  * @param[in] aInstance             A pointer to the OpenThread instance.
  *

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -949,6 +949,7 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_FAST_START_MODE_ENABLE
+    void DisableFastStartMode(void);
     void HandleNotifierEvents(Events aEvents);
     bool NetDataContainsOtherSrpServers(void) const;
 #endif

--- a/tests/unit/test_srp_server.cpp
+++ b/tests/unit/test_srp_server.cpp
@@ -1368,6 +1368,22 @@ void TestSrpServerFastStartMode(void)
     VerifyOrQuit(srpServer->GetState() == Srp::Server::kStateRunning);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Start auto-enable mode and ensure "fast start mode" is turned
+    // off and the original AddressMode is restored on the SRP server.
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    srpServer->SetAutoEnableMode(true);
+
+    VerifyOrQuit(!srpServer->IsFastStartModeEnabled());
+    VerifyOrQuit(srpServer->IsAutoEnableMode());
+
+    VerifyOrQuit(srpServer->GetState() == Srp::Server::kStateDisabled);
+    VerifyOrQuit(srpServer->GetAddressMode() == Srp::Server::kAddressModeUnicast);
+
+    VerifyOrQuit(srpServer->EnableFastStartMode() == kErrorInvalidState);
+#endif
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Finalize OT instance and validate all heap allocations are freed.
 
     Log("Finalizing OT instance");


### PR DESCRIPTION
This commit updates the `Srp::Server` so that Fast Start Mode can be disabled by a call to `otSrpServerSetAutoEnableMode()`, in addition to the existing method of calling `otSrpServerSetEnabled()`.

The `test_srp_server` unit test is updated to validate this new behavior.