### PR TITLE
[mac] add helpers to set MAC extended address from an IPv6 IID

### DIFF
--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -38,6 +38,9 @@
 #include "common/code_utils.hpp"
 #include "common/random.hpp"
 #include "common/string.hpp"
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
+#include "net/ip6_address.hpp"
+#endif
 
 namespace ot {
 namespace Mac {
@@ -55,12 +58,20 @@ PanId GenerateRandomPanId(void)
 }
 
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
+
 void ExtAddress::GenerateRandom(void)
 {
     IgnoreError(Random::Crypto::Fill(*this));
     SetGroup(false);
     SetLocal(true);
 }
+
+void ExtAddress::SetFromIid(const Ip6::InterfaceIdentifier &aIid)
+{
+    Set(aIid.GetBytes());
+    ToggleLocal();
+}
+
 #endif
 
 bool ExtAddress::operator==(const ExtAddress &aOther) const { return (memcmp(m8, aOther.m8, sizeof(m8)) == 0); }
@@ -91,6 +102,14 @@ void ExtAddress::CopyAddress(uint8_t *aDst, const uint8_t *aSrc, CopyByteOrder a
         break;
     }
 }
+
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
+void Address::SetExtendedFromIid(const Ip6::InterfaceIdentifier &aIid)
+{
+    mShared.mExtAddress.SetFromIid(aIid);
+    mType = kTypeExtended;
+}
+#endif
 
 bool Address::operator==(const Address &aOther) const
 {

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -50,6 +50,13 @@
 #include "crypto/storage.hpp"
 
 namespace ot {
+
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
+namespace Ip6 {
+class InterfaceIdentifier;
+}
+#endif
+
 namespace Mac {
 
 /**
@@ -115,6 +122,13 @@ public:
      * Generates a random IEEE 802.15.4 Extended Address.
      */
     void GenerateRandom(void);
+
+    /**
+     * Sets the Extended Address from a given IPv6 Address Interface Identifier.
+     *
+     * @param[in] aIid   The IPv6 Interface Identifier to convert to Extended Address.
+     */
+    void SetFromIid(const Ip6::InterfaceIdentifier &aIid);
 #endif
 
     /**
@@ -355,6 +369,15 @@ public:
         mShared.mExtAddress.Set(aBuffer, aByteOrder);
         mType = kTypeExtended;
     }
+
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
+    /**
+     * Sets the address as an Extended Address from a given IPv6 Address Interface Identifier.
+     *
+     * @param[in] aIid   The IPv6 Interface Identifier to convert to Extended Address.
+     */
+    void SetExtendedFromIid(const Ip6::InterfaceIdentifier &aIid);
+#endif
 
     /**
      * Indicates whether or not the address is a Short Broadcast Address.

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -99,7 +99,7 @@ void Commissioner::SignalJoinerEvent(JoinerEvent aEvent, const Joiner *aJoiner) 
     }
     else if (aJoiner == mActiveJoiner)
     {
-        mJoinerIid.ConvertToExtAddress(joinerId);
+        joinerId.SetFromIid(mJoinerIid);
     }
     else
     {
@@ -900,7 +900,7 @@ template <> void Commissioner::HandleTmf<kUriRelayRx>(Coap::Message &aMessage, c
         Joiner         *joiner;
 
         mJoinerIid = joinerIid;
-        mJoinerIid.ConvertToExtAddress(receivedId);
+        receivedId.SetFromIid(mJoinerIid);
 
         joiner = FindBestMatchingJoinerEntry(receivedId);
         VerifyOrExit(joiner != nullptr);

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -256,18 +256,6 @@ void InterfaceIdentifier::SetFromExtAddress(const Mac::ExtAddress &aExtAddress)
     addr.CopyTo(mFields.m8);
 }
 
-void InterfaceIdentifier::ConvertToExtAddress(Mac::ExtAddress &aExtAddress) const
-{
-    aExtAddress.Set(mFields.m8);
-    aExtAddress.ToggleLocal();
-}
-
-void InterfaceIdentifier::ConvertToMacAddress(Mac::Address &aMacAddress) const
-{
-    aMacAddress.SetExtended(mFields.m8);
-    aMacAddress.GetExtended().ToggleLocal();
-}
-
 void InterfaceIdentifier::SetToLocator(uint16_t aLocator)
 {
     // Locator IID pattern `0000:00ff:fe00:xxxx`

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -409,20 +409,6 @@ public:
     void SetFromExtAddress(const Mac::ExtAddress &aExtAddress);
 
     /**
-     * Converts the Interface Identifier to an IEEE 802.15.4 Extended Address.
-     *
-     * @param[out]  aExtAddress  A reference to an Extended Address where the converted address is placed.
-     */
-    void ConvertToExtAddress(Mac::ExtAddress &aExtAddress) const;
-
-    /**
-     * Converts the Interface Identifier to an IEEE 802.15.4 MAC Address.
-     *
-     * @param[out]  aMacAddress  A reference to a MAC Address where the converted address is placed.
-     */
-    void ConvertToMacAddress(Mac::Address &aMacAddress) const;
-
-    /**
      * Sets the Interface Identifier to Routing/Anycast Locator pattern `0000:00ff:fe00:xxxx` with a given
      * locator (RLOC16 or ALOC16) value.
      *

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -804,7 +804,7 @@ void AddressResolver::HandleTmf<kUriAddressError>(Coap::Message &aMessage, const
     }
 
 #if OPENTHREAD_FTD
-    meshLocalIid.ConvertToExtAddress(extAddr);
+    extAddr.SetFromIid(meshLocalIid);
 
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -322,7 +322,7 @@ void DiscoverScanner::HandleDiscoveryResponse(Mle::RxInfo &aRxInfo) const
     result.mRssi     = aRxInfo.mMessage.GetAverageRss();
     result.mLqi      = aRxInfo.mMessage.GetAverageLqi();
 
-    aRxInfo.mMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(AsCoreType(&result.mExtAddress));
+    AsCoreType(&result.mExtAddress).SetFromIid(aRxInfo.mMessageInfo.GetPeerAddr().GetIid());
 
     for (; !offsetRange.IsEmpty(); offsetRange.AdvanceOffset(tlvInfo.GetSize()))
     {

--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -386,7 +386,7 @@ Error Initiator::FindNeighbor(const Ip6::Address &aDestination, Neighbor *&aNeig
     aNeighbor = nullptr;
 
     VerifyOrExit(aDestination.IsLinkLocalUnicast());
-    aDestination.GetIid().ConvertToMacAddress(macAddress);
+    macAddress.SetExtendedFromIid(aDestination.GetIid());
 
     aNeighbor = Get<NeighborTable>().FindNeighbor(macAddress);
     VerifyOrExit(aNeighbor != nullptr);

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -700,7 +700,7 @@ void MeshForwarder::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 
 void MeshForwarder::GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr)
 {
-    aIp6Addr.GetIid().ConvertToMacAddress(aMacAddr);
+    aMacAddr.SetExtendedFromIid(aIp6Addr.GetIid());
 
     if (aMacAddr.GetExtended() != Get<Mac::Mac>().GetExtAddress())
     {
@@ -720,7 +720,7 @@ void MeshForwarder::GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Mac::
     }
     else
     {
-        aIp6Addr.GetIid().ConvertToMacAddress(aMacAddr);
+        aMacAddr.SetExtendedFromIid(aIp6Addr.GetIid());
     }
 }
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1091,7 +1091,7 @@ bool Mle::IsCslSupported(void) const { return IsChild() && GetParent().IsThreadV
 
 void Mle::InitNeighbor(Neighbor &aNeighbor, const RxInfo &aRxInfo)
 {
-    aRxInfo.mMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(aNeighbor.GetExtAddress());
+    aNeighbor.GetExtAddress().SetFromIid(aRxInfo.mMessageInfo.GetPeerAddr().GetIid());
     aNeighbor.GetLinkInfo().Clear();
     aNeighbor.GetLinkInfo().AddRss(aRxInfo.mMessage.GetAverageRss());
     aNeighbor.ResetLinkFailures();
@@ -2300,7 +2300,7 @@ Error Mle::ProcessMessageSecurity(Crypto::AesCcm::Mode    aMode,
         break;
     }
 
-    senderAddress->GetIid().ConvertToExtAddress(extAddress);
+    extAddress.SetFromIid(senderAddress->GetIid());
     Crypto::AesCcm::GenerateNonce(extAddress, aHeader.GetFrameCounter(), Mac::Frame::kSecurityEncMic32, nonce);
 
     keySequence = aHeader.GetKeyId();
@@ -2405,7 +2405,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     IgnoreError(aMessage.Read(aMessage.GetOffset(), command));
     aMessage.MoveOffset(sizeof(command));
 
-    aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddr);
+    extAddr.SetFromIid(aMessageInfo.GetPeerAddr().GetIid());
     neighbor = (command == kCommandChildIdResponse) ? mNeighborTable.FindParent(extAddr)
                                                     : mNeighborTable.FindNeighbor(extAddr);
 
@@ -3074,7 +3074,7 @@ void Mle::HandleParentResponse(RxInfo &aRxInfo)
 
     SuccessOrExit(error = aRxInfo.mMessage.ReadAndMatchResponseTlvWith(mParentRequestChallenge));
 
-    aRxInfo.mMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddress);
+    extAddress.SetFromIid(aRxInfo.mMessageInfo.GetPeerAddr().GetIid());
 
     if (IsChild() && mParent.GetExtAddress() == extAddress)
     {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -707,7 +707,7 @@ void MleRouter::HandleLinkRequest(RxInfo &aRxInfo)
         ExitNow(error = kErrorParse);
     }
 
-    aRxInfo.mMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(info.mExtAddress);
+    info.mExtAddress.SetFromIid(aRxInfo.mMessageInfo.GetPeerAddr().GetIid());
 
     info.mLinkMargin = Get<Mac::Mac>().ComputeLinkMargin(aRxInfo.mMessage.GetAverageRss());
 
@@ -1472,7 +1472,7 @@ void MleRouter::HandleParentRequest(RxInfo &aRxInfo)
     // the network (because Leader would reject any further address solicit).
     // ==> Verified below when checking the scan mask.
 
-    aRxInfo.mMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(info.mChildExtAddress);
+    info.mChildExtAddress.SetFromIid(aRxInfo.mMessageInfo.GetPeerAddr().GetIid());
 
     SuccessOrExit(error = aRxInfo.mMessage.ReadVersionTlv(version));
 
@@ -2105,7 +2105,7 @@ void MleRouter::HandleChildIdRequest(RxInfo &aRxInfo)
 
     VerifyOrExit(IsAttached(), error = kErrorInvalidState);
 
-    aRxInfo.mMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddr);
+    extAddr.SetFromIid(aRxInfo.mMessageInfo.GetPeerAddr().GetIid());
 
     child = mChildTable.FindChild(extAddr, Child::kInStateAnyExceptInvalid);
     VerifyOrExit(child != nullptr, error = kErrorAlready);
@@ -2278,7 +2278,7 @@ void MleRouter::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
 
     tlvList.Add(Tlv::kSourceAddress);
 
-    aRxInfo.mMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddr);
+    extAddr.SetFromIid(aRxInfo.mMessageInfo.GetPeerAddr().GetIid());
     child = mChildTable.FindChild(extAddr, Child::kInStateAnyExceptInvalid);
 
     if (child == nullptr)
@@ -2790,7 +2790,7 @@ void MleRouter::HandleDiscoveryRequest(RxInfo &aRxInfo)
         {
             otThreadDiscoveryRequestInfo info;
 
-            aRxInfo.mMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(AsCoreType(&info.mExtAddress));
+            AsCoreType(&info.mExtAddress).SetFromIid(aRxInfo.mMessageInfo.GetPeerAddr().GetIid());
             info.mVersion  = discoveryRequestTlv.GetVersion();
             info.mIsJoiner = discoveryRequestTlv.IsJoiner();
 

--- a/src/core/thread/neighbor_table.cpp
+++ b/src/core/thread/neighbor_table.cpp
@@ -138,7 +138,7 @@ Neighbor *NeighborTable::FindNeighbor(const Ip6::Address &aIp6Address, Neighbor:
 
     if (aIp6Address.IsLinkLocalUnicast())
     {
-        aIp6Address.GetIid().ConvertToMacAddress(macAddress);
+        macAddress.SetExtendedFromIid(aIp6Address.GetIid());
     }
 
     if (Get<Mle::Mle>().IsRoutingLocator(aIp6Address))

--- a/src/core/utils/link_metrics_manager.cpp
+++ b/src/core/utils/link_metrics_manager.cpp
@@ -214,7 +214,7 @@ void LinkMetricsManager::HandleMgmtResponse(const otIp6Address *aAddress, otLink
     Subject        *subject;
     Neighbor       *neighbor;
 
-    AsCoreType(aAddress).GetIid().ConvertToExtAddress(extAddress);
+    extAddress.SetFromIid(AsCoreType(aAddress).GetIid());
     neighbor = Get<NeighborTable>().FindNeighbor(extAddress);
     VerifyOrExit(neighbor != nullptr);
 


### PR DESCRIPTION
This commit add new helper methods `Mac::ExtAddress::SetFromIid()` and `Mac::Address::SetExtendedFromIid()` which set the Extended MAC Address from a given IPv6 Interface Identifier (IID). These methods replace similar ones on `Ip6::InterfaceIdentifier` class (`ConvertToExtAddress()` and `ConvertToMacAddress()`) to improve code readability. It is more intuitive to call a `Set` method on the object being modified rather than passing it as input to a `Convert` method.