### PR TITLE
[cli] add LQ In to the neighbor table output

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -2888,11 +2888,10 @@ Print table of neighbors.
 
 ```bash
 > neighbor table
-| Role | RLOC16 | Age | Avg RSSI | Last RSSI |R|D|N| Extended MAC     |
-+------+--------+-----+----------+-----------+-+-+-+------------------+
-|   C  | 0xcc01 |  96 |      -46 |       -46 |1|1|1| 1eb9ba8a6522636b |
-|   R  | 0xc800 |   2 |      -29 |       -29 |1|1|1| 9a91556102c39ddb |
-|   R  | 0xf000 |   3 |      -28 |       -28 |1|1|1| 0ad7ed6beaa6016d |
+| Role | RLOC16 | Age | Avg RSSI | Last RSSI | LQ In |R|D|N| Extended MAC     | Version |
++------+--------+-----+----------+-----------+-------+-+-+-+------------------+---------+
+|   R  | 0x2000 |   4 |      -68 |       -68 |     3 |1|1|1| fa97259e4eb574e4 |       5 |
+|   R  | 0xf000 |   0 |      -96 |       -97 |     1 |1|1|1| ba9fd148fba30fbd |       5 |
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -4528,8 +4528,7 @@ template <> otError Interpreter::Process<Cmd("neighbor")>(Arg aArgs[])
         if (isTable)
         {
             static const char *const kNeighborTableTitles[] = {
-                "Role", "RLOC16", "Age", "Avg RSSI", "Last RSSI", "LQ In", "R", "D", "N", "Extended MAC", "Version"
-            };
+                "Role", "RLOC16", "Age", "Avg RSSI", "Last RSSI", "LQ In", "R", "D", "N", "Extended MAC", "Version"};
 
             static const uint8_t kNeighborTableColumnWidths[] = {
                 6, 8, 5, 10, 11, 7, 1, 1, 1, 18, 9,

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -4528,11 +4528,11 @@ template <> otError Interpreter::Process<Cmd("neighbor")>(Arg aArgs[])
         if (isTable)
         {
             static const char *const kNeighborTableTitles[] = {
-                "Role", "RLOC16", "Age", "Avg RSSI", "Last RSSI", "R", "D", "N", "Extended MAC", "Version",
+                "Role", "RLOC16", "Age", "Avg RSSI", "Last RSSI", "LQ In", "R", "D", "N", "Extended MAC", "Version"
             };
 
             static const uint8_t kNeighborTableColumnWidths[] = {
-                6, 8, 5, 10, 11, 1, 1, 1, 18, 9,
+                6, 8, 5, 10, 11, 7, 1, 1, 1, 18, 9,
             };
 
             OutputTableHeader(kNeighborTableTitles, kNeighborTableColumnWidths);
@@ -4570,6 +4570,7 @@ template <> otError Interpreter::Process<Cmd("neighbor")>(Arg aArgs[])
                 OutputFormat("| %3lu ", ToUlong(neighborInfo.mAge));
                 OutputFormat("| %8d ", neighborInfo.mAverageRssi);
                 OutputFormat("| %9d ", neighborInfo.mLastRssi);
+                OutputFormat("| %5u ", neighborInfo.mLinkQualityIn);
                 OutputFormat("|%1d", neighborInfo.mRxOnWhenIdle);
                 OutputFormat("|%1d", neighborInfo.mFullThreadDevice);
                 OutputFormat("|%1d", neighborInfo.mFullNetworkData);

--- a/tests/scripts/expect/cli-neighbor.exp
+++ b/tests/scripts/expect/cli-neighbor.exp
@@ -38,9 +38,9 @@ set extaddr [get_extaddr]
 
 switch_node 1
 send "neighbor table\n"
-expect "| Role | RLOC16 | Age | Avg RSSI | Last RSSI |R|D|N| Extended MAC     | Version |"
-expect "+------+--------+-----+----------+-----------+-+-+-+------------------+---------+"
-expect -re "\\| +C +\\| 0x$rloc \\| +\\d+ \\| +-?\\d+ \\| +-?\\d+ \\|1\\|0\\|0\\| $extaddr \\| +\\d+ \\|"
+expect "| Role | RLOC16 | Age | Avg RSSI | Last RSSI | LQ In |R|D|N| Extended MAC     | Version |"
+expect "+------+--------+-----+----------+-----------+-------+-+-+-+------------------+---------+"
+expect -re "\\| +C +\\| 0x$rloc \\| +\\d+ \\| +-?\\d+ \\| +-?\\d+ \\| +\\d+ \\|1\\|0\\|0\\| $extaddr \\| +\\d+ \\|"
 expect_line "Done"
 send "neighbor list\n"
 expect "0x$rloc"


### PR DESCRIPTION
This allows a node to asses its LinkQuality In to its neighbors. Similar to what is already available via router info. Useful when not all its neighbors are routers.

# Sample output
```
| Role | RLOC16 | Age | Avg RSSI | Last RSSI | LQ In |R|D|N| Extended MAC     | Version |
+------+--------+-----+----------+-----------+-------+-+-+-+------------------+---------+
|   R  | 0x2000 |   4 |      -68 |       -68 |     3 |1|1|1| fa97259e4eb574e4 |       5 | 
|   R  | 0xf000 |   0 |      -96 |       -97 |     1 |1|1|1| ba9fd148fba30fbd |       5 |
-----------------------------------------------^^^^^ added
```