### PR TITLE
[ipv4] fix `Cidr::Clear()`

### DIFF
--- a/src/core/net/ip4_types.hpp
+++ b/src/core/net/ip4_types.hpp
@@ -189,7 +189,7 @@ private:
 /**
  * Represents an IPv4 CIDR block.
  */
-class Cidr : public otIp4Cidr, public Unequatable<Cidr>, public Clearable<Address>
+class Cidr : public otIp4Cidr, public Unequatable<Cidr>, public Clearable<Cidr>
 {
     friend class Address;
 


### PR DESCRIPTION
The `Cidr` class was incorrectly inheriting from `Clearable<Address>` instead of `Clearable<Cidr>`. This oversight meant that calling `Clear()` on a `Cidr` object would not clear its `mLength` member, only the `mAddress` field. This change corrects the template parameter for the `Clearable` base class to `Cidr`, ensuring the entire object is properly zeroed out.

This bug could cause issues in the NAT64 translator. When a user calls `otNat64ClearIp4Cidr()` to disable translation, the underlying `mIp4Cidr.Clear()` method would fail to clear the CIDR length. The `Nat64::Translator` would check `mIp4Cidr.mLength > 0` in its `UpdateState()` method to determine if a valid CIDR is configured. Because `mLength` was not cleared, this check would pass incorrectly, causing NAT64 translation to continue with an invalid, partially-cleared CIDR instead of stopping as expected.