### PR TITLE
[networkdata] reset Notifier::mWaitingForResponse field when device role changes to leader

### DIFF
--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -238,6 +238,14 @@ void Notifier::HandleNotifierEvents(Events aEvents)
     }
 #endif
 
+    if (aEvents.ContainsAny(kEventThreadRoleChanged))
+    {
+        if (Get<Mle::MleRouter>().GetRole() == Mle::kRoleLeader)
+        {
+            mWaitingForResponse = false;
+        }
+    }
+
     if (aEvents.ContainsAny(kEventThreadNetdataChanged | kEventThreadRoleChanged | kEventThreadChildRemoved))
     {
         SynchronizeServerData();


### PR DESCRIPTION
This PR proposes a fix to the issues: https://github.com/openthread/openthread/issues/11339, https://github.com/openthread/openthread/issues/10567

A brief description of the issue:
1. When PBBR (leader) is shutdown, the SBBR (router) received a Data Response.
2. SBBR tried to become PBBR but at this time the leader has gone and SBBR is still a router. But `mWaitingForResponse` is already set to true.
3. When SBBR becomes the leader, since `mWaitingForResponse` is already `true`, `SynchronizeServerData` will exit directly and SBBR cannot become a PBBR quickly. 

So a probable fix is to reset `mWaitingForResponse` when the role changes to leader.

Depends-On: openthread/ot-br-posix#2762

Depend on the change in ot-br-posix to verify that this PR fixes the issue.