### PR TITLE
[udp] no changing netif of bound sockets

### DIFF
--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -33,7 +33,11 @@
 
 #include "openthread-core-config.h"
 
+#include "common/as_core_type.hpp"
+#include "common/code_utils.hpp"
+#include "common/error.hpp"
 #include "instance/instance.hpp"
+#include "net/udp6.hpp"
 
 using namespace ot;
 
@@ -44,7 +48,9 @@ otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSett
 
 otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aContext)
 {
-    return AsCoreType(aInstance).Get<Ip6::Udp>().Open(AsCoreType(aSocket), Ip6::kNetifThreadHost, aCallback, aContext);
+    AsCoreType(aInstance).Get<Ip6::Udp>().Open(AsCoreType(aSocket), Ip6::kNetifThreadHost, aCallback, aContext);
+
+    return kErrorNone;
 }
 
 bool otUdpIsOpen(otInstance *aInstance, const otUdpSocket *aSocket)
@@ -59,9 +65,23 @@ otError otUdpClose(otInstance *aInstance, otUdpSocket *aSocket)
 
 otError otUdpBind(otInstance *aInstance, otUdpSocket *aSocket, const otSockAddr *aSockName, otNetifIdentifier aNetif)
 {
-    AsCoreType(aSocket).SetNetifId(MapEnum(aNetif));
+    Error                   error;
+    Ip6::Udp::SocketHandle &socketHandle = AsCoreType(aSocket);
+    Ip6::NetifIdentifier    oldNetif     = socketHandle.GetNetifId();
 
-    return AsCoreType(aInstance).Get<Ip6::Udp>().Bind(AsCoreType(aSocket), AsCoreType(aSockName));
+    VerifyOrExit(!socketHandle.IsBound(), error = kErrorInvalidArgs);
+
+    socketHandle.SetNetifId(MapEnum(aNetif));
+
+    error = AsCoreType(aInstance).Get<Ip6::Udp>().Bind(socketHandle, AsCoreType(aSockName));
+
+exit:
+    if (error != kErrorNone && socketHandle.GetNetifId() != oldNetif)
+    {
+        socketHandle.SetNetifId(oldNetif);
+    }
+
+    return error;
 }
 
 otError otUdpConnect(otInstance *aInstance, otUdpSocket *aSocket, const otSockAddr *aSockName)

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1812,7 +1812,7 @@ Error Coap::Start(uint16_t aPort, Ip6::NetifIdentifier aNetifIdentifier)
 
     VerifyOrExit(!mSocket.IsBound());
 
-    SuccessOrExit(error = mSocket.Open(aNetifIdentifier));
+    mSocket.Open(aNetifIdentifier);
     socketOpened = true;
 
     SuccessOrExit(error = mSocket.Bind(aPort));

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -69,7 +69,7 @@ void JoinerRouter::Start(void)
 
         VerifyOrExit(!mSocket.IsBound());
 
-        IgnoreError(mSocket.Open(Ip6::kNetifThreadInternal));
+        mSocket.Open(Ip6::kNetifThreadInternal);
         IgnoreError(mSocket.Bind(port));
         IgnoreError(Get<Ip6::Filter>().AddUnsecurePort(port));
         LogInfo("Joiner Router: start");

--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -685,11 +685,11 @@ SecureTransport::SecureTransport(Instance &aInstance, LinkSecurityMode aLayerTwo
 
 Error SecureTransport::Open(Ip6::NetifIdentifier aNetifIdentifier)
 {
-    Error error;
+    Error error = kErrorNone;
 
     VerifyOrExit(!mIsOpen, error = kErrorAlready);
 
-    SuccessOrExit(error = mSocket.Open(aNetifIdentifier));
+    mSocket.Open(aNetifIdentifier);
     mIsOpen                      = true;
     mRemainingConnectionAttempts = mMaxConnectionAttempts;
 

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -165,7 +165,7 @@ void Client::Start(void)
 {
     VerifyOrExit(!mSocket.IsBound());
 
-    IgnoreError(mSocket.Open(Ip6::kNetifThreadInternal));
+    mSocket.Open(Ip6::kNetifThreadInternal);
     IgnoreError(mSocket.Bind(kDhcpClientPort));
 
     ProcessNextIdentityAssociation();

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -135,7 +135,7 @@ void Server::Start(void)
 {
     VerifyOrExit(!mSocket.IsOpen());
 
-    IgnoreError(mSocket.Open(Ip6::kNetifThreadInternal));
+    mSocket.Open(Ip6::kNetifThreadInternal);
     IgnoreError(mSocket.Bind(kDhcpServerPort));
 
 exit:

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -793,9 +793,9 @@ Error Client::Start(void)
     Error error;
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_BIND_UDP_TO_THREAD_NETIF
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThreadInternal));
+    mSocket.Open(Ip6::kNetifThreadInternal);
 #else
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifUnspecified));
+    mSocket.Open(Ip6::kNetifUnspecified);
 #endif
 
     SuccessOrExit(error = mSocket.Bind(0));

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -80,7 +80,7 @@ Error Server::Start(void)
 
     VerifyOrExit(!IsRunning());
 
-    SuccessOrExit(error = mSocket.Open(kBindUnspecifiedNetif ? Ip6::kNetifUnspecified : Ip6::kNetifThreadInternal));
+    mSocket.Open(kBindUnspecifiedNetif ? Ip6::kNetifUnspecified : Ip6::kNetifThreadInternal);
     SuccessOrExit(error = mSocket.Bind(kPort));
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -54,7 +54,7 @@ Error Client::Start(void)
 {
     Error error;
 
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifUnspecified));
+    mSocket.Open(Ip6::kNetifUnspecified);
     SuccessOrExit(error = mSocket.Bind(0));
 
 exit:

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -398,7 +398,7 @@ Error Client::Start(const Ip6::SockAddr &aServerSockAddr, Requester aRequester)
     VerifyOrExit(GetState() == kStateStopped,
                  error = (aServerSockAddr == GetServerAddress()) ? kErrorNone : kErrorBusy);
 
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThreadInternal));
+    mSocket.Open(Ip6::kNetifThreadInternal);
 
     error = mSocket.Connect(aServerSockAddr);
 

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -812,7 +812,7 @@ Error Server::PrepareSocket(void)
 #endif
 
     VerifyOrExit(!mSocket.IsOpen());
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThreadInternal));
+    mSocket.Open(Ip6::kNetifThreadInternal);
     error = mSocket.Bind(mPort);
 
 exit:

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -141,7 +141,11 @@ public:
          *
          * @param[in] aNetifId   The network interface identifier.
          */
-        void SetNetifId(NetifIdentifier aNetifId) { mNetifId = static_cast<otNetifIdentifier>(aNetifId); }
+        void SetNetifId(NetifIdentifier aNetifId)
+        {
+            OT_ASSERT(!IsBound());
+            mNetifId = static_cast<otNetifIdentifier>(aNetifId);
+        }
 
         /**
          * Indicates whether or not the socket can use platform UDP.
@@ -217,11 +221,8 @@ public:
          * Opens the UDP socket.
          *
          * @param[in]  aNetifId   The network interface identifier.
-         *
-         * @retval kErrorNone     Successfully opened the socket.
-         * @retval kErrorFailed   Failed to open the socket.
          */
-        Error Open(NetifIdentifier aNetifId);
+        void Open(NetifIdentifier aNetifId);
 
         /**
          * Returns if the UDP socket is open.
@@ -498,11 +499,8 @@ public:
      * @param[in]  aNetifId  A network interface identifier.
      * @param[in]  aHandler  A pointer to a function that is called when receiving UDP messages.
      * @param[in]  aContext  A pointer to arbitrary context information.
-     *
-     * @retval kErrorNone     Successfully opened the socket.
-     * @retval kErrorFailed   Failed to open the socket.
      */
-    Error Open(SocketHandle &aSocket, NetifIdentifier aNetifId, ReceiveHandler aHandler, void *aContext);
+    void Open(SocketHandle &aSocket, NetifIdentifier aNetifId, ReceiveHandler aHandler, void *aContext);
 
     /**
      * Returns if a UDP socket is open.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -164,7 +164,7 @@ Error Mle::Enable(void)
     Error error = kErrorNone;
 
     UpdateLinkLocalAddress();
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThreadInternal));
+    mSocket.Open(Ip6::kNetifThreadInternal);
     SuccessOrExit(error = mSocket.Bind(kUdpPort));
 
 #if OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE

--- a/tests/gtest/fake_platform.cpp
+++ b/tests/gtest/fake_platform.cpp
@@ -66,7 +66,6 @@ FakePlatform::FakePlatform()
     assert(sPlatform == nullptr);
     sPlatform = this;
 
-    fprintf(stderr, "fake platform start\r\n");
     mTransmitFrame.mPsdu = mTransmitBuffer;
 
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
@@ -670,5 +669,9 @@ void otPlatDnssdStopRecordQuerier(otInstance *, const otPlatDnssdRecordQuerier *
 void otPlatOtnsStatus(const char *aStatus) { OT_UNUSED_VARIABLE(aStatus); }
 #endif
 
-void otPlatAssertFail(const char *, int) {}
+void otPlatAssertFail(const char *aFileName, int aLineNumber)
+{
+    fprintf(stderr, "Fake platform assertion failure at %s:%d\r\n", aFileName, aLineNumber);
+    abort();
+}
 } // extern "C"

--- a/tests/toranj/cli/test-014-address-resolver.py
+++ b/tests/toranj/cli/test-014-address-resolver.py
@@ -268,10 +268,11 @@ verify_within(check_cache_entry_ramp_down_to_initial_retry_delay, 60)
 
 # Send to r1 from all addresses on r2.
 
-r2.udp_open()
 for num in range(num_addresses):
+    r2.udp_open()
     r2.udp_bind(prefix + '2:' + str(num), port)
     r2.udp_send(prefix + '1', port, 'hi_r1_from_r2_snoop_me')
+    r2.udp_close()
 
 # Verify that we see all addresses from r2 as snooped in cache table.
 # At most two of them should be marked as non-evictable.
@@ -398,11 +399,11 @@ verify(len(cache_table) == max_cache_entries)
 # Send from c2 to r1 and verify that snoop optimization uses at most
 # `max_snooped_non_evictable` entries
 
-c2.udp_open()
-
 for num in range(num_addresses):
+    c2.udp_open()
     c2.udp_bind(prefix + 'c2:' + str(num), port)
     c2.udp_send(prefix + '1', port, 'hi_r1_from_c2_snoop_me')
+    c2.udp_close()
 
 
 def check_cache_entry_contains_max_allowed_snopped():

--- a/tests/unit/test_srp_server.cpp
+++ b/tests/unit/test_srp_server.cpp
@@ -1082,7 +1082,7 @@ void TestSrpClientDelayedResponse(void)
 
         sServerRxCount = 0;
 
-        SuccessOrQuit(udpSocket.Open(Ip6::kNetifThreadInternal));
+        udpSocket.Open(Ip6::kNetifThreadInternal);
         SuccessOrQuit(udpSocket.Bind(kServerPort));
 
         serverSockAddr.SetAddress(sInstance->Get<Mle::Mle>().GetMeshLocalRloc());
@@ -1233,7 +1233,7 @@ void TestSrpClientSingleServiceMode(void)
 
         sServerRxCount = 0;
 
-        SuccessOrQuit(udpSocket.Open(Ip6::kNetifThreadInternal));
+        udpSocket.Open(Ip6::kNetifThreadInternal);
         SuccessOrQuit(udpSocket.Bind(kServerPort));
 
         serverSockAddr.SetAddress(sInstance->Get<Mle::Mle>().GetMeshLocalRloc());


### PR DESCRIPTION
The UDP socket may or may not be created from the platform layer based on the network interface specified when Udp::Open(), changing the network would result in inconsistent states. This commit defers creating platform socket in Udp::Bind() and disallows changing the network interface of a bound socket to make sure the states are consistent in OpenThread stack and the platform stack.