### PR TITLE
[dns] add common `TxtDataEncoder`

### DIFF
--- a/src/core/net/dns_types.cpp
+++ b/src/core/net/dns_types.cpp
@@ -1390,6 +1390,24 @@ exit:
     return error;
 }
 
+Error TxtDataEncoder::AppendBytesEntry(const char *aKey, const void *aBuffer, uint16_t aLength)
+{
+    return TxtEntry(aKey, reinterpret_cast<const uint8_t *>(aBuffer), aLength).AppendTo(mAppender);
+}
+
+Error TxtDataEncoder::AppendStringEntry(const char *aKey, const char *aStringValue)
+{
+    Error    error;
+    uint16_t length = StringLength(aStringValue, kMaxStringEntryLength + 1);
+
+    VerifyOrExit(length <= kMaxStringEntryLength, error = kErrorInvalidArgs);
+
+    error = AppendBytesEntry(aKey, aStringValue, length);
+
+exit:
+    return error;
+}
+
 bool AaaaRecord::IsValid(void) const
 {
     return GetType() == Dns::ResourceRecord::kTypeAaaa && GetSize() == sizeof(*this);


### PR DESCRIPTION
This commit moves and enhances the `TxtDataEncoder` class, relocating it to the common `dns_types.hpp` header file.

The new `TxtDataEncoder` provides helper methods to append TXT entries with a variety of value types, including `NameData`, C-strings, or an unsigned integer (in big-endian format). This enhanced encoder is then used by the `BorderAgent` when preparing MeshCoP TXT data and also by the TREL module.