### PR TITLE
[routing-manager] remove confusing log of nat64 prefix discovery

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -4318,7 +4318,10 @@ void RoutingManager::Nat64PrefixManager::Discover(void)
     }
     else
     {
-        LogWarn("Failed to discover infraif NAT64 prefix: %s", ErrorToString(error));
+        if (error != kErrorNotImplemented)
+        {
+            LogWarn("Failed to discover infraif NAT64 prefix: %s", ErrorToString(error));
+        }
         Get<RoutingManager>().ScheduleRoutingPolicyEvaluation(kAfterRandomDelay);
     }
 }


### PR DESCRIPTION
The PR removes the warn log when `DiscoverNat64Prefix` fails.

Note that `otPlatInfraIfDiscoverNat64Prefix` has an empty implementation now and it always returns UNIMPLEMENTED error. So now we constantly see the warn log on devices, which is confusing.

As I went through the previous [discussion](https://github.com/openthread/openthread/pull/11654#discussion_r2179211929), we are currently in a temporary state. Let's add the warn log back once the `otPlatInfraIfDiscoverNat64Prefix` is implemented again.