### PR TITLE
[config] include logging.h

### DIFF
--- a/src/core/config/logging.h
+++ b/src/core/config/logging.h
@@ -34,6 +34,8 @@
 #ifndef CONFIG_LOGGING_H_
 #define CONFIG_LOGGING_H_
 
+#include <openthread/platform/logging.h>
+
 /**
  * @addtogroup config-logging
  *


### PR DESCRIPTION
This commit includes `<openthread/platform/logging.h>` because it uses `OT_LOG_LEVEL_CRIT`.