### PR TITLE
[utils] add a flag to use std new

### DIFF
--- a/src/core/config/misc.h
+++ b/src/core/config/misc.h
@@ -618,6 +618,15 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_USE_STD_NEW
+ *
+ * Define 1 to enable using std <new>.
+ */
+#ifndef OPENTHREAD_CONFIG_USE_STD_NEW
+#define OPENTHREAD_CONFIG_USE_STD_NEW 0
+#endif
+
+/**
  * @}
  */
 

--- a/src/include/common/new.hpp
+++ b/src/include/common/new.hpp
@@ -34,10 +34,16 @@
 #ifndef OT_INCLUDE_COMMON_NEW_HPP_
 #define OT_INCLUDE_COMMON_NEW_HPP_
 
+#include <openthread/config.h>
+
+#if defined(OPENTHREAD_CONFIG_USE_STD_NEW) && OPENTHREAD_CONFIG_USE_STD_NEW
+#include <new> // IWYU pragma: keep
+#else
 #include <stddef.h>
 
 #include <openthread/platform/toolchain.h>
 
 inline void *operator new(size_t, void *p) throw() { return p; }
+#endif
 
 #endif // OT_INCLUDE_COMMON_NEW_HPP_

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@
 option(OT_BUILD_GTEST "enable gtest")
 
 if(OT_FTD AND BUILD_TESTING AND (NOT OT_PLATFORM STREQUAL "nexus"))
+    target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_USE_STD_NEW=1")
     add_subdirectory(unit)
     if(OT_BUILD_GTEST)
         add_subdirectory(gtest)

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -26,8 +26,6 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-// Disable OpenThread's own new implementation to avoid duplicate definition
-#define OT_INCLUDE_COMMON_NEW_HPP_
 #include "test_platform.h"
 
 #include <map>


### PR DESCRIPTION
The noexcept placement new is standard in c++11. This commit adds a config `OPENTHREAD_CONFIG_USE_STD_NEW` to allow using `<new>`. The default behavior is still using OpenThread's own placement new implementation.