### PR TITLE
[coap] ensure correct retransmission timer scheduling

### DIFF
--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -821,6 +821,7 @@ private:
     Message *InitMessage(Message *aMessage, Type aType, Uri aUri);
     Message *InitResponse(Message *aMessage, const Message &aRequest);
 
+    void        ScheduleRetransmissionTimer(void);
     static void HandleRetransmissionTimer(Timer &aTimer);
     void        HandleRetransmissionTimer(void);
 


### PR DESCRIPTION
This commit introduces `CoapBase::ScheduleRetransmissionTimer()`, a new method that calculates the next retransmission timer fire time based on all queued messages in `mPendingRequests` and then schedules (starts or stops) the timer.

This method is now used whenever `mPendingRequests` is updated (a new message is added or an existing message is removed). It is also used in `HandleRetransmissionTimer()`, the timer's callback. This change centralizes timer scheduling, simplifying the logic.

This also addresses an issue in the existing code where `HandleRetransmissionTimer()` iterated over `mPendingRequests` to determine expired messages and calculate the next fire time. However, finalizing an expired message could trigger its `ResponseHandler` callback, from which the caller may start or abort CoAP message tx and  modify `mPendingRequests` and reschedule the timer, leading to incorrect fire time calculations (`NextFireTime` can be incorrect which would then improperly re-schedules the timer, stop it or schedule it to a later time).

With this change, `HandleRetransmissionTimer()` first finalizes expired messages (potentially invoking callbacks) and then calls `ScheduleRetransmissionTimer()` to calculate the next fire time based on the updated `mPendingRequests`, ensuring accurate timer scheduling.

----

Should help address https://github.com/openthread/openthread/issues/11339. Also related to https://github.com/openthread/openthread/pull/11346.  Thanks to @Irving-cl for debugging and finding this issue. 