### PR TITLE
[otci] fix parsing of dns_resolve4 and csl get/set methods

### DIFF
--- a/tools/otci/tests/test_otci.py
+++ b/tools/otci/tests/test_otci.py
@@ -334,7 +334,7 @@ class TestOTCI(unittest.TestCase):
             leader.udp_bind("::", 1234, netif=netif)
             leader.udp_send(leader.get_ipaddr_rloc(), 1234, text='hello')
             leader.udp_send(leader.get_ipaddr_rloc(), 1234, random_bytes=3)
-            leader.udp_send(leader.get_ipaddr_rloc(), 1234, hex='112233')
+            leader.udp_send(leader.get_ipaddr_rloc(), 1234, hex_str='112233')
             leader.wait(1)
             leader.udp_close()
 


### PR DESCRIPTION
fix parsing of

* `dns_resolve4`: returns a synthesized ipv6 address, but parsing expected an ipv4 address

fix csl methods

* add support for getting csl uncertainty/accuracy
* add support for setting the csl channel
* remove the command for getting the csl period which is not supported by the cli
* 
renames variables/arguments that had a python builtin name