### PR TITLE
[tcat] improved debug info format using hexadecimal + ASCII dump

### DIFF
--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -874,6 +874,7 @@ Error TcatAgent::VerifyHash(const Message &aIncomingMessage,
     VerifyOrExit(mRandomChallenge != 0, error = kErrorSecurity);
 
     CalculateHash(mRandomChallenge, reinterpret_cast<const char *>(aBuf), aBufLen, hash);
+    DumpDebg("Hash", &hash, sizeof(hash));
 
     VerifyOrExit(aIncomingMessage.Compare(aOffset, hash), error = kErrorSecurity);
 

--- a/src/core/radio/ble_secure.cpp
+++ b/src/core/radio/ble_secure.cpp
@@ -420,6 +420,7 @@ void BleSecure::HandleTlsReceive(void *aContext, uint8_t *aBuf, uint16_t aLength
 void BleSecure::HandleTlsReceive(uint8_t *aBuf, uint16_t aLength)
 {
     VerifyOrExit(mReceivedMessage != nullptr);
+    DumpDebg("Rx", aBuf, aLength);
 
     if (!mTlvMode)
     {
@@ -527,6 +528,11 @@ void BleSecure::HandleTransmit(void)
     Error        error   = kErrorNone;
     ot::Message *message = mTransmitQueue.GetHead();
 
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)
+    uint16_t len;
+    uint8_t  buf[kTlsDataMaxSize];
+#endif
+
     VerifyOrExit(message != nullptr);
     mTransmitQueue.Dequeue(*message);
 
@@ -536,7 +542,11 @@ void BleSecure::HandleTransmit(void)
     }
 
     SuccessOrExit(error = mTls.Send(*message));
-    LogDebg("Transmit");
+
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)
+    len = message->ReadBytes(message->GetOffset(), buf, sizeof(buf));
+    DumpDebg("Tx", buf, len);
+#endif
 
 exit:
     FreeMessageOnError(message, error);

--- a/tools/tcat_ble_client/ble/ble_stream.py
+++ b/tools/tcat_ble_client/ble/ble_stream.py
@@ -57,7 +57,7 @@ class BleStream:
             await self.client.disconnect()
 
     def __handle_rx(self, _: BleakGATTCharacteristic, data: bytearray):
-        logger.debug(f'received {len(data)} bytes')
+        logger.debug(f'rx {len(data)} bytes')
         self.__receive_buffer += data
         self.__last_recv_time = time.time()
 
@@ -74,7 +74,7 @@ class BleStream:
         return self
 
     async def send(self, data):
-        logger.debug(f'sending {data}')
+        logger.debug(f'tx {len(data)} bytes')
         services = self.client.services.get_service(self.service_uuid)
         rx_char = services.get_characteristic(self.rx_char_uuid)
         for s in BleStream.__sliced(data, rx_char.max_write_without_response_size):
@@ -88,10 +88,10 @@ class BleStream:
         while time.time() - self.__last_recv_time <= recv_timeout:
             await sleep(0.1)
 
-        message = self.__receive_buffer[:bufsize]
+        data = self.__receive_buffer[:bufsize]
         self.__receive_buffer = self.__receive_buffer[bufsize:]
-        logger.debug(f'retrieved {message}')
-        return message
+        logger.debug(f'rx {len(data)} bytes')
+        return data
 
     async def disconnect(self):
         if self.client.is_connected:

--- a/tools/tcat_ble_client/ble/ble_stream_secure.py
+++ b/tools/tcat_ble_client/ble/ble_stream_secure.py
@@ -114,6 +114,7 @@ class BleStreamSecure:
         return True
 
     async def send(self, bytes):
+        logger.debug(f"tx {len(bytes)} bytes\n" + utils.hexdump_ot("Tx", bytes))
         self.ssl_object.write(bytes)
         encode = self.outgoing.read(4096)
         await self.stream.send(encode)
@@ -140,6 +141,8 @@ class BleStreamSecure:
                     await asyncio.sleep(0.1)
                     more = await self.stream.recv(buffersize)
                 self.incoming.write(more)
+
+        logger.debug(f"rx {len(decode)} bytes\n" + utils.hexdump_ot("Rx", decode))
         return decode
 
     async def send_with_resp(self, bytes):

--- a/tools/tcat_ble_client/ble/udp_stream.py
+++ b/tools/tcat_ble_client/ble/udp_stream.py
@@ -45,14 +45,14 @@ class UdpStream:
         self.address = (address, self.BASE_PORT + node_id)
 
     async def send(self, data):
-        logger.debug(f'sending {len(data)} bytes: {data}')
+        logger.debug(f'tx {len(data)} bytes')
         return self.socket.sendto(data, self.address)
 
     async def recv(self, bufsize):
         ready = select.select([self.socket], [], [], self.MAX_SERVER_TIMEOUT_SEC)
         if ready[0]:
             data = self.socket.recv(bufsize)
-            logger.debug(f'received {len(data)} bytes: {data}')
+            logger.debug(f'rx {len(data)} bytes')
             return data
         else:
             raise Exception('simulation UdpStream recv timeout - likely, TCAT is stopped on TCAT Device')


### PR DESCRIPTION
This improves debuggability of TCAT client and server, by using one unified format (hex + ASCII) to show transmitted and received TCAT data within the TLS session, as well as showing size of the encrypted (TLS) data. For encrypted data, only size is now shown to avoid clutter. Showing the hex + ASCII dump allows devs/testers to visually read TCAT TLVs from screen and identify how all TCAT commands are processed by the Thread device.