### PR TITLE
[wakeup-tx-scheduler] fix potential integer conversion warnings

### DIFF
--- a/src/core/mac/wakeup_tx_scheduler.cpp
+++ b/src/core/mac/wakeup_tx_scheduler.cpp
@@ -110,7 +110,8 @@ Mac::TxFrame *WakeupTxScheduler::PrepareWakeupFrame(Mac::TxFrames &aTxFrames)
     // the "free space" between the "n+1"-th and "n+2"-th wake-up frame.
     rendezvousTimeUs = mIntervalUs;
     rendezvousTimeUs += (mIntervalUs - (kWakeupFrameLength + kParentRequestLength) * kOctetDuration) / 2;
-    frame->GetRendezvousTimeIe()->SetRendezvousTime(rendezvousTimeUs / kUsPerTenSymbols);
+
+    frame->GetRendezvousTimeIe()->SetRendezvousTime(ClampToUint16(rendezvousTimeUs / kUsPerTenSymbols));
 
     connectionIe = frame->GetConnectionIe();
     connectionIe->SetRetryInterval(kConnectionRetryInterval);

--- a/src/core/mac/wakeup_tx_scheduler.hpp
+++ b/src/core/mac/wakeup_tx_scheduler.hpp
@@ -119,7 +119,7 @@ private:
     Mac::ExtAddress mWedAddress;
     TimeMicro       mTxTimeUs;             // Point in time when the next TX occurs.
     TimeMicro       mTxEndTimeUs;          // Point in time when the wake-up sequence is over.
-    uint16_t        mTxRequestAheadTimeUs; // How much ahead the TX MAC operation needs to be requested.
+    uint32_t        mTxRequestAheadTimeUs; // How much ahead the TX MAC operation needs to be requested.
     uint16_t        mIntervalUs;           // Interval between consecutive wake-up frames.
     WakeupTimer     mTimer;
     bool            mIsRunning;


### PR DESCRIPTION
This commit resolves compiler warnings/errors related to potential integer overflows and unsafe narrowing conversions.

- The type of `mTxRequestAheadTimeUs` is changed from `uint16_t` to `uint32_t` to avoid potential overflow when calculating the TX time.
- A `ClampToUint16()` utility is now used before setting the rendezvous time. This safely converts the calculated `rendezvousTimeUs` to a 16-bit integer, preventing a narrowing conversion warning.

----

Should help fix the following errors when `./script/test build` (on mac OS x with C++ toolchain: `AppleClang 17.0.0.17000013`)
```
/Users/abtink/github/openthread/src/core/mac/wakeup_tx_scheduler.cpp:113:70: error: implicit conversion loses integer precision: 'uint32_t' (aka 'unsigned int') to 'uint16_t' (aka 'unsigned short') [-Werror,-Wimplicit-int-conversion]
  113 |     frame->GetRendezvousTimeIe()->SetRendezvousTime(rendezvousTimeUs / kUsPerTenSymbols);
      |                                   ~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
/Users/abtink/github/openthread/src/core/mac/wakeup_tx_scheduler.cpp:163:51: error: implicit conversion loses integer precision: 'uint32_t' (aka 'unsigned int') to 'uint16_t' (aka 'unsigned short') [-Werror,-Wimplicit-int-conversion]
  163 |     mTxRequestAheadTimeUs = Mac::kCslRequestAhead + Get<Mac::Mac>().CalculateRadioBusTransferTime(kWakeupFrameSize);
      |                           ~ ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
```