### PR TITLE
[tlvs] add helper to append an empty TLV

### DIFF
--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -282,6 +282,8 @@ template Error Tlv::AppendUintTlv<uint8_t>(Message &aMessage, uint8_t aType, uin
 template Error Tlv::AppendUintTlv<uint16_t>(Message &aMessage, uint8_t aType, uint16_t aValue);
 template Error Tlv::AppendUintTlv<uint32_t>(Message &aMessage, uint8_t aType, uint32_t aValue);
 
+Error Tlv::AppendEmptyTlv(Message &aMessage, uint8_t aType) { return AppendTlv(aMessage, aType, nullptr, 0); }
+
 Error Tlv::AppendTlv(Message &aMessage, uint8_t aType, const void *aValue, uint16_t aLength)
 {
     Error       error = kErrorNone;

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -538,6 +538,36 @@ public:
     }
 
     /**
+     * Appends an empty TLV (no value) with a given type to a message.
+     *
+     * On success this method grows the message by the size of the TLV.
+     *
+     * @param[in]  aMessage      The message to append to.
+     * @param[in]  aType         The TLV type to append.
+     *
+     * @retval kErrorNone     Successfully appended the TLV to the message.
+     * @retval kErrorNoBufs   Insufficient available buffers to grow the message.
+     */
+    static Error AppendEmptyTlv(Message &aMessage, uint8_t aType);
+
+    /**
+     * Appends an empty TLV (no value) with a given type to a message.
+     *
+     * On success this method grows the message by the size of the TLV.
+     *
+     * @tparam     TlvType       The TLV type to append.
+     *
+     * @param[in]  aMessage      The message to append to.
+     *
+     * @retval kErrorNone     Successfully appended the TLV to the message.
+     * @retval kErrorNoBufs   Insufficient available buffers to grow the message.
+     */
+    template <typename TlvType> static Error AppendEmpty(Message &aMessage)
+    {
+        return AppendEmptyTlv(aMessage, TlvType::kType);
+    }
+
+    /**
      * Appends a TLV with a given type and value to a message.
      *
      * If the TLV length is longer than maximum base TLV size defined by `kBaseTlvMaxLength` then

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -251,10 +251,7 @@ Error Server::AppendChildTableAsChildTlvs(Message &aMessage)
         SuccessOrExit(error = childTlv.AppendTo(aMessage));
     }
 
-    // Add empty TLV to indicate end of the list
-
-    childTlv.InitAsEmpty();
-    SuccessOrExit(error = childTlv.AppendTo(aMessage));
+    error = Tlv::AppendEmpty<ChildTlv>(aMessage);
 
 exit:
     return error;
@@ -274,10 +271,7 @@ Error Server::AppendRouterNeighborTlvs(Message &aMessage)
         }
     }
 
-    // Add empty TLV to indicate end of the list
-
-    neighborTlv.InitAsEmpty();
-    SuccessOrExit(error = neighborTlv.AppendTo(aMessage));
+    error = Tlv::AppendEmpty<RouterNeighborTlv>(aMessage);
 
 exit:
     return error;
@@ -286,18 +280,13 @@ exit:
 Error Server::AppendChildTableIp6AddressList(Message &aMessage)
 {
     Error error = kErrorNone;
-    Tlv   tlv;
 
     for (const Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {
         SuccessOrExit(error = AppendChildIp6AddressListTlv(aMessage, child));
     }
 
-    // Add empty TLV to indicate end of the list
-
-    tlv.SetType(Tlv::kChildIp6AddressList);
-    tlv.SetLength(0);
-    SuccessOrExit(error = aMessage.Append(tlv));
+    error = Tlv::AppendEmpty<ChildIp6AddressListTlv>(aMessage);
 
 exit:
     return error;
@@ -952,10 +941,7 @@ Error Server::AppendChildTableAsChildTlvs(Coap::Message *&aAnswer, AnswerInfo &a
         SuccessOrExit(error = CheckAnswerLength(aAnswer, aInfo));
     }
 
-    // Add empty TLV to indicate end of the list
-
-    childTlv.InitAsEmpty();
-    SuccessOrExit(error = childTlv.AppendTo(*aAnswer));
+    error = Tlv::AppendEmpty<ChildTlv>(*aAnswer);
 
 exit:
     return error;
@@ -979,10 +965,7 @@ Error Server::AppendRouterNeighborTlvs(Coap::Message *&aAnswer, AnswerInfo &aInf
         SuccessOrExit(error = CheckAnswerLength(aAnswer, aInfo));
     }
 
-    // Add empty TLV to indicate end of the list
-
-    neighborTlv.InitAsEmpty();
-    SuccessOrExit(error = neighborTlv.AppendTo(*aAnswer));
+    error = Tlv::AppendEmpty<RouterNeighborTlv>(*aAnswer);
 
 exit:
     return error;
@@ -991,7 +974,6 @@ exit:
 Error Server::AppendChildTableIp6AddressList(Coap::Message *&aAnswer, AnswerInfo &aInfo)
 {
     Error error = kErrorNone;
-    Tlv   tlv;
 
     for (const Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {
@@ -999,11 +981,7 @@ Error Server::AppendChildTableIp6AddressList(Coap::Message *&aAnswer, AnswerInfo
         SuccessOrExit(error = CheckAnswerLength(aAnswer, aInfo));
     }
 
-    // Add empty TLV to indicate end of the list
-
-    tlv.SetType(Tlv::kChildIp6AddressList);
-    tlv.SetLength(0);
-    SuccessOrExit(error = aAnswer->Append(tlv));
+    error = Tlv::AppendEmpty<ChildIp6AddressListTlv>(*aAnswer);
 
 exit:
     return error;

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -702,15 +702,6 @@ public:
     void InitFrom(const Child &aChild);
 
     /**
-     * Initializes the TLV as empty (zero length).
-     */
-    void InitAsEmpty(void)
-    {
-        SetType(kChild);
-        SetLength(0);
-    }
-
-    /**
      * Returns the Flags field (`kFlags*` constants define bits in flags).
      *
      * @returns The Flags field.
@@ -899,15 +890,6 @@ public:
      * @param[in] aRouter   The router to initialize the TLV from.
      */
     void InitFrom(const Router &aRouter);
-
-    /**
-     * Initializes the TLV as empty (zero length).
-     */
-    void InitAsEmpty(void)
-    {
-        SetType(kRouterNeighbor);
-        SetLength(0);
-    }
 
     /**
      * Returns the Flags field (`kFlags*` constants define bits in flags).

--- a/src/core/utils/history_tracker_server.cpp
+++ b/src/core/utils/history_tracker_server.cpp
@@ -325,20 +325,10 @@ Error Server::AppendNetworkInfo(Coap::Message *&aAnswer, AnswerInfo &aInfo, cons
         SuccessOrExit(error = CheckAnswerLength(aAnswer, aInfo));
     }
 
-    SuccessOrExit(error = AppendEmptyTlv(*aAnswer, Tlv::kNetworkInfo));
+    SuccessOrExit(error = Tlv::AppendEmpty<NetworkInfoTlv>(*aAnswer));
 
 exit:
     return error;
-}
-
-Error Server::AppendEmptyTlv(Coap::Message &aAnswer, Tlv::Type aTlvType)
-{
-    Tlv tlv;
-
-    tlv.SetType(aTlvType);
-    tlv.SetLength(0);
-
-    return aAnswer.Append(tlv);
 }
 
 } // namespace HistoryTracker

--- a/src/core/utils/history_tracker_server.hpp
+++ b/src/core/utils/history_tracker_server.hpp
@@ -90,7 +90,6 @@ private:
     void  SendNextAnswer(Coap::Message &aAnswer, const Ip6::Address &aDestination);
     void  PrepareMessageInfoForDest(const Ip6::Address &aDestination, Tmf::MessageInfo &aMessageInfo) const;
     Error AppendNetworkInfo(Coap::Message *&aAnswer, AnswerInfo &aInfo, const RequestTlv &aRequestTlv);
-    Error AppendEmptyTlv(Coap::Message &aAnswer, Tlv::Type aTlvType);
 
     static void HandleAnswerResponse(void                *aContext,
                                      otMessage           *aMessage,


### PR DESCRIPTION
Introduces a new helper `Tlv::AppendEmptyTlv()` and a templated version `Tlv::AppendEmpty<TlvType>()` to simplify appending empty TLVs to a message.

This avoids repetitive manual construction of empty TLVs in different parts of the codebase.