### PR TITLE
[routing-manager] make getter methods const

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -536,7 +536,7 @@ public:
      * @retval kErrorNotFound     No more entries in the table.
      * @retval kErrorInvalidArgs  The @p aIterator is not valid (e.g. used to iterate over other entry types).
      */
-    Error GetNextRdnssAddrEntry(PrefixTableIterator &aIterator, RdnssAddrEntry &aEntry)
+    Error GetNextRdnssAddrEntry(PrefixTableIterator &aIterator, RdnssAddrEntry &aEntry) const
     {
         return mRxRaTracker.GetNextRdnssAddr(aIterator, aEntry);
     }
@@ -567,7 +567,7 @@ public:
      * @retval kErrorNotFound     No more entries in the table.
      * @retval kErrorInvalidArgs  The @p aIterator is not valid (e.g. used to iterate over other entry types).
      */
-    Error GetNextIfAddrEntry(PrefixTableIterator &aIterator, IfAddrEntry &aEntry)
+    Error GetNextIfAddrEntry(PrefixTableIterator &aIterator, IfAddrEntry &aEntry) const
     {
         return mRxRaTracker.GetNextIfAddr(aIterator, aEntry);
     }


### PR DESCRIPTION
make `RoutingManager::GetNextRdnssAddrEntry()` and `RoutingManager::GetNextIfAddrEntry()` const.

These methods are simple getters that do not modify the state of `RoutingManager` and call const methods on `mRxRaTracker`. This change makes them consistent with other similar getter methods in RoutingManager like `GetNextPrefixTableEntry()` and `GetNextRouterEntry()`.