### PR TITLE
[format] enable simplify demorgan option

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,8 +20,5 @@ Checks: >
   readability-redundant-member-init,
   readability-simplify-boolean-expr,
   readability-static-accessed-through-instance
-CheckOptions:
-  - key: readability-simplify-boolean-expr.SimplifyDeMorgan
-    value: false
 WarningsAsErrors: '*'
 HeaderFilterRegex: '(examples|include|src).*(?<!third_party.*repo)'

--- a/src/core/common/debug.hpp
+++ b/src/core/common/debug.hpp
@@ -55,7 +55,10 @@
 #define OT_ASSERT(cond)                            \
     do                                             \
     {                                              \
-        if (!(cond))                               \
+        if (cond)                                  \
+        {                                          \
+        }                                          \
+        else                                       \
         {                                          \
             otPlatAssertFail(FILE_NAME, __LINE__); \
             while (1)                              \
@@ -75,7 +78,10 @@
 #define OT_ASSERT(cond) \
     do                  \
     {                   \
-        if (!(cond))    \
+        if (cond)       \
+        {               \
+        }               \
+        else            \
         {               \
             while (1)   \
             {           \

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -721,7 +721,7 @@ void Server::CommitSrpUpdate(Error                    aError,
 exit:
     if (aMessageInfo != nullptr)
     {
-        if (aError == kErrorNone && !(grantedLease == hostLease && grantedKeyLease == hostKeyLease))
+        if (aError == kErrorNone && (grantedLease != hostLease || grantedKeyLease != hostKeyLease))
         {
             SendResponse(aDnsHeader, grantedLease, grantedKeyLease, useShortLease, *aMessageInfo);
         }

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -112,7 +112,7 @@ exit:
 #if OPENTHREAD_CONFIG_CHANNEL_MANAGER_CSL_CHANNEL_SELECT_ENABLE
 void ChannelManager::ChangeCslChannel(uint8_t aChannel)
 {
-    if (!(!Get<Mle::Mle>().IsRxOnWhenIdle() && Get<Mac::Mac>().IsCslEnabled()))
+    if (Get<Mle::Mle>().IsRxOnWhenIdle() || !Get<Mac::Mac>().IsCslEnabled())
     {
         // cannot select or use other channel
         ExitNow();

--- a/src/lib/platform/exit_code.h
+++ b/src/lib/platform/exit_code.h
@@ -113,7 +113,10 @@ const char *otExitCodeToString(uint8_t aExitCode);
 #define VerifyOrDie(aCondition, aExitCode)                                                         \
     do                                                                                             \
     {                                                                                              \
-        if (!(aCondition))                                                                         \
+        if (aCondition)                                                                            \
+        {                                                                                          \
+        }                                                                                          \
+        else                                                                                       \
         {                                                                                          \
             const char *start = strrchr(__FILE__, '/');                                            \
             OT_UNUSED_VARIABLE(start);                                                             \

--- a/tests/unit/test_util.h
+++ b/tests/unit/test_util.h
@@ -66,7 +66,10 @@ extern "C" {
 #define VerifyOrQuit(...)                                                                                       \
     do                                                                                                          \
     {                                                                                                           \
-        if (!(OT_FIRST_ARG(__VA_ARGS__)))                                                                       \
+        if ((OT_FIRST_ARG(__VA_ARGS__)))                                                                        \
+        {                                                                                                       \
+        }                                                                                                       \
+        else                                                                                                    \
         {                                                                                                       \
             fprintf(stderr, "\nFAILED %s:%d - VerifyOrQuit(%s) " OT_SECOND_ARG(__VA_ARGS__) "\n", __FUNCTION__, \
                     __LINE__, _Stringize(OT_FIRST_ARG(__VA_ARGS__)));                                           \


### PR DESCRIPTION
This PR turns on the `SimplifyDeMorgan` option in clang-format and simplifies some conditions as suggested.

This PR also fixes some warnings caused by the option by applying the same enhancement in https://github.com/openthread/openthread/pull/11500.

