### PR TITLE
[nat64] improve unit tests for `Nat64::Translator`

### DIFF
--- a/src/core/net/nat64_translator.hpp
+++ b/src/core/net/nat64_translator.hpp
@@ -124,7 +124,9 @@ public:
     /**
      * Represents the counters for the protocols supported by NAT64.
      */
-    class ProtocolCounters : public otNat64ProtocolCounters, public Clearable<ProtocolCounters>
+    class ProtocolCounters : public otNat64ProtocolCounters,
+                             public Clearable<ProtocolCounters>,
+                             public Equatable<ProtocolCounters>
     {
         friend class Translator;
 

--- a/tests/unit/test_nat64.cpp
+++ b/tests/unit/test_nat64.cpp
@@ -26,171 +26,216 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "net/nat64_translator.hpp"
+#include <stdio.h>
 
 #include "test_platform.h"
 #include "test_util.hpp"
 
-#include <inttypes.h>
-#include <string.h>
-
-#include "common/code_utils.hpp"
-#include "common/debug.hpp"
-#include "common/message.hpp"
 #include "instance/instance.hpp"
-#include "net/ip6.hpp"
 
 #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
 
 namespace ot {
-namespace BorderRouter {
+namespace Nat64 {
+
+#define Log(...) printf(OT_FIRST_ARG(__VA_ARGS__) "\n" OT_REST_ARGS(__VA_ARGS__))
 
 static ot::Instance *sInstance;
 
-void DumpMessageInHex(const char *prefix, const uint8_t *aBuf, size_t aBufLen)
+void DumpIp6Message(const char *aTextMessage, const Message &aMessage)
 {
-    // This function dumps all packets the output of this function can be imported to packet analyser for debugging.
-    printf("%s", prefix);
-    for (size_t i = 0; i < aBufLen; i++)
+    Ip6::Headers ip6Headers;
+
+    Log("%s", aTextMessage);
+
+    if (ip6Headers.ParseFrom(aMessage) != kErrorNone)
     {
-        printf("%02x", aBuf[i]);
-    }
-    printf("\n");
-}
-
-bool CheckMessage(const Message &aMessage, const uint8_t *aExpectedMessage, size_t aExpectedMessageLen)
-{
-    uint8_t  readMessage[OPENTHREAD_CONFIG_IP6_MAX_DATAGRAM_LENGTH];
-    uint16_t messageLength;
-    bool     success = true;
-
-    success       = success && (aMessage.GetLength() == aExpectedMessageLen);
-    messageLength = aMessage.ReadBytes(0, readMessage, aMessage.GetLength());
-    success       = success && (aExpectedMessageLen == messageLength);
-    success       = success && (memcmp(readMessage, aExpectedMessage, aExpectedMessageLen) == 0);
-
-    if (!success)
-    {
-        printf("Expected Message\n");
-        for (size_t i = 0; i < aExpectedMessageLen; i++)
-        {
-            printf("%02x%c", aExpectedMessage[i], " \n"[(i & 0xf) == 0xf]);
-        }
-        printf("\n");
-        printf("Actual Message\n");
-        for (uint16_t i = 0; i < messageLength; i++)
-        {
-            printf("%02x%c", readMessage[i], " \n"[(i & 0xf) == 0xf]);
-        }
-        printf("\n");
+        Log("    Malformed IPv6 message");
+        ExitNow();
     }
 
-    return success;
-}
+    Log("    IPv6 Headers");
+    Log("       src      : %s", ip6Headers.GetSourceAddress().ToString().AsCString());
+    Log("       dst      : %s", ip6Headers.GetDestinationAddress().ToString().AsCString());
+    Log("       proto    : %s", otIp6ProtoToString(ip6Headers.GetIpProto()));
 
-template <size_t N>
-void TestCase6To4(const char *aTestName,
-                  const uint8_t (&aIp6Message)[N],
-                  Nat64::Translator::Result aResult,
-                  const uint8_t            *aOutMessage,
-                  size_t                    aOutMessageLen)
-{
-    Message *msg = sInstance->Get<Ip6::Ip6>().NewMessage(0);
-
-    printf("Testing NAT64 6 to 4: %s\n", aTestName);
-
-    VerifyOrQuit(msg != nullptr);
-    SuccessOrQuit(msg->AppendBytes(aIp6Message, N));
-
-    DumpMessageInHex("I ", aIp6Message, N);
-
-    VerifyOrQuit(sInstance->Get<Nat64::Translator>().TranslateFromIp6(*msg) == aResult);
-
-    if (aOutMessage != nullptr)
+    if (ip6Headers.IsTcp() || ip6Headers.IsUdp())
     {
-        DumpMessageInHex("O ", aOutMessage, aOutMessageLen);
-        VerifyOrQuit(CheckMessage(*msg, aOutMessage, aOutMessageLen));
+        Log("       src-port : %u", ip6Headers.GetSourcePort());
+        Log("       dst-port : %u", ip6Headers.GetDestinationPort());
+    }
+    else if (ip6Headers.IsIcmp6())
+    {
+        Log("       icmp6-id : %u", ip6Headers.GetIcmpHeader().GetId());
     }
 
-    printf("  ... PASS\n");
+exit:
+    return;
 }
 
-template <size_t N>
-void TestCase4To6(const char *aTestName,
-                  const uint8_t (&aIp4Message)[N],
-                  Nat64::Translator::Result aResult,
-                  const uint8_t            *aOutMessage,
-                  size_t                    aOutMessageLen)
+void DumpIp4Message(const char *aTextMessage, const Message &aMessage)
 {
-    Message *msg = sInstance->Get<Ip6::Ip6>().NewMessage(0);
+    Ip4::Headers ip4Headers;
 
-    printf("Testing NAT64 4 to 6: %s\n", aTestName);
+    Log("%s", aTextMessage);
 
-    VerifyOrQuit(msg != nullptr);
-    SuccessOrQuit(msg->AppendBytes(aIp4Message, N));
-
-    DumpMessageInHex("I ", aIp4Message, N);
-
-    VerifyOrQuit(sInstance->Get<Nat64::Translator>().TranslateToIp6(*msg) == aResult);
-
-    if (aOutMessage != nullptr)
+    if (ip4Headers.ParseFrom(aMessage) != kErrorNone)
     {
-        DumpMessageInHex("O ", aOutMessage, aOutMessageLen);
-        VerifyOrQuit(CheckMessage(*msg, aOutMessage, aOutMessageLen));
+        Log("    Malformed IPv4 message");
+        ExitNow();
     }
 
-    printf("  ... PASS\n");
+    Log("    IPv4 Headers");
+    Log("       src      : %s", ip4Headers.GetSourceAddress().ToString().AsCString());
+    Log("       dst      : %s", ip4Headers.GetDestinationAddress().ToString().AsCString());
+    Log("       proto    : %s", ip4Headers.IsIcmp4() ? "ICMP4" : otIp6ProtoToString(ip4Headers.GetIpProto()));
+
+    if (ip4Headers.IsTcp() || ip4Headers.IsUdp())
+    {
+        Log("       src-port : %u", ip4Headers.GetSourcePort());
+        Log("       dst-port : %u", ip4Headers.GetDestinationPort());
+    }
+    else if (ip4Headers.IsIcmp4())
+    {
+        Log("       icmp4-id : %u", ip4Headers.GetIcmpHeader().GetId());
+    }
+
+exit:
+    return;
 }
 
-void PrintCounters(const otNat64Counters &aCounter)
+void VerifyMessage(const Message &aMessage, const uint8_t *aExpectedContent, uint16_t aExpectedLength)
 {
-    printf(" ... 4To6Packets = %" PRIu64 "\n", aCounter.m4To6Packets);
-    printf(" ... 4To6Bytes   = %" PRIu64 "\n", aCounter.m4To6Bytes);
-    printf(" ... 6To4Packets = %" PRIu64 "\n", aCounter.m6To4Packets);
-    printf(" ... 6To4Bytes   = %" PRIu64 "\n", aCounter.m6To4Bytes);
+    VerifyOrQuit(aMessage.GetLength() == aExpectedLength);
+    VerifyOrQuit(aMessage.CompareBytes(0, aExpectedContent, aExpectedLength));
 }
 
-void PrintProtocolCounters(const otNat64ProtocolCounters &aCounter)
+const char *ResultToString(Translator::Result aResult)
 {
-    printf(" Total \n");
-    PrintCounters(aCounter.mTotal);
-    printf(" ICMP \n");
-    PrintCounters(aCounter.mIcmp);
-    printf(" UDP \n");
-    PrintCounters(aCounter.mUdp);
-    printf(" TCP \n");
-    PrintCounters(aCounter.mTcp);
+    const char *string = "Invalid";
+
+    switch (aResult)
+    {
+    case Translator::kNotTranslated:
+        string = "NotTranslated";
+        break;
+    case Translator::kForward:
+        string = "Forward";
+        break;
+    case Translator::kDrop:
+        string = "Drop";
+        break;
+    }
+
+    return string;
 }
 
-void VerifyCounters(const otNat64ProtocolCounters &aExpected, const otNat64ProtocolCounters &aActual)
+void Verify6To4(const char        *aTestName,
+                const uint8_t     *aIp6Message,
+                const uint16_t     aIp6Length,
+                const uint8_t     *aIp4Message,
+                uint16_t           aIp4Length,
+                Translator::Result aResult)
 {
-    printf("Expected packet counters: \n");
-    PrintProtocolCounters(aExpected);
-    printf("Actual packet counters: \n");
-    PrintProtocolCounters(aActual);
-    VerifyOrQuit(memcmp(&aExpected, &aActual, sizeof(aActual)) == 0);
-    printf("  ... PASS\n");
+    Message           *message = sInstance->Get<Ip6::Ip6>().NewMessage(0);
+    Translator::Result result;
+
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - ");
+    Log("Translate IPv6 to IPv4: %s", aTestName);
+
+    VerifyOrQuit(message != nullptr);
+    SuccessOrQuit(message->AppendBytes(aIp6Message, aIp6Length));
+
+    DumpIp6Message("IPv6 message", *message);
+
+    result = sInstance->Get<Translator>().TranslateFromIp6(*message);
+    Log("Result: %s (expecting:%s)", ResultToString(result), ResultToString(aResult));
+    VerifyOrQuit(result == aResult);
+
+    if (aIp4Message != nullptr)
+    {
+        DumpIp4Message("Translated IPv4 message", *message);
+        VerifyMessage(*message, aIp4Message, aIp4Length);
+    }
 }
 
-void TestNat64(void)
+template <uint16_t kIp6Length, uint16_t kIp4Length>
+void Verify6To4(const char *aTestName,
+                const uint8_t (&aIp6Message)[kIp6Length],
+                const uint8_t (&aIp4Message)[kIp4Length],
+                Translator::Result aResult)
 {
-    Ip6::Prefix  nat64prefix;
-    Ip4::Cidr    nat64cidr;
-    Ip6::Address ip6Source;
-    Ip6::Address ip6Dest;
+    Verify6To4(aTestName, aIp6Message, kIp6Length, aIp4Message, kIp4Length, aResult);
+}
+
+template <uint16_t kIp6Length>
+void Verify6To4(const char *aTestName, const uint8_t (&aIp6Message)[kIp6Length], Translator::Result aResult)
+{
+    Verify6To4(aTestName, aIp6Message, kIp6Length, nullptr, 0, aResult);
+}
+
+void Verify4To6(const char        *aTestName,
+                const uint8_t     *aIp4Message,
+                uint16_t           aIp4Length,
+                const uint8_t     *aIp6Message,
+                uint16_t           aIp6Length,
+                Translator::Result aResult)
+{
+    Message           *message = sInstance->Get<Ip6::Ip6>().NewMessage(0);
+    Translator::Result result;
+
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - ");
+    Log("Translate IPv4 to IPv6: %s", aTestName);
+
+    VerifyOrQuit(message != nullptr);
+    SuccessOrQuit(message->AppendBytes(aIp4Message, aIp4Length));
+
+    DumpIp4Message("IPv4 message", *message);
+
+    result = sInstance->Get<Translator>().TranslateToIp6(*message);
+    Log("Result: %s (expecting:%s)", ResultToString(result), ResultToString(aResult));
+    VerifyOrQuit(result == aResult);
+
+    if (aIp6Message != nullptr)
+    {
+        DumpIp6Message("Translated IPv6 message", *message);
+        VerifyMessage(*message, aIp6Message, aIp6Length);
+    }
+}
+
+template <uint16_t kIp4Length, uint16_t kIp6Length>
+void Verify4To6(const char *aTestName,
+                const uint8_t (&aIp4Message)[kIp4Length],
+                const uint8_t (&aIp6Message)[kIp6Length],
+                Translator::Result aResult)
+{
+    Verify4To6(aTestName, aIp4Message, kIp4Length, aIp6Message, kIp6Length, aResult);
+}
+
+template <uint16_t kIp4Length>
+void Verify4To6(const char *aTestName, const uint8_t (&aIp4Message)[kIp4Length], Translator::Result aResult)
+{
+    Verify4To6(aTestName, aIp4Message, kIp4Length, nullptr, 0, aResult);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+void TestNat64Translation(void)
+{
+    Ip6::Prefix prefix;
+    Ip4::Cidr   cidr;
+
+    Log("--------------------------------------------------------------------------------------------");
+    Log("TestNat64Translation");
 
     sInstance = testInitInstance();
+    VerifyOrQuit(sInstance != nullptr);
 
-    {
-        const uint8_t ip6Address[] = {0xfd, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-        const uint8_t ip4Address[] = {192, 168, 123, 1};
+    SuccessOrQuit(prefix.FromString("fd01::/96"));
+    SuccessOrQuit(cidr.FromString("192.168.123.1/32"));
 
-        nat64cidr.Set(ip4Address, 32);
-        nat64prefix.Set(ip6Address, 96);
-        SuccessOrQuit(sInstance->Get<Nat64::Translator>().SetIp4Cidr(nat64cidr));
-        sInstance->Get<Nat64::Translator>().SetNat64Prefix(nat64prefix);
-    }
+    SuccessOrQuit(sInstance->Get<Translator>().SetIp4Cidr(cidr));
+    sInstance->Get<Translator>().SetNat64Prefix(prefix);
 
     {
         // fd02::1               fd01::ac10:f3c5       UDP      52     43981 → 4660 Len=4
@@ -204,7 +249,7 @@ void TestNat64(void)
                                       0x4d, 192,  168,  123,  1,    172,  16,   243,  197,  0xab, 0xcd,
                                       0x12, 0x34, 0x00, 0x0c, 0xa1, 0x8d, 0x61, 0x62, 0x63, 0x64};
 
-        TestCase6To4("good v6 udp datagram", kIp6Packet, Nat64::Translator::kForward, kIp4Packet, sizeof(kIp4Packet));
+        Verify6To4("Valid v6 UDP", kIp6Packet, kIp4Packet, Translator::kForward);
     }
 
     {
@@ -219,7 +264,7 @@ void TestNat64(void)
             0x00, 0x00, 0x00, 0x01, 0xab, 0xcd, 0x12, 0x34, 0x00, 0x0c, 0xe3, 0x31, 0x61, 0x62, 0x63, 0x64,
         };
 
-        TestCase4To6("good v4 udp datagram", kIp4Packet, Nat64::Translator::kForward, kIp6Packet, sizeof(kIp6Packet));
+        Verify4To6("Valid v4 UDP", kIp4Packet, kIp6Packet, Translator::kForward);
     }
 
     {
@@ -236,7 +281,7 @@ void TestNat64(void)
                                       0x12, 0x34, 0x87, 0x65, 0x43, 0x21, 0x12, 0x34, 0x56, 0x78, 0x50,
                                       0x10, 0x00, 0x01, 0x1e, 0x54, 0x00, 0x00, 0x61, 0x62, 0x63, 0x64};
 
-        TestCase6To4("good v6 tcp datagram", kIp6Packet, Nat64::Translator::kForward, kIp4Packet, sizeof(kIp4Packet));
+        Verify6To4("Valid v6 TCP", kIp6Packet, kIp4Packet, Translator::kForward);
     }
 
     {
@@ -253,7 +298,7 @@ void TestNat64(void)
             0x12, 0x34, 0x56, 0x78, 0x50, 0x10, 0x00, 0x01, 0x5f, 0xf8, 0x00, 0x00, 0x61, 0x62, 0x63, 0x64,
         };
 
-        TestCase4To6("good v4 tcp datagram", kIp4Packet, Nat64::Translator::kForward, kIp6Packet, sizeof(kIp6Packet));
+        Verify4To6("Valid v4 TCP", kIp4Packet, kIp6Packet, Translator::kForward);
     }
 
     {
@@ -268,8 +313,7 @@ void TestNat64(void)
                                       0x5d, 192,  168,  123,  1,    172,  16,   243,  197,  0x08, 0x00,
                                       0x88, 0x7c, 0xaa, 0xbb, 0x00, 0x01, 0x61, 0x62, 0x63, 0x64};
 
-        TestCase6To4("good v6 icmp ping request datagram", kIp6Packet, Nat64::Translator::kForward, kIp4Packet,
-                     sizeof(kIp4Packet));
+        Verify6To4("Valid v6 ICMP ping", kIp6Packet, kIp4Packet, Translator::kForward);
     }
 
     {
@@ -284,8 +328,7 @@ void TestNat64(void)
             0x00, 0x00, 0x00, 0x01, 0x81, 0x00, 0x75, 0x59, 0xaa, 0xbb, 0x00, 0x01, 0x61, 0x62, 0x63, 0x64,
         };
 
-        TestCase4To6("good v4 icmp ping response datagram", kIp4Packet, Nat64::Translator::kForward, kIp6Packet,
-                     sizeof(kIp6Packet));
+        Verify4To6("Valid v4 ICMP ping", kIp4Packet, kIp6Packet, Translator::kForward);
     }
 
     {
@@ -294,7 +337,7 @@ void TestNat64(void)
                                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xfd, 0x01,
                                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 172,  16,   243};
 
-        TestCase6To4("bad v6 datagram", kIp6Packet, Nat64::Translator::kDrop, nullptr, 0);
+        Verify6To4("Invalid v6", kIp6Packet, Translator::kDrop);
     }
 
     {
@@ -302,7 +345,7 @@ void TestNat64(void)
         const uint8_t kIp4Packet[] = {0x45, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x3f, 0x11,
                                       0xa0, 0x4c, 172,  16,   243,  197,  192,  168,  123};
 
-        TestCase4To6("bad v4 datagram", kIp4Packet, Nat64::Translator::kDrop, nullptr, 0);
+        Verify4To6("Invalid v4", kIp4Packet, Translator::kDrop);
     }
 
     {
@@ -311,33 +354,33 @@ void TestNat64(void)
                                       0x4c, 172,  16,   243,  197,  192,  168,  123,  2,    0xab, 0xcd,
                                       0x12, 0x34, 0x00, 0x0c, 0xa1, 0x8c, 0x61, 0x62, 0x63, 0x64};
 
-        TestCase4To6("no v4 mapping", kIp4Packet, Nat64::Translator::kDrop, nullptr, 0);
+        Verify4To6("No v4 mapping", kIp4Packet, Translator::kDrop);
     }
+
+    Log("End of TestNat64Translation");
 
     testFreeInstance(sInstance);
 }
 
-void TestPacketCounter(void)
+void TestNat64Counters(void)
 {
-    Ip6::Prefix  nat64prefix;
-    Ip4::Cidr    nat64cidr;
-    Ip6::Address ip6Source;
-    Ip6::Address ip6Dest;
+    Ip6::Prefix                        prefix;
+    Ip4::Cidr                          cidr;
+    Translator::AddressMappingIterator iter;
+    Translator::AddressMapping         mapping;
+    Translator::ProtocolCounters       expectedCounters;
 
-    printf("Test: Packet counter is cleared for new mappings.\n");
+    Log("--------------------------------------------------------------------------------------------");
+    Log("TestNat64Counters");
 
     sInstance = testInitInstance();
+    VerifyOrQuit(sInstance != nullptr);
 
-    {
-        const uint8_t ip6Address[] = {0xfd, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-        const uint8_t ip4Address[] = {192, 168, 123, 1};
+    SuccessOrQuit(prefix.FromString("fd01::/96"));
+    SuccessOrQuit(cidr.FromString("192.168.123.1/32"));
 
-        nat64cidr.Set(ip4Address, 32);
-        nat64prefix.Set(ip6Address, 96);
-        SuccessOrQuit(sInstance->Get<Nat64::Translator>().SetIp4Cidr(nat64cidr));
-        sInstance->Get<Nat64::Translator>().SetNat64Prefix(nat64prefix);
-    }
+    SuccessOrQuit(sInstance->Get<Translator>().SetIp4Cidr(cidr));
+    sInstance->Get<Translator>().SetNat64Prefix(prefix);
 
     // Step 1: Make the mapping table dirty.
     {
@@ -352,62 +395,29 @@ void TestPacketCounter(void)
                                       0x4d, 192,  168,  123,  1,    172,  16,   243,  197,  0xab, 0xcd,
                                       0x12, 0x34, 0x00, 0x0c, 0xa1, 0x8d, 0x61, 0x62, 0x63, 0x64};
 
-        TestCase6To4("initial translation", kIp6Packet, Nat64::Translator::kForward, kIp4Packet, sizeof(kIp4Packet));
+        Verify6To4("First translation", kIp6Packet, kIp4Packet, Translator::kForward);
     }
 
-    {
-        Nat64::Translator::AddressMappingIterator iter;
-        otNat64AddressMapping                     mapping;
-        size_t                                    totalMappingCount = 0;
+    iter.Init(*sInstance);
 
-        iter.Init(*sInstance);
+    SuccessOrQuit(iter.GetNext(mapping));
 
-        while (iter.GetNext(mapping) == kErrorNone)
-        {
-            totalMappingCount++;
-            VerifyCounters(otNat64ProtocolCounters{.mTotal =
-                                                       {
-                                                           .m4To6Packets = 0,
-                                                           .m4To6Bytes   = 0,
-                                                           .m6To4Packets = 1,
-                                                           .m6To4Bytes   = 12,
-                                                       },
-                                                   .mIcmp =
-                                                       {
-                                                           .m4To6Packets = 0,
-                                                           .m4To6Bytes   = 0,
-                                                           .m6To4Packets = 0,
-                                                           .m6To4Bytes   = 0,
-                                                       },
-                                                   .mUdp =
-                                                       {
-                                                           .m4To6Packets = 0,
-                                                           .m4To6Bytes   = 0,
-                                                           .m6To4Packets = 1,
-                                                           .m6To4Bytes   = 12,
-                                                       },
-                                                   .mTcp =
-                                                       {
-                                                           .m4To6Packets = 0,
-                                                           .m4To6Bytes   = 0,
-                                                           .m6To4Packets = 0,
-                                                           .m6To4Bytes   = 0,
-                                                       }},
-                           mapping.mCounters);
-        }
-        VerifyOrQuit(totalMappingCount == 1);
-    }
+    expectedCounters.Clear();
+    expectedCounters.mUdp.m6To4Packets   = 1;
+    expectedCounters.mUdp.m6To4Bytes     = 12;
+    expectedCounters.mTotal.m6To4Packets = 1;
+    expectedCounters.mTotal.m6To4Bytes   = 12;
+    VerifyOrQuit(AsCoreType(&mapping.mCounters) == expectedCounters);
+
+    VerifyOrQuit(iter.GetNext(mapping) == kErrorNotFound);
 
     // Step 2: Release the mapping table item.
     {
-        const uint8_t ip6Address[] = {0xfd, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-        const uint8_t ip4Address[] = {192, 168, 124, 1};
+        SuccessOrQuit(prefix.FromString("fd01::/96"));
+        SuccessOrQuit(cidr.FromString("192.168.124.1/32"));
 
-        nat64cidr.Set(ip4Address, 32);
-        nat64prefix.Set(ip6Address, 96);
-        SuccessOrQuit(sInstance->Get<Nat64::Translator>().SetIp4Cidr(nat64cidr));
-        sInstance->Get<Nat64::Translator>().SetNat64Prefix(nat64prefix);
+        SuccessOrQuit(sInstance->Get<Translator>().SetIp4Cidr(cidr));
+        sInstance->Get<Translator>().SetNat64Prefix(prefix);
     }
 
     // Step 3: Reuse the same object for new mapping table item.
@@ -424,55 +434,26 @@ void TestPacketCounter(void)
                                       0x4d, 192,  168,  124,  1,    172,  16,   243,  197,  0xab, 0xcd,
                                       0x12, 0x34, 0x00, 0x0c, 0xa0, 0x8d, 0x61, 0x62, 0x63, 0x64};
 
-        TestCase6To4("translation with new mapping", kIp6Packet, Nat64::Translator::kForward, kIp4Packet,
-                     sizeof(kIp4Packet));
+        Verify6To4("Translation with new mapping", kIp6Packet, kIp4Packet, Translator::kForward);
     }
 
-    {
-        Nat64::Translator::AddressMappingIterator iter;
-        otNat64AddressMapping                     mapping;
-        size_t                                    totalMappingCount = 0;
+    iter.Init(*sInstance);
 
-        iter.Init(*sInstance);
+    SuccessOrQuit(iter.GetNext(mapping));
 
-        while (iter.GetNext(mapping) == kErrorNone)
-        {
-            totalMappingCount++;
-            VerifyCounters(otNat64ProtocolCounters{.mTotal =
-                                                       {
-                                                           .m4To6Packets = 0,
-                                                           .m4To6Bytes   = 0,
-                                                           .m6To4Packets = 1,
-                                                           .m6To4Bytes   = 12,
-                                                       },
-                                                   .mIcmp =
-                                                       {
-                                                           .m4To6Packets = 0,
-                                                           .m4To6Bytes   = 0,
-                                                           .m6To4Packets = 0,
-                                                           .m6To4Bytes   = 0,
-                                                       },
-                                                   .mUdp =
-                                                       {
-                                                           .m4To6Packets = 0,
-                                                           .m4To6Bytes   = 0,
-                                                           .m6To4Packets = 1,
-                                                           .m6To4Bytes   = 12,
-                                                       },
-                                                   .mTcp =
-                                                       {
-                                                           .m4To6Packets = 0,
-                                                           .m4To6Bytes   = 0,
-                                                           .m6To4Packets = 0,
-                                                           .m6To4Bytes   = 0,
-                                                       }},
-                           mapping.mCounters);
-        }
-        VerifyOrQuit(totalMappingCount == 1);
-    }
+    expectedCounters.Clear();
+    expectedCounters.mUdp.m6To4Packets   = 1;
+    expectedCounters.mUdp.m6To4Bytes     = 12;
+    expectedCounters.mTotal.m6To4Packets = 1;
+    expectedCounters.mTotal.m6To4Bytes   = 12;
+    VerifyOrQuit(AsCoreType(&mapping.mCounters) == expectedCounters);
+
+    VerifyOrQuit(iter.GetNext(mapping) == kErrorNotFound);
+
+    Log("End of TestNat64Counters");
 }
 
-} // namespace BorderRouter
+} // namespace Nat64
 } // namespace ot
 
 #endif // OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
@@ -480,11 +461,12 @@ void TestPacketCounter(void)
 int main(void)
 {
 #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
-    ot::BorderRouter::TestNat64();
-    ot::BorderRouter::TestPacketCounter();
+    ot::Nat64::TestNat64Translation();
+    ot::Nat64::TestNat64Counters();
     printf("All tests passed\n");
-#else  // OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
+#else
     printf("NAT64 is not enabled\n");
-#endif // OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
+#endif
+
     return 0;
 }


### PR DESCRIPTION
This change enhances the unit tests for the NAT64 `Translator` to improve readability. The key improvements include:

- Replaced raw hex dumps of packets with new helper functions that parse and log IPv4/IPv6 headers in a human-readable format.
- Simplified the counter tests and validation of the `ProtocolCounters`.
- Reworked the main test case functions, `Verify6To4()` and `Verify4To6()`, to leverage the new logging and verification
  helpers for better output.