### PR TITLE
[trel] use `LinkedList` for TREL peer tracking

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (504)
+#define OPENTHREAD_API_VERSION (505)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/trel.h
+++ b/include/openthread/trel.h
@@ -68,7 +68,7 @@ typedef struct otTrelPeer
 /**
  * Represents an iterator for iterating over TREL peer table entries.
  */
-typedef uint16_t otTrelPeerIterator;
+typedef const void *otTrelPeerIterator;
 
 /**
  * Enables or disables TREL operation.


### PR DESCRIPTION
This commit updates the internal data structure used for tracking TREL peers. Peer tracking now uses a `LinkedList` of `Peer` objects allocated from a pre-allocated `Pool<Peer>`, instead of using a fixed-size `Array<Peer>`.

This change allows for future enhancements, such as using heap-allocated `Peer` entries and/or extending the `Peer` object to track additional (dynamically allocated) information.