### PR TITLE
[style] use OT_FALL_THROUGH

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1411,7 +1411,7 @@ void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo 
                     {
                     case kErrorNone:
                         resource.HandleRequest(aMessage, aMessageInfo);
-                        // Fall through
+                        OT_FALL_THROUGH;
                     case kErrorBusy:
                         error = kErrorNone;
                         break;

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -2065,7 +2065,7 @@ void Client::UpdateState(void)
 
         mHostInfo.SetState(kToRefresh);
 
-        // Fall through
+        OT_FALL_THROUGH;
 
     case kToAdd:
     case kToRefresh:
@@ -2075,7 +2075,7 @@ void Client::UpdateState(void)
         // for empty service list.
         VerifyOrExit(!mServices.IsEmpty() && (mHostInfo.IsAutoAddressEnabled() || (mHostInfo.GetNumAddresses() > 0)));
 
-        // Fall through
+        OT_FALL_THROUGH;
 
     case kToRemove:
         shouldUpdate = true;

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -483,7 +483,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_BORDER_AGENT_EPHEMERA
         break;
     case OT_BORDER_AGENT_STATE_DISABLED:
         error = OT_ERROR_NOT_CAPABLE;
-        // Fall through
+        OT_FALL_THROUGH;
     case OT_BORDER_AGENT_STATE_STOPPED:
         ExitNow();
     }


### PR DESCRIPTION
This commit replaces `// Fall through` with `OT_FALL_THROUGH` because the former is not recognized by some compilers.