### PR TITLE
[coap] match only token for multicast and anycast (#11570)

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1020,10 +1020,9 @@ Message *CoapBase::FindRelatedRequest(const Message          &aResponse,
     {
         aMetadata.ReadFrom(message);
 
-        if (((aMetadata.mDestinationAddress == aMessageInfo.GetPeerAddr()) ||
-             aMetadata.mDestinationAddress.IsMulticast() ||
-             aMetadata.mDestinationAddress.GetIid().IsAnycastLocator()) &&
-            (aMetadata.mDestinationPort == aMessageInfo.GetPeerPort()))
+        if (((aMetadata.mDestinationAddress == aMessageInfo.GetPeerAddr() &&
+              aMetadata.mDestinationPort == aMessageInfo.GetPeerPort()) ||
+             aMetadata.mDestinationAddress.IsMulticast() || aMetadata.mDestinationAddress.GetIid().IsAnycastLocator()))
         {
             switch (aResponse.GetType())
             {


### PR DESCRIPTION
Update coap message response matching according to CoAP [RFC 7252 - 8.2. Request/Response Layer](https://www.rfc-editor.org/rfc/rfc7252#section-8.2) resolving #11570.

I am not sure if anycast should also behave accordingly, currently expanded to anycast address aswell.