### PR TITLE
[test] remove the node type rcp-ncp

### DIFF
--- a/script/test
+++ b/script/test
@@ -282,7 +282,7 @@ do_cert()
         rcp | rcp-cli | cli)
             export NODE_TYPE=sim
             ;;
-        rcp-ncp | ncp)
+        ncp)
             export NODE_TYPE=ncp-sim
             ;;
     esac
@@ -504,7 +504,6 @@ print_usage()
 ENVIRONMENTS:
     OT_NODE_TYPE    'cli' for CLI simulation, 'ncp' for NCP simulation.
                     'rcp' or 'rcp-cli' for CLI on POSIX platform.
-                    'rcp-ncp' for NCP on POSIX platform.
                     The default is 'cli'.
     OT_NATIVE_IP    1 to enable platform UDP and netif on POSIX platform. The default is 0.
     OT_BUILDDIR     The output directory for cmake build. By default the directory is './build'. For example,


### PR DESCRIPTION
This PR removes the obsolete OT_NODE_TYPE in `script/test`.

The type `rcp-ncp` was meant to run nodes of NCP on posix. But we don't have NCP on posix anymore. So this can be removed.
<img width="2591" height="978" alt="Screenshot 2025-07-24 at 17 05 50" src="https://github.com/user-attachments/assets/e3e9eae1-7c2b-4115-afaf-bfdfd9300d97" />
