### PR TITLE
[trel] explicitly request trel ack for broadcast tx to known neighbors

### DIFF
--- a/src/core/radio/trel_interface.hpp
+++ b/src/core/radio/trel_interface.hpp
@@ -149,7 +149,7 @@ private:
 
     // Methods used by `Trel::Link`.
     void  Init(void);
-    Error Send(const Packet &aPacket, bool aIsDiscovery = false);
+    Error Send(Packet &aPacket, bool aIsDiscovery = false);
 
     // Callbacks from `otPlatTrel`.
     void HandleReceived(uint8_t *aBuffer, uint16_t aLength, const Ip6::SockAddr &aSenderAddr);

--- a/src/core/radio/trel_link.hpp
+++ b/src/core/radio/trel_link.hpp
@@ -220,6 +220,7 @@ private:
 class NeighborInfo
 {
     friend class Link;
+    friend class Interface;
 
 private:
     uint32_t GetPendingTrelAckCount(void) const { return (mTrelPreviousPendingAcks + mTrelCurrentPendingAcks); }


### PR DESCRIPTION
This commit modifies the TREL module to explicitly request TREL acknowledgements for broadcast transmissions directed to known neighbors. This ensures quicker discovery of when a TREL peer is no longer available.