### PR TITLE
[cli] add `srp server port` command to retrieve SRP server port

### DIFF
--- a/src/cli/README_SRP_SERVER.md
+++ b/src/cli/README_SRP_SERVER.md
@@ -37,6 +37,7 @@ faststart
 help
 host
 lease
+port
 seqnum
 service
 state
@@ -189,6 +190,18 @@ Set LEASE and KEY-LEASE values.
 
 ```bash
 > srp server lease 1800 7200 86400 1209600
+Done
+```
+
+### port
+
+Usage: `srp server port`
+
+Get the port number the SRP server is listening to. If the server is not running, `0` will be returned.
+
+```bash
+> srp server port
+53536
 Done
 ```
 

--- a/src/cli/cli_srp_server.cpp
+++ b/src/cli/cli_srp_server.cpp
@@ -555,6 +555,18 @@ exit:
 }
 
 /**
+ * @cli srp server port (get)
+ * @code
+ * srp server port
+ * 53536
+ * Done
+ * @endcode
+ * @par api_copy
+ * #otSrpServerGetPort
+ */
+template <> otError SrpServer::Process<Cmd("port")>(Arg aArgs[]) { return ProcessGet(aArgs, otSrpServerGetPort); }
+
+/**
  * @cli srp server seqnum (get,set)
  * @code
  * srp server seqnum 20
@@ -613,6 +625,7 @@ otError SrpServer::Process(Arg aArgs[])
 #endif
         CmdEntry("host"),
         CmdEntry("lease"),
+        CmdEntry("port"),
         CmdEntry("seqnum"),
         CmdEntry("service"),
         CmdEntry("state"),

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1264,17 +1264,8 @@ class NodeImpl:
                 return service
 
     def get_srp_server_port(self):
-        """Returns the SRP server UDP port by parsing
-           the SRP Server Data in Network Data.
-        """
-
-        for service in self.get_services():
-            # 0x5d is used to indicate SRP/DNS unicast entry
-            if int(service[1], 16) == 0x5d:
-                # The SRP server data contains IPv6 address (16 bytes)
-                # followed by UDP port number (two bytes) and then
-                # the version field (one byte)
-                return int(service[2][2 * 16:2 * 16 + 4], 16)
+        self.send_command('srp server port')
+        return int(self._expect_result(r'\d+'))
 
     def srp_client_start(self, server_address, server_port):
         self.send_command(f'srp client start {server_address} {server_port}')


### PR DESCRIPTION
This commit adds the `srp server port` CLI command, which maps to the `otSrpServerGetPort()` API. This new command is now used in `thread-cert/node.py` to implement `get_srp_server_port()`, allowing direct retrieval of the SRP server port instead of indirectly parsing the network data entry.