### PR TITLE
[coap] block2 fix PrepareNextBlockRequest to not return error

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -633,7 +633,6 @@ Error CoapBase::PrepareNextBlockRequest(Message::BlockType aType,
                                         Message           &aMessage)
 {
     Error            error       = kErrorNone;
-    Error            errorMd     = kErrorNone;
     bool             isOptionSet = false;
     uint16_t         blockOption = 0;
     Option::Iterator iterator;
@@ -691,10 +690,10 @@ Error CoapBase::PrepareNextBlockRequest(Message::BlockType aType,
         aRequest.SetMoreBlocksFlag(aMoreBlocks);
     }
 
+    error = metadata.AppendTo(aRequestOld);
+
 exit:
-    errorMd = metadata.AppendTo(aRequestOld);
-    // Use error from earlier if it exists
-    return (error == kErrorNone) ? errorMd : error;
+    return error;
 }
 
 Error CoapBase::SendNextBlock1Request(Message                &aRequest,


### PR DESCRIPTION
For issue: https://github.com/openthread/openthread/issues/10261
Dependency on: https://github.com/openthread/openthread/pull/12097

__I have made a major change to what I'm delivering in the PR when compared to the original approach__

When testing using esp-idf v5.5.1 I found that when using a BlockWise Transfer Request (Block2), that the process stopped with a parsing error during creation of the 3rd request.

esp-idf uses their own fork of openthread/openthread, and then pulls in that fork to espressif/esp-idf.
The 5.5 branch of esp-idf is currently using this branch of their fork of openthread
(https://github.com/espressif/openthread/tree/b945928d722177cd9caeab2e1025499628c101ef)

There is something wrong with how subsequent block2 requests are being created.  
The initial block2 request is well formed and the SendNextBlock2Request is able to send it.
The second block2 request is not well formed (even though it is successfully sent) and when it is used by PrepareNextBlockRequest to prepare the 3rd Request a parsing error occurs.

I built this PR on top of PR#12097

I was able to successfully resolve issue with this change in that branch.  Code review of openthread/openthread showed that the same issue existed in master branch.

This is a fix, I was able to determine what the difference between the initial request and the second request were that causes the parsing error during preparation of the 3rd request.  It was a misalignment of the option offset.

Below is a code snippet of how I am running code
```
otError get_coap_file(
  otInstance *instance
  const std::string_view url,
  otCoapResponseHandler handler,
  void *context,
  otCoapBlockwiseReceiveHook receive_hook,
  otCoapBlockSzx block_size) {

  std::shared_ptr<CoapUrlInfo> coapUrlInfo = parse_coap_url_(url);

  otMessage *message = nullptr;
  message = otCoapNewMessage(instance, nullptr);
  if (message == nullptr) {
    return OT_ERROR_NO_BUFS;
  }
  otCoapMessageInit(message, OT_COAP_TYPE_CONFIRMABLE, OT_COAP_CODE_GET);
  otCoapMessageGenerateToken(message, OT_COAP_DEFAULT_TOKEN_LENGTH);
  for (const std::string& segment : coapUrlInfo->path_segments) {
    otCoapMessageAppendUriPathOptions(message, segment.c_str());
  }
  otCoapMessageAppendBlock2Option(message, 0, false, block_size);

  char ip6_str[OT_IP6_ADDRESS_STRING_SIZE];
  const otIp6Address *address = &(coapUrlInfo->address);
  otIp6AddressToString(address, ip6_str, sizeof(ip6_str));
  otMessageInfo message_info;
  memset(&message_info, 0, sizeof(message_info));
  message_info.mPeerAddr = coapUrlInfo->address;
  message_info.mPeerPort = coapUrlInfo->port;
  message_info.mHopLimit = 64;

  this->is_coap_file_finished_ = false;
  error = otCoapSendRequestBlockWiseWithParameters(instance,message,&message_info,handler,context,nullptr,nullptr,receive_hook);
}
```