### PR TITLE
[trel] simplify `Peer::Matches()` for name matching

### DIFF
--- a/src/core/radio/trel_peer.cpp
+++ b/src/core/radio/trel_peer.cpp
@@ -222,11 +222,24 @@ exit:
     return;
 }
 
-bool Peer::Matches(const ServiceNameMatcher &aMatcher) const { return NameMatch(mServiceName, aMatcher.mServiceName); }
-
-bool Peer::Matches(const HostNameMatcher &aMatcher) const
+bool Peer::Matches(NameMatchType aType, const char *aName) const
 {
-    return mResolvingHost && NameMatch(mHostName, aMatcher.mHostName);
+    bool matches = false;
+
+    switch (aType)
+    {
+    case kMatchServiceName:
+        matches = NameMatch(mServiceName, aName);
+        break;
+
+    case kMatchHostName:
+        VerifyOrExit(mResolvingHost);
+        matches = NameMatch(mHostName, aName);
+        break;
+    }
+
+exit:
+    return matches;
 }
 
 bool Peer::NameMatch(const Heap::String &aHeapString, const char *aName)

--- a/src/core/radio/trel_peer.hpp
+++ b/src/core/radio/trel_peer.hpp
@@ -226,24 +226,10 @@ private:
     };
 
 #if OPENTHREAD_CONFIG_TREL_MANAGE_DNSSD_ENABLE
-    struct ServiceNameMatcher
+    enum NameMatchType : uint8_t
     {
-        explicit ServiceNameMatcher(const char *SrerviceName)
-            : mServiceName(SrerviceName)
-        {
-        }
-
-        const char *mServiceName;
-    };
-
-    struct HostNameMatcher
-    {
-        explicit HostNameMatcher(const char *aHostName)
-            : mHostName(aHostName)
-        {
-        }
-
-        const char *mHostName;
+        kMatchServiceName,
+        kMatchHostName,
     };
 
     class AddressArray : public Heap::Array<Ip6::Address>
@@ -271,8 +257,7 @@ private:
 
 #if OPENTHREAD_CONFIG_TREL_MANAGE_DNSSD_ENABLE
     void SetPort(uint16_t aPort);
-    bool Matches(const ServiceNameMatcher &aMatcher) const;
-    bool Matches(const HostNameMatcher &aMatcher) const;
+    bool Matches(NameMatchType aType, const char *aName) const;
     void SignalPeerRemoval(void);
 
     static bool NameMatch(const Heap::String &aHeapString, const char *aName);

--- a/src/core/radio/trel_peer_discoverer.cpp
+++ b/src/core/radio/trel_peer_discoverer.cpp
@@ -340,7 +340,7 @@ void PeerDiscoverer::HandleBrowseResult(const Dnssd::BrowseResult &aResult)
 
     VerifyOrExit(IsRunning());
 
-    peer = Get<PeerTable>().FindMatching(Peer::ServiceNameMatcher(aResult.mServiceInstance));
+    peer = Get<PeerTable>().FindMatching(Peer::kMatchServiceName, aResult.mServiceInstance);
 
     if (aResult.mTtl == 0)
     {
@@ -416,7 +416,7 @@ void PeerDiscoverer::HandleSrvResult(const Dnssd::SrvResult &aResult)
 
     VerifyOrExit(IsRunning());
 
-    peer = Get<PeerTable>().FindMatching(Peer::ServiceNameMatcher(aResult.mServiceInstance));
+    peer = Get<PeerTable>().FindMatching(Peer::kMatchServiceName, aResult.mServiceInstance);
     VerifyOrExit(peer != nullptr);
 
     if (aResult.mTtl == 0)
@@ -455,7 +455,7 @@ void PeerDiscoverer::HandleTxtResult(const Dnssd::TxtResult &aResult)
 
     VerifyOrExit(IsRunning());
 
-    peer = Get<PeerTable>().FindMatching(Peer::ServiceNameMatcher(aResult.mServiceInstance));
+    peer = Get<PeerTable>().FindMatching(Peer::kMatchServiceName, aResult.mServiceInstance);
     VerifyOrExit(peer != nullptr);
 
     peer->mTxtDataValidated = false;
@@ -502,7 +502,7 @@ void PeerDiscoverer::StartHostAddressResolver(Peer &aPeer)
 
     VerifyOrExit(!aPeer.mResolvingHost);
 
-    sameHostPeer = Get<PeerTable>().FindMatching(Peer::HostNameMatcher(aPeer.mHostName.AsCString()));
+    sameHostPeer = Get<PeerTable>().FindMatching(Peer::kMatchHostName, aPeer.mHostName.AsCString());
 
     aPeer.mResolvingHost = true;
 
@@ -530,7 +530,7 @@ void PeerDiscoverer::StopHostAddressResolver(Peer &aPeer)
     aPeer.mResolvingHost = false;
     aPeer.mHostAddresses.Free();
 
-    VerifyOrExit(!Get<PeerTable>().ContainsMatching(Peer::HostNameMatcher(aPeer.mHostName.AsCString())));
+    VerifyOrExit(!Get<PeerTable>().ContainsMatching(Peer::kMatchHostName, aPeer.mHostName.AsCString()));
 
     Get<Dnssd>().StopIp6AddressResolver(AddressResolver(aPeer));
 
@@ -613,7 +613,7 @@ void PeerDiscoverer::HandleAddressResult(const Dnssd::AddressResult &aResult)
             continue;
         }
 
-        if (peer.Matches(Peer::HostNameMatcher(aResult.mHostName)))
+        if (peer.Matches(Peer::kMatchHostName, aResult.mHostName))
         {
             UpdatePeerAddresses(peer, sortedAddresses);
             UpdatePeerState(peer);


### PR DESCRIPTION
Consolidates the two overloaded `Peer::Matches()` methods for service and host name matching into a single method.

This change introduces a new `NameMatchType` enum, which is used to specify whether to match against a service name or a host name. This removes the need for the now-unnecessary `ServiceNameMatcher` and `HostNameMatcher` structs, simplifying the calling code and the `Peer` class.