### PR TITLE
[examples] define `OPENTHREAD_FTD` and `OPENTHREAD_MTD`

### DIFF
--- a/examples/apps/cli/ftd.cmake
+++ b/examples/apps/cli/ftd.cmake
@@ -33,6 +33,13 @@ add_executable(ot-cli-ftd
 
 target_include_directories(ot-cli-ftd PRIVATE ${COMMON_INCLUDES})
 
+target_compile_definitions(ot-cli-ftd
+    PRIVATE
+        OPENTHREAD_FTD=1
+        OPENTHREAD_MTD=0
+        OPENTHREAD_RADIO=0
+)
+
 if(NOT DEFINED OT_PLATFORM_LIB_FTD)
     set(OT_PLATFORM_LIB_FTD ${OT_PLATFORM_LIB})
 endif()

--- a/examples/apps/cli/mtd.cmake
+++ b/examples/apps/cli/mtd.cmake
@@ -33,6 +33,13 @@ add_executable(ot-cli-mtd
 
 target_include_directories(ot-cli-mtd PRIVATE ${COMMON_INCLUDES})
 
+target_compile_definitions(ot-cli-mtd
+    PRIVATE
+        OPENTHREAD_FTD=0
+        OPENTHREAD_MTD=1
+        OPENTHREAD_RADIO=0
+)
+
 if(NOT DEFINED OT_PLATFORM_LIB_MTD)
     set(OT_PLATFORM_LIB_MTD ${OT_PLATFORM_LIB})
 endif()

--- a/examples/apps/cli/radio.cmake
+++ b/examples/apps/cli/radio.cmake
@@ -33,6 +33,13 @@ add_executable(ot-cli-radio
 
 target_include_directories(ot-cli-radio PRIVATE ${COMMON_INCLUDES})
 
+target_compile_definitions(ot-cli-radio
+    PRIVATE
+        OPENTHREAD_FTD=0
+        OPENTHREAD_MTD=0
+        OPENTHREAD_RADIO=1
+)
+
 if(NOT DEFINED OT_PLATFORM_LIB_RCP)
     set(OT_PLATFORM_LIB_RCP ${OT_PLATFORM_LIB})
 endif()


### PR DESCRIPTION
Resolves #6673 