### PR TITLE
[coap] simplify `Coap::TxParameters` validation

### DIFF
--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -209,19 +209,13 @@ otError otCoapSendRequestBlockWiseWithParameters(otInstance                 *aIn
                                                  otCoapBlockwiseTransmitHook aTransmitHook,
                                                  otCoapBlockwiseReceiveHook  aReceiveHook)
 {
-    Error                     error;
-    const Coap::TxParameters &txParameters = Coap::TxParameters::From(aTxParameters);
+    Error error;
 
     VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
-    if (aTxParameters != nullptr)
-    {
-        VerifyOrExit(txParameters.IsValid(), error = kErrorInvalidArgs);
-    }
-
     error = AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SendMessage(
-        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), txParameters, aHandler, aContext, aTransmitHook,
-        aReceiveHook);
+        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), AsCoreTypePtr(aTxParameters), aHandler, aContext,
+        aTransmitHook, aReceiveHook);
 
 exit:
     return error;
@@ -237,17 +231,10 @@ otError otCoapSendRequestWithParameters(otInstance               *aInstance,
 {
     Error error;
 
-    const Coap::TxParameters &txParameters = Coap::TxParameters::From(aTxParameters);
-
     VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
-    if (aTxParameters != nullptr)
-    {
-        VerifyOrExit(txParameters.IsValid(), error = kErrorInvalidArgs);
-    }
-
     error = AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SendMessage(
-        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), txParameters, aHandler, aContext);
+        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), AsCoreTypePtr(aTxParameters), aHandler, aContext);
 
 exit:
     return error;
@@ -305,7 +292,7 @@ otError otCoapSendResponseBlockWiseWithParameters(otInstance                 *aI
     VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
     error = AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SendMessage(
-        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), Coap::TxParameters::From(aTxParameters), nullptr, aContext,
+        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), AsCoreTypePtr(aTxParameters), nullptr, aContext,
         aTransmitHook, nullptr);
 exit:
     return error;
@@ -322,7 +309,7 @@ otError otCoapSendResponseWithParameters(otInstance               *aInstance,
     VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
     error = AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SendMessage(
-        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), Coap::TxParameters::From(aTxParameters), nullptr, nullptr);
+        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), AsCoreTypePtr(aTxParameters), nullptr, nullptr);
 
 exit:
     return error;

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -95,33 +95,11 @@ class TxParameters : public otCoapTxParameters
 
 public:
     /**
-     * Converts a pointer to `otCoapTxParameters` to `Coap::TxParamters`
-     *
-     * If the pointer is `nullptr`, the default parameters are used instead.
-     *
-     * @param[in] aTxParameters   A pointer to tx parameter.
-     *
-     * @returns A reference to corresponding `TxParamters` if  @p aTxParameters is not `nullptr`, otherwise the default
-     *          tx parameters.
-     */
-    static const TxParameters &From(const otCoapTxParameters *aTxParameters)
-    {
-        return aTxParameters ? *static_cast<const TxParameters *>(aTxParameters) : GetDefault();
-    }
-
-    /**
-     * Validates whether the CoAP transmission parameters are valid.
-     *
-     * @returns Whether the parameters are valid.
-     */
-    bool IsValid(void) const;
-
-    /**
-     * Returns default CoAP tx parameters.
+     * Returns the default CoAP tx parameters.
      *
      * @returns The default tx parameters.
      */
-    static const TxParameters &GetDefault(void) { return static_cast<const TxParameters &>(kDefaultTxParameters); }
+    static const TxParameters &GetDefault(void);
 
 private:
     static constexpr uint32_t kDefaultAckTimeout                 = 2000; // in msec
@@ -132,6 +110,7 @@ private:
     static constexpr uint8_t  kMaxRetransmit                     = OT_COAP_MAX_RETRANSMIT;
     static constexpr uint32_t kMinAckTimeout                     = OT_COAP_MIN_ACK_TIMEOUT;
 
+    Error    ValidateFor(const Message &aMessage) const;
     uint32_t CalculateInitialRetransmissionTimeout(void) const;
     uint32_t CalculateExchangeLifetime(void) const;
     uint32_t CalculateMaxTransmitWait(void) const;
@@ -465,7 +444,7 @@ public:
      *
      * @param[in]  aMessage      A reference to the message to send.
      * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
-     * @param[in]  aTxParameters A reference to transmission parameters for this message.
+     * @param[in]  aTxParameters A pointer to `TxParameters`. If `nullptr`, default `TxParameters` will be used.
      * @param[in]  aHandler      A function pointer that shall be called on response reception or time-out.
      * @param[in]  aContext      A pointer to arbitrary context information.
      * @param[in]  aTransmitHook A pointer to a hook function for outgoing block-wise transfer.
@@ -476,9 +455,9 @@ public:
      */
     Error SendMessage(Message                    &aMessage,
                       const Ip6::MessageInfo     &aMessageInfo,
-                      const TxParameters         &aTxParameters,
-                      otCoapResponseHandler       aHandler      = nullptr,
-                      void                       *aContext      = nullptr,
+                      const TxParameters         *aTxParameters,
+                      otCoapResponseHandler       aHandler,
+                      void                       *aContext,
                       otCoapBlockwiseTransmitHook aTransmitHook = nullptr,
                       otCoapBlockwiseReceiveHook  aReceiveHook  = nullptr);
 #else  // OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
@@ -492,7 +471,7 @@ public:
      *
      * @param[in]  aMessage      A reference to the message to send.
      * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
-     * @param[in]  aTxParameters A reference to transmission parameters for this message.
+     * @param[in]  aTxParameters A pointer to `TxParameters`. If `nullptr`, default `TxParameters` will be used.
      * @param[in]  aHandler      A function pointer that shall be called on response reception or time-out.
      * @param[in]  aContext      A pointer to arbitrary context information.
      *
@@ -501,7 +480,7 @@ public:
      */
     Error SendMessage(Message                &aMessage,
                       const Ip6::MessageInfo &aMessageInfo,
-                      const TxParameters     &aTxParameters,
+                      const TxParameters     *aTxParameters,
                       ResponseHandler         aHandler,
                       void                   *aContext);
 #endif // OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -66,7 +66,7 @@ Error SecureSession::SendMessage(Message                    &aMessage,
                                  otCoapBlockwiseTransmitHook aTransmitHook,
                                  otCoapBlockwiseReceiveHook  aReceiveHook)
 {
-    return IsConnected() ? CoapBase::SendMessage(aMessage, GetMessageInfo(), TxParameters::GetDefault(), aHandler,
+    return IsConnected() ? CoapBase::SendMessage(aMessage, GetMessageInfo(), /* aTxParameters */ nullptr, aHandler,
                                                  aContext, aTransmitHook, aReceiveHook)
                          : kErrorInvalidState;
 }


### PR DESCRIPTION
This commit simplifies the validation of `Coap::TxParameters`.

The primary `SendMessage()` method is updated to accept `TxParameters` as a pointer, where `nullptr` is mapped to the default `TxParameters`. The user-provided `TxParameters` are now validated in the primary `SendMessage()` method by calling `TxParameters::ValidateFor()` replacing checks previously performed in `coap_api.cpp` source file.

This commit also adds a set of `static_assert()` checks to validate the default `TxParameters` at compile-time, ensuring all its properties are within valid ranges and that duration calculations will not cause an overflow.

This approach simplifies the API by removing the `TxParameters::From()` helper and centralizes `TxParameters` selection and validation logic within the core `CoapBase` class.