### PR TITLE
[meshcop] simplify Discovery Request or Response TLV processing

### DIFF
--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -973,44 +973,25 @@ private:
 typedef StringTlvInfo<Tlv::kThreadDomainName, Tlv::kMaxThreadDomainNameLength> ThreadDomainNameTlv;
 
 /**
- * Implements Discovery Request TLV generation and parsing.
+ * Implements Discovery Request TLV value format.
  */
 OT_TOOL_PACKED_BEGIN
-class DiscoveryRequestTlv : public Tlv, public TlvInfo<Tlv::kDiscoveryRequest>
+class DiscoveryRequestTlvValue : public Clearable<DiscoveryRequestTlvValue>
 {
 public:
-    /**
-     * Initializes the TLV.
-     */
-    void Init(void)
-    {
-        SetType(kDiscoveryRequest);
-        SetLength(sizeof(*this) - sizeof(Tlv));
-        mFlags    = 0;
-        mReserved = 0;
-    }
-
-    /**
-     * Indicates whether or not the TLV appears to be well-formed.
-     *
-     * @retval TRUE   If the TLV appears to be well-formed.
-     * @retval FALSE  If the TLV does not appear to be well-formed.
-     */
-    bool IsValid(void) const { return GetLength() >= sizeof(*this) - sizeof(Tlv); }
-
     /**
      * Returns the Version value.
      *
      * @returns The Version value.
      */
-    uint8_t GetVersion(void) const { return mFlags >> kVersionOffset; }
+    uint8_t GetVersion(void) const { return ReadBits<uint8_t, kVersionMask>(mFlags[0]); }
 
     /**
      * Sets the Version value.
      *
      * @param[in]  aVersion  The Version value.
      */
-    void SetVersion(uint8_t aVersion) { WriteBits<uint8_t, kVersionMask>(mFlags, aVersion); }
+    void SetVersion(uint8_t aVersion) { WriteBits<uint8_t, kVersionMask>(mFlags[0], aVersion); }
 
     /**
      * Indicates whether or not the Joiner flag is set.
@@ -1018,64 +999,46 @@ public:
      * @retval TRUE   If the Joiner flag is set.
      * @retval FALSE  If the Joiner flag is not set.
      */
-    bool IsJoiner(void) const { return (mFlags & kJoinerMask) != 0; }
+    bool GetJoinerFlag(void) const { return GetBit<uint8_t>(mFlags[0], kJoinerFlagOffset); }
 
     /**
      * Sets the Joiner flag.
-     *
-     * @param[in]  aJoiner  TRUE if set, FALSE otherwise.
      */
-    void SetJoiner(bool aJoiner) { WriteBit<uint8_t>(mFlags, kJoinerOffset, aJoiner); }
+    void SetJoinerFlag(void) { SetBit<uint8_t>(mFlags[0], kJoinerFlagOffset); }
 
 private:
-    static constexpr uint8_t kVersionOffset = 4;
-    static constexpr uint8_t kVersionMask   = 0xf << kVersionOffset;
-    static constexpr uint8_t kJoinerOffset  = 3;
-    static constexpr uint8_t kJoinerMask    = 1 << kJoinerOffset;
+    static constexpr uint8_t kVersionOffset    = 4;
+    static constexpr uint8_t kVersionMask      = 0xf << kVersionOffset;
+    static constexpr uint8_t kJoinerFlagOffset = 3;
 
-    uint8_t mFlags;
-    uint8_t mReserved;
+    uint8_t mFlags[2];
 } OT_TOOL_PACKED_END;
 
 /**
- * Implements Discovery Response TLV generation and parsing.
+ * Defines Discovery Request TLV constants and types.
+ */
+typedef SimpleTlvInfo<Tlv::kDiscoveryRequest, DiscoveryRequestTlvValue> DiscoveryRequestTlv;
+
+/**
+ * Implements Discovery Response TLV value format.
  */
 OT_TOOL_PACKED_BEGIN
-class DiscoveryResponseTlv : public Tlv, public TlvInfo<Tlv::kDiscoveryResponse>
+class DiscoveryResponseTlvValue : public Clearable<DiscoveryResponseTlvValue>
 {
 public:
-    /**
-     * Initializes the TLV.
-     */
-    void Init(void)
-    {
-        SetType(kDiscoveryResponse);
-        SetLength(sizeof(*this) - sizeof(Tlv));
-        mFlags    = 0;
-        mReserved = 0;
-    }
-
-    /**
-     * Indicates whether or not the TLV appears to be well-formed.
-     *
-     * @retval TRUE   If the TLV appears to be well-formed.
-     * @retval FALSE  If the TLV does not appear to be well-formed.
-     */
-    bool IsValid(void) const { return GetLength() >= sizeof(*this) - sizeof(Tlv); }
-
     /**
      * Returns the Version value.
      *
      * @returns The Version value.
      */
-    uint8_t GetVersion(void) const { return ReadBits<uint8_t, kVersionMask>(mFlags); }
+    uint8_t GetVersion(void) const { return ReadBits<uint8_t, kVersionMask>(mFlags[0]); }
 
     /**
      * Sets the Version value.
      *
      * @param[in]  aVersion  The Version value.
      */
-    void SetVersion(uint8_t aVersion) { WriteBits<uint8_t, kVersionMask>(mFlags, aVersion); }
+    void SetVersion(uint8_t aVersion) { WriteBits<uint8_t, kVersionMask>(mFlags[0], aVersion); }
 
     /**
      * Indicates whether or not the Native Commissioner flag is set.
@@ -1083,17 +1046,12 @@ public:
      * @retval TRUE   If the Native Commissioner flag is set.
      * @retval FALSE  If the Native Commissioner flag is not set.
      */
-    bool IsNativeCommissioner(void) const { return GetBit<uint8_t>(mFlags, kNativeOffset); }
+    bool GetNativeCommissionerFlag(void) const { return GetBit<uint8_t>(mFlags[0], kNativeFlagOffset); }
 
     /**
      * Sets the Native Commissioner flag.
-     *
-     * @param[in]  aNativeCommissioner  TRUE if set, FALSE otherwise.
      */
-    void SetNativeCommissioner(bool aNativeCommissioner)
-    {
-        WriteBit<uint8_t>(mFlags, kNativeOffset, aNativeCommissioner);
-    }
+    void SetNativeCommissionerFlag(void) { SetBit<uint8_t>(mFlags[0], kNativeFlagOffset); }
 
     /**
      * Indicates whether or not the Commercial Commissioning Mode flag is set.
@@ -1101,24 +1059,26 @@ public:
      * @retval TRUE   If the Commercial Commissioning Mode flag is set.
      * @retval FALSE  If the Commercial Commissioning Mode flag is not set.
      */
-    bool IsCommercialCommissioningMode(void) const { return GetBit<uint8_t>(mFlags, kCcmOffset); }
+    bool GetCcmFlag(void) const { return GetBit<uint8_t>(mFlags[0], kCcmFlagOffset); }
 
     /**
      * Sets the Commercial Commissioning Mode flag.
-     *
-     * @param[in]  aCcm  TRUE if set, FALSE otherwise.
      */
-    void SetCommercialCommissioningMode(bool aCcm) { WriteBit<uint8_t>(mFlags, kCcmOffset, aCcm); }
+    void SetCcmFlag(void) { SetBit<uint8_t>(mFlags[0], kCcmFlagOffset); }
 
 private:
-    static constexpr uint8_t kVersionOffset = 4;
-    static constexpr uint8_t kVersionMask   = 0xf << kVersionOffset;
-    static constexpr uint8_t kNativeOffset  = 3;
-    static constexpr uint8_t kCcmOffset     = 2;
+    static constexpr uint8_t kVersionOffset    = 4;
+    static constexpr uint8_t kVersionMask      = 0xf << kVersionOffset;
+    static constexpr uint8_t kNativeFlagOffset = 3;
+    static constexpr uint8_t kCcmFlagOffset    = 2;
 
-    uint8_t mFlags;
-    uint8_t mReserved;
+    uint8_t mFlags[2];
 } OT_TOOL_PACKED_END;
+
+/**
+ * Defines Discovery Response TLV constants and types.
+ */
+typedef SimpleTlvInfo<Tlv::kDiscoveryResponse, DiscoveryResponseTlvValue> DiscoveryResponseTlv;
 
 #if OPENTHREAD_CONFIG_JOINER_ADV_EXPERIMENTAL_ENABLE
 


### PR DESCRIPTION
This change simplifies `DiscoveryRequestTlv` and `DiscoveryResponseTlv` generation and processing.

New types `DiscoveryRequestTlvValue` and `DiscoveryResponseTlvValue` are introduced to represent the value (payload) of these TLVs. This s simplifies the call sites by using the generic `Tlv::Append<T>()` and `Tlv::Read<T>()`.