### PR TITLE
[posix] passing nullptr to SettingsFile::SetSettingsPath sets default settings path

### DIFF
--- a/src/posix/platform/settings_file.cpp
+++ b/src/posix/platform/settings_file.cpp
@@ -56,7 +56,8 @@ char SettingsFile::sSettingsPath[] = OPENTHREAD_CONFIG_POSIX_SETTINGS_PATH;
 const char *SettingsFile::GetSettingsPath(void) { return sSettingsPath; }
 void        SettingsFile::SetSettingsPath(const char *aSettingsPath)
 {
-    snprintf(sSettingsPath, sizeof(sSettingsPath), "%s", aSettingsPath);
+    snprintf(sSettingsPath, sizeof(sSettingsPath), "%s",
+             aSettingsPath == nullptr ? OPENTHREAD_CONFIG_POSIX_SETTINGS_PATH : aSettingsPath);
 }
 
 otError SettingsFile::Init(const char *aSettingsFileBaseName)


### PR DESCRIPTION
Given that `SettingsFile::SetSettingsPath` can be called with `nullptr` due to `platformSettingsInit(aPlatformConfig->mDataPath)`, this PR adds check for `nullptr` in `SettingsFile::SetSettingsPath` and will uses default `OPENTHREAD_CONFIG_POSIX_SETTINGS_PATH` value if `nullptr` is passed.

Fixes https://github.com/openthread/ot-br-posix/issues/3181