### PR TITLE
[mac] force rx_on_when_idle to true during active scan

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -293,10 +293,12 @@ void Mac::PerformActiveScan(void)
     if (UpdateScanChannel() == kErrorNone)
     {
         // If there are more channels to scan, send the beacon request.
+        mLinks.SetRxOnWhenIdle(true);
         BeginTransmit();
     }
     else
     {
+        mLinks.SetRxOnWhenIdle(mRxOnWhenIdle);
         mLinks.SetPanId(mPanId);
         FinishOperation();
         ReportActiveScanResult(nullptr);


### PR DESCRIPTION
This PR forces mLinks.SetRxOnWhenIdle to true when performing an active scan. 

Previously, when we have an SED which is connected to a thread network (i.e. state == child), it is unable to perform scan command because rx is turned off.