### PR TITLE
[mle] prevent router eligibility for 90s after restoring as an FTD child

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -4281,7 +4281,7 @@ void Mle::PrevRoleRestorer::HandleTimer(void)
 {
     VerifyOrExit(mState != kIdle);
 
-#if OPENTRHEAD_FTD
+#if OPENTHREAD_FTD
     if (mState == kChildRestoredRouterDelay)
     {
         Get<Mle>().SetRouterEligible(true);
@@ -4331,7 +4331,7 @@ void Mle::PrevRoleRestorer::SendChildUpdate(void)
 
 void  Mle::PrevRoleRestorer::HandleChildRestored(void)
 {
-#if OPENTRHEAD_FTD
+#if OPENTHREAD_FTD
     if (IsRestoringChildRole())
     {
         mState = kChildRestoredRouterDelay;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1839,7 +1839,7 @@ private:
         static constexpr uint8_t  kMaxChildUpdatesToRestoreRole     = kMaxChildKeepAliveAttempts;
         static constexpr uint32_t kChildUpdateRetxDelay             = kUnicastRetxDelay; /// 1000 msec
         static constexpr uint16_t kRetxJitter                       = 5;
-        static constexpr uint16_t kChildRestoredRouterEligibleDelay = 90000; // in ms
+        static constexpr uint32_t kChildRestoredRouterEligibleDelay = 90000; // in ms
 
         enum State : uint8_t
         {


### PR DESCRIPTION
These changes help to clean up the reset process by making FTD children avoid becoming routers for 90s after successfully restoring their role to their previous parent.

This only takes effect when the child successfully restores it's connection to the same parent that it had prior to the reset. In this case, it implies that at least that parent router is available in the network to serve other possible children within it's range, if necessary, during the limited 90s window.