### PR TITLE
[mdns] improve local host address logging

### DIFF
--- a/src/core/net/mdns.hpp
+++ b/src/core/net/mdns.hpp
@@ -1182,6 +1182,8 @@ private:
             bool         mAdded;
         };
 
+        void LogAddressChange(bool aAdded, AddrType aAddrType, const Ip6::Address &aAddress) const;
+
         using EventTimer = TimerMilliIn<Core, &Core::HandleLocalHostEventTimer>;
 
         Heap::String          mName;


### PR DESCRIPTION
This commit refines the logging of local host address events in the `Mdns` module.

Address update events signaled from the platform layer are now logged at the `Debug` level instead of `Info`. This avoids excessive logging from platform implementations that use periodic polling for address monitoring.

Instead, after the events are processed, an `Info` level log is now generated only if the address list has changed. This new log specifies which addresses were added or removed. Additionally, the format for IPv4 addresses (tracked as IPv4-mapped IPv6 addresses) is updated to use the standard dotted-decimal notation, making the logs easier to read.