### PR TITLE
[trel] fix compilation issue when `otPlatTrelNotifyPeerSocketAddressDifference` is undefined

### DIFF
--- a/src/core/radio/trel_peer_discoverer.cpp
+++ b/src/core/radio/trel_peer_discoverer.cpp
@@ -106,7 +106,12 @@ exit:
 void PeerDiscoverer::NotifyPeerSocketAddressDifference(const Ip6::SockAddr &aPeerSockAddr,
                                                        const Ip6::SockAddr &aRxSockAddr)
 {
+#if OPENTHREAD_CONFIG_TREL_MANAGE_DNSSD_ENABLE
+    OT_UNUSED_VARIABLE(aPeerSockAddr);
+    OT_UNUSED_VARIABLE(aRxSockAddr);
+#else
     otPlatTrelNotifyPeerSocketAddressDifference(&GetInstance(), &aPeerSockAddr, &aRxSockAddr);
+#endif
 }
 
 void PeerDiscoverer::PostServiceTask(void)


### PR DESCRIPTION
When using `OPENTHREAD_CONFIG_TREL_MANAGE_DNSSD_ENABLE` the TREL peer discovery platform code is not needed anymore.
Added `otPlatTrelNotifyPeerSocketAddressDifference` under the same logic as the rest of the TREL platform API that is not used when `OPENTHREAD_CONFIG_TREL_MANAGE_DNSSD_ENABLE` is true.