### PR TITLE
[core] check exclusive selection of FTD, MTD, or RADIO configs

### DIFF
--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -40,6 +40,10 @@
 
 namespace ot {
 
+#if (OPENTHREAD_FTD + OPENTHREAD_MTD + OPENTHREAD_RADIO) != 1
+#error "Exactly one of {OPENTHREAD_FTD, OPENTHREAD_MTD, OPENTHREAD_RADIO} MUST be set"
+#endif
+
 #if !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
 
 // Define the raw storage used for OpenThread instance (in single-instance case).


### PR DESCRIPTION
This commit adds a check in `instance.cpp` to ensure that exactly one of the `OPENTHREAD_CONFIG_FTD`, `OPENTHREAD_CONFIG_MTD`, or `OPENTHREAD_CONFIG_RADIO` configuration options is enabled. This enforces a clear definition of the build type and prevents potential conflicts or unexpected behavior arising from ambiguous or incorrect configurations.