### PR TITLE
[crypto] PSA API: extend Crypto platform API to support HKDF-SHA256

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (570)
+#define OPENTHREAD_API_VERSION (571)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/crypto.h
+++ b/include/openthread/platform/crypto.h
@@ -60,10 +60,11 @@ extern "C" {
  */
 typedef enum
 {
-    OT_CRYPTO_KEY_TYPE_RAW,   ///< Key Type: Raw Data.
-    OT_CRYPTO_KEY_TYPE_AES,   ///< Key Type: AES.
-    OT_CRYPTO_KEY_TYPE_HMAC,  ///< Key Type: HMAC.
-    OT_CRYPTO_KEY_TYPE_ECDSA, ///< Key Type: ECDSA.
+    OT_CRYPTO_KEY_TYPE_RAW,    ///< Key Type: Raw Data.
+    OT_CRYPTO_KEY_TYPE_AES,    ///< Key Type: AES.
+    OT_CRYPTO_KEY_TYPE_HMAC,   ///< Key Type: HMAC.
+    OT_CRYPTO_KEY_TYPE_ECDSA,  ///< Key Type: ECDSA.
+    OT_CRYPTO_KEY_TYPE_DERIVE, ///< Key Type: Derive.
 } otCryptoKeyType;
 
 /**
@@ -75,6 +76,7 @@ typedef enum
     OT_CRYPTO_KEY_ALG_AES_ECB,      ///< Key Algorithm: AES ECB.
     OT_CRYPTO_KEY_ALG_HMAC_SHA_256, ///< Key Algorithm: HMAC SHA-256.
     OT_CRYPTO_KEY_ALG_ECDSA,        ///< Key Algorithm: ECDSA.
+    OT_CRYPTO_KEY_ALG_HKDF_SHA256,  ///< Key Algorithm: HKDF SHA-256.
 } otCryptoKeyAlgorithm;
 
 /**
@@ -88,6 +90,7 @@ enum
     OT_CRYPTO_KEY_USAGE_DECRYPT     = 1 << 2, ///< Key Usage: AES ECB.
     OT_CRYPTO_KEY_USAGE_SIGN_HASH   = 1 << 3, ///< Key Usage: Sign Hash.
     OT_CRYPTO_KEY_USAGE_VERIFY_HASH = 1 << 4, ///< Key Usage: Verify Hash.
+    OT_CRYPTO_KEY_USAGE_DERIVE      = 1 << 5, ///< Key Usage: Derive.
 };
 
 /**

--- a/src/core/crypto/storage.hpp
+++ b/src/core/crypto/storage.hpp
@@ -57,10 +57,11 @@ namespace Storage {
  */
 enum KeyType : uint8_t
 {
-    kKeyTypeRaw   = OT_CRYPTO_KEY_TYPE_RAW,   ///< Key Type: Raw Data.
-    kKeyTypeAes   = OT_CRYPTO_KEY_TYPE_AES,   ///< Key Type: AES.
-    kKeyTypeHmac  = OT_CRYPTO_KEY_TYPE_HMAC,  ///< Key Type: HMAC.
-    kKeyTypeEcdsa = OT_CRYPTO_KEY_TYPE_ECDSA, ///< Key Type: ECDSA.
+    kKeyTypeRaw    = OT_CRYPTO_KEY_TYPE_RAW,    ///< Key Type: Raw Data.
+    kKeyTypeAes    = OT_CRYPTO_KEY_TYPE_AES,    ///< Key Type: AES.
+    kKeyTypeHmac   = OT_CRYPTO_KEY_TYPE_HMAC,   ///< Key Type: HMAC.
+    kKeyTypeEcdsa  = OT_CRYPTO_KEY_TYPE_ECDSA,  ///< Key Type: ECDSA.
+    kKeyTypeDerive = OT_CRYPTO_KEY_TYPE_DERIVE, ///< Key Type: Derive.
 };
 
 /**
@@ -72,6 +73,7 @@ enum KeyAlgorithm : uint8_t
     kKeyAlgorithmAesEcb     = OT_CRYPTO_KEY_ALG_AES_ECB,      ///< Key Algorithm: AES ECB.
     kKeyAlgorithmHmacSha256 = OT_CRYPTO_KEY_ALG_HMAC_SHA_256, ///< Key Algorithm: HMAC SHA-256.
     kKeyAlgorithmEcdsa      = OT_CRYPTO_KEY_ALG_ECDSA,        ///< Key Algorithm: ECDSA.
+    kKeyAlgorithmHkdfSha256 = OT_CRYPTO_KEY_ALG_HKDF_SHA256,  ///< Key Algorithm: HKDF SHA-256.
 };
 
 constexpr uint8_t kUsageNone       = OT_CRYPTO_KEY_USAGE_NONE;        ///< Key Usage: Key Usage is empty.
@@ -80,6 +82,7 @@ constexpr uint8_t kUsageEncrypt    = OT_CRYPTO_KEY_USAGE_ENCRYPT;     ///< Key U
 constexpr uint8_t kUsageDecrypt    = OT_CRYPTO_KEY_USAGE_DECRYPT;     ///< Key Usage: AES ECB.
 constexpr uint8_t kUsageSignHash   = OT_CRYPTO_KEY_USAGE_SIGN_HASH;   ///< Key Usage: Sign Hash.
 constexpr uint8_t kUsageVerifyHash = OT_CRYPTO_KEY_USAGE_VERIFY_HASH; ///< Key Usage: Verify Hash.
+constexpr uint8_t kUsageDerive     = OT_CRYPTO_KEY_USAGE_DERIVE;      ///< Key Usage: Derive.
 
 /**
  * Defines the key storage types.


### PR DESCRIPTION
This is another PR in the series intended to break down the large PR #11445 into smaller chunks.

Specifically, it enables the use of the PSA Crypto API backend for HKDF operations, which is required for TREL (Thread Radio Encapsulation Link) and to pass unit tests after contributing PSA API support.

PR includes the following commit:

**[crypto] PSA API: extend Crypto platform API to support HKDF-SHA256**

This commit adds PSA API support for HKDF-SHA256 for TREL in OpenThread platform API.