### PR TITLE
[nat64] use IP headers for `Mapping::Matches`

### DIFF
--- a/src/core/net/nat64_translator.hpp
+++ b/src/core/net/nat64_translator.hpp
@@ -307,12 +307,10 @@ private:
         void       Touch(TimeMilli aNow, uint8_t aProtocol);
         InfoString ToString(void) const;
         void       CopyTo(AddressMapping &aMapping, TimeMilli aNow) const;
-        bool       Matches(const Ip4::Address &aIp4Address) const { return mIp4Address == aIp4Address; }
-        bool       Matches(const Ip6::Address &aIp6Address) const { return mIp6Address == aIp6Address; }
-        bool       Matches(const uint16_t aPort) const { return mTranslatedPortOrId == aPort; }
+        bool       Matches(const Ip6::Headers &aIp6Headers) const;
+        bool       Matches(const Ip4::Headers &aIp4Headers) const;
         bool       Matches(const TimeMilli aNow) const { return mExpiry < aNow; }
-        bool       Matches(const Ip6::Address &aIp6Address, const uint16_t aPort) const;
-        bool       Matches(const Ip4::Address &aIp4Address, const uint16_t aPort) const;
+        bool       Matches(const uint16_t aPort) const { return mTranslatedPortOrId == aPort; }
 
         Mapping         *mNext;
         uint64_t         mId;


### PR DESCRIPTION
This change updates the `Mapping::Matches` methods to accept `Ip4::Headers` and `Ip6::Headers` objects instead of separate IP address and port arguments.

This simplifies the callers `FindOrAllocateMapping` and `FindMapping` by encapsulating the conditional logic for port translation within the `Mapping::Matches` methods. This allows for a single, unified `FindMatching` method on the active mappings list.