### PR TITLE
[test] relax mDNS query checks in `border-router` tests

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_dnssd_instance_name_with_space.py
+++ b/tests/scripts/thread-cert/border_router/test_dnssd_instance_name_with_space.py
@@ -178,6 +178,10 @@ class TestDnssdInstanceNameWithSpace(thread_cert.TestCase):
             print('not match: ', dig_answer, record,
                   list(a == b or (callable(b) and b(a)) for a, b in zip(dig_answer, record)))
 
+        # Additional records are optional. Ignore if missing.
+        if additional:
+            return
+
         self.fail((record, dig_result))
 
     def _match_record(self, record, match):
@@ -205,8 +209,6 @@ class TestDnssdInstanceNameWithSpace(thread_cert.TestCase):
                 self._assert_have_answer(dig_result, record, additional=False)
 
         if 'ADDITIONAL' in expected_result:
-            self.assertGreaterEqual(len(dig_result['ADDITIONAL']), len(expected_result['ADDITIONAL']), dig_result)
-
             for record in expected_result['ADDITIONAL']:
                 self._assert_have_answer(dig_result, record, additional=True)
 

--- a/tests/scripts/thread-cert/border_router/test_dnssd_server.py
+++ b/tests/scripts/thread-cert/border_router/test_dnssd_server.py
@@ -302,6 +302,10 @@ class TestDnssdServerOnBr(thread_cert.TestCase):
             print('not match: ', dig_answer, record,
                   list(a == b or (callable(b) and b(a)) for a, b in zip(dig_answer, record)))
 
+        # Additional records are optional. Ignore if missing.
+        if additional:
+            return
+
         self.fail((record, dig_result))
 
     def _match_record(self, record, match):
@@ -332,8 +336,6 @@ class TestDnssdServerOnBr(thread_cert.TestCase):
                 self._assert_have_answer(dig_result, record, additional=False)
 
         if 'ADDITIONAL' in expected_result:
-            self.assertGreaterEqual(len(dig_result['ADDITIONAL']), len(expected_result['ADDITIONAL']), dig_result)
-
             for record in expected_result['ADDITIONAL']:
                 self._assert_have_answer(dig_result, record, additional=True)
 

--- a/tests/scripts/thread-cert/border_router/test_dnssd_server_multi_border_routers.py
+++ b/tests/scripts/thread-cert/border_router/test_dnssd_server_multi_border_routers.py
@@ -382,6 +382,10 @@ class TestDnssdServerOnMultiBr(thread_cert.TestCase):
             print('not match: ', dig_answer, record,
                   list(a == b or (callable(b) and b(a)) for a, b in zip(dig_answer, record)))
 
+        # Additional records are optional. Ignore if missing.
+        if additional:
+            return
+
         self.fail((record, dig_result))
 
     def _match_record(self, record, match):
@@ -412,8 +416,6 @@ class TestDnssdServerOnMultiBr(thread_cert.TestCase):
                 self._assert_have_answer(dig_result, record, additional=False)
 
         if 'ADDITIONAL' in expected_result:
-            self.assertGreaterEqual(len(dig_result['ADDITIONAL']), len(expected_result['ADDITIONAL']), dig_result)
-
             for record in expected_result['ADDITIONAL']:
                 self._assert_have_answer(dig_result, record, additional=True)
 


### PR DESCRIPTION
This commit relaxes the `border_router` test scripts that check mDNS query results. The test will no longer fail if an expected record does not appear in the additional section.

This change aligns with RFC 6763 section 12, which specifies that additional records are recommended but not required. Particularly, a TXT record is not recommended for an SRV query (section 12.2), and a TXT query has no recommended additional records (section 12.3).

The test will now validate the additional record if it is present but will not fail if it is absent.