### PR TITLE
[mle] don't allow FTD upgrade to Router while Leader is attaching

### DIFF
--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -3529,6 +3529,11 @@ void Mle::ProcessAddressSolicit(AddrSolicitInfo &aInfo)
     aInfo.mResponse = kAddrSolicitNoAddressAvailable;
     aInfo.mRouter   = nullptr;
 
+    // The leader may have chosen to begin the attachment process assuming it's own partition
+    // was a singleton. Don't allow any devices to upgrade while it is in the attaching
+    // process because it could change the preconditions for the decision to reattach.
+    VerifyOrExit(!IsAttaching());
+
     LogInfo("AddrSolicit Reason: %s", RouterUpgradeReasonToString(aInfo.mReason));
 
     if (aInfo.mRequestedRloc16 != kInvalidRloc16)


### PR DESCRIPTION
This prevents the leader from allowing FTD devices' address solicit to succeed while it is in the attaching state.

Upon processing an advertisement from a different partition, the leader may evaluate it's own partition to be a singleton vs another partition with routers and choose to start attaching. If a router is upgraded during that time, the leader is committed to leaving already and the other devices on that partition may get stranded if the router is upgraded. 

i.e. The router and other devices may now see the partition as non-singleton, and if it has a higher partition ID than other partitions, they will be stuck for the duration of the network ID timeout.

This can be seen for example in formation graphs where an "extra" partition is maintained for longer than expected:
<img width="664" height="349" alt="image" src="https://github.com/user-attachments/assets/d0c9f525-f209-4769-a2c6-59c0d69cbc71" />
