### PR TITLE
[child] convert `Neighbor` to `const void*` for the address comparison

### DIFF
--- a/src/core/thread/child_table.hpp
+++ b/src/core/thread/child_table.hpp
@@ -308,7 +308,7 @@ public:
      */
     bool Contains(const Neighbor &aNeighbor) const
     {
-        const Child *child = reinterpret_cast<const Child *>(&aNeighbor);
+        const void *child = &aNeighbor;
 
         return (mChildren <= child) && (child < GetArrayEnd(mChildren));
     }


### PR DESCRIPTION
When using some special OT configurations, the ot-cli-ftd will crash. The crash path is `MessageFramer::PrepareMacHeaders()` -> `Get<NeighborTable>().FindNeighbor()` -> `Get<ChildTable>().Contains()`. The crash happens in the `ChildTable::Contains()`. Here is the crash message: `kernel: traps: ot-cli-ftd[122376] trap invalid opcode ip:5640b7713b8e sp:7ffd6425c5f0 error:0 in ot-cli-ftd[313b8e,5640b7400000+426000]`.

The root cause of the crash is that the `CandidateParent` is an 4 bytes aligned class in some configurations and the `Child` is an 8 bytes aligned class. When converting the `CandidateParent` to `Neighbor` and then converting the `Neighbor` to `Child`, the program will crash due to the alignment issues.

This commit converts the `Neighbor` to the `const void *` in `ChildTable::Contains()` for the address comparison.