### PR TITLE
[message] disallow `SetPriority()` on enqueued messages in `PriorityQueue`

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -328,30 +328,16 @@ bool Message::IsMleCommand(Mle::Command aMleCommand) const
 
 Error Message::SetPriority(Priority aPriority)
 {
-    Error          error    = kErrorNone;
-    uint8_t        priority = static_cast<uint8_t>(aPriority);
-    PriorityQueue *priorityQueue;
+    Error   error    = kErrorNone;
+    uint8_t priority = static_cast<uint8_t>(aPriority);
 
     static_assert(kNumPriorities <= 4, "`Metadata::mPriority` as a 2-bit field cannot fit all `Priority` values");
 
     VerifyOrExit(priority < kNumPriorities, error = kErrorInvalidArgs);
 
-    VerifyOrExit(IsInAQueue(), GetMetadata().mPriority = priority);
-    VerifyOrExit(GetMetadata().mPriority != priority);
-
-    priorityQueue = GetPriorityQueue();
-
-    if (priorityQueue != nullptr)
-    {
-        priorityQueue->Dequeue(*this);
-    }
+    VerifyOrExit(!IsInAPriorityQueue(), error = kErrorInvalidState);
 
     GetMetadata().mPriority = priority;
-
-    if (priorityQueue != nullptr)
-    {
-        priorityQueue->Enqueue(*this);
-    }
 
 exit:
     return error;
@@ -869,7 +855,7 @@ void Message::SetMessageQueue(MessageQueue *aMessageQueue)
 void Message::SetPriorityQueue(PriorityQueue *aPriorityQueue)
 {
     GetMetadata().mQueue       = aPriorityQueue;
-    GetMetadata().mInPriorityQ = true;
+    GetMetadata().mInPriorityQ = aPriorityQueue != nullptr;
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -633,13 +633,15 @@ public:
 
     /**
      * Sets the messages priority.
-     * If the message is already queued in a priority queue, changing the priority ensures to
-     * update the message in the associated queue.
+     *
+     * If the message is already enqueued in a priority queue, the priority cannot be changed and `kErrorInvalidState`
+     * is returned.
      *
      * @param[in]  aPriority  The message priority level.
      *
      * @retval kErrorNone          Successfully set the priority for the message.
      * @retval kErrorInvalidArgs   Priority level is not invalid.
+     * @retval kErrorInvalidState  Message is already queued in a priority queue.
      */
     Error SetPriority(Priority aPriority);
 
@@ -1569,6 +1571,8 @@ private:
     }
 
     bool IsInAQueue(void) const { return (GetMetadata().mQueue != nullptr); }
+    bool IsInAPriorityQueue(void) const { return GetMetadata().mInPriorityQ; }
+
     void SetMessageQueue(MessageQueue *aMessageQueue);
     void SetPriorityQueue(PriorityQueue *aPriorityQueue);
 


### PR DESCRIPTION
This commit modifies `Message::SetPriority()` to prevent changing a message's priority after it has been enqueued in a `PriorityQueue`. Attempting to do so will now return `kErrorInvalidState`.

The functionality for altering the priority of an already-enqueued message is not currently used or required. Should this behavior become necessary in the future, the recommended approach is to explicitly dequeue the message first, then change its priority, and finally re-add it to the queue. This makes the intended behavior clearer and more explicit within the code.

This commit also updates the `test_priority_queue` unit test to reflect this change.