### PR TITLE
[debug] check NDEBUG for OT_ASSERT

### DIFF
--- a/src/core/common/debug.hpp
+++ b/src/core/common/debug.hpp
@@ -69,6 +69,11 @@
 
 #elif defined(__APPLE__) || defined(__linux__)
 
+#ifdef NDEBUG
+#error \
+    "OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT is not defined, OT_ASSERT requires assert() to work, but NDEBUG is defined!"
+#endif
+
 #include <assert.h>
 
 #define OT_ASSERT(cond) assert(cond)

--- a/src/core/config/misc.h
+++ b/src/core/config/misc.h
@@ -335,7 +335,11 @@
  * Define as 1 to enable assert function `OT_ASSERT()` within OpenThread code and its libraries.
  */
 #ifndef OPENTHREAD_CONFIG_ASSERT_ENABLE
+#ifndef NDEBUG
 #define OPENTHREAD_CONFIG_ASSERT_ENABLE 1
+#else
+#define OPENTHREAD_CONFIG_ASSERT_ENABLE 0
+#endif
 #endif
 
 /**


### PR DESCRIPTION
This commit verifies NDEBUG is not defined when OT_ASSERT is enabled and is delegated to assert().