### PR TITLE
[tests] explicitly enable/disable border agent in `test_publish_meshcop_service`

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
+++ b/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
@@ -164,6 +164,8 @@ class PublishMeshCopService(thread_cert.TestCase):
         br2_service = self.check_meshcop_service(br2, host)
         self.assertNotEqual(br1_service['host'], br2_service['host'])
 
+        br1.disable_border_agent()
+        self.simulator.go(5)
         br1.stop_otbr_service()
         self.simulator.go(5)
         br2.enable_backbone_router()
@@ -171,6 +173,8 @@ class PublishMeshCopService(thread_cert.TestCase):
         self.assertEqual(len(host.browse_mdns_services('_meshcop._udp')), 1)
         br1.start_otbr_service()
         self.simulator.go(10)
+        br1.enable_border_agent()
+        self.simulator.go(5)
         self.assertEqual(len(host.browse_mdns_services('_meshcop._udp')), 2)
         self.check_meshcop_service(br1, host)
         self.check_meshcop_service(br2, host)

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1453,6 +1453,14 @@ class NodeImpl:
         self.send_command(cmd)
         return int(self._expect_command_output()[0])
 
+    def enable_border_agent(self):
+        self.send_command('ba enable')
+        self._expect_done()
+
+    def disable_border_agent(self):
+        self.send_command('ba disable')
+        self._expect_done()
+
     def get_border_agent_counters(self):
         cmd = 'ba counters'
         self.send_command(cmd)


### PR DESCRIPTION
The `test_publish_meshcop_service` is updated to explicitly disable the border agent before stopping the `otbr-service`. This makes the test more reliable by ensuring the MeshCoP service is unpublished before stopping `otbr-service`.