### PR TITLE
[coap] update `Interceptor` to use `Msg`

### DIFF
--- a/src/core/backbone_router/backbone_tmf.cpp
+++ b/src/core/backbone_router/backbone_tmf.cpp
@@ -96,11 +96,14 @@ bool BackboneTmfAgent::HandleResource(const char *aUriPath, ot::Coap::Msg &aMsg)
     return didHandle;
 }
 
-Error BackboneTmfAgent::Filter(const ot::Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext)
+Error BackboneTmfAgent::Filter(void *aContext, const ot::Coap::Msg &aRxMsg)
 {
-    OT_UNUSED_VARIABLE(aMessage);
+    return static_cast<BackboneTmfAgent *>(aContext)->Filter(aRxMsg);
+}
 
-    return static_cast<BackboneTmfAgent *>(aContext)->IsBackboneTmfMessage(aMessageInfo) ? kErrorNone : kErrorNotTmf;
+Error BackboneTmfAgent::Filter(const ot::Coap::Msg &aRxMsg) const
+{
+    return IsBackboneTmfMessage(aRxMsg.mMessageInfo) ? kErrorNone : kErrorNotTmf;
 }
 
 bool BackboneTmfAgent::IsBackboneTmfMessage(const Ip6::MessageInfo &aMessageInfo) const

--- a/src/core/backbone_router/backbone_tmf.hpp
+++ b/src/core/backbone_router/backbone_tmf.hpp
@@ -93,7 +93,8 @@ private:
     static bool  HandleResource(CoapBase &aCoapBase, const char *aUriPath, ot::Coap::Msg &aMsg);
     bool         HandleResource(const char *aUriPath, ot::Coap::Msg &aMsg);
     void         LogError(const char *aText, const Ip6::Address &aAddress, Error aError) const;
-    static Error Filter(const ot::Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext);
+    static Error Filter(void *aContext, const ot::Coap::Msg &aRxMsg);
+    Error        Filter(const ot::Coap::Msg &aRxMsg) const;
 };
 
 } // namespace BackboneRouter

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -878,7 +878,7 @@ void CoapBase::ProcessReceivedRequest(Msg &aRxMsg)
 
     if (mInterceptor.IsSet())
     {
-        SuccessOrExit(error = mInterceptor.Invoke(aRxMsg.mMessage, aRxMsg.mMessageInfo));
+        SuccessOrExit(error = mInterceptor.Invoke(aRxMsg));
     }
 
     // Check if `mResponseCache` has a matching cached response for this

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -275,17 +275,15 @@ class CoapBase : public InstanceLocator, private NonCopyable
 {
 public:
     /**
-     * Pointer is called before CoAP server processing a CoAP message.
+     * Function pointer callback invoked before CoAP processing a received CoAP message.
      *
-     * @param[in]   aMessage        A reference to the message.
-     @ @param[in]   aMessageInfo    A reference to the message info associated with @p aMessage.
-     * @param[in]   aContext        A pointer to arbitrary context information.
+     * @param[in]   aContext    A pointer to arbitrary context information.
+     * @param[in]   aRxMsg      The received `Msg` (CoAP message and its associated `Ip6::MessageInfo`).
      *
-     * @retval  kErrorNone      Server should continue processing this message, other return values indicates the
-     *                          server should stop processing this message.
+     * @retval  kErrorNone      Continue processing this message
      * @retval  kErrorNotTmf    The message is not a TMF message.
      */
-    typedef Error (*Interceptor)(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext);
+    typedef Error (*Interceptor)(void *aContext, const Msg &aRxMsg);
 
     /**
      * Clears all requests and responses used by this CoAP agent and stops all timers.

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -197,12 +197,12 @@ bool Agent::HandleResource(const char *aUriPath, Msg &aMsg)
     return didHandle;
 }
 
-Error Agent::Filter(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext)
-{
-    OT_UNUSED_VARIABLE(aMessage);
+Error Agent::Filter(void *aContext, const Msg &aRxMsg) { return static_cast<Agent *>(aContext)->Filter(aRxMsg); }
 
-    return static_cast<Agent *>(aContext)->IsTmfMessage(aMessageInfo.GetPeerAddr(), aMessageInfo.GetSockAddr(),
-                                                        aMessageInfo.GetSockPort())
+Error Agent::Filter(const Msg &aRxMsg) const
+{
+    return IsTmfMessage(aRxMsg.mMessageInfo.GetPeerAddr(), aRxMsg.mMessageInfo.GetSockAddr(),
+                        aRxMsg.mMessageInfo.GetSockPort())
                ? kErrorNone
                : kErrorNotTmf;
 }

--- a/src/core/thread/tmf.hpp
+++ b/src/core/thread/tmf.hpp
@@ -230,10 +230,10 @@ public:
 private:
     template <Uri kUri> void HandleTmf(Msg &aMsg);
 
-    static bool HandleResource(CoapBase &aCoapBase, const char *aUriPath, Msg &aMsg);
-    bool        HandleResource(const char *aUriPath, Msg &aMsg);
-
-    static Error Filter(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext);
+    static bool  HandleResource(CoapBase &aCoapBase, const char *aUriPath, Msg &aMsg);
+    bool         HandleResource(const char *aUriPath, Msg &aMsg);
+    static Error Filter(void *aContext, const Msg &aRxMsg);
+    Error        Filter(const Msg &aRxMsg) const;
 };
 
 #if OPENTHREAD_CONFIG_SECURE_TRANSPORT_ENABLE


### PR DESCRIPTION
This commit updates the `CoapBase::Interceptor` function pointer type to accept `const Msg &` instead of separate `const Message &` and `const Ip6::MessageInfo &` arguments. It also reorders the `void *` to match other CoAP callbacks.

Implementations in `BackboneTmfAgent::Filter` and `Agent::Filter` have been updated to match the new signature.