### PR TITLE
[mle] ignore Child Update Request when detached

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3350,16 +3350,20 @@ exit:
 
 void Mle::HandleChildUpdateRequest(RxInfo &aRxInfo)
 {
+    VerifyOrExit(IsAttached());
+
 #if OPENTHREAD_FTD
     if (IsRouterOrLeader())
     {
         HandleChildUpdateRequestOnParent(aRxInfo);
+        ExitNow();
     }
-    else
 #endif
-    {
-        HandleChildUpdateRequestOnChild(aRxInfo);
-    }
+
+    HandleChildUpdateRequestOnChild(aRxInfo);
+
+exit:
+    return;
 }
 
 void Mle::HandleChildUpdateRequestOnChild(RxInfo &aRxInfo)


### PR DESCRIPTION
This commit updates `Mle` to ensure that a device ignores a received "Child Update Request" message if it is currently detached. This prevents the device from sending a "Child Update Response" in this state. This behavior is particularly important when a device is trying to restore its previous role as a router or leader.

----

Thanks to @trebbert-lutron for finding this issue. 