### PR TITLE
[netdata] use `Mle` constants in `RemoveTemporaryData()` methods

### DIFF
--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -650,17 +650,16 @@ bool MutableNetworkData::RemoveTemporaryDataIn(PrefixTlv &aPrefix)
                 BorderRouterTlv *borderRouter = As<BorderRouterTlv>(cur);
                 ContextTlv      *context      = aPrefix.FindSubTlv<ContextTlv>();
 
-                // Replace p_border_router_16
                 for (BorderRouterEntry *entry = borderRouter->GetFirstEntry(); entry <= borderRouter->GetLastEntry();
                      entry                    = entry->GetNext())
                 {
                     if ((entry->IsDhcp() || entry->IsConfigure()) && (context != nullptr))
                     {
-                        entry->SetRloc(0xfc00 | context->GetContextId());
+                        entry->SetRloc(Mle::kAloc16DhcpAgentStart + context->GetContextId() - 1);
                     }
                     else
                     {
-                        entry->SetRloc(0xfffe);
+                        entry->SetRloc(Mle::kInvalidRloc16);
                     }
                 }
 
@@ -671,11 +670,10 @@ bool MutableNetworkData::RemoveTemporaryDataIn(PrefixTlv &aPrefix)
             {
                 HasRouteTlv *hasRoute = As<HasRouteTlv>(cur);
 
-                // Replace r_border_router_16
                 for (HasRouteEntry *entry = hasRoute->GetFirstEntry(); entry <= hasRoute->GetLastEntry();
                      entry                = entry->GetNext())
                 {
-                    entry->SetRloc(0xfffe);
+                    entry->SetRloc(Mle::kInvalidRloc16);
                 }
 
                 break;
@@ -685,13 +683,12 @@ bool MutableNetworkData::RemoveTemporaryDataIn(PrefixTlv &aPrefix)
                 break;
             }
 
-            // keep stable tlv
             cur = cur->GetNext();
         }
         else
         {
-            // remove temporary tlv
             uint8_t subTlvSize = cur->GetSize();
+
             RemoveTlv(cur);
             aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - subTlvSize);
         }
@@ -718,13 +715,12 @@ bool MutableNetworkData::RemoveTemporaryDataIn(ServiceTlv &aService)
                 break;
             }
 
-            // keep stable tlv
             cur = cur->GetNext();
         }
         else
         {
-            // remove temporary tlv
             uint8_t subTlvSize = cur->GetSize();
+
             RemoveTlv(cur);
             aService.SetSubTlvsLength(aService.GetSubTlvsLength() - subTlvSize);
         }


### PR DESCRIPTION
This commit replaces hardcoded magic numbers for RLOC addresses with their corresponding named constants from the `Mle` namespace.

- The DHCP Agent RLOC is now set using `Mle::kAloc16DhcpAgentStart`.
- The invalid RLOC address `0xfffe` is replaced by `Mle::kInvalidRloc16`.

This change improves code readability and maintainability. Redundant comments were also removed.