### PR TITLE
[core] move `ThreadLinkInfo` to its own header and source files

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -703,6 +703,8 @@ openthread_core_files = [
   "thread/router_table.hpp",
   "thread/src_match_controller.cpp",
   "thread/src_match_controller.hpp",
+  "thread/thread_link_info.cpp",
+  "thread/thread_link_info.hpp",
   "thread/thread_netif.cpp",
   "thread/thread_netif.hpp",
   "thread/thread_tlvs.hpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -246,6 +246,7 @@ set(COMMON_SOURCES
     thread/router.cpp
     thread/router_table.cpp
     thread/src_match_controller.cpp
+    thread/thread_link_info.cpp
     thread/thread_netif.cpp
     thread/time_sync_service.cpp
     thread/tmf.cpp

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -59,6 +59,7 @@
 #include "mac/mac_types.hpp"
 #include "thread/child_mask.hpp"
 #include "thread/link_quality.hpp"
+#include "thread/thread_link_info.hpp"
 
 /**
  * Represents an opaque (and empty) type for an OpenThread message buffer.
@@ -147,7 +148,6 @@ class Message;
 class MessagePool;
 class MessageQueue;
 class PriorityQueue;
-class ThreadLinkInfo;
 
 /**
  * Represents the link security mode indicating whether to use MAC (layer two) security.

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -40,56 +40,6 @@ namespace ot {
 
 RegisterLogModule("MeshForwarder");
 
-void ThreadLinkInfo::SetFrom(const Mac::RxFrame &aFrame)
-{
-    Clear();
-
-    if (kErrorNone != aFrame.GetSrcPanId(mPanId))
-    {
-        IgnoreError(aFrame.GetDstPanId(mPanId));
-    }
-
-    {
-        Mac::PanId dstPanId;
-
-        if (kErrorNone != aFrame.GetDstPanId(dstPanId))
-        {
-            dstPanId = mPanId;
-        }
-
-        mIsDstPanIdBroadcast = (dstPanId == Mac::kPanIdBroadcast);
-    }
-
-    if (aFrame.GetSecurityEnabled())
-    {
-        uint8_t keyIdMode;
-
-        // MAC Frame Security was already validated at the MAC
-        // layer. As a result, `GetKeyIdMode()` will never return
-        // failure here.
-        IgnoreError(aFrame.GetKeyIdMode(keyIdMode));
-
-        mLinkSecurity = (keyIdMode == Mac::Frame::kKeyIdMode0) || (keyIdMode == Mac::Frame::kKeyIdMode1);
-    }
-    else
-    {
-        mLinkSecurity = false;
-    }
-    mChannel = aFrame.GetChannel();
-    mRss     = aFrame.GetRssi();
-    mLqi     = aFrame.GetLqi();
-#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    if (aFrame.GetTimeIe() != nullptr)
-    {
-        mNetworkTimeOffset = aFrame.ComputeNetworkTimeOffset();
-        mTimeSyncSeq       = aFrame.ReadTimeSyncSeq();
-    }
-#endif
-#if OPENTHREAD_CONFIG_MULTI_RADIO
-    mRadioType = static_cast<uint8_t>(aFrame.GetRadioType());
-#endif
-}
-
 void MeshForwarder::Counters::UpdateOnTxDone(const Message &aMessage, bool aTxSuccess)
 {
     if (aMessage.GetType() == Message::kTypeIp6)

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -55,6 +55,7 @@
 #include "thread/indirect_sender.hpp"
 #include "thread/lowpan.hpp"
 #include "thread/network_data_leader.hpp"
+#include "thread/thread_link_info.hpp"
 
 namespace ot {
 
@@ -74,80 +75,6 @@ class HistoryTracker;
  *
  * @{
  */
-
-/**
- * Represents link-specific information for messages received from the Thread radio.
- */
-class ThreadLinkInfo : public otThreadLinkInfo, public Clearable<ThreadLinkInfo>
-{
-public:
-    /**
-     * Returns the IEEE 802.15.4 Source PAN ID.
-     *
-     * @returns The IEEE 802.15.4 Source PAN ID.
-     */
-    Mac::PanId GetPanId(void) const { return mPanId; }
-
-    /**
-     * Returns the IEEE 802.15.4 Channel.
-     *
-     * @returns The IEEE 802.15.4 Channel.
-     */
-    uint8_t GetChannel(void) const { return mChannel; }
-
-    /**
-     * Returns whether the Destination PAN ID is broadcast.
-     *
-     * @retval TRUE   If Destination PAN ID is broadcast.
-     * @retval FALSE  If Destination PAN ID is not broadcast.
-     */
-    bool IsDstPanIdBroadcast(void) const { return mIsDstPanIdBroadcast; }
-
-    /**
-     * Indicates whether or not link security is enabled.
-     *
-     * @retval TRUE   If link security is enabled.
-     * @retval FALSE  If link security is not enabled.
-     */
-    bool IsLinkSecurityEnabled(void) const { return mLinkSecurity; }
-
-    /**
-     * Returns the Received Signal Strength (RSS) in dBm.
-     *
-     * @returns The Received Signal Strength (RSS) in dBm.
-     */
-    int8_t GetRss(void) const { return mRss; }
-
-    /**
-     * Returns the frame/radio Link Quality Indicator (LQI) value.
-     *
-     * @returns The Link Quality Indicator value.
-     */
-    uint8_t GetLqi(void) const { return mLqi; }
-
-#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    /**
-     * Returns the Time Sync Sequence.
-     *
-     * @returns The Time Sync Sequence.
-     */
-    uint8_t GetTimeSyncSeq(void) const { return mTimeSyncSeq; }
-
-    /**
-     * Returns the time offset to the Thread network time (in microseconds).
-     *
-     * @returns The time offset to the Thread network time (in microseconds).
-     */
-    int64_t GetNetworkTimeOffset(void) const { return mNetworkTimeOffset; }
-#endif
-
-    /**
-     * Sets the `ThreadLinkInfo` from a given received frame.
-     *
-     * @param[in] aFrame  A received frame.
-     */
-    void SetFrom(const Mac::RxFrame &aFrame);
-};
 
 /**
  * Implements mesh forwarding within Thread.
@@ -678,8 +605,6 @@ private:
 /**
  * @}
  */
-
-DefineCoreType(otThreadLinkInfo, ThreadLinkInfo);
 
 } // namespace ot
 

--- a/src/core/thread/thread_link_info.cpp
+++ b/src/core/thread/thread_link_info.cpp
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements `ThreadLinkInfo`
+ */
+
+#include "thread_link_info.hpp"
+
+namespace ot {
+
+void ThreadLinkInfo::SetFrom(const Mac::RxFrame &aFrame)
+{
+    Clear();
+
+    if (kErrorNone != aFrame.GetSrcPanId(mPanId))
+    {
+        IgnoreError(aFrame.GetDstPanId(mPanId));
+    }
+
+    {
+        Mac::PanId dstPanId;
+
+        if (kErrorNone != aFrame.GetDstPanId(dstPanId))
+        {
+            dstPanId = mPanId;
+        }
+
+        mIsDstPanIdBroadcast = (dstPanId == Mac::kPanIdBroadcast);
+    }
+
+    if (aFrame.GetSecurityEnabled())
+    {
+        uint8_t keyIdMode;
+
+        // MAC Frame Security was already validated at the MAC
+        // layer. As a result, `GetKeyIdMode()` will never return
+        // failure here.
+        IgnoreError(aFrame.GetKeyIdMode(keyIdMode));
+
+        mLinkSecurity = (keyIdMode == Mac::Frame::kKeyIdMode0) || (keyIdMode == Mac::Frame::kKeyIdMode1);
+    }
+    else
+    {
+        mLinkSecurity = false;
+    }
+    mChannel = aFrame.GetChannel();
+    mRss     = aFrame.GetRssi();
+    mLqi     = aFrame.GetLqi();
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    if (aFrame.GetTimeIe() != nullptr)
+    {
+        mNetworkTimeOffset = aFrame.ComputeNetworkTimeOffset();
+        mTimeSyncSeq       = aFrame.ReadTimeSyncSeq();
+    }
+#endif
+#if OPENTHREAD_CONFIG_MULTI_RADIO
+    mRadioType = static_cast<uint8_t>(aFrame.GetRadioType());
+#endif
+}
+
+} // namespace ot

--- a/src/core/thread/thread_link_info.hpp
+++ b/src/core/thread/thread_link_info.hpp
@@ -1,0 +1,125 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for link-specific information for messages received from the Thread radio.
+ */
+
+#ifndef THREAD_LINK_INFO_HPP_
+#define THREAD_LINK_INFO_HPP_
+
+#include "openthread-core-config.h"
+
+#include <openthread/message.h>
+
+#include "common/clearable.hpp"
+#include "mac/mac_frame.hpp"
+#include "mac/mac_types.hpp"
+
+namespace ot {
+
+/**
+ * Represents link-specific information for messages received from the Thread radio.
+ */
+class ThreadLinkInfo : public otThreadLinkInfo, public Clearable<ThreadLinkInfo>
+{
+public:
+    /**
+     * Returns the IEEE 802.15.4 Source PAN ID.
+     *
+     * @returns The IEEE 802.15.4 Source PAN ID.
+     */
+    Mac::PanId GetPanId(void) const { return mPanId; }
+
+    /**
+     * Returns the IEEE 802.15.4 Channel.
+     *
+     * @returns The IEEE 802.15.4 Channel.
+     */
+    uint8_t GetChannel(void) const { return mChannel; }
+
+    /**
+     * Returns whether the Destination PAN ID is broadcast.
+     *
+     * @retval TRUE   If Destination PAN ID is broadcast.
+     * @retval FALSE  If Destination PAN ID is not broadcast.
+     */
+    bool IsDstPanIdBroadcast(void) const { return mIsDstPanIdBroadcast; }
+
+    /**
+     * Indicates whether or not link security is enabled.
+     *
+     * @retval TRUE   If link security is enabled.
+     * @retval FALSE  If link security is not enabled.
+     */
+    bool IsLinkSecurityEnabled(void) const { return mLinkSecurity; }
+
+    /**
+     * Returns the Received Signal Strength (RSS) in dBm.
+     *
+     * @returns The Received Signal Strength (RSS) in dBm.
+     */
+    int8_t GetRss(void) const { return mRss; }
+
+    /**
+     * Returns the frame/radio Link Quality Indicator (LQI) value.
+     *
+     * @returns The Link Quality Indicator value.
+     */
+    uint8_t GetLqi(void) const { return mLqi; }
+
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    /**
+     * Returns the Time Sync Sequence.
+     *
+     * @returns The Time Sync Sequence.
+     */
+    uint8_t GetTimeSyncSeq(void) const { return mTimeSyncSeq; }
+
+    /**
+     * Returns the time offset to the Thread network time (in microseconds).
+     *
+     * @returns The time offset to the Thread network time (in microseconds).
+     */
+    int64_t GetNetworkTimeOffset(void) const { return mNetworkTimeOffset; }
+#endif
+
+    /**
+     * Sets the `ThreadLinkInfo` from a given received frame.
+     *
+     * @param[in] aFrame  A received frame.
+     */
+    void SetFrom(const Mac::RxFrame &aFrame);
+};
+
+DefineCoreType(otThreadLinkInfo, ThreadLinkInfo);
+
+} // namespace ot
+
+#endif // THREAD_LINK_INFO_HPP_


### PR DESCRIPTION
This commit refactors the `ThreadLinkInfo` definition by moving it into its own dedicated header (`thread_link_info.hpp`) and source (`.cpp`) files. Previously, this definition was part of `mesh_forwarder.hpp`.

This change simplifies the overall code structure. It also allows the new `thread_link_info.hpp` header to be included by other modules, such as `message.hpp`, thereby avoiding the need for forward declarations.