### PR TITLE
[mle] add methods for leader and partition ID selection

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -2129,6 +2129,8 @@ private:
 #if OPENTHREAD_FTD
     void     SetAlternateRloc16(uint16_t aRloc16);
     void     ClearAlternateRloc16(void);
+    uint8_t  SelectLeaderId(void) const;
+    uint32_t SelectPartitionId(void) const;
     void     HandleDetachStart(void);
     void     HandleChildStart(AttachMode aMode);
     void     HandleSecurityPolicyChanged(void);


### PR DESCRIPTION
This commit extracts the logic for selecting a leader ID and a partition ID out of the `BecomeLeader()` method into two new private helper methods: `SelectLeaderId()` and `SelectPartitionId()`.

This is a pure refactoring that does not alter behavior. It improves the readability and maintainability of the `BecomeLeader()` method by simplifying its implementation.