### PR TITLE
[coap] introduce `Coap::Msg` to simplify method calls

### DIFF
--- a/src/core/backbone_router/backbone_tmf.cpp
+++ b/src/core/backbone_router/backbone_tmf.cpp
@@ -62,27 +62,21 @@ exit:
     return error;
 }
 
-bool BackboneTmfAgent::HandleResource(CoapBase               &aCoapBase,
-                                      const char             *aUriPath,
-                                      ot::Coap::Message      &aMessage,
-                                      const Ip6::MessageInfo &aMessageInfo)
+bool BackboneTmfAgent::HandleResource(CoapBase &aCoapBase, const char *aUriPath, ot::Coap::Msg &aMsg)
 {
-    return static_cast<BackboneTmfAgent &>(aCoapBase).HandleResource(aUriPath, aMessage, aMessageInfo);
+    return static_cast<BackboneTmfAgent &>(aCoapBase).HandleResource(aUriPath, aMsg);
 }
 
-bool BackboneTmfAgent::HandleResource(const char             *aUriPath,
-                                      ot::Coap::Message      &aMessage,
-                                      const Ip6::MessageInfo &aMessageInfo)
+bool BackboneTmfAgent::HandleResource(const char *aUriPath, ot::Coap::Msg &aMsg)
 {
-    OT_UNUSED_VARIABLE(aMessage);
-    OT_UNUSED_VARIABLE(aMessageInfo);
+    OT_UNUSED_VARIABLE(aMsg);
 
     bool didHandle = true;
     Uri  uri       = UriFromPath(aUriPath);
 
-#define Case(kUri, Type)                                     \
-    case kUri:                                               \
-        Get<Type>().HandleTmf<kUri>(aMessage, aMessageInfo); \
+#define Case(kUri, Type)                   \
+    case kUri:                             \
+        Get<Type>().HandleTmf<kUri>(aMsg); \
         break
 
     switch (uri)

--- a/src/core/backbone_router/backbone_tmf.hpp
+++ b/src/core/backbone_router/backbone_tmf.hpp
@@ -90,12 +90,9 @@ public:
     void UnsubscribeMulticast(const Ip6::Address &aAddress);
 
 private:
-    static bool HandleResource(CoapBase               &aCoapBase,
-                               const char             *aUriPath,
-                               ot::Coap::Message      &aMessage,
-                               const Ip6::MessageInfo &aMessageInfo);
-    bool        HandleResource(const char *aUriPath, ot::Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    void        LogError(const char *aText, const Ip6::Address &aAddress, Error aError) const;
+    static bool  HandleResource(CoapBase &aCoapBase, const char *aUriPath, ot::Coap::Msg &aMsg);
+    bool         HandleResource(const char *aUriPath, ot::Coap::Msg &aMsg);
+    void         LogError(const char *aText, const Ip6::Address &aAddress, Error aError) const;
     static Error Filter(const ot::Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext);
 };
 

--- a/src/core/backbone_router/bbr_manager.hpp
+++ b/src/core/backbone_router/bbr_manager.hpp
@@ -166,23 +166,22 @@ private:
     static constexpr uint8_t  kDefaultHoplimit = 1;
     static constexpr uint32_t kTimerInterval   = 1000;
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
-    void HandleMulticastListenerRegistration(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void HandleMulticastListenerRegistration(const Coap::Msg &aMsg);
 
-    void SendMulticastListenerRegistrationResponse(const Coap::Message    &aMessage,
-                                                   const Ip6::MessageInfo &aMessageInfo,
-                                                   MlrStatus               aStatus,
-                                                   Ip6::Address           *aFailedAddresses,
-                                                   uint8_t                 aFailedAddressNum);
+    void SendMulticastListenerRegistrationResponse(const Coap::Msg &aMsg,
+                                                   MlrStatus        aStatus,
+                                                   Ip6::Address    *aFailedAddresses,
+                                                   uint8_t          aFailedAddressNum);
     void SendBackboneMulticastListenerRegistration(const Ip6::Address *aAddresses,
                                                    uint8_t             aAddressNum,
                                                    uint32_t            aTimeout);
 #endif
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
-    void  HandleDuaRegistration(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void  HandleDuaRegistration(const Coap::Msg &aMsg);
     Error SendBackboneAnswer(const Ip6::MessageInfo      &aQueryMessageInfo,
                              const Ip6::Address          &aDua,
                              uint16_t                     aSrcRloc16,
@@ -200,10 +199,7 @@ private:
     void  HandleProactiveBackboneNotification(const Ip6::Address             &aDua,
                                               const Ip6::InterfaceIdentifier &aMeshLocalIid,
                                               uint32_t                        aTimeSinceLastTransaction);
-    void  SendDuaRegistrationResponse(const Coap::Message    &aMessage,
-                                      const Ip6::MessageInfo &aMessageInfo,
-                                      const Ip6::Address     &aTarget,
-                                      DuaStatus               aStatus);
+    void  SendDuaRegistrationResponse(const Coap::Msg &aMsg, const Ip6::Address &aTarget, DuaStatus aStatus);
 #endif
     void HandleNotifierEvents(Events aEvents);
 

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -303,11 +303,11 @@ private:
         CoapDtlsSession(Instance &aInstance, Dtls::Transport &aDtlsTransport);
 
         Error ForwardToCommissioner(OwnedPtr<Coap::Message> aForwardMessage, const Message &aMessage);
-        void  HandleTmfCommissionerKeepAlive(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+        void  HandleTmfCommissionerKeepAlive(Coap::Msg &aMsg);
         void  HandleTmfRelayTx(Coap::Message &aMessage);
         void  HandleTmfProxyTx(Coap::Message &aMessage);
         void  HandleTmfDatasetGet(Coap::Message &aMessage, Uri aUri);
-        Error ForwardToLeader(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, Uri aUri);
+        Error ForwardToLeader(const Coap::Msg &aMsg, Uri aUri);
         void  SendErrorMessage(Error aError, const Coap::Token &aToken);
 
         static void HandleConnected(ConnectEvent aEvent, void *aContext);
@@ -319,11 +319,8 @@ private:
         void        HandleLeaderResponseToFwdTmf(const ForwardContext &aForwardContext,
                                                  const Coap::Message  *aResponse,
                                                  Error                 aResult);
-        static bool HandleResource(CoapBase               &aCoapBase,
-                                   const char             *aUriPath,
-                                   Coap::Message          &aMessage,
-                                   const Ip6::MessageInfo &aMessageInfo);
-        bool        HandleResource(const char *aUriPath, Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+        static bool HandleResource(CoapBase &aCoapBase, const char *aUriPath, Coap::Msg &aMsg);
+        bool        HandleResource(const char *aUriPath, Coap::Msg &aMsg);
         static void HandleTimer(Timer &aTimer);
         void        HandleTimer(void);
 
@@ -350,7 +347,7 @@ private:
     // Callback from Notifier
     void HandleNotifierEvents(Events aEvents);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     // Callbacks used with `Dtls::Transport`.
     static SecureSession *HandleAcceptSession(void *aContext, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -401,7 +401,7 @@ private:
     static void HandleSecureAgentConnectEvent(Dtls::Session::ConnectEvent aEvent, void *aContext);
     void        HandleSecureAgentConnectEvent(Dtls::Session::ConnectEvent aEvent);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     void HandleRelayReceive(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -530,16 +530,16 @@ exit:
     mTimer.Start(kSendSetDelay);
 }
 
-void DatasetManager::HandleGet(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo) const
+void DatasetManager::HandleGet(const Coap::Msg &aMsg) const
 {
     Error          error    = kErrorNone;
-    Coap::Message *response = ProcessGetRequest(aMessage, kCheckSecurityPolicyFlags);
+    Coap::Message *response = ProcessGetRequest(aMsg.mMessage, kCheckSecurityPolicyFlags);
 
     VerifyOrExit(response != nullptr);
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*response, aMessageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*response, aMsg.mMessageInfo));
 
     LogInfo("sent %s dataset get response to %s", IsActiveDataset() ? "active" : "pending",
-            aMessageInfo.GetPeerAddr().ToString().AsCString());
+            aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());
 
 exit:
     FreeMessageOnError(response, error);
@@ -878,11 +878,7 @@ exit:
     return isValid;
 }
 
-template <>
-void ActiveDatasetManager::HandleTmf<kUriActiveGet>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
-{
-    DatasetManager::HandleGet(aMessage, aMessageInfo);
-}
+template <> void ActiveDatasetManager::HandleTmf<kUriActiveGet>(Coap::Msg &aMsg) { DatasetManager::HandleGet(aMsg); }
 
 void ActiveDatasetManager::HandleTimer(Timer &aTimer) { aTimer.Get<ActiveDatasetManager>().HandleTimer(); }
 
@@ -1002,11 +998,7 @@ exit:
     Clear();
 }
 
-template <>
-void PendingDatasetManager::HandleTmf<kUriPendingGet>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
-{
-    DatasetManager::HandleGet(aMessage, aMessageInfo);
-}
+template <> void PendingDatasetManager::HandleTmf<kUriPendingGet>(Coap::Msg &aMsg) { DatasetManager::HandleGet(aMsg); }
 
 void PendingDatasetManager::HandleTimer(Timer &aTimer) { aTimer.Get<PendingDatasetManager>().HandleTimer(); }
 

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -279,7 +279,7 @@ private:
     bool  IsPendingDataset(void) const { return (mType == Dataset::kPending); }
     void  Restore(const Dataset &aDataset);
     Error ApplyConfiguration(const Dataset &aDataset) const;
-    void  HandleGet(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo) const;
+    void  HandleGet(const Coap::Msg &aMsg) const;
     void  HandleTimer(void);
     Error Save(const Dataset &aDataset, bool aAllowOlderTimestamp);
     void  LocalSave(const Dataset &aDataset);
@@ -302,11 +302,9 @@ private:
 #endif
 
 #if OPENTHREAD_FTD
-    Error HandleSetOrReplace(MgmtCommand aCommand, const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    Error HandleSetOrReplace(MgmtCommand aCommand, const Coap::Msg &aMsg);
     Error ProcessSetOrReplaceRequest(MgmtCommand aCommand, const Coap::Message &aMessage, RequestInfo &aInfo) const;
-    void  SendSetOrReplaceResponse(const Coap::Message    &aRequest,
-                                   const Ip6::MessageInfo &aMessageInfo,
-                                   StateTlv::State         aState);
+    void  SendSetOrReplaceResponse(const Coap::Msg &aMsg, StateTlv::State aState);
 #endif
 
     Type                      mType;
@@ -390,7 +388,7 @@ public:
 #endif
 
 private:
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void) { DatasetManager::HandleTimer(); }
@@ -477,7 +475,7 @@ private:
     void        HandleTimer(void) { DatasetManager::HandleTimer(); }
 
     void                     HandleDelayTimer(void);
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     using DelayTimer = TimerMilliIn<PendingDatasetManager, &PendingDatasetManager::HandleDelayTimer>;
 

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -85,23 +85,23 @@ exit:
     return error;
 }
 
-template <>
-void EnergyScanClient::HandleTmf<kUriEnergyReport>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void EnergyScanClient::HandleTmf<kUriEnergyReport>(Coap::Msg &aMsg)
 {
     uint32_t               mask;
     MeshCoP::EnergyListTlv energyListTlv;
 
-    VerifyOrExit(aMessage.IsConfirmablePostRequest());
+    VerifyOrExit(aMsg.mMessage.IsConfirmablePostRequest());
 
     LogInfo("Received %s", UriToString<kUriEnergyReport>());
 
-    SuccessOrExit(MeshCoP::ChannelMaskTlv::FindIn(aMessage, mask));
+    SuccessOrExit(MeshCoP::ChannelMaskTlv::FindIn(aMsg.mMessage, mask));
 
-    SuccessOrExit(MeshCoP::Tlv::FindTlv(aMessage, MeshCoP::Tlv::kEnergyList, sizeof(energyListTlv), energyListTlv));
+    SuccessOrExit(
+        MeshCoP::Tlv::FindTlv(aMsg.mMessage, MeshCoP::Tlv::kEnergyList, sizeof(energyListTlv), energyListTlv));
 
     mCallback.InvokeIfSet(mask, energyListTlv.GetEnergyList(), energyListTlv.GetEnergyListLength());
 
-    SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+    SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMsg));
 
     LogInfo("Sent %s ack", UriToString<kUriEnergyReport>());
 

--- a/src/core/meshcop/energy_scan_client.hpp
+++ b/src/core/meshcop/energy_scan_client.hpp
@@ -85,7 +85,7 @@ public:
                     void                              *aContext);
 
 private:
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     Callback<otCommissionerEnergyReportCallback> mCallback;
 };

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -207,7 +207,7 @@ private:
                                              const char *aVendorData);
     void        FreeJoinerFinalizeMessage(void);
     void        SendJoinerFinalize(void);
-    void        SendJoinerEntrustResponse(const Coap::Message &aRequest, const Ip6::MessageInfo &aRequestInfo);
+    void        SendJoinerEntrustResponse(const Coap::Msg &aMsg);
     static void HandleDiscoverResult(Mle::DiscoverScanner::ScanResult *aResult, void *aContext);
     void        HandleDiscoverResult(Mle::DiscoverScanner::ScanResult *aResult);
     static void HandleSecureCoapClientConnect(Dtls::Session::ConnectEvent aEvent, void *aContext);
@@ -215,7 +215,7 @@ private:
 
     DeclareTmfResponseHandlerIn(Joiner, HandleJoinerFinalizeResponse);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     using JoinerTimer = TimerMilliIn<Joiner, &Joiner::HandleTimer>;
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -151,10 +151,8 @@ exit:
     FreeMessageOnError(message, error);
 }
 
-template <> void JoinerRouter::HandleTmf<kUriRelayTx>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void JoinerRouter::HandleTmf<kUriRelayTx>(Coap::Msg &aMsg)
 {
-    OT_UNUSED_VARIABLE(aMessageInfo);
-
     Error                    error;
     uint16_t                 joinerPort;
     Ip6::InterfaceIdentifier joinerIid;
@@ -164,25 +162,25 @@ template <> void JoinerRouter::HandleTmf<kUriRelayTx>(Coap::Message &aMessage, c
     Message::Settings        settings(kNoLinkSecurity, Message::kPriorityNet);
     Ip6::MessageInfo         messageInfo;
 
-    VerifyOrExit(aMessage.IsNonConfirmablePostRequest(), error = kErrorDrop);
+    VerifyOrExit(aMsg.mMessage.IsNonConfirmablePostRequest(), error = kErrorDrop);
 
     LogInfo("Received %s", UriToString<kUriRelayTx>());
 
-    SuccessOrExit(error = Tlv::Find<JoinerUdpPortTlv>(aMessage, joinerPort));
-    SuccessOrExit(error = Tlv::Find<JoinerIidTlv>(aMessage, joinerIid));
+    SuccessOrExit(error = Tlv::Find<JoinerUdpPortTlv>(aMsg.mMessage, joinerPort));
+    SuccessOrExit(error = Tlv::Find<JoinerIidTlv>(aMsg.mMessage, joinerIid));
 
-    SuccessOrExit(error = Tlv::FindTlvValueOffsetRange(aMessage, Tlv::kJoinerDtlsEncapsulation, offsetRange));
+    SuccessOrExit(error = Tlv::FindTlvValueOffsetRange(aMsg.mMessage, Tlv::kJoinerDtlsEncapsulation, offsetRange));
 
     VerifyOrExit((message = mSocket.NewMessage(0, settings)) != nullptr, error = kErrorNoBufs);
 
-    SuccessOrExit(error = message->AppendBytesFromMessage(aMessage, offsetRange));
+    SuccessOrExit(error = message->AppendBytesFromMessage(aMsg.mMessage, offsetRange));
 
     messageInfo.GetPeerAddr().SetToLinkLocalAddress(joinerIid);
     messageInfo.SetPeerPort(joinerPort);
 
     SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));
 
-    if (Tlv::Find<JoinerRouterKekTlv>(aMessage, kek) == kErrorNone)
+    if (Tlv::Find<JoinerRouterKekTlv>(aMsg.mMessage, kek) == kErrorNone)
     {
         LogInfo("Received kek");
 

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -96,7 +96,7 @@ private:
 
     void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     DeclareTmfResponseHandlerIn(JoinerRouter, HandleJoinerEntrustResponse);
 

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -49,10 +49,8 @@ Leader::Leader(Instance &aInstance)
 {
 }
 
-template <> void Leader::HandleTmf<kUriLeaderPetition>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Leader::HandleTmf<kUriLeaderPetition>(Coap::Msg &aMsg)
 {
-    OT_UNUSED_VARIABLE(aMessageInfo);
-
     CommissioningData             data;
     CommissionerIdTlv::StringType commissionerId;
     StateTlv::State               state = StateTlv::kReject;
@@ -61,9 +59,9 @@ template <> void Leader::HandleTmf<kUriLeaderPetition>(Coap::Message &aMessage, 
 
     VerifyOrExit(Get<Mle::Mle>().IsLeader());
 
-    VerifyOrExit(Get<Mle::Mle>().IsRoutingLocator(aMessageInfo.GetPeerAddr()));
+    VerifyOrExit(Get<Mle::Mle>().IsRoutingLocator(aMsg.mMessageInfo.GetPeerAddr()));
 
-    SuccessOrExit(Tlv::Find<CommissionerIdTlv>(aMessage, commissionerId));
+    SuccessOrExit(Tlv::Find<CommissionerIdTlv>(aMsg.mMessage, commissionerId));
 
     if (mTimer.IsRunning())
     {
@@ -71,7 +69,7 @@ template <> void Leader::HandleTmf<kUriLeaderPetition>(Coap::Message &aMessage, 
         ResignCommissioner();
     }
 
-    data.Init(aMessageInfo.GetPeerAddr().GetIid().GetLocator(), ++mSessionId);
+    data.Init(aMsg.mMessageInfo.GetPeerAddr().GetIid().GetLocator(), ++mSessionId);
     SuccessOrExit(Get<NetworkData::Leader>().SetCommissioningData(&data, data.GetLength()));
 
     IgnoreError(StringCopy(mCommissionerId, commissionerId));
@@ -80,17 +78,15 @@ template <> void Leader::HandleTmf<kUriLeaderPetition>(Coap::Message &aMessage, 
     mTimer.Start(kLeaderPetitionTimeout);
 
 exit:
-    SendPetitionResponse(aMessage, aMessageInfo, state);
+    SendPetitionResponse(aMsg, state);
 }
 
-void Leader::SendPetitionResponse(const Coap::Message    &aRequest,
-                                  const Ip6::MessageInfo &aMessageInfo,
-                                  StateTlv::State         aState)
+void Leader::SendPetitionResponse(const Coap::Msg &aMsg, StateTlv::State aState)
 {
     Error          error = kErrorNone;
     Coap::Message *message;
 
-    message = Get<Tmf::Agent>().NewPriorityResponseMessage(aRequest);
+    message = Get<Tmf::Agent>().NewPriorityResponseMessage(aMsg.mMessage);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<StateTlv>(*message, aState));
@@ -105,7 +101,7 @@ void Leader::SendPetitionResponse(const Coap::Message    &aRequest,
         SuccessOrExit(error = Tlv::Append<CommissionerSessionIdTlv>(*message, mSessionId));
     }
 
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, aMessageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, aMsg.mMessageInfo));
 
     LogInfo("Sent %s response", UriToString<kUriLeaderPetition>());
 
@@ -114,7 +110,7 @@ exit:
     LogWarnOnError(error, "send petition response");
 }
 
-template <> void Leader::HandleTmf<kUriLeaderKeepAlive>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Leader::HandleTmf<kUriLeaderKeepAlive>(Coap::Msg &aMsg)
 {
     uint8_t                state;
     uint16_t               sessionId;
@@ -125,9 +121,9 @@ template <> void Leader::HandleTmf<kUriLeaderKeepAlive>(Coap::Message &aMessage,
 
     VerifyOrExit(Get<Mle::Mle>().IsLeader());
 
-    SuccessOrExit(Tlv::Find<StateTlv>(aMessage, state));
+    SuccessOrExit(Tlv::Find<StateTlv>(aMsg.mMessage, state));
 
-    SuccessOrExit(Tlv::Find<CommissionerSessionIdTlv>(aMessage, sessionId));
+    SuccessOrExit(Tlv::Find<CommissionerSessionIdTlv>(aMsg.mMessage, sessionId));
 
     borderAgentLocator = Get<NetworkData::Leader>().FindInCommissioningData<BorderAgentLocatorTlv>();
 
@@ -142,7 +138,7 @@ template <> void Leader::HandleTmf<kUriLeaderKeepAlive>(Coap::Message &aMessage,
     }
     else
     {
-        uint16_t rloc = aMessageInfo.GetPeerAddr().GetIid().GetLocator();
+        uint16_t rloc = aMsg.mMessageInfo.GetPeerAddr().GetIid().GetLocator();
 
         if (borderAgentLocator->GetBorderAgentLocator() != rloc)
         {
@@ -154,25 +150,23 @@ template <> void Leader::HandleTmf<kUriLeaderKeepAlive>(Coap::Message &aMessage,
         mTimer.Start(kLeaderPetitionTimeout);
     }
 
-    SendKeepAliveResponse(aMessage, aMessageInfo, responseState);
+    SendKeepAliveResponse(aMsg, responseState);
 
 exit:
     return;
 }
 
-void Leader::SendKeepAliveResponse(const Coap::Message    &aRequest,
-                                   const Ip6::MessageInfo &aMessageInfo,
-                                   StateTlv::State         aState)
+void Leader::SendKeepAliveResponse(const Coap::Msg &aMsg, StateTlv::State aState)
 {
     Error          error = kErrorNone;
     Coap::Message *message;
 
-    message = Get<Tmf::Agent>().NewPriorityResponseMessage(aRequest);
+    message = Get<Tmf::Agent>().NewPriorityResponseMessage(aMsg.mMessage);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<StateTlv>(*message, aState));
 
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, aMessageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, aMsg.mMessageInfo));
 
     LogInfo("Sent %s response", UriToString<kUriLeaderKeepAlive>());
 

--- a/src/core/meshcop/meshcop_leader.hpp
+++ b/src/core/meshcop/meshcop_leader.hpp
@@ -98,15 +98,11 @@ private:
 
     void HandleTimer(void);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
-    void SendPetitionResponse(const Coap::Message    &aRequest,
-                              const Ip6::MessageInfo &aMessageInfo,
-                              StateTlv::State         aState);
+    void SendPetitionResponse(const Coap::Msg &aMsg, StateTlv::State aState);
 
-    void SendKeepAliveResponse(const Coap::Message    &aRequest,
-                               const Ip6::MessageInfo &aMessageInfo,
-                               StateTlv::State         aState);
+    void SendKeepAliveResponse(const Coap::Msg &aMsg, StateTlv::State aState);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -81,23 +81,22 @@ exit:
     return error;
 }
 
-template <>
-void PanIdQueryClient::HandleTmf<kUriPanIdConflict>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void PanIdQueryClient::HandleTmf<kUriPanIdConflict>(Coap::Msg &aMsg)
 {
     uint16_t panId;
     uint32_t mask;
 
-    VerifyOrExit(aMessage.IsConfirmablePostRequest());
+    VerifyOrExit(aMsg.mMessage.IsConfirmablePostRequest());
 
     LogInfo("Received %s", UriToString<kUriPanIdConflict>());
 
-    SuccessOrExit(Tlv::Find<MeshCoP::PanIdTlv>(aMessage, panId));
+    SuccessOrExit(Tlv::Find<MeshCoP::PanIdTlv>(aMsg.mMessage, panId));
 
-    SuccessOrExit(MeshCoP::ChannelMaskTlv::FindIn(aMessage, mask));
+    SuccessOrExit(MeshCoP::ChannelMaskTlv::FindIn(aMsg.mMessage, mask));
 
     mCallback.InvokeIfSet(panId, mask);
 
-    SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+    SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMsg));
 
     LogInfo("Sent %s response", UriToString<kUriPanIdConflict>());
 

--- a/src/core/meshcop/panid_query_client.hpp
+++ b/src/core/meshcop/panid_query_client.hpp
@@ -80,7 +80,7 @@ public:
                     void                               *aContext);
 
 private:
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     Callback<otCommissionerPanIdConflictCallback> mCallback;
 };

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -1111,7 +1111,7 @@ void TcatAgent::NotifyStateChange(void)
                                                    mState == kStateConnected);
 }
 
-template <> void TcatAgent::HandleTmf<kUriTcatEnable>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void TcatAgent::HandleTmf<kUriTcatEnable>(Coap::Msg &aMsg)
 {
     Error          error        = kErrorNone;
     Coap::Message *message      = nullptr;
@@ -1119,13 +1119,14 @@ template <> void TcatAgent::HandleTmf<kUriTcatEnable>(Coap::Message &aMessage, c
     uint16_t       durationSec  = 0;
     uint32_t       durationMs;
 
-    VerifyOrExit(aMessage.IsConfirmablePostRequest());
-    LogInfo("Received %s from %s", UriToString<kUriTcatEnable>(), aMessageInfo.GetPeerAddr().ToString().AsCString());
-    message = Get<Tmf::Agent>().NewResponseMessage(aMessage);
+    VerifyOrExit(aMsg.mMessage.IsConfirmablePostRequest());
+    LogInfo("Received %s from %s", UriToString<kUriTcatEnable>(),
+            aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());
+    message = Get<Tmf::Agent>().NewResponseMessage(aMsg.mMessage);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
-    SuccessOrExit(error = Tlv::Find<DelayTimerTlv>(aMessage, delayTimerMs));
-    switch (Tlv::Find<DurationTlv>(aMessage, durationSec))
+    SuccessOrExit(error = Tlv::Find<DelayTimerTlv>(aMsg.mMessage, delayTimerMs));
+    switch (Tlv::Find<DurationTlv>(aMsg.mMessage, durationSec))
     {
     case kErrorNone:
         break;
@@ -1149,7 +1150,7 @@ exit:
             Tlv::Append<StateTlv>(*message, error == kErrorNone ? StateTlv::State::kAccept : StateTlv::State::kReject);
         if (error == kErrorNone)
         {
-            error = Get<Tmf::Agent>().SendMessage(*message, aMessageInfo);
+            error = Get<Tmf::Agent>().SendMessage(*message, aMsg.mMessageInfo);
         }
         FreeMessageOnError(message, error);
     }

--- a/src/core/meshcop/tcat_agent.hpp
+++ b/src/core/meshcop/tcat_agent.hpp
@@ -414,7 +414,7 @@ public:
      */
     bool GetApplicationResponsePending(void) const { return mApplicationResponsePending; }
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
 private:
     void  NotifyApplicationResponseSent(void) { mApplicationResponsePending = false; }

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -358,7 +358,7 @@ private:
 
 #endif // OPENTHREAD_FTD
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
 #if OPENTHREAD_FTD
 

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -52,24 +52,23 @@ void AnnounceBeginServer::SendAnnounce(uint32_t aChannelMask, uint8_t aCount, ui
     AnnounceSenderBase::SendAnnounce(aCount);
 }
 
-template <>
-void AnnounceBeginServer::HandleTmf<kUriAnnounceBegin>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void AnnounceBeginServer::HandleTmf<kUriAnnounceBegin>(Coap::Msg &aMsg)
 {
     uint32_t mask;
     uint8_t  count;
     uint16_t period;
 
-    VerifyOrExit(aMessage.IsPostRequest());
-    SuccessOrExit(MeshCoP::ChannelMaskTlv::FindIn(aMessage, mask));
+    VerifyOrExit(aMsg.mMessage.IsPostRequest());
+    SuccessOrExit(MeshCoP::ChannelMaskTlv::FindIn(aMsg.mMessage, mask));
 
-    SuccessOrExit(Tlv::Find<MeshCoP::CountTlv>(aMessage, count));
-    SuccessOrExit(Tlv::Find<MeshCoP::PeriodTlv>(aMessage, period));
+    SuccessOrExit(Tlv::Find<MeshCoP::CountTlv>(aMsg.mMessage, count));
+    SuccessOrExit(Tlv::Find<MeshCoP::PeriodTlv>(aMsg.mMessage, period));
 
     SendAnnounce(mask, count, period);
 
-    if (aMessage.IsConfirmable() && !aMessageInfo.GetSockAddr().IsMulticast())
+    if (aMsg.mMessage.IsConfirmable() && !aMsg.mMessageInfo.GetSockAddr().IsMulticast())
     {
-        SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+        SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMsg));
         LogInfo("Sent %s response", UriToString<kUriAnnounceBegin>());
     }
 

--- a/src/core/thread/announce_begin_server.hpp
+++ b/src/core/thread/announce_begin_server.hpp
@@ -71,7 +71,7 @@ private:
     static constexpr uint16_t kDefaultPeriod = 1000;
     static constexpr uint16_t kDefaultJitter = 0;
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     static void HandleTimer(Timer &aTimer);
 };

--- a/src/core/thread/anycast_locator.cpp
+++ b/src/core/thread/anycast_locator.cpp
@@ -109,20 +109,19 @@ exit:
 
 #if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_SEND_RESPONSE
 
-template <>
-void AnycastLocator::HandleTmf<kUriAnycastLocate>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void AnycastLocator::HandleTmf<kUriAnycastLocate>(Coap::Msg &aMsg)
 {
     Coap::Message *message = nullptr;
 
-    VerifyOrExit(aMessage.IsConfirmablePostRequest());
+    VerifyOrExit(aMsg.mMessage.IsConfirmablePostRequest());
 
-    message = Get<Tmf::Agent>().NewResponseMessage(aMessage);
+    message = Get<Tmf::Agent>().NewResponseMessage(aMsg.mMessage);
     VerifyOrExit(message != nullptr);
 
     SuccessOrExit(Tlv::Append<ThreadMeshLocalEidTlv>(*message, Get<Mle::Mle>().GetMeshLocalEid().GetIid()));
     SuccessOrExit(Tlv::Append<ThreadRloc16Tlv>(*message, Get<Mle::Mle>().GetRloc16()));
 
-    SuccessOrExit(Get<Tmf::Agent>().SendMessage(*message, aMessageInfo));
+    SuccessOrExit(Get<Tmf::Agent>().SendMessage(*message, aMsg.mMessageInfo));
     message = nullptr;
 
 exit:

--- a/src/core/thread/anycast_locator.hpp
+++ b/src/core/thread/anycast_locator.hpp
@@ -97,7 +97,7 @@ private:
 
     void HandleResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aError);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     Callback<LocatorCallback> mCallback;
 };

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -571,21 +571,18 @@ exit:
     LogInfo("Received %s response: %s", UriToString<kUriDuaRegistrationRequest>(), ErrorToString(error));
 }
 
-template <>
-void DuaManager::HandleTmf<kUriDuaRegistrationNotify>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void DuaManager::HandleTmf<kUriDuaRegistrationNotify>(Coap::Msg &aMsg)
 {
-    OT_UNUSED_VARIABLE(aMessageInfo);
-
     Error error;
 
-    VerifyOrExit(aMessage.IsPostRequest(), error = kErrorParse);
+    VerifyOrExit(aMsg.mMessage.IsPostRequest(), error = kErrorParse);
 
-    if (aMessage.IsConfirmable() && Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo) == kErrorNone)
+    if (aMsg.mMessage.IsConfirmable() && Get<Tmf::Agent>().SendEmptyAck(aMsg) == kErrorNone)
     {
         LogInfo("Sent %s ack", UriToString<kUriDuaRegistrationNotify>());
     }
 
-    error = ProcessDuaResponse(aMessage);
+    error = ProcessDuaResponse(aMsg.mMessage);
 
 exit:
     OT_UNUSED_VARIABLE(error);

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -221,7 +221,7 @@ private:
 
     DeclareTmfResponseHandlerIn(DuaManager, HandleDuaResponse);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     Error ProcessDuaResponse(Coap::Message &aMessage);
 

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -69,7 +69,7 @@ private:
     static constexpr uint8_t  kMinCount    = 1;
     static constexpr uint8_t  kMaxCount    = 3;
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     static void HandleScanResult(Mac::EnergyScanResult *aResult, void *aContext);
     void        HandleScanResult(Mac::EnergyScanResult *aResult);

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -2416,7 +2416,7 @@ private:
     void     HandleAdvertiseTrickleTimer(void);
     void     HandleTimeTick(void);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     DeclareTmfResponseHandlerFullParamIn(Mle, HandleAddressSolicitResponse);
 

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -3573,22 +3573,22 @@ exit:
     return;
 }
 
-template <> void Mle::HandleTmf<kUriAddressSolicit>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Mle::HandleTmf<kUriAddressSolicit>(Coap::Msg &aMsg)
 {
     Coap::Message  *response = nullptr;
     AddrSolicitInfo info;
 
     VerifyOrExit(IsLeader() && !IsAttaching());
 
-    Log(kMessageReceive, kTypeAddressSolicit, aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeAddressSolicit, aMsg.mMessageInfo.GetPeerAddr());
 
-    SuccessOrExit(info.ParseFrom(aMessage));
+    SuccessOrExit(info.ParseFrom(aMsg.mMessage));
 
     ProcessAddressSolicit(info);
 
     // Prepare and send response
 
-    response = Get<Tmf::Agent>().NewPriorityResponseMessage(aMessage);
+    response = Get<Tmf::Agent>().NewPriorityResponseMessage(aMsg.mMessage);
     VerifyOrExit(response != nullptr);
 
     SuccessOrExit(Tlv::Append<ThreadStatusTlv>(*response, info.mResponse));
@@ -3606,10 +3606,10 @@ template <> void Mle::HandleTmf<kUriAddressSolicit>(Coap::Message &aMessage, con
         SuccessOrExit(routerMaskTlv.AppendTo(*response));
     }
 
-    SuccessOrExit(Get<Tmf::Agent>().SendMessage(*response, aMessageInfo));
+    SuccessOrExit(Get<Tmf::Agent>().SendMessage(*response, aMsg.mMessageInfo));
     response = nullptr;
 
-    Log(kMessageSend, kTypeAddressReply, aMessageInfo.GetPeerAddr());
+    Log(kMessageSend, kTypeAddressReply, aMsg.mMessageInfo.GetPeerAddr());
 
     // If assigning a new RLOC16 (e.g., on promotion of a child to
     // router role) we clear any address cache entries associated
@@ -3622,8 +3622,8 @@ template <> void Mle::HandleTmf<kUriAddressSolicit>(Coap::Message &aMessage, con
     {
         uint16_t oldRloc16;
 
-        VerifyOrExit(IsRoutingLocator(aMessageInfo.GetPeerAddr()));
-        oldRloc16 = aMessageInfo.GetPeerAddr().GetIid().GetLocator();
+        VerifyOrExit(IsRoutingLocator(aMsg.mMessageInfo.GetPeerAddr()));
+        oldRloc16 = aMsg.mMessageInfo.GetPeerAddr().GetIid().GetLocator();
 
         VerifyOrExit(oldRloc16 != info.mRouter->GetRloc16());
         VerifyOrExit(!RouterIdMatch(oldRloc16, GetRloc16()));
@@ -3634,7 +3634,7 @@ exit:
     FreeMessage(response);
 }
 
-template <> void Mle::HandleTmf<kUriAddressRelease>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Mle::HandleTmf<kUriAddressRelease>(Coap::Msg &aMsg)
 {
     uint16_t        rloc16;
     Mac::ExtAddress extAddress;
@@ -3643,12 +3643,12 @@ template <> void Mle::HandleTmf<kUriAddressRelease>(Coap::Message &aMessage, con
 
     VerifyOrExit(mRole == kRoleLeader);
 
-    VerifyOrExit(aMessage.IsConfirmablePostRequest());
+    VerifyOrExit(aMsg.mMessage.IsConfirmablePostRequest());
 
-    Log(kMessageReceive, kTypeAddressRelease, aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeAddressRelease, aMsg.mMessageInfo.GetPeerAddr());
 
-    SuccessOrExit(Tlv::Find<ThreadRloc16Tlv>(aMessage, rloc16));
-    SuccessOrExit(Tlv::Find<ThreadExtMacAddressTlv>(aMessage, extAddress));
+    SuccessOrExit(Tlv::Find<ThreadRloc16Tlv>(aMsg.mMessage, rloc16));
+    SuccessOrExit(Tlv::Find<ThreadExtMacAddressTlv>(aMsg.mMessage, extAddress));
 
     routerId = RouterIdFromRloc16(rloc16);
     router   = mRouterTable.FindRouterById(routerId);
@@ -3657,9 +3657,9 @@ template <> void Mle::HandleTmf<kUriAddressRelease>(Coap::Message &aMessage, con
 
     IgnoreError(mRouterTable.Release(routerId));
 
-    SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+    SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMsg));
 
-    Log(kMessageSend, kTypeAddressReleaseReply, aMessageInfo.GetPeerAddr());
+    Log(kMessageSend, kTypeAddressReleaseReply, aMsg.mMessageInfo.GetPeerAddr());
 
 exit:
     return;

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -544,7 +544,7 @@ private:
 #endif
     };
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     void HandleTimer(void);
 
@@ -617,9 +617,7 @@ private:
     Error UpdateCommissioningData(uint16_t aDataLength, CommissioningDataTlv *&aDataTlv);
     Error SetCommissioningData(const Message &aMessage);
 
-    void SendCommissioningSetResponse(const Coap::Message     &aRequest,
-                                      const Ip6::MessageInfo  &aMessageInfo,
-                                      MeshCoP::StateTlv::State aState);
+    void SendCommissioningSetResponse(const Coap::Msg &aMsg, MeshCoP::StateTlv::State aState);
     void IncrementVersions(bool aIncludeStable);
     void IncrementVersions(const ChangedFlags &aFlags);
 

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -619,24 +619,23 @@ exit:
     return error;
 }
 
-template <>
-void Server::HandleTmf<kUriDiagnosticGetQuery>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Server::HandleTmf<kUriDiagnosticGetQuery>(Coap::Msg &aMsg)
 {
-    VerifyOrExit(aMessage.IsPostRequest());
+    VerifyOrExit(aMsg.mMessage.IsPostRequest());
 
     LogInfo("Received %s from %s", UriToString<kUriDiagnosticGetQuery>(),
-            aMessageInfo.GetPeerAddr().ToString().AsCString());
+            aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());
 
     // DIAG_GET.qry may be sent as a confirmable request.
-    if (aMessage.IsConfirmable())
+    if (aMsg.mMessage.IsConfirmable())
     {
-        IgnoreError(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+        IgnoreError(Get<Tmf::Agent>().SendEmptyAck(aMsg));
     }
 
 #if OPENTHREAD_MTD
-    SendAnswer(aMessageInfo.GetPeerAddr(), aMessage);
+    SendAnswer(aMsg.mMessageInfo.GetPeerAddr(), aMsg.mMessage);
 #elif OPENTHREAD_FTD
-    PrepareAndSendAnswers(aMessageInfo.GetPeerAddr(), aMessage);
+    PrepareAndSendAnswers(aMsg.mMessageInfo.GetPeerAddr(), aMsg.mMessage);
 #endif
 
 exit:
@@ -986,48 +985,47 @@ exit:
 
 #endif // OPENTHREAD_FTD
 
-template <>
-void Server::HandleTmf<kUriDiagnosticGetRequest>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Server::HandleTmf<kUriDiagnosticGetRequest>(Coap::Msg &aMsg)
 {
     Error          error    = kErrorNone;
     Coap::Message *response = nullptr;
 
-    VerifyOrExit(aMessage.IsConfirmablePostRequest(), error = kErrorDrop);
+    VerifyOrExit(aMsg.mMessage.IsConfirmablePostRequest(), error = kErrorDrop);
 
     LogInfo("Received %s from %s", UriToString<kUriDiagnosticGetRequest>(),
-            aMessageInfo.GetPeerAddr().ToString().AsCString());
+            aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());
 
-    response = Get<Tmf::Agent>().NewResponseMessage(aMessage);
+    response = Get<Tmf::Agent>().NewResponseMessage(aMsg.mMessage);
     VerifyOrExit(response != nullptr, error = kErrorNoBufs);
 
-    IgnoreError(response->SetPriority(aMessage.GetPriority()));
-    SuccessOrExit(error = AppendRequestedTlvs(aMessage, *response));
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*response, aMessageInfo));
+    IgnoreError(response->SetPriority(aMsg.mMessage.GetPriority()));
+    SuccessOrExit(error = AppendRequestedTlvs(aMsg.mMessage, *response));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*response, aMsg.mMessageInfo));
 
 exit:
     FreeMessageOnError(response, error);
 }
 
-template <> void Server::HandleTmf<kUriDiagnosticReset>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Server::HandleTmf<kUriDiagnosticReset>(Coap::Msg &aMsg)
 {
     uint16_t offset = 0;
     uint8_t  type;
     Tlv      tlv;
 
-    VerifyOrExit(aMessage.IsConfirmablePostRequest());
+    VerifyOrExit(aMsg.mMessage.IsConfirmablePostRequest());
 
     LogInfo("Received %s from %s", UriToString<kUriDiagnosticReset>(),
-            aMessageInfo.GetPeerAddr().ToString().AsCString());
+            aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());
 
-    SuccessOrExit(aMessage.Read(aMessage.GetOffset(), tlv));
+    SuccessOrExit(aMsg.mMessage.Read(aMsg.mMessage.GetOffset(), tlv));
 
     VerifyOrExit(tlv.GetType() == Tlv::kTypeList);
 
-    offset = aMessage.GetOffset() + sizeof(Tlv);
+    offset = aMsg.mMessage.GetOffset() + sizeof(Tlv);
 
     for (uint8_t i = 0; i < tlv.GetLength(); i++)
     {
-        SuccessOrExit(aMessage.Read(offset + i, type));
+        SuccessOrExit(aMsg.mMessage.Read(offset + i, type));
 
         switch (type)
         {
@@ -1048,7 +1046,7 @@ template <> void Server::HandleTmf<kUriDiagnosticReset>(Coap::Message &aMessage,
         }
     }
 
-    IgnoreError(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+    IgnoreError(Get<Tmf::Agent>().SendEmptyAck(aMsg));
 
 exit:
     return;
@@ -1151,23 +1149,22 @@ exit:
     mGetCallback.InvokeIfSet(aResult, aMessage, aMessageInfo);
 }
 
-template <>
-void Client::HandleTmf<kUriDiagnosticGetAnswer>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Client::HandleTmf<kUriDiagnosticGetAnswer>(Coap::Msg &aMsg)
 {
-    VerifyOrExit(aMessage.IsConfirmablePostRequest());
+    VerifyOrExit(aMsg.mMessage.IsConfirmablePostRequest());
 
     LogInfo("Received %s from %s", ot::UriToString<kUriDiagnosticGetAnswer>(),
-            aMessageInfo.GetPeerAddr().ToString().AsCString());
+            aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());
 
 #if OPENTHREAD_CONFIG_MESH_DIAG_ENABLE && OPENTHREAD_FTD
     // Let the `MeshDiag` process the message first.
-    if (!Get<Utils::MeshDiag>().HandleDiagnosticGetAnswer(aMessage, aMessageInfo))
+    if (!Get<Utils::MeshDiag>().HandleDiagnosticGetAnswer(aMsg.mMessage, aMsg.mMessageInfo))
 #endif
     {
-        mGetCallback.InvokeIfSet(kErrorNone, &aMessage, &aMessageInfo);
+        mGetCallback.InvokeIfSet(kErrorNone, &aMsg.mMessage, &aMsg.mMessageInfo);
     }
 
-    IgnoreError(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+    IgnoreError(Get<Tmf::Agent>().SendEmptyAck(aMsg));
 
 exit:
     return;

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -270,7 +270,7 @@ private:
     Error AppendBrPrefixTlv(uint8_t aTlvType, Message &aMessage);
 #endif
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
 #if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
     VendorNameTlv::StringType      mVendorName;
@@ -374,7 +374,7 @@ private:
 
     DeclareTmfResponseHandlerFullParamIn(Client, HandleGetResponse);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     static void ParseIp6AddrList(Ip6AddrList &aIp6Addrs, const Message &aMessage, OffsetRange aOffsetRange);
     static void ParseMacCounters(const MacCountersTlv &aMacCountersTlv, MacCounters &aMacCounters);

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -47,25 +47,24 @@ PanIdQueryServer::PanIdQueryServer(Instance &aInstance)
 {
 }
 
-template <>
-void PanIdQueryServer::HandleTmf<kUriPanIdQuery>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void PanIdQueryServer::HandleTmf<kUriPanIdQuery>(Coap::Msg &aMsg)
 {
     uint16_t panId;
     uint32_t mask;
 
-    VerifyOrExit(aMessage.IsPostRequest());
-    SuccessOrExit(MeshCoP::ChannelMaskTlv::FindIn(aMessage, mask));
+    VerifyOrExit(aMsg.mMessage.IsPostRequest());
+    SuccessOrExit(MeshCoP::ChannelMaskTlv::FindIn(aMsg.mMessage, mask));
 
-    SuccessOrExit(Tlv::Find<MeshCoP::PanIdTlv>(aMessage, panId));
+    SuccessOrExit(Tlv::Find<MeshCoP::PanIdTlv>(aMsg.mMessage, panId));
 
     mChannelMask  = mask;
-    mCommissioner = aMessageInfo.GetPeerAddr();
+    mCommissioner = aMsg.mMessageInfo.GetPeerAddr();
     mPanId        = panId;
     mTimer.Start(kScanDelay);
 
-    if (aMessage.IsConfirmable() && !aMessageInfo.GetSockAddr().IsMulticast())
+    if (aMsg.mMessage.IsConfirmable() && !aMsg.mMessageInfo.GetSockAddr().IsMulticast())
     {
-        SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+        SuccessOrExit(Get<Tmf::Agent>().SendEmptyAck(aMsg));
         LogInfo("Sent %s ack", UriToString<kUriPanIdQuery>());
     }
 

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -62,7 +62,7 @@ public:
 private:
     static constexpr uint32_t kScanDelay = 1000; ///< SCAN_DELAY (in msec)
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     static void HandleScanResult(Mac::ActiveScanResult *aScanResult, void *aContext);
     void        HandleScanResult(Mac::ActiveScanResult *aScanResult);

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -85,35 +85,31 @@ Agent::Agent(Instance &aInstance)
 
 Error Agent::Start(void) { return Coap::Start(kUdpPort, Ip6::kNetifThreadInternal); }
 
-template <> void Agent::HandleTmf<kUriRelayRx>(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Agent::HandleTmf<kUriRelayRx>(Msg &aMsg)
 {
-    OT_UNUSED_VARIABLE(aMessage);
-    OT_UNUSED_VARIABLE(aMessageInfo);
+    OT_UNUSED_VARIABLE(aMsg);
 
 #if (OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE)
-    Get<MeshCoP::Commissioner>().HandleTmf<kUriRelayRx>(aMessage, aMessageInfo);
+    Get<MeshCoP::Commissioner>().HandleTmf<kUriRelayRx>(aMsg);
 #endif
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    Get<MeshCoP::BorderAgent::Manager>().HandleTmf<kUriRelayRx>(aMessage, aMessageInfo);
+    Get<MeshCoP::BorderAgent::Manager>().HandleTmf<kUriRelayRx>(aMsg);
 #endif
 }
 
-bool Agent::HandleResource(CoapBase               &aCoapBase,
-                           const char             *aUriPath,
-                           Message                &aMessage,
-                           const Ip6::MessageInfo &aMessageInfo)
+bool Agent::HandleResource(CoapBase &aCoapBase, const char *aUriPath, Msg &aMsg)
 {
-    return static_cast<Agent &>(aCoapBase).HandleResource(aUriPath, aMessage, aMessageInfo);
+    return static_cast<Agent &>(aCoapBase).HandleResource(aUriPath, aMsg);
 }
 
-bool Agent::HandleResource(const char *aUriPath, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+bool Agent::HandleResource(const char *aUriPath, Msg &aMsg)
 {
     bool didHandle = true;
     Uri  uri       = UriFromPath(aUriPath);
 
-#define Case(kUri, Type)                                     \
-    case kUri:                                               \
-        Get<Type>().HandleTmf<kUri>(aMessage, aMessageInfo); \
+#define Case(kUri, Type)                   \
+    case kUri:                             \
+        Get<Type>().HandleTmf<kUri>(aMsg); \
         break
 
     switch (uri)
@@ -307,22 +303,19 @@ Coap::SecureSession *SecureAgent::HandleDtlsAccept(void)
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
 
-bool SecureAgent::HandleResource(CoapBase               &aCoapBase,
-                                 const char             *aUriPath,
-                                 Message                &aMessage,
-                                 const Ip6::MessageInfo &aMessageInfo)
+bool SecureAgent::HandleResource(CoapBase &aCoapBase, const char *aUriPath, Msg &aMsg)
 {
-    return static_cast<SecureAgent &>(aCoapBase).HandleResource(aUriPath, aMessage, aMessageInfo);
+    return static_cast<SecureAgent &>(aCoapBase).HandleResource(aUriPath, aMsg);
 }
 
-bool SecureAgent::HandleResource(const char *aUriPath, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+bool SecureAgent::HandleResource(const char *aUriPath, Msg &aMsg)
 {
     bool didHandle = false;
     Uri  uri       = UriFromPath(aUriPath);
 
     if (uri == kUriJoinerFinalize)
     {
-        Get<MeshCoP::Commissioner>().HandleTmf<kUriJoinerFinalize>(aMessage, aMessageInfo);
+        Get<MeshCoP::Commissioner>().HandleTmf<kUriJoinerFinalize>(aMsg);
         didHandle = true;
     }
 

--- a/src/core/thread/tmf.hpp
+++ b/src/core/thread/tmf.hpp
@@ -49,13 +49,12 @@ namespace Tmf {
  *
  * The class `Type` MUST declare a template method of the following format:
  *
- *  template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+ *  template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
  *
  * @param[in] Type      The `Type` in which the TMF handler is declared.
  * @param[in] kUri      The `Uri` which is handled.
  */
-#define DeclareTmfHandler(Type, kUri) \
-    template <> void Type::HandleTmf<kUri>(Coap::Message & aMessage, const Ip6::MessageInfo &aMessageInfo)
+#define DeclareTmfHandler(Type, kUri) template <> void Type::HandleTmf<kUri>(Coap::Msg & aMsg)
 
 /**
  * Declares a TMF/CoAP response handler method in a given class `Type`.
@@ -106,6 +105,7 @@ namespace Tmf {
 constexpr uint16_t kUdpPort = 61631; ///< TMF UDP Port
 
 typedef Coap::Message Message; ///< A TMF message.
+typedef Coap::Msg     Msg;     ///< A TMF message along with its `Ip6::MessageInfo`.
 
 /**
  * Represents message information for a TMF message.
@@ -228,13 +228,10 @@ public:
     static Message::Priority DscpToPriority(uint8_t aDscp);
 
 private:
-    template <Uri kUri> void HandleTmf(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Msg &aMsg);
 
-    static bool HandleResource(CoapBase               &aCoapBase,
-                               const char             *aUriPath,
-                               Message                &aMessage,
-                               const Ip6::MessageInfo &aMessageInfo);
-    bool        HandleResource(const char *aUriPath, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    static bool HandleResource(CoapBase &aCoapBase, const char *aUriPath, Msg &aMsg);
+    bool        HandleResource(const char *aUriPath, Msg &aMsg);
 
     static Error Filter(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext);
 };
@@ -259,11 +256,8 @@ private:
     Coap::SecureSession           *HandleDtlsAccept(void);
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
-    static bool HandleResource(CoapBase               &aCoapBase,
-                               const char             *aUriPath,
-                               Message                &aMessage,
-                               const Ip6::MessageInfo &aMessageInfo);
-    bool        HandleResource(const char *aUriPath, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    static bool HandleResource(CoapBase &aCoapBase, const char *aUriPath, Msg &aMsg);
+    bool        HandleResource(const char *aUriPath, Msg &aMsg);
 #endif
 };
 

--- a/src/core/utils/history_tracker_client.hpp
+++ b/src/core/utils/history_tracker_client.hpp
@@ -102,12 +102,12 @@ private:
     static constexpr uint16_t kResponseTimeout = 5000;
 
     Error SendQuery(Tlv::Type aTlvType, uint16_t aMaxEntries, uint32_t aMaxEntryAge, uint16_t aRloc16);
-    Error ProcessAnswer(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    Error ProcessAnswer(const Coap::Msg &aMsg);
     void  ProcessNetInfoAnswer(const Coap::Message &aMessage);
     void  Finalize(Error aError);
     void  HandleTimer(void);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     union Callbacks
     {

--- a/src/core/utils/history_tracker_server.cpp
+++ b/src/core/utils/history_tracker_server.cpp
@@ -47,18 +47,19 @@ Server::Server(Instance &aInstance)
 {
 }
 
-template <> void Server::HandleTmf<kUriHistoryQuery>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Server::HandleTmf<kUriHistoryQuery>(Coap::Msg &aMsg)
 {
-    VerifyOrExit(aMessage.IsPostRequest());
+    VerifyOrExit(aMsg.mMessage.IsPostRequest());
 
-    LogInfo("Received %s from %s", UriToString<kUriHistoryQuery>(), aMessageInfo.GetPeerAddr().ToString().AsCString());
+    LogInfo("Received %s from %s", UriToString<kUriHistoryQuery>(),
+            aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());
 
-    if (aMessage.IsConfirmable())
+    if (aMsg.mMessage.IsConfirmable())
     {
-        IgnoreError(Get<Tmf::Agent>().SendEmptyAck(aMessage, aMessageInfo));
+        IgnoreError(Get<Tmf::Agent>().SendEmptyAck(aMsg));
     }
 
-    PrepareAndSendAnswers(aMessageInfo.GetPeerAddr(), aMessage);
+    PrepareAndSendAnswers(aMsg.mMessageInfo.GetPeerAddr(), aMsg.mMessage);
 
 exit:
     return;

--- a/src/core/utils/history_tracker_server.hpp
+++ b/src/core/utils/history_tracker_server.hpp
@@ -100,7 +100,7 @@ private:
                                      const Ip6::MessageInfo *aMessageInfo,
                                      Error                   aResult);
 
-    template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
     Coap::MessageQueue mAnswerQueue;
 };


### PR DESCRIPTION
This commit introduces `Coap::Msg`, a class that encapsulates `Coap::Message` and its associated `Ip6::MessageInfo`.

`Coap` methods and TMF resource handlers are updated to use `Coap::Msg` when handling received messages. This change simplifies method signatures by reducing the number of parameters and enables future extensibility for tracking additional information related to received CoAP messages.