### PR TITLE
[dhcp6] style fixes and minor enhancements

### DIFF
--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -110,21 +110,21 @@ private:
     bool ProcessNextIdentityAssociation(void);
 
     Error AppendHeader(Message &aMessage);
-    Error AppendClientIdentifier(Message &aMessage);
-    Error AppendIaNa(Message &aMessage, uint16_t aRloc16);
-    Error AppendIaAddress(Message &aMessage, uint16_t aRloc16);
-    Error AppendElapsedTime(Message &aMessage);
-    Error AppendRapidCommit(Message &aMessage);
+    Error AppendClientIdOption(Message &aMessage);
+    Error AppendIaNaOption(Message &aMessage, uint16_t aRloc16);
+    Error AppendIaAddressOption(Message &aMessage, uint16_t aRloc16);
+    Error AppendElapsedTimeOption(Message &aMessage);
+    Error AppendRapidCommitOption(Message &aMessage);
 
     void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     void     ProcessReply(Message &aMessage);
-    uint16_t FindOption(Message &aMessage, uint16_t aOffset, uint16_t aLength, Code aCode);
-    Error    ProcessServerIdentifier(Message &aMessage, uint16_t aOffset);
-    Error    ProcessClientIdentifier(Message &aMessage, uint16_t aOffset);
-    Error    ProcessIaNa(Message &aMessage, uint16_t aOffset);
-    Error    ProcessStatusCode(Message &aMessage, uint16_t aOffset);
-    Error    ProcessIaAddress(Message &aMessage, uint16_t aOffset);
+    uint16_t FindOption(Message &aMessage, uint16_t aOffset, uint16_t aLength, Option::Code aCode);
+    Error    ProcessServerIdOption(Message &aMessage, uint16_t aOffset);
+    Error    ProcessClientIdOption(Message &aMessage, uint16_t aOffset);
+    Error    ProcessIaNaOption(Message &aMessage, uint16_t aOffset);
+    Error    ProcessStatusCodeOption(Message &aMessage, uint16_t aOffset);
+    Error    ProcessIaAddressOption(Message &aMessage, uint16_t aOffset);
 
     static void HandleTrickleTimer(TrickleTimer &aTrickleTimer);
     void        HandleTrickleTimer(void);

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -171,28 +171,28 @@ private:
     void AddPrefixAgent(const Ip6::Prefix &aIp6Prefix, const Lowpan::Context &aContext);
 
     Error AppendHeader(Message &aMessage, const TransactionId &aTransactionId);
-    Error AppendClientIdentifier(Message &aMessage, ClientIdentifier &aClientId);
-    Error AppendServerIdentifier(Message &aMessage);
-    Error AppendIaNa(Message &aMessage, IaNa &aIaNa);
-    Error AppendStatusCode(Message &aMessage, Status aStatusCode);
-    Error AppendIaAddress(Message &aMessage, ClientIdentifier &aClientId);
-    Error AppendRapidCommit(Message &aMessage);
+    Error AppendClientIdOption(Message &aMessage, ClientIdOption &aClientIdOption);
+    Error AppendServerIdOption(Message &aMessage);
+    Error AppendIaNaOption(Message &aMessage, IaNaOption &aIaNaOption);
+    Error AppendStatusCodeOption(Message &aMessage, StatusCodeOption::Status aStatusCode);
+    Error AppendIaAddressOption(Message &aMessage, ClientIdOption &aClientIdOption);
+    Error AppendRapidCommitOption(Message &aMessage);
     Error AppendVendorSpecificInformation(Message &aMessage);
 
-    Error AddIaAddress(Message &aMessage, const Ip6::Address &aPrefix, ClientIdentifier &aClientId);
+    Error AddIaAddressOption(Message &aMessage, const Ip6::Address &aPrefix, ClientIdOption &aClientIdOption);
     void  HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void  ProcessSolicit(Message &aMessage, const Ip6::Address &aDst, const TransactionId &aTransactionId);
 
-    uint16_t FindOption(Message &aMessage, uint16_t aOffset, uint16_t aLength, Code aCode);
-    Error    ProcessClientIdentifier(Message &aMessage, uint16_t aOffset, ClientIdentifier &aClientId);
-    Error    ProcessIaNa(Message &aMessage, uint16_t aOffset, IaNa &aIaNa);
-    Error    ProcessIaAddress(Message &aMessage, uint16_t aOffset);
-    Error    ProcessElapsedTime(Message &aMessage, uint16_t aOffset);
+    uint16_t FindOption(Message &aMessage, uint16_t aOffset, uint16_t aLength, Option::Code aCode);
+    Error    ProcessClientIdOption(Message &aMessage, uint16_t aOffset, ClientIdOption &aClientIdOption);
+    Error    ProcessIaNaOption(Message &aMessage, uint16_t aOffset, IaNaOption &aIaNaOption);
+    Error    ProcessIaAddressOption(Message &aMessage, uint16_t aOffset);
+    Error    ProcessElapsedTimeOption(Message &aMessage, uint16_t aOffset);
 
     Error SendReply(const Ip6::Address  &aDst,
                     const TransactionId &aTransactionId,
-                    ClientIdentifier    &aClientId,
-                    IaNa                &aIaNa);
+                    ClientIdOption      &aClientIdOption,
+                    IaNaOption          &aIaNaOption);
 
     using ServerSocket = Ip6::Udp::SocketIn<Server, &Server::HandleUdpReceive>;
 


### PR DESCRIPTION
This commit contains style fixes and smaller enhancements in DHCP6-related definitions and types. Mainly, the DHCP6 `Option` sub-classes are renamed to include the `Option` suffix (e.g., `IaAddressOption`), harmonizing the naming style with `Tlv` and other `Option` classes (e.g., `Nd6` or `Dns` options).