### PR TITLE
[mdns] increase `TxMessageHistory` expire timeout

### DIFF
--- a/src/core/net/mdns.hpp
+++ b/src/core/net/mdns.hpp
@@ -1685,7 +1685,7 @@ private:
         void HandleTimer(void);
 
     private:
-        static constexpr uint32_t kExpireInterval = TimeMilli::SecToMsec(10); // in msec
+        static constexpr uint32_t kExpireInterval = TimeMilli::SecToMsec(100); // in msec
 
         struct MsgInfo : public Clearable<MsgInfo>, public Equatable<MsgInfo>
         {


### PR DESCRIPTION
This commit increases `TxMessageHistory::kExpireInterval` from 10 to 100 seconds.

This interval determines how long information about previously transmitted mDNS messages from the MDNS module is retained. This history is used to detect whether a received message originates from the mDNS module itself.

The increased interval safeguards against potentially longer delays on the platform side when receiving packets.