### PR TITLE
[posix] fix the compile errors of src/posix/platform/alarm.cpp

### DIFF
--- a/src/posix/platform/alarm.cpp
+++ b/src/posix/platform/alarm.cpp
@@ -173,7 +173,7 @@ void otPlatAlarmMicroStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
     sUsAlarm     = aT0 + aDt;
     sIsUsRunning = true;
 
-#ifdef __linux__
+#if defined(__linux__) && !OPENTHREAD_POSIX_VIRTUAL_TIME
     if (sRealTimeSignal != 0)
     {
         struct itimerspec its;
@@ -190,7 +190,7 @@ void otPlatAlarmMicroStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
             otLogWarnPlat("Failed to update microsecond timer: %s", strerror(errno));
         }
     }
-#endif // __linux__
+#endif // defined( __linux__) && !OPENTHREAD_POSIX_VIRTUAL_TIME
 }
 
 void otPlatAlarmMicroStop(otInstance *aInstance)
@@ -199,7 +199,7 @@ void otPlatAlarmMicroStop(otInstance *aInstance)
 
     sIsUsRunning = false;
 
-#ifdef __linux__
+#if defined(__linux__) && !OPENTHREAD_POSIX_VIRTUAL_TIME
     if (sRealTimeSignal != 0)
     {
         struct itimerspec its = {{0, 0}, {0, 0}};
@@ -209,7 +209,7 @@ void otPlatAlarmMicroStop(otInstance *aInstance)
             otLogWarnPlat("Failed to stop microsecond timer: %s", strerror(errno));
         }
     }
-#endif // __linux__
+#endif // defined( __linux__) && !OPENTHREAD_POSIX_VIRTUAL_TIME
 }
 #endif // OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 


### PR DESCRIPTION
The definition of sMicroTimer and sRealTimeSignal are wrapped by the `__linux__`, `OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE` and `!OPENTHREAD_POSIX_VIRTUAL_TIME`. But the code using these two variables is not completely wrapped by these three macros. It causes the compile errors in some conditions.

This commit wraps all the code that uses these two variables with these three macros.