### PR TITLE
[dns] Signal an error immediately when no upstream DNS servers are reachable

### DIFF
--- a/examples/platforms/simulation/dns.c
+++ b/examples/platforms/simulation/dns.c
@@ -32,11 +32,13 @@
 
 #if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE
 
-void otPlatDnsStartUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery)
+otError otPlatDnsStartUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aTxn);
     OT_UNUSED_VARIABLE(aQuery);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
 void otPlatDnsCancelUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery *aTxn)

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (494)
+#define OPENTHREAD_API_VERSION (495)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/dns.h
+++ b/include/openthread/platform/dns.h
@@ -68,8 +68,12 @@ typedef struct otPlatDnsUpstreamQuery otPlatDnsUpstreamQuery;
  * @param[in] aInstance  The OpenThread instance structure.
  * @param[in] aTxn       A pointer to the opaque DNS query transaction object.
  * @param[in] aQuery     A message buffer of the DNS payload that should be sent to upstream DNS server.
+ *
+ * @retval  OT_ERROR_NO_BUFS            No more DNS query can be supported.
+ * @retval  OT_ERROR_NO_ROUTE           No reachable upstream DNS server error.
+ * @retval  OT_ERROR_NONE               The query is successfully sent to upstream DNS server(s).
  */
-void otPlatDnsStartUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery);
+otError otPlatDnsStartUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery);
 
 /**
  * Cancels a transaction of upstream query.

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -961,7 +961,9 @@ Error Server::ResolveByUpstream(const Request &aRequest)
     txn = AllocateUpstreamQueryTransaction(*aRequest.mMessageInfo);
     VerifyOrExit(txn != nullptr, error = kErrorNoBufs);
 
-    otPlatDnsStartUpstreamQuery(&GetInstance(), txn, aRequest.mMessage);
+    error = otPlatDnsStartUpstreamQuery(&GetInstance(), txn, aRequest.mMessage);
+    VerifyOrExit(error == kErrorNone);
+
     mCounters.mUpstreamDnsCounters.mQueries++;
 
 exit:
@@ -2263,11 +2265,13 @@ bool Server::IsProxyAddressValid(const Ip6::Address &aAddress)
 } // namespace ot
 
 #if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE && OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_MOCK_PLAT_APIS_ENABLE
-void otPlatDnsStartUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery)
+otError otPlatDnsStartUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aTxn);
     OT_UNUSED_VARIABLE(aQuery);
+
+    return OT_ERROR_NONE;
 }
 
 void otPlatDnsCancelUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery *aTxn)

--- a/src/posix/platform/resolver.hpp
+++ b/src/posix/platform/resolver.hpp
@@ -69,8 +69,12 @@ public:
      *
      * @param[in] aTxn   A pointer to the OpenThread upstream DNS query transaction.
      * @param[in] aQuery A pointer to a message for the payload of the DNS query.
+     *
+     * @retval  OT_ERROR_NO_BUFS            No more DNS query can be supported.
+     * @retval  OT_ERROR_NO_ROUTE           No reachable upstream DNS server error.
+     * @retval  OT_ERROR_NONE               The query is successfully sent to upstream DNS server(s).
      */
-    void Query(otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery);
+    otError Query(otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery);
 
     /**
      * Cancels a upstream DNS query transaction.

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -700,11 +700,12 @@ otError otPlatUdpLeaveMulticastGroup(otUdpSocket        *aUdpSocket,
 #endif // OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
 
 #if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE
-void otPlatDnsStartUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery)
+otError otPlatDnsStartUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aTxn);
     OT_UNUSED_VARIABLE(aQuery);
+    return OT_ERROR_NONE;
 }
 
 void otPlatDnsCancelUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery *aTxn)


### PR DESCRIPTION
Currently, the platform resolver detects that no upstream servers are reachable but does not immediately signal an error back to the OT core. This leads to the client's DNS query eventually timing out instead of receiving an immediate `ServFail` response, which is the expected behavior in this scenario.

Also, log messages might misleadingly indicate forwarding attempts to `127.0.0.1` or `8.8.8.8`, which don't actually happen if no servers are configured internally.

This PR modifies the resolver and `otPlatDnsStartUpstreamQuery` API:

If no servers are found or no servers are reachable, `otPlatDnsStartUpstreamQuery` immediately returns with `error = OT_ERROR_NO_ROUTE`.

