### PR TITLE
[border-agent] simplify `SendErrorMessage` in `CoapDtlsSession`

### DIFF
--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -327,8 +327,7 @@ private:
         void  HandleTmfProxyTx(Coap::Message &aMessage);
         void  HandleTmfDatasetGet(Coap::Message &aMessage, Uri aUri);
         Error ForwardToLeader(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, Uri aUri);
-        void  SendErrorMessage(const ForwardContext &aForwardContext, Error aError);
-        void  SendErrorMessage(const Coap::Message &aRequest, Error aError);
+        void  SendErrorMessage(Error aError, const uint8_t *aToken, uint8_t aTokenLength);
 
         static void HandleConnected(ConnectEvent aEvent, void *aContext);
         void        HandleConnected(ConnectEvent aEvent);
@@ -371,8 +370,6 @@ private:
     void HandleSessionConnected(CoapDtlsSession &aSession);
     void HandleSessionDisconnected(CoapDtlsSession &aSession, CoapDtlsSession::ConnectEvent aEvent);
     void HandleCommissionerPetitionAccepted(CoapDtlsSession &aSession);
-
-    static Coap::Message::Code CoapCodeFromError(Error aError);
 
     void PostServiceTask(void);
     void HandleServiceTask(void);


### PR DESCRIPTION
Consolidates the two overloaded `SendErrorMessage()` methods in the `CoapDtlsSession` class into a single implementation.

The new `SendErrorMessage()` method now accepts the token information directly, rather than a `Coap::Message` or a `ForwardContext` object. This simplifies the call sites and removes the now-unused `CoapCodeFromError()` helper function (the conversion is now done in the consolidated `SendErrorMessage()`).