### PR TITLE
[rx-ra-tracker] use a new `Events` struct for callbacks

### DIFF
--- a/src/core/border_router/multi_ail_detector.cpp
+++ b/src/core/border_router/multi_ail_detector.cpp
@@ -62,6 +62,15 @@ void MultiAilDetector::Stop(void)
     mReachablePeerBrCount = 0;
 }
 
+void MultiAilDetector::HandleRxRaTrackerEvents(const RxRaTracker::Events &aEvents)
+{
+    VerifyOrExit(aEvents.mDecisionFactorChanged);
+    Evaluate();
+
+exit:
+    return;
+}
+
 void MultiAilDetector::Evaluate(void)
 {
     uint16_t count;

--- a/src/core/border_router/multi_ail_detector.hpp
+++ b/src/core/border_router/multi_ail_detector.hpp
@@ -43,6 +43,7 @@
 #endif
 
 #include "border_router/br_types.hpp"
+#include "border_router/rx_ra_tracker.hpp"
 #include "common/callback.hpp"
 #include "common/error.hpp"
 #include "common/locator.hpp"
@@ -52,7 +53,6 @@ namespace ot {
 namespace BorderRouter {
 
 class NetDataBrTracker;
-class RxRaTracker;
 class RoutingManager;
 
 /**
@@ -110,7 +110,7 @@ private:
     void HandleTimer(void);
 
     // Callback from `RxRaTracker`
-    void HandleRxRaTrackerDecisionFactorChanged(void) { Evaluate(); }
+    void HandleRxRaTrackerEvents(const RxRaTracker::Events &aEvents);
 
     using DetectCallback = Callback<MultiAilCallback>;
     using DetectTimer    = TimerMilliIn<MultiAilDetector, &MultiAilDetector::HandleTimer>;

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -827,7 +827,7 @@ private:
         const Ip6::Prefix &GetFavoredPrefix(RoutePreference &aPreference) const;
         void               Evaluate(void);
         void               HandleInfraIfDiscoverDone(const Ip6::Prefix &aPrefix);
-        void               HandleRaDiscoverChanged(void);
+        void               HandleRxRaTrackerChanged(void);
         void               HandleTimer(void);
 
     private:
@@ -1028,8 +1028,10 @@ private:
 
     bool NetworkDataContainsUlaRoute(void) const;
 
-    void HandleRxRaTrackerDecisionFactorChanged(void);
     void HandleLocalOnLinkPrefixChanged(void);
+
+    // Callback from `RxRaTracker`
+    void HandleRxRaTrackerEvents(const RxRaTracker::Events &aEvents);
 
     static bool IsValidBrUlaPrefix(const Ip6::Prefix &aBrUlaPrefix);
 


### PR DESCRIPTION
This commit enhances `RxRaTracker` by introducing a new `Events` struct for handling callbacks. This change replaces the previous `HandleRxRaTrackerDecisionFactorChanged()` method with a more versatile `HandleRxRaTrackerEvents()` that accepts the `Events` struct as an argument.

The new `Events` struct includes boolean flags for:
- `mInitialDiscoveryFinished`
- `mDecisionFactorChanged`
- `mLocalRaHeaderChanged`

This allows `RxRaTracker` to communicate more specific events to `RoutingManager` and `MultiAilDetector`, enabling them to take the proper action based on the events. The `SignalTask` has been renamed to `EventTask` to better reflect its new role in handling these events.

---

~Currently contains the commit from https://github.com/openthread/openthread/pull/12080. please check and review the last commit in this PR.~