### PR TITLE
[routing-manager] remove duplicate logging of RA header

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1400,8 +1400,6 @@ void RoutingManager::RxRaTracker::ProcessRaHeader(const RouterAdvert::Header &aR
     prefix.Clear();
     entry = aRouter.mRoutePrefixes.FindMatching(prefix);
 
-    LogInfo("- RA Header - default route - lifetime:%u", aRaHeader.GetRouterLifetime());
-
     if (entry == nullptr)
     {
         VerifyOrExit(aRaHeader.GetRouterLifetime() != 0);


### PR DESCRIPTION
There were duplicate logging lines for the received RA header.
```
otbr-agent[458170]: 00:00:35.453 [I] RoutingManager: - RA Header - flags - M:1 O:1 S:0
otbr-agent[458170]: 00:00:35.453 [I] RoutingManager: - RA Header - default route - lifetime:1800                                    
otbr-agent[458170]: 00:00:35.453 [I] RoutingManager: - RA Header - default route - lifetime:1800
otbr-agent[458170]: 00:00:35.453 [I] RoutingManager: - PIO 2001:db8:9:2::/64 (valid:5943, preferred:3943)
otbr-agent[458170]: 00:00:35.453 [I] RoutingManager: - RDNSS 2001:db8:9:2:0:0:0:1 (lifetime:1800)           
otbr-agent[458170]: 00:00:35.453 [I] P-Resolver----: Set recursive DNS server list, count: 1
```