### PR TITLE
[rx-ra-tracker] use `mIsRunning` in stale timer callback

### DIFF
--- a/src/core/border_router/rx_ra_tracker.cpp
+++ b/src/core/border_router/rx_ra_tracker.cpp
@@ -881,7 +881,7 @@ void RxRaTracker::DetermineStaleTimeFor(const RoutePrefix &aPrefix, NextFireTime
 
 void RxRaTracker::HandleStaleTimer(void)
 {
-    VerifyOrExit(Get<RoutingManager>().IsRunning());
+    VerifyOrExit(mIsRunning);
 
     LogInfo("Stale timer expired");
     mRsSender.Start();


### PR DESCRIPTION
`RxRaTracker` can run independently of `RoutingManager`. Its stale timer callback should check its own running state (`mIsRunning`) instead of `RoutingManager`'s state.

This commit corrects the logic in `HandleStaleTimer()` to use the local `mIsRunning` flag.