### PR TITLE
[mle] avoid overwriting parent candidate during child ID request phase

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -5085,6 +5085,8 @@ void Mle::Attacher::HandleParentResponse(RxInfo &aRxInfo)
 
     Log(kMessageReceive, kTypeParentResponse, aRxInfo.mMessageInfo.GetPeerAddr(), sourceAddress);
 
+    VerifyOrExit(mState != kStateChildIdRequest, error = kErrorInvalidState);
+
     SuccessOrExit(error = aRxInfo.mMessage.ReadVersionTlv(version));
 
     SuccessOrExit(error = aRxInfo.mMessage.ReadAndMatchResponseTlvWith(mParentRequestChallenge));


### PR DESCRIPTION
Avoid overwriting parent candidate during child ID request phase.

Addresses issue here https://github.com/openthread/openthread/issues/11952