### PR TITLE
[github-actions] add `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to ot-commissioner build

### DIFF
--- a/.github/workflows/simulation-1.1.yml
+++ b/.github/workflows/simulation-1.1.yml
@@ -323,13 +323,14 @@ jobs:
       run: |
         cd /tmp/ot-commissioner
         script/bootstrap.sh
-        cmake -GNinja                           \
-              -DCMAKE_CXX_STANDARD=11           \
-              -DCMAKE_CXX_STANDARD_REQUIRED=ON  \
-              -DCMAKE_BUILD_TYPE=Release        \
-              -DCMAKE_INSTALL_PREFIX=/usr/local \
-              -DOT_COMM_COVERAGE=ON             \
-              -DOT_COMM_CCM=OFF                 \
+        cmake -GNinja                            \
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+              -DCMAKE_CXX_STANDARD=11            \
+              -DCMAKE_CXX_STANDARD_REQUIRED=ON   \
+              -DCMAKE_BUILD_TYPE=Release         \
+              -DCMAKE_INSTALL_PREFIX=/usr/local  \
+              -DOT_COMM_COVERAGE=ON              \
+              -DOT_COMM_CCM=OFF                  \
               -S . -B build
         cmake --build build
         sudo cmake --install build


### PR DESCRIPTION
Resolves:
  ```
  CMake Error at third_party/googletest/repo/CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
  ```