### PR TITLE
[mle] move child ID allocation logic to `ChildTable`

### DIFF
--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -39,6 +39,9 @@
 
 namespace ot {
 
+//---------------------------------------------------------------------------------------------------------------------
+// `ChildTable::Iterator`
+
 ChildTable::Iterator::Iterator(Instance &aInstance, Child::StateFilter aFilter)
     : InstanceLocator(aInstance)
     , ItemPtrIterator(nullptr)
@@ -71,8 +74,12 @@ exit:
     return;
 }
 
+//---------------------------------------------------------------------------------------------------------------------
+// `ChildTable`
+
 ChildTable::ChildTable(Instance &aInstance)
     : InstanceLocator(aInstance)
+    , mNextChildId(Mle::kMaxChildId)
     , mMaxChildrenAllowed(kMaxChildren)
 {
     for (Child &child : mChildren)
@@ -110,6 +117,26 @@ Child *ChildTable::GetNewChild(void)
 
 exit:
     return child;
+}
+
+uint16_t ChildTable::AllocateNewChildRloc16(void)
+{
+    uint16_t rloc16;
+
+    do
+    {
+        mNextChildId++;
+
+        if (mNextChildId > Mle::kMaxChildId)
+        {
+            mNextChildId = Mle::kMinChildId;
+        }
+
+        rloc16 = Get<Mle::Mle>().GetRloc16() | mNextChildId;
+
+    } while (FindChild(rloc16, Child::kInStateAnyExceptInvalid) != nullptr);
+
+    return rloc16;
 }
 
 const Child *ChildTable::FindChild(const Child::AddressMatcher &aMatcher) const

--- a/src/core/thread/child_table.hpp
+++ b/src/core/thread/child_table.hpp
@@ -137,6 +137,13 @@ public:
     Child *GetNewChild(void);
 
     /**
+     * Allocates a new child ID and returns the corresponding RLOC16.
+     *
+     * @returns The allocated child RLOC16.
+     */
+    uint16_t AllocateNewChildRloc16(void);
+
+    /**
      * Searches the child table for a `Child` with a given RLOC16 also matching a given state filter.
      *
      * @param[in]  aRloc16  A RLOC16 address.
@@ -330,6 +337,7 @@ private:
     const Child *FindChild(const Child::AddressMatcher &aMatcher) const;
     void         RefreshStoredChildren(void);
 
+    uint16_t mNextChildId;
     uint16_t mMaxChildrenAllowed;
     Child    mChildren[kMaxChildren];
 };

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -106,7 +106,6 @@ Mle::Mle(Instance &aInstance)
     , mMaxChildIpAddresses(0)
 #endif
     , mParentPriority(kParentPriorityUnspecified)
-    , mNextChildId(kMaxChildId)
     , mPreviousPartitionIdRouter(0)
     , mPreviousPartitionId(0)
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -2324,7 +2324,6 @@ private:
     uint8_t mMaxChildIpAddresses;
 #endif
     int8_t   mParentPriority;
-    uint16_t mNextChildId;
     uint32_t mPreviousPartitionIdRouter;
     uint32_t mPreviousPartitionId;
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -2855,23 +2855,7 @@ Error Mle::SendChildIdResponse(Child &aChild)
 
     if ((aChild.GetRloc16() == 0) || !HasMatchingRouterIdWith(aChild.GetRloc16()))
     {
-        uint16_t rloc16;
-
-        // Pick next Child ID that is not being used
-        do
-        {
-            mNextChildId++;
-
-            if (mNextChildId > kMaxChildId)
-            {
-                mNextChildId = kMinChildId;
-            }
-
-            rloc16 = Get<Mac::Mac>().GetShortAddress() | mNextChildId;
-
-        } while (mChildTable.FindChild(rloc16, Child::kInStateAnyExceptInvalid) != nullptr);
-
-        aChild.SetRloc16(rloc16);
+        aChild.SetRloc16(mChildTable.AllocateNewChildRloc16());
     }
 
     SuccessOrExit(error = message->AppendAddress16Tlv(aChild.GetRloc16()));


### PR DESCRIPTION
This commit moves the child ID allocation logic from `Mle` to `ChildTable`.

A new `AllocateNewChildRloc16()` method is added to `ChildTable` to contain the allocation logic, and the `mNextChildId` counter is moved to `ChildTable`. `Mle` is updated to use this new method.

This refactoring improves code encapsulation by making the `ChildTable` responsible for managing all aspects of the children it contains, including ID allocation.