### PR TITLE
[core] introduce `VendorInfo` class for vendor parameters

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -613,6 +613,8 @@ openthread_core_files = [
   "thread/tmf.hpp",
   "thread/uri_paths.cpp",
   "thread/uri_paths.hpp",
+  "thread/vendor_info.cpp",
+  "thread/vendor_info.hpp",
   "thread/version.cpp",
   "thread/version.hpp",
   "utils/channel_manager.cpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -276,6 +276,7 @@ set(COMMON_SOURCES
     thread/time_sync_service.cpp
     thread/tmf.cpp
     thread/uri_paths.cpp
+    thread/vendor_info.cpp
     thread/version.cpp
     utils/channel_manager.cpp
     utils/channel_monitor.cpp

--- a/src/core/api/netdiag_api.cpp
+++ b/src/core/api/netdiag_api.cpp
@@ -71,45 +71,39 @@ otError otThreadSendDiagnosticReset(otInstance         *aInstance,
 
 #endif // OPENTHREAD_CONFIG_TMF_NETDIAG_CLIENT_ENABLE
 
-const char *otThreadGetVendorName(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<NetworkDiagnostic::Server>().GetVendorName();
-}
+const char *otThreadGetVendorName(otInstance *aInstance) { return AsCoreType(aInstance).Get<VendorInfo>().GetName(); }
 
-const char *otThreadGetVendorModel(otInstance *aInstance)
-{
-    return AsCoreType(aInstance).Get<NetworkDiagnostic::Server>().GetVendorModel();
-}
+const char *otThreadGetVendorModel(otInstance *aInstance) { return AsCoreType(aInstance).Get<VendorInfo>().GetModel(); }
 
 const char *otThreadGetVendorSwVersion(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<NetworkDiagnostic::Server>().GetVendorSwVersion();
+    return AsCoreType(aInstance).Get<VendorInfo>().GetSwVersion();
 }
 
 const char *otThreadGetVendorAppUrl(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<NetworkDiagnostic::Server>().GetVendorAppUrl();
+    return AsCoreType(aInstance).Get<VendorInfo>().GetAppUrl();
 }
 
 #if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
 otError otThreadSetVendorName(otInstance *aInstance, const char *aVendorName)
 {
-    return AsCoreType(aInstance).Get<NetworkDiagnostic::Server>().SetVendorName(aVendorName);
+    return AsCoreType(aInstance).Get<VendorInfo>().SetName(aVendorName);
 }
 
 otError otThreadSetVendorModel(otInstance *aInstance, const char *aVendorModel)
 {
-    return AsCoreType(aInstance).Get<NetworkDiagnostic::Server>().SetVendorModel(aVendorModel);
+    return AsCoreType(aInstance).Get<VendorInfo>().SetModel(aVendorModel);
 }
 
 otError otThreadSetVendorSwVersion(otInstance *aInstance, const char *aVendorSwVersion)
 {
-    return AsCoreType(aInstance).Get<NetworkDiagnostic::Server>().SetVendorSwVersion(aVendorSwVersion);
+    return AsCoreType(aInstance).Get<VendorInfo>().SetSwVersion(aVendorSwVersion);
 }
 
 otError otThreadSetVendorAppUrl(otInstance *aInstance, const char *aVendorAppUrl)
 {
-    return AsCoreType(aInstance).Get<NetworkDiagnostic::Server>().SetVendorAppUrl(aVendorAppUrl);
+    return AsCoreType(aInstance).Get<VendorInfo>().SetAppUrl(aVendorAppUrl);
 }
 #endif
 

--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -167,6 +167,7 @@ Instance::Instance(void)
     , mNetworkDataPublisher(*this)
 #endif
     , mNetworkDataServiceManager(*this)
+    , mVendorInfo(*this)
     , mNetworkDiagnosticServer(*this)
 #if OPENTHREAD_CONFIG_TMF_NETDIAG_CLIENT_ENABLE
     , mNetworkDiagnosticClient(*this)

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -144,6 +144,7 @@
 #include "thread/thread_netif.hpp"
 #include "thread/time_sync_service.hpp"
 #include "thread/tmf.hpp"
+#include "thread/vendor_info.hpp"
 #include "utils/channel_manager.hpp"
 #include "utils/channel_monitor.hpp"
 #include "utils/heap.hpp"
@@ -590,6 +591,8 @@ private:
 
     NetworkData::Service::Manager mNetworkDataServiceManager;
 
+    VendorInfo mVendorInfo;
+
     NetworkDiagnostic::Server mNetworkDiagnosticServer;
 #if OPENTHREAD_CONFIG_TMF_NETDIAG_CLIENT_ENABLE
     NetworkDiagnostic::Client mNetworkDiagnosticClient;
@@ -985,6 +988,8 @@ template <> inline Dns::Dso &Instance::Get(void) { return mDnsDso; }
 #if OPENTHREAD_CONFIG_MULTICAST_DNS_ENABLE
 template <> inline Dns::Multicast::Core &Instance::Get(void) { return mMdnsCore; }
 #endif
+
+template <> inline VendorInfo &Instance::Get(void) { return mVendorInfo; }
 
 template <> inline NetworkDiagnostic::Server &Instance::Get(void) { return mNetworkDiagnosticServer; }
 

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -41,18 +41,6 @@ RegisterLogModule("NetDiag");
 
 namespace NetworkDiagnostic {
 
-const char Server::kVendorName[]      = OPENTHREAD_CONFIG_NET_DIAG_VENDOR_NAME;
-const char Server::kVendorModel[]     = OPENTHREAD_CONFIG_NET_DIAG_VENDOR_MODEL;
-const char Server::kVendorSwVersion[] = OPENTHREAD_CONFIG_NET_DIAG_VENDOR_SW_VERSION;
-const char Server::kVendorAppUrl[]    = OPENTHREAD_CONFIG_NET_DIAG_VENDOR_APP_URL;
-
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-static constexpr char kVendorNamePrefix[] = "RD:";
-
-static_assert(CheckConstStringPrefix(OPENTHREAD_CONFIG_NET_DIAG_VENDOR_NAME, kVendorNamePrefix),
-              "VENDOR_NAME MUST start with 'RD:' prefix for a reference device.");
-#endif
-
 //---------------------------------------------------------------------------------------------------------------------
 // Server
 
@@ -60,51 +48,7 @@ Server::Server(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mNonPreferredChannels(0)
 {
-    static_assert(sizeof(kVendorName) <= sizeof(VendorNameTlv::StringType), "VENDOR_NAME is too long");
-    static_assert(sizeof(kVendorModel) <= sizeof(VendorModelTlv::StringType), "VENDOR_MODEL is too long");
-    static_assert(sizeof(kVendorSwVersion) <= sizeof(VendorSwVersionTlv::StringType), "VENDOR_SW_VERSION is too long");
-    static_assert(sizeof(kVendorAppUrl) <= sizeof(VendorAppUrlTlv::StringType), "VENDOR_APP_URL is too long");
-
-#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
-    memcpy(mVendorName, kVendorName, sizeof(kVendorName));
-    memcpy(mVendorModel, kVendorModel, sizeof(kVendorModel));
-    memcpy(mVendorSwVersion, kVendorSwVersion, sizeof(kVendorSwVersion));
-    memcpy(mVendorAppUrl, kVendorAppUrl, sizeof(kVendorAppUrl));
-#endif
 }
-
-#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
-
-Error Server::SetVendorName(const char *aVendorName)
-{
-    Error error;
-
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    VerifyOrExit(aVendorName != nullptr && StringStartsWith(aVendorName, kVendorNamePrefix), error = kErrorInvalidArgs);
-#endif
-
-    SuccessOrExit(error = StringCopy(mVendorName, aVendorName, kStringCheckUtf8Encoding));
-
-exit:
-    return error;
-}
-
-Error Server::SetVendorModel(const char *aVendorModel)
-{
-    return StringCopy(mVendorModel, aVendorModel, kStringCheckUtf8Encoding);
-}
-
-Error Server::SetVendorSwVersion(const char *aVendorSwVersion)
-{
-    return StringCopy(mVendorSwVersion, aVendorSwVersion, kStringCheckUtf8Encoding);
-}
-
-Error Server::SetVendorAppUrl(const char *aVendorAppUrl)
-{
-    return StringCopy(mVendorAppUrl, aVendorAppUrl, kStringCheckUtf8Encoding);
-}
-
-#endif
 
 void Server::PrepareMessageInfoForDest(const Ip6::Address &aDestination, Tmf::MessageInfo &aMessageInfo) const
 {
@@ -515,19 +459,19 @@ Error Server::AppendDiagTlv(uint8_t aTlvType, Message &aMessage)
     }
 
     case Tlv::kVendorName:
-        error = Tlv::Append<VendorNameTlv>(aMessage, GetVendorName());
+        error = Tlv::Append<VendorNameTlv>(aMessage, Get<VendorInfo>().GetName());
         break;
 
     case Tlv::kVendorModel:
-        error = Tlv::Append<VendorModelTlv>(aMessage, GetVendorModel());
+        error = Tlv::Append<VendorModelTlv>(aMessage, Get<VendorInfo>().GetModel());
         break;
 
     case Tlv::kVendorSwVersion:
-        error = Tlv::Append<VendorSwVersionTlv>(aMessage, GetVendorSwVersion());
+        error = Tlv::Append<VendorSwVersionTlv>(aMessage, Get<VendorInfo>().GetSwVersion());
         break;
 
     case Tlv::kVendorAppUrl:
-        error = Tlv::Append<VendorAppUrlTlv>(aMessage, GetVendorAppUrl());
+        error = Tlv::Append<VendorAppUrlTlv>(aMessage, Get<VendorInfo>().GetAppUrl());
         break;
 
     case Tlv::kThreadStackVersion:

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -118,87 +118,6 @@ public:
         mNonPreferredChannelsResetCallback.Set(aCallback, aContext);
     }
 
-#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
-    /**
-     * Returns the vendor name string.
-     *
-     * @returns The vendor name string.
-     */
-    const char *GetVendorName(void) const { return mVendorName; }
-
-    /**
-     * Sets the vendor name string.
-     *
-     * @param[in] aVendorName     The vendor name string.
-     *
-     * If `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is enabled, @p aVendorName must start with the "RD:" prefix.
-     * This is enforced to ensure reference devices are identifiable. If @p aVendorName does not follow this pattern,
-     * the name is rejected, and `kErrorInvalidArgs` is returned.
-     *
-     * @retval kErrorNone         Successfully set the vendor name.
-     * @retval kErrorInvalidArgs  @p aVendorName is not valid. It is too long, is not UTF-8, or does not start with
-     *                            the "RD:" prefix when `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is enabled.
-     */
-    Error SetVendorName(const char *aVendorName);
-
-    /**
-     * Returns the vendor model string.
-     *
-     * @returns The vendor model string.
-     */
-    const char *GetVendorModel(void) const { return mVendorModel; }
-
-    /**
-     * Sets the vendor model string.
-     *
-     * @param[in] aVendorModel     The vendor model string.
-     *
-     * @retval kErrorNone         Successfully set the vendor model.
-     * @retval kErrorInvalidArgs  @p aVendorModel is not valid (too long or not UTF8).
-     */
-    Error SetVendorModel(const char *aVendorModel);
-
-    /**
-     * Returns the vendor software version string.
-     *
-     * @returns The vendor software version string.
-     */
-    const char *GetVendorSwVersion(void) const { return mVendorSwVersion; }
-
-    /**
-     * Sets the vendor sw version string
-     *
-     * @param[in] aVendorSwVersion     The vendor sw version string.
-     *
-     * @retval kErrorNone         Successfully set the vendor sw version.
-     * @retval kErrorInvalidArgs  @p aVendorSwVersion is not valid (too long or not UTF8).
-     */
-    Error SetVendorSwVersion(const char *aVendorSwVersion);
-
-    /**
-     * Returns the vendor app URL string.
-     *
-     * @returns the vendor app URL string.
-     */
-    const char *GetVendorAppUrl(void) const { return mVendorAppUrl; }
-
-    /**
-     * Sets the vendor app URL string.
-     *
-     * @param[in] aVendorAppUrl     The vendor app URL string
-     *
-     * @retval kErrorNone         Successfully set the vendor app URL.
-     * @retval kErrorInvalidArgs  @p aVendorAppUrl is not valid (too long or not UTF8).
-     */
-    Error SetVendorAppUrl(const char *aVendorAppUrl);
-
-#else
-    const char *GetVendorName(void) const { return kVendorName; }
-    const char *GetVendorModel(void) const { return kVendorModel; }
-    const char *GetVendorSwVersion(void) const { return kVendorSwVersion; }
-    const char *GetVendorAppUrl(void) const { return kVendorAppUrl; }
-#endif // OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
-
 private:
     static constexpr uint16_t kMaxChildEntries              = 398;
     static constexpr uint16_t kAnswerMessageLengthThreshold = 800;
@@ -223,11 +142,6 @@ private:
         Coap::Message    *mFirstAnswer;
     };
 #endif
-
-    static const char kVendorName[];
-    static const char kVendorModel[];
-    static const char kVendorSwVersion[];
-    static const char kVendorAppUrl[];
 
     Error AppendDiagTlv(uint8_t aTlvType, Message &aMessage);
     Error AppendIp6AddressList(Message &aMessage);
@@ -276,13 +190,6 @@ private:
 #endif
 
     template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
-
-#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
-    VendorNameTlv::StringType      mVendorName;
-    VendorModelTlv::StringType     mVendorModel;
-    VendorSwVersionTlv::StringType mVendorSwVersion;
-    VendorAppUrlTlv::StringType    mVendorAppUrl;
-#endif
 
 #if OPENTHREAD_FTD
     Coap::MessageQueue mAnswerQueue;

--- a/src/core/thread/vendor_info.cpp
+++ b/src/core/thread/vendor_info.cpp
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the vendor information.
+ */
+
+#include "vendor_info.hpp"
+
+#include "instance/instance.hpp"
+
+namespace ot {
+
+const char VendorInfo::kName[]      = OPENTHREAD_CONFIG_NET_DIAG_VENDOR_NAME;
+const char VendorInfo::kModel[]     = OPENTHREAD_CONFIG_NET_DIAG_VENDOR_MODEL;
+const char VendorInfo::kSwVersion[] = OPENTHREAD_CONFIG_NET_DIAG_VENDOR_SW_VERSION;
+const char VendorInfo::kAppUrl[]    = OPENTHREAD_CONFIG_NET_DIAG_VENDOR_APP_URL;
+
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+static constexpr char kNamePrefix[] = "RD:";
+
+static_assert(CheckConstStringPrefix(OPENTHREAD_CONFIG_NET_DIAG_VENDOR_NAME, kNamePrefix),
+              "VENDOR_NAME MUST start with 'RD:' prefix for a reference device.");
+#endif
+
+VendorInfo::VendorInfo(Instance &aInstance)
+    : InstanceLocator(aInstance)
+{
+    static_assert(sizeof(kName) <= sizeof(NameStringType), "VENDOR_NAME is too long");
+    static_assert(sizeof(kModel) <= sizeof(ModelStringType), "VENDOR_MODEL is too long");
+    static_assert(sizeof(kSwVersion) <= sizeof(SwVersionStringType), "VENDOR_SW_VERSION is too long");
+    static_assert(sizeof(kAppUrl) <= sizeof(AppUrlStringType), "VENDOR_APP_URL is too long");
+
+#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
+    memcpy(mName, kName, sizeof(kName));
+    memcpy(mModel, kModel, sizeof(kModel));
+    memcpy(mSwVersion, kSwVersion, sizeof(kSwVersion));
+    memcpy(mAppUrl, kAppUrl, sizeof(kAppUrl));
+#endif
+}
+
+#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
+
+Error VendorInfo::SetName(const char *aName)
+{
+    Error error;
+
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+    VerifyOrExit(aName != nullptr && StringStartsWith(aName, kNamePrefix), error = kErrorInvalidArgs);
+#endif
+
+    SuccessOrExit(error = StringCopy(mName, aName, kStringCheckUtf8Encoding));
+
+exit:
+    return error;
+}
+
+Error VendorInfo::SetModel(const char *aModel) { return StringCopy(mModel, aModel, kStringCheckUtf8Encoding); }
+
+Error VendorInfo::SetSwVersion(const char *aSwVersion)
+{
+    return StringCopy(mSwVersion, aSwVersion, kStringCheckUtf8Encoding);
+}
+
+Error VendorInfo::SetAppUrl(const char *aAppUrl) { return StringCopy(mAppUrl, aAppUrl, kStringCheckUtf8Encoding); }
+
+#endif // OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
+
+} // namespace ot

--- a/src/core/thread/vendor_info.hpp
+++ b/src/core/thread/vendor_info.hpp
@@ -1,0 +1,162 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for maintaining vendor information (name, model, etc).
+ */
+
+#ifndef OT_CORE_THREAD_VENDOR_INFO_HPP_
+#define OT_CORE_THREAD_VENDOR_INFO_HPP_
+
+#include "openthread-core-config.h"
+
+#include "common/error.hpp"
+#include "common/locator.hpp"
+#include "common/non_copyable.hpp"
+#include "thread/network_diagnostic_tlvs.hpp"
+
+namespace ot {
+
+/**
+ * Represents the vendor information.
+ */
+class VendorInfo : public InstanceLocator, private NonCopyable
+{
+public:
+    /**
+     * Initializes the `VendorInfo`.
+     *
+     * @param[in] aInstance  The OpenThread instance.
+     */
+    explicit VendorInfo(Instance &aInstance);
+
+#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
+    /**
+     * Returns the vendor name string.
+     *
+     * @returns The vendor name string.
+     */
+    const char *GetName(void) const { return mName; }
+
+    /**
+     * Sets the vendor name string.
+     *
+     * @param[in] aName     The vendor name string.
+     *
+     * If `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is enabled, @p aName must start with the "RD:" prefix.
+     * This is enforced to ensure reference devices are identifiable. If @p aName does not follow this pattern,
+     * the name is rejected, and `kErrorInvalidArgs` is returned.
+     *
+     * @retval kErrorNone         Successfully set the vendor name.
+     * @retval kErrorInvalidArgs  @p aName is not valid. It is too long, is not UTF-8, or does not start with
+     *                            the "RD:" prefix when `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is enabled.
+     */
+    Error SetName(const char *aName);
+
+    /**
+     * Returns the vendor model string.
+     *
+     * @returns The vendor model string.
+     */
+    const char *GetModel(void) const { return mModel; }
+
+    /**
+     * Sets the vendor model string.
+     *
+     * @param[in] aModel     The vendor model string.
+     *
+     * @retval kErrorNone         Successfully set the vendor model.
+     * @retval kErrorInvalidArgs  @p aModel is not valid (too long or not UTF8).
+     */
+    Error SetModel(const char *aModel);
+
+    /**
+     * Returns the vendor software version string.
+     *
+     * @returns The vendor software version string.
+     */
+    const char *GetSwVersion(void) const { return mSwVersion; }
+
+    /**
+     * Sets the vendor sw version string
+     *
+     * @param[in] aSwVersion     The vendor sw version string.
+     *
+     * @retval kErrorNone         Successfully set the vendor sw version.
+     * @retval kErrorInvalidArgs  @p aSwVersion is not valid (too long or not UTF8).
+     */
+    Error SetSwVersion(const char *aSwVersion);
+
+    /**
+     * Returns the vendor app URL string.
+     *
+     * @returns the vendor app URL string.
+     */
+    const char *GetAppUrl(void) const { return mAppUrl; }
+
+    /**
+     * Sets the vendor app URL string.
+     *
+     * @param[in] aAppUrl     The vendor app URL string
+     *
+     * @retval kErrorNone         Successfully set the vendor app URL.
+     * @retval kErrorInvalidArgs  @p aAppUrl is not valid (too long or not UTF8).
+     */
+    Error SetAppUrl(const char *aAppUrl);
+
+#else
+    const char *GetName(void) const { return kName; }
+    const char *GetModel(void) const { return kModel; }
+    const char *GetSwVersion(void) const { return kSwVersion; }
+    const char *GetAppUrl(void) const { return kAppUrl; }
+#endif // OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
+
+private:
+    // String buffer types (max size specified by corresponding TLV)
+    typedef NetworkDiagnostic::VendorNameTlv::StringType      NameStringType;
+    typedef NetworkDiagnostic::VendorModelTlv::StringType     ModelStringType;
+    typedef NetworkDiagnostic::VendorSwVersionTlv::StringType SwVersionStringType;
+    typedef NetworkDiagnostic::VendorAppUrlTlv::StringType    AppUrlStringType;
+
+    static const char kName[];
+    static const char kModel[];
+    static const char kSwVersion[];
+    static const char kAppUrl[];
+
+#if OPENTHREAD_CONFIG_NET_DIAG_VENDOR_INFO_SET_API_ENABLE
+    NameStringType      mName;
+    ModelStringType     mModel;
+    SwVersionStringType mSwVersion;
+    AppUrlStringType    mAppUrl;
+#endif
+};
+
+} // namespace ot
+
+#endif // OT_CORE_THREAD_VENDOR_INFO_HPP_


### PR DESCRIPTION
This commit introduces a new `VendorInfo` class to encapsulate vendor-related information such as vendor name, model, and software version.

Previously, these parameters were managed within the `NetworkDiagnostic` module. Moving them to a dedicated class facilitates sharing and utilization by other modules across the OT core (e.g., Border Agent, TCAT, Joiner).