### PR TITLE
[dns] introduce `DecompressRecordData()` and use it in mDNS

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (497)
+#define OPENTHREAD_API_VERSION (498)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/mdns.h
+++ b/include/openthread/mdns.h
@@ -836,10 +836,16 @@ otError otMdnsStopIp4AddressResolver(otInstance *aInstance, const otMdnsAddressR
  * MUST NOT include the domain name. The reason for a separate first label is to allow it to include a dot `.`
  * character (as allowed for service instance labels).
  *
- * Discovered results are reported through the `mCallback` function in @p aQuerier, providing the raw record
- * data bytes. A removed record data is indicated with a TTL value of zero. The callback may be invoked immediately
- * with cached information (if available) and potentially before this function returns. When cached results are used,
- * the reported TTL value will reflect the original TTL from the last received response.
+ * Discovered results are reported through the `mCallback` function in @p aQuerier, providing the record data bytes
+ * (RDATA). For NS, CNAME, SOA, PTR, MX, RP, AFSDB, RT, PX, SRV, KX, DNAME, and NSEC record types, the RDATA format
+ * contains one or more DNS names (which may use DNS name compression). For the above list, the reported record data
+ * bytes via @p mCallback will be decompressed to contain the full DNS name(s). For all other record types, the record
+ * data bytes are provided exactly as they appear in the received mDNS response. This aligns the implementation with
+ * RFC 6762 (section 18.14) regarding the use of name compression.
+ *
+ * A removed record data is indicated with a TTL value of zero. The callback may be invoked immediately with cached
+ * information (if available) and potentially before this function returns. When cached results are used, the reported
+ * TTL value will reflect the original TTL from the last received response.
  *
  * Multiple querier instances can be started for the same name, provided they use different callback functions.
  *


### PR DESCRIPTION
This commit updates the mDNS `RecordQuerier` to handle record types where the RDATA contains one or more potentially compressed DNS names. For these types, the reported record data is now decompressed to include the full DNS names. This enhancement applies to the following record types: NS, CNAME, SOA, PTR, MX, RP, AFSDB, RT, PX, SRV, KX, DNAME, and NSEC.

To achieve this, a helper `ResourceRecord::DecompressRecordData()` method is introduced. This method uses a "recipe" formula specific to each supported record type. The recipe defines the number of prefix bytes before the first embedded name, the number of DNS names, and the minimum number of suffix bytes after the names. A common implementation then uses this recipe to parse and decompress the RDATA. This approach makes the implementation flexible and allows for easier addition of new record types and formats in the future.

Unit test `test_dns` is updated to validate the newly added method.