### PR TITLE
[cli] Added CLI to generate one time passcode

### DIFF
--- a/include/openthread/border_agent.h
+++ b/include/openthread/border_agent.h
@@ -407,6 +407,12 @@ const otBorderAgentCounters *otBorderAgentGetCounters(otInstance *aInstance);
 #define OT_BORDER_AGENT_MAX_EPHEMERAL_KEY_TIMEOUT (10 * 60 * 1000u)
 
 /**
+ * Fixed length of the Thread Administration Sharing One-Time Passcode (TAP) string.
+ * This includes the 9-digit passcode and a null termination character.
+ */
+#define OT_BORDER_AGENT_EPHEMERAL_TAP_STR_LENGTH (10)
+
+/**
  * Represents Border Agent's Ephemeral Key Manager state.
  */
 typedef enum otBorderAgentEphemeralKeyState
@@ -545,6 +551,25 @@ void otBorderAgentEphemeralKeySetCallback(otInstance                       *aIns
  * @returns Human-readable string corresponding to @p aState.
  */
 const char *otBorderAgentEphemeralKeyStateToString(otBorderAgentEphemeralKeyState aState);
+
+/**
+ * Generates a Thread Administration One-Time Passcode (TAP) and starts using the TAP as the ephemeral key.
+ *
+ * This function generates an 8-digit random number, appends a Verhoeff checksum
+ * as the 9th digit to create a 9-digit TAP, and automatically starts the ephemeral
+ * key with the generated passcode.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ * @param[out] aTap       A pointer to buffer to store the generated TAP string.
+ *                        Length of the buffer needing to be >= OT_BORDER_AGENT_EPHEMERAL_TAP_STR_LENGTH.
+ * @param[in]  aTimeout   Timeout in milliseconds (0 for default).
+ * @param[in]  aUdpPort   UDP port (0 for default).
+ *
+ * @retval OT_ERROR_NONE          Successfully generated TAP and started ephemeral key.
+ * @retval OT_ERROR_INVALID_ARGS  Invalid arguments provided.
+ * @retval OT_ERROR_FAILED        Failed to generate TAP or start ephemeral key.
+ */
+otError otBorderAgentGenerateTapAndKeyStart(otInstance *aInstance, char *aTap, uint32_t aTimeout, uint16_t aUdpPort);
 
 /**
  * @}

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -529,6 +529,33 @@ Done
 Done
 ```
 
+### ba ephemeralkey tap-start \[timeout\] \[port\]
+
+Generate a 9-digit Thread Administration One-Time Passcode (TAP) and start the ephemeral key service.
+
+This command generates a cryptographically secure 9-digit passcode consisting of:
+- An 8-digit random number
+- A Verhoeff checksum digit as the 9th digit for validation
+
+The generated TAP is automatically used to start the ephemeral key service, enabling secure commissioning without requiring a pre-shared key.
+
+**Parameters:**
+- `timeout` (optional): Timeout in milliseconds for the ephemeral key session. If not specified, the default timeout is used.
+- `port` (optional): UDP port for the ephemeral key service. If not specified, the default port is used.
+
+**Usage Notes:**
+- The generated 9-digit TAP is displayed and can be shared with commissioners for secure device onboarding
+- The Verhoeff checksum provides error detection for manual entry of the passcode
+- The ephemeral key service must be enabled before using this command (`ba ephemeralkey enable`)
+- Use `ba ephemeralkey state` to check the current status of the ephemeral key service
+- Use `ba ephemeralkey stop` to terminate the ephemeral key session
+
+```bash
+> ba ephemeralkey tap-start 5000 49155
+156429873
+Done
+```
+
 ### ba ephemeralkey stop
 
 Stops the ephemeral key use and disconnects any session using it.
@@ -3224,7 +3251,6 @@ Tears down the P2P link identified by the extended address.
 > p2p unlink dead00beef00cafe
 Done
 ```
-
 ### panid
 
 Get the IEEE 802.15.4 PAN ID value.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -657,6 +657,39 @@ template <> otError Interpreter::Process<Cmd("ba")>(Arg aArgs[])
             error = otBorderAgentEphemeralKeyStart(GetInstancePtr(), aArgs[2].GetCString(), timeout, port);
         }
         /**
+         * @cli ba ephemeralkey tap-start [timeout-in-msec] [port]
+         * @code
+         * ba ephemeralkey tap-start 5000 1234
+         * 156429873
+         * Done
+         * @endcode
+         * @cparam ba ephemeralkey tap-start [@ca{timeout-in-msec}] [@ca{port}]
+         * @par api_copy
+         * #otBorderAgentGenerateTapAndKeyStart
+         */
+        else if (aArgs[1] == "tap-start")
+        {
+            char     tap[OT_BORDER_AGENT_EPHEMERAL_TAP_STR_LENGTH]; // 9 digits + null terminator
+            uint32_t timeout = 0;
+            uint16_t port    = 0;
+
+
+            if (!aArgs[2].IsEmpty())
+            {
+                SuccessOrExit(error = aArgs[2].ParseAsUint32(timeout));
+            }
+
+            if (!aArgs[3].IsEmpty())
+            {
+                SuccessOrExit(error = aArgs[3].ParseAsUint16(port));
+            }
+
+            SuccessOrExit(error = otBorderAgentGenerateTapAndKeyStart(GetInstancePtr(), tap, timeout, port));
+
+            // Output the generated TAP
+            OutputLine("%s", tap);
+        }
+        /**
          * @cli ba ephemeralkey stop
          * @code
          * ba ephemeralkey stop

--- a/src/core/api/border_agent_api.cpp
+++ b/src/core/api/border_agent_api.cpp
@@ -165,6 +165,11 @@ const char *otBorderAgentEphemeralKeyStateToString(otBorderAgentEphemeralKeyStat
     return MeshCoP::BorderAgent::EphemeralKeyManager::StateToString(MapEnum(aState));
 }
 
+otError otBorderAgentGenerateTapAndKeyStart(otInstance *aInstance, char *aTap, uint32_t aTimeout, uint16_t aUdpPort)
+{
+    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent::EphemeralKeyManager>().GenerateTapAndKeyStart(aTap, aTimeout, aUdpPort);
+}
+
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
 
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE

--- a/src/core/meshcop/border_agent_ephemeral_key.hpp
+++ b/src/core/meshcop/border_agent_ephemeral_key.hpp
@@ -162,6 +162,20 @@ public:
      */
     static const char *StateToString(State aState);
 
+    /**
+     * Generates a TAP and starts using the TAP as the ephemeral key.
+     *
+     * @param[out] aTap      Buffer to store generated TAP.
+     *                       Length of the buffer needing to be >= OT_BORDER_AGENT_EPHEMERAL_TAP_STR_LENGTH.
+     * @param[in]  aTimeout  Timeout in milliseconds.
+     * @param[in]  aUdpPort  UDP port.
+     *
+     * @retval kErrorNone           Successfully generated TAP and started ephemeral key.
+     * @retval kErrorFailed         Failed to generate TAP or start ephemeral key.
+     * @retval kErrorInvalidState   A previously set ephemeral key is still in use or feature is disabled.
+     */
+     Error GenerateTapAndKeyStart(char *aTap, uint32_t aTimeout, uint16_t aUdpPort);
+
 private:
     static constexpr uint16_t kMaxConnectionAttempts = 10;
 


### PR DESCRIPTION
 - Added CLI to generate 9 digit one time passcode from openthread stack only which is required to generate ePSKC for thread harness test DH 12.3