### PR TITLE
[border-router] introduce `br_log` for logging helpers

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -375,6 +375,8 @@ openthread_core_files = [
   "backbone_router/multicast_listeners_table.hpp",
   "backbone_router/ndproxy_table.cpp",
   "backbone_router/ndproxy_table.hpp",
+  "border_router/br_log.cpp",
+  "border_router/br_log.hpp",
   "border_router/br_tracker.cpp",
   "border_router/br_tracker.hpp",
   "border_router/br_types.cpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -95,6 +95,7 @@ set(COMMON_SOURCES
     backbone_router/bbr_manager.cpp
     backbone_router/multicast_listeners_table.cpp
     backbone_router/ndproxy_table.cpp
+    border_router/br_log.cpp
     border_router/br_tracker.cpp
     border_router/br_types.cpp
     border_router/dhcp6_pd_client.cpp

--- a/src/core/border_router/br_log.cpp
+++ b/src/core/border_router/br_log.cpp
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements common Border Router logging helper functions.
+ */
+
+#include "br_log.hpp"
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+
+#include "instance/instance.hpp"
+
+namespace ot {
+namespace BorderRouter {
+
+RegisterLogModule("BorderRouting");
+
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
+
+void LogRaHeader(const RouterAdvert::Header &aRaHeader)
+{
+    LogInfo("- RA Header - flags - M:%u O:%u S:%u", aRaHeader.IsManagedAddressConfigFlagSet(),
+            aRaHeader.IsOtherConfigFlagSet(), aRaHeader.IsSnacRouterFlagSet());
+    LogInfo("- RA Header - default route - lifetime:%u", aRaHeader.GetRouterLifetime());
+}
+
+void LogPrefixInfoOption(const Ip6::Prefix      &aPrefix,
+                         uint32_t                aValidLifetime,
+                         uint32_t                aPreferredLifetime,
+                         PrefixInfoOption::Flags aFlags)
+{
+    LogInfo("- PIO %s (valid:%lu, preferred:%lu, flags - L:%u A:%u P:%u)", aPrefix.ToString().AsCString(),
+            ToUlong(aValidLifetime), ToUlong(aPreferredLifetime), (aFlags & PrefixInfoOption::kOnLinkFlag) ? 1 : 0,
+            (aFlags & PrefixInfoOption::kAutoConfigFlag) ? 1 : 0,
+            (aFlags & PrefixInfoOption::kDhcp6PdPreferredFlag) ? 1 : 0);
+}
+
+void LogRouteInfoOption(const Ip6::Prefix &aPrefix, uint32_t aLifetime, RoutePreference aPreference)
+{
+    LogInfo("- RIO %s (lifetime:%lu, prf:%s)", aPrefix.ToString().AsCString(), ToUlong(aLifetime),
+            RoutePreferenceToString(aPreference));
+}
+
+void LogRecursiveDnsServerOption(const Ip6::Address &aAddress, uint32_t aLifetime)
+{
+    LogInfo("- RDNSS %s (lifetime:%lu)", aAddress.ToString().AsCString(), ToUlong(aLifetime));
+}
+
+#endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
+
+} // namespace BorderRouter
+} // namespace ot
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE

--- a/src/core/border_router/br_log.hpp
+++ b/src/core/border_router/br_log.hpp
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes common Border Router logging helper functions.
+ */
+
+#ifndef BR_LOG_HPP_
+#define BR_LOG_HPP_
+
+#include "openthread-core-config.h"
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+
+#include "border_router/br_types.hpp"
+#include "net/ip6_address.hpp"
+
+namespace ot {
+namespace BorderRouter {
+
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
+
+/**
+ * Logs a Router Advertisement (RA) header at info log level.
+ *
+ * @param[in] aRaHeader  The RA header to log.
+ */
+void LogRaHeader(const RouterAdvert::Header &aRaHeader);
+
+/**
+ * Logs a Prefix Information Option (PIO) at info log level.
+ *
+ * @param[in] aPrefix             The IPv6 prefix.
+ * @param[in] aValidLifetime      The valid lifetime in seconds.
+ * @param[in] aPreferredLifetime  The preferred lifetime in seconds.
+ * @param[in] aFlags              The PIO flags.
+ */
+void LogPrefixInfoOption(const Ip6::Prefix      &aPrefix,
+                         uint32_t                aValidLifetime,
+                         uint32_t                aPreferredLifetime,
+                         PrefixInfoOption::Flags aFlags);
+
+/**
+ * Logs a Route Information Option (RIO) at info log level.
+ *
+ * @param[in] aPrefix      The IPv6 prefix.
+ * @param[in] aLifetime    The route lifetime in seconds.
+ * @param[in] aPreference  The route preference.
+ */
+void LogRouteInfoOption(const Ip6::Prefix &aPrefix, uint32_t aLifetime, RoutePreference aPreference);
+
+/**
+ * Logs a Recursive DNS Server (RDNSS) option at info log level.
+ *
+ * @param[in] aAddress   The IPv6 address of the DNS server.
+ * @param[in] aLifetime  The lifetime of the DNS server address in seconds.
+ */
+void LogRecursiveDnsServerOption(const Ip6::Address &aAddress, uint32_t aLifetime);
+
+#else
+
+void LogRaHeader(const RouterAdvert::Header &) {}
+void LogPrefixInfoOption(const Ip6::Prefix &, uint32_t, uint32_t, PrefixInfoOption::Flags) {}
+void LogRouteInfoOption(const Ip6::Prefix &, uint32_t, RoutePreference) {}
+void LogRecursiveDnsServerOption(const Ip6::Address &, uint32_t) {}
+
+#endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
+
+} // namespace BorderRouter
+} // namespace ot
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+
+#endif // BR_LOG_HPP_

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -41,13 +41,14 @@
 #include <openthread/platform/border_routing.h>
 #include <openthread/platform/infra_if.h>
 
+#include "border_router/br_log.hpp"
 #include "instance/instance.hpp"
 
 namespace ot {
 
 namespace BorderRouter {
 
-RegisterLogModule("RoutingManager");
+RegisterLogModule("BorderRouting");
 
 RoutingManager::RoutingManager(Instance &aInstance)
     : InstanceLocator(aInstance)
@@ -836,35 +837,6 @@ exit:
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
-void RoutingManager::LogRaHeader(const RouterAdvert::Header &aRaHeader)
-{
-    LogInfo("- RA Header - flags - M:%u O:%u S:%u", aRaHeader.IsManagedAddressConfigFlagSet(),
-            aRaHeader.IsOtherConfigFlagSet(), aRaHeader.IsSnacRouterFlagSet());
-    LogInfo("- RA Header - default route - lifetime:%u", aRaHeader.GetRouterLifetime());
-}
-
-void RoutingManager::LogPrefixInfoOption(const Ip6::Prefix      &aPrefix,
-                                         uint32_t                aValidLifetime,
-                                         uint32_t                aPreferredLifetime,
-                                         PrefixInfoOption::Flags aFlags)
-{
-    LogInfo("- PIO %s (valid:%lu, preferred:%lu, flags - L:%u A:%u P:%u)", aPrefix.ToString().AsCString(),
-            ToUlong(aValidLifetime), ToUlong(aPreferredLifetime), (aFlags & PrefixInfoOption::kOnLinkFlag) ? 1 : 0,
-            (aFlags & PrefixInfoOption::kAutoConfigFlag) ? 1 : 0,
-            (aFlags & PrefixInfoOption::kDhcp6PdPreferredFlag) ? 1 : 0);
-}
-
-void RoutingManager::LogRouteInfoOption(const Ip6::Prefix &aPrefix, uint32_t aLifetime, RoutePreference aPreference)
-{
-    LogInfo("- RIO %s (lifetime:%lu, prf:%s)", aPrefix.ToString().AsCString(), ToUlong(aLifetime),
-            RoutePreferenceToString(aPreference));
-}
-
-void RoutingManager::LogRecursiveDnsServerOption(const Ip6::Address &aAddress, uint32_t aLifetime)
-{
-    LogInfo("- RDNSS %s (lifetime:%lu)", aAddress.ToString().AsCString(), ToUlong(aLifetime));
-}
-
 const char *RoutingManager::RouterAdvOriginToString(RouterAdvOrigin aRaOrigin)
 {
     static const char *const kOriginStrings[] = {
@@ -883,13 +855,6 @@ const char *RoutingManager::RouterAdvOriginToString(RouterAdvOrigin aRaOrigin)
 
     return kOriginStrings[aRaOrigin];
 }
-
-#else
-
-void RoutingManager::LogRaHeader(const RouterAdvert::Header &) {}
-void RoutingManager::LogPrefixInfoOption(const Ip6::Prefix &, uint32_t, uint32_t, PrefixInfoOption::Flags) {}
-void RoutingManager::LogRouteInfoOption(const Ip6::Prefix &, uint32_t, RoutePreference) {}
-void RoutingManager::LogRecursiveDnsServerOption(const Ip6::Address &, uint32_t) {}
 
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1576,14 +1576,6 @@ private:
 
     static bool IsValidBrUlaPrefix(const Ip6::Prefix &aBrUlaPrefix);
 
-    static void LogRaHeader(const RouterAdvert::Header &aRaHeader);
-    static void LogPrefixInfoOption(const Ip6::Prefix      &aPrefix,
-                                    uint32_t                aValidLifetime,
-                                    uint32_t                aPreferredLifetime,
-                                    PrefixInfoOption::Flags aFlags);
-    static void LogRouteInfoOption(const Ip6::Prefix &aPrefix, uint32_t aLifetime, RoutePreference aPreference);
-    static void LogRecursiveDnsServerOption(const Ip6::Address &aAddress, uint32_t aLifetime);
-
     static const char *RouterAdvOriginToString(RouterAdvOrigin aRaOrigin);
 
     //------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This change introduces new files `br_log.cpp` and `br_log.hpp` to house common logging helper functions for the border router modules.

Helper functions for logging Router Advertisement (RA) headers, Prefix Information Options (PIO), Route Information Options (RIO), and other related options are moved into this new module.

The log module name is also updated from `RoutingManager` to a more general `BorderRouting`.

This change improves code structure by decoupling logging functionalities from the `RoutingManager`.