### PR TITLE
[coap] add `otCoapSetResponseFallback` to process unmatched responses

### DIFF
--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -353,6 +353,18 @@ typedef void (*otCoapResponseHandler)(void                *aContext,
 typedef void (*otCoapRequestHandler)(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 
 /**
+ * Pointer is called as a fallback if a response did not match a stored CoAP request.
+ *
+ * @param[in]  aContext      A pointer to arbitrary context information.
+ * @param[in]  aMessage      A pointer to the message.
+ * @param[in]  aMessageInfo  A pointer to the message info for @p aMessage.
+ *
+ * @retval  TRUE   The fallback handled the response.
+ * @retval  FALSE  OpenThread takes default actions for response.
+ */
+typedef bool (*otCoapResponseFallback)(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
+
+/**
  * Pointer is called when a CoAP message with a block-wise transfer option is received.
  *
  * Is available when OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE configuration
@@ -1016,11 +1028,11 @@ void otCoapSetDefaultHandler(otInstance *aInstance, otCoapRequestHandler aHandle
  * Sets a fallback handler for CoAP responses not matching any active/pending request.
  *
  * @param[in] aInstance  A pointer to an OpenThread instance.
- * @param[in] aHandler   A function pointer that shall be called as a fallback for responses without matching CoAP
- *                       request.
+ * @param[in] aHandler   A function pointer that shall be called as a fallback for responses without matching
+ *                       active/pending CoAP requests.
  * @param[in] aContext   A pointer to arbitrary context information. May be NULL if not used.
  */
-void otCoapSetResponseFallback(otInstance *aInstance, otCoapRequestHandler aHandler, void *aContext);
+void otCoapSetResponseFallback(otInstance *aInstance, otCoapResponseFallback aHandler, void *aContext);
 
 /**
  * Sends a CoAP response from the server with custom transmission parameters.

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -1013,6 +1013,16 @@ void otCoapRemoveBlockWiseResource(otInstance *aInstance, otCoapBlockwiseResourc
 void otCoapSetDefaultHandler(otInstance *aInstance, otCoapRequestHandler aHandler, void *aContext);
 
 /**
+ * Sets a fallback handler for CoAP responses not matching any active/pending request.
+ *
+ * @param[in] aInstance  A pointer to an OpenThread instance.
+ * @param[in] aHandler   A function pointer that shall be called as a fallback for responses without matching CoAP
+ *                       request.
+ * @param[in] aContext   A pointer to arbitrary context information. May be NULL if not used.
+ */
+void otCoapSetResponseFallback(otInstance *aInstance, otCoapRequestHandler aHandler, void *aContext);
+
+/**
  * Sends a CoAP response from the server with custom transmission parameters.
  *
  * @param[in]  aInstance        A pointer to an OpenThread instance.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (530)
+#define OPENTHREAD_API_VERSION (531)
 
 /**
  * @addtogroup api-instance

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -287,7 +287,7 @@ void otCoapSetDefaultHandler(otInstance *aInstance, otCoapRequestHandler aHandle
     AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SetDefaultHandler(aHandler, aContext);
 }
 
-void otCoapSetResponseFallback(otInstance *aInstance, otCoapRequestHandler aHandler, void *aContext)
+void otCoapSetResponseFallback(otInstance *aInstance, otCoapResponseFallback aHandler, void *aContext)
 {
     AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SetResponseFallback(aHandler, aContext);
 }

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -287,6 +287,11 @@ void otCoapSetDefaultHandler(otInstance *aInstance, otCoapRequestHandler aHandle
     AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SetDefaultHandler(aHandler, aContext);
 }
 
+void otCoapSetResponseFallback(otInstance *aInstance, otCoapRequestHandler aHandler, void *aContext)
+{
+    AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SetResponseFallback(aHandler, aContext);
+}
+
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
 otError otCoapSendResponseBlockWiseWithParameters(otInstance                 *aInstance,
                                                   otMessage                  *aMessage,

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1287,7 +1287,11 @@ exit:
 
     if (error == kErrorNone && request == nullptr)
     {
-        if (aMessage.IsConfirmable() || aMessage.IsNonConfirmable())
+        if (mResponseFallback.IsSet())
+        {
+            mResponseFallback.Invoke(&aMessage, &aMessageInfo);
+        }
+        else if (aMessage.IsConfirmable() || aMessage.IsNonConfirmable())
         {
             // Successfully parsed a header but no matching request was
             // found - reject the message by sending reset.

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1293,11 +1293,7 @@ exit:
 
     if (error == kErrorNone && request == nullptr)
     {
-        if (mResponseFallback.IsSet())
-        {
-            mResponseFallback.Invoke(&aMessage, &aMessageInfo);
-        }
-        else if (aMessage.IsConfirmable() || aMessage.IsNonConfirmable())
+        if (!InvokeResponseFallback(aMessage, aMessageInfo) && aMessage.RequireResetOnError())
         {
             // Successfully parsed a header but no matching request was
             // found - reject the message by sending reset.

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -400,12 +400,21 @@ public:
      */
     void RemoveResource(Resource &aResource);
 
-    /* Sets the default handler for unhandled CoAP requests.
+    /**
+     * Sets the default handler for unhandled CoAP requests.
      *
      * @param[in]  aHandler   A function pointer that shall be called when an unhandled request arrives.
      * @param[in]  aContext   A pointer to arbitrary context information. May be `nullptr` if not used.
      */
     void SetDefaultHandler(RequestHandler aHandler, void *aContext) { mDefaultHandler.Set(aHandler, aContext); }
+
+    /**
+     * Sets a fallback handler for CoAP responses not matching any active/pending request.
+     *
+     * @param[in]  aHandler   A function pointer that shall be called as a fallback for isolated responses.
+     * @param[in]  aContext   A pointer to arbitrary context information. May be `nullptr` if not used.
+     */
+    void SetResponseFallback(RequestHandler aHandler, void *aContext) { mResponseFallback.Set(aHandler, aContext); }
 
     /**
      * Allocates a new message with a CoAP header.
@@ -878,6 +887,7 @@ private:
     ResponsesQueue        mResponsesQueue;
 
     Callback<RequestHandler> mDefaultHandler;
+    Callback<RequestHandler> mResponseFallback;
 
     ResourceHandler mResourceHandler;
 

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -735,6 +735,17 @@ public:
     bool IsNonConfirmablePostRequest(void) const;
 
     /**
+     * Checks if the message requires an reset response if an error during low level CoAP processing occurred.
+     *
+     * A reset message is expected to be sent for NON and CON messages if the message can not be processed or a
+     * duplicated message has been received.
+     *
+     * @retval  TRUE   Expect to respond with CoAP reset message on error.
+     * @retval  FALSE  No CoAP reset message should be sent on error.
+     */
+    bool RequireResetOnError(void) { return IsConfirmable() || IsNonConfirmable(); }
+
+    /**
      * Creates a copy of this CoAP message.
      *
      * It allocates the new message from the same message pool as the original one and copies @p aLength octets


### PR DESCRIPTION
adding two extensions:
1. Add an api function to configure a response fallback callback with `otCoapSetResponseFallback`.
2. Enable fire and forget for NON requests, supporting requests which do not expect a response.

This PR is related and resolves #11582 as described in option 1 in the proposed solutions.