### PR TITLE
[mle] remove `kReattachStart` from `ReattachState` enum

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -231,7 +231,8 @@ Error Mle::Start(StartMode aMode)
 
     if (aMode == kNormalAttach)
     {
-        mReattachState = kReattachStart;
+        mReattachState =
+            (Get<MeshCoP::ActiveDatasetManager>().Restore() == kErrorNone) ? kReattachActive : kReattachStop;
     }
 
     if ((aMode == kAnnounceAttach) || (GetRloc16() == kInvalidRloc16))
@@ -629,18 +630,6 @@ void Mle::Attach(AttachMode aMode)
     if (!IsDetached())
     {
         mAttachCounter = 0;
-    }
-
-    if (mReattachState == kReattachStart)
-    {
-        if (Get<MeshCoP::ActiveDatasetManager>().Restore() == kErrorNone)
-        {
-            mReattachState = kReattachActive;
-        }
-        else
-        {
-            mReattachState = kReattachStop;
-        }
     }
 
     mParentCandidate.Clear();
@@ -4224,7 +4213,6 @@ const char *Mle::ReattachStateToString(ReattachState aState)
 {
     static const char *const kReattachStateStrings[] = {
         "",                                 // (0) kReattachStop
-        "reattaching",                      // (1) kReattachStart
         "reattaching with Active Dataset",  // (2) kReattachActive
         "reattaching with Pending Dataset", // (3) kReattachPending
     };
@@ -4233,7 +4221,6 @@ const char *Mle::ReattachStateToString(ReattachState aState)
     {
         InitEnumValidatorCounter();
         ValidateNextEnum(kReattachStop);
-        ValidateNextEnum(kReattachStart);
         ValidateNextEnum(kReattachActive);
         ValidateNextEnum(kReattachPending);
     };

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1328,7 +1328,6 @@ private:
     enum ReattachState : uint8_t
     {
         kReattachStop,    // Reattach process is disabled or finished
-        kReattachStart,   // Start reattach process
         kReattachActive,  // Reattach using stored Active Dataset
         kReattachPending, // Reattach using stored Pending Dataset
     };


### PR DESCRIPTION
This commit simplifies the code by removing the `kReattachStart` state from the `ReattachState` enumeration. This enum is used after MLE `Start()` to track whether to attempt to attach using a persisted Active or Pending Dataset.

Previously, `kReattachStart` was a transitory state set in `Start()` and then changed in the `Attach()` method to either `kReattachActive`
 or `kReattachStop`, based on whether the device had a saved Active
 Dataset.

This change simplifies the code by determining the state directly in `Mle::Start()`, which allows for the removal of the now unnecessary `kReattachStart` case.