### PR TITLE
[socket] Fix default netif used when opening an UDP socket

### DIFF
--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -44,7 +44,8 @@ otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSett
 
 otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aContext)
 {
-    return AsCoreType(aInstance).Get<Ip6::Udp>().Open(AsCoreType(aSocket), Ip6::kNetifThreadHost, aCallback, aContext);
+    return AsCoreType(aInstance).Get<Ip6::Udp>().Open(AsCoreType(aSocket), Ip6::kNetifThreadInternal, aCallback,
+                                                      aContext);
 }
 
 bool otUdpIsOpen(otInstance *aInstance, const otUdpSocket *aSocket)

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -792,7 +792,7 @@ Error Client::Start(void)
 {
     Error error;
 
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifUnspecified));
+    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThreadInternal));
     SuccessOrExit(error = mSocket.Bind(0));
 
 exit:

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -54,7 +54,7 @@ Error Client::Start(void)
 {
     Error error;
 
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifUnspecified));
+    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThreadInternal));
     SuccessOrExit(error = mSocket.Bind(0));
 
 exit:


### PR DESCRIPTION
After kNetifThreadHost was introduced, the default netif for the UDP open API was changed from kNetifThread to kNetifThreadHost. This change can cause issues on devices that implement the UDP platform code.
For example, if the Thread shell is used to open a socket and then connect is called to set the destination to another device, the transmission may fail in some cases. This happens because the packet is sent via the host Thread interface instead of the internal one. The default value should be the internal interface, and if the user needs to change it, they can use the bind command.

The default interface has also been updated to kNetifThreadInternal for the DNS and SNP clients, as these modules are intended for communication within the Thread network.