### PR TITLE
Initialize key instance offset in KeyRefManager constructor

### DIFF
--- a/src/core/crypto/storage.hpp
+++ b/src/core/crypto/storage.hpp
@@ -124,13 +124,7 @@ public:
      *
      * @param[in]  aInstance     A reference to the OpenThread instance.
      */
-    explicit KeyRefManager(Instance &aInstance)
-        : InstanceLocator(aInstance)
-#if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
-        , mExtraOffset(0)
-#endif
-    {
-    }
+    explicit KeyRefManager(Instance &aInstance);
 
     /**
      * Determines the `KeyRef` to use for a given `Type`.

--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -309,14 +309,9 @@ Instance::Instance(void)
     , mIsInitialized(false)
     , mId(Random::NonCrypto::GetUint32())
 {
-#if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE && OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
-#if OPENTHREAD_CONFIG_MULTIPLE_STATIC_INSTANCE_ENABLE
-    mCryptoStorageKeyRefManager.SetKeyRefExtraOffset(Crypto::Storage::KeyRefManager::kKeyRefExtraOffset * GetIdx(this));
-#else
-#error "MULTIPLE_INSTANCE (without static allocation) is used with PLATFORM_KEY_REFERENCES_ENABLE " \
-       "The `KeyRef` values will be shared across different `Instance` objects"
-#endif
-#endif
+    // Note: KeyRefManager::mExtraOffset is now set in KeyRefManager constructor
+    // to ensure it's set before KeyManager is constructed. This prevents key
+    // collisions where all instances use offset 0 during KeyManager initialization.
 }
 
 #if (OPENTHREAD_MTD || OPENTHREAD_FTD) && !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE


### PR DESCRIPTION
Contention can arise during the instance initialization process in which the KeyRefManager initializes the reference offset to 0 before the Instance class updates the offset with an instance specific value. Before the instances can update the offset, later instances will perform key export and destruction operations using the reference addresses of earlier instances, which will cause keys to not be found temporarily.

The effect of this situation is that an existing network key from the active dataset can not be found for any instance on device start up, only when the key is set after initialization. When a device restarts and tries to reconnect to a network, the device will be able to connect and join, but the network key update will restart the device's frame counter, which will cause security errors for secured message exchanges, such as an address solicit.

This commit moves the KeyRefManager offset update for multiple instances to the KeyRefManager constructor rather than the instance constructor to avoid this initialization contention.

Details for the issue can be found in #12208 