### PR TITLE
[mdns] restart probing on Register() if in conflict state

### DIFF
--- a/src/core/net/mdns.hpp
+++ b/src/core/net/mdns.hpp
@@ -1172,6 +1172,7 @@ private:
         void SetCallback(const Callback &aCallback);
         void ClearCallback(void) { mCallback.Clear(); }
         void MarkToInvokeCallbackUnconditionally(void);
+        void DecideToProbeOnRegister(void);
         void StartProbing(void);
         void SetStateToConflict(void);
         void SetStateToRemoving(void);

--- a/tests/unit/test_mdns.cpp
+++ b/tests/unit/test_mdns.cpp
@@ -5319,23 +5319,7 @@ void TestHostConflict(void)
     VerifyOrQuit(!sConflictCallback.mWasCalled);
 
     Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
-    Log("Register the conflicted `HostEntry` again, and make sure no probes are sent");
-
-    sRegCallbacks[1].Reset();
-    sConflictCallback.Reset();
-    sDnsMessages.Clear();
-
-    SuccessOrQuit(mdns->RegisterHost(host, 1, HandleCallback));
-    AdvanceTime(5000);
-
-    VerifyOrQuit(sRegCallbacks[1].mWasCalled);
-    VerifyOrQuit(sRegCallbacks[1].mError == kErrorDuplicated);
-    VerifyOrQuit(!sConflictCallback.mWasCalled);
-
-    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
-    Log("Unregister the conflicted host and register it again immediately, make sure we see probes");
-
-    SuccessOrQuit(mdns->UnregisterHost(host));
+    Log("Register the conflicted `HostEntry` again, and make sure probes are sent");
 
     sConflictCallback.Reset();
     sRegCallbacks[0].Reset();
@@ -5481,23 +5465,7 @@ void TestServiceConflict(void)
     VerifyOrQuit(!sConflictCallback.mWasCalled);
 
     Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
-    Log("Register the conflicted `ServiceEntry` again, and make sure no probes are sent");
-
-    sRegCallbacks[1].Reset();
-    sConflictCallback.Reset();
-    sDnsMessages.Clear();
-
-    SuccessOrQuit(mdns->RegisterService(service, 1, HandleCallback));
-    AdvanceTime(5000);
-
-    VerifyOrQuit(sRegCallbacks[1].mWasCalled);
-    VerifyOrQuit(sRegCallbacks[1].mError == kErrorDuplicated);
-    VerifyOrQuit(!sConflictCallback.mWasCalled);
-
-    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
-    Log("Unregister the conflicted host and register it again immediately, make sure we see probes");
-
-    SuccessOrQuit(mdns->UnregisterService(service));
+    Log("Register the conflicted `ServiceEntry` again, and make sure probes are sent");
 
     sConflictCallback.Reset();
     sRegCallbacks[0].Reset();


### PR DESCRIPTION
This commit enhances mDNS to allow reprobing for registrations currently in a conflict state. Upon an explicit `Register()` call, the mDNS module will now restart the probing process. This allows the device to attempt to claim the name again if the conflict has been resolved on the network.

Unit tests are updated to verify this behavior.