### PR TITLE
[border-agent] check that BA is enabled in `RegisterService()`

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -466,6 +466,7 @@ void BorderAgent::RegisterService(void)
     uint16_t       txtDataBufferSize;
     uint16_t       txtDataLength;
 
+    VerifyOrExit(IsEnabled());
     VerifyOrExit(Get<Dnssd>().IsReady());
 
     // Allocate a large enough buffer to fit both the TXT data

--- a/tests/nexus/test_border_agent.cpp
+++ b/tests/nexus/test_border_agent.cpp
@@ -1787,6 +1787,26 @@ void TestBorderAgentServiceRegistration(void)
     sBrowseOutcomes.Clear();
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    Log("Change the base service name while agent is disabled and validate no service is registered");
+
+    SuccessOrQuit(node0.Get<MeshCoP::BorderAgent>().SetServiceBaseName("NewName"));
+
+    VerifyOrQuit(!node0.Get<MeshCoP::BorderAgent>().IsEnabled());
+
+    nexus.AdvanceTime(30 * Time::kOneSecondInMsec);
+
+    iterator = node0.Get<Dns::Multicast::Core>().AllocateIterator();
+    VerifyOrQuit(iterator != nullptr);
+
+    VerifyOrQuit(node0.Get<Dns::Multicast::Core>().GetNextService(*iterator, service, entryState) == kErrorNotFound);
+
+    node0.Get<Dns::Multicast::Core>().FreeIterator(*iterator);
+
+    VerifyOrQuit(sBrowseOutcomes.IsEmpty());
+
+    SuccessOrQuit(node0.Get<MeshCoP::BorderAgent>().SetServiceBaseName("OpenThreadAgent"));
+
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Re-enable Border Agent and validate that service is registered again");
 
     node0.Get<MeshCoP::BorderAgent>().SetEnabled(true);


### PR DESCRIPTION
This change adds a check at the beginning of `RegisterService()` to ensure that the border agent is enabled before attempting to register a service.

Previously, methods like `SetServiceBaseName()` would call `RegisterService()` regardless of whether the agent was enabled, leading to unintended service registration attempts on a disabled agent.

This commit also adds a new test case to verify that changing the service base name on a disabled border agent does not result in a service being registered.