### PR TITLE
[posix] update Posix::Resolver to support IPv6 addresses for servers.

### DIFF
--- a/src/posix/platform/resolver.cpp
+++ b/src/posix/platform/resolver.cpp
@@ -97,6 +97,7 @@ void Resolver::LoadDnsServerListFromConf(void)
 
     while (fp.good() && std::getline(fp, line) && mUpstreamDnsServerCount < kMaxUpstreamServerCount)
     {
+        // Skip the lines that don't start with "nameserver"
         if (line.find(kNameserverItem, 0))
         {
             continue;

--- a/src/posix/platform/resolver.cpp
+++ b/src/posix/platform/resolver.cpp
@@ -97,22 +97,25 @@ void Resolver::LoadDnsServerListFromConf(void)
 
     while (fp.good() && std::getline(fp, line) && mUpstreamDnsServerCount < kMaxUpstreamServerCount)
     {
-        if (line.find(kNameserverItem, 0) == 0)
+        if (line.find(kNameserverItem, 0))
         {
-            const char *addressString = &line.c_str()[sizeof(kNameserverItem)];
-            if (inet_pton(AF_INET, addressString, &ip4Address) == 1)
-            {
-                otIp4ToIp4MappedIp6Address(&ip4Address, &ip6Address);
-                LogInfo("Got nameserver #%d: %s", mUpstreamDnsServerCount, &line.c_str()[sizeof(kNameserverItem)]);
-                mUpstreamDnsServerList[mUpstreamDnsServerCount] = ip6Address;
-                mUpstreamDnsServerCount++;
-            }
-            else if (inet_pton(AF_INET6, addressString, &ip6Address) == 1)
-            {
-                LogInfo("Got nameserver #%d: %s", mUpstreamDnsServerCount, &line.c_str()[sizeof(kNameserverItem)]);
-                mUpstreamDnsServerList[mUpstreamDnsServerCount] = ip6Address;
-                mUpstreamDnsServerCount++;
-            }
+            continue;
+        }
+
+        const char *addressString = &line.c_str()[sizeof(kNameserverItem)];
+
+        if (inet_pton(AF_INET, addressString, &ip4Address) == 1)
+        {
+            otIp4ToIp4MappedIp6Address(&ip4Address, &ip6Address);
+            LogInfo("Got nameserver #%d: %s", mUpstreamDnsServerCount, addressString);
+            mUpstreamDnsServerList[mUpstreamDnsServerCount] = ip6Address;
+            mUpstreamDnsServerCount++;
+        }
+        else if (inet_pton(AF_INET6, addressString, &ip6Address) == 1)
+        {
+            LogInfo("Got nameserver #%d: %s", mUpstreamDnsServerCount, addressString);
+            mUpstreamDnsServerList[mUpstreamDnsServerCount] = ip6Address;
+            mUpstreamDnsServerCount++;
         }
     }
 

--- a/src/posix/platform/resolver.hpp
+++ b/src/posix/platform/resolver.hpp
@@ -109,9 +109,10 @@ private:
     {
         otPlatDnsUpstreamQuery *mThreadTxn;
         int                     mUdpFd;
+        sa_family_t             mFamily;
     };
 
-    static int CreateUdpSocket(void);
+    static int CreateUdpSocket(sa_family_t aFamily);
 
     Transaction *GetTransaction(int aFd);
     Transaction *GetTransaction(otPlatDnsUpstreamQuery *aThreadTxn);
@@ -123,10 +124,10 @@ private:
     void TryRefreshDnsServerList(void);
     void LoadDnsServerListFromConf(void);
 
-    bool      mIsResolvConfEnabled    = true;
-    int       mUpstreamDnsServerCount = 0;
-    in_addr_t mUpstreamDnsServerList[kMaxUpstreamServerCount];
-    uint64_t  mUpstreamDnsServerListFreshness = 0;
+    bool         mIsResolvConfEnabled    = true;
+    int          mUpstreamDnsServerCount = 0;
+    otIp6Address mUpstreamDnsServerList[kMaxUpstreamServerCount];
+    uint64_t     mUpstreamDnsServerListFreshness = 0;
 
     Transaction mUpstreamTransaction[kMaxUpstreamTransactionCount];
 };

--- a/src/posix/platform/resolver.hpp
+++ b/src/posix/platform/resolver.hpp
@@ -99,7 +99,7 @@ public:
      *                                 IPv6 address or an IPv4-mapped IPv6 address.
      * @param[in] aNumServers          The number of upstream DNS servers.
      */
-    void SetUpstreamDnsServers(const otIp6Address *aUpstreamDnsServers, int aNumServers);
+    void SetUpstreamDnsServers(const otIp6Address *aUpstreamDnsServers, uint32_t aNumServers);
 
 private:
     static constexpr uint64_t kDnsServerListNullCacheTimeoutMs = 1 * 60 * 1000;  // 1 minute
@@ -108,7 +108,8 @@ private:
     struct Transaction
     {
         otPlatDnsUpstreamQuery *mThreadTxn;
-        int                     mUdpFd;
+        int                     mUdpFd4;
+        int                     mUdpFd6;
     };
 
     static int CreateUdpSocket(sa_family_t aFamily);
@@ -117,14 +118,13 @@ private:
     Transaction *GetTransaction(otPlatDnsUpstreamQuery *aThreadTxn);
     Transaction *AllocateTransaction(otPlatDnsUpstreamQuery *aThreadTxn);
 
-    void ForwardResponse(Transaction *aTxn);
+    void ForwardResponse(otPlatDnsUpstreamQuery *aThreadTxn, int aFd);
     void CloseTransaction(Transaction *aTxn);
-    void FinishTransaction(int aFd);
     void TryRefreshDnsServerList(void);
     void LoadDnsServerListFromConf(void);
 
     bool         mIsResolvConfEnabled    = true;
-    int          mUpstreamDnsServerCount = 0;
+    uint32_t     mUpstreamDnsServerCount = 0;
     otIp6Address mUpstreamDnsServerList[kMaxUpstreamServerCount];
     uint64_t     mUpstreamDnsServerListFreshness = 0;
 

--- a/src/posix/platform/resolver.hpp
+++ b/src/posix/platform/resolver.hpp
@@ -109,7 +109,6 @@ private:
     {
         otPlatDnsUpstreamQuery *mThreadTxn;
         int                     mUdpFd;
-        sa_family_t             mFamily;
     };
 
     static int CreateUdpSocket(sa_family_t aFamily);


### PR DESCRIPTION
This PR enhances the DNS resolver (`resolver.cpp`) to support IPv6 addresses in upstream DNS server configurations, allowing for greater flexibility and compatibility in IPv6-enabled environments.

**Key Changes:**

*   **IPv6 Parsing in `LoadDnsServerListFromConf`:**
    *   The `LoadDnsServerListFromConf` function now parses both IPv4 and IPv6 addresses from `/etc/resolv.conf` using `inet_pton` with `AF_INET` and `AF_INET6`.
    *   Parsed addresses are stored in `mUpstreamDnsServerList`.
*   **IPv6 Handling in `Query`:**