### PR TITLE
[posix] make the link-local route's metric configurable

### DIFF
--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -141,10 +141,22 @@
 #endif
 
 /**
+ * @def OPENTHREAD_POSIX_CONFIG_NETIF_LINK_LOCAL_ROUTE_METRIC
+ *
+ * This setting configures the link-local route metric on the Thread network interface.
+ * Define as 0 to use the default prefix route metric.
+ *
+ * Note: The feature works on Linux kernel v4.18+.
+ */
+#ifndef OPENTHREAD_POSIX_CONFIG_NETIF_LINK_LOCAL_ROUTE_METRIC
+#define OPENTHREAD_POSIX_CONFIG_NETIF_LINK_LOCAL_ROUTE_METRIC 0
+#endif
+
+/**
  * @def OPENTHREAD_POSIX_CONFIG_NETIF_PREFIX_ROUTE_METRIC
  *
- * This setting configures the prefix route metric on the Thread network interface.
- * Define as 0 to use use the default prefix route metric.
+ * This setting configures the non-link-local prefix route metric on the Thread network interface.
+ * Define as 0 to use the default prefix route metric.
  *
  * Note: The feature works on Linux kernel v4.18+.
  */


### PR DESCRIPTION
This PR allows to configure the link-local route's metric via macro on Linux. By using a larger metric, we can prevent host processes from accidentally sending traffic to Thread network interface. 

For example, when the mDNS daemon on the BR wants to respond to a `QU` mDNS question, it will send the mDNS response to a link-local address. In a multi-network environment, it could wrongly go to the Thread network interface if the socket is not explicitly bound to the desired interface. 