### PR TITLE
[test] increase `simulator.go()` time in key sequence jump test

### DIFF
--- a/tests/scripts/thread-cert/test_mle_msg_key_seq_jump.py
+++ b/tests/scripts/thread-cert/test_mle_msg_key_seq_jump.py
@@ -256,7 +256,7 @@ class MleMsgKeySeqJump(thread_cert.TestCase):
         self.assertEqual(child.get_key_sequence_counter(), 25)
 
         child.start()
-        self.simulator.go(2)
+        self.simulator.go(5)
 
         self.assertEqual(child.get_state(), 'child')
         self.assertEqual(leader.get_key_sequence_counter(), 25)


### PR DESCRIPTION
Increase the simulation wait time from 2 to 5 seconds in the `test_mle_msg_key_seq_jump` after child restart.

This larger time window accounts for randomness in the timing of the Child Update transmission. This makes the test more robust by ensuring the child has sufficient time to send its "Child Update Request".

---

Should help address failure like this one:
https://github.com/openthread/openthread/actions/runs/20580011318/job/59105301918?pr=12248