### PR TITLE
[dns-client] add support for arbitrary DNS record type query

### DIFF
--- a/include/openthread/dns_client.h
+++ b/include/openthread/dns_client.h
@@ -647,6 +647,139 @@ otError otDnsServiceResponseGetHostAddress(const otDnsServiceResponse *aResponse
                                            uint32_t                   *aTtl);
 
 /**
+ * An opaque representation of a response to a query for an arbitrary record type.
+ *
+ * Pointers to instance of this type are provided from callback `otDnsRecordCallback`.
+ */
+typedef struct otDnsRecordResponse otDnsRecordResponse;
+
+/**
+ * Pointer is called when a DNS response is received for a DNS query to an arbitrary record type.
+ *
+ * Within this callback the user can use `otDnsRecordResponseGet{Item}()` functions along with the @p aResponse
+ * pointer to get more info about the response.
+ *
+ * The @p aResponse pointer can only be used within this callback and after returning from this function it will not
+ * stay valid, so the user MUST NOT retain the @p aResponse pointer for later use.
+ *
+ * @param[in]  aError     The result of the DNS transaction.
+ * @param[in]  aResponse  A pointer to the response (it is always non-NULL).
+ * @param[in]  aContext   A pointer to application-specific context.
+ *
+ * The @p aError can have the following:
+ *
+ *  - OT_ERROR_NONE              A response was received successfully.
+ *  - OT_ERROR_ABORT             A DNS transaction was aborted by the stack.
+ *  - OT_ERROR_RESPONSE_TIMEOUT  No DNS response has been received within timeout.
+ *
+ */
+typedef void (*otDnsRecordCallback)(otError aError, const otDnsRecordResponse *aResponse, void *aContext);
+
+/**
+ * Represents a section in a DNS query/response message.
+ */
+typedef enum
+{
+    OT_DNS_SECTION_ANSWER,     ///< Answer section.
+    OT_DNS_SECTION_AUTHORITY,  ///< Authority section.
+    OT_DNS_SECTION_ADDITIONAL, ///< Additional section.
+} otDnsRecordSection;
+
+/**
+ * Represents info for a record in an `otDnsRecordResponse`.
+ *
+ * This struct is used as input to `otDnsRecordResponseGetRecordInfo()`.
+ */
+typedef struct otDnsRecordInfo
+{
+    char              *mNameBuffer;     ///< Buffer to output the name (MUST NOT be NULL).
+    uint16_t           mNameBufferSize; ///< Size of `mNameBuffer`.
+    uint16_t           mRecordType;     ///< The record type.
+    uint16_t           mRecordLength;   ///< The record data length (in bytes).
+    uint32_t           mTtl;            ///< Record TTL (in seconds).
+    uint8_t           *mDataBuffer;     ///< Buffer to output the data (Can be NULL if data not needed).
+    uint16_t           mDataBufferSize; ///< On input, size of `mDataBuffer`. On output number of bytes written.
+    otDnsRecordSection mSection;        ///< Indicates the section of the record.
+} otDnsRecordInfo;
+
+/**
+ * Sends a DNS query for a given record type and name.
+ *
+ * Requires `OPENTHREAD_CONFIG_DNS_CLIENT_ARBITRARY_RECORD_QUERY_ENABLE`.
+ *
+ * The @p aConfig can be NULL. In this case the default config (from `otDnsClientGetDefaultConfig()`) will be used as
+ * the config for this query. In a non-NULL @p aConfig, some of the fields can be left unspecified (value zero). The
+ * unspecified fields are then replaced by the values from the default config.
+ *
+ * @param[in]  aInstance        A pointer to an OpenThread instance.
+ * @param[in]  aRecordType      The resource record type to query.
+ * @param[in]  aFirstLabel      The first label of the name to be queried (can be NULL if not needed).
+ * @param[in]  aNextLabels      The next labels of the name to be queried (MUST NOT be NULL).
+ * @param[in]  aCallback        A function pointer that shall be called on response reception or time-out.
+ * @param[in]  aContext         A pointer to arbitrary context information used when @p aCallback is invoked.
+ * @param[in]  aConfig          A pointer to the config to use for this query.
+ *
+ * @retval OT_ERROR_NONE          Query sent successfully. @p aCallback will be invoked to report the outcome.
+ * @retval OT_ERROR_NO_BUFS       Insufficient buffer to prepare and send query.
+ * @retval OT_ERROR_INVALID_STATE Cannot send query since Thread interface is not up.
+ */
+otError otDnsClientQueryRecord(otInstance             *aInstance,
+                               uint16_t                aRecordType,
+                               const char             *aFirstLabel,
+                               const char             *aNextLabels,
+                               otDnsRecordCallback     aCallback,
+                               void                   *aContext,
+                               const otDnsQueryConfig *aConfig);
+
+/**
+ * Gets the query name associated with a record query DNS response.
+ *
+ * MUST only be used from `otDnsRecordCallback`.
+ *
+ * @param[in]  aResponse         A pointer to the response.
+ * @param[out] aNameBuffer       A buffer to char array to output the full query name (MUST NOT be NULL).
+ * @param[in]  aNameBufferSize   The size of @p aNameBuffer.
+ *
+ * @retval OT_ERROR_NONE     The full query name was read successfully.
+ * @retval OT_ERROR_NO_BUFS  The name does not fit in @p aNameBuffer.
+ */
+otError otDnsRecordResponseGetQueryName(const otDnsRecordResponse *aResponse,
+                                        char                      *aNameBuffer,
+                                        uint16_t                   aNameBufferSize);
+
+/**
+ * Reads the records from a DNS query response.
+ *
+ * MUST only be used from `otDnsRecordCallback`.
+ *
+ * The response may include multiple records. @p aIndex can be used to iterate through the list. Index zero gets the
+ * first record and so on. When we reach the end of the list, `OT_ERROR_NOT_FOUND` is returned.
+ *
+ * Upon successful retrieval (`OT_ERROR_NONE`):
+ * - `mRecordLength` is set to the actual length of the record's data.
+ * - The data is copied into `mDataBuffer` (if not `NULL`) up to its capacity specified by `mDataBufferSize`.
+ * - `mDataBufferSize` is then updated to reflect the number of bytes actually written into `mDataBuffer`.
+ *
+ * If the retrieved record type is PTR (12), CNAME (5), DNAME (39), NS (2), or SRV (33), the record data in the
+ * received response contains a DNS name which may use DNS name compression. For these specific record types, the
+ * record data is first decompressed such that it contains the full uncompressed DNS name. This decompressed data is
+ * then provided in `mDataBuffer`, and `mRecordDataLength` will indicate the length of this decompressed data. For all
+ * other record types, the record data is read and provided as it appears in the received response message.
+ *
+ * @param[in]  aResponse       A pointer to the response.
+ * @param[in]  aIndex          The record index to retrieve.
+ * @param[out] aRecordInfo     A pointer to a `otDnsRecordInfo` to populate with read record info.
+ *
+ * @retval OT_ERROR_NONE       The record was read successfully.
+ * @retval OT_ERROR_NOT_FOUND  No record in @p aResponse at @p aIndex.
+ * @retval OT_ERROR_PARSE      Could not parse the records in the @p aResponse.
+ * @retval OT_ERROR_NO_BUFS    The record name does not fit in the provided `mNameBufferSize` in @p aRecordInfo, or
+ *                             failed to allocate buffer to decompress a compressed DNS name (PTR, SRV, CNAME).
+ */
+otError otDnsRecordResponseGetRecordInfo(const otDnsRecordResponse *aResponse,
+                                         uint16_t                   aIndex,
+                                         otDnsRecordInfo           *aRecordInfo);
+/**
  * @}
  */
 

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (493)
+#define OPENTHREAD_API_VERSION (494)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1561,6 +1561,28 @@ Service instance label is provided first, followed by the service name (note tha
 
 The parameters after `service-name` are optional. Any unspecified (or zero) value for these optional parameters is replaced by the value from the current default config (`dns config`).
 
+### dns query \<record-type\> \<first-label\> \<next-labels\> \[DNS server IP\] \[DNS server port\] \[response timeout (ms)\] \[max tx attempts\] \[recursion desired (boolean)\]
+
+Requires `OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE` and `OPENTHREAD_CONFIG_DNS_CLIENT_ARBITRARY_RECORD_QUERY_ENABLE`.
+
+Sends a DNS query for a given record type and DNS name. DNS name is provided as a first label, followed by the next labels which are dot '.' separated. Note that the first label can itself contain the dot '.' character.
+
+The `record-type` is a numerical value corresponding to the DNS RRType values.
+
+The parameters after `next-labels` are optional. Any unspecified (or zero) value for these optional parameters is replaced by the value from the current default config (`dns config`).
+
+If record type is `PTR` (12), `CNAME` (5), `DNAME` (39), `NS` (2), or `SRV` (33), the record data in the received response contains a DNS name which may use DNS name compression. For these specific record types, the record data is first decompressed such that it contains the full uncompressed DNS name. This decompressed data is then provided in the output. For all other record types, the record data is read and provided as it appears in the received response message.
+
+```bash
+> dns query 25 myhost default.service.arpa.
+DNS query response for myhost.default.service.arpa.
+0)
+    RecordType:25, RecordLength: 32, TTL:7108, Section:answer
+    Name:myhost.default.service.arpa.
+    RecordData:[001900010000e02d00440201030d4983605c0406803deb2d672cc42224773977]
+Done
+```
+
 ### dns server upstream \[enable|disable\]
 
 Enable/Disable the upstream DNS feature. If no argument is provided, it prints whether the upstream DNS feature is enabled.

--- a/src/cli/cli_dns.cpp
+++ b/src/cli/cli_dns.cpp
@@ -410,6 +410,55 @@ exit:
 
 #endif // OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE
 
+#if OPENTHREAD_CONFIG_DNS_CLIENT_ARBITRARY_RECORD_QUERY_ENABLE
+
+/**
+ * @cli dns query
+ * @cparam dns query @ca{record-type} @ca{first-label} @ca{next-labels} <!--
+ * -->                 [@ca{DNS-server-IP}] [@ca{DNS-server-port}] <!--
+ * -->                 [@ca{response-timeout-ms}] [@ca{max-tx-attempts}] <!--
+ * -->                 [@ca{recursion-desired-boolean}]
+ * @code
+ * dns query 25 myhost default.service.arpa.
+ * DNS query response for myhost.default.service.arpa.
+ * 0)
+ *     RecordType:25, RecordLength: 32, TTL:7108, Section:answer
+ *     Name:myhost.default.service.arpa.
+ *     RecordData:[001900010000e02d00440201030d4983605c0406803deb2d672cc42224773977]
+ * Done
+ * @endcode
+ * @par
+ * Send a DNS query for a given record type and DNS name.
+ * DNS name is provided as a first label, followed by the next labels
+ * which are dot '.' separated. Note that the first label can itself
+ * contain the dot '.' character.
+ * @par
+ * The parameters after `next-labels` are optional. Any unspecified (or zero)
+ * value for these optional parameters is replaced by the value from the
+ * current default config (`dns config`).
+ * @par
+ * `OPENTHREAD_CONFIG_DNS_CLIENT_ARBITRARY_RECORD_QUERY_ENABLE` is required.
+ */
+template <> otError Dns::Process<Cmd("query")>(Arg aArgs[])
+{
+    otError           error = OT_ERROR_NONE;
+    otDnsQueryConfig  queryConfig;
+    otDnsQueryConfig *config = &queryConfig;
+    uint16_t          recordType;
+
+    SuccessOrExit(error = aArgs[0].ParseAsUint16(recordType));
+    VerifyOrExit(!aArgs[2].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+    SuccessOrExit(error = GetDnsConfig(aArgs + 3, config));
+    SuccessOrExit(error = otDnsClientQueryRecord(GetInstancePtr(), recordType, aArgs[1].GetCString(),
+                                                 aArgs[2].GetCString(), &HandleDnsRecordResponse, this, config));
+    error = OT_ERROR_PENDING;
+
+exit:
+    return error;
+}
+
+#endif // OPENTHREAD_CONFIG_DNS_CLIENT_ARBITRARY_RECORD_QUERY_ENABLE
+
 //----------------------------------------------------------------------------------------------------------------------
 
 void Dns::OutputResult(otError aError) { Interpreter::GetInterpreter().OutputResult(aError); }
@@ -650,6 +699,78 @@ void Dns::HandleDnsServiceResponse(otError aError, const otDnsServiceResponse *a
 }
 
 #endif // OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE
+
+#if OPENTHREAD_CONFIG_DNS_CLIENT_ARBITRARY_RECORD_QUERY_ENABLE
+void Dns::HandleDnsRecordResponse(otError aError, const otDnsRecordResponse *aResponse, void *aContext)
+{
+    static_cast<Dns *>(aContext)->HandleDnsRecordResponse(aError, aResponse);
+}
+
+void Dns::HandleDnsRecordResponse(otError aError, const otDnsRecordResponse *aResponse)
+{
+    char            name[OT_DNS_MAX_NAME_SIZE];
+    uint8_t         data[kMaxRrDataSize];
+    otDnsRecordInfo recordInfo;
+
+    IgnoreError(otDnsRecordResponseGetQueryName(aResponse, name, sizeof(name)));
+
+    OutputLine("DNS query response for %s ", name);
+
+    SuccessOrExit(aError);
+
+    for (uint16_t index = 0;; index++)
+    {
+        ClearAllBytes(recordInfo);
+        recordInfo.mNameBuffer     = name;
+        recordInfo.mNameBufferSize = sizeof(name);
+        recordInfo.mDataBuffer     = data;
+        recordInfo.mDataBufferSize = sizeof(name);
+
+        aError = otDnsRecordResponseGetRecordInfo(aResponse, index, &recordInfo);
+
+        if (aError == OT_ERROR_NOT_FOUND)
+        {
+            aError = OT_ERROR_NONE;
+            ExitNow();
+        }
+
+        SuccessOrExit(aError);
+
+        OutputLine("%u)", index);
+        OutputLine(kIndentSize, "RecordType:%u, RecordLength:%u, TTL:%lu, Section:%s", recordInfo.mRecordType,
+                   recordInfo.mRecordLength, ToUlong(recordInfo.mTtl), RecordSectionToString(recordInfo.mSection));
+        OutputLine(kIndentSize, "Name:%s", recordInfo.mNameBuffer);
+        OutputFormat(kIndentSize, "RecordData:[");
+        OutputBytes(recordInfo.mDataBuffer, recordInfo.mDataBufferSize);
+
+        if (recordInfo.mDataBufferSize != recordInfo.mRecordLength)
+        {
+            OutputFormat("...");
+        }
+
+        OutputLine("]");
+    }
+
+exit:
+    OutputResult(aError);
+}
+
+const char *Dns::RecordSectionToString(otDnsRecordSection aSection)
+{
+    const char *const kSectionString[] = {
+        "answer",     // (0) OT_DNS_SECTION_ANSWER
+        "authority",  // (1) OT_DNS_SECTION_AUTHORITY
+        "additional", // (2) OT_DNS_SECTION_ADDITIONAL
+    };
+
+    static_assert(0 == OT_DNS_SECTION_ANSWER, "OT_DNS_SECTION_ANSWER value is incorrect");
+    static_assert(1 == OT_DNS_SECTION_AUTHORITY, "OT_DNS_SECTION_AUTHORITY value is incorrect");
+    static_assert(2 == OT_DNS_SECTION_ADDITIONAL, "OT_DNS_SECTION_ADDITIONALATA value is incorrect");
+
+    return Stringify(aSection, kSectionString);
+}
+#endif // OPENTHREAD_CONFIG_DNS_CLIENT_ARBITRARY_RECORD_QUERY_ENABLE
+
 #endif // OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
 
 #if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
@@ -716,6 +837,9 @@ otError Dns::Process(Arg aArgs[])
 #endif
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
         CmdEntry("config"),
+#if OPENTHREAD_CONFIG_DNS_CLIENT_ARBITRARY_RECORD_QUERY_ENABLE
+        CmdEntry("query"),
+#endif
         CmdEntry("resolve"),
 #if OPENTHREAD_CONFIG_DNS_CLIENT_NAT64_ENABLE
         CmdEntry("resolve4"),

--- a/src/cli/cli_dns.hpp
+++ b/src/cli/cli_dns.hpp
@@ -92,6 +92,9 @@ public:
 private:
     static constexpr uint8_t  kIndentSize     = 4;
     static constexpr uint16_t kMaxTxtDataSize = OPENTHREAD_CONFIG_CLI_TXT_RECORD_MAX_SIZE;
+    static constexpr uint8_t  kMaxRrDataSize  = 128;
+
+    static const char *const kServiceModeStrings[];
 
     using Command = CommandEntry<Dns>;
 
@@ -104,9 +107,8 @@ private:
     otError     ParseDnsServiceMode(const Arg &aArg, otDnsServiceMode &aMode) const;
     static void HandleDnsAddressResponse(otError aError, const otDnsAddressResponse *aResponse, void *aContext);
     void        HandleDnsAddressResponse(otError aError, const otDnsAddressResponse *aResponse);
-#if OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE
-    static const char *const kServiceModeStrings[];
 
+#if OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE
     typedef otError (&ResolveServiceFn)(otInstance *,
                                         const char *,
                                         const char *,
@@ -121,7 +123,15 @@ private:
     static void HandleDnsServiceResponse(otError aError, const otDnsServiceResponse *aResponse, void *aContext);
     void        HandleDnsServiceResponse(otError aError, const otDnsServiceResponse *aResponse);
 #endif
+
+#if OPENTHREAD_CONFIG_DNS_CLIENT_ARBITRARY_RECORD_QUERY_ENABLE
+    static void HandleDnsRecordResponse(otError aError, const otDnsRecordResponse *aResponse, void *aContext);
+    void        HandleDnsRecordResponse(otError aError, const otDnsRecordResponse *aResponse);
+
+    static const char *RecordSectionToString(otDnsRecordSection aSection);
 #endif
+
+#endif // OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
 };
 
 } // namespace Cli

--- a/src/core/api/dns_api.cpp
+++ b/src/core/api/dns_api.cpp
@@ -253,4 +253,38 @@ otError otDnsServiceResponseGetHostAddress(const otDnsServiceResponse *aResponse
 
 #endif // OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE
 
+#if OPENTHREAD_CONFIG_DNS_CLIENT_ARBITRARY_RECORD_QUERY_ENABLE
+
+otError otDnsClientQueryRecord(otInstance             *aInstance,
+                               uint16_t                aRecordType,
+                               const char             *aFirstLabel,
+                               const char             *aNextLabels,
+                               otDnsRecordCallback     aCallback,
+                               void                   *aContext,
+                               const otDnsQueryConfig *aConfig)
+{
+    AssertPointerIsNotNull(aNextLabels);
+
+    return AsCoreType(aInstance).Get<Dns::Client>().QueryRecord(aRecordType, aFirstLabel, aNextLabels, aCallback,
+                                                                aContext, AsCoreTypePtr(aConfig));
+}
+
+otError otDnsRecordResponseGetQueryName(const otDnsRecordResponse *aResponse,
+                                        char                      *aNameBuffer,
+                                        uint16_t                   aNameBufferSize)
+{
+    AssertPointerIsNotNull(aNameBuffer);
+
+    return AsCoreType(aResponse).GetQueryName(aNameBuffer, aNameBufferSize);
+}
+
+otError otDnsRecordResponseGetRecordInfo(const otDnsRecordResponse *aResponse,
+                                         uint16_t                   aIndex,
+                                         otDnsRecordInfo           *aRecordInfo)
+{
+    return AsCoreType(aResponse).GetRecordInfo(aIndex, AsCoreType(aRecordInfo));
+}
+
+#endif // OPENTHREAD_CONFIG_DNS_CLIENT_ARBITRARY_RECORD_QUERY_ENABLE
+
 #endif // OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE

--- a/src/core/config/dns_client.h
+++ b/src/core/config/dns_client.h
@@ -85,6 +85,15 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_DNS_CLIENT_ARBITRARY_RECORD_QUERY_ENABLE
+ *
+ * Define to 1 to enable support for a query of arbitrary DNS record type.
+ */
+#ifndef OPENTHREAD_CONFIG_DNS_CLIENT_ARBITRARY_RECORD_QUERY_ENABLE
+#define OPENTHREAD_CONFIG_DNS_CLIENT_ARBITRARY_RECORD_QUERY_ENABLE 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_SERVER_ADDRESS_AUTO_SET_ENABLE
  *
  * Set to 1 for DNS client to automatically set and update the server IPv6 address in the default config (when it is

--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -1267,6 +1267,7 @@ public:
     // Resource Record Types.
     static constexpr uint16_t kTypeZero  = 0;   ///< Zero as special indicator for the SIG RR (SIG(0) from RFC 2931).
     static constexpr uint16_t kTypeA     = 1;   ///< Address record (IPv4).
+    static constexpr uint16_t kTypeNs    = 2;   ///< NS record (an authoritative name server).
     static constexpr uint16_t kTypeSoa   = 6;   ///< Start of (zone of) authority.
     static constexpr uint16_t kTypeCname = 5;   ///< CNAME record.
     static constexpr uint16_t kTypePtr   = 12;  ///< PTR record.
@@ -1275,6 +1276,7 @@ public:
     static constexpr uint16_t kTypeKey   = 25;  ///< KEY record.
     static constexpr uint16_t kTypeAaaa  = 28;  ///< IPv6 address record.
     static constexpr uint16_t kTypeSrv   = 33;  ///< SRV locator record.
+    static constexpr uint16_t kTypeDname = 39;  ///< DNAME record.
     static constexpr uint16_t kTypeOpt   = 41;  ///< Option record.
     static constexpr uint16_t kTypeNsec  = 47;  ///< NSEC record.
     static constexpr uint16_t kTypeAny   = 255; ///< ANY record.


### PR DESCRIPTION
This commit introduces a new feature in `Dns::Client` to support sending DNS queries for arbitrary record types. Callers are notified of received response via a callback. New methods are provided to parse and read all records in the response. Public APIs and related CLI commands for this new feature are also added.

The `OPENTHREAD_CONFIG_DNS_CLIENT_ARBITRARY_RECORD_QUERY_ENABLE` build configuration is added to control this feature. This allows projects that do not require arbitrary DNS query functionality to disable it, avoiding its associated firmware code size overhead.

Importantly, if a retrieved record type is PTR, CNAME, DNAME, NS, or SRV, the record data in the received response contains a DNS name which may use DNS name compression. For these specific record types, the record data is first decompressed such that it contains the uncompressed DNS name. For all other record types, the record data is read and provided as it appears in the received response message.

----

While this PR/commit itself doesn't contain any new tests for the new DNS client API, the PR #11357 (which adds support for this on the DNSSD name server/resolver (SRP and discovery proxy)) includes detailed tests that also use and cover the newly added behavior in this PR.
