### PR TITLE
[nat64] schedule evaluation of policy when `Nat64PrefixManager::Discover()` fails

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -4145,6 +4145,7 @@ void RoutingManager::Nat64PrefixManager::Discover(void)
     else
     {
         LogWarn("Failed to discover infraif NAT64 prefix: %s", ErrorToString(error));
+        Get<RoutingManager>().ScheduleRoutingPolicyEvaluation(kAfterRandomDelay);
     }
 }
 


### PR DESCRIPTION
Previously we were relying on the platform to call `otPlatInfraIfDiscoverNat64PrefixDone` to trigger the evaluation of NAT64 prefix. Since https://github.com/openthread/openthread/pull/11481, we're no longer doing proactive DNS-based prefix discoveries and it never calls the callback `otPlatInfraIfDiscoverNat64PrefixDone`. 

That means NAT64 evaluation can only happen when `RoutingManager::EvaluateRoutingPolicy` is triggered, which can cause a at most 3-minute delay (`kRaBeaconInterval`), between enabling NAT64 feature and the feature starts to work.

This PR triggers the evaluation of routing policy when `Nat64PrefixManager::Discover()` fails to ensure the feature starts to work on time. 