### PR TITLE
[br-tracker] move iteration logic out of `RoutingManager::Iterator`

### DIFF
--- a/src/core/border_router/br_tracker.hpp
+++ b/src/core/border_router/br_tracker.hpp
@@ -54,7 +54,6 @@ class RoutingManager;
  */
 class NetDataPeerBrTracker : public InstanceLocator
 {
-    friend class RoutingManager;
     friend class ot::Notifier;
 
 public:

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -2122,11 +2122,11 @@ Error RoutingManager::RxRaTracker::GetNextEntry(PrefixTableIterator &aIterator, 
 
     ClearAllBytes(aEntry);
 
-    SuccessOrExit(error = iterator.AdvanceToNextEntry());
+    SuccessOrExit(error = iterator.AdvanceToNextPrefixEntry());
 
     iterator.GetRouter()->CopyInfoTo(aEntry.mRouter, iterator.GetInitTime(), iterator.GetInitUptime());
 
-    switch (iterator.GetEntryType())
+    switch (iterator.GetPrefixType())
     {
     case Iterator::kOnLinkPrefix:
         iterator.GetEntry<OnLinkPrefix>()->CopyInfoTo(aEntry, iterator.GetInitTime());
@@ -2268,7 +2268,7 @@ void RoutingManager::RxRaTracker::Iterator::Init(const Entry<Router> *aRoutersHe
     SetType(kUnspecified);
     SetRouter(aRoutersHead);
     SetEntry(nullptr);
-    SetEntryType(kRoutePrefix);
+    SetPrefixType(kRoutePrefix);
 }
 
 Error RoutingManager::RxRaTracker::Iterator::AdvanceToNextRouter(Type aType)
@@ -2300,7 +2300,7 @@ exit:
     return error;
 }
 
-Error RoutingManager::RxRaTracker::Iterator::AdvanceToNextEntry(void)
+Error RoutingManager::RxRaTracker::Iterator::AdvanceToNextPrefixEntry(void)
 {
     Error error = kErrorNone;
 
@@ -2308,7 +2308,7 @@ Error RoutingManager::RxRaTracker::Iterator::AdvanceToNextEntry(void)
 
     if (HasEntry())
     {
-        switch (GetEntryType())
+        switch (GetPrefixType())
         {
         case kOnLinkPrefix:
             SetEntry(GetEntry<OnLinkPrefix>()->GetNext());
@@ -2321,7 +2321,7 @@ Error RoutingManager::RxRaTracker::Iterator::AdvanceToNextEntry(void)
 
     while (!HasEntry())
     {
-        switch (GetEntryType())
+        switch (GetPrefixType())
         {
         case kOnLinkPrefix:
 
@@ -2329,7 +2329,7 @@ Error RoutingManager::RxRaTracker::Iterator::AdvanceToNextEntry(void)
             // the current router.
 
             SetEntry(GetRouter()->mRoutePrefixes.GetHead());
-            SetEntryType(kRoutePrefix);
+            SetPrefixType(kRoutePrefix);
             break;
 
         case kRoutePrefix:
@@ -2343,7 +2343,7 @@ Error RoutingManager::RxRaTracker::Iterator::AdvanceToNextEntry(void)
 
             SuccessOrExit(error = AdvanceToNextRouter(kPrefixIterator));
             SetEntry(GetRouter()->mOnLinkPrefixes.GetHead());
-            SetEntryType(kOnLinkPrefix);
+            SetPrefixType(kOnLinkPrefix);
             break;
         }
     }
@@ -2395,32 +2395,6 @@ Error RoutingManager::RxRaTracker::Iterator::AdvanceToNextIfAddrEntry(const Entr
 exit:
     return error;
 }
-
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
-
-Error RoutingManager::RxRaTracker::Iterator::AdvanceToNextPeerBr(const PeerBr *aPeerBrsHead)
-{
-    Error error = kErrorNone;
-
-    if (GetType() == kUnspecified)
-    {
-        SetType(kPeerBrIterator);
-        SetEntry(aPeerBrsHead);
-    }
-    else
-    {
-        VerifyOrExit(GetType() == kPeerBrIterator, error = kErrorInvalidArgs);
-        VerifyOrExit(GetPeerBrEntry() != nullptr, error = kErrorNotFound);
-        SetEntry(GetPeerBrEntry()->GetNext());
-    }
-
-    VerifyOrExit(GetPeerBrEntry() != nullptr, error = kErrorNotFound);
-
-exit:
-    return error;
-}
-
-#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
 
 //---------------------------------------------------------------------------------------------------------------------
 // RxRaTracker::Router

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1154,9 +1154,8 @@ private:
 
         //-  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 
-        class Iterator : public PrefixTableIterator
+        struct Iterator : public PrefixTableIterator
         {
-        public:
             enum Type : uint8_t
             {
                 kUnspecified,
@@ -1164,10 +1163,10 @@ private:
                 kPrefixIterator,
                 kRdnssAddrIterator,
                 kIfAddrIterator,
-                kPeerBrIterator,
+                kNetDataBrIterator, // Used by `NetDataPeerBrTracker`
             };
 
-            enum EntryType : uint8_t
+            enum PrefixType : uint8_t
             {
                 kOnLinkPrefix,
                 kRoutePrefix,
@@ -1175,35 +1174,27 @@ private:
 
             void                 Init(const Entry<Router> *aRoutersHead, uint32_t aUptime);
             Error                AdvanceToNextRouter(Type aType);
-            Error                AdvanceToNextEntry(void);
+            Error                AdvanceToNextPrefixEntry(void);
             Error                AdvanceToNextRdnssAddrEntry(void);
             Error                AdvanceToNextIfAddrEntry(const Entry<IfAddress> *aListHead);
             uint32_t             GetInitUptime(void) const { return mData0; }
+            void                 SetInitUptime(uint32_t aUptime) { mData0 = aUptime; }
             TimeMilli            GetInitTime(void) const { return TimeMilli(mData1); }
-            Type                 GetType(void) const { return static_cast<Type>(mData2); }
+            void                 SetInitTime(void) { mData1 = TimerMilli::GetNow().GetValue(); }
             const Entry<Router> *GetRouter(void) const { return static_cast<const Entry<Router> *>(mPtr1); }
-            EntryType            GetEntryType(void) const { return static_cast<EntryType>(mData3); }
+            void                 SetRouter(const Entry<Router> *aRouter) { mPtr1 = aRouter; }
+            Type                 GetType(void) const { return static_cast<Type>(mData2); }
+            void                 SetType(Type aType) { mData2 = aType; }
+            const void          *GetEntry(void) const { return mPtr2; }
+            void                 SetEntry(const void *aEntry) { mPtr2 = aEntry; }
+            bool                 HasEntry(void) const { return mPtr2 != nullptr; }
+            PrefixType           GetPrefixType(void) const { return static_cast<PrefixType>(mData3); }
+            void                 SetPrefixType(PrefixType aType) { mData3 = aType; }
 
             template <typename ObjectType> const Entry<ObjectType> *GetEntry(void) const
             {
                 return static_cast<const Entry<ObjectType> *>(mPtr2);
             }
-
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
-            using PeerBr = NetDataPeerBrTracker::PeerBr;
-
-            Error         AdvanceToNextPeerBr(const PeerBr *aPeerBrsHead);
-            const PeerBr *GetPeerBrEntry(void) const { return static_cast<const PeerBr *>(mPtr2); }
-#endif
-
-        private:
-            void SetRouter(const Entry<Router> *aRouter) { mPtr1 = aRouter; }
-            void SetInitUptime(uint32_t aUptime) { mData0 = aUptime; }
-            void SetInitTime(void) { mData1 = TimerMilli::GetNow().GetValue(); }
-            void SetEntry(const void *aEntry) { mPtr2 = aEntry; }
-            bool HasEntry(void) const { return mPtr2 != nullptr; }
-            void SetEntryType(EntryType aType) { mData3 = aType; }
-            void SetType(Type aType) { mData2 = aType; }
         };
 
         //-  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -


### PR DESCRIPTION
This change moves the logic for iterating over the `NetDataPeerBrTracker` entries from `RoutingManager::RxRaTracker::Iterator` directly into the `NetDataPeerBrTracker::GetNext()` method.

This decouples the `NetDataPeerBrTracker` from the `RoutingManager`'s iterator implementation, allowing the removal of `RoutingManager` as a friend class of `NetDataPeerBrTracker`.

This commit also includes smaller enhancements and changes to the `RoutingManager::RxRaTracker::Iterator`:
- `Iterator::EntryType` is renamed to `PrefixType` for clarity.
- `Iterator::AdvanceToNextEntry()` is renamed to  `AdvanceToNextPrefixEntry()`.