### PR TITLE
[cli] include non-sensitive dataset info to debug command

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1436,6 +1436,7 @@ The generated output encompasses the following information:
 - Uptime and attach time
 - Channel
 - PAN IDs, extended MAC address, and RLOC16
+- Active Dataset (non-sensitive)
 - Unicast and multicast IPv6 address list
 - Network Data
 - Partition ID

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -6622,6 +6622,7 @@ template <> otError Interpreter::Process<Cmd("debug")>(Arg aArgs[])
         "channel",
         "panid",
         "extpanid",
+        "dataset active -ns",
         "ipaddr -v",
         "ipmaddr",
         "netdata show",


### PR DESCRIPTION
This commit adds `dataset active -n`s to the list of commands executed by the `debug` CLI command. This includes non-sensitive active dataset information (e.g. Channel, PAN ID, and Network Name) in the diagnostic output.