### PR TITLE
[fuzz] log CLI input in fuzzer

### DIFF
--- a/tests/fuzz/cli.cpp
+++ b/tests/fuzz/cli.cpp
@@ -131,6 +131,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     buffer = fdp.ConsumeRemainingBytes();
 
+    Log("CLI Input: \"%s\"", reinterpret_cast<char *>(buffer));
+
     otCliInputLine(reinterpret_cast<char *>(buffer));
 
     nexus.AdvanceTime(60 * 1000);


### PR DESCRIPTION
This change adds a log statement to the CLI fuzzer to print the fuzzer-generated input string that is passed to the CLI interpreter. This is useful for debugging fuzz test failures