### PR TITLE
[trel] fix a format error of log

### DIFF
--- a/src/core/radio/trel_peer.cpp
+++ b/src/core/radio/trel_peer.cpp
@@ -100,7 +100,7 @@ void Peer::ScheduleToRemoveAfter(uint32_t aDelay)
     mRemoveTime = TimerMilli::GetNow() + aDelay;
 
     Log(kRemoving);
-    LogInfo("    after %u msec", aDelay);
+    LogInfo("    after %lu msec", ToUlong(aDelay));
 
     SetState(kStateRemoving);
 


### PR DESCRIPTION
According to precedents in other parts of the OpenThread source code, a 32-bit unsigned integer should be printed using `%lu` instead of `%u`.