### PR TITLE
[netdiag] add ability to fetch raw diag TLVs

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (554)
+#define OPENTHREAD_API_VERSION (555)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/netdiag.h
+++ b/include/openthread/netdiag.h
@@ -334,6 +334,23 @@ otError otThreadGetNextDiagnosticTlv(const otMessage       *aMessage,
                                      otNetworkDiagTlv      *aNetworkDiagTlv);
 
 /**
+ * Get the entire raw TLV response from a network diagnostic request.
+ *
+ * Requires `OPENTHREAD_CONFIG_TMF_NETDIAG_CLIENT_ENABLE`.
+ *
+ * @param[in] aMessage              A pointer to a message.
+ * @param[in] aBufferCapacity       The capacity of the output buffer.
+ * @param[out] aNetworkDiagTlvs     A buffer to write the TLV response into.
+ * @param[out] aBytesWritten        The number of bytes written to the buffer.
+
+ * @retval OT_ERROR_NONE       Successfully completed the Network Diagnostic TLV fetch request.
+ * @retval OT_ERROR_NO_BUFS    The length of the returned message is larger than the buffer capacity.
+ */
+otError otThreadGetRawDiagnosticTlvs(const otMessage       *aMessage,
+                                     uint16_t               aBufferCapacity,
+                                     uint8_t               *aNetworkDiagTlvs,
+                                     uint16_t              *aBytesWritten);
+/**
  * Pointer is called when Network Diagnostic Get response is received.
  *
  * @param[in]  aError        The error when failed to get the response.

--- a/src/core/api/netdiag_api.cpp
+++ b/src/core/api/netdiag_api.cpp
@@ -49,6 +49,16 @@ otError otThreadGetNextDiagnosticTlv(const otMessage       *aMessage,
     return NetworkDiagnostic::Client::GetNextDiagTlv(AsCoapMessage(aMessage), *aIterator, *aNetworkDiagTlv);
 }
 
+otError otThreadGetRawDiagnosticTlvs(const otMessage       *aMessage,
+                                     uint16_t               aBufferCapacity,
+                                     uint8_t               *aNetworkDiagTlvs,
+                                     uint16_t              *aBytesWritten)
+{
+    AssertPointerIsNotNull(aNetworkDiagTlvs);
+
+    return NetworkDiagnostic::Client::GetRawDiagTlvs(AsCoapMessage(aMessage), aBufferCapacity, aNetworkDiagTlvs, aBytesWritten);
+}
+
 otError otThreadSendDiagnosticGet(otInstance                    *aInstance,
                                   const otIp6Address            *aDestination,
                                   const uint8_t                  aTlvTypes[],

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -1601,6 +1601,18 @@ exit:
     return error;
 }
 
+Error Client::GetRawDiagTlvs(const Coap::Message &aMessage, uint16_t aBufferCapacity, uint8_t *aNetworkDiagTlvs, uint16_t *aBytesWritten)
+{
+    Error    error  = kErrorNone;
+    uint16_t length = aMessage.GetLength() - aMessage.GetOffset();
+
+    VerifyOrExit(length <= aBufferCapacity, error = kErrorNoBufs);
+    *aBytesWritten = aMessage.ReadBytes(aMessage.GetOffset(), aNetworkDiagTlvs, length);
+
+exit:
+    return error;
+}
+
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 const char *Client::UriToString(Uri aUri)

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -354,6 +354,19 @@ public:
     static Error GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator, TlvInfo &aTlvInfo);
 
     /**
+     * @brief Get the entire Network Diagnostic TLV response.
+     *
+     * @param[in]  aMessage         A pointer to a message.
+     * @param[in]  aBufferCapacity  The capacity of the output buffer.
+     * @param[out] aNetworkDiagTlvs A buffer to write the TLV response into.
+     * @param[out] aBytesWritten    The number of bytes written to the buffer.
+     *
+     * @retval kErrorNone   Successfully completed the Network Diagnostic TLV fetch request.
+     * @retval kErrorNoBufs The length of the returned message is larger than the buffer capacity.
+     */
+    static Error GetRawDiagTlvs(const Coap::Message &aMessage, uint16_t aBufferCapacity, uint8_t *aNetworkDiagTlvs, uint16_t *aBytesWritten);
+
+    /**
      * This method returns the query ID used for the last Network Diagnostic Query command.
      *
      * @returns The query ID used for last query.


### PR DESCRIPTION
The iterator for fetching diagnostic TLV requests is useful for applications that directly integrate with the Openthread API. However, it can be awkward to use this API to expose the ability for external applications to fetch these TLVs (OTBR, for example).