### PR TITLE
[mdns] add config to persist state on post-probe conflict

### DIFF
--- a/src/core/config/mdns.h
+++ b/src/core/config/mdns.h
@@ -96,6 +96,25 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MULTICAST_DNS_PERSIST_STATE_ON_POST_PROBE_CONFLICT
+ *
+ * Specifies the behavior of the mDNS module when a late conflict is detected. A late conflict occurs after a name has
+ * been successfully probed and claimed (post-probe). When enabled, the mDNS module will continue advertising/answering
+ * for the claimed name. The device essentially prioritizes the stability of the established advertisement. When
+ * disabled the mDNS module will transition the entry to the "conflict" state and stop answering/advertising for the
+ * name. Regardless of this configuration, the conflict callback is still invoked, informing other modules (such as the
+ * module that requested the registration) so they can decide on a higher-level resolution action.
+ *
+ * This configuration is enabled by default, especially in Thread use cases like the SRP Advertising Proxy. This is
+ * because post-probe conflicts are often transient or benign in these environments. Since the device (acting as
+ * the SRP Server) has already accepted an SRP registration from a remote Thread Node (SRP client), it is desirable for
+ * the mDNS advertisement to mirror the SRP registered service and maintain its discoverability.
+ */
+#ifndef OPENTHREAD_CONFIG_MULTICAST_DNS_PERSIST_STATE_ON_POST_PROBE_CONFLICT
+#define OPENTHREAD_CONFIG_MULTICAST_DNS_PERSIST_STATE_ON_POST_PROBE_CONFLICT 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_MULTICAST_DNS_VERBOSE_LOGGING_ENABLE
  *
  * Define as 1 to enable the multicast DNS (mDNS) verbose logging feature at build-time.

--- a/src/core/net/mdns.cpp
+++ b/src/core/net/mdns.cpp
@@ -1351,9 +1351,15 @@ void Core::Entry::SetStateToConflict(void)
     switch (GetState())
     {
     case kProbing:
-    case kRegistered:
         SetState(kConflict);
         break;
+
+    case kRegistered:
+#if !OPENTHREAD_CONFIG_MULTICAST_DNS_PERSIST_STATE_ON_POST_PROBE_CONFLICT
+        SetState(kConflict);
+#endif
+        break;
+
     case kConflict:
     case kRemoving:
         break;


### PR DESCRIPTION
This commit introduces a new mDNS OpenThread configuration, `OPENTHREAD_CONFIG_MULTICAST_DNS_PERSIST_STATE_ON_POST_PROBE_CONFLICT`, to control behavior when a late conflict is detected for an already registered mDNS entry.

When this option is enabled (the default), the mDNS entry remains in the `kRegistered` state, and the device continues to advertise and answer for the name. This prioritizes advertisement stability, which is desirable in use cases like the SRP Advertising Proxy where post-probe conflicts can be transient. If the option is disabled, the entry's state transitions to `kConflict`, and the device stops advertising the name.

Regardless of this configuration, the conflict callback is still invoked, informing other modules (such as the module that requested the registration) so they can decide on a higher-level resolution action.