### PR TITLE
[mle] Limit the number of better partition attach attempts to avoid flooding when advertisement trickle timer resets

### DIFF
--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -1192,7 +1192,14 @@ Error Mle::HandleAdvertisementOnFtd(RxInfo &aRxInfo, uint16_t aSourceAddress, co
 #endif
         )
         {
-            Attach(kBetterPartition);
+            // To avoid flooding of parent requests and parent dropping the request as duplicated (especially when
+            // neighbor belonging to different partition has the trickle timer reset), limit the better partition attach
+            // attempts
+            if ((TimerMilli::GetNow() - aRxInfo.mNeighbor->GetLastHeard()) >
+                (kParentRequestRouterTimeout - kParentRequestDuplicateMargin))
+            {
+                Attach(kBetterPartition);
+            }
         }
 
         ExitNow(error = kErrorDrop);


### PR DESCRIPTION
When the neighbor on different partition resets its trickle timer, it is possible to receive advertisements more frequently and each advertisement trigger a better partition attach attempt. This can flood the network and also the neighbor might drop the parent request if it is within parent request timeout duration. To avoid this, limit the better partition attach attempts to greater than parent request timeout duration. 