### PR TITLE
**Describe the bug** A clear and concise description of what the bug is.

### DIFF
--- a/src/cli/cli_config.h
+++ b/src/cli/cli_config.h
@@ -53,7 +53,11 @@
  * The maximum size of the CLI line in bytes including the null terminator.
  */
 #ifndef OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+#define OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH 640
+#else
 #define OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH 384
+#endif
 #endif
 
 /**


### PR DESCRIPTION
OT-Host Reference Device build is not set correctly configured.
By default, Reference Device has to be able to manage more than 384 characters in cli and subscribe to more than 2 IPv6 multicast adresses.

**To Reproduce** Information to reproduce the behavior, including:
1. Git commit id
2. IEEE 802.15.4 hardware platform
3. Build steps
4. Network topology

1. 2421ba9a9808390750f2e8cccd41d5d9010fedd2
2. NXP FRDM Board

3. For test C_5_10_12, reference device has to be able to manage following command : udp send FD00:0DB9:0000:0000:0000:00FF:FE00:FC38 61631 -x 4102ff5b6cb16e026d72ff0ef0ff0e000000000000000000010001777aff0e000000000000000000010002777aff0e000000000000000000010003777aff0e000000000000000000010004777aff0e000000000000000000010005777aff0e000000000000000000010006777aff0e000000000000000000010007777aff0e000000000000000000010008777aff0e000000000000000000010009777aff0e00000000000000000001000a777aff0e00000000000000000001000b777aff0e00000000000000000001000c777aff0e00000000000000000001000d777aff0e00000000000000000001000e777aff0e00000000000000000001000f777a (565 characters)

To test it, this is possible to test this command without created network. 
If return value is 'Error6: Parse', this command will not be managed correctly by Reference Device during C_5_10_12 test. 
If return is 'Invalid State', this is the expected when network is not created yet.

For test C_5_10_10, reference device has to be able to subscribe to at least 3 IPv6 multicast addresses. Reference Device has to be able to return "Done" for this command: ipmaddr add ff04::1234:777a:1 ff05::1234:777a:2 ff0e::1234:77a:3

4. those issues can be tested without network.

**Expected behavior** A clear and concise description of what you expected to happen. Reference Device should not returned an error during C_5_10_10 and C_5_10_12

**Console/log output** If applicable, add console/log output to help explain your problem.

**Additional context** Add any other context about the problem here.