### PR TITLE
[mdns] add API to get the list of local host IP addresses

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (496)
+#define OPENTHREAD_API_VERSION (497)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/mdns.h
+++ b/include/openthread/mdns.h
@@ -40,6 +40,7 @@
 #include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
+#include <openthread/nat64.h>
 #include <openthread/platform/dnssd.h>
 
 #ifdef __cplusplus
@@ -140,6 +141,20 @@ typedef enum otMdnsEntryState
     OT_MDNS_ENTRY_STATE_CONFLICT,   ///< Name conflict was detected.
     OT_MDNS_ENTRY_STATE_REMOVING,   ///< Entry is being removed (sending "goodbye" announcements).
 } otMdnsEntryState;
+
+/**
+ * Represents a local host IPv4 or IPv6 address entry.
+ */
+typedef struct otMdnsLocalHostAddress
+{
+    bool     mIsIp6;        ///< Indicates whether the address is IPv6 (`true`) or IPv4 (`false`).
+    uint32_t mInfraIfIndex; ///< The infrastructure network interface index.
+    union
+    {
+        otIp6Address mIp6; ///< The IPv6 address (valid when `mIsIp6` is true).
+        otIp4Address mIp4; ///< The IPv4 address (valid when `mIsIp6` is false).
+    } mAddress;            ///< The address.
+} otMdnsLocalHostAddress;
 
 /**
  * Enables or disables the mDNS module.
@@ -496,6 +511,27 @@ otError otMdnsGetNextService(otInstance       *aInstance,
  * @retval OT_ERROR_INVALID_ARG  Iterator is not valid.
  */
 otError otMdnsGetNextKey(otInstance *aInstance, otMdnsIterator *aIterator, otMdnsKey *aKey, otMdnsEntryState *aState);
+
+/**
+ * Iterates over the local host IPv6 and IPv4 addresses tracked by OpenThread mDNS module.
+ *
+ * Requires `OPENTHREAD_CONFIG_MULTICAST_DNS_ENTRY_ITERATION_API_ENABLE`.
+ *
+ * The platform layer is responsible for monitoring and reporting all host IPv4 and IPv6 addresses to the OpenThread
+ * mDNS module, which then tracks the full address list (see `otPlatMdnsHandleHostAddressEvent()`). This function
+ * allows iteration through this tracked list, primarily intended for information and debugging purposes.
+ *
+ * @param[in]   aInstance           The OpenThread instance.
+ * @param[out]  aIterator           Pointer to the iterator to use.
+ * @param[out]  aAddress            Pointer to an `otMdnsLocalHostAddress` to output the next address entry.
+ *
+ * @retval OT_ERROR_NONE            The @p aAddress, and @p aIterator are updated successfully.
+ * @retval OT_ERROR_NOT_FOUND       Reached the end of the list.
+ * @retval OT_ERROR_INVALID_ARGS    Iterator is not valid.
+ */
+otError otMdnsGetNextLocalHostAddress(otInstance             *aInstance,
+                                      otMdnsIterator         *aIterator,
+                                      otMdnsLocalHostAddress *aAddress);
 
 /**
  * Represents a service browser.

--- a/src/core/api/mdns_api.cpp
+++ b/src/core/api/mdns_api.cpp
@@ -166,6 +166,17 @@ otError otMdnsGetNextKey(otInstance *aInstance, otMdnsIterator *aIterator, otMdn
     return AsCoreType(aInstance).Get<Dns::Multicast::Core>().GetNextKey(*aIterator, *aKey, *aState);
 }
 
+otError otMdnsGetNextLocalHostAddress(otInstance             *aInstance,
+                                      otMdnsIterator         *aIterator,
+                                      otMdnsLocalHostAddress *aAddress)
+
+{
+    AssertPointerIsNotNull(aIterator);
+    AssertPointerIsNotNull(aAddress);
+
+    return AsCoreType(aInstance).Get<Dns::Multicast::Core>().GetNextLocalHostAddress(*aIterator, *aAddress);
+}
+
 #endif // OPENTHREAD_CONFIG_MULTICAST_DNS_ENTRY_ITERATION_API_ENABLE
 
 otError otMdnsStartBrowser(otInstance *aInstance, const otMdnsBrowser *aBroswer)

--- a/src/core/net/mdns.hpp
+++ b/src/core/net/mdns.hpp
@@ -118,6 +118,7 @@ public:
     typedef otMdnsHost             Host;             ///< Host information.
     typedef otMdnsService          Service;          ///< Service information.
     typedef otMdnsKey              Key;              ///< Key information.
+    typedef otMdnsLocalHostAddress LocalHostAddress; ///< Local host address information.
     typedef otMdnsBrowser          Browser;          ///< Browser.
     typedef otMdnsBrowseCallback   BrowseCallback;   ///< Browser callback.
     typedef otMdnsBrowseResult     BrowseResult;     ///< Browser result.
@@ -668,6 +669,7 @@ public:
      * structure (like `mServiceType`) remain valid until the next call to any OpenThread stack's public or platform
      * API/callback.
      *
+     * @param[in]  aIterator   The iterator to use.
      * @param[out] aService    A `Service` to return the information about the next service entry.
      * @param[out] aState      An `EntryState` to return the entry state.
      *
@@ -683,6 +685,7 @@ public:
      * On success, @p aKey is populated with information about the next key. Pointers within the `Key` structure
      * (like `mName`) remain valid until the next call to any OpenThread stack's public or platform API/callback.
      *
+     * @param[in]  aIterator   The iterator to use.
      * @param[out] aKey        A `Key` to return the information about the next key entry.
      * @param[out] aState      An `EntryState` to return the entry state.
      *
@@ -691,6 +694,18 @@ public:
      * @retval kErrorInvalidArg   @p aIterator is not valid.
      */
     Error GetNextKey(Iterator &aIterator, Key &aKey, EntryState &aState) const;
+
+    /**
+     * Iterates over the local host IPv6 and IPv4 addresses.
+     *
+     * @param[in]   aIterator      The iterator to use.
+     * @param[out]  aAddress       A `LocalHostAddress` to output the next address entry.
+     *
+     * @retval kErrorNone           The @p aAddress and @p aIterator are updated successfully.
+     * @retval kErrorNotFound       Reached the end of the list.
+     * @retval kErrorInvalidArgs    Iterator is not valid.
+     */
+    Error GetNextLocalHostAddress(Iterator &aIterator, LocalHostAddress &aAddress);
 
     /**
      * Iterates over browsers.
@@ -2148,6 +2163,7 @@ private:
         Error GetNextHost(Host &aHost, EntryState &aState);
         Error GetNextService(Service &aService, EntryState &aState);
         Error GetNextKey(Key &aKey, EntryState &aState);
+        Error GetNextLocalHostAddress(LocalHostAddress &aAddress);
         Error GetNextBrowser(Browser &aBrowser, CacheInfo &aInfo);
         Error GetNextSrvResolver(SrvResolver &aResolver, CacheInfo &aInfo);
         Error GetNextTxtResolver(TxtResolver &aResolver, CacheInfo &aInfo);
@@ -2165,6 +2181,7 @@ private:
             kService,
             kHostKey,
             kServiceKey,
+            kLocalHostAddress,
             kBrowser,
             kSrvResolver,
             kTxtResolver,
@@ -2181,6 +2198,7 @@ private:
         {
             const HostEntry    *mHostEntry;
             const ServiceEntry *mServiceEntry;
+            uint16_t            mLocalHostAddrIndex;
             const BrowseCache  *mBrowseCache;
             const SrvCache     *mSrvCache;
             const TxtCache     *mTxtCache;


### PR DESCRIPTION
This commit introduces an API to iterate over the local host IPv6 and IPv4 addresses known to the OpenThread mDNS module.

The platform layer is responsible for monitoring and reporting all host IPv4 and IPv6 addresses to the OpenThread mDNS module, which then tracks the full address list
(see `otPlatMdnsHandleHostAddressEvent()`). The newly added function allows iteration through this tracked list, primarily intended for information and debugging purposes.

This commit also adds a CLI command to utilize the new API. Additionally, the `test_mdns` unit test has been updated to validate the functionality of the newly added API.