### PR TITLE
[otci] add support for IPv4, vendor commands, networkdiagnostics

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1196,9 +1196,9 @@ CSL period is shown in microseconds.
 
 ```bash
 > csl
-Channel: 11
-Period: 160000us
-Timeout: 1000s
+channel: 11
+period: 160000us
+timeout: 1000s
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -7535,7 +7535,7 @@ template <> otError Interpreter::Process<Cmd("networkdiagnostic")>(Arg aArgs[])
      * @code
      * networkdiagnostic get ff02::1 0 1
      * DIAG_GET.rsp/ans: 00080e336e1c41494e1c01020c00
-     * Ext Address: '0e336e1c41494e1c'
+     * Ext Address: 0e336e1c41494e1c
      * Rloc16: 0x0c00
      * Done
      * DIAG_GET.rsp/ans: 00083efcdb7e3f9eb0f201021800

--- a/tools/otci/README.md
+++ b/tools/otci/README.md
@@ -1,6 +1,6 @@
 # OpenThread Control Interface
 
-The OpenThread Control Interface (OTCI) is a library which provides uniform python interfaces to connect and control various kinds of devices running OpenThread.
+The OpenThread Control Interface (OTCI) is a library which provides uniform Python interfaces to connect and control various kinds of devices running OpenThread.
 
 ## Supported device types
 
@@ -22,7 +22,7 @@ node1 = otci.connect_otbr_ssh("192.168.1.101")
 # Connect to an OpenThread CLI device via Serial
 node2 = otci.connect_cli_serial("/dev/ttyACM0"))
 
-# Start node1 to become Leader
+# Start node1 and wait for it to become the Leader
 node1.dataset_init_buffer()
 node1.dataset_set_buffer(network_name='test', network_key='00112233445566778899aabbccddeeff', panid=0xface, channel=11)
 node1.dataset_commit_buffer('active')
@@ -32,7 +32,7 @@ node1.thread_start()
 node1.wait(5)
 assert node1.get_state() == "leader"
 
-# Start Commissioner on node1
+# Start the Commissioner role on node1
 node1.commissioner_start()
 node1.wait(3)
 
@@ -42,11 +42,11 @@ node1.commissioner_add_joiner("TEST123",eui64='*')
 node2.ifconfig_up()
 node2.set_router_selection_jitter(1)
 
-# Start Joiner on node2 to join the network
+# Start the Joiner role on node2 and wait for it to join the network
 node2.joiner_start("TEST123")
 node2.wait(10, expect_line="Join success")
 
-# Wait for node 2 to become Router
+# Wait for node 2 to become a Router
 node2.thread_start()
 node2.wait(5)
 assert node2.get_state() == "router"

--- a/tools/otci/otci/__init__.py
+++ b/tools/otci/otci/__init__.py
@@ -28,8 +28,9 @@
 #
 
 from . import errors
-from .constants import THREAD_VERSION_1_1, THREAD_VERSION_1_2
+from .constants import THREAD_VERSION_1_1, THREAD_VERSION_1_2, THREAD_VERSION_1_3, THREAD_VERSION_1_4
 from .command_handlers import OTCommandHandler
+from .connectors import OtCliHandler
 from .otci import OTCI
 from .otci import (
     connect_cli_sim,
@@ -56,6 +57,7 @@ _connectors = [
 __all__ = [
     'OTCI',
     'OTCommandHandler',
+    'OTCliHandler',
     'errors',
     'Rloc16',
     'ChildId',

--- a/tools/otci/otci/connectors.py
+++ b/tools/otci/otci/connectors.py
@@ -138,12 +138,12 @@ class OtNcpSim(OtCliPopen):
 class OtCliSerial(OtCliHandler):
     """Connector for OT CLI SOC devices via Serial."""
 
-    def __init__(self, dev: str, baudrate: int):
+    def __init__(self, dev: str, baudrate: int, timeout: float = 0.1):
         self.__dev = dev
         self.__baudrate = baudrate
 
         import serial
-        self.__serial = serial.Serial(self.__dev, self.__baudrate, timeout=0.1, exclusive=True)
+        self.__serial = serial.Serial(self.__dev, self.__baudrate, timeout=timeout, exclusive=True)
         self.writeline('\r\n')
         self.__linebuffer = b''
 

--- a/tools/otci/otci/types.py
+++ b/tools/otci/otci/types.py
@@ -127,6 +127,22 @@ class Ip6Prefix(ipaddress.IPv6Network):
         return super().__hash__()
 
 
+class Ip4Addr(ipaddress.IPv4Address):
+    """Represents an IPv4 address."""
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            other = ipaddress.IPv4Address(other)
+
+        return super().__eq__(other)
+
+    def __repr__(self):
+        return self.compressed
+
+    def __hash__(self):
+        return super().__hash__()
+
+
 SecurityPolicy = namedtuple('SecurityPolicy', ['rotation_time', 'flags'])
 """Represents a Security Policy configuration."""
 

--- a/tools/otci/otci/utils.py
+++ b/tools/otci/otci/utils.py
@@ -69,5 +69,5 @@ def bits_set(number: int) -> Generator[int, int, None]:
     while number != 0:
         if number & 1:
             yield idx
-        else:
-            number >>= 1
+        number >>= 1
+        idx += 1


### PR DESCRIPTION
With Thread 1.4 the cli application not can also (dns) resolve
IPv4 addresses. This commit adds the same support in otci

* dns_resolve4

Implements support for vendor operations in otci get/set

* vendor_name
* vendor_model
* vendor_sw_version

Implements network diagnostic commands

* get
* reset
* non_preferred_channels

Various other (small changes)"

* allow setting read timeout on serial connections
* allow replacing read routine filter
* expose latest thread versions in the public module api
* expand the definition of dns_get_config
* replaces mgmtget/mgmtset with the correct mgmtgetcommand and mgmtsetcommand
* replaces addressmode with the correct addrmode
* adds an `ignore_result` option to `execute_command`
* adds a missing `diag` command
* removes some unexisting getters