### PR TITLE
[message] add platform deinit hook and MessagePool dtor

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (559)
+#define OPENTHREAD_API_VERSION (560)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/messagepool.h
+++ b/include/openthread/platform/messagepool.h
@@ -106,6 +106,15 @@ void otPlatMessagePoolFree(otInstance *aInstance, otMessageBuffer *aBuffer);
  */
 uint16_t otPlatMessagePoolNumFreeBuffers(otInstance *aInstance);
 
+/**
+ * Deinitialize the platform implemented message pool.
+ *
+ * Is used when `OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT` is enabled.
+ *
+ * @param[in] aInstance  A pointer to the OpenThread instance.
+ */
+void otPlatMessagePoolDeinit(otInstance *aInstance);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -58,6 +58,10 @@ MessagePool::MessagePool(Instance &aInstance)
 #endif
 }
 
+#if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
+MessagePool::~MessagePool(void) { otPlatMessagePoolDeinit(&GetInstance()); }
+#endif
+
 Message *MessagePool::Allocate(Message::Type aType, uint16_t aReserveHeader, const Message::Settings &aSettings)
 {
     Error    error = kErrorNone;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -1849,6 +1849,13 @@ public:
      */
     explicit MessagePool(Instance &aInstance);
 
+#if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
+    /**
+     * Tears down the object and releases platform managed resources.
+     */
+    ~MessagePool(void);
+#endif
+
     /**
      * Allocates a new message with specified settings.
      *


### PR DESCRIPTION
Add a MessagePool destructor that calls the new `otPlatMessagePoolDeinit` hook so platform-managed buffer pools get torn down,