### PR TITLE
[border-agent] add 'rv' key to MeshCoP TXT data

### DIFF
--- a/include/openthread/border_agent.h
+++ b/include/openthread/border_agent.h
@@ -126,6 +126,7 @@ typedef struct otBorderAgentSessionIterator
  *
  * Fields:
  * Border Agent Id (id)                 - 4 + 16 = 20 bytes
+ * Version of TXT record format (rv)    - 4 + 1  = 5 bytes
  * Network Name (nn)                    - 4 + 16 = 20 bytes
  * ExtendedPanId (xp)                   - 4 + 8 = 12 bytes
  * Thread Version (tv)                  - 4 + 5 = 9 bytes
@@ -138,7 +139,7 @@ typedef struct otBorderAgentSessionIterator
  * Backbone Router Domain Name (dn)     - 4 + 16 = 20 bytes
  * On-Mesh Routable Prefix (omr)        - 5 + 9 = 14 bytes
  *
- * Maximum possible data length: 146 bytes
+ * Maximum possible data length: 151 bytes
  */
 #define OT_BORDER_AGENT_MESHCOP_SERVICE_TXT_DATA_MAX_LENGTH 256
 

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (507)
+#define OPENTHREAD_API_VERSION (508)
 
 /**
  * @addtogroup api-instance

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -45,6 +45,7 @@ RegisterLogModule("BorderAgent");
 //----------------------------------------------------------------------------------------------------------------------
 // `BorderAgent`
 
+const char BorderAgent::kTxtDataRecordVersion[] = "1";
 #if OPENTHREAD_CONFIG_BORDER_AGENT_MESHCOP_SERVICE_ENABLE
 const char BorderAgent::kServiceType[]            = "_meshcop._udp";
 const char BorderAgent::kDefaultBaseServiceName[] = OPENTHREAD_CONFIG_BORDER_AGENT_MESHCOP_SERVICE_BASE_NAME;
@@ -542,6 +543,7 @@ Error BorderAgent::PrepareServiceTxtData(uint8_t *aBuffer, uint16_t aBufferSize,
         }
     }
 #endif
+    SuccessOrExit(error = encoder.AppendStringEntry("rv", kTxtDataRecordVersion));
     SuccessOrExit(error = encoder.AppendNameEntry("nn", Get<NetworkNameManager>().GetNetworkName().GetAsData()));
     SuccessOrExit(error = encoder.AppendEntry("xp", Get<ExtendedPanIdManager>().GetExtPanId()));
     SuccessOrExit(error = encoder.AppendStringEntry("tv", kThreadVersionString));

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -620,6 +620,7 @@ private:
 
     using ServiceTask = TaskletIn<BorderAgent, &BorderAgent::HandleServiceTask>;
 
+    static const char kTxtDataRecordVersion[];
 #if OPENTHREAD_CONFIG_BORDER_AGENT_MESHCOP_SERVICE_ENABLE
     static const char kServiceType[];
     static const char kDefaultBaseServiceName[];

--- a/tests/nexus/test_border_agent.cpp
+++ b/tests/nexus/test_border_agent.cpp
@@ -897,6 +897,7 @@ void ValidateMeshCoPTxtData(TxtData &aTxtData, Node &aNode)
 
     SuccessOrQuit(aNode.Get<BorderAgent>().GetId(id));
     aTxtData.ValidateKey("id", id);
+    aTxtData.ValidateKey("rv", "1");
     aTxtData.ValidateKey("nn", aNode.Get<NetworkNameManager>().GetNetworkName().GetAsCString());
     aTxtData.ValidateKey("xp", aNode.Get<ExtendedPanIdManager>().GetExtPanId());
     aTxtData.ValidateKey("tv", kThreadVersionString);


### PR DESCRIPTION
This commit updates `BorderAgent::PrepareServiceTxtData()` to include the "rv" key. This key represents the version of the TXT record format. Per the Thread specification, it must be set to "1". Values other than "1" are reserved for the future and MUST NOT be used.

This commit also updates `test_border_agent` to validate this key.