### PR TITLE
[dhcp6-client] remove undefined method declaration

### DIFF
--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -52,11 +52,6 @@ Client::Client(Instance &aInstance)
     ClearAllBytes(mIdentityAssociations);
 }
 
-bool Client::MatchNetifAddressWithPrefix(const Ip6::Netif::UnicastAddress &aNetifAddress, const Ip6::Prefix &aIp6Prefix)
-{
-    return aNetifAddress.HasPrefix(aIp6Prefix);
-}
-
 void Client::UpdateAddresses(void)
 {
     bool                            found          = false;
@@ -82,7 +77,7 @@ void Client::UpdateAddresses(void)
                 continue;
             }
 
-            if (MatchNetifAddressWithPrefix(idAssociation.mNetifAddress, config.GetPrefix()))
+            if (idAssociation.mNetifAddress.HasPrefix(config.GetPrefix()))
             {
                 found = true;
                 break;
@@ -121,7 +116,7 @@ void Client::UpdateAddresses(void)
                     idAssociation = &ia;
                 }
             }
-            else if (MatchNetifAddressWithPrefix(ia.mNetifAddress, config.GetPrefix()))
+            else if (ia.mNetifAddress.HasPrefix(config.GetPrefix()))
             {
                 found         = true;
                 idAssociation = &ia;

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -81,6 +81,7 @@ public:
     void UpdateAddresses(void);
 
 private:
+    static constexpr uint16_t kNumPrefixes      = OPENTHREAD_CONFIG_DHCP6_CLIENT_NUM_PREFIXES;
     static constexpr uint32_t kTrickleTimerImin = 1;
     static constexpr uint32_t kTrickleTimerImax = 120;
 
@@ -104,13 +105,7 @@ private:
     void Start(void);
     void Stop(void);
 
-    static bool MatchNetifAddressWithPrefix(const Ip6::Netif::UnicastAddress &aNetifAddress,
-                                            const Ip6::Prefix                &aIp6Prefix);
-
     void Solicit(uint16_t aRloc16);
-
-    void AddIdentityAssociation(uint16_t aRloc16, otIp6Prefix &aIp6Prefix);
-    void RemoveIdentityAssociation(uint16_t aRloc16, otIp6Prefix &aIp6Prefix);
 
     bool ProcessNextIdentityAssociation(void);
 
@@ -136,13 +131,11 @@ private:
 
     using ClientSocket = Ip6::Udp::SocketIn<Client, &Client::HandleUdpReceive>;
 
-    ClientSocket mSocket;
-    TrickleTimer mTrickleTimer;
-
-    TransactionId mTransactionId;
-    TimeMilli     mStartTime;
-
-    IdentityAssociation  mIdentityAssociations[OPENTHREAD_CONFIG_DHCP6_CLIENT_NUM_PREFIXES];
+    ClientSocket         mSocket;
+    TrickleTimer         mTrickleTimer;
+    TransactionId        mTransactionId;
+    TimeMilli            mStartTime;
+    IdentityAssociation  mIdentityAssociations[kNumPrefixes];
     IdentityAssociation *mIdentityAssociationCurrent;
 };
 


### PR DESCRIPTION
This commit removes an undefined method declaration in `Dhcp6::Client` and inlines a simple method used for prefix checks.