### PR TITLE
[spinel] Add missing config header to fix compiler warning.

### DIFF
--- a/src/lib/spinel/spinel_driver.hpp
+++ b/src/lib/spinel/spinel_driver.hpp
@@ -29,6 +29,8 @@
 #ifndef SPINEL_DRIVER_HPP_
 #define SPINEL_DRIVER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/instance.h>
 
 #include "lib/spinel/coprocessor_type.h"


### PR DESCRIPTION
Add openthread-core-config header as this file uses OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE option, otherwise compiler throws a warning when stack is built with optimization flag for multipan case.