### PR TITLE
[settings] change save/delete methods to return `void`

### DIFF
--- a/src/core/api/border_agent_api.cpp
+++ b/src/core/api/border_agent_api.cpp
@@ -74,12 +74,14 @@ void otBorderAgentSetVendorTxtData(otInstance *aInstance, const uint8_t *aVendor
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
 otError otBorderAgentGetId(otInstance *aInstance, otBorderAgentId *aId)
 {
-    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().GetId(AsCoreType(aId));
+    AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().GetId(AsCoreType(aId));
+    return kErrorNone;
 }
 
 otError otBorderAgentSetId(otInstance *aInstance, const otBorderAgentId *aId)
 {
-    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().SetId(AsCoreType(aId));
+    AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().SetId(AsCoreType(aId));
+    return kErrorNone;
 }
 #endif
 

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -278,7 +278,7 @@ Error RoutingManager::LoadOrGenerateRandomBrUlaPrefix(void)
         mBrUlaPrefix.SetSubnetId(0);
         mBrUlaPrefix.SetLength(kBrUlaPrefixLength);
 
-        IgnoreError(Get<Settings>().Save<Settings::BrUlaPrefix>(mBrUlaPrefix));
+        Get<Settings>().Save<Settings::BrUlaPrefix>(mBrUlaPrefix);
         generated = true;
     }
 
@@ -3010,7 +3010,7 @@ void RoutingManager::OnLinkPrefixManager::Init(void)
         // We clear the entries in `Settings` and re-write the entries
         // from `mOldLocalPrefixes` array.
 
-        IgnoreError(Get<Settings>().DeleteAllBrOnLinkPrefixes());
+        Get<Settings>().DeleteAllBrOnLinkPrefixes();
 
         for (OldPrefix &oldPrefix : mOldLocalPrefixes)
         {
@@ -3387,7 +3387,7 @@ void RoutingManager::OnLinkPrefixManager::DeprecateOldPrefix(const Ip6::Prefix &
 
         removedPrefix = entry->mPrefix;
 
-        IgnoreError(Get<Settings>().RemoveBrOnLinkPrefix(removedPrefix));
+        Get<Settings>().RemoveBrOnLinkPrefix(removedPrefix);
     }
 
     entry->mPrefix     = aPrefix;
@@ -3424,7 +3424,7 @@ void RoutingManager::OnLinkPrefixManager::HandleTimer(void)
     case kDeprecating:
         if (nextExpireTime.GetNow() >= mExpireTime)
         {
-            IgnoreError(Get<Settings>().RemoveBrOnLinkPrefix(mLocalPrefix));
+            Get<Settings>().RemoveBrOnLinkPrefix(mLocalPrefix);
             SetState(kIdle);
         }
         else
@@ -3449,7 +3449,7 @@ void RoutingManager::OnLinkPrefixManager::HandleTimer(void)
     for (const Ip6::Prefix &prefix : expiredPrefixes)
     {
         LogInfo("Old local on-link prefix %s expired", prefix.ToString().AsCString());
-        IgnoreError(Get<Settings>().RemoveBrOnLinkPrefix(prefix));
+        Get<Settings>().RemoveBrOnLinkPrefix(prefix);
         mOldLocalPrefixes.RemoveMatching(prefix);
     }
 

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -252,7 +252,6 @@ Error Settings::ReadOperationalDataset(MeshCoP::Dataset::Type aType, MeshCoP::Da
     aDataset.SetLength(static_cast<uint8_t>(length));
 
 exit:
-    OT_ASSERT(error != kErrorNotImplemented);
     return error;
 }
 
@@ -262,7 +261,6 @@ void Settings::DeleteOperationalDataset(MeshCoP::Dataset::Type aType)
     Error error = Get<SettingsDriver>().Delete(key);
 
     Log(kActionDelete, error, key);
-    OT_ASSERT(error != kErrorNotImplemented);
 }
 
 #if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
@@ -286,13 +284,11 @@ Error Settings::AddChildInfo(const ChildInfo &aChildInfo)
     return error;
 }
 
-Error Settings::DeleteAllChildInfo(void)
+void Settings::DeleteAllChildInfo(void)
 {
     Error error = Get<SettingsDriver>().Delete(kKeyChildInfo);
 
     Log(kActionDeleteAll, error, kKeyChildInfo);
-
-    return error;
 }
 
 Settings::ChildInfoIterator::ChildInfoIterator(Instance &aInstance)
@@ -373,26 +369,22 @@ exit:
     return error;
 }
 
-Error Settings::RemoveBrOnLinkPrefix(const Ip6::Prefix &aPrefix)
+void Settings::RemoveBrOnLinkPrefix(const Ip6::Prefix &aPrefix)
 {
-    Error          error = kErrorNotFound;
     BrOnLinkPrefix brPrefix;
 
     for (int index = 0; ReadBrOnLinkPrefix(index, brPrefix) == kErrorNone; index++)
     {
         if (brPrefix.GetPrefix() == aPrefix)
         {
-            SuccessOrExit(error = Get<SettingsDriver>().Delete(kKeyBrOnLinkPrefixes, index));
+            IgnoreError(Get<SettingsDriver>().Delete(kKeyBrOnLinkPrefixes, index));
             brPrefix.Log("Removed");
             break;
         }
     }
-
-exit:
-    return error;
 }
 
-Error Settings::DeleteAllBrOnLinkPrefixes(void) { return Get<SettingsDriver>().Delete(kKeyBrOnLinkPrefixes); }
+void Settings::DeleteAllBrOnLinkPrefixes(void) { IgnoreError(Get<SettingsDriver>().Delete(kKeyBrOnLinkPrefixes)); }
 
 Error Settings::ReadBrOnLinkPrefix(int aIndex, BrOnLinkPrefix &aBrOnLinkPrefix)
 {
@@ -424,7 +416,7 @@ Error Settings::ReadEntry(Key aKey, void *aValue, uint16_t aMaxLength) const
     return error;
 }
 
-Error Settings::SaveEntry(Key aKey, const void *aValue, void *aPrev, uint16_t aLength)
+void Settings::SaveEntry(Key aKey, const void *aValue, void *aPrev, uint16_t aLength)
 {
     Error    error      = kErrorNone;
     uint16_t readLength = aLength;
@@ -442,16 +434,14 @@ Error Settings::SaveEntry(Key aKey, const void *aValue, void *aPrev, uint16_t aL
 
     Log(action, error, aKey, aValue);
 
-    return error;
+    SuccessOrAssert(error);
 }
 
-Error Settings::DeleteEntry(Key aKey)
+void Settings::DeleteEntry(Key aKey)
 {
     Error error = Get<SettingsDriver>().Delete(aKey);
 
     Log(kActionDelete, error, aKey);
-
-    return error;
 }
 
 void Settings::Log(Action aAction, Error aError, Key aKey, const void *aValue)

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -847,7 +847,6 @@ public:
      *
      * @retval kErrorNone             Successfully read the entry.
      * @retval kErrorNotFound         No corresponding value in the setting store.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
      */
     template <typename EntryType> Error Read(EntryType &aEntry) const
     {
@@ -873,7 +872,6 @@ public:
      *
      * @retval kErrorNone             Successfully read the value.
      * @retval kErrorNotFound         No corresponding value in the setting store.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
      */
     template <typename EntryType> Error Read(typename EntryType::ValueType &aValue) const
     {
@@ -893,15 +891,12 @@ public:
      * @tparam EntryType              The settings entry type.
      *
      * @param[in] aEntry              The entry value to be saved.
-     *
-     * @retval kErrorNone             Successfully saved Network Info in settings.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
      */
-    template <typename EntryType> Error Save(const EntryType &aEntry)
+    template <typename EntryType> void Save(const EntryType &aEntry)
     {
         EntryType prev;
 
-        return SaveEntry(EntryType::kKey, &aEntry, &prev, sizeof(EntryType));
+        SaveEntry(EntryType::kKey, &aEntry, &prev, sizeof(EntryType));
     }
 
     /**
@@ -918,15 +913,12 @@ public:
      * @tparam EntryType              The settings entry type.
      *
      * @param[in] aValue              The entry value to be saved.
-     *
-     * @retval kErrorNone             Successfully saved Network Info in settings.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
      */
-    template <typename EntryType> Error Save(const typename EntryType::ValueType &aValue)
+    template <typename EntryType> void Save(const typename EntryType::ValueType &aValue)
     {
         typename EntryType::ValueType prev;
 
-        return SaveEntry(EntryType::kKey, &aValue, &prev, sizeof(typename EntryType::ValueType));
+        SaveEntry(EntryType::kKey, &aValue, &prev, sizeof(typename EntryType::ValueType));
     }
 
     /**
@@ -937,11 +929,8 @@ public:
      *  - It must provide a constant `EntryType::kKey` to specify the associated entry settings key.
      *
      * @tparam EntryType             The settings entry type.
-     *
-     * @retval kErrorNone            Successfully deleted the value.
-     * @retval kErrorNotImplemented  The platform does not implement settings functionality.
      */
-    template <typename EntryType> Error Delete(void) { return DeleteEntry(EntryType::kKey); }
+    template <typename EntryType> void Delete(void) { DeleteEntry(EntryType::kKey); }
 
 #if OPENTHREAD_FTD
     /**
@@ -952,7 +941,7 @@ public:
      * @param[in]   aChildInfo            A reference to a `ChildInfo` structure to be saved/added.
      *
      * @retval kErrorNone             Successfully saved the Child Info in settings.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
+     * @retval kErrorNoBufs           Ran out of space in the settings.
      */
     Error AddChildInfo(const ChildInfo &aChildInfo);
 
@@ -960,11 +949,8 @@ public:
      * Deletes all Child Info entries from the settings.
      *
      * @note Child Info is a list-based settings property and can contain multiple entries.
-     *
-     * @retval kErrorNone            Successfully deleted the value.
-     * @retval kErrorNotImplemented  The platform does not implement settings functionality.
      */
-    Error DeleteAllChildInfo(void);
+    void DeleteAllChildInfo(void);
 
     /**
      * Enables range-based `for` loop iteration over all child info entries in the `Settings`.
@@ -1029,7 +1015,6 @@ public:
          *
          * @retval kErrorNone            The entry was deleted successfully.
          * @retval kErrorInvalidState    The entry is not valid (iterator has reached end of list).
-         * @retval kErrorNotImplemented  The platform does not implement settings functionality.
          */
         Error Delete(void);
 
@@ -1090,7 +1075,7 @@ public:
      * @param[in] aBrOnLinkPrefix    The on-link prefix to save (add or updated).
      *
      * @retval kErrorNone             Successfully added or updated the entry in settings.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
+     * @retval kErrorNoBufs           Ran out of space in the settings.
      */
     Error AddOrUpdateBrOnLinkPrefix(const BrOnLinkPrefix &aBrOnLinkPrefix);
 
@@ -1098,19 +1083,13 @@ public:
      * Removes an on-link prefix entry matching a given prefix.
      *
      * @param[in] aPrefix            The prefix to remove
-     *
-     * @retval kErrorNone            Successfully removed the matching entry in settings.
-     * @retval kErrorNotImplemented  The platform does not implement settings functionality.
      */
-    Error RemoveBrOnLinkPrefix(const Ip6::Prefix &aPrefix);
+    void RemoveBrOnLinkPrefix(const Ip6::Prefix &aPrefix);
 
     /**
      * Deletes all on-link prefix entries from the settings.
-     *
-     * @retval kErrorNone            Successfully deleted the entries.
-     * @retval kErrorNotImplemented  The platform does not implement settings functionality.
      */
-    Error DeleteAllBrOnLinkPrefixes(void);
+    void DeleteAllBrOnLinkPrefixes(void);
 
     /**
      * Retrieves an entry from on-link prefixes list at a given index.
@@ -1120,7 +1099,6 @@ public:
      *
      * @retval kErrorNone             Successfully read the value.
      * @retval kErrorNotFound         No corresponding value in the setting store.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
      */
     Error ReadBrOnLinkPrefix(int aIndex, BrOnLinkPrefix &aBrOnLinkPrefix);
 
@@ -1144,8 +1122,8 @@ private:
     static Key KeyForDatasetType(MeshCoP::Dataset::Type aType);
 
     Error ReadEntry(Key aKey, void *aValue, uint16_t aMaxLength) const;
-    Error SaveEntry(Key aKey, const void *aValue, void *aPrev, uint16_t aLength);
-    Error DeleteEntry(Key aKey);
+    void  SaveEntry(Key aKey, const void *aValue, void *aPrev, uint16_t aLength);
+    void  DeleteEntry(Key aKey);
 
     static void Log(Action aAction, Error aError, Key aKey, const void *aValue = nullptr);
 

--- a/src/core/common/settings_driver.hpp
+++ b/src/core/common/settings_driver.hpp
@@ -38,6 +38,7 @@
 
 #include <openthread/platform/settings.h>
 
+#include "common/debug.hpp"
 #include "common/encoding.hpp"
 #include "common/error.hpp"
 #include "common/locator.hpp"
@@ -111,6 +112,8 @@ public:
 #else
         error = otPlatSettingsAdd(GetInstancePtr(), aKey, value, aValueLength);
 #endif
+        OT_ASSERT(error != kErrorNotImplemented);
+
         return error;
     }
 
@@ -133,6 +136,8 @@ public:
 #else
         error = otPlatSettingsDelete(GetInstancePtr(), aKey, aIndex);
 #endif
+        OT_ASSERT(error != kErrorNotImplemented);
+
         return error;
     }
 
@@ -162,6 +167,8 @@ public:
 #else
         error = otPlatSettingsGet(GetInstancePtr(), aKey, aIndex, value, aValueLength);
 #endif
+        OT_ASSERT(error != kErrorNotImplemented);
+
         return error;
     }
 
@@ -206,6 +213,8 @@ public:
 #else
         error = otPlatSettingsSet(GetInstancePtr(), aKey, value, aValueLength);
 #endif
+        OT_ASSERT(error != kErrorNotImplemented);
+
         return error;
     }
 

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -76,10 +76,8 @@ BorderAgent::BorderAgent(Instance &aInstance)
 }
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
-Error BorderAgent::GetId(Id &aId)
+void BorderAgent::GetId(Id &aId)
 {
-    Error error = kErrorNone;
-
     if (mIdInitialized)
     {
         aId = mId;
@@ -89,32 +87,30 @@ Error BorderAgent::GetId(Id &aId)
     if (Get<Settings>().Read<Settings::BorderAgentId>(mId) != kErrorNone)
     {
         mId.GenerateRandom();
-        SuccessOrExit(error = Get<Settings>().Save<Settings::BorderAgentId>(mId));
+        Get<Settings>().Save<Settings::BorderAgentId>(mId);
     }
 
     mIdInitialized = true;
     aId            = mId;
 
 exit:
-    return error;
+    return;
 }
 
-Error BorderAgent::SetId(const Id &aId)
+void BorderAgent::SetId(const Id &aId)
 {
-    Error error = kErrorNone;
-
     if (mIdInitialized)
     {
         VerifyOrExit(aId != mId);
     }
 
-    SuccessOrExit(error = Get<Settings>().Save<Settings::BorderAgentId>(aId));
+    Get<Settings>().Save<Settings::BorderAgentId>(aId);
     mId            = aId;
     mIdInitialized = true;
     PostServiceTask();
 
 exit:
-    return error;
+    return;
 }
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
 
@@ -537,10 +533,8 @@ Error BorderAgent::PrepareServiceTxtData(uint8_t *aBuffer, uint16_t aBufferSize,
     {
         Id id;
 
-        if (GetId(id) == kErrorNone)
-        {
-            SuccessOrExit(error = encoder.AppendEntry("id", id));
-        }
+        GetId(id);
+        SuccessOrExit(error = encoder.AppendEntry("id", id));
     }
 #endif
     SuccessOrExit(error = encoder.AppendStringEntry("rv", kTxtDataRecordVersion));

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -193,11 +193,8 @@ public:
      * Border Router/Agent device.
      *
      * @param[out] aId  Reference to return the Border Agent ID.
-     *
-     * @retval kErrorNone  If successfully retrieved the Border Agent ID.
-     * @retval ...         If failed to retrieve the Border Agent ID.
      */
-    Error GetId(Id &aId);
+    void GetId(Id &aId);
 
     /**
      * Sets the Border Agent ID.
@@ -207,11 +204,8 @@ public:
      * method, a random ID will be generated and returned when `GetId()` is called.
      *
      * @param[in] aId   The Border Agent ID.
-     *
-     * @retval kErrorNone  If successfully set the Border Agent ID.
-     * @retval ...         If failed to set the Border Agent ID.
      */
-    Error SetId(const Id &aId);
+    void SetId(const Id &aId);
 #endif
 
     /**

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -948,11 +948,11 @@ bool Client::ChangeHostAndServiceStates(const ItemState *aNewStates, ServiceStat
         case AutoStart::kSelectedUnicast:
             info.SetServerAddress(GetServerAddress().GetAddress());
             info.SetServerPort(GetServerAddress().GetPort());
-            IgnoreError(Get<Settings>().Save(info));
+            Get<Settings>().Save(info);
             break;
 
         case AutoStart::kSelectedAnycast:
-            IgnoreError(Get<Settings>().Delete<Settings::SrpClientInfo>());
+            Get<Settings>().Delete<Settings::SrpClientInfo>();
             break;
         }
     }
@@ -1187,7 +1187,7 @@ Error Client::ReadOrGenerateKey(KeyInfo &aKeyInfo)
         {
             SuccessOrExit(error = aKeyInfo.Generate());
         }
-        IgnoreError(Get<Settings>().Delete<Settings::SrpEcdsaKey>());
+        Get<Settings>().Delete<Settings::SrpEcdsaKey>();
     }
     else
     {
@@ -1214,7 +1214,7 @@ Error Client::ReadOrGenerateKey(KeyInfo &aKeyInfo)
     }
 
     SuccessOrExit(error = aKeyInfo.Generate());
-    IgnoreError(Get<Settings>().Save<Settings::SrpEcdsaKey>(aKeyInfo));
+    Get<Settings>().Save<Settings::SrpEcdsaKey>(aKeyInfo);
 
 exit:
     return error;

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -711,7 +711,7 @@ void Server::CommitSrpUpdate(Error                    aError,
 
         mHasRegisteredAnyService = true;
         info.SetPort(GetSocket().mSockName.mPort);
-        IgnoreError(Get<Settings>().Save(info));
+        Get<Settings>().Save(info);
     }
 #endif
 

--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -297,7 +297,7 @@ void ChildTable::RefreshStoredChildren(void)
 {
     const Child *child = &mChildren[0];
 
-    SuccessOrExit(Get<Settings>().DeleteAllChildInfo());
+    Get<Settings>().DeleteAllChildInfo();
 
     for (uint16_t num = mMaxChildrenAllowed; num != 0; num--, child++)
     {

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -140,7 +140,7 @@ Error DuaManager::GenerateDomainUnicastAddressIid(void)
         if (dadCounter != mDadCounter)
         {
             mDadCounter = dadCounter;
-            IgnoreError(Store());
+            Store();
         }
 
         LogInfo("Generated DUA: %s", mDomainUnicastAddress.GetAddress().ToString().AsCString());
@@ -208,12 +208,12 @@ exit:
     return;
 }
 
-Error DuaManager::Store(void)
+void DuaManager::Store(void)
 {
     Settings::DadInfo dadInfo;
 
     dadInfo.SetDadCounter(mDadCounter);
-    return Get<Settings>().Save(dadInfo);
+    Get<Settings>().Save(dadInfo);
 }
 
 void DuaManager::AddDomainUnicastAddress(void)

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -188,7 +188,7 @@ private:
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
     Error GenerateDomainUnicastAddressIid(void);
-    Error Store(void);
+    void  Store(void);
 
     void AddDomainUnicastAddress(void);
     void RemoveDomainUnicastAddress(void);

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -473,7 +473,7 @@ void KeyManager::MacFrameCounterUsed(uint32_t aMacFrameCounter)
 
     if (mMacFrameCounters.Get154() >= mStoredMacFrameCounter)
     {
-        IgnoreError(Get<Mle::Mle>().Store());
+        Get<Mle::Mle>().Store();
     }
 
 exit:
@@ -490,7 +490,7 @@ void KeyManager::IncrementTrelMacFrameCounter(void)
 
     if (mMacFrameCounters.GetTrel() >= mStoredMacFrameCounter)
     {
-        IgnoreError(Get<Mle::Mle>().Store());
+        Get<Mle::Mle>().Store();
     }
 }
 #endif
@@ -501,7 +501,7 @@ void KeyManager::IncrementMleFrameCounter(void)
 
     if (mMleFrameCounter >= mStoredMleFrameCounter)
     {
-        IgnoreError(Get<Mle::Mle>().Store());
+        Get<Mle::Mle>().Store();
     }
 }
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -529,9 +529,8 @@ exit:
     return;
 }
 
-Error Mle::Store(void)
+void Mle::Store(void)
 {
-    Error                 error = kErrorNone;
     Settings::NetworkInfo networkInfo;
 
     networkInfo.Init();
@@ -558,7 +557,7 @@ Error Mle::Store(void)
             parentInfo.SetExtAddress(mParent.GetExtAddress());
             parentInfo.SetVersion(mParent.GetVersion());
 
-            SuccessOrExit(error = Get<Settings>().Save(parentInfo));
+            Get<Settings>().Save(parentInfo);
         }
     }
     else
@@ -579,7 +578,7 @@ Error Mle::Store(void)
     networkInfo.SetMacFrameCounter(Get<KeyManager>().GetMaximumMacFrameCounter() + mStoreFrameCounterAhead);
     networkInfo.SetDeviceMode(mDeviceMode.Get());
 
-    SuccessOrExit(error = Get<Settings>().Save(networkInfo));
+    Get<Settings>().Save(networkInfo);
 
     Get<KeyManager>().SetStoredMleFrameCounter(networkInfo.GetMleFrameCounter());
     Get<KeyManager>().SetStoredMacFrameCounter(networkInfo.GetMacFrameCounter());
@@ -587,7 +586,7 @@ Error Mle::Store(void)
     LogDebg("Store Network Information");
 
 exit:
-    return error;
+    return;
 }
 
 Error Mle::BecomeDetached(void)
@@ -882,7 +881,7 @@ Error Mle::SetDeviceMode(DeviceMode aDeviceMode)
 
     LogNote("Mode 0x%02x -> 0x%02x [%s]", oldMode.Get(), mDeviceMode.Get(), mDeviceMode.ToString().AsCString());
 
-    IgnoreError(Store());
+    Store();
 
 #if OPENTHREAD_FTD
     if (!aDeviceMode.IsFullThreadDevice())
@@ -1232,7 +1231,7 @@ void Mle::HandleNotifierEvents(Events aEvents)
 
         if (aEvents.Contains(kEventThreadKeySeqCounterChanged) || IsAttached())
         {
-            IgnoreError(Store());
+            Store();
         }
     }
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -175,11 +175,8 @@ public:
 
     /**
      * Stores network information into non-volatile memory.
-     *
-     * @retval kErrorNone      Successfully store the network information.
-     * @retval kErrorNoBufs    Could not store the network information due to insufficient memory space.
      */
-    Error Store(void);
+    void Store(void);
 
     /**
      * Generates an MLE Announce message.

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -498,7 +498,7 @@ void Slaac::GetIidSecretKey(IidSecretKey &aKey) const
         IgnoreError(Random::Crypto::Fill(aKey));
     }
 
-    IgnoreError(Get<Settings>().Save<Settings::SlaacIidSecretKey>(aKey));
+    Get<Settings>().Save<Settings::SlaacIidSecretKey>(aKey);
 
     LogInfo("Generated and saved secret key");
 

--- a/tests/nexus/test_border_agent.cpp
+++ b/tests/nexus/test_border_agent.cpp
@@ -1249,7 +1249,7 @@ void ValidateMeshCoPTxtData(TxtData &aTxtData, Node &aNode)
     aTxtData.ValidateFormat();
     aTxtData.LogAllTxtEntries();
 
-    SuccessOrQuit(aNode.Get<BorderAgent>().GetId(id));
+    aNode.Get<BorderAgent>().GetId(id);
     aTxtData.ValidateKey("id", id);
     aTxtData.ValidateKey("rv", "1");
     aTxtData.ValidateKey("nn", aNode.Get<NetworkNameManager>().GetNetworkName().GetAsCString());
@@ -1375,7 +1375,7 @@ void TestBorderAgentTxtDataCallback(void)
     newId.GenerateRandom();
 
     callbackInvoked = false;
-    SuccessOrQuit(node0.Get<BorderAgent>().SetId(newId));
+    node0.Get<BorderAgent>().SetId(newId);
 
     nexus.AdvanceTime(1);
     ReadAndValidateMeshCoPTxtData(node0);
@@ -1384,7 +1384,7 @@ void TestBorderAgentTxtDataCallback(void)
     // correctly detected and does not trigger the callback.
 
     callbackInvoked = false;
-    SuccessOrQuit(node0.Get<BorderAgent>().SetId(newId));
+    node0.Get<BorderAgent>().SetId(newId);
     nexus.AdvanceTime(1);
     VerifyOrQuit(!callbackInvoked);
 


### PR DESCRIPTION
This commit simplifies the `Settings` API by modifying all "Save" and "Delete" methods to return `void` instead of `Error`.

Settings operations are required for a Thread device to function, so a failure to save or delete from non-volatile storage should be treated as a critical error. Previously, the code effectively ignored these errors using `IgnoreError()`. This change instead treats any such failure as a critical error, triggering an assert within the `Settings` module.

The key changes include:
- `Settings::Save<T>()`, `Delete<T>()`, `DeleteAllChildInfo()`, and similar methods now return `void`.
- Internal `Settings` methods use `SuccessOrAssert()` to assert on errors.
- The responsibility for asserting on `kErrorNotImplemented` is moved to the `SettingsDriver` layer.

This update simplifies the caller logic by removing the need for `IgnoreError()` at many call sites. Consequently, several methods that primarily wrapped `Settings` calls, such as `Mle::Store()` and `BorderAgent::SetId()`, have also been updated to return `void`.