### PR TITLE
[netdiag] ignore duplicate TLVs in Diag Get request

### DIFF
--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -329,8 +329,11 @@ Error Server::AppendMacCounters(Message &aMessage)
 
 Error Server::AppendRequestedTlvs(const Message &aRequest, Message &aResponse)
 {
-    Error       error;
-    OffsetRange offsetRange;
+    Error         error;
+    OffsetRange   offsetRange;
+    TlvTypeBitSet processedTlvs;
+
+    processedTlvs.Clear();
 
     SuccessOrExit(error = Tlv::FindTlvValueOffsetRange(aRequest, Tlv::kTypeList, offsetRange));
 
@@ -340,6 +343,14 @@ Error Server::AppendRequestedTlvs(const Message &aRequest, Message &aResponse)
 
         SuccessOrExit(error = aRequest.Read(offsetRange, tlvType));
         offsetRange.AdvanceOffset(sizeof(tlvType));
+
+        if (processedTlvs.Has(tlvType))
+        {
+            continue;
+        }
+
+        processedTlvs.Add(tlvType);
+
         SuccessOrExit(error = AppendDiagTlv(tlvType, aResponse));
     }
 
@@ -350,7 +361,10 @@ exit:
 #if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
 Error Server::AppendRequestedTlvsForTcat(const Message &aRequest, Message &aResponse, OffsetRange &aOffsetRange)
 {
-    Error error = kErrorNone;
+    Error         error = kErrorNone;
+    TlvTypeBitSet processedTlvs;
+
+    processedTlvs.Clear();
 
     while (!aOffsetRange.IsEmpty())
     {
@@ -358,6 +372,13 @@ Error Server::AppendRequestedTlvsForTcat(const Message &aRequest, Message &aResp
 
         SuccessOrExit(error = aRequest.Read(aOffsetRange, tlvType));
         aOffsetRange.AdvanceOffset(sizeof(uint8_t));
+
+        if (processedTlvs.Has(tlvType))
+        {
+            continue;
+        }
+
+        processedTlvs.Add(tlvType);
 
 #if OPENTHREAD_FTD
         switch (tlvType)

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -38,9 +38,11 @@
 
 #include <openthread/netdiag.h>
 
+#include "common/bit_set.hpp"
 #include "common/callback.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
+#include "common/numeric_limits.hpp"
 #include "net/udp6.hpp"
 #include "thread/network_diagnostic_tlvs.hpp"
 #include "thread/tmf.hpp"
@@ -195,6 +197,8 @@ public:
 private:
     static constexpr uint16_t kMaxChildEntries              = 398;
     static constexpr uint16_t kAnswerMessageLengthThreshold = 800;
+
+    typedef BitSet<NumericLimits<uint8_t>::kMax + 1> TlvTypeBitSet; // A bitset to store TLV types.
 
 #if OPENTHREAD_FTD
     struct AnswerInfo


### PR DESCRIPTION
This commit ensures that the Network Diagnostic server correctly handles duplicate TLV types within a "Diagnostic Get" request.

Previously, if the `TypeList` TLV in a request contained duplicate type entries, the server would process each one, leading to redundant diagnostic TLVs being appended to the response message.

This is now fixed by using a `BitSet` to track the TLV types that have already been processed from the request. If a duplicate type is encountered, it is skipped, ensuring that each requested diagnostic TLV is added to the response only once. This logic is applied to both the standard and TCAT-specific request handling paths.