### PR TITLE
[tcat] improve TCAT Commissioner output logging for SSL errors

### DIFF
--- a/tools/tcat_ble_client/ble/ble_stream.py
+++ b/tools/tcat_ble_client/ble/ble_stream.py
@@ -49,6 +49,9 @@ class BleStream:
         self.tx_char_uuid = tx_char_uuid
         self.rx_char_uuid = rx_char_uuid
 
+    def __str__(self):
+        return f"BleStream[{self.client}]"
+
     async def __aenter__(self):
         return self
 

--- a/tools/tcat_ble_client/ble/udp_stream.py
+++ b/tools/tcat_ble_client/ble/udp_stream.py
@@ -44,6 +44,9 @@ class UdpStream:
         self.socket.setblocking(False)
         self.address = (address, self.BASE_PORT + node_id)
 
+    def __str__(self):
+        return f"UdpStream[{self.address[0]}:{self.address[1]}]"
+
     async def send(self, data):
         logger.debug(f'tx {len(data)} bytes')
         return self.socket.sendto(data, self.address)
@@ -55,4 +58,4 @@ class UdpStream:
             logger.debug(f'rx {len(data)} bytes')
             return data
         else:
-            raise Exception('simulation UdpStream recv timeout - likely, TCAT is stopped on TCAT Device')
+            raise socket.timeout('simulation UdpStream recv timeout - likely, TCAT is stopped on TCAT Device')

--- a/tools/tcat_ble_client/cli/cli.py
+++ b/tools/tcat_ble_client/cli/cli.py
@@ -27,7 +27,7 @@
 """
 import readline
 import shlex
-from argparse import ArgumentParser
+from argparse import Namespace
 from ble.ble_stream_secure import BleStreamSecure
 from cli.base_commands import (DisconnectCommand, HelpCommand, HelloCommand, CommissionCommand, DecommissionCommand,
                                ExtractDatasetCommand, GetCommissionerCertificate, GetDeviceIdCommand, GetPskdHash,
@@ -45,7 +45,7 @@ class CLI:
 
     def __init__(self,
                  dataset: ThreadDataset,
-                 cmd_args: Optional[ArgumentParser] = None,
+                 cmd_args: Optional[Namespace] = None,
                  ble_sstream: Optional[BleStreamSecure] = None):
         self._commands = {
             'help': HelpCommand(),


### PR DESCRIPTION
This PR provides more structured logging for ssl.py errors, and displays the OpenSSL verify error code. This is used for certification to validate reasons of handshake failure.

NOTE: the commit '[tcat] improved debug info format using hexadecimal + ASCII dump' is still included in this one - this comes from the other PR, #11881 .  That means the diff will not correctly show for this PR yet - will rebase once #11881 is merged.
