### PR TITLE
[coap] update `Instance::Get<Type>()` to support application CoAP comonents

### DIFF
--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -41,7 +41,7 @@ using namespace ot;
 
 otMessage *otCoapNewMessage(otInstance *aInstance, const otMessageSettings *aSettings)
 {
-    return AsCoreType(aInstance).GetApplicationCoap().NewMessage(Message::Settings::From(aSettings));
+    return AsCoreType(aInstance).Get<Coap::ApplicationCoap>().NewMessage(Message::Settings::From(aSettings));
 }
 
 void otCoapMessageInit(otMessage *aMessage, otCoapType aType, otCoapCode aCode)
@@ -219,9 +219,9 @@ otError otCoapSendRequestBlockWiseWithParameters(otInstance                 *aIn
         VerifyOrExit(txParameters.IsValid(), error = kErrorInvalidArgs);
     }
 
-    error = AsCoreType(aInstance).GetApplicationCoap().SendMessage(AsCoapMessage(aMessage), AsCoreType(aMessageInfo),
-                                                                   txParameters, aHandler, aContext, aTransmitHook,
-                                                                   aReceiveHook);
+    error = AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SendMessage(
+        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), txParameters, aHandler, aContext, aTransmitHook,
+        aReceiveHook);
 
 exit:
     return error;
@@ -246,8 +246,8 @@ otError otCoapSendRequestWithParameters(otInstance               *aInstance,
         VerifyOrExit(txParameters.IsValid(), error = kErrorInvalidArgs);
     }
 
-    error = AsCoreType(aInstance).GetApplicationCoap().SendMessage(AsCoapMessage(aMessage), AsCoreType(aMessageInfo),
-                                                                   txParameters, aHandler, aContext);
+    error = AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SendMessage(
+        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), txParameters, aHandler, aContext);
 
 exit:
     return error;
@@ -255,36 +255,36 @@ exit:
 
 otError otCoapStart(otInstance *aInstance, uint16_t aPort)
 {
-    return AsCoreType(aInstance).GetApplicationCoap().Start(aPort);
+    return AsCoreType(aInstance).Get<Coap::ApplicationCoap>().Start(aPort);
 }
 
-otError otCoapStop(otInstance *aInstance) { return AsCoreType(aInstance).GetApplicationCoap().Stop(); }
+otError otCoapStop(otInstance *aInstance) { return AsCoreType(aInstance).Get<Coap::ApplicationCoap>().Stop(); }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
 void otCoapAddBlockWiseResource(otInstance *aInstance, otCoapBlockwiseResource *aResource)
 {
-    AsCoreType(aInstance).GetApplicationCoap().AddBlockWiseResource(AsCoreType(aResource));
+    AsCoreType(aInstance).Get<Coap::ApplicationCoap>().AddBlockWiseResource(AsCoreType(aResource));
 }
 
 void otCoapRemoveBlockWiseResource(otInstance *aInstance, otCoapBlockwiseResource *aResource)
 {
-    AsCoreType(aInstance).GetApplicationCoap().RemoveBlockWiseResource(AsCoreType(aResource));
+    AsCoreType(aInstance).Get<Coap::ApplicationCoap>().RemoveBlockWiseResource(AsCoreType(aResource));
 }
 #endif
 
 void otCoapAddResource(otInstance *aInstance, otCoapResource *aResource)
 {
-    AsCoreType(aInstance).GetApplicationCoap().AddResource(AsCoreType(aResource));
+    AsCoreType(aInstance).Get<Coap::ApplicationCoap>().AddResource(AsCoreType(aResource));
 }
 
 void otCoapRemoveResource(otInstance *aInstance, otCoapResource *aResource)
 {
-    AsCoreType(aInstance).GetApplicationCoap().RemoveResource(AsCoreType(aResource));
+    AsCoreType(aInstance).Get<Coap::ApplicationCoap>().RemoveResource(AsCoreType(aResource));
 }
 
 void otCoapSetDefaultHandler(otInstance *aInstance, otCoapRequestHandler aHandler, void *aContext)
 {
-    AsCoreType(aInstance).GetApplicationCoap().SetDefaultHandler(aHandler, aContext);
+    AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SetDefaultHandler(aHandler, aContext);
 }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
@@ -299,9 +299,9 @@ otError otCoapSendResponseBlockWiseWithParameters(otInstance                 *aI
 
     VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
-    error = AsCoreType(aInstance).GetApplicationCoap().SendMessage(AsCoapMessage(aMessage), AsCoreType(aMessageInfo),
-                                                                   Coap::TxParameters::From(aTxParameters), nullptr,
-                                                                   aContext, aTransmitHook, nullptr);
+    error = AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SendMessage(
+        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), Coap::TxParameters::From(aTxParameters), nullptr, aContext,
+        aTransmitHook, nullptr);
 exit:
     return error;
 }
@@ -316,7 +316,7 @@ otError otCoapSendResponseWithParameters(otInstance               *aInstance,
 
     VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
-    error = AsCoreType(aInstance).GetApplicationCoap().SendMessage(
+    error = AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SendMessage(
         AsCoapMessage(aMessage), AsCoreType(aMessageInfo), Coap::TxParameters::From(aTxParameters), nullptr, nullptr);
 
 exit:

--- a/src/core/api/coap_secure_api.cpp
+++ b/src/core/api/coap_secure_api.cpp
@@ -43,8 +43,8 @@ otError otCoapSecureStart(otInstance *aInstance, uint16_t aPort)
 {
     otError error;
 
-    SuccessOrExit(error = AsCoreType(aInstance).GetApplicationCoapSecure().Open());
-    error = AsCoreType(aInstance).GetApplicationCoapSecure().Bind(aPort);
+    SuccessOrExit(error = AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().Open());
+    error = AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().Bind(aPort);
 
 exit:
     return error;
@@ -58,8 +58,8 @@ otError otCoapSecureStartWithMaxConnAttempts(otInstance                  *aInsta
 {
     Error error = kErrorAlready;
 
-    SuccessOrExit(
-        AsCoreType(aInstance).GetApplicationCoapSecure().SetMaxConnectionAttempts(aMaxAttempts, aCallback, aContext));
+    SuccessOrExit(AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SetMaxConnectionAttempts(
+        aMaxAttempts, aCallback, aContext));
     error = otCoapSecureStart(aInstance, aPort);
 
 exit:
@@ -73,16 +73,16 @@ void otCoapSecureSetCertificate(otInstance    *aInstance,
                                 const uint8_t *aPrivateKey,
                                 uint32_t       aPrivateKeyLength)
 {
-    AsCoreType(aInstance).GetApplicationCoapSecure().SetCertificate(aX509Cert, aX509Length, aPrivateKey,
-                                                                    aPrivateKeyLength);
+    AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SetCertificate(aX509Cert, aX509Length, aPrivateKey,
+                                                                            aPrivateKeyLength);
 }
 
 void otCoapSecureSetCaCertificateChain(otInstance    *aInstance,
                                        const uint8_t *aX509CaCertificateChain,
                                        uint32_t       aX509CaCertChainLength)
 {
-    AsCoreType(aInstance).GetApplicationCoapSecure().SetCaCertificateChain(aX509CaCertificateChain,
-                                                                           aX509CaCertChainLength);
+    AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SetCaCertificateChain(aX509CaCertificateChain,
+                                                                                   aX509CaCertChainLength);
 }
 #endif // MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 
@@ -96,7 +96,8 @@ void otCoapSecureSetPsk(otInstance    *aInstance,
     AssertPointerIsNotNull(aPsk);
     AssertPointerIsNotNull(aPskIdentity);
 
-    AsCoreType(aInstance).GetApplicationCoapSecure().SetPreSharedKey(aPsk, aPskLength, aPskIdentity, aPskIdLength);
+    AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SetPreSharedKey(aPsk, aPskLength, aPskIdentity,
+                                                                             aPskIdLength);
 }
 #endif // MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
 
@@ -108,14 +109,14 @@ otError otCoapSecureGetPeerCertificateBase64(otInstance    *aInstance,
 {
     AssertPointerIsNotNull(aPeerCert);
 
-    return AsCoreType(aInstance).GetApplicationCoapSecure().GetPeerCertificateBase64(aPeerCert, aCertLength,
-                                                                                     aCertBufferSize);
+    return AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().GetPeerCertificateBase64(aPeerCert, aCertLength,
+                                                                                             aCertBufferSize);
 }
 #endif // defined(MBEDTLS_BASE64_C) && defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
 
 void otCoapSecureSetSslAuthMode(otInstance *aInstance, bool aVerifyPeerCertificate)
 {
-    AsCoreType(aInstance).GetApplicationCoapSecure().SetSslAuthMode(aVerifyPeerCertificate);
+    AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SetSslAuthMode(aVerifyPeerCertificate);
 }
 
 otError otCoapSecureConnect(otInstance                     *aInstance,
@@ -123,26 +124,32 @@ otError otCoapSecureConnect(otInstance                     *aInstance,
                             otHandleCoapSecureClientConnect aHandler,
                             void                           *aContext)
 {
-    AsCoreType(aInstance).GetApplicationCoapSecure().SetConnectCallback(aHandler, aContext);
+    AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SetConnectCallback(aHandler, aContext);
 
-    return AsCoreType(aInstance).GetApplicationCoapSecure().Connect(AsCoreType(aSockAddr));
+    return AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().Connect(AsCoreType(aSockAddr));
 }
 
-void otCoapSecureDisconnect(otInstance *aInstance) { AsCoreType(aInstance).GetApplicationCoapSecure().Disconnect(); }
+void otCoapSecureDisconnect(otInstance *aInstance)
+{
+    AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().Disconnect();
+}
 
 bool otCoapSecureIsConnected(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).GetApplicationCoapSecure().IsConnected();
+    return AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().IsConnected();
 }
 
 bool otCoapSecureIsConnectionActive(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).GetApplicationCoapSecure().IsConnectionActive();
+    return AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().IsConnectionActive();
 }
 
-bool otCoapSecureIsClosed(otInstance *aInstance) { return AsCoreType(aInstance).GetApplicationCoapSecure().IsClosed(); }
+bool otCoapSecureIsClosed(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().IsClosed();
+}
 
-void otCoapSecureStop(otInstance *aInstance) { AsCoreType(aInstance).GetApplicationCoapSecure().Close(); }
+void otCoapSecureStop(otInstance *aInstance) { AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().Close(); }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
 otError otCoapSecureSendRequestBlockWise(otInstance                 *aInstance,
@@ -152,8 +159,8 @@ otError otCoapSecureSendRequestBlockWise(otInstance                 *aInstance,
                                          otCoapBlockwiseTransmitHook aTransmitHook,
                                          otCoapBlockwiseReceiveHook  aReceiveHook)
 {
-    return AsCoreType(aInstance).GetApplicationCoapSecure().SendMessage(AsCoapMessage(aMessage), aHandler, aContext,
-                                                                        aTransmitHook, aReceiveHook);
+    return AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SendMessage(AsCoapMessage(aMessage), aHandler,
+                                                                                aContext, aTransmitHook, aReceiveHook);
 }
 #endif
 
@@ -162,41 +169,42 @@ otError otCoapSecureSendRequest(otInstance           *aInstance,
                                 otCoapResponseHandler aHandler,
                                 void                 *aContext)
 {
-    return AsCoreType(aInstance).GetApplicationCoapSecure().SendMessage(AsCoapMessage(aMessage), aHandler, aContext);
+    return AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SendMessage(AsCoapMessage(aMessage), aHandler,
+                                                                                aContext);
 }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
 void otCoapSecureAddBlockWiseResource(otInstance *aInstance, otCoapBlockwiseResource *aResource)
 {
-    AsCoreType(aInstance).GetApplicationCoapSecure().AddBlockWiseResource(AsCoreType(aResource));
+    AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().AddBlockWiseResource(AsCoreType(aResource));
 }
 
 void otCoapSecureRemoveBlockWiseResource(otInstance *aInstance, otCoapBlockwiseResource *aResource)
 {
-    AsCoreType(aInstance).GetApplicationCoapSecure().RemoveBlockWiseResource(AsCoreType(aResource));
+    AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().RemoveBlockWiseResource(AsCoreType(aResource));
 }
 #endif
 
 void otCoapSecureAddResource(otInstance *aInstance, otCoapResource *aResource)
 {
-    AsCoreType(aInstance).GetApplicationCoapSecure().AddResource(AsCoreType(aResource));
+    AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().AddResource(AsCoreType(aResource));
 }
 
 void otCoapSecureRemoveResource(otInstance *aInstance, otCoapResource *aResource)
 {
-    AsCoreType(aInstance).GetApplicationCoapSecure().RemoveResource(AsCoreType(aResource));
+    AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().RemoveResource(AsCoreType(aResource));
 }
 
 void otCoapSecureSetClientConnectEventCallback(otInstance                     *aInstance,
                                                otHandleCoapSecureClientConnect aHandler,
                                                void                           *aContext)
 {
-    AsCoreType(aInstance).GetApplicationCoapSecure().SetConnectCallback(aHandler, aContext);
+    AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SetConnectCallback(aHandler, aContext);
 }
 
 void otCoapSecureSetDefaultHandler(otInstance *aInstance, otCoapRequestHandler aHandler, void *aContext)
 {
-    AsCoreType(aInstance).GetApplicationCoapSecure().SetDefaultHandler(aHandler, aContext);
+    AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SetDefaultHandler(aHandler, aContext);
 }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
@@ -208,8 +216,8 @@ otError otCoapSecureSendResponseBlockWise(otInstance                 *aInstance,
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
-    return AsCoreType(aInstance).GetApplicationCoapSecure().SendMessage(AsCoapMessage(aMessage), nullptr, aContext,
-                                                                        aTransmitHook);
+    return AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SendMessage(AsCoapMessage(aMessage), nullptr,
+                                                                                aContext, aTransmitHook);
 }
 #endif
 
@@ -217,7 +225,7 @@ otError otCoapSecureSendResponse(otInstance *aInstance, otMessage *aMessage, con
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
-    return AsCoreType(aInstance).GetApplicationCoapSecure().SendMessage(AsCoapMessage(aMessage));
+    return AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SendMessage(AsCoapMessage(aMessage));
 }
 
 #endif // OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -937,6 +937,25 @@ private:
     Error        Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 };
 
+#if OPENTHREAD_CONFIG_COAP_API_ENABLE
+/**
+ * Represents an Application CoAP.
+ */
+class ApplicationCoap : public Coap
+{
+public:
+    /**
+     * Initializes the object.
+     *
+     * @param[in] aInstance      A reference to the OpenThread instance.
+     */
+    explicit ApplicationCoap(Instance &aInstance)
+        : Coap(aInstance)
+    {
+    }
+};
+#endif
+
 } // namespace Coap
 
 DefineCoreType(otCoapTxParameters, Coap::TxParameters);

--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -504,8 +504,8 @@ void Instance::GetBufferInfo(BufferInfo &aInfo)
 #endif
 
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
-    GetApplicationCoap().GetRequestMessages().GetInfo(aInfo.mApplicationCoapQueue);
-    GetApplicationCoap().GetCachedResponses().GetInfo(aInfo.mApplicationCoapQueue);
+    Get<Coap::ApplicationCoap>().GetRequestMessages().GetInfo(aInfo.mApplicationCoapQueue);
+    Get<Coap::ApplicationCoap>().GetCachedResponses().GetInfo(aInfo.mApplicationCoapQueue);
 #endif
 }
 

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -354,24 +354,6 @@ public:
     static Utils::Heap &GetHeap(void);
 #endif
 
-#if OPENTHREAD_CONFIG_COAP_API_ENABLE
-    /**
-     * Returns a reference to application COAP object.
-     *
-     * @returns A reference to the application COAP object.
-     */
-    Coap::Coap &GetApplicationCoap(void) { return mApplicationCoap; }
-#endif
-
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-    /**
-     * Returns a reference to application COAP Secure object.
-     *
-     * @returns A reference to the application COAP Secure object.
-     */
-    Coap::ApplicationCoapSecure &GetApplicationCoapSecure(void) { return mApplicationCoapSecure; }
-#endif
-
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     /**
      * Enables/disables the "DNS name compressions" mode.
@@ -672,7 +654,7 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
-    Coap::Coap mApplicationCoap;
+    Coap::ApplicationCoap mApplicationCoap;
 #endif
 
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
@@ -1103,6 +1085,14 @@ template <> inline Srp::Server &Instance::Get(void) { return mSrpServer; }
 template <> inline Srp::AdvertisingProxy &Instance::Get(void) { return mSrpAdvertisingProxy; }
 #endif
 #endif // OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
+
+#if OPENTHREAD_CONFIG_COAP_API_ENABLE
+template <> inline Coap::ApplicationCoap &Instance::Get(void) { return mApplicationCoap; }
+#endif
+
+#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+template <> inline Coap::ApplicationCoapSecure &Instance::Get(void) { return mApplicationCoapSecure; }
+#endif
 
 #if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
 template <> inline Ble::BleSecure &Instance::Get(void) { return mApplicationBleSecure; }


### PR DESCRIPTION
This commit updates the template method `Instance::Get<Type>()` to support retrieving the `ApplicationCoap` and `ApplicationCoapSecure` sub-components within the `Instance` hierarchy. This change replaces the previous direct methods used to access these CoAP components, providing a more consistent approach to accessing sub-components.