### PR TITLE
[mle] delay Child Update Request for non-sleepy children

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3235,6 +3235,26 @@ void Mle::DelayedSender::RemoveScheduledParentResponses(void)
     RemoveMatchingSchedules(kTypeParentResponse, destination);
 }
 
+void Mle::DelayedSender::ScheduleChildUpdateRequestToChild(const Child &aChild, uint32_t aDelay)
+{
+    Ip6::Address destination;
+    uint16_t     childRloc16;
+
+    destination.SetToLinkLocalAddress(aChild.GetExtAddress());
+    RemoveMatchingSchedules(kTypeChildUpdateRequestOfChild, destination);
+
+    childRloc16 = aChild.GetRloc16();
+    AddSchedule(kTypeChildUpdateRequestOfChild, destination, aDelay, &childRloc16, sizeof(uint16_t));
+}
+
+void Mle::DelayedSender::RemoveScheduledChildUpdateRequestToChild(const Child &aChild)
+{
+    Ip6::Address destination;
+
+    destination.SetToLinkLocalAddress(aChild.GetExtAddress());
+    RemoveMatchingSchedules(kTypeChildUpdateRequestOfChild, destination);
+}
+
 void Mle::DelayedSender::ScheduleAdvertisement(const Ip6::Address &aDestination, uint32_t aDelay)
 {
     VerifyOrExit(!HasMatchingSchedule(kTypeAdvertisement, aDestination));
@@ -3393,6 +3413,22 @@ void Mle::DelayedSender::Execute(const Schedule &aSchedule)
 
         IgnoreError(aSchedule.Read(sizeof(Header), info));
         Get<Mle>().SendParentResponse(info);
+        break;
+    }
+
+    case kTypeChildUpdateRequestOfChild:
+    {
+        uint16_t rloc16;
+        Child   *child;
+
+        IgnoreError(aSchedule.Read(sizeof(Header), rloc16));
+        child = Get<ChildTable>().FindChild(rloc16, Child::kInStateValidOrRestoring);
+
+        if (child != nullptr)
+        {
+            IgnoreError(Get<Mle>().SendChildUpdateRequestToChild(*child));
+        }
+
         break;
     }
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1323,6 +1323,13 @@ private:
     static constexpr uint8_t  kDefaultLeaderWeight           = 64;
     static constexpr uint8_t  kAlternateRloc16Timeout        = 8; // Time to use alternate RLOC16 (in sec).
 
+    // Child Update Tx constants (used by parent to restore former
+    // children upon its own role restoration).
+    static constexpr uint32_t kMinChildUpdateRestoreDelay          = 250;  // in msec
+    static constexpr uint32_t kEarlyChildUpdateRestoreDelay        = 1250; // in msec
+    static constexpr uint32_t kMaxChildUpdateRestoreDelay          = 5000; // in msec
+    static constexpr uint16_t kThresholdToUseEarlyChildUpdateDelay = 10;
+
     // Threshold to accept a router upgrade request with reason
     // `kBorderRouterRequest` (number of BRs acting as router in
     // Network Data).
@@ -1708,9 +1715,12 @@ private:
 
         void ScheduleDataRequest(const Ip6::Address &aDestination, uint32_t aDelay);
         void ScheduleChildUpdateRequestToParent(uint32_t aDelay);
+        void RemoveScheduledChildUpdateRequestToParent(void);
 #if OPENTHREAD_FTD
         void ScheduleParentResponse(const ParentResponseInfo &aInfo, uint32_t aDelay);
         void RemoveScheduledParentResponses(void);
+        void ScheduleChildUpdateRequestToChild(const Child &aChild, uint32_t aDelay);
+        void RemoveScheduledChildUpdateRequestToChild(const Child &aChild);
         void ScheduleAdvertisement(const Ip6::Address &aDestination, uint32_t aDelay);
         void ScheduleMulticastDataResponse(uint32_t aDelay);
         void ScheduleLinkRequest(const Router &aRouter, uint32_t aDelay);
@@ -1721,7 +1731,6 @@ private:
                                        const DiscoveryResponseInfo &aInfo,
                                        uint32_t                     aDelay);
 #endif
-        void RemoveScheduledChildUpdateRequestToParent(void);
 
         void HandleTimer(void);
         void GetQueueInfo(MessageQueue::Info &aQueueInfo) const { mSchedules.GetInfo(aQueueInfo); }

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -400,6 +400,8 @@ void Mle::SetStateLeader(uint16_t aRloc16, LeaderStartMode aStartMode)
 
 void Mle::SetStateRouterOrLeader(DeviceRole aRole, uint16_t aRloc16, LeaderStartMode aStartMode)
 {
+    uint16_t childCount;
+
     if (aRole == kRoleLeader)
     {
         IgnoreError(Get<MeshCoP::ActiveDatasetManager>().Restore());
@@ -432,13 +434,53 @@ void Mle::SetStateRouterOrLeader(DeviceRole aRole, uint16_t aRloc16, LeaderStart
         Get<AddressResolver>().Clear();
     }
 
-    // Remove children that do not have a matching RLOC16
+    childCount = 0;
+
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValidOrRestoring))
     {
+        uint32_t minDelay;
+        uint32_t maxDelay;
+
         if (RouterIdFromRloc16(child.GetRloc16()) != mRouterId)
         {
+            // Remove children that do not have a matching RLOC16
             RemoveNeighbor(child);
+            continue;
         }
+
+        // Schedule Child Update Request TX to rx-on (non-sleepy) children.
+        // Sleepy children are handled and recovered in the `HandleTimeTick()`.
+
+        if (!child.IsRxOnWhenIdle() || !child.IsStateRestored())
+        {
+            continue;
+        }
+
+        // We spread the "Child Update Request" transmissions to avoid an
+        // initial burst of traffic and allow collection of response from the
+        // children.
+
+        // We track the number of rx-on children. The first 10
+        // (`kThresholdToUseEarlyChildUpdateDelay`) children are
+        // scheduled within a shorter early delay window (
+        // [250ms, 1250ms]), and the rest are scheduled after in
+        // longer ([1250ms, 5000ms]).
+
+        childCount++;
+
+        if (childCount <= kThresholdToUseEarlyChildUpdateDelay)
+        {
+            minDelay = kMinChildUpdateRestoreDelay;
+            maxDelay = kEarlyChildUpdateRestoreDelay;
+        }
+        else
+        {
+            minDelay = kEarlyChildUpdateRestoreDelay;
+            maxDelay = kMaxChildUpdateRestoreDelay;
+        }
+
+        mDelayedSender.ScheduleChildUpdateRequestToChild(child,
+                                                         Random::NonCrypto::GetUint32InRange(minDelay, maxDelay));
     }
 
     LogNote("Partition ID 0x%lx", ToUlong(mLeaderData.GetPartitionId()));
@@ -1652,7 +1694,7 @@ void Mle::HandleTimeTick(void)
             LogInfo("Child 0x%04x timeout expired", child.GetRloc16());
             RemoveNeighbor(child);
         }
-        else if (IsRouterOrLeader() && child.IsStateRestored())
+        else if (IsRouterOrLeader() && child.IsStateRestored() && !child.IsRxOnWhenIdle())
         {
             IgnoreError(SendChildUpdateRequestToChild(child));
         }


### PR DESCRIPTION
This commit enhances the mechanism of sending "Child Update Requests" by a parent to restore its former children after it restores its previous router/leader role.

Previously, the device would send "Child Update Request" messages to all its former children simultaneously. This commit changes this to schedule delayed "Child Update Request" messages only to its non-sleepy (rx-on-when-idle) children. The transmissions are spread out randomly to avoid a burst of traffic.

To ensure this scales properly, the first 10 non-sleepy children are scheduled within a shorter delay window of [250ms, 1250ms], and the rest are scheduled in a longer window of [1250ms, 5000ms].

The previous mechanism in `HandleTimeTick()` for sending "Child Update Request" is now only used for sleepy children.