### PR TITLE
[nat64] optimize `Translator::Mapping` memory usage

### DIFF
--- a/src/core/net/nat64_translator.cpp
+++ b/src/core/net/nat64_translator.cpp
@@ -361,12 +361,16 @@ Translator::Mapping::InfoString Translator::Mapping::ToString(void) const
 
 void Translator::Mapping::CopyTo(AddressMapping &aMapping, TimeMilli aNow) const
 {
-    aMapping.mId                 = mId;
-    aMapping.mIp4                = mIp4Address;
-    aMapping.mIp6                = mIp6Address;
+    ClearAllBytes(aMapping);
+
+    aMapping.mId       = mId;
+    aMapping.mIp4      = mIp4Address;
+    aMapping.mIp6      = mIp6Address;
+    aMapping.mCounters = mCounters;
+#if OPENTHREAD_CONFIG_NAT64_PORT_TRANSLATION_ENABLE
     aMapping.mSrcPortOrId        = mSrcPortOrId;
     aMapping.mTranslatedPortOrId = mTranslatedPortOrId;
-    aMapping.mCounters           = mCounters;
+#endif
 
     // We are removing expired mappings lazily, and an expired mapping
     // might become active again before actually removed. Report the
@@ -488,9 +492,6 @@ Translator::Mapping *Translator::AllocateMapping(const Ip6::Headers &aIp6Headers
 #if OPENTHREAD_CONFIG_NAT64_PORT_TRANSLATION_ENABLE
     mapping->mSrcPortOrId        = GetSourcePortOrIcmp6Id(aIp6Headers);
     mapping->mTranslatedPortOrId = AllocateSourcePort(mapping->mSrcPortOrId);
-#else
-    mapping->mSrcPortOrId        = 0;
-    mapping->mTranslatedPortOrId = 0;
 #endif
     mapping->Touch(aIp6Headers.GetIpProto());
 

--- a/src/core/net/nat64_translator.hpp
+++ b/src/core/net/nat64_translator.hpp
@@ -310,16 +310,20 @@ private:
         bool       Matches(const Ip6::Headers &aIp6Headers) const;
         bool       Matches(const Ip4::Headers &aIp4Headers) const;
         bool       Matches(const TimeMilli aNow) const { return mExpiry < aNow; }
-        bool       Matches(const uint16_t aPort) const { return mTranslatedPortOrId == aPort; }
+#if OPENTHREAD_CONFIG_NAT64_PORT_TRANSLATION_ENABLE
+        bool Matches(const uint16_t aPort) const { return mTranslatedPortOrId == aPort; }
+#endif
 
         Mapping         *mNext;
         uint64_t         mId;
         Ip4::Address     mIp4Address;
         Ip6::Address     mIp6Address;
-        uint16_t         mSrcPortOrId;
-        uint16_t         mTranslatedPortOrId;
         TimeMilli        mExpiry;
         ProtocolCounters mCounters;
+#if OPENTHREAD_CONFIG_NAT64_PORT_TRANSLATION_ENABLE
+        uint16_t mSrcPortOrId;
+        uint16_t mTranslatedPortOrId;
+#endif
     };
 
     Error    TranslateIcmp4(Message &aMessage, uint16_t aOriginalId);


### PR DESCRIPTION
This commit places the `mSrcPortOrId` and `mTranslatedPortOrId` members of the `Translator::Mapping` struct under the `OPENTHREAD_CONFIG_NAT64_PORT_TRANSLATION_ENABLE` build-time flag.

This optimization reduces the memory footprint of each `Mapping` entry and the `mMappingPool` when the NAT64 port translation feature is disabled.