### PR TITLE
[mle] refactor `BecomeLeader` to use enum for weight check

### DIFF
--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -181,7 +181,7 @@ otError otThreadBecomeRouter(otInstance *aInstance)
 
 otError otThreadBecomeLeader(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<Mle::Mle>().BecomeLeader(/* aCheckWeight */ true);
+    return AsCoreType(aInstance).Get<Mle::Mle>().BecomeLeader(Mle::Mle::kCheckLeaderWeight);
 }
 
 uint8_t otThreadGetRouterDowngradeThreshold(otInstance *aInstance)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1655,7 +1655,7 @@ uint32_t Mle::Reattach(void)
         }
 
 #if OPENTHREAD_FTD
-        if (IsFullThreadDevice() && BecomeLeader(/* aCheckWeight */ false) == kErrorNone)
+        if (IsFullThreadDevice() && BecomeLeader(kIgnoreLeaderWeight) == kErrorNone)
         {
             ExitNow();
         }

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -810,21 +810,26 @@ public:
     Error BecomeRouter(ThreadStatusTlv::Status aStatus);
 
     /**
-     * Becomes a leader and starts a new partition.
-     *
-     * If the device is already attached, this method can be used to attempt to take over as the leader, creating a new
-     * partition. For this to work, the local leader weight must be greater than the weight of the current leader. The
-     * @p aCheckWeight can be used to ensure that this check is performed.
-     *
-     * @param[in] aCheckWeight      Check that the local leader weight is larger than the weight of the current leader.
-     *
-     * @retval kErrorNone           Successfully become a Leader and started a new partition.
-     * @retval kErrorInvalidState   Thread is not enabled.
-     * @retval kErrorNotCapable     Device is not capable of becoming a leader (not router eligible), or
-     *                              @p aCheckWeight is true and cannot override the current leader due to its local
-     *                              leader weight being same or smaller than current leader's weight.
+     * Specifies the leader weight check behavior used in `BecomeLeader()`.
      */
-    Error BecomeLeader(bool aCheckWeight);
+    enum LeaderWeightCheck : uint8_t{
+        kCheckLeaderWeight,  ///< Enforces that the local leader weight is greater than the current leader's weight.
+        kIgnoreLeaderWeight, ///< Skips the leader weight check, attempting to become leader regardless.
+    };
+
+    /**
+     * Attempts to become the leader and start a new partition.
+     *
+     * If the device is already attached, this method can be used to take over the leader role.
+     *
+     * @param[in] aMode             Specifies whether to enforce or ignore the leader weight check.
+     *
+     * @retval kErrorNone           Successfully became leader and started a new partition.
+     * @retval kErrorInvalidState   The Thread interface is not enabled.
+     * @retval kErrorNotCapable     The device is not router-eligible, or the leader weight check is enabled and the
+     *                              local leader weight is less than or equal to the current leader's weight.
+     */
+    Error BecomeLeader(LeaderWeightCheck aMode);
 
 #if OPENTHREAD_CONFIG_MLE_DEVICE_PROPERTY_LEADER_WEIGHT_ENABLE
     /**

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -216,7 +216,7 @@ exit:
     return error;
 }
 
-Error Mle::BecomeLeader(bool aCheckWeight)
+Error Mle::BecomeLeader(LeaderWeightCheck aMode)
 {
     Error    error = kErrorNone;
     Router  *router;
@@ -232,7 +232,7 @@ Error Mle::BecomeLeader(bool aCheckWeight)
     VerifyOrExit(!IsLeader(), error = kErrorNone);
     VerifyOrExit(IsRouterEligible(), error = kErrorNotCapable);
 
-    if (aCheckWeight && IsAttached())
+    if ((aMode == kCheckLeaderWeight) && IsAttached())
     {
         VerifyOrExit(mLeaderWeight > mLeaderData.GetWeighting(), error = kErrorNotCapable);
     }


### PR DESCRIPTION
This commit refactors the `Mle::BecomeLeader()` method to use a new `LeaderWeightCheck` enum instead of a boolean parameter for checking the leader weight.

The new enum, with values `kCheckLeaderWeight` and `kIgnoreLeaderWeight`, makes the intent at the call sites more explicit and improves code readability by avoiding the ambiguity of a `true`/`false` flag. The functional behavior remains unchanged.