### PR TITLE
[mesh-forwarder] avoid forwarding multicast messages back to SED originator

### DIFF
--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -81,8 +81,8 @@ void MeshForwarder::SendMessage(OwnedPtr<Message> aMessagePtr)
 
                 for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValidOrRestoring))
                 {
-                    if (!child.IsRxOnWhenIdle() &&
-                        (destinedForAll || child.HasIp6Address(destination)) && !child.HasIp6Address(ip6Header.GetSource()))
+                    if (!child.IsRxOnWhenIdle() && (destinedForAll || child.HasIp6Address(destination)) &&
+                        !child.HasIp6Address(ip6Header.GetSource()))
                     {
                         mIndirectSender.AddMessageForSleepyChild(message, child);
                     }


### PR DESCRIPTION
As suggested in [this review](https://github.com/openthread/openthread/pull/12295#discussion_r2719183658). Here a seperate PR removing Multicast Loopbacks to SED's from FTD's over the radio.