### PR TITLE
[routing-manager] enhance MultiAilDetector

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -987,7 +987,7 @@ private:
 
         bool           mDetected;
         uint16_t       mNetDataPeerBrCount;
-        uint16_t       mRxRaTrackerPeerBrCount;
+        uint16_t       mRxRaTrackerReachablePeerBrCount;
         DetectTimer    mTimer;
         DetectCallback mCallback;
     };
@@ -1052,7 +1052,7 @@ private:
         Error GetNextRdnssAddr(PrefixTableIterator &aIterator, RdnssAddrEntry &aEntry) const;
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
-        uint16_t CountPeerBrs(void) const;
+        uint16_t CountReachablePeerBrs(void) const;
 #endif
 
         // Callbacks notifying of changes


### PR DESCRIPTION
This commit counts only reachable peer BRs for quick multi-AIL detection when peer BR moves to a different infrastructure link.