### PR TITLE
[uptime] add `GetUptimeInSeconds()` method for simplified uptime retrieval

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1085,7 +1085,7 @@ RoutingManager::NetDataPeerBrTracker::NetDataPeerBrTracker(Instance &aInstance)
 
 uint16_t RoutingManager::NetDataPeerBrTracker::CountPeerBrs(uint32_t &aMinAge) const
 {
-    uint32_t uptime = Uptime::MsecToSec(Get<Uptime>().GetUptime());
+    uint32_t uptime = Get<Uptime>().GetUptimeInSeconds();
     uint16_t count  = 0;
 
     aMinAge = NumericLimits<uint16_t>::kMax;
@@ -1148,7 +1148,7 @@ void RoutingManager::NetDataPeerBrTracker::HandleNotifierEvents(Events aEvents)
         VerifyOrExit(newEntry != nullptr, LogWarn("Failed to allocate `PeerBr` entry"));
 
         newEntry->mRloc16       = rloc16;
-        newEntry->mDiscoverTime = Uptime::MsecToSec(Get<Uptime>().GetUptime());
+        newEntry->mDiscoverTime = Get<Uptime>().GetUptimeInSeconds();
 
         mPeerBrs.Push(*newEntry);
     }
@@ -1212,7 +1212,7 @@ void RoutingManager::RxRaTracker::ProcessRouterAdvertMessage(const RouterAdvert:
 
         router = newEntry;
         router->Clear();
-        router->mDiscoverTime = Uptime::MsecToSec(Get<Uptime>().GetUptime());
+        router->mDiscoverTime = Get<Uptime>().GetUptimeInSeconds();
         router->mAddress      = aSrcAddress;
 
         mRouters.Push(*newEntry);
@@ -2020,7 +2020,7 @@ exit:
 
 void RoutingManager::RxRaTracker::InitIterator(PrefixTableIterator &aIterator) const
 {
-    static_cast<Iterator &>(aIterator).Init(mRouters.GetHead(), Uptime::MsecToSec(Get<Uptime>().GetUptime()));
+    static_cast<Iterator &>(aIterator).Init(mRouters.GetHead(), Get<Uptime>().GetUptimeInSeconds());
 }
 
 Error RoutingManager::RxRaTracker::GetNextEntry(PrefixTableIterator &aIterator, PrefixTableEntry &aEntry) const

--- a/src/core/common/uptime.cpp
+++ b/src/core/common/uptime.cpp
@@ -85,6 +85,8 @@ void Uptime::GetUptime(char *aBuffer, uint16_t aSize) const
     UptimeToString(GetUptime(), writer, /* aIncludeMsec */ true);
 }
 
+uint32_t Uptime::GetUptimeInSeconds(void) const { return MsecToSec(GetUptime()); }
+
 void Uptime::HandleTimer(void)
 {
     if (mTimer.GetFireTime() == mStartTime)

--- a/src/core/common/uptime.hpp
+++ b/src/core/common/uptime.hpp
@@ -102,6 +102,13 @@ public:
     static void UptimeToString(uint64_t aUptime, StringWriter &aWriter, bool aIncludeMsec);
 
     /**
+     * Returns the current device uptime in seconds.
+     *
+     * @returns The uptime in seconds.
+     */
+    uint32_t GetUptimeInSeconds(void) const;
+
+    /**
      * Converts a given uptime as number of milliseconds to number of seconds.
      *
      * @param[in] aUptimeInMilliseconds    Uptime in milliseconds (as `uint64_t`).

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -256,7 +256,7 @@ void Mle::ResetCounters(void)
 
 uint32_t Mle::GetCurrentAttachDuration(void) const
 {
-    return IsAttached() ? Uptime::MsecToSec(Get<Uptime>().GetUptime()) - mLastAttachTime : 0;
+    return IsAttached() ? Get<Uptime>().GetUptimeInSeconds() - mLastAttachTime : 0;
 }
 
 void Mle::UpdateRoleTimeCounters(DeviceRole aRole)
@@ -298,7 +298,7 @@ void Mle::SetRole(DeviceRole aRole)
 
     if ((oldRole == kRoleDetached) && IsAttached())
     {
-        mLastAttachTime = Uptime::MsecToSec(Get<Uptime>().GetUptime());
+        mLastAttachTime = Get<Uptime>().GetUptimeInSeconds();
     }
 
     UpdateRoleTimeCounters(oldRole);

--- a/src/core/thread/neighbor.cpp
+++ b/src/core/thread/neighbor.cpp
@@ -44,7 +44,7 @@ void Neighbor::SetState(State aState)
 
     if (mState == kStateValid)
     {
-        mConnectionStart = Uptime::MsecToSec(Get<Uptime>().GetUptime());
+        mConnectionStart = Get<Uptime>().GetUptimeInSeconds();
     }
 
 exit:
@@ -53,7 +53,7 @@ exit:
 
 uint32_t Neighbor::GetConnectionTime(void) const
 {
-    return IsStateValid() ? Uptime::MsecToSec(Get<Uptime>().GetUptime()) - mConnectionStart : 0;
+    return IsStateValid() ? Get<Uptime>().GetUptimeInSeconds() - mConnectionStart : 0;
 }
 
 bool Neighbor::AddressMatcher::Matches(const Neighbor &aNeighbor) const


### PR DESCRIPTION
This commit introduces a new method, `Uptime::GetUptimeInSeconds()`, which returns the device's uptime in seconds. This new method simplifies existing code that performed manual conversion of the uptime from milliseconds to seconds.