### PR TITLE
[border-agent] use `OwnedPtr` for message management

### DIFF
--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -294,7 +294,8 @@ private:
         friend Heap::Allocatable<CoapDtlsSession>;
 
     public:
-        Error    ForwardToCommissioner(Coap::Message &aForwardMessage, const Message &aMessage);
+        Error    SendMessage(OwnedPtr<Coap::Message> aMessage);
+        Error    ForwardToCommissioner(OwnedPtr<Coap::Message> aForwardMessage, const Message &aMessage);
         void     Cleanup(void);
         bool     IsActiveCommissioner(void) const { return mIsActiveCommissioner; }
         uint64_t GetAllocationTime(void) const { return mAllocationTime; }


### PR DESCRIPTION
This commit updates the `BorderAgent` implementation to consistently use `OwnedPtr` for managing the lifecycle of `Coap::Message` and `Message` objects.

This change improves memory safety and simplify the code. Message objects are now automatically deallocated when the `OwnedPtr` goes out of scope, which eliminates all manual calls to `FreeMessage()` and `FreeMessageOnError()`, preventing potential memory leaks and making the code more robust.