### PR TITLE
[test] clean intermediates on GitHub actions

### DIFF
--- a/script/cmake-build
+++ b/script/cmake-build
@@ -70,6 +70,9 @@ readonly OT_SRCDIR
 OT_PLATFORMS=(simulation posix android-ndk)
 readonly OT_PLATFORMS
 
+OT_CLEAN_INTERMEDIATES="${OT_CLEAN_INTERMEDIATES-${GITHUB_ACTION-}}"
+readonly OT_CLEAN_INTERMEDIATES
+
 OT_POSIX_SIM_COMMON_OPTIONS=(
     "-DOT_ANYCAST_LOCATOR=ON"
     "-DOT_BLE_TCAT=ON"
@@ -139,6 +142,10 @@ build()
     fi
 
     cd "${OT_SRCDIR}"
+
+    if [[ -n $OT_CLEAN_INTERMEDIATES ]]; then
+        find "${builddir}" \( -name '*.o' -o -name '*.a' \) -delete
+    fi
 }
 
 main()


### PR DESCRIPTION
This commit enhances the build process by introducing a mechanism to automatically clean intermediate build artifacts. Specifically, it configures the build script to remove object and archive files, a process that is conditionally activated, primarily within GitHub Actions workflows, to optimize build environments and manage disk space more efficiently.