### PR TITLE
[core] use `kNullChar` constant instead of '\0' literal

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -209,7 +209,7 @@ otError otThreadSetNetworkName(otInstance *aInstance, const char *aNetworkName)
 #if !OPENTHREAD_CONFIG_ALLOW_EMPTY_NETWORK_NAME
     // Thread interfaces support a zero length name internally for backwards compatibility, but new names
     // must be at least one valid character long.
-    VerifyOrExit(nullptr != aNetworkName && aNetworkName[0] != '\0', error = kErrorInvalidArgs);
+    VerifyOrExit(nullptr != aNetworkName && aNetworkName[0] != kNullChar, error = kErrorInvalidArgs);
 #endif
 
     error = AsCoreType(aInstance).Get<MeshCoP::NetworkNameManager>().SetNetworkName(aNetworkName);

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1374,7 +1374,7 @@ void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo 
         SuccessOrExit(error = iterator.Advance());
     }
 
-    curUriPath[0] = '\0';
+    curUriPath[0] = kNullChar;
 
     for (const ResourceBlockWise &resource : mBlockWiseResources)
     {

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -261,7 +261,7 @@ Error Message::ReadUriPathOptions(char (&aUriPath)[kMaxReceivedUriPath + 1]) con
         SuccessOrExit(error = iterator.Advance(kOptionUriPath));
     }
 
-    *curUriPath = '\0';
+    *curUriPath = kNullChar;
 
 exit:
     return error;

--- a/src/core/common/string.hpp
+++ b/src/core/common/string.hpp
@@ -375,7 +375,7 @@ inline constexpr bool AreStringsInOrder(const char *aFirst, const char *aSecond)
 {
     return (*aFirst < *aSecond)
                ? true
-               : ((*aFirst > *aSecond) || (*aFirst == '\0') ? false : AreStringsInOrder(aFirst + 1, aSecond + 1));
+               : ((*aFirst > *aSecond) || (*aFirst == kNullChar) ? false : AreStringsInOrder(aFirst + 1, aSecond + 1));
 }
 
 /**

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -136,7 +136,7 @@ Error Diags::ProcessEcho(uint8_t aArgsLength, char *aArgs[])
             output[i] = '0' + i % 10;
         }
 
-        output[number] = '\0';
+        output[number] = kNullChar;
 
         Output("%s\r\n", output);
     }
@@ -637,7 +637,7 @@ Error Diags::ParseReceiveConfigFormat(const char *aFormat, ReceiveConfig &aConfi
 
     VerifyOrExit(aFormat != nullptr, error = kErrorInvalidArgs);
 
-    for (const char *arg = aFormat; *arg != '\0'; arg++)
+    for (const char *arg = aFormat; *arg != kNullChar; arg++)
     {
         switch (*arg)
         {

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -55,6 +55,7 @@
 #include "common/non_copyable.hpp"
 #include "common/random.hpp"
 #include "common/serial_number.hpp"
+#include "common/string.hpp"
 #include "common/tasklet.hpp"
 #include "common/time_ticker.hpp"
 #include "common/timer.hpp"

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -64,7 +64,7 @@ Commissioner::Commissioner(Instance &aInstance)
 
     IgnoreError(SetId("OpenThread Commissioner"));
 
-    mProvisioningUrl[0] = '\0';
+    mProvisioningUrl[0] = kNullChar;
 }
 
 void Commissioner::SetState(State aState)

--- a/src/core/meshcop/meshcop.cpp
+++ b/src/core/meshcop/meshcop.cpp
@@ -68,7 +68,7 @@ bool JoinerPskd::operator==(const JoinerPskd &aOther) const
             ExitNow();
         }
 
-        if (m8[i] == '\0')
+        if (m8[i] == kNullChar)
         {
             break;
         }

--- a/src/core/meshcop/network_name.cpp
+++ b/src/core/meshcop/network_name.cpp
@@ -89,13 +89,13 @@ Error NetworkName::Set(const NameData &aNameData)
     data.SetLength(newLen);
 
     // Ensure the new name does not match the current one.
-    if (data.MatchesBytesIn(m8) && m8[newLen] == '\0')
+    if (data.MatchesBytesIn(m8) && m8[newLen] == kNullChar)
     {
         ExitNow(error = kErrorAlready);
     }
 
     data.CopyBytesTo(m8);
-    m8[newLen] = '\0';
+    m8[newLen] = kNullChar;
 
 exit:
     return error;

--- a/src/core/meshcop/network_name.hpp
+++ b/src/core/meshcop/network_name.hpp
@@ -111,7 +111,7 @@ public:
     /**
      * Initializes the Network Name as an empty string.
      */
-    NetworkName(void) { m8[0] = '\0'; }
+    NetworkName(void) { m8[0] = kNullChar; }
 
     /**
      * Gets the Network Name as a null terminated C string.

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -196,7 +196,7 @@ Error TcatAgent::Connected(MeshCoP::Tls::Extension &aTls)
     if (aTls.GetThreadAttributeFromPeerCertificate(
             kCertificateDomainName, reinterpret_cast<uint8_t *>(&mCommissionerDomainName), &len) == kErrorNone)
     {
-        mCommissionerDomainName.m8[len] = '\0';
+        mCommissionerDomainName.m8[len] = kNullChar;
         mCommissionerHasDomainName      = true;
     }
 
@@ -204,7 +204,7 @@ Error TcatAgent::Connected(MeshCoP::Tls::Extension &aTls)
     if (aTls.GetThreadAttributeFromPeerCertificate(
             kCertificateNetworkName, reinterpret_cast<uint8_t *>(&mCommissionerNetworkName), &len) == kErrorNone)
     {
-        mCommissionerNetworkName.m8[len] = '\0';
+        mCommissionerNetworkName.m8[len] = kNullChar;
         mCommissionerHasNetworkName      = true;
     }
 

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -256,7 +256,7 @@ void Client::Response::InitServiceInfo(ServiceInfo &aServiceInfo) const
 
     if ((aServiceInfo.mHostNameBuffer != nullptr) && (aServiceInfo.mHostNameBufferSize > 0))
     {
-        aServiceInfo.mHostNameBuffer[0] = '\0';
+        aServiceInfo.mHostNameBuffer[0] = kNullChar;
     }
 }
 

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -147,7 +147,6 @@ bool Prefix::IsValidNat64PrefixLength(uint8_t aLength)
 Error Prefix::FromString(const char *aString)
 {
     constexpr char kSlashChar = '/';
-    constexpr char kNullChar  = '\0';
 
     Error       error = kErrorParse;
     const char *cur;
@@ -510,12 +509,7 @@ void Address::SynthesizeFromIp4Address(const Prefix &aPrefix, const Ip4::Address
     }
 }
 
-Error Address::FromString(const char *aString)
-{
-    constexpr char kNullChar = '\0';
-
-    return ParseFrom(aString, kNullChar);
-}
+Error Address::FromString(const char *aString) { return ParseFrom(aString, kNullChar); }
 
 Error Address::ParseFrom(const char *aString, char aTerminatorChar)
 {

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -436,7 +436,7 @@ Error Server::SetDomain(const char *aDomain)
 
         memcpy(buf, aDomain, length);
         buf[length]     = '.';
-        buf[length + 1] = '\0';
+        buf[length + 1] = kNullChar;
 
         error = mDomain.Set(buf);
     }

--- a/src/core/utils/parse_cmdline.cpp
+++ b/src/core/utils/parse_cmdline.cpp
@@ -63,10 +63,10 @@ Error ParseCmd(char *aCommandString, Arg aArgs[], uint8_t aArgsMaxLength)
         }
         else if (IsSeparator(*cmd))
         {
-            *cmd = '\0';
+            *cmd = kNullChar;
         }
 
-        if ((*cmd != '\0') && ((index == 0) || (*(cmd - 1) == '\0')))
+        if ((*cmd != kNullChar) && ((index == 0) || (*(cmd - 1) == kNullChar)))
         {
             if (index == aArgsMaxLength - 1)
             {
@@ -136,7 +136,7 @@ Error ParseAsUint64(const char *aString, uint64_t &aUint64)
         VerifyOrExit(newValue >= value, error = kErrorInvalidArgs);
         value = newValue;
         cur++;
-    } while (*cur != '\0');
+    } while (*cur != kNullChar);
 
     aUint64 = value;
 


### PR DESCRIPTION
This change replaces all instances of the null character literal '\0' with the `kNullChar` constant throughout the `src/core/` files. This improves code readability and consistency, making the intent of the code more explicit.