### PR TITLE
[git-tool] do not use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,7 +268,7 @@ jobs:
         tar xf gcc-arm
     - name: Build
       env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
         export PATH=/tmp/${{ matrix.gcc_extract_dir }}/bin:$PATH
         script/check-arm-build

--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -67,7 +67,7 @@ jobs:
         submodules: true
     - name: Build OTBR Docker
       env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
         ./script/test build_otbr_docker
     - name: Bootstrap
@@ -183,7 +183,7 @@ jobs:
         echo "FIREWALL=0" >> $GITHUB_ENV
     - name: Build OTBR Docker
       env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        PR_BODY: "${{ github.event.pull_request.body }}"
         TREL: ${{ matrix.otbr_trel }}
       run: |
         ./script/test build_otbr_docker

--- a/.github/workflows/otns.yml
+++ b/.github/workflows/otns.yml
@@ -46,7 +46,7 @@ env:
   VIRTUAL_TIME: 1
   VIRTUAL_TIME_UART: 1
   MAX_NETWORK_SIZE: 999
-  GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+  PR_BODY: "${{ github.event.pull_request.body }}"
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -282,7 +282,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Bootstrap
       env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
         sudo apt-get --no-install-recommends install -y expect ninja-build lcov
         sudo bash script/install_socat

--- a/.github/workflows/simulation-1.1.yml
+++ b/.github/workflows/simulation-1.1.yml
@@ -318,7 +318,7 @@ jobs:
         cache: pip
     - name: Bootstrap
       env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
         sudo apt-get update
         sudo apt-get install -y avahi-daemon avahi-utils lcov

--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -72,7 +72,7 @@ jobs:
         cache: pip
     - name: Bootstrap
       env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build lcov
@@ -107,7 +107,7 @@ jobs:
         cache: pip
     - name: Bootstrap
       env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build lcov
@@ -144,7 +144,7 @@ jobs:
         cache: pip
     - name: Bootstrap
       env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build
@@ -182,7 +182,7 @@ jobs:
         submodules: true
     - name: Bootstrap
       env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
         brew update
         brew install ninja
@@ -204,7 +204,7 @@ jobs:
         submodules: true
     - name: Bootstrap
       env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build lcov

--- a/script/git-tool
+++ b/script/git-tool
@@ -47,41 +47,14 @@ apply_dependencies()
         depends_on_pr="$(echo "${dependency}" | tr -d '\r\n' | cut -d# -f2)"
         echo "pr: #${depends_on_pr}"
         git pull --no-edit --no-rebase origin "pull/${depends_on_pr}/merge"
-    done < <(grep -E "^Depends-On: *${project_name}" || true)
-}
-
-get_pr_body()
-{
-    local pr
-
-    if [[ -z ${PR_BODY+x} ]]; then
-        echo 'PR_BODY is not set' >&2
-    else
-        echo 'PR_BODY is set' >&2
-        echo "${PR_BODY}"
-        return 0
-    fi
-
-    [[ ${GITHUB_ACTIONS+x} && ${GITHUB_REF-} =~ ^refs/pull/[0-9]+/merge ]] || {
-        echo 'Not a pull request.' >&2
-        return 0
-    }
-
-    pr="$(echo "${GITHUB_REF}" | cut -d/ -f3)"
-
-    # do not print GITHUB_TOKEN
-    set +x
-    curl -H "authorization: Bearer ${GITHUB_TOKEN}" -H 'content-type: application/json' \
-        "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${pr}" \
-        | jq -r .body
-    set -x
+    done < <(grep -E "^Depends-On: *${project_name}" <<<"${PR_BODY:-}" || true)
 }
 
 try_update()
 {
     cd "$1"
 
-    get_pr_body | apply_dependencies
+    apply_dependencies
 }
 
 try_clone()
@@ -95,7 +68,7 @@ try_clone()
         dest_dir="$(git clone "$@" 2>&1 | tee | cut -d\' -f2)"
 
         cd "${dest_dir}"
-        get_pr_body | apply_dependencies
+        apply_dependencies
     fi
 }
 


### PR DESCRIPTION
This commit stops using GITHUB_TOKEN in git-tool for better security.

Depends-On: openthread/ot-nrf528xx#989