### PR TITLE
[mle] prevent router eligibility for 90s after restoring as an FTD child

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1829,21 +1829,24 @@ private:
         bool  IsRestoringChildRole(void) const { return mState == kRestoringChildRole; }
         bool  IsRestoringRouterOrLeaderRole(void) const { return mState == kRestoringRouterOrLeaderRole; }
         void  HandleTimer(void);
+        void  HandleChildRestored(void);
 
         void               GenerateRandomChallenge(void) { mChallenge.GenerateRandom(); }
         const TxChallenge &GetChallenge(void) const { return mChallenge; }
 
     private:
-        static constexpr uint32_t kMaxStartDelay                = 25;
-        static constexpr uint8_t  kMaxChildUpdatesToRestoreRole = kMaxChildKeepAliveAttempts;
-        static constexpr uint32_t kChildUpdateRetxDelay         = kUnicastRetxDelay; /// 1000 msec
-        static constexpr uint16_t kRetxJitter                   = 5;
+        static constexpr uint32_t kMaxStartDelay                    = 25;
+        static constexpr uint8_t  kMaxChildUpdatesToRestoreRole     = kMaxChildKeepAliveAttempts;
+        static constexpr uint32_t kChildUpdateRetxDelay             = kUnicastRetxDelay; /// 1000 msec
+        static constexpr uint16_t kRetxJitter                       = 5;
+        static constexpr uint16_t kChildRestoredRouterEligibleDelay = 90000; // in ms
 
         enum State : uint8_t
         {
             kIdle,
             kRestoringChildRole,
             kRestoringRouterOrLeaderRole,
+            kChildRestoredRouterDelay,
         };
 
         void SetState(State aState);


### PR DESCRIPTION
These changes help to clean up the reset process by making FTD children avoid becoming routers for 90s after successfully restoring their role to their previous parent.

This only takes effect when the child successfully restores it's connection to the same parent that it had prior to the reset. In this case, it implies that at least that parent router is available in the network to serve other possible children within it's range, if necessary, during the limited 90s window.