### PR TITLE
[posix] allow set POSIX TUN device at runtime

### DIFF
--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -140,9 +140,15 @@ enum
 
     OT_POSIX_OPT_RADIO_VERSION,
     OT_POSIX_OPT_REAL_TIME_SIGNAL,
+#if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
+    OT_POSIX_OPT_TUN_DEVICE,
+#endif
 };
 
 static const struct option kOptions[] = {
+#if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
+    {"tun-device", required_argument, NULL, OT_POSIX_OPT_TUN_DEVICE},
+#endif
     {"backbone-interface-name", required_argument, NULL, OT_POSIX_OPT_BACKBONE_INTERFACE_NAME},
     {"debug-level", required_argument, NULL, OT_POSIX_OPT_DEBUG_LEVEL},
     {"dry-run", no_argument, NULL, OT_POSIX_OPT_DRY_RUN},
@@ -161,6 +167,9 @@ static void PrintUsage(const char *aProgramName, FILE *aStream, int aExitCode)
             "Syntax:\n"
             "    %s [Options] RadioURL [RadioURL]\n"
             "Options:\n"
+#if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
+            "        --tun-device              POSIX TUN Device.\n"
+#endif
             "    -B  --backbone-interface-name Backbone network interface name.\n"
             "    -d  --debug-level             Debug level of logging.\n"
             "    -h  --help                    Display this usage information.\n"
@@ -189,6 +198,9 @@ static void ParseArg(int aArgCount, char *aArgVector[], PosixConfig *aConfig)
     aConfig->mPlatformConfig.mSpeedUpFactor       = 1;
     aConfig->mLogLevel                            = OT_LOG_LEVEL_CRIT;
     aConfig->mPlatformConfig.mInterfaceName       = OPENTHREAD_POSIX_CONFIG_THREAD_NETIF_DEFAULT_NAME;
+#if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
+    aConfig->mPlatformConfig.mTunDevice = NULL;
+#endif
 #ifdef SIGRTMIN
     aConfig->mPlatformConfig.mRealTimeSignal = SIGRTMIN;
 #endif
@@ -254,6 +266,11 @@ static void ParseArg(int aArgCount, char *aArgVector[], PosixConfig *aConfig)
             {
                 aConfig->mPlatformConfig.mRealTimeSignal = atoi(optarg);
             }
+            break;
+#endif
+#if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
+        case OT_POSIX_OPT_TUN_DEVICE:
+            aConfig->mPlatformConfig.mTunDevice = optarg;
             break;
 #endif
         case '?':

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -83,6 +83,8 @@ typedef struct otPlatformCoprocessorUrls
  */
 typedef struct otPlatformConfig
 {
+    const char *mTunDevice;                           ///< The POSIX TUN device path.
+                                                      ///< Used if `OT_PLATFORM_NETIF` is enabled.
     const char               *mBackboneInterfaceName; ///< Backbone network interface name.
     const char               *mInterfaceName;         ///< Thread network interface name.
     otPlatformCoprocessorUrls mCoprocessorUrls;       ///< Coprocessor URLs.

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -2232,9 +2232,14 @@ void platformNetifInit(otPlatformConfig *aPlatformConfig)
     (void)LogNote;
     (void)LogDebg;
 
-    if (aPlatformConfig->mTunDevice == NULL) {
+#if defined(__linux__) || defined(__NetBSD__) ||                                                       \
+    (defined(__APPLE__) && (OPENTHREAD_POSIX_CONFIG_MACOS_TUN_OPTION == OT_POSIX_CONFIG_MACOS_TUN)) || \
+    defined(__FreeBSD__)
+    if (aPlatformConfig->mTunDevice == NULL)
+    {
         aPlatformConfig->mTunDevice = OPENTHREAD_POSIX_TUN_DEVICE;
     }
+#endif
 
     sIpFd = ot::Posix::SocketWithCloseExec(AF_INET6, SOCK_DGRAM, IPPROTO_IP, ot::Posix::kSocketNonBlock);
     VerifyOrDie(sIpFd >= 0, OT_EXIT_ERROR_ERRNO);

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -2235,7 +2235,7 @@ void platformNetifInit(otPlatformConfig *aPlatformConfig)
 #if defined(__linux__) || defined(__NetBSD__) ||                                                       \
     (defined(__APPLE__) && (OPENTHREAD_POSIX_CONFIG_MACOS_TUN_OPTION == OT_POSIX_CONFIG_MACOS_TUN)) || \
     defined(__FreeBSD__)
-    if (aPlatformConfig->mTunDevice == NULL)
+    if (aPlatformConfig->mTunDevice == nullptr)
     {
         aPlatformConfig->mTunDevice = OPENTHREAD_POSIX_TUN_DEVICE;
     }

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -2033,7 +2033,8 @@ static void platformConfigureTunDevice(otPlatformConfig *aPlatformConfig)
     struct ifreq ifr;
     const char  *interfaceName;
 
-    sTunFd = open(OPENTHREAD_POSIX_TUN_DEVICE, O_RDWR | O_CLOEXEC | O_NONBLOCK);
+    sTunFd = open((aPlatformConfig->mTunDevice == NULL ? OPENTHREAD_POSIX_TUN_DEVICE : aPlatformConfig->mTunDevice),
+                  O_RDWR | O_CLOEXEC | O_NONBLOCK);
     VerifyOrDie(sTunFd >= 0, OT_EXIT_ERROR_ERRNO);
 
     memset(&ifr, 0, sizeof(ifr));
@@ -2134,9 +2135,7 @@ static void platformConfigureTunDevice(otPlatformConfig *aPlatformConfig)
     const char *last_slash;
     const char *path;
 
-    (void)aPlatformConfig;
-
-    path = OPENTHREAD_POSIX_TUN_DEVICE;
+    path = (aPlatformConfig->mTunDevice == NULL ? OPENTHREAD_POSIX_TUN_DEVICE : aPlatformConfig->mTunDevice);
 
     sTunFd = open(path, O_RDWR | O_NONBLOCK);
     VerifyOrDie(sTunFd >= 0, OT_EXIT_ERROR_ERRNO);
@@ -2150,7 +2149,8 @@ static void platformConfigureTunDevice(otPlatformConfig *aPlatformConfig)
     err   = ioctl(sTunFd, TUNSIFHEAD, &flags);
     VerifyOrDie(err == 0, OT_EXIT_ERROR_ERRNO);
 
-    last_slash = strrchr(OPENTHREAD_POSIX_TUN_DEVICE, '/');
+    last_slash =
+        strrchr((aPlatformConfig->mTunDevice == NULL ? OPENTHREAD_POSIX_TUN_DEVICE : aPlatformConfig->mTunDevice), '/');
     VerifyOrDie(last_slash != nullptr, OT_EXIT_ERROR_ERRNO);
     last_slash++;
 

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -1983,6 +1983,15 @@ exit:
 }
 #endif
 
+#if defined(__linux__) || defined(__NetBSD__) ||                                                       \
+    (defined(__APPLE__) && (OPENTHREAD_POSIX_CONFIG_MACOS_TUN_OPTION == OT_POSIX_CONFIG_MACOS_TUN)) || \
+    defined(__FreeBSD__)
+static const char *platformGetTunDevicePath(otPlatformConfig *aPlatformConfig)
+{
+    return aPlatformConfig->mTunDevice == NULL ? OPENTHREAD_POSIX_TUN_DEVICE : aPlatformConfig->mTunDevice;
+}
+#endif
+
 #ifdef __linux__
 static void SetAddrGenModeToNone(void)
 {
@@ -2033,8 +2042,7 @@ static void platformConfigureTunDevice(otPlatformConfig *aPlatformConfig)
     struct ifreq ifr;
     const char  *interfaceName;
 
-    sTunFd = open((aPlatformConfig->mTunDevice == NULL ? OPENTHREAD_POSIX_TUN_DEVICE : aPlatformConfig->mTunDevice),
-                  O_RDWR | O_CLOEXEC | O_NONBLOCK);
+    sTunFd = open(platformGetTunDevicePath(aPlatformConfig), O_RDWR | O_CLOEXEC | O_NONBLOCK);
     VerifyOrDie(sTunFd >= 0, OT_EXIT_ERROR_ERRNO);
 
     memset(&ifr, 0, sizeof(ifr));
@@ -2135,7 +2143,7 @@ static void platformConfigureTunDevice(otPlatformConfig *aPlatformConfig)
     const char *last_slash;
     const char *path;
 
-    path = (aPlatformConfig->mTunDevice == NULL ? OPENTHREAD_POSIX_TUN_DEVICE : aPlatformConfig->mTunDevice);
+    path = platformGetTunDevicePath(aPlatformConfig);
 
     sTunFd = open(path, O_RDWR | O_NONBLOCK);
     VerifyOrDie(sTunFd >= 0, OT_EXIT_ERROR_ERRNO);
@@ -2149,8 +2157,7 @@ static void platformConfigureTunDevice(otPlatformConfig *aPlatformConfig)
     err   = ioctl(sTunFd, TUNSIFHEAD, &flags);
     VerifyOrDie(err == 0, OT_EXIT_ERROR_ERRNO);
 
-    last_slash =
-        strrchr((aPlatformConfig->mTunDevice == NULL ? OPENTHREAD_POSIX_TUN_DEVICE : aPlatformConfig->mTunDevice), '/');
+    last_slash = strrchr(platformGetTunDevicePath(aPlatformConfig), '/');
     VerifyOrDie(last_slash != nullptr, OT_EXIT_ERROR_ERRNO);
     last_slash++;
 


### PR DESCRIPTION
This commit introduces allows users to pass the POSIX TUN device path through a command line flag (`--tun-device`) when starting the daemon / cli if `OT_PLATFORM_NETIF` is enabled.
- If users doesn't not set this flag, the POSIX TUN device path will be default to `OPENTHREAD_POSIX_TUN_DEVICE`.