### PR TITLE
[github-actions] disable Discovery Proxy in the otbr Backbone CI

### DIFF
--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -61,6 +61,7 @@ jobs:
       # packet verification can't handle it because of the order of context ID
       # of OMR prefix and Domain prefix is not deterministic.
       BORDER_ROUTING: 0
+      DISCOVERY_PROXY: 0
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:

--- a/script/test
+++ b/script/test
@@ -68,6 +68,9 @@ readonly VERBOSE
 BORDER_ROUTING="${BORDER_ROUTING:-1}"
 readonly BORDER_ROUTING
 
+DISCOVERY_PROXY="${DISCOVERY_PROXY:-1}"
+readonly DISCOVERY_PROXY
+
 NAT64="${NAT64:-0}"
 readonly NAT64
 
@@ -359,12 +362,12 @@ do_build_otbr_docker()
         "-DOT_SRP_CLIENT=ON"
         "-DOT_FULL_LOGS=ON"
         "-DOT_UPTIME=ON"
-        "-DOTBR_DNS_UPSTREAM_QUERY=ON"
         "-DOTBR_DUA_ROUTING=ON"
         "-DOTBR_DHCP6_PD=ON"
     )
     local args=(
         "BORDER_ROUTING=${BORDER_ROUTING}"
+        "DISCOVERY_PROXY=${DISCOVERY_PROXY}"
         "INFRA_IF_NAME=eth0"
         "BACKBONE_ROUTER=1"
         "REFERENCE_DEVICE=1"


### PR DESCRIPTION
This PR disables Discovery Proxy in otbr Backbone CI.

Because in this item, `BORDER_ROUTING` is explicitly disabled and it is required by OT discovery proxy.

This PR removes `"-DOTBR_DNS_UPSTREAM_QUERY=ON"` in build script because this option will automatically handled in the cmake options file and it also depends on BORDER_ROUTING. Force it to be ON will cause a conflict when BORDER_ROUTING is OFF.

Depends-On: openthread/ot-br-posix#3153