### PR TITLE
[dnssd] echo all questions in the response on `NameError`

### DIFF
--- a/tests/unit/test_dns_client.cpp
+++ b/tests/unit/test_dns_client.cpp
@@ -238,8 +238,9 @@ void FinalizeTest(void)
 
 //---------------------------------------------------------------------------------------------------------------------
 
-static const char kHostName[]     = "elden";
-static const char kHostFullName[] = "elden.default.service.arpa.";
+static const char kHostName[]        = "elden";
+static const char kHostFullName[]    = "elden.default.service.arpa.";
+static const char kNonExistingName[] = "noname.nodomain.";
 
 static const char kService1Name[]      = "_srv._udp";
 static const char kService1FullName[]  = "_srv._udp.default.service.arpa.";
@@ -803,6 +804,16 @@ void TestDnsClient(void)
     {
         VerifyOrQuit(addresses.Contains(sAddressInfo.mHostAddresses[index]));
     }
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Validate DNS Client `ResolveAddress()` for an invalid (non-existing) name
+
+    sAddressInfo.Reset();
+    Log("ResolveAddress(%s)", kNonExistingName);
+    SuccessOrQuit(dnsClient->ResolveAddress(kNonExistingName, AddressCallback, sInstance));
+    AdvanceTime(100);
+    VerifyOrQuit(sAddressInfo.mCallbackCount == 1);
+    VerifyOrQuit(sAddressInfo.mError == kErrorNotFound);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Validate DNS Client `ResolveIp4Address()`


### PR DESCRIPTION
This commit updates the DNSSD server/resolver to ensure it includes the questions in the response message when the returned RCODE is `NameError` (NXDOMAIN). It also clears the question count and any partially appended content if there is a failure to append all questions (when `kResponseServerFailure` (SERVFAIL) is returned).

It also adds a test case in `test_dns_client` to resolve a non-existent name and validate the included questions.

---

- Resolves #11505 