### PR TITLE
[trel] implement delayed peer removal in `PeerTable`

### DIFF
--- a/src/core/radio/trel_peer_discoverer.hpp
+++ b/src/core/radio/trel_peer_discoverer.hpp
@@ -91,6 +91,8 @@ public:
     void NotifyPeerSocketAddressDifference(const Ip6::SockAddr &aPeerSockAddr, const Ip6::SockAddr &aRxSockAddr);
 
 private:
+    static constexpr uint32_t kRemoveDelay = 7 * Time::kOneSecondInMsec;
+
     class TxtData
     {
     public:


### PR DESCRIPTION
This commit updates `Trel::Peer` and `PeerTable` to allow scheduling a `Peer` for removal from the table after a given delay. This enables smoother peer removal, especially for transient issues, by avoiding abrupt disconnections.

To implement this, a `State` has been added to the `Peer` class, tracking whether a peer is in `kStateValid` or `kStateRemoving`. If a peer scheduled for removal is discovered again, it will be re-added and marked as valid. Logging is also updated to show these new state transitions. Additionally, `EvictPeer()` is updated to prioritize evicting peers already scheduled for removal.

To ensure consistent API behavior, peers that are scheduled for removal are skipped when iterating over the peer table using `otTrelGetNextPeer()` or `otTrelGetNumberOfPeers()`.