### PR TITLE
[ip6-mpl] do not process MPL options if rx-off-when-idle

### DIFF
--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -119,6 +119,8 @@ Error Mpl::ProcessOption(Message &aMessage, const MplOption &aOption, bool &aRec
 {
     Error error;
 
+    VerifyOrExit(Get<Mle::Mle>().IsRxOnWhenIdle(), error = kErrorNone);
+
     // Check if the MPL Data Message is new.
     error = UpdateSeedSet(aOption.GetSeedId(), aOption.GetSequence());
 
@@ -136,6 +138,7 @@ Error Mpl::ProcessOption(Message &aMessage, const MplOption &aOption, bool &aRec
         error = kErrorNone;
     }
 
+exit:
     return error;
 }
 


### PR DESCRIPTION
**Describe the bug** A clear and concise description of what the bug is.

When an SED receives a multicast packet (e.g. Realm-Local All Thread Nodes `ping FF33:40:FD5B:281F:1EF6:923C:0:1`), it wakes up 5 more times (1s interval) because of `Mpl::HandleTimeTick`. 

**To Reproduce** Information to reproduce the behavior, including:

1. Git commit id: a12ff0d0f54fd41954b45047fcdd08f302731c5f
2. IEEE 802.15.4 hardware platform: ESP32-H2
3. Build steps: [esp-idf openthread light sleep example](https://github.com/espressif/esp-idf/tree/master/examples/openthread/ot_sleepy_device/light_sleep)
4. Network topology: 1 x leader, 1 x SED

**Expected behavior** A clear and concise description of what you expected to happen.

Do not process MPL options if rx-off-when-idle (refer to below suggestion).

~~For sleepy devices, `Mpl::HandleTimeTick` should only be triggered upon reception (or transmission) of a packet within `OPENTHREAD_CONFIG_MPL_SEED_SET_ENTRY_LIFETIME`, instead of once every 1s by default.~~

~~Because a device which is rx-off-when-idle would not be able to receive any packets within those 5s if it has a sufficiently large pollperiod, these wake-ups will not result in useful behavior.~~

~~This ensures that an SED does not wake up an additional 5 more times whenever a multicast packet is received, which could severely impact power consumption.~~

**Console/log output** If applicable, add console/log output to help explain your problem.

For an SED with pollperiod = 10s, when it receives a multicast ping:

<img width="2485" height="1413" alt="Image" src="https://github.com/user-attachments/assets/15c04d9c-4604-47f7-ba4e-c0312f367161" />

**Additional context** Add any other context about the problem here.

N.A.