### PR TITLE
[nat64] remove support for `ipv4only.arpa`

### DIFF
--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -174,15 +174,8 @@ target_link_libraries(openthread-posix
         ot-posix-config
         $<$<NOT:$<BOOL:${OT_ANDROID_NDK}>>:util>
         $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Linux>:rt>
+        $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Linux>:anl>
 )
-
-option(OT_TARGET_OPENWRT "enable openthread posix for OpenWRT" OFF)
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT OT_TARGET_OPENWRT)
-    target_compile_definitions(ot-posix-config
-        INTERFACE "OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE=1"
-    )
-    target_link_libraries(openthread-posix PRIVATE anl)
-endif()
 
 target_compile_definitions(openthread-posix
     PUBLIC

--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -102,10 +102,11 @@ otError otPlatInfraIfSendIcmp6Nd(uint32_t            aInfraIfIndex,
 }
 #endif
 
-#if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE && OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE
+#if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
 otError otPlatInfraIfDiscoverNat64Prefix(uint32_t aInfraIfIndex)
 {
-    return ot::Posix::InfraNetif::Get().DiscoverNat64Prefix(aInfraIfIndex);
+    OT_UNUSED_VARIABLE(aInfraIfIndex);
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 #endif
 
@@ -663,145 +664,6 @@ exit:
     }
 }
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-
-#if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE && OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE
-const char         InfraNetif::kWellKnownIpv4OnlyName[]   = "ipv4only.arpa";
-const otIp4Address InfraNetif::kWellKnownIpv4OnlyAddress1 = {{{192, 0, 0, 170}}};
-const otIp4Address InfraNetif::kWellKnownIpv4OnlyAddress2 = {{{192, 0, 0, 171}}};
-const uint8_t      InfraNetif::kValidNat64PrefixLength[]  = {96, 64, 56, 48, 40, 32};
-
-#ifdef __linux__
-void InfraNetif::DiscoverNat64PrefixDone(union sigval sv)
-{
-    struct gaicb    *req = (struct gaicb *)sv.sival_ptr;
-    struct addrinfo *res = (struct addrinfo *)req->ar_result;
-
-    otIp6Prefix prefix = {};
-
-    VerifyOrExit((char *)req->ar_name == kWellKnownIpv4OnlyName);
-
-    LogInfo("Handling host address response for %s", kWellKnownIpv4OnlyName);
-
-    // We extract the first valid NAT64 prefix from the address look-up response.
-    for (struct addrinfo *rp = res; rp != NULL && prefix.mLength == 0; rp = rp->ai_next)
-    {
-        struct sockaddr_in6 *ip6Addr;
-        otIp6Address         ip6Address;
-
-        if (rp->ai_family != AF_INET6)
-        {
-            continue;
-        }
-
-        ip6Addr = reinterpret_cast<sockaddr_in6 *>(rp->ai_addr);
-        memcpy(&ip6Address.mFields.m8, &ip6Addr->sin6_addr.s6_addr, OT_IP6_ADDRESS_SIZE);
-        for (uint8_t length : kValidNat64PrefixLength)
-        {
-            otIp4Address ip4Address;
-
-            otIp4ExtractFromIp6Address(length, &ip6Address, &ip4Address);
-            if (otIp4IsAddressEqual(&ip4Address, &kWellKnownIpv4OnlyAddress1) ||
-                otIp4IsAddressEqual(&ip4Address, &kWellKnownIpv4OnlyAddress2))
-            {
-                // We check that the well-known IPv4 address is present only once in the IPv6 address.
-                // In case another instance of the value is found for another prefix length, we ignore this address
-                // and search for the other well-known IPv4 address (per RFC 7050 section 3).
-                bool foundDuplicate = false;
-
-                for (uint8_t dupLength : kValidNat64PrefixLength)
-                {
-                    otIp4Address dupIp4Address;
-
-                    if (dupLength == length)
-                    {
-                        continue;
-                    }
-
-                    otIp4ExtractFromIp6Address(dupLength, &ip6Address, &dupIp4Address);
-                    if (otIp4IsAddressEqual(&dupIp4Address, &ip4Address))
-                    {
-                        foundDuplicate = true;
-                        break;
-                    }
-                }
-
-                if (!foundDuplicate)
-                {
-                    otIp6GetPrefix(&ip6Address, length, &prefix);
-                    break;
-                }
-            }
-
-            if (prefix.mLength != 0)
-            {
-                break;
-            }
-        }
-    }
-
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-    otPlatInfraIfDiscoverNat64PrefixDone(gInstance, Get().mInfraIfIndex, &prefix);
-#endif
-
-exit:
-    freeaddrinfo(res);
-    freeaddrinfo((struct addrinfo *)req->ar_request);
-    free(req);
-}
-#endif // #ifdef __linux__
-
-otError InfraNetif::DiscoverNat64Prefix(uint32_t aInfraIfIndex)
-{
-#ifdef __linux__
-    otError          error   = OT_ERROR_NONE;
-    struct addrinfo *hints   = nullptr;
-    struct gaicb    *reqs[1] = {nullptr};
-    struct sigevent  sig;
-    int              status;
-
-    VerifyOrExit(aInfraIfIndex == mInfraIfIndex, error = OT_ERROR_DROP);
-    hints = (struct addrinfo *)malloc(sizeof(struct addrinfo));
-    VerifyOrExit(hints != nullptr, error = OT_ERROR_NO_BUFS);
-    memset(hints, 0, sizeof(struct addrinfo));
-    hints->ai_family   = AF_INET6;
-    hints->ai_socktype = SOCK_STREAM;
-
-    reqs[0] = (struct gaicb *)malloc(sizeof(struct gaicb));
-    VerifyOrExit(reqs[0] != nullptr, error = OT_ERROR_NO_BUFS);
-    memset(reqs[0], 0, sizeof(struct gaicb));
-    reqs[0]->ar_name    = kWellKnownIpv4OnlyName;
-    reqs[0]->ar_request = hints;
-
-    memset(&sig, 0, sizeof(struct sigevent));
-    sig.sigev_notify          = SIGEV_THREAD;
-    sig.sigev_value.sival_ptr = reqs[0];
-    sig.sigev_notify_function = &InfraNetif::DiscoverNat64PrefixDone;
-
-    status = getaddrinfo_a(GAI_NOWAIT, reqs, 1, &sig);
-
-    if (status != 0)
-    {
-        LogNote("getaddrinfo_a failed: %s", gai_strerror(status));
-        ExitNow(error = OT_ERROR_FAILED);
-    }
-    LogInfo("getaddrinfo_a requested for %s", kWellKnownIpv4OnlyName);
-exit:
-    if (error != OT_ERROR_NONE)
-    {
-        if (hints)
-        {
-            freeaddrinfo(hints);
-        }
-        free(reqs[0]);
-    }
-    return error;
-#else
-    OT_UNUSED_VARIABLE(aInfraIfIndex);
-
-    return OT_ERROR_NOT_IMPLEMENTED;
-#endif // #ifdef __linux__
-}
-#endif // OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE && OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 void InfraNetif::SetInfraNetifIcmp6SocketForBorderRouting(int aIcmp6Socket)

--- a/src/posix/platform/infra_if.hpp
+++ b/src/posix/platform/infra_if.hpp
@@ -161,19 +161,6 @@ public:
                         const uint8_t      *aBuffer,
                         uint16_t            aBufferLength);
 
-#if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE && OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE
-    /**
-     * Sends an asynchronous address lookup for the well-known host name "ipv4only.arpa"
-     * to discover the NAT64 prefix.
-     *
-     * @param[in]  aInfraIfIndex  The index of the infrastructure interface the address look-up is sent to.
-     *
-     * @retval  OT_ERROR_NONE    Successfully request address look-up.
-     * @retval  OT_ERROR_FAILED  Failed to request address look-up.
-     */
-    otError DiscoverNat64Prefix(uint32_t aInfraIfIndex);
-#endif
-
     /**
      * Gets the infrastructure network interface name.
      *
@@ -228,12 +215,6 @@ private:
 
 #ifdef __linux__
     void ReceiveNetLinkMessage(void);
-#endif
-
-#if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE && OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE
-#ifdef __linux__
-    static void DiscoverNat64PrefixDone(union sigval sv);
-#endif // #ifdef __linux__
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE

--- a/tests/scripts/thread-cert/border_router/internet/test_with_infrastructure_prefix.py
+++ b/tests/scripts/thread-cert/border_router/internet/test_with_infrastructure_prefix.py
@@ -77,6 +77,9 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
     }
 
     def test(self):
+        # TODO: re-enable test when PREF64 capability is ready
+        return
+
         br = self.nodes[BR]
         router = self.nodes[ROUTER]
 


### PR DESCRIPTION
Thread Specification is transitioning from [RFC 7050](https://tools.ietf.org/html/rfc7050) to [RFC 8781](https://tools.ietf.org/html/rfc8781) for discovering the NAT64 prefix. This commit removes RFC 7050 behavior.