### PR TITLE
[nat64] simplify and enhance handling of counters

### DIFF
--- a/src/core/api/nat64_api.cpp
+++ b/src/core/api/nat64_api.cpp
@@ -85,12 +85,16 @@ otError otNat64GetNextAddressMapping(otInstance                    *aInstance,
 
 void otNat64GetCounters(otInstance *aInstance, otNat64ProtocolCounters *aCounters)
 {
-    AsCoreType(aInstance).Get<Nat64::Translator>().GetCounters(AsCoreType(aCounters));
+    AssertPointerIsNotNull(aCounters);
+
+    *aCounters = AsCoreType(aInstance).Get<Nat64::Translator>().GetCounters();
 }
 
 void otNat64GetErrorCounters(otInstance *aInstance, otNat64ErrorCounters *aCounters)
 {
-    AsCoreType(aInstance).Get<Nat64::Translator>().GetErrorCounters(AsCoreType(aCounters));
+    AssertPointerIsNotNull(aCounters);
+
+    *aCounters = AsCoreType(aInstance).Get<Nat64::Translator>().GetErrorCounters();
 }
 
 otError otNat64GetCidr(otInstance *aInstance, otIp4Cidr *aCidr)

--- a/src/core/net/nat64_translator.cpp
+++ b/src/core/net/nat64_translator.cpp
@@ -73,6 +73,9 @@ Translator::Translator(Instance &aInstance)
     mNat64Prefix.Clear();
     mIp4Cidr.Clear();
     mTimer.Start(kIdleTimeout);
+
+    mCounters.Clear();
+    ClearAllBytes(mErrorCounters);
 }
 
 Message *Translator::NewIp4Message(const Message::Settings &aSettings)
@@ -203,13 +206,13 @@ Translator::Result Translator::TranslateFromIp6(Message &aMessage)
 
     aMessage.SetType(Message::kTypeIp4);
 
-    mCounters.Count6To4Packet(ip6Headers.GetIpProto(), ip6Headers.GetIpLength());
-    mapping->mCounters.Count6To4Packet(ip6Headers.GetIpProto(), ip6Headers.GetIpLength());
+    mCounters.Count6To4Packet(ip6Headers);
+    mapping->mCounters.Count6To4Packet(ip6Headers);
 
 exit:
     if (result == kDrop)
     {
-        mErrorCounters.Count6To4(dropReason);
+        mErrorCounters.mCount6To4[dropReason]++;
     }
 
     return result;
@@ -318,13 +321,13 @@ Translator::Result Translator::TranslateToIp6(Message &aMessage)
 
     aMessage.SetType(Message::kTypeIp6);
 
-    mCounters.Count4To6Packet(ip4Headers.GetIpProto(), ip4Headers.GetIpLength() - sizeof(Ip4::Header));
-    mapping->mCounters.Count4To6Packet(ip4Headers.GetIpProto(), ip4Headers.GetIpLength() - sizeof(Ip4::Header));
+    mCounters.Count4To6Packet(ip4Headers);
+    mapping->mCounters.Count4To6Packet(ip4Headers);
 
 exit:
     if (result == kDrop)
     {
-        mErrorCounters.Count4To6(dropReason);
+        mErrorCounters.mCount4To6[dropReason]++;
     }
 
     return result;
@@ -751,48 +754,56 @@ exit:
     return error;
 }
 
-void Translator::ProtocolCounters::Count6To4Packet(uint8_t aProtocol, uint64_t aPacketSize)
+void Translator::ProtocolCounters::Count6To4Packet(const Ip6::Headers &aIp6Headers)
 {
-    switch (aProtocol)
+    uint16_t size = aIp6Headers.GetIpLength();
+
+    switch (aIp6Headers.GetIpProto())
     {
     case Ip6::kProtoUdp:
-        mUdp.m6To4Packets++;
-        mUdp.m6To4Bytes += aPacketSize;
+        Update6To4(mUdp, size);
         break;
     case Ip6::kProtoTcp:
-        mTcp.m6To4Packets++;
-        mTcp.m6To4Bytes += aPacketSize;
+        Update6To4(mTcp, size);
         break;
     case Ip6::kProtoIcmp6:
-        mIcmp.m6To4Packets++;
-        mIcmp.m6To4Bytes += aPacketSize;
+        Update6To4(mIcmp, size);
         break;
     }
 
-    mTotal.m6To4Packets++;
-    mTotal.m6To4Bytes += aPacketSize;
+    Update6To4(mTotal, size);
 }
 
-void Translator::ProtocolCounters::Count4To6Packet(uint8_t aProtocol, uint64_t aPacketSize)
+void Translator::ProtocolCounters::Update6To4(Counters &aCounters, uint16_t aSize)
 {
-    switch (aProtocol)
+    aCounters.m6To4Packets++;
+    aCounters.m6To4Bytes += aSize;
+}
+
+void Translator::ProtocolCounters::Count4To6Packet(const Ip4::Headers &aIp4Headers)
+{
+    uint16_t size = aIp4Headers.GetIpLength() - sizeof(Ip4::Header);
+
+    switch (aIp4Headers.GetIpProto())
     {
     case Ip4::kProtoUdp:
-        mUdp.m4To6Packets++;
-        mUdp.m4To6Bytes += aPacketSize;
+        Update4To6(mUdp, size);
         break;
     case Ip4::kProtoTcp:
-        mTcp.m4To6Packets++;
-        mTcp.m4To6Bytes += aPacketSize;
+        Update4To6(mTcp, size);
         break;
     case Ip4::kProtoIcmp:
-        mIcmp.m4To6Packets++;
-        mIcmp.m4To6Bytes += aPacketSize;
+        Update4To6(mIcmp, size);
         break;
     }
 
-    mTotal.m4To6Packets++;
-    mTotal.m4To6Bytes += aPacketSize;
+    Update4To6(mTotal, size);
+}
+
+void Translator::ProtocolCounters::Update4To6(Counters &aCounters, uint16_t aSize)
+{
+    aCounters.m4To6Packets++;
+    aCounters.m4To6Bytes += aSize;
 }
 
 void Translator::UpdateState(void)

--- a/src/core/net/nat64_translator.hpp
+++ b/src/core/net/nat64_translator.hpp
@@ -75,6 +75,7 @@ public:
     typedef otNat64AddressMapping         AddressMapping;         ///< Address mapping.
     typedef otNat64AddressMappingIterator AddressMappingIterator; ///< Address mapping Iterator.
     typedef otNat64DropReason             DropReason;             ///< Drop reason.
+    typedef otNat64ErrorCounters          ErrorCounters;          ///< Error counters.
 
     /**
      * The possible results of NAT64 translation.
@@ -94,20 +95,13 @@ public:
         friend class Translator;
 
     private:
-        void Count6To4Packet(uint8_t aProtocol, uint64_t aPacketSize);
-        void Count4To6Packet(uint8_t aProtocol, uint64_t aPacketSize);
-    };
+        typedef otNat64Counters Counters;
 
-    /**
-     * Represents the counters of dropped packets due to errors when handling NAT64 packets.
-     */
-    class ErrorCounters : public otNat64ErrorCounters, public Clearable<otNat64ErrorCounters>
-    {
-        friend class Translator;
+        void Count6To4Packet(const Ip6::Headers &aIp6Headers);
+        void Count4To6Packet(const Ip4::Headers &aIp4Headers);
 
-    public:
-        void Count4To6(DropReason aReason) { mCount4To6[aReason]++; }
-        void Count6To4(DropReason aReason) { mCount6To4[aReason]++; }
+        static void Update6To4(Counters &aCounters, uint16_t aSize);
+        static void Update4To6(Counters &aCounters, uint16_t aSize);
     };
 
     /**
@@ -253,18 +247,18 @@ public:
      *
      * The counters are initialized to zero when the OpenThread instance is initialized.
      *
-     * @param[out] aCounters A `ProtocolCounters` where the counters of NAT64 translator will be placed.
+     * @returns The protocol counters.
      */
-    void GetCounters(ProtocolCounters &aCounters) const { aCounters = mCounters; }
+    const ProtocolCounters &GetCounters(void) const { return mCounters; }
 
     /**
      * Gets the NAT64 translator error counters.
      *
      * The counters are initialized to zero when the OpenThread instance is initialized.
      *
-     * @param[out] aCounters  An `ErrorCounters` where the counters of NAT64 translator will be placed.
+     * @returns The error counters.
      */
-    void GetErrorCounters(ErrorCounters &aCounters) const { aCounters = mErrorCounters; }
+    const ErrorCounters &GetErrorCounters(void) const { return mErrorCounters; }
 
     /**
      * Gets the configured CIDR in the NAT64 translator.
@@ -365,7 +359,6 @@ private:
 DefineMapEnum(otNat64State, Nat64::State);
 #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
 DefineCoreType(otNat64ProtocolCounters, Nat64::Translator::ProtocolCounters);
-DefineCoreType(otNat64ErrorCounters, Nat64::Translator::ErrorCounters);
 #endif
 
 } // namespace ot


### PR DESCRIPTION
This commit simplifies and enhances the NAT64 translator's counter implementation.

- The `mProtocolCounters` and `mErrorCounters` are explicitly cleared in the `Translator` constructor, ensuring they are properly zero-initialized.
- The `ErrorCounters` C++ wrapper class is removed, and the counters are now updated directly based on `DropReason`.
- The `ProtocolCounters::Count*Packet()` methods are updated to accept `Ip6::Headers` and `Ip4::Headers` inputs directly, which simplifies the call sites.
- Private helper methods, `Update6To4()` and `Update4To6()`, are introduced in `ProtocolCounters` to reduce code duplication when incrementing packet and byte counts.