### PR TITLE
[history-tracker] add Network Data DNS/SRP address entry tracking

### DIFF
--- a/include/openthread/history_tracker.h
+++ b/include/openthread/history_tracker.h
@@ -241,6 +241,35 @@ typedef struct otHistoryTrackerExternalRouteInfo
 } otHistoryTrackerExternalRouteInfo;
 
 /**
+ * Represents the DNS/SRP server address type parsed from Network Data service entries.
+ */
+typedef enum
+{
+    OT_HISTORY_TRACKER_DNS_SRP_ADDR_TYPE_UNICAST_LOCAL, ///< Unicast address type local (in server data).
+    OT_HISTORY_TRACKER_DNS_SRP_ADDR_TYPE_UNICAST_INFRA, ///< Unicast address type infrastructure (in service data).
+    OT_HISTORY_TRACKER_DNS_SRP_ADDR_TYPE_ANYCAST,       ///< Anycast address type.
+} otHistoryTrackerDnsSrpAddrType;
+
+/**
+ * Represents DNS/SRP server address information parsed from a Network Data service entry.
+ *
+ * The `mType` field specifies the entry type. Some fields are only applicable to specific types.
+ * - The `mPort` field is only applicable for `OT_HISTORY_TRACKER_DNS_SRP_ADDR_TYPE_UNICAST_*` types.
+ * - The `mSequenceNumber` field is only applicable for the `OT_HISTORY_TRACKER_DNS_SRP_ADDR_TYPE_ANYCAST` type.
+ * - Other fields are common and used for all address types.
+ */
+typedef struct otHistoryTrackerDnsSrpAddrInfo
+{
+    otIp6Address                   mAddress;        ///< The server address.
+    uint16_t                       mRloc16;         ///< The RLOC16 of the Border Router adding/removing the entry.
+    uint16_t                       mPort;           ///< Port number.
+    uint8_t                        mSequenceNumber; ///< Anycast sequence number.
+    uint8_t                        mVersion;        ///< Version number.
+    otHistoryTrackerDnsSrpAddrType mType;           ///< Address type.
+    otHistoryTrackerNetDataEvent   mEvent;          ///< Indicates the event (added/removed).
+} otHistoryTrackerDnsSrpAddrInfo;
+
+/**
  * Represents events during the Border Agent's ePSKc journey.
  */
 typedef enum
@@ -421,6 +450,22 @@ const otHistoryTrackerExternalRouteInfo *otHistoryTrackerIterateExternalRouteHis
     otInstance               *aInstance,
     otHistoryTrackerIterator *aIterator,
     uint32_t                 *aEntryAge);
+
+/**
+ * Iterates over the entries in the Network Data SRP/DNS address history list.
+ *
+ * @param[in]     aInstance  A pointer to the OpenThread instance.
+ * @param[in,out] aIterator  A pointer to an iterator. MUST be initialized or the behavior is undefined.
+ * @param[out]    aEntryAge  A pointer to a variable to output the entry's age. MUST NOT be NULL.
+ *                           Age is provided as the duration (in milliseconds) from when entry was recorded to
+ *                           @p aIterator initialization time. It is set to `OT_HISTORY_TRACKER_MAX_AGE` for entries
+ *                           older than max age.
+ *
+ * @returns The `otHistoryTrackerDnsSrpAddrInfo` entry or `NULL` if no more entries in the list.
+ */
+const otHistoryTrackerDnsSrpAddrInfo *otHistoryTrackerIterateDnsSrpAddrHistory(otInstance               *aInstance,
+                                                                               otHistoryTrackerIterator *aIterator,
+                                                                               uint32_t                 *aEntryAge);
 
 /**
  * Iterates over the entries in the Border Agent ePSKc history list.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (519)
+#define OPENTHREAD_API_VERSION (520)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README_HISTORY.md
+++ b/src/cli/README_HISTORY.md
@@ -11,6 +11,7 @@ The number of entries recorded for each history list is configurable through a s
 Usage : `history [command] ...`
 
 - [help](#help)
+- [dnssrpaddr](#dnssrpaddr)
 - [ipaddr](#ipaddr)
 - [ipmaddr](#ipmaddr)
 - [neighbor](#neighbor)
@@ -63,6 +64,48 @@ rxtx
 tx
 Done
 >
+```
+
+### dnssrpaddr
+
+Usage `history dnssrpaddr [list] [<num-entries>]`
+
+Print the network data DNS/SRP address history. Each entry provides:
+
+- Event: Possible values are `Added` or `Removed`.
+- Address of DNS/SRP server.
+- Address type: `uni-local` unicast address local (address in server data) or `uni-infra` infrastructure server (addr in service data), or `anycast`.
+- Port: Server port number, only applicable when address type is unicast.
+- Sequence Number: Anycast sequence number, only applicable when address type is anycast.
+- Version number.
+- RLOC16 of the BR adding/removing this entry in Network Data.
+
+```bash
+> history dnssrpaddr
+| Age                  | Event   | Address                                 | Type      |Port/Seq| Ver | RLOC16 |
++----------------------+---------+-----------------------------------------+-----------+--------+-----+--------+
+|         00:00:07.150 | Added   | fd4f:59ae:348a:aa48:74a4:6de9:7a30:5dfb | uni-local |   1234 |   0 | 0x0000 |
+|         00:00:09.351 | Removed | fd00:0:0:0:0:0:0:1234                   | uni-infra |  51525 |   1 | 0x0000 |
+|         00:00:28.479 | Added   | fd00:0:0:0:0:0:0:1234                   | uni-infra |  51525 |   1 | 0x0000 |
+|         00:00:30.133 | Removed | fd4f:59ae:348a:aa48:0:ff:fe00:fc10      |   anycast |      1 |   2 | 0x0000 |
+|         00:01:02.609 | Added   | fd4f:59ae:348a:aa48:0:ff:fe00:fc10      |   anycast |      1 |   2 | 0x0000 |
+|         00:01:03.574 | Removed | fd4f:59ae:348a:aa48:74a4:6de9:7a30:5dfb | uni-local |  50152 |   2 | 0x0000 |
+|         00:01:33.631 | Added   | fd4f:59ae:348a:aa48:74a4:6de9:7a30:5dfb | uni-local |  50152 |   2 | 0x0000 |
+Done
+```
+
+Print the history as a list.
+
+```bash
+> history dnssrpaddr list
+00:00:19.646 -> event:Added addr:fd4f:59ae:348a:aa48:74a4:6de9:7a30:5dfb type:uni-local port:1234 ver:0 rloc16:0x0000
+00:00:21.847 -> event:Removed addr:fd00:0:0:0:0:0:0:1234 type:uni-infra port:51525 ver:1 rloc16:0x0000
+00:00:40.975 -> event:Added addr:fd00:0:0:0:0:0:0:1234 type:uni-infra port:51525 ver:1 rloc16:0x0000
+00:00:42.629 -> event:Removed addr:fd4f:59ae:348a:aa48:0:ff:fe00:fc10 type:anycast seqno:1 ver:2 rloc16:0x0000
+00:01:15.105 -> event:Added addr:fd4f:59ae:348a:aa48:0:ff:fe00:fc10 type:anycast seqno:1 ver:2 rloc16:0x0000
+00:01:16.070 -> event:Removed addr:fd4f:59ae:348a:aa48:74a4:6de9:7a30:5dfb type:uni-local port:50152 ver:2 rloc16:0x0000
+00:01:46.127 -> event:Added addr:fd4f:59ae:348a:aa48:74a4:6de9:7a30:5dfb type:uni-local port:50152 ver:2 rloc16:0x0000
+Done
 ```
 
 ### ipaddr

--- a/src/cli/cli_history.hpp
+++ b/src/cli/cli_history.hpp
@@ -100,6 +100,7 @@ private:
     static const char *MessagePriorityToString(uint8_t aPriority);
     static const char *RadioTypeToString(const otHistoryTrackerMessageInfo &aInfo);
     static const char *MessageTypeToString(const otHistoryTrackerMessageInfo &aInfo);
+    static const char *DnsSrpAddrTypeToString(otHistoryTrackerDnsSrpAddrType aType);
 };
 
 } // namespace Cli

--- a/src/core/api/history_tracker_api.cpp
+++ b/src/core/api/history_tracker_api.cpp
@@ -129,6 +129,16 @@ const otHistoryTrackerExternalRouteInfo *otHistoryTrackerIterateExternalRouteHis
                                                                                           *aEntryAge);
 }
 
+const otHistoryTrackerDnsSrpAddrInfo *otHistoryTrackerIterateDnsSrpAddrHistory(otInstance               *aInstance,
+                                                                               otHistoryTrackerIterator *aIterator,
+                                                                               uint32_t                 *aEntryAge)
+{
+    AssertPointerIsNotNull(aEntryAge);
+
+    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateDnsSrpAddrHistory(AsCoreType(aIterator),
+                                                                                       *aEntryAge);
+}
+
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
 const otHistoryTrackerBorderAgentEpskcEvent *otHistoryTrackerIterateBorderAgentEpskcEventHistory(
     otInstance               *aInstance,

--- a/src/core/config/history_tracker.h
+++ b/src/core/config/history_tracker.h
@@ -161,6 +161,17 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_HISTORY_TRACKER_DNSSRP_ADDR_LIST_SIZE
+ *
+ * Specifies the maximum number of entries in Network Data DNS/SRP Address history list.
+ *
+ * Set to zero to prevent the History Tracker module from collecting this info.
+ */
+#ifndef OPENTHREAD_CONFIG_HISTORY_TRACKER_DNSSRP_ADDR_LIST_SIZE
+#define OPENTHREAD_CONFIG_HISTORY_TRACKER_DNSSRP_ADDR_LIST_SIZE 32
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_HISTORY_TRACKER_EPSKC_EVENT_SIZE
  *
  * Specifies the maximum number of entries in Border Agent ePSKc history list.

--- a/src/core/thread/network_data_service.cpp
+++ b/src/core/thread/network_data_service.cpp
@@ -181,6 +181,8 @@ Error Iterator::GetNextDnsSrpAnycastInfo(DnsSrpAnycastInfo &aInfo)
     Error   error         = kErrorNone;
     uint8_t serviceNumber = Manager::kDnsSrpAnycastServiceNumber;
 
+    aInfo.Clear();
+
     do
     {
         ServiceData serviceData;
@@ -228,6 +230,8 @@ Error Manager::FindPreferredDnsSrpAnycastInfo(DnsSrpAnycastInfo &aInfo) const
     Iterator          iterator(GetInstance());
     DnsSrpAnycastInfo info;
     DnsSrpAnycastInfo maxNumericalSeqNumInfo;
+
+    aInfo.Clear();
 
     // Determine the entry with largest seq number in two ways:
     // `aInfo` will track the largest using serial number arithmetic
@@ -320,6 +324,8 @@ Error Iterator::GetNextDnsSrpUnicastInfo(DnsSrpUnicastType aType, DnsSrpUnicastI
 {
     Error   error         = kErrorNone;
     uint8_t serviceNumber = Manager::kDnsSrpUnicastServiceNumber;
+
+    aInfo.Clear();
 
     do
     {

--- a/src/core/thread/network_data_service.hpp
+++ b/src/core/thread/network_data_service.hpp
@@ -39,7 +39,9 @@
 #include <openthread/netdata.h>
 
 #include "backbone_router/bbr_leader.hpp"
+#include "common/clearable.hpp"
 #include "common/encoding.hpp"
+#include "common/equatable.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/serial_number.hpp"
@@ -55,7 +57,7 @@ const uint32_t kThreadEnterpriseNumber = ServiceTlv::kThreadEnterpriseNumber; //
 /**
  * Represents information about an DNS/SRP server parsed from related Network Data service entries.
  */
-struct DnsSrpAnycastInfo
+struct DnsSrpAnycastInfo : public Clearable<DnsSrpAnycastInfo>, public Equatable<DnsSrpAnycastInfo>
 {
     Ip6::Address mAnycastAddress; ///< The anycast address associated with the DNS/SRP servers.
     uint8_t      mSequenceNumber; ///< Sequence number used to notify SRP client if they need to re-register.
@@ -75,7 +77,7 @@ enum DnsSrpUnicastType : uint8_t
 /**
  * Represents information about an DNS/SRP server parsed from related Network Data service entries.
  */
-struct DnsSrpUnicastInfo
+struct DnsSrpUnicastInfo : public Clearable<DnsSrpUnicastInfo>, public Equatable<DnsSrpUnicastInfo>
 {
     Ip6::SockAddr mSockAddr; ///< The socket address (IPv6 address and port) of the DNS/SRP server.
     uint8_t       mVersion;  ///< Version number.

--- a/src/core/utils/history_tracker.cpp
+++ b/src/core/utils/history_tracker.cpp
@@ -348,9 +348,18 @@ void HistoryTracker::RecordRouterTableChange(void)
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_NET_DATA
 void HistoryTracker::RecordNetworkDataChange(void)
 {
-    NetworkData::Iterator            iterator;
-    NetworkData::OnMeshPrefixConfig  prefix;
-    NetworkData::ExternalRouteConfig route;
+    static const NetworkData::Service::DnsSrpUnicastType kDnsSrpUnicastTypes[] = {
+        NetworkData::Service::kAddrInServiceData,
+        NetworkData::Service::kAddrInServerData,
+    };
+
+    NetworkData::Iterator                   iterator;
+    NetworkData::OnMeshPrefixConfig         prefix;
+    NetworkData::ExternalRouteConfig        route;
+    NetworkData::Service::DnsSrpUnicastInfo unicastInfo;
+    NetworkData::Service::DnsSrpAnycastInfo anycastInfo;
+    NetworkData::Service::Iterator          newDataIterator(GetInstance(), Get<NetworkData::Leader>());
+    NetworkData::Service::Iterator          prvDataIterator(GetInstance(), mPreviousNetworkData);
 
     // On mesh prefix entries
 
@@ -396,6 +405,51 @@ void HistoryTracker::RecordNetworkDataChange(void)
         }
     }
 
+    // DNS/SRP Unicast/Anycast entries
+
+    for (NetworkData::Service::DnsSrpUnicastType type : kDnsSrpUnicastTypes)
+    {
+        prvDataIterator.Reset();
+
+        while (prvDataIterator.GetNextDnsSrpUnicastInfo(type, unicastInfo) == kErrorNone)
+        {
+            if (!NetDataContainsDnsSrpUnicast(Get<NetworkData::Leader>(), unicastInfo, type))
+            {
+                RecordDnsSrpAddrEvent(kNetDataEntryRemoved, unicastInfo, type);
+            }
+        }
+
+        newDataIterator.Reset();
+
+        while (newDataIterator.GetNextDnsSrpUnicastInfo(type, unicastInfo) == kErrorNone)
+        {
+            if (!NetDataContainsDnsSrpUnicast(mPreviousNetworkData, unicastInfo, type))
+            {
+                RecordDnsSrpAddrEvent(kNetDataEntryAdded, unicastInfo, type);
+            }
+        }
+    }
+
+    prvDataIterator.Reset();
+
+    while (prvDataIterator.GetNextDnsSrpAnycastInfo(anycastInfo) == kErrorNone)
+    {
+        if (!NetDataContainsDnsSrpAnycast(Get<NetworkData::Leader>(), anycastInfo))
+        {
+            RecordDnsSrpAddrEvent(kNetDataEntryRemoved, anycastInfo);
+        }
+    }
+
+    newDataIterator.Reset();
+
+    while (newDataIterator.GetNextDnsSrpAnycastInfo(anycastInfo) == kErrorNone)
+    {
+        if (!NetDataContainsDnsSrpAnycast(mPreviousNetworkData, anycastInfo))
+        {
+            RecordDnsSrpAddrEvent(kNetDataEntryAdded, anycastInfo);
+        }
+    }
+
     SuccessOrAssert(Get<NetworkData::Leader>().CopyNetworkData(NetworkData::kFullSet, mPreviousNetworkData));
 }
 
@@ -421,6 +475,93 @@ void HistoryTracker::RecordExternalRouteEvent(NetDataEvent aEvent, const Network
 
 exit:
     return;
+}
+
+void HistoryTracker::RecordDnsSrpAddrEvent(NetDataEvent                                   aEvent,
+                                           const NetworkData::Service::DnsSrpUnicastInfo &aUnicastInfo,
+                                           NetworkData::Service::DnsSrpUnicastType        aType)
+{
+    DnsSrpAddrInfo *entry = mDnsSrpAddrHistory.AddNewEntry();
+
+    VerifyOrExit(entry != nullptr);
+
+    entry->mAddress        = aUnicastInfo.mSockAddr.mAddress;
+    entry->mRloc16         = aUnicastInfo.mRloc16;
+    entry->mPort           = aUnicastInfo.mSockAddr.mPort;
+    entry->mSequenceNumber = 0;
+    entry->mVersion        = aUnicastInfo.mVersion;
+    entry->mEvent          = aEvent;
+
+    switch (aType)
+    {
+    case NetworkData::Service::kAddrInServerData:
+        entry->mType = kDnsSrpAddrTypeUnicastLocal;
+        break;
+    case NetworkData::Service::kAddrInServiceData:
+        entry->mType = kDnsSrpAddrTypeUnicastInfra;
+        break;
+    }
+
+exit:
+    return;
+}
+
+void HistoryTracker::RecordDnsSrpAddrEvent(NetDataEvent                                   aEvent,
+                                           const NetworkData::Service::DnsSrpAnycastInfo &aAnycastInfo)
+{
+    DnsSrpAddrInfo *entry = mDnsSrpAddrHistory.AddNewEntry();
+
+    VerifyOrExit(entry != nullptr);
+
+    entry->mAddress        = aAnycastInfo.mAnycastAddress;
+    entry->mRloc16         = aAnycastInfo.mRloc16;
+    entry->mPort           = kAnycastServerPort;
+    entry->mSequenceNumber = aAnycastInfo.mSequenceNumber;
+    entry->mVersion        = aAnycastInfo.mVersion;
+    entry->mEvent          = aEvent;
+    entry->mType           = kDnsSrpAddrTypeAnycast;
+
+exit:
+    return;
+}
+
+bool HistoryTracker::NetDataContainsDnsSrpUnicast(const NetworkData::NetworkData                &aNetworkData,
+                                                  const NetworkData::Service::DnsSrpUnicastInfo &aUnicastInfo,
+                                                  NetworkData::Service::DnsSrpUnicastType        aType) const
+{
+    bool                                    contains = false;
+    NetworkData::Service::Iterator          iterator(GetInstance(), aNetworkData);
+    NetworkData::Service::DnsSrpUnicastInfo unicastInfo;
+
+    while (iterator.GetNextDnsSrpUnicastInfo(aType, unicastInfo) == kErrorNone)
+    {
+        if (unicastInfo == aUnicastInfo)
+        {
+            contains = true;
+            break;
+        }
+    }
+
+    return contains;
+}
+
+bool HistoryTracker::NetDataContainsDnsSrpAnycast(const NetworkData::NetworkData                &aNetworkData,
+                                                  const NetworkData::Service::DnsSrpAnycastInfo &aAnycastInfo) const
+{
+    bool                                    contains = false;
+    NetworkData::Service::Iterator          iterator(GetInstance(), aNetworkData);
+    NetworkData::Service::DnsSrpAnycastInfo anycastInfo;
+
+    while (iterator.GetNextDnsSrpAnycastInfo(anycastInfo) == kErrorNone)
+    {
+        if (anycastInfo == aAnycastInfo)
+        {
+            contains = true;
+            break;
+        }
+    }
+
+    return contains;
 }
 
 #endif // OPENTHREAD_CONFIG_HISTORY_TRACKER_NET_DATA
@@ -464,6 +605,7 @@ void HistoryTracker::HandleTimer(void)
     mNeighborHistory.UpdateAgedEntries();
     mOnMeshPrefixHistory.UpdateAgedEntries();
     mExternalRouteHistory.UpdateAgedEntries();
+    mDnsSrpAddrHistory.UpdateAgedEntries();
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
     mEpskcEventHistory.UpdateAgedEntries();
 #endif


### PR DESCRIPTION
This commit introduces a new feature in `HistoryTracker` to track Network Data DNS/SRP unicast/anycast address entries. This new functionality records when different Border Routers add or remove these entries in the Network Data. This change also introduces new public APIs and CLI command `history dnssrpaddr` to expose this information.