### PR TITLE
[mbedtls] fix build failure by including crypto.h

### DIFF
--- a/third_party/mbedtls/mbedtls-config.h
+++ b/third_party/mbedtls/mbedtls-config.h
@@ -38,7 +38,7 @@
 
 #include <openthread/config.h>
 #include <openthread/platform/logging.h>
-#include <openthread/platform/memory.h>
+#include <openthread/platform/crypto.h>
 
 #define MBEDTLS_PLATFORM_SNPRINTF_MACRO snprintf
 


### PR DESCRIPTION
Replace the include of `<openthread/platform/memory.h>` with `<openthread/platform/crypto.h>` in the mbedTLS config header file.

Recent PR #12290 introduced `otPlatCryptoCAlloc()` and `otPlatCryptoFree()` platform APIs and updated the mbedTLS config to use them. This commit ensures the correct header is included to prevent build errors regarding use of undeclared functions (e.g. "error: use of undeclared identifier 'otPlatCryptoCAlloc'").


----

Background: Observing the following build error after #12290.
- This is on MacBook Pro (M4) running macOS Sequoia (15.7.3).
- Toolchain: `AppleClang 17.0.0.17000013`. 

We should try to to cover this in the Github CI builds.

```
/Users/abtink/github/openthread/third_party/mbedtls/repo/library/platform.c:44:56: error: use of undeclared identifier 'otPlatCryptoCAlloc'; did you mean 'otPlatCAlloc'?
   44 | static void * (*mbedtls_calloc_func)(size_t, size_t) = MBEDTLS_PLATFORM_STD_CALLOC;
      |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                        otPlatCAlloc
/Users/abtink/github/openthread/third_party/mbedtls/openthread-mbedtls-config.h:117:42: note: expanded from macro 'MBEDTLS_PLATFORM_STD_CALLOC'
  117 | #define MBEDTLS_PLATFORM_STD_CALLOC      otPlatCryptoCAlloc /**< Default allocator to use, can be undefined */
      |                                          ^
/Users/abtink/github/openthread/include/openthread/platform/memory.h:72:7: note: 'otPlatCAlloc' declared here
   72 | void *otPlatCAlloc(size_t aNum, size_t aSize);
      |       ^
/Users/abtink/github/openthread/third_party/mbedtls/repo/library/platform.c:45:44: error: use of undeclared identifier 'otPlatCryptoFree'
   45 | static void (*mbedtls_free_func)(void *) = MBEDTLS_PLATFORM_STD_FREE;
      |                                            ^
/Users/abtink/github/openthread/third_party/mbedtls/openthread-mbedtls-config.h:118:42: note: expanded from macro 'MBEDTLS_PLATFORM_STD_FREE'
  118 | #define MBEDTLS_PLATFORM_STD_FREE        otPlatCryptoFree   /**< Default free to use, can be undefined */
      |                                          ^
2 errors generated.
```

