### PR TITLE
[border-agent] fix meshcop service update issue

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -172,6 +172,12 @@ void BorderAgent::HandleNotifierEvents(Events aEvents)
         }
     }
 
+    if (aEvents.ContainsAny(kEventThreadRoleChanged | kEventThreadExtPanIdChanged | kEventThreadNetworkNameChanged |
+                            kEventThreadBackboneRouterStateChanged | kEventActiveDatasetChanged))
+    {
+        PostNotifyMeshCoPServiceChangedTask();
+    }
+
     if (aEvents.ContainsAny(kEventPskcChanged))
     {
         Pskc pskc;
@@ -184,12 +190,6 @@ void BorderAgent::HandleNotifierEvents(Events aEvents)
         // new pskc will be applied for next connection.
         SuccessOrExit(mDtlsTransport.SetPsk(pskc.m8, Pskc::kSize));
         pskc.Clear();
-    }
-
-    if (aEvents.ContainsAny(kEventThreadRoleChanged | kEventThreadExtPanIdChanged | kEventThreadNetworkNameChanged |
-                            kEventThreadBackboneRouterStateChanged | kEventActiveDatasetChanged))
-    {
-        PostNotifyMeshCoPServiceChangedTask();
     }
 
 exit:


### PR DESCRIPTION
This PR fixes an issue in BorderAgent when handling Notifier events.

If the events contain 'Epskc' and BA is not running, then the meshcop service update will be skipped.

--

Depends-On: openthread/ot-br-posix#2727