### PR TITLE
[common] move bit-related macros to `bit_utils.hpp`

### DIFF
--- a/src/core/common/bit_set.hpp
+++ b/src/core/common/bit_set.hpp
@@ -36,9 +36,9 @@
 
 #include "openthread-core-config.h"
 
+#include "common/bit_utils.hpp"
 #include "common/clearable.hpp"
 #include "common/equatable.hpp"
-#include "common/numeric_limits.hpp"
 
 namespace ot {
 

--- a/src/core/common/bit_utils.hpp
+++ b/src/core/common/bit_utils.hpp
@@ -40,6 +40,26 @@
 
 namespace ot {
 
+static constexpr uint8_t kBitsPerByte = 8; ///< Number of bits in a byte.
+
+/**
+ * Returns the bit-size (number of bits) of a given type or variable.
+ *
+ * @param[in] aItem   The item (type or variable or expression) to get the bit-size of.
+ *
+ * @returns Number of bits of @p aItem.
+ */
+#define BitSizeOf(aItem) (sizeof(aItem) * kBitsPerByte)
+
+/**
+ * Determines number of bytes to represent a given number of bits.
+ *
+ * @param[in] aBitSize    The bit-size (number of bits).
+ *
+ * @returns Number of bytes to represent @p aBitSize.
+ */
+#define BytesForBitSize(aBitSize) static_cast<uint8_t>(((aBitSize) + (kBitsPerByte - 1)) / kBitsPerByte)
+
 /**
  * Counts the number of `1` bits in the binary representation of a given unsigned int bit-mask value.
  *

--- a/src/core/common/numeric_limits.hpp
+++ b/src/core/common/numeric_limits.hpp
@@ -38,26 +38,6 @@
 
 namespace ot {
 
-static constexpr uint8_t kBitsPerByte = 8; ///< Number of bits in a byte.
-
-/**
- * Returns the bit-size (number of bits) of a given type or variable.
- *
- * @param[in] aItem   The item (type or variable or expression) to get the bit-size of.
- *
- * @returns Number of bits of @p aItem.
- */
-#define BitSizeOf(aItem) (sizeof(aItem) * kBitsPerByte)
-
-/**
- * Determines number of byes to represent a given number of bits.
- *
- * @param[in] aBitSize    The bit-size (number of bits).
- *
- * @returns Number of bytes to represent @p aBitSize.
- */
-#define BytesForBitSize(aBitSize) static_cast<uint8_t>(((aBitSize) + (kBitsPerByte - 1)) / kBitsPerByte)
-
 /**
  * Provides a way to query properties of arithmetic types.
  *

--- a/src/core/common/time_ticker.hpp
+++ b/src/core/common/time_ticker.hpp
@@ -36,9 +36,9 @@
 
 #include "openthread-core-config.h"
 
+#include "common/bit_utils.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
-#include "common/numeric_limits.hpp"
 #include "common/time.hpp"
 #include "common/timer.hpp"
 

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -39,11 +39,10 @@
 #include <openthread/ip6.h>
 
 #include "common/as_core_type.hpp"
+#include "common/bit_utils.hpp"
 #include "common/clearable.hpp"
 #include "common/encoding.hpp"
 #include "common/equatable.hpp"
-#include "common/num_utils.hpp"
-#include "common/numeric_limits.hpp"
 #include "common/string.hpp"
 #include "mac/mac_types.hpp"
 


### PR DESCRIPTION
This change moves the `kBitsPerByte` constant and the `BitSizeOf()` and `BytesForBitSize()` macros from `numeric_limits.hpp` to the more specialized `bit_utils.hpp` header.

This consolidation places common bit-utility definitions into a more appropriate, dedicated header, improving code organization and logical grouping. Headers that relied on these definitions are updated accordingly.