### PR TITLE
[diag] deprecate otPlatDiagRadioTransmitDone() and otPlatDiagRadioReceiveDone()

### DIFF
--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -612,17 +612,7 @@ static void radioReceive(otInstance *aInstance)
         sState  = OT_RADIO_STATE_RECEIVE;
         sTxWait = false;
 
-#if OPENTHREAD_CONFIG_DIAG_ENABLE
-
-        if (otPlatDiagModeGet())
-        {
-            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, OT_ERROR_NONE);
-        }
-        else
-#endif
-        {
-            otPlatRadioTxDone(aInstance, &sTransmitFrame, (isAck ? &sReceiveFrame : NULL), OT_ERROR_NONE);
-        }
+        otPlatRadioTxDone(aInstance, &sTransmitFrame, (isAck ? &sReceiveFrame : NULL), OT_ERROR_NONE);
     }
     else if (!isAck || sPromiscuous)
     {
@@ -667,18 +657,7 @@ void radioSendMessage(otInstance *aInstance)
     if (!sTxWait)
     {
         sState = OT_RADIO_STATE_RECEIVE;
-
-#if OPENTHREAD_CONFIG_DIAG_ENABLE
-
-        if (otPlatDiagModeGet())
-        {
-            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, OT_ERROR_NONE);
-        }
-        else
-#endif
-        {
-            otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_NONE);
-        }
+        otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_NONE);
     }
 #else
     // Wait for echo radio in virtual time mode.
@@ -885,16 +864,7 @@ exit:
 
     if (error != OT_ERROR_ABORT)
     {
-#if OPENTHREAD_CONFIG_DIAG_ENABLE
-        if (otPlatDiagModeGet())
-        {
-            otPlatDiagRadioReceiveDone(aInstance, error == OT_ERROR_NONE ? &sReceiveFrame : NULL, error);
-        }
-        else
-#endif
-        {
-            otPlatRadioReceiveDone(aInstance, error == OT_ERROR_NONE ? &sReceiveFrame : NULL, error);
-        }
+        otPlatRadioReceiveDone(aInstance, error == OT_ERROR_NONE ? &sReceiveFrame : NULL, error);
     }
 }
 

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (517)
+#define OPENTHREAD_API_VERSION (518)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -910,6 +910,9 @@ extern void otPlatRadioReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, 
 /**
  * The radio driver calls this function to notify OpenThread diagnostics module of a received frame.
  *
+ * @note This function is deprecated and will be removed in the future. It is recommended to use the function
+ *       `otPlatRadioReceiveDone()`.
+ *
  * Is used when diagnostics is enabled.
  *
  * @param[in]  aInstance The OpenThread instance structure.
@@ -981,6 +984,9 @@ extern void otPlatRadioTxDone(otInstance *aInstance, otRadioFrame *aFrame, otRad
 
 /**
  * The radio driver calls this function to notify OpenThread diagnostics module that the transmission has completed.
+ *
+ * @note This function is deprecated and will be removed in the future. It is recommended to use the function
+ *       `otPlatRadioTxDone()`.
  *
  * Is used when diagnostics is enabled.
  *

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -154,7 +154,7 @@ Error Diags::ProcessStart(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
-    otPlatDiagModeSet(true);
+    Get<Radio>().SetDiagMode(true);
 
     return kErrorNone;
 }
@@ -164,7 +164,7 @@ Error Diags::ProcessStop(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
-    otPlatDiagModeSet(false);
+    Get<Radio>().SetDiagMode(false);
 
     return kErrorNone;
 }
@@ -500,7 +500,7 @@ Error Diags::ProcessStart(uint8_t aArgsLength, char *aArgs[])
     otPlatAlarmMilliStop(&GetInstance());
     SuccessOrExit(error = Get<Radio>().Receive(mChannel));
     SuccessOrExit(error = Get<Radio>().SetTransmitPower(mTxPower));
-    otPlatDiagModeSet(true);
+    Get<Radio>().SetDiagMode(true);
     mStats.Clear();
 
 exit:
@@ -547,7 +547,7 @@ Error Diags::ProcessStop(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgs);
 
     otPlatAlarmMilliStop(&GetInstance());
-    otPlatDiagModeSet(false);
+    Get<Radio>().SetDiagMode(false);
     Get<Radio>().SetPromiscuous(false);
     Get<Mac::SubMac>().SetRxOnWhenIdle(false);
 
@@ -1195,11 +1195,11 @@ Error Diags::ProcessCmd(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        Output("diagnostics mode is %s\r\n", otPlatDiagModeGet() ? "enabled" : "disabled");
+        Output("diagnostics mode is %s\r\n", IsEnabled() ? "enabled" : "disabled");
         ExitNow();
     }
 
-    if (!otPlatDiagModeGet() && !StringMatch(aArgs[0], "start"))
+    if (!IsEnabled() && !StringMatch(aArgs[0], "start"))
     {
         Output("diagnostics mode is disabled\r\n");
         ExitNow(error = kErrorInvalidState);
@@ -1249,7 +1249,7 @@ void Diags::Output(const char *aFormat, ...)
     va_end(args);
 }
 
-bool Diags::IsEnabled(void) { return otPlatDiagModeGet(); }
+bool Diags::IsEnabled(void) { return Get<Radio>().GetDiagMode(); }
 
 } // namespace FactoryDiags
 } // namespace ot

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -38,6 +38,7 @@
 
 #include <openthread/radio_stats.h>
 #include <openthread/platform/crypto.h>
+#include <openthread/platform/diag.h>
 #include <openthread/platform/radio.h>
 
 #include "common/locator.hpp"
@@ -847,6 +848,22 @@ public:
      */
     uint32_t GetBusLatency(void);
 
+#if OPENTHREAD_CONFIG_DIAG_ENABLE
+    /**
+     * Enables/disables the factory diagnostics mode.
+     *
+     * @param[in]  aMode  TRUE to enable diagnostics mode, FALSE otherwise.
+     */
+    void SetDiagMode(bool aMode);
+
+    /**
+     * Gets the current diagnostic mode of the radio.
+     *
+     * @returns TRUE if factory diagnostics mode is enabled, FALSE otherwise.
+     */
+    bool GetDiagMode(void);
+#endif
+
 private:
     otInstance *GetInstancePtr(void) const { return reinterpret_cast<otInstance *>(&InstanceLocator::GetInstance()); }
 
@@ -1029,6 +1046,10 @@ inline uint32_t Radio::GetBusSpeed(void) { return otPlatRadioGetBusSpeed(GetInst
 
 inline uint32_t Radio::GetBusLatency(void) { return otPlatRadioGetBusLatency(GetInstancePtr()); }
 
+#if OPENTHREAD_CONFIG_DIAG_ENABLE
+inline void Radio::SetDiagMode(bool aMode) { otPlatDiagModeSet(aMode); }
+inline bool Radio::GetDiagMode(void) { return otPlatDiagModeGet(); }
+#endif
 #else //----------------------------------------------------------------------------------------------------------------
 
 inline otRadioCaps Radio::GetCaps(void)
@@ -1133,6 +1154,10 @@ inline uint32_t Radio::GetBusSpeed(void) { return 0; }
 
 inline uint32_t Radio::GetBusLatency(void) { return 0; }
 
+#if OPENTHREAD_CONFIG_DIAG_ENABLE
+inline void Radio::SetDiagMode(bool) {}
+inline bool Radio::GetDiagMode(void) { return false; }
+#endif
 #endif // #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 
 } // namespace ot

--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -179,10 +179,6 @@ exit:
 
 void RadioSpinel::SetCallbacks(const struct RadioSpinelCallbacks &aCallbacks)
 {
-#if OPENTHREAD_CONFIG_DIAG_ENABLE
-    assert(aCallbacks.mDiagReceiveDone != nullptr);
-    assert(aCallbacks.mDiagTransmitDone != nullptr);
-#endif
     assert(aCallbacks.mEnergyScanDone != nullptr);
     assert(aCallbacks.mReceiveDone != nullptr);
     assert(aCallbacks.mTransmitDone != nullptr);
@@ -756,32 +752,14 @@ void RadioSpinel::RadioReceive(void)
         }
     }
 
-#if OPENTHREAD_CONFIG_DIAG_ENABLE
-    if (otPlatDiagModeGet())
-    {
-        mCallbacks.mDiagReceiveDone(mInstance, &mRxRadioFrame, OT_ERROR_NONE);
-    }
-    else
-#endif
-    {
-        mCallbacks.mReceiveDone(mInstance, &mRxRadioFrame, OT_ERROR_NONE);
-    }
+    mCallbacks.mReceiveDone(mInstance, &mRxRadioFrame, OT_ERROR_NONE);
 exit:
     return;
 }
 
 void RadioSpinel::TransmitDone(otRadioFrame *aFrame, otRadioFrame *aAckFrame, otError aError)
 {
-#if OPENTHREAD_CONFIG_DIAG_ENABLE
-    if (otPlatDiagModeGet())
-    {
-        mCallbacks.mDiagTransmitDone(mInstance, aFrame, aError);
-    }
-    else
-#endif
-    {
-        mCallbacks.mTransmitDone(mInstance, aFrame, aAckFrame, aError);
-    }
+    mCallbacks.mTransmitDone(mInstance, aFrame, aAckFrame, aError);
 }
 
 void RadioSpinel::ProcessRadioStateMachine(void)

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -107,34 +107,6 @@ struct RadioSpinelCallbacks
      */
     void (*mSwitchoverDone)(otInstance *aInstance, bool aSuccess);
 
-#if OPENTHREAD_CONFIG_DIAG_ENABLE
-    /**
-     * This callback notifies diagnostics module using `RadioSpinel` of a received frame.
-     *
-     * This callback is used when diagnostics is enabled.
-     *
-     * @param[in]  aInstance  The OpenThread instance structure.
-     * @param[in]  aFrame     A pointer to the received frame or NULL if the receive operation failed.
-     * @param[in]  aError     OT_ERROR_NONE when successfully received a frame,
-     *                        OT_ERROR_ABORT when reception was aborted and a frame was not received,
-     *                        OT_ERROR_NO_BUFS when a frame could not be received due to lack of rx buffer space.
-     */
-    void (*mDiagReceiveDone)(otInstance *aInstance, otRadioFrame *aFrame, Error aError);
-
-    /**
-     * This callback notifies diagnostics module using `RadioSpinel` that the transmission has completed.
-     *
-     * This callback is used when diagnostics is enabled.
-     *
-     * @param[in]  aInstance  The OpenThread instance structure.
-     * @param[in]  aFrame     A pointer to the frame that was transmitted.
-     * @param[in]  aError     OT_ERROR_NONE when the frame was transmitted,
-     *                        OT_ERROR_CHANNEL_ACCESS_FAILURE tx could not take place due to activity on the
-     * channel, OT_ERROR_ABORT when transmission was aborted for other reasons.
-     */
-    void (*mDiagTransmitDone)(otInstance *aInstance, otRadioFrame *aFrame, Error aError);
-#endif // OPENTHREAD_CONFIG_DIAG_ENABLE
-
     /**
      * This method saves the radio spinel metrics to the temporary storage.
      *

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -92,10 +92,6 @@ void Radio::Init(const char *aUrl)
     VerifyOrDie(mRadioUrl.GetPath() != nullptr, OT_EXIT_INVALID_ARGUMENTS);
 
     memset(&callbacks, 0, sizeof(callbacks));
-#if OPENTHREAD_CONFIG_DIAG_ENABLE
-    callbacks.mDiagReceiveDone  = otPlatDiagRadioReceiveDone;
-    callbacks.mDiagTransmitDone = otPlatDiagRadioTransmitDone;
-#endif // OPENTHREAD_CONFIG_DIAG_ENABLE
     callbacks.mEnergyScanDone    = otPlatRadioEnergyScanDone;
     callbacks.mBusLatencyChanged = otPlatRadioBusLatencyChanged;
     callbacks.mReceiveDone       = otPlatRadioReceiveDone;


### PR DESCRIPTION
The radio platform API otPlatDiagRadioTransmitDone() and otPlatDiagRadioReceiveDone() are the same with the API otPlatRadioTxDone() and otPlatRadioReceiveDone(). This commit removes the API otPlatDiagRadioTransmitDone() and otPlatDiagRadioReceiveDone() to let the MAC layer and the diag module to use the same radio API to send and receive 154 frames. So that the diag module could process the ACK frame in the future.

Depends-On: openthread/ot-nrf528xx#1072
