### PR TITLE
[dns-client] add destructor to ensure proper cleanup

### DIFF
--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -675,6 +675,11 @@ public:
     explicit Client(Instance &aInstance);
 
     /**
+     * Destructor of `Client`
+     */
+    ~Client(void) { Stop(); }
+
+    /**
      * Starts the DNS client.
      *
      * @retval kErrorNone     Successfully started the DNS client.


### PR DESCRIPTION
Adds a destructor to the `Dns::Client` class to ensure that `Stop()` is called when a `Client` object is destroyed (freeing all allocated queries).

This change prevents false memory leak reports from fuzzer tests when an `ot::Instance` is destroyed during ongoing DNS queries (retries).