### PR TITLE
[posix] allow set vendor name and model at runtime via flags

### DIFF
--- a/include/openthread/netdiag.h
+++ b/include/openthread/netdiag.h
@@ -428,8 +428,6 @@ const char *otThreadGetVendorAppUrl(otInstance *aInstance);
 /**
  * Set the vendor name string.
  *
- * Requires `OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE`.
- *
  * @p aVendorName should be UTF8 with max length of 32 chars (`MAX_VENDOR_NAME_TLV_LENGTH`). Maximum length does not
  * include the null `\0` character.
  *
@@ -443,8 +441,6 @@ otError otThreadSetVendorName(otInstance *aInstance, const char *aVendorName);
 
 /**
  * Set the vendor model string.
- *
- * Requires `OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE`.
  *
  * @p aVendorModel should be UTF8 with max length of 32 chars (`MAX_VENDOR_MODEL_TLV_LENGTH`). Maximum length does not
  * include the null `\0` character.

--- a/src/core/api/netdiag_api.cpp
+++ b/src/core/api/netdiag_api.cpp
@@ -91,7 +91,6 @@ const char *otThreadGetVendorAppUrl(otInstance *aInstance)
     return AsCoreType(aInstance).Get<NetworkDiagnostic::Server>().GetVendorAppUrl();
 }
 
-#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
 otError otThreadSetVendorName(otInstance *aInstance, const char *aVendorName)
 {
     return AsCoreType(aInstance).Get<NetworkDiagnostic::Server>().SetVendorName(aVendorName);
@@ -102,6 +101,7 @@ otError otThreadSetVendorModel(otInstance *aInstance, const char *aVendorModel)
     return AsCoreType(aInstance).Get<NetworkDiagnostic::Server>().SetVendorModel(aVendorModel);
 }
 
+#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
 otError otThreadSetVendorSwVersion(otInstance *aInstance, const char *aVendorSwVersion)
 {
     return AsCoreType(aInstance).Get<NetworkDiagnostic::Server>().SetVendorSwVersion(aVendorSwVersion);

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -58,15 +58,14 @@ Server::Server(Instance &aInstance)
     static_assert(sizeof(kVendorSwVersion) <= sizeof(VendorSwVersionTlv::StringType), "VENDOR_SW_VERSION is too long");
     static_assert(sizeof(kVendorAppUrl) <= sizeof(VendorAppUrlTlv::StringType), "VENDOR_APP_URL is too long");
 
-#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
     memcpy(mVendorName, kVendorName, sizeof(kVendorName));
     memcpy(mVendorModel, kVendorModel, sizeof(kVendorModel));
+
+#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
     memcpy(mVendorSwVersion, kVendorSwVersion, sizeof(kVendorSwVersion));
     memcpy(mVendorAppUrl, kVendorAppUrl, sizeof(kVendorAppUrl));
 #endif
 }
-
-#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
 
 Error Server::SetVendorName(const char *aVendorName)
 {
@@ -77,6 +76,8 @@ Error Server::SetVendorModel(const char *aVendorModel)
 {
     return StringCopy(mVendorModel, aVendorModel, kStringCheckUtf8Encoding);
 }
+
+#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
 
 Error Server::SetVendorSwVersion(const char *aVendorSwVersion)
 {

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -118,7 +118,6 @@ public:
         mNonPreferredChannelsResetCallback.Set(aCallback, aContext);
     }
 
-#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
     /**
      * Returns the vendor name string.
      *
@@ -153,6 +152,7 @@ public:
      */
     Error SetVendorModel(const char *aVendorModel);
 
+#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
     /**
      * Returns the vendor software version string.
      *
@@ -188,8 +188,6 @@ public:
     Error SetVendorAppUrl(const char *aVendorAppUrl);
 
 #else
-    const char *GetVendorName(void) const { return kVendorName; }
-    const char *GetVendorModel(void) const { return kVendorModel; }
     const char *GetVendorSwVersion(void) const { return kVendorSwVersion; }
     const char *GetVendorAppUrl(void) const { return kVendorAppUrl; }
 #endif // OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
@@ -272,9 +270,9 @@ private:
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
+    VendorNameTlv::StringType  mVendorName;
+    VendorModelTlv::StringType mVendorModel;
 #if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
-    VendorNameTlv::StringType      mVendorName;
-    VendorModelTlv::StringType     mVendorModel;
     VendorSwVersionTlv::StringType mVendorSwVersion;
     VendorAppUrlTlv::StringType    mVendorAppUrl;
 #endif

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -93,6 +93,8 @@ typedef struct otPlatformConfig
                                                       ///< directly after initialization.
     CoprocessorType mCoprocessorType;                 ///< The co-processor type. This field is used to pass
                                                       ///< the type to the app layer.
+    const char *mVendorName;                          ///< Vendor name. Used if OT_VENDOR_NAME not set at compile time.
+    const char *mVendorModel; ///< Vendor model. Used if OT_VENDOR_MODEL not set at compile time.
 } otPlatformConfig;
 
 /**

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -42,6 +42,7 @@
 #include <openthread/border_router.h>
 #include <openthread/cli.h>
 #include <openthread/heap.h>
+#include <openthread/netdiag.h>
 #include <openthread/tasklet.h>
 #include <openthread/trel.h>
 #include <openthread/platform/alarm-milli.h>
@@ -280,6 +281,15 @@ otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
         OT_ASSERT(gInstance != nullptr);
 
         platformSetUp(aPlatformConfig);
+    }
+
+    if (aPlatformConfig->mVendorName != NULL)
+    {
+        otThreadSetVendorName(gInstance, aPlatformConfig->mVendorName);
+    }
+    if (aPlatformConfig->mVendorModel != NULL)
+    {
+        otThreadSetVendorModel(gInstance, aPlatformConfig->mVendorModel);
     }
 
     return gInstance;

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -285,11 +285,21 @@ otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
 
     if (aPlatformConfig->mVendorName != NULL)
     {
-        otThreadSetVendorName(gInstance, aPlatformConfig->mVendorName);
+        otError error = otThreadSetVendorName(gInstance, aPlatformConfig->mVendorName);
+        if (error != OT_ERROR_NONE)
+        {
+            otPlatLog(OT_LOG_LEVEL_CRIT, OT_LOG_REGION_API, "Failed to set vendor name");
+            exit(OT_EXIT_INVALID_ARGUMENTS);
+        }
     }
     if (aPlatformConfig->mVendorModel != NULL)
     {
-        otThreadSetVendorModel(gInstance, aPlatformConfig->mVendorModel);
+        otError error = otThreadSetVendorModel(gInstance, aPlatformConfig->mVendorModel);
+        if (error != OT_ERROR_NONE)
+        {
+            otPlatLog(OT_LOG_LEVEL_CRIT, OT_LOG_REGION_API, "Failed to set vendor model");
+            exit(OT_EXIT_INVALID_ARGUMENTS);
+        }
     }
 
     return gInstance;


### PR DESCRIPTION
This commit allows users to pass the vendor name and model through command line flags `--vendor-name` and `--vendor-model` when starting the daemon / cli only if `OT_VENDOR_NAME` and `OT_VENDOR_MODEL` are not set at compile-time.

These flags have no default value and will exit the program if not set.