### PR TITLE
[mle] simplify `WillBecomeRouterSoon` for clarity

### DIFF
--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -320,7 +320,7 @@ void DuaManager::HandleNotifierEvents(Events aEvents)
             // Wait for link establishment with neighboring routers.
             UpdateRegistrationDelay(kNewRouterRegistrationDelay);
         }
-        else if (mle.IsExpectedToBecomeRouterSoon())
+        else if (mle.WillBecomeRouterSoon())
         {
             // Will check again in case the device decides to stay REED when jitter timeout expires.
             UpdateRegistrationDelay(mle.GetRouterRoleTransitionTimeout() + kNewRouterRegistrationDelay + 1);
@@ -434,7 +434,7 @@ void DuaManager::PerformNextRegistration(void)
     // Only send DUA.req when necessary
 #if OPENTHREAD_CONFIG_DUA_ENABLE
 #if OPENTHREAD_FTD
-    if (!mle.IsRouterOrLeader() && mle.IsExpectedToBecomeRouterSoon())
+    if (!mle.IsRouterOrLeader() && mle.WillBecomeRouterSoon())
     {
         UpdateRegistrationDelay(mle.GetRouterRoleTransitionTimeout() + kNewRouterRegistrationDelay + 1);
         ExitNow();

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -990,7 +990,7 @@ public:
      * @retval TRUE   If the REED is going to become a Router soon.
      * @retval FALSE  If the REED is not going to become a Router soon.
      */
-    bool IsExpectedToBecomeRouterSoon(void) const;
+    bool WillBecomeRouterSoon(void) const;
 
     /**
      * Removes a link to a neighbor.

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -3453,13 +3453,24 @@ exit:
     return error;
 }
 
-bool Mle::IsExpectedToBecomeRouterSoon(void) const
+bool Mle::WillBecomeRouterSoon(void) const
 {
     static constexpr uint8_t kMaxDelay = 10;
 
-    return IsRouterEligible() && IsChild() && !mAddressSolicitRejected &&
-           ((mRouterRoleTransition.IsPending() && mRouterRoleTransition.GetTimeout() <= kMaxDelay) ||
-            mAddressSolicitPending);
+    bool willBecomeRouter = false;
+
+    VerifyOrExit(IsRouterEligible() && IsChild());
+    VerifyOrExit(!mAddressSolicitRejected);
+
+    if (!mAddressSolicitPending)
+    {
+        VerifyOrExit(mRouterRoleTransition.IsPending() && mRouterRoleTransition.GetTimeout() <= kMaxDelay);
+    }
+
+    willBecomeRouter = true;
+
+exit:
+    return willBecomeRouter;
 }
 
 template <> void Mle::HandleTmf<kUriAddressSolicit>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -154,7 +154,7 @@ Error Notifier::UpdateInconsistentData(void)
     // Don't send this Server Data Notification if the device is going
     // to upgrade to Router.
 
-    if (Get<Mle::Mle>().IsExpectedToBecomeRouterSoon())
+    if (Get<Mle::Mle>().WillBecomeRouterSoon())
     {
         ExitNow(error = kErrorInvalidState);
     }


### PR DESCRIPTION
This commit renames `IsExpectedToBecomeRouterSoon()` to `WillBecomeRouterSoon()` to better reflect its behavior.

The implementation is simplified by using the `VerifyOrExit` pattern instead of a single complex boolean expression, which improves code readability.