### PR TITLE
[trel] fix possible use-after-free in `HandleTxtResult()`

### DIFF
--- a/src/core/radio/trel_peer_discoverer.hpp
+++ b/src/core/radio/trel_peer_discoverer.hpp
@@ -252,7 +252,6 @@ private:
     void StopServiceResolvers(Peer &aPeer);
     void HandleSrvResult(const Dnssd::SrvResult &aResult);
     void HandleTxtResult(const Dnssd::TxtResult &aResult);
-    void ProcessPeerTxtData(const Dnssd::TxtResult &aResult, Peer &aPeer);
     void StartHostAddressResolver(Peer &aPeer);
     void StopHostAddressResolver(Peer &aPeer);
     void HandleAddressResult(const Dnssd::AddressResult &aResult);


### PR DESCRIPTION
This change fixes a potential use-after-free issue in the `PeerDiscoverer::HandleTxtResult()` method.

When processing a TXT record, the corresponding `Peer` object could be removed if it was identified as the device itself. However, a subsequent call to `UpdatePeerState()` would still use the dangling reference to the removed `Peer` object.

The fix merges the logic from the now-removed `ProcessPeerTxtData()` method directly into `HandleTxtResult()`. After a `Peer` is removed, the local `peer` pointer is set to `nullptr`, and the call to `UpdatePeerState()` is guarded by a null check to prevent using the invalid pointer.


----

Discovered by fuzzer -> https://github.com/openthread/openthread/actions/runs/16734588204/job/47370469916?pr=11779