### PR TITLE
[coap] move blockwise transfer logic to dedicated methods

### DIFF
--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -812,6 +812,14 @@ private:
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
 
     Error ProcessBlockwiseSend(Message &aMessage, BlockwiseTransmitHook aTransmitHook, void *aContext);
+    Error ProcessBlockwiseResponse(Message                &aResponse,
+                                   const Ip6::MessageInfo &aMessageInfo,
+                                   Message                &aRequest,
+                                   const Metadata         &aMetadata);
+    Error ProcessBlockwiseRequest(Message                      &aMessage,
+                                  const Ip6::MessageInfo       &aMessageInfo,
+                                  Message::UriPathStringBuffer &aUriPath,
+                                  bool                         &aDidHandle);
     void  FreeLastBlockResponse(void);
     Error CacheLastBlockResponse(Message *aResponse);
     Error PrepareNextBlockRequest(Message::BlockType aType,

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -246,7 +246,7 @@ exit:
     return error;
 }
 
-Error Message::ReadUriPathOptions(char (&aUriPath)[kMaxReceivedUriPath + 1]) const
+Error Message::ReadUriPathOptions(UriPathStringBuffer &aUriPath) const
 {
     char            *curUriPath = aUriPath;
     Error            error      = kErrorNone;

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -192,6 +192,8 @@ public:
     typedef ot::Coap::Type Type; ///< CoAP Type.
     typedef ot::Coap::Code Code; ///< CoAP Code.
 
+    typedef char UriPathStringBuffer[kMaxReceivedUriPath + 1]; ///< Buffer to store a received URI Path string.
+
     /**
      * CoAP Block1/Block2 Types
      */
@@ -457,15 +459,14 @@ public:
     Error AppendUriPathOptions(const char *aUriPath);
 
     /**
-     * Reads the Uri-Path options and constructs the URI path in the buffer referenced by @p `aUriPath`.
+     * Reads the Uri-Path options and constructs the URI path in the buffer referenced by @p aUriPath.
      *
-     * @param[in] aUriPath  A reference to the buffer for storing URI path.
-     *                      NOTE: The buffer size must be `kMaxReceivedUriPath + 1`.
+     * @param[out] aUriPath  A reference to the buffer to output the read URI path.
      *
      * @retval  kErrorNone   Successfully read the Uri-Path options.
      * @retval  kErrorParse  CoAP Option header not well-formed.
      */
-    Error ReadUriPathOptions(char (&aUriPath)[kMaxReceivedUriPath + 1]) const;
+    Error ReadUriPathOptions(UriPathStringBuffer &aUriPath) const;
 
     /**
      * Appends a Uri-Query option.


### PR DESCRIPTION
This change reorganizes the CoAP blockwise transfer implementation to improve code structure and readability.

The logic for handling blockwise transfers is extracted from `ProcessReceivedRequest()` and `ProcessReceivedResponse()` into two new private helper methods: `ProcessBlockwiseRequest()` and `ProcessBlockwiseResponse()`.

This separation makes the main request and response processing methods simpler and more focused on their primary role, delegating the complexities of blockwise transfers to dedicated functions.

Additionally, this change introduces `Message::UriPathStringBuffer` as a `typedef` to provide a clear and consistent type for handling URI path string buffers.

------

~This PR builds on top of commits from earlier PRs #12235, #12237. and #12239. Please review and check the last commit. Thanks.~
