### PR TITLE
[docs] add guide on using python venv for cp-caps test

### DIFF
--- a/tools/cp-caps/README.md
+++ b/tools/cp-caps/README.md
@@ -20,12 +20,42 @@ This test is used for testing RCP capabilities.
 - DUT : The device under test.
 - Reference Device : The device that supports all tested features.
 
-### Python Dependences
+## Python Virtual Environment Setup
 
-Before running the test script on PC, testers should install dependences first.
+It is recommended to use a Python virtual environment to manage project dependencies and avoid conflicts with system-wide packages.
+
+### Creation
+
+Create a virtual environment named `.venv` in the project directory:
+```bash
+$ cd openthread
+$ python3 -m venv .venv
+```
+
+### Activation
+
+Activate the virtual environment using the following command:
+
+```bash
+$ source .venv/bin/activate
+```
+
+After activation, your shell prompt should indicate that you are working within the virtual environment.
+
+### Dependency Installation
+
+Once the virtual environment is activated, install the required dependencies using `pip`:
 
 ```bash
 $ pip3 install -r ./tools/cp-caps/requirements.txt ./tools/otci
+```
+
+### Deactivation
+
+When you are finished working in the virtual environment, you can deactivate it by running the following command. This will return you to your system's global Python environment.
+
+```bash
+$ deactivate
 ```
 
 ### Reference Device

--- a/tools/cp-caps/README.md
+++ b/tools/cp-caps/README.md
@@ -46,6 +46,7 @@ It is recommended to use a Python virtual environment to manage project dependen
 ### Creation
 
 Create a virtual environment named `.venv` in the project directory:
+
 ```bash
 $ cd openthread
 $ python3 -m venv .venv

--- a/tools/cp-caps/README.md
+++ b/tools/cp-caps/README.md
@@ -20,6 +20,25 @@ This test is used for testing RCP capabilities.
 - DUT : The device under test.
 - Reference Device : The device that supports all tested features.
 
+### Reference Device
+
+The [nRF52840DK][ot-nrf528xx-nrf52840] is set as the reference device by default. Testers can also select the other Thread device as the reference device.
+
+[ot-nrf528xx-nrf52840]: https://github.com/openthread/ot-nrf528xx/blob/main/src/nrf52840/README.md
+
+Quick guide to setting up the nRF52840DK:
+
+```bash
+$ git clone git@github.com:openthread/ot-nrf528xx.git
+$ cd ot-nrf528xx/
+$ git submodule update --init
+$ ./script/bootstrap
+$ ./script/build nrf52840 UART_trans -DOT_DIAGNOSTIC=ON -DOT_CSL_RECEIVER=ON -DOT_LINK_METRICS_INITIATOR=ON -DOT_LINK_METRICS_SUBJECT=ON -DOT_WAKEUP_COORDINATOR=ON
+$ arm-none-eabi-objcopy -O ihex build/bin/ot-cli-ftd ot-cli-ftd.hex
+$ nrfutil device program --firmware ot-cli-ftd.hex --options chip_erase_mode=ERASE_ALL
+$ nrfutil device reset --reset-kind=RESET_PIN
+```
+
 ## Python Virtual Environment Setup
 
 It is recommended to use a Python virtual environment to manage project dependencies and avoid conflicts with system-wide packages.
@@ -56,25 +75,6 @@ When you are finished working in the virtual environment, you can deactivate it 
 
 ```bash
 $ deactivate
-```
-
-### Reference Device
-
-The [nRF52840DK][ot-nrf528xx-nrf52840] is set as the reference device by default. Testers can also select the other Thread device as the reference device.
-
-[ot-nrf528xx-nrf52840]: https://github.com/openthread/ot-nrf528xx/blob/main/src/nrf52840/README.md
-
-Quick guide to setting up the nRF52840DK:
-
-```bash
-$ git clone git@github.com:openthread/ot-nrf528xx.git
-$ cd ot-nrf528xx/
-$ git submodule update --init
-$ ./script/bootstrap
-$ ./script/build nrf52840 UART_trans -DOT_DIAGNOSTIC=ON -DOT_CSL_RECEIVER=ON -DOT_LINK_METRICS_INITIATOR=ON -DOT_LINK_METRICS_SUBJECT=ON -DOT_WAKEUP_COORDINATOR=ON
-$ arm-none-eabi-objcopy -O ihex build/bin/ot-cli-ftd ot-cli-ftd.hex
-$ nrfutil device program --firmware ot-cli-ftd.hex --options chip_erase_mode=ERASE_ALL
-$ nrfutil device reset --reset-kind=RESET_PIN
 ```
 
 ## Test Commands


### PR DESCRIPTION
Added comprehensive Python virtual environment setup guide to the cp-caps README.md file.

This includes detailed sections for creation,activation, dependency installation, and deactivation of virtual environments to help users properly set up their testing environment and avoid package conflicts.