### PR TITLE
[routing-manager] add `Publish()`/`Unpublish()` in `Nat64PrefixManager`

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1556,12 +1556,12 @@ private:
 
     private:
         void Discover(void);
-        void Publish(void);
+        void Publish(const Ip6::Prefix &aPrefix, RoutePreference aPreference);
+        void Unpublish(void);
 
         using Nat64Timer = TimerMilliIn<RoutingManager, &RoutingManager::HandleNat64PrefixManagerTimer>;
 
-        bool mEnabled;
-
+        bool            mEnabled;
         Ip6::Prefix     mInfraIfPrefix;       // The latest NAT64 prefix discovered on the infrastructure interface.
         Ip6::Prefix     mLocalPrefix;         // The local prefix (from BR ULA prefix).
         Ip6::Prefix     mPublishedPrefix;     // The prefix to publish in Net Data (empty or local or from infra-if).


### PR DESCRIPTION
This commit introduces `Publish()` and `Unpublish()` private helper methods in `Nat64PrefixManager` to encapsulate and centralize the logic for managing the published NAT64 prefix in the Network Data.

- `Publish(aPrefix, aPreference)` adds the given prefix to the Network Data. It handles removing any previously published prefix if the new prefix or preference differs.
- `Unpublish()` removes the currently published NAT64 prefix from the Network Data, if one exists.

These new helpers simplify the logic within the `Evaluate()` and `Stop()` methods, reduce code duplication, and improve overall clarity.