### PR TITLE
[posix] fix misleading log message in DNS resolver

### DIFF
--- a/src/posix/platform/resolver.cpp
+++ b/src/posix/platform/resolver.cpp
@@ -143,7 +143,7 @@ void Resolver::LoadDnsServerListFromConf(void)
 
     if (mUpstreamDnsServerCount == 0)
     {
-        LogCrit("No domain name servers found in %s, default to 127.0.0.1", kResolvConfFullPath);
+        LogCrit("No domain name servers found in %s", kResolvConfFullPath);
     }
 
     mUpstreamDnsServerListFreshness = otPlatTimeGet();


### PR DESCRIPTION
The log message "No domain name servers found in %s, default to 127.0.0.1" is misleading because the code does not actually default to 127.0.0.1 if no nameservers are found. 

This commit updates the log message to accurately reflect the behavior.