### PR TITLE
[link-metrics] make union packed to fix warning

### DIFF
--- a/src/core/thread/link_metrics_tlvs.hpp
+++ b/src/core/thread/link_metrics_tlvs.hpp
@@ -153,7 +153,7 @@ public:
 
 private:
     uint8_t mMetricsTypeId;
-    union
+    union OT_TOOL_PACKED_FIELD
     {
         uint8_t  m8;
         uint32_t m32;


### PR DESCRIPTION
Clang warns that mMetricsValue is less aligned that its union type. Make the union packed to fix this.