### PR TITLE
[mesh-forwarder] fix Ip6 route selected when OMR prefix has been removed but the OMR address is still valid

### DIFF
--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -293,6 +293,13 @@ public:
      */
     static const char *EcnToString(Ecn aEcn);
 
+    /**
+     * Indicates whether the address is on the thread link or not.
+     *
+     * @returns TRUE if the address is on the thread link, FALSE otherwise.
+     */
+    bool IsOnLink(const Address &aAddress) const;
+
 #if OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
 
     typedef otBorderRoutingCounters BrCounters; ///< Border Routing counters.
@@ -376,7 +383,6 @@ private:
                   OwnedPtr<Message> &aMessagePtr,
                   uint8_t            aIpProto,
                   Message::Ownership aMessageOwnership);
-    bool  IsOnLink(const Address &aAddress) const;
     Error RouteLookup(const Address &aSource, const Address &aDestination) const;
 #if OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
     void UpdateBorderRoutingCounters(const Header &aHeader, uint16_t aMessageLength, bool aIsInbound);

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -430,7 +430,7 @@ Error MeshForwarder::UpdateIp6RouteFtd(const Ip6::Header &aIp6Header, Message &a
     {
         mMeshDest = neighbor->GetRloc16();
     }
-    else if (Get<NetworkData::Leader>().IsOnMesh(aIp6Header.GetDestination()))
+    else if (Get<Ip6::Ip6>().IsOnLink(aIp6Header.GetDestination()))
     {
         SuccessOrExit(error = Get<AddressResolver>().Resolve(aIp6Header.GetDestination(), mMeshDest));
     }


### PR DESCRIPTION
Let's consider this scenario:
Topology:
```
TED1 --- TBR --- TED2
```
All devices have joined the same Thread network, with the TBR connected to the infrastructure network interface. The TBR publishes an OMR prefix in the Thread network via the Thread network data. As a result, all other devices assign themselves an OMR prefix address on the Thread link (referred to as OMR1 on TED1 and OMR2 on TED2).

Within the Thread network, devices can communicate using their OMR prefix addresses. For example, on the TBR, both OMR1 and OMR2 are accessible via the ping command.

However, if the TBR loses its connection to the infrastructure network interface, it updates its service configuration: the OMR prefix is removed.Other device will also update their network data. However, the OMR prefix address is not removed immediately. In the Thread implementation, this address is marked as deprecated, but it remains valid.

At this point, the thread device no longer has a route for the OMR addresses since the OMR prefix has been removed from the Network Data(Get<NetworkData::Leader>().IsOnMesh() will return false). However, these addresses should still be reachable within the Thread network.

Also another topic:
The `mMeshDest` variable appears to remain unchanged in this scenario. If no `mMeshDest` is explicitly selected for a destination address, the previous result is reused for the current destination address. Would this behavior be considered a bug, or was it deliberately designed this way?