### PR TITLE
[mle] centralize `ChildUpdate` reject response logic

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -2262,6 +2262,7 @@ private:
     void       HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void       ReestablishLinkWithNeighbor(Neighbor &aNeighbor);
     Error      SendChildUpdateRequestToParent(ChildUpdateRequestMode aMode);
+    Error      SendChildUpdateRejectResponse(const RxChallenge &aChallenge, const Ip6::Address &aDestination);
     Error      SendChildUpdateResponse(const TlvList      &aTlvList,
                                        const RxChallenge  &aChallenge,
                                        const Ip6::Address &aDestination);

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -2255,8 +2255,7 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
         // Status TLV (error).
         if (mode.IsRxOnWhenIdle())
         {
-            tlvList.Add(Tlv::kStatus);
-            SendChildUpdateResponseToChild(nullptr, aRxInfo.mMessageInfo, tlvList, challenge);
+            IgnoreError(SendChildUpdateRejectResponse(challenge, aRxInfo.mMessageInfo.GetPeerAddr()));
         }
 
         ExitNow();


### PR DESCRIPTION
Introduces a new private method `Mle::SendChildUpdateRejectResponse()` to consolidate the logic for sending a reject response to a "Child Update Request".

This new method creates a response containing the Source Address TLV, Status TLV, and (if applicable) Response TLV.

The new method is now used in `Mle::HandleChildUpdateRequestOnChild()` when the device is not a parent of the sender, and in `Mle::HandleChildUpdateRequestOnParent()` when a request from an unknown child is received. This change removes duplicated code from both locations.