### PR TITLE
[mbedtls] call `mbedtls_ssl_set_hostname` on setup

### DIFF
--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -311,6 +311,13 @@ Error SecureSession::Setup(void)
         VerifyOrExit(rval == 0);
     }
 
+#if defined(MBEDTLS_X509_CRT_PARSE_C)
+    if (!mIsServer)
+    {
+        mbedtls_ssl_set_hostname(&mSsl, nullptr);
+    }
+#endif
+
     mReceiveMessage = nullptr;
     mMessageSubType = Message::kSubTypeNone;
 


### PR DESCRIPTION
Due to CVE-2025-27809, on newer versions of mbedtls, handshake will fail unless hostname is set earlier.

TLS clients are not affected if they operate in a closed ecosystem where the trusted certificate authority only issues certificates to trusted hosts.

In this case, `mbedtls_ssl_set_hostname` with nullptr should be called to avoid failures.

More information on CVE-2025-27809: https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-03-1/