### PR TITLE
[cmake] enable running toranj cli test

### DIFF
--- a/script/cmake-build
+++ b/script/cmake-build
@@ -67,7 +67,7 @@ OT_CMAKE_NINJA_TARGET=${OT_CMAKE_NINJA_TARGET-}
 OT_SRCDIR="$(cd "$(dirname "$0")"/.. && pwd)"
 readonly OT_SRCDIR
 
-OT_PLATFORMS=(simulation posix android-ndk)
+OT_PLATFORMS=(simulation posix android-ndk toranj)
 readonly OT_PLATFORMS
 
 OT_POSIX_SIM_COMMON_OPTIONS=(
@@ -117,7 +117,7 @@ readonly OT_POSIX_SIM_COMMON_OPTIONS
 
 die()
 {
-    echo " ** ERROR: Openthread CMake doesn't support platform \"$1\""
+    echo " ** ERROR: OpenThread CMake doesn't support platform \"$1\""
     exit 1
 }
 
@@ -227,6 +227,24 @@ Could not fild the Android NDK CMake toolchain file
                 "-DOT_UDP_FORWARD=ON"
             )
             options+=("${OT_POSIX_SIM_COMMON_OPTIONS[@]}" "${local_options[@]}")
+            ;;
+        toranj)
+            platform="simulation"
+            OT_CMAKE_BUILD_DIR="build/toranj"
+            local_options+=(
+                "-DOT_15_4=ON"
+                "-DOT_APP_CLI=ON"
+                "-DOT_APP_NCP=OFF"
+                "-DOT_APP_RCP=OFF"
+                "-DOT_LOG_OUTPUT=PLATFORM_DEFINED"
+                "-DOT_PLATFORM_KEY_REF=OFF"
+                "-DOT_PROJECT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h"
+                "-DOT_THREAD_VERSION=1.4"
+                "-DOT_TORANJ_CLI=ON"
+                "-DOT_COVERAGE=ON"
+                "-DOT_TREL=OFF"
+            )
+            options=("${local_options[@]}")
             ;;
         *)
             options+=("-DCMAKE_TOOLCHAIN_FILE=examples/platforms/${platform}/arm-none-eabi.cmake")

--- a/tests/toranj/CMakeLists.txt
+++ b/tests/toranj/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2020, The OpenThread Authors.
+#  Copyright (c) 2025, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -26,25 +26,29 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-option(OT_BUILD_GTEST "enable gtest")
+file(GLOB TEST_SCRIPTS "${CMAKE_CURRENT_SOURCE_DIR}/cli/test-*.py")
 
-if(OT_FTD AND BUILD_TESTING AND (NOT OT_PLATFORM STREQUAL "nexus"))
-    add_subdirectory(unit)
-    if(OT_BUILD_GTEST)
-        add_subdirectory(gtest)
+foreach(SCRIPT ${TEST_SCRIPTS})
+    # Extract the base name of the script for the test name
+    get_filename_component(TEST_NAME "${SCRIPT}" NAME_WE)
+
+    if(TEST_NAME MATCHES "-multi-radio-")
+        message(STATUS "skipping non multi radio test ${TEST_NAME}")
+        continue()
     endif()
-endif()
 
-option(OT_FUZZ_TARGETS "enable fuzz targets" OFF)
+    add_test(
+        NAME "${TEST_NAME}"
+        COMMAND "${SCRIPT}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 
-if(OT_FUZZ_TARGETS)
-    add_subdirectory(fuzz)
-endif()
-
-if(OT_PLATFORM STREQUAL "nexus")
-    add_subdirectory(nexus)
-endif()
-
-if(OT_TORANJ_CLI)
-    add_subdirectory(toranj)
-endif()
+    if(OT_LOG_OUTPUT STREQUAL "PLATFORM_DEFINED")
+        set(TORANJ_SAVE_LOGS "1")
+    else()
+        set(TORANJ_SAVE_LOGS "0")
+    endif()
+    set_property(TEST "${TEST_NAME}" PROPERTY ENVIRONMENT
+        top_builddir="${PROJECT_BINARY_DIR}"
+        TORANJ_VERBOSE=1
+        TORANJ_SAVE_LOGS="${TORANJ_SAVE_LOGS}")
+endforeach()

--- a/tests/toranj/cli/cli.py
+++ b/tests/toranj/cli/cli.py
@@ -96,7 +96,7 @@ class Node(object):
     _SPEED_UP_FACTOR = 1  # defines the default time speed up factor
 
     # Determine whether to save logs in a file.
-    _SAVE_LOGS = True
+    _SAVE_LOGS = os.getenv('TORANJ_SAVE_LOGS', '1') == '1'
 
     # name of  log file (if _SAVE_LOGS is `True`)
     _LOG_FNAME = 'ot-logs'


### PR DESCRIPTION
This commit wraps toranj cli tests into cmake so that we can run the test one by one easily.

```bash
./script/cmake-build toranj
cd build/toranj
ctest -R test-014-address-resolver
```