### PR TITLE
[nat64] improve `AddressMappingIterator` & expiration time calculation

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (529)
+#define OPENTHREAD_API_VERSION (530)
 
 /**
  * @addtogroup api-instance

--- a/src/core/api/nat64_api.cpp
+++ b/src/core/api/nat64_api.cpp
@@ -68,19 +68,17 @@ void otNat64SetReceiveIp4Callback(otInstance *aInstance, otNat64ReceiveIp4Callba
 
 void otNat64InitAddressMappingIterator(otInstance *aInstance, otNat64AddressMappingIterator *aIterator)
 {
-    AssertPointerIsNotNull(aIterator);
-
-    AsCoreType(aInstance).Get<Nat64::Translator>().InitAddressMappingIterator(*aIterator);
+    AsCoreType(aIterator).Init(AsCoreType(aInstance));
 }
 
 otError otNat64GetNextAddressMapping(otInstance                    *aInstance,
                                      otNat64AddressMappingIterator *aIterator,
                                      otNat64AddressMapping         *aMapping)
 {
-    AssertPointerIsNotNull(aIterator);
+    OT_UNUSED_VARIABLE(aInstance);
     AssertPointerIsNotNull(aMapping);
 
-    return AsCoreType(aInstance).Get<Nat64::Translator>().GetNextAddressMapping(*aIterator, *aMapping);
+    return AsCoreType(aIterator).GetNext(*aMapping);
 }
 
 void otNat64GetCounters(otInstance *aInstance, otNat64ProtocolCounters *aCounters)

--- a/src/core/net/nat64_translator.cpp
+++ b/src/core/net/nat64_translator.cpp
@@ -730,21 +730,20 @@ void Translator::HandleTimer(void)
     OT_UNUSED_VARIABLE(numReleased);
 }
 
-void Translator::InitAddressMappingIterator(AddressMappingIterator &aIterator)
+void Translator::AddressMappingIterator::Init(Instance &aInstance)
 {
-    aIterator.mPtr = mActiveMappings.GetHead();
+    SetMapping(aInstance.Get<Translator>().mActiveMappings.GetHead());
+    SetInitTime(TimerMilli::GetNow());
 }
 
-Error Translator::GetNextAddressMapping(AddressMappingIterator &aIterator, AddressMapping &aMapping)
+Error Translator::AddressMappingIterator::GetNext(AddressMapping &aMapping)
 {
-    Error    error   = kErrorNotFound;
-    Mapping *mapping = static_cast<Mapping *>(aIterator.mPtr);
+    Error error = kErrorNone;
 
-    VerifyOrExit(mapping != nullptr);
+    VerifyOrExit(GetMapping() != nullptr, error = kErrorNotFound);
 
-    mapping->CopyTo(aMapping, TimerMilli::GetNow());
-    aIterator.mPtr = mapping->GetNext();
-    error          = kErrorNone;
+    GetMapping()->CopyTo(aMapping, GetInitTime());
+    SetMapping(GetMapping()->GetNext());
 
 exit:
     return error;

--- a/tests/unit/test_nat64.cpp
+++ b/tests/unit/test_nat64.cpp
@@ -360,8 +360,9 @@ void TestPacketCounter(void)
         otNat64AddressMapping                     mapping;
         size_t                                    totalMappingCount = 0;
 
-        sInstance->Get<Nat64::Translator>().InitAddressMappingIterator(iter);
-        while (sInstance->Get<Nat64::Translator>().GetNextAddressMapping(iter, mapping) == kErrorNone)
+        iter.Init(*sInstance);
+
+        while (iter.GetNext(mapping) == kErrorNone)
         {
             totalMappingCount++;
             VerifyCounters(otNat64ProtocolCounters{.mTotal =
@@ -432,8 +433,9 @@ void TestPacketCounter(void)
         otNat64AddressMapping                     mapping;
         size_t                                    totalMappingCount = 0;
 
-        sInstance->Get<Nat64::Translator>().InitAddressMappingIterator(iter);
-        while (sInstance->Get<Nat64::Translator>().GetNextAddressMapping(iter, mapping) == kErrorNone)
+        iter.Init(*sInstance);
+
+        while (iter.GetNext(mapping) == kErrorNone)
         {
             totalMappingCount++;
             VerifyCounters(otNat64ProtocolCounters{.mTotal =


### PR DESCRIPTION
This commit improves the NAT64 address mapping iterator to ensure the remaining lifetime for all mapping entries is reported consistently.

The iterator now internally stores a timestamp upon initialization. This timestamp is then used as a common reference to calculate the remaining lifetime for each `otNat64AddressMapping` entry, ensuring consistent values throughout a single iteration.

The public C APIs remain unchanged, while the underlying implementation and the `otNat64AddressMappingIterator` struct are updated.