### PR TITLE
[coap] enhance block-wise transfer `BlockSzx` handling

### DIFF
--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -100,19 +100,16 @@ otError otCoapMessageAppendUriQueryOptions(otMessage *aMessage, const char *aUri
     return AsCoapMessage(aMessage).AppendUriQueryOptions(aUriQuery);
 }
 
-uint16_t otCoapBlockSizeFromExponent(otCoapBlockSzx aSize)
-{
-    return static_cast<uint16_t>(1 << (static_cast<uint8_t>(aSize) + Coap::Message::kBlockSzxBase));
-}
+uint16_t otCoapBlockSizeFromExponent(otCoapBlockSzx aSize) { return Coap::BlockSizeFromExponent(MapEnum(aSize)); }
 
 otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSzx aSize)
 {
-    return AsCoapMessage(aMessage).AppendBlockOption(Coap::Message::kBlockType2, aNum, aMore, aSize);
+    return AsCoapMessage(aMessage).AppendBlockOption(Coap::Message::kBlockType2, aNum, aMore, MapEnum(aSize));
 }
 
 otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSzx aSize)
 {
-    return AsCoapMessage(aMessage).AppendBlockOption(Coap::Message::kBlockType1, aNum, aMore, aSize);
+    return AsCoapMessage(aMessage).AppendBlockOption(Coap::Message::kBlockType1, aNum, aMore, MapEnum(aSize));
 }
 
 otError otCoapMessageAppendProxyUriOption(otMessage *aMessage, const char *aUriPath)

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -154,6 +154,29 @@ enum OptionNumber : uint16_t
 };
 
 /**
+ * CoAP Block Size Exponents
+ */
+enum BlockSzx : uint8_t
+{
+    kBlockSzx16   = OT_COAP_OPTION_BLOCK_SZX_16,   ///< 16  bytes.
+    kBlockSzx32   = OT_COAP_OPTION_BLOCK_SZX_32,   ///< 32  bytes.
+    kBlockSzx64   = OT_COAP_OPTION_BLOCK_SZX_64,   ///< 64  bytes.
+    kBlockSzx128  = OT_COAP_OPTION_BLOCK_SZX_128,  ///< 128 bytes.
+    kBlockSzx256  = OT_COAP_OPTION_BLOCK_SZX_256,  ///< 256 bytes.
+    kBlockSzx512  = OT_COAP_OPTION_BLOCK_SZX_512,  ///< 512 bytes.
+    kBlockSzx1024 = OT_COAP_OPTION_BLOCK_SZX_1024, ///< 1024 bytes.
+};
+
+/**
+ * Converts a CoAP Block Size Exponent (SZX) to the actual block size (in bytes).
+ *
+ * @param[in]   aBlockSzx     Block size exponent.
+ *
+ * @returns The actual size corresponding to @o aBlockSzx.
+ */
+uint16_t BlockSizeFromExponent(BlockSzx aBlockSzx);
+
+/**
  * Implements CoAP message generation and parsing.
  */
 class Message : public ot::Message
@@ -177,8 +200,6 @@ public:
         kBlockType1 = 1,
         kBlockType2 = 2,
     };
-
-    static constexpr uint8_t kBlockSzxBase = 4;
 
     /**
      * Initializes the CoAP header.
@@ -469,7 +490,7 @@ public:
      * @retval kErrorInvalidArgs  The option type is not equal or greater than the last option type.
      * @retval kErrorNoBufs       The option length exceeds the buffer size.
      */
-    Error AppendBlockOption(BlockType aType, uint32_t aNum, bool aMore, otCoapBlockSzx aSize);
+    Error AppendBlockOption(BlockType aType, uint32_t aNum, bool aMore, BlockSzx aSize);
 
     /**
      * Appends a Proxy-Uri option.
@@ -558,7 +579,7 @@ public:
      *
      * @returns The block size.
      */
-    otCoapBlockSzx GetBlockWiseBlockSize(void) const { return GetHelpData().mBlockWiseData.mBlockSize; }
+    BlockSzx GetBlockWiseBlockSize(void) const { return GetHelpData().mBlockWiseData.mBlockSize; }
 #endif // OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
 
     /**
@@ -625,7 +646,7 @@ public:
      *
      * @param[in]   aBlockSize    Block size value to set.
      */
-    void SetBlockWiseBlockSize(otCoapBlockSzx aBlockSize) { GetHelpData().mBlockWiseData.mBlockSize = aBlockSize; }
+    void SetBlockWiseBlockSize(BlockSzx aBlockSize) { GetHelpData().mBlockWiseData.mBlockSize = aBlockSize; }
 #endif // OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
 
     /**
@@ -859,9 +880,9 @@ private:
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
     struct BlockWiseData
     {
-        uint32_t       mBlockNumber;
-        bool           mMoreBlocks;
-        otCoapBlockSzx mBlockSize;
+        uint32_t mBlockNumber;
+        bool     mMoreBlocks;
+        BlockSzx mBlockSize;
     };
 #endif
 
@@ -1187,6 +1208,7 @@ DefineCoreType(otCoapOption, Coap::Option);
 DefineCoreType(otCoapOptionIterator, Coap::Option::Iterator);
 DefineMapEnum(otCoapType, Coap::Type);
 DefineMapEnum(otCoapCode, Coap::Code);
+DefineMapEnum(otCoapBlockSzx, Coap::BlockSzx);
 
 /**
  * Casts an `otMessage` pointer to a `Coap::Message` reference.


### PR DESCRIPTION
This change improves the internal implementation of CoAP block-wise transfers.

Introduces an internal `Coap::BlockSzx` enum to mirror the public `otCoapBlockSzx` enum, improving the separation between the API and the implementation. All internal functions are updated to use the new `BlockSzx` enum.

The logic from `otCoapBlockSizeFromExponent()` is moved into a new core `Coap::BlockSizeFromExponent()` function. The public function becomes a simple wrapper.

A new helper function, `CoapBase::DetermineBlockSzxFromSize()`, is added to replace a `switch` statement, simplifying the logic for determining block size from a given buffer length.

`ResourceBlockWise` is updated to inherit from `LinkedListEntry`, aligning it with the common pattern used for managing resource lists.