### PR TITLE
[meshcop] use milliseconds for leader petition timeout constant

### DIFF
--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -78,7 +78,7 @@ template <> void Leader::HandleTmf<kUriLeaderPetition>(Coap::Message &aMessage, 
     IgnoreError(StringCopy(mCommissionerId, commissionerId));
 
     state = StateTlv::kAccept;
-    mTimer.Start(Time::SecToMsec(kTimeoutLeaderPetition));
+    mTimer.Start(kLeaderPetitionTimeout);
 
 exit:
     SendPetitionResponse(aMessage, aMessageInfo, state);
@@ -152,7 +152,7 @@ template <> void Leader::HandleTmf<kUriLeaderKeepAlive>(Coap::Message &aMessage,
         }
 
         responseState = StateTlv::kAccept;
-        mTimer.Start(Time::SecToMsec(kTimeoutLeaderPetition));
+        mTimer.Start(kLeaderPetitionTimeout);
     }
 
     SendKeepAliveResponse(aMessage, aMessageInfo, responseState);

--- a/src/core/meshcop/meshcop_leader.hpp
+++ b/src/core/meshcop/meshcop_leader.hpp
@@ -98,7 +98,7 @@ public:
     void SetEmptyCommissionerData(void);
 
 private:
-    static constexpr uint32_t kTimeoutLeaderPetition = 50; // TIMEOUT_LEAD_PET (seconds)
+    static constexpr uint32_t kLeaderPetitionTimeout = 50 * Time::kOneSecondInMsec; // TIMEOUT_LEAD_PET (in msec)
 
     OT_TOOL_PACKED_BEGIN
     class CommissioningData
@@ -131,10 +131,8 @@ private:
 
     using LeaderTimer = TimerMilliIn<Leader, &Leader::HandleTimer>;
 
-    LeaderTimer mTimer;
-
-    uint32_t mDelayTimerMinimal;
-
+    LeaderTimer                   mTimer;
+    uint32_t                      mDelayTimerMinimal;
     CommissionerIdTlv::StringType mCommissionerId;
     uint16_t                      mSessionId;
 };


### PR DESCRIPTION
This commit replaces `kTimeoutLeaderPetition` (in seconds) with `kLeaderPetitionTimeout` (in milliseconds). This change avoids repeated calls to `Time::SecToMsec()` when starting the commissioner session timer.