### PR TITLE
[diags] Add delay between transmit done and next transmit

### DIFF
--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -38,6 +38,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
+#include <openthread/platform/alarm-micro.h>
+#endif
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
 #include <openthread/platform/radio.h>
@@ -942,6 +945,13 @@ void Diags::TransmitDone(Error aError)
     }
     else if (mTxPackets > 1)
     {
+#ifdef OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
+        // A short delay to give RCP time to process the previous transaction.
+        constexpr uint32_t kInterTransactionDelayUsec = 50;
+        uint32_t start = otPlatAlarmMicroGetNow();
+
+        while ((otPlatAlarmMicroGetNow() - start) < kInterTransactionDelayUsec){};
+#endif
         mTxPackets--;
         IgnoreError(TransmitPacket());
     }


### PR DESCRIPTION
Currently, in 'diag send' test context, next packet is sent right after transmit done reception. However in a RCP architecture, timing is too short and the host must ask for a retry which leads to bad performance.

Before modification, delay between VALUE_IS LAST_STATUS and next VALUE_SET STREAM is 37us. 34us is too tight for  RCP to handle current transaction and to prepare next one. After modification, delay is 100us: 1us in usleep + call of usleep function which takes around 60us, which is long enough to avoid retry and then increase performance.

[Testing]
Before modification
'diag send' test is failing on RCP architecture due to retries on each STREAM_RAW. Aftermodification
'diag send' test is passing.