### PR TITLE
[message] add `IncreaseLength()` helper method

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -287,6 +287,18 @@ exit:
     return error;
 }
 
+Error Message::IncreaseLength(uint16_t aSize)
+{
+    Error    error;
+    uint16_t length = GetLength();
+
+    VerifyOrExit(CanAddSafely<uint16_t>(length, aSize), error = kErrorNoBufs);
+    error = SetLength(length + aSize);
+
+exit:
+    return error;
+}
+
 uint8_t Message::GetBufferCount(void) const
 {
     uint8_t rval = 1;
@@ -367,12 +379,10 @@ void Message::InvokeTxCallback(Error aError)
 Error Message::AppendBytes(const void *aBuf, uint16_t aLength)
 {
     Error    error;
-    uint16_t oldLength = GetLength();
+    uint16_t offset = GetLength();
 
-    VerifyOrExit(CanAddSafely<uint16_t>(oldLength, aLength), error = kErrorNoBufs);
-
-    SuccessOrExit(error = SetLength(oldLength + aLength));
-    WriteBytes(oldLength, aBuf, aLength);
+    SuccessOrExit(error = IncreaseLength(aLength));
+    WriteBytes(offset, aBuf, aLength);
 
 exit:
     return error;
@@ -385,7 +395,7 @@ Error Message::AppendBytesFromMessage(const Message &aMessage, const OffsetRange
 
 Error Message::AppendBytesFromMessage(const Message &aMessage, uint16_t aOffset, uint16_t aLength)
 {
-    Error    error       = kErrorNone;
+    Error    error;
     uint16_t writeOffset = GetLength();
     Chunk    chunk;
 
@@ -393,8 +403,7 @@ Error Message::AppendBytesFromMessage(const Message &aMessage, uint16_t aOffset,
 
     VerifyOrExit(aMessage.GetLength() >= aOffset + aLength, error = kErrorParse);
 
-    VerifyOrExit(CanAddSafely<uint16_t>(GetLength(), aLength), error = kErrorNoBufs);
-    SuccessOrExit(error = SetLength(GetLength() + aLength));
+    SuccessOrExit(error = IncreaseLength(aLength));
 
     aMessage.GetFirstChunk(aOffset, aLength, chunk);
 

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -500,6 +500,16 @@ public:
     Error SetLength(uint16_t aLength);
 
     /**
+     * Increases the message length by a given number of bytes.
+     *
+     * @param[in]  aSize     The number of bytes to increase the message length by.
+     *
+     * @retval kErrorNone    Successfully increased the length of the message.
+     * @retval kErrorNoBufs  Failed to allocate new buffers to grow the message.
+     */
+    Error IncreaseLength(uint16_t aSize);
+
+    /**
      * Returns the number of buffers in the message.
      */
     uint8_t GetBufferCount(void) const;

--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -358,7 +358,7 @@ Error Tlv::UpdateTlv(Message &aMessage, Bookmark aBookmark, bool aShouldWriteLen
             // need to move the written value bytes forward to make
             // room for the Extended TLV header.
 
-            SuccessOrExit(error = aMessage.SetLength(aMessage.GetLength() + sizeof(ExtendedTlv) - sizeof(Tlv)));
+            SuccessOrExit(error = aMessage.IncreaseLength(sizeof(ExtendedTlv) - sizeof(Tlv)));
 
             aMessage.WriteBytesFromMessage(/* aWriteOffset */ startOffset + sizeof(ExtendedTlv), aMessage,
                                            /* aReadOffset */ startOffset + sizeof(Tlv), length);


### PR DESCRIPTION
This commit adds a new helper `Message::IncreaseLength()` to grow the message by increasing its length by a given number of bytes.