### PR TITLE
[format] upgrade clang-format to 19

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,7 +5,6 @@ Checks: >
   bugprone-too-small-loop-variable,
   google-explicit-constructor,
   google-readability-casting,
-  misc-include-cleaner,
   misc-unused-using-decls,
   modernize-loop-convert,
   modernize-use-bool-literals,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Bootstrap
       run: |
         sudo apt-get update
-        sudo apt-get --no-install-recommends install -y clang-format-16 clang-tidy-16 shellcheck iwyu
+        sudo apt-get --no-install-recommends install -y clang-format-19 clang-tidy-19 shellcheck iwyu
         python3 -m pip install yapf==0.31.0
         sudo snap install shfmt
         npm install prettier@2.0.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ This will open up a text editor where you can specify which commits to squash.
 
 #### Coding Conventions and Style
 
-OpenThread uses and enforces the [OpenThread Coding Conventions and Style](STYLE_GUIDE.md) on all code, except for code located in [third_party](third_party). Use `script/make-pretty` and `script/make-pretty check` to automatically reformat code and check for code-style compliance, respectively. OpenThread currently requires [clang-format v16.0.0](https://releases.llvm.org/download.html#16.0.0) for C/C++ and [yapf v0.31.0](https://github.com/google/yapf) for Python.
+OpenThread uses and enforces the [OpenThread Coding Conventions and Style](STYLE_GUIDE.md) on all code, except for code located in [third_party](third_party). Use `script/make-pretty` and `script/make-pretty check` to automatically reformat code and check for code-style compliance, respectively. OpenThread currently requires [clang-format v19](https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.0) for C/C++ and [yapf v0.31.0](https://github.com/google/yapf) for Python.
 
 As part of the cleanup process, you should also run `script/make-pretty check` to ensure that your code passes the baseline code style checks.
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -116,7 +116,7 @@
 
 - OpenThread uses `script/make-pretty` to reformat code and enforce code format and style. `script/make-pretty check` build target is included in OpenThread's continuous integration and must pass before a pull request is merged.
 
-- `script/make-pretty` requires [clang-format v16.0.0](https://releases.llvm.org/download.html#16.0.0) for C/C++ and [yapf v0.31.0](https://github.com/google/yapf) for Python.
+- `script/make-pretty` requires [clang-format v19](https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.0) for C/C++ and [yapf v0.31.0](https://github.com/google/yapf) for Python.
 
 ### File Names
 

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -83,7 +83,7 @@ typedef enum otCoapType
 /**
  * Helper macro to define CoAP Code values.
  */
-#define OT_COAP_CODE(c, d) ((((c)&0x7) << 5) | ((d)&0x1f))
+#define OT_COAP_CODE(c, d) ((((c) & 0x7) << 5) | ((d) & 0x1f))
 
 /**
  * CoAP Code values.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (522)
+#define OPENTHREAD_API_VERSION (523)
 
 /**
  * @addtogroup api-instance

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -33,12 +33,14 @@
 
 set -euxo pipefail
 
+LLVM_MAJOR_VERSION="19"
+
 install_packages_pretty_format()
 {
     echo 'Installing pretty tools useful for code contributions...'
 
     # add clang-format and clang-tidy for pretty
-    sudo apt-get --no-install-recommends install -y clang-format-16 clang-tidy-16 || echo 'WARNING: could not install clang-format-16 and clang-tidy-16, which is useful if you plan to contribute C/C++ code to the OpenThread project.'
+    sudo apt-get --no-install-recommends install -y clang-format-"${LLVM_MAJOR_VERSION}" clang-tidy-"${LLVM_MAJOR_VERSION}" || echo "WARNING: could not install clang-format-${LLVM_MAJOR_VERSION} and clang-tidy-${LLVM_MAJOR_VERSION}, which is useful if you plan to contribute C/C++ code to the OpenThread project."
 
     # add yapf for pretty
     python3 -m pip install yapf==0.31.0 || echo 'WARNING: could not install yapf, which is useful if you plan to contribute python code to the OpenThread project.'
@@ -113,14 +115,14 @@ install_packages_brew()
     echo 'Installing pretty tools useful for code contributions...'
 
     # add clang-format for pretty
-    CLANG_FORMAT_VERSION="clang-format version 16"
-    command -v clang-format-16 || (command -v clang-format && (clang-format --version | grep -q "${CLANG_FORMAT_VERSION}")) || {
-        brew install llvm@16
-        sudo ln -s "$(brew --prefix llvm@16)/bin/clang-format" /usr/local/bin/clang-format-16
-        sudo ln -s "$(brew --prefix llvm@16)/bin/clang-tidy" /usr/local/bin/clang-tidy-16
-        sudo ln -s "$(brew --prefix llvm@16)/bin/clang-apply-replacements" /usr/local/bin/clang-apply-replacements-16
-        sudo ln -s "$(brew --prefix llvm@16)/bin/run-clang-tidy" /usr/local/bin/run-clang-tidy-16
-    } || echo 'WARNING: could not install llvm@16, which is useful if you plan to contribute C/C++ code to the OpenThread project.'
+    CLANG_FORMAT_VERSION="clang-format version ${LLVM_MAJOR_VERSION}"
+    command -v clang-format-"${LLVM_MAJOR_VERSION}" || (command -v clang-format && (clang-format --version | grep -q "${CLANG_FORMAT_VERSION}")) || {
+        brew install llvm@"${LLVM_MAJOR_VERSION}"
+        sudo ln -s "$(brew --prefix llvm@${LLVM_MAJOR_VERSION})/bin/clang-format" /usr/local/bin/clang-format-"${LLVM_MAJOR_VERSION}"
+        sudo ln -s "$(brew --prefix llvm@${LLVM_MAJOR_VERSION})/bin/clang-tidy" /usr/local/bin/clang-tidy-"${LLVM_MAJOR_VERSION}"
+        sudo ln -s "$(brew --prefix llvm@${LLVM_MAJOR_VERSION})/bin/clang-apply-replacements" /usr/local/bin/clang-apply-replacements-"${LLVM_MAJOR_VERSION}"
+        sudo ln -s "$(brew --prefix llvm@${LLVM_MAJOR_VERSION})/bin/run-clang-tidy" /usr/local/bin/run-clang-tidy-"${LLVM_MAJOR_VERSION}"
+    } || echo "WARNING: could not install llvm@${LLVM_MAJOR_VERSION}, which is useful if you plan to contribute C/C++ code to the OpenThread project."
 
     # add yapf for pretty
     python3 -m pip install yapf || echo 'Failed to install python code formatter yapf. Install it manually if you need.'

--- a/script/clang-format
+++ b/script/clang-format
@@ -27,7 +27,9 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-CLANG_FORMAT_VERSION="clang-format version 16.0"
+LLVM_MAJOR_NUMBER_VERSION="19"
+LLVM_NUMBER_VERSION="19.1.0"
+CLANG_FORMAT_VERSION="clang-format version ${LLVM_NUMBER_VERSION}"
 
 die()
 {
@@ -39,18 +41,18 @@ die()
 # expand_aliases shell option is set using shopt.
 shopt -s expand_aliases
 
-if command -v clang-format-16 >/dev/null; then
-    alias clang-format=clang-format-16
+if command -v clang-format-"${LLVM_MAJOR_NUMBER_VERSION}" >/dev/null; then
+    alias clang-format=clang-format-"\${LLVM_MAJOR_NUMBER_VERSION}"
 elif command -v clang-format >/dev/null; then
     case "$(clang-format --version)" in
         *"$CLANG_FORMAT_VERSION"*) ;;
 
         *)
-            die "$(clang-format --version); clang-format 16.0 required"
+            die "$(clang-format --version); clang-format ${LLVM_NUMBER_VERSION} required"
             ;;
     esac
 else
-    die "clang-format 16.0 required"
+    die "clang-format ${LLVM_NUMBER_VERSION} required"
 fi
 
 clang-format "$@" || die

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -27,8 +27,10 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-CLANG_TIDY_VERSION="LLVM version 16.0"
-CLANG_APPLY_REPLACEMENTS_VERSION="clang-apply-replacements version 16.0"
+LLVM_MAJOR_NUMBER_VERSION="19"
+LLVM_NUMBER_VERSION="19.1.0"
+CLANG_TIDY_VERSION="LLVM version ${LLVM_NUMBER_VERSION}"
+CLANG_APPLY_REPLACEMENTS_VERSION="clang-apply-replacements version ${LLVM_NUMBER_VERSION}"
 
 die()
 {
@@ -36,9 +38,9 @@ die()
     exit 1
 }
 
-# Search for clang-tidy-16
-if command -v clang-tidy-16 >/dev/null; then
-    clang_tidy=$(command -v clang-tidy-16)
+# Search for clang-tidy-"${LLVM_MAJOR_NUMBER_VERSION}"
+if command -v clang-tidy-"${LLVM_MAJOR_NUMBER_VERSION}" >/dev/null; then
+    clang_tidy=$(command -v clang-tidy-"${LLVM_MAJOR_NUMBER_VERSION}")
 elif command -v clang-tidy >/dev/null; then
     clang_tidy=$(command -v clang-tidy)
     case "$($clang_tidy --version)" in
@@ -49,12 +51,12 @@ elif command -v clang-tidy >/dev/null; then
             ;;
     esac
 else
-    die "clang-tidy 16.0 required"
+    die "clang-tidy ${LLVM_NUMBER_VERSION} required"
 fi
 
-# Search for clang-apply-replacements-16
-if command -v clang-apply-replacements-16 >/dev/null; then
-    clang_apply_replacements=$(command -v clang-apply-replacements-16)
+# Search for clang-apply-replacements-"${LLVM_MAJOR_NUMBER_VERSION}"
+if command -v clang-apply-replacements-"${LLVM_MAJOR_NUMBER_VERSION}" >/dev/null; then
+    clang_apply_replacements=$(command -v clang-apply-replacements-"${LLVM_MAJOR_NUMBER_VERSION}")
 elif command -v clang-apply-replacements >/dev/null; then
     clang_apply_replacements=$(command -v clang-apply-replacements)
     case "$($clang_apply_replacements --version)" in
@@ -65,20 +67,20 @@ elif command -v clang-apply-replacements >/dev/null; then
             ;;
     esac
 else
-    die "clang-apply-replacements 16.0 required"
+    die "clang-apply-replacements ${LLVM_NUMBER_VERSION} required"
 fi
 
-# Search for run-clang-tidy-16.py
-if command -v run-clang-tidy-16.py >/dev/null; then
-    run_clang_tidy=$(command -v run-clang-tidy-16.py)
-elif command -v run-clang-tidy-16 >/dev/null; then
-    run_clang_tidy=$(command -v run-clang-tidy-16)
+# Search for run-clang-tidy-"${LLVM_MAJOR_NUMBER_VERSION}".py
+if command -v run-clang-tidy-"${LLVM_MAJOR_NUMBER_VERSION}".py >/dev/null; then
+    run_clang_tidy=$(command -v run-clang-tidy-"${LLVM_MAJOR_NUMBER_VERSION}".py)
+elif command -v run-clang-tidy-"${LLVM_MAJOR_NUMBER_VERSION}" >/dev/null; then
+    run_clang_tidy=$(command -v run-clang-tidy-"${LLVM_MAJOR_NUMBER_VERSION}")
 elif command -v run-clang-tidy.py >/dev/null; then
     run_clang_tidy=$(command -v run-clang-tidy.py)
 elif command -v run-clang-tidy >/dev/null; then
     run_clang_tidy=$(command -v run-clang-tidy)
 else
-    die "run-clang-tidy.py 16.0 required"
+    die "run-clang-tidy.py ${LLVM_NUMBER_VERSION} required"
 fi
 
 $run_clang_tidy -clang-tidy-binary "$clang_tidy" -clang-apply-replacements-binary "$clang_apply_replacements" "$@" || die

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -8278,10 +8278,7 @@ void Interpreter::SetCommandTimeout(uint32_t aTimeoutMilli)
 
 otError Interpreter::ProcessCommand(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                                   \
-    {                                                              \
-        aCommandString, &Interpreter::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &Interpreter::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
 #if OPENTHREAD_FTD || OPENTHREAD_MTD

--- a/src/cli/cli_br.cpp
+++ b/src/cli/cli_br.cpp
@@ -1106,41 +1106,28 @@ exit:
 
 otError Br::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                          \
-    {                                                     \
-        aCommandString, &Br::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &Br::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
 #if OPENTHREAD_CONFIG_IP6_BR_COUNTERS_ENABLE
         CmdEntry("counters"),
 #endif
-        CmdEntry("disable"),
-        CmdEntry("enable"),
-        CmdEntry("infraif"),
-        CmdEntry("init"),
+        CmdEntry("disable"),     CmdEntry("enable"),    CmdEntry("infraif"),      CmdEntry("init"),
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
         CmdEntry("multiail"),
 #endif
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
         CmdEntry("nat64prefix"),
 #endif
-        CmdEntry("omrconfig"),
-        CmdEntry("omrprefix"),
-        CmdEntry("onlinkprefix"),
+        CmdEntry("omrconfig"),   CmdEntry("omrprefix"), CmdEntry("onlinkprefix"),
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
         CmdEntry("pd"),
 #endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
         CmdEntry("peers"),
 #endif
-        CmdEntry("prefixtable"),
-        CmdEntry("raoptions"),
-        CmdEntry("rdnsstable"),
-        CmdEntry("rioprf"),
-        CmdEntry("routeprf"),
-        CmdEntry("routers"),
-        CmdEntry("state"),
+        CmdEntry("prefixtable"), CmdEntry("raoptions"), CmdEntry("rdnsstable"),   CmdEntry("rioprf"),
+        CmdEntry("routeprf"),    CmdEntry("routers"),   CmdEntry("state"),
     };
 
 #undef CmdEntry

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -796,27 +796,18 @@ exit:
 
 otError Coap::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                            \
-    {                                                       \
-        aCommandString, &Coap::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &Coap::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
         CmdEntry("cancel"),
 #endif
-        CmdEntry("delete"),
-        CmdEntry("get"),
+        CmdEntry("delete"),     CmdEntry("get"),
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
         CmdEntry("observe"),
 #endif
-        CmdEntry("parameters"),
-        CmdEntry("post"),
-        CmdEntry("put"),
-        CmdEntry("resource"),
-        CmdEntry("set"),
-        CmdEntry("start"),
-        CmdEntry("stop"),
+        CmdEntry("parameters"), CmdEntry("post"),  CmdEntry("put"),  CmdEntry("resource"),
+        CmdEntry("set"),        CmdEntry("start"), CmdEntry("stop"),
     };
 
 #undef CmdEntry

--- a/src/cli/cli_coap.hpp
+++ b/src/cli/cli_coap.hpp
@@ -79,7 +79,8 @@ private:
     using Command = CommandEntry<Coap>;
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
-    enum BlockType : uint8_t{
+    enum BlockType : uint8_t
+    {
         kBlockType1,
         kBlockType2,
     };
@@ -97,7 +98,7 @@ private:
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
     otError ProcessRequest(Arg aArgs[], otCoapCode aCoapCode, bool aCoapObserve = false);
 #else
-    otError        ProcessRequest(Arg aArgs[], otCoapCode aCoapCode);
+    otError ProcessRequest(Arg aArgs[], otCoapCode aCoapCode);
 #endif
 
     static void HandleRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -733,10 +733,7 @@ template <> otError CoapSecure::Process<Cmd("x509")>(Arg aArgs[])
 
 otError CoapSecure::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                                  \
-    {                                                             \
-        aCommandString, &CoapSecure::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &CoapSecure::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
         CmdEntry("connect"),  CmdEntry("delete"),       CmdEntry("disconnect"),  CmdEntry("get"),

--- a/src/cli/cli_coap_secure.hpp
+++ b/src/cli/cli_coap_secure.hpp
@@ -87,7 +87,8 @@ private:
     using Command = CommandEntry<CoapSecure>;
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
-    enum BlockType : uint8_t{
+    enum BlockType : uint8_t
+    {
         kBlockType1,
         kBlockType2,
     };

--- a/src/cli/cli_commissioner.cpp
+++ b/src/cli/cli_commissioner.cpp
@@ -656,10 +656,7 @@ template <> otError Commissioner::Process<Cmd("state")>(Arg aArgs[])
 
 otError Commissioner::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                                    \
-    {                                                               \
-        aCommandString, &Commissioner::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &Commissioner::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
         CmdEntry("announce"),  CmdEntry("energy"),  CmdEntry("id"),    CmdEntry("joiner"),

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -1287,20 +1287,11 @@ void Dataset::HandleDatasetUpdater(otError aError)
 
 otError Dataset::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                               \
-    {                                                          \
-        aCommandString, &Dataset::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &Dataset::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
-        CmdEntry("active"),
-        CmdEntry("clear"),
-        CmdEntry("commit"),
-        CmdEntry("init"),
-        CmdEntry("mgmtgetcommand"),
-        CmdEntry("mgmtsetcommand"),
-        CmdEntry("pending"),
-        CmdEntry("set"),
+        CmdEntry("active"),         CmdEntry("clear"),          CmdEntry("commit"),  CmdEntry("init"),
+        CmdEntry("mgmtgetcommand"), CmdEntry("mgmtsetcommand"), CmdEntry("pending"), CmdEntry("set"),
         CmdEntry("tlvs"),
 #if OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE && OPENTHREAD_FTD
         CmdEntry("updater"),

--- a/src/cli/cli_dns.cpp
+++ b/src/cli/cli_dns.cpp
@@ -825,10 +825,7 @@ exit:
 
 otError Dns::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                           \
-    {                                                      \
-        aCommandString, &Dns::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &Dns::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
 
@@ -852,8 +849,7 @@ otError Dns::Process(Arg aArgs[])
         CmdEntry("server"),
 #endif
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE && OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE
-        CmdEntry("service"),
-        CmdEntry("servicehost"),
+        CmdEntry("service"),     CmdEntry("servicehost"),
 #endif
     };
 

--- a/src/cli/cli_history.cpp
+++ b/src/cli/cli_history.cpp
@@ -1556,10 +1556,7 @@ const char *History::DnsSrpAddrTypeToString(otHistoryTrackerDnsSrpAddrType aType
 
 otError History::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                               \
-    {                                                          \
-        aCommandString, &History::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &History::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
         CmdEntry("dnssrpaddr"), CmdEntry("ipaddr"), CmdEntry("ipmaddr"), CmdEntry("neighbor"),

--- a/src/cli/cli_joiner.cpp
+++ b/src/cli/cli_joiner.cpp
@@ -216,10 +216,7 @@ template <> otError Joiner::Process<Cmd("state")>(Arg aArgs[])
 
 otError Joiner::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                              \
-    {                                                         \
-        aCommandString, &Joiner::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &Joiner::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
         CmdEntry("discerner"), CmdEntry("id"), CmdEntry("start"), CmdEntry("state"), CmdEntry("stop"),

--- a/src/cli/cli_link_metrics.cpp
+++ b/src/cli/cli_link_metrics.cpp
@@ -377,10 +377,7 @@ exit:
 
 otError LinkMetrics::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                                   \
-    {                                                              \
-        aCommandString, &LinkMetrics::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &LinkMetrics::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
         CmdEntry("config"), CmdEntry("mgmt"), CmdEntry("probe"), CmdEntry("query"), CmdEntry("request"),

--- a/src/cli/cli_mac_filter.cpp
+++ b/src/cli/cli_mac_filter.cpp
@@ -445,10 +445,7 @@ exit:
 
 otError MacFilter::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                                 \
-    {                                                            \
-        aCommandString, &MacFilter::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &MacFilter::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
         CmdEntry("addr"),

--- a/src/cli/cli_mdns.cpp
+++ b/src/cli/cli_mdns.cpp
@@ -1257,10 +1257,7 @@ exit:
 
 otError Mdns::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                            \
-    {                                                       \
-        aCommandString, &Mdns::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &Mdns::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE

--- a/src/cli/cli_mesh_diag.cpp
+++ b/src/cli/cli_mesh_diag.cpp
@@ -291,10 +291,7 @@ exit:
 
 otError MeshDiag::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                                \
-    {                                                           \
-        aCommandString, &MeshDiag::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &MeshDiag::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
         CmdEntry("childip6"), CmdEntry("childtable"), CmdEntry("responsetimeout"), CmdEntry("routerneighbortable"),

--- a/src/cli/cli_network_data.cpp
+++ b/src/cli/cli_network_data.cpp
@@ -963,25 +963,20 @@ exit:
 
 otError NetworkData::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                                   \
-    {                                                              \
-        aCommandString, &NetworkData::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &NetworkData::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_SIGNAL_NETWORK_DATA_FULL
         CmdEntry("full"),
 #endif
-        CmdEntry("length"),
-        CmdEntry("maxlength"),
+        CmdEntry("length"),    CmdEntry("maxlength"),
 #if OPENTHREAD_CONFIG_NETDATA_PUBLISHER_ENABLE
         CmdEntry("publish"),
 #endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
         CmdEntry("register"),
 #endif
-        CmdEntry("show"),
-        CmdEntry("steeringdata"),
+        CmdEntry("show"),      CmdEntry("steeringdata"),
 #if OPENTHREAD_CONFIG_NETDATA_PUBLISHER_ENABLE
         CmdEntry("unpublish"),
 #endif

--- a/src/cli/cli_srp_client.cpp
+++ b/src/cli/cli_srp_client.cpp
@@ -976,10 +976,7 @@ void SrpClient::HandleCallback(otError                    aError,
 
 otError SrpClient::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                                 \
-    {                                                            \
-        aCommandString, &SrpClient::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &SrpClient::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
         CmdEntry("autostart"),     CmdEntry("callback"), CmdEntry("host"),    CmdEntry("keyleaseinterval"),

--- a/src/cli/cli_srp_server.cpp
+++ b/src/cli/cli_srp_server.cpp
@@ -581,29 +581,19 @@ template <> otError SrpServer::Process<Cmd("seqnum")>(Arg aArgs[])
 
 otError SrpServer::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                                 \
-    {                                                            \
-        aCommandString, &SrpServer::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &SrpServer::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
         CmdEntry("addrmode"),
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
         CmdEntry("auto"),
 #endif
-        CmdEntry("disable"),
-        CmdEntry("domain"),
-        CmdEntry("enable"),
+        CmdEntry("disable"),   CmdEntry("domain"), CmdEntry("enable"),
 #if OPENTHREAD_CONFIG_SRP_SERVER_FAST_START_MODE_ENABLE
         CmdEntry("faststart"),
 #endif
-        CmdEntry("host"),
-        CmdEntry("lease"),
-        CmdEntry("port"),
-        CmdEntry("seqnum"),
-        CmdEntry("service"),
-        CmdEntry("state"),
-        CmdEntry("ttl"),
+        CmdEntry("host"),      CmdEntry("lease"),  CmdEntry("port"),   CmdEntry("seqnum"),
+        CmdEntry("service"),   CmdEntry("state"),  CmdEntry("ttl"),
     };
 
     static_assert(BinarySearch::IsSorted(kCommands), "kCommands is not sorted");

--- a/src/cli/cli_tcat.cpp
+++ b/src/cli/cli_tcat.cpp
@@ -409,10 +409,7 @@ template <> otError Tcat::Process<Cmd("stop")>(Arg aArgs[])
 
 otError Tcat::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                            \
-    {                                                       \
-        aCommandString, &Tcat::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &Tcat::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {CmdEntry("advid"), CmdEntry("devid"), CmdEntry("start"), CmdEntry("stop")};
 

--- a/src/cli/cli_tcp.cpp
+++ b/src/cli/cli_tcp.cpp
@@ -776,10 +776,7 @@ exit:
 
 otError TcpExample::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                                  \
-    {                                                             \
-        aCommandString, &TcpExample::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &TcpExample::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
         CmdEntry("abort"), CmdEntry("benchmark"), CmdEntry("bind"), CmdEntry("connect"), CmdEntry("deinit"),

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -433,10 +433,7 @@ exit:
 
 otError UdpExample::Process(Arg aArgs[])
 {
-#define CmdEntry(aCommandString)                                  \
-    {                                                             \
-        aCommandString, &UdpExample::Process<Cmd(aCommandString)> \
-    }
+#define CmdEntry(aCommandString) {aCommandString, &UdpExample::Process<Cmd(aCommandString)>}
 
     static constexpr Command kCommands[] = {
         CmdEntry("bind"),         CmdEntry("close"), CmdEntry("connect"),

--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -286,7 +286,7 @@ public:
      */
     void RecordFrameTransmitStatus(const TxFrame &aFrame, Error aError, uint8_t aRetryCount, bool aWillRetx);
 #else
-    void    RecordFrameTransmitStatus(const TxFrame &, Error, uint8_t, bool) {}
+    void RecordFrameTransmitStatus(const TxFrame &, Error, uint8_t, bool) {}
 #endif
 
 private:

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -800,10 +800,7 @@ void BorderAgent::EphemeralKeyManager::UpdateCountersAndRecordEvent(Deactivation
         kReason, HistoryTracker::Local::kEvent, &Counters::kCounter, \
     }
 #else
-#define ReasonEntry(kReason, kCounter, kEvent) \
-    {                                          \
-        kReason, 0, &Counters::kCounter        \
-    }
+#define ReasonEntry(kReason, kCounter, kEvent) {kReason, 0, &Counters::kCounter}
 #endif
 
     static const ReasonToCounterEventEntry kReasonToCounterEventEntries[] = {

--- a/src/core/meshcop/secure_transport.hpp
+++ b/src/core/meshcop/secure_transport.hpp
@@ -238,7 +238,7 @@ private:
 #if !OPENTHREAD_CONFIG_TLS_API_ENABLE
     static constexpr uint16_t kApplicationDataMaxLength = 1152;
 #else
-    static constexpr uint16_t         kApplicationDataMaxLength = OPENTHREAD_CONFIG_DTLS_APPLICATION_DATA_MAX_LENGTH;
+    static constexpr uint16_t kApplicationDataMaxLength = OPENTHREAD_CONFIG_DTLS_APPLICATION_DATA_MAX_LENGTH;
 #endif
 
     enum State : uint8_t
@@ -775,17 +775,17 @@ private:
 
 #else
 
-    static int       HandleMbedtlsExportKeys(void                *aContext,
-                                             const unsigned char *aMasterSecret,
-                                             const unsigned char *aKeyBlock,
-                                             size_t               aMacLength,
-                                             size_t               aKeyLength,
-                                             size_t               aIvLength);
-    int              HandleMbedtlsExportKeys(const unsigned char *aMasterSecret,
-                                             const unsigned char *aKeyBlock,
-                                             size_t               aMacLength,
-                                             size_t               aKeyLength,
-                                             size_t               aIvLength);
+    static int HandleMbedtlsExportKeys(void                *aContext,
+                                       const unsigned char *aMasterSecret,
+                                       const unsigned char *aKeyBlock,
+                                       size_t               aMacLength,
+                                       size_t               aKeyLength,
+                                       size_t               aIvLength);
+    int        HandleMbedtlsExportKeys(const unsigned char *aMasterSecret,
+                                       const unsigned char *aKeyBlock,
+                                       size_t               aMacLength,
+                                       size_t               aKeyLength,
+                                       size_t               aIvLength);
 
 #endif // (MBEDTLS_VERSION_NUMBER >= 0x03000000)
 #endif // MBEDTLS_SSL_EXPORT_KEYS

--- a/src/core/net/nat64_translator.cpp
+++ b/src/core/net/nat64_translator.cpp
@@ -146,7 +146,7 @@ Translator::Result Translator::TranslateFromIp6(Message &aMessage)
 #if OPENTHREAD_CONFIG_NAT64_PORT_TRANSLATION_ENABLE
     srcPortOrId = mapping->mTranslatedPortOrId;
 #else
-    srcPortOrId           = ip6Headers.IsIcmp6() ? ip6Headers.GetIcmpHeader().GetId() : ip6Headers.GetSourcePort();
+    srcPortOrId = ip6Headers.IsIcmp6() ? ip6Headers.GetIcmpHeader().GetId() : ip6Headers.GetSourcePort();
 #endif
 
     aMessage.RemoveHeader(sizeof(Ip6::Header));
@@ -252,7 +252,7 @@ Translator::Result Translator::TranslateToIp6(Message &aMessage)
 #if OPENTHREAD_CONFIG_NAT64_PORT_TRANSLATION_ENABLE
     dstPortOrId = mapping->mSrcPortOrId;
 #else
-    dstPortOrId           = ip4Headers.IsIcmp4() ? ip4Headers.GetIcmpHeader().GetId() : ip4Headers.GetDestinationPort();
+    dstPortOrId = ip4Headers.IsIcmp4() ? ip4Headers.GetIcmpHeader().GetId() : ip4Headers.GetDestinationPort();
 #endif
 
     aMessage.RemoveHeader(sizeof(Ip4::Header));
@@ -442,7 +442,7 @@ Translator::AddressMapping *Translator::AllocateMapping(const Ip6::Headers &aIp6
     // Allocate a unique source port or ICMP Id
     mapping->mTranslatedPortOrId = AllocateSourcePort(mapping->mSrcPortOrId);
 #else
-    mapping->mSrcPortOrId = 0;
+    mapping->mSrcPortOrId        = 0;
     mapping->mTranslatedPortOrId = 0;
 #endif
     mapping->Touch(TimerMilli::GetNow(), aIp6Headers.GetIpProto());
@@ -458,7 +458,7 @@ Translator::AddressMapping *Translator::FindOrAllocateMapping(const Ip6::Headers
     uint16_t srcPortOrId    = aIp6Headers.IsIcmp6() ? aIp6Headers.GetIcmpHeader().GetId() : aIp6Headers.GetSourcePort();
     AddressMapping *mapping = mActiveAddressMappings.FindMatching(aIp6Headers.GetSourceAddress(), srcPortOrId);
 #else
-    AddressMapping *mapping      = mActiveAddressMappings.FindMatching(aIp6Headers.GetSourceAddress());
+    AddressMapping *mapping = mActiveAddressMappings.FindMatching(aIp6Headers.GetSourceAddress());
 #endif
 
     // Exit if we found a valid mapping.
@@ -478,7 +478,7 @@ Translator::AddressMapping *Translator::FindMapping(const Ip4::Headers &aIp4Head
 #if OPENTHREAD_CONFIG_NAT64_PORT_TRANSLATION_ENABLE
     AddressMapping *mapping = mActiveAddressMappings.FindMatching(aIp4Headers.GetDestinationAddress(), dstPortOrId);
 #else
-    AddressMapping *mapping      = mActiveAddressMappings.FindMatching(aIp4Headers.GetDestinationAddress());
+    AddressMapping *mapping = mActiveAddressMappings.FindMatching(aIp4Headers.GetDestinationAddress());
     OT_UNUSED_VARIABLE(dstPortOrId);
 #endif
 

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -941,7 +941,8 @@ private:
     class AutoStart : public Clearable<AutoStart>
     {
     public:
-        enum State : uint8_t{
+        enum State : uint8_t
+        {
             kDisabled,                 // Disabled.
             kFirstTimeSelecting,       // Trying to select a server for the first time since AutoStart was enabled.
             kReselecting,              // Trying to select a server again (previously selected server was removed).
@@ -1058,7 +1059,7 @@ private:
     static const char *StateToString(State aState);
     void               LogRetryWaitInterval(void) const;
 #else
-    void                                 LogRetryWaitInterval(void) const {}
+    void LogRetryWaitInterval(void) const {}
 #endif
 
     static const char kDefaultDomainName[];

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -267,7 +267,8 @@ public:
         void ResetTime(void);
 
     private:
-        enum Status : uint8_t{
+        enum Status : uint8_t
+        {
             kDisabled,
             kSleep,
             kReceive,
@@ -1111,14 +1112,14 @@ inline Error Radio::ReceiveAt(uint8_t, uint32_t, uint32_t) { return kErrorNone; 
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-inline void  Radio::UpdateCslSampleTime(uint32_t) {}
+inline void Radio::UpdateCslSampleTime(uint32_t) {}
 
 inline Error Radio::EnableCsl(uint32_t, Mac::ShortAddress aShortAddr, const Mac::ExtAddress &)
 {
     return kErrorNotImplemented;
 }
 
-inline Error    Radio::ResetCsl(void) { return kErrorNotImplemented; }
+inline Error Radio::ResetCsl(void) { return kErrorNotImplemented; }
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE || \
@@ -1160,8 +1161,8 @@ inline uint32_t Radio::GetBusSpeed(void) { return 0; }
 inline uint32_t Radio::GetBusLatency(void) { return 0; }
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-inline void     Radio::SetDiagMode(bool) {}
-inline bool     Radio::GetDiagMode(void) { return false; }
+inline void Radio::SetDiagMode(bool) {}
+inline bool Radio::GetDiagMode(void) { return false; }
 #endif
 #endif // #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 

--- a/src/core/radio/trel_peer_discoverer.hpp
+++ b/src/core/radio/trel_peer_discoverer.hpp
@@ -265,7 +265,7 @@ private:
     static void HandleAddressResult(otInstance *aInstance, const otPlatDnssdAddressResult *aResult);
 
 #else
-    void        HandleDiscoveredPeerInfo(const PeerInfo &aInfo);
+    void HandleDiscoveredPeerInfo(const PeerInfo &aInfo);
 #endif
 
     using ServiceTask = TaskletIn<PeerDiscoverer, &PeerDiscoverer::HandleServiceTask>;

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -601,7 +601,7 @@ void KeyManager::GetPskc(Pskc &aPskc) const
         aPskc.Clear();
     }
 #else
-    aPskc       = mPskc;
+    aPskc = mPskc;
 #endif
 }
 

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -629,7 +629,7 @@ private:
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
     PskcRef mPskcRef;
 #else
-    Pskc       mPskc;
+    Pskc mPskc;
 #endif
 
     KekKeyMaterial mKek;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -794,7 +794,8 @@ public:
     /**
      * Specifies the leader weight check behavior used in `BecomeLeader()`.
      */
-    enum LeaderWeightCheck : uint8_t{
+    enum LeaderWeightCheck : uint8_t
+    {
         kCheckLeaderWeight,  ///< Enforces that the local leader weight is greater than the current leader's weight.
         kIgnoreLeaderWeight, ///< Skips the leader weight check, attempting to become leader regardless.
     };
@@ -1422,7 +1423,8 @@ private:
     };
 
 #if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
-    enum WedAttachState : uint8_t{
+    enum WedAttachState : uint8_t
+    {
         kWedDetached,
         kWedAttaching,
         kWedAttached,
@@ -2115,7 +2117,7 @@ private:
                           uint8_t                                  aTlvsLength,
                           const LinkMetrics::Initiator::QueryInfo *aQueryInfo = nullptr);
 #else
-    Error       SendDataRequest(const Ip6::Address &aDestination, const uint8_t *aTlvs, uint8_t aTlvsLength);
+    Error SendDataRequest(const Ip6::Address &aDestination, const uint8_t *aTlvs, uint8_t aTlvsLength);
 #endif
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -233,23 +233,23 @@ private:
 #if OPENTHREAD_MTD
     void SendAnswer(const Ip6::Address &aDestination, const Message &aRequest);
 #elif OPENTHREAD_FTD
-    Error       AllocateAnswer(Coap::Message *&aAnswer, AnswerInfo &aInfo);
-    Error       CheckAnswerLength(Coap::Message *&aAnswer, AnswerInfo &aInfo);
-    bool        IsLastAnswer(const Coap::Message &aAnswer) const;
-    void        FreeAllRelatedAnswers(Coap::Message &aFirstAnswer);
-    void        PrepareAndSendAnswers(const Ip6::Address &aDestination, const Message &aRequest);
-    void        SendNextAnswer(Coap::Message &aAnswer, const Ip6::Address &aDestination);
-    Error       AppendChildTable(Message &aMessage);
-    Error       AppendChildTableAsChildTlvs(Coap::Message *&aAnswer, AnswerInfo &aInfo);
-    Error       AppendRouterNeighborTlvs(Coap::Message *&aAnswer, AnswerInfo &aInfo);
-    Error       AppendChildTableIp6AddressList(Coap::Message *&aAnswer, AnswerInfo &aInfo);
-    Error       AppendChildIp6AddressListTlv(Message &aAnswer, const Child &aChild);
-    Error       AppendEnhancedRoute(Message &aMessage);
+    Error AllocateAnswer(Coap::Message *&aAnswer, AnswerInfo &aInfo);
+    Error CheckAnswerLength(Coap::Message *&aAnswer, AnswerInfo &aInfo);
+    bool  IsLastAnswer(const Coap::Message &aAnswer) const;
+    void  FreeAllRelatedAnswers(Coap::Message &aFirstAnswer);
+    void  PrepareAndSendAnswers(const Ip6::Address &aDestination, const Message &aRequest);
+    void  SendNextAnswer(Coap::Message &aAnswer, const Ip6::Address &aDestination);
+    Error AppendChildTable(Message &aMessage);
+    Error AppendChildTableAsChildTlvs(Coap::Message *&aAnswer, AnswerInfo &aInfo);
+    Error AppendRouterNeighborTlvs(Coap::Message *&aAnswer, AnswerInfo &aInfo);
+    Error AppendChildTableIp6AddressList(Coap::Message *&aAnswer, AnswerInfo &aInfo);
+    Error AppendChildIp6AddressListTlv(Message &aAnswer, const Child &aChild);
+    Error AppendEnhancedRoute(Message &aMessage);
 
 #if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
-    Error       AppendChildTableAsChildTlvs(Message &aMessage);
-    Error       AppendRouterNeighborTlvs(Message &aMessage);
-    Error       AppendChildTableIp6AddressList(Message &aMessage);
+    Error AppendChildTableAsChildTlvs(Message &aMessage);
+    Error AppendRouterNeighborTlvs(Message &aMessage);
+    Error AppendChildTableIp6AddressList(Message &aMessage);
 #endif
 
     static void HandleAnswerResponse(void                *aContext,

--- a/src/core/utils/heap.cpp
+++ b/src/core/utils/heap.cpp
@@ -177,8 +177,7 @@ void Heap::Free(void *aPointer)
 
             if (right.GetSize() > left->GetSize())
             {
-                for (const uint16_t offset = BlockOffset(right); prev->GetNext() != offset; prev = &BlockNext(*prev))
-                    ;
+                for (const uint16_t offset = BlockOffset(right); prev->GetNext() != offset; prev = &BlockNext(*prev));
             }
             else
             {

--- a/src/include/common/code_utils.hpp
+++ b/src/include/common/code_utils.hpp
@@ -68,7 +68,7 @@
  * @returns The aligned pointer.
  */
 #define OT_ALIGN(aPointer, aAlignment) \
-    ((void *)(((uintptr_t)(aPointer) + (aAlignment)-1UL) & ~((uintptr_t)(aAlignment)-1UL)))
+    ((void *)(((uintptr_t)(aPointer) + (aAlignment) - 1UL) & ~((uintptr_t)(aAlignment) - 1UL)))
 
 // Calculates the aligned variable size.
 #define OT_ALIGNED_VAR_SIZE(size, align_type) (((size) + (sizeof(align_type) - 1)) / sizeof(align_type))

--- a/src/lib/spinel/spinel.h
+++ b/src/lib/spinel/spinel.h
@@ -470,7 +470,7 @@
 #define SPINEL_FRAME_BUFFER_SIZE (SPINEL_FRAME_MAX_SIZE + SPINEL_ENCRYPTER_EXTRA_DATA_SIZE)
 
 /// Macro for generating bit masks using bit index from the spec
-#define SPINEL_BIT_MASK(bit_index, field_bit_count) ((1 << ((field_bit_count)-1)) >> (bit_index))
+#define SPINEL_BIT_MASK(bit_index, field_bit_count) ((1 << ((field_bit_count) - 1)) >> (bit_index))
 
 #define SPINEL_BITS_PER_BYTE 8 // Number of bits in a byte
 
@@ -5028,7 +5028,7 @@ typedef uint32_t spinel_prop_key_t;
 #define SPINEL_HEADER_FLAG 0x80
 #define SPINEL_HEADER_FLAGS_SHIFT 6
 #define SPINEL_HEADER_FLAGS_MASK (3 << SPINEL_HEADER_FLAGS_SHIFT)
-#define SPINEL_HEADER_GET_FLAG(x) (((x)&SPINEL_HEADER_FLAGS_MASK) >> SPINEL_HEADER_FLAGS_SHIFT)
+#define SPINEL_HEADER_GET_FLAG(x) (((x) & SPINEL_HEADER_FLAGS_MASK) >> SPINEL_HEADER_FLAGS_SHIFT)
 
 #define SPINEL_HEADER_TID_SHIFT 0
 #define SPINEL_HEADER_TID_MASK (15 << SPINEL_HEADER_TID_SHIFT)
@@ -5045,8 +5045,8 @@ typedef uint32_t spinel_prop_key_t;
 
 #define SPINEL_HEADER_INVALID_IID 0xFF
 
-#define SPINEL_HEADER_GET_IID(x) (((x)&SPINEL_HEADER_IID_MASK) >> SPINEL_HEADER_IID_SHIFT)
-#define SPINEL_HEADER_GET_TID(x) (spinel_tid_t)(((x)&SPINEL_HEADER_TID_MASK) >> SPINEL_HEADER_TID_SHIFT)
+#define SPINEL_HEADER_GET_IID(x) (((x) & SPINEL_HEADER_IID_MASK) >> SPINEL_HEADER_IID_SHIFT)
+#define SPINEL_HEADER_GET_TID(x) (spinel_tid_t)(((x) & SPINEL_HEADER_TID_MASK) >> SPINEL_HEADER_TID_SHIFT)
 
 #define SPINEL_GET_NEXT_TID(x) (spinel_tid_t)((x) >= 0xF ? 1 : (x) + 1)
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -2578,8 +2578,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_DEBUG_TEST_ASSERT>(vo
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_DEBUG_TEST_WATCHDOG>(void)
 {
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    while (true)
-        ;
+    while (true);
 #endif
 
     OT_UNREACHABLE_CODE(return OT_ERROR_NONE;)

--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -44,10 +44,7 @@ constexpr bool NcpBase::AreHandlerEntriesSorted(const HandlerEntry *aHandlerEntr
 
 NcpBase::PropertyHandler NcpBase::FindGetPropertyHandler(spinel_prop_key_t aKey)
 {
-#define OT_NCP_GET_HANDLER_ENTRY(aPropertyName)                   \
-    {                                                             \
-        aPropertyName, &NcpBase::HandlePropertyGet<aPropertyName> \
-    }
+#define OT_NCP_GET_HANDLER_ENTRY(aPropertyName) {aPropertyName, &NcpBase::HandlePropertyGet<aPropertyName>}
 
     constexpr static HandlerEntry sHandlerEntries[] = {
         OT_NCP_GET_HANDLER_ENTRY(SPINEL_PROP_LAST_STATUS),
@@ -411,10 +408,7 @@ NcpBase::PropertyHandler NcpBase::FindGetPropertyHandler(spinel_prop_key_t aKey)
 
 NcpBase::PropertyHandler NcpBase::FindSetPropertyHandler(spinel_prop_key_t aKey)
 {
-#define OT_NCP_SET_HANDLER_ENTRY(aPropertyName)                   \
-    {                                                             \
-        aPropertyName, &NcpBase::HandlePropertySet<aPropertyName> \
-    }
+#define OT_NCP_SET_HANDLER_ENTRY(aPropertyName) {aPropertyName, &NcpBase::HandlePropertySet<aPropertyName>}
 
     constexpr static HandlerEntry sHandlerEntries[] = {
         OT_NCP_SET_HANDLER_ENTRY(SPINEL_PROP_POWER_STATE),
@@ -713,10 +707,7 @@ NcpBase::PropertyHandler NcpBase::FindSetPropertyHandler(spinel_prop_key_t aKey)
 
 NcpBase::PropertyHandler NcpBase::FindInsertPropertyHandler(spinel_prop_key_t aKey)
 {
-#define OT_NCP_INSERT_HANDLER_ENTRY(aPropertyName)                   \
-    {                                                                \
-        aPropertyName, &NcpBase::HandlePropertyInsert<aPropertyName> \
-    }
+#define OT_NCP_INSERT_HANDLER_ENTRY(aPropertyName) {aPropertyName, &NcpBase::HandlePropertyInsert<aPropertyName>}
 
     constexpr static HandlerEntry sHandlerEntries[] = {
 #if OPENTHREAD_CONFIG_PLATFORM_POWER_CALIBRATION_ENABLE
@@ -769,10 +760,7 @@ NcpBase::PropertyHandler NcpBase::FindInsertPropertyHandler(spinel_prop_key_t aK
 
 NcpBase::PropertyHandler NcpBase::FindRemovePropertyHandler(spinel_prop_key_t aKey)
 {
-#define OT_NCP_REMOVE_HANDLER_ENTRY(aPropertyName)                   \
-    {                                                                \
-        aPropertyName, &NcpBase::HandlePropertyRemove<aPropertyName> \
-    }
+#define OT_NCP_REMOVE_HANDLER_ENTRY(aPropertyName) {aPropertyName, &NcpBase::HandlePropertyRemove<aPropertyName>}
 
     constexpr static HandlerEntry sHandlerEntries[] = {
 #if OPENTHREAD_MTD || OPENTHREAD_FTD

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -58,10 +58,10 @@ extern "C" {
  */
 enum
 {
-    OT_PLATFORM_CONFIG_SPI_DEFAULT_MODE        = 0,       ///< Default SPI Mode: CPOL=0, CPHA=0.
-    OT_PLATFORM_CONFIG_SPI_DEFAULT_SPEED_HZ    = 1000000, ///< Default SPI speed in hertz.
-    OT_PLATFORM_CONFIG_SPI_DEFAULT_CS_DELAY_US = 20,      ///< Default delay after SPI C̅S̅ assertion, in µsec.
-    OT_PLATFORM_CONFIG_SPI_DEFAULT_RESET_DELAY_MS = 0, ///< Default delay after R̅E̅S̅E̅T̅ assertion, in milliseconds.
+    OT_PLATFORM_CONFIG_SPI_DEFAULT_MODE           = 0,       ///< Default SPI Mode: CPOL=0, CPHA=0.
+    OT_PLATFORM_CONFIG_SPI_DEFAULT_SPEED_HZ       = 1000000, ///< Default SPI speed in hertz.
+    OT_PLATFORM_CONFIG_SPI_DEFAULT_CS_DELAY_US    = 20,      ///< Default delay after SPI C̅S̅ assertion, in µsec.
+    OT_PLATFORM_CONFIG_SPI_DEFAULT_RESET_DELAY_MS = 0,       ///< Default delay after R̅E̅S̅E̅T̅ assertion, in milliseconds.
     OT_PLATFORM_CONFIG_SPI_DEFAULT_ALIGN_ALLOWANCE =
         16, ///< Default maximum number of 0xFF bytes to clip from start of MISO frame.
     OT_PLATFORM_CONFIG_SPI_DEFAULT_SMALL_PACKET_SIZE =

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -1476,17 +1476,17 @@ exit:
 #if defined(__APPLE__) || defined(__NetBSD__) || defined(__FreeBSD__)
 
 #if defined(__FreeBSD__)
-#define ROUNDUP(a) ((a) > 0 ? (1 + (((a)-1) | (sizeof(uint32_t) - 1))) : sizeof(uint32_t))
+#define ROUNDUP(a) ((a) > 0 ? (1 + (((a) - 1) | (sizeof(uint32_t) - 1))) : sizeof(uint32_t))
 #endif
 
 #if defined(__APPLE__)
-#define ROUNDUP(a) ((a) > 0 ? (1 + (((a)-1) | (sizeof(uint32_t) - 1))) : sizeof(uint32_t))
+#define ROUNDUP(a) ((a) > 0 ? (1 + (((a) - 1) | (sizeof(uint32_t) - 1))) : sizeof(uint32_t))
 #define DARWIN_SA_SIZE(sa) ROUNDUP(sa->sa_len)
 #define SA_SIZE(sa) DARWIN_SA_SIZE(sa)
 #endif
 
 #if defined(__NetBSD__)
-#define RT_ROUNDUP2(a, n) ((a) > 0 ? (1 + (((a)-1U) | ((n)-1))) : (n))
+#define RT_ROUNDUP2(a, n) ((a) > 0 ? (1 + (((a) - 1U) | ((n) - 1))) : (n))
 #define RT_ROUNDUP(a) RT_ROUNDUP2((a), sizeof(uint64_t))
 #define SA_SIZE(sa) RT_ROUNDUP(sa->sa_len)
 #endif

--- a/src/posix/platform/radio.hpp
+++ b/src/posix/platform/radio.hpp
@@ -144,7 +144,7 @@ private:
 #if OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_ENABLE
     Spinel::VendorRadioSpinel mRadioSpinel;
 #else
-    Spinel::RadioSpinel     mRadioSpinel;
+    Spinel::RadioSpinel mRadioSpinel;
 #endif
 
 #if OPENTHREAD_POSIX_CONFIG_RCP_CAPS_DIAG_ENABLE

--- a/src/posix/platform/radio_url.cpp
+++ b/src/posix/platform/radio_url.cpp
@@ -43,30 +43,30 @@ const char *otSysGetRadioUrlHelpString(void)
     "\n"
 
 #if OPENTHREAD_POSIX_CONFIG_SPINEL_SPI_INTERFACE_ENABLE
-#define OT_SPINEL_SPI_RADIO_URL_HELP_BUS                                                                           \
-    "Protocol=[spinel+spi*]           Specify the Spinel interface as the Spinel SPI interface\n"                  \
-    "    spinel+spi://${PATH_TO_SPI_DEVICE}?${Parameters}\n"                                                       \
-    "Parameters:\n"                                                                                                \
-    "    gpio-int-device[=gpio-device-path]\n"                                                                     \
-    "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"           \
-    "                                  `I̅N̅T̅` pin.\n"                                                         \
-    "    gpio-int-line[=line-offset]\n"                                                                            \
-    "                                  The offset index of `I̅N̅T̅` pin for the associated GPIO device.\n"      \
-    "    gpio-reset-device[=gpio-device-path]\n"                                                                   \
-    "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"           \
-    "                                  `R̅E̅S̅` pin. If not specified, the process will direct exist when an\n" \
-    "                                  RCP reset is required.\n"                                                   \
-    "    gpio-reset-line[=line-offset]\n"                                                                          \
-    "                                  The offset index of `R̅E̅S̅` pin for the associated GPIO device. This\n" \
-    "                                  is required if `gpio-reset-device` is specified.\n"                         \
-    "    spi-mode[=mode]               Specify the SPI mode to use (0-3).\n"                                       \
-    "    spi-speed[=hertz]             Specify the SPI speed in hertz.\n"                                          \
-    "    spi-cs-delay[=usec]           Specify the delay after C̅S̅ assertion, in µsec.\n"                      \
-    "    spi-reset-delay[=ms]          Specify the delay after R̅E̅S̅E̅T̅ assertion, in milliseconds.\n"      \
-    "    spi-align-allowance[=n]       Specify the maximum number of 0xFF bytes to clip from start of\n"           \
-    "                                  MISO frame. Max value is 16.\n"                                             \
-    "    spi-small-packet=[n]          Specify the smallest packet we can receive in a single transaction.\n"      \
-    "                                  (larger packets will require two transactions). Default value is 32.\n"     \
+#define OT_SPINEL_SPI_RADIO_URL_HELP_BUS                                                                       \
+    "Protocol=[spinel+spi*]           Specify the Spinel interface as the Spinel SPI interface\n"              \
+    "    spinel+spi://${PATH_TO_SPI_DEVICE}?${Parameters}\n"                                                   \
+    "Parameters:\n"                                                                                            \
+    "    gpio-int-device[=gpio-device-path]\n"                                                                 \
+    "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"       \
+    "                                  `I̅N̅T̅` pin.\n"                                                           \
+    "    gpio-int-line[=line-offset]\n"                                                                        \
+    "                                  The offset index of `I̅N̅T̅` pin for the associated GPIO device.\n"        \
+    "    gpio-reset-device[=gpio-device-path]\n"                                                               \
+    "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"       \
+    "                                  `R̅E̅S̅` pin. If not specified, the process will direct exist when an\n"   \
+    "                                  RCP reset is required.\n"                                               \
+    "    gpio-reset-line[=line-offset]\n"                                                                      \
+    "                                  The offset index of `R̅E̅S̅` pin for the associated GPIO device. This\n"   \
+    "                                  is required if `gpio-reset-device` is specified.\n"                     \
+    "    spi-mode[=mode]               Specify the SPI mode to use (0-3).\n"                                   \
+    "    spi-speed[=hertz]             Specify the SPI speed in hertz.\n"                                      \
+    "    spi-cs-delay[=usec]           Specify the delay after C̅S̅ assertion, in µsec.\n"                       \
+    "    spi-reset-delay[=ms]          Specify the delay after R̅E̅S̅E̅T̅ assertion, in milliseconds.\n"            \
+    "    spi-align-allowance[=n]       Specify the maximum number of 0xFF bytes to clip from start of\n"       \
+    "                                  MISO frame. Max value is 16.\n"                                         \
+    "    spi-small-packet=[n]          Specify the smallest packet we can receive in a single transaction.\n"  \
+    "                                  (larger packets will require two transactions). Default value is 32.\n" \
     "\n"
 #else
 #define OT_SPINEL_SPI_RADIO_URL_HELP_BUS

--- a/src/posix/platform/rcp_caps_diag.cpp
+++ b/src/posix/platform/rcp_caps_diag.cpp
@@ -34,10 +34,8 @@
 namespace ot {
 namespace Posix {
 
-#define SPINEL_ENTRY(aCategory, aCommand, aKey)                                      \
-    {                                                                                \
-        aCategory, aCommand, aKey, &RcpCapsDiag::HandleSpinelCommand<aCommand, aKey> \
-    }
+#define SPINEL_ENTRY(aCategory, aCommand, aKey) \
+    {aCategory, aCommand, aKey, &RcpCapsDiag::HandleSpinelCommand<aCommand, aKey>}
 
 template <> otError RcpCapsDiag::HandleSpinelCommand<SPINEL_CMD_PROP_VALUE_GET, SPINEL_PROP_CAPS>(void)
 {

--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -325,8 +325,7 @@ uint8_t *SpiInterface::GetRealRxFrameStart(uint8_t *aSpiRxFrameBuffer, uint8_t a
     uint8_t       *start = aSpiRxFrameBuffer;
     const uint8_t *end   = aSpiRxFrameBuffer + aAlignAllowance;
 
-    for (; start != end && ((start[0] == 0xff) || (start[0] == 0x00)); start++)
-        ;
+    for (; start != end && ((start[0] == 0xff) || (start[0] == 0x00)); start++);
 
     aSkipLength = static_cast<uint16_t>(start - aSpiRxFrameBuffer);
 


### PR DESCRIPTION
This PR updates the clang-format version from 16 to 19.

We just updated the version from 14 to 16. But very unfortunately clang-format-16 was just deprecated recently. So this time we update the version to the latest available one. There are newer releases than 19 (like 20) but as I tested, sudo apt-get install -y clang-format-19 can work while 20 doesn't work.

`misc-include-cleaner` in clang-tidy-19 exerts a very strict check which requires to directly include all headers for every symbols in the source file. For example:
```
/home/runner/work/openthread/openthread/src/core/utils/channel_manager.cpp:68:43: error: no header providing "uint8_t" is directly included [misc-include-cleaner,-warnings-as-errors]
   35 | void ChannelManager::RequestChannelChange(uint8_t aChannel)
      |                                           ^
/home/runner/work/openthread/openthread/src/core/utils/channel_manager.cpp:90:9: error: no header providing "LogInfo" is directly included [misc-include-cleaner,-warnings-as-errors]
   90 |         LogInfo("Already operating on the requested channel %d", aChannel);
      |         ^
/home/runner/work/openthread/openthread/src/core/utils/channel_manager.cpp:91:9: error: no header providing "ExitNow" is directly included [misc-include-cleaner,-warnings-as-errors]
   91 |         ExitNow();
      |         ^
/home/runner/work/openthread/openthread/src/core/utils/channel_manager.cpp:97:9: error: no header providing "VerifyOrExit" is directly included [misc-include-cleaner,-warnings-as-errors]
   97 |         VerifyOrExit(mChannel != aChannel);
```
However in our current code we intentionally use some indirect include. So this PR disables `misc-include-cleaner`.