### PR TITLE
[test] fix `get_srp_server_port()` to handle the version field

### DIFF
--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1269,12 +1269,12 @@ class NodeImpl:
         """
 
         for service in self.get_services():
-            # TODO: for now, we are using 0xfd as the SRP service data.
-            #       May use a dedicated bit flag for SRP server.
+            # 0x5d is used to indicate SRP/DNS unicast entry
             if int(service[1], 16) == 0x5d:
                 # The SRP server data contains IPv6 address (16 bytes)
-                # followed by UDP port number.
-                return int(service[2][2 * 16:], 16)
+                # followed by UDP port number (two bytes) and then
+                # the version field (one byte)
+                return int(service[2][2 * 16:2 * 16 + 4], 16)
 
     def srp_client_start(self, server_address, server_port):
         self.send_command(f'srp client start {server_address} {server_port}')


### PR DESCRIPTION
This commit fixes `get_srp_server_port()` in `thread-cert/node.py`. This function parses Network Data service entries, searching for an SRP/DNS unicast (non-preferred) entry, and then attempts to parse the published port number of the SRP server by examining the last  bytes of the "server data".

The SRP/DNS unicast entry was previously updated to optionally include a "version" field at the end of the "server data". This update caused the port number parsing to fail, as the code did not account for the extra byte corresponding to the version field.

This commit resolves this issue by ensuring that the two bytes are correctly read and interpreted as the port number, regardless of the presence of the version field.