### PR TITLE
[csl] update CSL sync time whenever CSL parameters are re-initialized.

### DIFF
--- a/src/core/mac/sub_mac_csl_receiver.cpp
+++ b/src/core/mac/sub_mac_csl_receiver.cpp
@@ -131,6 +131,8 @@ void SubMac::SetCslParams(uint16_t aPeriod, uint8_t aChannel, ShortAddress aShor
     {
         mCslSampleTimeRadio = static_cast<uint32_t>(Get<Radio>().GetNow());
         mCslSampleTimeLocal = TimerMicro::GetNow();
+        // Update CSL sync time whenever CSL parameters are re-initialized.
+        mCslLastSync = mCslSampleTimeLocal;
 
         HandleCslTimer();
     }


### PR DESCRIPTION
When the CSL feature is first enabled on a child device, the OpenThread stack starts CSL sampling before sending the Child Update Request packet([code link](https://github.com/openthread/openthread/blob/main/src/core/mac/mac.cpp#L2522)). The last CSL sync sample time, initialized as `0`, is updated only when the Child Update Request is sent. However, since CSL sampling begins earlier, the first CSL receive operation calculates the elapsed time in [`GetCslWindowEdges`](https://github.com/openthread/openthread/blob/main/src/core/mac/sub_mac_csl_receiver.cpp#L250) using `0` as the last sync time.

 Similarly, when CSL parameters are re-initialized, the stack should update `mCslLastSync`. Continuing to use an outdated sync time results in inaccurate calculations and is not reasonable behavior.

This PR fixed this issue.