### PR TITLE
[border-agent] inline `ForwardContext::ToHeader()`

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -1152,7 +1152,9 @@ void Manager::CoapDtlsSession::HandleLeaderResponseToFwdTmf(const ForwardContext
         }
     }
 
-    SuccessOrExit(error = aForwardContext.ToHeader(*forwardMessage, aResponse->GetCode()));
+    forwardMessage->Init(Coap::kTypeNonConfirmable, static_cast<Coap::Code>(aResponse->GetCode()));
+
+    SuccessOrExit(error = forwardMessage->SetToken(aForwardContext.mToken, aForwardContext.mTokenLength));
 
     if (aResponse->GetLength() > aResponse->GetOffset())
     {
@@ -1401,13 +1403,6 @@ Manager::CoapDtlsSession::ForwardContext::ForwardContext(CoapDtlsSession     &aS
     , mTokenLength(aMessage.GetTokenLength())
 {
     memcpy(mToken, aMessage.GetToken(), mTokenLength);
-}
-
-Error Manager::CoapDtlsSession::ForwardContext::ToHeader(Coap::Message &aMessage, uint8_t aCode) const
-{
-    aMessage.Init(Coap::kTypeNonConfirmable, static_cast<Coap::Code>(aCode));
-
-    return aMessage.SetToken(mToken, mTokenLength);
 }
 
 } // namespace BorderAgent

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -301,23 +301,17 @@ private:
         uint64_t GetAllocationTime(void) const { return mAllocationTime; }
 
     private:
-        class ForwardContext : public ot::LinkedListEntry<ForwardContext>,
-                               public Heap::Allocatable<ForwardContext>,
-                               private ot::NonCopyable
+        struct ForwardContext : public ot::LinkedListEntry<ForwardContext>,
+                                public Heap::Allocatable<ForwardContext>,
+                                private ot::NonCopyable
         {
-            friend class Heap::Allocatable<ForwardContext>;
-
-        public:
-            Error ToHeader(Coap::Message &aMessage, uint8_t aCode) const;
+            ForwardContext(CoapDtlsSession &aSession, const Coap::Message &aMessage, Uri aUri);
 
             CoapDtlsSession &mSession;
             ForwardContext  *mNext;
             Uri              mUri;
             uint8_t          mTokenLength;
             uint8_t          mToken[Coap::Message::kMaxTokenLength];
-
-        private:
-            ForwardContext(CoapDtlsSession &aSession, const Coap::Message &aMessage, Uri aUri);
         };
 
         CoapDtlsSession(Instance &aInstance, Dtls::Transport &aDtlsTransport);


### PR DESCRIPTION
Remove the `CoapDtlsSession::ForwardContext::ToHeader()` helper method and move its logic directly into the `HandleCoapResponse()` method. This simplifies the implementation by removing an unnecessary function call for a single-use case.

Additionally, convert `ForwardContext` from a `class` to a `struct`. This change makes the constructor public, removing the need for a `friend` declaration for `Heap::Allocatable`, and better reflects its role as a simple data structure.