### PR TITLE
[border-router] make `RxRaTracker` handle netdata events directly

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -446,7 +446,6 @@ void RoutingManager::HandleNotifierEvents(Events aEvents)
 
     if (mIsRunning && aEvents.Contains(kEventThreadNetdataChanged))
     {
-        Get<RxRaTracker>().HandleNetDataChange();
         mOnLinkPrefixManager.HandleNetDataChange();
         ScheduleRoutingPolicyEvaluation(kAfterRandomDelay);
     }

--- a/src/core/border_router/rx_ra_tracker.cpp
+++ b/src/core/border_router/rx_ra_tracker.cpp
@@ -502,6 +502,14 @@ exit:
     return;
 }
 
+void RxRaTracker::HandleNotifierEvents(Events aEvents)
+{
+    if (aEvents.Contains(kEventThreadNetdataChanged))
+    {
+        HandleNetDataChange();
+    }
+}
+
 void RxRaTracker::HandleNetDataChange(void)
 {
     NetworkData::Iterator           iterator = NetworkData::kIteratorInit;

--- a/src/core/border_router/rx_ra_tracker.hpp
+++ b/src/core/border_router/rx_ra_tracker.hpp
@@ -73,6 +73,7 @@ class NetDataBrTracker;
 class RxRaTracker : public InstanceLocator
 {
     friend class NetDataBrTracker;
+    friend class ot::Notifier;
 
 public:
     /**
@@ -279,7 +280,6 @@ public:
     // Callbacks notifying of changes
     void RemoveOrDeprecateOldEntries(TimeMilli aTimeThreshold);
     void HandleLocalOnLinkPrefixChanged(void);
-    void HandleNetDataChange(void);
 
 private:
     static constexpr uint32_t kStaleTime = 600; // 10 minutes.
@@ -497,6 +497,9 @@ private:
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
     void ReportChangesToHistoryTracker(Router &aRouter, bool aRemoved);
 #endif
+    void HandleNotifierEvents(Events aEvents);
+    void HandleNetDataChange(void);
+
     // Tasklet or timer callbacks
     void HandleSignalTask(void);
     void HandleRdnssAddrTask(void);

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -161,6 +161,7 @@ void Notifier::EmitEvents(void)
     Get<Extension::ExtensionBase>().HandleNotifierEvents(events);
 #endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    Get<BorderRouter::RxRaTracker>().HandleNotifierEvents(events);
     Get<BorderRouter::RoutingManager>().HandleNotifierEvents(events);
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
     Get<BorderRouter::NetDataBrTracker>().HandleNotifierEvents(events);


### PR DESCRIPTION
This change makes the `RxRaTracker` a direct listener of network data change events from the `Notifier`.

Previously, the `RoutingManager` would receive the network data change event and then call `RxRaTracker::HandleNetDataChange()`. This created an unnecessary dependency between the two components.

By making `RxRaTracker` a direct listener, we decouple it from `RoutingManager`. The `HandleNetDataChange()` method in `RxRaTracker` is also made private as it is now only called from within the class.