### PR TITLE
[tests] add dnssd api implementations in FakePlatform

### DIFF
--- a/tests/gtest/fake_platform.cpp
+++ b/tests/gtest/fake_platform.cpp
@@ -41,6 +41,7 @@
 #include <openthread/tcat.h>
 #include <openthread/platform/ble.h>
 #include <openthread/platform/diag.h>
+#include <openthread/platform/dnssd.h>
 #include <openthread/platform/dso_transport.h>
 #include <openthread/platform/entropy.h>
 #include <openthread/platform/logging.h>
@@ -610,6 +611,60 @@ otError otPlatUdpLeaveMulticastGroup(otUdpSocket *, otNetifIdentifier, const otI
 {
     return OT_ERROR_NOT_IMPLEMENTED;
 }
+
+otPlatDnssdState otPlatDnssdGetState(otInstance *) { return OT_PLAT_DNSSD_STOPPED; }
+
+void otPlatDnssdRegisterService(otInstance *,
+                                const otPlatDnssdService *,
+                                otPlatDnssdRequestId,
+                                otPlatDnssdRegisterCallback)
+{
+}
+
+void otPlatDnssdUnregisterService(otInstance *,
+                                  const otPlatDnssdService *,
+                                  otPlatDnssdRequestId,
+                                  otPlatDnssdRegisterCallback)
+{
+}
+
+void otPlatDnssdRegisterHost(otInstance *, const otPlatDnssdHost *, otPlatDnssdRequestId, otPlatDnssdRegisterCallback)
+{
+}
+
+void otPlatDnssdUnregisterHost(otInstance *, const otPlatDnssdHost *, otPlatDnssdRequestId, otPlatDnssdRegisterCallback)
+{
+}
+
+void otPlatDnssdRegisterKey(otInstance *, const otPlatDnssdKey *, otPlatDnssdRequestId, otPlatDnssdRegisterCallback) {}
+
+void otPlatDnssdUnregisterKey(otInstance *, const otPlatDnssdKey *, otPlatDnssdRequestId, otPlatDnssdRegisterCallback)
+{
+}
+
+void otPlatDnssdStartBrowser(otInstance *, const otPlatDnssdBrowser *) {}
+
+void otPlatDnssdStopBrowser(otInstance *, const otPlatDnssdBrowser *) {}
+
+void otPlatDnssdStartSrvResolver(otInstance *, const otPlatDnssdSrvResolver *) {}
+
+void otPlatDnssdStopSrvResolver(otInstance *, const otPlatDnssdSrvResolver *) {}
+
+void otPlatDnssdStartTxtResolver(otInstance *, const otPlatDnssdTxtResolver *) {}
+
+void otPlatDnssdStopTxtResolver(otInstance *, const otPlatDnssdTxtResolver *) {}
+
+void otPlatDnssdStartIp6AddressResolver(otInstance *, const otPlatDnssdAddressResolver *) {}
+
+void otPlatDnssdStopIp6AddressResolver(otInstance *, const otPlatDnssdAddressResolver *) {}
+
+void otPlatDnssdStartIp4AddressResolver(otInstance *, const otPlatDnssdAddressResolver *) {}
+
+void otPlatDnssdStopIp4AddressResolver(otInstance *, const otPlatDnssdAddressResolver *) {}
+
+void otPlatDnssdStartRecordQuerier(otInstance *, const otPlatDnssdRecordQuerier *) {}
+
+void otPlatDnssdStopRecordQuerier(otInstance *, const otPlatDnssdRecordQuerier *) {}
 
 #if OPENTHREAD_CONFIG_OTNS_ENABLE
 void otPlatOtnsStatus(const char *aStatus) { OT_UNUSED_VARIABLE(aStatus); }


### PR DESCRIPTION
This PR adds fake implementations for OT dnssd platform APIs.

The background is that I'm trying to enable the OT Dnssd Server functions (Discovery Proxy) in ot-br-posix by default. Once it's enabled, `openthread-ftd` needs implemenation of dnssd platform APIs. To make some unit tests (in ot-br-posix) build successfully, these fake implementations are required.