### PR TITLE
[notifier] streamline event delivery to core modules

### DIFF
--- a/src/core/backbone_router/bbr_leader.cpp
+++ b/src/core/backbone_router/bbr_leader.cpp
@@ -143,10 +143,13 @@ const char *Leader::DomainPrefixEventToString(DomainPrefixEvent aEvent)
 
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
-void Leader::Update(void)
+void Leader::HandleNotifierEvents(Events aEvents)
 {
-    UpdateBackboneRouterPrimary();
-    UpdateDomainPrefixConfig();
+    if (aEvents.Contains(kEventThreadNetdataChanged))
+    {
+        UpdateBackboneRouterPrimary();
+        UpdateDomainPrefixConfig();
+    }
 }
 
 void Leader::UpdateBackboneRouterPrimary(void)

--- a/src/core/backbone_router/bbr_leader.hpp
+++ b/src/core/backbone_router/bbr_leader.hpp
@@ -47,6 +47,7 @@
 #include "common/locator.hpp"
 #include "common/log.hpp"
 #include "common/non_copyable.hpp"
+#include "common/notifier.hpp"
 #include "net/ip6_address.hpp"
 
 namespace ot {
@@ -83,6 +84,8 @@ enum DomainPrefixEvent : uint8_t
  */
 class Leader : public InstanceLocator, private NonCopyable
 {
+    friend class ot::Notifier;
+
 public:
     // Primary Backbone Router Service state or state change.
     enum State : uint8_t
@@ -107,11 +110,6 @@ public:
      * Resets the cached Primary Backbone Router.
      */
     void Reset(void);
-
-    /**
-     * Updates the cached Primary Backbone Router if any when new network data is available.
-     */
-    void Update(void);
 
     /**
      * Gets the Primary Backbone Router in the Thread Network.
@@ -177,6 +175,7 @@ public:
     bool IsDomainUnicast(const Ip6::Address &aAddress) const;
 
 private:
+    void HandleNotifierEvents(Events aEvents);
     void UpdateBackboneRouterPrimary(void);
     void UpdateDomainPrefixConfig(void);
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -98,6 +98,18 @@ void Notifier::EmitEvents(void)
     // Emit events to core internal modules
 
     Get<Mle::Mle>().HandleNotifierEvents(events);
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
+    Get<BackboneRouter::Leader>().HandleNotifierEvents(events);
+#endif
+#if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
+    Get<Dhcp6::Server>().HandleNotifierEvents(events);
+#endif
+#if OPENTHREAD_CONFIG_NEIGHBOR_DISCOVERY_AGENT_ENABLE
+    Get<NeighborDiscovery::Agent>().HandleNotifierEvents(events);
+#endif
+#if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
+    Get<Dhcp6::Client>().HandleNotifierEvents(events);
+#endif
     Get<EnergyScanServer>().HandleNotifierEvents(events);
 #if OPENTHREAD_FTD
     Get<MeshCoP::JoinerRouter>().HandleNotifierEvents(events);

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -57,6 +57,14 @@ bool Client::MatchNetifAddressWithPrefix(const Ip6::Netif::UnicastAddress &aNeti
     return aNetifAddress.HasPrefix(aIp6Prefix);
 }
 
+void Client::HandleNotifierEvents(Events aEvents)
+{
+    if (aEvents.Contains(kEventThreadNetdataChanged))
+    {
+        UpdateAddresses();
+    }
+}
+
 void Client::UpdateAddresses(void)
 {
     bool                            found          = false;

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -41,6 +41,7 @@
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/non_copyable.hpp"
+#include "common/notifier.hpp"
 #include "common/timer.hpp"
 #include "common/trickle_timer.hpp"
 #include "mac/mac.hpp"
@@ -67,6 +68,8 @@ namespace Dhcp6 {
  */
 class Client : public InstanceLocator, private NonCopyable
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * Initializes the object.
@@ -74,11 +77,6 @@ public:
      * @param[in]  aInstance     A reference to the OpenThread instance.
      */
     explicit Client(Instance &aInstance);
-
-    /**
-     * Update addresses that shall be automatically created using DHCP.
-     */
-    void UpdateAddresses(void);
 
 private:
     static constexpr uint32_t kTrickleTimerImin = 1;
@@ -130,6 +128,9 @@ private:
     Error    ProcessIaNa(Message &aMessage, uint16_t aOffset);
     Error    ProcessStatusCode(Message &aMessage, uint16_t aOffset);
     Error    ProcessIaAddress(Message &aMessage, uint16_t aOffset);
+
+    void HandleNotifierEvents(Events aEvents);
+    void UpdateAddresses(void);
 
     static void HandleTrickleTimer(TrickleTimer &aTrickleTimer);
     void        HandleTrickleTimer(void);

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -51,7 +51,15 @@ Server::Server(Instance &aInstance)
     ClearAllBytes(mPrefixAgents);
 }
 
-Error Server::UpdateService(void)
+void Server::HandleNotifierEvents(Events aEvents)
+{
+    if (aEvents.Contains(kEventThreadNetdataChanged))
+    {
+        UpdateService();
+    }
+}
+
+void Server::UpdateService(void)
 {
     Error                           error  = kErrorNone;
     uint16_t                        rloc16 = Get<Mle::Mle>().GetRloc16();
@@ -122,8 +130,6 @@ Error Server::UpdateService(void)
     {
         Stop();
     }
-
-    return error;
 }
 
 void Server::Start(void)

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -40,6 +40,7 @@
 
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
+#include "common/notifier.hpp"
 #include "mac/mac.hpp"
 #include "mac/mac_types.hpp"
 #include "net/dhcp6.hpp"
@@ -64,6 +65,8 @@ namespace Dhcp6 {
 
 class Server : public InstanceLocator, private NonCopyable
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * Initializes the object.
@@ -71,11 +74,6 @@ public:
      * @param[in]  aInstance     A reference to the OpenThread instance.
      */
     explicit Server(Instance &aInstance);
-
-    /**
-     * Updates DHCP Agents and DHCP ALOCs.
-     */
-    Error UpdateService(void);
 
 private:
     class PrefixAgent
@@ -164,6 +162,9 @@ private:
     };
 
     static constexpr uint16_t kNumPrefixes = OPENTHREAD_CONFIG_DHCP6_SERVER_NUM_PREFIXES;
+
+    void HandleNotifierEvents(Events aEvents);
+    void UpdateService(void);
 
     void Start(void);
     void Stop(void);

--- a/src/core/net/nd_agent.cpp
+++ b/src/core/net/nd_agent.cpp
@@ -40,6 +40,14 @@
 namespace ot {
 namespace NeighborDiscovery {
 
+void Agent::HandleNotifierEvents(Events aEvents)
+{
+    if (aEvents.Contains(kEventThreadNetdataChanged))
+    {
+        UpdateService();
+    }
+}
+
 void Agent::UpdateService(void)
 {
     Error                           error;

--- a/src/core/net/nd_agent.hpp
+++ b/src/core/net/nd_agent.hpp
@@ -40,6 +40,7 @@
 
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
+#include "common/notifier.hpp"
 #include "net/netif.hpp"
 
 namespace ot {
@@ -47,6 +48,8 @@ namespace NeighborDiscovery {
 
 class Agent : public InstanceLocator, private NonCopyable
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * Initializes the object.
@@ -59,14 +62,12 @@ public:
         FreeAloc();
     }
 
-    /**
-     * Updates the Neighbor Discovery Agents using current Thread Network Data.
-     */
-    void UpdateService(void);
-
 private:
     void FreeAloc(void) { mAloc.mNext = &mAloc; }
     bool IsAlocInUse(void) const { return mAloc.mNext != &mAloc; }
+
+    void HandleNotifierEvents(Events aEvents);
+    void UpdateService(void);
 
     Ip6::Netif::UnicastAddress mAloc;
 };

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1222,23 +1222,8 @@ void Mle::HandleNotifierEvents(Events aEvents)
             }
         }
 
-#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-        Get<BackboneRouter::Leader>().Update();
-#endif
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
         UpdateServiceAlocs();
-#endif
-
-#if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
-        IgnoreError(Get<Dhcp6::Server>().UpdateService());
-#endif
-
-#if OPENTHREAD_CONFIG_NEIGHBOR_DISCOVERY_AGENT_ENABLE
-        Get<NeighborDiscovery::Agent>().UpdateService();
-#endif
-
-#if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
-        Get<Dhcp6::Client>().UpdateAddresses();
 #endif
     }
 


### PR DESCRIPTION
This commit updates the `Notifier` to directly signal events to `BackboneRouter::Leader`, `Dhcp6::Server`, `Dhcp6::Client`, and `NeighborDiscovery::Agent`. These classes were previously notified indirectly through `Mle::HandleNotifierEvent()`.