### PR TITLE
[mac] clear mode2 key only on mac destruction

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -135,6 +135,11 @@ public:
     explicit Mac(Instance &aInstance);
 
     /**
+     * Clears the Mode2Key on destruction.
+     */
+    ~Mac(void) { ClearMode2Key(); }
+
+    /**
      * Starts an IEEE 802.15.4 Active Scan.
      *
      * @param[in]  aScanChannels  A bit vector indicating which channels to scan. Zero is mapped to all channels.

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -693,7 +693,6 @@ void KeyManager::DestroyTemporaryKeys(void)
     mMleKey.Clear();
     mKek.Clear();
     Get<Mac::SubMac>().ClearMacKeys();
-    Get<Mac::Mac>().ClearMode2Key();
 }
 
 void KeyManager::DestroyPersistentKeys(void) { Get<Crypto::Storage::KeyRefManager>().DestroyPersistentKeys(); }


### PR DESCRIPTION
This PR adjusts how the `MAC Mode2 key` is cleared to avoid invalidating it in certain runtime flows.

In the previous behavior, when the OpenThread instance is initialized, Mac is constructed and sets the Mode2 key. If otInstanceErasePersistentInfo is called afterwards, the call chain reaches KeyManager::DestroyTemporaryKeys(), where the Mode2 key is cleared. However, there is no subsequent point where the Mode2 key is re-set. If Thread is then enabled and a frame using Key ID Mode 2 is received, the Mode2 key remains invalid, which can lead to incorrect behavior.

To fix this, this PR removes the Mode2 key clearing from `KeyManager::DestroyTemporaryKeys()` and clears the Mode2 key in the Mac destructor. This ensures that the Mode2 key stays valid for the lifetime of the Mac (and thus the OpenThread instance) after initialization, and is only cleared when Mac is destroyed.