### PR TITLE
[secure-transport] add `~SecureTransport()` destructor

### DIFF
--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -721,6 +721,7 @@ public:
 
 protected:
     SecureTransport(Instance &aInstance, LinkSecurityMode aLayerTwoSecurity, bool aDatagramTransport);
+    ~SecureTransport(void) { Close(); }
 
 #if OPENTHREAD_CONFIG_TLS_API_ENABLE
     void SetExtension(Extension &aExtension) { mExtension = &aExtension; }


### PR DESCRIPTION
This commit adds a destructor for `SecureTransport` that closes the socket, and disconnects and removes any tracked sessions.

Removing the sessions ensures that the `SecureSession` instances and any data allocated within them are properly freed. This handles the case where the `otInstance` itself is destroyed, ensuring that all heap-allocated items are cleaned up correctly to prevent memory leaks.