### PR TITLE
[tools] replace find_element_by_id() with find_element() in harness-automation

### DIFF
--- a/tools/harness-automation/autothreadharness/harness_case.py
+++ b/tools/harness-automation/autothreadharness/harness_case.py
@@ -38,6 +38,7 @@ import unittest
 
 from selenium import webdriver
 from selenium.webdriver import ActionChains
+from selenium.webdriver.common import by
 from selenium.webdriver.support.ui import Select
 from selenium.common.exceptions import UnexpectedAlertPresentException
 from selenium.common.exceptions import NoSuchElementException
@@ -382,8 +383,8 @@ class HarnessCase(unittest.TestCase):
 
         # Detect Sniffer
         try:
-            dialog = self._browser.find_element_by_id('capture-Setup-modal')
-        except BaseException:
+            dialog = self._browser.find_element(by.By.ID, 'capture-Setup-modal')
+        except NoSuchElementException:
             logger.exception('Failed to get dialog.')
         else:
             if dialog and dialog.get_attribute('aria-hidden') == 'false':
@@ -394,11 +395,11 @@ class HarnessCase(unittest.TestCase):
                         logger.info('Still detecting..')
                     elif 'Not' in status:
                         logger.warning('Sniffer device not verified!')
-                        button = dialog.find_element_by_id('snifferAutoDetectBtn')
+                        button = dialog.find_element(by.By.ID, 'snifferAutoDetectBtn')
                         button.click()
                     elif 'Verified' in status:
                         logger.info('Verified!')
-                        button = dialog.find_element_by_id('saveCaptureSettings')
+                        button = dialog.find_element(by.By.ID, 'saveCaptureSettings')
                         button.click()
                         break
                     else:
@@ -413,16 +414,16 @@ class HarnessCase(unittest.TestCase):
         time.sleep(1)
 
         try:
-            skip_button = self._browser.find_element_by_id('SkipPrepareDevice')
+            skip_button = self._browser.find_element(by.By.ID, 'SkipPrepareDevice')
             if skip_button.is_enabled():
                 skip_button.click()
                 time.sleep(1)
-        except BaseException:
+        except NoSuchElementException:
             logger.info('Still detecting sniffers')
 
         try:
-            next_button = self._browser.find_element_by_id('nextButton')
-        except BaseException:
+            next_button = self._browser.find_element(by.By.ID, 'nextButton')
+        except NoSuchElementException:
             logger.exception('Failed to finish setup')
             return
 
@@ -434,25 +435,25 @@ class HarnessCase(unittest.TestCase):
         try:
             if self.child_timeout or self.sed_polling_interval:
                 logger.info('finding general Setup button')
-                button = self._browser.find_element_by_id('general-Setup')
+                button = self._browser.find_element(by.By.ID, 'general-Setup')
                 button.click()
                 time.sleep(2)
 
-                dialog = self._browser.find_element_by_id('general-Setup-modal')
+                dialog = self._browser.find_element(by.By.ID, 'general-Setup-modal')
                 if dialog.get_attribute('aria-hidden') != 'false':
                     raise Exception('Missing General Setup dialog')
 
-                field = dialog.find_element_by_id('inp_general_child_update_wait_time')
+                field = dialog.find_element(by.By.ID, 'inp_general_child_update_wait_time')
                 field.clear()
                 if self.child_timeout:
                     field.send_keys(str(self.child_timeout))
 
-                field = dialog.find_element_by_id('inp_general_sed_polling_rate')
+                field = dialog.find_element(by.By.ID, 'inp_general_sed_polling_rate')
                 field.clear()
                 if self.sed_polling_interval:
                     field.send_keys(str(self.sed_polling_interval))
 
-                button = dialog.find_element_by_id('saveGeneralSettings')
+                button = dialog.find_element(by.By.ID, 'saveGeneralSettings')
                 button.click()
                 time.sleep(1)
 
@@ -471,8 +472,8 @@ class HarnessCase(unittest.TestCase):
 
     def _add_device(self, port, device_type_id):
         browser = self._browser
-        test_bed = browser.find_element_by_id('test-bed')
-        device = browser.find_element_by_id(device_type_id)
+        test_bed = browser.find_element(by.By.ID, 'test-bed')
+        device = browser.find_element(by.By.ID, device_type_id)
         # drag
         action_chains = ActionChains(browser)
         action_chains.click_and_hold(device)
@@ -498,7 +499,7 @@ class HarnessCase(unittest.TestCase):
         Connect number of golden devices required by each case.
         """
         browser = self._browser
-        test_bed = browser.find_element_by_id('test-bed')
+        test_bed = browser.find_element(by.By.ID, 'test-bed')
         time.sleep(3)
         selected_hw_set = test_bed.find_elements_by_class_name('selected-hw')
         selected_hw_num = len(selected_hw_set)
@@ -722,7 +723,7 @@ class HarnessCase(unittest.TestCase):
 
         # enable AUTO DUT
         if self.auto_dut:
-            checkbox_auto_dut = browser.find_element_by_id('EnableAutoDutSelection')
+            checkbox_auto_dut = browser.find_element(by.By.ID, 'EnableAutoDutSelection')
             if not checkbox_auto_dut.is_selected():
                 checkbox_auto_dut.click()
                 time.sleep(1)
@@ -746,7 +747,7 @@ class HarnessCase(unittest.TestCase):
         while True:
             try:
                 self._connect_devices()
-                button_next = browser.find_element_by_id('nextBtn')
+                button_next = browser.find_element(by.By.ID, 'nextBtn')
                 if not wait_until(
                         lambda: 'disabled' not in button_next.get_attribute('class'),
                         times=(30 + 4 * number_of_devices_to_add),
@@ -812,7 +813,7 @@ class HarnessCase(unittest.TestCase):
         """Select the test case.
         """
         # select the case
-        elem = Select(self._browser.find_element_by_id('select-dut'))
+        elem = Select(self._browser.find_element(by.By.ID, 'select-dut'))
         elem.select_by_value(str(role))
         time.sleep(1)
 
@@ -848,9 +849,9 @@ class HarnessCase(unittest.TestCase):
         checkbox.click()
         time.sleep(1)
 
-        elem = self._browser.find_element_by_id('runTest')
+        elem = self._browser.find_element(by.By.ID, 'runTest')
         elem.click()
-        if not wait_until(lambda: self._browser.find_element_by_id('stopTest') and True, 10):
+        if not wait_until(lambda: self._browser.find_element(by.By.ID, 'stopTest') and True, 10):
             raise Exception('Failed to start test case')
 
     def _collect_result(self):
@@ -876,8 +877,8 @@ class HarnessCase(unittest.TestCase):
         logger.info('self timeout %d', self.timeout)
         while not done and self.timeout:
             try:
-                dialog = self._browser.find_element_by_id('RemoteConfirm')
-            except BaseException:
+                dialog = self._browser.find_element(by.By.ID, 'RemoteConfirm')
+            except NoSuchElementException:
                 logger.exception('Failed to get dialog.')
             else:
                 if dialog and dialog.get_attribute('aria-hidden') == 'false':
@@ -894,12 +895,12 @@ class HarnessCase(unittest.TestCase):
                     if done is None:
                         raise FailError('Unexpected dialog occurred')
 
-                    dialog.find_element_by_id('ConfirmOk').click()
+                    dialog.find_element(by.By.ID, 'ConfirmOk').click()
 
             time.sleep(1)
 
             try:
-                stop_button = self._browser.find_element_by_id('stopTest')
+                stop_button = self._browser.find_element(by.By.ID, 'stopTest')
                 if done:
                     stop_button.click()
                     # wait for stop procedure end
@@ -923,7 +924,7 @@ class HarnessCase(unittest.TestCase):
                         logger.info(res)
 
         # Wait until case really stopped
-        wait_until(lambda: self._browser.find_element_by_id('runTest') and True, 30)
+        wait_until(lambda: self._browser.find_element(by.By.ID, 'runTest') and True, 30)
 
         if error:
             raise FailError('Fail for previous exceptions')
@@ -941,7 +942,7 @@ class HarnessCase(unittest.TestCase):
             return done
 
         if title.startswith('Start DUT'):
-            body = dialog.find_element_by_id('cnfrmMsg').text
+            body = dialog.find_element(by.By.ID, 'cnfrmMsg').text
             if 'Sleepy End Device' in body:
                 self.dut.mode = 's'
                 self.dut.child_timeout = self.child_timeout
@@ -962,7 +963,7 @@ class HarnessCase(unittest.TestCase):
 
         elif title.startswith('MAC Address Required') or title.startswith('DUT Random Extended MAC Address Required'):
             mac = self.dut.mac
-            inp = dialog.find_element_by_id('cnfrmInpText')
+            inp = dialog.find_element(by.By.ID, 'cnfrmInpText')
             inp.clear()
             inp.send_keys('0x%s' % mac)
 
@@ -978,25 +979,25 @@ class HarnessCase(unittest.TestCase):
                 raise FailError('No link local address found')
 
             logger.info('Link local address is %s', ll64)
-            inp = dialog.find_element_by_id('cnfrmInpText')
+            inp = dialog.find_element(by.By.ID, 'cnfrmInpText')
             inp.clear()
             inp.send_keys(ll64)
 
         elif title.startswith('Enter Channel'):
             self.dut.channel = self.channel
-            inp = dialog.find_element_by_id('cnfrmInpText')
+            inp = dialog.find_element(by.By.ID, 'cnfrmInpText')
             inp.clear()
             inp.send_keys(str(self.dut.channel))
 
         elif title.startswith('User Action Needed'):
-            body = dialog.find_element_by_id('cnfrmMsg').text
+            body = dialog.find_element(by.By.ID, 'cnfrmMsg').text
             if body.startswith('Power Down the DUT'):
                 self.dut.stop()
             return True
 
         elif title.startswith('Short Address'):
             short_addr = '0x%s' % self.dut.short_addr
-            inp = dialog.find_element_by_id('cnfrmInpText')
+            inp = dialog.find_element(by.By.ID, 'cnfrmInpText')
             inp.clear()
             inp.send_keys(short_addr)
 
@@ -1011,7 +1012,7 @@ class HarnessCase(unittest.TestCase):
                 raise Exception('No mesh local address found')
 
             logger.info('Mesh local address is %s', ml64)
-            inp = dialog.find_element_by_id('cnfrmInpText')
+            inp = dialog.find_element(by.By.ID, 'cnfrmInpText')
             inp.clear()
             inp.send_keys(ml64)
 
@@ -1038,7 +1039,7 @@ class HarnessCase(unittest.TestCase):
                 input('Bring DUT and press enter to continue..')
 
         elif title.startswith('Configure Prefix on DUT'):
-            body = dialog.find_element_by_id('cnfrmMsg').text
+            body = dialog.find_element(by.By.ID, 'cnfrmMsg').text
             body = body.split(': ')[1]
             params = reduce(
                 lambda params, param: params.update(((param[0].strip(' '), param[1]),)) or params,

--- a/tools/harness-automation/cases/leader_5_1_13.py
+++ b/tools/harness-automation/cases/leader_5_1_13.py
@@ -28,6 +28,7 @@
 #
 
 from autothreadharness.harness_case import HarnessCase
+from selenium.webdriver.common import by
 import time
 import unittest
 
@@ -39,7 +40,7 @@ class Leader_5_1_13(HarnessCase):
 
     def on_dialog(self, dialog, title):
         if title.startswith('User Input Required'):
-            # body = dialog.find_element_by_id('cnfrmMsg').text
+            # body = dialog.find_element(by.By.ID, 'cnfrmMsg').text
             # if body.startswith('Reset Leader'):
             self.dut.stop()
             time.sleep(1)

--- a/tools/harness-automation/cases/leader_5_5_1.py
+++ b/tools/harness-automation/cases/leader_5_5_1.py
@@ -32,6 +32,7 @@ import time
 import unittest
 
 from autothreadharness.harness_case import HarnessCase
+from selenium.webdriver.common import by
 
 
 class Leader_5_5_1(HarnessCase):
@@ -41,7 +42,7 @@ class Leader_5_5_1(HarnessCase):
 
     def on_dialog(self, dialog, title):
         if title.startswith('User Input Required'):
-            body = dialog.find_element_by_id('cnfrmMsg').text
+            body = dialog.find_element(by.By.ID, 'cnfrmMsg').text
             match = re.search(r'(?<=Leader Timeout\[)\d+(?= Seconds\])', body)
             if match:
                 timeout = int(match.group(0)) / 2

--- a/tools/harness-automation/cases/router_5_1_7.py
+++ b/tools/harness-automation/cases/router_5_1_7.py
@@ -30,6 +30,7 @@
 import unittest
 
 from autothreadharness.harness_case import HarnessCase
+from selenium.webdriver.common import by
 
 
 class Router_5_1_7(HarnessCase):
@@ -39,7 +40,7 @@ class Router_5_1_7(HarnessCase):
 
     def on_dialog(self, dialog, title):
         if title.startswith('Enter Router Max Child Count'):
-            inp = dialog.find_element_by_id('cnfrmInpText')
+            inp = dialog.find_element(by.By.ID, 'cnfrmInpText')
             inp.clear()
             inp.send_keys('5')
             return False

--- a/tools/harness-automation/cases_R140/leader_5_1_13.py
+++ b/tools/harness-automation/cases_R140/leader_5_1_13.py
@@ -31,6 +31,7 @@ import unittest
 import time
 
 from autothreadharness.harness_case import HarnessCase
+from selenium.webdriver.common import by
 
 
 class Leader_5_1_13(HarnessCase):
@@ -40,7 +41,7 @@ class Leader_5_1_13(HarnessCase):
 
     def on_dialog(self, dialog, title):
         if title.startswith('User Input Required'):
-            # body = dialog.find_element_by_id('cnfrmMsg').text
+            # body = dialog.find_element(by.By.ID, 'cnfrmMsg').text
             # if body.startswith('Reset Leader'):
             self.dut.stop()
             time.sleep(1)

--- a/tools/harness-automation/cases_R140/leader_5_5_1.py
+++ b/tools/harness-automation/cases_R140/leader_5_5_1.py
@@ -32,6 +32,7 @@ import time
 import unittest
 
 from autothreadharness.harness_case import HarnessCase
+from selenium.webdriver.common import by
 
 
 class Leader_5_5_1(HarnessCase):
@@ -41,7 +42,7 @@ class Leader_5_5_1(HarnessCase):
 
     def on_dialog(self, dialog, title):
         if title.startswith('User Input Required'):
-            body = dialog.find_element_by_id('cnfrmMsg').text
+            body = dialog.find_element(by.By.ID, 'cnfrmMsg').text
             match = re.search(r'(?<=Leader Timeout\[)\d+(?= Seconds\])', body)
             if match:
                 timeout = int(match.group(0)) / 2

--- a/tools/harness-automation/cases_R140/router_5_1_7.py
+++ b/tools/harness-automation/cases_R140/router_5_1_7.py
@@ -30,6 +30,7 @@
 import unittest
 
 from autothreadharness.harness_case import HarnessCase
+from selenium.webdriver.common import by
 
 
 class Router_5_1_7(HarnessCase):
@@ -39,7 +40,7 @@ class Router_5_1_7(HarnessCase):
 
     def on_dialog(self, dialog, title):
         if title.startswith('Enter Router Max Child Count'):
-            inp = dialog.find_element_by_id('cnfrmInpText')
+            inp = dialog.find_element(by.By.ID, 'cnfrmInpText')
             inp.clear()
             inp.send_keys('5')
             return False


### PR DESCRIPTION
The find_element_by_* is deprecated and removed in a future version of Selenium. This commit replaces find_element_by_id() with find_element().