### PR TITLE
[dhcp6-pd-client] allow custom values for kMinPreferredLifetime

### DIFF
--- a/src/core/border_router/dhcp6_pd_client.hpp
+++ b/src/core/border_router/dhcp6_pd_client.hpp
@@ -141,12 +141,14 @@ private:
     static constexpr uint32_t kJitterDivisor       = 10;
 
     // The constants below are in seconds
-    static constexpr uint32_t kMinPreferredLifetime                 = 30 * Time::kOneMinuteInSec;
-    static constexpr uint32_t kMaxPreferredLifetime                 = 4 * Time::kOneHourInSec;
+    static constexpr uint32_t kMinPreferredLifetime = OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_MIN_LIFETIME;
+    static constexpr uint32_t kMaxPreferredLifetime = OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_MAX_LIFETIME;
     static constexpr uint32_t kMaxValidMarginAfterPreferredLifetime = 2 * Time::kOneMinuteInSec;
     static constexpr uint32_t kMinT1                                = 5 * Time::kOneMinuteInSec;
     static constexpr uint32_t kMinT1MarginBeforePreferredLifetime   = 15 * Time::kOneMinuteInSec;
     static constexpr uint32_t kMinT2MarginBeforePreferredLifetime   = 6 * Time::kOneMinuteInSec;
+
+    static_assert(kMaxPreferredLifetime > kMinPreferredLifetime, "invalid min/max values for preferred lifetime");
 
     // Default T1 and T2 as 0.5 and 0.8 times the preferred lifetime
     // if they are zero (represented as 5/10 and 8/10).

--- a/src/core/config/border_routing.h
+++ b/src/core/config/border_routing.h
@@ -219,6 +219,27 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_MIN_LIFETIME
+ *
+ * This parameter sets the minimum preferred lifetime (in seconds) for the Border Router's built-in OpenThread
+ * DHCPv6 Prefix Delegation (PD) client feature. The default value is suggested based on:
+ * https://datatracker.ietf.org/doc/draft-ietf-snac-simple/.
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_MIN_LIFETIME
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_MIN_LIFETIME (30 * 60)
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_MAX_LIFETIME
+ *
+ * This parameter sets the maximum preferred lifetime (in seconds) for the Border Router's built-in OpenThread
+ * DHCPv6 Prefix Delegation (PD) client feature.
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_MAX_LIFETIME
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_MAX_LIFETIME (4 * 60 * 60)
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_BORDER_ROUTING_TESTING_API_ENABLE
  *
  * Define to 1 to enable testing related APIs to be provided by the `RoutingManager`.


### PR DESCRIPTION
 This PR adds support for custom values to be used for kMinPreferredLifetime (and kMaxPreferredLifetime).