### PR TITLE
[mle] introduce `Connectivity` and `ConnectivityTlvValue` types

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1033,11 +1033,11 @@ public:
                                  const LeaderData &aLeaderDataB);
 
     /**
-     * Fills an ConnectivityTlv.
+     * Fills a `ConnectivityTlvValue`.
      *
-     * @param[out]  aTlv  A reference to the tlv to be filled.
+     * @param[out]  aTlvValue  A reference to a `ConnectivityTlvValue` be filled.
      */
-    void FillConnectivityTlv(ConnectivityTlv &aTlv);
+    void FillConnectivityTlvValue(ConnectivityTlvValue &aTlvValue) const;
 
     /**
      * Schedule tx of MLE Advertisement message (unicast) to the given neighboring router after a random delay.
@@ -1598,6 +1598,7 @@ private:
         Error ReadFrameCounterTlvs(uint32_t &aLinkFrameCounter, uint32_t &aMleFrameCounter) const;
         Error ReadTlvRequestTlv(TlvList &aTlvList) const;
         Error ReadLeaderDataTlv(LeaderData &aLeaderData) const;
+        Error ReadConnectivityTlv(Connectivity &aConnectivity) const;
         Error ReadAndSetNetworkDataTlv(const LeaderData &aLeaderData) const;
         Error ReadAndSaveActiveDataset(const MeshCoP::Timestamp &aActiveTimestamp) const;
         Error ReadAndSavePendingDataset(const MeshCoP::Timestamp &aPendingTimestamp) const;
@@ -1795,16 +1796,10 @@ private:
         void Clear(void);
         void CopyTo(Parent &aParent) const;
 
-        RxChallenge mRxChallenge;
-        int8_t      mPriority;
-        uint8_t     mLinkQuality3;
-        uint8_t     mLinkQuality2;
-        uint8_t     mLinkQuality1;
-        uint16_t    mSedBufferSize;
-        uint8_t     mSedDatagramCount;
-        uint8_t     mLinkMargin;
-        LeaderData  mLeaderData;
-        bool        mIsSingleton;
+        RxChallenge  mRxChallenge;
+        Connectivity mConnectivity;
+        uint8_t      mLinkMargin;
+        LeaderData   mLeaderData;
     };
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1925,7 +1920,7 @@ private:
         bool  PrepareAnnounceState(void);
         bool  IsBetterParent(uint16_t                aRloc16,
                              uint8_t                 aTwoWayLinkMargin,
-                             const ConnectivityTlv  &aConnectivityTlv,
+                             const Connectivity     &aConnectivity,
                              uint16_t                aVersion,
                              const Mac::CslAccuracy &aCslAccuracy);
 
@@ -2364,6 +2359,7 @@ private:
     void     ClearAlternateRloc16(void);
     uint8_t  SelectLeaderId(void) const;
     uint32_t SelectPartitionId(void) const;
+    void     DetermineConnectivity(Connectivity &aConnectivity) const;
     void     HandleDetachStart(void);
     void     HandleChildStart(void);
     void     HandleSecurityPolicyChanged(void);

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -653,206 +653,54 @@ public:
 };
 
 /**
- * Implements Connectivity TLV generation and parsing.
+ * Represents a Connectivity TLV value.
  */
 OT_TOOL_PACKED_BEGIN
-class ConnectivityTlv : public Tlv, public TlvInfo<Tlv::kConnectivity>
+class ConnectivityTlvValue
 {
 public:
     /**
-     * Initializes the TLV.
+     * Initializes the Connectivity TLV value from a given `Connectivity` object.
+     *
+     * @param[in] aConnectivity   The `Connectivity` to use for initialization.
      */
-    void Init(void)
-    {
-        SetType(kConnectivity);
-        SetLength(sizeof(*this) - sizeof(Tlv));
-    }
+    void InitFrom(const Connectivity &aConnectivity);
 
     /**
-     * Indicates whether or not the TLV appears to be well-formed.
+     * Gets the connectivity information from the TLV value.
      *
-     * @retval TRUE   If the TLV appears to be well-formed.
-     * @retval FALSE  If the TLV does not appear to be well-formed.
+     * @param[out] aConnectivity  A reference to a `Connectivity` object to output the information.
      */
-    bool IsValid(void) const
-    {
-        return IsSedBufferingIncluded() ||
-               (GetLength() == sizeof(*this) - sizeof(Tlv) - sizeof(mSedBufferSize) - sizeof(mSedDatagramCount));
-    }
+    void GetConnectivity(Connectivity &aConnectivity) const;
 
     /**
-     * Indicates whether or not the sed buffer size and datagram count are included.
+     * Parses a Connectivity TLV value from a given message.
      *
-     * @retval TRUE   If the sed buffer size and datagram count are included.
-     * @retval FALSE  If the sed buffer size and datagram count are not included.
+     * The SED Buffer Size and Datagram Count fields are optional in the Connectivity TLV. If not present in the
+     * message, this method populates them with their default minimum values defined by Thread specification.
+     *
+     * @param[in] aMessage        The message to parse from.
+     * @param[in] aOffsetRange    The offset range within the message containing the TLV value.
+     *
+     * @retval kErrorNone   Successfully parsed the TLV value.
+     * @retval kErrorParse  Failed to parse the TLV value from the message.
      */
-    bool IsSedBufferingIncluded(void) const { return GetLength() >= sizeof(*this) - sizeof(Tlv); }
-
-    /**
-     * Returns the Parent Priority value.
-     *
-     * @returns The Parent Priority value.
-     */
-    int8_t GetParentPriority(void) const;
-
-    /**
-     * Sets the Parent Priority value.
-     *
-     * @param[in] aParentPriority  The Parent Priority value.
-     */
-    void SetParentPriority(int8_t aParentPriority);
-
-    /**
-     * Returns the Link Quality 3 value.
-     *
-     * @returns The Link Quality 3 value.
-     */
-    uint8_t GetLinkQuality3(void) const { return mLinkQuality3; }
-
-    /**
-     * Sets the Link Quality 3 value.
-     *
-     * @param[in]  aLinkQuality  The Link Quality 3 value.
-     */
-    void SetLinkQuality3(uint8_t aLinkQuality) { mLinkQuality3 = aLinkQuality; }
-
-    /**
-     * Returns the Link Quality 2 value.
-     *
-     * @returns The Link Quality 2 value.
-     */
-    uint8_t GetLinkQuality2(void) const { return mLinkQuality2; }
-
-    /**
-     * Sets the Link Quality 2 value.
-     *
-     * @param[in]  aLinkQuality  The Link Quality 2 value.
-     */
-    void SetLinkQuality2(uint8_t aLinkQuality) { mLinkQuality2 = aLinkQuality; }
-
-    /**
-     * Sets the Link Quality 1 value.
-     *
-     * @returns The Link Quality 1 value.
-     */
-    uint8_t GetLinkQuality1(void) const { return mLinkQuality1; }
-
-    /**
-     * Sets the Link Quality 1 value.
-     *
-     * @param[in]  aLinkQuality  The Link Quality 1 value.
-     */
-    void SetLinkQuality1(uint8_t aLinkQuality) { mLinkQuality1 = aLinkQuality; }
-
-    /**
-     * Increments the Link Quality N field in TLV for a given Link Quality N (1,2,3).
-     *
-     * The Link Quality N field specifies the number of neighboring router devices with which the sender shares a link
-     * of quality N.
-     *
-     * @param[in] aLinkQuality  The Link Quality N (1,2,3) field to update.
-     */
-    void IncrementLinkQuality(LinkQuality aLinkQuality);
-
-    /**
-     * Sets the Active Routers value.
-     *
-     * @returns The Active Routers value.
-     */
-    uint8_t GetActiveRouters(void) const { return mActiveRouters; }
-
-    /**
-     * Indicates whether or not the partition is a singleton based on Active Routers value.
-     *
-     * @retval TRUE   The partition is a singleton.
-     * @retval FALSE  The partition is not a singleton.
-     */
-    bool IsSingleton(void) const { return (mActiveRouters <= 1); }
-
-    /**
-     * Sets the Active Routers value.
-     *
-     * @param[in]  aActiveRouters  The Active Routers value.
-     */
-    void SetActiveRouters(uint8_t aActiveRouters) { mActiveRouters = aActiveRouters; }
-
-    /**
-     * Returns the Leader Cost value.
-     *
-     * @returns The Leader Cost value.
-     */
-    uint8_t GetLeaderCost(void) const { return mLeaderCost; }
-
-    /**
-     * Sets the Leader Cost value.
-     *
-     * @param[in]  aCost  The Leader Cost value.
-     */
-    void SetLeaderCost(uint8_t aCost) { mLeaderCost = aCost; }
-
-    /**
-     * Returns the ID Sequence value.
-     *
-     * @returns The ID Sequence value.
-     */
-    uint8_t GetIdSequence(void) const { return mIdSequence; }
-
-    /**
-     * Sets the ID Sequence value.
-     *
-     * @param[in]  aSequence  The ID Sequence value.
-     */
-    void SetIdSequence(uint8_t aSequence) { mIdSequence = aSequence; }
-
-    /**
-     * Returns the SED Buffer Size value.
-     *
-     * @returns The SED Buffer Size value.
-     */
-    uint16_t GetSedBufferSize(void) const
-    {
-        uint16_t buffersize = OPENTHREAD_CONFIG_DEFAULT_SED_BUFFER_SIZE;
-
-        if (IsSedBufferingIncluded())
-        {
-            buffersize = BigEndian::HostSwap16(mSedBufferSize);
-        }
-        return buffersize;
-    }
-
-    /**
-     * Sets the SED Buffer Size value.
-     *
-     * @param[in]  aSedBufferSize  The SED Buffer Size value.
-     */
-    void SetSedBufferSize(uint16_t aSedBufferSize) { mSedBufferSize = BigEndian::HostSwap16(aSedBufferSize); }
-
-    /**
-     * Returns the SED Datagram Count value.
-     *
-     * @returns The SED Datagram Count value.
-     */
-    uint8_t GetSedDatagramCount(void) const
-    {
-        uint8_t count = OPENTHREAD_CONFIG_DEFAULT_SED_DATAGRAM_COUNT;
-
-        if (IsSedBufferingIncluded())
-        {
-            count = mSedDatagramCount;
-        }
-        return count;
-    }
-
-    /**
-     * Sets the SED Datagram Count value.
-     *
-     * @param[in]  aSedDatagramCount  The SED Datagram Count value.
-     */
-    void SetSedDatagramCount(uint8_t aSedDatagramCount) { mSedDatagramCount = aSedDatagramCount; }
+    Error ParseFrom(const Message &aMessage, const OffsetRange &aOffsetRange);
 
 private:
     static constexpr uint8_t kFlagsParentPriorityOffset = 6;
     static constexpr uint8_t kFlagsParentPriorityMask   = (3 << kFlagsParentPriorityOffset);
+
+    static constexpr uint8_t kMinSize = 7; // Exclude the optional `mSedBufferSize` and `mSedDatagramCount`.
+
+    // The default minimum values to use when the optional fields
+    // `mSedBufferSize`, `mSedDatagramCount` are not included. These
+    // numbers are from Thread Conformance Specification 1.4.1-dr3:
+    // "A Thread Router MUST be able to buffer at least one 1280-octet
+    // IPv6 datagram destined for an attached SED".
+
+    static constexpr uint16_t kMinSedBufferSize    = 1280;
+    static constexpr uint8_t  kMinSedDatagramCount = 1;
 
     uint8_t  mFlags;
     uint8_t  mLinkQuality3;
@@ -864,6 +712,11 @@ private:
     uint16_t mSedBufferSize;
     uint8_t  mSedDatagramCount;
 } OT_TOOL_PACKED_END;
+
+/**
+ * Defines Connectivity TLV constants.
+ */
+typedef TlvInfo<Tlv::kConnectivity> ConnectivityTlv;
 
 /**
  * Provides constants and methods for generation and parsing of Address Registration TLV.

--- a/src/core/thread/mle_types.cpp
+++ b/src/core/thread/mle_types.cpp
@@ -191,6 +191,27 @@ bool RxChallenge::operator==(const TxChallenge &aTxChallenge) const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+// Connectivity
+
+void Connectivity::IncrementNumForLinkQuality(uint8_t aLinkQuality)
+{
+    switch (aLinkQuality)
+    {
+    case kLinkQuality1:
+        mLinkQuality1++;
+        break;
+    case kLinkQuality2:
+        mLinkQuality2++;
+        break;
+    case kLinkQuality3:
+        mLinkQuality3++;
+        break;
+    default:
+        break;
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 
 const char *RoleToString(DeviceRole aRole)
 {

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -42,10 +42,9 @@
 #if OPENTHREAD_CONFIG_P2P_ENABLE
 #include <openthread/provisional/p2p.h>
 #endif
+#include <openthread/netdiag.h>
 #include <openthread/thread.h>
-#if OPENTHREAD_FTD
 #include <openthread/thread_ftd.h>
-#endif
 
 #include "common/array.hpp"
 #include "common/as_core_type.hpp"
@@ -67,6 +66,8 @@ namespace ot {
 class Message;
 
 namespace Mle {
+
+class Mle;
 
 /**
  * @addtogroup core-mle-core
@@ -744,6 +745,92 @@ public:
 
 private:
     uint8_t m8[RxChallenge::kMaxSize];
+};
+
+/**
+ * Represents device connectivity info from Connectivity TLV.
+ */
+class Connectivity : public otNetworkDiagConnectivity, public Clearable<Connectivity>
+{
+    friend class Mle;
+
+public:
+    /**
+     * Returns the Parent Priority value.
+     *
+     * @returns The Parent Priority value.
+     */
+    int8_t GetParentPriority(void) const { return mParentPriority; }
+
+    /**
+     * Returns the number of neighbors with link quality 3.
+     *
+     * @returns The number of neighbors with link quality 3.
+     */
+    uint8_t GetNumLinkQuality3(void) const { return mLinkQuality3; }
+
+    /**
+     * Returns the number of neighbors with link quality 2.
+     *
+     * @returns The number of neighbors with link quality 2.
+     */
+    uint8_t GetNumLinkQuality2(void) const { return mLinkQuality2; }
+
+    /**
+     * Returns the number of neighbors with link quality 1.
+     *
+     * @returns The number of neighbors with link quality 1.
+     */
+    uint8_t GetNumLinkQuality1(void) const { return mLinkQuality1; }
+
+    /**
+     * Returns the Leader Cost value.
+     *
+     * @returns The Leader Cost value.
+     */
+    uint8_t GetLeaderCost(void) const { return mLeaderCost; }
+
+    /**
+     * Returns the Router ID Sequence value.
+     *
+     * @returns The Router ID Sequence value.
+     */
+    uint8_t GetIdSequence(void) const { return mIdSequence; }
+
+    /**
+     * Returns the Active Routers value.
+     *
+     * @returns The Active Routers value.
+     */
+    uint8_t GetActiveRouterCount(void) const { return mActiveRouters; }
+
+    /**
+     * Indicates whether or not the partition is a singleton based on Active Router Count.
+     *
+     * @retval TRUE   The partition is a singleton.
+     * @retval FALSE  The partition is not a singleton.
+     */
+    bool IsSingleton(void) const { return (mActiveRouters <= 1); }
+
+    /**
+     * Returns the SED Buffer Size value.
+     *
+     * @returns The SED Buffer Size value.
+     */
+    uint16_t GetSedBufferSize(void) const { return mSedBufferSize; }
+
+    /**
+     * Returns the SED Datagram Count value.
+     *
+     * @returns The SED Datagram Count value.
+     */
+    uint8_t GetSedDatagramCount(void) const { return mSedDatagramCount; }
+
+private:
+    static constexpr uint16_t kDefaultSedBufferSize    = OPENTHREAD_CONFIG_DEFAULT_SED_BUFFER_SIZE;
+    static constexpr uint8_t  kDefaultSedDatagramCount = OPENTHREAD_CONFIG_DEFAULT_SED_DATAGRAM_COUNT;
+
+    void IncrementNumForLinkQuality(uint8_t aLinkQuality);
 };
 
 /**

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -549,11 +549,10 @@ Error Server::AppendDiagTlv(uint8_t aTlvType, Message &aMessage)
 
     case Tlv::kConnectivity:
     {
-        ConnectivityTlv tlv;
+        ConnectivityTlvValue tlvValue;
 
-        tlv.Init();
-        Get<Mle::Mle>().FillConnectivityTlv(tlv);
-        error = tlv.AppendTo(aMessage);
+        Get<Mle::Mle>().FillConnectivityTlvValue(tlvValue);
+        error = Tlv::Append<ConnectivityTlv>(aMessage, &tlvValue, sizeof(tlvValue));
         break;
     }
 
@@ -1298,12 +1297,10 @@ Error Client::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator,
 
         case Tlv::kConnectivity:
         {
-            ConnectivityTlv connectivityTlv;
+            ConnectivityTlvValue tlvValue;
 
-            VerifyOrExit(!tlvInfo.mIsExtended, error = kErrorParse);
-            SuccessOrExit(error = aMessage.Read(offset, connectivityTlv));
-            VerifyOrExit(connectivityTlv.IsValid(), error = kErrorParse);
-            connectivityTlv.GetConnectivity(aDiagTlv.mData.mConnectivity);
+            SuccessOrExit(error = tlvValue.ParseFrom(aMessage, tlvInfo.mValueOffsetRange));
+            tlvValue.GetConnectivity(AsCoreType(&aDiagTlv.mData.mConnectivity));
             break;
         }
 

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -39,6 +39,7 @@
 #include <openthread/netdiag.h>
 #include <openthread/thread.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/encoding.hpp"
 #include "common/message.hpp"
@@ -276,45 +277,20 @@ typedef SimpleTlvInfo<Tlv::kBrLocalOnlinkPrefix, Ip6::NetworkPrefix> BrLocalOnli
  */
 typedef SimpleTlvInfo<Tlv::kBrFavoredOnLinkPrefix, Ip6::NetworkPrefix> BrFavoredOnLinkPrefixTlv;
 
-typedef otNetworkDiagConnectivity Connectivity; ///< Network Diagnostic Connectivity value.
+/**
+ * Represents information parsed from Connectivity TLV.
+ */
+typedef Mle::Connectivity Connectivity;
 
 /**
- * Implements Connectivity TLV generation and parsing.
+ * Represents a Connectivity TLV value.
  */
-OT_TOOL_PACKED_BEGIN
-class ConnectivityTlv : public Mle::ConnectivityTlv
-{
-public:
-    static constexpr uint8_t kType = ot::NetworkDiagnostic::Tlv::kConnectivity; ///< The TLV Type value.
+typedef Mle::ConnectivityTlvValue ConnectivityTlvValue;
 
-    /**
-     * Initializes the TLV.
-     */
-    void Init(void)
-    {
-        Mle::ConnectivityTlv::Init();
-        ot::Tlv::SetType(kType);
-    }
-
-    /**
-     * Retrieves the `Connectivity` value.
-     *
-     * @param[out] aConnectivity   A reference to `Connectivity` to populate.
-     */
-    void GetConnectivity(Connectivity &aConnectivity) const
-    {
-        aConnectivity.mParentPriority   = GetParentPriority();
-        aConnectivity.mLinkQuality3     = GetLinkQuality3();
-        aConnectivity.mLinkQuality2     = GetLinkQuality2();
-        aConnectivity.mLinkQuality1     = GetLinkQuality1();
-        aConnectivity.mLeaderCost       = GetLeaderCost();
-        aConnectivity.mIdSequence       = GetIdSequence();
-        aConnectivity.mActiveRouters    = GetActiveRouters();
-        aConnectivity.mSedBufferSize    = GetSedBufferSize();
-        aConnectivity.mSedDatagramCount = GetSedDatagramCount();
-    }
-
-} OT_TOOL_PACKED_END;
+/**
+ * Defines Connectivity TLV constants.
+ */
+typedef TlvInfo<Tlv::kConnectivity> ConnectivityTlv;
 
 /**
  * Implements Route TLV generation and parsing.
@@ -1126,6 +1102,9 @@ private:
 } OT_TOOL_PACKED_END;
 
 } // namespace NetworkDiagnostic
+
+DefineCoreType(otNetworkDiagConnectivity, NetworkDiagnostic::Connectivity);
+
 } // namespace ot
 
 #endif // OT_CORE_THREAD_NETWORK_DIAGNOSTIC_TLVS_HPP_


### PR DESCRIPTION
This change separates the Connectivity TLV value format from its logical structure by introducing `ConnectivityTlvValue` (raw format) and `Connectivity` (parsed info). This replaces the `ConnectivityTlv` class and enables value format sharing between MLE and Network Diagnostics (without improper TLV inheritance).

It also updates `ParentCandidate` to use the new `Connectivity` class for better field encapsulation. It also updates `ConnectivityTlvValue` parsing to handle optional fields and enforce spec-defined minimums for these fields.