### PR TITLE
Add "dataset active -nonactive" support.

### DIFF
--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -125,6 +125,7 @@ private:
     template <CommandId kCommandId> otError Process(Arg aArgs[]);
 
     otError Print(otOperationalDatasetTlvs &aDatasetTlvs);
+    otError PrintNonsensitive(otOperationalDatasetTlvs &aDatasetTlvs);
 
 #if OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE && OPENTHREAD_FTD
     otError     ProcessUpdater(Arg aArgs[]);

--- a/tests/scripts/expect/cli-dataset.exp
+++ b/tests/scripts/expect/cli-dataset.exp
@@ -45,6 +45,15 @@ expect -re {Network Name: [^\r\n]+}
 expect -re {PAN ID: 0x[0-9a-f]{4}}
 expect -re {PSKc: [0-9a-f]{32}}
 expect -re {Security Policy: \d+ o?n?r?c?b?}
+send "dataset active -nonsensitive\n"
+expect -re {Active Timestamp: \d+}
+expect -re {Channel: (\d+)}
+expect -re {Channel Mask: 0x[0-9a-f]{8}}
+expect -re {Ext PAN ID: [0-9a-f]{16}}
+expect -re {Mesh Local Prefix: ([0-9a-f]{1,4}:){3}[0-9a-f]{1,4}::\/64}
+expect -re {Network Name: [^\r\n]+}
+expect -re {PAN ID: 0x[0-9a-f]{4}}
+expect -re {Security Policy: \d+ o?n?r?c?b?}
 send "dataset pending\n"
 expect "Error 23: NotFound"
 send "dataset init active\n"
@@ -135,6 +144,22 @@ expect "Network Key: aabbccddeeff00112233445566778899"
 expect "Network Name: OT-network"
 expect "PAN ID: 0xface"
 expect "PSKc: 00112233445566778899aabbccddeeff"
+expect "Security Policy: 678 onrc"
+expect_line "Done"
+send "dataset pending -nonsensitive"
+expect "Pending Timestamp: 100"
+expect "Active Timestamp: 100"
+if {$channel == 11} {
+    expect "Channel: 18"
+} else {
+    expect "Channel: 11"
+}
+expect "Channel Mask: 0x03fff800"
+expect -re {Delay: \d+}
+expect "Ext PAN ID: aabbccddeeff0011"
+expect "Mesh Local Prefix: fdde:4860:0:0::/64"
+expect "Network Name: OT-network"
+expect "PAN ID: 0xface"
 expect "Security Policy: 678 onrc"
 expect_line "Done"
 send "dataset pending -x\n"


### PR DESCRIPTION
This CLI command prints out the nonsensitive data set fields, i.e., excluding the network key and PSKc fields.