### PR TITLE
[discover-scan] simplify and enhance discovery response parsing

### DIFF
--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -349,15 +349,12 @@ public:
      *
      * @returns The Steering Data length.
      */
-    uint8_t GetSteeringDataLength(void) const
-    {
-        return GetLength() <= sizeof(mSteeringData) ? GetLength() : sizeof(mSteeringData);
-    }
+    uint8_t GetSteeringDataLength(void) const { return Min<uint8_t>(GetLength(), SteeringData::kMaxLength); }
 
     /**
      * Sets all bits in the Bloom Filter to zero.
      */
-    void Clear(void) { memset(mSteeringData, 0, GetSteeringDataLength()); }
+    void Clear(void) { ClearAllBytes(mSteeringData); }
 
     /**
      * Copies the Steering Data from the TLV into a given `SteeringData` variable.


### PR DESCRIPTION
This commit enhances the parsing of discovery response messages in `DiscoverScanner::HandleDiscoveryResponse()`.

The parsing logic is updated to first restrict the message to the content of the `Discovery` TLV. This allows for a simpler and more robust processing of the nested MeshCoP sub-TLVs. Instead of looping through all sub-TLVs, the new approach directly looks for each expected sub-TLV.

This change provides a clearer distinction between required TLVs (`DiscoveryResponseTlv`, `ExtendedPanIdTlv`, `NetworkNameTlv`) and optional ones. The handling of optional TLVs like `JoinerUdpPortTlv` and `SteeringDataTlv` is improved to explicitly manage the case where they are not found.

Additionally, this commit includes minor cleanups to `SteeringDataTlv` to simplify its implementation.