### PR TITLE
[mle] use `PrevRoleRestorer` for child update challenge

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1755,10 +1755,8 @@ private:
         bool  IsRestoringRouterOrLeaderRole(void) const { return mState == kRestoringRouterOrLeaderRole; }
         void  HandleTimer(void);
 
-#if OPENTHREAD_FTD
         void               GenerateRandomChallenge(void) { mChallenge.GenerateRandom(); }
         const TxChallenge &GetChallenge(void) const { return mChallenge; }
-#endif
 
     private:
         static constexpr uint32_t kMaxStartDelay                = 25;
@@ -1782,12 +1780,10 @@ private:
 
         using DelayTimer = TimerMilliIn<Mle, &Mle::HandleRoleRestorerTimer>;
 
-        State      mState;
-        uint8_t    mAttempts;
-        DelayTimer mTimer;
-#if OPENTHREAD_FTD
+        State       mState;
+        uint8_t     mAttempts;
+        DelayTimer  mTimer;
         TxChallenge mChallenge;
-#endif
     };
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This commit updates the challenge/response mechanism used when a detached device sends a "Child Update Request" to restore its role as a child.

Previously, this process shared the `mParentRequestChallenge` with the parent search mechanism. This logic is now consolidated within the `PrevRoleRestorer` class, which now manages the generation and tracking of the `TxChallenge` used in "Child Update Request".

This change simplifies the `Mle` class design and makes the child role restoration logic separate from the parent search and attach process. This separation allows for future enhancements where a device may run both mechanisms in parallel.