### PR TITLE
[dns] add a common helper `UpdateRecordLengthInMessage()`

### DIFF
--- a/src/core/net/dns_types.cpp
+++ b/src/core/net/dns_types.cpp
@@ -805,6 +805,15 @@ bool Name::IsSameDomain(const char *aDomain1, const char *aDomain2)
     return IsSubDomainOf(aDomain1, aDomain2) && IsSubDomainOf(aDomain2, aDomain1);
 }
 
+void ResourceRecord::UpdateRecordLengthInMessage(Message &aMessage, uint16_t aOffset)
+{
+    ResourceRecord record;
+
+    IgnoreError(aMessage.Read(aOffset, record));
+    record.SetLength(aMessage.GetLength() - aOffset - sizeof(ResourceRecord));
+    aMessage.Write(aOffset, record);
+}
+
 Error ResourceRecord::ParseRecords(const Message &aMessage, uint16_t &aOffset, uint16_t aNumRecords)
 {
     Error error = kErrorNone;

--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -1378,6 +1378,18 @@ public:
     uint32_t GetSize(void) const { return sizeof(ResourceRecord) + GetLength(); }
 
     /**
+     * Updates the record length in a message.
+     *
+     * This method should be called after all the record data fields are appended to the message. It uses the current
+     * message length along with @p aOffset to determine the record length and then updates it within the @p aMessage.
+     * The @p aOffset should point to to the start of the `ResourceRecord` in @p aMessage.
+     *
+     * @param[in] aMessage   The message to update.
+     * @param[in] aOffset    The offset to the start of `ResourceRecord` in @p aMessage.
+     */
+    static void UpdateRecordLengthInMessage(Message &aMessage, uint16_t aOffset);
+
+    /**
      * Parses and skips over a given number of resource records in a message from a given offset.
      *
      * @param[in]     aMessage     The message from which to parse/read the resource records. `aMessage.GetOffset()`

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -502,7 +502,7 @@ Error Server::Response::AppendPtrRecord(const char *aInstanceLabel, uint32_t aTt
     SuccessOrExit(error = Name::AppendLabel(aInstanceLabel, *mMessage));
     SuccessOrExit(error = Name::AppendPointerLabel(mOffsets.mServiceName, *mMessage));
 
-    UpdateRecordLength(ptrRecord, recordOffset);
+    ResourceRecord::UpdateRecordLengthInMessage(*mMessage, recordOffset);
 
     IncResourceRecordCount();
 
@@ -554,7 +554,7 @@ Error Server::Response::AppendSrvRecord(const char *aHostName,
     SuccessOrExit(error = Name::AppendMultipleLabels(hostLabels, *mMessage));
     SuccessOrExit(error = Name::AppendPointerLabel(mOffsets.mDomainName, *mMessage));
 
-    UpdateRecordLength(srvRecord, recordOffset);
+    ResourceRecord::UpdateRecordLengthInMessage(*mMessage, recordOffset);
 
     IncResourceRecordCount();
 
@@ -690,18 +690,6 @@ Error Server::Response::AppendTxtRecord(const void *aTxtData, uint16_t aTxtLengt
 
 exit:
     return error;
-}
-
-void Server::Response::UpdateRecordLength(ResourceRecord &aRecord, uint16_t aOffset)
-{
-    // Calculates RR DATA length and updates and re-writes it in the
-    // response message. This should be called immediately
-    // after all the fields in the record are written in the message.
-    // `aOffset` gives the offset in the message to the start of the
-    // record.
-
-    aRecord.SetLength(mMessage->GetLength() - aOffset - sizeof(Dns::ResourceRecord));
-    mMessage->Write(aOffset, aRecord);
 }
 
 void Server::Response::IncResourceRecordCount(void)

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -412,7 +412,6 @@ private:
         Error AppendHostAddresses(AddrType aAddrType, const Ip6::Address *aAddrs, uint16_t aAddrsLength, uint32_t aTtl);
         Error AppendAaaaRecord(const Ip6::Address &aAddress, uint32_t aTtl);
         Error AppendARecord(const Ip6::Address &aAddress, uint32_t aTtl);
-        void  UpdateRecordLength(ResourceRecord &aRecord, uint16_t aOffset);
         void  IncResourceRecordCount(void);
         void  Send(const Ip6::MessageInfo &aMessageInfo);
         void  Answer(const HostInfo &aHostInfo, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/net/mdns.cpp
+++ b/src/core/net/mdns.cpp
@@ -456,17 +456,6 @@ void Core::UpdateCacheFlushFlagIn(ResourceRecord &aResourceRecord, Section aSect
     }
 }
 
-void Core::UpdateRecordLengthInMessage(ResourceRecord &aRecord, Message &aMessage, uint16_t aOffset)
-{
-    // Determines the records DATA length and updates it in a message.
-    // Should be called immediately after all the fields in the
-    // record are appended to the message. `aOffset` gives the offset
-    // in the message to the start of the record.
-
-    aRecord.SetLength(aMessage.GetLength() - aOffset - sizeof(ResourceRecord));
-    aMessage.Write(aOffset, aRecord);
-}
-
 void Core::UpdateCompressOffset(uint16_t &aOffset, uint16_t aNewOffset)
 {
     if ((aOffset == kUnspecifiedOffset) && (aNewOffset != kUnspecifiedOffset))
@@ -1477,7 +1466,7 @@ void Core::Entry::AppendNsecRecordTo(TxMessage       &aTxMessage,
 
     SuccessOrAssert(message.AppendBytes(&bitmap, bitmap.GetSize()));
 
-    UpdateRecordLengthInMessage(nsec, message, offset);
+    ResourceRecord::UpdateRecordLengthInMessage(message, offset);
     aTxMessage.IncrementRecordCount(aSection);
 
     mAppendedNsec = true;
@@ -2950,7 +2939,7 @@ void Core::ServiceEntry::AppendSrvRecordTo(TxMessage &aTxMessage, Section aSecti
     offset = message->GetLength();
     SuccessOrAssert(message->Append(srv));
     AppendHostNameTo(aTxMessage, aSection);
-    UpdateRecordLengthInMessage(srv, *message, offset);
+    ResourceRecord::UpdateRecordLengthInMessage(*message, offset);
 
     aTxMessage.IncrementRecordCount(aSection);
 
@@ -3015,7 +3004,7 @@ void Core::ServiceEntry::AppendPtrRecordTo(TxMessage &aTxMessage, Section aSecti
     offset = message->GetLength();
     SuccessOrAssert(message->Append(ptr));
     AppendServiceNameTo(aTxMessage, aSection);
-    UpdateRecordLengthInMessage(ptr, *message, offset);
+    ResourceRecord::UpdateRecordLengthInMessage(*message, offset);
 
     aTxMessage.IncrementRecordCount(aSection);
 
@@ -3351,7 +3340,7 @@ void Core::ServiceType::AppendPtrRecordTo(TxMessage &aResponse, uint16_t aServic
     offset = message->GetLength();
     SuccessOrAssert(message->Append(ptr));
     aResponse.AppendServiceType(kAnswerSection, mServiceType.AsCString(), aServiceTypeOffset);
-    UpdateRecordLengthInMessage(ptr, *message, offset);
+    ResourceRecord::UpdateRecordLengthInMessage(*message, offset);
 
     aResponse.IncrementRecordCount(kAnswerSection);
 
@@ -5914,7 +5903,7 @@ void Core::BrowseCache::AppendKnownAnswer(TxMessage &aTxMessage, const PtrEntry 
     SuccessOrAssert(Name::AppendLabel(aPtrEntry.mServiceInstance.AsCString(), message));
     aTxMessage.AppendServiceType(kAnswerSection, mServiceType.AsCString(), mServiceTypeOffset);
 
-    UpdateRecordLengthInMessage(ptr, message, offset);
+    ResourceRecord::UpdateRecordLengthInMessage(message, offset);
 
     aTxMessage.IncrementRecordCount(kAnswerSection);
 }

--- a/src/core/net/mdns.hpp
+++ b/src/core/net/mdns.hpp
@@ -2223,7 +2223,6 @@ private:
     static void     UpdateCacheFlushFlagIn(ResourceRecord &aResourceRecord,
                                            Section         aSection,
                                            bool            aIsLegacyUnicast = false);
-    static void     UpdateRecordLengthInMessage(ResourceRecord &aRecord, Message &aMessage, uint16_t aOffset);
     static void     UpdateCompressOffset(uint16_t &aOffset, uint16_t aNewOffse);
     static bool     QuestionMatches(uint16_t aQuestionRrType, uint16_t aRrType);
     static bool     RrClassIsInternetOrAny(uint16_t aRrClass);

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -1028,7 +1028,6 @@ private:
     Error        AppendAaaaRecord(const Ip6::Address &aAddress, MsgInfo &aInfo) const;
     Error        AppendUpdateLeaseOptRecord(MsgInfo &aInfo);
     Error        AppendSignature(MsgInfo &aInfo);
-    void         UpdateRecordLengthInMessage(Dns::ResourceRecord &aRecord, uint16_t aOffset, Message &aMessage) const;
     void         HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void         ProcessResponse(Message &aMessage);
     bool         IsResponseMessageIdValid(uint16_t aId) const;


### PR DESCRIPTION
This commit adds `ResourceRecord::UpdateRecordLengthInMessage()` helper method in `dns_types.hpp`.

This common helper is then used in the SRP client, DNSSD server, and mDNS modules, replacing similar methods previously implemented within these modules.