### PR TITLE
[dnssd] smaller enhancements in `Server`

### DIFF
--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -573,7 +573,7 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE
-    static bool               ShouldForwardToUpstream(const Request &aRequest);
+    bool                      ShouldForwardToUpstream(const Request &aRequest) const;
     UpstreamQueryTransaction *AllocateUpstreamQueryTransaction(const Ip6::MessageInfo &aMessageInfo);
     void                      ResetUpstreamQueryTransaction(UpstreamQueryTransaction &aTxn, Error aError);
     Error                     ResolveByUpstream(const Request &aRequest);


### PR DESCRIPTION
This commit contains a few smaller enhancements in the DNS-SD server implementation:
- `ShouldForwardToUpstream()` now checks the `mEnableUpstreamQuery`.
- The `ResolveByUpstream()` method now handles its own error logging.
- Comments are added/updated to improve code readability.