### PR TITLE
[secure-transport] add `~SecureSession(void)` destructor

### DIFF
--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -221,6 +221,7 @@ public:
 
 protected:
     explicit SecureSession(SecureTransport &aTransport);
+    ~SecureSession(void) { FreeMbedtls(); }
 
     bool IsSessionInUse(void) const { return (mNext != this); }
 


### PR DESCRIPTION
This commit adds a destructor for `SecureSession` which ensures the freeing of any mbedTls allocated items. This addresses memory leaks detected by fuzzer tests when `otInstance` is destroyed, though this situation is unlikely in typical OpenThread stack integrations.