### PR TITLE
[dns] fix name length check in `Name::AppendMultipleLabels()`

### DIFF
--- a/src/core/net/dns_types.cpp
+++ b/src/core/net/dns_types.cpp
@@ -258,7 +258,7 @@ Error Name::AppendMultipleLabels(const char *aLabels, Message &aMessage)
                 ExitNow();
             }
 
-            VerifyOrExit(index + 1 < kMaxEncodedLength, error = kErrorInvalidArgs);
+            VerifyOrExit(index + 1 <= kMaxEncodedLength, error = kErrorInvalidArgs);
             SuccessOrExit(error = AppendLabel(&aLabels[labelStartIndex], labelLength, aMessage));
 
             labelStartIndex = index + 1;


### PR DESCRIPTION
Corrects an off-by-one error in the length validation within the `Name::AppendMultipleLabels()` method.

The previous check (`index + 1 < kMaxEncodedLength`) would incorrectly return an `kErrorInvalidArgs` error if the encoded name length was exactly equal to `kMaxEncodedLength`.

The check is updated to `index + 1 <= kMaxEncodedLength` to allow for names of the maximum valid length. This issue was discovered by fuzz testing.