### PR TITLE
[mdns] restart probing for registered entries on conflict detection

### DIFF
--- a/src/core/net/mdns.cpp
+++ b/src/core/net/mdns.cpp
@@ -2111,7 +2111,10 @@ void Core::HostEntry::HandleConflict(void)
     State oldState = GetState();
 
     SetStateToConflict();
+
     VerifyOrExit(oldState == kRegistered);
+    StartProbing();
+
     Get<Core>().InvokeConflictCallback(mName.AsCString(), nullptr);
 
 exit:
@@ -2709,6 +2712,8 @@ void Core::ServiceEntry::HandleConflict(void)
     UpdateServiceTypes();
 
     VerifyOrExit(oldState == kRegistered);
+    StartProbing();
+
     Get<Core>().InvokeConflictCallback(mServiceInstance.AsCString(), mServiceType.AsCString());
 
 exit:

--- a/tests/unit/test_mdns.cpp
+++ b/tests/unit/test_mdns.cpp
@@ -5365,6 +5365,33 @@ void TestHostConflict(void)
     VerifyOrQuit(StringMatch(sConflictCallback.mName.AsCString(), host.mHostName, kStringCaseInsensitiveMatch));
     VerifyOrQuit(!sConflictCallback.mHasServiceType);
 
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
+    Log("Since the host was registered before, after conflict probes should be sent again");
+
+    sConflictCallback.Reset();
+    sRegCallbacks[0].Reset();
+
+    for (uint8_t probeCount = 0; probeCount < 3; probeCount++)
+    {
+        sDnsMessages.Clear();
+
+        VerifyOrQuit(!sRegCallbacks[0].mWasCalled);
+        AdvanceTime(250);
+
+        VerifyOrQuit(!sDnsMessages.IsEmpty());
+        dnsMsg = sDnsMessages.GetHead();
+        dnsMsg->ValidateHeader(kMulticastQuery, /* Q */ 1, /* Ans */ 0, /* Auth */ 2, /* Addnl */ 0);
+        dnsMsg->ValidateAsProbeFor(host, /* aUnicastRequest */ (probeCount == 0));
+        VerifyOrQuit(dnsMsg->GetNext() == nullptr);
+    }
+
+    AdvanceTime(500);
+
+    VerifyOrQuit(!sConflictCallback.mWasCalled);
+    VerifyOrQuit(!sRegCallbacks[0].mWasCalled);
+
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
+
     SuccessOrQuit(mdns->SetEnabled(false, kInfraIfIndex));
     VerifyOrQuit(sHeapAllocatedPtrs.GetLength() <= heapAllocations);
 
@@ -5514,9 +5541,32 @@ void TestServiceConflict(void)
     VerifyOrQuit(
         StringMatch(sConflictCallback.mServiceType.AsCString(), service.mServiceType, kStringCaseInsensitiveMatch));
 
-    sDnsMessages.Clear();
-    AdvanceTime(20000);
-    VerifyOrQuit(sDnsMessages.IsEmpty());
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
+    Log("Since the service was registered before, after conflict probes should be sent again");
+
+    sConflictCallback.Reset();
+    sRegCallbacks[0].Reset();
+
+    for (uint8_t probeCount = 0; probeCount < 3; probeCount++)
+    {
+        sDnsMessages.Clear();
+
+        VerifyOrQuit(!sRegCallbacks[0].mWasCalled);
+        AdvanceTime(250);
+
+        VerifyOrQuit(!sDnsMessages.IsEmpty());
+        dnsMsg = sDnsMessages.GetHead();
+        dnsMsg->ValidateHeader(kMulticastQuery, /* Q */ 1, /* Ans */ 0, /* Auth */ 2, /* Addnl */ 0);
+        dnsMsg->ValidateAsProbeFor(service, /* aUnicastRequest */ (probeCount == 0));
+        VerifyOrQuit(dnsMsg->GetNext() == nullptr);
+    }
+
+    AdvanceTime(500);
+
+    VerifyOrQuit(!sConflictCallback.mWasCalled);
+    VerifyOrQuit(!sRegCallbacks[0].mWasCalled);
+
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
 
     SuccessOrQuit(mdns->SetEnabled(false, kInfraIfIndex));
     VerifyOrQuit(sHeapAllocatedPtrs.GetLength() <= heapAllocations);


### PR DESCRIPTION
When a name conflict is detected for a host or service entry that was already in the `kRegistered` state, the entry now automatically restarts the probing process.

This ensures that the device attempts to recover if a transient conflict arises after successful registration, without requiring intervention from higher layers. The conflict callback is still invoked as before to signal this event, allowing next layer to take different actions.

The unit tests are updated to verify this new behavior.