### PR TITLE
[multi-ail-detector] allow detector to run independently of Border Routing

### DIFF
--- a/doc/ot_api_doc.h
+++ b/doc/ot_api_doc.h
@@ -119,6 +119,7 @@
  * @defgroup api-border-agent-txt-data   Border Agent TXT Data Parser
  * @defgroup api-border-router           Border Router
  * @defgroup api-border-routing          Border Routing Manager
+ * @defgroup api-multi-ail-detection     Border Router Multi AIL Detection
  * @defgroup api-commissioner            Commissioner
  * @defgroup api-thread-general          General
  * @brief This module includes functions for all Thread roles.

--- a/include/openthread/BUILD.gn
+++ b/include/openthread/BUILD.gn
@@ -78,6 +78,7 @@ source_set("openthread") {
     "mdns.h",
     "mesh_diag.h",
     "message.h",
+    "multi_ail_detection.h",
     "multi_radio.h",
     "nat64.h",
     "ncp.h",

--- a/include/openthread/border_routing.h
+++ b/include/openthread/border_routing.h
@@ -41,6 +41,7 @@
 #include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
+#include <openthread/multi_ail_detection.h> // IWYU pragma: keep
 #include <openthread/netdata.h>
 
 #ifdef __cplusplus
@@ -640,68 +641,6 @@ otError otBorderRoutingGetNextPeerBrEntry(otInstance                           *
  * @returns The number of peer BRs.
  */
 uint16_t otBorderRoutingCountPeerBrs(otInstance *aInstance, uint32_t *aMinAge);
-
-/**
- * A callback function pointer called when the multi-AIL detection state changes.
- *
- * This callback function is invoked by the OpenThread stack whenever the Routing Manager determines a change in
- * whether Border Routers on the Thread mesh might be connected to different Adjacent Infrastructure Links (AILs).
- *
- * See `otBorderRoutingIsMultiAilDetected()` for more details.
- *
- * @param[in] aDetected   `TRUE` if multiple AILs are now detected, `FALSE` otherwise.
- * @param[in] aContext    A pointer to arbitrary context information provided when the callback was registered
- *                        using `otBorderRoutingSetMultiAilCallback()`.
- */
-typedef void (*otBorderRoutingMultiAilCallback)(bool aDetected, void *aContext);
-
-/**
- * Gets the current detected state regarding multiple Adjacent Infrastructure Links (AILs).
- *
- * Requires `OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE`.
- *
- * It returns whether the Routing Manager currently believes that Border Routers (BRs) on the Thread mesh may be
- * connected to different AILs.
- *
- * The detection mechanism operates as follows: The Routing Manager monitors the number of peer BRs listed in the
- * Thread Network Data (see `otBorderRoutingCountPeerBrs()`) and compares this count with the number of peer BRs
- * discovered by processing received Router Advertisement (RA) messages on its connected AIL. If the count derived from
- * Network Data consistently exceeds the count derived from RAs for a detection duration of 10 minutes, it concludes
- * that BRs are likely connected to different AILs. To clear state a shorter window of 1 minute is used.
- *
- * The detection window of 10 minutes helps to avoid false positives due to transient changes. The Routing Manager uses
- * 200 seconds for reachability checks of peer BRs (sending Neighbor Solicitation). Stale Network Data entries are
- * also expected to age out within a few minutes. So a 10-minute detection time accommodates both cases.
- *
- * While generally effective, this detection mechanism may get less reliable in scenarios with a large number of
- * BRs, particularly exceeding ten. This is related to the "Network Data Publisher" mechanism, where BRs might refrain
- * from publishing their external route information in the Network Data to conserve its limited size, potentially
- * skewing the Network Data BR count.
- *
- * @param[in] aInstance  A pointer to the OpenThread instance.
- *
- * @retval TRUE   Has detected that BRs are likely connected to multiple AILs.
- * @retval FALSE  Has not detected (or no longer detects) that BRs are connected to multiple AILs.
- */
-bool otBorderRoutingIsMultiAilDetected(otInstance *aInstance);
-
-/**
- * Sets a callback function to be notified of changes in the multi-AIL detection state.
- *
- * Requires `OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE`.
- *
- * Subsequent calls to this function will overwrite the previous callback setting. Using `NULL` for @p aCallback will
- * disable the callback.
- *
- * @param[in] aInstance  A pointer to the OpenThread instance.
- * @param[in] aCallback  A pointer to the function (`otBorderRoutingMultiAilCallback`) to be called
- *                       upon state changes, or `NULL` to unregister a previously set callback.
- * @param[in] aContext   A pointer to application-specific context that will be passed back
- *                       in the `aCallback` function. This can be `NULL` if no context is needed.
- */
-void otBorderRoutingSetMultiAilCallback(otInstance                     *aInstance,
-                                        otBorderRoutingMultiAilCallback aCallback,
-                                        void                           *aContext);
 
 /**
  * Iterates over the Recursive DNS Server (RDNSS) address entries.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (549)
+#define OPENTHREAD_API_VERSION (550)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/multi_ail_detection.h
+++ b/include/openthread/multi_ail_detection.h
@@ -1,0 +1,157 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * @brief
+ *  This file defines the OpenThread Border Router Multi-AIL Detection API.
+ */
+
+#ifndef OPENTHREAD_MULTI_AIL_DETECTION_H_
+#define OPENTHREAD_MULTI_AIL_DETECTION_H_
+
+#include <stdbool.h>
+
+#include <openthread/instance.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @addtogroup api-multi-ail-detection
+ *
+ * @brief
+ *  This module includes functions for the OpenThread Multi-AIL Detection feature.
+ *
+ * @{
+ *
+ * All the functions in this module require both the `OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE` and
+ * `OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE` to be enabled.
+ */
+
+/**
+ * A callback function pointer called when the multi-AIL detection state changes.
+ *
+ * This callback function is invoked by the OpenThread stack whenever the detector determines a change in whether
+ * Border Routers on the Thread mesh might be connected to different Adjacent Infrastructure Links (AILs).
+ *
+ * See `otBorderRoutingIsMultiAilDetected()` for more details.
+ *
+ * @param[in] aDetected   `TRUE` if multiple AILs are now detected, `FALSE` otherwise.
+ * @param[in] aContext    A pointer to arbitrary context information provided when the callback was registered
+ *                        using `otBorderRoutingSetMultiAilCallback()`.
+ */
+typedef void (*otBorderRoutingMultiAilCallback)(bool aDetected, void *aContext);
+
+/**
+ * Enables or disables the Multi-AIL Detector.
+ *
+ * If `OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_AUTO_ENABLE_MODE` is enabled, the detector is enabled
+ * by default and starts running when the infra-if network is initialized and becomes active (running).
+ *
+ * @param[in] aInstance  A pointer to the OpenThread instance.
+ * @param[in] aEnable    TRUE to enable the detector, FALSE to disable.
+ */
+void otBorderRoutingSetMultiAilDetectionEnabled(otInstance *aInstance, bool aEnable);
+
+/**
+ * Checks if the Multi-AIL Detector is enabled.
+ *
+ * @param[in] aInstance  A pointer to the OpenThread instance.
+ *
+ * @retval TRUE   If the detector is enabled.
+ * @retval FALSE  If the detector is disabled.
+ */
+bool otBorderRoutingIsMultiAilDetectionEnabled(otInstance *aInstance);
+
+/**
+ * Checks if the Multi-AIL Detector is running.
+ *
+ * The detector runs when it is enabled and the infrastructure interface is also active.
+ *
+ * @param[in] aInstance  A pointer to the OpenThread instance.
+ *
+ * @retval TRUE   If the detector is running.
+ * @retval FALSE  If the detector is not running.
+ */
+bool otBorderRoutingIsMultiAilDetectionRunning(otInstance *aInstance);
+
+/**
+ * Gets the current detected state regarding multiple Adjacent Infrastructure Links (AILs).
+ *
+ * It returns whether the detector currently believes that Border Routers (BRs) on the Thread mesh may be connected to
+ * different AILs.
+ *
+ * The detection mechanism operates as follows: The detector monitors the number of peer BRs listed in the
+ * Thread Network Data (see `otBorderRoutingCountPeerBrs()`) and compares this count with the number of peer BRs
+ * discovered by processing received Router Advertisement (RA) messages on its connected AIL. If the count derived from
+ * Network Data consistently exceeds the count derived from RAs for a detection duration of 10 minutes, it concludes
+ * that BRs are likely connected to different AILs. To clear state a shorter window of 1 minute is used.
+ *
+ * The detection window of 10 minutes helps to avoid false positives due to transient changes. The detector uses
+ * 200 seconds for reachability checks of peer BRs (sending Neighbor Solicitation). Stale Network Data entries are
+ * also expected to age out within a few minutes. So a 10-minute detection time accommodates both cases.
+ *
+ * While generally effective, this detection mechanism may get less reliable in scenarios with a large number of
+ * BRs, particularly exceeding ten. This is related to the "Network Data Publisher" mechanism, where BRs might refrain
+ * from publishing their external route information in the Network Data to conserve its limited size, potentially
+ * skewing the Network Data BR count.
+ *
+ * @param[in] aInstance  A pointer to the OpenThread instance.
+ *
+ * @retval TRUE   Has detected that BRs are likely connected to multiple AILs.
+ * @retval FALSE  Has not detected (or no longer detects) that BRs are connected to multiple AILs.
+ */
+bool otBorderRoutingIsMultiAilDetected(otInstance *aInstance);
+
+/**
+ * Sets a callback function to be notified of changes in the multi-AIL detection state.
+ *
+ * Subsequent calls to this function will overwrite the previous callback setting. Using `NULL` for @p aCallback will
+ * disable the callback.
+ *
+ * @param[in] aInstance  A pointer to the OpenThread instance.
+ * @param[in] aCallback  A pointer to the function (`otBorderRoutingMultiAilCallback`) to be called
+ *                       upon state changes, or `NULL` to unregister a previously set callback.
+ * @param[in] aContext   A pointer to application-specific context that will be passed back
+ *                       in the `aCallback` function. This can be `NULL` if no context is needed.
+ */
+void otBorderRoutingSetMultiAilCallback(otInstance                     *aInstance,
+                                        otBorderRoutingMultiAilCallback aCallback,
+                                        void                           *aContext);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // OPENTHREAD_MULTI_AIL_DETECTION_H_

--- a/src/cli/README_BR.md
+++ b/src/cli/README_BR.md
@@ -198,6 +198,34 @@ Done
 BR multi AIL callback: cleared
 ```
 
+Usage: `br multiail state`
+
+Outputs full state of multi-AIL detector:
+
+- Whether the detector is enabled.
+- Whether the detector is running (when it is enabled and the infra-if interface is also active).
+- Whether multi-AIL was detected.
+
+```bash
+> br multiail state
+Enabled: yes
+Running: yes
+Detected: no
+Done
+```
+
+Usage: `br multiail enable|disable`
+
+Enable or disable the multi-AIL detector.
+
+```bash
+> br multiail enable
+Done
+
+> br multiail disable
+Done
+```
+
 ### omrconfig
 
 Usage: `br omrconfig`

--- a/src/cli/cli_br.cpp
+++ b/src/cli/cli_br.cpp
@@ -197,6 +197,40 @@ template <> otError Br::Process<Cmd("multiail")>(Arg aArgs[])
 
         otBorderRoutingSetMultiAilCallback(GetInstancePtr(), callback, this);
     }
+    /**
+     * @cli br multiail state
+     * @code
+     * br multiail state
+     * Enabled: yes
+     * Running: yes
+     * Detected: no
+     * Done
+     * @endcode
+     * @par
+     * Outputs full state of multi-AIL detector:
+     * - Whether the detector is enabled.
+     * - Whether the detector is running (when it is enabled and the infra-if interface is also active).
+     * - Whether multi-AIL was detected.
+     */
+    else if (aArgs[0] == "state")
+    {
+        OutputLine("Enabled: %s", otBorderRoutingIsMultiAilDetectionEnabled(GetInstancePtr()) ? "yes" : "no");
+        OutputLine("Running: %s", otBorderRoutingIsMultiAilDetectionRunning(GetInstancePtr()) ? "yes" : "no");
+        OutputLine("Detected: %s", otBorderRoutingIsMultiAilDetected(GetInstancePtr()) ? "yes" : "no");
+    }
+    /**
+     * @cli br multiail (enable, disable)
+     * @code
+     * br multiail enable
+     * Done
+     * @endcode
+     * @cparam br multiail @ca{enable|disable}
+     * @par api_copy
+     * #otBorderRoutingSetMultiAilDetectionEnabled
+     */
+    else if (ProcessEnableDisable(aArgs, otBorderRoutingSetMultiAilDetectionEnabled) == OT_ERROR_NONE)
+    {
+    }
     else
     {
         error = OT_ERROR_INVALID_ARGS;

--- a/src/cli/cli_br.hpp
+++ b/src/cli/cli_br.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include <openthread/border_routing.h>
+#include <openthread/multi_ail_detection.h>
 
 #include "cli/cli_config.h"
 #include "cli/cli_history.hpp"

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -341,6 +341,7 @@ openthread_core_files = [
   "api/mdns_api.cpp",
   "api/mesh_diag_api.cpp",
   "api/message_api.cpp",
+  "api/multi_ail_detection_api.cpp",
   "api/multi_radio_api.cpp",
   "api/nat64_api.cpp",
   "api/netdata_api.cpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -67,6 +67,7 @@ set(COMMON_SOURCES
     api/mdns_api.cpp
     api/mesh_diag_api.cpp
     api/message_api.cpp
+    api/multi_ail_detection_api.cpp
     api/multi_radio_api.cpp
     api/nat64_api.cpp
     api/netdata_api.cpp

--- a/src/core/api/border_routing_api.cpp
+++ b/src/core/api/border_routing_api.cpp
@@ -293,22 +293,6 @@ uint16_t otBorderRoutingCountPeerBrs(otInstance *aInstance, uint32_t *aMinAge)
 
 #endif
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
-
-bool otBorderRoutingIsMultiAilDetected(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<BorderRouter::MultiAilDetector>().IsDetected();
-}
-
-void otBorderRoutingSetMultiAilCallback(otInstance                     *aInstance,
-                                        otBorderRoutingMultiAilCallback aCallback,
-                                        void                           *aContext)
-{
-    AsCoreType(aInstance).Get<BorderRouter::MultiAilDetector>().SetCallback(aCallback, aContext);
-}
-
-#endif
-
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
 
 void otBorderRoutingDhcp6PdSetEnabled(otInstance *aInstance, bool aEnabled)

--- a/src/core/api/multi_ail_detection_api.cpp
+++ b/src/core/api/multi_ail_detection_api.cpp
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * @brief
+ *   This file implements the OpenThread Multi-AIL Detection API.
+ */
+
+#include <openthread/multi_ail_detection.h>
+
+#include "instance/instance.hpp"
+
+using namespace ot;
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
+
+void otBorderRoutingSetMultiAilDetectionEnabled(otInstance *aInstance, bool aEnable)
+{
+    AsCoreType(aInstance).Get<BorderRouter::MultiAilDetector>().SetEnabled(aEnable);
+}
+
+bool otBorderRoutingIsMultiAilDetectionEnabled(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).Get<BorderRouter::MultiAilDetector>().IsEnabled();
+}
+
+bool otBorderRoutingIsMultiAilDetectionRunning(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).Get<BorderRouter::MultiAilDetector>().IsRunning();
+}
+
+bool otBorderRoutingIsMultiAilDetected(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).Get<BorderRouter::MultiAilDetector>().IsDetected();
+}
+
+void otBorderRoutingSetMultiAilCallback(otInstance                     *aInstance,
+                                        otBorderRoutingMultiAilCallback aCallback,
+                                        void                           *aContext)
+{
+    AsCoreType(aInstance).Get<BorderRouter::MultiAilDetector>().SetCallback(aCallback, aContext);
+}
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE

--- a/src/core/border_router/br_types.hpp
+++ b/src/core/border_router/br_types.hpp
@@ -66,7 +66,6 @@ typedef otBorderRoutingPeerBorderRouterEntry  PeerBrEntry;         ///< Peer Bor
 typedef otBorderRoutingPrefixTableEntry       Dhcp6PdPrefix;       ///< DHCPv6 PD prefix.
 typedef otPdProcessedRaInfo                   Dhcp6PdCounters;     ///< DHCPv6 PD counters.
 typedef otBorderRoutingRequestDhcp6PdCallback Dhcp6PdCallback;     ///< DHCPv6 PD callback.
-typedef otBorderRoutingMultiAilCallback       MultiAilCallback;    ///< Multi AIL detection callback.
 
 // IPv6 Neighbor Discovery (ND) types
 typedef Ip6::Nd::PrefixInfoOption         PrefixInfoOption;         ///< Prefix Info Option (PIO).

--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -184,6 +184,11 @@ Error InfraIf::HandleStateChanged(uint32_t aIfIndex, bool aIsRunning)
     mIsRunning = aIsRunning;
 
     Get<RxRaTracker>().HandleInfraIfStateChanged();
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
+    Get<MultiAilDetector>().HandleInfraIfStateChanged();
+#endif
+
     Get<RoutingManager>().HandleInfraIfStateChanged();
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ADVERTISING_PROXY_ENABLE

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -266,9 +266,6 @@ void RoutingManager::Start(void)
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
         mNat64PrefixManager.Start();
 #endif
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
-        Get<MultiAilDetector>().Start();
-#endif
     }
 }
 
@@ -283,9 +280,6 @@ void RoutingManager::Stop(void)
 #endif
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
     mNat64PrefixManager.Stop();
-#endif
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
-    Get<MultiAilDetector>().Stop();
 #endif
 
     SendRouterAdvertisement(kInvalidateAllPrevPrefixes);

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -167,6 +167,9 @@ void Notifier::EmitEvents(void)
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_TRACK_PEER_BR_INFO_ENABLE
     Get<BorderRouter::NetDataBrTracker>().HandleNotifierEvents(events);
 #endif
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
+    Get<BorderRouter::MultiAilDetector>().HandleNotifierEvents(events);
+#endif
 #endif
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
     Get<Srp::Client>().HandleNotifierEvents(events);

--- a/src/core/config/border_routing.h
+++ b/src/core/config/border_routing.h
@@ -86,18 +86,32 @@
 /**
  * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
  *
- * Define to 1 to enable Routing Manager multiple Adjacent Infrastructure Links (AILs) detection feature.
+ * Define to 1 to enable Multiple Adjacent Infrastructure Links (AILs) detection feature.
  *
- * The detection mechanism operates as follows: The Routing Manager monitors the number of peer BRs listed in the
- * Thread Network Data (see `otBorderRoutingCountPeerBrs()`) and compares this count with the number of peer BRs
- * discovered by processing received Router Advertisement (RA) messages on its connected AIL. If the count derived from
- * Network Data consistently exceeds the count derived from RAs for a detection duration of 10 minutes, it concludes
- * that BRs are likely connected to different AILs. To clear state a shorter window of 1 minute is used.
+ * The detection mechanism operates as follows: The detector monitors the number of peer BRs listed in the Thread
+ * Network Data (see `otBorderRoutingCountPeerBrs()`) and compares this count with the number of peer BRs discovered
+ * by processing received Router Advertisement (RA) messages on its connected AIL. If the count derived from Network
+ * Data consistently exceeds the count derived from RAs for a detection duration of 10 minutes, it concludes that BRs
+ * are likely connected to different AILs. To clear state a shorter window of 1 minute is used.
  *
  * See `otBorderRoutingIsMultiAilDetected()` for more details.
  */
 #ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
 #define OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE OPENTHREAD_CONFIG_BORDER_ROUTING_USE_HEAP_ENABLE
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_AUTO_ENABLE_MODE
+ *
+ * Specifies the "Auto Enable Mode" for Multi-AIL Detection feature.
+ *
+ * When "Auto Enable Mode" is set, the Multi-AIL Detector is enabled by default and starts running and monitoring
+ * when the infrastructure interface network is initialized and become active/running. If this mode is disabled, the
+ * detector will be in a disabled state initially and must be explicitly enabled using the public API
+ * `otBorderRoutingSetMultiAilDetectionEnabled()`.
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_AUTO_ENABLE_MODE
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_AUTO_ENABLE_MODE 1
 #endif
 
 /**

--- a/tests/toranj/cli/cli.py
+++ b/tests/toranj/cli/cli.py
@@ -856,6 +856,9 @@ class Node(object):
     def br_get_multiail(self):
         return self._cli_single_output('br multiail')
 
+    def br_get_multiail_state(self):
+        return self.cli('br multiail state')
+
     def br_get_ifaddrs(self):
         return self.cli('br ifaddrs')
 

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -1416,6 +1416,18 @@ void InitTest(bool aEnablBorderRouting = false, bool aAfterReset = false)
 
     SuccessOrQuit(otIp6SetEnabled(sInstance, true));
     SuccessOrQuit(otThreadSetEnabled(sInstance, true));
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_MULTI_AIL_DETECTION_ENABLE
+    // We explicitly disable the multi-AIL detector to prevent
+    // interference with the tests. The detector enables
+    // `RxRaTracker` and keeps it enabled even when Border Routing is
+    // disabled, which keeps prefix entries in the heap and can
+    // invalidate the heap allocation checks. It may also mess up the
+    // expected timing of RS (Router Solicitation) messages (starting
+    // the `RxRaTracker` early).
+    otBorderRoutingSetMultiAilDetectionEnabled(sInstance, false);
+#endif
+
     SuccessOrQuit(otBorderRoutingSetEnabled(sInstance, aEnablBorderRouting));
 
     // Reset all test flags


### PR DESCRIPTION
This commit updates the Multi-AIL Detection feature to operate independently of the Border Routing Manager. This fundamental change allows the detector to be enabled/disabled on its own, rather than being tied to the Border Routing Manager's state.

This change also moves the Multi-AIL detection API into a separate `openthread/multi_ail_detection.h` header and introduces new APIs to control the detector independently. Corresponding CLI commands are also added.

The `test-505-multi-ail-detection.py` is also updated to validate this new independent behavior. In particular that a device that is not enabled to act as a BR can independently run multi-AIL detection and determine whether, if it becomes a BR, it will cause multi-AIL issues.