### PR TITLE
[api] fix api doc of otBorderAgentSetId parameter

### DIFF
--- a/include/openthread/border_agent.h
+++ b/include/openthread/border_agent.h
@@ -342,7 +342,7 @@ otError otBorderAgentGetId(otInstance *aInstance, otBorderAgentId *aId);
  * a random ID will be generated and returned when `otBorderAgentGetId` is called.
  *
  * @param[in]    aInstance  A pointer to an OpenThread instance.
- * @param[out]   aId        A pointer to the Border Agent ID.
+ * @param[in]    aId        A pointer to the Border Agent ID.
  *
  * @retval OT_ERROR_NONE  If successfully set the Border Agent ID.
  * @retval ...            If failed to set the Border Agent ID.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (551)
+#define OPENTHREAD_API_VERSION (552)
 
 /**
  * @addtogroup api-instance


### PR DESCRIPTION
The parameter is a `in` instead of `out`.