### PR TITLE
[ip6] only forward thread multicast message to host

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1103,8 +1103,8 @@ void Ip6::DetermineAction(const Message &aMessage,
         }
 #endif
 
-        // Always forward multicast packets to host network stack
-        aForwardHost = true;
+        // Always forward multicast packets from thread to host network stack
+        aForwardHost = aMessage.IsOriginThreadNetif();
 
         // If subscribed to the multicast address, receive if it is from the
         // Thread netif or if multicast loop is allowed.


### PR DESCRIPTION
A Thread Border Router (TBR) is responsible for forwarding multicast packets between the Backbone (AIL) and the Thread interface. We encountered an issue where, after a SED attaches to the TBR, a multicast packet originating from the AIL is not only forwarded to the Thread network but is also mistakenly forwarded back to the AIL.

Topology:
```
Host  <====> TBR <----> SED
```
In this setup, the SED subscribes to the multicast group `ff05::123`.  When a multicast UDP message with destination address `ff05::123` is sent from the host, we observe that the TBR erroneously forwards the message back to the AIL.

The key code call chain is shown below:

This multicast message is origined host, so TBR will forward to thread netif, called
[Ip6::SendRaw](https://github.com/openthread/openthread/blob/main/src/core/net/ip6.cpp#L1037)

This message is a multicast, so it should be inserted the MPL option:
[SuccessOrExit(error = InsertMplOption(*aMessagePtr, header));](https://github.com/openthread/openthread/blob/main/src/core/net/ip6.cpp#L1061)

In the function `InsertMplOption`, this message need to be `PrepareMulticastToLargerThanRealmLocal`
[error = PrepareMulticastToLargerThanRealmLocal(aMessage, aHeader);](https://github.com/openthread/openthread/blob/main/src/core/net/ip6.cpp#L236)

In the function `PrepareMulticastToLargerThanRealmLocal`, TBR has a SED child, so this message will be enqueued for the furthur processed(send this message to the sleepy end device in some time).
[EnqueueDatagram(*messageCopy);](https://github.com/openthread/openthread/blob/main/src/core/net/ip6.cpp#L202)

When the enqueued message processed, `HandleDatagram` will be called, and thread stack will determine if this message should be forwarded:
[DetermineAction(*aMessagePtr, header, forwardThread, forwardHost, receive);
](https://github.com/openthread/openthread/blob/main/src/core/net/ip6.cpp#L1191)

And in the function `DetermineAction`, all multicast message should be forwarded to host:
[aForwardHost = true;](https://github.com/openthread/openthread/blob/main/src/core/net/ip6.cpp#L1107)

In this PR, fix this issue, only forward the message origined form thread to host.