### PR TITLE
[posix] enhance config header file

### DIFF
--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -256,6 +256,15 @@
 #define OPENTHREAD_POSIX_CONFIG_THREAD_NETIF_DEFAULT_NAME "wpan0"
 #endif
 
+/**
+ * @def OPENTHREAD_POSIX_VIRTUAL_TIME
+ *
+ * This setting configures whether to use virtual time.
+ */
+#ifndef OPENTHREAD_POSIX_VIRTUAL_TIME
+#define OPENTHREAD_POSIX_VIRTUAL_TIME 0
+#endif
+
 #ifdef __APPLE__
 
 /**
@@ -278,17 +287,6 @@
 #endif
 
 #endif // __APPLE__
-
-//---------------------------------------------------------------------------------------------------------------------
-// Removed or renamed POSIX specific configs.
-
-#ifdef OPENTHREAD_CONFIG_POSIX_APP_TREL_INTERFACE_NAME
-#error "OPENTHREAD_CONFIG_POSIX_APP_TREL_INTERFACE_NAME was removed (no longer applicable with TREL over DNS-SD)."
-#endif
-
-#ifdef OPENTHREAD_CONFIG_POSIX_TREL_USE_NETLINK_SOCKET
-#error "OPENTHREAD_CONFIG_POSIX_TREL_USE_NETLINK_SOCKET was removed (no longer applicable with TREL over DNS-SD)."
-#endif
 
 /**
  * @def OPENTHREAD_POSIX_CONFIG_TREL_UDP_PORT
@@ -442,6 +440,17 @@
  */
 #ifndef OPENTHREAD_POSIX_CONFIG_RESOLV_CONF_ENABLED_INIT
 #define OPENTHREAD_POSIX_CONFIG_RESOLV_CONF_ENABLED_INIT (!OPENTHREAD_POSIX_CONFIG_ANDROID_ENABLE)
+#endif
+
+//---------------------------------------------------------------------------------------------------------------------
+// Removed or renamed POSIX specific configs.
+
+#ifdef OPENTHREAD_CONFIG_POSIX_APP_TREL_INTERFACE_NAME
+#error "OPENTHREAD_CONFIG_POSIX_APP_TREL_INTERFACE_NAME was removed (no longer applicable with TREL over DNS-SD)."
+#endif
+
+#ifdef OPENTHREAD_CONFIG_POSIX_TREL_USE_NETLINK_SOCKET
+#error "OPENTHREAD_CONFIG_POSIX_TREL_USE_NETLINK_SOCKET was removed (no longer applicable with TREL over DNS-SD)."
 #endif
 
 #endif // OPENTHREAD_PLATFORM_POSIX_CONFIG_H_

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -57,15 +57,6 @@
 #include "lib/url/url.hpp"
 
 /**
- * @def OPENTHREAD_POSIX_VIRTUAL_TIME
- *
- * This setting configures whether to use virtual time.
- */
-#ifndef OPENTHREAD_POSIX_VIRTUAL_TIME
-#define OPENTHREAD_POSIX_VIRTUAL_TIME 0
-#endif
-
-/**
  * This is the socket name used by daemon mode.
  */
 #define OPENTHREAD_POSIX_DAEMON_SOCKET_NAME OPENTHREAD_POSIX_CONFIG_DAEMON_SOCKET_BASENAME ".sock"


### PR DESCRIPTION
This commit enhances the `openthread-posix-config.h` header by:

- Moving configurations defined in other headers (`platform-posix.h`) into this common header.
- Making sure the section containing guard checks for removed or renamed POSIX configurations is at the end of the header file.