### PR TITLE
[border-router] rename `RxRaTracker` callback for clarity

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -724,14 +724,15 @@ exit:
     return;
 }
 
-void RoutingManager::HandleRaPrefixTableChanged(void)
+void RoutingManager::HandleRxRaTrackerDecisionFactorChanged(void)
 {
     // This is a callback from `RxRaTracker` indicating that
-    // there has been a change in the table.
+    // there has been a change impacting one of the decision
+    // factors.
 
     VerifyOrExit(mIsRunning);
 
-    mOnLinkPrefixManager.HandleRaPrefixTableChanged();
+    mOnLinkPrefixManager.HandleRxRaTrackerChanged();
     mRoutePublisher.Evaluate();
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
     mMultiAilDetector.Evaluate();
@@ -1579,7 +1580,7 @@ bool RoutingManager::OnLinkPrefixManager::IsInitalEvaluationDone(void) const
     return (mAilPrefix.GetLength() != 0 || IsPublishingOrAdvertising());
 }
 
-void RoutingManager::OnLinkPrefixManager::HandleRaPrefixTableChanged(void)
+void RoutingManager::OnLinkPrefixManager::HandleRxRaTrackerChanged(void)
 {
     // This is a callback from `RxRaTracker` indicating that
     // there has been a change in the table. If the favored on-link

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -767,7 +767,7 @@ private:
         const Ip6::Prefix &GetFavoredPrefix(void) const { return mFavoredPrefix; }
         bool               AddressMatchesLocalPrefix(const Ip6::Address &aAddress) const;
         bool               IsInitalEvaluationDone(void) const;
-        void               HandleRaPrefixTableChanged(void);
+        void               HandleRxRaTrackerChanged(void);
         bool               ShouldPublishUlaRoute(void) const;
         Error              AppendAsPiosTo(RouterAdvert::TxMessage &aRaMessage);
         void               HandleNetDataChange(void);
@@ -1157,7 +1157,7 @@ private:
     void HandleNeighborAdvertisement(const InfraIf::Icmp6Packet &aPacket);
     bool NetworkDataContainsUlaRoute(void) const;
 
-    void HandleRaPrefixTableChanged(void);
+    void HandleRxRaTrackerDecisionFactorChanged(void);
     void HandleLocalOnLinkPrefixChanged(void);
 
     static bool IsValidBrUlaPrefix(const Ip6::Prefix &aBrUlaPrefix);

--- a/src/core/border_router/rx_ra_tracker.cpp
+++ b/src/core/border_router/rx_ra_tracker.cpp
@@ -804,7 +804,7 @@ exit:
 
 void RxRaTracker::HandleExpirationTimer(void) { Evaluate(); }
 
-void RxRaTracker::HandleSignalTask(void) { Get<RoutingManager>().HandleRaPrefixTableChanged(); }
+void RxRaTracker::HandleSignalTask(void) { Get<RoutingManager>().HandleRxRaTrackerDecisionFactorChanged(); }
 
 void RxRaTracker::HandleRdnssAddrTask(void) { mRdnssCallback.InvokeIfSet(); }
 


### PR DESCRIPTION
Renames the callback used by `RxRaTracker` to inform `RoutingManager` to `HandleRxRaTrackerDecisionFactorChanged()`.

This name more accurately reflects the triggering condition, as the callback is invoked whenever any of the "decision factors" change, not just when the on-link prefix table is updated.

For consistency, the related method in `OnLinkPrefixManager` is also renamed to `HandleRxRaTrackerChanged()`.