### PR TITLE
[udp] relax `SocketHandle::Matches()` for host interface

### DIFF
--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -46,7 +46,14 @@ bool Udp::SocketHandle::Matches(const MessageInfo &aMessageInfo) const
     bool matches = false;
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    VerifyOrExit(IsBackbone() == aMessageInfo.IsHostInterface());
+    if (aMessageInfo.IsHostInterface())
+    {
+        VerifyOrExit(IsBackbone() || (GetNetifId() == kNetifUnspecified));
+    }
+    else
+    {
+        VerifyOrExit(!IsBackbone());
+    }
 #endif
 
     VerifyOrExit(GetSockName().mPort == aMessageInfo.GetSockPort());


### PR DESCRIPTION
This commit relaxes the `SocketHandle::Matches()` method to allow a socket associated with `kNetifUnspecified` to match when `IsHostInterface()` is set. This is in addition to the existing behavior of matching a backbone socket under the same condition.