### PR TITLE
[udp] add platform API to set socket flags

### DIFF
--- a/examples/platforms/simulation/CMakeLists.txt
+++ b/examples/platforms/simulation/CMakeLists.txt
@@ -92,6 +92,7 @@ add_library(openthread-simulation
     system.c
     trel.c
     uart.c
+    udp.c
     virtual_time/alarm-sim.c
     virtual_time/platform-sim.c
     $<TARGET_OBJECTS:openthread-platform-utils>

--- a/examples/platforms/simulation/udp.c
+++ b/examples/platforms/simulation/udp.c
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "platform-simulation.h"
+
+#include <openthread/platform/udp.h>
+
+OT_TOOL_WEAK otError otPlatUdpSocket(otUdpSocket *aUdpSocket)
+{
+    OT_UNUSED_VARIABLE(aUdpSocket);
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+OT_TOOL_WEAK otError otPlatUdpClose(otUdpSocket *aUdpSocket)
+{
+    OT_UNUSED_VARIABLE(aUdpSocket);
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+OT_TOOL_WEAK otError otPlatUdpBind(otUdpSocket *aUdpSocket)
+{
+    OT_UNUSED_VARIABLE(aUdpSocket);
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+OT_TOOL_WEAK otError otPlatUdpBindToNetif(otUdpSocket *aUdpSocket, otNetifIdentifier aNetif)
+{
+    OT_UNUSED_VARIABLE(aUdpSocket);
+    OT_UNUSED_VARIABLE(aNetif);
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+OT_TOOL_WEAK otError otPlatUdpConnect(otUdpSocket *aUdpSocket)
+{
+    OT_UNUSED_VARIABLE(aUdpSocket);
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+OT_TOOL_WEAK otError otPlatUdpSend(otUdpSocket *aUdpSocket, otMessage *aMessage, const otMessageInfo *aMessageInfo)
+{
+    OT_UNUSED_VARIABLE(aUdpSocket);
+    OT_UNUSED_VARIABLE(aMessage);
+    OT_UNUSED_VARIABLE(aMessageInfo);
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+OT_TOOL_WEAK otError otPlatUdpJoinMulticastGroup(otUdpSocket        *aUdpSocket,
+                                                 otNetifIdentifier   aNetif,
+                                                 const otIp6Address *aAddress)
+{
+    OT_UNUSED_VARIABLE(aUdpSocket);
+    OT_UNUSED_VARIABLE(aNetif);
+    OT_UNUSED_VARIABLE(aAddress);
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+OT_TOOL_WEAK otError otPlatUdpLeaveMulticastGroup(otUdpSocket        *aUdpSocket,
+                                                  otNetifIdentifier   aNetif,
+                                                  const otIp6Address *aAddress)
+{
+    OT_UNUSED_VARIABLE(aUdpSocket);
+    OT_UNUSED_VARIABLE(aNetif);
+    OT_UNUSED_VARIABLE(aAddress);
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+OT_TOOL_WEAK otError otPlatUdpSetFlags(otUdpSocket *aUdpSocket, int aFlags)
+{
+    OT_UNUSED_VARIABLE(aUdpSocket);
+    OT_UNUSED_VARIABLE(aFlags);
+    return OT_ERROR_NOT_IMPLEMENTED;
+}

--- a/include/openthread/platform/udp.h
+++ b/include/openthread/platform/udp.h
@@ -54,6 +54,20 @@ extern "C" {
  */
 otError otPlatUdpSocket(otUdpSocket *aUdpSocket);
 
+#define OT_PLATFORM_UDP_REUSEADDR 1 ///< Allows binding to socket addresses not bound by any active socket.
+#define OT_PLATFORM_UDP_REUSEPORT 2 ///< Allows binding to socket addresses already bound by other sockets.
+
+/**
+ * Sets the UDP socket flags by platform.
+ *
+ * @param[in]   aUdpSocket  A pointer to the UDP socket.
+ * @param[in]   aFlags      Bitwise OR of the flags to set.
+ *
+ * @retval  OT_ERROR_NONE   Successfully initialized UDP socket by platform.
+ * @retval  OT_ERROR_FAILED Failed to initialize UDP Socket.
+ */
+otError otPlatUdpSetFlags(otUdpSocket *aUdpSocket, int aFlags);
+
 /**
  * Closes the UDP socket by platform.
  *

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -71,7 +71,7 @@ otError otUdpBind(otInstance *aInstance, otUdpSocket *aSocket, const otSockAddr 
     {
         socketHandle.SetNetifId(MapEnum(aNetif));
 
-        error = AsCoreType(aInstance).Get<Ip6::Udp>().Bind(socketHandle, AsCoreType(aSockName));
+        error = AsCoreType(aInstance).Get<Ip6::Udp>().Bind(socketHandle, AsCoreType(aSockName), 0);
     }
     else
     {

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -33,7 +33,10 @@
 
 #include "openthread-core-config.h"
 
+#include "common/as_core_type.hpp"
+#include "common/error.hpp"
 #include "instance/instance.hpp"
+#include "net/udp6.hpp"
 
 using namespace ot;
 
@@ -44,7 +47,9 @@ otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSett
 
 otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aContext)
 {
-    return AsCoreType(aInstance).Get<Ip6::Udp>().Open(AsCoreType(aSocket), Ip6::kNetifThreadHost, aCallback, aContext);
+    AsCoreType(aInstance).Get<Ip6::Udp>().Open(AsCoreType(aSocket), Ip6::kNetifThreadHost, aCallback, aContext);
+
+    return kErrorNone;
 }
 
 bool otUdpIsOpen(otInstance *aInstance, const otUdpSocket *aSocket)
@@ -59,9 +64,21 @@ otError otUdpClose(otInstance *aInstance, otUdpSocket *aSocket)
 
 otError otUdpBind(otInstance *aInstance, otUdpSocket *aSocket, const otSockAddr *aSockName, otNetifIdentifier aNetif)
 {
-    AsCoreType(aSocket).SetNetifId(MapEnum(aNetif));
+    Error                   error;
+    Ip6::Udp::SocketHandle &socketHandle = AsCoreType(aSocket);
 
-    return AsCoreType(aInstance).Get<Ip6::Udp>().Bind(AsCoreType(aSocket), AsCoreType(aSockName));
+    if (!socketHandle.IsBound())
+    {
+        socketHandle.SetNetifId(MapEnum(aNetif));
+
+        error = AsCoreType(aInstance).Get<Ip6::Udp>().Bind(socketHandle, AsCoreType(aSockName));
+    }
+    else
+    {
+        error = kErrorFailed;
+    }
+
+    return error;
 }
 
 otError otUdpConnect(otInstance *aInstance, otUdpSocket *aSocket, const otSockAddr *aSockName)

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1709,7 +1709,7 @@ Error Coap::Start(uint16_t aPort, Ip6::NetifIdentifier aNetifIdentifier)
 
     VerifyOrExit(!mSocket.IsBound());
 
-    SuccessOrExit(error = mSocket.Open(aNetifIdentifier));
+    mSocket.Open(aNetifIdentifier);
     socketOpened = true;
 
     SuccessOrExit(error = mSocket.Bind(aPort));

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -69,7 +69,7 @@ void JoinerRouter::Start(void)
 
         VerifyOrExit(!mSocket.IsBound());
 
-        IgnoreError(mSocket.Open(Ip6::kNetifThreadInternal));
+        mSocket.Open(Ip6::kNetifThreadInternal);
         IgnoreError(mSocket.Bind(port));
         IgnoreError(Get<Ip6::Filter>().AddUnsecurePort(port));
         LogInfo("Joiner Router: start");

--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -685,11 +685,11 @@ SecureTransport::SecureTransport(Instance &aInstance, LinkSecurityMode aLayerTwo
 
 Error SecureTransport::Open(Ip6::NetifIdentifier aNetifIdentifier)
 {
-    Error error;
+    Error error = kErrorNone;
 
     VerifyOrExit(!mIsOpen, error = kErrorAlready);
 
-    SuccessOrExit(error = mSocket.Open(aNetifIdentifier));
+    mSocket.Open(aNetifIdentifier);
     mIsOpen                      = true;
     mRemainingConnectionAttempts = mMaxConnectionAttempts;
 

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -165,7 +165,7 @@ void Client::Start(void)
 {
     VerifyOrExit(!mSocket.IsBound());
 
-    IgnoreError(mSocket.Open(Ip6::kNetifThreadInternal));
+    mSocket.Open(Ip6::kNetifThreadInternal);
     IgnoreError(mSocket.Bind(kDhcpClientPort));
 
     ProcessNextIdentityAssociation();

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -135,7 +135,7 @@ void Server::Start(void)
 {
     VerifyOrExit(!mSocket.IsOpen());
 
-    IgnoreError(mSocket.Open(Ip6::kNetifThreadInternal));
+    mSocket.Open(Ip6::kNetifThreadInternal);
     IgnoreError(mSocket.Bind(kDhcpServerPort));
 
 exit:

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -792,7 +792,7 @@ Error Client::Start(void)
 {
     Error error;
 
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifUnspecified));
+    mSocket.Open(Ip6::kNetifUnspecified);
     SuccessOrExit(error = mSocket.Bind(0));
 
 exit:

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -80,7 +80,7 @@ Error Server::Start(void)
 
     VerifyOrExit(!IsRunning());
 
-    SuccessOrExit(error = mSocket.Open(kBindUnspecifiedNetif ? Ip6::kNetifUnspecified : Ip6::kNetifThreadInternal));
+    mSocket.Open(kBindUnspecifiedNetif ? Ip6::kNetifUnspecified : Ip6::kNetifThreadInternal);
     SuccessOrExit(error = mSocket.Bind(kPort));
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -54,7 +54,7 @@ Error Client::Start(void)
 {
     Error error;
 
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifUnspecified));
+    mSocket.Open(Ip6::kNetifUnspecified);
     SuccessOrExit(error = mSocket.Bind(0));
 
 exit:

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -398,7 +398,7 @@ Error Client::Start(const Ip6::SockAddr &aServerSockAddr, Requester aRequester)
     VerifyOrExit(GetState() == kStateStopped,
                  error = (aServerSockAddr == GetServerAddress()) ? kErrorNone : kErrorBusy);
 
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThreadInternal));
+    mSocket.Open(Ip6::kNetifThreadInternal);
 
     error = mSocket.Connect(aServerSockAddr);
 

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -812,7 +812,7 @@ Error Server::PrepareSocket(void)
 #endif
 
     VerifyOrExit(!mSocket.IsOpen());
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThreadInternal));
+    mSocket.Open(Ip6::kNetifThreadInternal);
     error = mSocket.Bind(mPort);
 
 exit:

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -96,7 +96,7 @@ Message *Udp::Socket::NewMessage(uint16_t aReserved, const Message::Settings &aS
     return Get<Udp>().NewMessage(aReserved, aSettings);
 }
 
-Error Udp::Socket::Open(NetifIdentifier aNetifId) { return Get<Udp>().Open(*this, aNetifId, mHandler, mContext); }
+void Udp::Socket::Open(NetifIdentifier aNetifId) { Get<Udp>().Open(*this, aNetifId, mHandler, mContext); }
 
 bool Udp::Socket::IsOpen(void) const { return Get<Udp>().IsOpen(*this); }
 
@@ -224,10 +224,8 @@ exit:
     return error;
 }
 
-Error Udp::Open(SocketHandle &aSocket, NetifIdentifier aNetifId, ReceiveHandler aHandler, void *aContext)
+void Udp::Open(SocketHandle &aSocket, NetifIdentifier aNetifId, ReceiveHandler aHandler, void *aContext)
 {
-    Error error = kErrorNone;
-
     OT_ASSERT(!IsOpen(aSocket));
 
     aSocket.Clear();
@@ -235,15 +233,7 @@ Error Udp::Open(SocketHandle &aSocket, NetifIdentifier aNetifId, ReceiveHandler 
     aSocket.mHandler = aHandler;
     aSocket.mContext = aContext;
 
-#if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
-    error = Plat::Open(aSocket);
-#endif
-    SuccessOrExit(error);
-
     AddSocket(aSocket);
-
-exit:
-    return error;
 }
 
 Error Udp::Bind(SocketHandle &aSocket, const SockAddr &aSockAddr)
@@ -251,6 +241,7 @@ Error Udp::Bind(SocketHandle &aSocket, const SockAddr &aSockAddr)
     Error error = kErrorNone;
 
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
+    SuccessOrExit(error = Plat::Open(aSocket));
     SuccessOrExit(error = Plat::BindToNetif(aSocket));
 #endif
 

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -182,6 +182,12 @@ public:
         friend class Udp;
 
     public:
+        enum Flags : int
+        {
+            kReuseAddr = OT_PLATFORM_UDP_REUSEADDR,
+            kReusePort = OT_PLATFORM_UDP_REUSEPORT,
+        };
+
         /**
          * Initializes the object.
          *
@@ -235,12 +241,13 @@ public:
          * Binds the UDP socket.
          *
          * @param[in]  aSockAddr         A reference to the socket address.
+         * @param[in]  aFlags    The bitwise OR of flags to set.
          *
          * @retval kErrorNone            Successfully bound the socket.
          * @retval kErrorInvalidArgs     Unable to bind to Thread network interface with the given address.
          * @retval kErrorFailed          Failed to bind UDP Socket.
          */
-        Error Bind(const SockAddr &aSockAddr);
+        Error Bind(const SockAddr &aSockAddr, int aFlags = 0);
 
         /**
          * Binds the UDP socket.
@@ -521,7 +528,7 @@ public:
      * @retval kErrorInvalidArgs     Unable to bind to Thread network interface with the given address.
      * @retval kErrorFailed          Failed to bind UDP Socket.
      */
-    Error Bind(SocketHandle &aSocket, const SockAddr &aSockAddr);
+    Error Bind(SocketHandle &aSocket, const SockAddr &aSockAddr, int aFlags);
 
     /**
      * Connects a UDP socket.
@@ -659,7 +666,7 @@ private:
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
     struct Plat
     {
-        static Error Open(SocketHandle &aSocket);
+        static Error Open(SocketHandle &aSocket, int aFlags);
         static Error Close(SocketHandle &aSocket);
         static Error Bind(SocketHandle &aSocket);
         static Error BindToNetif(SocketHandle &aSocket);

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -141,7 +141,11 @@ public:
          *
          * @param[in] aNetifId   The network interface identifier.
          */
-        void SetNetifId(NetifIdentifier aNetifId) { mNetifId = static_cast<otNetifIdentifier>(aNetifId); }
+        void SetNetifId(NetifIdentifier aNetifId)
+        {
+            OT_ASSERT(!IsBound());
+            mNetifId = static_cast<otNetifIdentifier>(aNetifId);
+        }
 
         /**
          * Indicates whether or not the socket can use platform UDP.
@@ -217,11 +221,8 @@ public:
          * Opens the UDP socket.
          *
          * @param[in]  aNetifId   The network interface identifier.
-         *
-         * @retval kErrorNone     Successfully opened the socket.
-         * @retval kErrorFailed   Failed to open the socket.
          */
-        Error Open(NetifIdentifier aNetifId);
+        void Open(NetifIdentifier aNetifId);
 
         /**
          * Returns if the UDP socket is open.
@@ -498,11 +499,8 @@ public:
      * @param[in]  aNetifId  A network interface identifier.
      * @param[in]  aHandler  A pointer to a function that is called when receiving UDP messages.
      * @param[in]  aContext  A pointer to arbitrary context information.
-     *
-     * @retval kErrorNone     Successfully opened the socket.
-     * @retval kErrorFailed   Failed to open the socket.
      */
-    Error Open(SocketHandle &aSocket, NetifIdentifier aNetifId, ReceiveHandler aHandler, void *aContext);
+    void Open(SocketHandle &aSocket, NetifIdentifier aNetifId, ReceiveHandler aHandler, void *aContext);
 
     /**
      * Returns if a UDP socket is open.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -164,7 +164,7 @@ Error Mle::Enable(void)
     Error error = kErrorNone;
 
     UpdateLinkLocalAddress();
-    SuccessOrExit(error = mSocket.Open(Ip6::kNetifThreadInternal));
+    mSocket.Open(Ip6::kNetifThreadInternal);
     SuccessOrExit(error = mSocket.Bind(kUdpPort));
 
 #if OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -245,6 +245,26 @@ exit:
     return error;
 }
 
+otError otPlatUdpSetFlags(otUdpSocket *aUdpSocket, int aFlags)
+{
+    otError error = OT_ERROR_NONE;
+    int     fd;
+    int     optval;
+
+    fd = FdFromHandle(aUdpSocket->mHandle);
+
+    optval = static_cast<bool>(aFlags & OT_PLATFORM_UDP_REUSEADDR);
+
+    VerifyOrExit(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) == 0, error = OT_ERROR_FAILED);
+
+    optval = static_cast<bool>(aFlags & OT_PLATFORM_UDP_REUSEPORT);
+
+    VerifyOrExit(setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval)) == 0, error = OT_ERROR_FAILED);
+
+exit:
+    return error;
+}
+
 otError otPlatUdpClose(otUdpSocket *aUdpSocket)
 {
     otError error = OT_ERROR_NONE;

--- a/tests/gtest/fake_platform.cpp
+++ b/tests/gtest/fake_platform.cpp
@@ -595,12 +595,22 @@ void otPlatTrelSend(otInstance *, const uint8_t *, uint16_t, const otSockAddr *)
 const otPlatTrelCounters *otPlatTrelGetCounters(otInstance *) { return nullptr; }
 void                      otPlatTrelResetCounters(otInstance *) {}
 
-otError otPlatUdpSocket(otUdpSocket *) { return OT_ERROR_NOT_IMPLEMENTED; }
-otError otPlatUdpClose(otUdpSocket *) { return OT_ERROR_NOT_IMPLEMENTED; }
-otError otPlatUdpBind(otUdpSocket *) { return OT_ERROR_NOT_IMPLEMENTED; }
-otError otPlatUdpBindToNetif(otUdpSocket *, otNetifIdentifier) { return OT_ERROR_NOT_IMPLEMENTED; }
+otError otPlatUdpSocket(otUdpSocket *aUdpSocket) { return FakePlatform::CurrentPlatform().UdpSocketOpen(*aUdpSocket); }
+otError otPlatUdpClose(otUdpSocket *aUdpSocket) { return FakePlatform::CurrentPlatform().UdpSocketClose(*aUdpSocket); }
+otError otPlatUdpBind(otUdpSocket *aUdpSocket) { return FakePlatform::CurrentPlatform().UdpSocketBind(*aUdpSocket); }
+otError otPlatUdpBindToNetif(otUdpSocket *aUdpSocket, otNetifIdentifier aNetifId)
+{
+    return FakePlatform::CurrentPlatform().UdpSocketBindToNetif(*aUdpSocket, aNetifId);
+}
 otError otPlatUdpConnect(otUdpSocket *) { return OT_ERROR_NOT_IMPLEMENTED; }
-otError otPlatUdpSend(otUdpSocket *, otMessage *, const otMessageInfo *) { return OT_ERROR_NOT_IMPLEMENTED; }
+otError otPlatUdpSend(otUdpSocket *aUdpSocket, otMessage *aMessage, const otMessageInfo *aMessageInfo)
+{
+    return FakePlatform::CurrentPlatform().UdpSocketSend(*aUdpSocket, *aMessage, *aMessageInfo);
+}
+otError otPlatUdpSetFlags(otUdpSocket *aUdpSocket, int aFlags)
+{
+    return FakePlatform::CurrentPlatform().UdpSocketSetFlags(*aUdpSocket, aFlags);
+}
 otError otPlatUdpJoinMulticastGroup(otUdpSocket *, otNetifIdentifier, const otIp6Address *)
 {
     return OT_ERROR_NOT_IMPLEMENTED;

--- a/tests/gtest/fake_platform.cpp
+++ b/tests/gtest/fake_platform.cpp
@@ -65,7 +65,6 @@ FakePlatform::FakePlatform()
     assert(sPlatform == nullptr);
     sPlatform = this;
 
-    fprintf(stderr, "fake platform start\r\n");
     mTransmitFrame.mPsdu = mTransmitBuffer;
 
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
@@ -615,5 +614,9 @@ otError otPlatUdpLeaveMulticastGroup(otUdpSocket *, otNetifIdentifier, const otI
 void otPlatOtnsStatus(const char *aStatus) { OT_UNUSED_VARIABLE(aStatus); }
 #endif
 
-void otPlatAssertFail(const char *, int) {}
+void otPlatAssertFail(const char *aFileName, int aLineNumber)
+{
+    fprintf(stderr, "Fake platform assertion failure at %s:%d\r\n", aFileName, aLineNumber);
+    abort();
+}
 } // extern "C"

--- a/tests/gtest/fake_platform.hpp
+++ b/tests/gtest/fake_platform.hpp
@@ -43,6 +43,8 @@
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/radio.h>
 #include <openthread/platform/time.h>
+#include <openthread/platform/udp.h>
+#include "openthread/udp.h"
 
 bool operator<(const otExtAddress &aLeft, const otExtAddress &aRight);
 
@@ -126,6 +128,16 @@ public:
     virtual size_t SrcMatchCountShortEntries(void) const { return mSrcMatchShortAddrs.size(); }
     virtual void   SrcMatchClearExtEntries(void) { mSrcMatchExtAddrs.clear(); }
     virtual size_t SrcMatchCountExtEntries(void) const { return mSrcMatchExtAddrs.size(); }
+
+    virtual otError UdpSocketSetFlags(otUdpSocket &, int) { return OT_ERROR_NOT_IMPLEMENTED; }
+    virtual otError UdpSocketOpen(otUdpSocket &) { return OT_ERROR_NOT_IMPLEMENTED; }
+    virtual otError UdpSocketClose(otUdpSocket &) { return OT_ERROR_NOT_IMPLEMENTED; }
+    virtual otError UdpSocketSend(otUdpSocket &, otMessage &aMessage, const otMessageInfo &aMessageInfo)
+    {
+        return OT_ERROR_NOT_IMPLEMENTED;
+    }
+    virtual otError UdpSocketBind(otUdpSocket &) { return OT_ERROR_NOT_IMPLEMENTED; }
+    virtual otError UdpSocketBindToNetif(otUdpSocket &, otNetifIdentifier) { return OT_ERROR_NOT_IMPLEMENTED; }
 
 protected:
     void ProcessSchedules(uint64_t &aTimeout);

--- a/tests/gtest/udp_test.cpp
+++ b/tests/gtest/udp_test.cpp
@@ -41,7 +41,11 @@
 #include <openthread/udp.h>
 #include <openthread/platform/time.h>
 
+#define OPENTHREAD_FTD 1
+
 #include "core/common/as_core_type.hpp"
+#include "core/common/locator.hpp"
+#include "core/instance/instance.hpp"
 #include "core/net/ip6_address.hpp"
 #include "core/net/socket.hpp"
 #include "core/net/udp6.hpp"
@@ -50,11 +54,51 @@
 #include "mock_callback.hpp"
 
 using namespace ot;
+using ::testing::Truly;
 
 using MockReceiveCallback = MockCallback<void, otMessage *, const otMessageInfo *>;
 
-class UdpTest : public ::testing::Test
+class UdpTest : public ::testing::Test, public FakePlatform, public InstanceLocator
 {
+public:
+    UdpTest()
+        : InstanceLocator(AsCoreType(mInstance))
+    {
+    }
+
+    virtual otError UdpSocketOpen(otUdpSocket &aUdpSocket) override
+    {
+        aUdpSocket.mHandle = &aUdpSocket;
+        return OT_ERROR_NONE;
+    }
+
+    virtual otError UdpSocketClose(otUdpSocket &aUdpSocket) override
+    {
+        aUdpSocket.mHandle = nullptr;
+        return OT_ERROR_NONE;
+    }
+
+    virtual otError UdpSocketSetFlags(otUdpSocket &, int) override { return OT_ERROR_NONE; }
+
+    virtual otError UdpSocketBind(otUdpSocket &aUdpSocket) override
+    {
+        if (aUdpSocket.mSockName.mPort == 0)
+        {
+            aUdpSocket.mSockName.mPort = Get<Ip6::Udp>().GetEphemeralPort();
+        }
+
+        return OT_ERROR_NONE;
+    }
+
+    virtual otError UdpSocketBindToNetif(otUdpSocket &, otNetifIdentifier) override { return OT_ERROR_NONE; }
+
+    virtual otError UdpSocketSend(otUdpSocket &aSocket, otMessage &aMessage, const otMessageInfo &aMessageInfo) override
+    {
+        OT_UNUSED_VARIABLE(aSocket);
+        return Get<Ip6::Udp>().SendDatagram(AsCoreType(&aMessage),
+                                            AsCoreType(const_cast<otMessageInfo *>(&aMessageInfo)));
+    }
+
 protected:
     void SetUp() override
     {
@@ -69,10 +113,8 @@ protected:
         ASSERT_EQ(OT_ERROR_NONE, otIp6SetEnabled(FakePlatform::CurrentInstance(), true));
         ASSERT_EQ(OT_ERROR_NONE, otThreadSetEnabled(FakePlatform::CurrentInstance(), true));
 
-        mFakePlatform.GoInMs(10000);
+        GoInMs(10000);
     }
-
-    FakePlatform mFakePlatform;
 };
 
 TEST_F(UdpTest, shouldSuccessWhenBindingMulticastAddressAndReceiveFromIt)
@@ -87,7 +129,8 @@ TEST_F(UdpTest, shouldSuccessWhenBindingMulticastAddressAndReceiveFromIt)
     ASSERT_EQ(OT_ERROR_NONE, listenAddr.GetAddress().FromString("ff02::21"));
     listenAddr.SetPort(2121);
 
-    ASSERT_EQ(OT_ERROR_NONE, otUdpBind(FakePlatform::CurrentInstance(), &receiver, &listenAddr, OT_NETIF_UNSPECIFIED));
+    ASSERT_EQ(OT_ERROR_NONE,
+              otUdpBind(FakePlatform::CurrentInstance(), &receiver, &listenAddr, OT_NETIF_THREAD_INTERNAL));
 
     ASSERT_EQ(OT_ERROR_NONE, otIp6SubscribeMulticastAddress(FakePlatform::CurrentInstance(), &listenAddr.mAddress));
     EXPECT_CALL(receiverCallback, Call).Times(1);
@@ -108,7 +151,7 @@ TEST_F(UdpTest, shouldSuccessWhenBindingMulticastAddressAndReceiveFromIt)
 
     ASSERT_EQ(OT_ERROR_NONE, otUdpSend(FakePlatform::CurrentInstance(), &sender, message, &messageInfo));
 
-    mFakePlatform.GoInMs(1000);
+    GoInMs(1000);
 
     ASSERT_EQ(OT_ERROR_NONE, otUdpClose(FakePlatform::CurrentInstance(), &sender));
     ASSERT_EQ(OT_ERROR_NONE, otUdpClose(FakePlatform::CurrentInstance(), &receiver));
@@ -130,7 +173,8 @@ TEST_F(UdpTest, shouldSuccessWhenBindingMulticastAddressAndNoReceiveFromDifferen
     listenAddr.SetAddress(group1);
     listenAddr.SetPort(2121);
 
-    ASSERT_EQ(OT_ERROR_NONE, otUdpBind(FakePlatform::CurrentInstance(), &receiver, &listenAddr, OT_NETIF_UNSPECIFIED));
+    ASSERT_EQ(OT_ERROR_NONE,
+              otUdpBind(FakePlatform::CurrentInstance(), &receiver, &listenAddr, OT_NETIF_THREAD_INTERNAL));
 
     ASSERT_EQ(OT_ERROR_NONE, otIp6SubscribeMulticastAddress(FakePlatform::CurrentInstance(), &group1));
     ASSERT_EQ(OT_ERROR_NONE, otIp6SubscribeMulticastAddress(FakePlatform::CurrentInstance(), &group2));
@@ -152,7 +196,7 @@ TEST_F(UdpTest, shouldSuccessWhenBindingMulticastAddressAndNoReceiveFromDifferen
 
     ASSERT_EQ(OT_ERROR_NONE, otUdpSend(FakePlatform::CurrentInstance(), &sender, message, &messageInfo));
 
-    mFakePlatform.GoInMs(1000);
+    GoInMs(1000);
 
     ASSERT_EQ(OT_ERROR_NONE, otUdpClose(FakePlatform::CurrentInstance(), &sender));
     ASSERT_EQ(OT_ERROR_NONE, otUdpClose(FakePlatform::CurrentInstance(), &receiver));
@@ -170,7 +214,8 @@ TEST_F(UdpTest, shouldSuccessWhenBindingMulticastAddressAndNoReceiveIfNotSubscri
     ASSERT_EQ(OT_ERROR_NONE, listenAddr.GetAddress().FromString("ff02::21"));
     listenAddr.SetPort(2121);
 
-    ASSERT_EQ(OT_ERROR_NONE, otUdpBind(FakePlatform::CurrentInstance(), &receiver, &listenAddr, OT_NETIF_UNSPECIFIED));
+    ASSERT_EQ(OT_ERROR_NONE,
+              otUdpBind(FakePlatform::CurrentInstance(), &receiver, &listenAddr, OT_NETIF_THREAD_INTERNAL));
 
     EXPECT_CALL(receiverCallback, Call).Times(0);
 
@@ -190,7 +235,7 @@ TEST_F(UdpTest, shouldSuccessWhenBindingMulticastAddressAndNoReceiveIfNotSubscri
 
     ASSERT_EQ(OT_ERROR_NONE, otUdpSend(FakePlatform::CurrentInstance(), &sender, message, &messageInfo));
 
-    mFakePlatform.GoInMs(1000);
+    GoInMs(1000);
 
     ASSERT_EQ(OT_ERROR_NONE, otUdpClose(FakePlatform::CurrentInstance(), &sender));
     ASSERT_EQ(OT_ERROR_NONE, otUdpClose(FakePlatform::CurrentInstance(), &receiver));
@@ -211,5 +256,33 @@ TEST_F(UdpTest, shouldAbortOnBindingToNetworkInterfaceOnBoundSocket)
 
     EXPECT_EXIT(AsCoreType(&sock).SetNetifId(Ip6::kNetifThreadInternal), ::testing::KilledBySignal(SIGABRT),
                 "Fake platform assertion failure");
+    ASSERT_EQ(OT_ERROR_NONE, otUdpClose(FakePlatform::CurrentInstance(), &sock));
+}
+
+class SetFlagsUdpTest : public UdpTest
+{
+public:
+    MOCK_METHOD(otError, UdpSocketSetFlags, (otUdpSocket & aSocket, int aFlags), (override));
+};
+
+TEST_F(SetFlagsUdpTest, shouldCallPlatformSetFlagsWhenBindingSocket)
+{
+    otUdpSocket sock{};
+
+    EXPECT_CALL(*this, UdpSocketSetFlags(Truly([&sock](otUdpSocket &aSocket) -> bool { return &sock == &aSocket; }), 0))
+        .Times(1);
+
+    ASSERT_EQ(OT_ERROR_NONE, otUdpOpen(
+                                 FakePlatform::CurrentInstance(), &sock,
+                                 [](void *aContext, otMessage *, const otMessageInfo *) -> void {
+
+                                 },
+                                 this));
+
+    Ip6::SockAddr listenAddr;
+    ASSERT_EQ(OT_ERROR_NONE, listenAddr.GetAddress().FromString("ff02::21"));
+    listenAddr.SetPort(12345);
+
+    ASSERT_EQ(OT_ERROR_NONE, otUdpBind(FakePlatform::CurrentInstance(), &sock, &listenAddr, OT_NETIF_UNSPECIFIED));
     ASSERT_EQ(OT_ERROR_NONE, otUdpClose(FakePlatform::CurrentInstance(), &sock));
 }

--- a/tests/toranj/cli/test-014-address-resolver.py
+++ b/tests/toranj/cli/test-014-address-resolver.py
@@ -268,10 +268,11 @@ verify_within(check_cache_entry_ramp_down_to_initial_retry_delay, 60)
 
 # Send to r1 from all addresses on r2.
 
-r2.udp_open()
 for num in range(num_addresses):
+    r2.udp_open()
     r2.udp_bind(prefix + '2:' + str(num), port)
     r2.udp_send(prefix + '1', port, 'hi_r1_from_r2_snoop_me')
+    r2.udp_close()
 
 # Verify that we see all addresses from r2 as snooped in cache table.
 # At most two of them should be marked as non-evictable.
@@ -398,11 +399,11 @@ verify(len(cache_table) == max_cache_entries)
 # Send from c2 to r1 and verify that snoop optimization uses at most
 # `max_snooped_non_evictable` entries
 
-c2.udp_open()
-
 for num in range(num_addresses):
+    c2.udp_open()
     c2.udp_bind(prefix + 'c2:' + str(num), port)
     c2.udp_send(prefix + '1', port, 'hi_r1_from_c2_snoop_me')
+    c2.udp_close()
 
 
 def check_cache_entry_contains_max_allowed_snopped():

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -722,6 +722,12 @@ otError otPlatUdpLeaveMulticastGroup(otUdpSocket        *aUdpSocket,
     OT_UNUSED_VARIABLE(aAddress);
     return OT_ERROR_NONE;
 }
+otError otPlatUdpSetFlags(otUdpSocket *aUdpSocket, int aFlags)
+{
+    OT_UNUSED_VARIABLE(aUdpSocket);
+    OT_UNUSED_VARIABLE(aFlags);
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
 #endif // OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
 
 #if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE

--- a/tests/unit/test_srp_server.cpp
+++ b/tests/unit/test_srp_server.cpp
@@ -1082,7 +1082,7 @@ void TestSrpClientDelayedResponse(void)
 
         sServerRxCount = 0;
 
-        SuccessOrQuit(udpSocket.Open(Ip6::kNetifThreadInternal));
+        udpSocket.Open(Ip6::kNetifThreadInternal);
         SuccessOrQuit(udpSocket.Bind(kServerPort));
 
         serverSockAddr.SetAddress(sInstance->Get<Mle::Mle>().GetMeshLocalRloc());
@@ -1233,7 +1233,7 @@ void TestSrpClientSingleServiceMode(void)
 
         sServerRxCount = 0;
 
-        SuccessOrQuit(udpSocket.Open(Ip6::kNetifThreadInternal));
+        udpSocket.Open(Ip6::kNetifThreadInternal);
         SuccessOrQuit(udpSocket.Bind(kServerPort));
 
         serverSockAddr.SetAddress(sInstance->Get<Mle::Mle>().GetMeshLocalRloc());


### PR DESCRIPTION
This commit adds platform API to set SO_REUSEADDR and SO_REUSEPORT for
platform UDP sockets.