### PR TITLE
[mdns] support registering local host and its IPv6/IPv4 addresses

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (490)
+#define OPENTHREAD_API_VERSION (491)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/mdns.h
+++ b/include/openthread/mdns.h
@@ -204,6 +204,29 @@ bool otMdnsIsQuestionUnicastAllowed(otInstance *aInstance);
 void otMdnsSetConflictCallback(otInstance *aInstance, otMdnsConflictCallback aCallback);
 
 /**
+ * Gets the local host name.
+ *
+ * @param[in] aInstance     The OpenThread instance.
+ *
+ * @returns The local host name.
+ */
+const char *otMdnsGetLocalHostName(otInstance *aInstance);
+
+/**
+ * Sets the local host name.
+ *
+ * The local host name can be set only when the mDNS module is disabled. If not set the mDNS module itself will
+ * auto-generate the local host name.
+ *
+ * @param[in] aInstance   The OpenThread instance.
+ * @param[in] aName       The local host name to use, can be to `NULL` to allow the mDNS module to choose the name.
+ *
+ * @retval OT_ERROR_NONE            The local host name was successfully set.
+ * @retval OT_ERROR_INVALID_STATE   mDNS module is already enabled.
+ */
+otError otMdnsSetLocalHostName(otInstance *aInstance, const char *aName);
+
+/**
  * Registers or updates a host on mDNS.
  *
  * The fields in @p aHost follow these rules:

--- a/include/openthread/platform/mdns_socket.h
+++ b/include/openthread/platform/mdns_socket.h
@@ -75,6 +75,10 @@ typedef struct otPlatMdnsAddressInfo
  *
  * While enabled, all received messages MUST be reported back using `otPlatMdnsHandleReceive()` callback.
  *
+ * When enabled, the platform MUST also monitor and report all IPv4 and IPv6 addresses assigned to the network
+ * interface using the `otPlatMdnsHandleHostAddressEvent()` callback function. Refer to the documentation of this
+ * callback for detailed information on the callback's usage and parameters.
+ *
  * @param[in] aInstance        The OpernThread instance.
  * @param[in] aEnable          Indicate whether to enable or disable.
  * @param[in] aInfraInfIndex   The infrastructure network interface index.
@@ -153,6 +157,47 @@ extern void otPlatMdnsHandleReceive(otInstance                  *aInstance,
                                     otMessage                   *aMessage,
                                     bool                         aIsUnicast,
                                     const otPlatMdnsAddressInfo *aAddress);
+
+/**
+ * Callback to notify OpenThread mDNS module of host address changes.
+ *
+ * When `otPlatMdnsSetListeningEnabled()` enables mDNS listening on an @p aInfraIfIndex, the platform MUST monitor and
+ * report ALL IPv4 and IPv6 addresses assigned to this network interface.
+ *
+ * When mDNS is enabled:
+ * - The platform MUST retrieve ALL currently assigned IPv4 and IPv6 addresses on the specified interface.
+ * - For each retrieved address, the platform MUST call `otPlatMdnsHandleHostAddressEvent()`.
+ * - The IPv4 addresses are represented using IPv4-mapped IPv6 format.
+ *
+ * Ongoing monitoring (while enabled):
+ * - The platform MUST continuously monitor the specified interface for address changes.
+ * - If any addresses are added or removed, the platform MUST call this callback for each affected address, indicating
+ *   the change (addition or removal using @p aAdded).
+ *
+ *  When mDNS is disabled:
+ * - The platform MUST cease monitoring for address changes on the interface.
+ * - The platform does NOT need to explicitly signal the removal of addresses upon disable. The OpenThread stack
+ *   automatically clears its internal address list.
+ * - If address monitoring is re-enabled later, the platform MUST repeat the "enable" steps again, retrieving and
+ *   reporting ALL current addresses.
+ *
+ * The OpenThread stack maintains an internal list of host addresses. It updates this list automatically upon receiving
+ * calls to `otPlatMdnsHandleHostAddressEvent()`.
+ * - OpenThread's mDNS implementation uses a short guard time (4 msec) before taking action (e.g., announcing new
+ *   addresses). This allows multiple changes to be grouped and announced together.
+ * - OpenThread's mDNS implementation also handles transient changes, e.g., an address is removed and then quickly
+ *   re-added. It ensures that announcements are only made when there is a change to the list (from what was
+ *   announced before). This simplifies the platform's responsibility as it can simply report all observed changes.
+ *
+ * @param[in] aInstance     The OpenThread instance.
+ * @param[in] aAddress      IP Address. IPv4-mapped IPv6 format is used to represent an IPv4 address.
+ * @param[in] aAdded        Boolean to indicate whether the address added (`TRUE`) or removed (`FALSE`).
+ * @param[in] aInfraIfIndex The interface index.
+ */
+extern void otPlatMdnsHandleHostAddressEvent(otInstance         *aInstance,
+                                             const otIp6Address *aAddress,
+                                             bool                aAdded,
+                                             uint32_t            aInfraIfIndex);
 
 /**
  * @}

--- a/src/cli/cli_mdns.cpp
+++ b/src/cli/cli_mdns.cpp
@@ -86,6 +86,11 @@ template <> otError Mdns::Process<Cmd("unicastquestion")>(Arg aArgs[])
     return ProcessEnableDisable(aArgs, otMdnsIsQuestionUnicastAllowed, otMdnsSetQuestionUnicastAllowed);
 }
 
+template <> otError Mdns::Process<Cmd("localhostname")>(Arg aArgs[])
+{
+    return ProcessGetSet(aArgs, otMdnsGetLocalHostName, otMdnsSetLocalHostName);
+}
+
 void Mdns::OutputHost(const otMdnsHost &aHost)
 {
     OutputLine("Host %s", aHost.mHostName);
@@ -1209,6 +1214,7 @@ otError Mdns::Process(Arg aArgs[])
         CmdEntry("ip6resolvers"),
         CmdEntry("keys"),
 #endif
+        CmdEntry("localhostname"),
         CmdEntry("recordquerier"),
 #if OPENTHREAD_CONFIG_MULTICAST_DNS_ENTRY_ITERATION_API_ENABLE
         CmdEntry("recordqueriers"),

--- a/src/core/api/mdns_api.cpp
+++ b/src/core/api/mdns_api.cpp
@@ -61,6 +61,16 @@ void otMdnsSetConflictCallback(otInstance *aInstance, otMdnsConflictCallback aCa
     AsCoreType(aInstance).Get<Dns::Multicast::Core>().SetConflictCallback(aCallback);
 }
 
+const char *otMdnsGetLocalHostName(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).Get<Dns::Multicast::Core>().GetLocalHostName();
+}
+
+otError otMdnsSetLocalHostName(otInstance *aInstance, const char *aName)
+{
+    return AsCoreType(aInstance).Get<Dns::Multicast::Core>().SetLocalHostName(aName);
+}
+
 otError otMdnsRegisterHost(otInstance            *aInstance,
                            const otMdnsHost      *aHost,
                            otMdnsRequestId        aRequestId,

--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -405,6 +405,10 @@ void Instance::AfterInit(void)
     Get<Trel::Link>().AfterInit();
 #endif
 
+#if OPENTHREAD_CONFIG_MULTICAST_DNS_ENABLE
+    Get<Dns::Multicast::Core>().AfterInstanceInit();
+#endif
+
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 
 #if OPENTHREAD_ENABLE_VENDOR_EXTENSION


### PR DESCRIPTION
This commit enhances the native OpenThread mDNS implementation to streamline the registration of the local host and its IPv6/IPv4 addresses.

Previously, registering the local host required tracking host addresses and using `otMdnsRegisterHost()`, similar to registering any other host. This commit introduces a simpler alternative that handles both IPv6 and IPv4 addresses.

The changes in this PR include:

- The local host name can be explicitly set by the caller using new API `otMdnsSetLocalHostName`. However, if not provided, the mDNS module automatically generates a name derived from the device's Extended MAC address.
- A new platform API callback, `otPlatMdnsHandleHostAddressEvent`, is introduced to notify the OpenThread mDNS module of host address changes.
- The OpenThread mDNS maintains an internal list of host addresses, automatically updating it based on platform callbacks. A short guard time is used to group multiple changes before announcing them. Transient changes (e.g., address removal and re-addition) are handled to prevent unnecessary announcements.
- Host IPv4 addresses (A records) are now supported. The `HostEntry` class is updated to optionally include IPv4 addresses, in addition to the required IPv6 addresses.
- A detailed test case in `test_mdns` covers all new local host-related behaviors.