### PR TITLE
(UNDER WROK) [ip6] introduce `Ip6::RxMessage` to encapsulate `MessageInfo`

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -578,6 +578,7 @@ openthread_core_files = [
   "net/ip6_filter.hpp",
   "net/ip6_headers.cpp",
   "net/ip6_headers.hpp",
+  "net/ip6_message.hpp",
   "net/ip6_mpl.cpp",
   "net/ip6_mpl.hpp",
   "net/ip6_types.hpp",

--- a/src/core/backbone_router/backbone_tmf.cpp
+++ b/src/core/backbone_router/backbone_tmf.cpp
@@ -67,22 +67,20 @@ bool BackboneTmfAgent::HandleResource(CoapBase               &aCoapBase,
                                       ot::Coap::Message      &aMessage,
                                       const Ip6::MessageInfo &aMessageInfo)
 {
-    return static_cast<BackboneTmfAgent &>(aCoapBase).HandleResource(aUriPath, aMessage, aMessageInfo);
+    return static_cast<BackboneTmfAgent &>(aCoapBase).HandleResource(aUriPath,
+                                                                     Tmf::RxMessage::From(aMessage, aMessageInfo));
 }
 
-bool BackboneTmfAgent::HandleResource(const char             *aUriPath,
-                                      ot::Coap::Message      &aMessage,
-                                      const Ip6::MessageInfo &aMessageInfo)
+bool BackboneTmfAgent::HandleResource(const char *aUriPath, Tmf::RxMessage &aMessage)
 {
     OT_UNUSED_VARIABLE(aMessage);
-    OT_UNUSED_VARIABLE(aMessageInfo);
 
     bool didHandle = true;
     Uri  uri       = UriFromPath(aUriPath);
 
-#define Case(kUri, Type)                                     \
-    case kUri:                                               \
-        Get<Type>().HandleTmf<kUri>(aMessage, aMessageInfo); \
+#define Case(kUri, Type)                       \
+    case kUri:                                 \
+        Get<Type>().HandleTmf<kUri>(aMessage); \
         break
 
     switch (uri)

--- a/src/core/backbone_router/backbone_tmf.hpp
+++ b/src/core/backbone_router/backbone_tmf.hpp
@@ -90,12 +90,12 @@ public:
     void UnsubscribeMulticast(const Ip6::Address &aAddress);
 
 private:
-    static bool HandleResource(CoapBase               &aCoapBase,
-                               const char             *aUriPath,
-                               ot::Coap::Message      &aMessage,
-                               const Ip6::MessageInfo &aMessageInfo);
-    bool        HandleResource(const char *aUriPath, ot::Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    void        LogError(const char *aText, const Ip6::Address &aAddress, Error aError) const;
+    static bool  HandleResource(CoapBase               &aCoapBase,
+                                const char             *aUriPath,
+                                ot::Coap::Message      &aMessage,
+                                const Ip6::MessageInfo &aMessageInfo);
+    bool         HandleResource(const char *aUriPath, Tmf::RxMessage &aMessage);
+    void         LogError(const char *aText, const Ip6::Address &aAddress, Error aError) const;
     static Error Filter(const ot::Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext);
 };
 

--- a/src/core/backbone_router/bbr_manager.hpp
+++ b/src/core/backbone_router/bbr_manager.hpp
@@ -165,7 +165,7 @@ private:
     static constexpr uint8_t  kDefaultHoplimit = 1;
     static constexpr uint32_t kTimerInterval   = 1000;
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
     void HandleMulticastListenerRegistration(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1725,10 +1725,7 @@ exit:
     return error;
 }
 
-void Coap::HandleUdpReceive(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
-{
-    Receive(AsCoapMessage(&aMessage), aMessageInfo);
-}
+void Coap::HandleUdpReceive(Ip6::RxMessage &aMessage) { Receive(AsCoapMessage(&aMessage), aMessage.GetInfo()); }
 
 Error Coap::Send(CoapBase &aCoapBase, ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -922,7 +922,7 @@ public:
     Error Stop(void);
 
 protected:
-    void HandleUdpReceive(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void HandleUdpReceive(Ip6::RxMessage &aMessage);
 
     using CoapSocket = Ip6::Udp::SocketIn<Coap, &Coap::HandleUdpReceive>;
 

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -235,6 +235,7 @@ protected:
         TimeMilli   mTimestamp;   // The message timestamp.
         Message    *mNext;        // Next message in a doubly linked list.
         Message    *mPrev;        // Previous message in a doubly linked list.
+        void       *mInfo;        // Info associated with the message (typically an `Ip6::MessageInfo`).
         TxCallback  mTxCallback;  // The callback to inform message TX success or failure.
         void       *mTxContext;   // The arbitrary context associated with `mTxCallback`.
         RssAverager mRssAverager; // The averager maintaining the received signal strength (RSS) average.
@@ -1530,8 +1531,11 @@ protected:
         Message *mNext;
     };
 
-    uint16_t GetReserved(void) const { return GetMetadata().mReserved; }
-    void     SetReserved(uint16_t aReservedHeader) { GetMetadata().mReserved = aReservedHeader; }
+    uint16_t    GetReserved(void) const { return GetMetadata().mReserved; }
+    void        SetReserved(uint16_t aReservedHeader) { GetMetadata().mReserved = aReservedHeader; }
+    void       *GetInfo(void) { return GetMetadata().mInfo; }
+    const void *GetInfo(void) const { return GetMetadata().mInfo; }
+    void        SetInfo(void *aInfo) { GetMetadata().mInfo = aInfo; }
 
 private:
     class Chunk : public Data<kWithUint16Length>

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -355,11 +355,9 @@ Coap::Message::Code BorderAgent::CoapCodeFromError(Error aError)
     return code;
 }
 
-template <> void BorderAgent::HandleTmf<kUriRelayRx>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void BorderAgent::HandleTmf<kUriRelayRx>(Tmf::RxMessage &aMessage)
 {
     // This is from TMF agent.
-
-    OT_UNUSED_VARIABLE(aMessageInfo);
 
     Coap::Message   *message = nullptr;
     Error            error   = kErrorNone;

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -582,7 +582,7 @@ private:
     void Stop(void);
     void HandleNotifierEvents(Events aEvents);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
     static SecureSession *HandleAcceptSession(void *aContext, const Ip6::MessageInfo &aMessageInfo);
     CoapDtlsSession      *HandleAcceptSession(void);

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -873,10 +873,8 @@ exit:
     return;
 }
 
-template <> void Commissioner::HandleTmf<kUriRelayRx>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Commissioner::HandleTmf<kUriRelayRx>(Tmf::RxMessage &aMessage)
 {
-    OT_UNUSED_VARIABLE(aMessageInfo);
-
     Error                    error;
     uint16_t                 joinerPort;
     Ip6::InterfaceIdentifier joinerIid;
@@ -952,15 +950,14 @@ void Commissioner::HandleJoinerSessionTimer(void)
     Get<Tmf::SecureAgent>().Disconnect();
 }
 
-template <>
-void Commissioner::HandleTmf<kUriDatasetChanged>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Commissioner::HandleTmf<kUriDatasetChanged>(Tmf::RxMessage &aMessage)
 {
     VerifyOrExit(mState == kStateActive);
     VerifyOrExit(aMessage.IsConfirmablePostRequest());
 
     LogInfo("Received %s", UriToString<kUriDatasetChanged>());
 
-    SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+    SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessage.GetInfo()));
 
     LogInfo("Sent %s ack", UriToString<kUriDatasetChanged>());
 
@@ -968,11 +965,8 @@ exit:
     return;
 }
 
-template <>
-void Commissioner::HandleTmf<kUriJoinerFinalize>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Commissioner::HandleTmf<kUriJoinerFinalize>(Tmf::RxMessage &aMessage)
 {
-    OT_UNUSED_VARIABLE(aMessageInfo);
-
     StateTlv::State                state = StateTlv::kAccept;
     ProvisioningUrlTlv::StringType provisioningUrl;
 

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -421,7 +421,7 @@ private:
     static void HandleSecureAgentConnectEvent(Dtls::Session::ConnectEvent aEvent, void *aContext);
     void        HandleSecureAgentConnectEvent(Dtls::Session::ConnectEvent aEvent);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
     void HandleRelayReceive(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -878,10 +878,9 @@ exit:
     return isValid;
 }
 
-template <>
-void ActiveDatasetManager::HandleTmf<kUriActiveGet>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void ActiveDatasetManager::HandleTmf<kUriActiveGet>(Tmf::RxMessage &aMessage)
 {
-    DatasetManager::HandleGet(aMessage, aMessageInfo);
+    DatasetManager::HandleGet(aMessage, aMessage.GetInfo());
 }
 
 void ActiveDatasetManager::HandleTimer(Timer &aTimer) { aTimer.Get<ActiveDatasetManager>().HandleTimer(); }
@@ -999,10 +998,9 @@ exit:
     Clear();
 }
 
-template <>
-void PendingDatasetManager::HandleTmf<kUriPendingGet>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void PendingDatasetManager::HandleTmf<kUriPendingGet>(Tmf::RxMessage &aMessage)
 {
-    DatasetManager::HandleGet(aMessage, aMessageInfo);
+    DatasetManager::HandleGet(aMessage, aMessage.GetInfo());
 }
 
 void PendingDatasetManager::HandleTimer(Timer &aTimer) { aTimer.Get<PendingDatasetManager>().HandleTimer(); }

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -390,7 +390,7 @@ public:
 #endif
 
 private:
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aRxMessage);
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void) { DatasetManager::HandleTimer(); }
@@ -456,7 +456,7 @@ private:
     void        HandleTimer(void) { DatasetManager::HandleTimer(); }
 
     void                     HandleDelayTimer(void);
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
     using DelayTimer = TimerMilliIn<PendingDatasetManager, &PendingDatasetManager::HandleDelayTimer>;
 

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -368,20 +368,18 @@ void ActiveDatasetManager::StartLeader(void) { IgnoreError(GenerateLocal()); }
 void ActiveDatasetManager::StartLeader(void) {}
 #endif // OPENTHREAD_CONFIG_OPERATIONAL_DATASET_AUTO_INIT
 
-template <>
-void ActiveDatasetManager::HandleTmf<kUriActiveSet>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void ActiveDatasetManager::HandleTmf<kUriActiveSet>(Tmf::RxMessage &aMessage)
 {
-    SuccessOrExit(DatasetManager::HandleSetOrReplace(kMgmtSet, aMessage, aMessageInfo));
+    SuccessOrExit(DatasetManager::HandleSetOrReplace(kMgmtSet, aMessage, aMessage.GetInfo()));
     IgnoreError(ApplyConfiguration());
 
 exit:
     return;
 }
 
-template <>
-void ActiveDatasetManager::HandleTmf<kUriActiveReplace>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void ActiveDatasetManager::HandleTmf<kUriActiveReplace>(Tmf::RxMessage &aMessage)
 {
-    SuccessOrExit(DatasetManager::HandleSetOrReplace(kMgmtReplace, aMessage, aMessageInfo));
+    SuccessOrExit(DatasetManager::HandleSetOrReplace(kMgmtReplace, aMessage, aMessage.GetInfo()));
     IgnoreError(ApplyConfiguration());
 
 exit:
@@ -393,10 +391,9 @@ exit:
 
 void PendingDatasetManager::StartLeader(void) { StartDelayTimer(); }
 
-template <>
-void PendingDatasetManager::HandleTmf<kUriPendingSet>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void PendingDatasetManager::HandleTmf<kUriPendingSet>(Tmf::RxMessage &aMessage)
 {
-    SuccessOrExit(DatasetManager::HandleSetOrReplace(kMgmtSet, aMessage, aMessageInfo));
+    SuccessOrExit(DatasetManager::HandleSetOrReplace(kMgmtSet, aMessage, aMessage.GetInfo()));
     StartDelayTimer();
 
 exit:

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -85,8 +85,7 @@ exit:
     return error;
 }
 
-template <>
-void EnergyScanClient::HandleTmf<kUriEnergyReport>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void EnergyScanClient::HandleTmf<kUriEnergyReport>(Tmf::RxMessage &aMessage)
 {
     uint32_t               mask;
     MeshCoP::EnergyListTlv energyListTlv;
@@ -101,7 +100,7 @@ void EnergyScanClient::HandleTmf<kUriEnergyReport>(Coap::Message &aMessage, cons
 
     mCallback.InvokeIfSet(mask, energyListTlv.GetEnergyList(), energyListTlv.GetEnergyListLength());
 
-    SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+    SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessage.GetInfo()));
 
     LogInfo("Sent %s ack", UriToString<kUriEnergyReport>());
 

--- a/src/core/meshcop/energy_scan_client.hpp
+++ b/src/core/meshcop/energy_scan_client.hpp
@@ -85,7 +85,7 @@ public:
                     void                              *aContext);
 
 private:
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
     Callback<otCommissionerEnergyReportCallback> mCallback;
 };

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -508,7 +508,7 @@ exit:
     IgnoreError(Get<Ip6::Filter>().RemoveUnsecurePort(kJoinerUdpPort));
 }
 
-template <> void Joiner::HandleTmf<kUriJoinerEntrust>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Joiner::HandleTmf<kUriJoinerEntrust>(Tmf::RxMessage &aMessage)
 {
     Error         error;
     Dataset::Info datasetInfo;
@@ -529,7 +529,7 @@ template <> void Joiner::HandleTmf<kUriJoinerEntrust>(Coap::Message &aMessage, c
 
     LogInfo("Joiner successful!");
 
-    SendJoinerEntrustResponse(aMessage, aMessageInfo);
+    SendJoinerEntrustResponse(aMessage, aMessage.GetInfo());
 
     // Delay extended address configuration to allow DTLS wrap up.
     mTimer.Start(kConfigExtAddressDelay);

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -202,7 +202,7 @@ private:
                                              otError              aResult);
     void HandleJoinerFinalizeResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
     void HandleTimer(void);
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -114,7 +114,7 @@ void JoinerRouter::SetJoinerUdpPort(uint16_t aJoinerUdpPort)
     Start();
 }
 
-void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void JoinerRouter::HandleUdpReceive(Ip6::RxMessage &aMessage)
 {
     Error            error;
     Coap::Message   *message = nullptr;
@@ -130,8 +130,8 @@ void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &a
     message = Get<Tmf::Agent>().NewPriorityNonConfirmablePostMessage(kUriRelayRx);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
-    SuccessOrExit(error = Tlv::Append<JoinerUdpPortTlv>(*message, aMessageInfo.GetPeerPort()));
-    SuccessOrExit(error = Tlv::Append<JoinerIidTlv>(*message, aMessageInfo.GetPeerAddr().GetIid()));
+    SuccessOrExit(error = Tlv::Append<JoinerUdpPortTlv>(*message, aMessage.GetInfo().GetPeerPort()));
+    SuccessOrExit(error = Tlv::Append<JoinerIidTlv>(*message, aMessage.GetInfo().GetPeerAddr().GetIid()));
     SuccessOrExit(error = Tlv::Append<JoinerRouterLocatorTlv>(*message, Get<Mle::Mle>().GetRloc16()));
 
     offsetRange.InitFromMessageOffsetToEnd(aMessage);

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -151,10 +151,8 @@ exit:
     FreeMessageOnError(message, error);
 }
 
-template <> void JoinerRouter::HandleTmf<kUriRelayTx>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void JoinerRouter::HandleTmf<kUriRelayTx>(Tmf::RxMessage &aMessage)
 {
-    OT_UNUSED_VARIABLE(aMessageInfo);
-
     Error                    error;
     uint16_t                 joinerPort;
     Ip6::InterfaceIdentifier joinerIid;

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -94,7 +94,7 @@ private:
 
     void HandleNotifierEvents(Events aEvents);
 
-    void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void HandleUdpReceive(Ip6::RxMessage &aMessage);
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -96,7 +96,7 @@ private:
 
     void HandleUdpReceive(Ip6::RxMessage &aMessage);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
     static void HandleJoinerEntrustResponse(void                *aContext,
                                             otMessage           *aMessage,

--- a/src/core/meshcop/meshcop_leader.hpp
+++ b/src/core/meshcop/meshcop_leader.hpp
@@ -115,7 +115,7 @@ private:
 
     void HandleTimer(void);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
     void SendPetitionResponse(const Coap::Message    &aRequest,
                               const Ip6::MessageInfo &aMessageInfo,

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -81,8 +81,7 @@ exit:
     return error;
 }
 
-template <>
-void PanIdQueryClient::HandleTmf<kUriPanIdConflict>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void PanIdQueryClient::HandleTmf<kUriPanIdConflict>(Tmf::RxMessage &aMessage)
 {
     uint16_t panId;
     uint32_t mask;
@@ -97,7 +96,7 @@ void PanIdQueryClient::HandleTmf<kUriPanIdConflict>(Coap::Message &aMessage, con
 
     mCallback.InvokeIfSet(panId, mask);
 
-    SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+    SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessage.GetInfo()));
 
     LogInfo("Sent %s response", UriToString<kUriPanIdConflict>());
 

--- a/src/core/meshcop/panid_query_client.hpp
+++ b/src/core/meshcop/panid_query_client.hpp
@@ -80,7 +80,7 @@ public:
                     void                               *aContext);
 
 private:
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
     Callback<otCommissionerPanIdConflictCallback> mCallback;
 };

--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -744,6 +744,7 @@ private:
         kUnspecifiedCipherSuite,
     };
 
+    void HandleReceive(Ip6::RxMessage &aMessage) { HandleReceive(aMessage, aMessage.GetInfo()); }
     void RemoveDisconnectedSessions(void);
     void DecremenetRemainingConnectionAttempts(void);
     bool HasNoRemainingConnectionAttempts(void) const;

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -352,10 +352,8 @@ exit:
     return error;
 }
 
-void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Client::HandleUdpReceive(Ip6::RxMessage &aMessage)
 {
-    OT_UNUSED_VARIABLE(aMessageInfo);
-
     Header header;
 
     SuccessOrExit(aMessage.Read(aMessage.GetOffset(), header));

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -113,7 +113,7 @@ private:
     Error AppendElapsedTimeOption(Message &aMessage);
     Error AppendRapidCommitOption(Message &aMessage) { return RapidCommitOption::AppendTo(aMessage); }
 
-    void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void HandleUdpReceive(Ip6::RxMessage &aMessage);
 
     void  ProcessReply(const Message &aMessage);
     Error ProcessServerIdOption(const Message &aMessage);

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -174,7 +174,7 @@ exit:
     OT_UNUSED_VARIABLE(error);
 }
 
-void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Server::HandleUdpReceive(Ip6::RxMessage &aMessage)
 {
     Header header;
 
@@ -183,7 +183,7 @@ void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
 
     VerifyOrExit((header.GetMsgType() == kMsgTypeSolicit));
 
-    ProcessSolicit(aMessage, aMessageInfo.GetPeerAddr(), header.GetTransactionId());
+    ProcessSolicit(aMessage, aMessage.GetInfo().GetPeerAddr(), header.GetTransactionId());
 
 exit:
     return;

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -177,7 +177,7 @@ private:
     Error AppendRapidCommitOption(Message &aMessage) { return RapidCommitOption::AppendTo(aMessage); }
     Error AppendVendorSpecificInformation(Message &aMessage);
     Error AppendIaAddressOption(Message &aMessage, const Ip6::Address &aPrefix, const Mac::ExtAddress &aClientAddress);
-    void  HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void  HandleUdpReceive(Ip6::RxMessage &aMessage);
     void  ProcessSolicit(Message &aMessage, const Ip6::Address &aDst, const TransactionId &aTransactionId);
     Error ProcessClientIdOption(const Message &aMessage, ClientIdOption &aClientIdOption);
     Error ProcessIaNaOption(const Message &aMessage, uint32_t &aIaid);

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -1418,11 +1418,7 @@ exit:
     return matchedQuery;
 }
 
-void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMsgInfo)
-{
-    OT_UNUSED_VARIABLE(aMsgInfo);
-    ProcessResponse(aMessage);
-}
+void Client::HandleUdpReceive(Ip6::RxMessage &aMessage) { ProcessResponse(aMessage); }
 
 void Client::ProcessResponse(const Message &aResponseMessage)
 {

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -939,7 +939,7 @@ private:
     static void GetQueryTypeAndCallback(const Query &aQuery, QueryType &aType, Callback &aCallback, void *&aContext);
     Error       AppendNameFromQuery(const Query &aQuery, Message &aMessage);
     Query      *FindQueryById(uint16_t aMessageId);
-    void        HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMsgInfo);
+    void        HandleUdpReceive(Ip6::RxMessage &aMessage);
     void        ProcessResponse(const Message &aResponseMessage);
     Error       ParseResponse(const Message &aResponseMessage, Query *&aQuery, Error &aResponseError);
     bool        CanFinalizeQuery(Query &aQuery);

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -137,7 +137,7 @@ void Server::Stop(void)
 #endif
 }
 
-void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Server::HandleUdpReceive(Ip6::RxMessage &aMessage)
 {
     Request request;
 
@@ -146,16 +146,16 @@ void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
     // It returns `kErrorNone` to indicate that it successfully
     // processed the message.
 
-    VerifyOrExit(Get<Srp::Server>().HandleDnssdServerUdpReceive(aMessage, aMessageInfo) != kErrorNone);
+    VerifyOrExit(Get<Srp::Server>().HandleDnssdServerUdpReceive(aMessage) != kErrorNone);
 #endif
 
     request.mMessage     = &aMessage;
-    request.mMessageInfo = &aMessageInfo;
+    request.mMessageInfo = &aMessage.GetInfo();
     SuccessOrExit(aMessage.Read(aMessage.GetOffset(), request.mHeader));
 
     VerifyOrExit(request.mHeader.GetType() == Header::kTypeQuery);
 
-    LogInfo("Received query from %s", aMessageInfo.GetPeerAddr().ToString().AsCString());
+    LogInfo("Received query from %s", aMessage.GetInfo().GetPeerAddr().ToString().AsCString());
 
     ProcessQuery(request);
 

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -580,7 +580,7 @@ private:
 #endif
 
     bool IsRunning(void) const { return mSocket.IsBound(); }
-    void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void HandleUdpReceive(Ip6::RxMessage &aMessage);
     void ProcessQuery(Request &aRequest);
     void ResolveByProxy(Response &aResponse, const Ip6::MessageInfo &aMessageInfo);
     void RemoveQueryAndPrepareResponse(ProxyQuery &aQuery, ProxyQueryInfo &aInfo, Response &aResponse);

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -45,6 +45,7 @@
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "net/ip6_headers.hpp"
+#include "net/ip6_message.hpp"
 
 namespace ot {
 namespace Ip6 {
@@ -278,14 +279,13 @@ public:
     /**
      * Handles an ICMPv6 message.
      *
-     * @param[in]  aMessage      A reference to the ICMPv6 message.
-     * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
+     * @param[in]  aMessage      A reference to the ICMPv6 `RxMessage`.
      *
      * @retval kErrorNone     Successfully processed the ICMPv6 message.
      * @retval kErrorNoBufs   Insufficient buffers available to generate the reply.
      * @retval kErrorDrop     The ICMPv6 message was invalid and dropped.
      */
-    Error HandleMessage(Message &aMessage, MessageInfo &aMessageInfo);
+    Error HandleMessage(RxMessage &aMessage);
 
     /**
      * Indicates whether or not ICMPv6 Echo processing is enabled.
@@ -320,7 +320,7 @@ public:
     uint16_t GetEchoSequence(void) const { return mEchoSequence; }
 
 private:
-    Error HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMessageInfo);
+    Error HandleEchoRequest(const RxMessage &aRequestMessage);
 
     LinkedList<Handler> mHandlers;
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -897,15 +897,15 @@ Error Ip6::Receive(Header            &aIp6Header,
     {
 #if OPENTHREAD_CONFIG_TCP_ENABLE
     case kProtoTcp:
-        error = mTcp.HandleMessage(aIp6Header, *messagePtr, messageInfo);
+        error = mTcp.HandleMessage(aIp6Header, RxMessage::From(*messagePtr, messageInfo));
         break;
 #endif
     case kProtoUdp:
-        error = mUdp.HandleMessage(*messagePtr, messageInfo);
+        error = mUdp.HandleMessage(RxMessage::From(*messagePtr, messageInfo));
         break;
 
     case kProtoIcmp6:
-        error = mIcmp.HandleMessage(*messagePtr, messageInfo);
+        error = mIcmp.HandleMessage(RxMessage::From(*messagePtr, messageInfo));
         break;
 
     default:

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -56,6 +56,7 @@
 #include "net/icmp6.hpp"
 #include "net/ip6_address.hpp"
 #include "net/ip6_headers.hpp"
+#include "net/ip6_message.hpp"
 #include "net/ip6_mpl.hpp"
 #include "net/ip6_types.hpp"
 #include "net/netif.hpp"

--- a/src/core/net/ip6_message.hpp
+++ b/src/core/net/ip6_message.hpp
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for IPv6 packet processing.
+ */
+
+#ifndef IP6_MESSAGE_HPP_
+#define IP6_MESSAGE_HPP_
+
+#include "openthread-core-config.h"
+
+#include <openthread/ip6.h>
+
+#include "common/error.hpp"
+#include "common/message.hpp"
+#include "net/socket.hpp"
+
+namespace ot {
+namespace Ip6 {
+
+class Ip6;
+
+/**
+ * Represents a received IPv6 message.
+ */
+class RxMessage : public ot::Message
+{
+    friend class Ip6;
+
+public:
+    /**
+     * Gets the `MessageInfo` associated with this message.
+     *
+     * @returns  The associated `Ip6::MessageInfo`.
+     */
+    MessageInfo &GetInfo(void) { return *static_cast<MessageInfo *>(Message::GetInfo()); }
+
+    /**
+     * Gets the `MessageInfo` associated with this message.
+     *
+     * @returns  The associated `Ip6::MessageInfo`.
+     */
+    const MessageInfo &GetInfo(void) const { return *static_cast<const MessageInfo *>(Message::GetInfo()); }
+
+private:
+    void SetInfo(MessageInfo &aMessageInfo) { Message::SetInfo(&aMessageInfo); }
+
+    static RxMessage &From(Message &aMessage, MessageInfo &aMessageInfo)
+    {
+        RxMessage *rxMsg = static_cast<RxMessage *>(&aMessage);
+
+        rxMsg->SetInfo(aMessageInfo);
+        return *rxMsg;
+    }
+};
+
+} // namespace Ip6
+} // namespace ot
+
+#endif // IP6_MESSAGE_HPP_

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -256,10 +256,8 @@ void Client::HandleRetransmissionTimer(void)
     mRetransmissionTimer.FireAt(nextTime);
 }
 
-void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Client::HandleUdpReceive(Ip6::RxMessage &aMessage)
 {
-    OT_UNUSED_VARIABLE(aMessageInfo);
-
     Error         error = kErrorNone;
     Header        responseHeader;
     QueryMetadata queryMetadata;

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -257,7 +257,7 @@ private:
     void FinalizeSntpTransaction(Message &aQuery, const QueryMetadata &aQueryMetadata, uint64_t aTime, Error aResult);
 
     void HandleRetransmissionTimer(void);
-    void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void HandleUdpReceive(Ip6::RxMessage &aMessage);
 
     using RetxTimer    = TimerMilliIn<Client, &Client::HandleRetransmissionTimer>;
     using ClientSocket = Ip6::Udp::SocketIn<Client, &Client::HandleUdpReceive>;

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -1766,12 +1766,7 @@ exit:
     return error;
 }
 
-void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
-{
-    OT_UNUSED_VARIABLE(aMessageInfo);
-
-    ProcessResponse(aMessage);
-}
+void Client::HandleUdpReceive(Ip6::RxMessage &aMessage) { ProcessResponse(aMessage); }
 
 void Client::ProcessResponse(Message &aMessage)
 {

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -1029,7 +1029,7 @@ private:
     Error        AppendAaaaRecord(const Ip6::Address &aAddress, MsgInfo &aInfo) const;
     Error        AppendUpdateLeaseOptRecord(MsgInfo &aInfo);
     Error        AppendSignature(MsgInfo &aInfo, SignatureAppendMode aMode);
-    void         HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void         HandleUdpReceive(Ip6::RxMessage &aMessage);
     void         ProcessResponse(Message &aMessage);
     void         SelectNewMessageId(void);
     void         HandleUpdateDone(void);

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -856,7 +856,7 @@ void Server::HandleDnssdServerStateChange(void)
     }
 }
 
-Error Server::HandleDnssdServerUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+Error Server::HandleDnssdServerUdpReceive(Ip6::RxMessage &aMessage)
 {
     // This is called from` Dns::ServiceDiscovery::Server` when a UDP
     // message is received on its socket. We check whether we are
@@ -868,7 +868,7 @@ Error Server::HandleDnssdServerUdpReceive(Message &aMessage, const Ip6::MessageI
 
     VerifyOrExit((mState == kStateRunning) && !mSocket.IsOpen());
 
-    error = ProcessMessage(aMessage, aMessageInfo);
+    error = ProcessMessage(aMessage);
 
 exit:
     return error;
@@ -1704,17 +1704,17 @@ exit:
     FreeMessageOnError(response, error);
 }
 
-void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Server::HandleUdpReceive(Ip6::RxMessage &aMessage)
 {
-    Error error = ProcessMessage(aMessage, aMessageInfo);
+    Error error = ProcessMessage(aMessage);
 
     LogWarnOnError(error, "handle DNS message");
     OT_UNUSED_VARIABLE(error);
 }
 
-Error Server::ProcessMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+Error Server::ProcessMessage(Ip6::RxMessage &aMessage)
 {
-    return ProcessMessage(aMessage, TimerMilli::GetNow(), mTtlConfig, mLeaseConfig, &aMessageInfo);
+    return ProcessMessage(aMessage, TimerMilli::GetNow(), mTtlConfig, mLeaseConfig, &aMessage.GetInfo());
 }
 
 Error Server::ProcessMessage(Message                &aMessage,

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -945,7 +945,7 @@ private:
 
 #if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
     void  HandleDnssdServerStateChange(void);
-    Error HandleDnssdServerUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    Error HandleDnssdServerUdpReceive(Ip6::RxMessage &aMessage);
 #endif
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_FAST_START_MODE_ENABLE
@@ -967,7 +967,7 @@ private:
                           const Ip6::MessageInfo  *aMessageInfo,
                           const TtlConfig         &aTtlConfig,
                           const LeaseConfig       &aLeaseConfig);
-    Error ProcessMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    Error ProcessMessage(Ip6::RxMessage &aMessage);
     Error ProcessMessage(Message                &aMessage,
                          TimeMilli               aRxTime,
                          const TtlConfig        &aTtlConfig,
@@ -1005,7 +1005,7 @@ private:
                              uint32_t                 aKeyLease,
                              bool                     mUseShortLeaseOption,
                              const Ip6::MessageInfo  &aMessageInfo);
-    void        HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void        HandleUdpReceive(Ip6::RxMessage &aMessage);
     void        HandleLeaseTimer(void);
     static void HandleOutstandingUpdatesTimer(Timer &aTimer);
     void        HandleOutstandingUpdatesTimer(void);

--- a/src/core/net/tcp6.hpp
+++ b/src/core/net/tcp6.hpp
@@ -45,6 +45,7 @@
 #include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "net/ip6_headers.hpp"
+#include "net/ip6_message.hpp"
 #include "net/socket.hpp"
 
 /*
@@ -609,12 +610,11 @@ public:
      *
      * @param[in]  aIp6Header    A reference to a structure containing the segment's IPv6 header.
      * @param[in]  aMessage      A reference to the message containing the TCP segment.
-     * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
      *
      * @retval kErrorNone  Successfully processed the TCP segment.
      * @retval kErrorDrop  Dropped the TCP segment due to an invalid checksum.
      */
-    Error HandleMessage(ot::Ip6::Header &aIp6Header, Message &aMessage, MessageInfo &aMessageInfo);
+    Error HandleMessage(ot::Ip6::Header &aIp6Header, RxMessage &aMessage);
 
     /**
      * Automatically selects a local address and/or port for communication with the specified peer.

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -444,7 +444,7 @@ exit:
     return error;
 }
 
-Error Udp::HandleMessage(Message &aMessage, MessageInfo &aMessageInfo)
+Error Udp::HandleMessage(RxMessage &aMessage)
 {
     Error  error = kErrorNone;
     Header udpHeader;
@@ -452,19 +452,19 @@ Error Udp::HandleMessage(Message &aMessage, MessageInfo &aMessageInfo)
     SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), udpHeader));
 
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    SuccessOrExit(error = Checksum::VerifyMessageChecksum(aMessage, aMessageInfo, kProtoUdp));
+    SuccessOrExit(error = Checksum::VerifyMessageChecksum(aMessage, aMessage.GetInfo(), kProtoUdp));
 #endif
 
     aMessage.MoveOffset(sizeof(udpHeader));
-    aMessageInfo.mPeerPort = udpHeader.GetSourcePort();
-    aMessageInfo.mSockPort = udpHeader.GetDestinationPort();
+    aMessage.GetInfo().mPeerPort = udpHeader.GetSourcePort();
+    aMessage.GetInfo().mSockPort = udpHeader.GetDestinationPort();
 
     for (Receiver &receiver : mReceivers)
     {
-        VerifyOrExit(!receiver.HandleMessage(aMessage, aMessageInfo));
+        VerifyOrExit(!receiver.HandleMessage(aMessage, aMessage.GetInfo()));
     }
 
-    HandlePayload(aMessage, aMessageInfo);
+    HandlePayload(aMessage, aMessage.GetInfo());
 
 exit:
     return error;

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -46,11 +46,10 @@
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "net/ip6_headers.hpp"
+#include "net/ip6_message.hpp"
 
 namespace ot {
 namespace Ip6 {
-
-class Udp;
 
 /**
  * @addtogroup core-udp
@@ -338,8 +337,7 @@ public:
      * @tparam Owner                The type of the owner of this socket.
      * @tparam HandleUdpReceivePtr  A pointer to a non-static member method of `Owner` to handle received messages.
      */
-    template <typename Owner, void (Owner::*HandleUdpReceivePtr)(Message &aMessage, const MessageInfo &aMessageInfo)>
-    class SocketIn : public Socket
+    template <typename Owner, void (Owner::*HandleUdpReceivePtr)(RxMessage &aMessage)> class SocketIn : public Socket
     {
     public:
         /**
@@ -356,7 +354,9 @@ public:
     private:
         static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
         {
-            (reinterpret_cast<Owner *>(aContext)->*HandleUdpReceivePtr)(AsCoreType(aMessage), AsCoreType(aMessageInfo));
+            OT_UNUSED_VARIABLE(aMessageInfo);
+
+            (reinterpret_cast<Owner *>(aContext)->*HandleUdpReceivePtr)(static_cast<RxMessage &>(AsCoreType(aMessage)));
         }
     };
 
@@ -606,13 +606,12 @@ public:
     /**
      * Handles a received UDP message.
      *
-     * @param[in]  aMessage      A reference to the UDP message to process.
-     * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
+     * @param[in]  aMessage      A reference to the UDP `RxMessage` to process.
      *
      * @retval kErrorNone  Successfully processed the UDP message.
      * @retval kErrorDrop  Could not fully process the UDP message.
      */
-    Error HandleMessage(Message &aMessage, MessageInfo &aMessageInfo);
+    Error HandleMessage(RxMessage &aMessage);
 
     /**
      * Handles a received UDP message with offset set to the payload.

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -358,7 +358,7 @@ private:
 
 #endif // OPENTHREAD_FTD
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
 #if OPENTHREAD_FTD
 

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -52,8 +52,7 @@ void AnnounceBeginServer::SendAnnounce(uint32_t aChannelMask, uint8_t aCount, ui
     AnnounceSenderBase::SendAnnounce(aCount);
 }
 
-template <>
-void AnnounceBeginServer::HandleTmf<kUriAnnounceBegin>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void AnnounceBeginServer::HandleTmf<kUriAnnounceBegin>(Tmf::RxMessage &aMessage)
 {
     uint32_t mask;
     uint8_t  count;
@@ -67,9 +66,9 @@ void AnnounceBeginServer::HandleTmf<kUriAnnounceBegin>(Coap::Message &aMessage, 
 
     SendAnnounce(mask, count, period);
 
-    if (aMessage.IsConfirmable() && !aMessageInfo.GetSockAddr().IsMulticast())
+    if (aMessage.IsConfirmable() && !aMessage.GetInfo().GetSockAddr().IsMulticast())
     {
-        SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+        SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessage.GetInfo()));
         LogInfo("Sent %s response", UriToString<kUriAnnounceBegin>());
     }
 

--- a/src/core/thread/announce_begin_server.hpp
+++ b/src/core/thread/announce_begin_server.hpp
@@ -71,7 +71,7 @@ private:
     static constexpr uint16_t kDefaultPeriod = 1000;
     static constexpr uint16_t kDefaultJitter = 0;
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
     static void HandleTimer(Timer &aTimer);
 };

--- a/src/core/thread/anycast_locator.cpp
+++ b/src/core/thread/anycast_locator.cpp
@@ -109,8 +109,7 @@ exit:
 
 #if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_SEND_RESPONSE
 
-template <>
-void AnycastLocator::HandleTmf<kUriAnycastLocate>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void AnycastLocator::HandleTmf<kUriAnycastLocate>(Tmf::RxMessage &aMessage)
 {
     Coap::Message *message = nullptr;
 
@@ -122,7 +121,7 @@ void AnycastLocator::HandleTmf<kUriAnycastLocate>(Coap::Message &aMessage, const
     SuccessOrExit(Tlv::Append<ThreadMeshLocalEidTlv>(*message, Get<Mle::Mle>().GetMeshLocalEid().GetIid()));
     SuccessOrExit(Tlv::Append<ThreadRloc16Tlv>(*message, Get<Mle::Mle>().GetRloc16()));
 
-    SuccessOrExit(Get<Tmf::Agent>().SendMessage(*message, aMessageInfo));
+    SuccessOrExit(Get<Tmf::Agent>().SendMessage(*message, aMessage.GetInfo()));
     message = nullptr;
 
 exit:

--- a/src/core/thread/anycast_locator.hpp
+++ b/src/core/thread/anycast_locator.hpp
@@ -97,7 +97,7 @@ private:
 
     void HandleResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aError);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
     Callback<LocatorCallback> mCallback;
 };

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -583,16 +583,13 @@ exit:
     LogInfo("Received %s response: %s", UriToString<kUriDuaRegistrationRequest>(), ErrorToString(error));
 }
 
-template <>
-void DuaManager::HandleTmf<kUriDuaRegistrationNotify>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void DuaManager::HandleTmf<kUriDuaRegistrationNotify>(Tmf::RxMessage &aMessage)
 {
-    OT_UNUSED_VARIABLE(aMessageInfo);
-
     Error error;
 
     VerifyOrExit(aMessage.IsPostRequest(), error = kErrorParse);
 
-    if (aMessage.IsConfirmable() && Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo) == kErrorNone)
+    if (aMessage.IsConfirmable() && Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessage.GetInfo()) == kErrorNone)
     {
         LogInfo("Sent %s ack", UriToString<kUriDuaRegistrationNotify>());
     }

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -211,7 +211,7 @@ private:
                                   otError              aResult);
     void        HandleDuaResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
     Error ProcessDuaResponse(Coap::Message &aMessage);
 

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -50,8 +50,7 @@ EnergyScanServer::EnergyScanServer(Instance &aInstance)
 {
 }
 
-template <>
-void EnergyScanServer::HandleTmf<kUriEnergyScan>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void EnergyScanServer::HandleTmf<kUriEnergyScan>(Tmf::RxMessage &aMessage)
 {
     uint8_t      count;
     uint16_t     period;
@@ -83,11 +82,11 @@ void EnergyScanServer::HandleTmf<kUriEnergyScan>(Coap::Message &aMessage, const 
     mScanDuration       = scanDuration;
     mTimer.Start(kScanDelay);
 
-    mCommissioner = aMessageInfo.GetPeerAddr();
+    mCommissioner = aMessage.GetInfo().GetPeerAddr();
 
-    if (aMessage.IsConfirmable() && !aMessageInfo.GetSockAddr().IsMulticast())
+    if (aMessage.IsConfirmable() && !aMessage.GetInfo().GetSockAddr().IsMulticast())
     {
-        SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+        SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessage.GetInfo()));
         LogInfo("Sent %s ack", UriToString<kUriEnergyScan>());
     }
 

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -67,7 +67,7 @@ private:
     static constexpr uint32_t kScanDelay   = 1000; // SCAN_DELAY (milliseconds)
     static constexpr uint32_t kReportDelay = 500;  // Delay before sending a report (milliseconds)
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
     static void HandleScanResult(Mac::EnergyScanResult *aResult, void *aContext);
     void        HandleScanResult(Mac::EnergyScanResult *aResult);

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -2026,7 +2026,7 @@ private:
     Error      SendDataRequestToParent(void);
     Error      SendDataRequest(const Ip6::Address &aDestination);
     void       HandleNotifierEvents(Events aEvents);
-    void       HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void       HandleUdpReceive(Ip6::RxMessage &aMessage);
     void       ReestablishLinkWithNeighbor(Neighbor &aNeighbor);
     Error      SendChildUpdateRequestToParent(ChildUpdateRequestMode aMode);
     Error      SendChildUpdateResponse(const TlvList      &aTlvList,

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -2210,7 +2210,7 @@ private:
     void     HandleAddressSolicitResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
     void     HandleTimeTick(void);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE
     void SignalDuaAddressEvent(const Child &aChild, const Ip6::Address &aOldDua) const;

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -3462,7 +3462,7 @@ bool Mle::IsExpectedToBecomeRouterSoon(void) const
             mAddressSolicitPending);
 }
 
-template <> void Mle::HandleTmf<kUriAddressSolicit>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Mle::HandleTmf<kUriAddressSolicit>(Tmf::RxMessage &aMessage)
 {
     Error                   error          = kErrorNone;
     ThreadStatusTlv::Status responseStatus = ThreadStatusTlv::kNoAddressAvailable;
@@ -3475,7 +3475,7 @@ template <> void Mle::HandleTmf<kUriAddressSolicit>(Coap::Message &aMessage, con
 
     VerifyOrExit(aMessage.IsConfirmablePostRequest(), error = kErrorParse);
 
-    Log(kMessageReceive, kTypeAddressSolicit, aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeAddressSolicit, aMessage.GetInfo().GetPeerAddr());
 
     SuccessOrExit(error = Tlv::Find<ThreadExtMacAddressTlv>(aMessage, extAddress));
     SuccessOrExit(error = Tlv::Find<ThreadStatusTlv>(aMessage, status));
@@ -3556,7 +3556,7 @@ template <> void Mle::HandleTmf<kUriAddressSolicit>(Coap::Message &aMessage, con
 exit:
     if (error == kErrorNone)
     {
-        SendAddressSolicitResponse(aMessage, responseStatus, router, aMessageInfo);
+        SendAddressSolicitResponse(aMessage, responseStatus, router, aMessage.GetInfo());
     }
 }
 
@@ -3612,7 +3612,7 @@ exit:
     FreeMessage(message);
 }
 
-template <> void Mle::HandleTmf<kUriAddressRelease>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Mle::HandleTmf<kUriAddressRelease>(Tmf::RxMessage &aMessage)
 {
     uint16_t        rloc16;
     Mac::ExtAddress extAddress;
@@ -3623,7 +3623,7 @@ template <> void Mle::HandleTmf<kUriAddressRelease>(Coap::Message &aMessage, con
 
     VerifyOrExit(aMessage.IsConfirmablePostRequest());
 
-    Log(kMessageReceive, kTypeAddressRelease, aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeAddressRelease, aMessage.GetInfo().GetPeerAddr());
 
     SuccessOrExit(Tlv::Find<ThreadRloc16Tlv>(aMessage, rloc16));
     SuccessOrExit(Tlv::Find<ThreadExtMacAddressTlv>(aMessage, extAddress));
@@ -3635,9 +3635,9 @@ template <> void Mle::HandleTmf<kUriAddressRelease>(Coap::Message &aMessage, con
 
     IgnoreError(mRouterTable.Release(routerId));
 
-    SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+    SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessage.GetInfo()));
 
-    Log(kMessageSend, kTypeAddressReleaseReply, aMessageInfo.GetPeerAddr());
+    Log(kMessageSend, kTypeAddressReleaseReply, aMessage.GetInfo().GetPeerAddr());
 
 exit:
     return;

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -543,7 +543,7 @@ private:
 #endif
     };
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
     void HandleTimer(void);
 

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -262,7 +262,7 @@ private:
                                      Error                   aResult);
 #endif
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
 #if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
     VendorNameTlv::StringType      mVendorName;
@@ -367,7 +367,7 @@ private:
                                   otError              aResult);
     void        HandleGetResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
     static const char *UriToString(Uri aUri);

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -47,8 +47,7 @@ PanIdQueryServer::PanIdQueryServer(Instance &aInstance)
 {
 }
 
-template <>
-void PanIdQueryServer::HandleTmf<kUriPanIdQuery>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void PanIdQueryServer::HandleTmf<kUriPanIdQuery>(Tmf::RxMessage &aMessage)
 {
     uint16_t panId;
     uint32_t mask;
@@ -59,13 +58,13 @@ void PanIdQueryServer::HandleTmf<kUriPanIdQuery>(Coap::Message &aMessage, const 
     SuccessOrExit(Tlv::Find<MeshCoP::PanIdTlv>(aMessage, panId));
 
     mChannelMask  = mask;
-    mCommissioner = aMessageInfo.GetPeerAddr();
+    mCommissioner = aMessage.GetInfo().GetPeerAddr();
     mPanId        = panId;
     mTimer.Start(kScanDelay);
 
-    if (aMessage.IsConfirmable() && !aMessageInfo.GetSockAddr().IsMulticast())
+    if (aMessage.IsConfirmable() && !aMessage.GetInfo().GetSockAddr().IsMulticast())
     {
-        SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+        SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessage.GetInfo()));
         LogInfo("Sent %s ack", UriToString<kUriPanIdQuery>());
     }
 

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -62,7 +62,7 @@ public:
 private:
     static constexpr uint32_t kScanDelay = 1000; ///< SCAN_DELAY (in msec)
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Tmf::RxMessage &aMessage);
 
     static void HandleScanResult(Mac::ActiveScanResult *aScanResult, void *aContext);
     void        HandleScanResult(Mac::ActiveScanResult *aScanResult);

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -85,16 +85,15 @@ Agent::Agent(Instance &aInstance)
 
 Error Agent::Start(void) { return Coap::Start(kUdpPort, Ip6::kNetifThreadInternal); }
 
-template <> void Agent::HandleTmf<kUriRelayRx>(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Agent::HandleTmf<kUriRelayRx>(RxMessage &aMessage)
 {
     OT_UNUSED_VARIABLE(aMessage);
-    OT_UNUSED_VARIABLE(aMessageInfo);
 
 #if (OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE)
-    Get<MeshCoP::Commissioner>().HandleTmf<kUriRelayRx>(aMessage, aMessageInfo);
+    Get<MeshCoP::Commissioner>().HandleTmf<kUriRelayRx>(aMessage);
 #endif
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    Get<MeshCoP::BorderAgent>().HandleTmf<kUriRelayRx>(aMessage, aMessageInfo);
+    Get<MeshCoP::BorderAgent>().HandleTmf<kUriRelayRx>(aMessage);
 #endif
 }
 
@@ -103,17 +102,17 @@ bool Agent::HandleResource(CoapBase               &aCoapBase,
                            Message                &aMessage,
                            const Ip6::MessageInfo &aMessageInfo)
 {
-    return static_cast<Agent &>(aCoapBase).HandleResource(aUriPath, aMessage, aMessageInfo);
+    return static_cast<Agent &>(aCoapBase).HandleResource(aUriPath, RxMessage::From(aMessage, aMessageInfo));
 }
 
-bool Agent::HandleResource(const char *aUriPath, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+bool Agent::HandleResource(const char *aUriPath, RxMessage &aMessage)
 {
     bool didHandle = true;
     Uri  uri       = UriFromPath(aUriPath);
 
-#define Case(kUri, Type)                                     \
-    case kUri:                                               \
-        Get<Type>().HandleTmf<kUri>(aMessage, aMessageInfo); \
+#define Case(kUri, Type)                       \
+    case kUri:                                 \
+        Get<Type>().HandleTmf<kUri>(aMessage); \
         break
 
     switch (uri)
@@ -302,17 +301,17 @@ bool SecureAgent::HandleResource(CoapBase               &aCoapBase,
                                  Message                &aMessage,
                                  const Ip6::MessageInfo &aMessageInfo)
 {
-    return static_cast<SecureAgent &>(aCoapBase).HandleResource(aUriPath, aMessage, aMessageInfo);
+    return static_cast<SecureAgent &>(aCoapBase).HandleResource(aUriPath, RxMessage::From(aMessage, aMessageInfo));
 }
 
-bool SecureAgent::HandleResource(const char *aUriPath, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+bool SecureAgent::HandleResource(const char *aUriPath, RxMessage &aMessage)
 {
     bool didHandle = false;
     Uri  uri       = UriFromPath(aUriPath);
 
     if (uri == kUriJoinerFinalize)
     {
-        Get<MeshCoP::Commissioner>().HandleTmf<kUriJoinerFinalize>(aMessage, aMessageInfo);
+        Get<MeshCoP::Commissioner>().HandleTmf<kUriJoinerFinalize>(aMessage);
         didHandle = true;
     }
 


### PR DESCRIPTION
This change introduces `Ip6::RxMessage` which inherits from `ot::Message` and is intended to be used for a received IPv6 packet.

`Ip6::RxMessage` encapsulates the `Ip6::MessageInfo` associated with the received message. This is made possible by adding a new `void*` info member to `ot::Message` which `RxMessage` uses to store a pointer to its `MessageInfo`.

The main goal is to simplify the next layer IPv6/UDP handlers. The UDP receive handler signature is changed from `(Message &aMessage, const MessageInfo &aMessageInfo)` to a simpler `
(Ip6::RxMessage &aMessage)`.

All UDP receive handlers are updated to use the new `Ip6::RxMessage`.