### PR TITLE
[cp-caps] replace nrfjprog with nrfutil in docs

### DIFF
--- a/src/posix/README.md
+++ b/src/posix/README.md
@@ -118,8 +118,11 @@ To build and program the device with RCP application, complete the following ste
    b. nRF52840 Development Kit
 
    ```sh
-   # Program the image using the nrfjprog utility.
-   nrfjprog -f nrf52 --chiperase --program build/bin/ot-rcp.hex --reset
+   # Program the image using the nrfutil utility.
+   nrfutil device program --firmware build/bin/ot-rcp.hex --options chip_erase_mode=ERASE_ALL
+
+   # Reset the development kit using the nrfutil utility.
+   nrfutil device reset --reset-kind=RESET_PIN
    ```
 
    Disable the Mass Storage feature on the device, so that it does not interfere with the core RCP functionalities:

--- a/tools/cp-caps/README.md
+++ b/tools/cp-caps/README.md
@@ -43,7 +43,8 @@ $ git submodule update --init
 $ ./script/bootstrap
 $ ./script/build nrf52840 UART_trans -DOT_DIAGNOSTIC=ON -DOT_CSL_RECEIVER=ON -DOT_LINK_METRICS_INITIATOR=ON -DOT_LINK_METRICS_SUBJECT=ON -DOT_WAKEUP_COORDINATOR=ON
 $ arm-none-eabi-objcopy -O ihex build/bin/ot-cli-ftd ot-cli-ftd.hex
-$ nrfjprog -f nrf52 --chiperase --program ot-cli-ftd.hex --reset
+$ nrfutil device program --firmware ot-cli-ftd.hex --options chip_erase_mode=ERASE_ALL
+$ nrfutil device reset --reset-kind=RESET_PIN
 ```
 
 ## Test Commands


### PR DESCRIPTION
Nrfjprog is not longer recommended and was replaced by the nrfutil. Replaced documentation occurrences mentioning nrfjprog with nrfutil.