### PR TITLE
[history-tracker] move `HistoryTracker` to its own namespace

### DIFF
--- a/src/core/api/history_tracker_api.cpp
+++ b/src/core/api/history_tracker_api.cpp
@@ -47,7 +47,7 @@ const otHistoryTrackerNetworkInfo *otHistoryTrackerIterateNetInfoHistory(otInsta
 {
     AssertPointerIsNotNull(aEntryAge);
 
-    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateNetInfoHistory(AsCoreType(aIterator), *aEntryAge);
+    return AsCoreType(aInstance).Get<HistoryTracker::Local>().IterateNetInfoHistory(AsCoreType(aIterator), *aEntryAge);
 }
 
 const otHistoryTrackerUnicastAddressInfo *otHistoryTrackerIterateUnicastAddressHistory(
@@ -57,7 +57,7 @@ const otHistoryTrackerUnicastAddressInfo *otHistoryTrackerIterateUnicastAddressH
 {
     AssertPointerIsNotNull(aEntryAge);
 
-    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateUnicastAddressHistory(AsCoreType(aIterator),
+    return AsCoreType(aInstance).Get<HistoryTracker::Local>().IterateUnicastAddressHistory(AsCoreType(aIterator),
                                                                                            *aEntryAge);
 }
 
@@ -68,7 +68,7 @@ const otHistoryTrackerMulticastAddressInfo *otHistoryTrackerIterateMulticastAddr
 {
     AssertPointerIsNotNull(aEntryAge);
 
-    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateMulticastAddressHistory(AsCoreType(aIterator),
+    return AsCoreType(aInstance).Get<HistoryTracker::Local>().IterateMulticastAddressHistory(AsCoreType(aIterator),
                                                                                              *aEntryAge);
 }
 
@@ -78,7 +78,7 @@ const otHistoryTrackerMessageInfo *otHistoryTrackerIterateRxHistory(otInstance  
 {
     AssertPointerIsNotNull(aEntryAge);
 
-    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateRxHistory(AsCoreType(aIterator), *aEntryAge);
+    return AsCoreType(aInstance).Get<HistoryTracker::Local>().IterateRxHistory(AsCoreType(aIterator), *aEntryAge);
 }
 
 const otHistoryTrackerMessageInfo *otHistoryTrackerIterateTxHistory(otInstance               *aInstance,
@@ -87,7 +87,7 @@ const otHistoryTrackerMessageInfo *otHistoryTrackerIterateTxHistory(otInstance  
 {
     AssertPointerIsNotNull(aEntryAge);
 
-    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateTxHistory(AsCoreType(aIterator), *aEntryAge);
+    return AsCoreType(aInstance).Get<HistoryTracker::Local>().IterateTxHistory(AsCoreType(aIterator), *aEntryAge);
 }
 
 const otHistoryTrackerNeighborInfo *otHistoryTrackerIterateNeighborHistory(otInstance               *aInstance,
@@ -96,7 +96,7 @@ const otHistoryTrackerNeighborInfo *otHistoryTrackerIterateNeighborHistory(otIns
 {
     AssertPointerIsNotNull(aEntryAge);
 
-    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateNeighborHistory(AsCoreType(aIterator), *aEntryAge);
+    return AsCoreType(aInstance).Get<HistoryTracker::Local>().IterateNeighborHistory(AsCoreType(aIterator), *aEntryAge);
 }
 
 const otHistoryTrackerRouterInfo *otHistoryTrackerIterateRouterHistory(otInstance               *aInstance,
@@ -105,7 +105,7 @@ const otHistoryTrackerRouterInfo *otHistoryTrackerIterateRouterHistory(otInstanc
 {
     AssertPointerIsNotNull(aEntryAge);
 
-    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateRouterHistory(AsCoreType(aIterator), *aEntryAge);
+    return AsCoreType(aInstance).Get<HistoryTracker::Local>().IterateRouterHistory(AsCoreType(aIterator), *aEntryAge);
 }
 
 const otHistoryTrackerOnMeshPrefixInfo *otHistoryTrackerIterateOnMeshPrefixHistory(otInstance               *aInstance,
@@ -114,7 +114,7 @@ const otHistoryTrackerOnMeshPrefixInfo *otHistoryTrackerIterateOnMeshPrefixHisto
 {
     AssertPointerIsNotNull(aEntryAge);
 
-    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateOnMeshPrefixHistory(AsCoreType(aIterator),
+    return AsCoreType(aInstance).Get<HistoryTracker::Local>().IterateOnMeshPrefixHistory(AsCoreType(aIterator),
                                                                                          *aEntryAge);
 }
 
@@ -125,7 +125,7 @@ const otHistoryTrackerExternalRouteInfo *otHistoryTrackerIterateExternalRouteHis
 {
     AssertPointerIsNotNull(aEntryAge);
 
-    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateExternalRouteHistory(AsCoreType(aIterator),
+    return AsCoreType(aInstance).Get<HistoryTracker::Local>().IterateExternalRouteHistory(AsCoreType(aIterator),
                                                                                           *aEntryAge);
 }
 
@@ -135,7 +135,7 @@ const otHistoryTrackerDnsSrpAddrInfo *otHistoryTrackerIterateDnsSrpAddrHistory(o
 {
     AssertPointerIsNotNull(aEntryAge);
 
-    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateDnsSrpAddrHistory(AsCoreType(aIterator),
+    return AsCoreType(aInstance).Get<HistoryTracker::Local>().IterateDnsSrpAddrHistory(AsCoreType(aIterator),
                                                                                        *aEntryAge);
 }
 
@@ -147,14 +147,14 @@ const otHistoryTrackerBorderAgentEpskcEvent *otHistoryTrackerIterateBorderAgentE
 {
     AssertPointerIsNotNull(aEntryAge);
 
-    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateEpskcEventHistory(AsCoreType(aIterator),
+    return AsCoreType(aInstance).Get<HistoryTracker::Local>().IterateEpskcEventHistory(AsCoreType(aIterator),
                                                                                        *aEntryAge);
 }
 #endif
 
 void otHistoryTrackerEntryAgeToString(uint32_t aEntryAge, char *aBuffer, uint16_t aSize)
 {
-    Utils::HistoryTracker::EntryAgeToString(aEntryAge, aBuffer, aSize);
+    HistoryTracker::Local::EntryAgeToString(aEntryAge, aBuffer, aSize);
 }
 
 #endif // OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -152,7 +152,7 @@ void Notifier::EmitEvents(void)
     Get<Utils::Otns>().HandleNotifierEvents(events);
 #endif
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().HandleNotifierEvents(events);
+    Get<HistoryTracker::Local>().HandleNotifierEvents(events);
 #endif
 #if OPENTHREAD_ENABLE_VENDOR_EXTENSION
     Get<Extension::ExtensionBase>().HandleNotifierEvents(events);

--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -247,7 +247,7 @@ Instance::Instance(void)
     , mMeshDiag(*this)
 #endif
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    , mHistoryTracker(*this)
+    , mHistoryTrackerLocal(*this)
 #endif
 #if OPENTHREAD_CONFIG_LINK_METRICS_MANAGER_ENABLE
     , mLinkMetricsManager(*this)

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -682,7 +682,7 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Utils::HistoryTracker mHistoryTracker;
+    HistoryTracker::Local mHistoryTrackerLocal;
 #endif
 
 #if OPENTHREAD_CONFIG_LINK_METRICS_MANAGER_ENABLE
@@ -993,7 +993,7 @@ template <> inline Utils::MeshDiag &Instance::Get(void) { return mMeshDiag; }
 #endif
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-template <> inline Utils::HistoryTracker &Instance::Get(void) { return mHistoryTracker; }
+template <> inline HistoryTracker::Local &Instance::Get(void) { return mHistoryTrackerLocal; }
 #endif
 
 #if OPENTHREAD_CONFIG_LINK_METRICS_MANAGER_ENABLE

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -741,7 +741,7 @@ exit:
     case kErrorNone:
         Get<BorderAgent>().mCounters.mEpskcActivations++;
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-        Get<Utils::HistoryTracker>().RecordEpskcEvent(Utils::HistoryTracker::kEpskcActivated);
+        Get<HistoryTracker::Local>().RecordEpskcEvent(HistoryTracker::Local::kEpskcActivated);
 #endif
         break;
     case kErrorInvalidState:
@@ -790,14 +790,14 @@ void BorderAgent::EphemeralKeyManager::UpdateCountersAndRecordEvent(Deactivation
     struct ReasonToCounterEventEntry
     {
         DeactivationReason mReason;
-        uint8_t            mEvent; // Raw values of `Utils::HistoryTracker::Epskc` enum.
+        uint8_t            mEvent; // Raw values of `HistoryTracker::Local::Epskc` enum.
         uint32_t Counters::*mCounterPtr;
     };
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
 #define ReasonEntry(kReason, kCounter, kEvent)                       \
     {                                                                \
-        kReason, Utils::HistoryTracker::kEvent, &Counters::kCounter, \
+        kReason, HistoryTracker::Local::kEvent, &Counters::kCounter, \
     }
 #else
 #define ReasonEntry(kReason, kCounter, kEvent) \
@@ -818,7 +818,7 @@ void BorderAgent::EphemeralKeyManager::UpdateCountersAndRecordEvent(Deactivation
 #undef ReasonEntry
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Utils::HistoryTracker::EpskcEvent event = Utils::HistoryTracker::kEpskcDeactivatedUnknown;
+    HistoryTracker::EpskcEvent event = HistoryTracker::Local::kEpskcDeactivatedUnknown;
 #endif
 
     for (const ReasonToCounterEventEntry &entry : kReasonToCounterEventEntries)
@@ -827,14 +827,14 @@ void BorderAgent::EphemeralKeyManager::UpdateCountersAndRecordEvent(Deactivation
         {
             (Get<BorderAgent>().mCounters.*(entry.mCounterPtr))++;
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-            event = static_cast<Utils::HistoryTracker::EpskcEvent>(entry.mEvent);
+            event = static_cast<HistoryTracker::EpskcEvent>(entry.mEvent);
 #endif
             break;
         }
     }
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordEpskcEvent(event);
+    Get<HistoryTracker::Local>().RecordEpskcEvent(event);
 #endif
 }
 
@@ -900,7 +900,7 @@ void BorderAgent::EphemeralKeyManager::HandleSessionConnected(void)
     SetState(kStateConnected);
     Get<BorderAgent>().mCounters.mEpskcSecureSessionSuccesses++;
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordEpskcEvent(Utils::HistoryTracker::kEpskcConnected);
+    Get<HistoryTracker::Local>().RecordEpskcEvent(HistoryTracker::Local::kEpskcConnected);
 #endif
 }
 
@@ -940,7 +940,7 @@ void BorderAgent::EphemeralKeyManager::HandleCommissionerPetitionAccepted(void)
     SetState(kStateAccepted);
     Get<BorderAgent>().mCounters.mEpskcCommissionerPetitions++;
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordEpskcEvent(Utils::HistoryTracker::kEpskcPetitioned);
+    Get<HistoryTracker::Local>().RecordEpskcEvent(HistoryTracker::Local::kEpskcPetitioned);
 #endif
 }
 
@@ -1168,7 +1168,7 @@ void BorderAgent::CoapDtlsSession::HandleTmfCommissionerKeepAlive(Coap::Message 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE && OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
     if (Get<EphemeralKeyManager>().OwnsSession(*this))
     {
-        Get<Utils::HistoryTracker>().RecordEpskcEvent(Utils::HistoryTracker::kEpskcKeepAlive);
+        Get<HistoryTracker::Local>().RecordEpskcEvent(HistoryTracker::Local::kEpskcKeepAlive);
     }
 #endif
 
@@ -1504,7 +1504,7 @@ void BorderAgent::CoapDtlsSession::HandleTmfDatasetGet(Coap::Message &aMessage, 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE && OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
         if (Get<EphemeralKeyManager>().OwnsSession(*this))
         {
-            Get<Utils::HistoryTracker>().RecordEpskcEvent(Utils::HistoryTracker::kEpskcRetrievedActiveDataset);
+            Get<HistoryTracker::Local>().RecordEpskcEvent(HistoryTracker::Local::kEpskcRetrievedActiveDataset);
         }
 #endif
         break;
@@ -1515,7 +1515,7 @@ void BorderAgent::CoapDtlsSession::HandleTmfDatasetGet(Coap::Message &aMessage, 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE && OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
         if (Get<EphemeralKeyManager>().OwnsSession(*this))
         {
-            Get<Utils::HistoryTracker>().RecordEpskcEvent(Utils::HistoryTracker::kEpskcRetrievedPendingDataset);
+            Get<HistoryTracker::Local>().RecordEpskcEvent(HistoryTracker::Local::kEpskcRetrievedPendingDataset);
         }
 #endif
         break;

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -235,7 +235,7 @@ void Netif::SignalMulticastAddressChange(AddressEvent aEvent, const MulticastAdd
     Get<Notifier>().Signal(aEvent == kAddressAdded ? kEventIp6MulticastSubscribed : kEventIp6MulticastUnsubscribed);
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordAddressEvent(aEvent, aAddress, aOrigin);
+    Get<HistoryTracker::Local>().RecordAddressEvent(aEvent, aAddress, aOrigin);
 #endif
 
     if ((aOrigin == kOriginThread) && mAddressCallback.IsSet())
@@ -414,7 +414,7 @@ void Netif::SignalUnicastAddressChange(AddressEvent aEvent, const UnicastAddress
 #endif
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordAddressEvent(aEvent, aAddress);
+    Get<HistoryTracker::Local>().RecordAddressEvent(aEvent, aAddress);
 #endif
 
     if (!IsUnicastAddressExternal(aAddress) && mAddressCallback.IsSet())

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1246,7 +1246,7 @@ void MeshForwarder::UpdateSendMessage(Error aFrameTxError, Mac::Address &aMacDes
 #endif
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordTxMessage(*mSendMessage, aMacDest);
+    Get<HistoryTracker::Local>().RecordTxMessage(*mSendMessage, aMacDest);
 #endif
 
     LogMessage(kMessageTransmit, *mSendMessage, txError, &aMacDest);
@@ -1614,7 +1614,7 @@ exit:
 Error MeshForwarder::HandleDatagram(Message &aMessage, const Mac::Address &aMacSource)
 {
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordRxMessage(aMessage, aMacSource);
+    Get<HistoryTracker::Local>().RecordRxMessage(aMessage, aMacSource);
 #endif
 
     LogMessage(kMessageReceive, aMessage, kErrorNone, &aMacSource);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -832,7 +832,7 @@ Error Mle::SetDeviceMode(DeviceMode aDeviceMode)
     mDeviceMode = aDeviceMode;
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordNetworkInfo();
+    Get<HistoryTracker::Local>().RecordNetworkInfo();
 #endif
 
 #if OPENTHREAD_CONFIG_OTNS_ENABLE

--- a/src/core/thread/neighbor_table.cpp
+++ b/src/core/thread/neighbor_table.cpp
@@ -289,7 +289,7 @@ void NeighborTable::Signal(Event aEvent, const Neighbor &aNeighbor)
         }
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-        Get<Utils::HistoryTracker>().RecordNeighborEvent(aEvent, info);
+        Get<HistoryTracker::Local>().RecordNeighborEvent(aEvent, info);
 
         if (mCallback != nullptr)
 #endif

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -887,7 +887,7 @@ void RouterTable::HandleTableChanged(void)
 #endif
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<Utils::HistoryTracker>().RecordRouterTableChange();
+    Get<HistoryTracker::Local>().RecordRouterTableChange();
 #endif
 
     Get<Mle::Mle>().UpdateAdvertiseInterval();

--- a/src/core/utils/history_tracker.cpp
+++ b/src/core/utils/history_tracker.cpp
@@ -38,12 +38,12 @@
 #include "instance/instance.hpp"
 
 namespace ot {
-namespace Utils {
+namespace HistoryTracker {
 
 //---------------------------------------------------------------------------------------------------------------------
-// HistoryTracker
+// Local
 
-HistoryTracker::HistoryTracker(Instance &aInstance)
+Local::Local(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mTimer(aInstance)
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_NET_DATA
@@ -57,7 +57,7 @@ HistoryTracker::HistoryTracker(Instance &aInstance)
 #endif
 }
 
-void HistoryTracker::RecordNetworkInfo(void)
+void Local::RecordNetworkInfo(void)
 {
     NetworkInfo    *entry = mNetInfoHistory.AddNewEntry();
     Mle::DeviceMode mode;
@@ -74,7 +74,7 @@ exit:
     return;
 }
 
-void HistoryTracker::RecordMessage(const Message &aMessage, const Mac::Address &aMacAddress, MessageType aType)
+void Local::RecordMessage(const Message &aMessage, const Mac::Address &aMacAddress, MessageType aType)
 {
     MessageInfo *entry = nullptr;
     Ip6::Headers headers;
@@ -178,7 +178,7 @@ exit:
     return;
 }
 
-void HistoryTracker::RecordNeighborEvent(NeighborTable::Event aEvent, const NeighborTable::EntryInfo &aInfo)
+void Local::RecordNeighborEvent(NeighborTable::Event aEvent, const NeighborTable::EntryInfo &aInfo)
 {
     NeighborInfo *entry = mNeighborHistory.AddNewEntry();
 
@@ -239,8 +239,7 @@ exit:
     return;
 }
 
-void HistoryTracker::RecordAddressEvent(Ip6::Netif::AddressEvent          aEvent,
-                                        const Ip6::Netif::UnicastAddress &aUnicastAddress)
+void Local::RecordAddressEvent(Ip6::Netif::AddressEvent aEvent, const Ip6::Netif::UnicastAddress &aUnicastAddress)
 {
     UnicastAddressInfo *entry = mUnicastAddressHistory.AddNewEntry();
 
@@ -259,9 +258,9 @@ exit:
     return;
 }
 
-void HistoryTracker::RecordAddressEvent(Ip6::Netif::AddressEvent            aEvent,
-                                        const Ip6::Netif::MulticastAddress &aMulticastAddress,
-                                        Ip6::Netif::AddressOrigin           aAddressOrigin)
+void Local::RecordAddressEvent(Ip6::Netif::AddressEvent            aEvent,
+                               const Ip6::Netif::MulticastAddress &aMulticastAddress,
+                               Ip6::Netif::AddressOrigin           aAddressOrigin)
 {
     MulticastAddressInfo *entry = mMulticastAddressHistory.AddNewEntry();
 
@@ -276,7 +275,7 @@ exit:
 }
 
 #if OPENTHREAD_FTD
-void HistoryTracker::RecordRouterTableChange(void)
+void Local::RecordRouterTableChange(void)
 {
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ROUTER_LIST_SIZE > 0
 
@@ -346,7 +345,7 @@ void HistoryTracker::RecordRouterTableChange(void)
 #endif // OPENTHREAD_FTD
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_NET_DATA
-void HistoryTracker::RecordNetworkDataChange(void)
+void Local::RecordNetworkDataChange(void)
 {
     static const NetworkData::Service::DnsSrpUnicastType kDnsSrpUnicastTypes[] = {
         NetworkData::Service::kAddrInServiceData,
@@ -453,7 +452,7 @@ void HistoryTracker::RecordNetworkDataChange(void)
     SuccessOrAssert(Get<NetworkData::Leader>().CopyNetworkData(NetworkData::kFullSet, mPreviousNetworkData));
 }
 
-void HistoryTracker::RecordOnMeshPrefixEvent(NetDataEvent aEvent, const NetworkData::OnMeshPrefixConfig &aPrefix)
+void Local::RecordOnMeshPrefixEvent(NetDataEvent aEvent, const NetworkData::OnMeshPrefixConfig &aPrefix)
 {
     OnMeshPrefixInfo *entry = mOnMeshPrefixHistory.AddNewEntry();
 
@@ -465,7 +464,7 @@ exit:
     return;
 }
 
-void HistoryTracker::RecordExternalRouteEvent(NetDataEvent aEvent, const NetworkData::ExternalRouteConfig &aRoute)
+void Local::RecordExternalRouteEvent(NetDataEvent aEvent, const NetworkData::ExternalRouteConfig &aRoute)
 {
     ExternalRouteInfo *entry = mExternalRouteHistory.AddNewEntry();
 
@@ -477,9 +476,9 @@ exit:
     return;
 }
 
-void HistoryTracker::RecordDnsSrpAddrEvent(NetDataEvent                                   aEvent,
-                                           const NetworkData::Service::DnsSrpUnicastInfo &aUnicastInfo,
-                                           NetworkData::Service::DnsSrpUnicastType        aType)
+void Local::RecordDnsSrpAddrEvent(NetDataEvent                                   aEvent,
+                                  const NetworkData::Service::DnsSrpUnicastInfo &aUnicastInfo,
+                                  NetworkData::Service::DnsSrpUnicastType        aType)
 {
     DnsSrpAddrInfo *entry = mDnsSrpAddrHistory.AddNewEntry();
 
@@ -506,8 +505,7 @@ exit:
     return;
 }
 
-void HistoryTracker::RecordDnsSrpAddrEvent(NetDataEvent                                   aEvent,
-                                           const NetworkData::Service::DnsSrpAnycastInfo &aAnycastInfo)
+void Local::RecordDnsSrpAddrEvent(NetDataEvent aEvent, const NetworkData::Service::DnsSrpAnycastInfo &aAnycastInfo)
 {
     DnsSrpAddrInfo *entry = mDnsSrpAddrHistory.AddNewEntry();
 
@@ -525,9 +523,9 @@ exit:
     return;
 }
 
-bool HistoryTracker::NetDataContainsDnsSrpUnicast(const NetworkData::NetworkData                &aNetworkData,
-                                                  const NetworkData::Service::DnsSrpUnicastInfo &aUnicastInfo,
-                                                  NetworkData::Service::DnsSrpUnicastType        aType) const
+bool Local::NetDataContainsDnsSrpUnicast(const NetworkData::NetworkData                &aNetworkData,
+                                         const NetworkData::Service::DnsSrpUnicastInfo &aUnicastInfo,
+                                         NetworkData::Service::DnsSrpUnicastType        aType) const
 {
     bool                                    contains = false;
     NetworkData::Service::Iterator          iterator(GetInstance(), aNetworkData);
@@ -545,8 +543,8 @@ bool HistoryTracker::NetDataContainsDnsSrpUnicast(const NetworkData::NetworkData
     return contains;
 }
 
-bool HistoryTracker::NetDataContainsDnsSrpAnycast(const NetworkData::NetworkData                &aNetworkData,
-                                                  const NetworkData::Service::DnsSrpAnycastInfo &aAnycastInfo) const
+bool Local::NetDataContainsDnsSrpAnycast(const NetworkData::NetworkData                &aNetworkData,
+                                         const NetworkData::Service::DnsSrpAnycastInfo &aAnycastInfo) const
 {
     bool                                    contains = false;
     NetworkData::Service::Iterator          iterator(GetInstance(), aNetworkData);
@@ -567,7 +565,7 @@ bool HistoryTracker::NetDataContainsDnsSrpAnycast(const NetworkData::NetworkData
 #endif // OPENTHREAD_CONFIG_HISTORY_TRACKER_NET_DATA
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
-void HistoryTracker::RecordEpskcEvent(EpskcEvent aEvent)
+void Local::RecordEpskcEvent(EpskcEvent aEvent)
 {
     EpskcEvent *entry = mEpskcEventHistory.AddNewEntry();
 
@@ -579,7 +577,7 @@ exit:
 }
 #endif
 
-void HistoryTracker::HandleNotifierEvents(Events aEvents)
+void Local::HandleNotifierEvents(Events aEvents)
 {
     if (aEvents.ContainsAny(kEventThreadRoleChanged | kEventThreadRlocAdded | kEventThreadRlocRemoved |
                             kEventThreadPartitionIdChanged))
@@ -595,7 +593,7 @@ void HistoryTracker::HandleNotifierEvents(Events aEvents)
 #endif
 }
 
-void HistoryTracker::HandleTimer(void)
+void Local::HandleTimer(void)
 {
     mNetInfoHistory.UpdateAgedEntries();
     mUnicastAddressHistory.UpdateAgedEntries();
@@ -612,7 +610,7 @@ void HistoryTracker::HandleTimer(void)
     mTimer.Start(kAgeCheckPeriod);
 }
 
-void HistoryTracker::EntryAgeToString(uint32_t aEntryAge, char *aBuffer, uint16_t aSize)
+void Local::EntryAgeToString(uint32_t aEntryAge, char *aBuffer, uint16_t aSize)
 {
     StringWriter writer(aBuffer, aSize);
 
@@ -638,9 +636,9 @@ void HistoryTracker::EntryAgeToString(uint32_t aEntryAge, char *aBuffer, uint16_
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-// HistoryTracker::Timestamp
+// Local::Timestamp
 
-void HistoryTracker::Timestamp::SetToNow(void)
+void Local::Timestamp::SetToNow(void)
 {
     mTime = TimerMilli::GetNow();
 
@@ -653,27 +651,27 @@ void HistoryTracker::Timestamp::SetToNow(void)
     }
 }
 
-uint32_t HistoryTracker::Timestamp::GetDurationTill(TimeMilli aTime) const
+uint32_t Local::Timestamp::GetDurationTill(TimeMilli aTime) const
 {
     return IsDistantPast() ? kMaxAge : Min(aTime - mTime, kMaxAge);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-// HistoryTracker::List
+// Local::List
 
-HistoryTracker::List::List(void)
+Local::List::List(void)
     : mStartIndex(0)
     , mSize(0)
 {
 }
 
-void HistoryTracker::List::Clear(void)
+void Local::List::Clear(void)
 {
     mStartIndex = 0;
     mSize       = 0;
 }
 
-uint16_t HistoryTracker::List::Add(uint16_t aMaxSize, Timestamp aTimestamps[])
+uint16_t Local::List::Add(uint16_t aMaxSize, Timestamp aTimestamps[])
 {
     // Add a new entry and return its list index. Overwrites the
     // oldest entry if list is full.
@@ -690,11 +688,11 @@ uint16_t HistoryTracker::List::Add(uint16_t aMaxSize, Timestamp aTimestamps[])
     return mStartIndex;
 }
 
-Error HistoryTracker::List::Iterate(uint16_t        aMaxSize,
-                                    const Timestamp aTimestamps[],
-                                    Iterator       &aIterator,
-                                    uint16_t       &aListIndex,
-                                    uint32_t       &aEntryAge) const
+Error Local::List::Iterate(uint16_t        aMaxSize,
+                           const Timestamp aTimestamps[],
+                           Iterator       &aIterator,
+                           uint16_t       &aListIndex,
+                           uint32_t       &aEntryAge) const
 {
     Error error = kErrorNone;
 
@@ -709,7 +707,7 @@ exit:
     return error;
 }
 
-uint16_t HistoryTracker::List::MapEntryNumberToListIndex(uint16_t aEntryNumber, uint16_t aMaxSize) const
+uint16_t Local::List::MapEntryNumberToListIndex(uint16_t aEntryNumber, uint16_t aMaxSize) const
 {
     // Map the `aEntryNumber` to the list index. `aEntryNumber` value
     // of zero corresponds to the newest (the most recently added)
@@ -727,7 +725,7 @@ uint16_t HistoryTracker::List::MapEntryNumberToListIndex(uint16_t aEntryNumber, 
     return static_cast<uint16_t>(index);
 }
 
-void HistoryTracker::List::UpdateAgedEntries(uint16_t aMaxSize, Timestamp aTimestamps[])
+void Local::List::UpdateAgedEntries(uint16_t aMaxSize, Timestamp aTimestamps[])
 {
     TimeMilli now = TimerMilli::GetNow();
 
@@ -754,7 +752,7 @@ void HistoryTracker::List::UpdateAgedEntries(uint16_t aMaxSize, Timestamp aTimes
     }
 }
 
-} // namespace Utils
+} // namespace HistoryTracker
 } // namespace ot
 
 #endif // #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE

--- a/tests/nexus/test_border_agent.cpp
+++ b/tests/nexus/test_border_agent.cpp
@@ -39,7 +39,6 @@ namespace Nexus {
 using ActiveDatasetManager = MeshCoP::ActiveDatasetManager;
 using BorderAgent          = MeshCoP::BorderAgent;
 using EphemeralKeyManager  = MeshCoP::BorderAgent::EphemeralKeyManager;
-using HistoryTracker       = Utils::HistoryTracker;
 using EpskcEvent           = HistoryTracker::EpskcEvent;
 using Iterator             = HistoryTracker::Iterator;
 using ExtendedPanIdManager = MeshCoP::ExtendedPanIdManager;
@@ -764,7 +763,7 @@ EpskcEvent GetNewestEpskcEvent(Node &aNode)
     uint32_t          age;
     iter.Init();
 
-    epskcEvent = aNode.Get<HistoryTracker>().IterateEpskcEventHistory(iter, age);
+    epskcEvent = aNode.Get<HistoryTracker::Local>().IterateEpskcEventHistory(iter, age);
 
     VerifyOrQuit(epskcEvent != nullptr);
     return *epskcEvent;


### PR DESCRIPTION
This commit refactors `Utils::HistoryTracker` by moving it into its own dedicated `ot::HistoryTracker` namespace for better code organization.

The main implementation class is renamed from `HistoryTracker` to `Local`, making the new class `ot::HistoryTracker::Local`. This allows additional components (like server and client) to be defined within the `HistoryTracker` namespace.

Nested types, such as `Iterator`, are now direct members of the new `HistoryTracker` namespace.