### PR TITLE
[secure-transport] update log mapping

### DIFF
--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -1035,6 +1035,9 @@ void SecureTransport::HandleMbedtlsDebug(int aLevel, const char *aFile, int aLin
         break;
 
     case 4:
+        logLevel = kLogLevelDebg;
+        break;
+
     default:
         break;
     }


### PR DESCRIPTION
The log handler currently uses LogAt which causes link error when OpenThread logs are disabled by setting log level to `NONE`.

This commit adds LOG_LEVEL check into OT_SHOULD_LOG. This commit also adds the debug level mapping in SecureTransport.