### PR TITLE
[posix] use LogInfo if SPI reset device is not given

### DIFF
--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -155,7 +155,10 @@ otError SpiInterface::Init(ReceiveFrameCallback aCallback, void *aCallbackContex
     }
     else
     {
-        LogNote("gpio-reset-device is not given.");
+        // For some products, gpio-reset-device is not needed in the radio URL as
+        // the reset may be managed by another component in the system (e.g., by the BT stack).
+        // In this case, gpio-reset-device in the radio URL should not be given, and this is expected.
+        LogInfo("gpio-reset-device is not given.");
     }
 
     InitSpiDev(mRadioUrl.GetPath(), spiMode, spiSpeed);


### PR DESCRIPTION
For some products, `gpio-reset-device` is not needed in radio URL as the reset maybe management by other component in the system (e.g. by BT statck in some trinity chip). In this case, `gpio-reset-device` in the radio URL should not be given, and this is expected.

This pull request makes a minor logging change in the `SpiInterface::Init` method. The log level for the message indicating that `gpio-reset-device` is not provided has been changed from "Note" to "Info". 

* Changed log level from `LogNote` to `LogInfo` for the message about missing `gpio-reset-device` in `spi_interface.cpp`.