### PR TITLE
[nat64] add `otNat64StateToString()`

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (562)
+#define OPENTHREAD_API_VERSION (563)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/nat64.h
+++ b/include/openthread/nat64.h
@@ -525,6 +525,15 @@ otError otIp4AddressFromString(const char *aString, otIp4Address *aAddress);
 otError otNat64SynthesizeIp6Address(otInstance *aInstance, const otIp4Address *aIp4Address, otIp6Address *aIp6Address);
 
 /**
+ * Converts a given `otNat64State` to a human-readable string.
+ *
+ * @param[in] aState  The NAT64 state.
+ *
+ * @returns The string representation of @p aState.
+ */
+const char *otNat64StateToString(otNat64State aState);
+
+/**
  * @}
  */
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -645,18 +645,11 @@ template <> otError Interpreter::Process<Cmd("nat64")>(Arg aArgs[])
      */
     else if (aArgs[0] == "state")
     {
-        static const char *const kNat64State[] = {"Disabled", "NotRunning", "Idle", "Active"};
-
-        static_assert(0 == OT_NAT64_STATE_DISABLED, "OT_NAT64_STATE_DISABLED value is incorrect");
-        static_assert(1 == OT_NAT64_STATE_NOT_RUNNING, "OT_NAT64_STATE_NOT_RUNNING value is incorrect");
-        static_assert(2 == OT_NAT64_STATE_IDLE, "OT_NAT64_STATE_IDLE value is incorrect");
-        static_assert(3 == OT_NAT64_STATE_ACTIVE, "OT_NAT64_STATE_ACTIVE value is incorrect");
-
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
-        OutputLine("PrefixManager: %s", kNat64State[otNat64GetPrefixManagerState(GetInstancePtr())]);
+        OutputLine("PrefixManager: %s", otNat64StateToString(otNat64GetPrefixManagerState(GetInstancePtr())));
 #endif
 #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
-        OutputLine("Translator: %s", kNat64State[otNat64GetTranslatorState(GetInstancePtr())]);
+        OutputLine("Translator: %s", otNat64StateToString(otNat64GetTranslatorState(GetInstancePtr())));
 #endif
     }
 #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE

--- a/src/core/api/nat64_api.cpp
+++ b/src/core/api/nat64_api.cpp
@@ -180,3 +180,14 @@ void otIp4CidrToString(const otIp4Cidr *aCidr, char *aBuffer, uint16_t aSize)
 
     AsCoreType(aCidr).ToString(aBuffer, aSize);
 }
+
+const char *otNat64StateToString(otNat64State aState)
+{
+    const char *str = "Unknown";
+
+    VerifyOrExit(aState <= OT_NAT64_STATE_ACTIVE);
+    str = Nat64::StateToString(MapEnum(aState));
+
+exit:
+    return str;
+}

--- a/src/core/net/nat64_translator.cpp
+++ b/src/core/net/nat64_translator.cpp
@@ -33,14 +33,10 @@
 
 #include "nat64_translator.hpp"
 
-#if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
-
 #include "instance/instance.hpp"
 
 namespace ot {
 namespace Nat64 {
-
-RegisterLogModule("Nat64");
 
 const char *StateToString(State aState)
 {
@@ -62,6 +58,10 @@ const char *StateToString(State aState)
 
     return kStateString[aState];
 }
+
+#if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
+
+RegisterLogModule("Nat64");
 
 Translator::Translator(Instance &aInstance)
     : InstanceLocator(aInstance)
@@ -914,7 +914,7 @@ void Translator::SetEnabled(bool aEnable)
     }
 }
 
+#endif // OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
+
 } // namespace Nat64
 } // namespace ot
-
-#endif // OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE


### PR DESCRIPTION
This commit introduces a new public NAT66 related API function, `otNat64StateToString()`, to convert an `otNat64State` enum value into a human-readable string.

The `nat64 state` CLI command is updated to use this new function, removing its local and duplicated enum-to-string logic.