### PR TITLE
[coap] Set default netif identifier to Thread Internal

### DIFF
--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -938,7 +938,7 @@ public:
      * @retval kErrorNone    Successfully started the CoAP service.
      * @retval kErrorFailed  Failed to start CoAP agent.
      */
-    Error Start(uint16_t aPort, Ip6::NetifIdentifier aNetifIdentifier = Ip6::kNetifUnspecified);
+    Error Start(uint16_t aPort, Ip6::NetifIdentifier aNetifIdentifier = Ip6::kNetifThreadInternal);
 
     /**
      * Stops the CoAP service.


### PR DESCRIPTION
When coap start command is issued from CLI, there is no parameter passed for netif identifier, so default argument will be used. When mSocket.Open() is called and OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE is enabled, COAP socket will be opened at platform level and COAP's sender will use otPlatUdpSend API.
This commit fixes this behaviour, letting COAP communication to be performed over 15.4 link when commands are issued from CLI and OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE is enabled.