### PR TITLE
[mac] increase fuzz buffer size to support TREL

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1572,8 +1572,12 @@ Error RxFrame::ProcessReceiveAesCcm(const ExtAddress &aExtAddress, const KeyMate
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     aesCcm.Payload(GetPayload(), GetPayload(), GetPayloadLength(), Crypto::AesCcm::kDecrypt);
 #else
-    // For fuzz tests, execute AES but do not alter the payload
-    uint8_t fuzz[OT_RADIO_FRAME_MAX_SIZE];
+    // For fuzz tests, execute AES but do not alter the payload. A large
+    // temporary buffer (kFuzzMaxFrameSize = 1280 bytes) is used to
+    // account for TREL frames.
+    uint8_t fuzz[kFuzzMaxFrameSize];
+
+    OT_ASSERT(GetPayloadLength() <= sizeof(fuzz));
     aesCcm.Payload(fuzz, GetPayload(), GetPayloadLength(), Crypto::AesCcm::kDecrypt);
 #endif
     aesCcm.Finalize(tag);

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -1016,6 +1016,9 @@ public:
      */
     uint8_t ReadTimeSyncSeq(void) const { return GetTimeIe()->GetSequence(); }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+
+private:
+    static constexpr uint16_t kFuzzMaxFrameSize = 1280; // 1280 bytes to account for TREL frame size.
 };
 
 /**


### PR DESCRIPTION
The temporary buffer used in `RxFrame::ProcessReceiveAesCcm` under fuzzing build is increased to 1280 bytes. This change allows for fuzzing of larger TREL frames. A new constant `kFuzzMaxFrameSize` is introduced for this purpose.

---

Should help address https://github.com/openthread/openthread/actions/runs/16793265631/job/47558860017.