### PR TITLE
[coap] improve block-wise transfer handling (remove `HelpData` use)

### DIFF
--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -104,12 +104,24 @@ uint16_t otCoapBlockSizeFromExponent(otCoapBlockSzx aSize) { return Coap::BlockS
 
 otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSzx aSize)
 {
-    return AsCoapMessage(aMessage).AppendBlockOption(Coap::Message::kBlockType2, aNum, aMore, MapEnum(aSize));
+    Coap::BlockInfo blockInfo;
+
+    blockInfo.mBlockNumber = aNum;
+    blockInfo.mBlockSzx    = MapEnum(aSize);
+    blockInfo.mMoreBlocks  = aMore;
+
+    return AsCoapMessage(aMessage).AppendBlockOption(Coap::kOptionBlock2, blockInfo);
 }
 
 otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSzx aSize)
 {
-    return AsCoapMessage(aMessage).AppendBlockOption(Coap::Message::kBlockType1, aNum, aMore, MapEnum(aSize));
+    Coap::BlockInfo blockInfo;
+
+    blockInfo.mBlockNumber = aNum;
+    blockInfo.mBlockSzx    = MapEnum(aSize);
+    blockInfo.mMoreBlocks  = aMore;
+
+    return AsCoapMessage(aMessage).AppendBlockOption(Coap::kOptionBlock1, blockInfo);
 }
 
 otError otCoapMessageAppendProxyUriOption(otMessage *aMessage, const char *aUriPath)

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -728,7 +728,7 @@ protected:
     void SetResourceHandler(ResourceHandler aHandler) { mResourceHandler = aHandler; }
 
 private:
-    static constexpr uint16_t kMaxBlockLength = OPENTHREAD_CONFIG_COAP_MAX_BLOCK_LENGTH;
+    static constexpr uint16_t kMaxBlockSize = OPENTHREAD_CONFIG_COAP_MAX_BLOCK_LENGTH;
 
     struct Metadata : public Message::FooterData<Metadata>
     {
@@ -822,11 +822,10 @@ private:
                                   bool                         &aDidHandle);
     void  FreeLastBlockResponse(void);
     Error CacheLastBlockResponse(Message *aResponse);
-    Error PrepareNextBlockRequest(Message::BlockType aType,
-                                  bool               aMoreBlocks,
-                                  Message           &aRequestOld,
-                                  Message           &aRequest,
-                                  Message           &aMessage);
+    Error PrepareNextBlockRequest(uint16_t         aBlockOptionNumber,
+                                  Message         &aRequestOld,
+                                  Message         &aRequest,
+                                  const BlockInfo &aBlockInfo);
     Error ProcessBlock1Request(Message                 &aMessage,
                                const Ip6::MessageInfo  &aMessageInfo,
                                const ResourceBlockWise &aResource,
@@ -837,11 +836,11 @@ private:
     Error SendNextBlock1Request(Message                &aRequest,
                                 Message                &aMessage,
                                 const Ip6::MessageInfo &aMessageInfo,
-                                const Metadata         &aCoapMetadata);
+                                const Metadata         &aMetadata);
     Error SendNextBlock2Request(Message                &aRequest,
                                 Message                &aMessage,
                                 const Ip6::MessageInfo &aMessageInfo,
-                                const Metadata         &aCoapMetadata,
+                                const Metadata         &aMetadata,
                                 uint32_t                aTotalLength,
                                 bool                    aBeginBlock1Transfer);
 


### PR DESCRIPTION
This commit enhances the CoAP block-wise transfer implementation by removing the `BlockWiseData` struct within `Message::HelpData` and its associated getter/setter methods (e.g., `GetBlockWiseBlockNumber()`, `SetBlockWiseBlockNumber()`). The `Message` object is no longer responsible for carrying temporary state related to block-wise transfers, addressing the fragility of the previous design which used the reserved header portion of the `Message` to store these properties.

A new `BlockInfo` struct has been introduced to cleanly encapsulate the three pieces of information from a Block option: `mBlockNumber`, `mBlockSzx` (size exponent), and `mMoreBlocks` flag. It also includes utility methods like `GetBlockSize()` and `GetBlockOffsetPosition()` to simplify calculations.

All methods involved in block-wise transfers in `coap.cpp` (e.g., `ProcessBlockwiseSend`, `SendNextBlock1Request`) have been updated to use the new `BlockInfo` struct. They now create local `BlockInfo` variables and call `ReadBlockOptionValues()` to populate them.

This commit also includes minor cleanups and improvements:

- "Block size" is now used consistently instead of block length (e.g., `kMaxBlockLength` is renamed to `kMaxBlockSize`).
- `OffsetRange` is now used to read the payload in `SendNextBlock2Request` and `ProcessBlock1Request`, simplifying the code.
