### PR TITLE
[border-router] delay `RoutingManager` actions until initial discovery is complet

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -1026,8 +1026,11 @@ private:
 
     bool NetworkDataContainsUlaRoute(void) const;
 
-    void HandleRxRaTrackerDecisionFactorChanged(void);
     void HandleLocalOnLinkPrefixChanged(void);
+
+    // Callbacks from `RxRaTracker`
+    void HandleRxRaTrackerInitialDiscoveryFinished(void);
+    void HandleRxRaTrackerDecisionFactorChanged(void);
 
     static bool IsValidBrUlaPrefix(const Ip6::Prefix &aBrUlaPrefix);
 

--- a/src/core/border_router/rx_ra_tracker.hpp
+++ b/src/core/border_router/rx_ra_tracker.hpp
@@ -105,18 +105,17 @@ public:
     void SetEnabled(bool aEnable, Requester aRequester);
 
     /**
-     * Indicates whether the Router Solicitation (RS) transmission process is in progress.
+     * Indicates whether the the initial router discovery process (sending Router Solicitation (RS) message) is
+     * finished.
      *
-     * Upon `Start()`, the device performs the RS transmission process to discover routers on the infrastructure
-     * interface. The device sends three Router Solicitation (RS) messages every four seconds, starting with a random
-     * delay of up to one second for the first RS transmission. After sending the final RS message, the device waits
-     * one second before concluding the RS transmission process, at which point `IsRsTxInProgress()` returns `FALSE`.
-     * The RS transmission process is also performed if the stale timer for any discovered prefix expires.
+     * When `RxRaTracker` is started, it sends multiple RS message to discover routers on the infrastructure interface.
+     * It sends three RS messages every four seconds, starting with a random delay of up to one second for the first
+     * RS transmission. After sending the final RS message, it waits one second before concluding discovery process.
      *
-     * @retval TRUE   If the Router Solicitation transmission process is in progress.
-     * @retval FALSE  If the Router Solicitation transmission process is not in progress.
+     * @retval TRUE   If the initial router discovery process is finished.
+     * @retval FALSE  If the initial router discovery process is not finished.
      */
-    bool IsRsTxInProgress(void) const { return mRsSender.IsInProgress(); }
+    bool IsIntialRouterDiscoveryFinished(void) const { return mIntialDiscoveryFinished; }
 
     /**
      * Initializes a `PrefixTableIterator`.
@@ -581,6 +580,7 @@ private:
     bool                 mRoutingManagerEnabled : 1;
     bool                 mMultiAilDetectorEnabled : 1;
     bool                 mIsRunning : 1;
+    bool                 mIntialDiscoveryFinished : 1;
     RsSender             mRsSender;
     DecisionFactors      mDecisionFactors;
     RouterList           mRouters;

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -318,6 +318,7 @@ otError otPlatInfraIfSendIcmp6Nd(uint32_t            aInfraIfIndex,
     case Ip6::Icmp::Header::kTypeRouterSolicit:
         Log("  Router Solicit message");
         sRsEmitted = true;
+        otPlatInfraIfRecvIcmp6Nd(sInstance, kInfraIfIndex, &sInfraIfAddress, aBuffer, aBufferLength);
         break;
 
     case Ip6::Icmp::Header::kTypeRouterAdvert:


### PR DESCRIPTION
This commit introduces a new state, `mInitialDiscoveryFinished`, in `RxRaTracker` to track the completion of the initial router discovery process (transmission of Router Solicit messages to discover existing routers on the infrastructure network when `RxRaTracker` starts). When this initial discovery is finished, `RxRaTracker` invokes a new callback, `HandleRxRaTrackerInitialDiscoveryFinished()`, to notify the `RoutingManager`.

`RoutingManager` now handles cases where `RxRaTracker` may already be enabled and running (e.g., enabled by other components like `MultiAilDetector`). It therefore checks if `RxRaTracker` has already finished its initial router discovery. If so, it starts the policy evaluation after a short delay. Otherwise, it waits for the callback from `RxRaTracker` to signal completion. It also ensures it processes any previously discovered RA prefixes/info from `RxRaTracker` that may impact its decision factors.

This helps decouple the `RoutingManager` and `RxRaTracker`, further allowing them to run independent of each other.

Another important change in this commit is how `RoutingManager` processes received RS messages. It now ignores all incoming RS messages during the `RxRaTracker`'s initial router discovery period to avoid responding to its own RS messages or sending a premature RA (with incomplete information) before all routers on the infrastructure link are discovered.