### PR TITLE
[ip6] move `Message::Ownership` enum to `Ip6` class

### DIFF
--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -327,25 +327,6 @@ public:
     static constexpr uint8_t kNumPriorities = 4; ///< Number of priority levels.
 
     /**
-     * Represents the message ownership model when a `Message` instance is passed to a method/function.
-     */
-    enum Ownership : uint8_t
-    {
-        /**
-         * This value indicates that the method/function receiving a `Message` instance should take custody of the
-         * message (e.g., the method should `Free()` the message if no longer needed).
-         */
-        kTakeCustody,
-
-        /**
-         * This value indicates that the method/function receiving a `Message` instance does not own the message (e.g.,
-         * it should not `Free()` or `Enqueue()` it in a queue). The receiving method/function should create a
-         * copy/clone of the message to keep (if/when needed).
-         */
-        kCopyToUse,
-    };
-
-    /**
      * Represents an IPv6 message origin.
      */
     enum Origin : uint8_t

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -349,10 +349,16 @@ private:
 
     static constexpr uint16_t kMinimalMtu = 1280;
 
+    enum MessageOwnership : uint8_t
+    {
+        kTakeMessageCustody,
+        kCopyMessageToUse,
+    };
+
     static uint8_t PriorityToDscp(Message::Priority aPriority);
     static Error   TakeOrCopyMessagePtr(OwnedPtr<Message> &aTargetPtr,
                                         OwnedPtr<Message> &aMessagePtr,
-                                        Message::Ownership aMessageOwnership);
+                                        MessageOwnership   aMessageOwnership);
 
     void  EnqueueDatagram(Message &aMessage);
     void  HandleSendQueue(void);
@@ -365,7 +371,7 @@ private:
                      const Header      &aHeader,
                      uint8_t            aIpProto,
                      bool               aReceive,
-                     Message::Ownership aMessageOwnership);
+                     MessageOwnership   aMessageOwnership);
     Error HandleExtensionHeaders(OwnedPtr<Message> &aMessagePtr,
                                  const Header      &aHeader,
                                  uint8_t           &aNextHeader,
@@ -387,7 +393,7 @@ private:
     Error Receive(Header            &aIp6Header,
                   OwnedPtr<Message> &aMessagePtr,
                   uint8_t            aIpProto,
-                  Message::Ownership aMessageOwnership);
+                  MessageOwnership   aMessageOwnership);
 #if OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
     void UpdateBorderRoutingCounters(const Header &aHeader, uint16_t aMessageLength, bool aIsInbound);
 #endif


### PR DESCRIPTION
This commit moves the `Message::Ownership` enum definition to the `Ip6` class. This enum is exclusively used by the `Ip6` class to determine whether to clone a message or take direct custody. This model is not intended for use by other components. `OwnerPtr<>` is the recommended approach for conveying ownership transfers.