### PR TITLE
[coap] ensure `InvokeResponseFallback()` adheres to style guide

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1310,13 +1310,26 @@ exit:
 
     if (error == kErrorNone && request == nullptr)
     {
-        if (!InvokeResponseFallback(aMessage, aMessageInfo) && aMessage.RequireResetOnError())
+        bool didHandle = InvokeResponseFallback(aMessage, aMessageInfo);
+
+        if (!didHandle && aMessage.RequireResetOnError())
         {
             // Successfully parsed a header but no matching request was
             // found - reject the message by sending reset.
             IgnoreError(SendReset(aMessage, aMessageInfo));
         }
     }
+}
+
+bool CoapBase::InvokeResponseFallback(Message &aMessage, const Ip6::MessageInfo &aMessageInfo) const
+{
+    bool didHandle = false;
+
+    VerifyOrExit(mResponseFallback.IsSet());
+    didHandle = mResponseFallback.Invoke(&aMessage, &aMessageInfo);
+
+exit:
+    return didHandle;
 }
 
 void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -849,15 +849,7 @@ private:
                                      Message                *aResponse,
                                      const Ip6::MessageInfo *aMessageInfo,
                                      Error                   aResult);
-
-    inline bool InvokeResponseFallback(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
-    {
-        if (mResponseFallback.IsSet())
-        {
-            return mResponseFallback.Invoke(&aMessage, &aMessageInfo);
-        }
-        return false;
-    }
+    bool     InvokeResponseFallback(Message &aMessage, const Ip6::MessageInfo &aMessageInfo) const;
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
     void  FreeLastBlockResponse(void);


### PR DESCRIPTION
This commit moves the implementation of `InvokeResponseFallback()` to the `cpp` file. It also ensures that the implementation follows the style guide requirement of single `return` from any method/function.