### PR TITLE
[mle] allow children to efficiently request network data during reset

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1155,6 +1155,8 @@ Error Mle::SendChildUpdateRequestToParent(void) { return SendChildUpdateRequestT
 
 Error Mle::SendChildUpdateRequestToParent(ChildUpdateRequestMode aMode)
 {
+    static const uint8_t kRestoringChildTlvs[] = {Tlv::kNetworkData};
+
     Error                   error = kErrorNone;
     Ip6::Address            destination;
     TxMessage              *message     = nullptr;
@@ -1195,7 +1197,8 @@ Error Mle::SendChildUpdateRequestToParent(ChildUpdateRequestMode aMode)
         break;
     case kAppendChallengeTlv:
         mPrevRoleRestorer.GenerateRandomChallenge();
-        OT_FALL_THROUGH;
+        SuccessOrExit(error = message->AppendChallengeTlv(mPrevRoleRestorer.GetChallenge()));
+        break;
 
     case kToRestoreChildRole:
         // The challenge used for child role restoration is generated
@@ -1206,6 +1209,7 @@ Error Mle::SendChildUpdateRequestToParent(ChildUpdateRequestMode aMode)
         // response from the parent.
 
         SuccessOrExit(error = message->AppendChallengeTlv(mPrevRoleRestorer.GetChallenge()));
+        SuccessOrExit(error = message->AppendTlvRequestTlv(kRestoringChildTlvs));
         break;
     }
 


### PR DESCRIPTION
This PR allows former children coming out of reset to request the network data when sending a child update request in order to more efficiently rejoin the link.

Relates to https://threadgroup.atlassian.net/browse/SPEC-1228