### PR TITLE
[border-router] conditionally compile NAT64 `InfrIf` methods

### DIFF
--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -106,29 +106,23 @@ exit:
     }
 }
 
+#if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
+
 Error InfraIf::DiscoverNat64Prefix(void) const
 {
     OT_ASSERT(mInitialized);
 
-#if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
     return otPlatInfraIfDiscoverNat64Prefix(mIfIndex);
-#else
-    return kErrorNotImplemented;
-#endif
 }
 
 void InfraIf::DiscoverNat64PrefixDone(uint32_t aIfIndex, const Ip6::Prefix &aPrefix)
 {
     Error error = kErrorNone;
 
-    OT_UNUSED_VARIABLE(aPrefix);
-
     VerifyOrExit(mInitialized && mIsRunning, error = kErrorInvalidState);
     VerifyOrExit(aIfIndex == mIfIndex, error = kErrorInvalidArgs);
 
-#if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
     Get<RoutingManager>().HandleDiscoverNat64PrefixDone(aPrefix);
-#endif
 
 exit:
     if (error != kErrorNone)
@@ -136,6 +130,8 @@ exit:
         LogDebg("Failed to handle discovered NAT64 synthetic addresses: %s", ErrorToString(error));
     }
 }
+
+#endif // OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
 
 Error InfraIf::GetLinkLayerAddress(LinkLayerAddress &aLinkLayerAddress)
 {
@@ -233,7 +229,13 @@ extern "C" void otPlatInfraIfDiscoverNat64PrefixDone(otInstance        *aInstanc
                                                      uint32_t           aInfraIfIndex,
                                                      const otIp6Prefix *aIp6Prefix)
 {
+#if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
     AsCoreType(aInstance).Get<InfraIf>().DiscoverNat64PrefixDone(aInfraIfIndex, AsCoreType(aIp6Prefix));
+#else
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aInfraIfIndex);
+    OT_UNUSED_VARIABLE(aIp6Prefix);
+#endif
 }
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_ENABLE

--- a/src/core/border_router/infra_if.hpp
+++ b/src/core/border_router/infra_if.hpp
@@ -171,6 +171,7 @@ public:
      */
     void HandledReceived(uint32_t aIfIndex, const Ip6::Address &aSource, const Icmp6Packet &aPacket);
 
+#if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
     /**
      * Sends a request to discover the NAT64 prefix on the infrastructure interface.
      *
@@ -188,6 +189,7 @@ public:
      * @param[in]  aPrefix     The NAT64 prefix on the infrastructure link.
      */
     void DiscoverNat64PrefixDone(uint32_t aIfIndex, const Ip6::Prefix &aPrefix);
+#endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_ENABLE
 


### PR DESCRIPTION
This change makes the NAT64-related method in `InfraIf` conditionally compiled based on the configuration
`OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE`.

The methods `DiscoverNat64Prefix()`, `DiscoverNat64PrefixDone()`, and are now entirely excluded from the build when NAT64 border routing is disabled.