### PR TITLE
[mbedtls] move config file of OpenThread into src

### DIFF
--- a/script/check-scan-build
+++ b/script/check-scan-build
@@ -90,7 +90,7 @@ readonly OT_BUILD_OPTIONS
 
 OT_CFLAGS=(
     "-DMBEDTLS_DEBUG_C"
-    "-isystem $(pwd)/third_party/mbedtls"
+    "-isystem $(pwd)/src/third_party_config/mbedtls"
     "-isystem $(pwd)/third_party/mbedtls/repo/include"
     '-DMBEDTLS_CONFIG_FILE=\"mbedtls-config.h\"'
 )

--- a/src/third_party_config/mbedtls/.clang-format
+++ b/src/third_party_config/mbedtls/.clang-format
@@ -1,0 +1,4 @@
+---
+BasedOnStyle: InheritParentConfig
+ColumnLimit: 0
+...

--- a/src/third_party_config/mbedtls/mbedtls-config.h
+++ b/src/third_party_config/mbedtls/mbedtls-config.h
@@ -27,9 +27,11 @@
  */
 
 // Spans multiple lines to avoid being processed by unifdef
+// clang-format off
 #ifndef \
     MBEDTLS_CONFIG_H
 #define MBEDTLS_CONFIG_H
+// clang-format on
 
 #include "openthread-core-config.h"
 
@@ -126,42 +128,44 @@
 #define MBEDTLS_PK_WRITE_C
 #endif
 
-#define MBEDTLS_MPI_WINDOW_SIZE            1 /**< Maximum windows size used. */
-#define MBEDTLS_MPI_MAX_SIZE              32 /**< Maximum number of bytes for usable MPIs. */
-#define MBEDTLS_ECP_MAX_BITS             256 /**< Maximum bit size of groups */
-#define MBEDTLS_ECP_WINDOW_SIZE            2 /**< Maximum window size used */
-#define MBEDTLS_ECP_FIXED_POINT_OPTIM      0 /**< Enable fixed-point speed-up */
-#define MBEDTLS_ENTROPY_MAX_SOURCES        1 /**< Maximum number of sources supported */
+#define MBEDTLS_MPI_WINDOW_SIZE 1       /**< Maximum windows size used. */
+#define MBEDTLS_MPI_MAX_SIZE 32         /**< Maximum number of bytes for usable MPIs. */
+#define MBEDTLS_ECP_MAX_BITS 256        /**< Maximum bit size of groups */
+#define MBEDTLS_ECP_WINDOW_SIZE 2       /**< Maximum window size used */
+#define MBEDTLS_ECP_FIXED_POINT_OPTIM 0 /**< Enable fixed-point speed-up */
+#define MBEDTLS_ENTROPY_MAX_SOURCES 1   /**< Maximum number of sources supported */
 
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-#define MBEDTLS_PLATFORM_STD_CALLOC      otPlatCAlloc /**< Default allocator to use, can be undefined */
-#define MBEDTLS_PLATFORM_STD_FREE        otPlatFree /**< Default free to use, can be undefined */
+#define MBEDTLS_PLATFORM_STD_CALLOC otPlatCAlloc /**< Default allocator to use, can be undefined */
+#define MBEDTLS_PLATFORM_STD_FREE otPlatFree     /**< Default free to use, can be undefined */
 #else
 #define MBEDTLS_MEMORY_BUFFER_ALLOC_C
 #endif
 
 #if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
-#define MBEDTLS_SSL_MAX_CONTENT_LEN      2000 /**< Maxium fragment length in bytes */
+#define MBEDTLS_SSL_MAX_CONTENT_LEN 2000 /**< Maximum fragment length in bytes */
 #elif OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-#define MBEDTLS_SSL_MAX_CONTENT_LEN      900 /**< Maxium fragment length in bytes */
+#define MBEDTLS_SSL_MAX_CONTENT_LEN 900 /**< Maximum fragment length in bytes */
 #else
-#define MBEDTLS_SSL_MAX_CONTENT_LEN      768 /**< Maxium fragment length in bytes */
+#define MBEDTLS_SSL_MAX_CONTENT_LEN 768 /**< Maximum fragment length in bytes */
 #endif
 
-#define MBEDTLS_SSL_IN_CONTENT_LEN       MBEDTLS_SSL_MAX_CONTENT_LEN
-#define MBEDTLS_SSL_OUT_CONTENT_LEN      MBEDTLS_SSL_MAX_CONTENT_LEN
-#define MBEDTLS_SSL_CIPHERSUITES         MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
+#define MBEDTLS_SSL_IN_CONTENT_LEN MBEDTLS_SSL_MAX_CONTENT_LEN
+#define MBEDTLS_SSL_OUT_CONTENT_LEN MBEDTLS_SSL_MAX_CONTENT_LEN
+#define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
 
 // Spans multiple lines to avoid being processed by unifdef
+// clang-format off
 #if defined(\
     MBEDTLS_USER_CONFIG_FILE)
 #include MBEDTLS_USER_CONFIG_FILE
 #endif
+// clang-format on
 
 #include "mbedtls/version.h"
 #if (MBEDTLS_VERSION_NUMBER < 0x03000000)
-    // Configuration sanity check. Done automatically in Mbed TLS >= 3.0.
-    #include "mbedtls/check_config.h"
+// Configuration sanity check. Done automatically in Mbed TLS >= 3.0.
+#include "mbedtls/check_config.h"
 #endif
 
 #endif /* MBEDTLS_CONFIG_H */

--- a/third_party/mbedtls/BUILD.gn
+++ b/third_party/mbedtls/BUILD.gn
@@ -27,7 +27,7 @@
 
 declare_args() {
   # Configuration file for MbedTLS.
-  mbedtls_config_file = "mbedtls-config.h"
+  mbedtls_config_file = "../../src/third_party_config/mbedtls/mbedtls-config.h"
 
   # Extra dependencies for MbedTLS
   mbedtls_deps = [ "../../src/core:libopenthread_core_config" ]

--- a/third_party/mbedtls/CMakeLists.txt
+++ b/third_party/mbedtls/CMakeLists.txt
@@ -56,10 +56,10 @@ if(UNIFDEFALL_EXE AND SED_EXE AND UNIFDEF_VERSION VERSION_GREATER_EQUAL 2.10)
             "-I$<JOIN:$<TARGET_PROPERTY:ot-config,INTERFACE_INCLUDE_DIRECTORIES>,;-I>"
             "-I$<JOIN:${OT_PUBLIC_INCLUDES},;-I>"
             "-I${CMAKE_CURRENT_SOURCE_DIR}/repo/include"
-            "${CMAKE_CURRENT_SOURCE_DIR}/mbedtls-config.h" |
+            "${CMAKE_CURRENT_SOURCE_DIR}/../../src/third_party_config/mbedtls/mbedtls-config.h" |
             ${SED_EXE} '/openthread-core-config\.h/d' >
             openthread-mbedtls-config.h
-        MAIN_DEPENDENCY mbedtls-config.h
+        MAIN_DEPENDENCY ../../src/third_party_config/mbedtls/mbedtls-config.h
         COMMAND_EXPAND_LISTS
     )
 
@@ -71,7 +71,7 @@ if(UNIFDEFALL_EXE AND SED_EXE AND UNIFDEF_VERSION VERSION_GREATER_EQUAL 2.10)
     add_dependencies(mbedx509 openthread-mbedtls-config)
     add_dependencies(mbedcrypto openthread-mbedtls-config)
 else()
-    configure_file(mbedtls-config.h openthread-mbedtls-config.h COPYONLY)
+    configure_file(../../src/third_party_config/mbedtls/mbedtls-config.h openthread-mbedtls-config.h COPYONLY)
 endif()
 
 target_include_directories(ot-config SYSTEM


### PR DESCRIPTION
This commit moves the `mbedtls-config.h` into `src/third_party_config/mbedtls` not a third_party source.