### PR TITLE
[tcp][posix] ensure struct fields are initialized

### DIFF
--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -163,6 +163,7 @@ Error Tcp::Endpoint::Connect(const SockAddr &aSockName, uint32_t aFlags)
         struct sockaddr_in6 sin6p;
 
         tp.t_flags &= ~TF_FASTOPEN;
+        memset(&sin6p, 0, sizeof(sin6p));
         memcpy(&sin6p.sin6_addr, &aSockName.mAddress, sizeof(sin6p.sin6_addr));
         sin6p.sin6_port = BigEndian::HostSwap16(aSockName.mPort);
         error           = BsdErrorToOtError(tcp6_usr_connect(&tp, &sin6p));
@@ -193,6 +194,7 @@ Error Tcp::Endpoint::SendByReference(otLinkedBuffer &aBuffer, uint32_t aFlags)
 
     if (IS_FASTOPEN(tp.t_flags))
     {
+        memset(&sin6p, 0, sizeof(sin6p));
         memcpy(&sin6p.sin6_addr, &tp.faddr, sizeof(sin6p.sin6_addr));
         sin6p.sin6_port = tp.fport;
         name            = &sin6p;
@@ -221,6 +223,7 @@ Error Tcp::Endpoint::SendByExtension(size_t aNumBytes, uint32_t aFlags)
 
     if (IS_FASTOPEN(tp.t_flags))
     {
+        memset(&sin6p, 0, sizeof(sin6p));
         memcpy(&sin6p.sin6_addr, &tp.faddr, sizeof(sin6p.sin6_addr));
         sin6p.sin6_port = tp.fport;
         name            = &sin6p;

--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -163,7 +163,7 @@ Error Tcp::Endpoint::Connect(const SockAddr &aSockName, uint32_t aFlags)
         struct sockaddr_in6 sin6p;
 
         tp.t_flags &= ~TF_FASTOPEN;
-        memset(&sin6p, 0, sizeof(sin6p));
+        ClearAllBytes(sin6p);
         memcpy(&sin6p.sin6_addr, &aSockName.mAddress, sizeof(sin6p.sin6_addr));
         sin6p.sin6_port = BigEndian::HostSwap16(aSockName.mPort);
         error           = BsdErrorToOtError(tcp6_usr_connect(&tp, &sin6p));
@@ -194,7 +194,7 @@ Error Tcp::Endpoint::SendByReference(otLinkedBuffer &aBuffer, uint32_t aFlags)
 
     if (IS_FASTOPEN(tp.t_flags))
     {
-        memset(&sin6p, 0, sizeof(sin6p));
+        ClearAllBytes(sin6p);
         memcpy(&sin6p.sin6_addr, &tp.faddr, sizeof(sin6p.sin6_addr));
         sin6p.sin6_port = tp.fport;
         name            = &sin6p;

--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -223,7 +223,7 @@ Error Tcp::Endpoint::SendByExtension(size_t aNumBytes, uint32_t aFlags)
 
     if (IS_FASTOPEN(tp.t_flags))
     {
-        memset(&sin6p, 0, sizeof(sin6p));
+        ClearAllBytes(sin6p);
         memcpy(&sin6p.sin6_addr, &tp.faddr, sizeof(sin6p.sin6_addr));
         sin6p.sin6_port = tp.fport;
         name            = &sin6p;

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -474,7 +474,7 @@ otError otPlatUdpJoinMulticastGroup(otUdpSocket        *aUdpSocket,
     switch (aNetifIdentifier)
     {
     case OT_NETIF_UNSPECIFIED:
-        mreq.ipv6mr_interface = 0;
+        mreq.ipv6mr_interface = 0; // Explicitly set to 0 to clarify intention.
         break;
     case OT_NETIF_THREAD_HOST:
         mreq.ipv6mr_interface = gNetifIndex;
@@ -518,7 +518,7 @@ otError otPlatUdpLeaveMulticastGroup(otUdpSocket        *aUdpSocket,
     switch (aNetifIdentifier)
     {
     case OT_NETIF_UNSPECIFIED:
-        mreq.ipv6mr_interface = 0;
+        mreq.ipv6mr_interface = 0; // Explicitly set to 0 to clarify intention.
         break;
     case OT_NETIF_THREAD_HOST:
         mreq.ipv6mr_interface = gNetifIndex;

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -463,7 +463,7 @@ otError otPlatUdpJoinMulticastGroup(otUdpSocket        *aUdpSocket,
                                     const otIp6Address *aAddress)
 {
     otError          error = OT_ERROR_NONE;
-    struct ipv6_mreq mreq;
+    struct ipv6_mreq mreq  = {};
     int              fd;
 
     VerifyOrExit(aUdpSocket->mHandle != nullptr, error = OT_ERROR_INVALID_ARGS);
@@ -474,6 +474,7 @@ otError otPlatUdpJoinMulticastGroup(otUdpSocket        *aUdpSocket,
     switch (aNetifIdentifier)
     {
     case OT_NETIF_UNSPECIFIED:
+        mreq.ipv6mr_interface = 0;
         break;
     case OT_NETIF_THREAD_HOST:
         mreq.ipv6mr_interface = gNetifIndex;
@@ -506,7 +507,7 @@ otError otPlatUdpLeaveMulticastGroup(otUdpSocket        *aUdpSocket,
                                      const otIp6Address *aAddress)
 {
     otError          error = OT_ERROR_NONE;
-    struct ipv6_mreq mreq;
+    struct ipv6_mreq mreq  = {};
     int              fd;
 
     VerifyOrExit(aUdpSocket->mHandle != nullptr, error = OT_ERROR_INVALID_ARGS);
@@ -517,6 +518,7 @@ otError otPlatUdpLeaveMulticastGroup(otUdpSocket        *aUdpSocket,
     switch (aNetifIdentifier)
     {
     case OT_NETIF_UNSPECIFIED:
+        mreq.ipv6mr_interface = 0;
         break;
     case OT_NETIF_THREAD_HOST:
         mreq.ipv6mr_interface = gNetifIndex;


### PR DESCRIPTION
This aims to fix some instances in core/tcp6 and posix/udp where the complete struct was not initialized. In otPlatUdpJoinMulticastGroup and otPlatUdpLeaveMulticastGroup an explicit redundant setting to '0' is added just for clarity for people reading the code.