### PR TITLE
[routing-manager] enhance peer BR count tracking and signaling

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1213,7 +1213,7 @@ void RoutingManager::MultiAilDetector::Evaluate(void)
         mNetDataPeerBrCount = count;
     }
 
-    count = Get<RoutingManager>().mRxRaTracker.CountReachablePeerBrs();
+    count = Get<RoutingManager>().mRxRaTracker.GetReachablePeerBrCount();
 
     if (count != mRxRaTrackerReachablePeerBrCount)
     {
@@ -1814,6 +1814,10 @@ void RoutingManager::RxRaTracker::Evaluate(void)
         }
     }
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
+    mDecisionFactors.mReachablePeerBrCount = CountReachablePeerBrs();
+#endif
+
     if (oldFactors != mDecisionFactors)
     {
         mSignalTask.Post();
@@ -2023,14 +2027,6 @@ void RoutingManager::RxRaTracker::HandleRouterTimer(void)
             {
                 entry.ClearLifetime();
             }
-
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
-            // When a Peer BR becomes unreachable, post a task that will do multi-ail evaluation.
-            if (router.IsPeerBr())
-            {
-                mSignalTask.Post();
-            }
-#endif
         }
     }
 
@@ -2184,7 +2180,7 @@ exit:
     return error;
 }
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
 uint16_t RoutingManager::RxRaTracker::CountReachablePeerBrs(void) const
 {
     uint16_t count = 0;
@@ -2200,6 +2196,7 @@ uint16_t RoutingManager::RxRaTracker::CountReachablePeerBrs(void) const
     return count;
 }
 #endif
+
 //---------------------------------------------------------------------------------------------------------------------
 // RxRaTracker::Iterator
 

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1036,6 +1036,9 @@ private:
         bool ContainsDefaultOrNonUlaRoutePrefix(void) const { return mDecisionFactors.mHasNonUlaRoute; }
         bool ContainsNonUlaOnLinkPrefix(void) const { return mDecisionFactors.mHasNonUlaOnLink; }
         bool ContainsUlaOnLinkPrefix(void) const { return mDecisionFactors.mHasUlaOnLink; }
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
+        uint16_t GetReachablePeerBrCount(void) const { return mDecisionFactors.mReachablePeerBrCount; }
+#endif
 
         const Ip6::Prefix &GetFavoredOnLinkPrefix(void) const { return mDecisionFactors.mFavoredOnLinkPrefix; }
         void               SetHeaderFlagsOn(RouterAdvert::Header &aHeader) const;
@@ -1050,10 +1053,6 @@ private:
         Error GetNextEntry(PrefixTableIterator &aIterator, PrefixTableEntry &aEntry) const;
         Error GetNextRouter(PrefixTableIterator &aIterator, RouterEntry &aEntry) const;
         Error GetNextRdnssAddr(PrefixTableIterator &aIterator, RdnssAddrEntry &aEntry) const;
-
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
-        uint16_t CountReachablePeerBrs(void) const;
-#endif
 
         // Callbacks notifying of changes
         void RemoveOrDeprecateOldEntries(TimeMilli aTimeThreshold);
@@ -1242,6 +1241,9 @@ private:
             bool        mHasUlaOnLink : 1;
             bool        mHeaderManagedAddressConfigFlag : 1;
             bool        mHeaderOtherConfigFlag : 1;
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
+            uint16_t mReachablePeerBrCount;
+#endif
         };
 
         //-  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
@@ -1254,6 +1256,9 @@ private:
         void DetermineStaleTimeFor(const OnLinkPrefix &aPrefix, NextFireTime &aStaleTime);
         void DetermineStaleTimeFor(const RoutePrefix &aPrefix, NextFireTime &aStaleTime);
         void SendNeighborSolicitToRouter(const Router &aRouter);
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
+        uint16_t CountReachablePeerBrs(void) const;
+#endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_USE_HEAP_ENABLE
         template <class Type> Entry<Type> *AllocateEntry(void) { return Entry<Type>::Allocate(); }
 #else


### PR DESCRIPTION
This commit enhances how changes in the number of reachable peer Border Routers (BRs) are tracked and signaled. This tracking is handled by `RxRaTracker` and utilized by the `MultiAilDetector` to determine if BRs are connected to different AILs.

The `RxRaTracker::DecisionFactors` class now includes and tracks `mReachablePeerBrCount`. This value is updated in the `Evaluate()` method, which is invoked upon any change to the internal state tracked by `RxRaTracker` (e.g., changes in discovered prefixes or routers). This ensures that any change in the number of peer BRs is promptly detected and signaled to other sub-components, allowing them to update their state or take necessary actions.