### PR TITLE
[fuzz] increase wait time in CLI fuzzer

### DIFF
--- a/tests/fuzz/cli.cpp
+++ b/tests/fuzz/cli.cpp
@@ -133,7 +133,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     otCliInputLine(reinterpret_cast<char *>(buffer));
 
-    nexus.AdvanceTime(10 * 1000);
+    nexus.AdvanceTime(60 * 1000);
 
     free(buffer);
 


### PR DESCRIPTION
Increases the `nexus.AdvanceTime()` in the CLI fuzzer test from 10 to 60 seconds to make the test more robust.

For example, the previous 10-second wait was not sufficient for `Dns::Client` operations to complete, especially considering retries. This could cause false fuzzer memory leak reports.