### PR TITLE
[mdns] make `test_mdns` more robust

### DIFF
--- a/tests/unit/test_mdns.cpp
+++ b/tests/unit/test_mdns.cpp
@@ -4703,7 +4703,7 @@ void TestMultiPacket(void)
 
     Log("Since message is marked as `truncated`, mDNS should wait at least 400 msec");
 
-    AdvanceTime(400);
+    AdvanceTime(399);
     VerifyOrQuit(sDnsMessages.IsEmpty());
 
     AdvanceTime(2000);


### PR DESCRIPTION
This commit updates the wait time in the `test_mdns` unit test to handle a rare timing failure.

When a truncated message is sent, mDNS is expected to wait for a random delay of at least 400ms. The test previously waited exactly 400ms before checking for emitted messages, leading to rare failures if the random delay was precisely 400ms.

This change reduces the test's wait time to 399ms, ensuring it correctly verifies that no message is emitted during the initial delay period and making the test more robust.