### PR TITLE
[common] add enum-to-string conversion utility

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -276,6 +276,7 @@ openthread_core_files = [
   "common/data.hpp",
   "common/debug.hpp",
   "common/encoding.hpp",
+  "common/enum_to_string.hpp",
   "common/equatable.hpp",
   "common/error.cpp",
   "common/error.hpp",

--- a/src/core/backbone_router/bbr_leader.cpp
+++ b/src/core/backbone_router/bbr_leader.cpp
@@ -97,48 +97,30 @@ void Leader::LogBackboneRouterPrimary(State aState, const Config &aConfig) const
 
 const char *Leader::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "None",            //  (0) kStateNone
-        "Added",           //  (1) kStateAdded
-        "Removed",         //  (2) kStateRemoved
-        "Rereg triggered", //  (3) kStateToTriggerRereg
-        "Refreshed",       //  (4) kStateRefreshed
-        "Unchanged",       //  (5) kStateUnchanged
-    };
+#define StateMapList(_)                        \
+    _(kStateNone, "None")                      \
+    _(kStateAdded, "Added")                    \
+    _(kStateRemoved, "Removed")                \
+    _(kStateToTriggerRereg, "Rereg triggered") \
+    _(kStateRefreshed, "Refreshed")            \
+    _(kStateUnchanged, "Unchanged")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kStateNone);
-        ValidateNextEnum(kStateAdded);
-        ValidateNextEnum(kStateRemoved);
-        ValidateNextEnum(kStateToTriggerRereg);
-        ValidateNextEnum(kStateRefreshed);
-        ValidateNextEnum(kStateUnchanged);
-    };
+    DefineEnumStringArray(StateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 const char *Leader::DomainPrefixEventToString(DomainPrefixEvent aEvent)
 {
-    static const char *const kEventStrings[] = {
-        "Added",     // (0) kDomainPrefixAdded
-        "Removed",   // (1) kDomainPrefixRemoved
-        "Refreshed", // (2) kDomainPrefixRefreshed
-        "Unchanged", // (3) kDomainPrefixUnchanged
-    };
+#define DomainPrefixEventMapList(_)        \
+    _(kDomainPrefixAdded, "Added")         \
+    _(kDomainPrefixRemoved, "Removed")     \
+    _(kDomainPrefixRefreshed, "Refreshed") \
+    _(kDomainPrefixUnchanged, "Unchanged")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kDomainPrefixAdded);
-        ValidateNextEnum(kDomainPrefixRemoved);
-        ValidateNextEnum(kDomainPrefixRefreshed);
-        ValidateNextEnum(kDomainPrefixUnchanged);
-    };
+    DefineEnumStringArray(DomainPrefixEventMapList);
 
-    return kEventStrings[aEvent];
+    return kStrings[aEvent];
 }
 
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)

--- a/src/core/backbone_router/bbr_local.cpp
+++ b/src/core/backbone_router/bbr_local.cpp
@@ -443,21 +443,14 @@ void Local::AddDomainPrefixToNetworkData(void)
 
 const char *Local::ActionToString(Action aAction)
 {
-    static const char *const kActionStrings[] = {
-        "Set",    // (0) kActionSet
-        "Add",    // (1) kActionAdd
-        "Remove", // (2) kActionRemove
-    };
+#define ActionMapList(_) \
+    _(kActionSet, "Set") \
+    _(kActionAdd, "Add") \
+    _(kActionRemove, "Remove")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kActionSet);
-        ValidateNextEnum(kActionAdd);
-        ValidateNextEnum(kActionRemove);
-    };
+    DefineEnumStringArray(ActionMapList);
 
-    return kActionStrings[aAction];
+    return kStrings[aAction];
 }
 
 void Local::LogDomainPrefix(Action aAction, Error aError)

--- a/src/core/backbone_router/multicast_listeners_table.cpp
+++ b/src/core/backbone_router/multicast_listeners_table.cpp
@@ -136,22 +136,15 @@ void MulticastListenersTable::Log(Action              aAction,
                                   TimeMilli           aExpireTime,
                                   Error               aError) const
 {
-    static const char *const kActionStrings[] = {
-        "Add",    // (0) kAdd
-        "Remove", // (1) kRemove
-        "Expire", // (2) kExpire
-    };
+#define ActionMapList(_) \
+    _(kAdd, "Add")       \
+    _(kRemove, "Remove") \
+    _(kExpire, "Expire")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kAdd);
-        ValidateNextEnum(kRemove);
-        ValidateNextEnum(kExpire);
-    };
+    DefineEnumStringArray(ActionMapList);
 
-    LogDebg("%s %s expire %lu: %s", kActionStrings[aAction], aAddress.ToString().AsCString(),
-            ToUlong(aExpireTime.GetValue()), ErrorToString(aError));
+    LogDebg("%s %s expire %lu: %s", kStrings[aAction], aAddress.ToString().AsCString(), ToUlong(aExpireTime.GetValue()),
+            ErrorToString(aError));
 }
 #else
 void MulticastListenersTable::Log(Action, const Ip6::Address &, TimeMilli, Error) const {}

--- a/src/core/border_router/dhcp6_pd_client.cpp
+++ b/src/core/border_router/dhcp6_pd_client.cpp
@@ -1018,74 +1018,45 @@ exit:
 
 const char *Dhcp6PdClient::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "Stopped",    // (0) kStateStopped
-        "ToSolicit",  // (1) kStateToSolicit
-        "Soliciting", // (2) kStateSoliciting
-        "Requesting", // (3) kStateRequesting
-        "ToRenew",    // (4) kStateToRenew
-        "Renewing",   // (5) kStateRenewing
-        "Rebinding",  // (6) kStateRebinding
-        "Releasing",  // (7) kStateReleasing
-    };
+#define StateMapList(_)               \
+    _(kStateStopped, "Stopped")       \
+    _(kStateToSolicit, "ToSolicit")   \
+    _(kStateSoliciting, "Soliciting") \
+    _(kStateRequesting, "Requesting") \
+    _(kStateToRenew, "ToRenew")       \
+    _(kStateRenewing, "Renewing")     \
+    _(kStateRebinding, "Rebinding")   \
+    _(kStateReleasing, "Releasing")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kStateStopped);
-        ValidateNextEnum(kStateToSolicit);
-        ValidateNextEnum(kStateSoliciting);
-        ValidateNextEnum(kStateRequesting);
-        ValidateNextEnum(kStateToRenew);
-        ValidateNextEnum(kStateRenewing);
-        ValidateNextEnum(kStateRebinding);
-        ValidateNextEnum(kStateReleasing);
-    };
+    DefineEnumStringArray(StateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 const char *Dhcp6PdClient::MsgTypeToString(MsgType aMsgType)
 {
-    static const char *const kMsgTypeStrings[]{
-        "Solicit",            // (1) kMsgTypeSolicit
-        "Advertise",          // (2) kMsgTypeAdvertise
-        "Request",            // (3) kMsgTypeRequest
-        "Confirm",            // (4) kMsgTypeConfirm
-        "Renew",              // (5) kMsgTypeRenew
-        "Rebind",             // (6) kMsgTypeRebind
-        "Reply",              // (7) kMsgTypeReply
-        "Release",            // (8) kMsgTypeRelease
-        "Decline",            // (9) kMsgTypeDecline
-        "Reconfigure",        // (10) kMsgTypeReconfigure
-        "InformationRequest", // (11) kMsgTypeInformationRequest
-    };
+#define MsgTypeMapList(_)                 \
+    _(kMsgTypeNone, "UnknownMsg")         \
+    _(kMsgTypeSolicit, "Solicit")         \
+    _(kMsgTypeAdvertise, "Advertise")     \
+    _(kMsgTypeRequest, "Request")         \
+    _(kMsgTypeConfirm, "Confirm")         \
+    _(kMsgTypeRenew, "Renew")             \
+    _(kMsgTypeRebind, "Rebind")           \
+    _(kMsgTypeReply, "Reply")             \
+    _(kMsgTypeRelease, "Release")         \
+    _(kMsgTypeDecline, "Decline")         \
+    _(kMsgTypeReconfigure, "Reconfigure") \
+    _(kMsgTypeInformationRequest, "InformationRequest")
 
-    struct EnumCheck
+    DefineEnumStringArray(MsgTypeMapList);
+
+    if (aMsgType > kMsgTypeInformationRequest)
     {
-        InitEnumValidatorCounter();
-        SkipNextEnum();
-        ValidateNextEnum(kMsgTypeSolicit);
-        ValidateNextEnum(kMsgTypeAdvertise);
-        ValidateNextEnum(kMsgTypeRequest);
-        ValidateNextEnum(kMsgTypeConfirm);
-        ValidateNextEnum(kMsgTypeRenew);
-        ValidateNextEnum(kMsgTypeRebind);
-        ValidateNextEnum(kMsgTypeReply);
-        ValidateNextEnum(kMsgTypeRelease);
-        ValidateNextEnum(kMsgTypeDecline);
-        ValidateNextEnum(kMsgTypeReconfigure);
-        ValidateNextEnum(kMsgTypeInformationRequest);
-    };
+        aMsgType = kMsgTypeNone;
+    }
 
-    const char *string = "UnknownMsg";
-
-    VerifyOrExit(aMsgType != 0);
-    VerifyOrExit(aMsgType <= kMsgTypeInformationRequest);
-    string = kMsgTypeStrings[aMsgType - kMsgTypeSolicit];
-
-exit:
-    return string;
+    return kStrings[aMsgType];
 }
 
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)

--- a/src/core/border_router/multi_ail_detector.cpp
+++ b/src/core/border_router/multi_ail_detector.cpp
@@ -214,21 +214,14 @@ void MultiAilDetector::HandleTimer(void)
 
 const char *MultiAilDetector::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "Disabled", // (0) kStateDisabled
-        "Stopped",  // (1) kStateStopped
-        "Running",  // (2) kStateRunning
-    };
+#define StateMapList(_)           \
+    _(kStateDisabled, "Disabled") \
+    _(kStateStopped, "Stopped")   \
+    _(kStateRunning, "Running")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kStateDisabled);
-        ValidateNextEnum(kStateStopped);
-        ValidateNextEnum(kStateRunning);
-    };
+    DefineEnumStringArray(StateMapList)
 
-    return kStateStrings[aState];
+        return kStrings[aState];
 }
 
 #endif

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1086,21 +1086,14 @@ RoutingManager::OmrPrefixManager::InfoString RoutingManager::OmrPrefixManager::F
 
 const char *RoutingManager::OmrPrefixManager::OmrConfigToString(OmrConfig aConfig)
 {
-    static const char *const kConfigStrings[] = {
-        "auto",     // (0) kOmrConfigAuto
-        "custom",   // (1) kOmrConfigCustom
-        "disabled", // (2) kOmrConfigDisabled
-    };
+#define OmrConfigMapList(_)       \
+    _(kOmrConfigAuto, "auto")     \
+    _(kOmrConfigCustom, "custom") \
+    _(kOmrConfigDisabled, "disabled")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kOmrConfigAuto);
-        ValidateNextEnum(kOmrConfigCustom);
-        ValidateNextEnum(kOmrConfigDisabled);
-    };
+    DefineEnumStringArray(OmrConfigMapList);
 
-    return kConfigStrings[aConfig];
+    return kStrings[aConfig];
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1680,23 +1673,15 @@ void RoutingManager::OnLinkPrefixManager::HandleTimer(void)
 
 const char *RoutingManager::OnLinkPrefixManager::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "Removed",     // (0) kIdle
-        "Publishing",  // (1) kPublishing
-        "Advertising", // (2) kAdvertising
-        "Deprecating", // (3) kDeprecating
-    };
+#define OnLinkPrefixManagerStateMapList(_) \
+    _(kIdle, "Removed")                    \
+    _(kPublishing, "Publishing")           \
+    _(kAdvertising, "Advertising")         \
+    _(kDeprecating, "Deprecating")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kIdle);
-        ValidateNextEnum(kPublishing);
-        ValidateNextEnum(kAdvertising);
-        ValidateNextEnum(kDeprecating);
-    };
+    DefineEnumStringArray(OnLinkPrefixManagerStateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -2168,21 +2153,14 @@ exit:
 
 const char *RoutingManager::RoutePublisher::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "none",      // (0) kDoNotPublish
-        "def-route", // (1) kPublishDefault
-        "ula",       // (2) kPublishUla
-    };
+#define RoutePublisherStateMapList(_) \
+    _(kDoNotPublish, "none")          \
+    _(kPublishDefault, "def-route")   \
+    _(kPublishUla, "ula")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kDoNotPublish);
-        ValidateNextEnum(kPublishDefault);
-        ValidateNextEnum(kPublishUla);
-    };
+    DefineEnumStringArray(RoutePublisherStateMapList)
 
-    return kStateStrings[aState];
+        return kStrings[aState];
 }
 
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
@@ -2851,23 +2829,15 @@ exit:
 
 const char *RoutingManager::PdPrefixManager::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "Disabled", // (0) kDisabled
-        "Stopped",  // (1) kStopped
-        "Running",  // (2) kRunning
-        "Idle",     // (3) kIdle
-    };
+#define PdPrefixManagerStateMapList(_)   \
+    _(kDhcp6PdStateDisabled, "Disabled") \
+    _(kDhcp6PdStateStopped, "Stopped")   \
+    _(kDhcp6PdStateRunning, "Running")   \
+    _(kDhcp6PdStateIdle, "Idle")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kDhcp6PdStateDisabled);
-        ValidateNextEnum(kDhcp6PdStateStopped);
-        ValidateNextEnum(kDhcp6PdStateRunning);
-        ValidateNextEnum(kDhcp6PdStateIdle);
-    };
+    DefineEnumStringArray(PdPrefixManagerStateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 #if !OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_ENABLE

--- a/src/core/border_router/rx_ra_tracker.cpp
+++ b/src/core/border_router/rx_ra_tracker.cpp
@@ -1371,21 +1371,14 @@ exit:
 
 const char *RxRaTracker::RouterAdvOriginToString(RouterAdvOrigin aRaOrigin)
 {
-    static const char *const kOriginStrings[] = {
-        "",                          // (0) kAnotherRouter
-        "(this BR routing-manager)", // (1) kThisBrRoutingManager
-        "(this BR other sw entity)", // (2) kThisBrOtherEntity
-    };
+#define RouterAdvOriginMapList(_)                         \
+    _(kAnotherRouter, "")                                 \
+    _(kThisBrRoutingManager, "(this BR routing-manager)") \
+    _(kThisBrOtherEntity, "(this BR other sw entity)")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kAnotherRouter);
-        ValidateNextEnum(kThisBrRoutingManager);
-        ValidateNextEnum(kThisBrOtherEntity);
-    };
+    DefineEnumStringArray(RouterAdvOriginMapList);
 
-    return kOriginStrings[aRaOrigin];
+    return kStrings[aRaOrigin];
 }
 
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)

--- a/src/core/common/enum_to_string.hpp
+++ b/src/core/common/enum_to_string.hpp
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file defines utility macros for converting enums to string.
+ */
+
+#ifndef OT_CORE_COMMON_ENUM_TO_STRING_HPP_
+#define OT_CORE_COMMON_ENUM_TO_STRING_HPP_
+
+#include "common/string.hpp"
+
+/**
+ * Defines a `static constexpr` array named `kStrings[]` for enum to string conversion and validates it at
+ * compile-time.
+ *
+ * This macro uses the X-Macro pattern. It requires a list macro (`kMapList`) that defines the mapping between enum
+ * values and their string representations.
+ *
+ * The `kMapList` macro MUST accept a single parameter, which is a "visitor" macro (`_`). The visitor macro will be
+ * called for each entry in the list.
+ *
+ * The entries in `kMapList` MUST be sorted based on their enum value, starting from zero. Each entry MUST be a `_()`
+ * call with the enum value and its corresponding string literal.
+ *
+ * It is recommended to use `_` as the visitor macro parameter name. This helps `clang-format` to format the list with
+ * one entry per line, improving readability.
+ *
+ * Example:
+ *
+ *     #define StateMapList(_)       \
+ *         _(kStateIdle, "Idle")     \
+ *         _(kStateStart, "Start")   \
+ *         _(kStateRunning, "Running")
+ *
+ * `DefineEnumStringArray(StateMapList)` will expand at compile time to:
+ *
+ * 1. An `const` array definition:
+ *    `static constexpr const char *const kStrings[] = { "Idle", "Start", "Running", };`
+ *
+ * 2. A set of static assertions for validation:
+ *    `static_assert(AreConstStringsEqual(kStrings[kStateIdle], "Idle"), "kStateIdle is invalid");`
+ *    `static_assert(AreConstStringsEqual(kStrings[kStateStart], "Start"), "kStateStart is invalid");`
+ *    // ... and so on for all entries.
+ *
+ * The `kStrings[]` array can then be used to convert an enum value to its string representation.
+ *
+ * @param[in] kMapList   The X-Macro list that defines the enum-to-string mapping.
+ */
+#define DefineEnumStringArray(kMapList)                                                     \
+    static constexpr const char *const kStrings[] = {kMapList(_DefineEnumMapArrayElement)}; \
+    kMapList(_ValidateEnumMapEntry)
+
+//---------------------------------------------------------------------------------------------------------------------
+// Private macros
+
+#define _DefineEnumMapArrayElement(kEnum, kString) kString,
+
+#define _ValidateEnumMapEntry(kEnum, kString) \
+    static_assert(AreConstStringsEqual(kStrings[kEnum], kString), #kEnum " value is incorrect. list is not sorted");
+
+#endif // OT_CORE_COMMON_ENUM_TO_STRING_HPP_

--- a/src/core/common/error.cpp
+++ b/src/core/common/error.cpp
@@ -35,53 +35,55 @@
 
 #include "common/array.hpp"
 #include "common/code_utils.hpp"
+#include "common/enum_to_string.hpp"
 
 namespace ot {
 
 const char *ErrorToString(Error aError)
 {
-    static const char *const kErrorStrings[kNumErrors] = {
-        "OK",                         // (0)  kErrorNone
-        "Failed",                     // (1)  kErrorFailed
-        "Drop",                       // (2)  kErrorDrop
-        "NoBufs",                     // (3)  kErrorNoBufs
-        "NoRoute",                    // (4)  kErrorNoRoute
-        "Busy",                       // (5)  kErrorBusy
-        "Parse",                      // (6)  kErrorParse
-        "InvalidArgs",                // (7)  kErrorInvalidArgs
-        "Security",                   // (8)  kErrorSecurity
-        "AddressQuery",               // (9)  kErrorAddressQuery
-        "NoAddress",                  // (10) kErrorNoAddress
-        "Abort",                      // (11) kErrorAbort
-        "NotImplemented",             // (12) kErrorNotImplemented
-        "InvalidState",               // (13) kErrorInvalidState
-        "NoAck",                      // (14) kErrorNoAck
-        "ChannelAccessFailure",       // (15) kErrorChannelAccessFailure
-        "Detached",                   // (16) kErrorDetached
-        "FcsErr",                     // (17) kErrorFcs
-        "NoFrameReceived",            // (18) kErrorNoFrameReceived
-        "UnknownNeighbor",            // (19) kErrorUnknownNeighbor
-        "InvalidSourceAddress",       // (20) kErrorInvalidSourceAddress
-        "AddressFiltered",            // (21) kErrorAddressFiltered
-        "DestinationAddressFiltered", // (22) kErrorDestinationAddressFiltered
-        "NotFound",                   // (23) kErrorNotFound
-        "Already",                    // (24) kErrorAlready
-        "ReservedError25",            // (25) Error 25 is reserved
-        "Ipv6AddressCreationFailure", // (26) kErrorIp6AddressCreationFailure
-        "NotCapable",                 // (27) kErrorNotCapable
-        "ResponseTimeout",            // (28) kErrorResponseTimeout
-        "Duplicated",                 // (29) kErrorDuplicated
-        "ReassemblyTimeout",          // (30) kErrorReassemblyTimeout
-        "NotTmf",                     // (31) kErrorNotTmf
-        "NonLowpanDataFrame",         // (32) kErrorNotLowpanDataFrame
-        "ReservedError33",            // (33) Error 33 is reserved
-        "LinkMarginLow",              // (34) kErrorLinkMarginLow
-        "InvalidCommand",             // (35) kErrorInvalidCommand
-        "Pending",                    // (36) kErrorPending
-        "Rejected",                   // (37) kErrorRejected
-    };
+#define ErrorMapList(_)                                               \
+    _(kErrorNone, "OK")                                               \
+    _(kErrorFailed, "Failed")                                         \
+    _(kErrorDrop, "Drop")                                             \
+    _(kErrorNoBufs, "NoBufs")                                         \
+    _(kErrorNoRoute, "NoRoute")                                       \
+    _(kErrorBusy, "Busy")                                             \
+    _(kErrorParse, "Parse")                                           \
+    _(kErrorInvalidArgs, "InvalidArgs")                               \
+    _(kErrorSecurity, "Security")                                     \
+    _(kErrorAddressQuery, "AddressQuery")                             \
+    _(kErrorNoAddress, "NoAddress")                                   \
+    _(kErrorAbort, "Abort")                                           \
+    _(kErrorNotImplemented, "NotImplemented")                         \
+    _(kErrorInvalidState, "InvalidState")                             \
+    _(kErrorNoAck, "NoAck")                                           \
+    _(kErrorChannelAccessFailure, "ChannelAccessFailure")             \
+    _(kErrorDetached, "Detached")                                     \
+    _(kErrorFcs, "FcsErr")                                            \
+    _(kErrorNoFrameReceived, "NoFrameReceived")                       \
+    _(kErrorUnknownNeighbor, "UnknownNeighbor")                       \
+    _(kErrorInvalidSourceAddress, "InvalidSourceAddress")             \
+    _(kErrorAddressFiltered, "AddressFiltered")                       \
+    _(kErrorDestinationAddressFiltered, "DestinationAddressFiltered") \
+    _(kErrorNotFound, "NotFound")                                     \
+    _(kErrorAlready, "Already")                                       \
+    _(25, "ReservedError25")                                          \
+    _(kErrorIp6AddressCreationFailure, "Ipv6AddressCreationFailure")  \
+    _(kErrorNotCapable, "NotCapable")                                 \
+    _(kErrorResponseTimeout, "ResponseTimeout")                       \
+    _(kErrorDuplicated, "Duplicated")                                 \
+    _(kErrorReassemblyTimeout, "ReassemblyTimeout")                   \
+    _(kErrorNotTmf, "NotTmf")                                         \
+    _(kErrorNotLowpanDataFrame, "NonLowpanDataFrame")                 \
+    _(33, "ReservedError33")                                          \
+    _(kErrorLinkMarginLow, "LinkMarginLow")                           \
+    _(kErrorInvalidCommand, "InvalidCommand")                         \
+    _(kErrorPending, "Pending")                                       \
+    _(kErrorRejected, "Rejected")
 
-    return static_cast<size_t>(aError) < GetArrayLength(kErrorStrings) ? kErrorStrings[aError] : "UnknownErrorType";
+    DefineEnumStringArray(ErrorMapList);
+
+    return static_cast<size_t>(aError) < GetArrayLength(kStrings) ? kStrings[aError] : "UnknownErrorType";
 }
 
 } // namespace ot

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -336,23 +336,15 @@ exit:
 
 const char *Message::PriorityToString(Priority aPriority)
 {
-    static const char *const kPriorityStrings[] = {
-        "low",    // (0) kPriorityLow
-        "normal", // (1) kPriorityNormal
-        "high",   // (2) kPriorityHigh
-        "net",    // (3) kPriorityNet
-    };
+#define PriorityMapList(_)       \
+    _(kPriorityLow, "low")       \
+    _(kPriorityNormal, "normal") \
+    _(kPriorityHigh, "high")     \
+    _(kPriorityNet, "net")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kPriorityLow);
-        ValidateNextEnum(kPriorityNormal);
-        ValidateNextEnum(kPriorityHigh);
-        ValidateNextEnum(kPriorityNet);
-    };
+    DefineEnumStringArray(PriorityMapList);
 
-    return kPriorityStrings[aPriority];
+    return kStrings[aPriority];
 }
 
 void Message::RegisterTxCallback(TxCallback aCallback, void *aContext)

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -117,90 +117,59 @@ void SettingsBase::BorderAgentId::Log(Action aAction, const MeshCoP::BorderAgent
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 const char *SettingsBase::ActionToString(Action aAction)
 {
-    static const char *const kActionStrings[] = {
-        "Read",     // (0) kActionRead
-        "Saved",    // (1) kActionSave
-        "Re-saved", // (2) kActionResave
-        "Deleted",  // (3) kActionDelete
-#if OPENTHREAD_FTD
-        "Added",      // (4) kActionAdd,
-        "Removed",    // (5) kActionRemove,
-        "Deleted all" // (6) kActionDeleteAll
-#endif
-    };
+#define ActionMapList(_)         \
+    _(kActionRead, "Read")       \
+    _(kActionSave, "Saved")      \
+    _(kActionResave, "Re-saved") \
+    _(kActionDelete, "Deleted")  \
+    FtdActionMapList(_)
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kActionRead);
-        ValidateNextEnum(kActionSave);
-        ValidateNextEnum(kActionResave);
-        ValidateNextEnum(kActionDelete);
 #if OPENTHREAD_FTD
-        ValidateNextEnum(kActionAdd);
-        ValidateNextEnum(kActionRemove);
-        ValidateNextEnum(kActionDeleteAll);
+#define FtdActionMapList(_)     \
+    _(kActionAdd, "Added")      \
+    _(kActionRemove, "Removed") \
+    _(kActionDeleteAll, "Deleted all")
+#else
+#define FtdActionMapList(_)
 #endif
-    };
 
-    return kActionStrings[aAction];
+    DefineEnumStringArray(ActionMapList);
+
+    return kStrings[aAction];
 }
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
 const char *SettingsBase::KeyToString(Key aKey)
 {
-    static const char *const kKeyStrings[] = {
-        "",                  // (0)  (Unused)
-        "ActiveDataset",     // (1)  kKeyActiveDataset
-        "PendingDataset",    // (2)  kKeyPendingDataset
-        "NetworkInfo",       // (3)  kKeyNetworkInfo
-        "ParentInfo",        // (4)  kKeyParentInfo
-        "ChildInfo",         // (5)  kKeyChildInfo
-        "",                  // (6)  Removed (previously auto-start).
-        "SlaacIidSecretKey", // (7)  kKeySlaacIidSecretKey
-        "DadInfo",           // (8)  kKeyDadInfo
-        "",                  // (9)  Removed (previously OMR prefix).
-        "",                  // (10) Removed (previously on-link prefix).
-        "SrpEcdsaKey",       // (11) kKeySrpEcdsaKey
-        "SrpClientInfo",     // (12) kKeySrpClientInfo
-        "SrpServerInfo",     // (13) kKeySrpServerInfo
-        "",                  // (14) Removed (previously NAT64 prefix)
-        "BrUlaPrefix",       // (15) kKeyBrUlaPrefix
-        "BrOnLinkPrefixes",  // (16) kKeyBrOnLinkPrefixes
-        "BorderAgentId",     // (17) kKeyBorderAgentId
-        "TcatCommrCert"      // (18) kKeyTcatCommrCert
-    };
+#define KeyMapList(_)                             \
+    _(0, "")                                      \
+    _(kKeyActiveDataset, "ActiveDataset")         \
+    _(kKeyPendingDataset, "PendingDataset")       \
+    _(kKeyNetworkInfo, "NetworkInfo")             \
+    _(kKeyParentInfo, "ParentInfo")               \
+    _(kKeyChildInfo, "ChildInfo")                 \
+    _(6, "")                                      \
+    _(kKeySlaacIidSecretKey, "SlaacIidSecretKey") \
+    _(kKeyDadInfo, "DadInfo")                     \
+    _(9, "")                                      \
+    _(10, "")                                     \
+    _(kKeySrpEcdsaKey, "SrpEcdsaKey")             \
+    _(kKeySrpClientInfo, "SrpClientInfo")         \
+    _(kKeySrpServerInfo, "SrpServerInfo")         \
+    _(14, "")                                     \
+    _(kKeyBrUlaPrefix, "BrUlaPrefix")             \
+    _(kKeyBrOnLinkPrefixes, "BrOnLinkPrefixes")   \
+    _(kKeyBorderAgentId, "BorderAgentId")         \
+    _(kKeyTcatCommrCert, "TcatCommrCert")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        SkipNextEnum();
-        ValidateNextEnum(kKeyActiveDataset);
-        ValidateNextEnum(kKeyPendingDataset);
-        ValidateNextEnum(kKeyNetworkInfo);
-        ValidateNextEnum(kKeyParentInfo);
-        ValidateNextEnum(kKeyChildInfo);
-        SkipNextEnum();
-        ValidateNextEnum(kKeySlaacIidSecretKey);
-        ValidateNextEnum(kKeyDadInfo);
-        SkipNextEnum();
-        SkipNextEnum();
-        ValidateNextEnum(kKeySrpEcdsaKey);
-        ValidateNextEnum(kKeySrpClientInfo);
-        ValidateNextEnum(kKeySrpServerInfo);
-        SkipNextEnum();
-        ValidateNextEnum(kKeyBrUlaPrefix);
-        ValidateNextEnum(kKeyBrOnLinkPrefixes);
-        ValidateNextEnum(kKeyBorderAgentId);
-        ValidateNextEnum(kKeyTcatCommrCert);
-    };
+    DefineEnumStringArray(KeyMapList);
 
     static_assert(kLastKey == kKeyTcatCommrCert, "kLastKey is not valid");
 
     OT_ASSERT(aKey <= kLastKey);
 
-    return kKeyStrings[aKey];
+    return kStrings[aKey];
 }
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
 

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -47,6 +47,7 @@
 #include "common/array.hpp"
 #include "common/as_core_type.hpp"
 #include "common/debug.hpp"
+#include "common/enum_to_string.hpp"
 #include "common/error.hpp"
 #include "common/heap.hpp"
 #include "common/locator.hpp"

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2303,45 +2303,37 @@ uint8_t Mac::ComputeLinkMargin(int8_t aRss) const { return ot::ComputeLinkMargin
 
 const char *Mac::OperationToString(Operation aOperation)
 {
-    static const char *const kOperationStrings[] = {
-        "Idle",               // (0) kOperationIdle
-        "ActiveScan",         // (1) kOperationActiveScan
-        "EnergyScan",         // (2) kOperationEnergyScan
-        "TransmitBeacon",     // (3) kOperationTransmitBeacon
-        "TransmitDataDirect", // (4) kOperationTransmitDataDirect
-        "TransmitPoll",       // (5) kOperationTransmitPoll
-        "WaitingForData",     // (6) kOperationWaitingForData
+#define OperationMapList(_)                               \
+    _(kOperationIdle, "Idle")                             \
+    _(kOperationActiveScan, "ActiveScan")                 \
+    _(kOperationEnergyScan, "EnergyScan")                 \
+    _(kOperationTransmitBeacon, "TransmitBeacon")         \
+    _(kOperationTransmitDataDirect, "TransmitDataDirect") \
+    _(kOperationTransmitPoll, "TransmitPoll")             \
+    _(kOperationWaitingForData, "WaitingForData")         \
+    FtdOperationMapList(_) CslTxOperationMapList(_) WakeupOperationMapList(_)
+
 #if OPENTHREAD_FTD
-        "TransmitDataIndirect", // (7) kOperationTransmitDataIndirect
+#define FtdOperationMapList(_) _(kOperationTransmitDataIndirect, "TransmitDataIndirect")
+#else
+#define FtdOperationMapList(_)
 #endif
+
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-        "TransmitDataCsl", // (8) kOperationTransmitDataCsl
+#define CslTxOperationMapList(_) _(kOperationTransmitDataCsl, "TransmitDataCsl")
+#else
+#define CslTxOperationMapList(_)
 #endif
+
 #if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
-        "TransmitWakeup", // kOperationTransmitWakeup
+#define WakeupOperationMapList(_) _(kOperationTransmitWakeup, "TransmitWakeup")
+#else
+#define WakeupOperationMapList(_)
 #endif
-    };
 
-    struct OperationChecker
-    {
-        InitEnumValidatorCounter();
+    DefineEnumStringArray(OperationMapList);
 
-        ValidateNextEnum(kOperationIdle);
-        ValidateNextEnum(kOperationActiveScan);
-        ValidateNextEnum(kOperationEnergyScan);
-        ValidateNextEnum(kOperationTransmitBeacon);
-        ValidateNextEnum(kOperationTransmitDataDirect);
-        ValidateNextEnum(kOperationTransmitPoll);
-        ValidateNextEnum(kOperationWaitingForData);
-#if OPENTHREAD_FTD
-        ValidateNextEnum(kOperationTransmitDataIndirect);
-#endif
-#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-        ValidateNextEnum(kOperationTransmitDataCsl);
-#endif
-    };
-
-    return kOperationStrings[aOperation];
+    return kStrings[aOperation];
 }
 
 void Mac::LogFrameRxFailure(const RxFrame *aFrame, Error aError) const

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -1126,46 +1126,36 @@ exit:
 
 const char *SubMac::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "Disabled",    // (0) kStateDisabled
-        "Sleep",       // (1) kStateSleep
-        "Receive",     // (2) kStateReceive
-        "CsmaBackoff", // (3) kStateCsmaBackoff
-        "Transmit",    // (4) kStateTransmit
-        "EnergyScan",  // (5) kStateEnergyScan
+#define StateMapList(_)                 \
+    _(kStateDisabled, "Disabled")       \
+    _(kStateSleep, "Sleep")             \
+    _(kStateReceive, "Receive")         \
+    _(kStateCsmaBackoff, "CsmaBackoff") \
+    _(kStateTransmit, "Transmit")       \
+    _(kStateEnergyScan, "EnergyScan")   \
+    DelayBeforeRetxStateMapList(_) ClsTxStateMapList(_) RadioSampleMapList(_)
+
 #if OPENTHREAD_CONFIG_MAC_ADD_DELAY_ON_NO_ACK_ERROR_BEFORE_RETRY
-        "DelayBeforeRetx", // (6) kStateDelayBeforeRetx
+#define DelayBeforeRetxStateMapList(_) _(kStateDelayBeforeRetx, "DelayBeforeRetx")
+#else
+#define DelayBeforeRetxStateMapList(_)
 #endif
+
 #if !OPENTHREAD_MTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-        "CslTransmit", // (7) kStateCslTransmit
+#define ClsTxStateMapList(_) _(kStateCslTransmit, "CslTransmit")
+#else
+#define ClsTxStateMapList(_)
 #endif
+
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-        "RadioSample", // (8) kStateRadioSample
+#define RadioSampleMapList(_) _(kStateRadioSample, "RadioSample")
+#else
+#define RadioSampleMapList(_)
 #endif
-    };
 
-    struct StateValueChecker
-    {
-        InitEnumValidatorCounter();
+    DefineEnumStringArray(StateMapList);
 
-        ValidateNextEnum(kStateDisabled);
-        ValidateNextEnum(kStateSleep);
-        ValidateNextEnum(kStateReceive);
-        ValidateNextEnum(kStateCsmaBackoff);
-        ValidateNextEnum(kStateTransmit);
-        ValidateNextEnum(kStateEnergyScan);
-#if OPENTHREAD_CONFIG_MAC_ADD_DELAY_ON_NO_ACK_ERROR_BEFORE_RETRY
-        ValidateNextEnum(kStateDelayBeforeRetx);
-#endif
-#if !OPENTHREAD_MTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-        ValidateNextEnum(kStateCslTransmit);
-#endif
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-        ValidateNextEnum(kStateRadioSample);
-#endif
-    };
-
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 // LCOV_EXCL_STOP

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -1074,22 +1074,14 @@ void Manager::CoapDtlsSession::HandleTimer(void)
 
 void Manager::CoapDtlsSession::LogUri(Action aAction, const char *aUriString, const char *aTxt)
 {
-    static const char *const kActionStrings[] = {
-        "Receive", // kReceive
-        "Send",    // kSend
-        "Forward", // kForward,
-    };
+#define ActionMapList(_)   \
+    _(kReceive, "Receive") \
+    _(kSend, "Send")       \
+    _(kForward, "Forward")
 
-    struct EnumChecker
-    {
-        InitEnumValidatorCounter();
+    DefineEnumStringArray(ActionMapList);
 
-        ValidateNextEnum(kReceive);
-        ValidateNextEnum(kSend);
-        ValidateNextEnum(kForward);
-    };
-
-    LogInfo("%s %s%s - session %u", kActionStrings[aAction], aUriString, aTxt, mIndex);
+    LogInfo("%s %s%s - session %u", kStrings[aAction], aUriString, aTxt, mIndex);
 }
 
 #endif

--- a/src/core/meshcop/border_agent_ephemeral_key.cpp
+++ b/src/core/meshcop/border_agent_ephemeral_key.cpp
@@ -377,54 +377,34 @@ exit:
 
 const char *EphemeralKeyManager::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "Disabled",  // (0) kStateDisabled
-        "Stopped",   // (1) kStateStopped
-        "Started",   // (2) kStateStarted
-        "Connected", // (3) kStateConnected
-        "Accepted",  // (4) kStateAccepted
-    };
+#define StateMapList(_)             \
+    _(kStateDisabled, "Disabled")   \
+    _(kStateStopped, "Stopped")     \
+    _(kStateStarted, "Started")     \
+    _(kStateConnected, "Connected") \
+    _(kStateAccepted, "Accepted")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kStateDisabled);
-        ValidateNextEnum(kStateStopped);
-        ValidateNextEnum(kStateStarted);
-        ValidateNextEnum(kStateConnected);
-        ValidateNextEnum(kStateAccepted);
-    };
+    DefineEnumStringArray(StateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 const char *EphemeralKeyManager::DeactivationReasonToString(DeactivationReason aReason)
 {
-    static const char *const kReasonStrings[] = {
-        "LocalDisconnect",   // (0) kReasonLocalDisconnect
-        "PeerDisconnect",    // (1) kReasonPeerDisconnect
-        "SessionError",      // (2) kReasonSessionError
-        "SessionTimeout",    // (3) kReasonSessionTimeout
-        "MaxFailedAttempts", // (4) kReasonMaxFailedAttempts
-        "EpskcTimeout",      // (5) kReasonEpskcTimeout
-        "Unknown",           // (6) kReasonUnknown
-    };
+#define ReasonMapList(_)                             \
+    _(kReasonLocalDisconnect, "LocalDisconnect")     \
+    _(kReasonPeerDisconnect, "PeerDisconnect")       \
+    _(kReasonSessionError, "SessionError")           \
+    _(kReasonSessionTimeout, "SessionTimeout")       \
+    _(kReasonMaxFailedAttempts, "MaxFailedAttempts") \
+    _(kReasonEpskcTimeout, "EpskcTimeout")           \
+    _(kReasonUnknown, "Unknown")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kReasonLocalDisconnect);
-        ValidateNextEnum(kReasonPeerDisconnect);
-        ValidateNextEnum(kReasonSessionError);
-        ValidateNextEnum(kReasonSessionTimeout);
-        ValidateNextEnum(kReasonMaxFailedAttempts);
-        ValidateNextEnum(kReasonEpskcTimeout);
-        ValidateNextEnum(kReasonUnknown);
-    };
+    DefineEnumStringArray(ReasonMapList);
 
-    return kReasonStrings[aReason];
+    return kStrings[aReason];
 }
 
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)

--- a/src/core/meshcop/border_agent_tracker.cpp
+++ b/src/core/meshcop/border_agent_tracker.cpp
@@ -259,21 +259,14 @@ void Tracker::LogOnError(Error, const char *, const char *) {}
 
 const char *Tracker::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "Stopped",
-        "PendingDnssd",
-        "Running",
-    };
+#define StateMapList(_)                   \
+    _(kStateStopped, "Stopped")           \
+    _(kStatePendingDnssd, "PendingDnssd") \
+    _(kStateRunning, "Running")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kStateStopped);
-        ValidateNextEnum(kStatePendingDnssd);
-        ValidateNextEnum(kStateRunning);
-    };
+    DefineEnumStringArray(StateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -1029,21 +1029,14 @@ exit:
 
 const char *Commissioner::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "disabled", // (0) kStateDisabled
-        "petition", // (1) kStatePetition
-        "active",   // (2) kStateActive
-    };
+#define StateMapList(_)           \
+    _(kStateDisabled, "disabled") \
+    _(kStatePetition, "petition") \
+    _(kStateActive, "active")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kStateDisabled);
-        ValidateNextEnum(kStatePetition);
-        ValidateNextEnum(kStateActive);
-    };
+    DefineEnumStringArray(StateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 void Commissioner::LogJoinerEntry(const char *aAction, const Joiner &aJoiner) const

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -581,27 +581,17 @@ void Joiner::HandleTimer(void)
 
 const char *Joiner::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "Idle",       // (0) kStateIdle
-        "Discover",   // (1) kStateDiscover
-        "Connecting", // (2) kStateConnect
-        "Connected",  // (3) kStateConnected
-        "Entrust",    // (4) kStateEntrust
-        "Joined",     // (5) kStateJoined
-    };
+#define StateMapList(_)             \
+    _(kStateIdle, "Idle")           \
+    _(kStateDiscover, "Discover")   \
+    _(kStateConnect, "Connecting")  \
+    _(kStateConnected, "Connected") \
+    _(kStateEntrust, "Entrust")     \
+    _(kStateJoined, "Joined")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kStateIdle);
-        ValidateNextEnum(kStateDiscover);
-        ValidateNextEnum(kStateConnect);
-        ValidateNextEnum(kStateConnected);
-        ValidateNextEnum(kStateEntrust);
-        ValidateNextEnum(kStateJoined);
-    };
+    DefineEnumStringArray(StateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 // LCOV_EXCL_STOP

--- a/src/core/meshcop/secure_transport.cpp
+++ b/src/core/meshcop/secure_transport.cpp
@@ -611,25 +611,16 @@ void SecureSession::Process(void)
 
 const char *SecureSession::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "Disconnected",  // (0) kStateDisconnected
-        "Initializing",  // (1) kStateInitializing
-        "Connecting",    // (2) kStateConnecting
-        "Connected",     // (3) kStateConnected
-        "Disconnecting", // (4) kStateDisconnecting
-    };
+#define StateMapList(_)                   \
+    _(kStateDisconnected, "Disconnected") \
+    _(kStateInitializing, "Initializing") \
+    _(kStateConnecting, "Connecting")     \
+    _(kStateConnected, "Connected")       \
+    _(kStateDisconnecting, "Disconnecting")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kStateDisconnected);
-        ValidateNextEnum(kStateInitializing);
-        ValidateNextEnum(kStateConnecting);
-        ValidateNextEnum(kStateConnected);
-        ValidateNextEnum(kStateDisconnecting);
-    };
+    DefineEnumStringArray(StateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 #endif

--- a/src/core/net/dns_dso.cpp
+++ b/src/core/net/dns_dso.cpp
@@ -1295,77 +1295,47 @@ exit:
 
 const char *Dso::Connection::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "Disconnected",            // (0) kStateDisconnected,
-        "Connecting",              // (1) kStateConnecting,
-        "ConnectedButSessionless", // (2) kStateConnectedButSessionless,
-        "EstablishingSession",     // (3) kStateEstablishingSession,
-        "SessionEstablished",      // (4) kStateSessionEstablished,
-    };
+#define StateMapList(_)                                         \
+    _(kStateDisconnected, "Disconnected")                       \
+    _(kStateConnecting, "Connecting")                           \
+    _(kStateConnectedButSessionless, "ConnectedButSessionless") \
+    _(kStateEstablishingSession, "EstablishingSession")         \
+    _(kStateSessionEstablished, "SessionEstablished")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kStateDisconnected);
-        ValidateNextEnum(kStateConnecting);
-        ValidateNextEnum(kStateConnectedButSessionless);
-        ValidateNextEnum(kStateEstablishingSession);
-        ValidateNextEnum(kStateSessionEstablished);
-    };
+    DefineEnumStringArray(StateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 const char *Dso::Connection::MessageTypeToString(MessageType aMessageType)
 {
-    static const char *const kMessageTypeStrings[] = {
-        "Request",        // (0) kRequestMessage
-        "Response",       // (1) kResponseMessage
-        "Unidirectional", // (2) kUnidirectionalMessage
-    };
+#define MessageTypeMapList(_)       \
+    _(kRequestMessage, "Request")   \
+    _(kResponseMessage, "Response") \
+    _(kUnidirectionalMessage, "Unidirectional")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kRequestMessage);
-        ValidateNextEnum(kResponseMessage);
-        ValidateNextEnum(kUnidirectionalMessage);
-    };
+    DefineEnumStringArray(MessageTypeMapList);
 
-    return kMessageTypeStrings[aMessageType];
+    return kStrings[aMessageType];
 }
 
 const char *Dso::Connection::DisconnectReasonToString(DisconnectReason aReason)
 {
-    static const char *const kDisconnectReasonStrings[] = {
-        "FailedToConnect",         // (0) kReasonFailedToConnect
-        "ResponseTimeout",         // (1) kReasonResponseTimeout
-        "PeerDoesNotSupportDso",   // (2) kReasonPeerDoesNotSupportDso
-        "PeerClosed",              // (3) kReasonPeerClosed
-        "PeerAborted",             // (4) kReasonPeerAborted
-        "InactivityTimeout",       // (5) kReasonInactivityTimeout
-        "KeepAliveTimeout",        // (6) kReasonKeepAliveTimeout
-        "ServerRetryDelayRequest", // (7) kReasonServerRetryDelayRequest
-        "PeerMisbehavior",         // (8) kReasonPeerMisbehavior
-        "Unknown",                 // (9) kReasonUnknown
-    };
+#define DisconnectReasonMapList(_)                               \
+    _(kReasonFailedToConnect, "FailedToConnect")                 \
+    _(kReasonResponseTimeout, "ResponseTimeout")                 \
+    _(kReasonPeerDoesNotSupportDso, "PeerDoesNotSupportDso")     \
+    _(kReasonPeerClosed, "PeerClosed")                           \
+    _(kReasonPeerAborted, "PeerAborted")                         \
+    _(kReasonInactivityTimeout, "InactivityTimeout")             \
+    _(kReasonKeepAliveTimeout, "KeepAliveTimeout")               \
+    _(kReasonServerRetryDelayRequest, "ServerRetryDelayRequest") \
+    _(kReasonPeerMisbehavior, "PeerMisbehavior")                 \
+    _(kReasonUnknown, "Unknown")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kReasonFailedToConnect);
-        ValidateNextEnum(kReasonResponseTimeout);
-        ValidateNextEnum(kReasonPeerDoesNotSupportDso);
-        ValidateNextEnum(kReasonPeerClosed);
-        ValidateNextEnum(kReasonPeerAborted);
-        ValidateNextEnum(kReasonInactivityTimeout);
-        ValidateNextEnum(kReasonKeepAliveTimeout);
-        ValidateNextEnum(kReasonServerRetryDelayRequest);
-        ValidateNextEnum(kReasonPeerMisbehavior);
-        ValidateNextEnum(kReasonUnknown);
-    };
+    DefineEnumStringArray(DisconnectReasonMapList);
 
-    return kDisconnectReasonStrings[aReason];
+    return kStrings[aReason];
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1514,23 +1514,15 @@ const char *Ip6::IpProtoToString(uint8_t aIpProto)
 
 const char *Ip6::EcnToString(Ecn aEcn)
 {
-    static const char *const kEcnStrings[] = {
-        "no", // (0) kEcnNotCapable
-        "e1", // (1) kEcnCapable1  (ECT1)
-        "e0", // (2) kEcnCapable0  (ECT0)
-        "ce", // (3) kEcnMarked    (Congestion Encountered)
-    };
+#define EcnMapList(_)                \
+    _(kEcnNotCapable, "no")          \
+    _(kEcnCapable1, "e1") /* ECT1*/  \
+    _(kEcnCapable0, "e0") /* ECT0 */ \
+    _(kEcnMarked, "ce")   /* Congestion Encountered */
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kEcnNotCapable);
-        ValidateNextEnum(kEcnCapable1);
-        ValidateNextEnum(kEcnCapable0);
-        ValidateNextEnum(kEcnMarked);
-    };
+    DefineEnumStringArray(EcnMapList);
 
-    return kEcnStrings[aEcn];
+    return kStrings[aEcn];
 }
 
 // LCOV_EXCL_STOP

--- a/src/core/net/mdns.cpp
+++ b/src/core/net/mdns.cpp
@@ -4101,25 +4101,16 @@ bool Core::TxMessage::ShouldClearAppendStateOnReinit(const Entry &aEntry) const
 
 const char *Core::TxMessage::TypeToString(Type aType)
 {
-    static const char *const kTypeStrings[] = {
-        "multicast probe",         // kMulticastProbe
-        "multicast query",         // kMulticastQuery
-        "multicast response",      // kMulticastResponse
-        "unicast response",        // kUnicastResponse
-        "legacy-unicast response", // kLegacyUnicastResponse
-    };
+#define TypeMapList(_)                          \
+    _(kMulticastProbe, "multicast probe")       \
+    _(kMulticastQuery, "multicast query")       \
+    _(kMulticastResponse, "multicast response") \
+    _(kUnicastResponse, "unicast response")     \
+    _(kLegacyUnicastResponse, "legacy-unicast response")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kMulticastProbe);
-        ValidateNextEnum(kMulticastQuery);
-        ValidateNextEnum(kMulticastResponse);
-        ValidateNextEnum(kUnicastResponse);
-        ValidateNextEnum(kLegacyUnicastResponse);
-    };
+    DefineEnumStringArray(TypeMapList);
 
-    return kTypeStrings[aType];
+    return kStrings[aType];
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/core/net/nat64_translator.cpp
+++ b/src/core/net/nat64_translator.cpp
@@ -40,23 +40,15 @@ namespace Nat64 {
 
 const char *StateToString(State aState)
 {
-    static const char *const kStateString[] = {
-        "Disabled",
-        "NotRunning",
-        "Idle",
-        "Active",
-    };
+#define StateMapList(_)               \
+    _(kStateDisabled, "Disabled")     \
+    _(kStateNotRunning, "NotRunning") \
+    _(kStateIdle, "Idle")             \
+    _(kStateActive, "Active")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kStateDisabled);
-        ValidateNextEnum(kStateNotRunning);
-        ValidateNextEnum(kStateIdle);
-        ValidateNextEnum(kStateActive);
-    };
+    DefineEnumStringArray(StateMapList);
 
-    return kStateString[aState];
+    return kStrings[aState];
 }
 
 #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE

--- a/src/core/net/slaac_address.cpp
+++ b/src/core/net/slaac_address.cpp
@@ -460,21 +460,14 @@ exit:
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 void Slaac::LogAddress(Action aAction, const SlaacAddress &aAddress)
 {
-    static const char *const kActionStrings[] = {
-        "Adding",      // (0) kAdding
-        "Removing",    // (1) kRemoving
-        "Deprecating", // (2) kDeprecating
-    };
+#define ActionMapList(_)     \
+    _(kAdding, "Adding")     \
+    _(kRemoving, "Removing") \
+    _(kDeprecating, "Deprecating")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kAdding);
-        ValidateNextEnum(kRemoving);
-        ValidateNextEnum(kDeprecating);
-    };
+    DefineEnumStringArray(ActionMapList);
 
-    LogInfo("%s %s", kActionStrings[aAction], aAddress.GetAddress().ToString().AsCString());
+    LogInfo("%s %s", kStrings[aAction], aAddress.GetAddress().ToString().AsCString());
 }
 #else
 void Slaac::LogAddress(Action, const SlaacAddress &) {}

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -241,27 +241,17 @@ uint32_t Client::TxJitter::DetermineDelay(void)
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 const char *Client::TxJitter::ReasonToString(Reason aReason)
 {
-    static const char *const kReasonStrings[] = {
-        "OnDeviceReboot",    // (0) kOnDeviceReboot
-        "OnServerStart",     // (1) kOnServerStart
-        "OnServerRestart",   // (2) kOnServerRestart
-        "OnServerSwitch",    // (3) kOnServerSwitch
-        "OnSlaacAddrAdd",    // (4) kOnSlaacAddrAdd
-        "OnSlaacAddrRemove", // (5) kOnSlaacAddrRemove
-    };
+#define ReasonMapList(_)                   \
+    _(kOnDeviceReboot, "OnDeviceReboot")   \
+    _(kOnServerStart, "OnServerStart")     \
+    _(kOnServerRestart, "OnServerRestart") \
+    _(kOnServerSwitch, "OnServerSwitch")   \
+    _(kOnSlaacAddrAdd, "OnSlaacAddrAdd")   \
+    _(kOnSlaacAddrRemove, "OnSlaacAddrRemove")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kOnDeviceReboot);
-        ValidateNextEnum(kOnServerStart);
-        ValidateNextEnum(kOnServerRestart);
-        ValidateNextEnum(kOnServerSwitch);
-        ValidateNextEnum(kOnSlaacAddrAdd);
-        ValidateNextEnum(kOnSlaacAddrRemove);
-    };
+    DefineEnumStringArray(ReasonMapList);
 
-    return kReasonStrings[aReason];
+    return kStrings[aReason];
 }
 #endif
 
@@ -314,27 +304,17 @@ void Client::AutoStart::InvokeCallback(const Ip6::SockAddr *aServerSockAddr) con
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 const char *Client::AutoStart::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "Disabled",      // (0) kDisabled
-        "1stTimeSelect", // (1) kFirstTimeSelecting
-        "Reselect",      // (2) kReselecting
-        "Unicast-prf",   // (3) kSelectedUnicastPreferred
-        "Anycast",       // (4) kSelectedAnycast
-        "Unicast",       // (5) kSelectedUnicast
-    };
+#define AutoStartStateMapList(_)                \
+    _(kDisabled, "Disabled")                    \
+    _(kFirstTimeSelecting, "1stTimeSelect")     \
+    _(kReselecting, "Reselect")                 \
+    _(kSelectedUnicastPreferred, "Unicast-prf") \
+    _(kSelectedAnycast, "Anycast")              \
+    _(kSelectedUnicast, "Unicast")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kDisabled);
-        ValidateNextEnum(kFirstTimeSelecting);
-        ValidateNextEnum(kReselecting);
-        ValidateNextEnum(kSelectedUnicastPreferred);
-        ValidateNextEnum(kSelectedAnycast);
-        ValidateNextEnum(kSelectedUnicast);
-    };
+    DefineEnumStringArray(AutoStartStateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 #endif
 
@@ -2576,45 +2556,36 @@ exit:
 
 const char *Client::ItemStateToString(ItemState aState)
 {
-    static const char *const kItemStateStrings[] = {
-        "ToAdd",      // kToAdd      (0)
-        "Adding",     // kAdding     (1)
-        "ToRefresh",  // kToRefresh  (2)
-        "Refreshing", // kRefreshing (3)
-        "ToRemove",   // kToRemove   (4)
-        "Removing",   // kRemoving   (5)
-        "Registered", // kRegistered (6)
-        "Removed",    // kRemoved    (7)
-    };
+#define ItemStateMapList(_)      \
+    _(kToAdd, "ToAdd")           \
+    _(kAdding, "Adding")         \
+    _(kToRefresh, "ToRefresh")   \
+    _(kRefreshing, "Refreshing") \
+    _(kToRemove, "ToRemove")     \
+    _(kRemoving, "Removing")     \
+    _(kRegistered, "Registered") \
+    _(kRemoved, "Removed")
 
-    return kItemStateStrings[aState];
+    DefineEnumStringArray(ItemStateMapList);
+
+    return kStrings[aState];
 }
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 const char *Client::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "Stopped",  // kStateStopped  (0)
-        "Paused",   // kStatePaused   (1)
-        "ToUpdate", // kStateToUpdate (2)
-        "Updating", // kStateUpdating (3)
-        "Updated",  // kStateUpdated  (4)
-        "ToRetry",  // kStateToRetry  (5)
-    };
+#define StateMapList(_)           \
+    _(kStateStopped, "Stopped")   \
+    _(kStatePaused, "Paused")     \
+    _(kStateToUpdate, "ToUpdate") \
+    _(kStateUpdating, "Updating") \
+    _(kStateUpdated, "Updated")   \
+    _(kStateToRetry, "ToRetry")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kStateStopped);
-        ValidateNextEnum(kStatePaused);
-        ValidateNextEnum(kStateToUpdate);
-        ValidateNextEnum(kStateUpdating);
-        ValidateNextEnum(kStateUpdated);
-        ValidateNextEnum(kStateToRetry);
-    };
+    DefineEnumStringArray(StateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 void Client::LogRetryWaitInterval(void) const

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -1867,21 +1867,14 @@ void Server::HandleOutstandingUpdatesTimer(void)
 
 const char *Server::AddressModeToString(AddressMode aMode)
 {
-    static const char *const kAddressModeStrings[] = {
-        "unicast",           // (0) kAddressModeUnicast
-        "anycast",           // (1) kAddressModeAnycast
-        "unicast-force-add", // (2) kAddressModeUnicastForceAdd
-    };
+#define AddressModeMapList(_)         \
+    _(kAddressModeUnicast, "unicast") \
+    _(kAddressModeAnycast, "anycast") \
+    _(kAddressModeUnicastForceAdd, "unicast-force-add")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kAddressModeUnicast);
-        ValidateNextEnum(kAddressModeAnycast);
-        ValidateNextEnum(kAddressModeUnicastForceAdd);
-    };
+    DefineEnumStringArray(AddressModeMapList);
 
-    return kAddressModeStrings[aMode];
+    return kStrings[aMode];
 }
 
 void Server::UpdateResponseCounters(Dns::UpdateHeader::Response aResponseCode)
@@ -2080,27 +2073,16 @@ bool Server::Service::HasSubTypeServiceName(const char *aSubTypeServiceName) con
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 void Server::Service::Log(Action aAction) const
 {
-    static const char *const kActionStrings[] = {
-        "Add new",                   // (0) kAddNew
-        "Update existing",           // (1) kUpdateExisting
-        "Keep unchanged",            // (2) kKeepUnchanged
-        "Remove but retain name of", // (3) kRemoveButRetainName
-        "Fully remove",              // (4) kFullyRemove
-        "LEASE expired for",         // (5) kLeaseExpired
-        "KEY LEASE expired for",     // (6) kKeyLeaseExpired
-    };
+#define ActionMapList(_)                                 \
+    _(kAddNew, "Add new")                                \
+    _(kUpdateExisting, "Update existing")                \
+    _(kKeepUnchanged, "Keep unchanged")                  \
+    _(kRemoveButRetainName, "Remove but retain name of") \
+    _(kFullyRemove, "Fully remove")                      \
+    _(kLeaseExpired, "LEASE expired for")                \
+    _(kKeyLeaseExpired, "KEY LEASE expired for")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kAddNew);
-        ValidateNextEnum(kUpdateExisting);
-        ValidateNextEnum(kKeepUnchanged);
-        ValidateNextEnum(kRemoveButRetainName);
-        ValidateNextEnum(kFullyRemove);
-        ValidateNextEnum(kLeaseExpired);
-        ValidateNextEnum(kKeyLeaseExpired);
-    };
+    DefineEnumStringArray(ActionMapList);
 
     // We only log if the `Service` is marked as committed. This
     // ensures that temporary `Service` entries associated with a
@@ -2109,7 +2091,7 @@ void Server::Service::Log(Action aAction) const
 
     if (mIsCommitted)
     {
-        LogInfo("%s service '%s'", kActionStrings[aAction], GetInstanceName());
+        LogInfo("%s service '%s'", kStrings[aAction], GetInstanceName());
 
         for (const Heap::String &subType : mSubTypes)
         {

--- a/src/core/radio/trel_link.cpp
+++ b/src/core/radio/trel_link.cpp
@@ -510,23 +510,15 @@ void Link::HandleNotifierEvents(Events aEvents)
 
 const char *Link::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "Disabled", // (0) kStateDisabled
-        "Sleep",    // (1) kStateSleep
-        "Receive",  // (2) kStateReceive
-        "Transmit", // (3) kStateTransmit
-    };
+#define StateMapList(_)           \
+    _(kStateDisabled, "Disabled") \
+    _(kStateSleep, "Sleep")       \
+    _(kStateReceive, "Receive")   \
+    _(kStateTransmit, "Transmit")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kStateDisabled);
-        ValidateNextEnum(kStateSleep);
-        ValidateNextEnum(kStateReceive);
-        ValidateNextEnum(kStateTransmit);
-    };
+    DefineEnumStringArray(StateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 // LCOV_EXCL_STOP

--- a/src/core/radio/trel_peer.cpp
+++ b/src/core/radio/trel_peer.cpp
@@ -259,21 +259,14 @@ bool Peer::NameMatch(const Heap::String &aHeapString, const char *aName)
 
 const char *Peer::DnssdStateToString(DnssdState aState)
 {
-    static const char *const kStateStrings[] = {
-        "resolved",  // (0) kDnssdResolved
-        "removed",   // (1) kDnssdRemoved
-        "resolving", // (2) kDnssdResolving
-    };
+#define DnssdStateMapList(_)      \
+    _(kDnssdResolved, "resolved") \
+    _(kDnssdRemoved, "removed")   \
+    _(kDnssdResolving, "resolving")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kDnssdResolved);
-        ValidateNextEnum(kDnssdRemoved);
-        ValidateNextEnum(kDnssdResolving);
-    };
+    DefineEnumStringArray(DnssdStateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 void Peer::Log(Action aAction) const
@@ -316,25 +309,16 @@ void Peer::Log(Action aAction) const
 
 const char *Peer::ActionToString(Action aAction)
 {
-    static const char *const kActionStrings[] = {
-        "Added",    // (0) kAdded
-        "Re-added", // (1) kReAdded,
-        "Updated",  // (2) kUpdated
-        "Deleted",  // (3) kDeleted
-        "Evicting", // (4) kEvicting
-    };
+#define ActionMapList(_)    \
+    _(kAdded, "Added")      \
+    _(kReAdded, "Re-added") \
+    _(kUpdated, "Updated")  \
+    _(kDeleted, "Deleted")  \
+    _(kEvicting, "Evicting")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kAdded);
-        ValidateNextEnum(kReAdded);
-        ValidateNextEnum(kUpdated);
-        ValidateNextEnum(kDeleted);
-        ValidateNextEnum(kEvicting);
-    };
+    DefineEnumStringArray(ActionMapList);
 
-    return kActionStrings[aAction];
+    return kStrings[aAction];
 }
 
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -1069,51 +1069,43 @@ exit:
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
+const char *AddressResolver::EntryChangeToString(EntryChange aChange)
+{
+#define EntryChangeMapList(_)   \
+    _(kEntryAdded, "added")     \
+    _(kEntryUpdated, "updated") \
+    _(kEntryRemoved, "removed")
+
+    DefineEnumStringArray(EntryChangeMapList);
+
+    return kStrings[aChange];
+}
+
+const char *AddressResolver::ReasonToString(Reason aReason)
+{
+#define ReasonMapList(_)                                        \
+    _(kReasonQueryRequest, "query request")                     \
+    _(kReasonSnoop, "snoop")                                    \
+    _(kReasonReceivedNotification, "rx notification")           \
+    _(kReasonRemovingRouterId, "removing router id")            \
+    _(kReasonRemovingRloc16, "removing rloc16")                 \
+    _(kReasonReceivedIcmpDstUnreachNoRoute, "rx icmp no route") \
+    _(kReasonEvictingForNewEntry, "evicting for new entry")     \
+    _(kReasonRemovingEid, "removing eid")
+
+    DefineEnumStringArray(ReasonMapList);
+
+    return kStrings[aReason];
+}
+
 void AddressResolver::LogCacheEntryChange(EntryChange       aChange,
                                           Reason            aReason,
                                           const CacheEntry &aEntry,
                                           CacheEntryList   *aList)
 {
-    static const char *const kChangeStrings[] = {
-        "added",   // (0) kEntryAdded
-        "updated", // (1) kEntryUpdated
-        "removed", // (2) kEntryRemoved
-    };
-
-    static const char *const kReasonStrings[] = {
-        "query request",          // (0) kReasonQueryRequest
-        "snoop",                  // (1) kReasonSnoop
-        "rx notification",        // (2) kReasonReceivedNotification
-        "removing router id",     // (3) kReasonRemovingRouterId
-        "removing rloc16",        // (4) kReasonRemovingRloc16
-        "rx icmp no route",       // (5) kReasonReceivedIcmpDstUnreachNoRoute
-        "evicting for new entry", // (6) kReasonEvictingForNewEntry
-        "removing eid",           // (7) kReasonRemovingEid
-    };
-
-    struct ChangeEnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kEntryAdded);
-        ValidateNextEnum(kEntryUpdated);
-        ValidateNextEnum(kEntryRemoved);
-    };
-
-    struct ReasonEnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kReasonQueryRequest);
-        ValidateNextEnum(kReasonSnoop);
-        ValidateNextEnum(kReasonReceivedNotification);
-        ValidateNextEnum(kReasonRemovingRouterId);
-        ValidateNextEnum(kReasonRemovingRloc16);
-        ValidateNextEnum(kReasonReceivedIcmpDstUnreachNoRoute);
-        ValidateNextEnum(kReasonEvictingForNewEntry);
-        ValidateNextEnum(kReasonRemovingEid);
-    };
-
-    LogInfo("Cache entry %s: %s, 0x%04x%s%s - %s", kChangeStrings[aChange], aEntry.GetTarget().ToString().AsCString(),
-            aEntry.GetRloc16(), (aList == nullptr) ? "" : ", list:", ListToString(aList), kReasonStrings[aReason]);
+    LogInfo("Cache entry %s: %s, 0x%04x%s%s - %s", EntryChangeToString(aChange),
+            aEntry.GetTarget().ToString().AsCString(), aEntry.GetRloc16(),
+            (aList == nullptr) ? "" : ", list:", ListToString(aList), ReasonToString(aReason));
 }
 
 const char *AddressResolver::ListToString(const CacheEntryList *aList) const

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -379,6 +379,11 @@ private:
 
     static AddressResolver::CacheEntry *GetEntryAfter(CacheEntry *aPrev, CacheEntryList &aList);
 
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
+    static const char *EntryChangeToString(EntryChange aChange);
+    static const char *ReasonToString(Reason aReason);
+#endif
+
     CacheEntryPool     mCacheEntryPool;
     CacheEntryList     mCachedList;
     CacheEntryList     mSnoopedList;

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1363,42 +1363,32 @@ exit:
 
 const char *MeshForwarder::MessageActionToString(MessageAction aAction, Error aError)
 {
-    static const char *const kMessageActionStrings[] = {
-        "Received",                    // (0) kMessageReceive
-        "Sent",                        // (1) kMessageTransmit
-        "Prepping indir tx",           // (2) kMessagePrepareIndirect
-        "Dropping",                    // (3) kMessageDrop
-        "Dropping (reassembly queue)", // (4) kMessageReassemblyDrop
-        "Evicting",                    // (5) kMessageEvict
+#define MessageActionMapList(_)                              \
+    _(kMessageReceive, "Received")                           \
+    _(kMessageTransmit, "Sent")                              \
+    _(kMessagePrepareIndirect, "Prepping indir tx")          \
+    _(kMessageDrop, "Dropping")                              \
+    _(kMessageReassemblyDrop, "Dropping (reassembly queue)") \
+    _(kMessageEvict, "Evicting")                             \
+    QueueMgmntMessageActionMapList(_) DropQueueFullMessageActionMapList(_)
+
 #if OPENTHREAD_CONFIG_DELAY_AWARE_QUEUE_MANAGEMENT_ENABLE
-        "Marked ECN",            // (6) kMessageMarkEcn
-        "Dropping (queue mgmt)", // (7) kMessageQueueMgmtDrop
+#define QueueMgmntMessageActionMapList(_) \
+    _(kMessageMarkEcn, "Marked ECN")      \
+    _(kMessageQueueMgmtDrop, "Dropping (queue mgmt)")
+#else
+#define QueueMgmntMessageActionMapList(_)
 #endif
+
 #if (OPENTHREAD_CONFIG_MAX_FRAMES_IN_DIRECT_TX_QUEUE > 0)
-        "Dropping (dir queue full)", // (8) kMessageFullQueueDrop
+#define DropQueueFullMessageActionMapList(_) _(kMessageFullQueueDrop, "Dropping (dir queue full)")
+#else
+#define DropQueueFullMessageActionMapList(_)
 #endif
-    };
 
-    const char *string = kMessageActionStrings[aAction];
+    DefineEnumStringArray(MessageActionMapList);
 
-    struct MessageActionChecker
-    {
-        InitEnumValidatorCounter();
-
-        ValidateNextEnum(kMessageReceive);
-        ValidateNextEnum(kMessageTransmit);
-        ValidateNextEnum(kMessagePrepareIndirect);
-        ValidateNextEnum(kMessageDrop);
-        ValidateNextEnum(kMessageReassemblyDrop);
-        ValidateNextEnum(kMessageEvict);
-#if OPENTHREAD_CONFIG_DELAY_AWARE_QUEUE_MANAGEMENT_ENABLE
-        ValidateNextEnum(kMessageMarkEcn);
-        ValidateNextEnum(kMessageQueueMgmtDrop);
-#endif
-#if (OPENTHREAD_CONFIG_MAX_FRAMES_IN_DIRECT_TX_QUEUE > 0)
-        ValidateNextEnum(kMessageFullQueueDrop);
-#endif
-    };
+    const char *string = kStrings[aAction];
 
     if ((aAction == kMessageTransmit) && (aError != kErrorNone))
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2877,124 +2877,84 @@ void Mle::LogError(MessageAction aAction, MessageType aType, Error aError)
 
 const char *Mle::MessageActionToString(MessageAction aAction)
 {
-    static const char *const kMessageActionStrings[] = {
-        "Send",           // (0) kMessageSend
-        "Receive",        // (1) kMessageReceive
-        "Delay",          // (2) kMessageDelay
-        "Remove Delayed", // (3) kMessageRemoveDelayed
-    };
+#define MessageActionMapList(_)   \
+    _(kMessageSend, "Send")       \
+    _(kMessageReceive, "Receive") \
+    _(kMessageDelay, "Delay")     \
+    _(kMessageRemoveDelayed, "Remove Delayed")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kMessageSend);
-        ValidateNextEnum(kMessageReceive);
-        ValidateNextEnum(kMessageDelay);
-        ValidateNextEnum(kMessageRemoveDelayed);
-    };
+    DefineEnumStringArray(MessageActionMapList);
 
-    return kMessageActionStrings[aAction];
+    return kStrings[aAction];
 }
 
 const char *Mle::MessageTypeToString(MessageType aType)
 {
-    static const char *const kMessageTypeStrings[] = {
-        "Advertisement",         // (0)  kTypeAdvertisement
-        "Announce",              // (1)  kTypeAnnounce
-        "Child ID Request",      // (2)  kTypeChildIdRequest
-        "Child ID Request",      // (3)  kTypeChildIdRequestShort
-        "Child ID Response",     // (4)  kTypeChildIdResponse
-        "Child Update Request",  // (5)  kTypeChildUpdateRequestAsChild
-        "Child Update Response", // (6)  kTypeChildUpdateResponseAsChild
-        "Data Request",          // (7)  kTypeDataRequest
-        "Data Response",         // (8)  kTypeDataResponse
-        "Discovery Request",     // (9)  kTypeDiscoveryRequest
-        "Discovery Response",    // (10) kTypeDiscoveryResponse
-        "delayed message",       // (11) kTypeGenericDelayed
-        "UDP",                   // (12) kTypeGenericUdp
-        "Parent Request",        // (13) kTypeParentRequestToRouters
-        "Parent Request",        // (14) kTypeParentRequestToRoutersReeds
-        "Parent Response",       // (15) kTypeParentResponse
-#if OPENTHREAD_FTD
-        "Address Release",         // (16) kTypeAddressRelease
-        "Address Release Reply",   // (17) kTypeAddressReleaseReply
-        "Address Reply",           // (18) kTypeAddressReply
-        "Address Solicit",         // (19) kTypeAddressSolicit
-        "Child Update Request",    // (20) kTypeChildUpdateRequestOfChild
-        "Child Update Response",   // (21) kTypeChildUpdateResponseOfChild
-        "Child Update Response",   // (22) kTypeChildUpdateResponseOfUnknownChild
-        "Link Accept",             // (23) kTypeLinkAccept
-        "Link Accept and Request", // (24) kTypeLinkAcceptAndRequest
-        "Link Reject",             // (25) kTypeLinkReject
-        "Link Request",            // (26) kTypeLinkRequest
-        "Parent Request",          // (27) kTypeParentRequest
-#endif
-#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
-        "Link Metrics Management Request",  // (28) kTypeLinkMetricsManagementRequest
-        "Link Metrics Management Response", // (29) kTypeLinkMetricsManagementResponse
-        "Link Probe",                       // (30) kTypeLinkProbe
-#endif
-#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-        "Time Sync", // (31) kTypeTimeSync
-#endif
-#if OPENTHREAD_CONFIG_P2P_ENABLE
-        "P2P Link Request",            // (32) kTypeP2pLinkRequest
-        "P2P Link Accept and Request", // (33) kTypeP2pLinkAcceptAndRequest
-        "P2P Link Accept",             // (34) kTypeP2pLinkAccept
-        "P2P Link Tear Down",          // (35) kTypeP2pLinkTearDown
-#endif
-    };
+#define MessageTypeMapList(_)                                   \
+    _(kTypeAdvertisement, "Advertisement")                      \
+    _(kTypeAnnounce, "Announce")                                \
+    _(kTypeChildIdRequest, "Child ID Request")                  \
+    _(kTypeChildIdRequestShort, "Child ID Request")             \
+    _(kTypeChildIdResponse, "Child ID Response")                \
+    _(kTypeChildUpdateRequestAsChild, "Child Update Request")   \
+    _(kTypeChildUpdateResponseAsChild, "Child Update Response") \
+    _(kTypeDataRequest, "Data Request")                         \
+    _(kTypeDataResponse, "Data Response")                       \
+    _(kTypeDiscoveryRequest, "Discovery Request")               \
+    _(kTypeDiscoveryResponse, "Discovery Response")             \
+    _(kTypeGenericDelayed, "delayed message")                   \
+    _(kTypeGenericUdp, "UDP")                                   \
+    _(kTypeParentRequestToRouters, "Parent Request")            \
+    _(kTypeParentRequestToRoutersReeds, "Parent Request")       \
+    _(kTypeParentResponse, "Parent Response")                   \
+    FtdMessageTypeMapList(_) LinkMetricsMessageTypeMapList(_) TimeSyncMessageTypeMapList(_) P2pMessageTypeMapList(_)
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kTypeAdvertisement);
-        ValidateNextEnum(kTypeAnnounce);
-        ValidateNextEnum(kTypeChildIdRequest);
-        ValidateNextEnum(kTypeChildIdRequestShort);
-        ValidateNextEnum(kTypeChildIdResponse);
-        ValidateNextEnum(kTypeChildUpdateRequestAsChild);
-        ValidateNextEnum(kTypeChildUpdateResponseAsChild);
-        ValidateNextEnum(kTypeDataRequest);
-        ValidateNextEnum(kTypeDataResponse);
-        ValidateNextEnum(kTypeDiscoveryRequest);
-        ValidateNextEnum(kTypeDiscoveryResponse);
-        ValidateNextEnum(kTypeGenericDelayed);
-        ValidateNextEnum(kTypeGenericUdp);
-        ValidateNextEnum(kTypeParentRequestToRouters);
-        ValidateNextEnum(kTypeParentRequestToRoutersReeds);
-        ValidateNextEnum(kTypeParentResponse);
 #if OPENTHREAD_FTD
-        ValidateNextEnum(kTypeAddressRelease);
-        ValidateNextEnum(kTypeAddressReleaseReply);
-        ValidateNextEnum(kTypeAddressReply);
-        ValidateNextEnum(kTypeAddressSolicit);
-        ValidateNextEnum(kTypeChildUpdateRequestOfChild);
-        ValidateNextEnum(kTypeChildUpdateResponseOfChild);
-        ValidateNextEnum(kTypeChildUpdateResponseOfUnknownChild);
-        ValidateNextEnum(kTypeLinkAccept);
-        ValidateNextEnum(kTypeLinkAcceptAndRequest);
-        ValidateNextEnum(kTypeLinkReject);
-        ValidateNextEnum(kTypeLinkRequest);
-        ValidateNextEnum(kTypeParentRequest);
+#define FtdMessageTypeMapList(_)                                       \
+    _(kTypeAddressRelease, "Address Release")                          \
+    _(kTypeAddressReleaseReply, "Address Release Reply")               \
+    _(kTypeAddressReply, "Address Reply")                              \
+    _(kTypeAddressSolicit, "Address Solicit")                          \
+    _(kTypeChildUpdateRequestOfChild, "Child Update Request")          \
+    _(kTypeChildUpdateResponseOfChild, "Child Update Response")        \
+    _(kTypeChildUpdateResponseOfUnknownChild, "Child Update Response") \
+    _(kTypeLinkAccept, "Link Accept")                                  \
+    _(kTypeLinkAcceptAndRequest, "Link Accept and Request")            \
+    _(kTypeLinkReject, "Link Reject")                                  \
+    _(kTypeLinkRequest, "Link Request")                                \
+    _(kTypeParentRequest, "Parent Request")
+#else
+#define FtdMessageTypeMapList(_)
 #endif
-#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
-        ValidateNextEnum(kTypeLinkMetricsManagementRequest);
-        ValidateNextEnum(kTypeLinkMetricsManagementResponse);
-        ValidateNextEnum(kTypeLinkProbe);
-#endif
-#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-        ValidateNextEnum(kTypeTimeSync);
-#endif
-#if OPENTHREAD_CONFIG_P2P_ENABLE
-        ValidateNextEnum(kTypeP2pLinkRequest);
-        ValidateNextEnum(kTypeP2pLinkAcceptAndRequest);
-        ValidateNextEnum(kTypeP2pLinkAccept);
-        ValidateNextEnum(kTypeP2pLinkTearDown);
-#endif
-    };
 
-    return kMessageTypeStrings[aType];
+#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
+#define LinkMetricsMessageTypeMapList(_)                                      \
+    _(kTypeLinkMetricsManagementRequest, "Link Metrics Management Request")   \
+    _(kTypeLinkMetricsManagementResponse, "Link Metrics Management Response") \
+    _(kTypeLinkProbe, "Link Probe")
+#else
+#define LinkMetricsMessageTypeMapList(_)
+#endif
+
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+#define TimeSyncMessageTypeMapList(_) _(kTypeTimeSync, "Time Sync")
+#else
+#define TimeSyncMessageTypeMapList(_)
+#endif
+
+#if OPENTHREAD_CONFIG_P2P_ENABLE
+#define P2pMessageTypeMapList(_)                                   \
+    _(kTypeP2pLinkRequest, "P2P Link Request")                     \
+    _(kTypeP2pLinkAcceptAndRequest, "P2P Link Accept and Request") \
+    _(kTypeP2pLinkAccept, "P2P Link Accept")                       \
+    _(kTypeP2pLinkTearDown, "P2P Link Tear Down")
+#else
+#define P2pMessageTypeMapList(_)
+#endif
+
+    DefineEnumStringArray(MessageTypeMapList);
+
+    return kStrings[aType];
 }
 
 const char *Mle::MessageTypeActionToSuffixString(MessageType aType, MessageAction aAction)
@@ -5442,25 +5402,16 @@ exit:
 
 const char *Mle::Attacher::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "Idle",       // (0) kStateIdle
-        "Start",      // (1) kStateStart
-        "ParentReq",  // (2) kStateParent
-        "Announce",   // (3) kStateAnnounce
-        "ChildIdReq", // (4) kStateChildIdRequest
-    };
+#define AttacherStateMapList(_)         \
+    _(kStateIdle, "Idle")               \
+    _(kStateStart, "Start")             \
+    _(kStateParentRequest, "ParentReq") \
+    _(kStateAnnounce, "Announce")       \
+    _(kStateChildIdRequest, "ChildIdReq")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kStateIdle);
-        ValidateNextEnum(kStateStart);
-        ValidateNextEnum(kStateParentRequest);
-        ValidateNextEnum(kStateAnnounce);
-        ValidateNextEnum(kStateChildIdRequest);
-    };
+    DefineEnumStringArray(AttacherStateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
@@ -5469,46 +5420,29 @@ const char *Mle::Attacher::StateToString(State aState)
 
 const char *Mle::Attacher::AttachModeToString(AttachMode aMode)
 {
-    static const char *const kAttachModeStrings[] = {
-        "AnyPartition",    // (0) kAnyPartition
-        "SamePartition",   // (1) kSamePartition
-        "BetterPartition", // (2) kBetterPartition
-        "DowngradeToReed", // (3) kDowngradeToReed
-        "BetterParent",    // (4) kBetterParent
-        "SelectedParent",  // (5) kSelectedParent
-    };
+#define AttachModeMapList(_)               \
+    _(kAnyPartition, "AnyPartition")       \
+    _(kSamePartition, "SamePartition")     \
+    _(kBetterPartition, "BetterPartition") \
+    _(kDowngradeToReed, "DowngradeToReed") \
+    _(kBetterParent, "BetterParent")       \
+    _(kSelectedParent, "SelectedParent")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kAnyPartition);
-        ValidateNextEnum(kSamePartition);
-        ValidateNextEnum(kBetterPartition);
-        ValidateNextEnum(kDowngradeToReed);
-        ValidateNextEnum(kBetterParent);
-        ValidateNextEnum(kSelectedParent);
-    };
+    DefineEnumStringArray(AttachModeMapList);
 
-    return kAttachModeStrings[aMode];
+    return kStrings[aMode];
 }
 
 const char *Mle::Attacher::ReattachModeToString(ReattachMode aMode)
 {
-    static const char *const kReattachModeStrings[] = {
-        "",                                 // (0) kReattachModeStop
-        "reattaching with Active Dataset",  // (1) kReattachModeActive
-        "reattaching with Pending Dataset", // (2) kReattachModePending
-    };
+#define ReattachModeMapList(_)                                \
+    _(kReattachModeStop, "")                                  \
+    _(kReattachModeActive, "reattaching with Active Dataset") \
+    _(kReattachModePending, "reattaching with Pending Dataset")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kReattachModeStop);
-        ValidateNextEnum(kReattachModeActive);
-        ValidateNextEnum(kReattachModePending);
-    };
+    DefineEnumStringArray(ReattachModeMapList);
 
-    return kReattachModeStrings[aMode];
+    return kStrings[aMode];
 }
 
 #endif // OT_SHOULD_LOG_AT( OT_LOG_LEVEL_NOTE)

--- a/src/core/thread/mle_types.cpp
+++ b/src/core/thread/mle_types.cpp
@@ -36,6 +36,7 @@
 #include "common/array.hpp"
 #include "common/bit_utils.hpp"
 #include "common/code_utils.hpp"
+#include "common/enum_to_string.hpp"
 #include "common/message.hpp"
 #include "common/random.hpp"
 #include "utils/static_counter.hpp"
@@ -193,25 +194,16 @@ bool RxChallenge::operator==(const TxChallenge &aTxChallenge) const
 
 const char *RoleToString(DeviceRole aRole)
 {
-    static const char *const kRoleStrings[] = {
-        "disabled", // (0) kRoleDisabled
-        "detached", // (1) kRoleDetached
-        "child",    // (2) kRoleChild
-        "router",   // (3) kRoleRouter
-        "leader",   // (4) kRoleLeader
-    };
+#define RoleMapList(_)           \
+    _(kRoleDisabled, "disabled") \
+    _(kRoleDetached, "detached") \
+    _(kRoleChild, "child")       \
+    _(kRoleRouter, "router")     \
+    _(kRoleLeader, "leader")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kRoleDisabled);
-        ValidateNextEnum(kRoleDetached);
-        ValidateNextEnum(kRoleChild);
-        ValidateNextEnum(kRoleRouter);
-        ValidateNextEnum(kRoleLeader);
-    };
+    DefineEnumStringArray(RoleMapList);
 
-    return (aRole < GetArrayLength(kRoleStrings)) ? kRoleStrings[aRole] : "invalid";
+    return (aRole < GetArrayLength(kStrings)) ? kStrings[aRole] : "invalid";
 }
 
 } // namespace Mle

--- a/src/core/thread/neighbor.cpp
+++ b/src/core/thread/neighbor.cpp
@@ -228,31 +228,19 @@ void Neighbor::RemoveAllForwardTrackingSeriesInfo(void)
 
 const char *Neighbor::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "Invalid",        // (0) kStateInvalid
-        "Restored",       // (1) kStateRestored
-        "ParentReq",      // (2) kStateParentRequest
-        "ParentRes",      // (3) kStateParentResponse
-        "ChildIdReq",     // (4) kStateChildIdRequest
-        "LinkReq",        // (5) kStateLinkRequest
-        "ChildUpdateReq", // (6) kStateChildUpdateRequest
-        "Valid",          // (7) kStateValid
-    };
+#define StateMapList(_)                           \
+    _(kStateInvalid, "Invalid")                   \
+    _(kStateRestored, "Restored")                 \
+    _(kStateParentRequest, "ParentReq")           \
+    _(kStateParentResponse, "ParentRes")          \
+    _(kStateChildIdRequest, "ChildIdReq")         \
+    _(kStateLinkRequest, "LinkReq")               \
+    _(kStateChildUpdateRequest, "ChildUpdateReq") \
+    _(kStateValid, "Valid")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kStateInvalid);
-        ValidateNextEnum(kStateRestored);
-        ValidateNextEnum(kStateParentRequest);
-        ValidateNextEnum(kStateParentResponse);
-        ValidateNextEnum(kStateChildIdRequest);
-        ValidateNextEnum(kStateLinkRequest);
-        ValidateNextEnum(kStateChildUpdateRequest);
-        ValidateNextEnum(kStateValid);
-    };
+    DefineEnumStringArray(StateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 } // namespace ot

--- a/src/core/thread/network_data_publisher.cpp
+++ b/src/core/thread/network_data_publisher.cpp
@@ -462,25 +462,16 @@ void Publisher::Entry::LogUpdateTime(void) const
 
 const char *Publisher::Entry::StateToString(State aState)
 {
-    static const char *const kStateStrings[] = {
-        "NoEntry",  // (0) kNoEntry
-        "ToAdd",    // (1) kToAdd
-        "Adding",   // (2) kAdding
-        "Added",    // (3) kAdded
-        "Removing", // (4) kRemoving
-    };
+#define StateMapList(_)    \
+    _(kNoEntry, "NoEntry") \
+    _(kToAdd, "ToAdd")     \
+    _(kAdding, "Adding")   \
+    _(kAdded, "Added")     \
+    _(kRemoving, "Removing")
 
-    struct EnumCheck
-    {
-        InitEnumValidatorCounter();
-        ValidateNextEnum(kNoEntry);
-        ValidateNextEnum(kToAdd);
-        ValidateNextEnum(kAdding);
-        ValidateNextEnum(kAdded);
-        ValidateNextEnum(kRemoving);
-    };
+    DefineEnumStringArray(StateMapList);
 
-    return kStateStrings[aState];
+    return kStrings[aState];
 }
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE


### PR DESCRIPTION
This commit introduces a new `DefineEnumStringArray` macro to simplify the conversion of enums to their string representations. This utility uses the X-Macro pattern to generate a `constexpr` lookup array and validates the enum-to-string mapping at compile time using `static_assert`.

This approach replaces a more verbose and error-prone pattern that required manual definition of a string array and a separate struct for validation.