### PR TITLE
[tlv] improve encapsulation and docs for `Tlv::Info`

### DIFF
--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -65,14 +65,14 @@ Error Tlv::FindTlv(const Message &aMessage, uint8_t aType, uint16_t aMaxSize, Tl
 
 Error Tlv::FindTlv(const Message &aMessage, uint8_t aType, uint16_t aMaxSize, Tlv &aTlv, uint16_t &aOffset)
 {
-    Error      error;
-    ParsedInfo info;
+    Error error;
+    Info  info;
 
     SuccessOrExit(error = info.FindIn(aMessage, aType));
 
     info.mTlvOffsetRange.ShrinkLength(aMaxSize);
     aMessage.ReadBytes(info.mTlvOffsetRange, &aTlv);
-    aOffset = info.mTlvOffsetRange.GetOffset();
+    aOffset = info.GetTlvOffset();
 
 exit:
     return error;
@@ -80,17 +80,17 @@ exit:
 
 Error Tlv::FindTlvValueOffsetRange(const Message &aMessage, uint8_t aType, OffsetRange &aOffsetRange)
 {
-    Error      error;
-    ParsedInfo info;
+    Error error;
+    Info  info;
 
     SuccessOrExit(error = info.FindIn(aMessage, aType));
-    aOffsetRange = info.mValueOffsetRange;
+    aOffsetRange = info.GetValueOffsetRange();
 
 exit:
     return error;
 }
 
-Error Tlv::ParsedInfo::ParseFrom(const Message &aMessage, uint16_t aOffset)
+Error Tlv::Info::ParseFrom(const Message &aMessage, uint16_t aOffset)
 {
     OffsetRange offsetRange;
 
@@ -98,7 +98,7 @@ Error Tlv::ParsedInfo::ParseFrom(const Message &aMessage, uint16_t aOffset)
     return ParseFrom(aMessage, offsetRange);
 }
 
-Error Tlv::ParsedInfo::ParseFrom(const Message &aMessage, const OffsetRange &aOffsetRange)
+Error Tlv::Info::ParseFrom(const Message &aMessage, const OffsetRange &aOffsetRange)
 {
     Error       error;
     Tlv         tlv;
@@ -138,7 +138,7 @@ exit:
     return error;
 }
 
-Error Tlv::ParsedInfo::FindIn(const Message &aMessage, uint8_t aType)
+Error Tlv::Info::FindIn(const Message &aMessage, uint8_t aType)
 {
     Error       error = kErrorNotFound;
     OffsetRange offsetRange;
@@ -164,8 +164,8 @@ exit:
 
 Error Tlv::ReadStringTlv(const Message &aMessage, uint16_t aOffset, uint8_t aMaxStringLength, char *aValue)
 {
-    Error      error = kErrorNone;
-    ParsedInfo info;
+    Error error = kErrorNone;
+    Info  info;
 
     SuccessOrExit(error = info.ParseFrom(aMessage, aOffset));
 
@@ -195,8 +195,8 @@ template Error Tlv::ReadUintTlv<uint32_t>(const Message &aMessage, uint16_t aOff
 
 Error Tlv::ReadTlvValue(const Message &aMessage, uint16_t aOffset, void *aValue, uint8_t aMinLength)
 {
-    Error      error;
-    ParsedInfo info;
+    Error error;
+    Info  info;
 
     SuccessOrExit(error = info.ParseFrom(aMessage, aOffset));
 
@@ -211,11 +211,11 @@ exit:
 
 Error Tlv::FindStringTlv(const Message &aMessage, uint8_t aType, uint8_t aMaxStringLength, char *aValue)
 {
-    Error      error;
-    ParsedInfo info;
+    Error error;
+    Info  info;
 
     SuccessOrExit(error = info.FindIn(aMessage, aType));
-    error = ReadStringTlv(aMessage, info.mTlvOffsetRange.GetOffset(), aMaxStringLength, aValue);
+    error = ReadStringTlv(aMessage, info.GetTlvOffset(), aMaxStringLength, aValue);
 
 exit:
     return error;
@@ -223,11 +223,11 @@ exit:
 
 template <typename UintType> Error Tlv::FindUintTlv(const Message &aMessage, uint8_t aType, UintType &aValue)
 {
-    Error      error;
-    ParsedInfo info;
+    Error error;
+    Info  info;
 
     SuccessOrExit(error = info.FindIn(aMessage, aType));
-    error = ReadUintTlv<UintType>(aMessage, info.mTlvOffsetRange.GetOffset(), aValue);
+    error = ReadUintTlv<UintType>(aMessage, info.GetTlvOffset(), aValue);
 
 exit:
     return error;

--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -110,14 +110,14 @@ exit:
 
 void Initiator::HandleReport(const Message &aMessage, OffsetRange &aOffsetRange, const Ip6::Address &aAddress)
 {
-    Error           error     = kErrorNone;
-    bool            hasStatus = false;
-    bool            hasReport = false;
-    Tlv::ParsedInfo tlvInfo;
-    ReportSubTlv    reportTlv;
-    MetricsValues   values;
-    uint8_t         status;
-    uint8_t         typeId;
+    Error         error     = kErrorNone;
+    bool          hasStatus = false;
+    bool          hasReport = false;
+    Tlv::Info     tlvInfo;
+    ReportSubTlv  reportTlv;
+    MetricsValues values;
+    uint8_t       status;
+    uint8_t       typeId;
 
     OT_UNUSED_VARIABLE(error);
 
@@ -129,7 +129,7 @@ void Initiator::HandleReport(const Message &aMessage, OffsetRange &aOffsetRange,
     {
         SuccessOrExit(error = tlvInfo.ParseFrom(aMessage, aOffsetRange));
 
-        if (tlvInfo.mIsExtended)
+        if (tlvInfo.IsExtended())
         {
             continue;
         }
@@ -138,7 +138,7 @@ void Initiator::HandleReport(const Message &aMessage, OffsetRange &aOffsetRange,
         // - One or more Report Sub-TLVs (in case of success), or
         // - A single Status Sub-TLV (in case of failure).
 
-        switch (tlvInfo.mType)
+        switch (tlvInfo.GetType())
         {
         case StatusSubTlv::kType:
             VerifyOrExit(!hasStatus && !hasReport, error = kErrorDrop);
@@ -287,11 +287,11 @@ exit:
 
 Error Initiator::HandleManagementResponse(const Message &aMessage, const Ip6::Address &aAddress)
 {
-    Error           error = kErrorNone;
-    OffsetRange     offsetRange;
-    Tlv::ParsedInfo tlvInfo;
-    uint8_t         status;
-    bool            hasStatus = false;
+    Error       error = kErrorNone;
+    OffsetRange offsetRange;
+    Tlv::Info   tlvInfo;
+    uint8_t     status;
+    bool        hasStatus = false;
 
     VerifyOrExit(mMgmtResponseCallback.IsSet());
 
@@ -301,12 +301,12 @@ Error Initiator::HandleManagementResponse(const Message &aMessage, const Ip6::Ad
     {
         SuccessOrExit(error = tlvInfo.ParseFrom(aMessage, offsetRange));
 
-        if (tlvInfo.mIsExtended)
+        if (tlvInfo.IsExtended())
         {
             continue;
         }
 
-        switch (tlvInfo.mType)
+        switch (tlvInfo.GetType())
         {
         case StatusSubTlv::kType:
             VerifyOrExit(!hasStatus, error = kErrorParse);
@@ -402,13 +402,13 @@ Subject::Subject(Instance &aInstance)
 
 Error Subject::AppendReport(Message &aMessage, const Message &aRequestMessage, Neighbor &aNeighbor)
 {
-    Error           error = kErrorNone;
-    Tlv::ParsedInfo tlvInfo;
-    uint8_t         queryId;
-    bool            hasQueryId = false;
-    OffsetRange     offsetRange;
-    Tlv::Bookmark   tlvBookmark;
-    MetricsValues   values;
+    Error         error = kErrorNone;
+    Tlv::Info     tlvInfo;
+    uint8_t       queryId;
+    bool          hasQueryId = false;
+    OffsetRange   offsetRange;
+    Tlv::Bookmark tlvBookmark;
+    MetricsValues values;
 
     values.Clear();
 
@@ -423,22 +423,21 @@ Error Subject::AppendReport(Message &aMessage, const Message &aRequestMessage, N
     {
         SuccessOrExit(error = tlvInfo.ParseFrom(aRequestMessage, offsetRange));
 
-        if (tlvInfo.mIsExtended)
+        if (tlvInfo.IsExtended())
         {
             continue;
         }
 
-        switch (tlvInfo.mType)
+        switch (tlvInfo.GetType())
         {
         case SubTlv::kQueryId:
-            SuccessOrExit(error =
-                              Tlv::Read<QueryIdSubTlv>(aRequestMessage, tlvInfo.mTlvOffsetRange.GetOffset(), queryId));
+            SuccessOrExit(error = Tlv::Read<QueryIdSubTlv>(aRequestMessage, tlvInfo.GetTlvOffset(), queryId));
             hasQueryId = true;
             break;
 
         case SubTlv::kQueryOptions:
-            SuccessOrExit(error =
-                              ReadTypeIdsFromMessage(aRequestMessage, tlvInfo.mValueOffsetRange, values.GetMetrics()));
+            SuccessOrExit(
+                error = ReadTypeIdsFromMessage(aRequestMessage, tlvInfo.GetValueOffsetRange(), values.GetMetrics()));
             break;
 
         default:
@@ -496,7 +495,7 @@ Error Subject::HandleManagementRequest(const Message &aMessage, Neighbor &aNeigh
 {
     Error               error = kErrorNone;
     OffsetRange         offsetRange;
-    Tlv::ParsedInfo     tlvInfo;
+    Tlv::Info           tlvInfo;
     FwdProbingRegSubTlv fwdProbingSubTlv;
     EnhAckConfigSubTlv  enhAckConfigSubTlv;
     Metrics             metrics;
@@ -516,14 +515,14 @@ Error Subject::HandleManagementRequest(const Message &aMessage, Neighbor &aNeigh
 
         SuccessOrExit(error = tlvInfo.ParseFrom(aMessage, offsetRange));
 
-        if (tlvInfo.mIsExtended)
+        if (tlvInfo.IsExtended())
         {
             continue;
         }
 
-        tlvOffsetRange = tlvInfo.mTlvOffsetRange;
+        tlvOffsetRange = tlvInfo.GetTlvOffsetRange();
 
-        switch (tlvInfo.mType)
+        switch (tlvInfo.GetType())
         {
         case SubTlv::kFwdProbingReg:
             subTlv     = &fwdProbingSubTlv;

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -2707,7 +2707,7 @@ void Mle::HandleDiscoveryRequest(RxInfo &aRxInfo)
 {
     Error                             error                     = kErrorNone;
     bool                              parsedDiscoveryRequestTlv = false;
-    Tlv::ParsedInfo                   tlvInfo;
+    Tlv::Info                         tlvInfo;
     MeshCoP::DiscoveryRequestTlvValue discoveryRequestTlvValue;
     MeshCoP::ExtendedPanId            extPanId;
     OffsetRange                       offsetRange;
@@ -2723,12 +2723,12 @@ void Mle::HandleDiscoveryRequest(RxInfo &aRxInfo)
     {
         SuccessOrExit(error = tlvInfo.ParseFrom(aRxInfo.mMessage, offsetRange));
 
-        if (tlvInfo.mIsExtended)
+        if (tlvInfo.IsExtended())
         {
             continue;
         }
 
-        switch (tlvInfo.mType)
+        switch (tlvInfo.GetType())
         {
         case MeshCoP::Tlv::kDiscoveryRequest:
             SuccessOrExit(error = Tlv::Read<MeshCoP::DiscoveryRequestTlv>(aRxInfo.mMessage, offsetRange.GetOffset(),

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -1261,9 +1261,9 @@ void Client::ParseIp6AddrList(Ip6AddrList &aIp6Addrs, const Message &aMessage, O
 
 Error Client::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator, DiagTlv &aDiagTlv)
 {
-    Error           error;
-    uint16_t        offset = (aIterator == 0) ? aMessage.GetOffset() : aIterator;
-    Tlv::ParsedInfo tlvInfo;
+    Error     error;
+    uint16_t  offset = (aIterator == 0) ? aMessage.GetOffset() : aIterator;
+    Tlv::Info tlvInfo;
 
     while (offset < aMessage.GetLength())
     {
@@ -1271,7 +1271,7 @@ Error Client::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator,
 
         SuccessOrExit(error = tlvInfo.ParseFrom(aMessage, offset));
 
-        switch (tlvInfo.mType)
+        switch (tlvInfo.GetType())
         {
         case Tlv::kExtMacAddress:
             SuccessOrExit(error =
@@ -1299,7 +1299,7 @@ Error Client::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator,
         {
             ConnectivityTlvValue tlvValue;
 
-            SuccessOrExit(error = tlvValue.ParseFrom(aMessage, tlvInfo.mValueOffsetRange));
+            SuccessOrExit(error = tlvValue.ParseFrom(aMessage, tlvInfo.GetValueOffsetRange()));
             tlvValue.GetConnectivity(AsCoreType(&aDiagTlv.mData.mConnectivity));
             break;
         }
@@ -1309,7 +1309,7 @@ Error Client::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator,
             RouteTlv routeTlv;
             uint16_t bytesToRead = Min<uint16_t>(tlvInfo.GetSize(), sizeof(routeTlv));
 
-            VerifyOrExit(!tlvInfo.mIsExtended, error = kErrorParse);
+            VerifyOrExit(!tlvInfo.IsExtended(), error = kErrorParse);
             SuccessOrExit(error = aMessage.Read(offset, &routeTlv, bytesToRead));
             VerifyOrExit(routeTlv.IsValid(), error = kErrorParse);
             ParseRoute(routeTlv, aDiagTlv.mData.mRoute);
@@ -1333,14 +1333,13 @@ Error Client::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator,
             static_assert(sizeof(aDiagTlv.mData.mNetworkData.m8) >= NetworkData::NetworkData::kMaxSize,
                           "NetworkData array in `otNetworkDiagTlv` is too small");
 
-            VerifyOrExit(tlvInfo.mValueOffsetRange.GetLength() <= NetworkData::NetworkData::kMaxSize,
-                         error = kErrorParse);
-            aDiagTlv.mData.mNetworkData.mCount = static_cast<uint8_t>(tlvInfo.mValueOffsetRange.GetLength());
-            aMessage.ReadBytes(tlvInfo.mValueOffsetRange, aDiagTlv.mData.mNetworkData.m8);
+            VerifyOrExit(tlvInfo.GetLength() <= NetworkData::NetworkData::kMaxSize, error = kErrorParse);
+            aDiagTlv.mData.mNetworkData.mCount = static_cast<uint8_t>(tlvInfo.GetLength());
+            aMessage.ReadBytes(tlvInfo.GetValueOffsetRange(), aDiagTlv.mData.mNetworkData.m8);
             break;
 
         case Tlv::kIp6AddressList:
-            ParseIp6AddrList(aDiagTlv.mData.mIp6AddrList, aMessage, tlvInfo.mValueOffsetRange);
+            ParseIp6AddrList(aDiagTlv.mData.mIp6AddrList, aMessage, tlvInfo.GetValueOffsetRange());
             break;
 
         case Tlv::kMacCounters:
@@ -1373,23 +1372,25 @@ Error Client::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator,
 
         case Tlv::kChildTable:
         {
-            uint16_t   childInfoLength = GetArrayLength(aDiagTlv.mData.mChildTable.mTable);
-            ChildInfo *childInfo       = &aDiagTlv.mData.mChildTable.mTable[0];
-            uint8_t   &childCount      = aDiagTlv.mData.mChildTable.mCount;
+            uint16_t    childInfoLength = GetArrayLength(aDiagTlv.mData.mChildTable.mTable);
+            ChildInfo  *childInfo       = &aDiagTlv.mData.mChildTable.mTable[0];
+            uint8_t    &childCount      = aDiagTlv.mData.mChildTable.mCount;
+            OffsetRange offsetRange;
 
-            VerifyOrExit((tlvInfo.mValueOffsetRange.GetLength() % sizeof(ChildTableEntry)) == 0, error = kErrorParse);
+            VerifyOrExit((tlvInfo.GetLength() % sizeof(ChildTableEntry)) == 0, error = kErrorParse);
 
             // `DiagTlv` has a fixed array Child Table entries. If there
             // are more entries in the message, we read and return as
             // many as can fit in array and ignore the rest.
 
-            childCount = 0;
+            childCount  = 0;
+            offsetRange = tlvInfo.GetValueOffsetRange();
 
-            while (!tlvInfo.mValueOffsetRange.IsEmpty() && (childCount < childInfoLength))
+            while (!offsetRange.IsEmpty() && (childCount < childInfoLength))
             {
                 ChildTableEntry entry;
 
-                SuccessOrExit(error = aMessage.Read(tlvInfo.mValueOffsetRange, entry));
+                SuccessOrExit(error = aMessage.Read(offsetRange, entry));
 
                 childInfo->mTimeout     = entry.GetTimeout();
                 childInfo->mLinkQuality = entry.GetLinkQuality();
@@ -1398,16 +1399,16 @@ Error Client::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator,
 
                 childCount++;
                 childInfo++;
-                tlvInfo.mValueOffsetRange.AdvanceOffset(sizeof(ChildTableEntry));
+                offsetRange.AdvanceOffset(sizeof(ChildTableEntry));
             }
 
             break;
         }
 
         case Tlv::kChannelPages:
-            aDiagTlv.mData.mChannelPages.mCount = static_cast<uint8_t>(
-                Min(tlvInfo.mValueOffsetRange.GetLength(), GetArrayLength(aDiagTlv.mData.mChannelPages.m8)));
-            aMessage.ReadBytes(tlvInfo.mValueOffsetRange.GetOffset(), aDiagTlv.mData.mChannelPages.m8,
+            aDiagTlv.mData.mChannelPages.mCount =
+                static_cast<uint8_t>(Min(tlvInfo.GetLength(), GetArrayLength(aDiagTlv.mData.mChannelPages.m8)));
+            aMessage.ReadBytes(tlvInfo.GetValueOffset(), aDiagTlv.mData.mChannelPages.m8,
                                aDiagTlv.mData.mChannelPages.mCount);
             break;
 
@@ -1445,7 +1446,7 @@ Error Client::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator,
             break;
 
         case Tlv::kNonPreferredChannels:
-            SuccessOrExit(error = MeshCoP::ChannelMaskTlv::ParseValue(aMessage, tlvInfo.mValueOffsetRange,
+            SuccessOrExit(error = MeshCoP::ChannelMaskTlv::ParseValue(aMessage, tlvInfo.GetValueOffsetRange(),
                                                                       aDiagTlv.mData.mNonPreferredChannels));
             break;
 
@@ -1459,14 +1460,14 @@ Error Client::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator,
         }
 
         case Tlv::kBrIfAddrs:
-            ParseIp6AddrList(aDiagTlv.mData.mBrIfAddrList, aMessage, tlvInfo.mValueOffsetRange);
+            ParseIp6AddrList(aDiagTlv.mData.mBrIfAddrList, aMessage, tlvInfo.GetValueOffsetRange());
             break;
 
         case Tlv::kBrLocalOmrPrefix:
         case Tlv::kBrLocalOnlinkPrefix:
         case Tlv::kBrFavoredOnLinkPrefix:
         case Tlv::kBrDhcp6PdOmrPrefix:
-            SuccessOrExit(error = aMessage.Read(tlvInfo.mValueOffsetRange, aDiagTlv.mData.mBrPrefix));
+            SuccessOrExit(error = aMessage.Read(tlvInfo.GetValueOffsetRange(), aDiagTlv.mData.mBrPrefix));
             break;
 
         default:
@@ -1480,7 +1481,7 @@ Error Client::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator,
         if (!skipTlv)
         {
             // Exit if a TLV is recognized and parsed successfully.
-            aDiagTlv.mType = tlvInfo.mType;
+            aDiagTlv.mType = tlvInfo.GetType();
             aIterator      = offset;
             error          = kErrorNone;
             ExitNow();

--- a/src/core/utils/history_tracker_server.cpp
+++ b/src/core/utils/history_tracker_server.cpp
@@ -129,13 +129,13 @@ void Server::FreeAllRelatedAnswers(Coap::Message &aFirstAnswer)
 
 void Server::PrepareAndSendAnswers(const Ip6::Address &aDestination, const Message &aRequest)
 {
-    Coap::Message  *answer;
-    Error           error;
-    AnswerInfo      info;
-    OffsetRange     offsetRange;
-    Tlv::ParsedInfo tlvInfo;
-    RequestTlv      requestTlv;
-    AnswerTlv       answerTlv;
+    Coap::Message *answer;
+    Error          error;
+    AnswerInfo     info;
+    OffsetRange    offsetRange;
+    Tlv::Info      tlvInfo;
+    RequestTlv     requestTlv;
+    AnswerTlv      answerTlv;
 
     if (Tlv::Find<QueryIdTlv>(aRequest, info.mQueryId) == kErrorNone)
     {
@@ -152,12 +152,12 @@ void Server::PrepareAndSendAnswers(const Ip6::Address &aDestination, const Messa
     {
         SuccessOrExit(error = tlvInfo.ParseFrom(aRequest, offsetRange));
 
-        if (tlvInfo.mIsExtended)
+        if (tlvInfo.IsExtended())
         {
             continue;
         }
 
-        if (tlvInfo.mType == Tlv::kRequest)
+        if (tlvInfo.GetType() == Tlv::kRequest)
         {
             SuccessOrExit(error = aRequest.Read(offsetRange, requestTlv));
             VerifyOrExit(requestTlv.IsValid(), error = kErrorParse);


### PR DESCRIPTION
This change renames `Tlv::ParsedInfo` to `Tlv::Info` to make it more concise and to better reflect its purpose as a metadata holder for a TLV in a message.

The member variables of `Tlv::Info` are made private and public accessor methods are introduced to interact with the object's contenet. This helps ensure that the internal representation of the parsed TLV information is not modified directly by external modules. All existing caller are updated to use the new name and the public helper getter methods.

The Doxygen comments of `Tlv::Info` are also improved for better clarity. Unit test `test_tlv` is also updated to validate all the new methods.