### PR TITLE
[mdns] add validation for DNS names in mDNS APIs

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (541)
+#define OPENTHREAD_API_VERSION (542)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/mdns.h
+++ b/include/openthread/mdns.h
@@ -309,6 +309,7 @@ otError otMdnsSetLocalHostName(otInstance *aInstance, const char *aName);
  *
  * @retval OT_ERROR_NONE            Successfully started registration. @p aCallback will report the outcome.
  * @retval OT_ERROR_INVALID_STATE   mDNS module is not enabled.
+ * @retval OT_ERROR_INVALID_ARGS    The name in @p aHost is invalid.
  */
 otError otMdnsRegisterHost(otInstance            *aInstance,
                            const otMdnsHost      *aHost,
@@ -333,6 +334,7 @@ otError otMdnsRegisterHost(otInstance            *aInstance,
  *
  * @retval OT_ERROR_NONE            Successfully unregistered host.
  * @retval OT_ERROR_INVALID_STATE   mDNS module is not enabled.
+ * @retval OT_ERROR_INVALID_ARGS    The name in @p aHost is invalid.
  */
 otError otMdnsUnregisterHost(otInstance *aInstance, const otMdnsHost *aHost);
 
@@ -372,6 +374,7 @@ otError otMdnsUnregisterHost(otInstance *aInstance, const otMdnsHost *aHost);
  *
  * @retval OT_ERROR_NONE            Successfully started registration. @p aCallback will report the outcome.
  * @retval OT_ERROR_INVALID_STATE   mDNS module is not enabled.
+ * @retval OT_ERROR_INVALID_ARGS    A name in @p aService (instance, service type, sub-types, or host) is not valid.
  */
 otError otMdnsRegisterService(otInstance            *aInstance,
                               const otMdnsService   *aService,
@@ -399,6 +402,7 @@ otError otMdnsRegisterService(otInstance            *aInstance,
  *
  * @retval OT_ERROR_NONE            Successfully unregistered service.
  * @retval OT_ERROR_INVALID_STATE   mDNS module is not enabled.
+ * @retval OT_ERROR_INVALID_ARGS    A name in @p aService (instance or service type) is not valid.
  */
 otError otMdnsUnregisterService(otInstance *aInstance, const otMdnsService *aService);
 
@@ -429,6 +433,7 @@ otError otMdnsUnregisterService(otInstance *aInstance, const otMdnsService *aSer
  *
  * @retval OT_ERROR_NONE            Successfully started registration. @p aCallback will report the outcome.
  * @retval OT_ERROR_INVALID_STATE   mDNS module is not enabled.
+ * @retval OT_ERROR_INVALID_ARGS    A name in @p aKey is not valid.
  */
 otError otMdnsRegisterKey(otInstance            *aInstance,
                           const otMdnsKey       *aKey,
@@ -457,6 +462,7 @@ otError otMdnsRegisterKey(otInstance            *aInstance,
  *
  * @retval OT_ERROR_NONE            Successfully unregistered key
  * @retval OT_ERROR_INVALID_STATE   mDNS module is not enabled.
+ * @retval OT_ERROR_INVALID_ARGS    A name in @p aKey is not valid.
  */
 otError otMdnsUnregisterKey(otInstance *aInstance, const otMdnsKey *aKey);
 

--- a/src/core/net/dns_types.cpp
+++ b/src/core/net/dns_types.cpp
@@ -746,6 +746,69 @@ exit:
     return error;
 }
 
+Error Name::ValidateLabel(const char *aLabel)
+{
+    Error    error = kErrorInvalidArgs;
+    uint16_t length;
+
+    VerifyOrExit(aLabel != nullptr);
+
+    length = StringLength(aLabel, kMaxLabelSize);
+    VerifyOrExit((0 < length) && (length <= kMaxLabelLength));
+    error = kErrorNone;
+
+exit:
+    return error;
+}
+
+Error Name::ValidateName(const char *aName)
+{
+    Error    error           = kErrorNone;
+    uint16_t index           = 0;
+    uint16_t labelStartIndex = 0;
+    char     ch;
+    uint16_t length;
+
+    VerifyOrExit(aName != nullptr, error = kErrorInvalidArgs);
+    length = StringLength(aName, kMaxNameSize);
+
+    VerifyOrExit(length > 0, error = kErrorInvalidArgs);
+    VerifyOrExit(length <= kMaxNameLength, error = kErrorInvalidArgs);
+
+    do
+    {
+        ch = aName[index];
+
+        if ((ch == kNullChar) || (ch == kLabelSeparatorChar))
+        {
+            length = index - labelStartIndex;
+
+            VerifyOrExit(length <= kMaxLabelLength, error = kErrorInvalidArgs);
+
+            if (length == 0)
+            {
+                // Empty label (e.g., consecutive dots) is invalid, but we
+                // allow for two cases: (1) where `aName` ends with a dot
+                // (`length` is zero but we are at end of `aName` string
+                // and `ch` is null char. (2) if `aName` is just "." (we
+                // see a dot at index 0, and index 1 is null char).
+
+                VerifyOrExit((ch == kNullChar) || ((index == 0) && (aName[1] == kNullChar)), error = kErrorInvalidArgs);
+                error = kErrorNone;
+                ExitNow();
+            }
+
+            labelStartIndex = index + 1;
+        }
+
+        index++;
+
+    } while (ch != kNullChar);
+
+exit:
+    return error;
+}
+
 bool Name::IsSubDomainOf(const char *aName, const char *aDomain)
 {
     bool     match             = false;

--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -1001,6 +1001,37 @@ public:
     }
 
     /**
+     * Validates a DNS label.
+     *
+     * A label must be between 1 and 63 (`kMaxLabelLength`) characters long.
+     *
+     * @param[in] aLabel   The string containing the label.
+     *
+     * @retval kErrorNone         The label is valid.
+     * @retval kErrorInvalidArgs  The label is not valid (e.g., is `nullptr`, empty, or too long).
+     */
+    static Error ValidateLabel(const char *aLabel);
+
+    /**
+     * Validates a DNS name.
+     *
+     * A DNS name is a sequence of labels separated by dots.
+     *
+     * This method validates the following rules:
+     * - The name string is not `nullptr`.
+     * - The total length of the name is between 1 and 254 (`kMaxNameLength`) characters.
+     * - Each label is at most 63 (`kMaxLabelLength`) characters long.
+     * - Empty labels (e.g., consecutive dots `..`) are disallowed, except for a single trailing dot `.` at the end of
+     *   the name, or if the name is just ".".
+     *
+     * @param[in] aName           The string containing the name.
+     *
+     * @retval kErrorNone         The name is valid.
+     * @retval kErrorInvalidArgs  The name is not valid.
+     */
+    static Error ValidateName(const char *aName);
+
+    /**
      * Tests if a DNS name is a sub-domain of a given domain.
      *
      * Both @p aName and @p aDomain can end without dot ('.').

--- a/src/core/net/mdns.hpp
+++ b/src/core/net/mdns.hpp
@@ -313,6 +313,7 @@ public:
      *
      * @retval kErrorNone          Successfully started registration. @p aCallback will report the outcome.
      * @retval kErrorInvalidState  mDNS module is not enabled.
+     * @retval kErrorInvalidArgs   The host name in @p aHost is not valid.
      */
     Error RegisterHost(const Host &aHost, RequestId aRequestId, RegisterCallback aCallback);
 
@@ -333,6 +334,7 @@ public:
      *
      * @retval kErrorNone           Successfully unregistered host.
      * @retval kErrorInvalidState   mDNS module is not enabled.
+     * @retval kErrorInvalidArgs    The host name in @p aHost is not valid.
      */
     Error UnregisterHost(const Host &aHost);
 
@@ -370,6 +372,7 @@ public:
      *
      * @retval kErrorNone           Successfully started registration. @p aCallback will report the outcome.
      * @retval kErrorInvalidState   mDNS module is not enabled.
+     * @retval kErrorInvalidArgs    A name in @p aService (instance, service type, sub-types, or host) is not valid.
      */
     Error RegisterService(const Service &aService, RequestId aRequestId, RegisterCallback aCallback);
 
@@ -393,6 +396,7 @@ public:
      *
      * @retval kErrorNone            Successfully unregistered service.
      * @retval kErrorInvalidState    mDNS module is not enabled.
+     * @retval kErrorInvalidArgs     A name in @p aService (instance, service type) is not valid.
      */
     Error UnregisterService(const Service &aService);
 
@@ -421,6 +425,7 @@ public:
      *
      * @retval kErrorNone            Successfully started registration. @p aCallback will report the outcome.
      * @retval kErrorInvalidState    mDNS module is not enabled.
+     * @retval kErrorInvalidArgs     A name in @p aKey is not valid.
      */
     Error RegisterKey(const Key &aKey, RequestId aRequestId, RegisterCallback aCallback);
 
@@ -445,6 +450,7 @@ public:
      *
      * @retval kErrorNone            Successfully unregistered key
      * @retval kErrorInvalidState    mDNS module is not enabled.
+     * @retval kErrorInvalidArgs     A name in @p aKey is not valid.
      */
     Error UnregisterKey(const Key &aKey);
 
@@ -2313,6 +2319,9 @@ private:
 
     void      AfterInstanceInit(void);
     Error     SetEnabled(bool aEnable, uint32_t aInfraIfIndex, Requester aRequester);
+    Error     ValidateHostName(const Host &aHost) const;
+    Error     ValidateServiceNames(const Service &aService, bool aCheckHostAndSubTypeLabels) const;
+    Error     ValidateKeyName(const Key &aKey) const;
     void      HandleInfraIfStateChanged(void);
     void      HandleHostAddressEvent(const Ip6::Address &aAddress, bool aAdded, uint32_t aInfraIfIndex);
     void      HandleHostAddressRemoveAll(uint32_t aInfraIfIndex);

--- a/tests/unit/test_dns.cpp
+++ b/tests/unit/test_dns.cpp
@@ -591,6 +591,37 @@ void TestDnsName(void)
     VerifyOrQuit(!dnsName.Matches("Name.With.Dot", "_srv._tcp", "local."));
     VerifyOrQuit(!dnsName.Matches("Name.With.Dot", "_srv._udp", "arpa."));
 
+    printf("----------------------------------------------------------------\n");
+    printf("Name::ValidateLabel\n");
+
+    SuccessOrQuit(Dns::Name::ValidateLabel("a"));
+    SuccessOrQuit(Dns::Name::ValidateLabel("hello"));
+    SuccessOrQuit(Dns::Name::ValidateLabel("012345678901234567890123456789012345678901234567890123456789012")); // 63
+    VerifyOrQuit(Dns::Name::ValidateLabel("0123456789012345678901234567890123456789012345678901234567890123") ==
+                 kErrorInvalidArgs);
+    VerifyOrQuit(Dns::Name::ValidateLabel("") == kErrorInvalidArgs);
+
+    SuccessOrQuit(Dns::Name::ValidateName("a"));
+    SuccessOrQuit(Dns::Name::ValidateName("a.b.c"));
+    SuccessOrQuit(Dns::Name::ValidateName("a.b.c."));
+    SuccessOrQuit(Dns::Name::ValidateName("a.b.012345678901234567890123456789012345678901234567890123456789012."));
+    SuccessOrQuit(Dns::Name::ValidateName("."));
+
+    // Empty labels
+    VerifyOrQuit(Dns::Name::ValidateName("") == kErrorInvalidArgs);
+    VerifyOrQuit(Dns::Name::ValidateName("a..b") == kErrorInvalidArgs);
+    VerifyOrQuit(Dns::Name::ValidateName(".a.b") == kErrorInvalidArgs);
+    VerifyOrQuit(Dns::Name::ValidateName("a.b..") == kErrorInvalidArgs);
+
+    // Long labels or names
+    VerifyOrQuit(Dns::Name::ValidateName("a.b.0123456789012345678901234567890123456789012345678901234567890123.") ==
+                 kErrorInvalidArgs);
+    VerifyOrQuit(Dns::Name::ValidateName("012345678901234567890123456789012345678901234567890123456789012."
+                                         "012345678901234567890123456789012345678901234567890123456789012."
+                                         "012345678901234567890123456789012345678901234567890123456789012."
+                                         "012345678901234567890123456789012345678901234567890123456789012") ==
+                 kErrorInvalidArgs);
+
     message->Free();
     testFreeInstance(instance);
 }


### PR DESCRIPTION
This commit adds `Dns::Name::ValidateName()` and `ValidateLabel()` helper methods to validate a DNS name or label.

These methods are used at the entry of the mDNS `Register*()` and `Unregister*()` public APIs to validate the provided host, service, and key names. This prevents issues with malformed names and improves the robustness of the mDNS module.

Includes unit tests for the new validation methods.