### PR TITLE
[mac] Add public default constructor to ExtAddress

### DIFF
--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -95,6 +95,8 @@ OT_TOOL_PACKED_BEGIN
 class ExtAddress : public otExtAddress, public Equatable<ExtAddress>, public Clearable<ExtAddress>
 {
 public:
+    ExtAddress() = default;
+
     static constexpr uint16_t kInfoStringSize = 17; ///< Max chars for the info string (`ToString()`).
 
     /**

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -573,6 +573,7 @@ void Joiner::HandleTimer(void)
         break;
 
     case kStateJoined:
+    {
         Mac::ExtAddress extAddress;
 
         extAddress.GenerateRandom();
@@ -581,6 +582,7 @@ void Joiner::HandleTimer(void)
 
         error = kErrorNone;
         break;
+    }
 
     case kStateIdle:
     case kStateDiscover:


### PR DESCRIPTION
**Context / Problem**

The recent CRTP hardening made `Equatable<T>` / `Clearable<T>` constructors `private` and only accessible to the CRTP child `T`. This prevents misuse, but also means that derived types must expose their own public default constructor if they are meant to be value-initialized (`ExtAddress{}`).

Without a public default constructor in `ExtAddress`, code such as:

```cpp
SetExtendedAddress(Mac::ExtAddress{});
```

fails to compile with errors like:

```
error: 'Equatable<Type>::Equatable()' is private within this context
error: 'Clearable<Type>::Clearable()' is private within this context
```

**Change**

* Add a public default constructor to `ExtAddress`:

  ```cpp
  public:
      ExtAddress() = default;
  ```
* This restores value-initialization (`ExtAddress{}`) at call sites.

**Alternatives considered**

* `ExtAddress() { Clear(); }`: guarantees a zeroed address on construction, but makes `ExtAddress` non-trivial and breaks union semantics in `Mac::Address`.
* Keeping the status quo: breaks common usage patterns (`ExtAddress{}`).

