### PR TITLE
[crypto] allow null buffer in `AesCcm::Payload()`

### DIFF
--- a/src/core/crypto/aes_ccm.cpp
+++ b/src/core/crypto/aes_ccm.cpp
@@ -214,13 +214,21 @@ void AesCcm::Payload(void *aPlainText, void *aCipherText, uint32_t aLength, Mode
 
         if (aMode == kEncrypt)
         {
-            byte               = plaintextBytes[i];
-            ciphertextBytes[i] = byte ^ mCtrPad[mCtrLength++];
+            byte = plaintextBytes[i];
+
+            if (ciphertextBytes != nullptr)
+            {
+                ciphertextBytes[i] = byte ^ mCtrPad[mCtrLength++];
+            }
         }
         else
         {
-            byte              = ciphertextBytes[i] ^ mCtrPad[mCtrLength++];
-            plaintextBytes[i] = byte;
+            byte = ciphertextBytes[i] ^ mCtrPad[mCtrLength++];
+
+            if (plaintextBytes != nullptr)
+            {
+                plaintextBytes[i] = byte;
+            }
         }
 
         if (mBlockLength == sizeof(mBlock))

--- a/src/core/crypto/aes_ccm.hpp
+++ b/src/core/crypto/aes_ccm.hpp
@@ -136,6 +136,9 @@ public:
     /**
      * Processes the payload.
      *
+     * When decrypting (`kDecrypt`), @p aPlainText can be `nullptr` if the decrypted plaintext is not needed.
+     * Similarly, when encrypting (`kEncrypt`), @p aCipherText can be `nullptr` if the ciphertext is not needed.
+     *
      * @param[in,out]  aPlainText   A pointer to the plaintext.
      * @param[in,out]  aCipherText  A pointer to the ciphertext.
      * @param[in]      aLength      Payload length in bytes.

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1573,12 +1573,7 @@ Error RxFrame::ProcessReceiveAesCcm(const ExtAddress &aExtAddress, const KeyMate
     aesCcm.Payload(GetPayload(), GetPayload(), GetPayloadLength(), Crypto::AesCcm::kDecrypt);
 #else
     // For fuzz tests, execute AES but do not alter the payload. A large
-    // temporary buffer (kFuzzMaxFrameSize = 1280 bytes) is used to
-    // account for TREL frames.
-    uint8_t fuzz[kFuzzMaxFrameSize];
-
-    OT_ASSERT(GetPayloadLength() <= sizeof(fuzz));
-    aesCcm.Payload(fuzz, GetPayload(), GetPayloadLength(), Crypto::AesCcm::kDecrypt);
+    aesCcm.Payload(nullptr, GetPayload(), GetPayloadLength(), Crypto::AesCcm::kDecrypt);
 #endif
     aesCcm.Finalize(tag);
 

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -1016,9 +1016,6 @@ public:
      */
     uint8_t ReadTimeSyncSeq(void) const { return GetTimeIe()->GetSequence(); }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-
-private:
-    static constexpr uint16_t kFuzzMaxFrameSize = 1280; // 1280 bytes to account for TREL frame size.
 };
 
 /**


### PR DESCRIPTION
This commit updates `AesCcm::Payload()` to support a `nullptr` for the output buffer. When decrypting, the `aPlainText` can be null, and when encrypting, `aCipherText` can be null.

This change is useful when the caller only needs the authentication tag and does not require the actual decrypted or encrypted payload, thus avoiding the need to provide a temporary output buffer.

This is leveraged to simplify the MAC frame processing under fuzzing build (`OPENTHREAD_FUZZ_FUZZER_BUILD`), removing a large stack-allocated buffer (`kFuzzMaxFrameSize`).