### PR TITLE
[core] replace anonymous enums with `constexpr`

### DIFF
--- a/src/core/net/tcp6.hpp
+++ b/src/core/net/tcp6.hpp
@@ -641,11 +641,8 @@ public:
     bool IsInitialized(const Listener &aListener) const { return mListeners.Contains(aListener); }
 
 private:
-    enum
-    {
-        kDynamicPortMin = 49152, ///< Service Name and Transport Protocol Port Number Registry
-        kDynamicPortMax = 65535, ///< Service Name and Transport Protocol Port Number Registry
-    };
+    static constexpr uint16_t kDynamicPortMin = 49152;
+    static constexpr uint16_t kDynamicPortMax = 65535;
 
     static constexpr uint8_t kEstablishedCallbackFlag      = (1 << 0);
     static constexpr uint8_t kSendDoneCallbackFlag         = (1 << 1);

--- a/src/lib/spinel/spinel_buffer.hpp
+++ b/src/lib/spinel/spinel_buffer.hpp
@@ -535,21 +535,18 @@ private:
      *                             Current InFrame (being written)
      */
 
-    enum
-    {
-        kReadByteAfterFrameHasEnded = 0,      // Value returned by ReadByte() when frame has ended.
-        kMessageReadBufferSize      = 16,     // Size of message buffer array `mMessageBuffer`.
-        kUnknownFrameLength         = 0xffff, // Value used when frame length is unknown.
-        kSegmentHeaderSize          = 2,      // Length of the segment header.
-        kSegmentHeaderLengthMask    = 0x3fff, // Bit mask to get the length from the segment header
-        kMaxSegments                = 10,     // Max number of segments allowed in a frame
+    static constexpr uint8_t  kReadByteAfterFrameHasEnded = 0;      // Returned by ReadByte() when frame has ended.
+    static constexpr uint8_t  kMessageReadBufferSize      = 16;     // Size of message buffer array `mMessageBuffer`.
+    static constexpr uint16_t kUnknownFrameLength         = 0xffff; // Value used when frame length is unknown.
+    static constexpr uint16_t kSegmentHeaderSize          = 2;      // Length of the segment header.
+    static constexpr uint16_t kSegmentHeaderLengthMask    = 0x3fff; // Bit mask to get the len from the segment header.
+    static constexpr uint8_t  kMaxSegments                = 10;     // Max number of segments allowed in a frame.
 
-        kSegmentHeaderNoFlag               = 0,         // No flags are set.
-        kSegmentHeaderNewFrameFlag         = (1 << 15), // Indicates that this segment starts a new frame.
-        kSegmentHeaderMessageIndicatorFlag = (1 << 14), // Indicates this segment ends with a Message.
+    static constexpr uint16_t kSegmentHeaderNoFlag               = 0;         // No flags are set.
+    static constexpr uint16_t kSegmentHeaderNewFrameFlag         = (1 << 15); // This segment starts a new frame.
+    static constexpr uint16_t kSegmentHeaderMessageIndicatorFlag = (1 << 14); // This segment ends with a Message.
 
-        kNumPrios = (kPriorityHigh + 1), // Number of priorities.
-    };
+    static constexpr uint8_t kNumPrios = (kPriorityHigh + 1); // Number of priorities.
 
     enum ReadState
     {

--- a/src/lib/spinel/spinel_decoder.hpp
+++ b/src/lib/spinel/spinel_decoder.hpp
@@ -50,10 +50,7 @@ namespace Spinel {
 class Decoder
 {
 public:
-    enum
-    {
-        kMaxNestedStructs = 4, ///< Maximum number of nested structs.
-    };
+    static constexpr uint8_t kMaxNestedStructs = 4; ///< Maximum number of nested structs.
 
     /**
      * Initializes a `Decoder` object.

--- a/src/lib/spinel/spinel_encoder.hpp
+++ b/src/lib/spinel/spinel_encoder.hpp
@@ -649,11 +649,8 @@ public:
     void ClearNcpBuffer(void);
 
 private:
-    enum
-    {
-        kPackFormatBufferSize = 96, ///< Size of buffer used when encoding using `WritePacked()` or `WriteVPacked()`.
-        kMaxNestedStructs     = 4,  ///< Maximum number of nested structs.
-    };
+    static constexpr uint16_t kPackFormatBufferSize = 96; // Used when encoding using `WritePacked()`.
+    static constexpr uint8_t  kMaxNestedStructs     = 4;  // Maximum number of nested structs.
 
     Spinel::Buffer               &mNcpBuffer;
     Spinel::Buffer::WritePosition mStructPosition[kMaxNestedStructs];

--- a/src/lib/spinel/spinel_interface.hpp
+++ b/src/lib/spinel/spinel_interface.hpp
@@ -46,10 +46,7 @@ namespace Spinel {
 class SpinelInterface
 {
 public:
-    enum
-    {
-        kMaxFrameSize = OPENTHREAD_LIB_SPINEL_RX_FRAME_BUFFER_SIZE, ///< Maximum buffer size.
-    };
+    static constexpr uint16_t kMaxFrameSize = OPENTHREAD_LIB_SPINEL_RX_FRAME_BUFFER_SIZE; ///< Maximum buffer size.
 
     /**
      * Defines a receive frame buffer to store received spinel frame(s).

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -84,16 +84,13 @@ namespace Ncp {
 class NcpBase
 {
 public:
-    enum
-    {
-        kSpinelCmdHeaderSize = 2, ///< Size of spinel command header (in bytes).
-        kSpinelPropIdSize    = 3, ///< Size of spinel property identifier (in bytes).
+    static constexpr uint8_t kSpinelCmdHeaderSize = 2; ///< Size of spinel command header (in bytes).
+    static constexpr uint8_t kSpinelPropIdSize    = 3; ///< Size of spinel property identifier (in bytes).
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE && OPENTHREAD_RADIO
-        kSpinelInterfaceCount = SPINEL_HEADER_IID_MAX + 1, // Number of supported spinel interfaces
+    static constexpr uint8_t kSpinelInterfaceCount = SPINEL_HEADER_IID_MAX + 1; // Number of supported spinel interfaces
 #else
-        kSpinelInterfaceCount = 1, // Only one interface supported in single instance configuration
+    static constexpr uint8_t kSpinelInterfaceCount = 1; // Only one interface supported in single instance configuration
 #endif
-    };
 
     /**
      * Creates and initializes an NcpBase instance.
@@ -734,12 +731,9 @@ protected:
     static spinel_status_t ThreadErrorToSpinelStatus(otError aError);
     static uint8_t         LinkFlagsToFlagByte(bool aRxOnWhenIdle, bool aDeviceType, bool aNetworkData);
 
-    enum
-    {
-        kTxBufferSize       = OPENTHREAD_CONFIG_NCP_TX_BUFFER_SIZE, // Tx Buffer size (used by mTxFrameBuffer).
-        kResponseQueueSize  = OPENTHREAD_CONFIG_NCP_SPINEL_RESPONSE_QUEUE_SIZE,
-        kInvalidScanChannel = -1, // Invalid scan channel.
-    };
+    static constexpr uint16_t kTxBufferSize       = OPENTHREAD_CONFIG_NCP_TX_BUFFER_SIZE;
+    static constexpr uint16_t kResponseQueueSize  = OPENTHREAD_CONFIG_NCP_SPINEL_RESPONSE_QUEUE_SIZE;
+    static constexpr int8_t   kInvalidScanChannel = -1; // Invalid scan channel.
 
     Instance *mInstance;
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE && OPENTHREAD_RADIO

--- a/src/ncp/ncp_hdlc.hpp
+++ b/src/ncp/ncp_hdlc.hpp
@@ -81,12 +81,11 @@ public:
     void HandleHdlcReceiveDone(const uint8_t *aBuf, uint16_t aBufLength);
 
 private:
-    enum
-    {
-        kHdlcTxBufferSize = OPENTHREAD_CONFIG_NCP_HDLC_TX_CHUNK_SIZE,   // HDLC tx buffer size.
-        kRxBufferSize     = OPENTHREAD_CONFIG_NCP_HDLC_RX_BUFFER_SIZE + // Rx buffer size (should be large enough to fit
-                        OPENTHREAD_CONFIG_NCP_SPINEL_ENCRYPTER_EXTRA_DATA_SIZE, // one whole (decoded) received frame).
-    };
+    static constexpr uint16_t kHdlcTxBufferSize = OPENTHREAD_CONFIG_NCP_HDLC_TX_CHUNK_SIZE; // HDLC tx buffer size.
+
+    // Rx buffer size (should be large enough to fit one whole (decoded) received frame).
+    static constexpr uint16_t kRxBufferSize =
+        OPENTHREAD_CONFIG_NCP_HDLC_RX_BUFFER_SIZE + OPENTHREAD_CONFIG_NCP_SPINEL_ENCRYPTER_EXTRA_DATA_SIZE;
 
     enum HdlcTxState
     {

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -52,18 +52,15 @@ public:
     explicit NcpSpi(Instance *aInstance);
 
 private:
-    enum
-    {
-        /**
-         * SPI tx and rx buffer size (should fit a max length frame + SPI header).
-         */
-        kSpiBufferSize = OPENTHREAD_CONFIG_NCP_SPI_BUFFER_SIZE,
+    /**
+     * SPI tx and rx buffer size (should fit a max length frame + SPI header).
+     */
+    static constexpr uint16_t kSpiBufferSize = OPENTHREAD_CONFIG_NCP_SPI_BUFFER_SIZE;
 
-        /**
-         * Size of the SPI header (in bytes).
-         */
-        kSpiHeaderSize = Spinel::SpiFrame::kHeaderSize,
-    };
+    /**
+     * Size of the SPI header (in bytes).
+     */
+    static constexpr uint16_t kSpiHeaderSize = Spinel::SpiFrame::kHeaderSize;
 
     enum TxState
     {

--- a/src/posix/client.cpp
+++ b/src/posix/client.cpp
@@ -70,10 +70,7 @@ struct Config
     const char *mNetifName;
 };
 
-enum
-{
-    kLineBufferSize = OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH,
-};
+static constexpr uint16_t kLineBufferSize = OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH;
 
 static_assert(kLineBufferSize >= sizeof("> "), "kLineBufferSize is too small");
 static_assert(kLineBufferSize >= sizeof("Done\r\n"), "kLineBufferSize is too small");
@@ -208,11 +205,8 @@ exit:
     return ok;
 }
 
-enum
-{
-    kOptInterfaceName = 'I',
-    kOptHelp          = 'h',
-};
+constexpr char kOptInterfaceName = 'I';
+constexpr char kOptHelp          = 'h';
 
 const struct option kOptions[] = {
     {"interface-name", required_argument, NULL, kOptInterfaceName},

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -230,14 +230,10 @@ private:
     static int ForkPty(const Url::Url &aRadioUrl);
 #endif
 
-    enum
-    {
-        kMaxWaitTime   = 2000, ///< Maximum wait time in Milliseconds for socket to become writable (see `SendFrame`).
-        kResetTimeout  = 5000, ///< Maximum wait time in Milliseconds for file to become ready (see `ResetConnection`).
-        kOpenFileDelay = 50,   ///< Delay between open file calls, in Milliseconds (see `ResetConnection`).
-        kRemoveRcpDelay =
-            2000, ///< Delay for removing RCP device from host OS after hard reset (see `ResetConnection`).
-    };
+    static constexpr uint16_t kMaxWaitTime    = 2000; ///< Max wait time in msec for socket to become writable.
+    static constexpr uint16_t kResetTimeout   = 5000; ///< Max wait time in msec for file to become ready.
+    static constexpr uint16_t kOpenFileDelay  = 50;   ///< Delay between open file calls, in msec.
+    static constexpr uint16_t kRemoveRcpDelay = 2000; ///< Delay for removing RCP device from host OS after hard reset.
 
     ReceiveFrameCallback mReceiveFrameCallback;
     void                *mReceiveFrameContext;

--- a/src/posix/platform/multicast_routing.hpp
+++ b/src/posix/platform/multicast_routing.hpp
@@ -69,13 +69,10 @@ public:
     void HandleStateChange(otInstance *aInstance, otChangedFlags aFlags);
 
 private:
-    enum
-    {
-        kMulticastForwardingCacheExpireTimeout    = 300, //< Expire timeout of Multicast Forwarding Cache (in seconds)
-        kMulticastForwardingCacheExpiringInterval = 60,  //< Expire interval of Multicast Forwarding Cache (in seconds)
-        kMulticastForwardingCacheTableSize =
-            OPENTHREAD_POSIX_CONFIG_MAX_MULTICAST_FORWARDING_CACHE_TABLE, //< The max size of MFC table.
-    };
+    static constexpr uint16_t kMulticastForwardingCacheExpireTimeout    = 300; //< Expire timeout (in seconds)
+    static constexpr uint16_t kMulticastForwardingCacheExpiringInterval = 60;  //< Expire interval (in seconds)
+    static constexpr uint16_t kMulticastForwardingCacheTableSize =
+        OPENTHREAD_POSIX_CONFIG_MAX_MULTICAST_FORWARDING_CACHE_TABLE;
 
     enum MifIndex : uint8_t
     {


### PR DESCRIPTION
This commit replaces anonymous `enum`s used for defining constants with `static constexpr` variables across various modules.