### PR TITLE
[mesh-forwarder] evict lower priority msg on direct tx queue limit

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -157,7 +157,10 @@ void MessagePool::FreeBuffers(Buffer *aBuffer)
     }
 }
 
-Error MessagePool::ReclaimBuffers(Message::Priority aPriority) { return Get<MeshForwarder>().EvictMessage(aPriority); }
+Error MessagePool::ReclaimBuffers(Message::Priority aPriority)
+{
+    return Get<MeshForwarder>().EvictMessage(aPriority, MeshForwarder::kEvictReasonNoMessageBuffer);
+}
 
 uint16_t MessagePool::GetFreeBufferCount(void) const
 {

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -196,7 +196,7 @@ void MeshForwarder::HandleResolved(const Ip6::Address &aEid, Error aError)
     }
 }
 
-Error MeshForwarder::EvictMessage(Message::Priority aPriority)
+Error MeshForwarder::EvictMessage(Message::Priority aPriority, EvictReason aEvictReason)
 {
     Error    error = kErrorNotFound;
     Message *evict = nullptr;
@@ -222,11 +222,18 @@ Error MeshForwarder::EvictMessage(Message::Priority aPriority)
                 continue;
             }
 
+            if ((aEvictReason == kEvictReasonDirectTxQueueAtLimit) && !message->IsDirectTransmission())
+            {
+                continue;
+            }
+
             evict = message;
             error = kErrorNone;
             ExitNow();
         }
     }
+
+    VerifyOrExit(aEvictReason == kEvictReasonNoMessageBuffer);
 
     for (uint8_t priority = aPriority; priority < Message::kNumPriorities; priority++)
     {
@@ -254,7 +261,16 @@ Error MeshForwarder::EvictMessage(Message::Priority aPriority)
 exit:
     if ((error == kErrorNone) && (evict != nullptr))
     {
-        FinalizeAndRemoveMessage(*evict, kErrorNoBufs, kMessageEvict);
+        switch (aEvictReason)
+        {
+        case kEvictReasonDirectTxQueueAtLimit:
+            FinalizeAndRemoveMessage(*evict, kErrorDrop, kMessageFullQueueEvict);
+            break;
+
+        case kEvictReasonNoMessageBuffer:
+            FinalizeAndRemoveMessage(*evict, kErrorNoBufs, kMessageEvict);
+            break;
+        }
     }
 
     return error;

--- a/src/core/thread/mesh_forwarder_mtd.cpp
+++ b/src/core/thread/mesh_forwarder_mtd.cpp
@@ -54,8 +54,10 @@ void MeshForwarder::SendMessage(OwnedPtr<Message> aMessagePtr)
 #endif
 }
 
-Error MeshForwarder::EvictMessage(Message::Priority aPriority)
+Error MeshForwarder::EvictMessage(Message::Priority aPriority, EvictReason aEvictReason)
 {
+    OT_UNUSED_VARIABLE(aEvictReason);
+
     Error    error = kErrorNotFound;
     Message *message;
 
@@ -65,6 +67,8 @@ Error MeshForwarder::EvictMessage(Message::Priority aPriority)
 #endif
 
     VerifyOrExit((message = mSendQueue.GetTail()) != nullptr);
+
+    VerifyOrExit(!message->GetDoNotEvict());
 
     if (message->GetPriority() < static_cast<uint8_t>(aPriority))
     {


### PR DESCRIPTION
This commit updates `ApplyDirectTxQueueLimit()` to improve how the direct tx queue handles frame limits.

Previously, when the direct tx queue reached its configured frame count threshold, the code attempted to remove aged messages. If this was insufficient, the new incoming message was dropped.

With this change, after attempting to remove aged messages, the code now attempts to evict an existing lower-priority message (and all its frames) from the direct tx queue to make room for a new higher priority message. If no existing message can be evicted (i.e., all messages are of higher or equal priority), the new message is dropped.

---

Related to [SPEC-1444](https://threadgroup.atlassian.net/browse/SPEC-1444) and https://github.com/openthread/openthread/issues/12296
