### PR TITLE
[tmf] add `SendOwnedMessage()` to simplify message management

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -371,6 +371,25 @@ Error CoapBase::SendMessage(Message &aMessage, const Ip6::MessageInfo &aMessageI
     return SendMessage(aMessage, aMessageInfo, nullptr, nullptr);
 }
 
+Error CoapBase::SendOwnedMessage(OwnedPtr<Message>     &&aMessagePtr,
+                                 const Ip6::MessageInfo &aMessageInfo,
+                                 ResponseHandler         aHandler,
+                                 void                   *aContext)
+{
+    Error error;
+
+    SuccessOrExit(error = SendMessage(*aMessagePtr, aMessageInfo, aHandler, aContext));
+    aMessagePtr.Release();
+
+exit:
+    return error;
+}
+
+Error CoapBase::SendOwnedMessage(OwnedPtr<Message> &&aMessagePtr, const Ip6::MessageInfo &aMessageInfo)
+{
+    return SendOwnedMessage(aMessagePtr.PassOwnership(), aMessageInfo, nullptr, nullptr);
+}
+
 Error CoapBase::SendReset(Message &aRequest, const Ip6::MessageInfo &aMessageInfo)
 {
     return SendEmptyMessage(kTypeReset, aRequest, aMessageInfo);

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -41,6 +41,7 @@
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/non_copyable.hpp"
+#include "common/owned_ptr.hpp"
 #include "common/timer.hpp"
 #include "net/ip6.hpp"
 #include "net/netif.hpp"
@@ -607,6 +608,37 @@ public:
      * @retval kErrorNoBufs  Insufficient buffers available to send the CoAP response.
      */
     Error SendMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+
+    /**
+     * Sends an owned CoAP message with default transmission parameters, taking ownership on success.
+     *
+     * If Message ID was not set in the header (equal to 0), this method will assign unique Message ID to the message.
+     *
+     * @param[in]  aMessagePtr   An owned message pointer. Ownership is transferred on success (returning `kErrorNone`).
+     * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
+     * @param[in]  aHandler      A function pointer that shall be called on response reception or time-out.
+     * @param[in]  aContext      A pointer to arbitrary context information.
+     *
+     * @retval kErrorNone    Successfully sent CoAP message.
+     * @retval kErrorNoBufs  Insufficient buffers available to send the CoAP response.
+     */
+    Error SendOwnedMessage(OwnedPtr<Message>     &&aMessagePtr,
+                           const Ip6::MessageInfo &aMessageInfo,
+                           ResponseHandler         aHandler,
+                           void                   *aContext);
+
+    /**
+     * Sends an owned CoAP message with default transmission parameters, taking ownership on success.
+     *
+     * If Message ID was not set in the header (equal to 0), this method will assign unique Message ID to the message.
+     *
+     * @param[in]  aMessagePtr   An owned message pointer. Ownership is transferred on success (returning `kErrorNone`).
+     * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
+     *
+     * @retval kErrorNone    Successfully sent CoAP message.
+     * @retval kErrorNoBufs  Insufficient buffers available to send the CoAP response.
+     */
+    Error SendOwnedMessage(OwnedPtr<Message> &&aMessagePtr, const Ip6::MessageInfo &aMessageInfo);
 
     /**
      * Sends a CoAP reset message.

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -540,17 +540,16 @@ exit:
 
 void Joiner::SendJoinerEntrustResponse(const Coap::Message &aRequest, const Ip6::MessageInfo &aRequestInfo)
 {
-    Error            error = kErrorNone;
-    Coap::Message   *message;
-    Ip6::MessageInfo responseInfo(aRequestInfo);
+    OwnedPtr<Coap::Message> message;
+    Ip6::MessageInfo        responseInfo(aRequestInfo);
 
-    message = Get<Tmf::Agent>().NewPriorityResponseMessage(aRequest);
-    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+    message.Reset(Get<Tmf::Agent>().NewPriorityResponseMessage(aRequest));
+    VerifyOrExit(message != nullptr);
 
     message->SetSubType(Message::kSubTypeJoinerEntrust);
 
     responseInfo.GetSockAddr().Clear();
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, responseInfo));
+    SuccessOrExit(Get<Tmf::Agent>().SendOwnedMessage(message.PassOwnership(), responseInfo));
 
     SetState(kStateJoined);
 
@@ -558,7 +557,7 @@ void Joiner::SendJoinerEntrustResponse(const Coap::Message &aRequest, const Ip6:
     LogCert("[THCI] direction=send | type=JOIN_ENT.rsp");
 
 exit:
-    FreeMessageOnError(message, error);
+    return;
 }
 
 void Joiner::HandleTimer(void)

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -88,10 +88,10 @@ void Leader::SendPetitionResponse(const Coap::Message    &aRequest,
                                   const Ip6::MessageInfo &aMessageInfo,
                                   StateTlv::State         aState)
 {
-    Error          error = kErrorNone;
-    Coap::Message *message;
+    Error                   error = kErrorNone;
+    OwnedPtr<Coap::Message> message;
 
-    message = Get<Tmf::Agent>().NewPriorityResponseMessage(aRequest);
+    message.Reset(Get<Tmf::Agent>().NewPriorityResponseMessage(aRequest));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<StateTlv>(*message, aState));
@@ -106,12 +106,11 @@ void Leader::SendPetitionResponse(const Coap::Message    &aRequest,
         SuccessOrExit(error = Tlv::Append<CommissionerSessionIdTlv>(*message, mSessionId));
     }
 
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, aMessageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendOwnedMessage(message.PassOwnership(), aMessageInfo));
 
     LogInfo("Sent %s response", UriToString<kUriLeaderPetition>());
 
 exit:
-    FreeMessageOnError(message, error);
     LogWarnOnError(error, "send petition response");
 }
 
@@ -165,39 +164,37 @@ void Leader::SendKeepAliveResponse(const Coap::Message    &aRequest,
                                    const Ip6::MessageInfo &aMessageInfo,
                                    StateTlv::State         aState)
 {
-    Error          error = kErrorNone;
-    Coap::Message *message;
+    Error                   error = kErrorNone;
+    OwnedPtr<Coap::Message> message;
 
-    message = Get<Tmf::Agent>().NewPriorityResponseMessage(aRequest);
+    message.Reset(Get<Tmf::Agent>().NewPriorityResponseMessage(aRequest));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<StateTlv>(*message, aState));
 
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, aMessageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendOwnedMessage(message.PassOwnership(), aMessageInfo));
 
     LogInfo("Sent %s response", UriToString<kUriLeaderKeepAlive>());
 
 exit:
-    FreeMessageOnError(message, error);
     LogWarnOnError(error, "send keep alive response");
 }
 
 void Leader::SendDatasetChanged(const Ip6::Address &aAddress)
 {
-    Error            error = kErrorNone;
-    Tmf::MessageInfo messageInfo(GetInstance());
-    Coap::Message   *message;
+    Error                   error = kErrorNone;
+    Tmf::MessageInfo        messageInfo(GetInstance());
+    OwnedPtr<Coap::Message> message;
 
-    message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriDatasetChanged);
+    message.Reset(Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriDatasetChanged));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     messageInfo.SetSockAddrToRlocPeerAddrTo(aAddress);
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendOwnedMessage(message.PassOwnership(), messageInfo));
 
     LogInfo("Sent %s", UriToString<kUriDatasetChanged>());
 
 exit:
-    FreeMessageOnError(message, error);
     LogWarnOnError(error, "send dataset changed");
 }
 


### PR DESCRIPTION
This commit introduces `CoapBase::SendOwnedMessage()` to simplify message buffer management for callers.

The new method accepts an `OwnedPtr<Message>`, allowing callers to transfer ownership of a message to the TMF agent upon a successful send.

This change eliminates the common pattern of using `FreeMessageOnError` and makes the message management much safer and simpler. All callers that create and send TMF messages are updated to use the new `OwnedPtr` pattern.