### PR TITLE
[cli] fix output of fractional part of ping average round-trip time

### DIFF
--- a/src/cli/cli_ping.cpp
+++ b/src/cli/cli_ping.cpp
@@ -236,7 +236,7 @@ void PingSender::HandlePingStatistics(const otPingSenderStatistics *aStatistics)
         uint32_t avgRoundTripTime =
             1000 * static_cast<uint64_t>(aStatistics->mTotalRoundTripTime) / aStatistics->mReceivedCount;
 
-        OutputFormat(" Round-trip min/avg/max = %u/%u.%u/%u ms.", aStatistics->mMinRoundTripTime,
+        OutputFormat(" Round-trip min/avg/max = %u/%u.%03u/%u ms.", aStatistics->mMinRoundTripTime,
                      static_cast<uint16_t>(avgRoundTripTime / 1000), static_cast<uint16_t>(avgRoundTripTime % 1000),
                      aStatistics->mMaxRoundTripTime);
     }


### PR DESCRIPTION
This commit addresses an issue where the fractional part of the ping average round-trip time (RTT) was not consistently formatted. Previously, it used ".%u" with `(avgRoundTripTime % 1000)` which could omit leading zeros for fractional values. It now uses ".%03u" to ensure three digits are always displayed, padding with leading zeros when necessary.