### PR TITLE
[dhcp6-pd-client] initialize `msgType` to fix compiler warning

### DIFF
--- a/src/core/border_router/dhcp6_pd_client.cpp
+++ b/src/core/border_router/dhcp6_pd_client.cpp
@@ -198,9 +198,9 @@ void Dhcp6PdClient::SendMessage(void)
 {
     static const uint16_t kRequestedOptions[] = {BigEndian::HostSwap16(Option::kSolMaxRt)};
 
+    MsgType           msgType = kMsgTypeNone;
     OwnedPtr<Message> message;
     Header            header;
-    MsgType           msgType;
     Ip6::Address      dstAddr;
 
     switch (mState)
@@ -225,6 +225,8 @@ void Dhcp6PdClient::SendMessage(void)
     case kStateToRenew:
         ExitNow();
     }
+
+    VerifyOrExit(msgType != kMsgTypeNone);
 
     if (!mRetxTracker.ShouldRetx())
     {

--- a/src/core/net/dhcp6_types.hpp
+++ b/src/core/net/dhcp6_types.hpp
@@ -63,6 +63,7 @@ constexpr uint16_t kDhcpServerPort = 547; ///< DHCP Server port number.
  */
 enum MsgType : uint8_t
 {
+    kMsgTypeNone               = 0,  ///< Unused message type (reserved).
     kMsgTypeSolicit            = 1,  ///< Solicit message (client sends to locate servers).
     kMsgTypeAdvertise          = 2,  ///< Advertise message (server sends to indicate it is available).
     kMsgTypeRequest            = 3,  ///< Request message (client sends to request config parameters).


### PR DESCRIPTION
This commit updates `SendMessage()` to initialize the `msgType` variable before the `switch` statement.

This change addresses a compiler warning for a possibly uninitialized variable, flagged by `-Werror=maybe-uninitialized`.

Note that the situation where `mState` would be an undefined value is not technically possible in the current logic. However, the compiler cannot guarantee this and therefore generates a warning. Initializing the variable upfront resolves this issue.

----

This is an alternative fix from https://github.com/openthread/openthread/pull/11625. Thanks to @tanyanquan for reporting this.