### PR TITLE
[nat64] simplify `Translator::SendMessage()` using `OwnedPtr`

### DIFF
--- a/src/core/api/nat64_api.cpp
+++ b/src/core/api/nat64_api.cpp
@@ -58,7 +58,7 @@ otMessage *otIp4NewMessage(otInstance *aInstance, const otMessageSettings *aSett
 
 otError otNat64Send(otInstance *aInstance, otMessage *aMessage)
 {
-    return AsCoreType(aInstance).Get<Nat64::Translator>().SendMessage(AsCoreType(aMessage));
+    return AsCoreType(aInstance).Get<Nat64::Translator>().SendMessage(OwnedPtr<Message>(AsCoreTypePtr(aMessage)));
 }
 
 void otNat64SetReceiveIp4Callback(otInstance *aInstance, otNat64ReceiveIp4Callback aCallback, void *aContext)

--- a/src/core/net/nat64_translator.cpp
+++ b/src/core/net/nat64_translator.cpp
@@ -90,23 +90,14 @@ Message *Translator::NewIp4Message(const Message::Settings &aSettings)
     return message;
 }
 
-Error Translator::SendMessage(Message &aMessage)
+Error Translator::SendMessage(OwnedPtr<Message> aMessagePtr)
 {
-    bool   freed  = false;
-    Error  error  = kErrorDrop;
-    Result result = TranslateToIp6(aMessage);
+    Error error;
 
-    VerifyOrExit(result == kForward);
-
-    error = Get<Ip6::Ip6>().SendRaw(OwnedPtr<Message>(&aMessage).PassOwnership());
-    freed = true;
+    VerifyOrExit(TranslateToIp6(*aMessagePtr) == kForward, error = kErrorDrop);
+    error = Get<Ip6::Ip6>().SendRaw(aMessagePtr.PassOwnership());
 
 exit:
-    if (!freed)
-    {
-        aMessage.Free();
-    }
-
     return error;
 }
 

--- a/src/core/net/nat64_translator.hpp
+++ b/src/core/net/nat64_translator.hpp
@@ -166,10 +166,7 @@ public:
     /**
      * Translates an IPv4 datagram to an IPv6 datagram and sends it via Thread interface.
      *
-     * The caller transfers ownership of @p aMessage when making this call. OpenThread will free @p aMessage when
-     * processing is complete, including when a value other than `kErrorNone` is returned.
-     *
-     * @param[in]  aMessage          A reference to the message.
+     * @param[in] aMessagePtr   An owned pointer to a message (ownership is transferred to the method).
      *
      * @retval kErrorNone     Successfully processed the message.
      * @retval kErrorDrop     Message was well-formed but not fully processed due to datagram processing rules.
@@ -177,7 +174,7 @@ public:
      * @retval kErrorNoRoute  No route to host.
      * @retval kErrorParse    Encountered a malformed header when processing the message.
      */
-    Error SendMessage(Message &aMessage);
+    Error SendMessage(OwnedPtr<Message> aMessagePtr);
 
     /**
      * Allocate a new message buffer for sending an IPv4 message (which will be translated into an IPv6 datagram by


### PR DESCRIPTION
This commit simplifies the implementation of `SendMessage()` by changing its parameter from a `Message` reference to an `OwnedPtr`.

The `OwnedPtr` now manages the lifetime of the message, ensuring it is always freed, whether the translation and send operation succeed or fail. This change removes the need for a manual tracking flag and an explicit `Free()` call in the error path, resulting in cleaner and more robust code.