### PR TITLE
[routing-manager] new API to get infrastructure interface info

### DIFF
--- a/include/openthread/border_routing.h
+++ b/include/openthread/border_routing.h
@@ -222,6 +222,25 @@ typedef enum
 otError otBorderRoutingInit(otInstance *aInstance, uint32_t aInfraIfIndex, bool aInfraIfIsRunning);
 
 /**
+ * Gets the interface index and running state of the configured infrastructure interface.
+ *
+ * @note The running state in @p aInfraIfIsRunning reflects the Border Routing Manager's perspective. This state is set
+ * when `otBorderRoutingInit()` is called and is subsequently updated by the platform signaling changes via
+ * `otPlatInfraIfStateChanged()`.
+ *
+ * @param[in]  aInstance          A pointer to an OpenThread instance.
+ * @param[out] aInfraIfIndex      A pointer to output the interface index. MUST NOT be NULL.
+ * @param[out] aInfraIfIsRunning  A pointer to output whether the interface is running. Can be NULL if not needed.
+ *
+ * @retval OT_ERROR_NONE           Successfully retrieved the interface information.
+ * @retval OT_ERROR_INVALID_STATE  The Border Routing Manager is not initialized.
+ *
+ * @sa otBorderRoutingInit
+ * @sa otPlatInfraIfStateChanged
+ */
+otError otBorderRoutingGetInfraIfInfo(otInstance *aInstance, uint32_t *aInfraIfIndex, bool *aInfraIfIsRunning);
+
+/**
  * Enables or disables the Border Routing Manager.
  *
  * @note  The Border Routing Manager is disabled by default.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (515)
+#define OPENTHREAD_API_VERSION (516)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README_BR.md
+++ b/src/cli/README_BR.md
@@ -60,6 +60,18 @@ Initializes the Border Routing Manager on given infrastructure interface.
 Done
 ```
 
+### infraif
+
+Usage: `br infraif`
+
+Get the interface index and running state of the configured infrastructure interface.
+
+```bash
+> br infraif
+if-index:2, is-running:yes
+Done
+```
+
 ### enable
 
 Usage: `br enable`

--- a/src/cli/cli_br.cpp
+++ b/src/cli/cli_br.cpp
@@ -69,6 +69,30 @@ exit:
 }
 
 /**
+ * @cli br infraif
+ * @code
+ * br infraif
+ * if-index:2, is-running:yes
+ * Done
+ * @endcode
+ * @par
+ * Gets the interface index and running state of the configured infrastructure interface.
+ */
+template <> otError Br::Process<Cmd("infraif")>(Arg aArgs[])
+{
+    otError  error = OT_ERROR_NONE;
+    uint32_t ifIndex;
+    bool     isRunning;
+
+    VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+    SuccessOrExit(error = otBorderRoutingGetInfraIfInfo(GetInstancePtr(), &ifIndex, &isRunning));
+    OutputLine("if-index:%lu, is-running:%s", ToUlong(ifIndex), isRunning ? "yes" : "no");
+
+exit:
+    return error;
+}
+
+/**
  * @cli br enable
  * @code
  * br enable
@@ -1093,6 +1117,7 @@ otError Br::Process(Arg aArgs[])
 #endif
         CmdEntry("disable"),
         CmdEntry("enable"),
+        CmdEntry("infraif"),
         CmdEntry("init"),
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
         CmdEntry("multiail"),

--- a/src/core/api/border_routing_api.cpp
+++ b/src/core/api/border_routing_api.cpp
@@ -44,6 +44,20 @@ otError otBorderRoutingInit(otInstance *aInstance, uint32_t aInfraIfIndex, bool 
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().Init(aInfraIfIndex, aInfraIfIsRunning);
 }
 
+otError otBorderRoutingGetInfraIfInfo(otInstance *aInstance, uint32_t *aInfraIfIndex, bool *aInfraIfIsRunning)
+{
+    bool isRunning;
+
+    AssertPointerIsNotNull(aInfraIfIndex);
+
+    if (aInfraIfIsRunning == nullptr)
+    {
+        aInfraIfIsRunning = &isRunning;
+    }
+
+    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetInfraIfInfo(*aInfraIfIndex, *aInfraIfIsRunning);
+}
+
 otError otBorderRoutingSetEnabled(otInstance *aInstance, bool aEnabled)
 {
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().SetEnabled(aEnabled);

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -116,6 +116,18 @@ exit:
     return error;
 }
 
+Error RoutingManager::GetInfraIfInfo(uint32_t &aInfraIfIndex, bool &aInfraIfIsRunning) const
+{
+    Error error = kErrorNone;
+
+    VerifyOrExit(IsInitialized(), error = kErrorInvalidState);
+    aInfraIfIndex     = mInfraIf.GetIfIndex();
+    aInfraIfIsRunning = mInfraIf.IsRunning();
+
+exit:
+    return error;
+}
+
 Error RoutingManager::SetEnabled(bool aEnabled)
 {
     Error error = kErrorNone;

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -174,6 +174,17 @@ public:
     Error Init(uint32_t aInfraIfIndex, bool aInfraIfIsRunning);
 
     /**
+     * Gets the interface index of the currently configured infrastructure interface.
+     *
+     * @param[out] aInfraIfIndex      A reference to output the interface index.
+     * @param[out] aInfraIfIsRunning  A reference to output whether the interface is running.
+     *
+     * @retval kErrorNone           Successfully retrieved the interface information.
+     * @retval kErrorInvalidState   The Border Routing Manager is not initialized.
+     */
+    Error GetInfraIfInfo(uint32_t &aInfraIfIndex, bool &aInfraIfIsRunning) const;
+
+    /**
      * Enables/disables the Border Routing Manager.
      *
      * @note  The Border Routing Manager is enabled by default.


### PR DESCRIPTION
This commit introduces `otBorderRoutingGetInfraIfInfo()` to get the interface index and running state of the configured infrastructure interface. A corresponding CLI command is also added to retrieve this information.