### PR TITLE
[ip6] add message TX callback

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (512)
+#define OPENTHREAD_API_VERSION (513)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -859,6 +859,30 @@ const otBorderRoutingCounters *otIp6GetBorderRoutingCounters(otInstance *aInstan
 void otIp6ResetBorderRoutingCounters(otInstance *aInstance);
 
 /**
+ * Pointer is called when sending an IPv6 message succeeds or fails.
+ *
+ * This is used in `otIp6RegisterTxCallback()`.
+ *
+ * @param[in]  aMessage  A pointer to an IPv6 message that has succeeded or failed to be sent.
+ * @param[in]  aError    A result of sending the message.
+ * @param[in]  aContext  A pointer to application-specific context.
+ *
+ */
+typedef void (*otIp6TxCallback)(otMessage *aMessage, otError aError, void *aContext);
+
+/**
+ * Registers a callback that is called when sending an IPv6 message succeeds or fails.
+ *
+ * Requires `OPENTHREAD_CONFIG_TX_CALLBACK_API_ENABLE`.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ * @param[in]  aCallback  A pointer to a function that is called when sending an IPv6 message succeeds or fails.
+ * @param[in]  aContext   A pointer to application-specific context.
+ *
+ */
+void otIp6RegisterTxCallback(otInstance *aInstance, otIp6TxCallback aCallback, void *aContext);
+
+/**
  * @}
  */
 

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -284,3 +284,10 @@ void otIp6ResetBorderRoutingCounters(otInstance *aInstance)
     AsCoreType(aInstance).Get<Ip6::Ip6>().ResetBorderRoutingCounters();
 }
 #endif
+
+#if OPENTHREAD_CONFIG_TX_CALLBACK_API_ENABLE
+void otIp6RegisterTxCallback(otInstance *aInstance, otIp6TxCallback aCallback, void *aContext)
+{
+    return AsCoreType(aInstance).Get<MeshForwarder>().RegisterIp6TxCallback(aCallback, aContext);
+}
+#endif

--- a/src/core/config/mesh_forwarder.h
+++ b/src/core/config/mesh_forwarder.h
@@ -198,6 +198,18 @@
 #endif
 
 /**
+ *
+ * @def OPENTHREAD_CONFIG_TX_CALLBACK_API_ENABLE
+ *
+ * Define as 1 to enable the IPv6 message TX callback.
+ *
+ * When enabled, allows for registering a callback that is called when sending an IPv6 message succeeds or fails.
+ */
+#ifndef OPENTHREAD_CONFIG_TX_CALLBACK_API_ENABLE
+#define OPENTHREAD_CONFIG_TX_CALLBACK_API_ENABLE 0
+#endif
+
+/**
  * @}
  */
 

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -518,6 +518,13 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
 
         Get<MeshForwarder>().mCounters.UpdateOnTxDone(*message, aChild.GetIndirectTxSuccess());
 
+#if OPENTHREAD_CONFIG_TX_CALLBACK_API_ENABLE
+        if (message->GetType() == Message::kTypeIp6)
+        {
+            Get<MeshForwarder>().mIp6TxCallback.InvokeIfSet(message, txError);
+        }
+#endif
+
         if (message->GetIndirectTxChildMask().Has(childIndex))
         {
             message->GetIndirectTxChildMask().Remove(childIndex);

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1277,6 +1277,13 @@ void MeshForwarder::FinalizeMessageDirectTx(Message &aMessage, Error aError)
 
     mCounters.UpdateOnTxDone(aMessage, aMessage.GetTxSuccess());
 
+#if OPENTHREAD_CONFIG_TX_CALLBACK_API_ENABLE
+    if (aMessage.GetType() == Message::kTypeIp6)
+    {
+        mIp6TxCallback.InvokeIfSet(&aMessage, aError);
+    }
+#endif
+
     if (aMessage.IsMleCommand(Mle::kCommandDiscoveryRequest))
     {
         // Note that `HandleDiscoveryRequestFrameTxDone()` may update

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -282,6 +282,17 @@ public:
     void HandleDeferredAck(Neighbor &aNeighbor, Error aError);
 #endif
 
+#if OPENTHREAD_CONFIG_TX_CALLBACK_API_ENABLE
+    /**
+     * Registers a callback that is called when sending an IPv6 message succeeds or fails.
+     *
+     * @param[in]  aCallback A pointer to a function that is called when sending an IPv6 message succeeds or fails.
+     * @param[in]  aContext  A pointer to application-specific context.
+     *
+     */
+    void RegisterIp6TxCallback(otIp6TxCallback aCallback, void *aContext) { mIp6TxCallback.Set(aCallback, aContext); }
+#endif
+
 private:
     static constexpr uint8_t kFailedRouterTransmissions      = 4;
     static constexpr uint8_t kFailedCslDataPollTransmissions = 15;
@@ -599,6 +610,9 @@ private:
 
 #if OPENTHREAD_CONFIG_TX_QUEUE_STATISTICS_ENABLE
     TxQueueStats mTxQueueStats;
+#endif
+#if OPENTHREAD_CONFIG_TX_CALLBACK_API_ENABLE
+    Callback<otIp6TxCallback> mIp6TxCallback;
 #endif
 };
 


### PR DESCRIPTION
Add an optional API to register a callback called when an IPv6 message TX fails or succeeds.

This may be useful in the following use cases, among others:
1. More insightful network monitoring allowing to attribute the communication problems during a certain period to e.g. channel occupancy, noise or running out of buffers.
2. Application-layer reliability protocol making smarter decisions on when it should retransmit a message based on whether a message has been dropped at the source or in the mesh.