### PR TITLE
[core] remove unnecessary forward declarations of `class ThreadNetif`

### DIFF
--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -55,9 +55,6 @@
 #include "meshcop/meshcop_tlvs.hpp"
 
 namespace ot {
-
-class ThreadNetif;
-
 namespace MeshCoP {
 
 /**

--- a/src/core/thread/child_supervision.hpp
+++ b/src/core/thread/child_supervision.hpp
@@ -51,8 +51,6 @@
 
 namespace ot {
 
-class ThreadNetif;
-
 /**
  *
  * Child supervision feature provides a mechanism for parent

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -47,9 +47,6 @@
 #include "common/timer.hpp"
 
 namespace ot {
-
-class ThreadNetif;
-
 namespace Utils {
 
 class JamDetector : public InstanceLocator, private NonCopyable


### PR DESCRIPTION
Removes unnecessary `class ThreadNetif;` forward declarations in `meshcop.hpp`, `child_supervision.hpp`, and `jam_detector.hpp`.