### PR TITLE
[config] fix configs for reference device

### DIFF
--- a/src/cli/cli_config.h
+++ b/src/cli/cli_config.h
@@ -53,7 +53,11 @@
  * The maximum size of the CLI line in bytes including the null terminator.
  */
 #ifndef OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+#define OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH 640
+#else
 #define OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH 384
+#endif
 #endif
 
 /**

--- a/src/core/config/ip6.h
+++ b/src/core/config/ip6.h
@@ -61,7 +61,11 @@
  * The maximum number of supported IPv6 multicast addresses allows to be externally added.
  */
 #ifndef OPENTHREAD_CONFIG_IP6_MAX_EXT_MCAST_ADDRS
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+#define OPENTHREAD_CONFIG_IP6_MAX_EXT_MCAST_ADDRS 8
+#else
 #define OPENTHREAD_CONFIG_IP6_MAX_EXT_MCAST_ADDRS 2
+#endif
 #endif
 
 /**


### PR DESCRIPTION

### OT-Host Reference Device build is not correctly configured.

By default, OT-Host Reference Device has to be able to manage more at least 565 characters in cli and has to be able to subscribe to at least 3 IPv6 multicast adresses.


### **To Reproduce** Information to reproduce the behavior, including:

- Git commit id: [2421ba9a](https://github.com/openthread/openthread/commit/2421ba9a9808390750f2e8cccd41d5d9010fedd2)
- IEEE 802.15.4 hardware platform: NXP FRDM_RW612
- Build steps:

- Network topology:
	In **Thread harness test C_5_10_12 (DUT role: BR_1)**, reference device has to be able to manage a 565 characters command : 
`udp send FD00:0DB9:0000:0000:0000:00FF:FE00:FC38 61631 -x 4102ff5b6cb16e026d72ff0ef0ff0e000000000000000000010001777aff0e000000000000000000010002777aff0e000000000000000000010003777aff0e000000000000000000010004777aff0e000000000000000000010005777aff0e000000000000000000010006777aff0e000000000000000000010007777aff0e000000000000000000010008777aff0e000000000000000000010009777aff0e00000000000000000001000a777aff0e00000000000000000001000b777aff0e00000000000000000001000c777aff0e00000000000000000001000d777aff0e00000000000000000001000e777aff0e00000000000000000001000f777a `

	It is possible to test this command without created network:
	- If return value is `Error6: Parse`, this command will not be managed correctly by Reference Device during C_5_10_12 test.
	- If return value is `Invalid State`, this is the expected when network is not created yet.

	In **Thread Harness test C_5_10_10 (DUT role: BR_1)**, reference device has to be able to subscribe to at least 3 IPv6 multicast addresses. 
The default value for it is 2.
Reference Device has to be able to return `Done` for this command: `ipmaddr add ff04::1234:777a:1 ff05::1234:777a:2 ff0e::1234:77a:3`