### PR TITLE
[posix] add helpers in `Mainloop::Source` to update `Context`

### DIFF
--- a/src/posix/platform/alarm.cpp
+++ b/src/posix/platform/alarm.cpp
@@ -38,6 +38,7 @@
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
 
+#include "mainloop.hpp"
 #include "common/code_utils.hpp"
 
 static bool     sIsMsRunning = false;

--- a/src/posix/platform/daemon.cpp
+++ b/src/posix/platform/daemon.cpp
@@ -334,56 +334,38 @@ void Daemon::TearDown(void)
 #endif
 }
 
-void Daemon::Update(otSysMainloopContext &aContext)
+void Daemon::Update(Mainloop::Context &aContext)
 {
-    if (mListenSocket != -1)
-    {
-        FD_SET(mListenSocket, &aContext.mReadFdSet);
-        FD_SET(mListenSocket, &aContext.mErrorFdSet);
+    Mainloop::AddToReadFdSet(mListenSocket, aContext);
+    Mainloop::AddToErrorFdSet(mListenSocket, aContext);
 
-        if (aContext.mMaxFd < mListenSocket)
-        {
-            aContext.mMaxFd = mListenSocket;
-        }
-    }
-
-    if (mSessionSocket != -1)
-    {
-        FD_SET(mSessionSocket, &aContext.mReadFdSet);
-        FD_SET(mSessionSocket, &aContext.mErrorFdSet);
-
-        if (aContext.mMaxFd < mSessionSocket)
-        {
-            aContext.mMaxFd = mSessionSocket;
-        }
-    }
-
-    return;
+    Mainloop::AddToReadFdSet(mSessionSocket, aContext);
+    Mainloop::AddToErrorFdSet(mSessionSocket, aContext);
 }
 
-void Daemon::Process(const otSysMainloopContext &aContext)
+void Daemon::Process(const Mainloop::Context &aContext)
 {
     ssize_t rval;
 
     VerifyOrExit(mListenSocket != -1);
 
-    if (FD_ISSET(mListenSocket, &aContext.mErrorFdSet))
+    if (Mainloop::HasFdErrored(mListenSocket, aContext))
     {
         DieNowWithMessage("daemon socket error", OT_EXIT_FAILURE);
     }
-    else if (FD_ISSET(mListenSocket, &aContext.mReadFdSet))
+    else if (Mainloop::IsFdReadable(mListenSocket, aContext))
     {
         InitializeSessionSocket();
     }
 
     VerifyOrExit(mSessionSocket != -1);
 
-    if (FD_ISSET(mSessionSocket, &aContext.mErrorFdSet))
+    if (Mainloop::HasFdErrored(mSessionSocket, aContext))
     {
         close(mSessionSocket);
         mSessionSocket = -1;
     }
-    else if (FD_ISSET(mSessionSocket, &aContext.mReadFdSet))
+    else if (Mainloop::IsFdReadable(mSessionSocket, aContext))
     {
         uint8_t buffer[OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH];
 

--- a/src/posix/platform/daemon.hpp
+++ b/src/posix/platform/daemon.hpp
@@ -47,8 +47,8 @@ public:
 
     void SetUp(void);
     void TearDown(void);
-    void Update(otSysMainloopContext &aContext) override;
-    void Process(const otSysMainloopContext &aContext) override;
+    void Update(Mainloop::Context &aContext) override;
+    void Process(const Mainloop::Context &aContext) override;
     int  OutputFormatV(const char *aFormat, va_list aArguments);
 
 private:

--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -516,7 +516,7 @@ void InfraNetif::Deinit(void)
     mInfraIfIndex   = 0;
 }
 
-void InfraNetif::Update(otSysMainloopContext &aContext)
+void InfraNetif::Update(Mainloop::Context &aContext)
 {
 #ifdef __linux__
     VerifyOrExit(mNetLinkSocket != -1);
@@ -525,13 +525,11 @@ void InfraNetif::Update(otSysMainloopContext &aContext)
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
     VerifyOrExit(mInfraIfIcmp6Socket != -1);
 
-    FD_SET(mInfraIfIcmp6Socket, &aContext.mReadFdSet);
-    aContext.mMaxFd = OT_MAX(aContext.mMaxFd, mInfraIfIcmp6Socket);
+    Mainloop::AddToReadFdSet(mInfraIfIcmp6Socket, aContext);
 #endif
 
 #ifdef __linux__
-    FD_SET(mNetLinkSocket, &aContext.mReadFdSet);
-    aContext.mMaxFd = OT_MAX(aContext.mMaxFd, mNetLinkSocket);
+    Mainloop::AddToReadFdSet(mNetLinkSocket, aContext);
 #endif
 
 exit:
@@ -682,7 +680,7 @@ void InfraNetif::SetInfraNetifIcmp6SocketForBorderRouting(int aIcmp6Socket)
 }
 #endif
 
-void InfraNetif::Process(const otSysMainloopContext &aContext)
+void InfraNetif::Process(const Mainloop::Context &aContext)
 {
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
     VerifyOrExit(mInfraIfIcmp6Socket != -1);
@@ -693,14 +691,14 @@ void InfraNetif::Process(const otSysMainloopContext &aContext)
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-    if (FD_ISSET(mInfraIfIcmp6Socket, &aContext.mReadFdSet))
+    if (Mainloop::IsFdReadable(mInfraIfIcmp6Socket, aContext))
     {
         ReceiveIcmp6Message();
     }
 #endif
 
 #ifdef __linux__
-    if (FD_ISSET(mNetLinkSocket, &aContext.mReadFdSet))
+    if (Mainloop::IsFdReadable(mNetLinkSocket, aContext))
     {
         ReceiveNetLinkMessage();
     }

--- a/src/posix/platform/infra_if.hpp
+++ b/src/posix/platform/infra_if.hpp
@@ -64,14 +64,14 @@ public:
      *
      * @param[in,out]   aContext    A reference to the mainloop context.
      */
-    void Update(otSysMainloopContext &aContext) override;
+    void Update(Mainloop::Context &aContext) override;
 
     /**
      * Performs infrastructure network interface processing.
      *
      * @param[in]   aContext   A reference to the mainloop context.
      */
-    void Process(const otSysMainloopContext &aContext) override;
+    void Process(const Mainloop::Context &aContext) override;
 
     /**
      * Initializes the infrastructure network interface.

--- a/src/posix/platform/mainloop.hpp
+++ b/src/posix/platform/mainloop.hpp
@@ -40,6 +40,97 @@ namespace ot {
 namespace Posix {
 namespace Mainloop {
 
+typedef otSysMainloopContext Context; ///<  Represents a `Mainloop` context.
+
+/**
+ * Adds a file descriptor to the read set in the mainloop context.
+ *
+ * If the file descriptor @p aFd is valid (non-negative), this method adds it to `aContext.mReadFdSet` and
+ * updates `aContext.mMaxFd` if @p aFd is larger than the current max. If @p aFd is negative, no action is taken.
+ *
+ * @param[in]      aFd       The file descriptor to add.
+ * @param[in,out]  aContext  A reference to the mainloop context.
+ */
+void AddToReadFdSet(int aFd, Context &aContext);
+
+/**
+ * Adds a file descriptor to the write set in the mainloop context.
+ *
+ * If the file descriptor @p aFd is valid (non-negative), this method adds it to `aContext.mWriteFdSet` and
+ * updates `aContext.mMaxFd` if @p aFd is larger than the current max. If @p aFd is negative, no action is taken.
+ *
+ * @param[in]      aFd       The file descriptor to add.
+ * @param[in,out]  aContext  A reference to the mainloop context.
+ */
+void AddToWriteFdSet(int aFd, Context &aContext);
+
+/**
+ * Adds a file descriptor to the error set in the mainloop context.
+ *
+ * If the file descriptor @p aFd is valid (non-negative), this method adds it to `aContext.mErrorFdSet` and
+ * updates `aContext.mMaxFd` if @p aFd is larger than the current max. If @p aFd is negative, no action is taken.
+ *
+ * @param[in]      aFd       The file descriptor to add.
+ * @param[in,out]  aContext  A reference to the mainloop context.
+ */
+void AddToErrorFdSet(int aFd, Context &aContext);
+
+/**
+ * Checks if a file descriptor is in the read set of the mainloop context.
+ *
+ * This is intended to be called after the `select()` call has returned.
+ *
+ * @param[in]  aFd       The file descriptor to check.
+ * @param[in]  aContext  A reference to the mainloop context.
+ *
+ * @returns `true` if the given file descriptor is readable, `false` otherwise.
+ */
+inline bool IsFdReadable(int aFd, const Context &aContext) { return FD_ISSET(aFd, &aContext.mReadFdSet); }
+
+/**
+ * Checks if a file descriptor is in the write set of the mainloop context.
+ *
+ * This is intended to be called after the `select()` call has returned.
+ *
+ * @param[in]  aFd       The file descriptor to check.
+ * @param[in]  aContext  A reference to the mainloop context.
+ *
+ * @returns `true` if the given file descriptor is writable, `false` otherwise.
+ */
+inline bool IsFdWritable(int aFd, const Context &aContext) { return FD_ISSET(aFd, &aContext.mWriteFdSet); }
+
+/**
+ * Checks if a file descriptor is in the error set of the mainloop context.
+ *
+ * This is intended to be called after the `select()` call has returned.
+ *
+ * @param[in]  aFd       The file descriptor to check.
+ * @param[in]  aContext  A reference to the mainloop context.
+ *
+ * @returns `true` if the given file descriptor has an error, `false` otherwise.
+ */
+inline bool HasFdErrored(int aFd, const Context &aContext) { return FD_ISSET(aFd, &aContext.mErrorFdSet); }
+
+/**
+ * Gets the current timeout value from the mainloop context.
+ *
+ * @param[in]  aContext  A reference to the mainloop context.
+ *
+ * @returns The timeout value.
+ */
+uint64_t GetTimeout(const Context &aContext);
+
+/**
+ * Sets the timeout in the mainloop context if the new timeout is earlier than the existing one.
+ *
+ * This method compares `aTimeout` with the current timeout in `aContext` and updates the context's
+ * timeout to `aTimeout` if it is smaller (earlier).
+ *
+ * @param[in]      aTimeout  The new timeout value to potentially set.
+ * @param[in,out]  aContext  A reference to the mainloop context.
+ */
+void SetTimeoutIfEarlier(uint64_t aTimeout, Context &aContext);
+
 /**
  * Is the base for all mainloop event sources.
  */
@@ -53,21 +144,23 @@ public:
      *
      * @param[in,out]   aContext    A reference to the mainloop context.
      */
-    virtual void Update(otSysMainloopContext &aContext) = 0;
+    virtual void Update(Context &aContext) = 0;
 
     /**
      * Processes the mainloop events.
      *
      * @param[in]   aContext    A reference to the mainloop context.
      */
-    virtual void Process(const otSysMainloopContext &aContext) = 0;
+    virtual void Process(const Context &aContext) = 0;
 
     /**
      * Marks destructor virtual method.
      */
-    virtual ~Source() = default;
+    virtual ~Source(void) = default;
 
 private:
+    static void AddFd(int aFd, Context &aContext, fd_set &aFdSet);
+
     Source *mNext = nullptr;
 };
 
@@ -82,14 +175,14 @@ public:
      *
      * @param[in,out]   aContext    A reference to the mainloop context.
      */
-    void Update(otSysMainloopContext &aContext);
+    void Update(Context &aContext);
 
     /**
      * Processes events in the mainloop context.
      *
      * @param[in]   aContext    A reference to the mainloop context.
      */
-    void Process(const otSysMainloopContext &aContext);
+    void Process(const Context &aContext);
 
     /**
      * Adds a new event source into the mainloop.

--- a/src/posix/platform/mdns_socket.hpp
+++ b/src/posix/platform/mdns_socket.hpp
@@ -114,14 +114,14 @@ public:
      *
      * @param[in,out]   aContext    A reference to the mainloop context.
      */
-    void Update(otSysMainloopContext &aContext) override;
+    void Update(Mainloop::Context &aContext) override;
 
     /**
      * Performs `MdnsSocket` processing.
      *
      * @param[in]   aContext   A reference to the mainloop context.
      */
-    void Process(const otSysMainloopContext &aContext) override;
+    void Process(const Mainloop::Context &aContext) override;
 
     // otPlatMdns APIs
     otError SetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex);
@@ -158,11 +158,11 @@ private:
     void    StopAddressMonitoring(void);
     void    ReportInfraIfAddresses(void);
 #if (OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR == OT_POSIX_MDNS_ADDR_MONITOR_PERIODIC)
-    void UpdateTimeout(struct timeval &aTimeout);
+    void UpdateTimeout(Mainloop::Context &aContext);
     void ProcessTimeout(void);
 #elif (OPENTHREAD_POSIX_CONFIG_MDNS_ADDR_MONITOR == OT_POSIX_MDNS_ADDR_MONITOR_NETLINK)
-    void UpdateNetlink(otSysMainloopContext &aContext) const;
-    void ProcessNetlink(const otSysMainloopContext &aContext) const;
+    void UpdateNetlink(Mainloop::Context &aContext) const;
+    void ProcessNetlink(const Mainloop::Context &aContext) const;
     void ProcessNetlinkAddrEvent(void *aNetlinkMsg) const;
 #endif
 

--- a/src/posix/platform/multicast_routing.cpp
+++ b/src/posix/platform/multicast_routing.cpp
@@ -187,24 +187,23 @@ exit:
     return found;
 }
 
-void MulticastRoutingManager::Update(otSysMainloopContext &aContext)
+void MulticastRoutingManager::Update(Mainloop::Context &aContext)
 {
     VerifyOrExit(IsEnabled());
 
-    FD_SET(mMulticastRouterSock, &aContext.mReadFdSet);
-    aContext.mMaxFd = OT_MAX(aContext.mMaxFd, mMulticastRouterSock);
+    Mainloop::AddToReadFdSet(mMulticastRouterSock, aContext);
 
 exit:
     return;
 }
 
-void MulticastRoutingManager::Process(const otSysMainloopContext &aContext)
+void MulticastRoutingManager::Process(const Mainloop::Context &aContext)
 {
     VerifyOrExit(IsEnabled());
 
     ExpireMulticastForwardingCache();
 
-    if (FD_ISSET(mMulticastRouterSock, &aContext.mReadFdSet))
+    if (Mainloop::IsFdReadable(mMulticastRouterSock, aContext))
     {
         ProcessMulticastRouterMessages();
     }

--- a/src/posix/platform/multicast_routing.hpp
+++ b/src/posix/platform/multicast_routing.hpp
@@ -64,8 +64,8 @@ public:
     bool IsEnabled(void) const { return mMulticastRouterSock >= 0; }
     void SetUp(void);
     void TearDown(void);
-    void Update(otSysMainloopContext &aContext) override;
-    void Process(const otSysMainloopContext &aContext) override;
+    void Update(Mainloop::Context &aContext) override;
+    void Process(const Mainloop::Context &aContext) override;
     void HandleStateChange(otInstance *aInstance, otChangedFlags aFlags);
 
 private:

--- a/src/posix/platform/resolver.hpp
+++ b/src/posix/platform/resolver.hpp
@@ -36,6 +36,7 @@
 #include <sys/select.h>
 
 #include "logger.hpp"
+#include "mainloop.hpp"
 
 #if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE
 
@@ -92,14 +93,14 @@ public:
      *
      * @param[in,out]  aContext  The mainloop context.
      */
-    void UpdateFdSet(otSysMainloopContext &aContext);
+    void UpdateFdSet(Mainloop::Context &aContext);
 
     /**
      * Handles the result of select.
      *
      * @param[in]  aContext  The mainloop context.
      */
-    void Process(const otSysMainloopContext &aContext);
+    void Process(const Mainloop::Context &aContext);
 
     /**
      * Sets whether to retrieve upstream DNS servers from "resolv.conf".

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -565,7 +565,7 @@ namespace Posix {
 
 const char Udp::kLogModuleName[] = "Udp";
 
-void Udp::Update(otSysMainloopContext &aContext)
+void Udp::Update(Mainloop::Context &aContext)
 {
     VerifyOrExit(gNetifIndex != 0);
 
@@ -579,12 +579,7 @@ void Udp::Update(otSysMainloopContext &aContext)
         }
 
         fd = FdFromHandle(socket->mHandle);
-        FD_SET(fd, &aContext.mReadFdSet);
-
-        if (aContext.mMaxFd < fd)
-        {
-            aContext.mMaxFd = fd;
-        }
+        Mainloop::AddToReadFdSet(fd, aContext);
     }
 
 exit:
@@ -626,7 +621,7 @@ Udp &Udp::Get(void)
     return sInstance;
 }
 
-void Udp::Process(const otSysMainloopContext &aContext)
+void Udp::Process(const Mainloop::Context &aContext)
 {
     otMessageSettings msgSettings = {false, OT_MESSAGE_PRIORITY_NORMAL};
 
@@ -634,7 +629,7 @@ void Udp::Process(const otSysMainloopContext &aContext)
     {
         int fd = FdFromHandle(socket->mHandle);
 
-        if (fd > 0 && FD_ISSET(fd, &aContext.mReadFdSet))
+        if (fd > 0 && Mainloop::IsFdReadable(fd, aContext))
         {
             otMessageInfo messageInfo;
             otMessage    *message = nullptr;

--- a/src/posix/platform/udp.hpp
+++ b/src/posix/platform/udp.hpp
@@ -47,8 +47,8 @@ public:
     void SetUp(void);
     void TearDown(void);
     void Deinit(void);
-    void Update(otSysMainloopContext &aContext) override;
-    void Process(const otSysMainloopContext &aContext) override;
+    void Update(Mainloop::Context &aContext) override;
+    void Process(const Mainloop::Context &aContext) override;
 };
 
 } // namespace Posix

--- a/src/posix/platform/virtual_time.cpp
+++ b/src/posix/platform/virtual_time.cpp
@@ -43,6 +43,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include "mainloop.hpp"
 #include "utils.hpp"
 
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
@@ -220,22 +221,15 @@ void virtualTimeSendRadioSpinelWriteEvent(const uint8_t *aData, uint16_t aLength
     virtualTimeSendEvent(&event, offsetof(struct VirtualTimeEvent, mData) + event.mDataLength);
 }
 
-void virtualTimeUpdateFdSet(otSysMainloopContext *aContext)
-{
-    FD_SET(sSockFd, &aContext->mReadFdSet);
-    if (aContext->mMaxFd < sSockFd)
-    {
-        aContext->mMaxFd = sSockFd;
-    }
-}
+void virtualTimeUpdateFdSet(Mainloop::Context *aContext) { Mainloop::AddToReadFdSet(sSockFd, *aContext); }
 
-void virtualTimeProcess(otInstance *aInstance, const otSysMainloopContext *aContext)
+void virtualTimeProcess(otInstance *aInstance, const Mainloop::Context *aContext)
 {
     struct VirtualTimeEvent event;
 
     memset(&event, 0, sizeof(event));
 
-    if (FD_ISSET(sSockFd, &aContext->mReadFdSet))
+    if (Mainloop::IsFdReadable(sSockFd, *aContext))
     {
         virtualTimeReceiveEvent(&event);
     }


### PR DESCRIPTION
This commit adds new helper methods to `Mainloop::Source` that allow a source to update the `Mainloop::Context`. These helpers can be used to update or check the read/write/error `fd_set` (file-descriptor sets) or the timeout value in the context.