### PR TITLE
(UNDER WORK) [mle] improve address solicit logging

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -2232,6 +2232,16 @@ private:
                                              otMessage           *aMessage,
                                              const otMessageInfo *aMessageInfo,
                                              otError              aResult);
+
+    static const char *RouterUpgradeReasonToString(uint8_t aReason);
+    static const char *AddrSolicitResponseToString(uint8_t aStatus);
+
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
+    static void LogAddrSolicit(MessageAction aAction, const Ip6::Address &aPeerAddr, uint8_t aReason, uint16_t aRloc16);
+#else
+    static void LogAddrSolicit(MessageAction, const Ip6::Address &, uint8_t, uint16_t);
+#endif
+
 #endif // OPENTHREAD_FTD
 
     //------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This change enhances the logging for the MLE Address Solicit process to provide more detailed and human-readable information.

A new private helper function `LogAddrSolicit()` is introduced to centralize and improve the logging for both sending and receiving Address Solicit messages. This new log includes the solicit reason and the requested RLOC16.

To make logs easier to interpret, two new helper functions are added:
- `RouterUpgradeReasonToString()`
- `AddrSolicitResponseToString()`

These functions convert numeric reason and status codes into descriptive strings.

Additionally, the log message for sending an Address Solicit Response is updated to include the status and the assigned RLOC16, replacing a more generic log.