### PR TITLE
[posix] DNS resolver to handle link-local server address

### DIFF
--- a/src/posix/platform/resolver.cpp
+++ b/src/posix/platform/resolver.cpp
@@ -249,6 +249,11 @@ otError Resolver::SendQueryToServer(Transaction        *aTxn,
         memcpy(&serverAddr6.sin6_addr, &aServerAddress, sizeof(otIp6Address));
         serverAddr6.sin6_family = AF_INET6;
         serverAddr6.sin6_port   = htons(53);
+        if (IsIp6AddressLinkLocal(aServerAddress))
+        {
+            // Network interface index is required for link local destinations
+            serverAddr6.sin6_scope_id = otSysGetInfraNetifIndex();
+        }
 
         VerifyOrExit(sendto(aTxn->mUdpFd6, aPacket, aLength, MSG_DONTWAIT, reinterpret_cast<sockaddr *>(&serverAddr6),
                             sizeof(serverAddr6)) > 0,


### PR DESCRIPTION
When `sendto` is used with a Link-Local IPv6 destination, the index of the outgoing network interface must be included. 