### PR TITLE
[style] upgrade yapf to the 0.43.0 version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,16 +56,12 @@ jobs:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         submodules: recursive
-    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-      with:
-        python-version: '3.12'
-        cache: pip
     - name: Bootstrap
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y shellcheck iwyu
         sudo bash script/install-llvm.sh
-        python3 -m pip install yapf==0.31.0
+        python3 -m pip install yapf==0.43.0
         sudo snap install shfmt
         npm install prettier@2.0.4
     - name: Check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ This will open up a text editor where you can specify which commits to squash.
 
 #### Coding Conventions and Style
 
-OpenThread uses and enforces the [OpenThread Coding Conventions and Style](STYLE_GUIDE.md) on all code, except for code located in [third_party](third_party). Use `script/make-pretty` and `script/make-pretty check` to automatically reformat code and check for code-style compliance, respectively. OpenThread currently requires [clang-format v19](https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.7) for C/C++ and [yapf v0.31.0](https://github.com/google/yapf) for Python.
+OpenThread uses and enforces the [OpenThread Coding Conventions and Style](STYLE_GUIDE.md) on all code, except for code located in [third_party](third_party). Use `script/make-pretty` and `script/make-pretty check` to automatically reformat code and check for code-style compliance, respectively. OpenThread currently requires [clang-format v19](https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.7) for C/C++ and [yapf v0.43.0](https://github.com/google/yapf) for Python.
 
 As part of the cleanup process, you should also run `script/make-pretty check` to ensure that your code passes the baseline code style checks.
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -116,7 +116,7 @@
 
 - OpenThread uses `script/make-pretty` to reformat code and enforce code format and style. `script/make-pretty check` build target is included in OpenThread's continuous integration and must pass before a pull request is merged.
 
-- `script/make-pretty` requires [clang-format v19](https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.7) for C/C++ and [yapf v0.31.0](https://github.com/google/yapf) for Python.
+- `script/make-pretty` requires [clang-format v19](https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.7) for C/C++ and [yapf v0.43.0](https://github.com/google/yapf) for Python.
 
 ### File Names
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -46,7 +46,7 @@ install_packages_pretty_format()
     sudo bash "$(dirname "$0")/install-llvm.sh"
 
     # add yapf for pretty
-    python3 -m pip install yapf==0.31.0 || echo 'WARNING: could not install yapf, which is useful if you plan to contribute python code to the OpenThread project.'
+    python3 -m pip install yapf==0.43.0 || echo 'WARNING: could not install yapf, which is useful if you plan to contribute python code to the OpenThread project.'
 
     # add mdv for local size report
     python3 -m pip install mdv || echo 'WARNING: could not install mdv, which is required to post markdown size report for OpenThread.'
@@ -129,7 +129,7 @@ install_packages_brew()
         } || echo "WARNING: could not install llvm@${LLVM_MAJOR_VERSION}, which is useful if you plan to contribute C/C++ code to the OpenThread project."
 
         # add yapf for pretty
-        python3 -m pip install yapf || echo 'Failed to install python code formatter yapf. Install it manually if you need.'
+        python3 -m pip install yapf==0.43.0 || echo 'Failed to install python code formatter yapf. Install it manually if you need.'
     fi
 
     brew install include-what-you-use || echo 'WARNING: iwyu, which is useful to ensure applying the IWYU rules.'


### PR DESCRIPTION
This commit upgrades yapf which fixed the issue of deprecated lib2to3.