### PR TITLE
[instance] remove `otInstanceIsInitialized()` API and internal state

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -40,6 +40,7 @@
 #include <stdlib.h>
 
 #include <openthread/error.h>
+#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -52,7 +53,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (573)
+#define OPENTHREAD_API_VERSION (574)
 
 /**
  * @addtogroup api-instance
@@ -167,8 +168,11 @@ uint32_t otInstanceGetId(otInstance *aInstance);
  * @param[in] aInstance A pointer to an OpenThread instance.
  *
  * @returns TRUE if the given instance is valid/initialized, FALSE otherwise.
+ *
+ * @deprecated It is challenging for OpenThread to safely track whether an instance is initialized or not. So this API
+ * is deprecated and its implementation is removed in OpenThread.
  */
-bool otInstanceIsInitialized(otInstance *aInstance);
+OT_DEPRECATED("This API is removed and please refactor its usage") bool otInstanceIsInitialized(otInstance *aInstance);
 
 /**
  * Disables the OpenThread library.

--- a/include/openthread/platform/toolchain.h
+++ b/include/openthread/platform/toolchain.h
@@ -311,6 +311,21 @@ extern "C" {
 #endif
 
 /**
+ * @def OT_DEPRECATED
+ *
+ * Mark an API is deprecated with a message.
+ */
+#if defined(__cplusplus) && __cplusplus >= 201402L || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
+#define OT_DEPRECATED(msg) [[deprecated(msg)]]
+#elif defined(_MSC_VER)
+#define OT_DEPRECATED(msg) __declspec(deprecated(msg))
+#elif defined(__GNUC__) || defined(__clang__)
+#define OT_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#else
+#define OT_DEPRECATED(msg)
+#endif
+
+/**
  * @}
  */
 

--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -88,16 +88,6 @@ otInstance *otInstanceGetSingle(void) { return &Instance::Get(); }
 
 uint32_t otInstanceGetId(otInstance *aInstance) { return AsCoreType(aInstance).GetId(); }
 
-bool otInstanceIsInitialized(otInstance *aInstance)
-{
-#if OPENTHREAD_MTD || OPENTHREAD_FTD
-    return AsCoreType(aInstance).IsInitialized();
-#else
-    OT_UNUSED_VARIABLE(aInstance);
-    return true;
-#endif // OPENTHREAD_MTD || OPENTHREAD_FTD
-}
-
 void otInstanceFinalize(otInstance *aInstance) { AsCoreType(aInstance).Finalize(); }
 
 void otInstanceReset(otInstance *aInstance) { AsCoreType(aInstance).Reset(); }

--- a/src/core/api/tasklet_api.cpp
+++ b/src/core/api/tasklet_api.cpp
@@ -39,21 +39,12 @@ using namespace ot;
 
 void otTaskletsProcess(otInstance *aInstance)
 {
-    VerifyOrExit(otInstanceIsInitialized(aInstance));
     AsCoreType(aInstance).Get<Tasklet::Scheduler>().ProcessQueuedTasklets();
-
-exit:
-    return;
 }
 
 bool otTaskletsArePending(otInstance *aInstance)
 {
-    bool retval = false;
-    VerifyOrExit(otInstanceIsInitialized(aInstance));
-    retval = AsCoreType(aInstance).Get<Tasklet::Scheduler>().AreTaskletsPending();
-
-exit:
-    return retval;
+    return AsCoreType(aInstance).Get<Tasklet::Scheduler>().AreTaskletsPending();
 }
 
 OT_TOOL_WEAK void otTaskletsSignalPending(otInstance *) {}

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -254,11 +254,7 @@ void Timer::Scheduler::RemoveAll(const AlarmApi &aAlarmApi)
 
 extern "C" void otPlatAlarmMilliFired(otInstance *aInstance)
 {
-    VerifyOrExit(otInstanceIsInitialized(aInstance));
     AsCoreType(aInstance).Get<TimerMilli::Scheduler>().ProcessTimers();
-
-exit:
-    return;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -291,11 +287,7 @@ void TimerMicro::RemoveAll(Instance &aInstance) { aInstance.Get<Scheduler>().Rem
 
 extern "C" void otPlatAlarmMicroFired(otInstance *aInstance)
 {
-    VerifyOrExit(otInstanceIsInitialized(aInstance));
     AsCoreType(aInstance).Get<TimerMicro::Scheduler>().ProcessTimers();
-
-exit:
-    return;
 }
 #endif // OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -276,13 +276,6 @@ public:
 #endif
 
     /**
-     * Indicates whether or not the instance is valid/initialized and not yet finalized.
-     *
-     * @returns TRUE if the instance is valid/initialized, FALSE otherwise.
-     */
-    bool IsInitialized(void) const { return mIsInitialized; }
-
-    /**
      * Triggers a platform reset.
      *
      * The reset process ensures that all the OpenThread state/info (stored in volatile memory) is erased. Note that
@@ -764,8 +757,6 @@ private:
 #if OPENTHREAD_CONFIG_POWER_CALIBRATION_ENABLE && OPENTHREAD_CONFIG_PLATFORM_POWER_CALIBRATION_ENABLE
     Utils::PowerCalibration mPowerCalibration;
 #endif
-
-    bool mIsInitialized;
 
     uint32_t mId;
 };

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -48,8 +48,6 @@ extern "C" void otPlatRadioReceiveDone(otInstance *aInstance, otRadioFrame *aFra
     Instance     &instance = AsCoreType(aInstance);
     Mac::RxFrame *rxFrame  = static_cast<Mac::RxFrame *>(aFrame);
 
-    VerifyOrExit(instance.IsInitialized());
-
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     if (rxFrame != nullptr)
     {
@@ -67,26 +65,17 @@ extern "C" void otPlatRadioReceiveDone(otInstance *aInstance, otRadioFrame *aFra
     {
         instance.Get<Radio::Callbacks>().HandleReceiveDone(rxFrame, aError);
     }
-
-exit:
-    return;
 }
 
 extern "C" void otPlatRadioTxStarted(otInstance *aInstance, otRadioFrame *aFrame)
 {
-    Instance     &instance = AsCoreType(aInstance);
-    Mac::TxFrame &txFrame  = *static_cast<Mac::TxFrame *>(aFrame);
-
-    VerifyOrExit(instance.IsInitialized());
+    Mac::TxFrame &txFrame = *static_cast<Mac::TxFrame *>(aFrame);
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     txFrame.SetRadioType(Mac::kRadioTypeIeee802154);
 #endif
 
-    instance.Get<Radio::Callbacks>().HandleTransmitStarted(txFrame);
-
-exit:
-    return;
+    AsCoreType(aInstance).Get<Radio::Callbacks>().HandleTransmitStarted(txFrame);
 }
 
 extern "C" void otPlatRadioTxDone(otInstance *aInstance, otRadioFrame *aFrame, otRadioFrame *aAckFrame, otError aError)
@@ -94,8 +83,6 @@ extern "C" void otPlatRadioTxDone(otInstance *aInstance, otRadioFrame *aFrame, o
     Instance     &instance = AsCoreType(aInstance);
     Mac::TxFrame &txFrame  = *static_cast<Mac::TxFrame *>(aFrame);
     Mac::RxFrame *ackFrame = static_cast<Mac::RxFrame *>(aAckFrame);
-
-    VerifyOrExit(instance.IsInitialized());
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     if (ackFrame != nullptr)
@@ -126,30 +113,16 @@ extern "C" void otPlatRadioTxDone(otInstance *aInstance, otRadioFrame *aFrame, o
     {
         instance.Get<Radio::Callbacks>().HandleTransmitDone(txFrame, ackFrame, aError);
     }
-exit:
-    return;
 }
 
 extern "C" void otPlatRadioEnergyScanDone(otInstance *aInstance, int8_t aEnergyScanMaxRssi)
 {
-    Instance &instance = AsCoreType(aInstance);
-
-    VerifyOrExit(instance.IsInitialized());
-    instance.Get<Radio::Callbacks>().HandleEnergyScanDone(aEnergyScanMaxRssi);
-
-exit:
-    return;
+    AsCoreType(aInstance).Get<Radio::Callbacks>().HandleEnergyScanDone(aEnergyScanMaxRssi);
 }
 
 extern "C" void otPlatRadioBusLatencyChanged(otInstance *aInstance)
 {
-    Instance &instance = AsCoreType(aInstance);
-
-    VerifyOrExit(instance.IsInitialized());
-    instance.Get<Radio::Callbacks>().HandleBusLatencyChanged();
-
-exit:
-    return;
+    AsCoreType(aInstance).Get<Radio::Callbacks>().HandleBusLatencyChanged();
 }
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE

--- a/src/core/radio/trel_interface.cpp
+++ b/src/core/radio/trel_interface.cpp
@@ -177,13 +177,7 @@ extern "C" void otPlatTrelHandleReceived(otInstance       *aInstance,
                                          uint16_t          aLength,
                                          const otSockAddr *aSenderAddress)
 {
-    Instance &instance = AsCoreType(aInstance);
-
-    VerifyOrExit(instance.IsInitialized());
-    instance.Get<Interface>().HandleReceived(aBuffer, aLength, AsCoreType(aSenderAddress));
-
-exit:
-    return;
+    AsCoreType(aInstance).Get<Interface>().HandleReceived(aBuffer, aLength, AsCoreType(aSenderAddress));
 }
 
 void Interface::HandleReceived(uint8_t *aBuffer, uint16_t aLength, const Ip6::SockAddr &aSenderAddr)

--- a/src/core/radio/trel_peer_discoverer.cpp
+++ b/src/core/radio/trel_peer_discoverer.cpp
@@ -161,13 +161,8 @@ void PeerDiscoverer::RegisterService(void)
 
 extern "C" void otPlatTrelHandleDiscoveredPeerInfo(otInstance *aInstance, const otPlatTrelPeerInfo *aInfo)
 {
-    Instance &instance = AsCoreType(aInstance);
-
-    VerifyOrExit(instance.IsInitialized());
-    instance.Get<PeerDiscoverer>().HandleDiscoveredPeerInfo(*static_cast<const PeerDiscoverer::PeerInfo *>(aInfo));
-
-exit:
-    return;
+    AsCoreType(aInstance).Get<PeerDiscoverer>().HandleDiscoveredPeerInfo(
+        *static_cast<const PeerDiscoverer::PeerInfo *>(aInfo));
 }
 
 void PeerDiscoverer::HandleDiscoveredPeerInfo(const PeerInfo &aInfo)


### PR DESCRIPTION
This commit removes the `otInstanceIsInitialized` API and the corresponding `mIsInitialized` state from the Instance class.

The intention is to avoid incorrect life cycle management of OpenThread instances. Now OpenThread Instance supports 3 modes of management:

1. Singleton
2. Static Multiple
3. Dynamic Multiple

For 1 & 2, it is *undefined behavior* to access
`Instance::mIsInitialized` before constructing the instance or after destrubting it.

For 3, accessing `Instance::mIsInitialized` after the instance is destructed can be even dangerous because the memory could be already released.

This commit removes the API implementation intentionally to break building any downstream projects that are using it to *fail early and loudly*.

Internal checks for instance initialization are also removed from various core components (tasklets, timers, radio, TREL).

The `OPENTHREAD_API_VERSION` is incremented to reflect the API change.