### PR TITLE
[posix] fix `MdnsSocket` iteration over message queue

### DIFF
--- a/src/posix/platform/mdns_socket.cpp
+++ b/src/posix/platform/mdns_socket.cpp
@@ -345,6 +345,9 @@ void MdnsSocket::ClearTxQueue(void)
 
 void MdnsSocket::SendQueuedMessages(MsgType aMsgType)
 {
+    otMessage *message;
+    otMessage *nextMessage;
+
     switch (aMsgType)
     {
     case kIp6Msg:
@@ -355,8 +358,7 @@ void MdnsSocket::SendQueuedMessages(MsgType aMsgType)
         break;
     }
 
-    for (otMessage *message = otMessageQueueGetHead(&mTxQueue); message != NULL;
-         message            = otMessageQueueGetNext(&mTxQueue, message))
+    for (message = otMessageQueueGetHead(&mTxQueue); message != NULL; message = nextMessage)
     {
         bool                isTxPending = false;
         uint16_t            length;
@@ -366,6 +368,8 @@ void MdnsSocket::SendQueuedMessages(MsgType aMsgType)
         uint8_t             buffer[kMaxMessageLength];
         struct sockaddr_in6 addr6;
         struct sockaddr_in  addr;
+
+        nextMessage = otMessageQueueGetNext(&mTxQueue, message);
 
         length = otMessageGetLength(message);
 


### PR DESCRIPTION
This commit updates how `MdnsSocket::SendQueuedMessages()` iterates over the message queue. The iteration is changed to get the next message before processing the current one. This is necessary because the current message may be dequeued and freed within the loop, which would invalidate the pointer to the next message.