### PR TITLE
[mle] introduce `GenerateRandomDelay()` helper

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -701,7 +701,7 @@ uint32_t Mle::GetAttachStartDelay(void) const
 
     if (mAttachCounter == 0)
     {
-        delay = 1 + Random::NonCrypto::GetUint32InRange(0, kParentRequestRouterTimeout);
+        delay = GenerateRandomDelay(kParentRequestRouterTimeout);
         ExitNow();
     }
 #if OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_ENABLE
@@ -813,6 +813,13 @@ void Mle::SetStateChild(uint16_t aRloc16)
     }
 
     mPreviousParentRloc = mParent.GetRloc16();
+}
+
+uint32_t Mle::GenerateRandomDelay(uint32_t aMaxDelay) const
+{
+    // Generates a random delay within `[1, aMaxDelay]` (inclusive).
+
+    return 1 + Random::NonCrypto::GetUint32InRange(0, aMaxDelay);
 }
 
 void Mle::SetTimeout(uint32_t aTimeout, TimeoutAction aAction)
@@ -1601,7 +1608,7 @@ uint32_t Mle::Reattach(void)
             IgnoreError(Get<MeshCoP::PendingDatasetManager>().ApplyConfiguration());
             mReattachState = kReattachPending;
             SetAttachState(kAttachStateStart);
-            delay = 1 + Random::NonCrypto::GetUint32InRange(0, kAttachStartJitter);
+            delay = GenerateRandomDelay(kAttachStartJitter);
             ExitNow();
         }
 
@@ -2674,7 +2681,6 @@ void Mle::HandleAdvertisement(RxInfo &aRxInfo)
     Error      error = kErrorNone;
     uint16_t   sourceAddress;
     LeaderData leaderData;
-    uint32_t   delay;
 
     VerifyOrExit(IsAttached());
 
@@ -2723,8 +2729,8 @@ void Mle::HandleAdvertisement(RxInfo &aRxInfo)
 
     if (mRetrieveNewNetworkData || IsNetworkDataNewer(leaderData))
     {
-        delay = 1 + Random::NonCrypto::GetUint16InRange(0, kMleMaxResponseDelay);
-        mDelayedSender.ScheduleDataRequest(aRxInfo.mMessageInfo.GetPeerAddr(), delay);
+        mDelayedSender.ScheduleDataRequest(aRxInfo.mMessageInfo.GetPeerAddr(),
+                                           GenerateRandomDelay(kMleMaxResponseDelay));
     }
 
     aRxInfo.mClass = RxInfo::kPeerMessage;
@@ -2905,7 +2911,7 @@ exit:
 
         if (aRxInfo.mMessageInfo.GetSockAddr().IsMulticast())
         {
-            delay = 1 + Random::NonCrypto::GetUint16InRange(0, kMleMaxResponseDelay);
+            delay = GenerateRandomDelay(kMleMaxResponseDelay);
         }
         else
         {

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -2001,6 +2001,7 @@ private:
     void       SetLeaderData(uint32_t aPartitionId, uint8_t aWeighting, uint8_t aLeaderRouterId);
     void       SetLeaderData(const LeaderData &aLeaderData);
     void       SetTimeout(uint32_t aTimeout, TimeoutAction aAction);
+    uint32_t   GenerateRandomDelay(uint32_t aMaxDelay) const;
     void       InformPreviousChannel(void);
     void       ScheduleMessageTransmissionTimer(void);
     void       HandleAttachTimer(void);


### PR DESCRIPTION
This commit introduces `GenerateRandomDelay()`, to simplify the logic for generating a random delay up to a given max delay. This is then used through `Mle` class.