### PR TITLE
[border-router] manage `RxRaTracker` state via multiple requesters

### DIFF
--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -167,6 +167,7 @@ Error InfraIf::HandleStateChanged(uint32_t aIfIndex, bool aIsRunning)
 
     mIsRunning = aIsRunning;
 
+    Get<RxRaTracker>().HandleInfraIfStateChanged();
     Get<RoutingManager>().HandleInfraIfStateChanged();
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ADVERTISING_PROXY_ENABLE

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -260,7 +260,7 @@ void RoutingManager::Start(void)
         LogInfo("Starting");
 
         mIsRunning = true;
-        Get<RxRaTracker>().Start();
+        Get<RxRaTracker>().SetEnabled(true, RxRaTracker::kRequesterRoutingManager);
         mOnLinkPrefixManager.Start();
         mOmrPrefixManager.Start();
         mRoutePublisher.Start();
@@ -294,7 +294,7 @@ void RoutingManager::Stop(void)
 
     SendRouterAdvertisement(kInvalidateAllPrevPrefixes);
 
-    Get<RxRaTracker>().Stop();
+    Get<RxRaTracker>().SetEnabled(false, RxRaTracker::kRequesterRoutingManager);
 
     mTxRaInfo.mTxCount = 0;
 

--- a/src/core/border_router/rx_ra_tracker.cpp
+++ b/src/core/border_router/rx_ra_tracker.cpp
@@ -48,6 +48,9 @@ RegisterLogModule("BorderRouting");
 
 RxRaTracker::RxRaTracker(Instance &aInstance)
     : InstanceLocator(aInstance)
+    , mRoutingManagerEnabled(false)
+    , mMultiAilDetectorEnabled(false)
+    , mIsRunning(false)
     , mRsSender(aInstance)
     , mExpirationTimer(aInstance)
     , mStaleTimer(aInstance)
@@ -59,14 +62,50 @@ RxRaTracker::RxRaTracker(Instance &aInstance)
     mLocalRaHeader.Clear();
 }
 
+void RxRaTracker::SetEnabled(bool aEnable, Requester aRequester)
+{
+    switch (aRequester)
+    {
+    case kRequesterRoutingManager:
+        mRoutingManagerEnabled = aEnable;
+        break;
+    case kRequesterMultiAilDetector:
+        mMultiAilDetectorEnabled = aEnable;
+        break;
+    }
+
+    UpdateState();
+}
+
+void RxRaTracker::UpdateState(void)
+{
+    if ((mRoutingManagerEnabled || mMultiAilDetectorEnabled) && Get<InfraIf>().IsRunning())
+    {
+        Start();
+    }
+    else
+    {
+        Stop();
+    }
+}
+
 void RxRaTracker::Start(void)
 {
+    VerifyOrExit(!mIsRunning);
+    mIsRunning = true;
+
     mRsSender.Start();
     HandleNetDataChange();
+
+exit:
+    return;
 }
 
 void RxRaTracker::Stop(void)
 {
+    VerifyOrExit(mIsRunning);
+    mIsRunning = false;
+
     mRouters.Free();
     mIfAddresses.Free();
     mLocalRaHeader.Clear();
@@ -78,6 +117,9 @@ void RxRaTracker::Stop(void)
     mRdnssAddrTimer.Stop();
 
     mRsSender.Stop();
+
+exit:
+    return;
 }
 
 void RxRaTracker::HandleRsSenderFinished(TimeMilli aStartTime)

--- a/src/core/border_router/rx_ra_tracker.hpp
+++ b/src/core/border_router/rx_ra_tracker.hpp
@@ -74,6 +74,7 @@ class RxRaTracker : public InstanceLocator
 {
     friend class NetDataBrTracker;
     friend class ot::Notifier;
+    friend class InfraIf;
 
 public:
     /**
@@ -87,6 +88,15 @@ public:
     };
 
     /**
+     * Represents an entity requesting to enable/disable the `RxRaTracker`.
+     */
+    enum Requester : uint8_t
+    {
+        kRequesterRoutingManager,   ///< Requested by `RoutingManager`.
+        kRequesterMultiAilDetector, ///< Requested by `MultiAilDetector`.
+    };
+
+    /**
      * Initializes the `RxRaTracker` object.
      *
      * @param[in] aInstance  The OpenThread instance.
@@ -94,14 +104,15 @@ public:
     explicit RxRaTracker(Instance &aInstance);
 
     /**
-     * Starts the RA tracker.
+     * Enables or disables the `RxRaTracker`.
+     *
+     * The `RxRaTracker` can be enabled by multiple requesters (see `Requester`). It remains enabled as long as
+     * at least one requester has it enabled. It is disabled only when all requesters have disabled it.
+     *
+     * @param[in] aEnable      A boolean to enable/disable the  Tracker.
+     * @param[in] aRequester   The entity requesting to enable/disable.
      */
-    void Start(void);
-
-    /**
-     * Stops the RA tracker.
-     */
-    void Stop(void);
+    void SetEnabled(bool aEnable, Requester aRequester);
 
     /**
      * Indicates whether the Router Solicitation (RS) transmission process is in progress.
@@ -532,6 +543,9 @@ private:
 
     //-  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 
+    void UpdateState(void);
+    void Start(void);
+    void Stop(void);
     void HandleRsSenderFinished(TimeMilli aStartTime);
     void ProcessRaHeader(const RouterAdvert::Header &aRaHeader, Router &aRouter, RouterAdvOrigin aRaOrigin);
     void ProcessPrefixInfoOption(const PrefixInfoOption &aPio, Router &aRouter);
@@ -551,6 +565,9 @@ private:
 #endif
     void HandleNotifierEvents(Events aEvents);
     void HandleNetDataChange(void);
+
+    // Callback from `InfraIf`
+    void HandleInfraIfStateChanged(void) { UpdateState(); }
 
     // Tasklet or timer callbacks
     void HandleSignalTask(void);
@@ -576,6 +593,9 @@ private:
     using IfAddressList   = OwningList<Entry<IfAddress>>;
     using RdnssCallback   = Callback<RdnssAddrCallback>;
 
+    bool                 mRoutingManagerEnabled : 1;
+    bool                 mMultiAilDetectorEnabled : 1;
+    bool                 mIsRunning : 1;
     RsSender             mRsSender;
     DecisionFactors      mDecisionFactors;
     RouterList           mRouters;


### PR DESCRIPTION
This change introduces a mechanism to control the `RxRaTracker` from multiple sources.

A new method `RxRaTracker::SetEnabled()` is added, which accepts a `Requester` enum. The tracker now maintains separate enable flags for each requester (e.g., `RoutingManager`).

The `RxRaTracker` will start only when at least one requester has enabled it AND the infrastructure interface is initialized and running. It stops when all requesters have disabled it or when the interface goes down.

The `Start()` and `Stop()` methods are now private, managed by a new `UpdateState()` method to centralize the state logic. `InfraIf` is updated to notify `RxRaTracker` of state changes.

---

~This PR currently contains the commit from https://github.com/openthread/openthread/pull/12046. Please read and review the last commit on this PR. Thanks.~ 
