### PR TITLE
[test] fix syntax warning

### DIFF
--- a/tests/toranj/cli/cli.py
+++ b/tests/toranj/cli/cli.py
@@ -162,7 +162,7 @@ class Node(object):
             _log(f'$ Node{self._index}.cli(\'{cmd}\')', new_line=False)
 
         self._cli_process.send(cmd + '\n')
-        index = self._cli_process.expect(['(.*)Done\r\n', '.*Error (\d+):(.*)\r\n'])
+        index = self._cli_process.expect([r'(.*)Done\r\n', r'.*Error (\d+):(.*)\r\n'])
 
         if index == 0:
             result = [


### PR DESCRIPTION
This commit fixes the syntax error by declaring the regex pattern as raw string.

```
SyntaxWarning: invalid escape sequence '\d'
```