### PR TITLE
[coap] introduce `otCoapToken` to improve token handling

### DIFF
--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -256,6 +256,15 @@ typedef void (*otCoapRequestHandler)(void *aContext, otMessage *aMessage, const 
 typedef bool (*otCoapResponseFallback)(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 
 /**
+ * Represents a CoAP message token.
+ */
+typedef struct otCoapToken
+{
+    uint8_t m8[OT_COAP_MAX_TOKEN_LENGTH]; ///< The token bytes.
+    uint8_t mLength;                      ///< The token length in bytes.
+} otCoapToken;
+
+/**
  * Represents a CoAP resource.
  */
 typedef struct otCoapResource
@@ -327,22 +336,21 @@ void otCoapMessageInit(otMessage *aMessage, otCoapType aType, otCoapCode aCode);
 otError otCoapMessageInitResponse(otMessage *aResponse, const otMessage *aRequest, otCoapType aType, otCoapCode aCode);
 
 /**
- * Sets the Token value and length in a header.
+ * Writes the Token in the CoAP message.
  *
- * @param[in,out]  aMessage          A pointer to the CoAP message.
- * @param[in]      aToken            A pointer to the Token value.
- * @param[in]      aTokenLength      The Length of @p aToken.
+ * @param[in,out]  aMessage      The CoAP message.
+ * @param[in]      aToken        The Token to write.
  *
- * @retval OT_ERROR_NONE     Successfully set the Token value.
+ * @retval OT_ERROR_NONE     Successfully wrote the Token.
  * @retval OT_ERROR_NO_BUFS  Insufficient buffers to set the Token value.
  */
-otError otCoapMessageSetToken(otMessage *aMessage, const uint8_t *aToken, uint8_t aTokenLength);
+otError otCoapMessageWriteToken(otMessage *aMessage, const otCoapToken *aToken);
 
 /**
- * Sets the Token length and randomizes its value.
+ * Writes a randomly generated Token of a given length in the CoAP message.
  *
- * @param[in,out]  aMessage      A pointer to the CoAP message.
- * @param[in]      aTokenLength  The Length of a Token to set.
+ * @param[in,out]  aMessage      The CoAP message.
+ * @param[in]      aTokenLength  The Length of a Token (in bytes).
  */
 void otCoapMessageGenerateToken(otMessage *aMessage, uint8_t aTokenLength);
 
@@ -560,22 +568,26 @@ const char *otCoapMessageCodeToString(const otMessage *aMessage);
 uint16_t otCoapMessageGetMessageId(const otMessage *aMessage);
 
 /**
- * Returns the Token length.
+ * Reads the Token from the CoAP message.
  *
- * @param[in]  aMessage  A pointer to the CoAP message.
+ * @param[in]  aMessage  The CoAP message.
+ * @param[out] aToken    A pointer to a `otCoapToken` to output the read Token.
  *
- * @returns The Token length.
+ * @retval OT_ERROR_NONE    Successfully read the Token. @p aToken is updated.
+ * @retval OT_ERROR_PARSE   Failed to parse the header.
  */
-uint8_t otCoapMessageGetTokenLength(const otMessage *aMessage);
+otError otCoapMessageReadToken(const otMessage *aMessage, otCoapToken *aToken);
 
 /**
- * Returns a pointer to the Token value.
+ * Indicates whether two given CoAP Tokens are equal.
  *
- * @param[in]  aMessage  A pointer to the CoAP message.
+ * @param[in] aFirstToken    The first Token to compare.
+ * @param[in] aSecondToken   The second Token to compare.
  *
- * @returns A pointer to the Token value.
+ * @retval TRUE   If the two Tokens are equal.
+ * @retval FALSE  If the two Tokens are not equal.
  */
-const uint8_t *otCoapMessageGetToken(const otMessage *aMessage);
+bool otCoapMessageAreTokensEqual(const otCoapToken *aFirstToken, const otCoapToken *aSecondToken);
 
 //---------------------------------------------------------------------------------------------------------------------
 // `otCoapOptionIterator*` APIs - Iterating over CoAP Options in a CoAP message.
@@ -1004,6 +1016,47 @@ otError otCoapSendResponseBlockWise(otInstance                 *aInstance,
                                     const otMessageInfo        *aMessageInfo,
                                     void                       *aContext,
                                     otCoapBlockwiseTransmitHook aTransmitHook);
+
+//----------------------------------------------------------------------------------------------------------------------
+// Deprecated APIs
+
+/**
+ * Sets the Token value and length in a CoAP message.
+ *
+ * @deprecated This function is deprecated. Use `otCoapMessageWriteToken()` instead.
+ *
+ * @param[in,out]  aMessage          A pointer to the CoAP message.
+ * @param[in]      aToken            A pointer to the Token value.
+ * @param[in]      aTokenLength      The Length of @p aToken.
+ *
+ * @retval OT_ERROR_NONE     Successfully set the Token value.
+ * @retval OT_ERROR_NO_BUFS  Insufficient buffers to set the Token value.
+ */
+otError otCoapMessageSetToken(otMessage *aMessage, const uint8_t *aToken, uint8_t aTokenLength);
+
+/**
+ * Returns the Token length.
+ *
+ * @deprecated This function is deprecated. Use `otCoapMessageReadToken()` instead.
+ *
+ * @param[in]  aMessage  A pointer to the CoAP message.
+ *
+ * @returns The Token length.
+ */
+uint8_t otCoapMessageGetTokenLength(const otMessage *aMessage);
+
+/**
+ * Returns a pointer to the Token value.
+ *
+ * @deprecated This function is deprecated. Use `otCoapMessageReadToken()` instead.
+ *
+ * @note A previously returned pointer (`const uint8_t *`) will be invalidated upon the next call to this function.
+ *
+ * @param[in]  aMessage  A pointer to the CoAP message.
+ *
+ * @returns A pointer to the Token value.
+ */
+const uint8_t *otCoapMessageGetToken(const otMessage *aMessage);
 
 /**
  * @}

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (568)
+#define OPENTHREAD_API_VERSION (569)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -50,8 +50,6 @@ Coap::Coap(otInstance *aInstance, OutputImplementer &aOutputImplementer)
     , mUseDefaultResponseTxParameters(true)
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
     , mObserveSerial(0)
-    , mRequestTokenLength(0)
-    , mSubscriberTokenLength(0)
     , mSubscriberConfirmableNotifications(false)
     , mValidateObserveClient(false)
     , mNotificationSeriesCount(0)
@@ -84,7 +82,7 @@ otError Coap::CancelResourceSubscription(bool aSendCancelMessage)
     messageInfo.mPeerAddr = mRequestAddr;
     messageInfo.mPeerPort = OT_DEFAULT_COAP_PORT;
 
-    VerifyOrExit(mRequestTokenLength != 0, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mRequestToken.mLength != 0, error = OT_ERROR_INVALID_STATE);
 
     if (aSendCancelMessage)
     {
@@ -93,7 +91,7 @@ otError Coap::CancelResourceSubscription(bool aSendCancelMessage)
 
         otCoapMessageInit(message, OT_COAP_TYPE_CONFIRMABLE, OT_COAP_CODE_GET);
 
-        SuccessOrExit(error = otCoapMessageSetToken(message, mRequestToken, mRequestTokenLength));
+        SuccessOrExit(error = otCoapMessageWriteToken(message, &mRequestToken));
         SuccessOrExit(error = otCoapMessageAppendObserveOption(message, 1));
         SuccessOrExit(error = otCoapMessageAppendUriPathOptions(message, mRequestUri));
         SuccessOrExit(error = otCoapSendRequest(GetInstancePtr(), message, &messageInfo, &Coap::HandleResponse, this));
@@ -101,7 +99,7 @@ otError Coap::CancelResourceSubscription(bool aSendCancelMessage)
 
     ClearAllBytes(mRequestAddr);
     ClearAllBytes(mRequestUri);
-    mRequestTokenLength = 0;
+    ClearAllBytes(mRequestToken);
 
 exit:
 
@@ -118,7 +116,7 @@ void Coap::CancelSubscriber(void)
     OutputFormat("Removed subscriber ");
     OutputIp6AddressLine(mSubscriberSock.mAddress);
     ClearAllBytes(mSubscriberSock);
-    mSubscriberTokenLength = 0;
+    ClearAllBytes(mSubscriberToken);
 }
 #endif // OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
 
@@ -253,7 +251,7 @@ template <> otError Coap::Process<Cmd("set")>(Arg aArgs[])
         mResourceContent[sizeof(mResourceContent) - 1] = '\0';
 
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
-        if (mSubscriberTokenLength > 0)
+        if (mSubscriberToken.mLength > 0)
         {
             // determine the type of notification to send
             const bool isConNotification = mSubscriberConfirmableNotifications || mValidateObserveClient;
@@ -274,7 +272,7 @@ template <> otError Coap::Process<Cmd("set")>(Arg aArgs[])
                               (isConNotification ? OT_COAP_TYPE_CONFIRMABLE : OT_COAP_TYPE_NON_CONFIRMABLE),
                               OT_COAP_CODE_CONTENT);
 
-            SuccessOrExit(error = otCoapMessageSetToken(notificationMessage, mSubscriberToken, mSubscriberTokenLength));
+            SuccessOrExit(error = otCoapMessageWriteToken(notificationMessage, &mSubscriberToken));
             SuccessOrExit(error = otCoapMessageAppendObserveOption(notificationMessage, mObserveSerial++));
             SuccessOrExit(error = otCoapMessageSetPayloadMarker(notificationMessage));
             SuccessOrExit(error = otMessageAppend(notificationMessage, mResourceContent,
@@ -695,7 +693,7 @@ otError Coap::ProcessRequest(Arg aArgs[], otCoapCode aCoapCode)
     }
 
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
-    if (aCoapObserve && mRequestTokenLength)
+    if (aCoapObserve && mRequestToken.mLength)
     {
         // New observe request: cancel the existing observation silently, without sending an explicit cancel message.
         // Note: explicit cancellation MAY be sent by the user using 'coap cancel' per Section 3.6 of RFC7641.
@@ -781,8 +779,8 @@ otError Coap::ProcessRequest(Arg aArgs[], otCoapCode aCoapCode)
     {
         // Make a note of the message details for later so we can cancel it later.
         memcpy(&mRequestAddr, &coapDestinationIp, sizeof(mRequestAddr));
-        mRequestTokenLength = otCoapMessageGetTokenLength(message);
-        memcpy(mRequestToken, otCoapMessageGetToken(message), mRequestTokenLength);
+        SuccessOrExit(error = otCoapMessageReadToken(message, &mRequestToken));
+
         // Use `memcpy` instead of `strncpy` here because GCC will give warnings for `strncpy` when the dest's length is
         // not bigger than the src's length.
         memcpy(mRequestUri, coapUri, sizeof(mRequestUri) - 1);
@@ -940,7 +938,7 @@ void Coap::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo)
         otCoapMessageGetCode(aMessage) == OT_COAP_CODE_GET)
     {
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
-        if (observePresent && (mSubscriberTokenLength > 0) && (observe == 0))
+        if (observePresent && (mSubscriberToken.mLength > 0) && (observe == 0))
         {
             // There is already a subscriber: ignore the Observe option per Section 4.1 of RFC7641.
             observePresent = false;
@@ -959,10 +957,9 @@ void Coap::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo)
                     OutputLine("Subscribing client");
                     mSubscriberSock.mAddress = aMessageInfo->mPeerAddr;
                     mSubscriberSock.mPort    = aMessageInfo->mPeerPort;
-                    mSubscriberTokenLength   = otCoapMessageGetTokenLength(aMessage);
                     mValidateObserveClient   = false;
                     mNotificationSeriesCount = 0;
-                    memcpy(mSubscriberToken, otCoapMessageGetToken(aMessage), mSubscriberTokenLength);
+                    SuccessOrExit(error = otCoapMessageReadToken(aMessage, &mSubscriberToken));
 
                     /*
                      * Implementer note.
@@ -977,10 +974,13 @@ void Coap::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo)
                 else if (observe == 1)
                 {
                     // See if it matches our subscriber token
-                    if ((otCoapMessageGetTokenLength(aMessage) == mSubscriberTokenLength) &&
-                        (memcmp(otCoapMessageGetToken(aMessage), mSubscriberToken, mSubscriberTokenLength) == 0))
+
+                    otCoapToken token;
+
+                    SuccessOrExit(error = otCoapMessageReadToken(aMessage, &token));
+
+                    if (otCoapMessageAreTokensEqual(&token, &mSubscriberToken))
                     {
-                        // Unsubscribe request
                         CancelSubscriber();
                     }
                 }

--- a/src/cli/cli_coap.hpp
+++ b/src/cli/cli_coap.hpp
@@ -166,15 +166,13 @@ private:
     otIp6Address mRequestAddr;
     otSockAddr   mSubscriberSock;
     char         mRequestUri[kMaxUriLength];
-    uint8_t      mRequestToken[OT_COAP_MAX_TOKEN_LENGTH];
-    uint8_t      mSubscriberToken[OT_COAP_MAX_TOKEN_LENGTH];
+    otCoapToken  mRequestToken;
+    otCoapToken  mSubscriberToken;
 #endif
     char mUriPath[kMaxUriLength];
     char mResourceContent[kMaxBufferSize];
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
     uint32_t mObserveSerial;
-    uint8_t  mRequestTokenLength;
-    uint8_t  mSubscriberTokenLength;
     bool     mSubscriberConfirmableNotifications;
     bool     mValidateObserveClient;
     uint8_t  mNotificationSeriesCount;

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -400,7 +400,7 @@ Error CoapBase::SendHeaderResponse(Message::Code aCode, const Message &aRequest,
         ExitNow(error = kErrorInvalidArgs);
     }
 
-    SuccessOrExit(error = message->SetTokenFromMessage(aRequest));
+    SuccessOrExit(error = message->WriteTokenFromMessage(aRequest));
 
     SuccessOrExit(error = SendMessage(*message, aMessageInfo));
 
@@ -604,7 +604,7 @@ Message *CoapBase::FindRelatedRequest(const Message          &aResponse,
 
             case kTypeConfirmable:
             case kTypeNonConfirmable:
-                if (aResponse.IsTokenEqual(message))
+                if (aResponse.HasSameTokenAs(message))
                 {
                     request = &message;
                     ExitNow();
@@ -717,7 +717,7 @@ void CoapBase::ProcessReceivedResponse(Message &aMessage, const Ip6::MessageInfo
                 }
             }
         }
-        else if (aMessage.IsResponse() && aMessage.IsTokenEqual(*request))
+        else if (aMessage.IsResponse() && aMessage.HasSameTokenAs(*request))
         {
             // Piggybacked response.
 
@@ -1198,7 +1198,7 @@ Error CoapBase::PrepareNextBlockRequest(uint16_t         aBlockOptionNumber,
 
     // Per RFC 7959, all requests in a block-wise transfer MUST use the
     // same token.
-    IgnoreError(aRequest.SetTokenFromMessage(aRequestOld));
+    IgnoreError(aRequest.WriteTokenFromMessage(aRequestOld));
 
     // Copy options from last response to next message
 
@@ -1384,7 +1384,7 @@ Error CoapBase::ProcessBlock1Request(Message                 &aMessage,
         VerifyOrExit((response = NewMessage()) != nullptr, error = kErrorFailed);
         response->Init(kTypeAck, kCodeContinue);
         response->SetMessageId(aMessage.GetMessageId());
-        IgnoreError(response->SetToken(AsConst(aMessage).GetToken(), aMessage.GetTokenLength()));
+        SuccessOrExit(error = response->WriteTokenFromMessage(aMessage));
 
         SuccessOrExit(error = response->AppendBlockOption(kOptionBlock1, msgBlockInfo));
 
@@ -1440,7 +1440,7 @@ Error CoapBase::ProcessBlock2Request(Message                 &aMessage,
     response->Init(kTypeAck, kCodeContent);
     response->SetMessageId(aMessage.GetMessageId());
 
-    SuccessOrExit(error = response->SetTokenFromMessage(aMessage));
+    SuccessOrExit(error = response->WriteTokenFromMessage(aMessage));
 
     responseBlockInfo.mMoreBlocks = false;
 

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -297,8 +297,7 @@ private:
             CoapDtlsSession &mSession;
             ForwardContext  *mNext;
             Uri              mUri;
-            uint8_t          mTokenLength;
-            uint8_t          mToken[Coap::Message::kMaxTokenLength];
+            Coap::Token      mToken;
         };
 
         CoapDtlsSession(Instance &aInstance, Dtls::Transport &aDtlsTransport);
@@ -309,7 +308,7 @@ private:
         void  HandleTmfProxyTx(Coap::Message &aMessage);
         void  HandleTmfDatasetGet(Coap::Message &aMessage, Uri aUri);
         Error ForwardToLeader(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, Uri aUri);
-        void  SendErrorMessage(Error aError, const uint8_t *aToken, uint8_t aTokenLength);
+        void  SendErrorMessage(Error aError, const Coap::Token &aToken);
 
         static void HandleConnected(ConnectEvent aEvent, void *aContext);
         void        HandleConnected(ConnectEvent aEvent);


### PR DESCRIPTION
This commit introduces a new `otCoapToken` struct and a corresponding `Coap::Token` class to provide a clear and type-safe representation of a CoAP message token.

The CoAP APIs are updated to use these new types, replacing the use of raw `uint8_t` pointers and separate length parameters. This encapsulation enhances robustness and reduces the potential for errors in token handling.

The following new APIs are added:
- `otCoapMessageReadToken()`
- `otCoapMessageWriteToken()`
- `otCoapMessageAreTokensEqual()`

Importantly, several older APIs are now marked as deprecated (some returned pointers directly into `otMessage` data which is unsafe). While these APIs remain supported for now, their use is discouraged, and applications should migrate to the new APIs. Deprecated APIs:
- `otCoapMessageGetTokenLength()`
- `otCoapMessageGetToken()`
- `otCoapMessageSetToken()`

The internal implementation is updated to utilize the new `Token` class, and the CLI implementation is updated to use the new public APIs. Additionally, Doxygen documentations are updated for the new and updated APIs.