### PR TITLE
[mac] correctly find payload index for command frames

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1078,7 +1078,7 @@ uint8_t Frame::FindPayloadIndex(void) const
     }
 #endif // OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
 
-    if (!IsVersion2015() && (GetFrameControlField() & kFcfFrameTypeMask) == kTypeMacCmd)
+    if ((GetFrameControlField() & kFcfFrameTypeMask) == kTypeMacCmd)
     {
         index += kCommandIdSize;
     }


### PR DESCRIPTION
The `FindPayloadIndex()` method incorrectly skipped accounting for the Command ID field for MAC command frames when the frame version was
2015. The Command ID field is always present in Thread MAC command frames, regardless of the version.

This change removes the incorrect version check, ensuring the payload index is calculated correctly for all MAC command frames. This allows `ValidatePsdu()` to properly detect and reject invalid frames, such as a command frame missing its Command ID.