### PR TITLE
[history-tracker] enable tracking indirect tx

### DIFF
--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -500,6 +500,14 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
 
         message->InvokeTxCallback(txError);
 
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+        if (aFrame.IsEmpty())
+        {
+            aChild.GetMacAddress(macDest);
+        }
+
+        Get<HistoryTracker::Local>().RecordTxMessage(*message, macDest, txError == kErrorNone);
+#endif
         Get<MeshForwarder>().RemoveMessageIfNoPendingTx(*message);
     }
 

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -921,7 +921,7 @@ void MeshForwarder::UpdateSendMessage(Error aFrameTxError, Mac::Address &aMacDes
 #endif
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    Get<HistoryTracker::Local>().RecordTxMessage(*mSendMessage, aMacDest);
+    Get<HistoryTracker::Local>().RecordTxMessage(*mSendMessage, aMacDest, mSendMessage->GetTxSuccess());
 #endif
 
     LogMessage(kMessageTransmit, *mSendMessage, txError, &aMacDest);

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -63,10 +63,6 @@ namespace Mle {
 class DiscoverScanner;
 }
 
-namespace Utils {
-class HistoryTracker;
-}
-
 /**
  * @addtogroup core-mesh-forwarding
  *

--- a/src/core/utils/history_tracker.cpp
+++ b/src/core/utils/history_tracker.cpp
@@ -74,7 +74,10 @@ exit:
     return;
 }
 
-void Local::RecordMessage(const Message &aMessage, const Mac::Address &aMacAddress, MessageType aType)
+void Local::RecordMessage(const Message      &aMessage,
+                          const Mac::Address &aMacAddress,
+                          MessageType         aType,
+                          bool                aIsTxSuccess)
 {
     MessageInfo *entry = nullptr;
     Ip6::Headers headers;
@@ -127,7 +130,7 @@ void Local::RecordMessage(const Message &aMessage, const Mac::Address &aMacAddre
     entry->mIcmp6Type            = headers.IsIcmp6() ? headers.GetIcmpHeader().GetType() : 0;
     entry->mAveRxRss             = (aType == kRxMessage) ? aMessage.GetRssAverager().GetAverage() : Radio::kInvalidRssi;
     entry->mLinkSecurity         = aMessage.IsLinkSecurityEnabled();
-    entry->mTxSuccess            = (aType == kTxMessage) ? aMessage.GetTxSuccess() : true;
+    entry->mTxSuccess            = (aType == kTxMessage) ? aIsTxSuccess : true;
     entry->mPriority             = aMessage.GetPriority();
 
     if (aMacAddress.IsExtended())

--- a/src/core/utils/history_tracker.hpp
+++ b/src/core/utils/history_tracker.hpp
@@ -141,6 +141,9 @@ static constexpr uint8_t kNoNextHop = OT_HISTORY_TRACKER_NO_NEXT_HOP;
  */
 class Local : public InstanceLocator, private NonCopyable
 {
+#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+    friend class ot::IndirectSender;
+#endif
     friend class ot::MeshForwarder;
     friend class ot::Notifier;
     friend class ot::Mle::Mle;
@@ -491,13 +494,16 @@ private:
         RecordMessage(aMessage, aMacSource, kRxMessage);
     }
 
-    void RecordTxMessage(const Message &aMessage, const Mac::Address &aMacDest)
+    void RecordTxMessage(const Message &aMessage, const Mac::Address &aMacDest, bool aIsTxSuccess)
     {
-        RecordMessage(aMessage, aMacDest, kTxMessage);
+        RecordMessage(aMessage, aMacDest, kTxMessage, aIsTxSuccess);
     }
 
     void RecordNetworkInfo(void);
-    void RecordMessage(const Message &aMessage, const Mac::Address &aMacAddress, MessageType aType);
+    void RecordMessage(const Message      &aMessage,
+                       const Mac::Address &aMacAddress,
+                       MessageType         aType,
+                       bool                aIsTxSuccess = true);
     void RecordNeighborEvent(NeighborTable::Event aEvent, const NeighborTable::EntryInfo &aInfo);
     void RecordAddressEvent(Ip6::Netif::AddressEvent aEvent, const Ip6::Netif::UnicastAddress &aUnicastAddress);
     void RecordAddressEvent(Ip6::Netif::AddressEvent            aEvent,


### PR DESCRIPTION
The current history tracker only records direct transmissions, but indirect transmissions are also required for debugging. This PR adds support for tracking indirect transmissions.