### PR TITLE
(DO NOT MERGE) enable mDNS verbose logging and add extra logs

### DIFF
--- a/src/core/config/mdns.h
+++ b/src/core/config/mdns.h
@@ -121,6 +121,18 @@
 #define OPENTHREAD_CONFIG_MULTICAST_DEFAULT_DNS_VERBOSE_LOGGING_STATE 0
 #endif
 
+//~~~~~~~~~~~~~~~ DO NOT MERGE ~~~~~ INTENDED FOR TESTING ONLY ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// We override and enable verbose logging regardless of any other settings
+
+#undef OPENTHREAD_CONFIG_MULTICAST_DNS_VERBOSE_LOGGING_ENABLE
+#define OPENTHREAD_CONFIG_MULTICAST_DNS_VERBOSE_LOGGING_ENABLE 1
+
+#undef OPENTHREAD_CONFIG_MULTICAST_DEFAULT_DNS_VERBOSE_LOGGING_STATE
+#define OPENTHREAD_CONFIG_MULTICAST_DEFAULT_DNS_VERBOSE_LOGGING_STATE 1
+
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 /**
  * @def OPENTHREAD_CONFIG_MULTICAST_DNS_MOCK_PLAT_APIS_ENABLE
  *

--- a/src/core/net/mdns.cpp
+++ b/src/core/net/mdns.cpp
@@ -47,7 +47,7 @@ RegisterLogModule("MulticastDns");
 #if OPENTHREAD_CONFIG_MULTICAST_DNS_VERBOSE_LOGGING_ENABLE
 #define LogVerbose(...)              \
     if (Get<Core>().mVerboseLogging) \
-    LogAt(kLogLevelNone, __VA_ARGS__)
+    LogInfo(__VA_ARGS__)
 #else
 #define LogVerbose(...)
 #endif
@@ -424,6 +424,8 @@ Error Core::GetNextRecordQuerier(Iterator &aIterator, RecordQuerier &aQuerier, C
 
 void Core::InvokeConflictCallback(const char *aName, const char *aServiceType)
 {
+    LogVerbose("Invoking conflict callback: %s %s", aName, aServiceType == nullptr ? "" : aServiceType);
+
     if (mConflictCallback != nullptr)
     {
         mConflictCallback(&GetInstance(), aName, aServiceType);
@@ -2110,6 +2112,8 @@ void Core::HostEntry::HandleConflict(void)
 {
     State oldState = GetState();
 
+    LogVerbose("HostEntry %s - setting state to conflict", mName.AsCString());
+
     SetStateToConflict();
     VerifyOrExit(oldState == kRegistered);
     Get<Core>().InvokeConflictCallback(mName.AsCString(), nullptr);
@@ -2704,6 +2708,9 @@ void Core::ServiceEntry::ScheduleToRemoveIfEmpty(void)
 void Core::ServiceEntry::HandleConflict(void)
 {
     State oldState = GetState();
+
+    LogVerbose("ServiceEntry %s %s - setting state to conflict", mServiceInstance.AsCString(),
+               mServiceType.AsCString());
 
     SetStateToConflict();
     UpdateServiceTypes();


### PR DESCRIPTION
This commit contains two changes:

- It always enables `MULTICAST_DNS_VERBOSE_LOGGING_ENABLE` regardless of any other configs/options.
- It also adds new logs to indicate when a conflict is detected, helping to identify the message that caused the conflict and what it contained.