### PR TITLE
[posix] include `openthread/instance.h` in `src/posix/platform/settings.hpp`

### DIFF
--- a/src/posix/platform/settings.hpp
+++ b/src/posix/platform/settings.hpp
@@ -29,6 +29,8 @@
 #ifndef OT_POSIX_PLATFORM_SETTINGS_HPP_
 #define OT_POSIX_PLATFORM_SETTINGS_HPP_
 
+#include <openthread/instance.h>
+
 namespace ot {
 namespace Posix {
 


### PR DESCRIPTION
When compiling the Thread stack for Raspberry Pi platform, the compiler reports the following errors:

third_party/openthread/src/posix/platform/settings.hpp:42:39: error: unknown type name 'otInstance'
   42 | void PlatformSettingsGetSensitiveKeys(otInstance *aInstance, const uint16_t **aKeys, uint16_t *aKeysLength);
      |                                       ^
third_party/openthread/src/posix/platform/settings.hpp:42:68: error: unknown type name 'uint16_t'
   42 | void PlatformSettingsGetSensitiveKeys(otInstance *aInstance, const uint16_t **aKeys, uint16_t *aKeysLength);
      |                                                                    ^
third_party/openthread/src/posix/platform/settings.hpp:42:86: error: unknown type name 'uint16_t'
   42 | void PlatformSettingsGetSensitiveKeys(otInstance *aInstance, const uint16_t **aKeys, uint16_t *aKeysLength);

This commit adds the necessary header files to `src/posix/platform/settings.hpp` to resolve the compile errors.