### PR TITLE
[meshcop] adding `SteeringData::MergeBloomFilterWith()`

### DIFF
--- a/tests/unit/test_meshcop.cpp
+++ b/tests/unit/test_meshcop.cpp
@@ -54,63 +54,168 @@ void TestSteeringData(void)
     steeringData.SetToPermitAllJoiners();
 
     DumpBuffer("After SetToPermitAllJoiners()", steeringData.GetData(), steeringData.GetLength());
-    VerifyOrQuit(steeringData.GetLength() == 1, "after SetToPermitAllJoiners()");
-    VerifyOrQuit(steeringData.PermitsAllJoiners(), "after SetToPermitAllJoiners()");
-    VerifyOrQuit(!steeringData.IsEmpty(), "after SetToPermitAllJoiners()");
-    VerifyOrQuit(steeringData.Contains(joinerId1), "after SetToPermitAllJoiners()");
-    VerifyOrQuit(steeringData.Contains(joinerId2), "after SetToPermitAllJoiners()");
-    VerifyOrQuit(steeringData.Contains(indexes), "after SetToPermitAllJoiners()");
+    VerifyOrQuit(steeringData.GetLength() == 1);
+    VerifyOrQuit(steeringData.PermitsAllJoiners());
+    VerifyOrQuit(!steeringData.IsEmpty());
+    VerifyOrQuit(steeringData.Contains(joinerId1));
+    VerifyOrQuit(steeringData.Contains(joinerId2));
+    VerifyOrQuit(steeringData.Contains(indexes));
 
     steeringData.Clear();
 
     DumpBuffer("After Clear()", steeringData.GetData(), steeringData.GetLength());
-    VerifyOrQuit(steeringData.GetLength() == 1, "after Clear()");
-    VerifyOrQuit(!steeringData.PermitsAllJoiners(), "after Clear()");
-    VerifyOrQuit(steeringData.IsEmpty(), "after Clear()");
-    VerifyOrQuit(!steeringData.Contains(joinerId1), "after Clear()");
-    VerifyOrQuit(!steeringData.Contains(joinerId2), "after Clear()");
-    VerifyOrQuit(!steeringData.Contains(indexes), "after Clear()");
+    VerifyOrQuit(steeringData.GetLength() == 1);
+    VerifyOrQuit(!steeringData.PermitsAllJoiners());
+    VerifyOrQuit(steeringData.IsEmpty());
+    VerifyOrQuit(!steeringData.Contains(joinerId1));
+    VerifyOrQuit(!steeringData.Contains(joinerId2));
+    VerifyOrQuit(!steeringData.Contains(indexes));
 
-    for (uint8_t len = 1; len <= MeshCoP::SteeringData::kMaxLength; len++)
+    for (uint8_t len = MeshCoP::SteeringData::kMinLength; len <= MeshCoP::SteeringData::kMaxLength; len++)
     {
         printf("\n--------------------------------------------");
 
         steeringData.Init(len);
 
-        VerifyOrQuit(steeringData.GetLength() == len, "after Init()");
-        VerifyOrQuit(steeringData.IsEmpty(), "IsEmpy() failed after Init()");
-        VerifyOrQuit(!steeringData.PermitsAllJoiners(), "after Init()");
-        VerifyOrQuit(!steeringData.Contains(joinerId1), "after Init()");
-        VerifyOrQuit(!steeringData.Contains(joinerId2), "after Init()");
-        VerifyOrQuit(!steeringData.Contains(indexes), "after Init()");
+        VerifyOrQuit(steeringData.GetLength() == len);
+        VerifyOrQuit(steeringData.IsEmpty());
+        VerifyOrQuit(!steeringData.PermitsAllJoiners());
+        VerifyOrQuit(!steeringData.Contains(joinerId1));
+        VerifyOrQuit(!steeringData.Contains(joinerId2));
+        VerifyOrQuit(!steeringData.Contains(indexes));
 
         steeringData.UpdateBloomFilter(joinerId1);
-        DumpBuffer("After UpdateBloomFilter(joinerId1)", steeringData.GetData(), steeringData.GetLength());
-        VerifyOrQuit(steeringData.GetLength() == len, "after UpdateBloomFilter()");
-        VerifyOrQuit(!steeringData.IsEmpty(), "IsEmpy() failed after UpdateBloomFilter()");
-        VerifyOrQuit(!steeringData.PermitsAllJoiners(), "after UpdateBloomFilter");
-        VerifyOrQuit(steeringData.Contains(joinerId1), "after UpdateBloomFilter");
+        printf("\nAfter UpdateBloomFilter(joinerId1): %s", steeringData.ToString().AsCString());
+        VerifyOrQuit(steeringData.GetLength() == len);
+        VerifyOrQuit(!steeringData.IsEmpty());
+        VerifyOrQuit(!steeringData.PermitsAllJoiners());
+        VerifyOrQuit(steeringData.Contains(joinerId1));
 
         steeringData.UpdateBloomFilter(joinerId2);
-        DumpBuffer("After UpdateBloomFilter(joinerId2)", steeringData.GetData(), steeringData.GetLength());
-        VerifyOrQuit(steeringData.GetLength() == len, "after UpdateBloomFilter()");
-        VerifyOrQuit(!steeringData.IsEmpty(), "IsEmpy() failed after UpdateBloomFilter()");
-        VerifyOrQuit(!steeringData.PermitsAllJoiners(), "after UpdateBloomFilter");
-        VerifyOrQuit(steeringData.Contains(joinerId1), "after UpdateBloomFilter");
-        VerifyOrQuit(steeringData.Contains(joinerId2), "after UpdateBloomFilter");
-        VerifyOrQuit(steeringData.Contains(indexes), "after UpdateBloomFilter");
+        printf("\nAfter UpdateBloomFilter(joinerId2): %s", steeringData.ToString().AsCString());
+        VerifyOrQuit(steeringData.GetLength() == len);
+        VerifyOrQuit(!steeringData.IsEmpty());
+        VerifyOrQuit(!steeringData.PermitsAllJoiners());
+        VerifyOrQuit(steeringData.Contains(joinerId1));
+        VerifyOrQuit(steeringData.Contains(joinerId2));
+        VerifyOrQuit(steeringData.Contains(indexes));
     }
 
     steeringData.Init(0);
 
-    VerifyOrQuit(steeringData.GetLength() == 0, "after Init()");
-    VerifyOrQuit(steeringData.IsEmpty(), "IsEmpy() failed after Init()");
-    VerifyOrQuit(!steeringData.PermitsAllJoiners(), "after Init()");
-    VerifyOrQuit(!steeringData.Contains(joinerId1), "after Init()");
-    VerifyOrQuit(!steeringData.Contains(joinerId2), "after Init()");
-    VerifyOrQuit(!steeringData.Contains(indexes), "after Init()");
+    VerifyOrQuit(steeringData.GetLength() == 0);
+    VerifyOrQuit(steeringData.IsEmpty());
+    VerifyOrQuit(!steeringData.PermitsAllJoiners());
+    VerifyOrQuit(!steeringData.Contains(joinerId1));
+    VerifyOrQuit(!steeringData.Contains(joinerId2));
+    VerifyOrQuit(!steeringData.Contains(indexes));
 
     printf("TestSteeringData() passed\n");
+}
+
+void TestSteeringDataBloomFilterMerge(void)
+{
+    static constexpr uint8_t kMaxJoinerIds = 3;
+
+    static const uint8_t kTestSteeringDataLengths[] = {16, 8, 4, 2, 1};
+
+    Instance             *instance;
+    MeshCoP::SteeringData steeringData;
+    MeshCoP::SteeringData otherSteeringData;
+
+    Mac::ExtAddress joinerIds[kMaxJoinerIds];
+    Mac::ExtAddress otherJoinerIds[kMaxJoinerIds];
+
+    instance = static_cast<Instance *>(testInitInstance());
+    VerifyOrQuit(instance != nullptr);
+
+    printf("\n--------------------------------------------");
+    printf("\nTestSteeringDataBloomFilterMerge()");
+    printf("\nJoiner IDs for SteeringData");
+
+    for (Mac::ExtAddress &id : joinerIds)
+    {
+        uint8_t buffer[sizeof(Mac::ExtAddress)];
+
+        Random::NonCrypto::FillBuffer(buffer, sizeof(buffer));
+        id.Set(buffer);
+        printf("\n %s", id.ToString().AsCString());
+    }
+
+    printf("\n--------------------------------------------");
+    printf("\nJoiner IDs for OtherSteeringData");
+
+    for (Mac::ExtAddress &id : otherJoinerIds)
+    {
+        uint8_t buffer[sizeof(Mac::ExtAddress)];
+
+        Random::NonCrypto::FillBuffer(buffer, sizeof(buffer));
+        id.Set(buffer);
+        printf("\n %s", id.ToString().AsCString());
+    }
+
+    for (uint8_t length : kTestSteeringDataLengths)
+    {
+        for (uint8_t otherLength : kTestSteeringDataLengths)
+        {
+            printf("\n--------------------------------------------");
+            printf("\nLen:%u OtherLen:%u", length, otherLength);
+
+            steeringData.Init(length);
+            otherSteeringData.Init(otherLength);
+
+            VerifyOrQuit(steeringData.GetLength() == length);
+            VerifyOrQuit(otherSteeringData.GetLength() == otherLength);
+            VerifyOrQuit(steeringData.IsEmpty());
+            VerifyOrQuit(otherSteeringData.IsEmpty());
+
+            if (otherLength > length)
+            {
+                VerifyOrQuit(steeringData.MergeBloomFilterWith(otherSteeringData) != kErrorNone);
+                continue;
+            }
+
+            SuccessOrQuit(steeringData.MergeBloomFilterWith(otherSteeringData));
+
+            VerifyOrQuit(steeringData.GetLength() == length);
+            VerifyOrQuit(otherSteeringData.GetLength() == otherLength);
+            VerifyOrQuit(steeringData.IsEmpty());
+            VerifyOrQuit(otherSteeringData.IsEmpty());
+
+            for (Mac::ExtAddress &id : joinerIds)
+            {
+                steeringData.UpdateBloomFilter(id);
+                VerifyOrQuit(steeringData.Contains(id));
+            }
+
+            for (Mac::ExtAddress &id : otherJoinerIds)
+            {
+                otherSteeringData.UpdateBloomFilter(id);
+                VerifyOrQuit(otherSteeringData.Contains(id));
+            }
+
+            printf("\nSteering Data       : %s", steeringData.ToString().AsCString());
+            printf("\nOther Steering Data : %s", otherSteeringData.ToString().AsCString());
+
+            SuccessOrQuit(steeringData.MergeBloomFilterWith(otherSteeringData));
+
+            printf("\nMerged Steering Data: %s", steeringData.ToString().AsCString());
+
+            VerifyOrQuit(steeringData.GetLength() == length);
+
+            for (const Mac::ExtAddress &id : joinerIds)
+            {
+                VerifyOrQuit(steeringData.Contains(id));
+            }
+
+            for (const Mac::ExtAddress &id : otherJoinerIds)
+            {
+                VerifyOrQuit(steeringData.Contains(id));
+            }
+        }
+    }
+
+    printf("\nTestSteeringDataBloomFilterMerge() passed\n");
 }
 
 void TestTimestamp(void)
@@ -204,7 +309,9 @@ void TestTimestamp(void)
 int main(void)
 {
     ot::TestSteeringData();
+    ot::TestSteeringDataBloomFilterMerge();
     ot::TestTimestamp();
+
     printf("\nAll tests passed.\n");
     return 0;
 }


### PR DESCRIPTION
This commit adds a new method, `MergeBloomFilterWith()`, to `SteeringData` to allow combining two Bloom filters.

The method performs a bitwise OR operation between the current Steering Data Bloom filter and a given one. It handles cases where the given filter to merge has a shorter length than the target Bloom filter. It requires the target filter's length to be a multiple of the source's length.

A new unit test, `TestSteeringDataBloomFilterMerge()`, is included to validate the merge logic with various filter length combinations.