### PR TITLE
[coap] add overloads of `SendMessage` accepting `OwnedPtr<Message>`

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -372,9 +372,38 @@ Error CoapBase::SendMessage(Message                &aMessage,
 #endif
 }
 
+Error CoapBase::SendMessage(OwnedPtr<Message>       aMessage,
+                            const Ip6::MessageInfo &aMessageInfo,
+                            ResponseHandler         aHandler,
+                            void                   *aContext)
+{
+    Error error;
+
+    OT_ASSERT(aMessage != nullptr);
+
+    SuccessOrExit(error = SendMessage(*aMessage, aMessageInfo, aHandler, aContext));
+    aMessage.Release();
+
+exit:
+    return error;
+}
+
 Error CoapBase::SendMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     return SendMessage(aMessage, aMessageInfo, nullptr, nullptr);
+}
+
+Error CoapBase::SendMessage(OwnedPtr<Message> aMessage, const Ip6::MessageInfo &aMessageInfo)
+{
+    Error error;
+
+    OT_ASSERT(aMessage != nullptr);
+
+    SuccessOrExit(error = SendMessage(*aMessage, aMessageInfo));
+    aMessage.Release();
+
+exit:
+    return error;
 }
 
 Error CoapBase::SendReset(Message &aRequest, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -41,6 +41,7 @@
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/non_copyable.hpp"
+#include "common/owned_ptr.hpp"
 #include "common/timer.hpp"
 #include "net/ip6.hpp"
 #include "net/netif.hpp"
@@ -596,6 +597,7 @@ public:
      * @retval kErrorNoBufs  Insufficient buffers available to send the CoAP message.
      */
     Error SendMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo, const TxParameters &aTxParameters);
+
     /**
      * Sends a CoAP message with default transmission parameters.
      *
@@ -619,6 +621,27 @@ public:
      *
      * If Message ID was not set in the header (equal to 0), this method will assign unique Message ID to the message.
      *
+     * This flavor of `SendMessage()` accepts an `OwnedPtr<Message>` and therefore takes ownership of the passed-in
+     * message.
+     *
+     * @param[in]  aMessage      An `OwnedPtr` to the message to send.
+     * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
+     * @param[in]  aHandler      A function pointer that shall be called on response reception or time-out.
+     * @param[in]  aContext      A pointer to arbitrary context information.
+     *
+     * @retval kErrorNone    Successfully sent CoAP message.
+     * @retval kErrorNoBufs  Insufficient buffers available to send the CoAP response.
+     */
+    Error SendMessage(OwnedPtr<Message>       aMessage,
+                      const Ip6::MessageInfo &aMessageInfo,
+                      ResponseHandler         aHandler,
+                      void                   *aContext);
+
+    /**
+     * Sends a CoAP message with default transmission parameters.
+     *
+     * If Message ID was not set in the header (equal to 0), this method will assign unique Message ID to the message.
+     *
      * @param[in]  aMessage      A reference to the message to send.
      * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
      *
@@ -626,6 +649,22 @@ public:
      * @retval kErrorNoBufs  Insufficient buffers available to send the CoAP response.
      */
     Error SendMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+
+    /**
+     * Sends a CoAP message with default transmission parameters.
+     *
+     * If Message ID was not set in the header (equal to 0), this method will assign unique Message ID to the message.
+     *
+     * This flavor of `SendMessage()` accepts an `OwnedPtr<Message>` and therefore takes ownership of the passed-in
+     * message.
+     *
+     * @param[in]  aMessage      An `OwnedPtr` to the message to send.
+     * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
+     *
+     * @retval kErrorNone    Successfully sent CoAP message.
+     * @retval kErrorNoBufs  Insufficient buffers available to send the CoAP response.
+     */
+    Error SendMessage(OwnedPtr<Message> aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     /**
      * Sends a CoAP reset message.

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -497,8 +497,7 @@ Error Manager::EvictActiveCommissioner(void)
     messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
     messageInfo.SetSockPortToTmf();
 
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo));
-    message.Release();
+    error = Get<Tmf::Agent>().SendMessage(message.PassOwnership(), messageInfo);
 
 exit:
     return error;
@@ -695,10 +694,8 @@ Error Manager::CoapDtlsSession::ForwardToLeader(const Coap::Message    &aMessage
     messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
     messageInfo.SetSockPortToTmf();
 
-    // On success the message ownership is transferred.
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo, HandleLeaderResponseToFwdTmf,
-                                                        forwardContext.Get()));
-    message.Release();
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(message.PassOwnership(), messageInfo,
+                                                        HandleLeaderResponseToFwdTmf, forwardContext.Get()));
 
     // Release the ownership of `forwardContext` since `SendMessage()`
     // will own it. We take back ownership when the callback
@@ -982,9 +979,7 @@ void Manager::CoapDtlsSession::HandleTmfRelayTx(Coap::Message &aMessage)
     messageInfo.SetSockAddrToRlocPeerAddrTo(joinerRouterRloc);
     messageInfo.SetSockPortToTmf();
 
-    // On success the message ownership is transferred.
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo));
-    message.Release();
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(message.PassOwnership(), messageInfo));
 
     LogInfo("Forward %s to joiner router 0x%04x", UriToString<kUriRelayTx>(), joinerRouterRloc);
 


### PR DESCRIPTION
This change introduces new overloads for `Coap::SendMessage()` that accept an `OwnedPtr<Message>`, transferring ownership of the message to the CoAP layer upon being called.

The `BorderAgent` and `Commissioner` modules are updated to use this new method. The use of `OwnedPtr<Message>` simplifies the message allocation and cleanup. This removes the need for manual clean up calls
(e.g., `FreeMessageOnError()`) and makes the code safer.