### PR TITLE
[mac] add support for offloading data polls to radio layer

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (520)
+#define OPENTHREAD_API_VERSION (521)
 
 /**
  * @addtogroup api-instance

--- a/src/core/config/mac.h
+++ b/src/core/config/mac.h
@@ -559,6 +559,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MAC_DATA_POLL_OFFLOAD_ENABLE
+ *
+ * This setting specifies whether the Poll Offload functionality is enabled
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAC_DATA_POLL_OFFLOAD_ENABLE
+#define OPENTHREAD_CONFIG_MAC_DATA_POLL_OFFLOAD_ENABLE 0
+#endif
+
+/**
  * @}
  */
 

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -235,6 +235,23 @@ public:
      */
     Error RequestDataPollTransmission(void);
 
+#if OPENTHREAD_CONFIG_MAC_DATA_POLL_OFFLOAD_ENABLE
+    /**
+     * Request trasnmission of data poll (MAC Data Request) frames automatically by the
+     * radio layer.
+     *
+     * @retval kErrorNone          Automatic Data poll transmission request is scheduled successfully.
+     * @retval kErrorInvalidState  The MAC layer is not enabled.
+     */
+    Error StartRadioAutoPoll(TimeMilli aStartTime, uint32_t aPollPeriod);
+
+    /**
+     * Request termination of automatic data poll transmission by the radio layer.
+     *
+     */
+    void StopRadioAutoPoll();
+#endif
+
     /**
      * Returns a reference to the IEEE 802.15.4 Extended Address.
      *
@@ -448,6 +465,17 @@ public:
      * Requests.
      */
     bool IsInTransmitState(void) const;
+
+#if OPENTHREAD_CONFIG_MAC_DATA_POLL_OFFLOAD_ENABLE
+    /**
+     * Returns if the MAC layer is in radio poll state.
+     *
+     * The MAC layer is in radio poll transmit state when the data poll operation has been delegated to the radio layer.
+     * During this state, the MAC layer does nothing and will exit the state only when an ACK with FP = 1 is received, a
+     * TX error occurs or the MAC layer is requested to perform a direct frame transmission.
+     */
+    bool IsInRadioPollState(void) const { return (mOperation == kOperationRadioAutoPoll); }
+#endif
 
     /**
      * Registers a callback to provide received raw IEEE 802.15.4 frames.
@@ -789,6 +817,9 @@ private:
 #if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
         kOperationTransmitWakeup,
 #endif
+#if OPENTHREAD_CONFIG_MAC_DATA_POLL_OFFLOAD_ENABLE
+        kOperationRadioAutoPoll,
+#endif
     };
 
 #if OPENTHREAD_CONFIG_MAC_RETRY_SUCCESS_HISTOGRAM_ENABLE
@@ -837,6 +868,9 @@ private:
     void     UpdateNeighborLinkInfo(Neighbor &aNeighbor, const RxFrame &aRxFrame);
     bool     HandleMacCommand(RxFrame &aFrame);
     void     HandleTimer(void);
+#if OPENTHREAD_CONFIG_MAC_DATA_POLL_OFFLOAD_ENABLE
+    void BeginRadioAutoPoll();
+#endif
 
     void  Scan(Operation aScanOperation, uint32_t aScanChannels, uint16_t aScanDuration);
     Error UpdateScanChannel(void);
@@ -949,6 +983,11 @@ private:
 #endif
 
     KeyMaterial mMode2KeyMaterial;
+
+#if OPENTHREAD_CONFIG_MAC_DATA_POLL_OFFLOAD_ENABLE
+    TimeMilli mAutoPollStartTime;
+    uint32_t  mAutoPollPeriod;
+#endif
 };
 
 /**

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -740,6 +740,26 @@ public:
     }
 #endif // OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
 
+#if OPENTHREAD_CONFIG_MAC_DATA_POLL_OFFLOAD_ENABLE
+    /**
+     * Start Automatic Data Poll transmission using an initial frame counter and periodicity.
+     *
+     * @param[in] aFrame       A reference to the frame to be transmitted.
+     * @param[in] aStartTime   Timestamp for the first poll
+     * @param[in] aPollPeriod  Periodicity of the IEEE 802.15.4 data poll frame
+     *
+     * @retval kErrorNone            Successfully enabled automatic Data Poll transmission
+     * @retval kErrorNotImplemented  Radio driver doesn't support automatic Data Poll transmission.
+     */
+    Error StartAutoPoll(Mac::TxFrame &aFrame, TimeMilli aStartTime, uint32_t aPollPeriod);
+
+    /**
+     * Stop Automatic Data Poll transmission
+     *
+     */
+    void StopAutoPoll();
+#endif
+
     /**
      * Checks if a given channel is valid as a CSL channel.
      *
@@ -1055,6 +1075,15 @@ inline uint32_t Radio::GetBusLatency(void) { return otPlatRadioGetBusLatency(Get
 inline void Radio::SetDiagMode(bool aMode) { otPlatDiagModeSet(aMode); }
 inline bool Radio::GetDiagMode(void) { return otPlatDiagModeGet(); }
 #endif
+
+#if OPENTHREAD_CONFIG_MAC_DATA_POLL_OFFLOAD_ENABLE
+inline Error Radio::StartAutoPoll(Mac::TxFrame &aFrame, TimeMilli aStartTime, uint32_t aPollPeriod)
+{
+    return otPlatRadioStartAutoPoll(GetInstancePtr(), &aFrame, aStartTime.GetValue(), aPollPeriod);
+}
+inline void Radio::StopAutoPoll() { otPlatRadioStopAutoPoll(GetInstancePtr()); }
+#endif
+
 #else //----------------------------------------------------------------------------------------------------------------
 
 inline otRadioCaps Radio::GetCaps(void)

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -386,3 +386,20 @@ extern "C" OT_TOOL_WEAK void otPlatRadioSetRxOnWhenIdle(otInstance *aInstance, b
 }
 
 OT_TOOL_WEAK otError otPlatRadioSetChannelTargetPower(otInstance *, uint8_t, int16_t) { return kErrorNotImplemented; }
+
+#if OPENTHREAD_CONFIG_MAC_DATA_POLL_OFFLOAD_ENABLE
+extern "C" OT_TOOL_WEAK otError otPlatRadioStartAutoPoll(otInstance   *aInstance,
+                                                         otRadioFrame *aFrame,
+                                                         uint32_t      aStartTime,
+                                                         uint32_t      aPollPeriod)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aFrame);
+    OT_UNUSED_VARIABLE(aStartTime);
+    OT_UNUSED_VARIABLE(aPollPeriod);
+
+    return kErrorNotImplemented;
+}
+
+extern "C" OT_TOOL_WEAK void otPlatRadioStopAutoPoll(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
+#endif


### PR DESCRIPTION
This PR adds a new capability to the radio layer, the sending of MAC data poll frames. 

In a typical working situation, a Thread sleepy end device will sleep for most of the time, and wake up when a button is pressed or when sensor data needs to be updated. During this time it will also wake up periodically to send Mac Data polls. Usually the device only sends a Data poll and then goes back to sleep as the parent doesn't have any data buffered for him. Applications are designed to reduce the traffic destined for the Thread end device to preserve battery life.

This working pattern creates an opportunity for platforms that have a dedicated core for the radio layer. The power consumption of the device can be reduced by using the Mac Data Poll offloading mechanism. Only the low power radio core needs waking up for sending the periodic data poll frames. In this way the main application core can remain in sleep until there is data received that needs processing.

The PR introduces 2 new radio layer APIs `otPlatRadioStartAutoPoll` and `otPlatRadioStopAutoPoll` and a new compile option `OPENTHREAD_CONFIG_MAC_DATA_POLL_OFFLOAD_ENABLE` to enable this new feature. A platform that wants to take advantage of this feature needs to implement the 2 APIs according to the description from platform\radio.h

Switching to this polling mode happens after the device is attached to a parent and only if the parent is located on the 15.4 radio link. The MAC and SubMAC layers enter a radio poll state allowing the main core to sleep. When an ACK with FP=1 is received, the number of offloaded polls reaches 255 or an error occurs the radio layer will send a Mac Data Confirm and update the mac frame with the last frame counter and sequence number used by the Radio. From the perspective of the MAC layer it will look like just one poll was sent as for the non offloaded method.