### PR TITLE
[csl] update the argument of IndirectSender from Child to CslNeighbor

### DIFF
--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -143,7 +143,8 @@ Mac::TxFrame *DataPollHandler::HandleFrameRequest(Mac::TxFrames &aTxFrames)
     frame = &aTxFrames.GetTxFrame();
 #endif
 
-    VerifyOrExit(Get<IndirectSender>().PrepareFrameForChild(*frame, mFrameContext, *mIndirectTxChild) == kErrorNone,
+    VerifyOrExit(Get<IndirectSender>().PrepareFrameForSleepyNeighbor(*frame, mFrameContext, *mIndirectTxChild) ==
+                     kErrorNone,
                  frame = nullptr);
 
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
@@ -255,7 +256,7 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, 
         OT_ASSERT(false);
     }
 
-    Get<IndirectSender>().HandleSentFrameToChild(aFrame, mFrameContext, aError, aChild);
+    Get<IndirectSender>().HandleSentFrameToSleepyNeighbor(aFrame, mFrameContext, aError, aChild);
 
 exit:
     return;

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -409,7 +409,7 @@ void IndirectSender::HandleSentFrameToSleepyNeighbor(const Mac::TxFrame &aFrame,
     // in the (not common) case where the radio platform does not
     // support the "source address match" feature and always includes
     // "frame pending" flag in acks to data poll frames. In such a case,
-    // `IndirectSender` prepares and sends an empty frame to the sleepy child
+    // `IndirectSender` prepares and sends an empty frame to the sleepy neighbor
     // after it sends a data poll. Here in `HandleSentFrameToCslNeighbor()` we
     // exit quickly if we detect the "send done" is for the empty frame
     // to ensure we do not update any newly added indirect message after
@@ -481,7 +481,7 @@ void IndirectSender::HandleSentFrameToSleepyNeighbor(const Mac::TxFrame &aFrame,
         // disabled, all fragment frames of a larger message are
         // sent even if the transmission of an earlier fragment fail.
         // Note that `GetIndirectTxSuccess() tracks the tx success of
-        // the entire message to the sleepy neighbor child, while `txError = aError`
+        // the entire message to the sleepy neighbor, while `txError = aError`
         // represents the error status of the last fragment frame
         // transmission.
 

--- a/src/core/thread/indirect_sender.hpp
+++ b/src/core/thread/indirect_sender.hpp
@@ -94,9 +94,9 @@ public:
 
     public:
         /**
-         * Returns the number of queued messages for the child.
+         * Returns the number of queued messages for the sleepy neighbor.
          *
-         * @returns Number of queued messages for the child.
+         * @returns Number of queued messages for the sleepy neighbor.
          */
         uint16_t GetIndirectMessageCount(void) const { return mQueuedMessageCount; }
 
@@ -129,7 +129,7 @@ public:
         uint16_t mIndirectFragmentOffset : 14; // 6LoWPAN fragment offset for the indirect message.
         bool     mIndirectTxSuccess : 1;       // Indicates tx success/failure of current indirect message.
         bool     mWaitingForMessageUpdate : 1; // Indicates waiting for updating the indirect message.
-        uint16_t mQueuedMessageCount : 14;     // Number of queued indirect messages for the child.
+        uint16_t mQueuedMessageCount : 14;     // Number of queued indirect messages for the sleepy neighbor.
         bool     mUseShortAddress : 1;         // Indicates whether to use short or extended address.
         bool     mSourceMatchPending : 1;      // Indicates whether or not pending to add to src match table.
 
@@ -168,75 +168,75 @@ public:
 
 #if OPENTHREAD_FTD
     /**
-     * Adds a message for indirect transmission to a sleepy child.
+     * Adds a message for indirect transmission to a sleepy neighbor.
      *
-     * @param[in] aMessage  The message to add.
-     * @param[in] aChild    The (sleepy) child for indirect transmission.
+     * @param[in] aMessage     The message to add.
+     * @param[in] aCslNeighbor The (sleepy) neighbor for indirect transmission.
      */
-    void AddMessageForSleepyChild(Message &aMessage, Child &aChild);
+    void AddMessageForSleepyNeighbor(Message &aMessage, CslNeighbor &aCslNeighbor);
 
     /**
-     * Removes a message for indirect transmission to a sleepy child.
+     * Removes a message for indirect transmission to a sleepy neighbor.
      *
-     * @param[in] aMessage  The message to update.
-     * @param[in] aChild    The (sleepy) child for indirect transmission.
+     * @param[in] aMessage     The message to update.
+     * @param[in] aCslNeighbor The (sleepy) neighbor for indirect transmission.
      *
      * @retval kErrorNone          Successfully removed the message for indirect transmission.
-     * @retval kErrorNotFound      The message was not scheduled for indirect transmission to the child.
+     * @retval kErrorNotFound      The message was not scheduled for indirect transmission to the neighbor.
      */
-    Error RemoveMessageFromSleepyChild(Message &aMessage, Child &aChild);
+    Error RemoveMessageFromSleepyNeighbor(Message &aMessage, CslNeighbor &aCslNeighbor);
 
     /**
-     * Removes all added messages for a specific child and frees message (with no indirect/direct tx).
+     * Removes all added messages for a specific sleepy neighbor and frees message (with no indirect/direct tx).
      *
-     * @param[in]  aChild  A reference to a child whose messages shall be removed.
+     * @param[in]  aCslNeighbor  A reference to a sleepy neighbor whose messages shall be removed.
      */
-    void ClearAllMessagesForSleepyChild(Child &aChild);
+    void ClearAllMessagesForSleepyNeighbor(CslNeighbor &aCslNeighbor);
 
     /**
      * Finds the first queued message for a given sleepy child that also satisfies the conditions of a given
      * `MessageChecker`.
      *
-     * The caller MUST ensure that @p aChild is sleepy.
+     * The caller MUST ensure that @p aCslNeighbor is sleepy.
      *
-     * @param[in] aChild     The sleepy child to check.
-     * @param[in] aChecker   The predicate function to apply.
+     * @param[in] aCslNeighbor  The sleepy neighbor to check.
+     * @param[in] aChecker      The predicate function to apply.
      *
      * @returns A pointer to the matching queued message, or `nullptr` if none is found.
      */
-    Message *FindQueuedMessageForSleepyChild(const Child &aChild, MessageChecker aChecker)
+    Message *FindQueuedMessageForSleepyNeighbor(const CslNeighbor &aCslNeighbor, MessageChecker aChecker)
     {
-        return AsNonConst(AsConst(this)->FindQueuedMessageForSleepyChild(aChild, aChecker));
+        return AsNonConst(AsConst(this)->FindQueuedMessageForSleepyNeighbor(aCslNeighbor, aChecker));
     }
 
     /**
-     * Finds the first queued message for a given sleepy child that also satisfies the conditions of a given
+     * Finds the first queued message for a given sleepy neighbor that also satisfies the conditions of a given
      * `MessageChecker`.
      *
-     * The caller MUST ensure that @p aChild is sleepy.
+     * The caller MUST ensure that @p aCslNeighbor is sleepy.
      *
-     * @param[in] aChild     The sleepy child to check.
-     * @param[in] aChecker   The predicate function to apply.
+     * @param[in] aCslNeighbor  The sleepy neighbor to check.
+     * @param[in] aChecker      The predicate function to apply.
      *
      * @returns A pointer to the matching queued message, or `nullptr` if none is found.
      */
-    const Message *FindQueuedMessageForSleepyChild(const Child &aChild, MessageChecker aChecker) const;
+    const Message *FindQueuedMessageForSleepyNeighbor(const CslNeighbor &aCslNeighbor, MessageChecker aChecker) const;
 
     /**
-     * Indicates whether there is any queued message for a given sleepy child that also satisfies the conditions of a
+     * Indicates whether there is any queued message for a given sleepy neighbor that also satisfies the conditions of a
      * given `MessageChecker`.
      *
-     * The caller MUST ensure that @p aChild is sleepy.
+     * The caller MUST ensure that @p aCslNeighbor is sleepy.
      *
-     * @param[in] aChild    The sleepy child to check for.
-     * @param[in] aChecker  The predicate function to apply.
+     * @param[in] aCslNeighbor   The sleepy neighbor to check for.
+     * @param[in] aChecker       The predicate function to apply.
      *
-     * @retval TRUE   There is a queued message satisfying @p aChecker for sleepy child @p aChild.
-     * @retval FALSE  There is no queued message satisfying @p aChecker for sleepy child @p aChild.
+     * @retval TRUE   There is a queued message satisfying @p aChecker for sleepy neighbor @p aCslNeighbor.
+     * @retval FALSE  There is no queued message satisfying @p aChecker for sleepy neighbor @p aCslNeighbor.
      */
-    bool HasQueuedMessageForSleepyChild(const Child &aChild, MessageChecker aChecker) const
+    bool HasQueuedMessageForSleepyNeighbor(const CslNeighbor &aCslNeighbor, MessageChecker aChecker) const
     {
-        return (FindQueuedMessageForSleepyChild(aChild, aChecker) != nullptr);
+        return (FindQueuedMessageForSleepyNeighbor(aCslNeighbor, aChecker) != nullptr);
     }
 
     /**
@@ -268,14 +268,19 @@ private:
 #endif
 
 #if OPENTHREAD_FTD
+    uint16_t GetChildIndex(const CslNeighbor &aNeighbor) const;
+
     // Callbacks from `DataPollHandler`
-    Error PrepareFrameForChild(Mac::TxFrame &aFrame, FrameContext &aContext, Child &aChild);
-    void  HandleSentFrameToChild(const Mac::TxFrame &aFrame, const FrameContext &aContext, Error aError, Child &aChild);
+    Error PrepareFrameForSleepyNeighbor(Mac::TxFrame &aFrame, FrameContext &aContext, CslNeighbor &aCslNeighbor);
+    void  HandleSentFrameToSleepyNeighbor(const Mac::TxFrame &aFrame,
+                                          const FrameContext &aContext,
+                                          Error               aError,
+                                          CslNeighbor        &aCslNeighbor);
     void  HandleFrameChangeDone(Child &aChild);
 
-    void UpdateIndirectMessage(Child &aChild);
-    void RequestMessageUpdate(Child &aChild);
-    void ClearMessagesForRemovedChildren(void);
+    void UpdateIndirectMessage(CslNeighbor &aCslNeighbor);
+    void RequestMessageUpdate(CslNeighbor &aCslNeighbor);
+    void ClearMessagesForRemovedCslNeighbors(void);
 
     static bool AcceptAnyMessage(const Message &aMessage);
     static bool AcceptSupervisionMessage(const Message &aMessage);

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -83,7 +83,7 @@ void MeshForwarder::SendMessage(OwnedPtr<Message> aMessagePtr)
                 {
                     if (!child.IsRxOnWhenIdle() && (destinedForAll || child.HasIp6Address(destination)))
                     {
-                        mIndirectSender.AddMessageForSleepyChild(message, child);
+                        mIndirectSender.AddMessageForSleepyNeighbor(message, child);
                     }
                 }
             }
@@ -95,7 +95,7 @@ void MeshForwarder::SendMessage(OwnedPtr<Message> aMessagePtr)
             if ((neighbor != nullptr) && !neighbor->IsRxOnWhenIdle() && !message.IsDirectTransmission() &&
                 Get<ChildTable>().Contains(*neighbor))
             {
-                mIndirectSender.AddMessageForSleepyChild(message, *static_cast<Child *>(neighbor));
+                mIndirectSender.AddMessageForSleepyNeighbor(message, *static_cast<CslNeighbor *>(neighbor));
             }
             else
             {
@@ -110,7 +110,7 @@ void MeshForwarder::SendMessage(OwnedPtr<Message> aMessagePtr)
     {
         Child *child = Get<ChildSupervisor>().GetDestination(message);
         OT_ASSERT((child != nullptr) && !child->IsRxOnWhenIdle());
-        mIndirectSender.AddMessageForSleepyChild(message, *child);
+        mIndirectSender.AddMessageForSleepyNeighbor(message, *child);
         break;
     }
 
@@ -269,7 +269,7 @@ void MeshForwarder::RemoveMessagesForChild(Child &aChild, MessageChecker &aMessa
             continue;
         }
 
-        if (mIndirectSender.RemoveMessageFromSleepyChild(message, aChild) != kErrorNone)
+        if (mIndirectSender.RemoveMessageFromSleepyNeighbor(message, aChild) != kErrorNone)
         {
             const Neighbor *neighbor = nullptr;
 
@@ -304,7 +304,7 @@ void MeshForwarder::FinalizeMessageIndirectTxs(Message &aMessage)
 
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateAnyExceptInvalid))
     {
-        IgnoreError(mIndirectSender.RemoveMessageFromSleepyChild(aMessage, child));
+        IgnoreError(mIndirectSender.RemoveMessageFromSleepyNeighbor(aMessage, child));
         VerifyOrExit(!aMessage.GetIndirectTxChildMask().IsEmpty());
     }
 
@@ -403,7 +403,7 @@ Error MeshForwarder::UpdateIp6RouteFtd(const Ip6::Header &aIp6Header, Message &a
 
             if (!child->IsRxOnWhenIdle())
             {
-                mIndirectSender.AddMessageForSleepyChild(aMessage, *child);
+                mIndirectSender.AddMessageForSleepyNeighbor(aMessage, *child);
                 aMessage.ClearDirectTransmission();
             }
         }

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -2956,7 +2956,7 @@ Error Mle::SendChildUpdateRequestToChild(Child &aChild)
         // to the sleepy child if there is one already
         // queued.
 
-        VerifyOrExit(!Get<IndirectSender>().HasQueuedMessageForSleepyChild(aChild, IsMessageChildUpdateRequest));
+        VerifyOrExit(!Get<IndirectSender>().HasQueuedMessageForSleepyNeighbor(aChild, IsMessageChildUpdateRequest));
     }
 
     Get<MeshForwarder>().RemoveMessagesForChild(aChild, IsMessageChildUpdateRequest);
@@ -3230,7 +3230,7 @@ void Mle::RemoveNeighbor(Neighbor &aNeighbor)
             mNeighborTable.Signal(NeighborTable::kChildRemoved, aNeighbor);
         }
 
-        Get<IndirectSender>().ClearAllMessagesForSleepyChild(static_cast<Child &>(aNeighbor));
+        Get<IndirectSender>().ClearAllMessagesForSleepyNeighbor(static_cast<CslNeighbor &>(aNeighbor));
 
         if (aNeighbor.IsFullThreadDevice())
         {


### PR DESCRIPTION
Current implementation of the `IndirectSender` is only used for parents to send frames to the sleepy `Child`. For the P2P feature, a `Peer` will also send frames to another sleepy `Peer`. The `IndirectSender` can be reused by both the `Parent` and `Peer` to send frames to sleepy neighbors. The `CslNeighbor` is the base class for `Child` and `Peer`, and it includes all the information needed by `IndirectSender`.

This commit changes the argument of `IndirectSender` from `Child` to `CslNeighbor` and renames some functions to make `IndirectSender` more general for both the `Child` and `Peer`.

This commit only refactors the code, without changing the code logic.