### PR TITLE
[coap] simplify CoAP observe logic

### DIFF
--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -849,6 +849,12 @@ private:
 
 #endif // OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
 
+#if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
+    Error ProcessObserveSend(Message &aMessage, const Ip6::MessageInfo &aMessageInfo, bool &aShouldObserve);
+
+    static bool IsObserveSubscription(const Message &aMessage, const Metadata &aMetadata);
+#endif
+
     MessageQueue      mPendingRequests;
     uint16_t          mMessageId;
     TimerMilliContext mRetransmissionTimer;


### PR DESCRIPTION
This commit extracts observe-related logic from several methods into new dedicated helper functions `ProcessObserveSend()` and `IsObserveSubscription()`.

This change improves the clarity and maintainability of the main CoAP methods:

- `SendMessage()` now delegates observe cancellation logic to `ProcessObserveSend()`.
- `ScheduleRetransmissionTimer()` and `HandleRetransmissionTimer()` use the new `IsObserveSubscription()` helper to determine if a pending request is an active subscription that should not timeout.
- `ProcessReceivedResponse()` is simplified by separating the control flow for observe notifications from multicast responses.