### PR TITLE
[check-size] use `pull_request_target` event to trigger post report

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -62,7 +62,7 @@ jobs:
         cat /tmp/ot-size-report/report_pr >> $GITHUB_STEP_SUMMARY
     - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
       name: Post Report
-      if: ${{ github.event_name == 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request_target' }}
       id: post-report
       with:
         script: |


### PR DESCRIPTION
This commit changes the "post report" trigger event from `pull_request` to `pull_request_target` so to match the event type that triggers the `check-size` workflow.