### PR TITLE
[gitignore] add python virtual env folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ cmake-build-*/**
 # Python bytecodes
 __pycache__
 
+# Python environments
+.venv/
+venv/
+
 # Unit test files
 CTestTestfile.cmake
 ot-test-*

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ cmake-build-*/**
 __pycache__
 
 # Python environments
-.venv/
+.venv
 venv/
 
 # Unit test files


### PR DESCRIPTION
python venv is used when running test in tools/cp-caps