### PR TITLE
[utils] detect and handle overflow  in `Heap::CAlloc()`

### DIFF
--- a/src/core/utils/heap.hpp
+++ b/src/core/utils/heap.hpp
@@ -223,6 +223,7 @@ private:
     static constexpr uint16_t kSuperBlockOffset   = kAlignSize - sizeof(uint16_t);
     static constexpr uint16_t kFirstBlockOffset   = kAlignSize * 2 - sizeof(uint16_t);
     static constexpr uint16_t kGuardBlockOffset   = kMemorySize - sizeof(uint16_t);
+    static constexpr uint16_t kTotalSizeGuard     = kAlignSize + sizeof(Block);
 
     static_assert(kMemorySize % kAlignSize == 0, "The heap memory size is not aligned to kAlignSize!");
 


### PR DESCRIPTION
This commit fixes an issue with `Utils::Heap::CAlloc()` method. This method performs a multiplication of `aCount` and `aSize` input and then casts the result to `uint16_t`. This commit adds a check to ensure that this conversion does not result in an integer overflow, which would cause the size to warp to an unexpected smaller value.