### PR TITLE
[mle] refactor previous router/leader role restoration

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -294,13 +294,17 @@ Error Mle::RestorePrevRole(void)
 
     Error error = kErrorFailed;
 
+    VerifyOrExit(IsDetached());
     VerifyOrExit(GetRloc16() != kInvalidRloc16);
 
     if (IsRouterRloc16(GetRloc16()))
     {
 #if OPENTHREAD_FTD
         VerifyOrExit(mLastSavedRole == kRoleRouter || mLastSavedRole == kRoleLeader);
-        error = BecomeRouter(ThreadStatusTlv::kTooFewRouters);
+        VerifyOrExit(IsRouterEligible());
+        Get<MeshForwarder>().SetRxOnWhenIdle(true);
+        mRouterRoleRestorer.Start(mLastSavedRole);
+        error = kErrorNone;
 #endif
         ExitNow();
     }


### PR DESCRIPTION
This commit updates `RestorePrevRole()` to directly start the `RouterRoleRestorer` instead of calling `BecomeRouter()`.

Consequently, `BecomeRouter()` is simplified by removing the logic for handling the `kRoleDetached` state. The method now focuses on the child-to-router transition by sending an Address Solicit message, and its initial role validation is made more explicit.

This change ensures the logic for restoring a previous router/leader role is separate from the child-to-router transition logic.