### PR TITLE
[posix] implement address monitoring in `MdnsSocket`

### DIFF
--- a/src/posix/platform/mdns_socket.hpp
+++ b/src/posix/platform/mdns_socket.hpp
@@ -43,6 +43,15 @@
 namespace ot {
 namespace Posix {
 
+#define OT_POSIX_MDNS_ADDR_MONITOR_PERIODIC 1
+#define OT_POSIX_MDNS_ADDR_MONITOR_NETLINK 2
+
+#if (OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR == OT_POSIX_MDNS_ADDR_MONITOR_NETLINK)
+#error "The `OT_POSIX_MDNS_ADDR_MONITOR_NETLINK` is not supported yet"
+#elif (OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR != OT_POSIX_MDNS_ADDR_MONITOR_PERIODIC)
+#error "The `OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR` is not valid. MUST be one of `OT_POSIX_MDNS_ADDR_MONITOR_*`"
+#endif
+
 /**
  * Implements platform mDNS socket APIs.
  */
@@ -106,8 +115,9 @@ public:
     void    SendUnicast(otMessage *aMessage, const otPlatMdnsAddressInfo *aAddress);
 
 private:
-    static constexpr uint16_t kMaxMessageLength = 2000;
-    static constexpr uint16_t kMdnsPort         = 5353;
+    static constexpr uint16_t kMaxMessageLength  = 2000;
+    static constexpr uint16_t kMdnsPort          = 5353;
+    static constexpr uint64_t kAddrMonitorPeriod = OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR_PERIOD;
 
     enum MsgType : uint8_t
     {
@@ -130,6 +140,14 @@ private:
     void    ClearTxQueue(void);
     void    SendQueuedMessages(MsgType aMsgType);
     void    ReceiveMessage(MsgType aMsgType);
+
+#if (OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR == OT_POSIX_MDNS_ADDR_MONITOR_PERIODIC)
+    void StartAddressMonitoring(void) { ReportInfraIfAddresses(); }
+    void StopAddressMonitoring(void) {}
+    void ReportInfraIfAddresses(void);
+    void UpdateTimeout(struct timeval &aTimeout);
+    void ProcessTimeout(void);
+#endif
 
     otError OpenIp4Socket(uint32_t aInfraIfIndex);
     otError JoinOrLeaveIp4MulticastGroup(bool aJoin, uint32_t aInfraIfIndex);
@@ -163,6 +181,9 @@ private:
     otIp6Address   mMulticastIp6Address;
     otIp4Address   mMulticastIp4Address;
     otInstance    *mInstance;
+#if (OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR == OT_POSIX_MDNS_ADDR_MONITOR_PERIODIC)
+    uint64_t mNextReportTime;
+#endif
 };
 
 } // namespace Posix

--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -454,6 +454,32 @@
 #define OPENTHREAD_POSIX_CONFIG_RESOLV_CONF_ENABLED_INIT (!OPENTHREAD_POSIX_CONFIG_ANDROID_ENABLE)
 #endif
 
+/**
+ * @def OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR
+ *
+ * Specifies the behavior of `MdnsSocket` and how it implements monitoring and reporting of infra-interface IPv4 and
+ * IPv6 addresses.
+ *
+ * The valid values for this config, `OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR_*`, are defined in
+ *  `posix/platform/mdns_socket.h`.
+ */
+#ifndef OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR
+#define OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR OT_POSIX_MDNS_ADDR_MONITOR_PERIODIC
+#endif
+
+/**
+ * @def OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR_PERIOD
+ *
+ * Specifies the duration in milliseconds (ms) for the periodic check used by the `MdnsSocket` implementation to
+ * monitor and report the infra-interface IPv4 and IPv6 addresses.
+ *
+ * This is applicable only when `OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR` is set to
+ * `OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR_PERIODIC`.
+ */
+#ifndef OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR_PERIOD
+#define OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR_PERIOD (5000)
+#endif
+
 //---------------------------------------------------------------------------------------------------------------------
 // Removed or renamed POSIX specific configs.
 


### PR DESCRIPTION
This commit introduces an initial implementation in `Posix::MdnsSocket` to monitor and report all IPv4 and IPv6 addresses assigned to the infrastructure network interface. This mechanism is used by OpenThread's native mDNS module and was added in PRs #11353 and #11394.

A new configuration, `OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR`, is added to select the monitoring strategy. This commit implements the `OT_POSIX_MDNS_ADDR_MONITOR_PERIODIC` approach, where `getifaddrs()`
is used to enumerate addresses periodically. The polling interval is configured by  `OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR_PERIOD`.

Note that the OpenThread mDNS module itself tracks the list of reported addresses and will only take action when there is a change from what was previously announced. This allows the platform to simply report the full list of current addresses at each interval.


--------------

Validates the change in this PR running it locally:

```bash
abtink ~/sw/github/openthread (posix/mdns-addr-periodic) $ sudo ./src/posix/ot-cli 'spinel+hdlc+forkpty://examples/apps/ncp/ot-rcp?forkpty-arg=1'
> log level 4
Done

> mdns enable 2
Done

> mdns localhostaddrs
fe80:0:0:0:976b:f9a4:5b1f:7f8d
172.19.193.76
Done
```

We see the addresses on the interface:
```
abtink ~/sw/github/openthread (posix/mdns-addr-periodic) $ ip addr show dev ens4
2: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1460 qdisc mq state UP group default qlen 1000
    link/ether 42:01:ac:13:c1:4c brd ff:ff:ff:ff:ff:ff
    altname enp0s4
    altname enx4201ac13c14c
    inet 172.19.193.76/32 scope global dynamic noprefixroute ens4
       valid_lft 1960sec preferred_lft 1960sec
    inet6 fe80::976b:f9a4:5b1f:7f8d/64 scope link noprefixroute 
       valid_lft forever preferred_lft forever
```

And we see from the logs the periodic behavior:
```
./src/posix/ot-cli: RCP version: OPENTHREAD/thread-reference-20230706-1432-g4610a8e00; SIMULATION-RCP-toranj; Jun 26 2025 00:32:11
./src/posix/ot-cli: 00:00:11.332 [I] P-MdnsSocket--: Successfully opened IPv4 socket
./src/posix/ot-cli: 00:00:11.332 [I] P-MdnsSocket--: Successfully opened IPv6 socket
./src/posix/ot-cli: 00:00:11.332 [I] MulticastDns--: Host address event: remove all
./src/posix/ot-cli: 00:00:11.332 [I] MulticastDns--: Host address 0:0:0:0:0:ffff:ac13:c14c event: added
./src/posix/ot-cli: 00:00:11.332 [I] MulticastDns--: Host address fe80:0:0:0:976b:f9a4:5b1f:7f8d event: added
./src/posix/ot-cli: 00:00:11.332 [I] P-MdnsSocket--: Enabled
./src/posix/ot-cli: 00:00:11.332 [I] MulticastDns--: Enabling on infra-if-index 2
./src/posix/ot-cli: 00:00:11.332 [I] Settings------: Read BorderAgentId {id:7d49906b1a24d5047bbc5654d57216a3}
./src/posix/ot-cli: 00:00:16.332 [I] MulticastDns--: Host address event: remove all
./src/posix/ot-cli: 00:00:16.332 [I] MulticastDns--: Host address 0:0:0:0:0:ffff:ac13:c14c event: removed
./src/posix/ot-cli: 00:00:16.332 [I] MulticastDns--: Host address fe80:0:0:0:976b:f9a4:5b1f:7f8d event: removed
./src/posix/ot-cli: 00:00:16.333 [I] MulticastDns--: Host address 0:0:0:0:0:ffff:ac13:c14c event: added
./src/posix/ot-cli: 00:00:16.333 [I] MulticastDns--: Host address fe80:0:0:0:976b:f9a4:5b1f:7f8d event: added
./src/posix/ot-cli: 00:00:21.332 [I] MulticastDns--: Host address event: remove all
./src/posix/ot-cli: 00:00:21.332 [I] MulticastDns--: Host address 0:0:0:0:0:ffff:ac13:c14c event: removed
./src/posix/ot-cli: 00:00:21.332 [I] MulticastDns--: Host address fe80:0:0:0:976b:f9a4:5b1f:7f8d event: removed
./src/posix/ot-cli: 00:00:21.333 [I] MulticastDns--: Host address 0:0:0:0:0:ffff:ac13:c14c event: added
./src/posix/ot-cli: 00:00:21.333 [I] MulticastDns--: Host address fe80:0:0:0:976b:f9a4:5b1f:7f8d event: added
./src/posix/ot-cli: 00:00:26.334 [I] MulticastDns--: Host address event: remove all
./src/posix/ot-cli: 00:00:26.334 [I] MulticastDns--: Host address 0:0:0:0:0:ffff:ac13:c14c event: removed
./src/posix/ot-cli: 00:00:26.334 [I] MulticastDns--: Host address fe80:0:0:0:976b:f9a4:5b1f:7f8d event: removed
./src/posix/ot-cli: 00:00:26.334 [I] MulticastDns--: Host address 0:0:0:0:0:ffff:ac13:c14c event: added
./src/posix/ot-cli: 00:00:26.334 [I] MulticastDns--: Host address fe80:0:0:0:976b:f9a4:5b1f:7f8d event: added
```
After adding a new address using `ip -6 addr add fd00:abba::1/64 dev ens4`, we can see it is reflected in the mDNS module:

```bash
> mdns localhostaddrs
fe80:0:0:0:976b:f9a4:5b1f:7f8d
fd00:abba:0:0:0:0:0:1
172.19.193.76
Done
```

Removing it later `sudo ip -6 addr del fd00:abba::1/64 dev ens4`

```
> mdns localhostaddrs
fe80:0:0:0:976b:f9a4:5b1f:7f8d
172.19.193.76
Done
> 
```



