### PR TITLE
[uptime] introduce `UptimeMsec` and `UptimeSec` types

### DIFF
--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -107,13 +107,17 @@ otError otInstanceResetToBootloader(otInstance *aInstance) { return AsCoreType(a
 #endif
 
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
-uint64_t otInstanceGetUptime(otInstance *aInstance) { return AsCoreType(aInstance).Get<Uptime>().GetUptime(); }
+uint64_t otInstanceGetUptime(otInstance *aInstance) { return AsCoreType(aInstance).Get<UptimeTracker>().GetUptime(); }
 
 void otInstanceGetUptimeAsString(otInstance *aInstance, char *aBuffer, uint16_t aSize)
 {
     AssertPointerIsNotNull(aBuffer);
 
-    AsCoreType(aInstance).Get<Uptime>().GetUptime(aBuffer, aSize);
+    {
+        StringWriter writer(aBuffer, aSize);
+
+        UptimeToString(AsCoreType(aInstance).Get<UptimeTracker>().GetUptime(), writer, /* aIncludeMsec */ true);
+    }
 }
 #endif
 

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -531,7 +531,8 @@ otError otThreadWakeup(otInstance         *aInstance,
 void otConvertDurationInSecondsToString(uint32_t aDuration, char *aBuffer, uint16_t aSize)
 {
     StringWriter writer(aBuffer, aSize);
+    UptimeMsec   uptime = static_cast<UptimeMsec>(aDuration) * Time::kOneSecondInMsec;
 
-    Uptime::UptimeToString(Uptime::SecToMsec(aDuration), writer, /* aIncludeMsec */ false);
+    UptimeToString(uptime, writer, /* aIncludeMsec */ false);
 }
 #endif

--- a/src/core/border_router/br_tracker.cpp
+++ b/src/core/border_router/br_tracker.cpp
@@ -62,8 +62,8 @@ bool NetDataBrTracker::BrMatchesFilter(const BorderRouter &aEntry, Filter aFilte
 
 uint16_t NetDataBrTracker::CountBrs(Filter aFilter, uint32_t &aMinAge) const
 {
-    uint32_t uptime = Get<Uptime>().GetUptimeInSeconds();
-    uint16_t count  = 0;
+    UptimeSec uptime = Get<UptimeTracker>().GetUptimeInSeconds();
+    uint16_t  count  = 0;
 
     SetToUintMax(aMinAge);
 
@@ -148,7 +148,7 @@ void NetDataBrTracker::HandleNotifierEvents(Events aEvents)
         VerifyOrExit(newEntry != nullptr, LogWarn("Failed to allocate `BorderRouter` entry"));
 
         newEntry->mRloc16       = rloc16;
-        newEntry->mDiscoverTime = Get<Uptime>().GetUptimeInSeconds();
+        newEntry->mDiscoverTime = Get<UptimeTracker>().GetUptimeInSeconds();
 
         mBorderRouters.Push(*newEntry);
     }

--- a/src/core/border_router/br_tracker.hpp
+++ b/src/core/border_router/br_tracker.hpp
@@ -120,12 +120,12 @@ private:
             const NetworkData::Rlocs &mExcludeRlocs;
         };
 
-        uint32_t GetAge(uint32_t aUptime) const { return aUptime - mDiscoverTime; }
+        uint32_t GetAge(UptimeSec aUptime) const { return aUptime - mDiscoverTime; }
         bool     Matches(uint16_t aRloc16) const { return mRloc16 == aRloc16; }
         bool     Matches(const RlocFilter &aFilter) const { return !aFilter.mExcludeRlocs.Contains(mRloc16); }
 
         BorderRouter *mNext;
-        uint32_t      mDiscoverTime;
+        UptimeSec     mDiscoverTime;
         uint16_t      mRloc16;
     };
 

--- a/src/core/border_router/br_types.cpp
+++ b/src/core/border_router/br_types.cpp
@@ -231,7 +231,7 @@ void RdnssAddress::CopyInfoTo(RdnssAddrEntry &aEntry, TimeMilli aNow) const
 //---------------------------------------------------------------------------------------------------------------------
 // IfAddress
 
-void IfAddress::SetFrom(const Ip6::Address &aAddress, uint32_t aUptimeNow)
+void IfAddress::SetFrom(const Ip6::Address &aAddress, UptimeSec aUptimeNow)
 {
     mAddress       = aAddress;
     mLastUseUptime = aUptimeNow;
@@ -239,7 +239,7 @@ void IfAddress::SetFrom(const Ip6::Address &aAddress, uint32_t aUptimeNow)
 
 bool IfAddress::Matches(const InvalidChecker &aChecker) const { return !aChecker.Get<InfraIf>().HasAddress(mAddress); }
 
-void IfAddress::CopyInfoTo(IfAddrEntry &aEntry, uint32_t aUptimeNow) const
+void IfAddress::CopyInfoTo(IfAddrEntry &aEntry, UptimeSec aUptimeNow) const
 {
     aEntry.mAddress         = mAddress;
     aEntry.mSecSinceLastUse = aUptimeNow - mLastUseUptime;

--- a/src/core/border_router/br_types.hpp
+++ b/src/core/border_router/br_types.hpp
@@ -47,6 +47,7 @@
 #include "common/string.hpp"
 #include "common/time.hpp"
 #include "common/timer.hpp"
+#include "common/uptime.hpp"
 #include "net/ip6_address.hpp"
 #include "net/nd6.hpp"
 #include "thread/network_data.hpp"
@@ -493,7 +494,7 @@ public:
      * @param[in] aAddress    The IPv6 address.
      * @param[in] aUptimeNow  The current uptime (in seconds).
      */
-    void SetFrom(const Ip6::Address &aAddress, uint32_t aUptimeNow);
+    void SetFrom(const Ip6::Address &aAddress, UptimeSec aUptimeNow);
 
     /**
      * Indicates whether this interface address entry matches a given IPv6 address.
@@ -521,11 +522,11 @@ public:
      * @param[out] aEntry      The `IfAddrEntry` to copy information to.
      * @param[in]  aUptimeNow  The current uptime.
      */
-    void CopyInfoTo(IfAddrEntry &aEntry, uint32_t aUptimeNow) const;
+    void CopyInfoTo(IfAddrEntry &aEntry, UptimeSec aUptimeNow) const;
 
 private:
     Ip6::Address mAddress;
-    uint32_t     mLastUseUptime;
+    UptimeSec    mLastUseUptime;
 };
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -477,9 +477,9 @@ void RoutingManager::ScheduleRoutingPolicyEvaluation(ScheduleMode aMode)
         }
         else
         {
-            String<Uptime::kStringSize> string;
+            String<kUptimeStringSize> string;
 
-            Uptime::UptimeToString(duration, string, /* aIncludeMsec */ true);
+            UptimeToString(duration, string, /* aIncludeMsec */ true);
             LogInfo("Will evaluate routing policy in %s (%lu msec)", string.AsCString() + 3, ToUlong(duration));
         }
     }

--- a/src/core/border_router/rx_ra_tracker.cpp
+++ b/src/core/border_router/rx_ra_tracker.cpp
@@ -217,7 +217,7 @@ void RxRaTracker::HandleRouterAdvertisement(const InfraIf::Icmp6Packet &aPacket,
 
         router = newEntry;
         router->Clear();
-        router->mDiscoverTime = Get<Uptime>().GetUptimeInSeconds();
+        router->mDiscoverTime = Get<UptimeTracker>().GetUptimeInSeconds();
         router->mAddress      = aSrcAddress;
 
         mRouters.Push(*newEntry);
@@ -576,7 +576,7 @@ void RxRaTracker::UpdateIfAddresses(const Ip6::Address &aAddress)
         mIfAddresses.Push(*entry);
     }
 
-    entry->SetFrom(aAddress, Get<Uptime>().GetUptimeInSeconds());
+    entry->SetFrom(aAddress, Get<UptimeTracker>().GetUptimeInSeconds());
 
 exit:
     return;
@@ -1203,7 +1203,7 @@ exit:
 
 void RxRaTracker::InitIterator(PrefixTableIterator &aIterator) const
 {
-    static_cast<Iterator &>(aIterator).Init(mRouters.GetHead(), Get<Uptime>().GetUptimeInSeconds());
+    static_cast<Iterator &>(aIterator).Init(mRouters.GetHead(), Get<UptimeTracker>().GetUptimeInSeconds());
 }
 
 Error RxRaTracker::GetNextPrefixTableEntry(PrefixTableIterator &aIterator, PrefixTableEntry &aEntry) const
@@ -1393,7 +1393,7 @@ const char *RxRaTracker::RouterAdvOriginToString(RouterAdvOrigin aRaOrigin)
 //---------------------------------------------------------------------------------------------------------------------
 // RxRaTracker::Iterator
 
-void RxRaTracker::Iterator::Init(const Entry<Router> *aRoutersHead, uint32_t aUptime)
+void RxRaTracker::Iterator::Init(const Entry<Router> *aRoutersHead, UptimeSec aUptime)
 {
     SetInitUptime(aUptime);
     SetInitTime();
@@ -1627,7 +1627,7 @@ bool RxRaTracker::Router::IsPeerBr(void) const
     return mAllEntriesDisregarded && !(mOnLinkPrefixes.IsEmpty() && mRoutePrefixes.IsEmpty());
 }
 
-void RxRaTracker::Router::CopyInfoTo(RouterEntry &aEntry, TimeMilli aNow, uint32_t aUptime) const
+void RxRaTracker::Router::CopyInfoTo(RouterEntry &aEntry, TimeMilli aNow, UptimeSec aUptime) const
 {
     aEntry.mAddress                  = mAddress;
     aEntry.mMsecSinceLastUpdate      = aNow - mLastUpdateTime;

--- a/src/core/border_router/rx_ra_tracker.hpp
+++ b/src/core/border_router/rx_ra_tracker.hpp
@@ -420,7 +420,7 @@ private:
         Nat64PrefixList mNat64Prefixes;
 #endif
         RdnssAddressList mRdnssAddresses;
-        uint32_t         mDiscoverTime;
+        UptimeSec        mDiscoverTime;
         TimeMilli        mLastUpdateTime;
         TimeMilli        mTimeoutTime;
         uint8_t          mNsProbeCount;
@@ -455,7 +455,7 @@ private:
             kRoutePrefix,
         };
 
-        void  Init(const Entry<Router> *aRoutersHead, uint32_t aUptime);
+        void  Init(const Entry<Router> *aRoutersHead, UptimeSec aUptime);
         Error AdvanceToNextRouter(Type aType);
         Error AdvanceToNextPrefixEntry(void);
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
@@ -463,8 +463,8 @@ private:
 #endif
         Error                AdvanceToNextRdnssAddrEntry(void);
         Error                AdvanceToNextIfAddrEntry(const Entry<IfAddress> *aListHead);
-        uint32_t             GetInitUptime(void) const { return mData0; }
-        void                 SetInitUptime(uint32_t aUptime) { mData0 = aUptime; }
+        UptimeSec            GetInitUptime(void) const { return mData0; }
+        void                 SetInitUptime(UptimeSec aUptime) { mData0 = aUptime; }
         TimeMilli            GetInitTime(void) const { return TimeMilli(mData1); }
         void                 SetInitTime(void) { mData1 = TimerMilli::GetNow().GetValue(); }
         const Entry<Router> *GetRouter(void) const { return static_cast<const Entry<Router> *>(mPtr1); }

--- a/src/core/common/log.cpp
+++ b/src/core/common/log.cpp
@@ -99,7 +99,8 @@ void Logger::LogVarArgs(const char *aModuleName, LogLevel aLogLevel, const char 
     static_assert(sizeof(kModuleNamePadding) == kMaxLogModuleNameLength + 1, "Padding string is not correct");
 
 #if OPENTHREAD_CONFIG_LOG_PREPEND_UPTIME
-    ot::Uptime::UptimeToString(ot::Instance::Get().Get<ot::Uptime>().GetUptime(), logString, /* aInlcudeMsec */ true);
+    ot::UptimeToString(ot::Instance::Get().Get<ot::UptimeTracker>().GetUptime(), logString,
+                       /* aInlcudeMsec */ true);
     logString.Append(" ");
 #endif
 

--- a/src/core/common/uptime.hpp
+++ b/src/core/common/uptime.hpp
@@ -50,20 +50,24 @@
 
 namespace ot {
 
+typedef uint64_t UptimeMsec; ///< Uptime in milliseconds.
+
+typedef uint32_t UptimeSec; ///< Uptime in seconds.
+
+constexpr uint16_t kUptimeStringSize = OT_UPTIME_STRING_SIZE; ///< Recommended string size to represent uptime.
+
 /**
- * Implements tracking of device uptime (in msec).
+ * Implements tracking of device uptime.
  */
-class Uptime : public InstanceLocator, private NonCopyable
+class UptimeTracker : public InstanceLocator, private NonCopyable
 {
 public:
-    static constexpr uint16_t kStringSize = OT_UPTIME_STRING_SIZE; ///< Recommended string size to represent uptime.
-
     /**
-     * Initializes an `Uptime` instance.
+     * Initializes an `UptimeTracker` instance.
      *
      * @param[in] aInstance   The OpenThread instance.
      */
-    explicit Uptime(Instance &aInstance);
+    explicit UptimeTracker(Instance &aInstance);
 
     /**
      * Returns the current device uptime (in msec).
@@ -72,62 +76,14 @@ public:
      *
      * @returns The uptime (number of milliseconds).
      */
-    uint64_t GetUptime(void) const;
-
-    /**
-     * Gets the current uptime as a human-readable string.
-     *
-     * The string follows the format "<hh>:<mm>:<ss>.<mmmm>" for hours, minutes, seconds and millisecond (if uptime is
-     * shorter than one day) or "<dd>d.<hh>:<mm>:<ss>.<mmmm>" (if longer than a day).
-     *
-     * If the resulting string does not fit in @p aBuffer (within its @p aSize characters), the string will be
-     * truncated but the outputted string is always null-terminated.
-     *
-     * @param[out] aBuffer   A pointer to a char array to output the string.
-     * @param[in]  aSize     The size of @p aBuffer (in bytes). Recommended to use `OT_UPTIME_STRING_SIZE`.
-     */
-    void GetUptime(char *aBuffer, uint16_t aSize) const;
-
-    /**
-     * Converts an uptime value (number of milliseconds) to a human-readable string.
-     *
-     * The string follows the format "<hh>:<mm>:<ss>.<mmmm>" for hours, minutes, seconds and millisecond (if uptime is
-     * shorter than one day) or "<dd>d.<hh>:<mm>:<ss>.<mmmm>" (if longer than a day). @p aIncludeMsec can be used
-     * to determine whether `.<mmm>` milliseconds is included or omitted in the resulting string.
-     *
-     * @param[in]     aUptime        The uptime to convert.
-     * @param[in,out] aWriter        A `StringWriter` to append the converted string to.
-     * @param[in]     aIncludeMsec   Whether to include `.<mmm>` milliseconds in the string.
-     */
-    static void UptimeToString(uint64_t aUptime, StringWriter &aWriter, bool aIncludeMsec);
+    UptimeMsec GetUptime(void) const;
 
     /**
      * Returns the current device uptime in seconds.
      *
      * @returns The uptime in seconds.
      */
-    uint32_t GetUptimeInSeconds(void) const;
-
-    /**
-     * Converts a given uptime as number of milliseconds to number of seconds.
-     *
-     * @param[in] aUptimeInMilliseconds    Uptime in milliseconds (as `uint64_t`).
-     *
-     * @returns The converted @p aUptimeInMilliseconds to seconds (as `uint32_t`).
-     */
-    static uint32_t MsecToSec(uint64_t aUptimeInMilliseconds)
-    {
-        return static_cast<uint32_t>(aUptimeInMilliseconds / 1000u);
-    }
-
-    /**
-     * Converts a given uptime as number of seconds to number of milliseconds.
-     *
-     * @param[in] aUptimeInSeconds    Uptime in seconds (as `uint32_t`).
-     *
-     * @returns The converted @p aUptimeInSeconds to milliseconds (as `uint64_t`).
-     */
-    static uint64_t SecToMsec(uint32_t aUptimeInSeconds) { return static_cast<uint64_t>(aUptimeInSeconds) * 1000u; }
+    UptimeSec GetUptimeInSeconds(void) const;
 
 private:
     static constexpr uint32_t kTimerInterval = (1 << 30);
@@ -136,12 +92,25 @@ private:
 
     void HandleTimer(void);
 
-    using UptimeTimer = TimerMilliIn<Uptime, &Uptime::HandleTimer>;
+    using UptimeTimer = TimerMilliIn<UptimeTracker, &UptimeTracker::HandleTimer>;
 
     TimeMilli   mStartTime;
     uint32_t    mOverflowCount;
     UptimeTimer mTimer;
 };
+
+/**
+ * Converts an uptime value (number of milliseconds) to a human-readable string.
+ *
+ * The string follows the format "<hh>:<mm>:<ss>.<mmmm>" for hours, minutes, seconds and millisecond (if uptime is
+ * shorter than one day) or "<dd>d.<hh>:<mm>:<ss>.<mmmm>" (if longer than a day). @p aIncludeMsec can be used
+ * to determine whether `.<mmm>` milliseconds is included or omitted in the resulting string.
+ *
+ * @param[in]     aUptime        The uptime to convert.
+ * @param[in,out] aWriter        A `StringWriter` to append the converted string to.
+ * @param[in]     aIncludeMsec   Whether to include `.<mmm>` milliseconds in the string.
+ */
+void UptimeToString(UptimeMsec aUptime, StringWriter &aWriter, bool aIncludeMsec);
 
 } // namespace ot
 

--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -82,7 +82,7 @@ Instance::Instance(void)
 #endif
     , mRadio(*this)
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
-    , mUptime(*this)
+    , mUptimeTracker(*this)
 #endif
 #if OPENTHREAD_CONFIG_OTNS_ENABLE
     , mOtns(*this)

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -475,7 +475,7 @@ private:
     Radio mRadio;
 
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
-    Uptime mUptime;
+    UptimeTracker mUptimeTracker;
 #endif
 
 #if OPENTHREAD_CONFIG_OTNS_ENABLE
@@ -777,7 +777,7 @@ template <> inline Radio::Statistics &Instance::Get(void) { return mRadio.mStati
 #endif
 
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
-template <> inline Uptime &Instance::Get(void) { return mUptime; }
+template <> inline UptimeTracker &Instance::Get(void) { return mUptimeTracker; }
 #endif
 
 #if OPENTHREAD_CONFIG_OTNS_ENABLE

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -481,7 +481,7 @@ exit:
 void Manager::SessionIterator::Init(Instance &aInstance)
 {
     SetSession(static_cast<CoapDtlsSession *>(aInstance.Get<Manager>().mDtlsTransport.GetSessions().GetHead()));
-    SetInitTime(aInstance.Get<Uptime>().GetUptime());
+    SetInitTime(aInstance.Get<UptimeTracker>().GetUptime());
 }
 
 Error Manager::SessionIterator::GetNextSessionInfo(SessionInfo &aSessionInfo)
@@ -509,7 +509,7 @@ exit:
 Manager::CoapDtlsSession::CoapDtlsSession(Instance &aInstance, Dtls::Transport &aDtlsTransport)
     : Coap::SecureSession(aInstance, aDtlsTransport)
     , mTimer(aInstance, HandleTimer, this)
-    , mAllocationTime(aInstance.Get<Uptime>().GetUptime())
+    , mAllocationTime(aInstance.Get<UptimeTracker>().GetUptime())
     , mIndex(aInstance.Get<Manager>().GetNextSessionIndex())
 {
     SetResourceHandler(&HandleResource);

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -52,6 +52,7 @@
 #include "common/notifier.hpp"
 #include "common/owned_ptr.hpp"
 #include "common/tasklet.hpp"
+#include "common/uptime.hpp"
 #include "meshcop/border_agent_txt_data.hpp"
 #include "meshcop/dataset.hpp"
 #include "meshcop/secure_transport.hpp"
@@ -324,7 +325,7 @@ private:
 
         LinkedList<ForwardContext> mForwardContexts;
         TimerMilliContext          mTimer;
-        uint64_t                   mAllocationTime;
+        UptimeMsec                 mAllocationTime;
         uint16_t                   mIndex;
     };
 

--- a/src/core/meshcop/border_agent_tracker.cpp
+++ b/src/core/meshcop/border_agent_tracker.cpp
@@ -282,7 +282,7 @@ const char *Tracker::StateToString(State aState)
 void Tracker::Iterator::Init(Instance &aInstance)
 {
     SetAgentEntry(aInstance.Get<Tracker>().mAgents.GetHead());
-    SetInitUptime(aInstance.Get<Uptime>().GetUptime());
+    SetInitUptime(aInstance.Get<UptimeTracker>().GetUptime());
 }
 
 Error Tracker::Iterator::GetNextAgentInfo(AgentInfo &aInfo)
@@ -364,7 +364,7 @@ exit:
 Tracker::Agent::Agent(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mNext(nullptr)
-    , mDiscoverUptime(aInstance.Get<Uptime>().GetUptime())
+    , mDiscoverUptime(aInstance.Get<UptimeTracker>().GetUptime())
     , mLastUpdateUptime(mDiscoverUptime)
     , mPort(0)
 {
@@ -481,7 +481,7 @@ exit:
     return;
 }
 
-void Tracker::Agent::SetUpdateTimeToNow(void) { mLastUpdateUptime = Get<Uptime>().GetUptime(); }
+void Tracker::Agent::SetUpdateTimeToNow(void) { mLastUpdateUptime = Get<UptimeTracker>().GetUptime(); }
 
 bool Tracker::Agent::Matches(MatchType aType, const char *aName) const
 {
@@ -503,7 +503,7 @@ exit:
     return matches;
 }
 
-void Tracker::Agent::CopyInfoTo(AgentInfo &aInfo, uint64_t aUptimeNow) const
+void Tracker::Agent::CopyInfoTo(AgentInfo &aInfo, UptimeMsec aUptimeNow) const
 {
     ClearAllBytes(aInfo);
 

--- a/src/core/meshcop/border_agent_tracker.hpp
+++ b/src/core/meshcop/border_agent_tracker.hpp
@@ -52,6 +52,7 @@
 #include "common/locator.hpp"
 #include "common/owning_list.hpp"
 #include "common/retain_ptr.hpp"
+#include "common/uptime.hpp"
 #include "net/dnssd.hpp"
 #include "net/ip6_address.hpp"
 
@@ -105,8 +106,8 @@ public:
     private:
         const Agent *GetAgentEntry(void) const { return static_cast<const Agent *>(mPtr); }
         void         SetAgentEntry(const Agent *aEntry) { mPtr = aEntry; }
-        uint64_t     GetInitUptime(void) const { return mData; }
-        void         SetInitUptime(uint64_t aUptime) { mData = aUptime; }
+        UptimeMsec   GetInitUptime(void) const { return mData; }
+        void         SetInitUptime(UptimeMsec aUptime) { mData = aUptime; }
     };
 
     /**
@@ -180,14 +181,14 @@ private:
         void  ClearTxtData(void);
         void  SetUpdateTimeToNow(void);
         bool  Matches(MatchType aType, const char *aName) const;
-        void  CopyInfoTo(AgentInfo &aInfo, uint64_t aUptimeNow) const;
+        void  CopyInfoTo(AgentInfo &aInfo, UptimeMsec aUptimeNow) const;
 
         Agent          *mNext;
         Heap::String    mServiceName;
         RetainPtr<Host> mHost;
         Heap::Data      mTxtData;
-        uint64_t        mDiscoverUptime;
-        uint64_t        mLastUpdateUptime;
+        UptimeMsec      mDiscoverUptime;
+        UptimeMsec      mLastUpdateUptime;
         uint16_t        mPort;
     };
 

--- a/src/core/radio/trel_peer.cpp
+++ b/src/core/radio/trel_peer.cpp
@@ -88,7 +88,7 @@ void Peer::SetDnssdState(DnssdState aState)
 
     if (mDnssdState == kDnssdRemoved)
     {
-        uint32_t delay = DetermineExpirationDelay(Get<Uptime>().GetUptimeInSeconds());
+        uint32_t delay = DetermineExpirationDelay(Get<UptimeTracker>().GetUptimeInSeconds());
 
         Get<PeerTable>().mTimer.FireAtIfEarlier(TimerMilli::GetNow() + Time::SecToMsec(delay));
 
@@ -113,14 +113,14 @@ exit:
     return;
 }
 
-void Peer::UpdateLastInteractionTime(void) { mLastInteractionTime = Get<Uptime>().GetUptimeInSeconds(); }
+void Peer::UpdateLastInteractionTime(void) { mLastInteractionTime = Get<UptimeTracker>().GetUptimeInSeconds(); }
 
 uint32_t Peer::DetermineSecondsSinceLastInteraction(void) const
 {
-    return Get<Uptime>().GetUptimeInSeconds() - mLastInteractionTime;
+    return Get<UptimeTracker>().GetUptimeInSeconds() - mLastInteractionTime;
 }
 
-uint32_t Peer::DetermineExpirationDelay(uint32_t aUptimeNow) const
+uint32_t Peer::DetermineExpirationDelay(UptimeSec aUptimeNow) const
 {
     // Determines the remaining expiration delay (in seconds) relative
     // to the current time of `aUptimeNow`.
@@ -134,8 +134,8 @@ uint32_t Peer::DetermineExpirationDelay(uint32_t aUptimeNow) const
     // `uint32_t` max value, indicating that the peer is not
     // considered as expired.
 
-    uint32_t delay;
-    uint32_t expireTime;
+    uint32_t  delay;
+    UptimeSec expireTime;
 
     SetToUintMax(delay);
 
@@ -424,7 +424,7 @@ Error PeerTable::EvictPeer(void)
         // Find the peer in the 'kDnssdRemoved' state that has been
         // inactive (no send/receive interaction) for the longest duration.
 
-        uint32_t    uptimeNow           = Get<Uptime>().GetUptimeInSeconds();
+        UptimeSec   uptimeNow           = Get<UptimeTracker>().GetUptimeInSeconds();
         uint32_t    longestInactiveTime = 0;
         const Peer *selectedPeer        = nullptr;
 
@@ -463,8 +463,8 @@ exit:
 
 void PeerTable::HandleTimer(void)
 {
-    uint32_t uptimeNow = Get<Uptime>().GetUptimeInSeconds();
-    uint32_t delay;
+    UptimeSec uptimeNow = Get<UptimeTracker>().GetUptimeInSeconds();
+    uint32_t  delay;
 
     SetToUintMax(delay);
 

--- a/src/core/radio/trel_peer.hpp
+++ b/src/core/radio/trel_peer.hpp
@@ -52,6 +52,7 @@
 #include "common/owning_list.hpp"
 #include "common/pool.hpp"
 #include "common/timer.hpp"
+#include "common/uptime.hpp"
 #include "mac/mac_types.hpp"
 #include "meshcop/extended_panid.hpp"
 #include "net/socket.hpp"
@@ -217,12 +218,12 @@ private:
 
     struct ExpireChecker // Matches if the peer is in `kDnssdRemoved` and already expired.
     {
-        explicit ExpireChecker(uint32_t aUptimeNow)
+        explicit ExpireChecker(UptimeSec aUptimeNow)
             : mUptimeNow(aUptimeNow)
         {
         }
 
-        uint32_t mUptimeNow;
+        UptimeSec mUptimeNow;
     };
 
 #if OPENTHREAD_CONFIG_TREL_MANAGE_DNSSD_ENABLE
@@ -253,7 +254,7 @@ private:
     bool     Matches(const OtherExtPanIdMatcher &aMatcher) const { return GetExtPanId() != aMatcher.mExtPanId; }
     bool     Matches(const NonNeighborMatcher &aMatcher) const;
     bool     Matches(const ExpireChecker &aChecker) const;
-    uint32_t DetermineExpirationDelay(uint32_t aUptimeNow) const;
+    uint32_t DetermineExpirationDelay(UptimeSec aUptimeNow) const;
 
 #if OPENTHREAD_CONFIG_TREL_MANAGE_DNSSD_ENABLE
     void SetPort(uint16_t aPort);
@@ -275,7 +276,7 @@ private:
 
     Peer      *mNext;
     DnssdState mDnssdState;
-    uint32_t   mLastInteractionTime;
+    UptimeSec  mLastInteractionTime;
 #if OPENTHREAD_CONFIG_TREL_MANAGE_DNSSD_ENABLE
     bool         mExtAddressSet : 1;
     bool         mResolvingService : 1;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -257,18 +257,18 @@ const Counters &Mle::GetCounters(void)
 void Mle::ResetCounters(void)
 {
     ClearAllBytes(mCounters);
-    mLastUpdatedTimestamp = Get<Uptime>().GetUptime();
+    mLastUpdatedTimestamp = Get<UptimeTracker>().GetUptime();
 }
 
 uint32_t Mle::GetCurrentAttachDuration(void) const
 {
-    return IsAttached() ? Get<Uptime>().GetUptimeInSeconds() - mLastAttachTime : 0;
+    return IsAttached() ? Get<UptimeTracker>().GetUptimeInSeconds() - mLastAttachTime : 0;
 }
 
 void Mle::UpdateRoleTimeCounters(DeviceRole aRole)
 {
-    uint64_t currentUptimeMsec = Get<Uptime>().GetUptime();
-    uint64_t durationMsec      = currentUptimeMsec - mLastUpdatedTimestamp;
+    UptimeMsec currentUptimeMsec = Get<UptimeTracker>().GetUptime();
+    uint64_t   durationMsec      = currentUptimeMsec - mLastUpdatedTimestamp;
 
     mLastUpdatedTimestamp = currentUptimeMsec;
 
@@ -304,7 +304,7 @@ void Mle::SetRole(DeviceRole aRole)
 
     if ((oldRole == kRoleDetached) && IsAttached())
     {
-        mLastAttachTime = Get<Uptime>().GetUptimeInSeconds();
+        mLastAttachTime = Get<UptimeTracker>().GetUptimeInSeconds();
     }
 
     UpdateRoleTimeCounters(oldRole);

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -50,6 +50,7 @@
 #include "common/time_ticker.hpp"
 #include "common/timer.hpp"
 #include "common/trickle_timer.hpp"
+#include "common/uptime.hpp"
 #include "crypto/aes_ccm.hpp"
 #include "mac/mac.hpp"
 #include "mac/mac_types.hpp"
@@ -2460,8 +2461,8 @@ private:
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     uint32_t mCslTimeout;
 #endif
-    uint32_t         mLastAttachTime;
-    uint64_t         mLastUpdatedTimestamp;
+    UptimeSec        mLastAttachTime;
+    UptimeMsec       mLastUpdatedTimestamp;
     LeaderData       mLeaderData;
     Parent           mParent;
     NeighborTable    mNeighborTable;

--- a/src/core/thread/neighbor.cpp
+++ b/src/core/thread/neighbor.cpp
@@ -44,7 +44,7 @@ void Neighbor::SetState(State aState)
 
     if (mState == kStateValid)
     {
-        mConnectionStart = Get<Uptime>().GetUptimeInSeconds();
+        mConnectionStart = Get<UptimeTracker>().GetUptimeInSeconds();
     }
 
 exit:
@@ -53,7 +53,7 @@ exit:
 
 uint32_t Neighbor::GetConnectionTime(void) const
 {
-    return IsStateValid() ? Get<Uptime>().GetUptimeInSeconds() - mConnectionStart : 0;
+    return IsStateValid() ? Get<UptimeTracker>().GetUptimeInSeconds() - mConnectionStart : 0;
 }
 
 bool Neighbor::AddressMatcher::Matches(const Neighbor &aNeighbor) const

--- a/src/core/thread/neighbor.hpp
+++ b/src/core/thread/neighbor.hpp
@@ -761,7 +761,7 @@ private:
     // and this neighbor is the Subject.
     LinkMetrics::Metrics mEnhAckProbingMetrics;
 #endif
-    uint32_t mConnectionStart;
+    UptimeSec mConnectionStart;
 };
 
 DefineCoreType(otNeighborInfo, Neighbor::Info);


### PR DESCRIPTION
This change improves type safety and code clarity when handling uptime values. It introduces two new named types in the `ot` namespace:
- `UptimeMsec`:  representing uptime in milliseconds (`uint64_t`)
- `UptimeSec`: representing uptime in seconds (`uint32_t`).

To complement this, the `Uptime` class is renamed to `UptimeTracker` to clarify its role as the entity that tracks uptime.

The methods within `UptimeTracker` and member variables and parameters throughout the codebase are updated to use these new, more descriptive types instead of generic integer types.

Additionally, `UptimeToString()` is now a free function within the `ot` namespace.