### PR TITLE
[mle] ignore parent and child-update requests on parent when detaching

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1805,6 +1805,7 @@ private:
         void  HandleTimer(void);
         Error HandleChildUpdateResponse(uint32_t aTimeout);
         void  HandleStop(void);
+        bool  IsDetaching(void) const { return mState == kDetaching; }
 
     private:
         static constexpr uint32_t kTimeout = 1000;

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -1404,6 +1404,8 @@ void Mle::HandleParentRequest(RxInfo &aRxInfo)
     VerifyOrExit(IsRouterEligible());
     VerifyOrExit(!IsDetached() && !IsAttaching());
 
+    VerifyOrExit(!mDetacher.IsDetaching());
+
     VerifyOrExit(mRouterTable.GetLeaderAge() < mNetworkIdTimeout, error = kErrorDrop);
     VerifyOrExit(mRouterTable.GetPathCostToLeader() < kMaxRouteCost, error = kErrorDrop);
 
@@ -2204,6 +2206,8 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
     bool            childDidChange = false;
 
     Log(kMessageReceive, kTypeChildUpdateRequestOfChild, aRxInfo.mMessageInfo.GetPeerAddr());
+
+    VerifyOrExit(!mDetacher.IsDetaching());
 
     SuccessOrExit(error = aRxInfo.mMessage.ReadModeTlv(mode));
 


### PR DESCRIPTION
This change ensures that a parent device in the process of detaching from the network ignores incoming "Parent Request" and "Child Update Request" messages.

A new `Detacher::IsDetaching()` method is added to check for this state. This prevents potential inefficiencies that could arise if these requests were responded during the detachment procedure.