### PR TITLE
[posix] add runtime configuration file path support

### DIFF
--- a/src/posix/platform/config_file.cpp
+++ b/src/posix/platform/config_file.cpp
@@ -43,11 +43,14 @@
 namespace ot {
 namespace Posix {
 
-ConfigFile::ConfigFile(const char *aFilePath)
-    : mFilePath(aFilePath)
+ConfigFile::ConfigFile(const char *aFilePath) { SetFilePath(aFilePath); }
+
+void ConfigFile::SetFilePath(const char *aFilePath)
 {
-    assert(mFilePath != nullptr);
-    VerifyOrDie(strlen(mFilePath) + strlen(kSwapSuffix) < kFilePathMaxSize, OT_EXIT_FAILURE);
+    assert(aFilePath != nullptr);
+    VerifyOrDie(strlen(aFilePath) + strlen(kSwapSuffix) < kFilePathMaxSize, OT_EXIT_FAILURE);
+    strncpy(mFilePath, aFilePath, kFilePathMaxSize - 1);
+    mFilePath[kFilePathMaxSize - 1] = '\0';
 }
 
 bool ConfigFile::HasKey(const char *aKey) const

--- a/src/posix/platform/config_file.hpp
+++ b/src/posix/platform/config_file.hpp
@@ -51,6 +51,20 @@ public:
     explicit ConfigFile(const char *aFilePath);
 
     /**
+     * Sets the configuration file path.
+     *
+     * @param[in]  aFilePath  A pointer to the null-terminated file path.
+     */
+    void SetFilePath(const char *aFilePath);
+
+    /**
+     * Gets the configuration file path.
+     *
+     * @returns A pointer to the null-terminated file path.
+     */
+    const char *GetFilePath(void) const { return mFilePath; }
+
+    /**
      * Gets a configuration from the configuration file.
      *
      * @param[in]      aKey          The key string associated with the requested configuration.
@@ -113,7 +127,7 @@ private:
 
     void Strip(char *aString) const;
 
-    const char *mFilePath;
+    char mFilePath[kFilePathMaxSize];
 };
 
 } // namespace Posix

--- a/src/posix/platform/configuration.cpp
+++ b/src/posix/platform/configuration.cpp
@@ -54,6 +54,38 @@ const char Configuration::kKeySupportedChannelMask[] = "supported_channel_mask";
 const char Configuration::kKeyPreferredChannelMask[] = "preferred_channel_mask";
 const char Configuration::kCommaDelimiter[]          = ",";
 
+otError Configuration::SetFactoryConfigFile(const char *aFilePath)
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(aFilePath != nullptr, error = OT_ERROR_INVALID_ARGS);
+    mFactoryConfigFile.SetFilePath(aFilePath);
+    LogInfo("Factory configuration file path set to: %s", mFactoryConfigFile.GetFilePath());
+
+exit:
+    if (error == OT_ERROR_INVALID_ARGS)
+    {
+        LogCrit("Failed to set factory config file: %s", otThreadErrorToString(error));
+    }
+    return error;
+}
+
+otError Configuration::SetProductConfigFile(const char *aFilePath)
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(aFilePath != nullptr, error = OT_ERROR_INVALID_ARGS);
+    mProductConfigFile.SetFilePath(aFilePath);
+    LogInfo("Product configuration file path set to: %s", mProductConfigFile.GetFilePath());
+
+exit:
+    if (error == OT_ERROR_INVALID_ARGS)
+    {
+        LogCrit("Failed to set product config file: %s", otThreadErrorToString(error));
+    }
+    return error;
+}
+
 otError Configuration::SetRegion(uint16_t aRegionCode)
 {
     otError       error = OT_ERROR_NONE;

--- a/src/posix/platform/configuration.hpp
+++ b/src/posix/platform/configuration.hpp
@@ -67,6 +67,28 @@ public:
     }
 
     /**
+     * @brief Sets the path for the factory configuration file.
+     *
+     * @param[in] aFilePath  A null-terminated C string representing the new path to the
+     *                       factory configuration file. This parameter MUST NOT be `nullptr`.
+     *
+     * @retval OT_ERROR_NONE           The factory configuration file path was successfully updated.
+     * @retval OT_ERROR_INVALID_ARGS   If @p aFilePath is `nullptr`.
+     */
+    otError SetFactoryConfigFile(const char *aFilePath);
+
+    /**
+     * @brief Sets the path for the product configuration file.
+     *
+     * @param[in] aFilePath  A null-terminated C string representing the new path to the
+     *                       product configuration file. This parameter MUST NOT be `nullptr`.
+     *
+     * @retval OT_ERROR_NONE           The product configuration file path was successfully updated.
+     * @retval OT_ERROR_INVALID_ARGS   If @p aFilePath is `nullptr`.
+     */
+    otError SetProductConfigFile(const char *aFilePath);
+
+    /**
      * Set the region code.
      *
      * The radio region format is the 2-bytes ascii representation of the

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -170,6 +170,20 @@ void Radio::ProcessRadioUrl(const RadioUrl &aRadioUrl)
         mRadioSpinel.SetBusLatency(busLatency);
     }
 
+#if OPENTHREAD_POSIX_CONFIG_CONFIGURATION_FILE_ENABLE
+    if (aRadioUrl.HasParam("product-config-file"))
+    {
+        const char *configFile = aRadioUrl.GetValue("product-config-file");
+        SuccessOrDie(sConfig.SetProductConfigFile(configFile));
+    }
+
+    if (aRadioUrl.HasParam("factory-config-file"))
+    {
+        const char *configFile = aRadioUrl.GetValue("factory-config-file");
+        SuccessOrDie(sConfig.SetFactoryConfigFile(configFile));
+    }
+#endif // OPENTHREAD_POSIX_CONFIG_CONFIGURATION_FILE_ENABLE
+
     ProcessMaxPowerTable(aRadioUrl);
 
 #if OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE

--- a/src/posix/platform/radio_url.cpp
+++ b/src/posix/platform/radio_url.cpp
@@ -130,6 +130,14 @@ const char *otSysGetRadioUrlHelpString(void)
            "                                  Upto three IIDs can be provided with each IID separated by ',' \n"
            "                                  e.g. iid-list=1,2,3 \n"
 #endif
+#if OPENTHREAD_POSIX_CONFIG_CONFIGURATION_FILE_ENABLE
+           "    product-config-file[=path]    Specify a custom path to the openthread.conf product configuration\n"
+           "                                  file.\n"
+           "                                  If not specified, the default path set at build time is used.\n"
+           "    factory-config-file[=path]    Specify a custom path to the openthread.conf factory configuration\n"
+           "                                  file.\n"
+           "                                  If not specified, the default path set at build time is used.\n"
+#endif // OPENTHREAD_POSIX_CONFIG_CONFIGURATION_FILE_ENABLE
         ;
 }
 


### PR DESCRIPTION
This commit enhances the POSIX platform configuration system to support
dynamic configuration file paths at runtime instead of only build-time paths.

ConfigFile class:
- Replace const char* mFilePath with char mFilePath[kFilePathMaxSize] to allow
  dynamic path updates after construction
- Add SetFilePath() and GetFilePath() methods
- Update constructor to use SetFilePath() with proper bounds checking

Configuration class:
- Add SetFactoryConfigFile() and SetProductConfigFile() methods to update
  factory and product config file paths

Radio URL parameter support:
- Add support for 'product-config-file' parameter in radio URL
- Add support for 'factory-config-file' parameter in radio URL