### PR TITLE
[ip6] refactor and simplify `HandleDatagram()`

### DIFF
--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -388,7 +388,6 @@ private:
                   OwnedPtr<Message> &aMessagePtr,
                   uint8_t            aIpProto,
                   Message::Ownership aMessageOwnership);
-    Error RouteLookup(const Address &aSource, const Address &aDestination) const;
 #if OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
     void UpdateBorderRoutingCounters(const Header &aHeader, uint16_t aMessageLength, bool aIsInbound);
 #endif

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -356,6 +356,11 @@ private:
 
     void  EnqueueDatagram(Message &aMessage);
     void  HandleSendQueue(void);
+    void  DetermineAction(const Message &aMessage,
+                          const Header  &aHeader,
+                          bool          &aForwardThread,
+                          bool          &aForwardHost,
+                          bool          &aReceive) const;
     Error PassToHost(OwnedPtr<Message> &aMessagePtr,
                      const Header      &aHeader,
                      uint8_t            aIpProto,


### PR DESCRIPTION
This PR contains two related commits. They are kept as separate commit to make it easier to review.

**[ip6] refactor `HandleDatagram()` to use `DetermineAction()`**
    
This commit introduces the `DetermineAction()` method to refactor the code within `HandleDatagram()`. This new method centralizes the logic for determining the appropriate action (e.g., `forwardThread`, `forwardHost`, `receive`) for an IPv6 message based on its destination address and origin.
    
This commit only focuses on code refactoring and does not introduce any changes to the existing message processing logic.

----

**[ip6] simplify `DetermineAction()`**
    
This commit simplifies the `Ip6::DetermineAction()` method, which determines the appropriate actions (`forwardThread`, `forwardHost`, `receive`) for an IPv6 message based on its destination address and origin.

- The code now uses `ExitNow()` to exit the method as soon as a specific action is determined. This avoids deeply nested `if/else` blocks and makes the control flow easier to understand.
- Some negative conditional checks have been refactored into positive checks with early exits. For example, a condition like `if(!cond1 || !cond2)` that guarded further processing is now expressed as `if (cond1 && cond2) { ExitNow(); }`, making the logic more direct.
- New comments have been added to clarify more complex checks and conditions within the method.
- The `RouteLookup()` method has been removed and its logic inlined directly into `DetermineAction()`. This improves code readability and allows for clearer distinction between forwarding to a host due to Border Router functionality versus forwarding as a last resort when no specific route exists.