### PR TITLE
[build] enable format-nonliteral check in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,8 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
     endif()
 
     set(OT_CFLAGS
-        $<$<COMPILE_LANGUAGE:C>:${OT_CFLAGS} -Wall -Wextra -Wshadow>
-        $<$<COMPILE_LANGUAGE:CXX>:${OT_CFLAGS} -Wall -Wextra -Wshadow -Wno-c++14-compat -fno-exceptions>
+        $<$<COMPILE_LANGUAGE:C>:${OT_CFLAGS} -Wall -Wformat-nonliteral -Wextra -Wshadow>
+        $<$<COMPILE_LANGUAGE:CXX>:${OT_CFLAGS} -Wall -Wformat-nonliteral -Wextra -Wshadow -Wno-c++14-compat -fno-exceptions>
         $<$<CXX_COMPILER_ID:Clang>:-Wc99-extensions>
     )
 endif()

--- a/examples/apps/cli/cli_uart.cpp
+++ b/examples/apps/cli/cli_uart.cpp
@@ -34,6 +34,7 @@
 #include <openthread-system.h>
 #include <openthread/cli.h>
 #include <openthread/logging.h>
+#include <openthread/platform/debug_uart.h>
 
 #include "cli/cli_config.h"
 #include "common/code_utils.hpp"
@@ -221,7 +222,7 @@ static void Send(void)
     {
 #if OPENTHREAD_CONFIG_ENABLE_DEBUG_UART
         /* duplicate the output to the debug uart */
-        otSysDebugUart_write_bytes(reinterpret_cast<uint8_t *>(sTxBuffer + sTxHead), sSendLength);
+        otPlatDebugUart_write_bytes(reinterpret_cast<uint8_t *>(sTxBuffer + sTxHead), sSendLength);
 #endif
         IgnoreError(otPlatUartSend(reinterpret_cast<uint8_t *>(sTxBuffer + sTxHead), sSendLength));
     }

--- a/examples/platforms/utils/CMakeLists.txt
+++ b/examples/platforms/utils/CMakeLists.txt
@@ -47,6 +47,10 @@ if(OT_RTT_UART)
     )
 endif()
 
+target_compile_options(openthread-platform-utils PRIVATE
+    ${OT_CFLAGS}
+)
+
 target_include_directories(openthread-platform-utils PRIVATE
     ${OT_PUBLIC_INCLUDES}
     $<TARGET_PROPERTY:ot-config,INTERFACE_INCLUDE_DIRECTORIES>

--- a/examples/platforms/utils/logging_rtt.h
+++ b/examples/platforms/utils/logging_rtt.h
@@ -124,7 +124,8 @@ void utilsLogRttDeinit(void);
  * @param[in]  aFormat     A pointer to the format string.
  * @param[in]  ap          va_list matching information for aFormat
  */
-void utilsLogRttOutput(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list ap);
+void utilsLogRttOutput(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list ap)
+    OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(3, 0);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -383,6 +383,7 @@ void otMacFrameUpdateTimeIe(otRadioFrame *aFrame, uint64_t aRadioTime, otRadioCo
     uint8_t *timeIe;
     uint64_t time;
 
+    OT_UNUSED_VARIABLE(aRadioContext);
     VerifyOrExit((aFrame->mInfo.mTxInfo.mIeInfo != nullptr) && (aFrame->mInfo.mTxInfo.mIeInfo->mTimeIeOffset != 0));
 
     timeIe  = aFrame->mPsdu + aFrame->mInfo.mTxInfo.mIeInfo->mTimeIeOffset;
@@ -434,7 +435,6 @@ bool otMacFrameSrcAddrMatchCslReceiverPeer(const otRadioFrame *aFrame, const otR
         break;
 
     case Mac::Address::kTypeExtended:
-        VerifyOrExit(*reinterpret_cast<const uint64_t *>(aRadioContext->mCslExtAddress.m8) != 0);
         VerifyOrExit(src.GetExtended() == *static_cast<const Mac::ExtAddress *>(&aRadioContext->mCslExtAddress));
         matches = true;
         break;

--- a/examples/platforms/utils/otns_utils.cpp
+++ b/examples/platforms/utils/otns_utils.cpp
@@ -43,6 +43,10 @@ using namespace ot;
 #if OPENTHREAD_CONFIG_OTNS_ENABLE
 
 OT_TOOL_WEAK
-void otPlatOtnsStatus(const char *aStatus) { LogAlways("[OTNS] %s", aStatus); }
+void otPlatOtnsStatus(const char *aStatus)
+{
+    OT_UNUSED_VARIABLE(aStatus);
+    LogAlways("[OTNS] %s", aStatus);
+}
 
 #endif // OPENTHREAD_CONFIG_OTNS_ENABLE

--- a/include/openthread/cli.h
+++ b/include/openthread/cli.h
@@ -76,7 +76,8 @@ typedef struct otCliCommand
  *
  * @returns                Number of bytes written by the callback.
  */
-typedef int (*otCliOutputCallback)(void *aContext, const char *aFormat, va_list aArguments);
+typedef int (*otCliOutputCallback)(void *aContext, const char *aFormat, va_list aArguments)
+    OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 0);
 
 /**
  * Initialize the CLI module.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (566)
+#define OPENTHREAD_API_VERSION (567)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ncp.h
+++ b/include/openthread/ncp.h
@@ -42,6 +42,7 @@
 #include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/platform/logging.h>
+#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -135,7 +136,8 @@ otError otNcpStreamWrite(int aStreamId, const uint8_t *aDataPtr, int aDataLen);
  * @param[in]  aFormat     A pointer to the format string.
  * @param[in]  aArgs       va_list matching aFormat.
  */
-void otNcpPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list aArgs);
+void otNcpPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list aArgs)
+    OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(3, 0);
 
 //-----------------------------------------------------------------------------------------
 // Peek/Poke memory access control delegates

--- a/include/openthread/platform/debug_uart.h
+++ b/include/openthread/platform/debug_uart.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 
 #include <openthread/error.h>
+#include <openthread/platform/toolchain.h>
 
 /**
  * @file
@@ -82,7 +83,7 @@ extern "C" {
  *
  * This is a WEAK symbol that can easily be overridden as needed.
  */
-void otPlatDebugUart_printf(const char *fmt, ...);
+void otPlatDebugUart_printf(const char *fmt, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
 
 /**
  * Standard vprintf() to the debug uart, with no log decoration.
@@ -100,7 +101,7 @@ void otPlatDebugUart_printf(const char *fmt, ...);
  * symbol because the platform provides a UART_vprintf() like
  * function that can handle an arbitrary length output.
  */
-void otPlatDebugUart_vprintf(const char *fmt, va_list ap);
+void otPlatDebugUart_vprintf(const char *fmt, va_list ap) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 0);
 
 /**
  * Platform specific write single byte to Debug Uart

--- a/include/openthread/platform/diag.h
+++ b/include/openthread/platform/diag.h
@@ -42,6 +42,7 @@
 #include <openthread/error.h>
 #include <openthread/instance.h>
 #include <openthread/platform/radio.h>
+#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -72,7 +73,8 @@ typedef enum
  * @param[in]  aArguments  The format string arguments.
  * @param[out] aContext    A pointer to the user context.
  */
-typedef void (*otPlatDiagOutputCallback)(const char *aFormat, va_list aArguments, void *aContext);
+typedef void (*otPlatDiagOutputCallback)(const char *aFormat, va_list aArguments, void *aContext)
+    OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 0);
 
 /**
  * Sets the platform diag output callback.

--- a/include/openthread/platform/logging.h
+++ b/include/openthread/platform/logging.h
@@ -35,6 +35,8 @@
 #ifndef OPENTHREAD_PLATFORM_LOGGING_H_
 #define OPENTHREAD_PLATFORM_LOGGING_H_
 
+#include <openthread/platform/toolchain.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -146,7 +148,8 @@ typedef enum otLogRegion
  * @param[in]  aFormat     A pointer to the format string.
  * @param[in]  ...         Arguments for the format specification.
  */
-void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...);
+void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
+    OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(3, 4);
 
 /**
  * Handles OpenThread log level changes.

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -324,8 +324,9 @@ private:
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-    static void HandleDiagOutput(const char *aFormat, va_list aArguments, void *aContext);
-    void        HandleDiagOutput(const char *aFormat, va_list aArguments);
+    static void HandleDiagOutput(const char *aFormat, va_list aArguments, void *aContext)
+        OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 0);
+    void HandleDiagOutput(const char *aFormat, va_list aArguments) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 0);
 #endif
 
     void SetCommandTimeout(uint32_t aTimeoutMilli);

--- a/src/cli/cli_utils.hpp
+++ b/src/cli/cli_utils.hpp
@@ -553,7 +553,10 @@ public:
         otError error = OT_ERROR_NONE;
 
         VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
         OutputLine(FormatStringFor<ValueType>(), aGetHandler(GetInstancePtr()));
+#pragma GCC diagnostic pop
 
     exit:
         return error;
@@ -755,13 +758,9 @@ template <> inline constexpr const char *Utils::FormatStringFor<uint8_t>(void) {
 
 template <> inline constexpr const char *Utils::FormatStringFor<uint16_t>(void) { return "%u"; }
 
-template <> inline constexpr const char *Utils::FormatStringFor<uint32_t>(void) { return "%lu"; }
-
 template <> inline constexpr const char *Utils::FormatStringFor<int8_t>(void) { return "%d"; }
 
 template <> inline constexpr const char *Utils::FormatStringFor<int16_t>(void) { return "%d"; }
-
-template <> inline constexpr const char *Utils::FormatStringFor<int32_t>(void) { return "%ld"; }
 
 template <> inline constexpr const char *Utils::FormatStringFor<const char *>(void) { return "%s"; }
 
@@ -772,7 +771,8 @@ template <> inline otError Utils::ProcessGet<uint32_t>(Arg aArgs[], GetHandler<u
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
-    OutputLine(FormatStringFor<uint32_t>(), ToUlong(aGetHandler(GetInstancePtr())));
+    static_assert(sizeof(unsigned long) >= sizeof(uint32_t), "OpenThread assumes unsigned long is at least 32bit");
+    OutputLine("%lu", ToUlong(aGetHandler(GetInstancePtr())));
 
 exit:
     return error;
@@ -783,7 +783,8 @@ template <> inline otError Utils::ProcessGet<int32_t>(Arg aArgs[], GetHandler<in
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
-    OutputLine(FormatStringFor<int32_t>(), static_cast<long int>(aGetHandler(GetInstancePtr())));
+    static_assert(sizeof(long) >= sizeof(int32_t), "OpenThread assumes long is at least 32bit");
+    OutputLine("%ld", static_cast<long int>(aGetHandler(GetInstancePtr())));
 
 exit:
     return error;

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -661,13 +661,15 @@ protected:
     static unsigned int ConvertLogRegion(otLogRegion aLogRegion);
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-    static void HandleDiagOutput_Jump(const char *aFormat, va_list aArguments, void *aContext);
-    void        HandleDiagOutput(const char *aFormat, va_list aArguments);
+    static void HandleDiagOutput_Jump(const char *aFormat, va_list aArguments, void *aContext)
+        OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 0);
+    void HandleDiagOutput(const char *aFormat, va_list aArguments) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 0);
 #endif
 
 #if OPENTHREAD_CONFIG_NCP_CLI_STREAM_ENABLE
-    static int HandleCliOutput(void *aContext, const char *aFormat, va_list aArguments);
-    int        HandleCliOutput(const char *aFormat, va_list aArguments);
+    static int HandleCliOutput(void *aContext, const char *aFormat, va_list aArguments)
+        OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 0);
+    int HandleCliOutput(const char *aFormat, va_list aArguments) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 0);
 #endif
 
 #if OPENTHREAD_ENABLE_NCP_VENDOR_HOOK

--- a/src/posix/cli_readline.cpp
+++ b/src/posix/cli_readline.cpp
@@ -74,6 +74,9 @@ static void InputCallback(char *aLine)
 }
 
 static int OutputCallback(void *aContext, const char *aFormat, va_list aArguments)
+    OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 0);
+
+static int OutputCallback(void *aContext, const char *aFormat, va_list aArguments)
 {
     OT_UNUSED_VARIABLE(aContext);
 

--- a/src/posix/cli_stdio.cpp
+++ b/src/posix/cli_stdio.cpp
@@ -50,6 +50,8 @@
 
 namespace {
 
+int OutputCallback(void *aContext, const char *aFormat, va_list aArguments) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 0);
+
 int OutputCallback(void *aContext, const char *aFormat, va_list aArguments)
 {
     OT_UNUSED_VARIABLE(aContext);

--- a/src/posix/platform/daemon.cpp
+++ b/src/posix/platform/daemon.cpp
@@ -32,9 +32,7 @@
 #include <cutils/sockets.h>
 #endif
 #include <fcntl.h>
-#include <signal.h>
 #include <stdarg.h>
-#include <string.h>
 #include <sys/file.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -62,19 +60,16 @@ namespace {
 
 typedef char(Filename)[sizeof(sockaddr_un::sun_path)];
 
-void GetFilename(Filename &aFilename, const char *aPattern)
-{
-    int         rval;
-    const char *netIfName = strlen(gNetifName) > 0 ? gNetifName : OPENTHREAD_POSIX_CONFIG_THREAD_NETIF_DEFAULT_NAME;
-
-    rval = snprintf(aFilename, sizeof(aFilename), aPattern, netIfName);
-    if (rval < 0 && static_cast<size_t>(rval) >= sizeof(aFilename))
-    {
-        DieNow(OT_EXIT_INVALID_ARGUMENTS);
-    }
-}
-
 } // namespace
+
+// using macro to avoid the warning about format-nonliteral
+#define GetFilename(aFilename, aPattern)                                                                       \
+    do                                                                                                         \
+    {                                                                                                          \
+        int rval = snprintf(aFilename, sizeof(aFilename), aPattern,                                            \
+                            (gNetifName[0] ? gNetifName : OPENTHREAD_POSIX_CONFIG_THREAD_NETIF_DEFAULT_NAME)); \
+        VerifyOrDie(rval > 0 && static_cast<size_t>(rval) < sizeof(aFilename), OT_EXIT_INVALID_ARGUMENTS);     \
+    } while (0)
 
 const char Daemon::kLogModuleName[] = "Daemon";
 

--- a/src/posix/platform/daemon.hpp
+++ b/src/posix/platform/daemon.hpp
@@ -30,6 +30,10 @@
 
 #include "openthread-posix-config.h"
 
+#include <stdarg.h>
+
+#include <openthread/platform/toolchain.h>
+
 #include "core/common/non_copyable.hpp"
 
 #include "logger.hpp"
@@ -49,10 +53,10 @@ public:
     void TearDown(void);
     void Update(Mainloop::Context &aContext) override;
     void Process(const Mainloop::Context &aContext) override;
-    int  OutputFormatV(const char *aFormat, va_list aArguments);
+    int  OutputFormatV(const char *aFormat, va_list aArguments) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 0);
 
 private:
-    int  OutputFormat(const char *aFormat, ...);
+    int  OutputFormat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 3);
     void createListenSocketOrDie(void);
     void InitializeSessionSocket(void);
 

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -296,6 +296,12 @@ static bool sIsSyncingState = false;
 
 static const char kLogModuleName[] = "Netif";
 
+static void LogCrit(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
+static void LogWarn(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
+static void LogNote(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
+static void LogInfo(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
+static void LogDebg(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
+
 static void LogCrit(const char *aFormat, ...)
 {
     va_list args;

--- a/src/posix/platform/rcp_caps_diag.hpp
+++ b/src/posix/platform/rcp_caps_diag.hpp
@@ -126,13 +126,14 @@ private:
     void OutputExtendedSrcMatchTableSize(void);
     void OutputShortSrcMatchTableSize(void);
 
-    static void HandleDiagOutput(const char *aFormat, va_list aArguments, void *aContext);
-    void        HandleDiagOutput(const char *aFormat, va_list aArguments);
+    static void HandleDiagOutput(const char *aFormat, va_list aArguments, void *aContext)
+        OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 0);
+    void HandleDiagOutput(const char *aFormat, va_list aArguments) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 0);
 
     void OutputFormat(const char *aName, const char *aValue);
     void OutputFormat(const char *aName, uint32_t aValue);
     void OutputResult(const SpinelEntry &aEntry, otError error);
-    void Output(const char *aFormat, ...);
+    void Output(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 3);
 
     static const char *SupportToString(bool aSupport);
     static const char *RadioCapbilityToString(uint32_t aCapability);

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -497,13 +497,14 @@ void otSysMainloopProcess(otInstance *aInstance, const otSysMainloopContext *aMa
 bool IsSystemDryRun(void) { return gDryRun; }
 
 #if OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE && OPENTHREAD_POSIX_CONFIG_DAEMON_CLI_ENABLE
-void otSysCliInitUsingDaemon(otInstance *aInstance)
+namespace {
+int OutputCallback(void *aContext, const char *aFormat, va_list aArguments) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 0);
+
+int OutputCallback(void *aContext, const char *aFormat, va_list aArguments)
 {
-    otCliInit(
-        aInstance,
-        [](void *aContext, const char *aFormat, va_list aArguments) -> int {
-            return static_cast<ot::Posix::Daemon *>(aContext)->OutputFormatV(aFormat, aArguments);
-        },
-        &ot::Posix::Daemon::Get());
+    return static_cast<ot::Posix::Daemon *>(aContext)->OutputFormatV(aFormat, aArguments);
 }
+} // namespace
+
+void otSysCliInitUsingDaemon(otInstance *aInstance) { otCliInit(aInstance, OutputCallback, &ot::Posix::Daemon::Get()); }
 #endif

--- a/src/posix/platform/trel.cpp
+++ b/src/posix/platform/trel.cpp
@@ -79,6 +79,12 @@ static int  sSocket      = -1;
 
 static const char kLogModuleName[] = "Trel";
 
+static void LogCrit(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
+static void LogWarn(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
+static void LogNote(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
+static void LogInfo(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
+static void LogDebg(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
+
 static void LogCrit(const char *aFormat, ...)
 {
     va_list args;

--- a/src/posix/platform/utils.hpp
+++ b/src/posix/platform/utils.hpp
@@ -67,7 +67,7 @@ int SocketWithCloseExec(int aDomain, int aType, int aProtocol, SocketBlockOption
  * @retval OT_ERROR_NONE    The command was executed successfully.
  * @retval OT_ERROR_FAILED  It failed to execute the command.
  */
-otError ExecuteCommand(const char *aFormat, ...);
+otError ExecuteCommand(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
 
 } // namespace Posix
 } // namespace ot


### PR DESCRIPTION
This commit enables the format-nonliteral check for code missed in `#12236`. This commit also enables the format-nonliteral warnings in CMake to catch such warnings in future in CMake build.