### PR TITLE
[border-agent] move TXT data management to `TxtData` class

### DIFF
--- a/src/core/api/border_agent_api.cpp
+++ b/src/core/api/border_agent_api.cpp
@@ -67,7 +67,7 @@ otError otBorderAgentSetMeshCoPServiceBaseName(otInstance *aInstance, const char
 
 void otBorderAgentSetVendorTxtData(otInstance *aInstance, const uint8_t *aVendorData, uint16_t aVendorDataLength)
 {
-    AsCoreType(aInstance).Get<MeshCoP::BorderAgent::Manager>().SetVendorTxtData(aVendorData, aVendorDataLength);
+    AsCoreType(aInstance).Get<MeshCoP::BorderAgent::TxtData>().SetVendorData(aVendorData, aVendorDataLength);
 }
 #endif
 
@@ -106,7 +106,7 @@ void otBorderAgentSetMeshCoPServiceChangedCallback(otInstance                   
                                                    otBorderAgentMeshCoPServiceChangedCallback aCallback,
                                                    void                                      *aContext)
 {
-    AsCoreType(aInstance).Get<MeshCoP::BorderAgent::Manager>().SetServiceChangedCallback(aCallback, aContext);
+    AsCoreType(aInstance).Get<MeshCoP::BorderAgent::TxtData>().SetChangedCallback(aCallback, aContext);
 }
 
 otError otBorderAgentGetMeshCoPServiceTxtData(otInstance *aInstance, otBorderAgentMeshCoPServiceTxtData *aTxtData)

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -827,7 +827,7 @@ void RoutingManager::OmrPrefixManager::SetFavoredPrefix(const OmrPrefix &aOmrPre
     if (oldFavoredPrefix != mFavoredPrefix)
     {
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-        Get<MeshCoP::BorderAgent::Manager>().HandleFavoredOmrPrefixChanged();
+        Get<MeshCoP::BorderAgent::TxtData>().Refresh();
 #endif
         LogInfo("Favored OMR prefix: %s -> %s", FavoredToString(oldFavoredPrefix).AsCString(),
                 FavoredToString(mFavoredPrefix).AsCString());

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -132,6 +132,7 @@ void Notifier::EmitEvents(void)
 #endif
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
     Get<MeshCoP::BorderAgent::Manager>().HandleNotifierEvents(events);
+    Get<MeshCoP::BorderAgent::TxtData>().HandleNotifierEvents(events);
 #endif
 #if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
     Get<MlrManager>().HandleNotifierEvents(events);

--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -172,8 +172,8 @@ Instance::Instance(void)
     , mNetworkDiagnosticClient(*this)
 #endif
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    , mBorderAgentManager(*this)
     , mBorderAgentTxtData(*this)
+    , mBorderAgentManager(*this)
 #endif
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
     , mBorderAgentEphemeralKeyManager(*this)

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -592,8 +592,8 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    MeshCoP::BorderAgent::Manager mBorderAgentManager;
     MeshCoP::BorderAgent::TxtData mBorderAgentTxtData;
+    MeshCoP::BorderAgent::Manager mBorderAgentManager;
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -45,13 +45,13 @@
 #include "common/appender.hpp"
 #include "common/as_core_type.hpp"
 #include "common/heap_allocatable.hpp"
-#include "common/heap_data.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/owned_ptr.hpp"
 #include "common/tasklet.hpp"
+#include "meshcop/border_agent_txt_data.hpp"
 #include "meshcop/dataset.hpp"
 #include "meshcop/secure_transport.hpp"
 #include "net/dns_types.hpp"
@@ -102,9 +102,6 @@ struct Id : public otBorderAgentId, public Clearable<Id>, public Equatable<Id>
 
 class Manager : public InstanceLocator, private NonCopyable
 {
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-    friend class ot::BorderRouter::RoutingManager;
-#endif
 #if OPENTHREAD_CONFIG_BORDER_AGENT_MESHCOP_SERVICE_ENABLE
     friend ot::Dnssd;
 #endif
@@ -113,13 +110,13 @@ class Manager : public InstanceLocator, private NonCopyable
 #endif
     friend class ot::Notifier;
     friend class Tmf::Agent;
+    friend class TxtData;
 
     class CoapDtlsSession;
 
 public:
-    typedef otBorderAgentCounters                      Counters;               ///< Border Agent Counters.
-    typedef otBorderAgentSessionInfo                   SessionInfo;            ///< A session info.
-    typedef otBorderAgentMeshCoPServiceChangedCallback ServiceChangedCallback; ///< Service changed callback.
+    typedef otBorderAgentCounters    Counters;    ///< Border Agent Counters.
+    typedef otBorderAgentSessionInfo SessionInfo; ///< A session info.
 
     /**
      * Represents an iterator for secure sessions.
@@ -223,21 +220,6 @@ public:
      */
     uint16_t GetUdpPort(void) const;
 
-    /**
-     * Sets the callback function used by the Border Agent to notify any changes on the MeshCoP service TXT values.
-     *
-     * The callback is invoked when the state of MeshCoP service TXT values changes. For example, it is
-     * invoked when the network name or the extended PAN ID changes and pass the updated encoded TXT data to the
-     * application layer.
-     *
-     * This callback is invoked once right after this API is called to provide initial states of the MeshCoP
-     * service to the application.
-     *
-     * @param[in] aCallback  The callback to invoke when there are any changes of the MeshCoP service.
-     * @param[in] aContext   A pointer to application-specific context.
-     */
-    void SetServiceChangedCallback(ServiceChangedCallback aCallback, void *aContext);
-
 #if OPENTHREAD_CONFIG_BORDER_AGENT_MESHCOP_SERVICE_ENABLE
     /**
      * Sets the base name to construct the service instance name used when advertising the mDNS `_meshcop._udp` service
@@ -249,27 +231,6 @@ public:
      * @retval kErrorInvalidArgs   The name is too long or invalid.
      */
     Error SetServiceBaseName(const char *aBaseName);
-
-    /**
-     * Sets the vendor extra TXT data to be included when the Border Agent advertises the mDNS `_meshcop._udp` service.
-     *
-     * The provided @p aVendorData bytes are appended as they appear in the buffer to the end of the TXT data generated
-     * by the Border Agent itself, and are then included in the advertised mDNS `_meshcop._udp` service.
-     *
-     * This method itself does not perform any validation of the format of the provided @p aVendorData. Therefore, the
-     * caller MUST ensure it is formatted properly. Per the Thread specification, vendor-specific Key-Value TXT data
-     * pairs use TXT keys starting with 'v'. For example, `vn` for vendor name.
-     *
-     * The `BorderAgent` will create and retain its own copy of the bytes in @p aVendorData. So, the buffer passed to
-     * this method does not need to persist beyond the scope of the call.
-     *
-     * The vendor TXT data can be set at any time while the Border Agent is in any state. If there is a change from the
-     * previously set value, it will trigger an update of the registered mDNS service to advertise the new TXT data.
-     *
-     * @param[in] aVendorData        A pointer to the buffer containing the vendor TXT data.
-     * @param[in] aVendorDataLength  The length of @p aVendorData in bytes.
-     */
-    void SetVendorTxtData(const uint8_t *aVendorData, uint16_t aVendorDataLength);
 #endif
 
     /**
@@ -359,6 +320,8 @@ private:
     void UpdateState(void);
     void Start(void);
     void Stop(void);
+
+    // Callback from Notifier
     void HandleNotifierEvents(Events aEvents);
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
@@ -373,23 +336,19 @@ private:
     void HandleSessionDisconnected(CoapDtlsSession &aSession, CoapDtlsSession::ConnectEvent aEvent);
     void HandleCommissionerPetitionAccepted(CoapDtlsSession &aSession);
 
-    void PostServiceTask(void);
-    void HandleServiceTask(void);
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-    // Callback from `RoutingManager`
-    void HandleFavoredOmrPrefixChanged(void) { PostServiceTask(); }
-#endif
-
 #if OPENTHREAD_CONFIG_BORDER_AGENT_MESHCOP_SERVICE_ENABLE
+    // Callback from `BorderAgent::TxtData`.
+    void HandleServiceTxtDataChanged(void) { RegisterService(); }
+
+    // Callback from `Dnssd`
+    void HandleDnssdPlatformStateChange(void) { RegisterService(); }
+
     const char *GetServiceName(void);
     bool        IsServiceNameEmpty(void) const { return mServiceName[0] == kNullChar; }
     void        ConstrcutServiceName(const char *aBaseName, Dns::Name::LabelBuffer &aNameBuffer);
     void        RegisterService(void);
     void        UnregisterService(void);
-    void        HandleDnssdPlatformStateChange(void) { PostServiceTask(); }
 #endif
-
-    using ServiceTask = TaskletIn<Manager, &Manager::HandleServiceTask>;
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_MESHCOP_SERVICE_ENABLE
     static const char kServiceType[];
@@ -403,11 +362,8 @@ private:
     Id   mId;
     bool mIdInitialized;
 #endif
-    Callback<ServiceChangedCallback> mServiceChangedCallback;
-    ServiceTask                      mServiceTask;
 #if OPENTHREAD_CONFIG_BORDER_AGENT_MESHCOP_SERVICE_ENABLE
     Dns::Name::LabelBuffer mServiceName;
-    Heap::Data             mVendorTxtData;
 #endif
     Counters mCounters;
 };

--- a/tests/nexus/test_border_agent.cpp
+++ b/tests/nexus/test_border_agent.cpp
@@ -1403,7 +1403,7 @@ void TestBorderAgentTxtDataCallback(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Set MeshCoP service change callback. Will get initial values.
     Log("Set MeshCoP service change callback and check initial values");
-    node0.Get<Manager>().SetServiceChangedCallback(HandleServiceChanged, &callbackInvoked);
+    node0.Get<BaTxtData>().SetChangedCallback(HandleServiceChanged, &callbackInvoked);
     nexus.AdvanceTime(1);
 
     // Check the initial TXT entries
@@ -1904,7 +1904,7 @@ void TestBorderAgentServiceRegistration(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Set vendor TXT data and validate that it is included in the registered mDNS service");
 
-    node0.Get<Manager>().SetVendorTxtData(kVendorTxtData, sizeof(kVendorTxtData));
+    node0.Get<BaTxtData>().SetVendorData(kVendorTxtData, sizeof(kVendorTxtData));
     nexus.AdvanceTime(5 * Time::kOneSecondInMsec);
 
     iterator = node0.Get<Dns::Multicast::Core>().AllocateIterator();
@@ -1942,7 +1942,7 @@ void TestBorderAgentServiceRegistration(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Clear vendor TXT data and validate that the registered mDNS service is updated accordingly");
 
-    node0.Get<Manager>().SetVendorTxtData(nullptr, 0);
+    node0.Get<BaTxtData>().SetVendorData(nullptr, 0);
     nexus.AdvanceTime(5 * Time::kOneSecondInMsec);
 
     iterator = node0.Get<Dns::Multicast::Core>().AllocateIterator();

--- a/tests/unit/test_tasklet.cpp
+++ b/tests/unit/test_tasklet.cpp
@@ -106,13 +106,18 @@ void TestTasklet(void)
     sInstance = static_cast<Instance *>(testInitInstance());
     VerifyOrQuit(sInstance != nullptr);
 
-    sInstance->Get<Tasklet::Scheduler>().ProcessQueuedTasklets();
-
     {
         Tasklet::Scheduler &scheduler = sInstance->Get<Tasklet::Scheduler>();
         Tasklet             task1(*sInstance, HandleTask1);
         Tasklet             task2(*sInstance, HandleTask2);
         Tasklet             task3(*sInstance, HandleTask3);
+
+        Log("Process all initially posted tasks after `Instance` initialization");
+
+        while (scheduler.AreTaskletsPending())
+        {
+            scheduler.ProcessQueuedTasklets();
+        }
 
         VerifyOrQuit(!task1.IsPosted());
         VerifyOrQuit(!task2.IsPosted());


### PR DESCRIPTION
Moves the management of MeshCoP service TXT data from the `BorderAgent::Manager` class into the `TxtData` class.

This change improves separation of concerns by isolating all TXT data-related logic, including vendor TXT data, change callbacks, and notifier event handling, within the `TxtData` class. The `BorderAgent::Manager` is simplified and its responsibilities are more focused.

A new public method, `Refresh()`, is introduced on `TxtData` to provide a clear API for other modules to signal that the MeshCoP service TXT data needs to be re-evaluated and updated.