### PR TITLE
[dhcp6] fix uninitialized `msgType` warning in `Dhcp6PdClient::SendMessage`

### DIFF
--- a/src/core/border_router/dhcp6_pd_client.cpp
+++ b/src/core/border_router/dhcp6_pd_client.cpp
@@ -223,6 +223,7 @@ void Dhcp6PdClient::SendMessage(void)
     case kStateStopped:
     case kStateToSolicit:
     case kStateToRenew:
+    default:
         ExitNow();
     }
 


### PR DESCRIPTION
### Summary
This PR addresses a `-Wmaybe-uninitialized` compiler warning in `Dhcp6PdClient::SendMessage()` where `msgType` could potentially be used without being initialized.

```
error: 'msgType' may be used uninitialized [-Werror=maybe-uninitialized]
.../openthread/src/core/border_router/dhcp6_pd_client.cpp: In member function 'void ot::BorderRouter::Dhcp6PdClient::SendMessage()':
.../openthread/src/core/border_router/dhcp6_pd_client.cpp:203:23: note: 'msgType' was declared here
```

### Details
Previously, the `switch (mState)` statement did not handle all possible values of `mState`. Some states triggered `ExitNow()`, but the compiler could not guarantee that all code paths initialized `msgType` before use.

A `default: ExitNow();` case has been added to the `switch` statement to explicitly cover all remaining `State` values. This ensures that if any unhandled state is encountered, the function exits early without using an uninitialized `msgType`.

### Impact
- Fixes a build error when compiling with `-Werror=maybe-uninitialized`.
- No functional or behavioral changes to runtime logic.
- Improves safety and future-proofing if new enum values are introduced.