### PR TITLE
[mle] enhance role restoration logic in `Start()`

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1958,6 +1958,7 @@ private:
 
     Error      Start(StartMode aMode);
     void       Stop(StopMode aMode);
+    Error      RestorePrevRole(void);
     TxMessage *NewMleMessage(Command aCommand);
     void       SetRole(DeviceRole aRole);
     void       Attach(AttachMode aMode);


### PR DESCRIPTION
This commit refactors `Mle::Start()` by moving the logic for restoring the previous role into a new method, `RestorePrevRole()`.

This change simplifies the startup process and improves robustness by adding more validation checks within `RestorePrevRole()`. The new method ensures that the previously saved state information is consistent before it is applied. For example, it verifies that `mLastSavedRole` matches the saved RLOC16 and that parent information is valid if the saved role was Child. These checks protect against loading invalid settings and allow the device to start more quickly by ignoring inconsistent state.