### PR TITLE
[mdns] handle allocation failure in `RxMessage::Init()`

### DIFF
--- a/src/core/net/mdns.cpp
+++ b/src/core/net/mdns.cpp
@@ -4229,7 +4229,7 @@ Error Core::RxMessage::Init(Instance          &aInstance,
 
     mStartOffset[kQuestionSection] = offset;
 
-    SuccessOrAssert(mQuestions.ReserveCapacity(mRecordCounts.GetFor(kQuestionSection)));
+    SuccessOrExit(error = mQuestions.ReserveCapacity(mRecordCounts.GetFor(kQuestionSection)));
 
     for (numRecords = mRecordCounts.GetFor(kQuestionSection); numRecords > 0; numRecords--)
     {


### PR DESCRIPTION
This commit updates `RxMessage::Init()` to handle failures when reserving capacity for the questions array. Previously, an allocation failure would trigger an assertion.

By switching to `SuccessOrExit`, the method can now gracefully handle the allocation failure by returning an error and dropping the message. This aligns with the general error handling strategy for received messages and makes the implementation more robust against out-of-memory conditions.