### PR TITLE
[nat64] rename `GetIp6Prefix` to `GetNat64Prefix`

### DIFF
--- a/src/core/net/nat64_translator.cpp
+++ b/src/core/net/nat64_translator.cpp
@@ -663,6 +663,17 @@ void Translator::ClearIp4Cidr(void)
     UpdateState();
 }
 
+Error Translator::GetIp4Cidr(Ip4::Cidr &aCidr) const
+{
+    Error error = kErrorNone;
+
+    VerifyOrExit(mIp4Cidr.mLength > 0, error = kErrorNotFound);
+    aCidr = mIp4Cidr;
+
+exit:
+    return error;
+}
+
 void Translator::SetNat64Prefix(const Ip6::Prefix &aNat64Prefix)
 {
     if (aNat64Prefix.GetLength() == 0)
@@ -688,6 +699,17 @@ exit:
     return;
 }
 
+Error Translator::GetNat64Prefix(Ip6::Prefix &aPrefix) const
+{
+    Error error = kErrorNone;
+
+    VerifyOrExit(mNat64Prefix.mLength > 0, error = kErrorNotFound);
+    aPrefix = mNat64Prefix;
+
+exit:
+    return error;
+}
+
 void Translator::HandleTimer(void)
 {
     mActiveMappings.RemoveAndFreeAllMatching(TimerMilli::GetNow());
@@ -708,28 +730,6 @@ Error Translator::AddressMappingIterator::GetNext(AddressMapping &aMapping)
 
     GetMapping()->CopyTo(aMapping, GetInitTime());
     SetMapping(GetMapping()->GetNext());
-
-exit:
-    return error;
-}
-
-Error Translator::GetIp4Cidr(Ip4::Cidr &aCidr) const
-{
-    Error error = kErrorNone;
-
-    VerifyOrExit(mIp4Cidr.mLength > 0, error = kErrorNotFound);
-    aCidr = mIp4Cidr;
-
-exit:
-    return error;
-}
-
-Error Translator::GetIp6Prefix(Ip6::Prefix &aPrefix) const
-{
-    Error error = kErrorNone;
-
-    VerifyOrExit(mNat64Prefix.mLength > 0, error = kErrorNotFound);
-    aPrefix = mNat64Prefix;
 
 exit:
     return error;

--- a/src/core/net/nat64_translator.hpp
+++ b/src/core/net/nat64_translator.hpp
@@ -239,6 +239,16 @@ public:
     void ClearIp4Cidr(void);
 
     /**
+     * Gets the configured CIDR in the NAT64 translator.
+     *
+     * @param[out] aCidr        The `Ip4::Cidr` Where the configured CIDR will be placed.
+     *
+     * @retval kErrorNone       @p aCidr is set to the configured CIDR.
+     * @retval kErrorNotFound   The translator is not configured with an IPv4 CIDR.
+     */
+    Error GetIp4Cidr(Ip4::Cidr &aCidr) const;
+
+    /**
      * Sets the prefix of NAT64-mapped addresses in the thread network. The address mapping table will not be cleared.
      * Equals to `ClearNat64Prefix` when an empty prefix is provided.
      *
@@ -251,6 +261,16 @@ public:
      * The translator will return kNotTranslated for all IPv6 datagrams and kDrop for all IPv4 datagrams.
      */
     void ClearNat64Prefix(void);
+
+    /**
+     * Gets the configured IPv6 prefix in the NAT64 translator.
+     *
+     * @param[out] aPrefix      The `Ip6::Prefix` where the configured NAT64 prefix will be placed.
+     *
+     * @retval kErrorNone       @p aPrefix is set to the configured prefix.
+     * @retval kErrorNotFound   The translator is not configured with an IPv6 prefix.
+     */
+    Error GetNat64Prefix(Ip6::Prefix &aPrefix) const;
 
     /**
      * Gets the NAT64 translator counters.
@@ -269,26 +289,6 @@ public:
      * @returns The error counters.
      */
     const ErrorCounters &GetErrorCounters(void) const { return mErrorCounters; }
-
-    /**
-     * Gets the configured CIDR in the NAT64 translator.
-     *
-     * @param[out] aCidr        The `Ip4::Cidr` Where the configured CIDR will be placed.
-     *
-     * @retval kErrorNone       @p aCidr is set to the configured CIDR.
-     * @retval kErrorNotFound   The translator is not configured with an IPv4 CIDR.
-     */
-    Error GetIp4Cidr(Ip4::Cidr &aCidr) const;
-
-    /**
-     * Gets the configured IPv6 prefix in the NAT64 translator.
-     *
-     * @param[out] aPrefix      The `Ip6::Prefix` where the configured NAT64 prefix will be placed.
-     *
-     * @retval kErrorNone       @p aPrefix is set to the configured prefix.
-     * @retval kErrorNotFound   The translator is not configured with an IPv6 prefix.
-     */
-    Error GetIp6Prefix(Ip6::Prefix &aPrefix) const;
 
 private:
     // Timeouts are in milliseconds

--- a/tests/nexus/test_nat64_translator.cpp
+++ b/tests/nexus/test_nat64_translator.cpp
@@ -75,7 +75,7 @@ void TestNat64StateChanges(void)
     VerifyOrQuit(node.Get<Nat64::Translator>().GetState() == Nat64::kStateDisabled);
 
     VerifyOrQuit(node.Get<Nat64::Translator>().GetIp4Cidr(cidr) == kErrorNotFound);
-    VerifyOrQuit(node.Get<Nat64::Translator>().GetIp6Prefix(prefix) == kErrorNotFound);
+    VerifyOrQuit(node.Get<Nat64::Translator>().GetNat64Prefix(prefix) == kErrorNotFound);
 
     iterator.Init(node.GetInstance());
     VerifyOrQuit(iterator.GetNext(mapping) == kErrorNotFound);
@@ -88,7 +88,7 @@ void TestNat64StateChanges(void)
     VerifyOrQuit(node.Get<Nat64::Translator>().GetState() == Nat64::kStateNotRunning);
 
     VerifyOrQuit(node.Get<Nat64::Translator>().GetIp4Cidr(cidr) == kErrorNotFound);
-    VerifyOrQuit(node.Get<Nat64::Translator>().GetIp6Prefix(prefix) == kErrorNotFound);
+    VerifyOrQuit(node.Get<Nat64::Translator>().GetNat64Prefix(prefix) == kErrorNotFound);
 
     iterator.Init(node.GetInstance());
     VerifyOrQuit(iterator.GetNext(mapping) == kErrorNotFound);
@@ -102,7 +102,7 @@ void TestNat64StateChanges(void)
     VerifyOrQuit(node.Get<Nat64::Translator>().GetState() == Nat64::kStateNotRunning);
 
     VerifyOrQuit(node.Get<Nat64::Translator>().GetIp4Cidr(cidr) == kErrorNotFound);
-    VerifyOrQuit(node.Get<Nat64::Translator>().GetIp6Prefix(prefix) == kErrorNotFound);
+    VerifyOrQuit(node.Get<Nat64::Translator>().GetNat64Prefix(prefix) == kErrorNotFound);
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Set a valid CIDR");
@@ -112,7 +112,7 @@ void TestNat64StateChanges(void)
 
     VerifyOrQuit(node.Get<Nat64::Translator>().GetState() == Nat64::kStateNotRunning);
 
-    VerifyOrQuit(node.Get<Nat64::Translator>().GetIp6Prefix(prefix) == kErrorNotFound);
+    VerifyOrQuit(node.Get<Nat64::Translator>().GetNat64Prefix(prefix) == kErrorNotFound);
 
     SuccessOrQuit(node.Get<Nat64::Translator>().GetIp4Cidr(cidr));
     VerifyOrQuit(cidr == testCidr);
@@ -123,7 +123,7 @@ void TestNat64StateChanges(void)
     SuccessOrQuit(testPrefix.FromString("fd01::/96"));
     node.Get<Nat64::Translator>().SetNat64Prefix(testPrefix);
 
-    SuccessOrQuit(node.Get<Nat64::Translator>().GetIp6Prefix(prefix));
+    SuccessOrQuit(node.Get<Nat64::Translator>().GetNat64Prefix(prefix));
     VerifyOrQuit(prefix == testPrefix);
 
     SuccessOrQuit(node.Get<Nat64::Translator>().GetIp4Cidr(cidr));
@@ -139,7 +139,7 @@ void TestNat64StateChanges(void)
     VerifyOrQuit(sNotifierCallbackInvoked);
     VerifyOrQuit(sNotifierEvents & kEventNat64TranslatorStateChanged);
 
-    SuccessOrQuit(node.Get<Nat64::Translator>().GetIp6Prefix(prefix));
+    SuccessOrQuit(node.Get<Nat64::Translator>().GetNat64Prefix(prefix));
     VerifyOrQuit(prefix == testPrefix);
 
     SuccessOrQuit(node.Get<Nat64::Translator>().GetIp4Cidr(cidr));
@@ -160,7 +160,7 @@ void TestNat64StateChanges(void)
 
     VerifyOrQuit(node.Get<Nat64::Translator>().GetState() == Nat64::kStateDisabled);
 
-    SuccessOrQuit(node.Get<Nat64::Translator>().GetIp6Prefix(prefix));
+    SuccessOrQuit(node.Get<Nat64::Translator>().GetNat64Prefix(prefix));
     VerifyOrQuit(prefix == testPrefix);
 
     SuccessOrQuit(node.Get<Nat64::Translator>().GetIp4Cidr(cidr));
@@ -183,7 +183,7 @@ void TestNat64StateChanges(void)
     VerifyOrQuit(sNotifierCallbackInvoked);
     VerifyOrQuit(sNotifierEvents & kEventNat64TranslatorStateChanged);
 
-    SuccessOrQuit(node.Get<Nat64::Translator>().GetIp6Prefix(prefix));
+    SuccessOrQuit(node.Get<Nat64::Translator>().GetNat64Prefix(prefix));
     VerifyOrQuit(prefix == testPrefix);
 
     SuccessOrQuit(node.Get<Nat64::Translator>().GetIp4Cidr(cidr));
@@ -198,7 +198,7 @@ void TestNat64StateChanges(void)
 
     VerifyOrQuit(node.Get<Nat64::Translator>().GetState() == Nat64::kStateActive);
 
-    SuccessOrQuit(node.Get<Nat64::Translator>().GetIp6Prefix(prefix));
+    SuccessOrQuit(node.Get<Nat64::Translator>().GetNat64Prefix(prefix));
     VerifyOrQuit(prefix == testPrefix);
 
     SuccessOrQuit(node.Get<Nat64::Translator>().GetIp4Cidr(cidr));
@@ -215,7 +215,7 @@ void TestNat64StateChanges(void)
     nexus.AdvanceTime(1);
     VerifyOrQuit(node.Get<Nat64::Translator>().GetState() == Nat64::kStateNotRunning);
 
-    VerifyOrQuit(node.Get<Nat64::Translator>().GetIp6Prefix(prefix) == kErrorNotFound);
+    VerifyOrQuit(node.Get<Nat64::Translator>().GetNat64Prefix(prefix) == kErrorNotFound);
 
     SuccessOrQuit(node.Get<Nat64::Translator>().GetIp4Cidr(cidr));
     VerifyOrQuit(cidr == testCidr);
@@ -234,7 +234,7 @@ void TestNat64StateChanges(void)
     nexus.AdvanceTime(1);
     VerifyOrQuit(node.Get<Nat64::Translator>().GetState() == Nat64::kStateActive);
 
-    SuccessOrQuit(node.Get<Nat64::Translator>().GetIp6Prefix(prefix));
+    SuccessOrQuit(node.Get<Nat64::Translator>().GetNat64Prefix(prefix));
     VerifyOrQuit(prefix == testPrefix);
 
     SuccessOrQuit(node.Get<Nat64::Translator>().GetIp4Cidr(cidr));
@@ -254,7 +254,7 @@ void TestNat64StateChanges(void)
     nexus.AdvanceTime(1);
     VerifyOrQuit(node.Get<Nat64::Translator>().GetState() == Nat64::kStateNotRunning);
 
-    SuccessOrQuit(node.Get<Nat64::Translator>().GetIp6Prefix(prefix));
+    SuccessOrQuit(node.Get<Nat64::Translator>().GetNat64Prefix(prefix));
     VerifyOrQuit(prefix == testPrefix);
 
     VerifyOrQuit(node.Get<Nat64::Translator>().GetIp4Cidr(cidr) == kErrorNotFound);
@@ -273,7 +273,7 @@ void TestNat64StateChanges(void)
     nexus.AdvanceTime(1);
     VerifyOrQuit(node.Get<Nat64::Translator>().GetState() == Nat64::kStateActive);
 
-    SuccessOrQuit(node.Get<Nat64::Translator>().GetIp6Prefix(prefix));
+    SuccessOrQuit(node.Get<Nat64::Translator>().GetNat64Prefix(prefix));
     VerifyOrQuit(prefix == testPrefix);
 
     SuccessOrQuit(node.Get<Nat64::Translator>().GetIp4Cidr(cidr));
@@ -305,7 +305,7 @@ Message *PrepareMessage(Node               &aNode,
 
     ip6Header.SetSource(aSrcIp6Address);
 
-    SuccessOrQuit(aNode.Get<Nat64::Translator>().GetIp6Prefix(nat64Prefix));
+    SuccessOrQuit(aNode.Get<Nat64::Translator>().GetNat64Prefix(nat64Prefix));
     ip6Header.GetDestination().SynthesizeFromIp4Address(nat64Prefix, aDstIp4Address);
 
     ip6Header.SetNextHeader(Ip6::kProtoUdp);


### PR DESCRIPTION
This change renames `GetIp6Prefix()` to `GetNat64Prefix()` to more accurately reflect its purpose and to harmonize its name with the existing `SetNat64Prefix()` and `ClearNat64Prefix()` methods.

The related getter methods in the header and implementation files are also reordered for better organization.