### PR TITLE
[mle] improve logging for address solicit and router upgrade

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -2270,6 +2270,11 @@ private:
                                              otMessage           *aMessage,
                                              const otMessageInfo *aMessageInfo,
                                              otError              aResult);
+
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
+    const char *RouterUpgradeReasonToString(uint8_t aReason);
+#endif
+
 #endif // OPENTHREAD_FTD
 
     //------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This change introduces `RouterUpgradeReasonToString()` to provide human-readable strings for router upgrade reasons, which is used to enhance logging in `BecomeRouter()` and `ProcessAddressSolicit()`.

These additions provide clearer insight into why a device is attempting to become a router, aiding in debugging and network analysis.