### PR TITLE
[ip6] refactor `Filter::Accept` to `Filter::Apply` and return `Error`

### DIFF
--- a/src/core/net/ip6_filter.hpp
+++ b/src/core/net/ip6_filter.hpp
@@ -70,14 +70,14 @@ public:
     }
 
     /**
-     * Indicates whether or not the IPv6 datagram passes the filter.
+     * Applies the filter to an IPv6 datagram to determine if it should be dropped.
      *
      * @param[in]  aMessage  The IPv6 datagram to process.
      *
-     * @retval TRUE   Accept the IPv6 datagram.
-     * @retval FALSE  Reject the IPv6 datagram.
+     * @retval kErrorNone  The message is not filtered and should be accepted.
+     * @retval kErrorDrop  The message matches the filter criteria and should be dropped.
      */
-    bool Accept(Message &aMessage) const;
+    Error Apply(const Message &aMessage) const;
 
     /**
      * Adds a port to the allowed unsecured port list.

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1455,7 +1455,7 @@ void MeshForwarder::HandleFragment(RxInfo &aRxInfo)
         message->SetTimestampToNow();
         message->UpdateLinkInfoFrom(aRxInfo.mLinkInfo);
 
-        VerifyOrExit(Get<Ip6::Filter>().Accept(*message), error = kErrorDrop);
+        SuccessOrExit(error = Get<Ip6::Filter>().Apply(*message));
 
 #if OPENTHREAD_FTD
         CheckReachabilityToSendIcmpError(*message, aRxInfo.mMacAddrs);
@@ -1603,7 +1603,7 @@ void MeshForwarder::HandleLowpanHc(RxInfo &aRxInfo)
 
     message->UpdateLinkInfoFrom(aRxInfo.mLinkInfo);
 
-    VerifyOrExit(Get<Ip6::Filter>().Accept(*message), error = kErrorDrop);
+    SuccessOrExit(error = Get<Ip6::Filter>().Apply(*message));
 
 #if OPENTHREAD_FTD
     CheckReachabilityToSendIcmpError(*message, aRxInfo.mMacAddrs);


### PR DESCRIPTION
This commit refactors the IPv6 filter by renaming `Filter::Accept()` to `Filter::Apply()` and changing its return type from `bool` to `Error`.

The new method now returns `kErrorNone` for an accepted message and `kErrorDrop` for a message that should be dropped. This change improves clarity and aligns the filter's logic with the common `SuccessOrExit` error handling pattern used throughout the codebase.