### PR TITLE
[netdata] enhance `FindContext()` methods and `Lowpan::Context`

### DIFF
--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -167,7 +167,7 @@ private:
     void  UpdateService(void);
     void  Start(void);
     void  Stop(void);
-    void  AddPrefixAgent(const Ip6::Prefix &aIp6Prefix, const Lowpan::Context &aContext);
+    void  AddPrefixAgent(const Ip6::Prefix &aIp6Prefix, uint8_t aContextId);
     Error AppendHeader(Message &aMessage, const TransactionId &aTransactionId);
     Error AppendClientIdOption(Message &aMessage, const Mac::ExtAddress &aClientAddress);
     Error AppendServerIdOption(Message &aMessage);

--- a/src/core/net/nd_agent.cpp
+++ b/src/core/net/nd_agent.cpp
@@ -50,7 +50,6 @@ void Agent::HandleNotifierEvents(Events aEvents)
 
 void Agent::UpdateService(void)
 {
-    Error                           error;
     uint16_t                        rloc16 = Get<Mle::Mle>().GetRloc16();
     NetworkData::Iterator           iterator;
     NetworkData::OnMeshPrefixConfig prefixConfig;
@@ -70,15 +69,13 @@ void Agent::UpdateService(void)
                 continue;
             }
 
-            error = Get<NetworkData::Leader>().GetContext(AsCoreType(&prefixConfig.mPrefix.mPrefix), lowpanContext);
+            Get<NetworkData::Leader>().FindContextForAddress(AsCoreType(&prefixConfig.mPrefix.mPrefix), lowpanContext);
 
-            if ((error != kErrorNone) || (lowpanContext.mContextId != contextId))
+            if (lowpanContext.MatchesContextId(contextId))
             {
-                continue;
+                found = true;
+                break;
             }
-
-            found = true;
-            break;
         }
 
         if (!found)
@@ -99,11 +96,11 @@ void Agent::UpdateService(void)
             continue;
         }
 
-        error = Get<NetworkData::Leader>().GetContext(AsCoreType(&prefixConfig.mPrefix.mPrefix), lowpanContext);
+        Get<NetworkData::Leader>().FindContextForAddress(AsCoreType(&prefixConfig.mPrefix.mPrefix), lowpanContext);
 
-        if (error == kErrorNone)
+        if (lowpanContext.IsValid())
         {
-            uint16_t aloc16 = Mle::Aloc16::FromNdAgentContextId(lowpanContext.mContextId);
+            uint16_t aloc16 = Mle::Aloc16::FromNdAgentContextId(lowpanContext.GetContextId());
 
             mAloc.InitAsThreadOrigin();
             mAloc.GetAddress().SetToAnycastLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aloc16);

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -294,12 +294,13 @@ void DuaManager::HandleNotifierEvents(Events aEvents)
     Mle::Mle &mle = Get<Mle::Mle>();
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
-    if (aEvents.Contains(kEventThreadNetdataChanged))
+    if (aEvents.Contains(kEventThreadNetdataChanged) && Get<ThreadNetif>().HasUnicastAddress(GetDomainUnicastAddress()))
     {
         Lowpan::Context context;
-        // Remove a stale DUA address if any.
-        if (Get<ThreadNetif>().HasUnicastAddress(Get<DuaManager>().GetDomainUnicastAddress()) &&
-            (Get<NetworkData::Leader>().GetContext(Get<DuaManager>().GetDomainUnicastAddress(), context) != kErrorNone))
+
+        Get<NetworkData::Leader>().FindContextForAddress(GetDomainUnicastAddress(), context);
+
+        if (!context.IsValid())
         {
             RemoveDomainUnicastAddress();
         }

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -47,8 +47,13 @@
 #include "net/ip6.hpp"
 #include "net/ip6_address.hpp"
 #include "net/ip6_types.hpp"
+#include "thread/network_data_tlvs.hpp"
 
 namespace ot {
+
+namespace NetworkData {
+class Leader;
+}
 
 /**
  * @addtogroup core-6lowpan
@@ -68,14 +73,63 @@ namespace ot {
 namespace Lowpan {
 
 /**
- * Represents a LOWPAN_IPHC Context.
+ * Represents a 6LoWPAN IPHC Context.
  */
-struct Context : public Clearable<Context>
+class Context : public Clearable<Context>
 {
-    Ip6::Prefix mPrefix;       ///< The Prefix
-    uint8_t     mContextId;    ///< The Context ID.
-    bool        mCompressFlag; ///< The Context compression flag.
-    bool        mIsValid;      ///< Indicates whether the context is valid.
+    friend class ot::NetworkData::Leader;
+
+public:
+    /**
+     * Indicates whether the context entry is valid.
+     *
+     * @retval TRUE   The context is valid and can be used.
+     * @retval FALSE  The context is not valid.
+     */
+    bool IsValid(void) const { return mIsValid; }
+
+    /**
+     * Gets the IPv6 prefix associated with this context.
+     *
+     * @returns The IPv6 prefix.
+     */
+    const Ip6::Prefix &GetPrefix(void) const { return mPrefix; }
+
+    /**
+     * Gets the Context ID.
+     *
+     * @returns The Context ID.
+     */
+    uint8_t GetContextId(void) const { return mContextId; }
+
+    /**
+     * Gets the context compression flag.
+     *
+     * This flag indicates whether this context can be used for 6LoWPAN IPHC compression.
+     *
+     * @retval TRUE   Context compression is enabled.
+     * @retval FALSE  Context compression is disabled.
+     */
+    bool GetCompressFlag(void) const { return mCompressFlag; }
+
+    /**
+     * Checks whether this context is valid and matches a given Context ID.
+     *
+     * @param[in] aContextId  The Context ID to match.
+     *
+     * @retval TRUE   This context is valid and its ID matches @p aContextId.
+     * @retval FALSE  This context is not valid or its ID does not match.
+     */
+    bool MatchesContextId(uint8_t aContextId) const { return mIsValid && (mContextId == aContextId); }
+
+private:
+    void InitForMeshLocalPrefix(Instance &aInstance);
+    void InitFrom(const NetworkData::PrefixTlv &aPrefixTlv, const NetworkData::ContextTlv &aContextTlv);
+
+    Ip6::Prefix mPrefix;
+    uint8_t     mContextId;
+    bool        mCompressFlag : 1;
+    bool        mIsValid : 1;
 };
 
 /**

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -4660,9 +4660,11 @@ Error Mle::TxMessage::AppendAddressRegistrationEntry(const Ip6::Address &aAddres
     {
         Lowpan::Context context;
 
-        if ((Get<NetworkData::Leader>().GetContext(aAddress, context) == kErrorNone) && context.mCompressFlag)
+        Get<NetworkData::Leader>().FindContextForAddress(aAddress, context);
+
+        if (context.IsValid() && context.GetCompressFlag())
         {
-            ctlByte = AddressRegistrationTlv::ControlByteFor(context.mContextId);
+            ctlByte = AddressRegistrationTlv::ControlByteFor(context.GetContextId());
         }
     }
 

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -1910,14 +1910,16 @@ Error Mle::ProcessAddressRegistrationTlv(RxInfo &aRxInfo, Child &aChild)
             IgnoreError(aRxInfo.mMessage.Read(offsetRange, address.GetIid()));
             offsetRange.AdvanceOffset(sizeof(Ip6::InterfaceIdentifier));
 
-            if (Get<NetworkData::Leader>().GetContext(contextId, context) != kErrorNone)
+            Get<NetworkData::Leader>().FindContextForId(contextId, context);
+
+            if (!context.IsValid())
             {
                 LogWarn("Failed to get context %u for compressed address from child 0x%04x", contextId,
                         aChild.GetRloc16());
                 continue;
             }
 
-            address.SetPrefix(context.mPrefix);
+            address.SetPrefix(context.GetPrefix());
         }
         else
         {

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -107,26 +107,28 @@ public:
     uint8_t GetVersion(Type aType) const { return (aType == kFullSet) ? mVersion : mStableVersion; }
 
     /**
-     * Retrieves the 6LoWPAN Context information based on a given IPv6 address.
+     * Retrieves the 6LoWPAN Context information for a given IPv6 address.
      *
-     * @param[in]   aAddress  A reference to an IPv6 address.
-     * @param[out]  aContext  A reference to 6LoWPAN Context information.
+     * If there multiple matching prefixes in the Network Data, the longest one is used.
      *
-     * @retval kErrorNone       Successfully retrieved 6LoWPAN Context information.
-     * @retval kErrorNotFound   Could not find the 6LoWPAN Context information.
+     * If no matching context is found, the @p aContext structure is marked as invalid (i.e., `aContext.mIsValid` will
+     * be false).
+     *
+     * @param[in]   aAddress  The IPv6 address.
+     * @param[out]  aContext  A 6LoWPAN Context information to output the information.
      */
-    Error GetContext(const Ip6::Address &aAddress, Lowpan::Context &aContext) const;
+    void FindContextForAddress(const Ip6::Address &aAddress, Lowpan::Context &aContext) const;
 
     /**
      * Retrieves the 6LoWPAN Context information based on a given Context ID.
      *
-     * @param[in]   aContextId  The Context ID value.
-     * @param[out]  aContext    A reference to the 6LoWPAN Context information.
+     * If no context matching @p aContextId is found, the @p aContext structure is marked as invalid (i.e.,
+     * `aContext.mIsValid` will be false).
      *
-     * @retval kErrorNone       Successfully retrieved 6LoWPAN Context information.
-     * @retval kErrorNotFound   Could not find the 6LoWPAN Context information.
+     * @param[in]   aContextId  The Context ID.
+     * @param[out]  aContext    A `Lowpan::Context` structure to output the information.
      */
-    Error GetContext(uint8_t aContextId, Lowpan::Context &aContext) const;
+    void FindContextForId(uint8_t aContextId, Lowpan::Context &aContext) const;
 
     /**
      * Indicates whether or not the given IPv6 address is on-mesh.
@@ -447,7 +449,6 @@ private:
     Error DefaultRouteLookup(const PrefixTlv &aPrefix, uint16_t &aRloc16) const;
     Error LookupRouteIn(const PrefixTlv &aPrefixTlv, EntryChecker aEntryChecker, uint16_t &aRloc16) const;
     Error SteeringDataCheck(const FilterIndexes &aFilterIndexes) const;
-    void  GetContextForMeshLocalPrefix(Lowpan::Context &aContext) const;
     Error ReadCommissioningDataUint16SubTlv(MeshCoP::Tlv::Type aType, uint16_t &aValue) const;
     void  SignalNetDataChanged(void);
     const CommissioningDataTlv *FindCommissioningData(void) const;

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -365,14 +365,14 @@ bool Slaac::UpdateContextIdFor(SlaacAddress &aSlaacAddress)
 {
     bool            didChange = false;
     Lowpan::Context context;
+    uint8_t         contextId;
 
-    if (Get<NetworkData::Leader>().GetContext(aSlaacAddress.GetAddress(), context) != kErrorNone)
-    {
-        context.mContextId = SlaacAddress::kInvalidContextId;
-    }
+    Get<NetworkData::Leader>().FindContextForAddress(aSlaacAddress.GetAddress(), context);
 
-    VerifyOrExit(context.mContextId != aSlaacAddress.GetContextId());
-    aSlaacAddress.SetContextId(context.mContextId);
+    contextId = context.IsValid() ? context.GetContextId() : SlaacAddress::kInvalidContextId;
+
+    VerifyOrExit(contextId != aSlaacAddress.GetContextId());
+    aSlaacAddress.SetContextId(contextId);
     didChange = true;
 
 exit:

--- a/tests/unit/test_lowpan.hpp
+++ b/tests/unit/test_lowpan.hpp
@@ -40,18 +40,14 @@
 
 namespace ot {
 
-class TestIphcVector
+class TestIphcVector : public Clearable<TestIphcVector>
 {
 public:
-    enum
-    {
-        kContextUnused    = 255,
-        kPayloadMaxLength = 512
-    };
-
     struct Payload
     {
-        uint8_t  mData[kPayloadMaxLength];
+        static constexpr uint16_t kMaxLength = 512;
+
+        uint8_t  mData[kMaxLength];
         uint16_t mLength;
     };
 
@@ -60,10 +56,8 @@ public:
      */
     explicit TestIphcVector(const char *aTestName)
     {
-        memset(reinterpret_cast<void *>(this), 0, sizeof(TestIphcVector));
-        mTestName              = aTestName;
-        mSrcContext.mContextId = kContextUnused;
-        mDstContext.mContextId = kContextUnused;
+        Clear();
+        mTestName = aTestName;
     }
 
     /**


### PR DESCRIPTION
This commit enhances the `FindContext()` methods and converts the `Lowpan::Context` struct into a class.

The `FindContext()` methods are updated as follows:
- Renamed to `FindContextForAddress()` and `FindContextForId()` to more accurately reflect their function.
- The return type is changed from `Error` to `void`. Success is now indicated by checking the `IsValid()` state of the output `Context` object (matching how `Lowpan` class uses the `Context`). This change simplifies the callers and harmonizes the context check across different modules.

The `Lowpan::Context` struct is converted into a class, encapsulating its members by making them private and introducing public getters.