### PR TITLE
[mdns] use different default TTLs for addr and service records

### DIFF
--- a/src/core/net/mdns.cpp
+++ b/src/core/net/mdns.cpp
@@ -1976,7 +1976,7 @@ void Core::HostEntry::Register(const Host &aHost, const Callback &aCallback)
         ExitNow();
     }
 
-    mIp6AddrRecord.UpdateTtl(DetermineTtl(aHost.mTtl, kDefaultTtl));
+    mIp6AddrRecord.UpdateTtl(DetermineTtl(aHost.mTtl, kDefaultAddrTtl));
     mIp6AddrRecord.UpdateAddresses(aHost);
 
     DetermineNextFireTime();
@@ -1999,7 +1999,7 @@ void Core::HostEntry::Register(const LocalHost &aLocalHost, const Callback &aCal
     }
     else
     {
-        mIp6AddrRecord.UpdateTtl(kDefaultTtl);
+        mIp6AddrRecord.UpdateTtl(kDefaultAddrTtl);
         mIp6AddrRecord.UpdateAddresses(aLocalHost.GetIp6Addresses());
     }
 
@@ -2018,7 +2018,7 @@ void Core::HostEntry::Register(const LocalHost &aLocalHost, const Callback &aCal
             OT_ASSERT(mIp4AddrRecord != nullptr);
         }
 
-        mIp4AddrRecord->UpdateTtl(kDefaultTtl);
+        mIp4AddrRecord->UpdateTtl(kDefaultAddrTtl);
         mIp4AddrRecord->UpdateAddresses(aLocalHost.GetIp4Addresses());
     }
 
@@ -2541,7 +2541,7 @@ exit:
 void Core::ServiceEntry::Register(const Service &aService, const Callback &aCallback)
 {
     const char *hostName;
-    uint32_t    ttl = DetermineTtl(aService.mTtl, kDefaultTtl);
+    uint32_t    ttl = DetermineTtl(aService.mTtl, kDefaultServiceTtl);
 
     if (GetState() == kRemoving)
     {

--- a/src/core/net/mdns.hpp
+++ b/src/core/net/mdns.hpp
@@ -908,8 +908,9 @@ private:
     static constexpr uint32_t kResponseAggregationMaxDelay = 500; // msec
 
     static constexpr uint32_t kUnspecifiedTtl       = 0;
-    static constexpr uint32_t kDefaultTtl           = 120;
-    static constexpr uint32_t kDefaultKeyTtl        = kDefaultTtl;
+    static constexpr uint32_t kDefaultAddrTtl       = 120;
+    static constexpr uint32_t kDefaultServiceTtl    = 4500;
+    static constexpr uint32_t kDefaultKeyTtl        = 4500;
     static constexpr uint32_t kLegacyUnicastNsecTtl = 10;
     static constexpr uint32_t kNsecTtl              = 4500;
     static constexpr uint32_t kServicesPtrTtl       = 4500;


### PR DESCRIPTION
This commit updates the default TTL values used for mDNS records to better align with the recommendations.

Previously, a single `kDefaultTtl` of 120 seconds was used for all records when the registered entry did not explicitly specify the TTL to use. This commit introduces separate default TTLs:

- `kDefaultAddrTtl` for address records (`AAAA`, `A`) is kept at 120 seconds.
- `kDefaultServiceTtl` for all service records (`PTR`, `SRV`, `TXT`) is set to 4500 seconds.
- `kDefaultKeyTtl` is also updated to 4500 seconds for `KEY` records.

The code is updated to use the appropriate default TTL based on the record type.