### PR TITLE
[build] include necessary headers in spinel

### DIFF
--- a/src/lib/spinel/radio_spinel_metrics.h
+++ b/src/lib/spinel/radio_spinel_metrics.h
@@ -35,6 +35,8 @@
 #ifndef RADIO_SPINEL_METRICS_H_
 #define RADIO_SPINEL_METRICS_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/lib/spinel/spinel_encrypter.hpp
+++ b/src/lib/spinel/spinel_encrypter.hpp
@@ -25,6 +25,8 @@
  *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <cstddef>
+
 /**
  * Allows to encrypt spinel frames sent between Application Processor (AP) and Network Co-Processor (NCP).
  */


### PR DESCRIPTION
- Include `stdint.h` for `*int*_t` types. 
- Include `stddef.h` for `size_t` type.