### PR TITLE
[dataset] move `DelayTimerMinimal` to `PendingDatasetManager`

### DIFF
--- a/src/core/api/dataset_ftd_api.cpp
+++ b/src/core/api/dataset_ftd_api.cpp
@@ -48,12 +48,12 @@ otError otDatasetCreateNewNetwork(otInstance *aInstance, otOperationalDataset *a
 
 uint32_t otDatasetGetDelayTimerMinimal(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<MeshCoP::Leader>().GetDelayTimerMinimal();
+    return AsCoreType(aInstance).Get<MeshCoP::PendingDatasetManager>().GetDelayTimerMinimal();
 }
 
 otError otDatasetSetDelayTimerMinimal(otInstance *aInstance, uint32_t aDelayTimerMinimal)
 {
-    return AsCoreType(aInstance).Get<MeshCoP::Leader>().SetDelayTimerMinimal(aDelayTimerMinimal);
+    return AsCoreType(aInstance).Get<MeshCoP::PendingDatasetManager>().SetDelayTimerMinimal(aDelayTimerMinimal);
 }
 
 #endif // OPENTHREAD_FTD

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -892,6 +892,9 @@ void ActiveDatasetManager::HandleTimer(Timer &aTimer) { aTimer.Get<ActiveDataset
 PendingDatasetManager::PendingDatasetManager(Instance &aInstance)
     : DatasetManager(aInstance, Dataset::kPending, PendingDatasetManager::HandleTimer)
     , mDelayTimer(aInstance)
+#if OPENTHREAD_FTD
+    , mDelayTimerMinimal(DelayTimerTlv::kMinDelay)
+#endif
 {
 }
 

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -442,7 +442,28 @@ public:
      * Starts the Leader functions for maintaining the Active Operational Dataset.
      */
     void StartLeader(void);
-#endif
+
+    /**
+     * Gets the minimal delay timer.
+     *
+     * @retval the minimal delay timer (in ms).
+     */
+    uint32_t GetDelayTimerMinimal(void) const { return mDelayTimerMinimal; }
+
+    /**
+     * Sets the minimal delay timer value.
+     *
+     * This method is reserved for testing and demo purposes only. Changing this will render a production application
+     * non-compliant with the Thread Specification.
+     *
+     * @param[in]  aDelayTimerMinimal The value of minimal delay timer (in ms).
+     *
+     * @retval  kErrorNone         Successfully set the minimal delay timer.
+     * @retval  kErrorInvalidArgs  If @p aDelayTimerMinimal is not valid. It is zero or it is larger than or equal to
+     *                             the default minimum value of `DelayTimerTlv::kMinDelay`.
+     */
+    Error SetDelayTimerMinimal(uint32_t aDelayTimerMinimal);
+#endif // OPENTHREAD_FTD
 
 private:
 #if OPENTHREAD_FTD
@@ -461,6 +482,9 @@ private:
     using DelayTimer = TimerMilliIn<PendingDatasetManager, &PendingDatasetManager::HandleDelayTimer>;
 
     DelayTimer mDelayTimer;
+#if OPENTHREAD_FTD
+    uint32_t mDelayTimerMinimal;
+#endif
 };
 
 DeclareTmfHandler(PendingDatasetManager, kUriPendingGet);

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -45,7 +45,6 @@ RegisterLogModule("MeshCoPLeader");
 Leader::Leader(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mTimer(aInstance)
-    , mDelayTimerMinimal(DelayTimerTlv::kMinDelay)
     , mSessionId(Random::NonCrypto::GetUint16())
 {
 }
@@ -199,17 +198,6 @@ void Leader::SendDatasetChanged(const Ip6::Address &aAddress)
 exit:
     FreeMessageOnError(message, error);
     LogWarnOnError(error, "send dataset changed");
-}
-
-Error Leader::SetDelayTimerMinimal(uint32_t aDelayTimerMinimal)
-{
-    Error error = kErrorNone;
-
-    VerifyOrExit((aDelayTimerMinimal != 0 && aDelayTimerMinimal < DelayTimerTlv::kMinDelay), error = kErrorInvalidArgs);
-    mDelayTimerMinimal = aDelayTimerMinimal;
-
-exit:
-    return error;
 }
 
 void Leader::HandleTimer(void)

--- a/src/core/meshcop/meshcop_leader.hpp
+++ b/src/core/meshcop/meshcop_leader.hpp
@@ -76,23 +76,6 @@ public:
     void SendDatasetChanged(const Ip6::Address &aAddress);
 
     /**
-     * Sets minimal delay timer.
-     *
-     * @param[in]  aDelayTimerMinimal The value of minimal delay timer (in ms).
-     *
-     * @retval  kErrorNone         Successfully set the minimal delay timer.
-     * @retval  kErrorInvalidArgs  If @p aDelayTimerMinimal is not valid.
-     */
-    Error SetDelayTimerMinimal(uint32_t aDelayTimerMinimal);
-
-    /**
-     * Gets minimal delay timer.
-     *
-     * @retval the minimal delay timer (in ms).
-     */
-    uint32_t GetDelayTimerMinimal(void) const { return mDelayTimerMinimal; }
-
-    /**
      * Sets empty Commissioner Data TLV in the Thread Network Data.
      */
     void SetEmptyCommissionerData(void);
@@ -132,7 +115,6 @@ private:
     using LeaderTimer = TimerMilliIn<Leader, &Leader::HandleTimer>;
 
     LeaderTimer                   mTimer;
-    uint32_t                      mDelayTimerMinimal;
     CommissionerIdTlv::StringType mCommissionerId;
     uint16_t                      mSessionId;
 };


### PR DESCRIPTION
This change relocates the `mDelayTimerMinimal` member and its associated accessor methods, `GetDelayTimerMinimal()` and `SetDelayTimerMinimal()`, from the `MeshCoP::Leader` class to the `PendingDatasetManager` class.

This functionality is specific to the handling of the pending operational dataset. Placing it within `PendingDatasetManager` improves code structure and cohesion by grouping related parameters together.