### PR TITLE
[border-agent] read NetName and XPanId from active dataset for TXT data

### DIFF
--- a/tests/nexus/test_border_agent.cpp
+++ b/tests/nexus/test_border_agent.cpp
@@ -1251,10 +1251,14 @@ void ValidateMeshCoPTxtData(TxtData &aTxtData, Node &aNode)
     aNode.Get<BorderAgent>().GetId(id);
     aTxtData.ValidateKey("id", id);
     aTxtData.ValidateKey("rv", "1");
-    aTxtData.ValidateKey("nn", aNode.Get<NetworkNameManager>().GetNetworkName().GetAsCString());
-    aTxtData.ValidateKey("xp", aNode.Get<ExtendedPanIdManager>().GetExtPanId());
     aTxtData.ValidateKey("tv", kThreadVersionString);
     aTxtData.ValidateKey("xa", aNode.Get<Mac::Mac>().GetExtAddress());
+
+    if (aNode.Get<MeshCoP::ActiveDatasetManager>().IsComplete())
+    {
+        aTxtData.ValidateKey("nn", aNode.Get<NetworkNameManager>().GetNetworkName().GetAsCString());
+        aTxtData.ValidateKey("xp", aNode.Get<ExtendedPanIdManager>().GetExtPanId());
+    }
 
     if (aNode.Get<Mle::Mle>().IsAttached())
     {


### PR DESCRIPTION
This change updates `BorderAgent::PrepareServiceTxtData()` to read the Network Name (`nn` key) and Extended PAN ID (`xp` key) from the Active Dataset, after verifying that the dataset is valid and has an active timestamp.

Previously, these values were read directly from `NetworkNameManager` and `ExtendedPanIdManager`, which could provide default or initial values (during stack initialization). Reading from the Active Dataset ensures that the advertised service TXT data is consistent with the dataset currently in use by the device.

The `ValidateMeshCoPTxtData()` test is updated to reflect this behavior.