### PR TITLE
[br-tracker] initialize `aMinAge` to `uint32_t::kMax`

### DIFF
--- a/src/core/border_router/br_tracker.cpp
+++ b/src/core/border_router/br_tracker.cpp
@@ -49,7 +49,7 @@ uint16_t NetDataPeerBrTracker::CountPeerBrs(uint32_t &aMinAge) const
     uint32_t uptime = Get<Uptime>().GetUptimeInSeconds();
     uint16_t count  = 0;
 
-    aMinAge = NumericLimits<uint16_t>::kMax;
+    aMinAge = NumericLimits<uint32_t>::kMax;
 
     for (const PeerBr &peerBr : mPeerBrs)
     {


### PR DESCRIPTION
In `NetDataPeerBrTracker::CountPeerBrs()` method, the `aMinAge` output parameter is a `uint32_t` but it was incorrectly
initialized to `NumericLimits<uint16_t>::kMax`. 

This change corrects the initialization to use the `NumericLimits<uint32_t>::kMax` to ensure the minimum age calculation functions correctly over the full 32-bit range.