### PR TITLE
[routing-manager] set the legacy R flag to '1' whenever an ext route is published

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -2157,7 +2157,7 @@ exit:
     {
         LogInfo("RoutePublisher state: %s -> %s", StateToString(mState), StateToString(newState));
         UpdatePublishedRoute(newState);
-        Get<RoutingManager>().mOmrPrefixManager.UpdateDefaultRouteFlag(newState == kPublishDefault);
+        Get<RoutingManager>().mOmrPrefixManager.UpdateDefaultRouteFlag(newState != kDoNotPublish);
     }
 }
 


### PR DESCRIPTION
This change is proposed to comply with the Thread spec (1.4.1) for setting the value of the R flag (formerly indicating the value of P_default, now indicating "any external route"). Spec section 9.6.5.1 item 2 of the last numbered list.

The certification tests do test for this value; it should be '1' also if the BR offers only a ULA route to the AIL.

I didn't include the tests yet in this PR because it's quite some changes; and we may first want to discuss this change and its implications here (or in TC/JIR if it's spec-related). So currently, the tests will fail on this change.
One implication to consider is the variable naming and documentation of it: "P_default" or "DefaultRoute..." or "mDefaultRoute" are now not covering the true meaning of the flag anymore.

(In case people think this is the wrong behavior, we should reopen the TC discussion for this again.)
