### PR TITLE
[posix] fix region configuration loading order

### DIFF
--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -154,6 +154,21 @@ void Radio::ProcessRadioUrl(const RadioUrl &aRadioUrl)
         SuccessOrDie(mRadioSpinel.SetCcaEnergyDetectThreshold(value));
     }
 
+#if OPENTHREAD_POSIX_CONFIG_CONFIGURATION_FILE_ENABLE
+    // config files should be parsed before the region parameter
+    if (aRadioUrl.HasParam("product-config-file"))
+    {
+        const char *configFile = aRadioUrl.GetValue("product-config-file");
+        SuccessOrDie(sConfig.SetProductConfigFile(configFile));
+    }
+
+    if (aRadioUrl.HasParam("factory-config-file"))
+    {
+        const char *configFile = aRadioUrl.GetValue("factory-config-file");
+        SuccessOrDie(sConfig.SetFactoryConfigFile(configFile));
+    }
+#endif // OPENTHREAD_POSIX_CONFIG_CONFIGURATION_FILE_ENABLE
+
     if ((region = aRadioUrl.GetValue("region")) != nullptr)
     {
         uint16_t regionCode;
@@ -169,20 +184,6 @@ void Radio::ProcessRadioUrl(const RadioUrl &aRadioUrl)
         SuccessOrDie(aRadioUrl.ParseUint32("bus-latency", busLatency));
         mRadioSpinel.SetBusLatency(busLatency);
     }
-
-#if OPENTHREAD_POSIX_CONFIG_CONFIGURATION_FILE_ENABLE
-    if (aRadioUrl.HasParam("product-config-file"))
-    {
-        const char *configFile = aRadioUrl.GetValue("product-config-file");
-        SuccessOrDie(sConfig.SetProductConfigFile(configFile));
-    }
-
-    if (aRadioUrl.HasParam("factory-config-file"))
-    {
-        const char *configFile = aRadioUrl.GetValue("factory-config-file");
-        SuccessOrDie(sConfig.SetFactoryConfigFile(configFile));
-    }
-#endif // OPENTHREAD_POSIX_CONFIG_CONFIGURATION_FILE_ENABLE
 
     ProcessMaxPowerTable(aRadioUrl);
 


### PR DESCRIPTION
Fix the initialization order in ProcessRadioUrl() to ensure that configuration files are loaded before region settings are applied.

Previously, the region code was set before configuration files (product-config-file and factory-config-file) were processed. This caused region-specific settings such as target power to be applied from stale configuration data rather than the newly loaded configuration file.

The fix reorders the parameter processing sequence:
1. Basic radio parameters (fem-lnagain, cca-threshold)
2. Configuration file loading (product-config-file, factory-config-file)
3. Region setting (region)
4. Other parameters (bus-latency, max-power-table, coex settings)

This ensures that when a region is set, it will use the correct configuration data from the newly loaded files, allowing region-specific power settings and other parameters to be properly refreshed.