### PR TITLE
[mle] simplify MLE `StatusTlv`

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1282,7 +1282,7 @@ Error Mle::SendChildUpdateResponse(const TlvList      &aTlvList,
             break;
 
         case Tlv::kStatus:
-            SuccessOrExit(error = message->AppendStatusTlv(StatusTlv::kError));
+            SuccessOrExit(error = message->AppendStatusTlv(kStatusError));
             break;
 
         case Tlv::kAddressRegistration:
@@ -2249,7 +2249,7 @@ void Mle::HandleChildUpdateRequestOnChild(RxInfo &aRxInfo)
         switch (Tlv::Find<StatusTlv>(aRxInfo.mMessage, status))
         {
         case kErrorNone:
-            VerifyOrExit(status != StatusTlv::kError, IgnoreError(BecomeDetached()));
+            VerifyOrExit(status != kStatusError, IgnoreError(BecomeDetached()));
             break;
         case kErrorNotFound:
             break;
@@ -3539,7 +3539,7 @@ Error Mle::TxMessage::AppendSourceAddressTlv(void)
     return Tlv::Append<SourceAddressTlv>(*this, Get<Mle>().GetRloc16());
 }
 
-Error Mle::TxMessage::AppendStatusTlv(StatusTlv::Status aStatus) { return Tlv::Append<StatusTlv>(*this, aStatus); }
+Error Mle::TxMessage::AppendStatusTlv(Status aStatus) { return Tlv::Append<StatusTlv>(*this, aStatus); }
 
 Error Mle::TxMessage::AppendModeTlv(DeviceMode aMode) { return Tlv::Append<ModeTlv>(*this, aMode.Get()); }
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1542,7 +1542,7 @@ private:
         Error AppendTlvRequestTlv(const uint8_t *aTlvs, uint8_t aTlvsLength);
         Error AppendLeaderDataTlv(void);
         Error AppendScanMaskTlv(uint8_t aScanMask);
-        Error AppendStatusTlv(StatusTlv::Status aStatus);
+        Error AppendStatusTlv(Status aStatus);
         Error AppendLinkMarginTlv(uint8_t aLinkMargin);
         Error AppendVersionTlv(void);
         Error AppendAddressRegistrationTlv(AddressRegistrationMode aMode = kAppendAllAddresses);

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -2488,7 +2488,7 @@ void Mle::HandleChildUpdateResponseOnParent(RxInfo &aRxInfo)
     switch (Tlv::Find<StatusTlv>(aRxInfo.mMessage, status))
     {
     case kErrorNone:
-        VerifyOrExit(status != StatusTlv::kError, RemoveNeighbor(*child));
+        VerifyOrExit(status != kStatusError, RemoveNeighbor(*child));
         break;
     case kErrorNotFound:
         break;
@@ -3029,7 +3029,7 @@ void Mle::SendChildUpdateResponseToChild(Child                  *aChild,
         switch (tlvType)
         {
         case Tlv::kStatus:
-            SuccessOrExit(error = message->AppendStatusTlv(StatusTlv::kError));
+            SuccessOrExit(error = message->AppendStatusTlv(kStatusError));
             break;
 
         case Tlv::kLeaderData:

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -190,6 +190,11 @@ typedef TlvInfo<Tlv::kTlvRequest> TlvRequestTlv;
 typedef UintTlvInfo<Tlv::kLinkMargin, uint8_t> LinkMarginTlv;
 
 /**
+ * Defines Status TLV constants and types.
+ */
+typedef UintTlvInfo<Tlv::kStatus, uint8_t> StatusTlv;
+
+/**
  * Defines Version TLV constants and types.
  */
 typedef UintTlvInfo<Tlv::kVersion, uint16_t> VersionTlv;
@@ -880,20 +885,6 @@ private:
     uint16_t mSedBufferSize;
     uint8_t  mSedDatagramCount;
 } OT_TOOL_PACKED_END;
-
-/**
- * Specifies Status TLV status values.
- */
-struct StatusTlv : public UintTlvInfo<Tlv::kStatus, uint8_t>
-{
-    /**
-     * Status values.
-     */
-    enum Status : uint8_t
-    {
-        kError = 1, ///< Error.
-    };
-};
 
 /**
  * Provides constants and methods for generation and parsing of Address Registration TLV.

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -131,6 +131,15 @@ enum DeviceRole : uint8_t
 };
 
 /**
+ * Represents a status value in an MLE Status TLV.
+ */
+enum Status : uint8_t
+{
+    kStatusSuccess = 0, ///< Success status.
+    kStatusError   = 1, ///< Error status.
+};
+
+/**
  * Represents MLE commands.
  */
 enum Command : uint8_t


### PR DESCRIPTION
This commit simplifies the `StatusTlv` definitions. It introduces a new `Status` enum representing the the MLE status values.