### PR TITLE
[otci] support reliable transport

### DIFF
--- a/.github/workflows/otci.yml
+++ b/.github/workflows/otci.yml
@@ -54,6 +54,7 @@ jobs:
         virtual_time: [0, 1]
     env:
       VIRTUAL_TIME: ${{ matrix.virtual_time }}
+      OT_VT_USE_UNIX_SOCKET: ${{ matrix.virtual_time }}
       REAL_DEVICE: 0
     steps:
     - name: Harden Runner

--- a/tests/scripts/thread-cert/simulator.py
+++ b/tests/scripts/thread-cert/simulator.py
@@ -111,6 +111,12 @@ class RealTime(BaseSimulator):
         return time.time()
 
     def go(self, duration, **kwargs):
+        """Proceed the simulator for a given duration (in seconds).
+
+        Args:
+            duration: The duration in seconds to proceed.
+            **kwargs: Additional keyword arguments.
+        """
         time.sleep(duration)
 
     def stop(self):
@@ -572,7 +578,17 @@ class VirtualTime(BaseSimulator):
     def now(self):
         return self.current_time / 1000000
 
-    def go(self, duration, nodeid=None, maybeoff=False):
+    def go(self, duration, **kwargs):
+        """Proceed the simulator for a given duration (in seconds).
+
+        Args:
+            duration: The duration in seconds to proceed.
+            **kwargs: Additional keyword arguments, such as `maybeoff` (bool)
+                      to indicate if a node might be off, or `nodeid` (int).
+        """
+
+        nodeid = kwargs.get('nodeid', None)
+        maybeoff = kwargs.get('maybeoff', False)
         assert self.current_time == self._pause_time
         duration = int(duration * 1000000)
         dbg_print('running for %d us' % duration)

--- a/tools/otci/otci/command_handlers.py
+++ b/tools/otci/otci/command_handlers.py
@@ -128,7 +128,7 @@ class OtCliCommandRunner(OTCommandHandler):
         self.__otcli.writeline(cmd)
 
         if cmd in ('reset', 'factoryreset'):
-            self.wait(3)
+            self.wait(3, maybeoff=True)
             self.__otcli.writeline('extaddr')
             self.wait(1)
             return []
@@ -145,8 +145,8 @@ class OtCliCommandRunner(OTCommandHandler):
     def execute_platform_command(self, cmd: str, timeout: float = 10) -> List[str]:
         raise NotImplementedError(f'Platform command is not supported on {self.__class__.__name__}')
 
-    def wait(self, duration: float) -> List[str]:
-        self.__otcli.wait(duration)
+    def wait(self, duration: float, maybeoff=False) -> List[str]:
+        self.__otcli.wait(duration, maybeoff=maybeoff)
 
         output: List[str] = []
         try:

--- a/tools/otci/otci/connectors.py
+++ b/tools/otci/otci/connectors.py
@@ -48,7 +48,7 @@ class OtCliHandler(ABC):
         """
 
     @abstractmethod
-    def wait(self, duration: float) -> None:
+    def wait(self, duration: float, **kwargs) -> None:
         """Method wait should wait for a given duration.
 
         A normal implementation should just call `time.sleep(duration)`. This is intended for proceeding Virtual Time
@@ -64,7 +64,7 @@ class Simulator(ABC):
     """This abstract class defines interfaces for a Virtual Time Simulator."""
 
     @abstractmethod
-    def go(self, duration: float):
+    def go(self, duration: float, **kwargs):
         """Proceed the simulator for a given duration (in seconds)."""
         pass
 
@@ -89,10 +89,13 @@ class OtCliPopen(OtCliHandler):
         self.__otcli_proc.stdin.write(s + '\n')
         self.__otcli_proc.stdin.flush()
 
-    def wait(self, duration: float):
+    def wait(self, duration: float, **kwargs):
         if self.__simulator is not None:
+            if kwargs.get('maybeoff', False):
+                kwargs['nodeid'] = self.__nodeid
+
             # Virtual time simulation
-            self.__simulator.go(duration)
+            self.__simulator.go(duration, **kwargs)
         else:
             # Real time simulation
             time.sleep(duration)
@@ -167,7 +170,7 @@ class OtCliSerial(OtCliHandler):
     def writeline(self, s: str):
         self.__serial.write((s + '\r\n').encode('utf-8'))
 
-    def wait(self, duration: float):
+    def wait(self, duration: float, **kwargs):
         time.sleep(duration)
 
     def close(self):


### PR DESCRIPTION
This commit adds reliable transport in OTCI and switch the OTCI tests to use the reliable simulation transport.