### PR TITLE
[border-agent] handle Proxy/Relay TX TMF when active commissioner

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -1220,6 +1220,8 @@ void Manager::CoapDtlsSession::HandleTmfProxyTx(Coap::Message &aMessage)
     OffsetRange               offsetRange;
     UdpEncapsulationTlvHeader udpEncapHeader;
 
+    VerifyOrExit(IsActiveCommissioner(), error = kErrorInvalidState);
+
     SuccessOrExit(error = Tlv::FindTlvValueOffsetRange(aMessage, Tlv::kUdpEncapsulation, offsetRange));
 
     SuccessOrExit(error = aMessage.Read(offsetRange, udpEncapHeader));
@@ -1257,6 +1259,8 @@ void Manager::CoapDtlsSession::HandleTmfRelayTx(Coap::Message &aMessage)
     OffsetRange             offsetRange;
 
     VerifyOrExit(aMessage.IsNonConfirmablePostRequest());
+
+    VerifyOrExit(IsActiveCommissioner(), error = kErrorInvalidState);
 
     SuccessOrExit(error = Tlv::Find<JoinerRouterLocatorTlv>(aMessage, joinerRouterRloc));
 


### PR DESCRIPTION
This commit adds checks in `BorderAgent::HandleTmfProxyTx()` and `BorderAgent::HandleTmfRelayTx()` to verify that the session belongs to the current active commissioner rather than a candidate.

Specifically, `HandleTmfProxyTx()` uses the commissioner ALOC as the sender address, which is available only when commissioner petition is accepted.