### PR TITLE
[nat64] remove TODO comment for NAT64 prefix publisher check

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -2501,9 +2501,6 @@ void RoutingManager::Nat64PrefixManager::Evaluate(void)
     //   by this BR.
     // - The preferred NAT64 prefix in Network Data is same as the
     //   discovered infrastructure prefix.
-    //
-    // TODO: change to check RLOC16 to determine if the NAT64 prefix
-    // was published by this BR.
 
     shouldPublish =
         ((error == kErrorNotFound) || (netdataPrefixConfig.mPreference < preference) ||


### PR DESCRIPTION
This PR removes a misleading TODO comment in the NAT64 prefix manager.

The TODO suggested changing the NAT64 prefix publisher check to use the RLOC16 of the entry in the Network Data. However, this approach is flawed in scenarios with multiple Border Routers.

When multiple BRs publish the same NAT64 prefix with the same preference, `FindPreferredNat64Prefix()` may return an entry published by a different BR. An RLOC16 check would then incorrectly cause the current BR to believe it did not publish the prefix, potentially leading it to withdraw its entry and cause network instability.