### PR TITLE
[mle] improve `DelayedSender::Match()` and logging

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1733,6 +1733,7 @@ private:
         void Execute(const Schedule &aSchedule);
         bool HasMatchingSchedule(MessageType aMessageType, const Ip6::Address &aDestination) const;
         void RemoveMatchingSchedules(MessageType aMessageType, const Ip6::Address &aDestination);
+        void LogRemove(const Schedule &aSchedule);
 
         static bool Match(const Schedule &aSchedule, MessageType aMessageType, const Ip6::Address &aDestination);
 


### PR DESCRIPTION
This change enhances the `DelayedSender::Match()` method to support a wildcard destination address. When the unspecified address (`::`) is provided, the address check is skipped, allowing a match against any destination.

A new private helper method, `LogRemove()`, is introduced to ensure accurate logging when removing a delayed message schedule. Previously, `RemoveMatchingSchedules()` would log the address passed to it, which could be the wildcard `::` address. The new `LogRemove()` method logs the actual destination from the scheduled message header before it is removed.