### PR TITLE
[github-actions] add `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to mbedtls2 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,7 +210,7 @@ jobs:
         path: third_party/mbedtls/repo
     - name: Build
       run: |
-        ./script/test build
+        OT_OPTIONS='-DCMAKE_POLICY_VERSION_MINIMUM=3.5' ./script/test build
 
   arm-gcc:
     name: arm-gcc-${{ matrix.gcc_ver }}


### PR DESCRIPTION
Resolves:
```
CMake Error at third_party/mbedtls/repo/CMakeLists.txt:23 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```