### PR TITLE
[tests] update `test_detach` to be more robust

### DIFF
--- a/tests/scripts/thread-cert/test_detach.py
+++ b/tests/scripts/thread-cert/test_detach.py
@@ -98,6 +98,7 @@ class TestDetach(thread_cert.TestCase):
 
         child1.detach()
         self.assertEqual(child1.get_state(), 'disabled')
+        self.simulator.go(2)  # The router processes its child table every second; wait 2s to be safe.
         self.assertFalse(router1.get_child_table())
 
         router1.detach()


### PR DESCRIPTION
The router processes its child table every second. After a child gracefully detaches, wait some time to ensure that the router has processed the child table entry.