### PR TITLE
[thread-cert] simulator: mark virtual-time node 'awake' whenever an event is sent to it

### DIFF
--- a/tests/scripts/thread-cert/simulator.py
+++ b/tests/scripts/thread-cert/simulator.py
@@ -528,7 +528,8 @@ class VirtualTime(BaseSimulator):
 
         if len(event) == 5:
             event_time, sequence, port, type, datalen = event
-            dbg_print("Pop event: ", event_time, port, type, datalen)
+            data = b''
+            dbg_print("Pop event: ", event_time, port, type, datalen, "(no data)")
         else:
             event_time, sequence, port, type, datalen, data = event
             dbg_print(
@@ -562,6 +563,10 @@ class VirtualTime(BaseSimulator):
         elif type == self.OT_SIM_EVENT_UART_WRITE:
             message += data
             self._send_message(message, port)
+        else:
+            raise NotImplementedError(f'Unknown event type: {type}')
+
+        self.awake_devices.add(port)
 
     def sync_devices(self):
         self.current_time = self._pause_time


### PR DESCRIPTION
This marks a simulation node as 'awake' whenever an event is sent to it. This is required because the event will induce processing on the node followed by an alarm-event sent back to the simulator. The simulator needs to wait to properly catch this final alarm-event; otherwise, this alarm-event may be mistakenly processed as confirmation of a newer event that follows later, in case the OT node process is lagging in processing as may happen typically in CI environments.

Also the case of unknown event type is now raised as an exception, to avoid undetected errors in the simulation. This could cause an event to be not sent to the node at all while the node's time is updated by the simulator (using `self.devices[port]['time'] = event_time`) as if the node is up to date on the latest virtual time, which it isn't.