### PR TITLE
[border-agent] rename callback to `HandleLeaderResponseToFwdTmf`

### DIFF
--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -332,11 +332,13 @@ private:
 
         static void HandleConnected(ConnectEvent aEvent, void *aContext);
         void        HandleConnected(ConnectEvent aEvent);
-        static void HandleCoapResponse(void                *aContext,
-                                       otMessage           *aMessage,
-                                       const otMessageInfo *aMessageInfo,
-                                       otError              aResult);
-        void HandleCoapResponse(const ForwardContext &aForwardContext, const Coap::Message *aResponse, Error aResult);
+        static void HandleLeaderResponseToFwdTmf(void                *aContext,
+                                                 otMessage           *aMessage,
+                                                 const otMessageInfo *aMessageInfo,
+                                                 otError              aResult);
+        void        HandleLeaderResponseToFwdTmf(const ForwardContext &aForwardContext,
+                                                 const Coap::Message  *aResponse,
+                                                 Error                 aResult);
         static bool HandleUdpReceive(void *aContext, const otMessage *aMessage, const otMessageInfo *aMessageInfo);
         bool        HandleUdpReceive(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
         static bool HandleResource(CoapBase               &aCoapBase,


### PR DESCRIPTION
The `HandleCoapResponse` callback in `CoapDtlsSession` is renamed to `HandleLeaderResponseToFwdTmf`.

The new name more clearly indicates that this callback is used to handle the response from the leader for a forwarded TMF message. This improves code readability and makes the role of the callback more explicit.