### PR TITLE
[style] apply IWYU to public headers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,13 +63,14 @@ jobs:
     - name: Bootstrap
       run: |
         sudo apt-get update
-        sudo apt-get --no-install-recommends install -y clang-format-14 clang-tidy-14 shellcheck
+        sudo apt-get --no-install-recommends install -y clang-format-14 clang-tidy-14 shellcheck iwyu
         python3 -m pip install yapf==0.31.0
         sudo snap install shfmt
         npm install prettier@2.0.4
     - name: Check
       run: |
         script/make-pretty check
+        script/check-iwyu-public-header
 
   markdown-lint-check:
     runs-on: ubuntu-22.04

--- a/include/openthread/backbone_router.h
+++ b/include/openthread/backbone_router.h
@@ -35,6 +35,9 @@
 #ifndef OPENTHREAD_BACKBONE_ROUTER_H_
 #define OPENTHREAD_BACKBONE_ROUTER_H_
 
+#include <stdint.h>
+
+#include <openthread/error.h>
 #include <openthread/instance.h>
 
 #ifdef __cplusplus

--- a/include/openthread/backbone_router_ftd.h
+++ b/include/openthread/backbone_router_ftd.h
@@ -36,7 +36,12 @@
 #ifndef OPENTHREAD_BACKBONE_ROUTER_FTD_H_
 #define OPENTHREAD_BACKBONE_ROUTER_FTD_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include <openthread/backbone_router.h>
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/netdata.h>
 

--- a/include/openthread/ble_secure.h
+++ b/include/openthread/ble_secure.h
@@ -44,7 +44,12 @@
 #ifndef OPENTHREAD_BLE_SECURE_H_
 #define OPENTHREAD_BLE_SECURE_H_
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/message.h>
 #include <openthread/tcat.h>
 

--- a/include/openthread/border_agent.h
+++ b/include/openthread/border_agent.h
@@ -35,7 +35,11 @@
 #ifndef OPENTHREAD_BORDER_AGENT_H_
 #define OPENTHREAD_BORDER_AGENT_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include <openthread/dns.h>
+#include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
 

--- a/include/openthread/border_router.h
+++ b/include/openthread/border_router.h
@@ -35,7 +35,11 @@
 #ifndef OPENTHREAD_BORDER_ROUTER_H_
 #define OPENTHREAD_BORDER_ROUTER_H_
 
-#include <openthread/border_routing.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/netdata.h>
 

--- a/include/openthread/border_routing.h
+++ b/include/openthread/border_routing.h
@@ -35,7 +35,11 @@
 #ifndef OPENTHREAD_BORDER_ROUTING_H_
 #define OPENTHREAD_BORDER_ROUTING_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/netdata.h>
 

--- a/include/openthread/channel_manager.h
+++ b/include/openthread/channel_manager.h
@@ -35,6 +35,10 @@
 #ifndef OPENTHREAD_CHANNEL_MANAGER_H_
 #define OPENTHREAD_CHANNEL_MANAGER_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
 #include <openthread/instance.h>
 
 #ifdef __cplusplus

--- a/include/openthread/channel_monitor.h
+++ b/include/openthread/channel_monitor.h
@@ -35,6 +35,10 @@
 #ifndef OPENTHREAD_CHANNEL_MONITOR_H_
 #define OPENTHREAD_CHANNEL_MONITOR_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
 #include <openthread/instance.h>
 
 #ifdef __cplusplus

--- a/include/openthread/child_supervision.h
+++ b/include/openthread/child_supervision.h
@@ -35,6 +35,8 @@
 #ifndef OPENTHREAD_CHILD_SUPERVISION_H_
 #define OPENTHREAD_CHILD_SUPERVISION_H_
 
+#include <stdint.h>
+
 #include <openthread/instance.h>
 
 #ifdef __cplusplus

--- a/include/openthread/cli.h
+++ b/include/openthread/cli.h
@@ -38,6 +38,7 @@
 #include <stdarg.h>
 #include <stdint.h>
 
+#include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/platform/logging.h>
 

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -35,8 +35,12 @@
 #ifndef OPENTHREAD_COAP_H_
 #define OPENTHREAD_COAP_H_
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/message.h>
 

--- a/include/openthread/coap_secure.h
+++ b/include/openthread/coap_secure.h
@@ -44,9 +44,15 @@
 #ifndef OPENTHREAD_COAP_SECURE_H_
 #define OPENTHREAD_COAP_SECURE_H_
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include <openthread/coap.h>
+#include <openthread/error.h>
+#include <openthread/instance.h>
+#include <openthread/ip6.h>
+#include <openthread/message.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/commissioner.h
+++ b/include/openthread/commissioner.h
@@ -35,11 +35,14 @@
 #ifndef OPENTHREAD_COMMISSIONER_H_
 #define OPENTHREAD_COMMISSIONER_H_
 
-#include <openthread/dataset.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/joiner.h>
 #include <openthread/platform/radio.h>
-#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/crypto.h
+++ b/include/openthread/crypto.h
@@ -38,7 +38,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <openthread/error.h>
 #include <openthread/platform/crypto.h>
 
 #ifdef __cplusplus

--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -35,10 +35,15 @@
 #ifndef OPENTHREAD_DATASET_H_
 #define OPENTHREAD_DATASET_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/platform/crypto.h>
 #include <openthread/platform/radio.h>
+#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/dataset_ftd.h
+++ b/include/openthread/dataset_ftd.h
@@ -35,8 +35,11 @@
 #ifndef OPENTHREAD_DATASET_FTD_H_
 #define OPENTHREAD_DATASET_FTD_H_
 
+#include <stdint.h>
+
 #include <openthread/dataset.h>
-#include <openthread/ip6.h>
+#include <openthread/error.h>
+#include <openthread/instance.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/dataset_updater.h
+++ b/include/openthread/dataset_updater.h
@@ -35,7 +35,10 @@
 #ifndef OPENTHREAD_DATASET_UPDATER_H_
 #define OPENTHREAD_DATASET_UPDATER_H_
 
+#include <stdbool.h>
+
 #include <openthread/dataset.h>
+#include <openthread/error.h>
 #include <openthread/instance.h>
 
 #ifdef __cplusplus

--- a/include/openthread/diag.h
+++ b/include/openthread/diag.h
@@ -35,6 +35,10 @@
 #ifndef OPENTHREAD_DIAG_H_
 #define OPENTHREAD_DIAG_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/platform/diag.h>
 

--- a/include/openthread/dns.h
+++ b/include/openthread/dns.h
@@ -35,10 +35,10 @@
 #ifndef OPENTHREAD_DNS_H_
 #define OPENTHREAD_DNS_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <openthread/error.h>
-#include <openthread/instance.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/dns_client.h
+++ b/include/openthread/dns_client.h
@@ -35,7 +35,10 @@
 #ifndef OPENTHREAD_DNS_CLIENT_H_
 #define OPENTHREAD_DNS_CLIENT_H_
 
-#include <openthread/dns.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
 

--- a/include/openthread/dnssd_server.h
+++ b/include/openthread/dnssd_server.h
@@ -35,10 +35,11 @@
 #ifndef OPENTHREAD_DNSSD_SERVER_H_
 #define OPENTHREAD_DNSSD_SERVER_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <openthread/dns.h>
-#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
 
 #ifdef __cplusplus

--- a/include/openthread/heap.h
+++ b/include/openthread/heap.h
@@ -35,7 +35,7 @@
 #ifndef OPENTHREAD_HEAP_H_
 #define OPENTHREAD_HEAP_H_
 
-#include <openthread/instance.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/history_tracker.h
+++ b/include/openthread/history_tracker.h
@@ -27,10 +27,15 @@
 #ifndef OPENTHREAD_HISTORY_TRACKER_H_
 #define OPENTHREAD_HISTORY_TRACKER_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
+#include <openthread/message.h>
 #include <openthread/netdata.h>
 #include <openthread/thread.h>
+#include <openthread/platform/radio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/icmp6.h
+++ b/include/openthread/icmp6.h
@@ -35,8 +35,13 @@
 #ifndef OPENTHREAD_ICMP6_H_
 #define OPENTHREAD_ICMP6_H_
 
+#include <stdint.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/message.h>
+#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -35,11 +35,11 @@
 #ifndef OPENTHREAD_INSTANCE_H_
 #define OPENTHREAD_INSTANCE_H_
 
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 #include <openthread/error.h>
-#include <openthread/platform/logging.h>
-#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (511)
+#define OPENTHREAD_API_VERSION (512)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -35,8 +35,13 @@
 #ifndef OPENTHREAD_IP6_H_
 #define OPENTHREAD_IP6_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/message.h>
-#include <openthread/platform/radio.h>
+#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/jam_detection.h
+++ b/include/openthread/jam_detection.h
@@ -35,6 +35,10 @@
 #ifndef OPENTHREAD_JAM_DETECTION_H_
 #define OPENTHREAD_JAM_DETECTION_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
 #include <openthread/instance.h>
 
 #ifdef __cplusplus

--- a/include/openthread/joiner.h
+++ b/include/openthread/joiner.h
@@ -35,8 +35,11 @@
 #ifndef OPENTHREAD_JOINER_H_
 #define OPENTHREAD_JOINER_H_
 
+#include <stdint.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/platform/radio.h>
-#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -35,8 +35,13 @@
 #ifndef OPENTHREAD_LINK_H_
 #define OPENTHREAD_LINK_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include <openthread/commissioner.h>
 #include <openthread/dataset.h>
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/platform/radio.h>
 
 #ifdef __cplusplus

--- a/include/openthread/link_metrics.h
+++ b/include/openthread/link_metrics.h
@@ -35,8 +35,12 @@
 #ifndef LINK_METRICS_H_
 #define LINK_METRICS_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
-#include <openthread/message.h>
 #include <openthread/platform/radio.h>
 
 #ifdef __cplusplus

--- a/include/openthread/link_raw.h
+++ b/include/openthread/link_raw.h
@@ -35,6 +35,11 @@
 #ifndef OPENTHREAD_LINK_RAW_H_
 #define OPENTHREAD_LINK_RAW_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/platform/radio.h>
 
 #ifdef __cplusplus

--- a/include/openthread/logging.h
+++ b/include/openthread/logging.h
@@ -35,8 +35,12 @@
 #ifndef OPENTHREAD_LOGGING_H_
 #define OPENTHREAD_LOGGING_H_
 
+#include <stdarg.h>
+#include <stdint.h>
+
 #include <openthread/error.h>
 #include <openthread/platform/logging.h>
+#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/mdns.h
+++ b/include/openthread/mdns.h
@@ -35,6 +35,7 @@
 #ifndef OPENTHREAD_MULTICAST_DNS_H_
 #define OPENTHREAD_MULTICAST_DNS_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <openthread/error.h>

--- a/include/openthread/mesh_diag.h
+++ b/include/openthread/mesh_diag.h
@@ -35,8 +35,14 @@
 #ifndef OPENTHREAD_MESH_DIAG_H_
 #define OPENTHREAD_MESH_DIAG_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
 #include <openthread/instance.h>
+#include <openthread/ip6.h>
 #include <openthread/thread.h>
+#include <openthread/platform/radio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/message.h
+++ b/include/openthread/message.h
@@ -35,8 +35,11 @@
 #ifndef OPENTHREAD_MESSAGE_H_
 #define OPENTHREAD_MESSAGE_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
 #include <openthread/instance.h>
-#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/multi_radio.h
+++ b/include/openthread/multi_radio.h
@@ -35,6 +35,11 @@
 #ifndef OPENTHREAD_MULTI_RADIO_H_
 #define OPENTHREAD_MULTI_RADIO_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/platform/radio.h>
 
 #ifdef __cplusplus

--- a/include/openthread/nat64.h
+++ b/include/openthread/nat64.h
@@ -35,8 +35,14 @@
 #ifndef OPENTHREAD_NAT64_H_
 #define OPENTHREAD_NAT64_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/message.h>
+#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/ncp.h
+++ b/include/openthread/ncp.h
@@ -36,9 +36,12 @@
 #define OPENTHREAD_NCP_H_
 
 #include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
 
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/platform/logging.h>
-#include <openthread/platform/radio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/netdata.h
+++ b/include/openthread/netdata.h
@@ -35,8 +35,14 @@
 #ifndef OPENTHREAD_NETDATA_H_
 #define OPENTHREAD_NETDATA_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include <openthread/commissioner.h>
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
+#include <openthread/platform/radio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/netdata_publisher.h
+++ b/include/openthread/netdata_publisher.h
@@ -35,6 +35,12 @@
 #ifndef OPENTHREAD_NETDATA_PUBLISHER_H_
 #define OPENTHREAD_NETDATA_PUBLISHER_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
+#include <openthread/ip6.h>
 #include <openthread/netdata.h>
 
 #ifdef __cplusplus

--- a/include/openthread/netdiag.h
+++ b/include/openthread/netdiag.h
@@ -35,9 +35,16 @@
 #ifndef OPENTHREAD_NETDIAG_H_
 #define OPENTHREAD_NETDIAG_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include <openthread/dataset.h>
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
+#include <openthread/message.h>
 #include <openthread/thread.h>
+#include <openthread/platform/radio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/network_time.h
+++ b/include/openthread/network_time.h
@@ -35,6 +35,8 @@
 #ifndef OPENTHREAD_NETWORK_TIME_H_
 #define OPENTHREAD_NETWORK_TIME_H_
 
+#include <stdint.h>
+
 #include <openthread/error.h>
 #include <openthread/instance.h>
 

--- a/include/openthread/ping_sender.h
+++ b/include/openthread/ping_sender.h
@@ -35,6 +35,7 @@
 #ifndef OPENTHREAD_PING_SENDER_H_
 #define OPENTHREAD_PING_SENDER_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <openthread/error.h>

--- a/include/openthread/platform/ble.h
+++ b/include/openthread/platform/ble.h
@@ -39,6 +39,7 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <openthread/error.h>

--- a/include/openthread/platform/border_routing.h
+++ b/include/openthread/platform/border_routing.h
@@ -37,7 +37,7 @@
 
 #include <stdint.h>
 
-#include <openthread/error.h>
+#include <openthread/border_routing.h>
 #include <openthread/instance.h>
 
 #ifdef __cplusplus

--- a/include/openthread/platform/crypto.h
+++ b/include/openthread/platform/crypto.h
@@ -35,10 +35,12 @@
 #ifndef OPENTHREAD_PLATFORM_CRYPTO_H_
 #define OPENTHREAD_PLATFORM_CRYPTO_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 
 #include <openthread/error.h>
+#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/platform/debug_uart.h
+++ b/include/openthread/platform/debug_uart.h
@@ -29,8 +29,10 @@
 #ifndef OPENTHREAD_PLATFORM_DEBUG_UART_H_
 #define OPENTHREAD_PLATFORM_DEBUG_UART_H_
 
+#include <stdarg.h>
+#include <stdint.h>
+
 #include <openthread/error.h>
-#include <openthread/platform/logging.h>
 
 /**
  * @file

--- a/include/openthread/platform/diag.h
+++ b/include/openthread/platform/diag.h
@@ -35,10 +35,12 @@
 #ifndef OPENTHREAD_PLATFORM_DIAG_H_
 #define OPENTHREAD_PLATFORM_DIAG_H_
 
-#include <stddef.h>
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/platform/radio.h>
 
 #ifdef __cplusplus

--- a/include/openthread/platform/dns.h
+++ b/include/openthread/platform/dns.h
@@ -35,6 +35,8 @@
 #ifndef OPENTHREAD_PLATFORM_DNS_H_
 #define OPENTHREAD_PLATFORM_DNS_H_
 
+#include <stdbool.h>
+
 #include <openthread/instance.h>
 #include <openthread/message.h>
 

--- a/include/openthread/platform/dnssd.h
+++ b/include/openthread/platform/dnssd.h
@@ -37,7 +37,6 @@
 
 #include <stdint.h>
 
-#include <openthread/dns.h>
 #include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>

--- a/include/openthread/platform/dso_transport.h
+++ b/include/openthread/platform/dso_transport.h
@@ -35,9 +35,8 @@
 #ifndef OPENTHREAD_PLATFORM_DSO_TRANSPORT_H_
 #define OPENTHREAD_PLATFORM_DSO_TRANSPORT_H_
 
-#include <stdint.h>
+#include <stdbool.h>
 
-#include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/message.h>

--- a/include/openthread/platform/infra_if.h
+++ b/include/openthread/platform/infra_if.h
@@ -35,6 +35,7 @@
 #ifndef OPENTHREAD_PLATFORM_INFRA_IF_H_
 #define OPENTHREAD_PLATFORM_INFRA_IF_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <openthread/error.h>

--- a/include/openthread/platform/logging.h
+++ b/include/openthread/platform/logging.h
@@ -35,9 +35,6 @@
 #ifndef OPENTHREAD_PLATFORM_LOGGING_H_
 #define OPENTHREAD_PLATFORM_LOGGING_H_
 
-#include <stdarg.h>
-#include <stdint.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/openthread/platform/mdns_socket.h
+++ b/include/openthread/platform/mdns_socket.h
@@ -35,8 +35,10 @@
 #ifndef OPENTHREAD_PLATFORM_MULTICAST_DNS_SOCKET_H_
 #define OPENTHREAD_PLATFORM_MULTICAST_DNS_SOCKET_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
+#include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/message.h>

--- a/include/openthread/platform/messagepool.h
+++ b/include/openthread/platform/messagepool.h
@@ -35,9 +35,10 @@
 #ifndef OPENTHREAD_PLATFORM_MESSAGEPOOL_H_
 #define OPENTHREAD_PLATFORM_MESSAGEPOOL_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
-#include <openthread/message.h>
+#include <openthread/instance.h>
 
 /**
  * @addtogroup plat-messagepool

--- a/include/openthread/platform/misc.h
+++ b/include/openthread/platform/misc.h
@@ -35,8 +35,7 @@
 #ifndef OPENTHREAD_PLATFORM_MISC_H_
 #define OPENTHREAD_PLATFORM_MISC_H_
 
-#include <stdint.h>
-
+#include <openthread/error.h>
 #include <openthread/instance.h>
 
 #ifdef __cplusplus

--- a/include/openthread/platform/multipan.h
+++ b/include/openthread/platform/multipan.h
@@ -46,6 +46,7 @@
 #ifndef OPENTHREAD_PLATFORM_MULTIPAN_H_
 #define OPENTHREAD_PLATFORM_MULTIPAN_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <openthread/error.h>

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -35,11 +35,13 @@
 #ifndef OPENTHREAD_PLATFORM_RADIO_H_
 #define OPENTHREAD_PLATFORM_RADIO_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/platform/crypto.h>
+#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -35,6 +35,9 @@
 #ifndef OPENTHREAD_PLATFORM_SETTINGS_H_
 #define OPENTHREAD_PLATFORM_SETTINGS_H_
 
+#include <stdint.h>
+
+#include <openthread/error.h>
 #include <openthread/instance.h>
 
 #ifdef __cplusplus

--- a/include/openthread/platform/toolchain.h
+++ b/include/openthread/platform/toolchain.h
@@ -57,7 +57,6 @@
 #define OPENTHREAD_PLATFORM_TOOLCHAIN_H_
 
 #include <stdbool.h>
-#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/platform/trel.h
+++ b/include/openthread/platform/trel.h
@@ -35,9 +35,9 @@
 #ifndef OPENTHREAD_PLATFORM_TREL_H_
 #define OPENTHREAD_PLATFORM_TREL_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
-#include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
 

--- a/include/openthread/platform/udp.h
+++ b/include/openthread/platform/udp.h
@@ -35,6 +35,9 @@
 #ifndef OPENTHREAD_PLATFORM_UDP_H_
 #define OPENTHREAD_PLATFORM_UDP_H_
 
+#include <openthread/error.h>
+#include <openthread/ip6.h>
+#include <openthread/message.h>
 #include <openthread/udp.h>
 
 #ifdef __cplusplus

--- a/include/openthread/radio_stats.h
+++ b/include/openthread/radio_stats.h
@@ -37,7 +37,6 @@
 
 #include <stdint.h>
 
-#include <openthread/error.h>
 #include <openthread/instance.h>
 
 #ifdef __cplusplus

--- a/include/openthread/server.h
+++ b/include/openthread/server.h
@@ -35,6 +35,11 @@
 #ifndef OPENTHREAD_SERVER_H_
 #define OPENTHREAD_SERVER_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/netdata.h>
 
 #ifdef __cplusplus

--- a/include/openthread/sntp.h
+++ b/include/openthread/sntp.h
@@ -37,6 +37,8 @@
 
 #include <stdint.h>
 
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
 
 #ifdef __cplusplus

--- a/include/openthread/srp_client.h
+++ b/include/openthread/srp_client.h
@@ -35,7 +35,12 @@
 #ifndef OPENTHREAD_SRP_CLIENT_H_
 #define OPENTHREAD_SRP_CLIENT_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include <openthread/dns.h>
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
 
 #ifdef __cplusplus

--- a/include/openthread/srp_client_buffers.h
+++ b/include/openthread/srp_client_buffers.h
@@ -35,7 +35,11 @@
 #ifndef OPENTHREAD_SRP_CLIENT_BUFFERS_H_
 #define OPENTHREAD_SRP_CLIENT_BUFFERS_H_
 
+#include <stdint.h>
+
 #include <openthread/dns.h>
+#include <openthread/instance.h>
+#include <openthread/ip6.h>
 #include <openthread/srp_client.h>
 
 #ifdef __cplusplus

--- a/include/openthread/srp_server.h
+++ b/include/openthread/srp_server.h
@@ -35,9 +35,10 @@
 #ifndef OPENTHREAD_SRP_SERVER_H_
 #define OPENTHREAD_SRP_SERVER_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
-#include <openthread/dns.h>
+#include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
 

--- a/include/openthread/tasklet.h
+++ b/include/openthread/tasklet.h
@@ -35,6 +35,8 @@
 #ifndef OPENTHREAD_TASKLET_H_
 #define OPENTHREAD_TASKLET_H_
 
+#include <stdbool.h>
+
 #include <openthread/instance.h>
 
 #ifdef __cplusplus

--- a/include/openthread/tcat.h
+++ b/include/openthread/tcat.h
@@ -45,6 +45,9 @@
 #define OPENTHREAD_TCAT_H_
 
 #include <stdint.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/message.h>
 
 #ifdef __cplusplus

--- a/include/openthread/tcp.h
+++ b/include/openthread/tcp.h
@@ -35,6 +35,12 @@
 #ifndef OPENTHREAD_TCP_H_
 #define OPENTHREAD_TCP_H_
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
 
 #ifdef __cplusplus
@@ -64,7 +70,6 @@ typedef struct otLinkedBuffer
     size_t                 mLength; ///< Length of this linked buffer (number of bytes).
 } otLinkedBuffer;
 
-struct otTcpEndpoint;
 typedef struct otTcpEndpoint otTcpEndpoint;
 
 /**
@@ -554,7 +559,6 @@ otError otTcpAbort(otTcpEndpoint *aEndpoint);
  */
 otError otTcpEndpointDeinitialize(otTcpEndpoint *aEndpoint);
 
-struct otTcpListener;
 typedef struct otTcpListener otTcpListener;
 
 /**

--- a/include/openthread/tcp_ext.h
+++ b/include/openthread/tcp_ext.h
@@ -35,6 +35,10 @@
 #ifndef OPENTHREAD_TCP_EXT_H_
 #define OPENTHREAD_TCP_EXT_H_
 
+#include <stddef.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
 #include <openthread/tcp.h>
 
 #ifdef __cplusplus

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -35,9 +35,15 @@
 #ifndef OPENTHREAD_THREAD_H_
 #define OPENTHREAD_THREAD_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include <openthread/dataset.h>
+#include <openthread/error.h>
+#include <openthread/instance.h>
+#include <openthread/ip6.h>
 #include <openthread/link.h>
-#include <openthread/message.h>
+#include <openthread/platform/radio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -35,9 +35,15 @@
 #ifndef OPENTHREAD_THREAD_FTD_H_
 #define OPENTHREAD_THREAD_FTD_H_
 
-#include <openthread/link.h>
-#include <openthread/message.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/dataset.h>
+#include <openthread/error.h>
+#include <openthread/instance.h>
+#include <openthread/ip6.h>
 #include <openthread/thread.h>
+#include <openthread/platform/radio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/trel.h
+++ b/include/openthread/trel.h
@@ -35,7 +35,11 @@
 #ifndef OPENTHREAD_TREL_H_
 #define OPENTHREAD_TREL_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include <openthread/dataset.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/platform/radio.h>
 #include <openthread/platform/trel.h>

--- a/include/openthread/udp.h
+++ b/include/openthread/udp.h
@@ -35,6 +35,11 @@
 #ifndef OPENTHREAD_UDP_H_
 #define OPENTHREAD_UDP_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
 #include <openthread/ip6.h>
 #include <openthread/message.h>
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -48,6 +48,8 @@ install_packages_pretty_format()
 
     # add shfmt for shell pretty
     command -v shfmt || sudo apt-get install shfmt || echo 'WARNING: could not install shfmt, which is useful if you plan to contribute shell scripts to the OpenThread project.'
+
+    sudo apt-get --no-install-recommends install -y iwyu || echo 'WARNING: iwyu, which is useful to ensure applying the IWYU rules.'
 }
 
 install_packages_apt()
@@ -122,6 +124,8 @@ install_packages_brew()
 
     # add yapf for pretty
     python3 -m pip install yapf || echo 'Failed to install python code formatter yapf. Install it manually if you need.'
+
+    brew install include-what-you-use || echo 'WARNING: iwyu, which is useful to ensure applying the IWYU rules.'
 }
 
 install_packages_source()

--- a/script/check-iwyu-public-header
+++ b/script/check-iwyu-public-header
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+#  Copyright (c) 2025, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# Run this command on parent directory of openthread
+#
+
+set -euxo pipefail
+
+main()
+{
+    find include -name '*.h' -exec iwyu -I include {} \; 2>&1 \
+        | fix_include -n --nosafe_headers \
+        | tee >(cat 1>&2) \
+        | grep 'IWYU edited 0 files on your behalf.'
+}
+
+main "$@"

--- a/src/core/common/type_traits.hpp
+++ b/src/core/common/type_traits.hpp
@@ -34,6 +34,8 @@
 #ifndef OT_TYPE_TRAITS_HPP_
 #define OT_TYPE_TRAITS_HPP_
 
+#include <stdint.h>
+
 namespace ot {
 namespace TypeTraits {
 

--- a/src/lib/spinel/logger.hpp
+++ b/src/lib/spinel/logger.hpp
@@ -29,6 +29,8 @@
 #ifndef SPINEL_LOGGER_HPP_
 #define SPINEL_LOGGER_HPP_
 
+#include <stdint.h>
+
 #include <openthread/error.h>
 #include <openthread/platform/toolchain.h>
 

--- a/src/lib/spinel/spinel_decoder.hpp
+++ b/src/lib/spinel/spinel_decoder.hpp
@@ -37,6 +37,7 @@
 
 #include <openthread/ip6.h>
 #include <openthread/ncp.h>
+#include <openthread/platform/radio.h>
 
 #include "spinel.h"
 

--- a/src/lib/spinel/spinel_encoder.hpp
+++ b/src/lib/spinel/spinel_encoder.hpp
@@ -38,6 +38,7 @@
 #include <openthread/ip6.h>
 #include <openthread/message.h>
 #include <openthread/ncp.h>
+#include <openthread/platform/radio.h>
 
 #include "spinel.h"
 #include "spinel_buffer.hpp"

--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -55,6 +55,7 @@
 #endif
 
 #include <openthread/border_router.h>
+#include <openthread/border_routing.h>
 #include <openthread/platform/infra_if.h>
 
 #include "infra_if.hpp"

--- a/src/posix/platform/openthread-core-posix-config.h
+++ b/src/posix/platform/openthread-core-posix-config.h
@@ -34,6 +34,8 @@
 #ifndef OPENTHREAD_CORE_POSIX_CONFIG_H_
 #define OPENTHREAD_CORE_POSIX_CONFIG_H_
 
+#include <openthread/platform/logging.h>
+
 #include "openthread-posix-daemon-config.h"
 
 #ifndef OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS

--- a/src/posix/platform/utils.hpp
+++ b/src/posix/platform/utils.hpp
@@ -29,6 +29,8 @@
 #ifndef OT_POSIX_PLATFORM_UTILS_HPP_
 #define OT_POSIX_PLATFORM_UTILS_HPP_
 
+#include <stdint.h>
+
 #include <openthread/error.h>
 
 namespace ot {


### PR DESCRIPTION
It would be easier to use OpenThread public headers if they are self-contained and follows the [IWYU style guide](https://google.github.io/styleguide/cppguide.html#Include_What_You_Use). This commit fixes some style issues to make the public headers self-contained and IWYU. The existing pretty check is also extended to verify the OpenThread public headers are self-contained and follows IWYU.

Depends-On: openthread/ot-br-posix#2891