### PR TITLE
[message] improve scoping of `Buffer` constants

### DIFF
--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -141,9 +141,6 @@ class HmacSha256;
         }                                                        \
     } while (false)
 
-constexpr uint16_t kNumBuffers = OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS;
-constexpr uint16_t kBufferSize = OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE;
-
 class Message;
 class MessagePool;
 class MessageQueue;
@@ -166,6 +163,8 @@ class Buffer : public otMessageBuffer, public LinkedListEntry<Buffer>
     friend class Message;
 
 public:
+    static constexpr uint16_t kSize = OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE; ///< Size of buffer in bytes.
+
     typedef otMessageTxCallback TxCallback; ///< Message TX callback.
 
     /**
@@ -244,9 +243,9 @@ protected:
 #endif
     };
 
-    static_assert(kBufferSize > sizeof(Metadata) + sizeof(otMessageBuffer), "Metadata does not fit in a single buffer");
+    static_assert(kSize > sizeof(Metadata) + sizeof(otMessageBuffer), "Metadata does not fit in a single buffer");
 
-    static constexpr uint16_t kBufferDataSize     = kBufferSize - sizeof(otMessageBuffer);
+    static constexpr uint16_t kBufferDataSize     = kSize - sizeof(otMessageBuffer);
     static constexpr uint16_t kHeadBufferDataSize = kBufferDataSize - sizeof(Metadata);
 
     Metadata       &GetMetadata(void) { return mBuffer.mHead.mMetadata; }
@@ -270,7 +269,7 @@ private:
     } mBuffer;
 };
 
-static_assert(sizeof(Buffer) >= kBufferSize,
+static_assert(sizeof(Buffer) >= Buffer::kSize,
               "Buffer size is not valid. Increase OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE.");
 
 /**
@@ -1917,6 +1916,8 @@ public:
     void ResetMaxUsedBufferCount(void) { mMaxAllocated = mNumAllocated; }
 
 private:
+    static constexpr uint16_t kNumBuffers = OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS;
+
     Buffer *NewBuffer(Message::Priority aPriority);
     void    FreeBuffers(Buffer *aBuffer);
     Error   ReclaimBuffers(Message::Priority aPriority);

--- a/src/core/meshcop/meshcop.cpp
+++ b/src/core/meshcop/meshcop.cpp
@@ -334,7 +334,7 @@ void LogCertMessage(const char *aText, const Coap::Message &aMessage)
 {
     OT_UNUSED_VARIABLE(aText);
 
-    uint8_t  buf[kBufferSize];
+    uint8_t  buf[Buffer::kSize];
     uint16_t length = aMessage.GetLength() - aMessage.GetOffset();
 
     VerifyOrExit(length <= sizeof(buf));

--- a/src/core/meshcop/tcat_agent.hpp
+++ b/src/core/meshcop/tcat_agent.hpp
@@ -408,7 +408,7 @@ private:
     static constexpr uint16_t kTcatMaxDeviceIdSize       = OT_TCAT_MAX_DEVICEID_SIZE;
     static constexpr uint16_t kInstallCodeMaxSize        = 255;
     static constexpr uint16_t kCommissionerCertMaxLength = 1024;
-    static constexpr uint16_t kBufferReserve             = 2048 / (kBufferSize - sizeof(otMessageBuffer)) + 1;
+    static constexpr uint16_t kBufferReserve             = 2048 / (Buffer::kSize - sizeof(otMessageBuffer)) + 1;
     static constexpr uint8_t  kServiceNameMaxLength      = OT_TCAT_SERVICE_NAME_MAX_LENGTH;
     static constexpr uint8_t  kApplicationLayerMaxCount  = OT_TCAT_APPLICATION_LAYER_MAX_COUNT;
 

--- a/tests/unit/test_checksum.cpp
+++ b/tests/unit/test_checksum.cpp
@@ -173,7 +173,7 @@ void CorruptMessage(Message &aMessage)
 void TestUdpMessageChecksum(void)
 {
     constexpr uint16_t kMinSize = sizeof(Ip6::Udp::Header);
-    constexpr uint16_t kMaxSize = kBufferSize * 3 + 24;
+    constexpr uint16_t kMaxSize = Buffer::kSize * 3 + 24;
 
     const char *kSourceAddress = "fd00:1122:3344:5566:7788:99aa:bbcc:ddee";
     const char *kDestAddress   = "fd01:2345:6789:abcd:ef01:2345:6789:abcd";
@@ -241,7 +241,7 @@ void TestUdpMessageChecksum(void)
 void TestIcmp6MessageChecksum(void)
 {
     constexpr uint16_t kMinSize = sizeof(Ip6::Icmp::Header);
-    constexpr uint16_t kMaxSize = kBufferSize * 3 + 24;
+    constexpr uint16_t kMaxSize = Buffer::kSize * 3 + 24;
 
     const char *kSourceAddress = "fd00:feef:dccd:baab:9889:7667:5444:3223";
     const char *kDestAddress   = "fd01:abab:beef:cafe:1234:5678:9abc:0";
@@ -310,7 +310,7 @@ void TestIcmp6MessageChecksum(void)
 void TestTcp4MessageChecksum(void)
 {
     constexpr size_t kMinSize = sizeof(Ip4::Tcp::Header);
-    constexpr size_t kMaxSize = kBufferSize * 3 + 24;
+    constexpr size_t kMaxSize = Buffer::kSize * 3 + 24;
 
     const char *kSourceAddress = "12.34.56.78";
     const char *kDestAddress   = "87.65.43.21";
@@ -365,7 +365,7 @@ void TestTcp4MessageChecksum(void)
 void TestUdp4MessageChecksum(void)
 {
     constexpr uint16_t kMinSize = sizeof(Ip4::Udp::Header);
-    constexpr uint16_t kMaxSize = kBufferSize * 3 + 24;
+    constexpr uint16_t kMaxSize = Buffer::kSize * 3 + 24;
 
     const char *kSourceAddress = "12.34.56.78";
     const char *kDestAddress   = "87.65.43.21";

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -39,7 +39,7 @@ namespace ot {
 
 void TestMessage(void)
 {
-    static constexpr uint16_t kMaxSize    = (kBufferSize * 3 + 24);
+    static constexpr uint16_t kMaxSize    = (Buffer::kSize * 3 + 24);
     static constexpr uint16_t kOffsetStep = 101;
     static constexpr uint16_t kLengthStep = 21;
 


### PR DESCRIPTION
This commit moves two global constants, `kBufferSize` and `kNumBuffers`, into their respective class scopes to improve encapsulation and avoid potential name conflicts.

The `kBufferSize` constant is moved into the `Buffer` class as `Buffer::kSize`. As `kBufferSize` is a generic and commonly used name, this change prevents potential symbol collisions.

Similarly, the `kNumBuffers` constant is moved into the `MessagePool` class, as it is exclusively used within that class.

All usages of these constants have been updated throughout the codebase to reflect their new names.