### PR TITLE
[cli] provide default 'APP' log output implementation in CLI module; allow 'APP' log in Posix app ot-cli

### DIFF
--- a/examples/apps/cli/main.c
+++ b/examples/apps/cli/main.c
@@ -38,7 +38,6 @@
 #include <openthread/cli.h>
 #include <openthread/diag.h>
 #include <openthread/tasklet.h>
-#include <openthread/platform/logging.h>
 #include <openthread/platform/misc.h>
 
 #include "openthread-system.h"
@@ -163,14 +162,3 @@ pseudo_reset:
 
     return 0;
 }
-
-#if OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_APP
-void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
-{
-    va_list ap;
-
-    va_start(ap, aFormat);
-    otCliPlatLogv(aLogLevel, aLogRegion, aFormat, ap);
-    va_end(ap);
-}
-#endif

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -44,6 +44,7 @@ set(COMMON_SOURCES
     cli_history.cpp
     cli_joiner.cpp
     cli_link_metrics.cpp
+    cli_logging.cpp
     cli_mac_filter.cpp
     cli_mdns.cpp
     cli_mesh_diag.cpp

--- a/src/cli/cli_logging.cpp
+++ b/src/cli/cli_logging.cpp
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements default logging functionality for CLI apps.
+ */
+#include "openthread-core-config.h"
+
+#include <stdarg.h>
+
+#include <openthread/cli.h>
+#include <openthread/platform/logging.h>
+
+#include "config/logging.h"
+
+#if OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_APP
+
+extern "C" OT_TOOL_WEAK void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
+{
+    va_list ap;
+
+    va_start(ap, aFormat);
+    otCliPlatLogv(aLogLevel, aLogRegion, aFormat, ap);
+    va_end(ap);
+}
+
+#endif

--- a/src/cli/radio.cmake
+++ b/src/cli/radio.cmake
@@ -46,6 +46,7 @@ target_include_directories(openthread-cli-radio PUBLIC ${OT_PUBLIC_INCLUDES} PRI
 target_sources(openthread-cli-radio
     PRIVATE
         cli.cpp
+        cli_logging.cpp
         cli_utils.cpp
 )
 


### PR DESCRIPTION
Refactors the example CLI app and the CLI module code to provide a default implementation of the 'APP' log
output option for any CLI apps. This default is used when log output is configured to 'APP' output
and the CLI application itself does not provide its own implementation of `otPlatLog()`.

This extends the current logging option (syslog) for the Posix app ot-cli with the option to direct the log
output to the CLI app, which then prints it in stdout. This logging option can be enabled using the existing
-DOT_LOG_OUTPUT=APP. Previously, this gave a build error for the Posix platform. This logging method is
useful/required for running NCPs in OTNS, such that the simulator can capture all log output and at the same
time syslog is not overly burdened on the host machine.