### PR TITLE
[csl] use `mPanChannel` as default CSL channel

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2426,7 +2426,7 @@ exit:
 void Mac::UpdateCsl(void)
 {
     uint16_t period  = IsCslEnabled() ? GetCslPeriod() : 0;
-    uint8_t  channel = GetCslChannel() ? GetCslChannel() : mRadioChannel;
+    uint8_t  channel = GetCslChannel() ? GetCslChannel() : mPanChannel;
 
     if (mLinks.UpdateCsl(period, channel, Get<Mle::Mle>().GetParent().GetRloc16(),
                          Get<Mle::Mle>().GetParent().GetExtAddress()))


### PR DESCRIPTION
This commit updates the CSL channel selection logic. When a CSL channel is not explicitly set, the code now uses the tracked `mPanChannel` (the current Thread PAN channel) instead of `mRadioChannel` (the current channel the radio is listening on). This ensures that the CSL channel aligns with the Thread PAN channel, even when the radio temporarily switches to other channels, such as during an MLE discover scan.