### PR TITLE
[mesh-forwarder] rename `UpdateEidRlocCacheAndStaleChild()`

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1484,7 +1484,7 @@ void MeshForwarder::HandleFragment(RxInfo &aRxInfo)
         uint16_t datagramSize = fragmentHeader.GetDatagramSize();
 
 #if OPENTHREAD_FTD
-        UpdateRoutes(aRxInfo);
+        UpdateEidRlocCacheAndStaleChild(aRxInfo);
 #endif
 
         SuccessOrExit(error = FrameToMessage(aRxInfo, datagramSize, message));
@@ -1647,7 +1647,7 @@ void MeshForwarder::HandleLowpanHc(RxInfo &aRxInfo)
     Message *message = nullptr;
 
 #if OPENTHREAD_FTD
-    UpdateRoutes(aRxInfo);
+    UpdateEidRlocCacheAndStaleChild(aRxInfo);
 #endif
 
     SuccessOrExit(error = FrameToMessage(aRxInfo, 0, message));

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -489,7 +489,7 @@ private:
     void     SendIcmpErrorIfDstUnreach(const Message &aMessage, const Mac::Addresses &aMacAddrs);
     Error    CheckReachability(RxInfo &aRxInfo);
     Error    CheckReachability(uint16_t aMeshDest, const Ip6::Header &aIp6Header);
-    void     UpdateRoutes(RxInfo &aRxInfo);
+    void     UpdateEidRlocCacheAndStaleChild(RxInfo &aRxInfo);
     Error    FrameToMessage(RxInfo &aRxInfo, uint16_t aDatagramSize, Message *&aMessage);
     void     GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr);
     void     GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr);

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -586,7 +586,7 @@ void MeshForwarder::HandleMesh(RxInfo &aRxInfo)
     aRxInfo.mMacAddrs.mSource.SetShort(meshHeader.GetSource());
     aRxInfo.mMacAddrs.mDestination.SetShort(meshHeader.GetDestination());
 
-    UpdateRoutes(aRxInfo);
+    UpdateEidRlocCacheAndStaleChild(aRxInfo);
 
     if (Get<Mle::Mle>().HasRloc16(aRxInfo.GetDstAddr().GetShort()) ||
         Get<ChildTable>().HasMinimalChild(aRxInfo.GetDstAddr().GetShort()))
@@ -669,7 +669,7 @@ exit:
     return;
 }
 
-void MeshForwarder::UpdateRoutes(RxInfo &aRxInfo)
+void MeshForwarder::UpdateEidRlocCacheAndStaleChild(RxInfo &aRxInfo)
 {
     Neighbor *neighbor;
 
@@ -687,6 +687,9 @@ void MeshForwarder::UpdateRoutes(RxInfo &aRxInfo)
         Get<AddressResolver>().UpdateSnoopedCacheEntry(
             aRxInfo.mIp6Headers.GetSourceAddress(), aRxInfo.GetSrcAddr().GetShort(), aRxInfo.GetDstAddr().GetShort());
     }
+
+    // Detect if a former child has moved to a new parent by
+    // inspecting the received message.
 
     neighbor = Get<NeighborTable>().FindNeighbor(aRxInfo.mIp6Headers.GetSourceAddress());
     VerifyOrExit(neighbor != nullptr && !neighbor->IsFullThreadDevice());


### PR DESCRIPTION
This method inspects a received message to perform two key actions:
- Updating the EID-to-RLOC cache (for snoop optimization) and
- Detecting whether a former child device has moved to a new parent.

The renaming clarifies the specific responsibilities of this method.