### PR TITLE
[br-tracker] enhance `NetDataBrTracker` to support filtering

### DIFF
--- a/src/core/api/border_routing_api.cpp
+++ b/src/core/api/border_routing_api.cpp
@@ -268,15 +268,21 @@ otError otBorderRoutingGetNextPeerBrEntry(otInstance                           *
     AssertPointerIsNotNull(aIterator);
     AssertPointerIsNotNull(aEntry);
 
-    return AsCoreType(aInstance).Get<BorderRouter::NetDataPeerBrTracker>().GetNext(*aIterator, *aEntry);
+    return AsCoreType(aInstance).Get<BorderRouter::NetDataBrTracker>().GetNext(
+        BorderRouter::NetDataBrTracker::kExcludeThisDevice, *aIterator, *aEntry);
 }
 
 uint16_t otBorderRoutingCountPeerBrs(otInstance *aInstance, uint32_t *aMinAge)
 {
     uint32_t minAge;
 
-    return AsCoreType(aInstance).Get<BorderRouter::NetDataPeerBrTracker>().CountPeerBrs((aMinAge != nullptr) ? *aMinAge
-                                                                                                             : minAge);
+    if (aMinAge == nullptr)
+    {
+        aMinAge = &minAge;
+    }
+
+    return AsCoreType(aInstance).Get<BorderRouter::NetDataBrTracker>().CountBrs(
+        BorderRouter::NetDataBrTracker::kExcludeThisDevice, *aMinAge);
 }
 
 #endif

--- a/src/core/border_router/br_tracker.cpp
+++ b/src/core/border_router/br_tracker.cpp
@@ -35,26 +35,47 @@
 namespace ot {
 namespace BorderRouter {
 
-RegisterLogModule("BorderRouting");
+RegisterLogModule("BrTracker");
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
 
-NetDataPeerBrTracker::NetDataPeerBrTracker(Instance &aInstance)
+NetDataBrTracker::NetDataBrTracker(Instance &aInstance)
     : InstanceLocator(aInstance)
 {
 }
 
-uint16_t NetDataPeerBrTracker::CountPeerBrs(uint32_t &aMinAge) const
+bool NetDataBrTracker::BrMatchesFilter(const BorderRouter &aEntry, Filter aFilter) const
+{
+    bool matches = true;
+
+    switch (aFilter)
+    {
+    case kAllBorderRouters:
+        break;
+    case kExcludeThisDevice:
+        matches = !Get<Mle::Mle>().HasRloc16(aEntry.mRloc16);
+        break;
+    }
+
+    return matches;
+}
+
+uint16_t NetDataBrTracker::CountBrs(Filter aFilter, uint32_t &aMinAge) const
 {
     uint32_t uptime = Get<Uptime>().GetUptimeInSeconds();
     uint16_t count  = 0;
 
     aMinAge = NumericLimits<uint16_t>::kMax;
 
-    for (const PeerBr &peerBr : mPeerBrs)
+    for (const BorderRouter &entry : mBorderRouters)
     {
+        if (!BrMatchesFilter(entry, aFilter))
+        {
+            continue;
+        }
+
         count++;
-        aMinAge = Min(aMinAge, peerBr.GetAge(uptime));
+        aMinAge = Min(aMinAge, entry.GetAge(uptime));
     }
 
     if (count == 0)
@@ -65,30 +86,34 @@ uint16_t NetDataPeerBrTracker::CountPeerBrs(uint32_t &aMinAge) const
     return count;
 }
 
-Error NetDataPeerBrTracker::GetNext(TableIterator &aIterator, PeerBrEntry &aEntry) const
+Error NetDataBrTracker::GetNext(Filter aFilter, TableIterator &aIterator, BorderRouterEntry &aEntry) const
 {
     using Iterator = RoutingManager::RxRaTracker::Iterator;
 
-    Iterator     &iterator = static_cast<Iterator &>(aIterator);
-    Error         error    = kErrorNone;
-    const PeerBr *entry;
+    Iterator           &iterator = static_cast<Iterator &>(aIterator);
+    Error               error    = kErrorNone;
+    const BorderRouter *entry;
 
-    if (iterator.GetType() == Iterator::kUnspecified)
+    do
     {
-        iterator.SetType(Iterator::kNetDataBrIterator);
-        entry = mPeerBrs.GetHead();
-    }
-    else
-    {
-        VerifyOrExit(iterator.GetType() == Iterator::kNetDataBrIterator, error = kErrorInvalidArgs);
-        entry = static_cast<const PeerBr *>(iterator.GetEntry());
+        if (iterator.GetType() == Iterator::kUnspecified)
+        {
+            iterator.SetType(Iterator::kNetDataBrIterator);
+            entry = mBorderRouters.GetHead();
+        }
+        else
+        {
+            VerifyOrExit(iterator.GetType() == Iterator::kNetDataBrIterator, error = kErrorInvalidArgs);
+            entry = static_cast<const BorderRouter *>(iterator.GetEntry());
+            VerifyOrExit(entry != nullptr, error = kErrorNotFound);
+            entry = entry->GetNext();
+        }
+
         VerifyOrExit(entry != nullptr, error = kErrorNotFound);
-        entry = entry->GetNext();
-    }
 
-    VerifyOrExit(entry != nullptr, error = kErrorNotFound);
+        iterator.SetEntry(entry);
 
-    iterator.SetEntry(entry);
+    } while (!BrMatchesFilter(*entry, aFilter));
 
     aEntry.mRloc16 = entry->mRloc16;
     aEntry.mAge    = entry->GetAge(iterator.GetInitUptime());
@@ -97,7 +122,7 @@ exit:
     return error;
 }
 
-void NetDataPeerBrTracker::HandleNotifierEvents(Events aEvents)
+void NetDataBrTracker::HandleNotifierEvents(Events aEvents)
 {
     NetworkData::Rlocs rlocs;
 
@@ -105,29 +130,27 @@ void NetDataPeerBrTracker::HandleNotifierEvents(Events aEvents)
 
     Get<NetworkData::Leader>().FindRlocs(NetworkData::kBrProvidingExternalIpConn, NetworkData::kAnyRole, rlocs);
 
-    // Remove `PeerBr` entries no longer found in Network Data,
-    // or they match the device RLOC16. Then allocate and add
-    // entries for newly discovered peers.
+    // Remove `BorderRouter` entries no longer found in Network Data
+    // Then allocate and add entries for newly discovered BRs.
 
-    mPeerBrs.RemoveAndFreeAllMatching(PeerBr::Filter(rlocs));
-    mPeerBrs.RemoveAndFreeAllMatching(Get<Mle::Mle>().GetRloc16());
+    mBorderRouters.RemoveAndFreeAllMatching(BorderRouter::RlocFilter(rlocs));
 
     for (uint16_t rloc16 : rlocs)
     {
-        PeerBr *newEntry;
+        BorderRouter *newEntry;
 
-        if (Get<Mle::Mle>().HasRloc16(rloc16) || mPeerBrs.ContainsMatching(rloc16))
+        if (mBorderRouters.ContainsMatching(rloc16))
         {
             continue;
         }
 
-        newEntry = PeerBr::Allocate();
-        VerifyOrExit(newEntry != nullptr, LogWarn("Failed to allocate `PeerBr` entry"));
+        newEntry = BorderRouter::Allocate();
+        VerifyOrExit(newEntry != nullptr, LogWarn("Failed to allocate `BorderRouter` entry"));
 
         newEntry->mRloc16       = rloc16;
         newEntry->mDiscoverTime = Get<Uptime>().GetUptimeInSeconds();
 
-        mPeerBrs.Push(*newEntry);
+        mBorderRouters.Push(*newEntry);
     }
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1132,7 +1132,7 @@ void RoutingManager::MultiAilDetector::Evaluate(void)
 
     VerifyOrExit(Get<RoutingManager>().IsRunning());
 
-    count = Get<NetDataPeerBrTracker>().CountPeerBrs(minAge);
+    count = Get<NetDataBrTracker>().CountBrs(NetDataBrTracker::kExcludeThisDevice, minAge);
 
     if (count != mNetDataPeerBrCount)
     {

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -97,7 +97,7 @@ class RoutingManager : public InstanceLocator
 {
     friend class ot::Notifier;
     friend class ot::Instance;
-    friend class NetDataPeerBrTracker;
+    friend class NetDataBrTracker;
 
 public:
     typedef NetworkData::RoutePreference          RoutePreference;     ///< Route preference (high, medium, low).
@@ -997,7 +997,7 @@ private:
         // the same flow of execution, the callback is invoked after all the
         // changes are processed.
 
-        friend class NetDataPeerBrTracker;
+        friend class NetDataBrTracker;
 
     public:
         explicit RxRaTracker(Instance &aInstance);

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -163,7 +163,7 @@ void Notifier::EmitEvents(void)
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
     Get<BorderRouter::RoutingManager>().HandleNotifierEvents(events);
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
-    Get<BorderRouter::NetDataPeerBrTracker>().HandleNotifierEvents(events);
+    Get<BorderRouter::NetDataBrTracker>().HandleNotifierEvents(events);
 #endif
 #endif
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE

--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -265,7 +265,7 @@ Instance::Instance(void)
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
     , mRoutingManager(*this)
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
-    , mNetDataPeerBrTracker(*this)
+    , mNetDataBrTracker(*this)
 #endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_ENABLE
     , mDhcp6PdClient(*this)

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -706,7 +706,7 @@ private:
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
     BorderRouter::RoutingManager mRoutingManager;
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
-    BorderRouter::NetDataPeerBrTracker mNetDataPeerBrTracker;
+    BorderRouter::NetDataBrTracker mNetDataBrTracker;
 #endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_ENABLE
     BorderRouter::Dhcp6PdClient mDhcp6PdClient;
@@ -1086,7 +1086,7 @@ template <> inline Utils::Otns &Instance::Get(void) { return mOtns; }
 template <> inline BorderRouter::RoutingManager &Instance::Get(void) { return mRoutingManager; }
 template <> inline BorderRouter::InfraIf        &Instance::Get(void) { return mRoutingManager.mInfraIf; }
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
-template <> inline BorderRouter::NetDataPeerBrTracker &Instance::Get(void) { return mNetDataPeerBrTracker; }
+template <> inline BorderRouter::NetDataBrTracker &Instance::Get(void) { return mNetDataBrTracker; }
 #endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_ENABLE
 template <> inline BorderRouter::Dhcp6PdClient &Instance::Get(void) { return mDhcp6PdClient; }

--- a/tests/unit/test_dns_client.cpp
+++ b/tests/unit/test_dns_client.cpp
@@ -1597,6 +1597,18 @@ void TestDnsClient(void)
     srpServer->SetEnabled(false);
     AdvanceTime(100);
 
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
+    Log("Remove the route prefix (with NAT64 flag) from network data");
+
+    // This ensures the device is no longer tracked as a BR. This is
+    // required to release the associated heap allocation in
+    // `NetDataBrTracker`, which would otherwise cause the
+    // `heapAllocations` check to fail.
+
+    SuccessOrQuit(otBorderRouterRemoveRoute(sInstance, &routeConfig.mPrefix));
+    SuccessOrQuit(otBorderRouterRegister(sInstance));
+    AdvanceTime(1000);
+
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -1472,6 +1472,8 @@ void TestSamePrefixesFromMultipleRouters(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    AdvanceTime(3000);
+
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
     Log("End of TestSamePrefixesFromMultipleRouters");
@@ -1622,6 +1624,8 @@ void TestOmrSelection(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    AdvanceTime(3000);
+
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
     Log("End of TestOmrSelection");
@@ -1890,6 +1894,8 @@ void TestOmrConfig(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    AdvanceTime(3000);
+
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
     Log("End of TestOmrConfig");
@@ -2055,6 +2061,17 @@ void TestDefaultRoute(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    AdvanceTime(3000);
+
+    // Remove the manually added on-mesh prefix with a default route.
+    // This ensures the device is no longer considered a BR, so its heap
+    // allocation in `NetDataBrTracker` is released. Otherwise, the
+    // `heapAllocations` check would fail.
+
+    SuccessOrQuit(otBorderRouterRemoveOnMeshPrefix(sInstance, &prefixConfig.mPrefix));
+    SuccessOrQuit(otBorderRouterRegister(sInstance));
+    AdvanceTime(3000);
+
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
     Log("End of TestDefaultRoute");
@@ -2164,6 +2181,8 @@ void TestNonUlaPioWithOnlyOnLinkFlag(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    AdvanceTime(3000);
+
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
     Log("End of TestNonUlaPioWithOnlyOnLinkFlag");
@@ -2330,6 +2349,17 @@ void TestAdvNonUlaRoute(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    AdvanceTime(3000);
+
+    // Remove the manually added on-mesh prefix with a default route.
+    // This ensures the device is no longer considered a BR, so its
+    // heap allocation in `NetDataBrTracker` is released. Otherwise,
+    // the `heapAllocations` check would fail.
+
+    SuccessOrQuit(otBorderRouterRemoveOnMeshPrefix(sInstance, &prefixConfig.mPrefix));
+    SuccessOrQuit(otBorderRouterRegister(sInstance));
+    AdvanceTime(3000);
+
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
     Log("End of TestAdvNonUlaRoute");
@@ -2449,6 +2479,8 @@ void TestFavoredOnLinkPrefix(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    AdvanceTime(3000);
+
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
     Log("End of TestFavoredOnLinkPrefix");
@@ -2587,6 +2619,8 @@ void TestLocalOnLinkPrefixDeprecation(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    AdvanceTime(3000);
+
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
     Log("End of TestLocalOnLinkPrefixDeprecation");
@@ -2743,6 +2777,8 @@ void TestDomainPrefixAsOmr(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    AdvanceTime(3000);
+
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
     Log("End of TestDomainPrefixAsOmr");
@@ -3252,6 +3288,8 @@ void TestExtPanIdChange(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    AdvanceTime(3000);
+
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
     Log("End of TestExtPanIdChange");
@@ -3390,6 +3428,8 @@ void TestPrefixStaleTime(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    AdvanceTime(3000);
+
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
     Log("End of TestPrefixStaleTime");
@@ -3543,6 +3583,8 @@ void TestRouterNsProbe(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    AdvanceTime(3000);
+
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
     Log("End of TestRouterNsProbe");
@@ -3714,6 +3756,7 @@ void TestLearningAndCopyingOfFlags(void)
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
     VerifyDiscoveredRoutersIsEmpty();
+    AdvanceTime(3000);
 
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
@@ -3802,6 +3845,7 @@ void TestLearnRaHeader(void)
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
     VerifyDiscoveredRoutersIsEmpty();
+    AdvanceTime(3000);
 
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
@@ -4022,6 +4066,8 @@ void TestConflictingPrefix(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    AdvanceTime(3000);
+
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 
     Log("End of TestConflictingPrefix");
@@ -4536,6 +4582,8 @@ void TestNat64PrefixSelection(void)
     VerifyNat64PrefixInNetData(localNat64);
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    AdvanceTime(3000);
+
     VerifyOrQuit(sHeapAllocatedPtrs.GetLength() == heapAllocations);
 
     Log("End of TestNat64PrefixSelection");
@@ -4862,6 +4910,8 @@ void TestDhcp6Pd(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    AdvanceTime(3000);
+
     VerifyOrQuit(sHeapAllocatedPtrs.GetLength() <= heapAllocations);
 
     Log("End of TestDhcp6Pd");
@@ -5101,8 +5151,8 @@ void TestRdnss(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
-
     VerifyRdnssAddressTableIsEmpty();
+    AdvanceTime(3000);
 
     VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
 


### PR DESCRIPTION
This change enhances `NetDataBrTracker` to support filtering of Border Routers.

The `NetDataPeerBrTracker` is renamed to `NetDataBrTracker` to reflect that it can now track all Border Routers, not just peers.

A new `Filter` enum is introduced with `kAllBorderRouters` and `kExcludeThisDevice` options. This allows callers to specify whether to include the current device in the list of Border Routers.

The `CountPeerBrs()` and `GetNext()` methods are updated to `CountBrs()` and `GetNext()` respectively, and now accept a `Filter` parameter.

This change provides more flexibility to the `NetDataBrTracker` and makes the code more reusable. The unit tests are also updated to clean up resources to avoid heap allocation leaks at the end of tests.
