### PR TITLE
[trel] fix 'trel disable' CLI command to keep TREL disabled persistently; extend TREL API

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (536)
+#define OPENTHREAD_API_VERSION (537)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/trel.h
+++ b/include/openthread/trel.h
@@ -85,12 +85,34 @@ typedef const void *otTrelPeerIterator;
  * When @p aEnable is false, this function stops the DNS-SD browse on the service name "_trel._udp", stops advertising
  * TREL DNS-SD service, and clears the TREL peer table.
  *
+ * @warning This call interferes with the intended state of TREL operation which is managed by the auto-enabling
+ *          function. If TREL auto-enabling mode (@sa #otTrelSetAutoEnabling()) is active, TREL interface
+ *          operation should in most cases not be controlled directly via this call.
+ *
  * @note By default the OpenThread stack enables the TREL operation on start.
  *
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  * @param[in]  aEnable    A boolean to enable/disable the TREL operation.
  */
 void otTrelSetEnabled(otInstance *aInstance, bool aEnable);
+
+/**
+ * Enables or disables TREL auto-enabling mode.
+ *
+ * When @p aAutoEnablingMode is TRUE, the state of the TREL interface is automatically controlled by the
+ * OpenThread stack. If auto-enabling mode was previously disabled, and then enabled, this may lead
+ * to TREL operation being enabled immediately, or at a later time, under control of the stack.
+ *
+ * When @p aAutoEnablingMode is FALSE, the TREL interface state is not automatically managed anymore. If TREL was
+ * disabled, it remains disabled. If TREL was enabled, it will remain enabled until either explicitly disabled via
+ * #otTrelSetEnabled() or until the auto-enabling mode is turned on once again.
+ *
+ * @note By default the OpenThread stack enables the TREL auto-enabling mode on start.
+ *
+ * @param[in]  aInstance           A pointer to an OpenThread instance.
+ * @param[in]  aAutoEnablingMode   A boolean to enable/disable the TREL auto-enabling mode as defined above.
+ */
+void otTrelSetAutoEnabling(otInstance *aInstance, bool aAutoEnablingMode);
 
 /**
  * Indicates whether the TREL operation is enabled.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -4123,9 +4123,11 @@ Done
 
 ### trel
 
-Indicate whether TREL radio operation is enabled or not.
+Indicate whether TREL radio operation is currently enabled or not.
 
 `OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE` is required for all `trel` sub-commands.
+
+Note that TREL is enabled by default if `OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE` is enabled.
 
 ```bash
 > trel
@@ -4135,7 +4137,7 @@ Done
 
 ### trel enable
 
-Enable TREL operation.
+Enable TREL radio operation. TREL radio enabled/disabled state will now be automatically controlled by OpenThread. For this reason, the TREL radio's state may still be 'disabled' if the stack requires this.
 
 ```bash
 > trel enable
@@ -4144,7 +4146,7 @@ Done
 
 ### trel disable
 
-Disable TREL operation.
+Disable TREL radio operation. It will not be enabled again until either the "[trel enable](#trel-enable)" command is given, or the device is restarted.
 
 ```bash
 > trel disable

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -7235,8 +7235,9 @@ template <> otError Interpreter::Process<Cmd("trel")>(Arg aArgs[])
      * @par
      * Enables or disables the TREL radio operation.
      * @sa otTrelSetEnabled
+     * @sa otTrelSetAutoEnabling
      */
-    if (ProcessEnableDisable(aArgs, otTrelIsEnabled, otTrelSetEnabled) == OT_ERROR_NONE)
+    if (ProcessEnableDisable(aArgs, otTrelIsEnabled, HandleTrelSetEnable) == OT_ERROR_NONE)
     {
     }
     /**
@@ -7415,6 +7416,16 @@ void Interpreter::OutputTrelCounters(const otTrelCounters &aCounters)
     OutputLine("Failures %s", Uint64ToString(aCounters.mTxFailure, u64StringBuffer));
 }
 
+void Interpreter::HandleTrelSetEnable(otInstance *aInstance, bool aEnable)
+{
+    otTrelSetAutoEnabling(aInstance, aEnable);
+    // If TREL is enabled by CLI, we rely on the TREL auto-enabling function to further enable/disable TREL.
+    // If TREL is disabled by CLI, it's disabled immediately.
+    if (!aEnable)
+    {
+        otTrelSetEnabled(aInstance, false);
+    }
+}
 #endif
 
 template <> otError Interpreter::Process<Cmd("vendor")>(Arg aArgs[])

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -270,7 +270,8 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    void OutputTrelCounters(const otTrelCounters &aCounters);
+    void        OutputTrelCounters(const otTrelCounters &aCounters);
+    static void HandleTrelSetEnable(otInstance *aInstance, bool aEnable);
 #endif
 #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
     void OutputNat64Counters(const otNat64Counters &aCounters);

--- a/src/core/api/trel_api.cpp
+++ b/src/core/api/trel_api.cpp
@@ -46,6 +46,11 @@ void otTrelSetEnabled(otInstance *aInstance, bool aEnable)
     AsCoreType(aInstance).Get<Trel::Interface>().SetEnabled(aEnable);
 }
 
+void otTrelSetAutoEnabling(otInstance *aInstance, bool aAutoEnablingMode)
+{
+    AsCoreType(aInstance).Get<Trel::Interface>().SetAutoEnabling(aAutoEnablingMode);
+}
+
 bool otTrelIsEnabled(otInstance *aInstance) { return AsCoreType(aInstance).Get<Trel::Interface>().IsEnabled(); }
 
 void otTrelInitPeerIterator(otInstance *aInstance, otTrelPeerIterator *aIterator)

--- a/src/core/radio/trel_interface.cpp
+++ b/src/core/radio/trel_interface.cpp
@@ -45,6 +45,8 @@ Interface::Interface(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mInitialized(false)
     , mEnabled(false)
+    , mAutoEnablingMode(true)
+    , mAutoEnabledTarget(false)
     , mFiltered(false)
 {
 }
@@ -69,6 +71,41 @@ void Interface::SetEnabled(bool aEnable)
         Enable();
     }
     else
+    {
+        Disable();
+    }
+}
+
+void Interface::SetAutoEnabling(bool aAutoEnabling)
+{
+    mAutoEnablingMode = aAutoEnabling;
+
+    if (mAutoEnablingMode)
+    {
+        if (mAutoEnabledTarget)
+        {
+            Enable();
+        }
+        else
+        {
+            Disable();
+        }
+    }
+}
+
+void Interface::RequestEnable(void)
+{
+    mAutoEnabledTarget = true;
+    if (mAutoEnablingMode)
+    {
+        Enable();
+    }
+}
+
+void Interface::RequestDisable(void)
+{
+    mAutoEnabledTarget = false;
+    if (mAutoEnablingMode)
     {
         Disable();
     }

--- a/src/core/radio/trel_interface.hpp
+++ b/src/core/radio/trel_interface.hpp
@@ -75,8 +75,43 @@ public:
      * Enables or disables the TREL interface.
      *
      * @param[in] aEnable A boolean to enable/disable the TREL interface.
+     *
+     * @warning This call interferes with the auto-enabling function of the TREL interface. In most cases,
+     *          #RequestEnable() or #RequestDisable() should be used instead.
      */
     void SetEnabled(bool aEnable);
+
+    /**
+     * Sets the auto-enabling function for the TREL interface on or off.
+     *
+     * @param[in] aAutoEnabling If TRUE, enables the TREL interface to activate and deactivate automatically as
+     *                          required by the OpenThread stack. This is the default behavior.
+     *                          If FALSE, the auto-enabling function is deactivated and remains so until it is
+     *                          enabled again via this call, or via a device reset.
+     */
+    void SetAutoEnabling(bool aAutoEnabling);
+
+    /**
+     * Requests the TREL interface auto-enabling function to enable the TREL interface.
+     *
+     * This call is a safe version of #Enable(). If the auto-enabling function is active, the TREL interface is
+     * enabled immediately. If the auto-enabling function is inactive, the request will be remembered for the
+     * next time the auto-enabling function becomes active. This call is typically used by other modules to control
+     * TREL interface operation, while respecting explicit enable/disable overrides that were made via the TREL
+     * API.
+     */
+    void RequestEnable(void);
+
+    /**
+     * Requests the TREL interface auto-enabling function to disable the TREL interface.
+     *
+     * This call is a safe version of #Disable(). If the auto-enabling function is active, the TREL interface is
+     * disabled immediately. If the auto-enabling function is inactive, the request will be remembered for the
+     * next time the auto-enabling function becomes active. This call is typically used by other modules to control
+     * TREL interface operation, while respecting explicit enable/disable overrides that were made via the TREL
+     * API.
+     */
+    void RequestDisable(void);
 
     /**
      * Enables the TREL interface.
@@ -85,6 +120,9 @@ public:
      * to discover other devices supporting TREL. Device also registers a new service to be advertised using DNS-SD,
      * with the service name is "_trel._udp" indicating its support for TREL. Device is ready to receive TREL messages
      * from peers.
+     *
+     * @warning This call interferes with the auto-enabling function of the TREL interface. In most cases,
+     *          #RequestEnable() should be used instead.
      */
     void Enable(void);
 
@@ -93,11 +131,14 @@ public:
      *
      * This call stops the DNS-SD browse on the service name "_trel._udp", stops advertising TREL DNS-SD service, and
      * clears the TREL peer table.
+     *
+     * @warning This call interferes with the auto-enabling function of the TREL interface. In most cases,
+     *          #RequestDisable() should be used instead.
      */
     void Disable(void);
 
     /**
-     * Indicates whether the TREL interface is enabled.
+     * Indicates whether the TREL interface is currently enabled.
      *
      * @retval TRUE if the TREL interface is enabled.
      * @retval FALSE if the TREL interface is disabled.
@@ -156,6 +197,8 @@ private:
 
     bool     mInitialized : 1;
     bool     mEnabled : 1;
+    bool     mAutoEnablingMode : 1;
+    bool     mAutoEnabledTarget : 1;
     bool     mFiltered : 1;
     uint16_t mUdpPort;
     Packet   mRxPacket;

--- a/src/core/radio/trel_link.cpp
+++ b/src/core/radio/trel_link.cpp
@@ -72,7 +72,7 @@ void Link::AfterInit(void) { mInterface.Init(); }
 
 void Link::Enable(void)
 {
-    mInterface.Enable();
+    mInterface.RequestEnable();
 
     if (mState == kStateDisabled)
     {
@@ -82,7 +82,7 @@ void Link::Enable(void)
 
 void Link::Disable(void)
 {
-    mInterface.Disable();
+    mInterface.RequestDisable();
 
     if (mState != kStateDisabled)
     {


### PR DESCRIPTION
This updates the semantics of the CLI command 'trel disable' and extends the associated C API for this. Once disabled manually via CLI, it will keep TREL interface disabled until manually re-enabled again. This fixes the issue that each time 'ifconfig up' was invoked TREL would automatically restart, which is undesirable for test cases that need TREL disabled persistently.

It adds an 'auto-enabling' function to TrelInterface, which can be enabled/disabled via the API. Auto-enabling is active by default and should give the existing TREL interface enabling behavior. When the auto-enabling function is disabled, the TREL interface is fully under manual/API control.

The CLI command 'trel disable' does 2 things: disable the auto-enabling function, and stop the TREL interface. The CLI command 'trel enable' will enable the auto-enabling function, which in most cases also immediately enables the TREL interface again.