### PR TITLE
[nat64] improve naming for platform-discovered NAT64 prefix

### DIFF
--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -155,7 +155,7 @@ void InfraIf::DiscoverNat64PrefixDone(uint32_t aIfIndex, const Ip6::Prefix &aPre
     VerifyOrExit(mInitialized && mIsRunning, error = kErrorInvalidState);
     VerifyOrExit(aIfIndex == mIfIndex, error = kErrorInvalidArgs);
 
-    Get<RoutingManager>().HandleInfraIfDiscoverNat64PrefixDone(aPrefix);
+    Get<RoutingManager>().HandlePlatformDiscoveredNat64PrefixDone(aPrefix);
 
 exit:
     if (error != kErrorNone)

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -409,14 +409,16 @@ public:
     Error GetFavoredNat64Prefix(Ip6::Prefix &aPrefix, RoutePreference &aRoutePreference);
 
     /**
-     * Informs `RoutingManager` of the result of the discovery request of NAT64 prefix on infrastructure
-     * interface (`InfraIf::DiscoverNat64Prefix()`).
+    // Informs `RoutingManager` of a discovered NAT64 prefix from the platform.
+    //
+    // This is intended to be used by `InfraIf` to pass a NAT64 prefix that is discovered through a platform-specific
+    // mechanism (e.g., from DNS as per RFC 7050).
      *
-     * @param[in]  aPrefix  The discovered NAT64 prefix on `InfraIf`.
+     * @param[in]  aPrefix  The discovered NAT64 prefix.
      */
-    void HandleInfraIfDiscoverNat64PrefixDone(const Ip6::Prefix &aPrefix)
+    void HandlePlatformDiscoveredNat64PrefixDone(const Ip6::Prefix &aPrefix)
     {
-        mNat64PrefixManager.HandleInfraIfDiscoverDone(aPrefix);
+        mNat64PrefixManager.HandlePlatformDiscoveredPrefix(aPrefix);
     }
 
 #endif // OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
@@ -826,7 +828,7 @@ private:
         const Ip6::Prefix &GetLocalPrefix(void) const { return mLocalPrefix; }
         const Ip6::Prefix &GetFavoredPrefix(RoutePreference &aPreference) const;
         void               Evaluate(void);
-        void               HandleInfraIfDiscoverDone(const Ip6::Prefix &aPrefix);
+        void               HandlePlatformDiscoveredPrefix(const Ip6::Prefix &aPrefix);
         void               HandleRxRaTrackerChanged(void);
         void               HandleTimer(void);
 
@@ -839,7 +841,7 @@ private:
 
         bool            mEnabled;
         Ip6::Prefix     mRaTrackerPrefix;     // The best NAT64 prefix discovered from RAs (RFC 8781).
-        Ip6::Prefix     mInfraIfPrefix;       // The platform-provided NAT64 prefix (e.g., using DNS - RFC 7050).
+        Ip6::Prefix     mPlatformPrefix;      // The platform-provided NAT64 prefix (e.g., using DNS - RFC 7050).
         Ip6::Prefix     mLocalPrefix;         // The local prefix (from BR ULA prefix).
         Ip6::Prefix     mPublishedPrefix;     // The prefix to publish in Net Data (empty or local or from infra-if).
         RoutePreference mPublishedPreference; // The published prefix preference.

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -4627,7 +4627,7 @@ void TestNat64PrefixSelection(void)
     Ip6::Prefix                     localOmr;
     NetworkData::OnMeshPrefixConfig prefixConfig;
     Ip6::Prefix                     omrPrefix             = PrefixFromString("2000:0000:1111:4444::", 64);
-    Ip6::Prefix                     infraIfNat64Prefix    = PrefixFromString("2000:0:0:1:0:0::", 96);
+    Ip6::Prefix                     platformNat64Prefix   = PrefixFromString("2000:0:0:1:0:0::", 96);
     Ip6::Prefix                     raTrackerNat64PrefixA = PrefixFromString("2000:0:0:2:0:f::", 96);
     Ip6::Address                    routerAddressA        = AddressFromString("fd00::aaaa");
     Ip6::Prefix                     raTrackerNat64PrefixB = PrefixFromString("2000:0:0:2:0:0::", 96);
@@ -4663,18 +4663,18 @@ void TestNat64PrefixSelection(void)
     VerifyNat64PrefixInNetData(localNat64);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    // InfraIf NAT64 prefix (e.g. using DNS - RFC 7050) discovered. No infra-derived OMR prefix in Network Data. Check
-    // local NAT64 prefix in Network Data.
+    // Platform-provided NAT64 prefix (e.g. using DNS - RFC 7050) discovered. No infra-derived OMR prefix in Network
+    // Data. Check local NAT64 prefix in Network Data.
 
-    DiscoverNat64Prefix(infraIfNat64Prefix);
+    DiscoverNat64Prefix(platformNat64Prefix);
 
     AdvanceTime(20000);
 
     VerifyNat64PrefixInNetData(localNat64);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    // Add a medium preference OMR prefix into Network Data.
-    // Check InfraIf NAT64 prefix published in Network Data.
+    // Add a medium preference OMR prefix into Network Data. Check that the platform-provided NAT64 prefix is now
+    // published in Network Data.
 
     prefixConfig.Clear();
     prefixConfig.mPrefix       = omrPrefix;
@@ -4691,7 +4691,7 @@ void TestNat64PrefixSelection(void)
     AdvanceTime(20000);
 
     VerifyOmrPrefixInNetData(omrPrefix, /* aDefaultRoute */ false);
-    VerifyNat64PrefixInNetData(infraIfNat64Prefix);
+    VerifyNat64PrefixInNetData(platformNat64Prefix);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Send an RA from a router advertising a NAT64 prefix. Check that the RA-discovered NAT64 prefix is now favored
@@ -4747,16 +4747,16 @@ void TestNat64PrefixSelection(void)
     AdvanceTime(20000);
 
     VerifyOmrPrefixInNetData(omrPrefix, /* aDefaultRoute */ false);
-    VerifyNat64PrefixInNetData(infraIfNat64Prefix);
+    VerifyNat64PrefixInNetData(platformNat64Prefix);
 
     VerifyNat64PrefixTableIsEmpty();
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    // InfraIf NAT64 prefix removed.
+    // Platform-provided NAT64 prefix removed.
     // Check local NAT64 prefix in Network Data.
 
-    infraIfNat64Prefix.Clear();
-    DiscoverNat64Prefix(infraIfNat64Prefix);
+    platformNat64Prefix.Clear();
+    DiscoverNat64Prefix(platformNat64Prefix);
 
     AdvanceTime(20000);
 


### PR DESCRIPTION
This change renames the `mInfraIfPrefix` in Nat64PrefixManager to `mPlatformPrefix`.

The original name was ambiguous because both the RA-discovered prefix `mRaTrackerPrefix` and this prefix are sourced from the infrastructure link. The new name `mPlatformPrefix` clarifies that this prefix is discovered through a platform-specific mechanism (e.g., DNS-based discovery per RFC 7050), distinguishing it from prefixes discovered directly via RA.