### PR TITLE
[srp-server] fix fast-start mode disruption when device role changes

### DIFF
--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -325,7 +325,8 @@ bool Server::NetDataContainsOtherSrpServers(void) const
     while (Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(
                iterator, NetworkData::Service::kAddrInServerData, unicastInfo) == kErrorNone)
     {
-        if (!Get<Mle::Mle>().HasRloc16(unicastInfo.mRloc16))
+        if (!Get<Mle::Mle>().HasRloc16(unicastInfo.mRloc16) &&
+            Get<Mle::Mle>().GetMeshLocalEid() != unicastInfo.mSockAddr.GetAddress())
         {
             contains = true;
             ExitNow();


### PR DESCRIPTION
When in fast-start mode, the SRP server will be disabled and then immediately
enabled again if the device transfers from Child to Router. This commit fixes this
issue by also matching the ML-EID with the SRP server address in the Network Data.