### PR TITLE
[dns] update comments DNS-types to match IANA

### DIFF
--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -133,16 +133,16 @@ public:
     }
 
     /**
-     * Defines types of query.
+     * Defines types of query (OpCode).
      */
     enum QueryType : uint8_t
     {
-        kQueryTypeStandard = 0,
-        kQueryTypeInverse  = 1,
-        kQueryTypeStatus   = 2,
-        kQueryTypeNotify   = 4,
-        kQueryTypeUpdate   = 5,
-        kQueryTypeDso      = 6,
+        kQueryTypeStandard = 0, ///< Query
+        kQueryTypeInverse  = 1, ///< IQuery
+        kQueryTypeStatus   = 2, ///< Status
+        kQueryTypeNotify   = 4, ///< Notify
+        kQueryTypeUpdate   = 5, ///< Update
+        kQueryTypeDso      = 6, ///< DNS Stateful Operations
     };
 
     /**
@@ -234,25 +234,25 @@ public:
     void SetRecursionAvailableFlag(void) { mFlags[1] |= kRaFlagMask; }
 
     /**
-     * Defines response codes.
+     * Defines response codes (RCODEs).
      */
     enum Response : uint8_t
     {
-        kResponseSuccess         = 0,  ///< Success (no error condition).
-        kResponseFormatError     = 1,  ///< Server unable to interpret request due to format error.
-        kResponseServerFailure   = 2,  ///< Server encountered an internal failure.
-        kResponseNameError       = 3,  ///< Name that ought to exist, does not exists.
-        kResponseNotImplemented  = 4,  ///< Server does not support the query type (OpCode).
-        kResponseRefused         = 5,  ///< Server refused to perform operation for policy or security reasons.
-        kResponseNameExists      = 6,  ///< Some name that ought not to exist, does exist.
-        kResponseRecordExists    = 7,  ///< Some RRset that ought not to exist, does exist.
-        kResponseRecordNotExists = 8,  ///< Some RRset that ought to exist, does not exist.
-        kResponseNotAuth         = 9,  ///< Service is not authoritative for zone.
-        kResponseNotZone         = 10, ///< A name is not in the zone.
-        kDsoTypeNotImplemented   = 11, ///< DSO TLV TYPE is not implemented.
-        kResponseBadName         = 20, ///< Bad name.
-        kResponseBadAlg          = 21, ///< Bad algorithm.
-        kResponseBadTruncation   = 22, ///< Bad truncation.
+        kResponseSuccess         = 0,  ///< Success (no error condition, NoError).
+        kResponseFormatError     = 1,  ///< Server unable to interpret request due to format error (FormErr).
+        kResponseServerFailure   = 2,  ///< Server encountered an internal failure (ServFail).
+        kResponseNameError       = 3,  ///< Name that ought to exist, does not exist (NXDomain).
+        kResponseNotImplemented  = 4,  ///< Server does not support the query type or OpCode (NotImp).
+        kResponseRefused         = 5,  ///< Server refused to perform operation for policy/security reasons (Refused).
+        kResponseNameExists      = 6,  ///< Some name that ought not to exist, does exist (YXDomain).
+        kResponseRecordExists    = 7,  ///< Some RRset that ought not to exist, does exist (YXRRSet).
+        kResponseRecordNotExists = 8,  ///< Some RRset that ought to exist, does not exist (NXRRSet).
+        kResponseNotAuth         = 9,  ///< Service is not authoritative for zone (NotAuth).
+        kResponseNotZone         = 10, ///< A name is not in the zone (NotZone).
+        kDsoTypeNotImplemented   = 11, ///< DSO TLV TYPE is not implemented (DSOTYPENI).
+        kResponseBadName         = 20, ///< Bad name (BADNAME).
+        kResponseBadAlg          = 21, ///< Bad algorithm (BADALG).
+        kResponseBadTruncation   = 22, ///< Bad truncation (BADTRUNC).
     };
 
     /**
@@ -1400,14 +1400,14 @@ class ResourceRecord
     friend class OptRecord;
 
 public:
-    // Resource Record Types.
+    // Resource Record Types (RRTypes).
     static constexpr uint16_t kTypeZero  = 0;   ///< Zero as special indicator for the SIG RR (SIG(0) from RFC 2931).
-    static constexpr uint16_t kTypeA     = 1;   ///< Address record (IPv4).
+    static constexpr uint16_t kTypeA     = 1;   ///< IPv4 address record (A).
     static constexpr uint16_t kTypeNs    = 2;   ///< NS record (an authoritative name server).
     static constexpr uint16_t kTypeCname = 5;   ///< CNAME record.
     static constexpr uint16_t kTypeSoa   = 6;   ///< SOA record (start of (zone of) authority).
     static constexpr uint16_t kTypePtr   = 12;  ///< PTR record.
-    static constexpr uint16_t kTypeMx    = 15;  ///< MAX record (mail exchange).
+    static constexpr uint16_t kTypeMx    = 15;  ///< MX record (mail exchange).
     static constexpr uint16_t kTypeTxt   = 16;  ///< TXT record.
     static constexpr uint16_t kTypeRp    = 17;  ///< RP record (Responsible Person).
     static constexpr uint16_t kTypeAfsdb = 18;  ///< AFSDB record (AFS Data Base location).
@@ -1415,15 +1415,15 @@ public:
     static constexpr uint16_t kTypeSig   = 24;  ///< SIG record.
     static constexpr uint16_t kTypeKey   = 25;  ///< KEY record.
     static constexpr uint16_t kTypePx    = 26;  ///< PX record (X.400 mail mapping information).
-    static constexpr uint16_t kTypeAaaa  = 28;  ///< IPv6 address record.
+    static constexpr uint16_t kTypeAaaa  = 28;  ///< IPv6 address (AAAA) record.
     static constexpr uint16_t kTypeSrv   = 33;  ///< SRV locator record.
     static constexpr uint16_t kTypeKx    = 36;  ///< KX record (Key Exchanger).
     static constexpr uint16_t kTypeDname = 39;  ///< DNAME record.
-    static constexpr uint16_t kTypeOpt   = 41;  ///< Option record.
+    static constexpr uint16_t kTypeOpt   = 41;  ///< Option (OPT) record.
     static constexpr uint16_t kTypeNsec  = 47;  ///< NSEC record.
-    static constexpr uint16_t kTypeAny   = 255; ///< ANY record.
+    static constexpr uint16_t kTypeAny   = 255; ///< ANY (*) record.
 
-    // Resource Record Class Codes.
+    // Resource Record Class Codes (CLASS).
     static constexpr uint16_t kClassInternet = 1;   ///< Class code Internet (IN).
     static constexpr uint16_t kClassNone     = 254; ///< Class code None (NONE) - RFC 2136.
     static constexpr uint16_t kClassAny      = 255; ///< Class code Any (ANY).


### PR DESCRIPTION
This adds comments to DNS types, to ensure that official names from the IANA DNS parameters registry can be found in the OT source code when starting to search from that starting point. This will make development and code analysis easier for those not familiar with OT, or coming from the DNS world. The IANA names (which may deviate from RFC names) are from: https://www.iana.org/assignments/dns-parameters