### PR TITLE
[srp-client] use proportional jitter for retry timer

### DIFF
--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -1088,8 +1088,15 @@ exit:
         }
         else
         {
+            uint16_t retryJitter;
+
             LogRetryWaitInterval();
-            mTimer.Start(Random::NonCrypto::AddJitter(GetRetryWaitInterval(), kRetryIntervalJitter));
+
+            // Use a divisor of current retry interval for jitter
+            retryJitter = ClampToUint16(GetRetryWaitInterval() / kRetryJitterDivisor);
+            retryJitter = Max(retryJitter, kRetryIntervalJitter);
+            mTimer.Start(Random::NonCrypto::AddJitter(GetRetryWaitInterval(), retryJitter));
+
             GrowRetryWaitInterval();
             InvokeCallback(error);
         }

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -845,6 +845,7 @@ private:
 
     static constexpr uint16_t kTxFailureRetryJitter = 10;                                                      // in ms
     static constexpr uint16_t kRetryIntervalJitter  = OPENTHREAD_CONFIG_SRP_CLIENT_RETRY_WAIT_INTERVAL_JITTER; // in ms
+    static constexpr uint32_t kRetryJitterDivisor   = 5; // divisor for proportional jitter (1/N of retry interval)
 
     static_assert(kDefaultLease <= static_cast<uint32_t>(kMaxLease), "kDefaultLease is larger than max");
     static_assert(kDefaultKeyLease <= static_cast<uint32_t>(kMaxLease), "kDefaultKeyLease is larger than max");


### PR DESCRIPTION
This change updates the jitter calculation for the SRP client's retry mechanism.

Previously, a fixed jitter value was used. This could lead to synchronized retries from multiple clients, especially as the retry interval grows.

The new implementation calculates the jitter as a fraction of the current retry interval (1/5th), ensuring that the jitter scales with the wait time. This helps to better decorrelate retries from different clients.

A new constant `kRetryJitterDivisor` is introduced for this calculation. The jitter is clamped to a minimum value given by `kRetryIntervalJitter`.