### PR TITLE
[ci] cover `toranj` and `nexus` builds under `macos` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -376,6 +376,10 @@ jobs:
       run: |
         script/check-posix-build
         script/check-simulation-build
+        git clean -dfx
+        ./tests/toranj/build.sh all
+        git clean -dfx
+        ./tests/nexus/build.sh
 
   android-ndk:
     name: android-ndk


### PR DESCRIPTION
This commit enhances the CI checks by adding build steps for the `toranj` and `nexus` test suites to the `macos` jobs.

This ensures that any changes that might break the build of these test applications are caught early in the development process.