### PR TITLE
[border-agent] simplify forwarding logic to leader

### DIFF
--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -312,15 +312,12 @@ private:
 
             CoapDtlsSession &mSession;
             ForwardContext  *mNext;
-            uint16_t         mMessageId;
-            bool             mPetition : 1;
-            bool             mSeparate : 1;
-            uint8_t          mTokenLength : 4;
-            uint8_t          mType : 2;
+            Uri              mUri;
+            uint8_t          mTokenLength;
             uint8_t          mToken[Coap::Message::kMaxTokenLength];
 
         private:
-            ForwardContext(CoapDtlsSession &aSession, const Coap::Message &aMessage, bool aPetition, bool aSeparate);
+            ForwardContext(CoapDtlsSession &aSession, const Coap::Message &aMessage, Uri aUri);
         };
 
         CoapDtlsSession(Instance &aInstance, Dtls::Transport &aDtlsTransport);
@@ -331,7 +328,7 @@ private:
         void  HandleTmfDatasetGet(Coap::Message &aMessage, Uri aUri);
         Error ForwardToLeader(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, Uri aUri);
         void  SendErrorMessage(const ForwardContext &aForwardContext, Error aError);
-        void  SendErrorMessage(const Coap::Message &aRequest, bool aSeparate, Error aError);
+        void  SendErrorMessage(const Coap::Message &aRequest, Error aError);
 
         static void HandleConnected(ConnectEvent aEvent, void *aContext);
         void        HandleConnected(ConnectEvent aEvent);


### PR DESCRIPTION
This commit simplifies the CoAP message forwarding logic within the `CoapDtlsSession` by removing the `mPetition` and `mSeparate` boolean flags from the `ForwardContext`.

The `Uri` of the request is now stored directly in `ForwardContext` and used to determine the logic flow, making the code more explicit and easier to understand.

The `ForwardToLeader()` is only used with `kUriLeaderPetition` and `kUriLeaderKeepAlive`, both of which require a separate non-confirmable response in addition to an immediate CoAP Ack (i.e., as if `mSeparate ` is `true`).

This change removes the need for intermediate flags and simplifies the implementation of `ForwardToLeader()`, `SendErrorMessage()`, and the `ForwardContext` constructor and `ToHeader()` method. The CoAP message initialization is now more direct, always using `kTypeNonConfirmable` for forwarded responses and error messages.