### PR TITLE
[core] harmonize access to MLE component using `Get<Mle::Mle>()`

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -564,7 +564,6 @@ exit:
 
 Error MeshForwarder::UpdateIp6Route(Message &aMessage)
 {
-    Mle::Mle   &mle   = Get<Mle::Mle>();
     Error       error = kErrorNone;
     Ip6::Header ip6Header;
 
@@ -576,7 +575,7 @@ Error MeshForwarder::UpdateIp6Route(Message &aMessage)
 
     Get<MessageFramer>().DetermineMacSourceAddress(ip6Header.GetSource(), mMacAddrs);
 
-    if (mle.IsDisabled() || mle.IsDetached())
+    if (Get<Mle::Mle>().IsDisabled() || Get<Mle::Mle>().IsDetached())
     {
         if (ip6Header.GetDestination().IsLinkLocalMulticast())
         {
@@ -600,9 +599,9 @@ Error MeshForwarder::UpdateIp6Route(Message &aMessage)
         // with link security disabled, an End Device transmits
         // multicasts, as IEEE 802.15.4 unicasts to its parent.
 
-        if (mle.IsChild() && aMessage.IsLinkSecurityEnabled() && !aMessage.IsSubTypeMle())
+        if (Get<Mle::Mle>().IsChild() && aMessage.IsLinkSecurityEnabled() && !aMessage.IsSubTypeMle())
         {
-            mMacAddrs.mDestination.SetShort(mle.GetParentRloc16());
+            mMacAddrs.mDestination.SetShort(Get<Mle::Mle>().GetParentRloc16());
         }
         else
         {
@@ -613,9 +612,9 @@ Error MeshForwarder::UpdateIp6Route(Message &aMessage)
     {
         mMacAddrs.mDestination.SetExtendedFromIid(ip6Header.GetDestination().GetIid());
     }
-    else if (mle.IsMinimalEndDevice())
+    else if (Get<Mle::Mle>().IsMinimalEndDevice())
     {
-        mMacAddrs.mDestination.SetShort(mle.GetParentRloc16());
+        mMacAddrs.mDestination.SetShort(Get<Mle::Mle>().GetParentRloc16());
     }
     else
     {

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -369,7 +369,6 @@ exit:
 
 Error MeshForwarder::UpdateIp6RouteFtd(const Ip6::Header &aIp6Header, Message &aMessage)
 {
-    Mle::Mle &mle   = Get<Mle::Mle>();
     Error     error = kErrorNone;
     Neighbor *neighbor;
 
@@ -379,14 +378,14 @@ Error MeshForwarder::UpdateIp6RouteFtd(const Ip6::Header &aIp6Header, Message &a
     {
         mMeshDest = aMessage.GetMeshDest();
     }
-    else if (mle.IsRoutingLocator(aIp6Header.GetDestination()))
+    else if (Get<Mle::Mle>().IsRoutingLocator(aIp6Header.GetDestination()))
     {
         uint16_t rloc16 = aIp6Header.GetDestination().GetIid().GetLocator();
 
         VerifyOrExit(Mle::IsRouterIdValid(Mle::RouterIdFromRloc16(rloc16)), error = kErrorDrop);
         mMeshDest = rloc16;
     }
-    else if (mle.IsAnycastLocator(aIp6Header.GetDestination()))
+    else if (Get<Mle::Mle>().IsAnycastLocator(aIp6Header.GetDestination()))
     {
         uint16_t aloc16 = aIp6Header.GetDestination().GetIid().GetLocator();
 
@@ -396,7 +395,8 @@ Error MeshForwarder::UpdateIp6RouteFtd(const Ip6::Header &aIp6Header, Message &a
         // child of this device, prepare the message for indirect tx
         // to the sleepy child and un-mark message for direct tx.
 
-        if (mle.IsRouterOrLeader() && Mle::IsChildRloc16(mMeshDest) && mle.HasMatchingRouterIdWith(mMeshDest))
+        if (Get<Mle::Mle>().IsRouterOrLeader() && Mle::IsChildRloc16(mMeshDest) &&
+            Get<Mle::Mle>().HasMatchingRouterIdWith(mMeshDest))
         {
             Child *child = Get<ChildTable>().FindChild(mMeshDest, Child::kInStateValid);
 

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -212,12 +212,12 @@ void MlrManager::UpdateTimeTickerRegistration(void)
 void MlrManager::SendMlr(void)
 {
     Error        error;
-    Mle::Mle    &mle = Get<Mle::Mle>();
     AddressArray addresses;
 
     VerifyOrExit(!mMlrPending, error = kErrorBusy);
-    VerifyOrExit(mle.IsAttached(), error = kErrorInvalidState);
-    VerifyOrExit(mle.IsFullThreadDevice() || mle.GetParent().IsThreadVersion1p1(), error = kErrorInvalidState);
+    VerifyOrExit(Get<Mle::Mle>().IsAttached(), error = kErrorInvalidState);
+    VerifyOrExit(Get<Mle::Mle>().IsFullThreadDevice() || Get<Mle::Mle>().GetParent().IsThreadVersion1p1(),
+                 error = kErrorInvalidState);
     VerifyOrExit(Get<BackboneRouter::Leader>().HasPrimary(), error = kErrorInvalidState);
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
@@ -370,7 +370,6 @@ Error MlrManager::SendMlrMessage(const Ip6::Address   *aAddresses,
     OT_UNUSED_VARIABLE(aTimeout);
 
     Error            error   = kErrorNone;
-    Mle::Mle        &mle     = Get<Mle::Mle>();
     Coap::Message   *message = nullptr;
     Tmf::MessageInfo messageInfo(GetInstance());
     Ip6AddressesTlv  addressesTlv;
@@ -400,16 +399,16 @@ Error MlrManager::SendMlrMessage(const Ip6::Address   *aAddresses,
     OT_ASSERT(aTimeout == nullptr);
 #endif
 
-    if (!mle.IsFullThreadDevice() && mle.GetParent().IsThreadVersion1p1())
+    if (!Get<Mle::Mle>().IsFullThreadDevice() && Get<Mle::Mle>().GetParent().IsThreadVersion1p1())
     {
         uint8_t pbbrServiceId;
 
         SuccessOrExit(error = Get<BackboneRouter::Leader>().GetServiceId(pbbrServiceId));
-        mle.GetServiceAloc(pbbrServiceId, messageInfo.GetPeerAddr());
+        Get<Mle::Mle>().GetServiceAloc(pbbrServiceId, messageInfo.GetPeerAddr());
     }
     else
     {
-        messageInfo.GetPeerAddr().SetToRoutingLocator(mle.GetMeshLocalPrefix(),
+        messageInfo.GetPeerAddr().SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(),
                                                       Get<BackboneRouter::Leader>().GetServer16());
     }
 
@@ -607,9 +606,7 @@ void MlrManager::Reregister(void)
 
 void MlrManager::UpdateReregistrationDelay(bool aRereg)
 {
-    Mle::Mle &mle = Get<Mle::Mle>();
-
-    bool needSendMlr = (mle.IsFullThreadDevice() || mle.GetParent().IsThreadVersion1p1()) &&
+    bool needSendMlr = (Get<Mle::Mle>().IsFullThreadDevice() || Get<Mle::Mle>().GetParent().IsThreadVersion1p1()) &&
                        Get<BackboneRouter::Leader>().HasPrimary();
 
     if (!needSendMlr)

--- a/src/core/thread/neighbor_table.cpp
+++ b/src/core/thread/neighbor_table.cpp
@@ -46,15 +46,14 @@ NeighborTable::NeighborTable(Instance &aInstance)
 Neighbor *NeighborTable::FindParent(const Neighbor::AddressMatcher &aMatcher)
 {
     Neighbor *neighbor = nullptr;
-    Mle::Mle &mle      = Get<Mle::Mle>();
 
-    if (mle.GetParent().Matches(aMatcher))
+    if (Get<Mle::Mle>().GetParent().Matches(aMatcher))
     {
-        neighbor = &mle.GetParent();
+        neighbor = &Get<Mle::Mle>().GetParent();
     }
-    else if (mle.GetParentCandidate().Matches(aMatcher))
+    else if (Get<Mle::Mle>().GetParentCandidate().Matches(aMatcher))
     {
-        neighbor = &mle.GetParentCandidate();
+        neighbor = &Get<Mle::Mle>().GetParentCandidate();
     }
 
     return neighbor;


### PR DESCRIPTION
This change updates multiple modules to consistently use `Get<Mle::Mle>()` for accessing the MLE component, removing the need for local `Mle::Mle &mle` references.

This approach aligns with the common `Get<Module>()` access pattern used across the codebase, improving consistency.