### PR TITLE
[nd6] Add support for Recursive DNS Server (RDNSS) option

### DIFF
--- a/src/core/net/nd6.cpp
+++ b/src/core/net/nd6.cpp
@@ -171,6 +171,17 @@ uint8_t RouteInfoOption::OptionLengthForPrefix(uint8_t aPrefixLength)
 }
 
 //----------------------------------------------------------------------------------------------------------------------
+// RecursiveDNSServer
+
+void RecursiveDNSServer::Init(void)
+{
+    Clear();
+    SetType(kTypeRaFlagsExtension);
+
+    OT_UNUSED_VARIABLE(mReserved);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
 // RaFlagsExtOption
 
 void RaFlagsExtOption::Init(void)


### PR DESCRIPTION
*   This change is needed to support the advertisement of DNS server information in Router Advertisements, as requested in https://github.com/openthread/ot-br-posix/issues/2685.
*   The RDNSS option allows routers to inform hosts about available DNS servers.
