### PR TITLE
[mesh-forwarder] simplify destination MAC address determination

### DIFF
--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -371,7 +371,7 @@ uint16_t IndirectSender::PrepareDataFrame(Mac::TxFrame &aFrame, Child &aChild, M
 
     if (ip6Header.GetDestination().IsLinkLocalUnicast())
     {
-        Get<MeshForwarder>().GetMacDestinationAddress(ip6Header.GetDestination(), macAddrs.mDestination);
+        macAddrs.mDestination.SetExtendedFromIid(ip6Header.GetDestination().GetIid());
     }
     else
     {

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -632,9 +632,13 @@ Error MeshForwarder::UpdateIp6Route(Message &aMessage)
 
     if (mle.IsDisabled() || mle.IsDetached())
     {
-        if (ip6Header.GetDestination().IsLinkLocalUnicastOrMulticast())
+        if (ip6Header.GetDestination().IsLinkLocalMulticast())
         {
-            GetMacDestinationAddress(ip6Header.GetDestination(), mMacAddrs.mDestination);
+            mMacAddrs.mDestination.SetShort(Mac::kShortAddrBroadcast);
+        }
+        else if (ip6Header.GetDestination().IsLinkLocalUnicast())
+        {
+            mMacAddrs.mDestination.SetExtendedFromIid(ip6Header.GetDestination().GetIid());
         }
         else
         {
@@ -661,7 +665,7 @@ Error MeshForwarder::UpdateIp6Route(Message &aMessage)
     }
     else if (ip6Header.GetDestination().IsLinkLocalUnicast())
     {
-        GetMacDestinationAddress(ip6Header.GetDestination(), mMacAddrs.mDestination);
+        mMacAddrs.mDestination.SetExtendedFromIid(ip6Header.GetDestination().GetIid());
     }
     else if (mle.IsMinimalEndDevice())
     {
@@ -705,22 +709,6 @@ void MeshForwarder::GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac::Addre
     if (aMacAddr.GetExtended() != Get<Mac::Mac>().GetExtAddress())
     {
         aMacAddr.SetShort(Get<Mac::Mac>().GetShortAddress());
-    }
-}
-
-void MeshForwarder::GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr)
-{
-    if (aIp6Addr.IsMulticast())
-    {
-        aMacAddr.SetShort(Mac::kShortAddrBroadcast);
-    }
-    else if (Get<Mle::MleRouter>().IsRoutingLocator(aIp6Addr))
-    {
-        aMacAddr.SetShort(aIp6Addr.GetIid().GetLocator());
-    }
-    else
-    {
-        aMacAddr.SetExtendedFromIid(aIp6Addr.GetIid());
     }
 }
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -491,7 +491,6 @@ private:
     Error    CheckReachability(uint16_t aMeshDest, const Ip6::Header &aIp6Header);
     void     UpdateRoutes(RxInfo &aRxInfo);
     Error    FrameToMessage(RxInfo &aRxInfo, uint16_t aDatagramSize, Message *&aMessage);
-    void     GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr);
     void     GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr);
     Message *PrepareNextDirectTransmission(void);
     void     HandleMesh(RxInfo &aRxInfo);


### PR DESCRIPTION
This commit simplifies the process of determining the destination MAC address. Specifically, when the destination is a link-local unicast address, the MAC address is derived directly from its Interface Identifier (IID). This commit replaces and removes the `GetMacDestinationAddress()` method, with the calling code now directly determining the destination MAC address.