### PR TITLE
[routing-manager] introduce `MultiAilDetector`

### DIFF
--- a/include/openthread/border_routing.h
+++ b/include/openthread/border_routing.h
@@ -597,6 +597,68 @@ otError otBorderRoutingGetNextPeerBrEntry(otInstance                           *
 uint16_t otBorderRoutingCountPeerBrs(otInstance *aInstance, uint32_t *aMinAge);
 
 /**
+ * A callback function pointer called when the multi-AIL detection state changes.
+ *
+ * This callback function is invoked by the OpenThread stack whenever the Routing Manager determines a change in
+ * whether Border Routers on the Thread mesh might be connected to different Adjacent Infrastructure Links (AILs).
+ *
+ * See `otBorderRoutingIsMultiAilDetected()` for more details.
+ *
+ * @param[in] aDetected   `TRUE` if multiple AILs are now detected, `FALSE` otherwise.
+ * @param[in] aContext    A pointer to arbitrary context information provided when the callback was registered
+ *                        using `otBorderRoutingSetMultiAilCallback()`.
+ */
+typedef void (*otBorderRoutingMultiAilCallback)(bool aDetected, void *aContext);
+
+/**
+ * Gets the current detected state regarding multiple Adjacent Infrastructure Links (AILs).
+ *
+ * Requires `OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE`.
+ *
+ * It returns whether the Routing Manager currently believes that Border Routers (BRs) on the Thread mesh may be
+ * connected to different AILs.
+ *
+ * The detection mechanism operates as follows: The Routing Manager monitors the number of peer BRs listed in the
+ * Thread Network Data (see `otBorderRoutingCountPeerBrs()`) and compares this count with the number of peer BRs
+ * discovered by processing received Router Advertisement (RA) messages on its connected AIL. If the count derived from
+ * Network Data consistently exceeds the count derived from RAs for a detection duration of 10 minutes, it concludes
+ * that BRs are likely connected to different AILs. To clear state a shorter window of 1 minute is used.
+ *
+ * The detection window of 10 minutes helps to avoid false positives due to transient changes. The Routing Manager uses
+ * 200 seconds for reachability checks of peer BRs (sending Neighbor Solicitation). Stale Network Data entries are
+ * also expected to age out within a few minutes. So a 10-minute detection time accommodates both cases.
+ *
+ * While generally effective, this detection mechanism may get less reliable in scenarios with a large number of
+ * BRs, particularly exceeding ten. This is related to the "Network Data Publisher" mechanism, where BRs might refrain
+ * from publishing their external route information in the Network Data to conserve its limited size, potentially
+ * skewing the Network Data BR count.
+ *
+ * @param[in] aInstance  A pointer to the OpenThread instance.
+ *
+ * @retval TRUE   Has detected that BRs are likely connected to multiple AILs.
+ * @retval FALSE  Has not detected (or no longer detects) that BRs are connected to multiple AILs.
+ */
+bool otBorderRoutingIsMultiAilDetected(otInstance *aInstance);
+
+/**
+ * Sets a callback function to be notified of changes in the multi-AIL detection state.
+ *
+ * Requires `OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE`.
+ *
+ * Subsequent calls to this function will overwrite the previous callback setting. Using `NULL` for @p aCallback will
+ * disable the callback.
+ *
+ * @param[in] aInstance  A pointer to the OpenThread instance.
+ * @param[in] aCallback  A pointer to the function (`otBorderRoutingMultiAilCallback`) to be called
+ *                       upon state changes, or `NULL` to unregister a previously set callback.
+ * @param[in] aContext   A pointer to application-specific context that will be passed back
+ *                       in the `aCallback` function. This can be `NULL` if no context is needed.
+ */
+void otBorderRoutingSetMultiAilCallback(otInstance                     *aInstance,
+                                        otBorderRoutingMultiAilCallback aCallback,
+                                        void                           *aContext);
+
+/**
  * Iterates over the Recursive DNS Server (RDNSS) address entries.
  *
  * Address entries are discovered by processing the RDNSS options within received Router Advertisement messages from

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (498)
+#define OPENTHREAD_API_VERSION (499)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README_BR.md
+++ b/src/cli/README_BR.md
@@ -33,6 +33,7 @@ Print BR command help menu.
 counters
 disable
 enable
+multiail
 omrconfig
 omrprefix
 onlinkprefix
@@ -116,6 +117,47 @@ RS Rx: 0
 RS TxSuccess: 2
 RS TxFailed: 0
 Done
+```
+
+### multiail
+
+Usage : `br multiail`
+
+Requires `OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE`.
+
+Get the current detected state regarding multiple Adjacent Infrastructure Links (AILs) indicating whether the Routing Manager currently believes that Border Routers (BRs) on the Thread mesh may be connected to different AILs.
+
+The detection mechanism operates as follows: The Routing Manager monitors the number of peer BRs listed in the Thread Network Data (see `br peers`) and compares this count with the number of peer BRs discovered by processing received Router Advertisement (RA) messages on its connected AIL. If the count derived from Network Data consistently exceeds the count derived from RAs for a detection duration of 10 minutes, it concludes that BRs are likely connected to different AILs. To clear the state a shorter window of 1 minute is used.
+
+The detection window of 10 minutes helps to avoid false positives due to transient changes. The Routing Manager uses 200 seconds for reachability checks of peer BRs (sending Neighbor Solicitation). Stale Network Data entries are also expected to age out within a few minutes. So a 10-minute detection time accommodates both cases.
+
+While generally effective, this detection mechanism may get less reliable in scenarios with a large number of BRs, particularly exceeding ten. This is related to the "Network Data Publisher" mechanism, where BRs might refrain from publishing their external route information in the Network Data to conserve its limited size, potentially skewing the Network Data BR count.
+
+```bash
+> br multiail
+not detected
+Done
+
+> br multiail
+detected
+Done
+```
+
+Usage: `br multiail callback enable|disable`
+
+Enable or disable callback to be notified of changes in the multi-AIL detection state.
+
+```bash
+> br multiail callback enable
+Done
+
+BR multi AIL callback: detected
+
+> br multiail
+detected
+Done
+
+BR multi AIL callback: cleared
 ```
 
 ### omrconfig

--- a/src/cli/cli_br.hpp
+++ b/src/cli/cli_br.hpp
@@ -93,6 +93,11 @@ private:
 
     otError ParsePrefixTypeArgs(Arg aArgs[], PrefixType &aFlags);
     void    OutputRouterInfo(const otBorderRoutingRouterEntry &aEntry, RouterOutputMode aMode);
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
+    static void HandleMultiAilDetected(bool aDetected, void *aContext);
+    void        HandleMultiAilDetected(bool aDetected);
+#endif
 };
 
 } // namespace Cli

--- a/src/core/api/border_routing_api.cpp
+++ b/src/core/api/border_routing_api.cpp
@@ -257,6 +257,22 @@ uint16_t otBorderRoutingCountPeerBrs(otInstance *aInstance, uint32_t *aMinAge)
 
 #endif
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
+
+bool otBorderRoutingIsMultiAilDetected(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().IsMultiAilDetected();
+}
+
+void otBorderRoutingSetMultiAilCallback(otInstance                     *aInstance,
+                                        otBorderRoutingMultiAilCallback aCallback,
+                                        void                           *aContext)
+{
+    AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().SetMultiAilCallback(aCallback, aContext);
+}
+
+#endif
+
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
 
 void otBorderRoutingDhcp6PdSetEnabled(otInstance *aInstance, bool aEnabled)

--- a/src/core/config/border_routing.h
+++ b/src/core/config/border_routing.h
@@ -84,6 +84,23 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
+ *
+ * Define to 1 to enable Routing Manager multiple Adjacent Infrastructure Links (AILs) detection feature.
+ *
+ * The detection mechanism operates as follows: The Routing Manager monitors the number of peer BRs listed in the
+ * Thread Network Data (see `otBorderRoutingCountPeerBrs()`) and compares this count with the number of peer BRs
+ * discovered by processing received Router Advertisement (RA) messages on its connected AIL. If the count derived from
+ * Network Data consistently exceeds the count derived from RAs for a detection duration of 10 minutes, it concludes
+ * that BRs are likely connected to different AILs. To clear state a shorter window of 1 minute is used.
+ *
+ * See `otBorderRoutingIsMultiAilDetected()` for more details.
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE OPENTHREAD_CONFIG_BORDER_ROUTING_USE_HEAP_ENABLE
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_BORDER_ROUTING_REACHABILITY_CHECK_ICMP6_ERROR_ENABLE
  *
  * Define to 1 to allow Routing Manager to check for reachability of messages being forwarded by the BR and determine

--- a/tests/toranj/cli/cli.py
+++ b/tests/toranj/cli/cli.py
@@ -851,6 +851,9 @@ class Node(object):
     def br_count_peers(self):
         return self._cli_single_output('br peers count')
 
+    def br_get_multiail(self):
+        return self._cli_single_output('br multiail')
+
     #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     # trel
 

--- a/tests/toranj/cli/test-505-multi-ail-detection.py
+++ b/tests/toranj/cli/test-505-multi-ail-detection.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2025, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+
+from cli import verify
+from cli import verify_within
+import cli
+import time
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test description:
+#
+# Check multi AIL detection
+#
+#   -+-       _______
+#    |       /       \
+#   br1 --- br2 --- br3
+#
+
+test_name = __file__[:-3] if __file__.endswith('.py') else __file__
+print('-' * 120)
+print('Starting \'{}\''.format(test_name))
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Creating `cli.Nodes` instances
+
+speedup = 60
+cli.Node.set_time_speedup_factor(speedup)
+
+one_minute = 60
+
+br1 = cli.Node()
+br2 = cli.Node()
+br3 = cli.Node()
+
+IF_INDEX_1 = 1
+IF_INDEX_2 = 2
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Form topology
+
+br1.form("multiail")
+br2.join(br1)
+br3.join(br2)
+
+verify(br1.get_state() == 'leader')
+verify(br2.get_state() == 'router')
+verify(br3.get_state() == 'router')
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test implementation
+
+# Start first border router `br1`
+
+br1.srp_server_set_addr_mode('unicast')
+br1.srp_server_auto_enable()
+
+br1.br_init(IF_INDEX_1, 1)
+br1.br_enable()
+
+time.sleep(one_minute / speedup)
+verify(br1.br_get_state() == 'running')
+verify(br1.br_get_multiail() == 'not detected')
+
+# Start `br2` and `br3` together on a different AIL
+
+br2.br_init(IF_INDEX_2, 1)
+br2.br_enable()
+
+br3.br_init(IF_INDEX_2, 1)
+br3.br_enable()
+
+time.sleep(one_minute / speedup)
+verify(br2.br_get_state() == 'running')
+verify(br3.br_get_state() == 'running')
+
+verify(br2.br_get_multiail() == 'not detected')
+verify(br3.br_get_multiail() == 'not detected')
+
+# wait for longer than 10 minutes and check that multi AIL is detected
+
+time.sleep(10.01 * one_minute / speedup)
+
+verify(br1.br_get_multiail() == 'detected')
+verify(br2.br_get_multiail() == 'detected')
+verify(br3.br_get_multiail() == 'detected')
+
+# Disable `br1`
+
+br1.br_disable()
+verify(br1.br_get_state() == 'disabled')
+
+time.sleep(9 * one_minute / speedup)
+
+verify(br2.br_get_multiail() == 'not detected')
+verify(br3.br_get_multiail() == 'not detected')
+
+# Enable `br` again, wait for a short time (before detection) and disable it
+
+br1.br_enable()
+
+time.sleep(2 * one_minute / speedup)
+verify(br1.br_get_state() == 'running')
+
+br1.br_disable()
+verify(br1.br_get_state() == 'disabled')
+
+time.sleep(10 * one_minute / speedup)
+
+verify(br2.br_get_multiail() == 'not detected')
+verify(br3.br_get_multiail() == 'not detected')
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test finished
+
+cli.Node.finalize_all_nodes()
+
+print('\'{}\' passed.'.format(test_name))

--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -208,6 +208,7 @@ if [ "$TORANJ_CLI" = 1 ]; then
     run cli/test-502-multi-br-leader-failure-recovery.py
     run cli/test-503-peer-tbr-discovery.py
     run cli/test-504-br-icmp-unreach-err.py
+    run cli/test-505-multi-ail-detection.py
     run cli/test-601-channel-manager-channel-change.py
     # Skip the "channel-select" test on a TREL only radio link, since it
     # requires energy scan which is not supported in this case.


### PR DESCRIPTION
This commit introduces the `MultiAilDetector` feature within the `RoutingManager`. This feature detects whether Border Routers(BRs) on the Thread mesh might be connected to different Adjacent Infrastructure Links (AILs).

The feature can be enabled using the configuration option `OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE`.

The detection mechanism operates as follows: The Routing Manager monitors the number of peer BRs listed in the Thread Network Data and compares this with the number of peer BRs discovered by processing received Router Advertisements (RAs) on its local AIL.

If the count derived from Network Data consistently exceeds the count derived from RAs for a detection period of ten minutes, the detector concludes that BRs are likely connected to different AILs. This triggers a detection state change, and a registered callback is invoked. To clear this state, a shorter window of 1 minute is used.

Public APIs and corresponding CLI commands have been added to allow checking the current detection state and registering a callback for state change notifications.

This commit also includes test coverage for the newly added feature.