### PR TITLE
[border-agent] fix meshcop service omr entry

### DIFF
--- a/include/openthread/border_agent.h
+++ b/include/openthread/border_agent.h
@@ -117,7 +117,29 @@ typedef struct otBorderAgentSessionIterator
     uint64_t mData;
 } otBorderAgentSessionIterator;
 
-#define OT_BORDER_AGENT_MESHCOP_SERVICE_TXT_DATA_MAX_LENGTH 128
+/**
+ * Maximum length of the OT core generated MeshCoP Service TXT data.
+ *
+ * Each field has the format:
+ * | Length (1 byte) | "Keyname=" | Data |
+ *
+ * Fields:
+ * Border Agent Id (id)                 - 4 + 16 = 20 bytes
+ * Network Name (nn)                    - 4 + 16 = 20 bytes
+ * ExtendedPanId (xp)                   - 4 + 8 = 12 bytes
+ * THread Version (tv)                  - 4 + 5 = 9 bytes
+ * Extended Address (xa)                - 4 + 8 = 12 bytes
+ * State Bitmap (sb)                    - 4 + 4 = 8 bytes
+ * Partition Id (pt)                    - 4 + 4 = 8 bytes
+ * Active Timestamp (at)                - 4 + 8 = 12 bytes
+ * Backbone Router Sequence Number (sq) - 4 + 1 = 5 bytes
+ * Backbone Router Udp Port (bb)        - 4 + 2 = 6 bytes
+ * Backbone Router Domain Name (dn)     - 4 + 16 = 20 bytes
+ * On-Mesh Routable Prefix (omr)        - 5 + 9 = 14 bytes
+ *
+ * Maximum possible data length: 146 bytes
+ */
+#define OT_BORDER_AGENT_MESHCOP_SERVICE_TXT_DATA_MAX_LENGTH 256
 
 /**
  * Represents the Border Agent MeshCoP Service TXT data.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (495)
+#define OPENTHREAD_API_VERSION (496)
 
 /**
  * @addtogroup api-instance

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -408,7 +408,7 @@ Error BorderAgent::MeshCoPTxtEncoder::EncodeTxtData(void)
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     SuccessOrExit(error = AppendBbrTxtEntry(state));
 #endif
-#if OTBR_ENABLE_BORDER_ROUTING
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
     SuccessOrExit(error = AppendOmrTxtEntry());
 #endif
     mTxtData.mLength = mAppender.GetAppendedLength();
@@ -447,7 +447,8 @@ Error BorderAgent::MeshCoPTxtEncoder::AppendOmrTxtEntry(void)
     Ip6::Prefix                                   prefix;
     BorderRouter::RoutingManager::RoutePreference preference;
 
-    if ((error = Get<BorderRouter::RoutingManager>().GetFavoredOmrPrefix(prefix, preference)) == kErrorNone)
+    if (Get<BorderRouter::RoutingManager>().GetFavoredOmrPrefix(prefix, preference) == kErrorNone &&
+        prefix.GetLength() > 0)
     {
         uint8_t omrData[Ip6::NetworkPrefix::kSize + 1];
         omrData[0] = prefix.GetLength();


### PR DESCRIPTION
The PR fixes the issue of missing OMR entry in MeshCoP TXT record.

In previous PR, a wrong macro is used so `AppendOmrTxtEntry` is never enabled.