### PR TITLE
[routing-manager] update tracking of favored on-link prefix

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1403,7 +1403,7 @@ private:
         void               Stop(void);
         void               Evaluate(void);
         const Ip6::Prefix &GetLocalPrefix(void) const { return mLocalPrefix; }
-        const Ip6::Prefix &GetFavoredDiscoveredPrefix(void) const { return mFavoredDiscoveredPrefix; }
+        const Ip6::Prefix &GetFavoredPrefix(void) const { return mFavoredPrefix; }
         bool               AddressMatchesLocalPrefix(const Ip6::Address &aAddress) const;
         bool               IsInitalEvaluationDone(void) const;
         void               HandleRaPrefixTableChanged(void);
@@ -1435,6 +1435,8 @@ private:
 
         State GetState(void) const { return mState; }
         void  SetState(State aState);
+        void  SetAilPrefix(const Ip6::Prefix &aPrefix);
+        void  SetFavoredPrefix(const Ip6::Prefix &aPrefix);
         bool  IsPublishingOrAdvertising(void) const;
         void  GenerateLocalPrefix(void);
         void  PublishAndAdvertise(void);
@@ -1449,10 +1451,11 @@ private:
 
         using ExpireTimer = TimerMilliIn<RoutingManager, &RoutingManager::HandleOnLinkPrefixManagerTimer>;
 
-        Ip6::Prefix                       mLocalPrefix;
         State                             mState;
         TimeMilli                         mExpireTime;
-        Ip6::Prefix                       mFavoredDiscoveredPrefix;
+        Ip6::Prefix                       mLocalPrefix;
+        Ip6::Prefix                       mAilPrefix;
+        Ip6::Prefix                       mFavoredPrefix;
         Array<OldPrefix, kMaxOldPrefixes> mOldLocalPrefixes;
         ExpireTimer                       mTimer;
     };


### PR DESCRIPTION
This change enhances the favored on-link prefix selection logic within the `RoutingManager::OnLinkPrefixManager`.

It introduces two new prefix state variables:
- `mAilPrefix`: Tracks the on-link prefix discovered from Router Advertisements received on the Adjacent Infrastructure Link (AIL). This renames the previous `mFavoredDiscoveredPrefix`.
- `mFavoredPrefix`: Tracks the final selected favored prefix, which can be either the local prefix or the `mAilPrefix`.

The setters `SetAilPrefix()` and `SetFavoredPrefix()` are added to manage these state changes and provide additional logging.