### PR TITLE
[border-router] move `InfraIf` from `RoutingManager` to `Instance`

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -54,7 +54,6 @@ RoutingManager::RoutingManager(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mIsRunning(false)
     , mIsEnabled(false)
-    , mInfraIf(aInstance)
     , mOmrPrefixManager(aInstance)
     , mRioAdvertiser(aInstance)
     , mOnLinkPrefixManager(aInstance)
@@ -80,10 +79,10 @@ Error RoutingManager::Init(uint32_t aInfraIfIndex, bool aInfraIfIsRunning)
 
     VerifyOrExit(GetState() == kStateUninitialized || GetState() == kStateDisabled, error = kErrorInvalidState);
 
-    if (!mInfraIf.IsInitialized())
+    if (!Get<InfraIf>().IsInitialized())
     {
         LogInfo("Initializing - InfraIfIndex:%lu", ToUlong(aInfraIfIndex));
-        SuccessOrExit(error = mInfraIf.Init(aInfraIfIndex));
+        SuccessOrExit(error = Get<InfraIf>().Init(aInfraIfIndex));
         SuccessOrExit(error = LoadOrGenerateRandomBrUlaPrefix());
         mOmrPrefixManager.Init(mBrUlaPrefix);
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
@@ -91,35 +90,38 @@ Error RoutingManager::Init(uint32_t aInfraIfIndex, bool aInfraIfIsRunning)
 #endif
         mOnLinkPrefixManager.Init();
     }
-    else if (aInfraIfIndex != mInfraIf.GetIfIndex())
+    else if (aInfraIfIndex != Get<InfraIf>().GetIfIndex())
     {
-        LogInfo("Reinitializing - InfraIfIndex:%lu -> %lu", ToUlong(mInfraIf.GetIfIndex()), ToUlong(aInfraIfIndex));
+        LogInfo("Reinitializing - InfraIfIndex:%lu -> %lu", ToUlong(Get<InfraIf>().GetIfIndex()),
+                ToUlong(aInfraIfIndex));
 
 #if OPENTHREAD_CONFIG_MULTICAST_DNS_ENABLE && OPENTHREAD_CONFIG_MULTICAST_DNS_AUTO_ENABLE_ON_INFRA_IF
-        IgnoreError(Get<Dns::Multicast::Core>().SetEnabled(false, mInfraIf.GetIfIndex()));
+        IgnoreError(Get<Dns::Multicast::Core>().SetEnabled(false, Get<InfraIf>().GetIfIndex()));
 #endif
 
-        mInfraIf.SetIfIndex(aInfraIfIndex);
+        Get<InfraIf>().SetIfIndex(aInfraIfIndex);
     }
 
-    error = mInfraIf.HandleStateChanged(mInfraIf.GetIfIndex(), aInfraIfIsRunning);
+    error = Get<InfraIf>().HandleStateChanged(Get<InfraIf>().GetIfIndex(), aInfraIfIsRunning);
 
 exit:
     if (error != kErrorNone)
     {
-        mInfraIf.Deinit();
+        Get<InfraIf>().Deinit();
     }
 
     return error;
 }
+
+bool RoutingManager::IsInitialized(void) const { return Get<InfraIf>().IsInitialized(); }
 
 Error RoutingManager::GetInfraIfInfo(uint32_t &aInfraIfIndex, bool &aInfraIfIsRunning) const
 {
     Error error = kErrorNone;
 
     VerifyOrExit(IsInitialized(), error = kErrorInvalidState);
-    aInfraIfIndex     = mInfraIf.GetIfIndex();
-    aInfraIfIsRunning = mInfraIf.IsRunning();
+    aInfraIfIndex     = Get<InfraIf>().GetIfIndex();
+    aInfraIfIsRunning = Get<InfraIf>().IsRunning();
 
 exit:
     return error;
@@ -288,7 +290,7 @@ exit:
 
 void RoutingManager::EvaluateState(void)
 {
-    if (mIsEnabled && Get<Mle::Mle>().IsAttached() && mInfraIf.IsRunning())
+    if (mIsEnabled && Get<Mle::Mle>().IsAttached() && Get<InfraIf>().IsRunning())
     {
         Start();
     }
@@ -632,18 +634,18 @@ void RoutingManager::SendRouterAdvertisement(RouterAdvTxMode aRaTxMode)
 
     mTxRaInfo.IncrementTxCountAndSaveHash(packet);
 
-    SuccessOrExit(error = mInfraIf.Send(packet, destAddress));
+    SuccessOrExit(error = Get<InfraIf>().Send(packet, destAddress));
 
     mTxRaInfo.mLastTxTime = TimerMilli::GetNow();
     Get<Ip6::Ip6>().GetBorderRoutingCounters().mRaTxSuccess++;
-    LogInfo("Sent RA on %s", mInfraIf.ToString().AsCString());
+    LogInfo("Sent RA on %s", Get<InfraIf>().ToString().AsCString());
     DumpDebg("[BR-CERT] direction=send | type=RA |", packet.GetBytes(), packet.GetLength());
 
 exit:
     if (error != kErrorNone)
     {
         Get<Ip6::Ip6>().GetBorderRoutingCounters().mRaTxFailure++;
-        LogWarn("Failed to send RA on %s: %s", mInfraIf.ToString().AsCString(), ErrorToString(error));
+        LogWarn("Failed to send RA on %s: %s", Get<InfraIf>().ToString().AsCString(), ErrorToString(error));
     }
 }
 
@@ -658,7 +660,7 @@ void RoutingManager::HandleRouterSolicit(const InfraIf::Icmp6Packet &aPacket, co
     OT_UNUSED_VARIABLE(aSrcAddress);
 
     Get<Ip6::Ip6>().GetBorderRoutingCounters().mRsRx++;
-    LogInfo("Received RS from %s on %s", aSrcAddress.ToString().AsCString(), mInfraIf.ToString().AsCString());
+    LogInfo("Received RS from %s on %s", aSrcAddress.ToString().AsCString(), Get<InfraIf>().ToString().AsCString());
 
     ScheduleRoutingPolicyEvaluation(kToReplyToRs);
 }
@@ -687,13 +689,13 @@ void RoutingManager::HandleRouterAdvertisement(const InfraIf::Icmp6Packet &aPack
 
     Get<Ip6::Ip6>().GetBorderRoutingCounters().mRaRx++;
 
-    if (mInfraIf.HasAddress(aSrcAddress))
+    if (Get<InfraIf>().HasAddress(aSrcAddress))
     {
         raOrigin =
             mTxRaInfo.IsRaFromManager(raMsg) ? RxRaTracker::kThisBrRoutingManager : RxRaTracker::kThisBrOtherEntity;
     }
 
-    LogInfo("Received RA from %s on %s %s", aSrcAddress.ToString().AsCString(), mInfraIf.ToString().AsCString(),
+    LogInfo("Received RA from %s on %s %s", aSrcAddress.ToString().AsCString(), Get<InfraIf>().ToString().AsCString(),
             RouterAdvOriginToString(raOrigin));
 
     DumpDebg("[BR-CERT] direction=recv | type=RA |", aPacket.GetBytes(), aPacket.GetLength());
@@ -2596,7 +2598,7 @@ void RoutingManager::Nat64PrefixManager::HandleTimer(void)
 
 void RoutingManager::Nat64PrefixManager::Discover(void)
 {
-    Error error = Get<RoutingManager>().mInfraIf.DiscoverNat64Prefix();
+    Error error = Get<InfraIf>().DiscoverNat64Prefix();
 
     if (error == kErrorNone)
     {

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1104,7 +1104,7 @@ private:
     void  Start(void);
     void  Stop(void);
     void  HandleNotifierEvents(Events aEvents);
-    bool  IsInitialized(void) const { return mInfraIf.IsInitialized(); }
+    bool  IsInitialized(void) const;
     bool  IsEnabled(void) const { return mIsEnabled; }
     Error LoadOrGenerateRandomBrUlaPrefix(void);
 
@@ -1136,8 +1136,6 @@ private:
     // Indicates whether the Routing manager is enabled. The Routing
     // Manager will be stopped if we are disabled.
     bool mIsEnabled;
-
-    InfraIf mInfraIf;
 
     // The /48 BR ULA prefix loaded from local persistent storage or
     // randomly generated if none is found in persistent storage.

--- a/src/core/border_router/rx_ra_tracker.cpp
+++ b/src/core/border_router/rx_ra_tracker.cpp
@@ -928,7 +928,7 @@ void RxRaTracker::SendNeighborSolicitToRouter(const Router &aRouter)
 
     nsMsg.GetAsPacket(packet);
 
-    IgnoreError(Get<RoutingManager>().mInfraIf.Send(packet, aRouter.mAddress));
+    IgnoreError(Get<InfraIf>().Send(packet, aRouter.mAddress));
 
     LogInfo("Sent Neighbor Solicitation to %s - attempt:%u/%u", aRouter.mAddress.ToString().AsCString(),
             aRouter.mNsProbeCount, Router::kMaxNsProbes);
@@ -1519,7 +1519,7 @@ Error RxRaTracker::RsSender::SendRs(void)
     rsMsg.GetAsPacket(packet);
     destAddress.SetToLinkLocalAllRoutersMulticast();
 
-    error = Get<RoutingManager>().mInfraIf.Send(packet, destAddress);
+    error = Get<InfraIf>().Send(packet, destAddress);
 
     if (error == kErrorNone)
     {

--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -271,6 +271,7 @@ Instance::Instance(void)
     , mAnnounceSender(*this)
 #endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    , mInfraIf(*this)
     , mRxRaTracker(*this)
     , mRoutingManager(*this)
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -75,6 +75,7 @@
 #include "backbone_router/bbr_local.hpp"
 #include "backbone_router/bbr_manager.hpp"
 #include "border_router/dhcp6_pd_client.hpp"
+#include "border_router/infra_if.hpp"
 #include "border_router/routing_manager.hpp"
 #include "border_router/rx_ra_tracker.hpp"
 #include "coap/coap_secure.hpp"
@@ -718,6 +719,7 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    BorderRouter::InfraIf        mInfraIf;
     BorderRouter::RxRaTracker    mRxRaTracker;
     BorderRouter::RoutingManager mRoutingManager;
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
@@ -1103,9 +1105,9 @@ template <> inline LinkMetrics::Subject &Instance::Get(void) { return mSubject; 
 #endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+template <> inline BorderRouter::InfraIf        &Instance::Get(void) { return mInfraIf; }
 template <> inline BorderRouter::RxRaTracker    &Instance::Get(void) { return mRxRaTracker; }
 template <> inline BorderRouter::RoutingManager &Instance::Get(void) { return mRoutingManager; }
-template <> inline BorderRouter::InfraIf        &Instance::Get(void) { return mRoutingManager.mInfraIf; }
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
 template <> inline BorderRouter::NetDataBrTracker &Instance::Get(void) { return mNetDataBrTracker; }
 #endif


### PR DESCRIPTION
This commit moves the `InfraIf` member from `RoutingManager` to be owned directly by the `Instance`.

This change aligns the ownership of `InfraIf` with other core components and simplifies dependencies. Decoupling `InfraIf` from `RoutingManager` allows it to be accessed separately.