### PR TITLE
[border-router] centralize infra-if management in `InfraIf`

### DIFF
--- a/include/openthread/border_routing.h
+++ b/include/openthread/border_routing.h
@@ -211,19 +211,18 @@ typedef enum
 /**
  * Initializes the Border Routing Manager on given infrastructure interface.
  *
- * @note  This method MUST be called before any other otBorderRouting* APIs.
- * @note  This method can be re-called to change the infrastructure interface, but the Border Routing Manager should be
- *        disabled first, and re-enabled after.
+ * This function MUST be called before any other otBorderRouting* APIs.
+ *
+ * This function can also be used to re-initialize and switch the infrastructure interface index to a new one.
+ * Switching the interface index will trigger all components running on the previous interface (Border Routing,
+ * mDNS, etc) to be stopped (as if the previous if-index is no longer running) before restarting operations on the
+ * new interface.
  *
  * @param[in]  aInstance          A pointer to an OpenThread instance.
  * @param[in]  aInfraIfIndex      The infrastructure interface index.
  * @param[in]  aInfraIfIsRunning  A boolean that indicates whether the infrastructure
- *                                interface is running.
  *
  * @retval  OT_ERROR_NONE           Successfully started the Border Routing Manager on given infrastructure.
- * @retval  OT_ERROR_INVALID_STATE  The Border Routing Manager is in a state other than disabled or uninitialized.
- * @retval  OT_ERROR_INVALID_ARGS   The index of the infrastructure interface is not valid.
- * @retval  OT_ERROR_FAILED         Internal failure. Usually due to failure in generating random prefixes.
  *
  * @sa otPlatInfraIfStateChanged.
  * @sa otBorderRoutingSetEnabled.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (544)
+#define OPENTHREAD_API_VERSION (545)
 
 /**
  * @addtogroup api-instance

--- a/src/core/api/border_routing_api.cpp
+++ b/src/core/api/border_routing_api.cpp
@@ -41,21 +41,28 @@ using namespace ot;
 
 otError otBorderRoutingInit(otInstance *aInstance, uint32_t aInfraIfIndex, bool aInfraIfIsRunning)
 {
-    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().Init(aInfraIfIndex, aInfraIfIsRunning);
+    AsCoreType(aInstance).Get<BorderRouter::InfraIf>().Init(aInfraIfIndex, aInfraIfIsRunning);
+
+    return kErrorNone;
 }
 
 otError otBorderRoutingGetInfraIfInfo(otInstance *aInstance, uint32_t *aInfraIfIndex, bool *aInfraIfIsRunning)
 {
-    bool isRunning;
+    Error error = kErrorNone;
 
     AssertPointerIsNotNull(aInfraIfIndex);
 
-    if (aInfraIfIsRunning == nullptr)
+    VerifyOrExit(AsCoreType(aInstance).Get<BorderRouter::InfraIf>().IsInitialized(), error = kErrorInvalidState);
+
+    *aInfraIfIndex = AsCoreType(aInstance).Get<BorderRouter::InfraIf>().GetIfIndex();
+
+    if (aInfraIfIsRunning != nullptr)
     {
-        aInfraIfIsRunning = &isRunning;
+        *aInfraIfIsRunning = AsCoreType(aInstance).Get<BorderRouter::InfraIf>().IsRunning();
     }
 
-    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetInfraIfInfo(*aInfraIfIndex, *aInfraIfIsRunning);
+exit:
+    return error;
 }
 
 otError otBorderRoutingSetEnabled(otInstance *aInstance, bool aEnabled)

--- a/src/core/border_router/infra_if.hpp
+++ b/src/core/border_router/infra_if.hpp
@@ -101,13 +101,15 @@ public:
     /**
      * Initializes the `InfraIf`.
      *
-     * @param[in]  aIfIndex        The infrastructure interface index.
+     * This method can also be used to re-initialize and switch the infrastructure interface index to a new one.
+     * Switching the interface index will trigger all components running on the previous interface (Border Routing,
+     * mDNS, etc) to be stopped (as if the previous if-index is no longer running) before restarting operations on the
+     * new interface.
      *
-     * @retval  kErrorNone         Successfully initialized the `InfraIf`.
-     * @retval  kErrorInvalidArgs  The index of the infra interface is not valid.
-     * @retval  kErrorInvalidState The `InfraIf` is already initialized.
+     * @param[in]  aInfraIfIndex      The infrastructure network interface index.
+     * @param[in]  aInfraIfIsRunning  A boolean that indicates whether the infrastructure interface is running.
      */
-    Error Init(uint32_t aIfIndex);
+    void Init(uint32_t aInfraIfIndex, bool aInfraIfIsRunning);
 
     /**
      * Deinitilaizes the `InfraIf`.

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -156,27 +156,9 @@ public:
     explicit RoutingManager(Instance &aInstance);
 
     /**
-     * Initializes the routing manager on given infrastructure interface.
-     *
-     * @param[in]  aInfraIfIndex      An infrastructure network interface index.
-     * @param[in]  aInfraIfIsRunning  A boolean that indicates whether the infrastructure
-     *                                interface is running.
-     *
-     * @retval  kErrorNone         Successfully started the routing manager.
-     * @retval  kErrorInvalidArgs  The index of the infra interface is not valid.
+     * Initializes the routing manager.
      */
-    Error Init(uint32_t aInfraIfIndex, bool aInfraIfIsRunning);
-
-    /**
-     * Gets the interface index of the currently configured infrastructure interface.
-     *
-     * @param[out] aInfraIfIndex      A reference to output the interface index.
-     * @param[out] aInfraIfIsRunning  A reference to output whether the interface is running.
-     *
-     * @retval kErrorNone           Successfully retrieved the interface information.
-     * @retval kErrorInvalidState   The Border Routing Manager is not initialized.
-     */
-    Error GetInfraIfInfo(uint32_t &aInfraIfIndex, bool &aInfraIfIsRunning) const;
+    void Init(void);
 
     /**
      * Enables/disables the Border Routing Manager.
@@ -1103,13 +1085,12 @@ private:
     //------------------------------------------------------------------------------------------------------------------
     // Methods
 
-    void  EvaluateState(void);
-    void  Start(void);
-    void  Stop(void);
-    void  HandleNotifierEvents(Events aEvents);
-    bool  IsInitialized(void) const;
-    bool  IsEnabled(void) const { return mIsEnabled; }
-    Error LoadOrGenerateRandomBrUlaPrefix(void);
+    void EvaluateState(void);
+    void Start(void);
+    void Stop(void);
+    void HandleNotifierEvents(Events aEvents);
+    bool IsEnabled(void) const { return mIsEnabled; }
+    void LoadOrGenerateRandomBrUlaPrefix(void);
 
     void EvaluateRoutingPolicy(void);
     bool IsInitialPolicyEvaluationDone(void) const;

--- a/tests/fuzz/cli.cpp
+++ b/tests/fuzz/cli.cpp
@@ -111,7 +111,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     otCliInit(&node.GetInstance(), CliOutput, nullptr);
 
-    node.GetInstance().Get<BorderRouter::RoutingManager>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
+    node.GetInstance().Get<BorderRouter::InfraIf>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
     node.GetInstance().Get<BorderRouter::RoutingManager>().SetEnabled(true);
     node.GetInstance().Get<Srp::Server>().SetAutoEnableMode(true);
     node.GetInstance().Get<BorderRouter::RoutingManager>().SetDhcp6PdEnabled(true);

--- a/tests/fuzz/icmp6.cpp
+++ b/tests/fuzz/icmp6.cpp
@@ -100,7 +100,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     node.GetInstance().SetLogLevel(kLogLevelInfo);
 
-    node.GetInstance().Get<BorderRouter::RoutingManager>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
+    node.GetInstance().Get<BorderRouter::InfraIf>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
     node.GetInstance().Get<BorderRouter::RoutingManager>().SetEnabled(true);
     node.GetInstance().Get<Srp::Server>().SetAutoEnableMode(true);
     node.GetInstance().Get<BorderRouter::RoutingManager>().SetDhcp6PdEnabled(true);

--- a/tests/fuzz/ip6.cpp
+++ b/tests/fuzz/ip6.cpp
@@ -112,7 +112,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     node.GetInstance().SetLogLevel(kLogLevelInfo);
 
-    node.GetInstance().Get<BorderRouter::RoutingManager>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
+    node.GetInstance().Get<BorderRouter::InfraIf>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
     node.GetInstance().Get<BorderRouter::RoutingManager>().SetEnabled(true);
     node.GetInstance().Get<Srp::Server>().SetAutoEnableMode(true);
     node.GetInstance().Get<BorderRouter::RoutingManager>().SetDhcp6PdEnabled(true);

--- a/tests/fuzz/mdns.cpp
+++ b/tests/fuzz/mdns.cpp
@@ -111,7 +111,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     node.GetInstance().SetLogLevel(kLogLevelInfo);
 
-    node.GetInstance().Get<BorderRouter::RoutingManager>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
+    node.GetInstance().Get<BorderRouter::InfraIf>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
     node.GetInstance().Get<BorderRouter::RoutingManager>().SetEnabled(true);
     node.GetInstance().Get<Srp::Server>().SetAutoEnableMode(true);
     node.GetInstance().Get<BorderRouter::RoutingManager>().SetDhcp6PdEnabled(true);

--- a/tests/fuzz/radio-one-node.cpp
+++ b/tests/fuzz/radio-one-node.cpp
@@ -110,7 +110,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     node.GetInstance().SetLogLevel(kLogLevelInfo);
 
-    node.GetInstance().Get<BorderRouter::RoutingManager>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
+    node.GetInstance().Get<BorderRouter::InfraIf>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
     node.GetInstance().Get<BorderRouter::RoutingManager>().SetEnabled(true);
     node.GetInstance().Get<Srp::Server>().SetAutoEnableMode(true);
     node.GetInstance().Get<BorderRouter::RoutingManager>().SetDhcp6PdEnabled(true);

--- a/tests/fuzz/trel.cpp
+++ b/tests/fuzz/trel.cpp
@@ -101,7 +101,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     node.GetInstance().SetLogLevel(kLogLevelInfo);
 
-    node.GetInstance().Get<BorderRouter::RoutingManager>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
+    node.GetInstance().Get<BorderRouter::InfraIf>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
     node.GetInstance().Get<BorderRouter::RoutingManager>().SetEnabled(true);
     node.GetInstance().Get<Srp::Server>().SetAutoEnableMode(true);
     node.GetInstance().Get<BorderRouter::RoutingManager>().SetDhcp6PdEnabled(true);


### PR DESCRIPTION
This change moves the management of the infrastructure interface state out of the `RoutingManager` and centralizes it within the `InfraIf` class. This makes `InfraIf` a more self-contained component and simplifies the logic in `RoutingManager`.

The `RoutingManager` now depends on an initialized `InfraIf`. Its `Init()` method is simplified and is now called from `InfraIf::Init()`.

The public API `otBorderRoutingInit()` now directly initializes the `InfraIf`. The `InfraIf::Init()` method is updated to support re-initialization, allowing to switch to a new interface. When switching, it ensures that components on the previous interface are stopped before restarting on the new one.