### PR TITLE
[trel] ignore mDNS service removal for peer table update

### DIFF
--- a/src/core/radio/trel_interface.cpp
+++ b/src/core/radio/trel_interface.cpp
@@ -127,7 +127,7 @@ Error Interface::Send(Packet &aPacket, bool aIsDiscovery)
             Header::AckMode originalAckMode      = aPacket.GetHeader().GetAckMode();
             Neighbor       *neighbor;
 
-            if (!peer.IsStateValid())
+            if (!peer.HasValidSockAddr())
             {
                 continue;
             }
@@ -156,8 +156,10 @@ Error Interface::Send(Packet &aPacket, bool aIsDiscovery)
     case Header::kTypeUnicast:
     case Header::kTypeAck:
         peerEntry = Get<PeerTable>().FindMatching(aPacket.GetHeader().GetDestination());
-        VerifyOrExit((peerEntry != nullptr) && peerEntry->IsStateValid(), error = kErrorAbort);
-        otPlatTrelSend(&GetInstance(), aPacket.GetBuffer(), aPacket.GetLength(), &peerEntry->mSockAddr);
+        VerifyOrExit(peerEntry != nullptr, error = kErrorAbort);
+        VerifyOrExit(peerEntry->HasValidSockAddr(), error = kErrorAbort);
+        peerEntry->UpdateLastInteractionTime();
+        otPlatTrelSend(&GetInstance(), aPacket.GetBuffer(), aPacket.GetLength(), &peerEntry->GetSockAddr());
         break;
     }
 

--- a/src/core/radio/trel_link.cpp
+++ b/src/core/radio/trel_link.cpp
@@ -347,6 +347,11 @@ void Link::ProcessReceivedPacket(Packet &aPacket, const Ip6::SockAddr &aSockAddr
     mRxPacketSenderAddr = aSockAddr;
     mRxPacketPeer       = Get<PeerTable>().FindMatching(aPacket.GetHeader().GetSource());
 
+    if (mRxPacketPeer != nullptr)
+    {
+        mRxPacketPeer->UpdateLastInteractionTime();
+    }
+
     if (type != Header::kTypeBroadcast)
     {
         VerifyOrExit(aPacket.GetHeader().GetDestination() == Get<Mac::Mac>().GetExtAddress());

--- a/src/core/radio/trel_peer_discoverer.hpp
+++ b/src/core/radio/trel_peer_discoverer.hpp
@@ -119,8 +119,6 @@ public:
 #endif
 
 private:
-    static constexpr uint32_t kRemoveDelay = 7 * Time::kOneSecondInMsec;
-
     enum State : uint8_t
     {
         kStateStopped,      // Stopped.


### PR DESCRIPTION
This commit modifies TREL to disregard mDNS (DNS-SD) service removal events when updating the peer table. Since mDNS peer removal signals can be unreliable, this change prevents such signals from causing a peer's removal. Instead, a peer entry is retained as long as TREL packets and acks are successfully exchanged, moving towards the goal of eliminating TREL's dependency on mDNS for peer discovery and tracking.

This commit also introduces a new mechanism to track the last interaction time with each peer. This information is used to evict the least recently used entry when the peer table gets full and to remove inactive peers after a long expiration period (7.5 min) passes.

The `test_trel` Nexus test is updated to validate these new behaviors.

----

Related to [SPEC-1412](https://threadgroup.atlassian.net/browse/SPEC-1412)