### PR TITLE
[diags] Add delay between transmit done and next transmit

### DIFF
--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -37,6 +37,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
@@ -882,6 +883,7 @@ void Diags::TransmitDone(Error aError)
 
     if (mTxPackets > 1)
     {
+        usleep(1);
         mTxPackets--;
         IgnoreError(TransmitPacket());
     }


### PR DESCRIPTION
Currently, in 'diag send' test context, next packet is sent right after transmit done reception. 
However in a RCP architecture, timing is too short and the host must ask for a retry which leads to bad performance.

Before modification, 
delay between VALUE_IS LAST_STATUS and next VALUE_SET STREAM is 37us. 34us is too tight for  RCP to handle current transaction and to prepare next one. 
After modification, 
delay is 100us: 1us in usleep + call of usleep function which takes around 60us, which is long enough to avoid retry and then increase performance.

[Testing]
Before modification
'diag send' test is failing on RCP architecture due to retries on each STREAM_RAW. 
Aftermodification
'diag send' test is passing.