### PR TITLE
[multi-ail-detector] use direct callback from `RxRaTracker`

### DIFF
--- a/src/core/border_router/multi_ail_detector.hpp
+++ b/src/core/border_router/multi_ail_detector.hpp
@@ -52,6 +52,7 @@ namespace ot {
 namespace BorderRouter {
 
 class NetDataBrTracker;
+class RxRaTracker;
 class RoutingManager;
 
 /**
@@ -69,6 +70,7 @@ class RoutingManager;
 class MultiAilDetector : public InstanceLocator
 {
     friend class NetDataBrTracker;
+    friend class RxRaTracker;
     friend class RoutingManager;
 
 public:
@@ -106,6 +108,9 @@ private:
     void Stop(void);
     void Evaluate(void);
     void HandleTimer(void);
+
+    // Callback from `RxRaTracker`
+    void HandleRxRaTrackerDecisionFactorChanged(void) { Evaluate(); }
 
     using DetectCallback = Callback<MultiAilCallback>;
     using DetectTimer    = TimerMilliIn<MultiAilDetector, &MultiAilDetector::HandleTimer>;

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -602,9 +602,6 @@ void RoutingManager::HandleRxRaTrackerDecisionFactorChanged(void)
 
     mOnLinkPrefixManager.HandleRxRaTrackerChanged();
     mRoutePublisher.Evaluate();
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
-    Get<MultiAilDetector>().Evaluate();
-#endif
 
 exit:
     return;

--- a/src/core/border_router/rx_ra_tracker.cpp
+++ b/src/core/border_router/rx_ra_tracker.cpp
@@ -892,7 +892,14 @@ exit:
 
 void RxRaTracker::HandleExpirationTimer(void) { Evaluate(); }
 
-void RxRaTracker::HandleSignalTask(void) { Get<RoutingManager>().HandleRxRaTrackerDecisionFactorChanged(); }
+void RxRaTracker::HandleSignalTask(void)
+{
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
+    Get<MultiAilDetector>().HandleRxRaTrackerDecisionFactorChanged();
+#endif
+
+    Get<RoutingManager>().HandleRxRaTrackerDecisionFactorChanged();
+}
 
 void RxRaTracker::HandleRdnssAddrTask(void) { mRdnssCallback.InvokeIfSet(); }
 


### PR DESCRIPTION
This commit introduces a direct callback mechanism from `RxRaTracker` to `MultiAilDetector` to signal changes in decision factors. This is in preparation of future changes allowing `MultiAilDetector` to run independently of `RoutingManager`.

Previously, `RxRaTracker` would signal `RoutingManager`, which in turn would call `MultiAilDetector::Evaluate()`. This commit refactors this interaction by adding a new `HandleRxRaTrackerDecisionFactorChanged()` method to `MultiAilDetector`.