### PR TITLE
[size-report] correct the checkout ref

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Checkout Pull Request
       if: ${{ github.event_name == 'pull_request_target' }}
       run: |
-        git fetch origin pull/${{ github.event.pull_request.number }}/head
+        git fetch origin pull/${{ github.event.pull_request.number }}/merge
         git checkout FETCH_HEAD
     - name: Run
       env:


### PR DESCRIPTION
The commit corrects the checkout ref to `pull/<number>/merge`, which is the ref after merging and should be used for size checking.