### PR TITLE
[mle] reorganize `Detacher` methods

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -4248,51 +4248,6 @@ exit:
 }
 #endif // OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
 
-Error Mle::Detacher::Detach(DetachCallback aCallback, void *aContext)
-{
-    Error    error   = kErrorNone;
-    uint32_t timeout = kTimeout;
-
-    VerifyOrExit(mState == kIdle, error = kErrorBusy);
-
-    mCallback.Set(aCallback, aContext);
-
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-    Get<BorderRouter::RoutingManager>().RequestStop();
-#endif
-
-    switch (Get<Mle>().GetRole())
-    {
-    case kRoleLeader:
-        break;
-
-    case kRoleRouter:
-#if OPENTHREAD_FTD
-        Get<Mle>().SendAddressRelease();
-#endif
-        break;
-
-    case kRoleChild:
-        IgnoreError(Get<Mle>().SendChildUpdateRequestToParent(kAppendZeroTimeout));
-        break;
-
-    case kRoleDisabled:
-    case kRoleDetached:
-        // If device is already detached or disabled, we start the timer
-        // with zero duration to stop and invoke the callback when the
-        // timer fires, so the operation finishes immediately and
-        // asynchronously.
-        timeout = 0;
-        break;
-    }
-
-    mState = kDetaching;
-    mTimer.Start(timeout);
-
-exit:
-    return error;
-}
-
 //---------------------------------------------------------------------------------------------------------------------
 // TlvList
 
@@ -5374,6 +5329,51 @@ Mle::Detacher::Detacher(Instance &aInstance)
     , mState(kIdle)
     , mTimer(aInstance)
 {
+}
+
+Error Mle::Detacher::Detach(DetachCallback aCallback, void *aContext)
+{
+    Error    error   = kErrorNone;
+    uint32_t timeout = kTimeout;
+
+    VerifyOrExit(mState == kIdle, error = kErrorBusy);
+
+    mCallback.Set(aCallback, aContext);
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    Get<BorderRouter::RoutingManager>().RequestStop();
+#endif
+
+    switch (Get<Mle>().GetRole())
+    {
+    case kRoleLeader:
+        break;
+
+    case kRoleRouter:
+#if OPENTHREAD_FTD
+        Get<Mle>().SendAddressRelease();
+#endif
+        break;
+
+    case kRoleChild:
+        IgnoreError(Get<Mle>().SendChildUpdateRequestToParent(kAppendZeroTimeout));
+        break;
+
+    case kRoleDisabled:
+    case kRoleDetached:
+        // If device is already detached or disabled, we start the timer
+        // with zero duration to stop and invoke the callback when the
+        // timer fires, so the operation finishes immediately and
+        // asynchronously.
+        timeout = 0;
+        break;
+    }
+
+    mState = kDetaching;
+    mTimer.Start(timeout);
+
+exit:
+    return error;
 }
 
 void Mle::Detacher::HandleTimer(void)


### PR DESCRIPTION
This commit moves the `Detacher::Detach()` method implementation to group it with other `Detacher` method definitions.

When the `Detacher` class was added in PR #11723, its methods were intentionally kept in their original locations to keep the `git diff` smaller and easier to review.

This is a pure code-move refactoring to improve code organization and has no functional changes.