### PR TITLE
[radio] clarify radio Sleep state

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (528)
+#define OPENTHREAD_API_VERSION (529)
 
 /**
  * @addtogroup api-instance

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -415,7 +415,6 @@ void Mac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 #endif
     }
 
-    mLinks.SetRxOnWhenIdle(mRxOnWhenIdle || mPromiscuous);
     UpdateIdleMode();
 
 exit:
@@ -568,7 +567,7 @@ void Mac::UpdateIdleMode(void)
 
     VerifyOrExit(mOperation == kOperationIdle);
 
-    if (!mRxOnWhenIdle)
+    if (shouldSleep)
     {
 #if OPENTHREAD_CONFIG_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS
         if (mShouldDelaySleep)
@@ -2240,7 +2239,6 @@ void Mac::SetPromiscuous(bool aPromiscuous)
     mShouldDelaySleep = false;
 #endif
 
-    mLinks.SetRxOnWhenIdle(mRxOnWhenIdle || mPromiscuous);
     UpdateIdleMode();
 }
 

--- a/src/core/mac/mac_links.hpp
+++ b/src/core/mac/mac_links.hpp
@@ -408,19 +408,6 @@ public:
     }
 
     /**
-     * Indicates whether radio should stay in Receive or Sleep during idle periods.
-     *
-     * @param[in]  aRxOnWhenIdle  TRUE to keep radio in Receive, FALSE to put to Sleep during idle periods.
-     */
-    void SetRxOnWhenIdle(bool aRxOnWhenIdle)
-    {
-#if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-        mSubMac.SetRxOnWhenIdle(aRxOnWhenIdle);
-#endif
-        OT_UNUSED_VARIABLE(aRxOnWhenIdle);
-    }
-
-    /**
      * Enables all radio links.
      */
     void Enable(void)
@@ -447,7 +434,7 @@ public:
     }
 
     /**
-     * Transitions all radio links to Sleep.
+     * Transitions all radio links to Sleep, a.k.a. rx-off-when-idle mode.
      */
     void Sleep(void)
     {
@@ -502,7 +489,7 @@ public:
 #endif
 
     /**
-     * Transitions all radio links to Receive.
+     * Transitions all radio links to Receive, a.k.a. rx-on-when-idle mode.
      *
      * @param[in]  aChannel   The channel to use for receiving.
      */

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -543,7 +543,7 @@ private:
     enum State : uint8_t
     {
         kStateDisabled,    // Radio is disabled.
-        kStateSleep,       // Radio is in sleep.
+        kStateIdle,        // Radio is idle.
         kStateReceive,     // Radio in in receive.
         kStateCsmaBackoff, // CSMA backoff before transmission.
         kStateTransmit,    // Radio is transmitting.
@@ -553,10 +553,6 @@ private:
 #endif
 #if !OPENTHREAD_MTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
         kStateCslTransmit, // CSL transmission.
-#endif
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-        kStateRadioSample, // Mac layer has requested the SubMac to enter sleep state, but the SubMac is in the periodic
-                           // sample state.
 #endif
     };
 
@@ -607,7 +603,6 @@ private:
     bool ShouldHandleRetries(void) const;
     bool ShouldHandleEnergyScan(void) const;
     bool ShouldHandleTransmitTargetTime(void) const;
-    bool ShouldHandleTransitionToSleep(void) const;
 
     void ProcessTransmitSecurity(void);
     void SignalFrameCounterUsed(uint32_t aFrameCounter, uint8_t aKeyId);

--- a/src/core/mac/sub_mac_csl_receiver.cpp
+++ b/src/core/mac/sub_mac_csl_receiver.cpp
@@ -197,7 +197,7 @@ void SubMac::HandleCslReceiveOrSleep(uint32_t aTimeAhead, uint32_t aTimeAfter)
     {
         mIsCslSampling = false;
         mCslTimer.FireAt(mCslSampleTimeLocal - aTimeAhead);
-        if (mState == kStateRadioSample)
+        if (mState == kStateIdle)
         {
             LogDebg("CSL sleep %lu", ToUlong(mCslTimer.GetNow().GetValue()));
         }
@@ -292,7 +292,7 @@ void SubMac::LogReceived(RxFrame *aFrame)
             mIsCslSampling ? "CslSample" : "CslSleep",
             ToUlong(static_cast<uint32_t>(aFrame->mInfo.mRxInfo.mTimestamp)));
 
-    VerifyOrExit(mState == kStateRadioSample);
+    VerifyOrExit(mState == kStateIdle);
 
     GetCslWindowEdges(ahead, after);
     ahead -= kMinReceiveOnAhead + kCslReceiveTimeAhead;


### PR DESCRIPTION
This commit clarifies the Sleep state of radio to be maybe sleep with the platform supports OT_RADIO_CAPS_RX_ON_WHEN_IDLE.

With this clarification, the Receive() is equivalent to say the radio should never be turned off, and Sleep() is equivalent to say the radio may be turned off when idle. This clarification simplifies the semantic of radio API to support sleepy need with scheduled activities.

This commit also updates the sub mac layer interface to align with this behavior.