### PR TITLE
[mle] register `Message::TxCallback` when sending "Child ID Req"

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1283,10 +1283,6 @@ void MeshForwarder::FinalizeMessageDirectTx(Message &aMessage, Error aError)
         // `aMessage` and mark it again for direct transmission.
         Get<Mle::DiscoverScanner>().HandleDiscoveryRequestFrameTxDone(aMessage, aError);
     }
-    else if (aMessage.IsMleCommand(Mle::kCommandChildIdRequest))
-    {
-        Get<Mle::Mle>().HandleChildIdRequestTxDone(aMessage);
-    }
 
     aMessage.InvokeTxCallback(aError);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1751,7 +1751,14 @@ exit:
     FreeMessageOnError(message, error);
 }
 
-void Mle::HandleChildIdRequestTxDone(Message &aMessage)
+void Mle::HandleChildIdRequestTxDone(const otMessage *aMessage, otError aError, void *aContext)
+{
+    OT_UNUSED_VARIABLE(aError);
+
+    static_cast<Mle *>(aContext)->HandleChildIdRequestTxDone(AsCoreType(aMessage));
+}
+
+void Mle::HandleChildIdRequestTxDone(const Message &aMessage)
 {
     if (aMessage.GetTxSuccess() && !IsRxOnWhenIdle())
     {
@@ -1825,6 +1832,8 @@ Error Mle::SendChildIdRequest(void)
     SuccessOrExit(error = message->AppendActiveAndPendingTimestampTlvs());
 
     mParentCandidate.SetState(Neighbor::kStateValid);
+
+    message->RegisterTxCallback(HandleChildIdRequestTxDone, this);
 
     destination.SetToLinkLocalAddress(mParentCandidate.GetExtAddress());
     SuccessOrExit(error = message->SendTo(destination));

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -634,12 +634,6 @@ public:
         mParentResponseCallback.Set(aCallback, aContext);
     }
 #endif
-    /**
-     * Notifies MLE whether the Child ID Request message was transmitted successfully.
-     *
-     * @param[in]  aMessage  The transmitted message.
-     */
-    void HandleChildIdRequestTxDone(Message &aMessage);
 
     /**
      * Schedules a Child Update Request.
@@ -1993,6 +1987,7 @@ private:
     uint32_t   GetAttachStartDelay(void) const;
     void       SendParentRequest(ParentRequestType aType);
     Error      SendChildIdRequest(void);
+    void       HandleChildIdRequestTxDone(const Message &aMessage);
     Error      GetNextAnnounceChannel(uint8_t &aChannel) const;
     bool       HasMoreChannelsToAnnounce(void) const;
     bool       PrepareAnnounceState(void);
@@ -2012,6 +2007,8 @@ private:
                                       const Ip6::MessageInfo &aMessageInfo,
                                       uint16_t                aCmdOffset,
                                       const SecurityHeader   &aHeader);
+
+    static void HandleChildIdRequestTxDone(const otMessage *aMessage, otError aError, void *aContext);
 
 #if OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH
     void InformPreviousParent(void);


### PR DESCRIPTION
This commit updates the mechanism for notifying the transmit completion of a Child ID Request message.

Instead of `MeshForwarder` checking the message type and calling into `Mle` upon transmit completion, `Mle::SendChildIdRequest()` now registers a `TxCallback` directly on the message.

This change simplifies `MeshForwarder` by removing the need for it to be aware of specific `Mle` message types.