### PR TITLE
[gn] fix when `openthread_enable_core_config_args` is not enabled

### DIFF
--- a/script/check-gn-build
+++ b/script/check-gn-build
@@ -45,6 +45,7 @@ check_build()
 
 main()
 {
+    check_build --args="use_clang=true openthread_project_core_config_file=\"../examples/platforms/simulation/openthread-core-simulation-config.h\""
     for thread_version in 1.4 1.1; do
         for use_clang in true false; do
             check_build --args="use_clang=$use_clang openthread_config_thread_version=\"$thread_version\""

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -785,7 +785,7 @@ group("libopenthread_platform") {
 
 static_library("libopenthread-ftd") {
   sources = openthread_core_sources
-  if (openthread_config_tcp_enable) {
+  if (openthread_enable_core_config_args && openthread_config_tcp_enable) {
     deps = [ "../../third_party/tcplp" ]
   }
   public_deps = [ ":libopenthread_platform" ]
@@ -794,7 +794,7 @@ static_library("libopenthread-ftd") {
 
 static_library("libopenthread-mtd") {
   sources = openthread_core_sources
-  if (openthread_config_tcp_enable) {
+  if (openthread_enable_core_config_args && openthread_config_tcp_enable) {
     deps = [ "../../third_party/tcplp" ]
   }
   public_deps = [ ":libopenthread_platform" ]


### PR DESCRIPTION
This commit fixes gn build when `openthread_enable_core_config_args` is not enabled, in which case `openthread_config_tcp_enable` is not defined.