### PR TITLE
[border-agent] introduce `BorderAgent` namespace

### DIFF
--- a/src/core/api/border_agent_api.cpp
+++ b/src/core/api/border_agent_api.cpp
@@ -44,17 +44,17 @@ using namespace ot;
 
 void otBorderAgentSetEnabled(otInstance *aInstance, bool aEnabled)
 {
-    AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().SetEnabled(aEnabled);
+    AsCoreType(aInstance).Get<MeshCoP::BorderAgent::Manager>().SetEnabled(aEnabled);
 }
 
 bool otBorderAgentIsEnabled(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().IsEnabled();
+    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent::Manager>().IsEnabled();
 }
 
 bool otBorderAgentIsActive(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().IsRunning();
+    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent::Manager>().IsRunning();
 }
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_MESHCOP_SERVICE_ENABLE
@@ -62,32 +62,32 @@ otError otBorderAgentSetMeshCoPServiceBaseName(otInstance *aInstance, const char
 {
     AssertPointerIsNotNull(aBaseName);
 
-    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().SetServiceBaseName(aBaseName);
+    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent::Manager>().SetServiceBaseName(aBaseName);
 }
 
 void otBorderAgentSetVendorTxtData(otInstance *aInstance, const uint8_t *aVendorData, uint16_t aVendorDataLength)
 {
-    AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().SetVendorTxtData(aVendorData, aVendorDataLength);
+    AsCoreType(aInstance).Get<MeshCoP::BorderAgent::Manager>().SetVendorTxtData(aVendorData, aVendorDataLength);
 }
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
 otError otBorderAgentGetId(otInstance *aInstance, otBorderAgentId *aId)
 {
-    AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().GetId(AsCoreType(aId));
+    AsCoreType(aInstance).Get<MeshCoP::BorderAgent::Manager>().GetId(AsCoreType(aId));
     return kErrorNone;
 }
 
 otError otBorderAgentSetId(otInstance *aInstance, const otBorderAgentId *aId)
 {
-    AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().SetId(AsCoreType(aId));
+    AsCoreType(aInstance).Get<MeshCoP::BorderAgent::Manager>().SetId(AsCoreType(aId));
     return kErrorNone;
 }
 #endif
 
 uint16_t otBorderAgentGetUdpPort(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().GetUdpPort();
+    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent::Manager>().GetUdpPort();
 }
 
 void otBorderAgentInitSessionIterator(otInstance *aInstance, otBorderAgentSessionIterator *aIterator)
@@ -106,17 +106,17 @@ void otBorderAgentSetMeshCoPServiceChangedCallback(otInstance                   
                                                    otBorderAgentMeshCoPServiceChangedCallback aCallback,
                                                    void                                      *aContext)
 {
-    AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().SetServiceChangedCallback(aCallback, aContext);
+    AsCoreType(aInstance).Get<MeshCoP::BorderAgent::Manager>().SetServiceChangedCallback(aCallback, aContext);
 }
 
 otError otBorderAgentGetMeshCoPServiceTxtData(otInstance *aInstance, otBorderAgentMeshCoPServiceTxtData *aTxtData)
 {
-    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().PrepareServiceTxtData(*aTxtData);
+    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent::Manager>().PrepareServiceTxtData(*aTxtData);
 }
 
 const otBorderAgentCounters *otBorderAgentGetCounters(otInstance *aInstance)
 {
-    return &AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().GetCounters();
+    return &AsCoreType(aInstance).Get<MeshCoP::BorderAgent::Manager>().GetCounters();
 }
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE

--- a/src/core/api/border_agent_tracker_api.cpp
+++ b/src/core/api/border_agent_tracker_api.cpp
@@ -39,13 +39,13 @@ using namespace ot;
 
 void otBorderAgentTrackerSetEnabled(otInstance *aInstance, bool aEnable)
 {
-    AsCoreType(aInstance).Get<MeshCoP::BorderAgentTracker>().SetEnabled(aEnable,
-                                                                        MeshCoP::BorderAgentTracker::kRequesterUser);
+    AsCoreType(aInstance).Get<MeshCoP::BorderAgent::Tracker>().SetEnabled(
+        aEnable, MeshCoP::BorderAgent::Tracker::kRequesterUser);
 }
 
 bool otBorderAgentTrackerIsRunning(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<MeshCoP::BorderAgentTracker>().IsRunning();
+    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent::Tracker>().IsRunning();
 }
 
 void otBorderAgentTrackerInitIterator(otInstance *aInstance, otBorderAgentTrackerIterator *aIterator)

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -2447,7 +2447,7 @@ void RoutingManager::OmrPrefixManager::SetFavoredPrefix(const OmrPrefix &aOmrPre
     if (oldFavoredPrefix != mFavoredPrefix)
     {
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-        Get<MeshCoP::BorderAgent>().HandleFavoredOmrPrefixChanged();
+        Get<MeshCoP::BorderAgent::Manager>().HandleFavoredOmrPrefixChanged();
 #endif
         LogInfo("Favored OMR prefix: %s -> %s", FavoredToString(oldFavoredPrefix).AsCString(),
                 FavoredToString(mFavoredPrefix).AsCString());

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -131,7 +131,7 @@ void Notifier::EmitEvents(void)
     Get<AnnounceSender>().HandleNotifierEvents(events);
 #endif
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    Get<MeshCoP::BorderAgent>().HandleNotifierEvents(events);
+    Get<MeshCoP::BorderAgent::Manager>().HandleNotifierEvents(events);
 #endif
 #if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
     Get<MlrManager>().HandleNotifierEvents(events);

--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -172,7 +172,10 @@ Instance::Instance(void)
     , mNetworkDiagnosticClient(*this)
 #endif
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    , mBorderAgent(*this)
+    , mBorderAgentManager(*this)
+#endif
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+    , mBorderAgentEphemeralKeyManager(*this)
 #endif
 #if OPENTHREAD_CONFIG_BORDER_AGENT_TRACKER_ENABLE
     , mBorderAgentTracker(*this)

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -587,11 +587,15 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    MeshCoP::BorderAgent mBorderAgent;
+    MeshCoP::BorderAgent::Manager mBorderAgentManager;
+#endif
+
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+    MeshCoP::BorderAgent::EphemeralKeyManager mBorderAgentEphemeralKeyManager;
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_TRACKER_ENABLE
-    MeshCoP::BorderAgentTracker mBorderAgentTracker;
+    MeshCoP::BorderAgent::Tracker mBorderAgentTracker;
 #endif
 
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
@@ -1026,18 +1030,18 @@ template <> inline MeshCoP::DatasetUpdater &Instance::Get(void) { return mDatase
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-template <> inline MeshCoP::BorderAgent &Instance::Get(void) { return mBorderAgent; }
-#endif
-
-#if OPENTHREAD_CONFIG_BORDER_AGENT_TRACKER_ENABLE
-template <> inline MeshCoP::BorderAgentTracker &Instance::Get(void) { return mBorderAgentTracker; }
+template <> inline MeshCoP::BorderAgent::Manager &Instance::Get(void) { return mBorderAgentManager; }
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
 template <> inline MeshCoP::BorderAgent::EphemeralKeyManager &Instance::Get(void)
 {
-    return mBorderAgent.GetEphemeralKeyManager();
+    return mBorderAgentEphemeralKeyManager;
 }
+#endif
+
+#if OPENTHREAD_CONFIG_BORDER_AGENT_TRACKER_ENABLE
+template <> inline MeshCoP::BorderAgent::Tracker &Instance::Get(void) { return mBorderAgentTracker; }
 #endif
 
 #if OPENTHREAD_CONFIG_ANNOUNCE_SENDER_ENABLE

--- a/src/core/meshcop/border_agent_tracker.cpp
+++ b/src/core/meshcop/border_agent_tracker.cpp
@@ -39,15 +39,16 @@
 
 namespace ot {
 namespace MeshCoP {
+namespace BorderAgent {
 
 RegisterLogModule("BaTracker");
 
 //---------------------------------------------------------------------------------------------------------------------
-// BorderAgentTracker
+// Tracker
 
-const char BorderAgentTracker::kServiceType[] = "_meshcop._udp";
+const char Tracker::kServiceType[] = "_meshcop._udp";
 
-BorderAgentTracker::BorderAgentTracker(Instance &aInstance)
+Tracker::Tracker(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mState(kStateStopped)
     , mUserEnabled(false)
@@ -55,7 +56,7 @@ BorderAgentTracker::BorderAgentTracker(Instance &aInstance)
 {
 }
 
-void BorderAgentTracker::SetEnabled(bool aEnable, Requester aRequester)
+void Tracker::SetEnabled(bool aEnable, Requester aRequester)
 {
     switch (aRequester)
     {
@@ -70,9 +71,9 @@ void BorderAgentTracker::SetEnabled(bool aEnable, Requester aRequester)
     UpdateState();
 }
 
-void BorderAgentTracker::HandleDnssdPlatformStateChange(void) { UpdateState(); }
+void Tracker::HandleDnssdPlatformStateChange(void) { UpdateState(); }
 
-void BorderAgentTracker::UpdateState(void)
+void Tracker::UpdateState(void)
 {
     State newState;
 
@@ -110,12 +111,12 @@ exit:
     return;
 }
 
-void BorderAgentTracker::HandleBrowseResult(otInstance *aInstance, const otPlatDnssdBrowseResult *aResult)
+void Tracker::HandleBrowseResult(otInstance *aInstance, const otPlatDnssdBrowseResult *aResult)
 {
-    AsCoreType(aInstance).Get<BorderAgentTracker>().HandleBrowseResult(*aResult);
+    AsCoreType(aInstance).Get<Tracker>().HandleBrowseResult(*aResult);
 }
 
-void BorderAgentTracker::HandleBrowseResult(const Dnssd::BrowseResult &aResult)
+void Tracker::HandleBrowseResult(const Dnssd::BrowseResult &aResult)
 {
     Error  error = kErrorNone;
     Agent *newAgent;
@@ -158,12 +159,12 @@ exit:
     LogOnError(error, "add new agent", aResult.mServiceInstance);
 }
 
-void BorderAgentTracker::HandleSrvResult(otInstance *aInstance, const otPlatDnssdSrvResult *aResult)
+void Tracker::HandleSrvResult(otInstance *aInstance, const otPlatDnssdSrvResult *aResult)
 {
-    AsCoreType(aInstance).Get<BorderAgentTracker>().HandleSrvResult(*aResult);
+    AsCoreType(aInstance).Get<Tracker>().HandleSrvResult(*aResult);
 }
 
-void BorderAgentTracker::HandleSrvResult(const Dnssd::SrvResult &aResult)
+void Tracker::HandleSrvResult(const Dnssd::SrvResult &aResult)
 {
     Agent *agent;
 
@@ -188,12 +189,12 @@ exit:
     return;
 }
 
-void BorderAgentTracker::HandleTxtResult(otInstance *aInstance, const otPlatDnssdTxtResult *aResult)
+void Tracker::HandleTxtResult(otInstance *aInstance, const otPlatDnssdTxtResult *aResult)
 {
-    AsCoreType(aInstance).Get<BorderAgentTracker>().HandleTxtResult(*aResult);
+    AsCoreType(aInstance).Get<Tracker>().HandleTxtResult(*aResult);
 }
 
-void BorderAgentTracker::HandleTxtResult(const Dnssd::TxtResult &aResult)
+void Tracker::HandleTxtResult(const Dnssd::TxtResult &aResult)
 {
     Agent *agent;
 
@@ -215,12 +216,12 @@ exit:
     return;
 }
 
-void BorderAgentTracker::HandleAddressResult(otInstance *aInstance, const otPlatDnssdAddressResult *aResult)
+void Tracker::HandleAddressResult(otInstance *aInstance, const otPlatDnssdAddressResult *aResult)
 {
-    AsCoreType(aInstance).Get<BorderAgentTracker>().HandleAddressResult(*aResult);
+    AsCoreType(aInstance).Get<Tracker>().HandleAddressResult(*aResult);
 }
 
-void BorderAgentTracker::HandleAddressResult(const Dnssd::AddressResult &aResult)
+void Tracker::HandleAddressResult(const Dnssd::AddressResult &aResult)
 {
     Agent *agent;
 
@@ -235,14 +236,14 @@ exit:
     return;
 }
 
-bool BorderAgentTracker::NameMatch(const Heap::String &aHeapString, const char *aName)
+bool Tracker::NameMatch(const Heap::String &aHeapString, const char *aName)
 {
     return !aHeapString.IsNull() && StringMatch(aHeapString.AsCString(), aName, kStringCaseInsensitiveMatch);
 }
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
 
-void BorderAgentTracker::LogOnError(Error aError, const char *aText, const char *aName)
+void Tracker::LogOnError(Error aError, const char *aText, const char *aName)
 {
     if (aError != kErrorNone)
     {
@@ -252,11 +253,11 @@ void BorderAgentTracker::LogOnError(Error aError, const char *aText, const char 
 
 #else
 
-void BorderAgentTracker::LogOnError(Error, const char *, const char *) {}
+void Tracker::LogOnError(Error, const char *, const char *) {}
 
 #endif
 
-const char *BorderAgentTracker::StateToString(State aState)
+const char *Tracker::StateToString(State aState)
 {
     static const char *const kStateStrings[] = {
         "Stopped",
@@ -276,15 +277,15 @@ const char *BorderAgentTracker::StateToString(State aState)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-// BorderAgentTracker::Iterator
+// Tracker::Iterator
 
-void BorderAgentTracker::Iterator::Init(Instance &aInstance)
+void Tracker::Iterator::Init(Instance &aInstance)
 {
-    SetAgentEntry(aInstance.Get<BorderAgentTracker>().mAgents.GetHead());
+    SetAgentEntry(aInstance.Get<Tracker>().mAgents.GetHead());
     SetInitUptime(aInstance.Get<Uptime>().GetUptime());
 }
 
-Error BorderAgentTracker::Iterator::GetNextAgentInfo(AgentInfo &aInfo)
+Error Tracker::Iterator::GetNextAgentInfo(AgentInfo &aInfo)
 {
     Error        error = kErrorNone;
     const Agent *agent = GetAgentEntry();
@@ -298,14 +299,14 @@ exit:
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-// BorderAgentTracker::Host
+// Tracker::Host
 
-BorderAgentTracker::Host::Host(Instance &aInstance)
+Tracker::Host::Host(Instance &aInstance)
     : InstanceLocator(aInstance)
 {
 }
 
-BorderAgentTracker::Host::~Host(void)
+Tracker::Host::~Host(void)
 {
     VerifyOrExit(mName != nullptr);
     Get<Dnssd>().StopIp6AddressResolver(AddressResolver(mName.AsCString()));
@@ -314,7 +315,7 @@ exit:
     return;
 }
 
-Error BorderAgentTracker::Host::SetNameAndStartAddrResolver(const char *aHostName)
+Error Tracker::Host::SetNameAndStartAddrResolver(const char *aHostName)
 {
     Error error;
 
@@ -326,7 +327,7 @@ exit:
     return error;
 }
 
-void BorderAgentTracker::Host::SetAddresses(const Dnssd::AddressResult &aResult)
+void Tracker::Host::SetAddresses(const Dnssd::AddressResult &aResult)
 {
     Error                       error = kErrorNone;
     uint16_t                    length;
@@ -358,9 +359,9 @@ exit:
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-// BorderAgentTracker::Agent
+// Tracker::Agent
 
-BorderAgentTracker::Agent::Agent(Instance &aInstance)
+Tracker::Agent::Agent(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mNext(nullptr)
     , mDiscoverUptime(aInstance.Get<Uptime>().GetUptime())
@@ -369,7 +370,7 @@ BorderAgentTracker::Agent::Agent(Instance &aInstance)
 {
 }
 
-BorderAgentTracker::Agent::~Agent(void)
+Tracker::Agent::~Agent(void)
 {
     VerifyOrExit(mServiceName != nullptr);
     Get<Dnssd>().StopSrvResolver(SrvResolver(mServiceName.AsCString()));
@@ -379,7 +380,7 @@ exit:
     return;
 }
 
-Error BorderAgentTracker::Agent::SetServiceNameAndStartSrvTxtResolvers(const char *aServiceName)
+Error Tracker::Agent::SetServiceNameAndStartSrvTxtResolvers(const char *aServiceName)
 {
     Error error;
 
@@ -394,7 +395,7 @@ exit:
     return error;
 }
 
-void BorderAgentTracker::Agent::SetHost(const char *aHostName)
+void Tracker::Agent::SetHost(const char *aHostName)
 {
     Agent *matchingHostAgent;
 
@@ -413,7 +414,7 @@ void BorderAgentTracker::Agent::SetHost(const char *aHostName)
     // `Host` entry. Otherwise, we allocate a new one. Note that
     // `mHost` is defined as `RetainPtr` which does ref-counting.
 
-    matchingHostAgent = Get<BorderAgentTracker>().mAgents.FindMatching(kMatchHostName, aHostName);
+    matchingHostAgent = Get<Tracker>().mAgents.FindMatching(kMatchHostName, aHostName);
 
     if (matchingHostAgent != nullptr)
     {
@@ -434,7 +435,7 @@ exit:
     return;
 }
 
-void BorderAgentTracker::Agent::ClearHost(void)
+void Tracker::Agent::ClearHost(void)
 {
     VerifyOrExit(mHost != nullptr);
 
@@ -445,7 +446,7 @@ exit:
     return;
 }
 
-void BorderAgentTracker::Agent::SetPort(uint16_t aPort)
+void Tracker::Agent::SetPort(uint16_t aPort)
 {
     VerifyOrExit(mPort != aPort);
 
@@ -456,7 +457,7 @@ exit:
     return;
 }
 
-void BorderAgentTracker::Agent::SetTxtData(const uint8_t *aData, uint16_t aDataLength)
+void Tracker::Agent::SetTxtData(const uint8_t *aData, uint16_t aDataLength)
 {
     Error error = kErrorNone;
 
@@ -469,7 +470,7 @@ exit:
     LogOnError(error, "set TXT data", mServiceName.AsCString());
 }
 
-void BorderAgentTracker::Agent::ClearTxtData(void)
+void Tracker::Agent::ClearTxtData(void)
 {
     VerifyOrExit(!mTxtData.IsNull());
 
@@ -480,9 +481,9 @@ exit:
     return;
 }
 
-void BorderAgentTracker::Agent::SetUpdateTimeToNow(void) { mLastUpdateUptime = Get<Uptime>().GetUptime(); }
+void Tracker::Agent::SetUpdateTimeToNow(void) { mLastUpdateUptime = Get<Uptime>().GetUptime(); }
 
-bool BorderAgentTracker::Agent::Matches(MatchType aType, const char *aName) const
+bool Tracker::Agent::Matches(MatchType aType, const char *aName) const
 {
     bool matches = false;
 
@@ -502,7 +503,7 @@ exit:
     return matches;
 }
 
-void BorderAgentTracker::Agent::CopyInfoTo(AgentInfo &aInfo, uint64_t aUptimeNow) const
+void Tracker::Agent::CopyInfoTo(AgentInfo &aInfo, uint64_t aUptimeNow) const
 {
     ClearAllBytes(aInfo);
 
@@ -522,47 +523,48 @@ void BorderAgentTracker::Agent::CopyInfoTo(AgentInfo &aInfo, uint64_t aUptimeNow
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-// BorderAgentTracker::Browser
+// Tracker::Browser
 
-BorderAgentTracker::Browser::Browser(void)
+Tracker::Browser::Browser(void)
 {
     Clear();
     mServiceType = kServiceType;
-    mCallback    = BorderAgentTracker::HandleBrowseResult;
+    mCallback    = Tracker::HandleBrowseResult;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-// BorderAgentTracker::SrvResolver
+// Tracker::SrvResolver
 
-BorderAgentTracker::SrvResolver::SrvResolver(const char *aServiceName)
+Tracker::SrvResolver::SrvResolver(const char *aServiceName)
 {
     Clear();
     mServiceInstance = aServiceName;
     mServiceType     = kServiceType;
-    mCallback        = BorderAgentTracker::HandleSrvResult;
+    mCallback        = Tracker::HandleSrvResult;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-// BorderAgentTracker::TxtResolver
+// Tracker::TxtResolver
 
-BorderAgentTracker::TxtResolver::TxtResolver(const char *aServiceName)
+Tracker::TxtResolver::TxtResolver(const char *aServiceName)
 {
     Clear();
     mServiceInstance = aServiceName;
     mServiceType     = kServiceType;
-    mCallback        = BorderAgentTracker::HandleTxtResult;
+    mCallback        = Tracker::HandleTxtResult;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-// BorderAgentTracker::AddressResolver
+// Tracker::AddressResolver
 
-BorderAgentTracker::AddressResolver::AddressResolver(const char *aHostName)
+Tracker::AddressResolver::AddressResolver(const char *aHostName)
 {
     Clear();
     mHostName = aHostName;
-    mCallback = BorderAgentTracker::HandleAddressResult;
+    mCallback = Tracker::HandleAddressResult;
 }
 
+} // namespace BorderAgent
 } // namespace MeshCoP
 } // namespace ot
 

--- a/src/core/meshcop/border_agent_tracker.hpp
+++ b/src/core/meshcop/border_agent_tracker.hpp
@@ -57,11 +57,12 @@
 
 namespace ot {
 namespace MeshCoP {
+namespace BorderAgent {
 
 /**
  * Implements the Border Agent Tracker.
  */
-class BorderAgentTracker : public InstanceLocator
+class Tracker : public InstanceLocator
 {
     friend class ot::Dnssd;
 
@@ -113,7 +114,7 @@ public:
      *
      * @param[in]  aInstance  The OpenThread instance.
      */
-    explicit BorderAgentTracker(Instance &aInstance);
+    explicit Tracker(Instance &aInstance);
 
     /**
      * Enables or disables the Border Agent Tracker.
@@ -234,9 +235,10 @@ private:
     OwningList<Agent> mAgents;
 };
 
+} // namespace BorderAgent
 } // namespace MeshCoP
 
-DefineCoreType(otBorderAgentTrackerIterator, MeshCoP::BorderAgentTracker::Iterator);
+DefineCoreType(otBorderAgentTrackerIterator, MeshCoP::BorderAgent::Tracker::Iterator);
 
 } // namespace ot
 

--- a/src/core/net/dnssd.cpp
+++ b/src/core/net/dnssd.cpp
@@ -528,11 +528,11 @@ void Dnssd::HandleStateChange(void)
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_MESHCOP_SERVICE_ENABLE
-    Get<MeshCoP::BorderAgent>().HandleDnssdPlatformStateChange();
+    Get<MeshCoP::BorderAgent::Manager>().HandleDnssdPlatformStateChange();
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_TRACKER_ENABLE
-    Get<MeshCoP::BorderAgentTracker>().HandleDnssdPlatformStateChange();
+    Get<MeshCoP::BorderAgent::Tracker>().HandleDnssdPlatformStateChange();
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE && OPENTHREAD_CONFIG_TREL_MANAGE_DNSSD_ENABLE

--- a/src/core/net/ip6_filter.cpp
+++ b/src/core/net/ip6_filter.cpp
@@ -76,7 +76,7 @@ Error Filter::Apply(const Message &aMessage) const
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
         // Allow native commissioner traffic
         if (Get<KeyManager>().GetSecurityPolicy().mNativeCommissioningEnabled &&
-            dstPort == Get<MeshCoP::BorderAgent>().GetUdpPort())
+            dstPort == Get<MeshCoP::BorderAgent::Manager>().GetUdpPort())
         {
             ExitNow(error = kErrorNone);
         }

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -2817,8 +2817,8 @@ Error Mle::SendDiscoveryResponse(const Ip6::Address &aDestination, const Discove
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
     if (Get<KeyManager>().GetSecurityPolicy().mNativeCommissioningEnabled)
     {
-        SuccessOrExit(
-            error = Tlv::Append<MeshCoP::CommissionerUdpPortTlv>(*message, Get<MeshCoP::BorderAgent>().GetUdpPort()));
+        SuccessOrExit(error = Tlv::Append<MeshCoP::CommissionerUdpPortTlv>(
+                          *message, Get<MeshCoP::BorderAgent::Manager>().GetUdpPort()));
 
         discoveryResponseTlv.SetNativeCommissioner(true);
     }

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -94,7 +94,7 @@ template <> void Agent::HandleTmf<kUriRelayRx>(Message &aMessage, const Ip6::Mes
     Get<MeshCoP::Commissioner>().HandleTmf<kUriRelayRx>(aMessage, aMessageInfo);
 #endif
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    Get<MeshCoP::BorderAgent>().HandleTmf<kUriRelayRx>(aMessage, aMessageInfo);
+    Get<MeshCoP::BorderAgent::Manager>().HandleTmf<kUriRelayRx>(aMessage, aMessageInfo);
 #endif
 }
 

--- a/src/core/utils/history_tracker.hpp
+++ b/src/core/utils/history_tracker.hpp
@@ -153,7 +153,7 @@ class Local : public InstanceLocator, private NonCopyable
     friend class ot::RouterTable;
 #endif
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
-    friend class ot::MeshCoP::BorderAgent;
+    friend class ot::MeshCoP::BorderAgent::Manager;
     friend class ot::MeshCoP::BorderAgent::EphemeralKeyManager;
 #endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE

--- a/tests/nexus/test_border_agent.cpp
+++ b/tests/nexus/test_border_agent.cpp
@@ -37,7 +37,7 @@ namespace ot {
 namespace Nexus {
 
 using ActiveDatasetManager = MeshCoP::ActiveDatasetManager;
-using BorderAgent          = MeshCoP::BorderAgent;
+using Manager              = MeshCoP::BorderAgent::Manager;
 using EphemeralKeyManager  = MeshCoP::BorderAgent::EphemeralKeyManager;
 using EpskcEvent           = HistoryTracker::EpskcEvent;
 using Iterator             = HistoryTracker::Iterator;
@@ -48,16 +48,16 @@ using TxtEntry             = Dns::TxtEntry;
 
 void TestBorderAgent(void)
 {
-    Core                         nexus;
-    Node                        &node0 = nexus.CreateNode();
-    Node                        &node1 = nexus.CreateNode();
-    Node                        &node2 = nexus.CreateNode();
-    Node                        &node3 = nexus.CreateNode();
-    Ip6::SockAddr                sockAddr;
-    Pskc                         pskc;
-    Coap::Message               *message;
-    BorderAgent::SessionIterator iter;
-    BorderAgent::SessionInfo     sessionInfo;
+    Core                     nexus;
+    Node                    &node0 = nexus.CreateNode();
+    Node                    &node1 = nexus.CreateNode();
+    Node                    &node2 = nexus.CreateNode();
+    Node                    &node3 = nexus.CreateNode();
+    Ip6::SockAddr            sockAddr;
+    Pskc                     pskc;
+    Coap::Message           *message;
+    Manager::SessionIterator iter;
+    Manager::SessionInfo     sessionInfo;
 
     Log("------------------------------------------------------------------------------------------------------");
     Log("TestBorderAgent");
@@ -87,27 +87,27 @@ void TestBorderAgent(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Check Border Agent initial state");
 
-    VerifyOrQuit(node0.Get<BorderAgent>().IsEnabled());
-    VerifyOrQuit(node0.Get<BorderAgent>().IsRunning());
+    VerifyOrQuit(node0.Get<Manager>().IsEnabled());
+    VerifyOrQuit(node0.Get<Manager>().IsRunning());
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Check disabling and re-enabling of Border Agent");
 
-    node0.Get<BorderAgent>().SetEnabled(false);
-    VerifyOrQuit(!node0.Get<BorderAgent>().IsEnabled());
-    VerifyOrQuit(!node0.Get<BorderAgent>().IsRunning());
+    node0.Get<Manager>().SetEnabled(false);
+    VerifyOrQuit(!node0.Get<Manager>().IsEnabled());
+    VerifyOrQuit(!node0.Get<Manager>().IsRunning());
 
-    node0.Get<BorderAgent>().SetEnabled(true);
-    VerifyOrQuit(node0.Get<BorderAgent>().IsEnabled());
-    VerifyOrQuit(node0.Get<BorderAgent>().IsRunning());
+    node0.Get<Manager>().SetEnabled(true);
+    VerifyOrQuit(node0.Get<Manager>().IsEnabled());
+    VerifyOrQuit(node0.Get<Manager>().IsRunning());
 
-    SuccessOrQuit(node0.Get<Ip6::Filter>().AddUnsecurePort(node0.Get<BorderAgent>().GetUdpPort()));
+    SuccessOrQuit(node0.Get<Ip6::Filter>().AddUnsecurePort(node0.Get<Manager>().GetUdpPort()));
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Establish a DTLS connection to Border Agent");
 
     sockAddr.SetAddress(node0.Get<Mle::Mle>().GetLinkLocalAddress());
-    sockAddr.SetPort(node0.Get<BorderAgent>().GetUdpPort());
+    sockAddr.SetPort(node0.Get<Manager>().GetUdpPort());
 
     node0.Get<KeyManager>().GetPskc(pskc);
     SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SetPsk(pskc.m8, Pskc::kSize));
@@ -119,7 +119,7 @@ void TestBorderAgent(void)
 
     VerifyOrQuit(node1.Get<Tmf::SecureAgent>().IsConnected());
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mPskcSecureSessionSuccesses == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mPskcSecureSessionSuccesses == 1);
 
     iter.Init(node0.GetInstance());
     SuccessOrQuit(iter.GetNextSessionInfo(sessionInfo));
@@ -136,7 +136,7 @@ void TestBorderAgent(void)
     nexus.AdvanceTime(3 * Time::kOneSecondInMsec);
 
     VerifyOrQuit(!node1.Get<Tmf::SecureAgent>().IsConnected());
-    VerifyOrQuit(node0.Get<BorderAgent>().IsRunning());
+    VerifyOrQuit(node0.Get<Manager>().IsRunning());
 
     iter.Init(node0.GetInstance());
     VerifyOrQuit(iter.GetNextSessionInfo(sessionInfo) == kErrorNotFound);
@@ -151,7 +151,7 @@ void TestBorderAgent(void)
 
     VerifyOrQuit(node1.Get<Tmf::SecureAgent>().IsConnected());
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mPskcSecureSessionSuccesses == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mPskcSecureSessionSuccesses == 2);
 
     iter.Init(node0.GetInstance());
     SuccessOrQuit(iter.GetNextSessionInfo(sessionInfo));
@@ -170,8 +170,8 @@ void TestBorderAgent(void)
 
     nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mPskcSecureSessionSuccesses == 2);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mPskcCommissionerPetitions == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mPskcSecureSessionSuccesses == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mPskcCommissionerPetitions == 1);
 
     iter.Init(node0.GetInstance());
     SuccessOrQuit(iter.GetNextSessionInfo(sessionInfo));
@@ -209,7 +209,7 @@ void TestBorderAgent(void)
 
     nexus.AdvanceTime(5 * Time::kOneSecondInMsec);
 
-    VerifyOrQuit(node0.Get<BorderAgent>().IsRunning());
+    VerifyOrQuit(node0.Get<Manager>().IsRunning());
     VerifyOrQuit(!node1.Get<Tmf::SecureAgent>().IsConnected());
 
     iter.Init(node0.GetInstance());
@@ -230,8 +230,8 @@ void TestBorderAgent(void)
 
     nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mPskcSecureSessionSuccesses == 3);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mPskcCommissionerPetitions == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mPskcSecureSessionSuccesses == 3);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mPskcCommissionerPetitions == 2);
 
     iter.Init(node0.GetInstance());
     SuccessOrQuit(iter.GetNextSessionInfo(sessionInfo));
@@ -257,8 +257,8 @@ void TestBorderAgent(void)
     VerifyOrQuit(node2.Get<Tmf::SecureAgent>().IsConnected());
     VerifyOrQuit(node3.Get<Tmf::SecureAgent>().IsConnected());
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mPskcSecureSessionSuccesses == 5);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mPskcCommissionerPetitions == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mPskcSecureSessionSuccesses == 5);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mPskcCommissionerPetitions == 2);
 
     iter.Init(node0.GetInstance());
 
@@ -289,7 +289,7 @@ void TestBorderAgent(void)
     nexus.AdvanceTime(3 * Time::kOneSecondInMsec);
 
     VerifyOrQuit(!node1.Get<Tmf::SecureAgent>().IsConnected());
-    VerifyOrQuit(node0.Get<BorderAgent>().IsRunning());
+    VerifyOrQuit(node0.Get<Manager>().IsRunning());
 
     VerifyOrQuit(node2.Get<Tmf::SecureAgent>().IsConnected());
     VerifyOrQuit(node3.Get<Tmf::SecureAgent>().IsConnected());
@@ -392,15 +392,15 @@ void TestBorderAgentEphemeralKey(void)
     static constexpr uint16_t kEphemeralKeySize = sizeof(kEphemeralKey) - 1;
     static constexpr uint16_t kUdpPort          = 49155;
 
-    Core                         nexus;
-    Node                        &node0 = nexus.CreateNode();
-    Node                        &node1 = nexus.CreateNode();
-    Node                        &node2 = nexus.CreateNode();
-    Ip6::SockAddr                sockAddr;
-    Ip6::SockAddr                baSockAddr;
-    Pskc                         pskc;
-    BorderAgent::SessionIterator iter;
-    BorderAgent::SessionInfo     sessionInfo;
+    Core                     nexus;
+    Node                    &node0 = nexus.CreateNode();
+    Node                    &node1 = nexus.CreateNode();
+    Node                    &node2 = nexus.CreateNode();
+    Ip6::SockAddr            sockAddr;
+    Ip6::SockAddr            baSockAddr;
+    Pskc                     pskc;
+    Manager::SessionIterator iter;
+    Manager::SessionInfo     sessionInfo;
 
     Log("------------------------------------------------------------------------------------------------------");
     Log("TestBorderAgentEphemeralKey");
@@ -426,14 +426,14 @@ void TestBorderAgentEphemeralKey(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Check Border Agent ephemeral key counter's initial value");
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcActivations == 0);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcSecureSessionSuccesses == 0);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationTimeouts == 0);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationDisconnects == 0);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationMaxAttempts == 0);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationClears == 0);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcInvalidArgsErrors == 0);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcInvalidBaStateErrors == 0);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcActivations == 0);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcSecureSessionSuccesses == 0);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationTimeouts == 0);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationDisconnects == 0);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationMaxAttempts == 0);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationClears == 0);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcInvalidArgsErrors == 0);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcInvalidBaStateErrors == 0);
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Check Border Agent ephemeral key feature enabled");
@@ -443,7 +443,7 @@ void TestBorderAgentEphemeralKey(void)
     VerifyOrQuit(node0.Get<EphemeralKeyManager>().Start(kEphemeralKey, /* aTimeout */ 0, kUdpPort) ==
                  kErrorInvalidState);
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcInvalidBaStateErrors == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcInvalidBaStateErrors == 1);
 
     node0.Get<EphemeralKeyManager>().SetEnabled(true);
     VerifyOrQuit(node0.Get<EphemeralKeyManager>().GetState() == EphemeralKeyManager::kStateStopped);
@@ -463,7 +463,7 @@ void TestBorderAgentEphemeralKey(void)
 
     VerifyOrQuit(node0.Get<EphemeralKeyManager>().GetState() == EphemeralKeyManager::kStateStarted);
     VerifyOrQuit(node0.Get<EphemeralKeyManager>().GetUdpPort() == kUdpPort);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcActivations == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcActivations == 1);
 
     SuccessOrQuit(node0.Get<Ip6::Filter>().AddUnsecurePort(kUdpPort));
 
@@ -488,8 +488,8 @@ void TestBorderAgentEphemeralKey(void)
     VerifyOrQuit(node1.Get<Tmf::SecureAgent>().IsConnected());
     VerifyOrQuit(node0.Get<EphemeralKeyManager>().GetState() == EphemeralKeyManager::kStateConnected);
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcActivations == 1);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcSecureSessionSuccesses == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcActivations == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcSecureSessionSuccesses == 1);
 
     VerifyOrQuit(sEphemeralKeyCallbackCalled);
 
@@ -506,9 +506,9 @@ void TestBorderAgentEphemeralKey(void)
     VerifyOrQuit(node0.Get<EphemeralKeyManager>().GetState() == EphemeralKeyManager::kStateStopped);
     VerifyOrQuit(sEphemeralKeyCallbackCalled);
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcActivations == 1);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcSecureSessionSuccesses == 1);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationDisconnects == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcActivations == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcSecureSessionSuccesses == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationDisconnects == 1);
 
     nexus.AdvanceTime(10 * Time::kOneSecondInMsec);
 
@@ -528,9 +528,9 @@ void TestBorderAgentEphemeralKey(void)
     VerifyOrQuit(node1.Get<Tmf::SecureAgent>().IsConnected());
     VerifyOrQuit(node0.Get<EphemeralKeyManager>().GetState() == EphemeralKeyManager::kStateConnected);
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcActivations == 2);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcSecureSessionSuccesses == 2);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationDisconnects == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcActivations == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcSecureSessionSuccesses == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationDisconnects == 1);
 
     Log("  Check the ephemeral key timeout behavior");
 
@@ -541,10 +541,10 @@ void TestBorderAgentEphemeralKey(void)
     VerifyOrQuit(node0.Get<EphemeralKeyManager>().GetState() == EphemeralKeyManager::kStateStopped);
     VerifyOrQuit(sEphemeralKeyCallbackCalled);
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcActivations == 2);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcSecureSessionSuccesses == 2);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationTimeouts == 1);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationDisconnects == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcActivations == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcSecureSessionSuccesses == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationTimeouts == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationDisconnects == 1);
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Start using ephemeral key without any candidate connecting, check timeout");
@@ -561,10 +561,10 @@ void TestBorderAgentEphemeralKey(void)
     VerifyOrQuit(node0.Get<EphemeralKeyManager>().GetState() == EphemeralKeyManager::kStateStopped);
     VerifyOrQuit(sEphemeralKeyCallbackCalled);
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcActivations == 3);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcSecureSessionSuccesses == 2);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationTimeouts == 2);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationDisconnects == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcActivations == 3);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcSecureSessionSuccesses == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationTimeouts == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationDisconnects == 1);
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Check that ephemeral key use is stopped after max failed connection attempts");
@@ -599,11 +599,11 @@ void TestBorderAgentEphemeralKey(void)
     VerifyOrQuit(node0.Get<EphemeralKeyManager>().GetState() == EphemeralKeyManager::kStateStopped);
     VerifyOrQuit(sEphemeralKeyCallbackCalled);
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcActivations == 4);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcSecureSessionSuccesses == 2);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationTimeouts == 2);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationDisconnects == 1);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationMaxAttempts == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcActivations == 4);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcSecureSessionSuccesses == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationTimeouts == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationDisconnects == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationMaxAttempts == 1);
 
     node1.Get<Tmf::SecureAgent>().Close();
 
@@ -641,18 +641,18 @@ void TestBorderAgentEphemeralKey(void)
     nexus.AdvanceTime(3 * Time::kOneSecondInMsec);
     VerifyOrQuit(!node1.Get<Tmf::SecureAgent>().IsConnected());
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcActivations == 5);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcSecureSessionSuccesses == 3);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationTimeouts == 2);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationDisconnects == 1);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationMaxAttempts == 1);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationClears == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcActivations == 5);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcSecureSessionSuccesses == 3);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationTimeouts == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationDisconnects == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationMaxAttempts == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationClears == 1);
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Check ephemeral key can be used along with PSKc");
 
-    VerifyOrQuit(node0.Get<BorderAgent>().IsRunning());
-    SuccessOrQuit(node0.Get<Ip6::Filter>().AddUnsecurePort(node0.Get<BorderAgent>().GetUdpPort()));
+    VerifyOrQuit(node0.Get<Manager>().IsRunning());
+    SuccessOrQuit(node0.Get<Ip6::Filter>().AddUnsecurePort(node0.Get<Manager>().GetUdpPort()));
 
     node0.Get<EphemeralKeyManager>().SetEnabled(true);
     VerifyOrQuit(node0.Get<EphemeralKeyManager>().GetState() == EphemeralKeyManager::kStateStopped);
@@ -665,7 +665,7 @@ void TestBorderAgentEphemeralKey(void)
     Log("  Establish a secure session using PSKc (from node2)");
 
     baSockAddr.SetAddress(node0.Get<Mle::Mle>().GetLinkLocalAddress());
-    baSockAddr.SetPort(node0.Get<BorderAgent>().GetUdpPort());
+    baSockAddr.SetPort(node0.Get<Manager>().GetUdpPort());
 
     node0.Get<KeyManager>().GetPskc(pskc);
     SuccessOrQuit(node2.Get<Tmf::SecureAgent>().SetPsk(pskc.m8, Pskc::kSize));
@@ -709,12 +709,12 @@ void TestBorderAgentEphemeralKey(void)
     VerifyOrQuit(node0.Get<EphemeralKeyManager>().GetState() == EphemeralKeyManager::kStateStopped);
     VerifyOrQuit(sEphemeralKeyCallbackCalled);
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcActivations == 6);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcSecureSessionSuccesses == 4);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationTimeouts == 2);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationDisconnects == 1);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationMaxAttempts == 1);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcDeactivationClears == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcActivations == 6);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcSecureSessionSuccesses == 4);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationTimeouts == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationDisconnects == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationMaxAttempts == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcDeactivationClears == 2);
 
     Log("  Check the BA session using PSKc is still connected");
 
@@ -747,13 +747,13 @@ void TestBorderAgentEphemeralKey(void)
     VerifyOrQuit(node0.Get<EphemeralKeyManager>().Start(kTooShortEphemeralKey, /* aTimeout */ 0, kUdpPort) ==
                  kErrorInvalidArgs);
 
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcActivations == 6);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcInvalidArgsErrors == 1);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcActivations == 6);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcInvalidArgsErrors == 1);
 
     VerifyOrQuit(node0.Get<EphemeralKeyManager>().Start(kTooLongEphemeralKey, /* aTimeout */ 0, kUdpPort) ==
                  kErrorInvalidArgs);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcActivations == 6);
-    VerifyOrQuit(node0.Get<BorderAgent>().GetCounters().mEpskcInvalidArgsErrors == 2);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcActivations == 6);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mEpskcInvalidArgsErrors == 2);
 }
 
 EpskcEvent GetNewestEpskcEvent(Node &aNode)
@@ -1240,15 +1240,15 @@ void ValidateMeshCoPTxtData(TxtData &aTxtData, Node &aNode)
     static constexpr uint32_t kThreadRoleLeader             = 3 << 9;
     static constexpr uint32_t kFlagEpskcSupported           = 1 << 11;
 
-    BorderAgent::Id id;
-    uint32_t        stateBitmap;
-    uint32_t        threadIfStatus;
-    uint32_t        threadRole;
+    MeshCoP::BorderAgent::Id id;
+    uint32_t                 stateBitmap;
+    uint32_t                 threadIfStatus;
+    uint32_t                 threadRole;
 
     aTxtData.ValidateFormat();
     aTxtData.LogAllTxtEntries();
 
-    aNode.Get<BorderAgent>().GetId(id);
+    aNode.Get<Manager>().GetId(id);
     aTxtData.ValidateKey("id", id);
     aTxtData.ValidateKey("rv", "1");
     aTxtData.ValidateKey("tv", kThreadVersionString);
@@ -1273,8 +1273,8 @@ void ValidateMeshCoPTxtData(TxtData &aTxtData, Node &aNode)
 
     stateBitmap = aTxtData.ReadUint32Key("sb");
 
-    VerifyOrQuit((stateBitmap & kMaskConnectionMode) == aNode.Get<BorderAgent>().IsRunning() ? kConnectionModePskc
-                                                                                             : kConnectionModeDisabled);
+    VerifyOrQuit((stateBitmap & kMaskConnectionMode) == aNode.Get<Manager>().IsRunning() ? kConnectionModePskc
+                                                                                         : kConnectionModeDisabled);
     switch (aNode.Get<Mle::Mle>().GetRole())
     {
     case Mle::DeviceRole::kRoleDisabled:
@@ -1302,8 +1302,7 @@ void ValidateMeshCoPTxtData(TxtData &aTxtData, Node &aNode)
     VerifyOrQuit((stateBitmap & kMaskThreadIfStatus) == threadIfStatus);
     VerifyOrQuit((stateBitmap & kMaskThreadRole) == threadRole);
 
-    if (aNode.Get<BorderAgent>().Get<EphemeralKeyManager>().GetState() !=
-        BorderAgent::EphemeralKeyManager::kStateDisabled)
+    if (aNode.Get<EphemeralKeyManager>().GetState() != EphemeralKeyManager::kStateDisabled)
     {
         VerifyOrQuit(stateBitmap & kFlagEpskcSupported);
     }
@@ -1324,10 +1323,10 @@ void HandleServiceChanged(void *aContext) // Callback used in `TestBorderAgentTx
 
 void ReadAndValidateMeshCoPTxtData(Node &aNode)
 {
-    BorderAgent::ServiceTxtData serviceTxtData;
-    TxtData                     txtData;
+    Manager::ServiceTxtData serviceTxtData;
+    TxtData                 txtData;
 
-    SuccessOrQuit(aNode.Get<BorderAgent>().PrepareServiceTxtData(serviceTxtData));
+    SuccessOrQuit(aNode.Get<Manager>().PrepareServiceTxtData(serviceTxtData));
     txtData.Init(serviceTxtData.mData, serviceTxtData.mLength);
 
     ValidateMeshCoPTxtData(txtData, aNode);
@@ -1335,10 +1334,10 @@ void ReadAndValidateMeshCoPTxtData(Node &aNode)
 
 void TestBorderAgentTxtDataCallback(void)
 {
-    Core            nexus;
-    Node           &node0           = nexus.CreateNode();
-    bool            callbackInvoked = false;
-    BorderAgent::Id newId;
+    Core                     nexus;
+    Node                    &node0           = nexus.CreateNode();
+    bool                     callbackInvoked = false;
+    MeshCoP::BorderAgent::Id newId;
 
     Log("------------------------------------------------------------------------------------------------------");
     Log("TestBorderAgentTxtDataCallback");
@@ -1348,15 +1347,15 @@ void TestBorderAgentTxtDataCallback(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Set MeshCoP service change callback. Will get initial values.
     Log("Set MeshCoP service change callback and check initial values");
-    node0.Get<BorderAgent>().SetServiceChangedCallback(HandleServiceChanged, &callbackInvoked);
+    node0.Get<Manager>().SetServiceChangedCallback(HandleServiceChanged, &callbackInvoked);
     nexus.AdvanceTime(1);
 
     // Check the initial TXT entries
     ReadAndValidateMeshCoPTxtData(node0);
 
     // Check the Border Agent state
-    VerifyOrQuit(!node0.Get<BorderAgent>().IsRunning());
-    VerifyOrQuit(node0.Get<BorderAgent>().GetUdpPort() == 0);
+    VerifyOrQuit(!node0.Get<Manager>().IsRunning());
+    VerifyOrQuit(node0.Get<Manager>().GetUdpPort() == 0);
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Join Thread network and check updated values and states.
@@ -1368,8 +1367,8 @@ void TestBorderAgentTxtDataCallback(void)
     VerifyOrQuit(callbackInvoked);
     ReadAndValidateMeshCoPTxtData(node0);
 
-    VerifyOrQuit(node0.Get<BorderAgent>().IsRunning());
-    VerifyOrQuit(node0.Get<BorderAgent>().GetUdpPort() != 0);
+    VerifyOrQuit(node0.Get<Manager>().IsRunning());
+    VerifyOrQuit(node0.Get<Manager>().GetUdpPort() != 0);
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -1378,7 +1377,7 @@ void TestBorderAgentTxtDataCallback(void)
     newId.GenerateRandom();
 
     callbackInvoked = false;
-    node0.Get<BorderAgent>().SetId(newId);
+    node0.Get<Manager>().SetId(newId);
 
     nexus.AdvanceTime(1);
     ReadAndValidateMeshCoPTxtData(node0);
@@ -1387,7 +1386,7 @@ void TestBorderAgentTxtDataCallback(void)
     // correctly detected and does not trigger the callback.
 
     callbackInvoked = false;
-    node0.Get<BorderAgent>().SetId(newId);
+    node0.Get<Manager>().SetId(newId);
     nexus.AdvanceTime(1);
     VerifyOrQuit(!callbackInvoked);
 
@@ -1527,7 +1526,7 @@ void TestBorderAgentServiceRegistration(void)
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Disable Border Agent function on node1
-    node1.Get<MeshCoP::BorderAgent>().SetEnabled(false);
+    node1.Get<MeshCoP::BorderAgent::Manager>().SetEnabled(false);
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Enable mDNS
@@ -1543,7 +1542,7 @@ void TestBorderAgentServiceRegistration(void)
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    VerifyOrQuit(node0.Get<MeshCoP::BorderAgent>().IsEnabled());
+    VerifyOrQuit(node0.Get<MeshCoP::BorderAgent::Manager>().IsEnabled());
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Validate the registered mDNS MeshCop service by Border Agent");
@@ -1562,7 +1561,7 @@ void TestBorderAgentServiceRegistration(void)
     VerifyOrQuit(StringMatch(service.mServiceType, "_meshcop._udp"));
     VerifyOrQuit(StringStartsWith(service.mServiceInstance, kDefaultServiceBaseName));
     VerifyOrQuit(StringStartsWith(service.mHostName, "ot"));
-    VerifyOrQuit(service.mPort == node0.Get<MeshCoP::BorderAgent>().GetUdpPort());
+    VerifyOrQuit(service.mPort == node0.Get<MeshCoP::BorderAgent::Manager>().GetUdpPort());
     VerifyOrQuit(service.mSubTypeLabelsLength == 0);
     VerifyOrQuit(service.mTtl > 0);
     VerifyOrQuit(service.mInfraIfIndex == kInfraIfIndex);
@@ -1608,7 +1607,7 @@ void TestBorderAgentServiceRegistration(void)
     VerifyOrQuit(sSrvOutcomes.GetLength() == 1);
     VerifyOrQuit(StringStartsWith(sSrvOutcomes[0].mHostName, "ot"));
     VerifyOrQuit(sSrvOutcomes[0].mTtl > 0);
-    VerifyOrQuit(sSrvOutcomes[0].mPort == node0.Get<MeshCoP::BorderAgent>().GetUdpPort());
+    VerifyOrQuit(sSrvOutcomes[0].mPort == node0.Get<MeshCoP::BorderAgent::Manager>().GetUdpPort());
 
     VerifyOrQuit(sTxtOutcomes.GetLength() == 1);
     VerifyOrQuit(sTxtOutcomes[0].mTtl > 0);
@@ -1658,7 +1657,7 @@ void TestBorderAgentServiceRegistration(void)
 
         if (StringMatch(service.mServiceType, "_meshcop._udp"))
         {
-            VerifyOrQuit(service.mPort == node0.Get<MeshCoP::BorderAgent>().GetUdpPort());
+            VerifyOrQuit(service.mPort == node0.Get<MeshCoP::BorderAgent::Manager>().GetUdpPort());
             ValidateRegisteredServiceData(service, node0);
         }
         else if (StringMatch(service.mServiceType, "_meshcop-e._udp"))
@@ -1701,7 +1700,7 @@ void TestBorderAgentServiceRegistration(void)
     VerifyOrQuit(StringStartsWith(service.mServiceInstance, kDefaultServiceBaseName));
     VerifyOrQuit(StringStartsWith(service.mHostName, "ot"));
     VerifyOrQuit(service.mSubTypeLabelsLength == 0);
-    VerifyOrQuit(service.mPort == node0.Get<MeshCoP::BorderAgent>().GetUdpPort());
+    VerifyOrQuit(service.mPort == node0.Get<MeshCoP::BorderAgent::Manager>().GetUdpPort());
     VerifyOrQuit(service.mTtl > 0);
     VerifyOrQuit(service.mInfraIfIndex == kInfraIfIndex);
     VerifyOrQuit(entryState == OT_MDNS_ENTRY_STATE_REGISTERED);
@@ -1715,7 +1714,7 @@ void TestBorderAgentServiceRegistration(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Change the base service name and validate the new service");
 
-    SuccessOrQuit(node0.Get<MeshCoP::BorderAgent>().SetServiceBaseName("OpenThreadAgent"));
+    SuccessOrQuit(node0.Get<MeshCoP::BorderAgent::Manager>().SetServiceBaseName("OpenThreadAgent"));
 
     nexus.AdvanceTime(30 * Time::kOneSecondInMsec);
 
@@ -1733,7 +1732,7 @@ void TestBorderAgentServiceRegistration(void)
     VerifyOrQuit(StringStartsWith(service.mServiceInstance, "OpenThreadAgent"));
     VerifyOrQuit(StringStartsWith(service.mHostName, "ot"));
     VerifyOrQuit(service.mSubTypeLabelsLength == 0);
-    VerifyOrQuit(service.mPort == node0.Get<MeshCoP::BorderAgent>().GetUdpPort());
+    VerifyOrQuit(service.mPort == node0.Get<MeshCoP::BorderAgent::Manager>().GetUdpPort());
     VerifyOrQuit(service.mTtl > 0);
     VerifyOrQuit(service.mInfraIfIndex == kInfraIfIndex);
     VerifyOrQuit(entryState == OT_MDNS_ENTRY_STATE_REGISTERED);
@@ -1768,8 +1767,8 @@ void TestBorderAgentServiceRegistration(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Disable Border Agent and validate that registered service is removed");
 
-    node0.Get<MeshCoP::BorderAgent>().SetEnabled(false);
-    VerifyOrQuit(!node0.Get<MeshCoP::BorderAgent>().IsEnabled());
+    node0.Get<MeshCoP::BorderAgent::Manager>().SetEnabled(false);
+    VerifyOrQuit(!node0.Get<MeshCoP::BorderAgent::Manager>().IsEnabled());
 
     nexus.AdvanceTime(30 * Time::kOneSecondInMsec);
 
@@ -1789,9 +1788,9 @@ void TestBorderAgentServiceRegistration(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Change the base service name while agent is disabled and validate no service is registered");
 
-    SuccessOrQuit(node0.Get<MeshCoP::BorderAgent>().SetServiceBaseName("NewName"));
+    SuccessOrQuit(node0.Get<MeshCoP::BorderAgent::Manager>().SetServiceBaseName("NewName"));
 
-    VerifyOrQuit(!node0.Get<MeshCoP::BorderAgent>().IsEnabled());
+    VerifyOrQuit(!node0.Get<MeshCoP::BorderAgent::Manager>().IsEnabled());
 
     nexus.AdvanceTime(30 * Time::kOneSecondInMsec);
 
@@ -1804,13 +1803,13 @@ void TestBorderAgentServiceRegistration(void)
 
     VerifyOrQuit(sBrowseOutcomes.IsEmpty());
 
-    SuccessOrQuit(node0.Get<MeshCoP::BorderAgent>().SetServiceBaseName("OpenThreadAgent"));
+    SuccessOrQuit(node0.Get<MeshCoP::BorderAgent::Manager>().SetServiceBaseName("OpenThreadAgent"));
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Re-enable Border Agent and validate that service is registered again");
 
-    node0.Get<MeshCoP::BorderAgent>().SetEnabled(true);
-    VerifyOrQuit(node0.Get<MeshCoP::BorderAgent>().IsEnabled());
+    node0.Get<MeshCoP::BorderAgent::Manager>().SetEnabled(true);
+    VerifyOrQuit(node0.Get<MeshCoP::BorderAgent::Manager>().IsEnabled());
 
     nexus.AdvanceTime(30 * Time::kOneSecondInMsec);
 
@@ -1828,7 +1827,7 @@ void TestBorderAgentServiceRegistration(void)
     VerifyOrQuit(StringStartsWith(service.mServiceInstance, "OpenThreadAgent"));
     VerifyOrQuit(StringStartsWith(service.mHostName, "ot"));
     VerifyOrQuit(service.mSubTypeLabelsLength == 0);
-    VerifyOrQuit(service.mPort == node0.Get<MeshCoP::BorderAgent>().GetUdpPort());
+    VerifyOrQuit(service.mPort == node0.Get<MeshCoP::BorderAgent::Manager>().GetUdpPort());
     VerifyOrQuit(service.mTtl > 0);
     VerifyOrQuit(service.mInfraIfIndex == kInfraIfIndex);
     VerifyOrQuit(entryState == OT_MDNS_ENTRY_STATE_REGISTERED);
@@ -1849,7 +1848,7 @@ void TestBorderAgentServiceRegistration(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Set vendor TXT data and validate that it is included in the registered mDNS service");
 
-    node0.Get<BorderAgent>().SetVendorTxtData(kVendorTxtData, sizeof(kVendorTxtData));
+    node0.Get<Manager>().SetVendorTxtData(kVendorTxtData, sizeof(kVendorTxtData));
     nexus.AdvanceTime(5 * Time::kOneSecondInMsec);
 
     iterator = node0.Get<Dns::Multicast::Core>().AllocateIterator();
@@ -1866,7 +1865,7 @@ void TestBorderAgentServiceRegistration(void)
     VerifyOrQuit(StringStartsWith(service.mServiceInstance, "OpenThreadAgent"));
     VerifyOrQuit(StringStartsWith(service.mHostName, "ot"));
     VerifyOrQuit(service.mSubTypeLabelsLength == 0);
-    VerifyOrQuit(service.mPort == node0.Get<MeshCoP::BorderAgent>().GetUdpPort());
+    VerifyOrQuit(service.mPort == node0.Get<MeshCoP::BorderAgent::Manager>().GetUdpPort());
     VerifyOrQuit(service.mTtl > 0);
     VerifyOrQuit(service.mInfraIfIndex == kInfraIfIndex);
     VerifyOrQuit(entryState == OT_MDNS_ENTRY_STATE_REGISTERED);
@@ -1887,7 +1886,7 @@ void TestBorderAgentServiceRegistration(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Clear vendor TXT data and validate that the registered mDNS service is updated accordingly");
 
-    node0.Get<BorderAgent>().SetVendorTxtData(nullptr, 0);
+    node0.Get<Manager>().SetVendorTxtData(nullptr, 0);
     nexus.AdvanceTime(5 * Time::kOneSecondInMsec);
 
     iterator = node0.Get<Dns::Multicast::Core>().AllocateIterator();
@@ -1904,7 +1903,7 @@ void TestBorderAgentServiceRegistration(void)
     VerifyOrQuit(StringStartsWith(service.mServiceInstance, "OpenThreadAgent"));
     VerifyOrQuit(StringStartsWith(service.mHostName, "ot"));
     VerifyOrQuit(service.mSubTypeLabelsLength == 0);
-    VerifyOrQuit(service.mPort == node0.Get<MeshCoP::BorderAgent>().GetUdpPort());
+    VerifyOrQuit(service.mPort == node0.Get<MeshCoP::BorderAgent::Manager>().GetUdpPort());
     VerifyOrQuit(service.mTtl > 0);
     VerifyOrQuit(service.mInfraIfIndex == kInfraIfIndex);
     VerifyOrQuit(entryState == OT_MDNS_ENTRY_STATE_REGISTERED);

--- a/tests/nexus/test_border_agent_tracker.cpp
+++ b/tests/nexus/test_border_agent_tracker.cpp
@@ -40,16 +40,16 @@ void TestBorderAgentTracker(void)
 {
     static constexpr uint32_t kInfraIfIndex = 1;
 
-    Core                                   nexus;
-    Node                                  &node0 = nexus.CreateNode();
-    Node                                  &node1 = nexus.CreateNode();
-    Node                                  &node2 = nexus.CreateNode();
-    Node                                  &node3 = nexus.CreateNode();
-    MeshCoP::BorderAgentTracker::Iterator  iterator;
-    MeshCoP::BorderAgentTracker::AgentInfo agent;
-    Dns::Multicast::Core::Service          service;
-    uint16_t                               count;
-    bool                                   found;
+    Core                                     nexus;
+    Node                                    &node0 = nexus.CreateNode();
+    Node                                    &node1 = nexus.CreateNode();
+    Node                                    &node2 = nexus.CreateNode();
+    Node                                    &node3 = nexus.CreateNode();
+    MeshCoP::BorderAgent::Tracker::Iterator  iterator;
+    MeshCoP::BorderAgent::Tracker::AgentInfo agent;
+    Dns::Multicast::Core::Service            service;
+    uint16_t                                 count;
+    bool                                     found;
 
     Log("------------------------------------------------------------------------------------------------------");
     Log("TestBorderAgentTracker");
@@ -75,15 +75,15 @@ void TestBorderAgentTracker(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Check Border Agent Tracker's initial state");
 
-    VerifyOrQuit(!node0.Get<MeshCoP::BorderAgentTracker>().IsRunning());
+    VerifyOrQuit(!node0.Get<MeshCoP::BorderAgent::Tracker>().IsRunning());
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Enable Border Agent Tracker");
 
-    node0.Get<MeshCoP::BorderAgentTracker>().SetEnabled(true, MeshCoP::BorderAgentTracker::kRequesterUser);
+    node0.Get<MeshCoP::BorderAgent::Tracker>().SetEnabled(true, MeshCoP::BorderAgent::Tracker::kRequesterUser);
     nexus.AdvanceTime(10);
 
-    VerifyOrQuit(node0.Get<MeshCoP::BorderAgentTracker>().IsRunning());
+    VerifyOrQuit(node0.Get<MeshCoP::BorderAgent::Tracker>().IsRunning());
 
     nexus.AdvanceTime(5000);
 
@@ -109,7 +109,7 @@ void TestBorderAgentTracker(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Disable BA function on node0, ensure that it is removed from the `BorderAgentTracker` list");
 
-    node0.Get<MeshCoP::BorderAgent>().SetEnabled(false);
+    node0.Get<MeshCoP::BorderAgent::Manager>().SetEnabled(false);
     nexus.AdvanceTime(5000);
 
     iterator.Init(node0.GetInstance());
@@ -131,7 +131,7 @@ void TestBorderAgentTracker(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Re-enable BA function on node0, ensure that it is added again in the `BorderAgentTracker` list");
 
-    node0.Get<MeshCoP::BorderAgent>().SetEnabled(true);
+    node0.Get<MeshCoP::BorderAgent::Manager>().SetEnabled(true);
     nexus.AdvanceTime(5000);
 
     iterator.Init(node0.GetInstance());
@@ -153,10 +153,10 @@ void TestBorderAgentTracker(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Disable Border Agent Tracker");
 
-    node0.Get<MeshCoP::BorderAgentTracker>().SetEnabled(false, MeshCoP::BorderAgentTracker::kRequesterUser);
+    node0.Get<MeshCoP::BorderAgent::Tracker>().SetEnabled(false, MeshCoP::BorderAgent::Tracker::kRequesterUser);
     nexus.AdvanceTime(10);
 
-    VerifyOrQuit(!node0.Get<MeshCoP::BorderAgentTracker>().IsRunning());
+    VerifyOrQuit(!node0.Get<MeshCoP::BorderAgent::Tracker>().IsRunning());
 
     iterator.Init(node0.GetInstance());
     VerifyOrQuit(iterator.GetNextAgentInfo(agent) == kErrorNotFound);
@@ -164,10 +164,10 @@ void TestBorderAgentTracker(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Re-enable BA tracker and ensure all agents are discovered again");
 
-    node0.Get<MeshCoP::BorderAgentTracker>().SetEnabled(true, MeshCoP::BorderAgentTracker::kRequesterUser);
+    node0.Get<MeshCoP::BorderAgent::Tracker>().SetEnabled(true, MeshCoP::BorderAgent::Tracker::kRequesterUser);
     nexus.AdvanceTime(10);
 
-    VerifyOrQuit(node0.Get<MeshCoP::BorderAgentTracker>().IsRunning());
+    VerifyOrQuit(node0.Get<MeshCoP::BorderAgent::Tracker>().IsRunning());
 
     nexus.AdvanceTime(5000);
 

--- a/tests/unit/test_mdns.cpp
+++ b/tests/unit/test_mdns.cpp
@@ -1854,7 +1854,7 @@ Core *InitTest(void)
     // register the `_meshcop._udp` service from
     // interfering with this test.
 
-    sInstance->Get<MeshCoP::BorderAgent>().SetEnabled(false);
+    sInstance->Get<MeshCoP::BorderAgent::Manager>().SetEnabled(false);
 #endif
 
     return &sInstance->Get<Core>();

--- a/tests/unit/test_srp_adv_proxy.cpp
+++ b/tests/unit/test_srp_adv_proxy.cpp
@@ -547,7 +547,7 @@ void InitTest(void)
     // Disable the Border Agent to prevent its attempt to
     // register the `_meshcop._udp` service from
     // interfering with this test.
-    sInstance->Get<MeshCoP::BorderAgent>().SetEnabled(false);
+    sInstance->Get<MeshCoP::BorderAgent::Manager>().SetEnabled(false);
 #endif
 
     // Configure the `Dnssd` module to use `otPlatDnssd` APIs.


### PR DESCRIPTION
This change reorganizes the `BorderAgent` related classes into a new `MeshCoP::BorderAgent` namespace to improve code structure and clarity.

The following changes are included:

- `MeshCoP::BorderAgent` class is renamed to `Manager` and placed within the new `MeshCoP::BorderAgent` namespace.
- `MeshCoP::BorderAgentTracker` is renamed to `Tracker` under the new namespace.
- `EphemeralKeyManager` is moved from being a nested class in `BorderAgent` to `MeshCoP::BorderAgent::EphemeralKeyManager`.
- `EphemeralKeyManager` is now a direct member of the `Instance` class, simplifying accessing it.

All related API calls and test files are updated to reflect these changes.