### PR TITLE
[mdns] introduce auto-enable mode

### DIFF
--- a/include/openthread/border_routing.h
+++ b/include/openthread/border_routing.h
@@ -222,6 +222,25 @@ typedef enum
 otError otBorderRoutingInit(otInstance *aInstance, uint32_t aInfraIfIndex, bool aInfraIfIsRunning);
 
 /**
+ * Gets the interface index and running state of the configured infrastructure interface.
+ *
+ * @note The running state in @p aInfraIfIsRunning reflects the Border Routing Manager's perspective. This state is set
+ * when `otBorderRoutingInit()` is called and is subsequently updated by the platform signaling changes via
+ * `otPlatInfraIfStateChanged()`.
+ *
+ * @param[in]  aInstance          A pointer to an OpenThread instance.
+ * @param[out] aInfraIfIndex      A pointer to output the interface index. MUST NOT be NULL.
+ * @param[out] aInfraIfIsRunning  A pointer to output whether the interface is running. Can be NULL if not needed.
+ *
+ * @retval OT_ERROR_NONE           Successfully retrieved the interface information.
+ * @retval OT_ERROR_INVALID_STATE  The Border Routing Manager is not initialized.
+ *
+ * @sa otBorderRoutingInit
+ * @sa otPlatInfraIfStateChanged
+ */
+otError otBorderRoutingGetInfraIfInfo(otInstance *aInstance, uint32_t *aInfraIfIndex, bool *aInfraIfIsRunning);
+
+/**
  * Enables or disables the Border Routing Manager.
  *
  * @note  The Border Routing Manager is disabled by default.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (516)
+#define OPENTHREAD_API_VERSION (517)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (515)
+#define OPENTHREAD_API_VERSION (516)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/mdns.h
+++ b/include/openthread/mdns.h
@@ -185,6 +185,39 @@ otError otMdnsSetEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfI
 bool otMdnsIsEnabled(otInstance *aInstance);
 
 /**
+ * Enables or disables the mDNS auto-enable mode.
+ *
+ * Requires `OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE`.
+ *
+ * When this mode is enabled, the mDNS module uses the same infrastructure network interface as the Border Routing
+ * manager. The mDNS module is then automatically enabled or disabled based on the operational state of that interface
+ * (see `otBorderRoutingInit()` and `otPlatInfraIfStateChanged()`).
+ *
+ * It is recommended to use the auto-enable mode on Border Routers. The default state of this mode at initialization
+ * is controlled by the `OPENTHREAD_CONFIG_MULTICAST_DNS_AUTO_ENABLE_ON_INFRA_IF` configuration.
+ *
+ * The auto-enable mode can be disabled by a call to `otMdnsSetAutoEnableMode(false)` or by an explicit call to
+ * `otMdnsSetEnabled()`. Deactivating the auto-enable mode with `otMdnsSetAutoEnableMode(false)` will not change the
+ * current operational state of the mDNS module (e.g., if it is currently enabled, it remains enabled).
+ *
+ * @param[in] aInstance   The OpenThread instance.
+ * @param[in] aEnable     A boolean to enable or disable the auto-enable mode.
+ */
+void otMdnsSetAutoEnableMode(otInstance *aInstance, bool aEnable);
+
+/**
+ * Indicates whether the auto-enable mode is enabled or disabled.
+ *
+ * Requires `OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE`.
+ *
+ * @param[in] aInstance   The OpenThread instance.
+ *
+ * @retval TRUE   The auto-enable mode is enabled.
+ * @retval FALSE  The auto-enable mode is disabled.
+ */
+bool otMdnsGetAutoEnableMode(otInstance *aInstance);
+
+/**
  * Sets whether the mDNS module is allowed to send questions requesting unicast responses referred to as "QU" questions.
  *
  * The "QU" questions request unicast responses, in contrast to "QM" questions which request multicast responses.

--- a/src/cli/README_BR.md
+++ b/src/cli/README_BR.md
@@ -60,6 +60,18 @@ Initializes the Border Routing Manager on given infrastructure interface.
 Done
 ```
 
+### infraif
+
+Usage: `br infraif`
+
+Get the interface index and running state of the configured infrastructure interface.
+
+```bash
+> br infraif
+if-index:2, is-running:yes
+Done
+```
+
 ### enable
 
 Usage: `br enable`

--- a/src/cli/cli_br.cpp
+++ b/src/cli/cli_br.cpp
@@ -69,6 +69,30 @@ exit:
 }
 
 /**
+ * @cli br infraif
+ * @code
+ * br infraif
+ * if-index:2, is-running:yes
+ * Done
+ * @endcode
+ * @par
+ * Gets the interface index and running state of the configured infrastructure interface.
+ */
+template <> otError Br::Process<Cmd("infraif")>(Arg aArgs[])
+{
+    otError  error = OT_ERROR_NONE;
+    uint32_t ifIndex;
+    bool     isRunning;
+
+    VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+    SuccessOrExit(error = otBorderRoutingGetInfraIfInfo(GetInstancePtr(), &ifIndex, &isRunning));
+    OutputLine("if-index:%lu, is-running:%s", ToUlong(ifIndex), isRunning ? "yes" : "no");
+
+exit:
+    return error;
+}
+
+/**
  * @cli br enable
  * @code
  * br enable
@@ -1093,6 +1117,7 @@ otError Br::Process(Arg aArgs[])
 #endif
         CmdEntry("disable"),
         CmdEntry("enable"),
+        CmdEntry("infraif"),
         CmdEntry("init"),
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
         CmdEntry("multiail"),

--- a/src/cli/cli_mdns.cpp
+++ b/src/cli/cli_mdns.cpp
@@ -48,8 +48,23 @@ template <> otError Mdns::Process<Cmd("enable")>(Arg aArgs[])
     otError  error;
     uint32_t infraIfIndex;
 
-    SuccessOrExit(error = aArgs[0].ParseAsUint32(infraIfIndex));
-    VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    if (aArgs[0].IsEmpty())
+    {
+        bool isRunning;
+
+        // If no if-index is provided, we use the Border Router's
+        // infrastructure if-index (if any).
+
+        SuccessOrExit(error = otBorderRoutingGetInfraIfInfo(GetInstancePtr(), &infraIfIndex, &isRunning));
+        VerifyOrExit(isRunning, error = OT_ERROR_INVALID_STATE);
+    }
+    else
+#endif
+    {
+        SuccessOrExit(error = aArgs[0].ParseAsUint32(infraIfIndex));
+        VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+    }
 
     SuccessOrExit(error = otMdnsSetEnabled(GetInstancePtr(), true, infraIfIndex));
 
@@ -80,6 +95,13 @@ template <> otError Mdns::Process<Cmd("state")>(Arg aArgs[])
 exit:
     return error;
 }
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+template <> otError Mdns::Process<Cmd("auto")>(Arg aArgs[])
+{
+    return ProcessEnableDisable(aArgs, otMdnsGetAutoEnableMode, otMdnsSetAutoEnableMode);
+}
+#endif
 
 template <> otError Mdns::Process<Cmd("unicastquestion")>(Arg aArgs[])
 {
@@ -1241,6 +1263,9 @@ otError Mdns::Process(Arg aArgs[])
     }
 
     static constexpr Command kCommands[] = {
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+        CmdEntry("auto"),
+#endif
         CmdEntry("browser"),
 #if OPENTHREAD_CONFIG_MULTICAST_DNS_ENTRY_ITERATION_API_ENABLE
         CmdEntry("browsers"),

--- a/src/core/api/border_routing_api.cpp
+++ b/src/core/api/border_routing_api.cpp
@@ -44,6 +44,20 @@ otError otBorderRoutingInit(otInstance *aInstance, uint32_t aInfraIfIndex, bool 
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().Init(aInfraIfIndex, aInfraIfIsRunning);
 }
 
+otError otBorderRoutingGetInfraIfInfo(otInstance *aInstance, uint32_t *aInfraIfIndex, bool *aInfraIfIsRunning)
+{
+    bool isRunning;
+
+    AssertPointerIsNotNull(aInfraIfIndex);
+
+    if (aInfraIfIsRunning == nullptr)
+    {
+        aInfraIfIsRunning = &isRunning;
+    }
+
+    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetInfraIfInfo(*aInfraIfIndex, *aInfraIfIsRunning);
+}
+
 otError otBorderRoutingSetEnabled(otInstance *aInstance, bool aEnabled)
 {
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().SetEnabled(aEnabled);

--- a/src/core/api/mdns_api.cpp
+++ b/src/core/api/mdns_api.cpp
@@ -46,6 +46,18 @@ otError otMdnsSetEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfI
 
 bool otMdnsIsEnabled(otInstance *aInstance) { return AsCoreType(aInstance).Get<Dns::Multicast::Core>().IsEnabled(); }
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+void otMdnsSetAutoEnableMode(otInstance *aInstance, bool aEnable)
+{
+    AsCoreType(aInstance).Get<Dns::Multicast::Core>().SetAutoEnableMode(aEnable);
+}
+
+bool otMdnsGetAutoEnableMode(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).Get<Dns::Multicast::Core>().GetAutoEnableMode();
+}
+#endif
+
 void otMdnsSetQuestionUnicastAllowed(otInstance *aInstance, bool aAllow)
 {
     AsCoreType(aInstance).Get<Dns::Multicast::Core>().SetQuestionUnicastAllowed(aAllow);

--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -164,7 +164,7 @@ Error InfraIf::HandleStateChanged(uint32_t aIfIndex, bool aIsRunning)
     Get<Dns::ServiceDiscovery::Server>().HandleInfraIfStateChanged();
 #endif
 
-#if OPENTHREAD_CONFIG_MULTICAST_DNS_ENABLE && OPENTHREAD_CONFIG_MULTICAST_DNS_AUTO_ENABLE_ON_INFRA_IF
+#if OPENTHREAD_CONFIG_MULTICAST_DNS_ENABLE
     Get<Dns::Multicast::Core>().HandleInfraIfStateChanged();
 #endif
 

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -116,6 +116,18 @@ exit:
     return error;
 }
 
+Error RoutingManager::GetInfraIfInfo(uint32_t &aInfraIfIndex, bool &aInfraIfIsRunning) const
+{
+    Error error = kErrorNone;
+
+    VerifyOrExit(IsInitialized(), error = kErrorInvalidState);
+    aInfraIfIndex     = mInfraIf.GetIfIndex();
+    aInfraIfIsRunning = mInfraIf.IsRunning();
+
+exit:
+    return error;
+}
+
 Error RoutingManager::SetEnabled(bool aEnabled)
 {
     Error error = kErrorNone;

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -174,6 +174,17 @@ public:
     Error Init(uint32_t aInfraIfIndex, bool aInfraIfIsRunning);
 
     /**
+     * Gets the interface index of the currently configured infrastructure interface.
+     *
+     * @param[out] aInfraIfIndex      A reference to output the interface index.
+     * @param[out] aInfraIfIsRunning  A reference to output whether the interface is running.
+     *
+     * @retval kErrorNone           Successfully retrieved the interface information.
+     * @retval kErrorInvalidState   The Border Routing Manager is not initialized.
+     */
+    Error GetInfraIfInfo(uint32_t &aInfraIfIndex, bool &aInfraIfIsRunning) const;
+
+    /**
      * Enables/disables the Border Routing Manager.
      *
      * @note  The Border Routing Manager is enabled by default.


### PR DESCRIPTION
This commit introduces "auto-enable mode" in mDNS module. When this mode is enabled, the mDNS module uses the same infrastructure network interface as the Border Routing manager. The mDNS module is then automatically enabled or disabled based on the operational state of that interface. It is recommended to use the auto-enable mode on Border Routers. New APIs and CLI commands are added to manage this mode.

This commit also makes the if-index argument optional in `mdns enable` CLI command. If an index is not provided, the command defaults to using the Border Router's infrastructure interface. This helps simplify controlling the mDNS state in test scripts.