### PR TITLE
[netdata] enhance `NetworkData::Service::Iterator`

### DIFF
--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -2413,9 +2413,9 @@ exit:
 
 Error Client::SelectUnicastEntry(DnsSrpUnicastType aType, DnsSrpUnicastInfo &aInfo) const
 {
-    Error                                   error = kErrorNotFound;
-    DnsSrpUnicastInfo                       unicastInfo;
-    NetworkData::Service::Manager::Iterator iterator;
+    Error                          error = kErrorNotFound;
+    DnsSrpUnicastInfo              unicastInfo;
+    NetworkData::Service::Iterator iterator(GetInstance());
 #if OPENTHREAD_CONFIG_SRP_CLIENT_SAVE_SELECTED_SERVER_ENABLE
     Settings::SrpClientInfo savedInfo;
     bool                    hasSavedServerInfo = false;
@@ -2426,7 +2426,7 @@ Error Client::SelectUnicastEntry(DnsSrpUnicastType aType, DnsSrpUnicastInfo &aIn
     }
 #endif
 
-    while (Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(iterator, aType, unicastInfo) == kErrorNone)
+    while (iterator.GetNextDnsSrpUnicastInfo(aType, unicastInfo) == kErrorNone)
     {
         bool preferNewEntry;
 
@@ -2519,10 +2519,10 @@ void Client::SelectNextServer(bool aDisallowSwitchOnRegisteredHost)
 
     do
     {
-        DnsSrpUnicastInfo                       unicastInfo;
-        NetworkData::Service::Manager::Iterator iterator;
+        DnsSrpUnicastInfo              unicastInfo;
+        NetworkData::Service::Iterator iterator(GetInstance());
 
-        while (Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(iterator, type, unicastInfo) == kErrorNone)
+        while (iterator.GetNextDnsSrpUnicastInfo(type, unicastInfo) == kErrorNone)
         {
             if (selectNext)
             {

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -303,7 +303,7 @@ bool Server::NetDataContainsOtherSrpServers(void) const
     bool                                    contains = false;
     NetworkData::Service::DnsSrpAnycastInfo anycastInfo;
     NetworkData::Service::DnsSrpUnicastInfo unicastInfo;
-    NetworkData::Service::Manager::Iterator iterator;
+    NetworkData::Service::Iterator          iterator(GetInstance());
 
     if (Get<NetworkData::Service::Manager>().FindPreferredDnsSrpAnycastInfo(anycastInfo) == kErrorNone)
     {
@@ -313,8 +313,7 @@ bool Server::NetDataContainsOtherSrpServers(void) const
 
     iterator.Reset();
 
-    if (Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(
-            iterator, NetworkData::Service::kAddrInServiceData, unicastInfo) == kErrorNone)
+    if (iterator.GetNextDnsSrpUnicastInfo(NetworkData::Service::kAddrInServiceData, unicastInfo) == kErrorNone)
     {
         contains = true;
         ExitNow();
@@ -322,8 +321,7 @@ bool Server::NetDataContainsOtherSrpServers(void) const
 
     iterator.Reset();
 
-    while (Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(
-               iterator, NetworkData::Service::kAddrInServerData, unicastInfo) == kErrorNone)
+    while (iterator.GetNextDnsSrpUnicastInfo(NetworkData::Service::kAddrInServerData, unicastInfo) == kErrorNone)
     {
         if (!Get<Mle::Mle>().HasRloc16(unicastInfo.mRloc16) &&
             Get<Mle::Mle>().GetMeshLocalEid() != unicastInfo.mSockAddr.GetAddress())

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -587,13 +587,13 @@ Error AddressResolver::ResolveUsingNetDataServices(const Ip6::Address &aEid, uin
     // if successful, otherwise returns `kErrorNotFound`.
 
     Error                                   error = kErrorNotFound;
-    NetworkData::Service::Manager::Iterator iterator;
+    NetworkData::Service::Iterator          iterator(GetInstance());
     NetworkData::Service::DnsSrpUnicastInfo unicastInfo;
     NetworkData::Service::DnsSrpUnicastType type = NetworkData::Service::kAddrInServerData;
 
     VerifyOrExit(Get<Mle::Mle>().GetDeviceMode().GetNetworkDataType() == NetworkData::kFullSet);
 
-    while (Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(iterator, type, unicastInfo) == kErrorNone)
+    while (iterator.GetNextDnsSrpUnicastInfo(type, unicastInfo) == kErrorNone)
     {
         if (aEid == unicastInfo.mSockAddr.GetAddress())
         {

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -78,8 +78,9 @@ namespace ot {
 namespace NetworkData {
 
 namespace Service {
+class Iterator;
 class Manager;
-}
+} // namespace Service
 
 /**
  * @addtogroup core-netdata-core
@@ -109,6 +110,7 @@ class NetworkData : public InstanceLocator
     friend class Leader;
     friend class Publisher;
     friend class MutableNetworkData;
+    friend class Service::Iterator;
     friend class Service::Manager;
 
 public:

--- a/src/core/thread/network_data_publisher.cpp
+++ b/src/core/thread/network_data_publisher.cpp
@@ -690,10 +690,10 @@ void Publisher::DnsSrpServiceEntry::CountAnycastEntries(uint8_t &aNumEntries, ui
     //  (routers are preferred over end-devices. If same type, then
     //  the smaller RLOC16 value is preferred).
 
-    Service::Manager::Iterator iterator;
+    Service::Iterator          iterator(GetInstance());
     Service::DnsSrpAnycastInfo anycastInfo;
 
-    while (Get<Service::Manager>().GetNextDnsSrpAnycastInfo(iterator, anycastInfo) == kErrorNone)
+    while (iterator.GetNextDnsSrpAnycastInfo(anycastInfo) == kErrorNone)
     {
         if (anycastInfo.mSequenceNumber == mInfo.GetSequenceNumber() && (anycastInfo.mVersion >= mInfo.GetVersion()))
         {
@@ -709,10 +709,10 @@ void Publisher::DnsSrpServiceEntry::CountAnycastEntries(uint8_t &aNumEntries, ui
 
 bool Publisher::DnsSrpServiceEntry::HasAnyAnycastEntry(void) const
 {
-    Service::Manager::Iterator iterator;
+    Service::Iterator          iterator(GetInstance());
     Service::DnsSrpAnycastInfo anycastInfo;
 
-    return (Get<Service::Manager>().GetNextDnsSrpAnycastInfo(iterator, anycastInfo) == kErrorNone);
+    return (iterator.GetNextDnsSrpAnycastInfo(anycastInfo) == kErrorNone);
 }
 
 void Publisher::DnsSrpServiceEntry::CountUnicastEntries(Service::DnsSrpUnicastType aType,
@@ -726,10 +726,10 @@ void Publisher::DnsSrpServiceEntry::CountUnicastEntries(Service::DnsSrpUnicastTy
     // over end-devices. If same type, then the smaller RLOC16 value is
     // preferred).
 
-    Service::Manager::Iterator iterator;
+    Service::Iterator          iterator(GetInstance());
     Service::DnsSrpUnicastInfo unicastInfo;
 
-    while (Get<Service::Manager>().GetNextDnsSrpUnicastInfo(iterator, aType, unicastInfo) == kErrorNone)
+    while (iterator.GetNextDnsSrpUnicastInfo(aType, unicastInfo) == kErrorNone)
     {
         if (unicastInfo.mVersion >= mInfo.GetVersion())
         {
@@ -745,11 +745,11 @@ void Publisher::DnsSrpServiceEntry::CountUnicastEntries(Service::DnsSrpUnicastTy
 
 bool Publisher::DnsSrpServiceEntry::HasAnyServiceDataUnicastEntry(void) const
 {
-    Service::Manager::Iterator iterator;
+    Service::Iterator          iterator(GetInstance());
     Service::DnsSrpUnicastInfo unicastInfo;
     Service::DnsSrpUnicastType type = Service::kAddrInServiceData;
 
-    return (Get<Service::Manager>().GetNextDnsSrpUnicastInfo(iterator, type, unicastInfo) == kErrorNone);
+    return (iterator.GetNextDnsSrpUnicastInfo(type, unicastInfo) == kErrorNone);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/tests/unit/test_network_data.cpp
+++ b/tests/unit/test_network_data.cpp
@@ -735,7 +735,7 @@ void TestNetworkDataDsnSrpServices(void)
         const uint8_t kPreferredAnycastEntryIndex = 2;
 
         Service::Manager          &manager = instance->Get<Service::Manager>();
-        Service::Manager::Iterator iterator;
+        Service::Iterator          iterator(*instance);
         Service::DnsSrpAnycastInfo anycastInfo;
         Service::DnsSrpUnicastInfo unicastInfo;
         Service::DnsSrpUnicastType type;
@@ -766,7 +766,7 @@ void TestNetworkDataDsnSrpServices(void)
 
         for (const AnycastEntry &entry : kAnycastEntries)
         {
-            SuccessOrQuit(manager.GetNextDnsSrpAnycastInfo(iterator, anycastInfo));
+            SuccessOrQuit(iterator.GetNextDnsSrpAnycastInfo(anycastInfo));
 
             printf("\nanycastInfo { %s, seq:%d, rlco16:%04x, version:%u }",
                    anycastInfo.mAnycastAddress.ToString().AsCString(), anycastInfo.mSequenceNumber, anycastInfo.mRloc16,
@@ -775,7 +775,7 @@ void TestNetworkDataDsnSrpServices(void)
             VerifyOrQuit(entry.Matches(anycastInfo), "GetNextDnsSrpAnycastInfo() returned incorrect info");
         }
 
-        VerifyOrQuit(manager.GetNextDnsSrpAnycastInfo(iterator, anycastInfo) == kErrorNotFound,
+        VerifyOrQuit(iterator.GetNextDnsSrpAnycastInfo(anycastInfo) == kErrorNotFound,
                      "GetNextDnsSrpAnycastInfo() returned unexpected extra entry");
 
         // Find the preferred "DNS/SRP Anycast Service" entries in Network Data
@@ -791,37 +791,37 @@ void TestNetworkDataDsnSrpServices(void)
         printf("\n\n- - - - - - - - - - - - - - - - - - - -");
         printf("\nDNS/SRP Unicast Service entries (server data)\n");
 
-        iterator.Clear();
+        iterator.Reset();
         type = Service::kAddrInServerData;
 
         for (const UnicastEntry &entry : kUnicastEntriesFromServerData)
         {
-            SuccessOrQuit(manager.GetNextDnsSrpUnicastInfo(iterator, type, unicastInfo));
+            SuccessOrQuit(iterator.GetNextDnsSrpUnicastInfo(type, unicastInfo));
             printf("\nunicastInfo { %s, rloc16:%04x }", unicastInfo.mSockAddr.ToString().AsCString(),
                    unicastInfo.mRloc16);
 
             VerifyOrQuit(entry.Matches(unicastInfo), "GetNextDnsSrpUnicastInfo() returned incorrect info");
         }
 
-        VerifyOrQuit(manager.GetNextDnsSrpUnicastInfo(iterator, type, unicastInfo) == kErrorNotFound,
+        VerifyOrQuit(iterator.GetNextDnsSrpUnicastInfo(type, unicastInfo) == kErrorNotFound,
                      "GetNextDnsSrpUnicastInfo() returned unexpected extra entry");
 
         printf("\n\n- - - - - - - - - - - - - - - - - - - -");
         printf("\nDNS/SRP Unicast Service entries (service data)\n");
 
-        iterator.Clear();
+        iterator.Reset();
         type = Service::kAddrInServiceData;
 
         for (const UnicastEntry &entry : kUnicastEntriesFromServiceData)
         {
-            SuccessOrQuit(manager.GetNextDnsSrpUnicastInfo(iterator, type, unicastInfo));
+            SuccessOrQuit(iterator.GetNextDnsSrpUnicastInfo(type, unicastInfo));
             printf("\nunicastInfo { %s, rloc16:%04x }", unicastInfo.mSockAddr.ToString().AsCString(),
                    unicastInfo.mRloc16);
 
             VerifyOrQuit(entry.Matches(unicastInfo), "GetNextDnsSrpUnicastInfo() returned incorrect info");
         }
 
-        VerifyOrQuit(manager.GetNextDnsSrpUnicastInfo(iterator, type, unicastInfo) == kErrorNotFound,
+        VerifyOrQuit(iterator.GetNextDnsSrpUnicastInfo(type, unicastInfo) == kErrorNotFound,
                      "GetNextDnsSrpUnicastInfo() returned unexpected extra entry");
 
         printf("\n");
@@ -1036,7 +1036,7 @@ void TestNetworkDataDsnSrpAnycastSeqNumSelection(void)
 
     for (const TestInfo &test : kTests)
     {
-        Service::Manager::Iterator iterator;
+        Service::Iterator          iterator(*instance);
         Service::DnsSrpAnycastInfo anycastInfo;
 
         reinterpret_cast<TestLeader &>(instance->Get<Leader>()).Populate(test.mNetworkData, test.mNetworkDataLength);
@@ -1046,7 +1046,7 @@ void TestNetworkDataDsnSrpAnycastSeqNumSelection(void)
 
         for (uint8_t index = 0; index < test.mSeqNumbersLength; index++)
         {
-            SuccessOrQuit(manager.GetNextDnsSrpAnycastInfo(iterator, anycastInfo));
+            SuccessOrQuit(iterator.GetNextDnsSrpAnycastInfo(anycastInfo));
 
             printf("\n { %s, seq:%u, version:%u, rlco16:%04x }", anycastInfo.mAnycastAddress.ToString().AsCString(),
 
@@ -1056,7 +1056,7 @@ void TestNetworkDataDsnSrpAnycastSeqNumSelection(void)
             VerifyOrQuit(anycastInfo.mRloc16 == 0x5000 + index);
         }
 
-        VerifyOrQuit(manager.GetNextDnsSrpAnycastInfo(iterator, anycastInfo) == kErrorNotFound);
+        VerifyOrQuit(iterator.GetNextDnsSrpAnycastInfo(anycastInfo) == kErrorNotFound);
         SuccessOrQuit(manager.FindPreferredDnsSrpAnycastInfo(anycastInfo));
 
         printf("\n preferred -> seq:%u, version:%u ", anycastInfo.mSequenceNumber, anycastInfo.mVersion);


### PR DESCRIPTION
This commit enhances the `NetworkData::Service::Iterator` class. The `Iterator` is now a separate class from `Service::Manager`. It provides `GetNextDnsSrpAnycastInfo()` & `GetNextDnsSrpUnicastInfo()` methods, simplifying the code for iterating over these service entries. The `Iterator` is also generalized to track a given `NetworkData` instance, allowing it to iterate over service entries on any `NetworkData` object, not just the Leader's.
