### PR TITLE
[border-agent] check `StateTlv` in forwarded keep-alive response

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -1079,30 +1079,47 @@ void Manager::CoapDtlsSession::HandleLeaderResponseToFwdTmf(const ForwardContext
     forwardMessage.Reset(NewPriorityMessage());
     VerifyOrExit(forwardMessage != nullptr, error = kErrorNoBufs);
 
-    if ((aForwardContext.mUri == kUriLeaderPetition) && (aResponse->GetCode() == Coap::kCodeChanged))
+    if (aResponse->GetCode() == Coap::kCodeChanged)
     {
         uint8_t state;
 
         SuccessOrExit(error = Tlv::Find<StateTlv>(*aResponse, state));
 
-        if (state == StateTlv::kAccept)
+        switch (state)
         {
-            uint16_t sessionId;
+        case StateTlv::kAccept:
+            if (aForwardContext.mUri == kUriLeaderPetition)
+            {
+                uint16_t sessionId;
 
-            SuccessOrExit(error = Tlv::Find<CommissionerSessionIdTlv>(*aResponse, sessionId));
+                SuccessOrExit(error = Tlv::Find<CommissionerSessionIdTlv>(*aResponse, sessionId));
 
-            Get<Mle::Mle>().GetCommissionerAloc(sessionId, mCommissionerAloc.GetAddress());
-            Get<ThreadNetif>().AddUnicastAddress(mCommissionerAloc);
-            IgnoreError(Get<Ip6::Udp>().AddReceiver(mUdpReceiver));
-            mIsActiveCommissioner = true;
-            Get<Manager>().HandleCommissionerPetitionAccepted(*this);
+                Get<Mle::Mle>().GetCommissionerAloc(sessionId, mCommissionerAloc.GetAddress());
+                Get<ThreadNetif>().AddUnicastAddress(mCommissionerAloc);
+                IgnoreError(Get<Ip6::Udp>().AddReceiver(mUdpReceiver));
+                mIsActiveCommissioner = true;
+                Get<Manager>().HandleCommissionerPetitionAccepted(*this);
 
-            LogInfo("Commissioner accepted - SessionId:%u ALOC:%s", sessionId,
-                    mCommissionerAloc.GetAddress().ToString().AsCString());
-        }
-        else
-        {
+                LogInfo("Commissioner accepted - SessionId:%u ALOC:%s", sessionId,
+                        mCommissionerAloc.GetAddress().ToString().AsCString());
+            }
+
+            break;
+
+        case StateTlv::kReject:
             LogInfo("Commissioner rejected");
+
+            if (mIsActiveCommissioner)
+            {
+                IgnoreError(Get<Ip6::Udp>().RemoveReceiver(mUdpReceiver));
+                Get<ThreadNetif>().RemoveUnicastAddress(mCommissionerAloc);
+                mIsActiveCommissioner = false;
+            }
+
+            break;
+
+        default:
+            break;
         }
     }
 


### PR DESCRIPTION
This commit updates `BorderAgent` to correctly handle the `StateTlv` in a forwarded response from the leader specifically for the response to a forwarded `kUriLeaderKeepAlive` message.

The leader can reject a previously accepted active commissioner in the Keep-Alive response by including the `StateTlv` with a `kReject` status.

This commit ensures that if the `StateTlv` indicates the commissioner is rejected, the session is properly cleaned up. This cleanup involves removing the previously added commissioner ALOC and marking the session as no longer the active commissioner.