### PR TITLE
[netdiag] fix incorrect bitmask for `AnswerTlv` index

### DIFF
--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -1044,7 +1044,7 @@ public:
 
 private:
     static constexpr uint16_t kIsLastFlag = 1 << 15;
-    static constexpr uint16_t kIndexMask  = 0x7f;
+    static constexpr uint16_t kIndexMask  = 0x7fff;
 
     uint16_t GetFlagsIndex(void) const { return BigEndian::HostSwap16(mFlagsIndex); }
     void     SetFlagsIndex(uint16_t aFlagsIndex) { mFlagsIndex = BigEndian::HostSwap16(aFlagsIndex); }


### PR DESCRIPTION
The `kIndexMask` within `AnswerTlv` was incorrectly defined as `0x7f`, which only covers the lower 7 bits of the `mFlagsIndex` field. This would improperly truncate the message index value.

This change corrects the mask to `0x7fff`, which properly utilizes the lower 15 bits for the index, while the most significant bit remains reserved for the `kIsLastFlag`.