### PR TITLE
[mle] simplify logic for multicast address registration

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -2132,6 +2132,7 @@ private:
     void       SendAnnounce(uint8_t aChannel, AnnounceMode aMode);
     void       SendAnnounce(uint8_t aChannel, const Ip6::Address &aDestination, AnnounceMode aMode = kNormalAnnounce);
     bool       IsNetworkDataNewer(const LeaderData &aLeaderData);
+    bool       ShouldRegisterMulticastAddrsWithParent(void) const;
     Error      ProcessMessageSecurity(Crypto::AesCcm::Mode    aMode,
                                       Message                &aMessage,
                                       const Ip6::MessageInfo &aMessageInfo,


### PR DESCRIPTION
This change introduces `ShouldRegisterMulticastAddrsWithParent()` to consolidate the logic for determining when a child should register its multicast addresses with its parent, thereby avoiding repeated code.

The criteria for registration remain the same: a child registers its multicast addresses if it is a Sleepy End Device (SED), or if it is a Minimal End Device (MED) and its parent is running Thread 1.2 or a later version.