### PR TITLE
[utils] fix history tracker entry list issue

### DIFF
--- a/src/core/utils/history_tracker.hpp
+++ b/src/core/utils/history_tracker.hpp
@@ -410,6 +410,7 @@ private:
         Entry       *AddNewEntry(void) { return nullptr; }
         void         AddNewEntry(const Entry &) {}
         const Entry *Iterate(Iterator &, uint32_t &) const { return nullptr; }
+        void         UpdateAgedEntries(void) {}
         void         RemoveAgedEntries(void) {}
     };
 


### PR DESCRIPTION
Adds missing method `UpdateAgedEntries` for the template specialization of `EntryList` when size is 0.

Currently if we config any history entry size to 0, (for example, `OPENTHREAD_CONFIG_HISTORY_TRACKER_EPSKC_EVENT_SIZE`), the build fails:
```
/usr/local/home/irvingcl/Documents/git/openthread/src/core/utils/history_tracker.cpp: In member function ‘void ot::Utils::HistoryTracker::HandleTimer()’:                                                                                                                                                       
/usr/local/home/irvingcl/Documents/git/openthread/src/core/utils/history_tracker.cpp:468:24: error: ‘class ot::Utils::HistoryTracker::EntryList<otHistoryTrackerBorderAgentEpskcEvent, 0>’ has no member named ‘UpdateAgedEntries’; did you mean ‘RemoveAgedEntries’?                                           
  468 |     mEpskcEventHistory.UpdateAgedEntries();                                                                                                                                                                                                                                                                    
      |                        ^~~~~~~~~~~~~~~~~                                                                                                                                                                                                                                                                       
      |                        RemoveAgedEntries                                                                                                                                                                                                                                                                       
[427/792] Building CXX object src/core/CMakeFiles/openthread-ftd.dir/net/mdns.cpp.o                                                                                                                                                                                                                                    
ninja: build stopped: subcommand failed. 
```