### PR TITLE
[routing-manager] simplify PD prefix processing

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1709,8 +1709,8 @@ private:
 
         void UpdateState(void);
         void SetState(State aState);
-        void Process(const InfraIf::Icmp6Packet *aRaPacket, const PrefixTableEntry *aPrefixTableEntry);
-        void ProcessPdPrefix(PdPrefix &aPrefix, PdPrefix &aFavoredPrefix);
+        void EvaluateCandidatePrefix(PdPrefix &aPrefix, PdPrefix &aFavoredPrefix);
+        void ApplyFavoredPrefix(const PdPrefix &aFavoredPrefix);
         void WithdrawPrefix(void);
 
         static const char *StateToString(State aState);


### PR DESCRIPTION
This commit simplifies the processing of PD prefixes provided by the platform to `PdPrefixManager`. The platform can report DHCPv6 PD prefixes in two ways: through a Router Advertisement (RA) message containing Prefix Information Options (PIOs) or by providing a PD prefix directly.

Previously, these two paths were processed in a single method, which made the code harder to read and follow. This commit refactors the logic to separate these two paths while using common helper methods.

This change introduces `EvaluateCandidatePrefix()`, which evaluates a single candidate prefix and tracks the most favored one. After all candidates are evaluated, `ApplyFavoredPrefix()` is called to apply the most favored prefix and update the current PD prefix if necessary.