### PR TITLE
[network-data] align `FindPreferredNat64Prefix()` method name

### DIFF
--- a/src/core/api/nat64_api.cpp
+++ b/src/core/api/nat64_api.cpp
@@ -154,7 +154,8 @@ otError otNat64SynthesizeIp6Address(otInstance *aInstance, const otIp4Address *a
     otError                          err = OT_ERROR_NONE;
     NetworkData::ExternalRouteConfig nat64Prefix;
 
-    VerifyOrExit(AsCoreType(aInstance).Get<NetworkData::Leader>().GetPreferredNat64Prefix(nat64Prefix) == OT_ERROR_NONE,
+    VerifyOrExit(AsCoreType(aInstance).Get<NetworkData::Leader>().FindPreferredNat64Prefix(nat64Prefix) ==
+                     OT_ERROR_NONE,
                  err = OT_ERROR_INVALID_STATE);
     AsCoreType(aIp6Address).SynthesizeFromIp4Address(nat64Prefix.GetPrefix(), AsCoreType(aIp4Address));
 

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -4109,7 +4109,7 @@ void RoutingManager::Nat64PrefixManager::Evaluate(void)
 
     prefix = GetFavoredPrefix(preference);
 
-    error = Get<NetworkData::Leader>().GetPreferredNat64Prefix(netdataPrefixConfig);
+    error = Get<NetworkData::Leader>().FindPreferredNat64Prefix(netdataPrefixConfig);
 
     // NAT64 prefix is expected to be published from this BR
     // when one of the following is true:

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -491,7 +491,7 @@ Error Client::AddressResponse::GetAddress(uint16_t aIndex, Ip6::Address &aAddres
         ARecord                          aRecord;
         NetworkData::ExternalRouteConfig nat64Prefix;
 
-        VerifyOrExit(mInstance->Get<NetworkData::Leader>().GetPreferredNat64Prefix(nat64Prefix) == kErrorNone,
+        VerifyOrExit(mInstance->Get<NetworkData::Leader>().FindPreferredNat64Prefix(nat64Prefix) == kErrorNone,
                      error = kErrorInvalidState);
 
         section = (info.mQueryType == kIp4AddressQuery) ? kAnswerSection : kAdditionalDataSection;
@@ -1039,7 +1039,7 @@ Error Client::StartQuery(QueryInfo &aInfo, const char *aLabel, const char *aName
         NetworkData::ExternalRouteConfig nat64Prefix;
 
         VerifyOrExit(aInfo.mConfig.GetNat64Mode() == QueryConfig::kNat64Allow, error = kErrorInvalidArgs);
-        VerifyOrExit(Get<NetworkData::Leader>().GetPreferredNat64Prefix(nat64Prefix) == kErrorNone,
+        VerifyOrExit(Get<NetworkData::Leader>().FindPreferredNat64Prefix(nat64Prefix) == kErrorNone,
                      error = kErrorInvalidState);
     }
 #endif

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -93,7 +93,7 @@ exit:
     return error;
 }
 
-Error Leader::GetPreferredNat64Prefix(ExternalRouteConfig &aConfig) const
+Error Leader::FindPreferredNat64Prefix(ExternalRouteConfig &aConfig) const
 {
     Error               error    = kErrorNotFound;
     Iterator            iterator = kIteratorInit;

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -300,7 +300,7 @@ public:
                        uint8_t           &aServiceId) const;
 
     /**
-     * Gets the preferred NAT64 prefix from network data.
+     * Finds the preferred NAT64 prefix from network data.
      *
      * The returned prefix is the highest preference external route entry in Network Data with NAT64 flag set. If there
      * are multiple such entries the first one is returned.
@@ -310,7 +310,7 @@ public:
      * @retval kErrorNone       Found the NAT64 prefix and updated @p aConfig.
      * @retval kErrorNotFound   Could not find any NAT64 entry.
      */
-    Error GetPreferredNat64Prefix(ExternalRouteConfig &aConfig) const;
+    Error FindPreferredNat64Prefix(ExternalRouteConfig &aConfig) const;
 
     /**
      * Indicates whether or not the given IPv6 address matches any NAT64 prefixes.


### PR DESCRIPTION
This commit renames `GetPreferredNat64Prefix()` to `FindPreferredNat64Prefix()`.

The new name better aligns with the method's behavior, as it searches for a preferred NAT64 prefix in the Network Data and can return `kErrorNotFound`. This change also harmonizes the method name with other similar `Find...()` methods in the `NetworkData` class.