### PR TITLE
[cli] `joiner start` to use correct VendorInfo data

### DIFF
--- a/src/cli/cli_joiner.cpp
+++ b/src/cli/cli_joiner.cpp
@@ -157,12 +157,12 @@ template <> otError Joiner::Process<Cmd("start")>(Arg aArgs[])
     VerifyOrExit(!aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
 
     error = otJoinerStart(GetInstancePtr(),
-                          aArgs[0].GetCString(),           // aPskd
-                          aArgs[1].GetCString(),           // aProvisioningUrl (`nullptr` if aArgs[1] is empty)
-                          PACKAGE_NAME,                    // aVendorName
-                          OPENTHREAD_CONFIG_PLATFORM_INFO, // aVendorModel
-                          PACKAGE_VERSION,                 // aVendorSwVersion
-                          nullptr,                         // aVendorData
+                          aArgs[0].GetCString(),                    // aPskd
+                          aArgs[1].GetCString(),                    // aProvisioningUrl (`nullptr` if aArgs[1] is empty)
+                          otThreadGetVendorName(GetInstancePtr()),  // aVendorName
+                          otThreadGetVendorModel(GetInstancePtr()), // aVendorModel
+                          otThreadGetVendorSwVersion(GetInstancePtr()), // aVendorSwVersion
+                          nullptr,                                      // aVendorData
                           &Joiner::HandleCallback, this);
 
 exit:


### PR DESCRIPTION
This updates the Joiner CLI to use the correct VendorInfo data which is configured in the build or set at runtime. Benefit is that this data is also length-checked. Previously, the command could fail when PACKAGE_VERSION was length > 16.