### PR TITLE
[core] fix typo in rloc16 variable name

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3415,11 +3415,11 @@ void Mle::DelayedSender::Execute(const Schedule &aSchedule)
 
     case kTypeLinkRequest:
     {
-        uint16_t rlco16;
+        uint16_t rloc16;
         Router  *router;
 
-        IgnoreError(aSchedule.Read(sizeof(Header), rlco16));
-        router = Get<RouterTable>().FindRouterByRloc16(rlco16);
+        IgnoreError(aSchedule.Read(sizeof(Header), rloc16));
+        router = Get<RouterTable>().FindRouterByRloc16(rloc16);
 
         if (router != nullptr)
         {

--- a/tests/unit/test_network_data.cpp
+++ b/tests/unit/test_network_data.cpp
@@ -768,7 +768,7 @@ void TestNetworkDataDsnSrpServices(void)
         {
             SuccessOrQuit(iterator.GetNextDnsSrpAnycastInfo(anycastInfo));
 
-            printf("\nanycastInfo { %s, seq:%d, rlco16:%04x, version:%u }",
+            printf("\nanycastInfo { %s, seq:%d, rloc16:%04x, version:%u }",
                    anycastInfo.mAnycastAddress.ToString().AsCString(), anycastInfo.mSequenceNumber, anycastInfo.mRloc16,
                    anycastInfo.mVersion);
 
@@ -1046,7 +1046,7 @@ void TestNetworkDataDsnSrpAnycastSeqNumSelection(void)
         {
             SuccessOrQuit(iterator.GetNextDnsSrpAnycastInfo(anycastInfo));
 
-            printf("\n { %s, seq:%u, version:%u, rlco16:%04x }", anycastInfo.mAnycastAddress.ToString().AsCString(),
+            printf("\n { %s, seq:%u, version:%u, rloc16:%04x }", anycastInfo.mAnycastAddress.ToString().AsCString(),
 
                    anycastInfo.mSequenceNumber, anycastInfo.mVersion, anycastInfo.mRloc16);
 


### PR DESCRIPTION
This commit corrects a typo in the variable name `rloc16` which was incorrectly written as `rlco16`.