### PR TITLE
[udp] add `BindToNetif()` and socket state checks

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (567)
+#define OPENTHREAD_API_VERSION (568)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/udp.h
+++ b/include/openthread/udp.h
@@ -157,13 +157,14 @@ otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSett
 /**
  * Open a UDP/IPv6 socket.
  *
- * @param[in]  aInstance  A pointer to an OpenThread instance.
- * @param[in]  aSocket    A pointer to a UDP socket structure.
- * @param[in]  aCallback  A pointer to the application callback function.
- * @param[in]  aContext   A pointer to application-specific context.
+ * @param[in]      aInstance  A pointer to an OpenThread instance.
+ * @param[in,out]  aSocket    A pointer to a UDP socket structure.
+ * @param[in]      aCallback  A pointer to the application callback function.
+ * @param[in]      aContext   A pointer to application-specific context.
  *
- * @retval OT_ERROR_NONE    Successfully opened the socket.
- * @retval OT_ERROR_FAILED  Failed to open the socket.
+ * @retval OT_ERROR_NONE      Successfully opened the socket.
+ * @retval OT_ERROR_ALREADY   Socket is already open.
+ * @retval OT_ERROR_FAILED    Failed to open the socket.
  */
 otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aContext);
 
@@ -180,10 +181,12 @@ bool otUdpIsOpen(otInstance *aInstance, const otUdpSocket *aSocket);
 /**
  * Close a UDP/IPv6 socket.
  *
- * @param[in]  aInstance  A pointer to an OpenThread instance.
- * @param[in]  aSocket    A pointer to a UDP socket structure.
+ * Calling `otUdpClose()` on a socket that is not open is safe and has no effect.
  *
- * @retval OT_ERROR_NONE   Successfully closed the socket.
+ * @param[in]      aInstance  A pointer to an OpenThread instance.
+ * @param[in,out]  aSocket    A pointer to a UDP socket structure.
+ *
+ * @retval OT_ERROR_NONE   Successfully closed the socket, or the socket was not open.
  * @retval OT_ERROR_FAILED Failed to close UDP Socket.
  */
 otError otUdpClose(otInstance *aInstance, otUdpSocket *aSocket);
@@ -191,25 +194,28 @@ otError otUdpClose(otInstance *aInstance, otUdpSocket *aSocket);
 /**
  * Bind a UDP/IPv6 socket.
  *
- * @param[in]  aInstance  A pointer to an OpenThread instance.
- * @param[in]  aSocket    A pointer to a UDP socket structure.
- * @param[in]  aSockName  A pointer to an IPv6 socket address structure.
- * @param[in]  aNetif     The network interface to bind.
+ * @param[in]      aInstance  A pointer to an OpenThread instance.
+ * @param[in,out]  aSocket    A pointer to a UDP socket structure.
+ * @param[in]      aSockName  A pointer to an IPv6 socket address structure.
+ * @param[in]      aNetif     The network interface to bind.
  *
- * @retval OT_ERROR_NONE   Bind operation was successful.
- * @retval OT_ERROR_FAILED Failed to bind UDP socket.
+ * @retval OT_ERROR_NONE            Bind operation was successful.
+ * @retval OT_ERROR_INVALID_ARGS    The socket is not open.
+ * @retval OT_ERROR_ALREADY         The socket is already bound.
+ * @retval OT_ERROR_FAILED          Failed to bind UDP socket.
  */
 otError otUdpBind(otInstance *aInstance, otUdpSocket *aSocket, const otSockAddr *aSockName, otNetifIdentifier aNetif);
 
 /**
  * Connect a UDP/IPv6 socket.
  *
- * @param[in]  aInstance  A pointer to an OpenThread instance.
- * @param[in]  aSocket    A pointer to a UDP socket structure.
- * @param[in]  aSockName  A pointer to an IPv6 socket address structure.
+ * @param[in]      aInstance  A pointer to an OpenThread instance.
+ * @param[in,out]  aSocket    A pointer to a UDP socket structure.
+ * @param[in]      aSockName  A pointer to an IPv6 socket address structure.
  *
- * @retval OT_ERROR_NONE   Connect operation was successful.
- * @retval OT_ERROR_FAILED Failed to connect UDP socket.
+ * @retval OT_ERROR_NONE            Connect operation was successful.
+ * @retval OT_ERROR_INVALID_ARGS    The socket is not open.
+ * @retval OT_ERROR_FAILED          Failed to connect UDP socket.
  */
 otError otUdpConnect(otInstance *aInstance, otUdpSocket *aSocket, const otSockAddr *aSockName);
 
@@ -226,7 +232,7 @@ otError otUdpConnect(otInstance *aInstance, otUdpSocket *aSocket, const otSockAd
  * including freeing @p aMessage if the message buffer is no longer needed.
  *
  * @retval OT_ERROR_NONE           The message is successfully scheduled for sending.
- * @retval OT_ERROR_INVALID_ARGS   Invalid arguments are given.
+ * @retval OT_ERROR_INVALID_ARGS   The socket is not open, or invalid arguments are given.
  * @retval OT_ERROR_NO_BUFS        Insufficient available buffer to add the UDP and IPv6 headers.
  */
 otError otUdpSend(otInstance *aInstance, otUdpSocket *aSocket, otMessage *aMessage, const otMessageInfo *aMessageInfo);

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -44,7 +44,8 @@ otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSett
 
 otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aContext)
 {
-    return AsCoreType(aInstance).Get<Ip6::Udp>().Open(AsCoreType(aSocket), Ip6::kNetifThreadHost, aCallback, aContext);
+    return AsCoreType(aInstance).Get<Ip6::Udp>().Open(AsCoreType(aSocket), Ip6::kNetifThreadInternal, aCallback,
+                                                      aContext);
 }
 
 bool otUdpIsOpen(otInstance *aInstance, const otUdpSocket *aSocket)
@@ -59,9 +60,13 @@ otError otUdpClose(otInstance *aInstance, otUdpSocket *aSocket)
 
 otError otUdpBind(otInstance *aInstance, otUdpSocket *aSocket, const otSockAddr *aSockName, otNetifIdentifier aNetif)
 {
-    AsCoreType(aSocket).SetNetifId(MapEnum(aNetif));
+    Error error;
 
-    return AsCoreType(aInstance).Get<Ip6::Udp>().Bind(AsCoreType(aSocket), AsCoreType(aSockName));
+    SuccessOrExit(error = AsCoreType(aInstance).Get<Ip6::Udp>().BindToNetif(AsCoreType(aSocket), MapEnum(aNetif)));
+    error = AsCoreType(aInstance).Get<Ip6::Udp>().Bind(AsCoreType(aSocket), AsCoreType(aSockName));
+
+exit:
+    return error;
 }
 
 otError otUdpConnect(otInstance *aInstance, otUdpSocket *aSocket, const otSockAddr *aSockName)

--- a/tests/toranj/cli/test-014-address-resolver.py
+++ b/tests/toranj/cli/test-014-address-resolver.py
@@ -268,10 +268,11 @@ verify_within(check_cache_entry_ramp_down_to_initial_retry_delay, 60)
 
 # Send to r1 from all addresses on r2.
 
-r2.udp_open()
 for num in range(num_addresses):
+    r2.udp_open()
     r2.udp_bind(prefix + '2:' + str(num), port)
     r2.udp_send(prefix + '1', port, 'hi_r1_from_r2_snoop_me')
+    r2.udp_close()
 
 # Verify that we see all addresses from r2 as snooped in cache table.
 # At most two of them should be marked as non-evictable.
@@ -398,11 +399,11 @@ verify(len(cache_table) == max_cache_entries)
 # Send from c2 to r1 and verify that snoop optimization uses at most
 # `max_snooped_non_evictable` entries
 
-c2.udp_open()
-
 for num in range(num_addresses):
+    c2.udp_open()
     c2.udp_bind(prefix + 'c2:' + str(num), port)
     c2.udp_send(prefix + '1', port, 'hi_r1_from_c2_snoop_me')
+    c2.udp_close()
 
 
 def check_cache_entry_contains_max_allowed_snopped():


### PR DESCRIPTION
This change introduces `Udp::SocketHandle::BindToNetif()` as a centralized method to manage the creation and binding of platform UDP sockets, ensuring the socket state remains synchronized with the platform layer.

This new structure supports two distinct initialization patterns:
- Internal `Udp::Open()` where the `aNetifId` is provided upfront.
- Public API where `otUdpOpen()` does not include `aNetif` and the `aNetifId` is provided in `otUdpBind()`.

For the public API, this change defers the allocation of a platform UDP socket until `otUdpBind()` is invoked. This avoids unnecessary resource allocation on platform for sockets that won't use it.

Additionally, stricter state checks are added to the UDP methods/APIs. Methods `Bind()`, `Connect()`, and `SendTo()` now validate that the socket is open before use. `Bind()` also checks if a socket is already bound. The API documentation is updated accordingly.