### PR TITLE
[coap] fix retransmission timer issue

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -505,7 +505,10 @@ void CoapBase::HandleRetransmissionTimer(void)
         nextTime.UpdateIfEarlier(metadata.mNextTimerShot);
     }
 
-    mRetransmissionTimer.FireAt(nextTime);
+    if (nextTime.IsSet())
+    {
+        mRetransmissionTimer.FireAt(nextTime);
+    }
 }
 
 void CoapBase::FinalizeCoapTransaction(Message                &aRequest,


### PR DESCRIPTION
This PR fixes an issue in CoapBase retransmission timer.

The fix is required by these two issues: https://github.com/openthread/openthread/issues/11339, https://github.com/openthread/openthread/issues/10567

The change is to avoid that during `CoapBase::HandleRetransmissionTimer`, `mRetransmissionTimer` is set to fire at some time but the `nextTime` in the function is unset. Calling `mRetransmissionTimer.FireAt(nextTime)` makes the timer stop.

Depends-On: https://github.com/openthread/ot-br-posix/pull/2762

Depend on the change in ot-br-posix to verify that this PR fixes the issue.