### PR TITLE
[utils] fix clang-tidy false alarm in VerifyOrExit

### DIFF
--- a/src/include/common/code_utils.hpp
+++ b/src/include/common/code_utils.hpp
@@ -109,14 +109,17 @@
  * @param[in]  aCondition  A Boolean expression to be evaluated.
  * @param[in]  aAction     An optional expression or block to execute when the assertion fails.
  */
-#define VerifyOrExit(...)                 \
-    do                                    \
-    {                                     \
-        if (!(OT_FIRST_ARG(__VA_ARGS__))) \
-        {                                 \
-            OT_SECOND_ARG(__VA_ARGS__);   \
-            goto exit;                    \
-        }                                 \
+#define VerifyOrExit(...)               \
+    do                                  \
+    {                                   \
+        if (OT_FIRST_ARG(__VA_ARGS__))  \
+        {                               \
+        }                               \
+        else                            \
+        {                               \
+            OT_SECOND_ARG(__VA_ARGS__); \
+            goto exit;                  \
+        }                               \
     } while (false)
 
 /**


### PR DESCRIPTION
Previously, the `VerifyOrExit()` macro's condition caused clang-tidy to issue false positives regarding "boolean readability," suggesting simplifications via De Morgan's Theorem. This occurred because the macro wrapped the entire condition and then checked its negative.

This commit refactors the macro to evaluate the condition directly, which:

1. Eliminates the erroneous clang-tidy warnings.
2. Potentially enhances CPU branch prediction performance, as the condition is more likely to evaluate to true.