### PR TITLE
[nexus] ensure platform components are initialized first

### DIFF
--- a/tests/nexus/platform/nexus_alarm.hpp
+++ b/tests/nexus/platform/nexus_alarm.hpp
@@ -36,6 +36,11 @@ namespace Nexus {
 
 struct Alarm
 {
+    Alarm(void)
+        : mScheduled(false)
+    {
+    }
+
     bool ShouldTrigger(Time aNow) const { return mScheduled && (aNow >= mAlarmTime); }
 
     bool mScheduled;

--- a/tests/nexus/platform/nexus_node.hpp
+++ b/tests/nexus/platform/nexus_node.hpp
@@ -42,7 +42,26 @@
 namespace ot {
 namespace Nexus {
 
-class Node : public Heap::Allocatable<Node>, public LinkedListEntry<Node>, private Instance
+class Platform
+{
+public:
+    Radio    mRadio;
+    Alarm    mAlarm;
+    Mdns     mMdns;
+    Settings mSettings;
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+    Trel mTrel;
+#endif
+    bool mPendingTasklet;
+
+protected:
+    Platform(void)
+        : mPendingTasklet(false)
+    {
+    }
+};
+
+class Node : public Platform, public Heap::Allocatable<Node>, public LinkedListEntry<Node>, private Instance
 {
     friend class Heap::Allocatable<Node>;
 
@@ -81,15 +100,16 @@ public:
 
     static Node &From(otInstance *aInstance) { return static_cast<Node &>(*aInstance); }
 
-    Node    *mNext;
-    Radio    mRadio;
-    Alarm    mAlarm;
-    Mdns     mMdns;
-    Settings mSettings;
+    using Platform::mAlarm;
+    using Platform::mMdns;
+    using Platform::mPendingTasklet;
+    using Platform::mRadio;
+    using Platform::mSettings;
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    Trel mTrel;
+    using Platform::mTrel;
 #endif
-    bool mPendingTasklet;
+
+    Node *mNext;
 
 private:
     Node(void) = default;

--- a/tests/nexus/platform/nexus_radio.cpp
+++ b/tests/nexus/platform/nexus_radio.cpp
@@ -249,6 +249,13 @@ otError otPlatRadioAddCalibratedPower(otInstance *, uint8_t, int16_t, const uint
 //---------------------------------------------------------------------------------------------------------------------
 // Radio
 
+Radio::Radio(void)
+    : mState(kStateDisabled)
+    , mPromiscuous(false)
+    , mSrcMatchEnabled(false)
+{
+}
+
 bool Radio::CanReceiveOnChannel(uint8_t aChannel) const
 {
     bool canRx = false;

--- a/tests/nexus/platform/nexus_radio.hpp
+++ b/tests/nexus/platform/nexus_radio.hpp
@@ -58,6 +58,7 @@ struct Radio
         uint8_t mPsduBuffer[kMaxFrameSize];
     };
 
+    Radio(void);
     bool CanReceiveOnChannel(uint8_t aChannel) const;
     bool Matches(const Mac::Address &aAddress, Mac::PanId aPanId) const;
     bool HasFramePendingFor(const Mac::Address &aAddress) const;


### PR DESCRIPTION
This commit updates the `Nexus::Node` to initialize platform-specific components first. This is achieved by defining them in a `Platform` struct, which is inherited before `ot::Instance`.

This change ensures all platform components are ready and can be safely used from the `Instance` constructor and any of its sub-components.