### PR TITLE
[nat64] ensure translator is active before translation

### DIFF
--- a/tests/unit/test_nat64.cpp
+++ b/tests/unit/test_nat64.cpp
@@ -236,6 +236,7 @@ void TestNat64Translation(void)
 
     SuccessOrQuit(sInstance->Get<Translator>().SetIp4Cidr(cidr));
     sInstance->Get<Translator>().SetNat64Prefix(prefix);
+    sInstance->Get<Translator>().SetEnabled(true);
 
     {
         // fd02::1               fd01::ac10:f3c5       UDP      52     43981 → 4660 Len=4


### PR DESCRIPTION
This change adds an explicit check for `mState == kStateActive` at the beginning of the translation functions.

This single check replaces individual validations for a valid IPv4 CIDR and NAT64 prefix. This simplifies the entry logic and fixes a bug where the `Translator` could continue performing translations even after it was explicitly disabled via `SetEnabled(false)`.

Additionally, this change fixes a bug in `TranslateToIp6()` where an IPv4 message would be incorrectly marked as `kForward` when no IPv4 CIDR was configured (`mIp4Cidr.mLength == 0`). The correct behavior is to drop the packet, so the result is now set to `kDrop`.