### PR TITLE
[mle] use `ChildUpdateResponseInfo` to pass parameters

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1264,28 +1264,26 @@ exit:
     return error;
 }
 
-Error Mle::SendChildUpdateRejectResponse(const RxChallenge &aChallenge, const Ip6::Address &aDestination)
+Error Mle::SendChildUpdateRejectResponse(ChildUpdateResponseInfo &aInfo)
 {
     // Send a reject response which only includes a Source Address TLV,
     // a Status TLV, and a Response TLV when request contained a
     // Challenge TLV.
 
-    TlvList tlvList;
+    aInfo.mTlvList.Clear();
 
-    tlvList.Add(Tlv::kSourceAddress);
-    tlvList.Add(Tlv::kStatus);
+    aInfo.mTlvList.Add(Tlv::kSourceAddress);
+    aInfo.mTlvList.Add(Tlv::kStatus);
 
-    if (!aChallenge.IsEmpty())
+    if (!aInfo.mChallenge.IsEmpty())
     {
-        tlvList.Add(Tlv::kResponse);
+        aInfo.mTlvList.Add(Tlv::kResponse);
     }
 
-    return SendChildUpdateResponse(tlvList, aChallenge, aDestination);
+    return SendChildUpdateResponse(aInfo);
 }
 
-Error Mle::SendChildUpdateResponse(const TlvList      &aTlvList,
-                                   const RxChallenge  &aChallenge,
-                                   const Ip6::Address &aDestination)
+Error Mle::SendChildUpdateResponse(const ChildUpdateResponseInfo &aInfo)
 {
     Error      error = kErrorNone;
     TxMessage *message;
@@ -1293,7 +1291,7 @@ Error Mle::SendChildUpdateResponse(const TlvList      &aTlvList,
 
     VerifyOrExit((message = NewMleMessage(kCommandChildUpdateResponse)) != nullptr, error = kErrorNoBufs);
 
-    for (uint8_t tlvType : aTlvList)
+    for (uint8_t tlvType : aInfo.mTlvList)
     {
         switch (tlvType)
         {
@@ -1328,7 +1326,7 @@ Error Mle::SendChildUpdateResponse(const TlvList      &aTlvList,
             break;
 
         case Tlv::kResponse:
-            SuccessOrExit(error = message->AppendResponseTlv(aChallenge));
+            SuccessOrExit(error = message->AppendResponseTlv(aInfo.mChallenge));
             break;
 
         case Tlv::kLinkFrameCounter:
@@ -1354,9 +1352,9 @@ Error Mle::SendChildUpdateResponse(const TlvList      &aTlvList,
         }
     }
 
-    SuccessOrExit(error = message->SendTo(aDestination));
+    SuccessOrExit(error = message->SendTo(aInfo.mDestination));
 
-    Log(kMessageSend, kTypeChildUpdateResponseAsChild, aDestination);
+    Log(kMessageSend, kTypeChildUpdateResponseAsChild, aInfo.mDestination);
 
     if (checkAddress && HasUnregisteredAddress())
     {
@@ -2229,13 +2227,12 @@ void Mle::HandleChildUpdateRequest(RxInfo &aRxInfo)
 
 void Mle::HandleChildUpdateRequestOnChild(RxInfo &aRxInfo)
 {
-    Error       error           = kErrorNone;
-    bool        canTrustMessage = aRxInfo.IsNeighborStateValid();
-    uint16_t    sourceAddress;
-    RxChallenge challenge;
-    TlvList     requestedTlvList;
-    TlvList     tlvList;
-    uint8_t     linkMarginOut;
+    Error                   error           = kErrorNone;
+    bool                    canTrustMessage = aRxInfo.IsNeighborStateValid();
+    uint8_t                 linkMarginOut;
+    uint16_t                sourceAddress;
+    ChildUpdateResponseInfo info;
+    TlvList                 requestedTlvList;
 
     if (!IsAttached())
     {
@@ -2253,18 +2250,20 @@ void Mle::HandleChildUpdateRequestOnChild(RxInfo &aRxInfo)
 
     Log(kMessageReceive, kTypeChildUpdateRequestAsChild, aRxInfo.mMessageInfo.GetPeerAddr(), sourceAddress);
 
-    tlvList.Add(Tlv::kSourceAddress);
-    tlvList.Add(Tlv::kLeaderData);
+    info.mDestination = aRxInfo.mMessageInfo.GetPeerAddr();
 
-    switch (aRxInfo.mMessage.ReadChallengeTlv(challenge))
+    info.mTlvList.Add(Tlv::kSourceAddress);
+    info.mTlvList.Add(Tlv::kLeaderData);
+
+    switch (aRxInfo.mMessage.ReadChallengeTlv(info.mChallenge))
     {
     case kErrorNone:
-        tlvList.Add(Tlv::kResponse);
-        tlvList.Add(Tlv::kMleFrameCounter);
-        tlvList.Add(Tlv::kLinkFrameCounter);
+        info.mTlvList.Add(Tlv::kResponse);
+        info.mTlvList.Add(Tlv::kMleFrameCounter);
+        info.mTlvList.Add(Tlv::kLinkFrameCounter);
         break;
     case kErrorNotFound:
-        challenge.Clear();
+        info.mChallenge.Clear();
         break;
     default:
         ExitNow(error = kErrorParse);
@@ -2315,7 +2314,7 @@ void Mle::HandleChildUpdateRequestOnChild(RxInfo &aRxInfo)
             {
                 // MUST include CSL timeout TLV when request includes
                 // CSL accuracy
-                tlvList.Add(Tlv::kCslTimeout);
+                info.mTlvList.Add(Tlv::kCslTimeout);
             }
         }
 #endif
@@ -2323,7 +2322,7 @@ void Mle::HandleChildUpdateRequestOnChild(RxInfo &aRxInfo)
         switch (aRxInfo.mMessage.ReadTlvRequestTlv(requestedTlvList))
         {
         case kErrorNone:
-            tlvList.AddElementsFrom(requestedTlvList);
+            info.mTlvList.AddElementsFrom(requestedTlvList);
             break;
         case kErrorNotFound:
             break;
@@ -2334,7 +2333,7 @@ void Mle::HandleChildUpdateRequestOnChild(RxInfo &aRxInfo)
     else
     {
         // This device is not a child of the Child Update Request source.
-        error = SendChildUpdateRejectResponse(challenge, aRxInfo.mMessageInfo.GetPeerAddr());
+        error = SendChildUpdateRejectResponse(info);
         ExitNow();
     }
 
@@ -2342,13 +2341,13 @@ void Mle::HandleChildUpdateRequestOnChild(RxInfo &aRxInfo)
     ProcessKeySequence(aRxInfo);
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    if ((aRxInfo.mNeighbor != nullptr) && !challenge.IsEmpty())
+    if ((aRxInfo.mNeighbor != nullptr) && !info.mChallenge.IsEmpty())
     {
         aRxInfo.mNeighbor->ClearLastRxFragmentTag();
     }
 #endif
 
-    error = SendChildUpdateResponse(tlvList, challenge, aRxInfo.mMessageInfo.GetPeerAddr());
+    error = SendChildUpdateResponse(info);
 
 exit:
     LogProcessError(kTypeChildUpdateRequestAsChild, error);

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1645,6 +1645,13 @@ private:
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+    struct ChildUpdateResponseInfo
+    {
+        TlvList      mTlvList;     // The TLVs to include in the Child Update Response.
+        RxChallenge  mChallenge;   // The received challenge from the Child Update Request (can be empty if none).
+        Ip6::Address mDestination; // The destination address.
+    };
+
 #if OPENTHREAD_FTD
     struct ParentResponseInfo
     {
@@ -2262,10 +2269,8 @@ private:
     void       HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void       ReestablishLinkWithNeighbor(Neighbor &aNeighbor);
     Error      SendChildUpdateRequestToParent(ChildUpdateRequestMode aMode);
-    Error      SendChildUpdateRejectResponse(const RxChallenge &aChallenge, const Ip6::Address &aDestination);
-    Error      SendChildUpdateResponse(const TlvList      &aTlvList,
-                                       const RxChallenge  &aChallenge,
-                                       const Ip6::Address &aDestination);
+    Error      SendChildUpdateRejectResponse(ChildUpdateResponseInfo &aInfo);
+    Error      SendChildUpdateResponse(const ChildUpdateResponseInfo &aInfo);
     void       SetRloc16(uint16_t aRloc16);
     void       SetStateDetached(void);
     void       SetStateChild(uint16_t aRloc16);
@@ -2388,10 +2393,7 @@ private:
     void     SendParentResponse(const ParentResponseInfo &aInfo);
     Error    SendChildIdResponse(Child &aChild);
     Error    SendChildUpdateRequestToChild(Child &aChild);
-    void     SendChildUpdateResponseToChild(Child                  *aChild,
-                                            const Ip6::MessageInfo &aMessageInfo,
-                                            const TlvList          &aTlvList,
-                                            const RxChallenge      &aChallenge);
+    void     SendChildUpdateResponseToChild(Child *aChild, const ChildUpdateResponseInfo &aInfo);
     void     SendMulticastDataResponse(void);
     void     SendDataResponse(const Ip6::Address &aDestination,
                               const TlvList      &aTlvList,


### PR DESCRIPTION
This commit introduces the `ChildUpdateResponseInfo` struct to encapsulate parameters for sending "Child Update Response" messages.

The new struct holds the list of TLVs to include, the received challenge, and the destination address.

Related methods such as `SendChildUpdateResponse()` are updated to use the new struct. This simplifies the method signatures by reducing the number of arguments and improves code clarity by grouping related data.