### PR TITLE
[num-utils] add `SetToUintMax()` to prevent type-mismatch bugs

### DIFF
--- a/src/core/border_router/br_tracker.cpp
+++ b/src/core/border_router/br_tracker.cpp
@@ -65,7 +65,7 @@ uint16_t NetDataBrTracker::CountBrs(Filter aFilter, uint32_t &aMinAge) const
     uint32_t uptime = Get<Uptime>().GetUptimeInSeconds();
     uint16_t count  = 0;
 
-    aMinAge = NumericLimits<uint32_t>::kMax;
+    SetToUintMax(aMinAge);
 
     for (const BorderRouter &entry : mBorderRouters)
     {

--- a/src/core/border_router/dhcp6_pd_client.cpp
+++ b/src/core/border_router/dhcp6_pd_client.cpp
@@ -1337,7 +1337,7 @@ uint16_t Dhcp6PdClient::RetxTracker::DetermineElapsedTime(void)
 
     if (mLongElapsedTime)
     {
-        elapsed = NumericLimits<uint16_t>::kMax;
+        SetToUintMax(elapsed);
         ExitNow();
     }
 

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -163,7 +163,7 @@ uint16_t MessagePool::GetFreeBufferCount(void) const
 #if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
     rval = static_cast<uint16_t>(Instance::GetHeap().GetFreeSize() / sizeof(Buffer));
 #else
-    rval = NumericLimits<uint16_t>::kMax;
+    SetToUintMax(rval);
 #endif
 #elif OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
     rval = otPlatMessagePoolNumFreeBuffers(&GetInstance());
@@ -182,7 +182,7 @@ uint16_t MessagePool::GetTotalBufferCount(void) const
 #if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
     rval = static_cast<uint16_t>(Instance::GetHeap().GetCapacity() / sizeof(Buffer));
 #else
-    rval = NumericLimits<uint16_t>::kMax;
+    SetToUintMax(rval);
 #endif
 #else
     rval = OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS;

--- a/src/core/common/num_utils.hpp
+++ b/src/core/common/num_utils.hpp
@@ -145,6 +145,20 @@ template <typename IntType> int8_t ClampToInt8(IntType aValue)
 }
 
 /**
+ * Sets a given unsigned integer variable to its maximum possible value.
+ *
+ * @tparam UintType   The unsigned integer type.
+ *
+ * @param[out] aVariable  A reference to the variable to set to its max possible value.
+ */
+template <typename UintType> void SetToUintMax(UintType &aVariable)
+{
+    static_assert(TypeTraits::IsUint<UintType>::kValue, "UintType must be an unsigned int (8, 16, 32, or 64 bit len)");
+
+    aVariable = NumericLimits<UintType>::kMax;
+}
+
+/**
  * Indicates whether or not the addition of two unsigned integers will result in an overflow.
  *
  * @tparam UintType   The value type (MUST be `uint8_t`, `uint16_t`, `uint32_t`, or `uint64_t`).

--- a/src/core/net/mdns.cpp
+++ b/src/core/net/mdns.cpp
@@ -1051,7 +1051,9 @@ exit:
 
 uint32_t Core::RecordInfo::GetDurationSinceLastMulticast(TimeMilli aTime) const
 {
-    uint32_t duration = NumericLimits<uint32_t>::kMax;
+    uint32_t duration;
+
+    SetToUintMax(duration);
 
     VerifyOrExit(mIsPresent && mIsLastMulticastValid);
     VerifyOrExit(aTime > mLastMulticastTime, duration = 0);

--- a/src/core/radio/trel_peer.cpp
+++ b/src/core/radio/trel_peer.cpp
@@ -134,8 +134,10 @@ uint32_t Peer::DetermineExpirationDelay(uint32_t aUptimeNow) const
     // `uint32_t` max value, indicating that the peer is not
     // considered as expired.
 
-    uint32_t delay = NumericLimits<uint32_t>::kMax;
+    uint32_t delay;
     uint32_t expireTime;
+
+    SetToUintMax(delay);
 
     VerifyOrExit(mDnssdState == kDnssdRemoved);
 
@@ -462,7 +464,9 @@ exit:
 void PeerTable::HandleTimer(void)
 {
     uint32_t uptimeNow = Get<Uptime>().GetUptimeInSeconds();
-    uint32_t delay     = NumericLimits<uint32_t>::kMax;
+    uint32_t delay;
+
+    SetToUintMax(delay);
 
     RemoveAndFreeAllMatching(Peer::ExpireChecker(uptimeNow));
 

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -3510,7 +3510,7 @@ Error Mle::AddrSolicitInfo::ParseFrom(const Coap::Message &aMessage)
     case kErrorNone:
         break;
     case kErrorNotFound:
-        mXtalAccuracy = NumericLimits<uint16_t>::kMax;
+        SetToUintMax(mXtalAccuracy);
         break;
     default:
         ExitNow(error = kErrorParse);

--- a/src/core/utils/ping_sender.hpp
+++ b/src/core/utils/ping_sender.hpp
@@ -77,9 +77,9 @@ public:
             mSentCount          = 0;
             mReceivedCount      = 0;
             mTotalRoundTripTime = 0;
-            mMinRoundTripTime   = NumericLimits<uint16_t>::kMax;
-            mMaxRoundTripTime   = NumericLimits<uint16_t>::kMin;
+            mMaxRoundTripTime   = 0;
             mIsMulticast        = false;
+            SetToUintMax(mMinRoundTripTime);
         }
     };
 


### PR DESCRIPTION
Introduces a new template helper function `SetToUintMax()` in `common/num_utils.hpp`. This function sets a given unsigned integer variable to its maximum possible value.

The `SetToUintMax()` function infers the type of the variable, ensuring that the correct `NumericLimits<...>::kMax` is used. This prevents potential bugs where a variable could be assigned the max value of a wrong `uint` type.

Existing code across different modules is updated to use this new helper function, improving code safety and robustness.