### PR TITLE
Add equality helper and tests for otOperationalDataset

### DIFF
--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -37,6 +37,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 #include <openthread/error.h>
 #include <openthread/instance.h>
@@ -604,5 +605,28 @@ otError otDatasetUpdateTlvs(const otOperationalDataset *aDataset, otOperationalD
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#ifdef __cplusplus
+/**
+ * Defines equality for two Timestamps.
+ */
+inline bool operator==(const otTimestamp &aLhs, const otTimestamp &aRhs)
+{
+    return (aLhs.mSeconds == aRhs.mSeconds) && (aLhs.mTicks == aRhs.mTicks) &&
+           (aLhs.mAuthoritative == aRhs.mAuthoritative);
+}
+
+/**
+ * Defines equality for two Operational Datasets.
+ *
+ * Equality is intentionally scoped to the Active Timestamp and Extended PAN ID
+ * which are minimal set of fields needed to identify a Thread network.
+ */
+inline bool operator==(const otOperationalDataset &aLhs, const otOperationalDataset &aRhs)
+{
+    return (aLhs.mActiveTimestamp == aRhs.mActiveTimestamp) &&
+           (memcmp(aLhs.mExtendedPanId.m8, aRhs.mExtendedPanId.m8, OT_EXT_PAN_ID_SIZE) == 0);
+}
+#endif // __cplusplus
 
 #endif // OPENTHREAD_DATASET_H_

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (554)
+#define OPENTHREAD_API_VERSION (555)
 
 /**
  * @addtogroup api-instance


### PR DESCRIPTION
This is the part of the effort in https://github.com/openthread/openthread/issues/12190

This pull request introduces new equality operators for `otTimestamp` and `otOperationalDataset`, focusing on the fields relevant for network commissioning checks. It also provides comprehensive unit tests to validate the correctness of these operators. Additionally, the API version is incremented to reflect these changes.

### Equality operator additions

* Added a C++ `operator==` for `otTimestamp`, comparing seconds, ticks, and authoritative fields.
* Added a C++ `operator==` for `otOperationalDataset`, comparing only the `mActiveTimestamp` and `mExtendedPanId` fields to match commissioning requirements.

### Unit tests

* Added two new tests in `dataset_test.cpp`: one to verify equality when timestamps and Extended PAN IDs match, and another to confirm inequality when either differs.

### API version update

* Incremented `OPENTHREAD_API_VERSION` from 554 to 555 in `instance.h` to signal the API change.