### PR TITLE
[core] use `Tlv::AppendTlv` helper to simplify TLV appends

### DIFF
--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -606,17 +606,13 @@ Error Commissioner::SendMgmtCommissionerGetRequest(const uint8_t *aTlvs, uint8_t
     Error                   error = kErrorNone;
     OwnedPtr<Coap::Message> message;
     Tmf::MessageInfo        messageInfo(GetInstance());
-    Tlv                     tlv;
 
     message.Reset(Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriCommissionerGet));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     if (aLength > 0)
     {
-        tlv.SetType(Tlv::kGet);
-        tlv.SetLength(aLength);
-        SuccessOrExit(error = message->Append(tlv));
-        SuccessOrExit(error = message->AppendBytes(aTlvs, aLength));
+        SuccessOrExit(error = Tlv::AppendTlv(*message, Tlv::kGet, aTlvs, aLength));
     }
 
     messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();

--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -102,12 +102,7 @@ Error Initiator::AppendLinkMetricsQueryTlv(Message &aMessage, const QueryInfo &a
 
     if (aInfo.mTypeIdCount != 0)
     {
-        QueryOptionsSubTlv queryOptionsTlv;
-
-        queryOptionsTlv.Init();
-        queryOptionsTlv.SetLength(aInfo.mTypeIdCount);
-        SuccessOrExit(error = aMessage.Append(queryOptionsTlv));
-        SuccessOrExit(error = aMessage.AppendBytes(aInfo.mTypeIds, aInfo.mTypeIdCount));
+        SuccessOrExit(error = Tlv::AppendTlv(aMessage, QueryOptionsSubTlv::kType, aInfo.mTypeIds, aInfo.mTypeIdCount));
     }
 
 exit:

--- a/src/core/thread/link_metrics_tlvs.hpp
+++ b/src/core/thread/link_metrics_tlvs.hpp
@@ -80,6 +80,11 @@ typedef UintTlvInfo<SubTlv::kQueryId, uint8_t> QueryIdSubTlv;
 typedef UintTlvInfo<SubTlv::kStatus, uint8_t> StatusSubTlv;
 
 /**
+ * Defines Query Option Sub-TLV constants and types.
+ */
+typedef TlvInfo<SubTlv::kQueryOptions> QueryOptionsSubTlv;
+
+/**
  * Implements Link Metrics Report Sub-TLV generation and parsing.
  */
 OT_TOOL_PACKED_BEGIN
@@ -158,32 +163,6 @@ private:
         uint8_t  m8;
         uint32_t m32;
     } mMetricsValue;
-} OT_TOOL_PACKED_END;
-
-/**
- * Implements Link Metrics Query Options Sub-TLV generation and parsing.
- */
-OT_TOOL_PACKED_BEGIN
-class QueryOptionsSubTlv : public Tlv, public TlvInfo<SubTlv::kQueryOptions>
-{
-public:
-    /**
-     * Initializes the TLV.
-     */
-    void Init(void)
-    {
-        SetType(SubTlv::kQueryOptions);
-        SetLength(0);
-    }
-
-    /**
-     * Indicates whether or not the TLV appears to be well-formed.
-     *
-     * @retval TRUE   If the TLV appears to be well-formed.
-     * @retval FALSE  If the TLV does not appear to be well-formed.
-     */
-    bool IsValid(void) const { return GetLength() >= sizeof(uint8_t); }
-
 } OT_TOOL_PACKED_END;
 
 /**

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3049,15 +3049,11 @@ Error Mle::SendLinkMetricsManagementRequest(const Ip6::Address &aDestination, co
 {
     Error      error   = kErrorNone;
     TxMessage *message = NewMleMessage(kCommandLinkMetricsManagementRequest);
-    Tlv        tlv;
 
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
-    tlv.SetType(Tlv::kLinkMetricsManagement);
-    tlv.SetLength(static_cast<uint8_t>(aSubTlv.GetSize()));
-
-    SuccessOrExit(error = message->Append(tlv));
-    SuccessOrExit(error = aSubTlv.AppendTo(*message));
+    SuccessOrExit(error = Tlv::AppendTlv(*message, Tlv::kLinkMetricsManagement, &aSubTlv,
+                                         static_cast<uint16_t>(aSubTlv.GetSize())));
 
     error = message->SendTo(aDestination);
 

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -192,12 +192,8 @@ Error Notifier::SendServerDataNotification(uint16_t aOldRloc16, const NetworkDat
 
     if (aNetworkData != nullptr)
     {
-        ThreadTlv tlv;
-
-        tlv.SetType(ThreadTlv::kThreadNetworkData);
-        tlv.SetLength(aNetworkData->GetLength());
-        SuccessOrExit(error = message->Append(tlv));
-        SuccessOrExit(error = message->AppendBytes(aNetworkData->GetBytes(), aNetworkData->GetLength()));
+        SuccessOrExit(error = Tlv::AppendTlv(*message, ThreadTlv::kThreadNetworkData, aNetworkData->GetBytes(),
+                                             aNetworkData->GetLength()));
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BORDER_ROUTER_SIGNAL_NETWORK_DATA_FULL
         Get<Leader>().CheckForNetDataGettingFull(*aNetworkData, aOldRloc16);


### PR DESCRIPTION
This commit updates various modules to use the `Tlv::AppendTlv` helper method when appending a TLV with its value to a `Message`.