### PR TITLE
[instance] remove border agent disabling in `Finalize`

### DIFF
--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -430,9 +430,6 @@ void Instance::Finalize(void)
     mIsInitialized = false;
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
-#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    Get<MeshCoP::BorderAgent>().SetEnabled(false);
-#endif
     Get<Mle::Mle>().Stop();
     Get<ThreadNetif>().Down();
     Get<Mac::Mac>().SetEnabled(false);


### PR DESCRIPTION
This commit removes the explicit call to disable the `BorderAgent` during instance finalization. This change prevents issues where the call may trigger platform interactions that can fail due to the platform layer being deinitialized before the `Finalize` is called.