### PR TITLE
[netdata] add validation for incoming network data TLVs

### DIFF
--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -160,6 +160,18 @@ public:
     const uint8_t *GetBytes(void) const { return mTlvs; }
 
     /**
+     * Parses and validates all TLVs contained within the Network Data.
+     *
+     * Performs the following checks on all TLVs in the Network Data.
+     *  - Ensures correct TLV format and expected minimum length for known TLV types that can appear in Network Data.
+     *  - Validates sub-TLVs included in the known TLVs.
+     *
+     * @retval kErrorNone   Successfully validated all the TLVs in the Network Data.
+     * @retval kErrorParse  Network Data TLVs are not well-formed.
+     */
+    Error ValidateTlvs(void) const;
+
+    /**
      * Provides full or stable copy of the Thread Network Data.
      *
      * @param[in]     aType        The Network Data type to copy, the full set or stable subset.

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -453,13 +453,30 @@ Error Leader::SetNetworkData(uint8_t            aVersion,
                              const Message     &aMessage,
                              const OffsetRange &aOffsetRange)
 {
-    Error    error  = kErrorNone;
-    uint16_t length = aOffsetRange.GetLength();
+    Error   error = kErrorNone;
+    uint8_t oldData[kMaxSize];
+    uint8_t oldLength;
 
-    VerifyOrExit(length <= kMaxSize, error = kErrorParse);
-    SuccessOrExit(error = aMessage.Read(aOffsetRange.GetOffset(), GetBytes(), length));
+    VerifyOrExit(aOffsetRange.GetLength() <= kMaxSize, error = kErrorParse);
+    VerifyOrExit(aOffsetRange.GetEndOffset() <= aMessage.GetLength(), error = kErrorParse);
 
-    SetLength(static_cast<uint8_t>(length));
+    oldLength = sizeof(oldData);
+    IgnoreError(CopyNetworkData(kFullSet, oldData, oldLength));
+
+    aMessage.ReadBytes(aOffsetRange, GetBytes());
+    SetLength(static_cast<uint8_t>(aOffsetRange.GetLength()));
+
+    error = ValidateTlvs();
+
+    if (error != kErrorNone)
+    {
+        // Restores the old data back
+
+        memcpy(GetBytes(), oldData, oldLength);
+        SetLength(oldLength);
+        ExitNow();
+    }
+
     mVersion       = aVersion;
     mStableVersion = aStableVersion;
 


### PR DESCRIPTION
Introduces a new method `ValidateTlvs()` on `NetworkData` to perform structural validation of all TLVs within the network data.

This new validation is invoked from `Leader::SetNetworkData()` when receiving new network data. If the new data fails validation, it is rejected, and the previous network data is restored. This prevents a device from accepting and propagating malformed network data, which could lead to parsing errors or undefined behavior on devices.

The validation checks include:
- All TLVs and sub-TLVs are within the network data buffer bounds.
- Known TLV types like `PrefixTlv` and `ServiceTlv` are well-formed by calling their respective `IsValid()` methods.
- Container TLVs like `BorderRouterTlv` and `HasRouteTlv` have a length that is an exact multiple of their entry size.