### PR TITLE
[dnssd] support RDATA translation in discovery proxy

### DIFF
--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -350,6 +350,8 @@ private:
     };
 #endif
 
+    typedef Data<kWithUint16Length> RecordData;
+
     struct Questions
     {
         Questions(void) { mFirstRrType = 0, mSecondRrType = 0; }
@@ -420,7 +422,7 @@ private:
                               uint16_t    aPort);
         Error AppendTxtRecord(const ServiceInstanceInfo &aInstanceInfo);
         Error AppendTxtRecord(const void *aTxtData, uint16_t aTxtLength, uint32_t aTtl);
-        Error AppendGenericRecord(uint16_t aRrType, const void *aData, uint16_t aDataLength, uint32_t aTtl);
+        Error AppendGenericRecord(uint16_t aRrType, const RecordData &aData, uint32_t aTtl);
         Error AppendHostAddresses(AddrType aAddrType, const HostInfo &aHostInfo);
         Error AppendHostAddresses(const ServiceInstanceInfo &aInstanceInfo);
         Error AppendHostAddresses(AddrType aAddrType, const Ip6::Address *aAddrs, uint16_t aAddrsLength, uint32_t aTtl);
@@ -592,6 +594,7 @@ private:
 
     static const char kDefaultDomainName[];
     static const char kSubLabel[];
+    static const char kMdnsDomainName[];
 #if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE
     static const char *kBlockedDomains[];
 #endif

--- a/tests/unit/test_dnssd_discovery_proxy.cpp
+++ b/tests/unit/test_dnssd_discovery_proxy.cpp
@@ -1041,6 +1041,20 @@ void TestProxyBasic(void)
     const uint8_t kTxtData[] = {3, 'A', '=', '1', 0};
     const uint8_t kKeyData[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99};
 
+    const uint8_t kCnameData[] = {
+        10, 'p', 'r', 'o', 't', 'e', 'c', 't', 'o', 'r', 's', /* protectors */
+        5,  'l', 'o', 'c', 'a', 'l',                          /* local */
+        0,
+    };
+
+    const uint8_t kTranslatedCnameData[] = {
+        10, 'p', 'r', 'o', 't', 'e', 'c', 't', 'o', 'r', 's', /* protectors */
+        7,  'd', 'e', 'f', 'a', 'u', 'l', 't',                /* default */
+        7,  's', 'e', 'r', 'v', 'i', 'c', 'e',                /* service */
+        4,  'a', 'r', 'p', 'a',                               /* arpa */
+        0,
+    };
+
     Srp::Server                     *srpServer;
     Srp::Client                     *srpClient;
     Dns::Client                     *dnsClient;
@@ -1756,6 +1770,85 @@ void TestProxyBasic(void)
     VerifyOrQuit(sQueryRecordInfo.mRecords[0].mTtl == kTtl);
     VerifyOrQuit(sQueryRecordInfo.mRecords[0].mDataBufferSize == sizeof(kKeyData));
     VerifyOrQuit(!memcmp(sQueryRecordInfo.mRecords[0].mDataBuffer, kKeyData, sizeof(kKeyData)));
+    VerifyOrQuit(MapEnum(sQueryRecordInfo.mRecords[0].mSection) == Dns::Client::RecordInfo::kSectionAnswer);
+
+    Log("--------------------------------------------------------------------------------------------");
+
+    ResetPlatDnssdApiInfo();
+    sQueryRecordInfo.Reset();
+
+    Log("QueryRecord() for CNAME that requires RDATA translation");
+    SuccessOrQuit(dnsClient->QueryRecord(Dns::ResourceRecord::kTypeCname, "avengers", "default.service.arpa.",
+                                         RecordCallback, sInstance));
+    AdvanceTime(10);
+
+    // Check that a record querier is started
+
+    VerifyOrQuit(sStartBrowserInfo.mCallCount == 0);
+    VerifyOrQuit(sStopBrowserInfo.mCallCount == 0);
+    VerifyOrQuit(sStartSrvResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStopSrvResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStartTxtResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStopTxtResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStartIp6AddrResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStopIp6AddrResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStartIp4AddrResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStopIp4AddrResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStartRecordQuerierInfo.mCallCount == 1);
+    VerifyOrQuit(sStopRecordQuerierInfo.mCallCount == 0);
+
+    VerifyOrQuit(sStartRecordQuerierInfo.NameMatches("avengers", nullptr));
+
+    VerifyOrQuit(sQueryRecordInfo.mCallbackCount == 0);
+
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
+    Log("Invoke Record Querier callback");
+
+    recordResult.mFirstLabel       = "avengers";
+    recordResult.mNextLabels       = nullptr;
+    recordResult.mRecordType       = Dns::ResourceRecord::kTypeCname;
+    recordResult.mRecordData       = kCnameData;
+    recordResult.mRecordDataLength = sizeof(kCnameData);
+    recordResult.mTtl              = kTtl;
+    recordResult.mInfraIfIndex     = kInfraIfIndex;
+
+    InvokeRecordQuerierCallback(sStartRecordQuerierInfo.mCallback, recordResult);
+
+    AdvanceTime(10);
+
+    // Check that the record querier is stopped
+
+    VerifyOrQuit(sStartBrowserInfo.mCallCount == 0);
+    VerifyOrQuit(sStopBrowserInfo.mCallCount == 0);
+    VerifyOrQuit(sStartSrvResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStopSrvResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStartTxtResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStopTxtResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStartIp6AddrResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStopIp6AddrResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStartIp4AddrResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStopIp4AddrResolverInfo.mCallCount == 0);
+    VerifyOrQuit(sStartRecordQuerierInfo.mCallCount == 1);
+    VerifyOrQuit(sStopRecordQuerierInfo.mCallCount == 1);
+
+    VerifyOrQuit(sStopRecordQuerierInfo.NameMatches("avengers", nullptr));
+    VerifyOrQuit(sStopRecordQuerierInfo.mCallback == sStartRecordQuerierInfo.mCallback);
+
+    // Check that response is sent to client and validate
+    // that the CNAME RDATA is correctly translated.
+
+    VerifyOrQuit(sQueryRecordInfo.mCallbackCount == 1);
+    SuccessOrQuit(sQueryRecordInfo.mError);
+
+    VerifyOrQuit(!strcmp(sQueryRecordInfo.mQueryName, "avengers.default.service.arpa."));
+    VerifyOrQuit(sQueryRecordInfo.mNumRecords == 1);
+
+    VerifyOrQuit(!strcmp(sQueryRecordInfo.mRecords[0].mNameBuffer, "avengers.default.service.arpa."));
+    VerifyOrQuit(sQueryRecordInfo.mRecords[0].mRecordType == Dns::ResourceRecord::kTypeCname);
+    VerifyOrQuit(sQueryRecordInfo.mRecords[0].mRecordLength == sizeof(kTranslatedCnameData));
+    VerifyOrQuit(sQueryRecordInfo.mRecords[0].mTtl == kTtl);
+    VerifyOrQuit(sQueryRecordInfo.mRecords[0].mDataBufferSize == sizeof(kTranslatedCnameData));
+    VerifyOrQuit(!memcmp(sQueryRecordInfo.mRecords[0].mDataBuffer, kTranslatedCnameData, sizeof(kTranslatedCnameData)));
     VerifyOrQuit(MapEnum(sQueryRecordInfo.mRecords[0].mSection) == Dns::Client::RecordInfo::kSectionAnswer);
 
     Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");


### PR DESCRIPTION
This commit adds implementation for RDATA translation in the OpenThread native discovery proxy. Specifically, for certain record types (like CNAME) where the record data includes one or more embedded DNS names, this translation applies. If the embedded DNS name in RDATA uses the local mDNS domain (`local.`), it is replaced with the corresponding domain name for the Thread mesh network (`default.service.arpa.`). Otherwise, the name is included unchanged in the record data.

A new method, `AppendTranslatedRecordDataTo()`, is added to perform this translation. It utilizes the `DataRecipe` table, similar to `DecompressRecordData()`, to parse the record data and update the embedded DNS names as needed.

The `test_dnssd_discovery_proxy` unit test is updated to cover the new record data translation behavior.