### PR TITLE
[nat64] introduce helpers for getting port or ICMP ID

### DIFF
--- a/src/core/net/nat64_translator.hpp
+++ b/src/core/net/nat64_translator.hpp
@@ -344,6 +344,9 @@ private:
     uint16_t AllocateSourcePort(uint16_t aSrcPort);
 #endif
 
+    static uint16_t GetSourcePortOrIcmp6Id(const Ip6::Headers &aIp6Headers);
+    static uint16_t GetDestinationPortOrIcmp4Id(const Ip4::Headers &aIp4Headers);
+
     using TranslatorTimer = TimerMilliIn<Translator, &Translator::HandleTimer>;
 
     bool                           mEnabled;


### PR DESCRIPTION
This commit introduces two new `static` helper methods, `GetSourcePortOrIcmp6Id()` and `GetDestinationPortOrIcmp4Id()`, to the `Translator` class. This eliminates repeated similar code and improves overall readability.