### PR TITLE
[routing-manager] process RDNSS options and track addresses

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (483)
+#define OPENTHREAD_API_VERSION (484)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README_BR.md
+++ b/src/cli/README_BR.md
@@ -39,6 +39,7 @@ pd
 peers
 prefixtable
 raoptions
+rdnsstable
 rioprf
 routeprf
 routers
@@ -311,6 +312,30 @@ Clear any previously set additional options to append at the end of emitted Rout
 
 ```bash
 > br raoptions clear
+Done
+```
+
+### rdnsstable
+
+Usage: `br rdnsstable`
+
+Get the discovered Recursive DNS Server (RDNSS) address table by Border Routing Manager on the infrastructure link.
+
+Info per entry:
+
+- IPv6 address
+- Lifetime in seconds
+- Milliseconds since last received Router Advertisement containing this address
+- The router IPv6 address which advertised this prefix
+- Flags in received Router Advertisement header:
+  - M: Managed Address Config flag
+  - O: Other Config flag
+  - S: SNAC Router flag
+
+```bash
+> br rdnsstable
+fd00:1234:5678::1, lifetime:500, ms-since-rx:29526, router:ff02:0:0:0:0:0:0:1 (M:0 O:0 S:1)
+fd00:aaaa::2, lifetime:500, ms-since-rx:107, router:ff02:0:0:0:0:0:0:1 (M:0 O:0 S:1)
 Done
 ```
 

--- a/src/core/api/border_routing_api.cpp
+++ b/src/core/api/border_routing_api.cpp
@@ -190,6 +190,23 @@ otError otBorderRoutingGetNextRouterEntry(otInstance                         *aI
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetNextRouterEntry(*aIterator, *aEntry);
 }
 
+otError otBorderRoutingGetNextRdnssAddrEntry(otInstance                         *aInstance,
+                                             otBorderRoutingPrefixTableIterator *aIterator,
+                                             otBorderRoutingRdnssAddrEntry      *aEntry)
+{
+    AssertPointerIsNotNull(aIterator);
+    AssertPointerIsNotNull(aEntry);
+
+    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetNextRdnssAddrEntry(*aIterator, *aEntry);
+}
+
+void otBorderRoutingSetRdnssAddrCallback(otInstance                      *aInstance,
+                                         otBorderRoutingRdnssAddrCallback aCallback,
+                                         void                            *aContext)
+{
+    AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().SetRdnssAddrCallback(aCallback, aContext);
+}
+
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
 
 otError otBorderRoutingGetNextPeerBrEntry(otInstance                           *aInstance,


### PR DESCRIPTION
This commit introduces a mechanism in `RoutingManager` to parse and process Recursive DNS Server (RDNSS) options within received Router Advertisement (RA) messages. The list of discovered RDNSS addresses is tracked (per router) by `RoutingManager`, applying the advertised lifetime to properly age the discovered entries.

This commit adds a new public API to retrieve the list of tracked RDNSS addresses, along with a callback mechanism where OpenThread users can register to be notified of changes to the RDNSS list. This callback is invoked when any of the following changes occur:
- A new RDNSS address is advertised by a router.
- A previously discovered address is removed due to the router advertising it with a zero lifetime.
- A previously discovered address has aged out (its lifetime expired without being re-advertised).
- `RoutingManager` determines that the router advertising the address is now unreachable, resulting in the removal of all its associated entries.

This commit also adds corresponding CLI commands for the new API.

Furthermore, `test_routing_manager` is updated to include a test case covering all the newly added behaviors in detail.

----

Related to https://github.com/openthread/ot-br-posix/issues/2685