### PR TITLE
[mle] avoid scheduling `RetxTracker` timer when disabled

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -5556,6 +5556,9 @@ void Mle::RetxTracker::UpdateOnDataResponseRx(void)
 void Mle::RetxTracker::ScheduleTimer(void)
 {
     mTimer.Stop();
+
+    VerifyOrExit(!Get<Mle>().IsDisabled());
+
     mChildUpdate.Schedule(mTimer);
 
     // We defer sending Data Request while awaiting a Child Update
@@ -5565,11 +5568,16 @@ void Mle::RetxTracker::ScheduleTimer(void)
     {
         mDataRequest.Schedule(mTimer);
     }
+
+exit:
+    return;
 }
 
 void Mle::RetxTracker::HandleTimer(void)
 {
     TimeMilli now = TimerMilli::GetNow();
+
+    VerifyOrExit(!Get<Mle>().IsDisabled());
 
     if (mChildUpdate.ShouldSend(now))
     {


### PR DESCRIPTION
This commit adds a check in `RetxTracker::ScheduleTimer()` to ensure the timer is not scheduled if MLE operations are disabled.

This change improves safety by handling an edge case during the graceful detach process. In this scenario, a child sends a "Child Update Request" with a zero timeout and, upon receiving a response, immediately stops MLE. The added check prevents the retransmission timer from being incorrectly scheduled after MLE has been stopped.