### PR TITLE
[secure-transport] add option to specify NetifIdentifier

### DIFF
--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -137,7 +137,7 @@ Error Joiner::Start(const char      *aPskd,
     Get<Mac::Mac>().SetExtAddress(randomAddress);
     Get<Mle::MleRouter>().UpdateLinkLocalAddress();
 
-    SuccessOrExit(error = Get<Tmf::SecureAgent>().Open());
+    SuccessOrExit(error = Get<Tmf::SecureAgent>().Open(Ip6::NetifIdentifier::kNetifThreadInternal));
     SuccessOrExit(error = Get<Tmf::SecureAgent>().Bind(kJoinerUdpPort));
     Get<Tmf::SecureAgent>().SetConnectCallback(HandleSecureCoapClientConnect, this);
     Get<Tmf::SecureAgent>().SetPsk(joinerPskd);

--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -676,13 +676,13 @@ SecureTransport::SecureTransport(Instance &aInstance, LinkSecurityMode aLayerTwo
     OT_UNUSED_VARIABLE(mVerifyPeerCertificate);
 }
 
-Error SecureTransport::Open(void)
+Error SecureTransport::Open(Ip6::NetifIdentifier aNetifIdentifier)
 {
     Error error;
 
     VerifyOrExit(!mIsOpen, error = kErrorAlready);
 
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifUnspecified));
+    SuccessOrExit(error = mSocket.Open(aNetifIdentifier));
     mIsOpen                      = true;
     mRemainingConnectionAttempts = mMaxConnectionAttempts;
 

--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -592,10 +592,13 @@ public:
     /**
      * Opens the transport.
      *
+     * @param[in] aNetifIdentifier A network interface identifier. If not explicitly provided, kNetifUnspecified will
+     *                             be used by default.
+     *
      * @retval kErrorNone     Successfully opened the socket.
      * @retval kErrorAlready  The connection is already open.
      */
-    Error Open(void);
+    Error Open(Ip6::NetifIdentifier aNetifIdentifier = Ip6::NetifIdentifier::kNetifUnspecified);
 
     /**
      * Sets the maximum number of allowed connection requests before socket is automatically closed.


### PR DESCRIPTION
This commit aims to add the posibility to specify a netif identifier for SecureTransport::Open method. This method has now a default parameter, kNetifUnspecified, if no argument is explicitly passed by the user.