### PR TITLE
[diag] add `diag sweep` command

### DIFF
--- a/src/core/diags/README.md
+++ b/src/core/diags/README.md
@@ -365,6 +365,20 @@ Clear statistics during diagnostics mode.
 Done
 ```
 
+### diag sweep [async] \<length\>
+
+Transmit a single radio frame of a given length for every supported channel.
+
+- async: Use the non-blocking mode.
+- length: The length of packet. The valid range is [3, 127].
+
+```bash
+> diag sweep 100
+Done
+> diag send async 100
+Done
+```
+
 ### diag gpio get \<gpio\>
 
 Get the gpio value.

--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -225,6 +225,7 @@ private:
     Error ProcessStats(uint8_t aArgsLength, char *aArgs[]);
     Error ProcessStop(uint8_t aArgsLength, char *aArgs[]);
     Error ProcessStream(uint8_t aArgsLength, char *aArgs[]);
+    Error ProcessSweep(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_RADIO && !OPENTHREAD_RADIO_CLI
     Error ProcessEcho(uint8_t aArgsLength, char *aArgs[]);
 #endif
@@ -252,6 +253,7 @@ private:
         kTxCmdNone,
         kTxCmdRepeat,
         kTxCmdSend,
+        kTxCmdSweep,
     };
 
     Stats mStats;
@@ -269,6 +271,7 @@ private:
     bool          mIsAsyncSend : 1;
     bool          mDiagSendOn : 1;
     bool          mIsSleepOn : 1;
+    bool          mIsAsyncSweep : 1;
 #endif
 
     ReceiveConfig        mReceiveConfig;


### PR DESCRIPTION
This change introduces a new "diag sweep" command that iterates over all channels and transmits a frame of a given length.