### PR TITLE
[tcat] surface hash calculation internal errors to TCAT Commissioner

### DIFF
--- a/src/core/meshcop/tcat_agent.hpp
+++ b/src/core/meshcop/tcat_agent.hpp
@@ -465,7 +465,7 @@ private:
                      uint16_t       aLength,
                      const void    *aBuf,
                      size_t         aBufLen);
-    void  CalculateHash(uint64_t aChallenge, const char *aBuf, size_t aBufLen, Crypto::HmacSha256::Hash &aHash);
+    Error CalculateHash(uint64_t aChallenge, const char *aBuf, size_t aBufLen, Crypto::HmacSha256::Hash &aHash);
 
     bool    CheckCommandClassAuthorizationFlags(CommandClassFlags aCommissionerCommandClassFlags,
                                                 CommandClassFlags aDeviceCommandClassFlags,


### PR DESCRIPTION
Small change to surface any internal errors in the hash calculations to the TCAT Commissioner as general error. If not done, such errors are silently ignored and hard to diagnose in products.