### PR TITLE
[doxygen] expand `OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK`

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -2026,7 +2026,7 @@ PREDEFINED             = __attribute__(x)=
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      =
+EXPAND_AS_DEFINED      = OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have an


### PR DESCRIPTION
This commit fixes incorrect return type in doxygen generated doc by telling doxygen `OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK` should be expanded. Doxygen got confused with macros following function declarations.