### PR TITLE
[ip6] bypass filtering for multicast addresses larger than RealmLocal

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -963,7 +963,7 @@ Error Ip6::PassToHost(OwnedPtr<Message> &aMessagePtr,
         VerifyOrExit(aReceive, error = kErrorDrop);
     }
 
-    if (mReceiveFilterEnabled && aReceive)
+    if (mReceiveFilterEnabled && aReceive && !aHeader.GetDestination().IsMulticastLargerThanRealmLocal())
     {
         switch (aIpProto)
         {


### PR DESCRIPTION
Multicast addresses with scope larger than `RealmLocal` are no longer subject to the standard receive filter. They are passed directly to the host callback, allowing delivery and forwarding by the host.
This fixes a scenario where a `Thread Border Router` receives a larger-scope multicast from a `Thread Device`. Previously, if the Border Router was listening on the same multicast address and port, the receive filter could drop the packet, preventing it from being forwarded to other interfaces.