### PR TITLE
[posix] set sin6_scope_id / ipi6_ifindex for all transmits to link-local

### DIFF
--- a/examples/platforms/simulation/simul_utils.h
+++ b/examples/platforms/simulation/simul_utils.h
@@ -47,7 +47,7 @@ typedef struct utilsSocket
     union
     {
         struct sockaddr_in  mSockAddr4; ///< The IPv4 group sock address.
-        struct sockaddr_in6 mSockAddr6; ///< The IPv4 group sock address.
+        struct sockaddr_in6 mSockAddr6; ///< The IPv6 group sock address.
     } mGroupAddr;                       ///< The group sock address for simulating radio.
 } utilsSocket;
 


### PR DESCRIPTION
This will avoid the problem that scope id or ifindex remains 0 for a link-local transmission. If 0, the OS cannot decide which network interface to use based on address alone.