### PR TITLE
[coap] simplify response handler and use `Msg` class

### DIFF
--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -255,8 +255,12 @@ otError otCoapSendRequestWithParameters(otInstance               *aInstance,
 
     VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
-    error = AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SendMessage(
-        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), AsCoreTypePtr(aTxParameters), aHandler, aContext);
+    error = AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SendMessageWithResponseHandlerSeparateParams(
+        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), AsCoreTypePtr(aTxParameters), aHandler,
+#if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
+        /* aTransmitHook */ nullptr, /* aReceiveHook */ nullptr,
+#endif
+        aContext);
 
 exit:
     return error;
@@ -346,9 +350,9 @@ otError otCoapSendRequestBlockWiseWithParameters(otInstance                 *aIn
 
     VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
-    error = AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SendMessage(
-        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), AsCoreTypePtr(aTxParameters), aHandler, aContext,
-        aTransmitHook, aReceiveHook);
+    error = AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SendMessageWithResponseHandlerSeparateParams(
+        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), AsCoreTypePtr(aTxParameters), aHandler, aTransmitHook,
+        aReceiveHook, aContext);
 
 exit:
     return error;
@@ -362,8 +366,8 @@ otError otCoapSendRequestBlockWise(otInstance                 *aInstance,
                                    otCoapBlockwiseTransmitHook aTransmitHook,
                                    otCoapBlockwiseReceiveHook  aReceiveHook)
 {
-    return otCoapSendRequestBlockWiseWithParameters(aInstance, aMessage, aMessageInfo, aHandler, aContext, nullptr,
-                                                    aTransmitHook, aReceiveHook);
+    return otCoapSendRequestBlockWiseWithParameters(aInstance, aMessage, aMessageInfo, aHandler, aContext,
+                                                    /* aTxParameters */ nullptr, aTransmitHook, aReceiveHook);
 }
 
 otError otCoapSendResponseBlockWiseWithParameters(otInstance                 *aInstance,
@@ -377,9 +381,9 @@ otError otCoapSendResponseBlockWiseWithParameters(otInstance                 *aI
 
     VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
-    error = AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SendMessage(
-        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), AsCoreTypePtr(aTxParameters), nullptr, aContext,
-        aTransmitHook, nullptr);
+    error = AsCoreType(aInstance).Get<Coap::ApplicationCoap>().SendMessageWithResponseHandlerSeparateParams(
+        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), AsCoreTypePtr(aTxParameters), /* aResponseHandler */ nullptr,
+        aTransmitHook, /* aReceiveHook */ nullptr, aContext);
 exit:
     return error;
 }
@@ -390,8 +394,8 @@ otError otCoapSendResponseBlockWise(otInstance                 *aInstance,
                                     void                       *aContext,
                                     otCoapBlockwiseTransmitHook aTransmitHook)
 {
-    return otCoapSendResponseBlockWiseWithParameters(aInstance, aMessage, aMessageInfo, nullptr, aContext,
-                                                     aTransmitHook);
+    return otCoapSendResponseBlockWiseWithParameters(aInstance, aMessage, aMessageInfo, /* aTxParamters */ nullptr,
+                                                     aContext, aTransmitHook);
 }
 
 #endif // OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE

--- a/src/core/api/coap_secure_api.cpp
+++ b/src/core/api/coap_secure_api.cpp
@@ -159,8 +159,8 @@ otError otCoapSecureSendRequestBlockWise(otInstance                 *aInstance,
                                          otCoapBlockwiseTransmitHook aTransmitHook,
                                          otCoapBlockwiseReceiveHook  aReceiveHook)
 {
-    return AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SendMessage(AsCoapMessage(aMessage), aHandler,
-                                                                                aContext, aTransmitHook, aReceiveHook);
+    return AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SendMessageWithResponseHandlerSeparateParams(
+        AsCoapMessage(aMessage), aHandler, aTransmitHook, aReceiveHook, aContext);
 }
 #endif
 
@@ -169,8 +169,12 @@ otError otCoapSecureSendRequest(otInstance           *aInstance,
                                 otCoapResponseHandler aHandler,
                                 void                 *aContext)
 {
-    return AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SendMessage(AsCoapMessage(aMessage), aHandler,
-                                                                                aContext);
+    return AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SendMessageWithResponseHandlerSeparateParams(
+        AsCoapMessage(aMessage), aHandler,
+#if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
+        /* aTransmitHook */ nullptr, /* aReceiveHook */ nullptr,
+#endif
+        aContext);
 }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
@@ -216,8 +220,8 @@ otError otCoapSecureSendResponseBlockWise(otInstance                 *aInstance,
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
-    return AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SendMessage(AsCoapMessage(aMessage), nullptr,
-                                                                                aContext, aTransmitHook);
+    return AsCoreType(aInstance).Get<Coap::ApplicationCoapSecure>().SendMessageWithResponseHandlerSeparateParams(
+        AsCoapMessage(aMessage), /* aResponseHandler */ nullptr, aTransmitHook, /* aReceiveHook */ nullptr, aContext);
 }
 #endif
 

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -58,27 +58,32 @@ void SecureSession::Cleanup(void)
     mTransmitTask.Unpost();
 }
 
-#if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
-
-Error SecureSession::SendMessage(Message                    &aMessage,
-                                 ResponseHandler             aHandler,
-                                 void                       *aContext,
-                                 otCoapBlockwiseTransmitHook aTransmitHook,
-                                 otCoapBlockwiseReceiveHook  aReceiveHook)
-{
-    return IsConnected() ? CoapBase::SendMessage(aMessage, GetMessageInfo(), /* aTxParameters */ nullptr, aHandler,
-                                                 aContext, aTransmitHook, aReceiveHook)
-                         : kErrorInvalidState;
-}
-
-#else
-
 Error SecureSession::SendMessage(Message &aMessage, ResponseHandler aHandler, void *aContext)
 {
     return IsConnected() ? CoapBase::SendMessage(aMessage, GetMessageInfo(), aHandler, aContext) : kErrorInvalidState;
 }
 
-#endif // OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
+Error SecureSession::SendMessage(Message &aMessage)
+{
+    return IsConnected() ? CoapBase::SendMessage(aMessage, GetMessageInfo()) : kErrorInvalidState;
+}
+
+Error SecureSession::SendMessageWithResponseHandlerSeparateParams(Message                      &aMessage,
+                                                                  ResponseHandlerSeparateParams aHandler,
+#if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
+                                                                  BlockwiseTransmitHook aTransmitHook,
+                                                                  BlockwiseReceiveHook  aReceiveHook,
+#endif
+                                                                  void *aContext)
+{
+    return IsConnected() ? CoapBase::SendMessageWithResponseHandlerSeparateParams(aMessage, GetMessageInfo(),
+                                                                                  /* aTxParameters */ nullptr, aHandler,
+#if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
+                                                                                  aTransmitHook, aReceiveHook,
+#endif
+                                                                                  aContext)
+                         : kErrorInvalidState;
+}
 
 Error SecureSession::Transmit(CoapBase &aCoapBase, ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -73,9 +73,37 @@ public:
      */
     void SetConnectCallback(ConnectHandler aHandler, void *aContext) { mConnectCallback.Set(aHandler, aContext); }
 
-#if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
     /**
      * Sends a CoAP message over secure DTLS session.
+     *
+     * If Message Id was not set in the header (equal to 0), this function will assign unique Message Id to the message.
+     *
+     * @param[in]  aMessage      A reference to the message to send.
+     * @param[in]  aHandler      A function pointer that shall be called on response reception or time-out.
+     * @param[in]  aContext      A pointer to arbitrary context information.
+     *
+     * @retval kErrorNone          Successfully sent CoAP message.
+     * @retval kErrorNoBufs        Failed to allocate retransmission data.
+     * @retval kErrorInvalidState  DTLS connection was not initialized.
+     */
+    Error SendMessage(Message &aMessage, ResponseHandler aHandler, void *aContext);
+
+    /**
+     * Sends a CoAP message over secure DTLS session.
+     *
+     * @param[in]  aMessage      A reference to the message to send.
+     *
+     * @retval kErrorNone          Successfully sent CoAP message.
+     * @retval kErrorNoBufs        Failed to allocate retransmission data.
+     * @retval kErrorInvalidState  DTLS connection was not initialized.
+     */
+    Error SendMessage(Message &aMessage);
+
+    /**
+     * Sends a CoAP message over secure DTLS session using `ResponseHandlerSeparateParams` handle type.
+     *
+     * This version of `SendMessage()` is intended for use by the public OT CoAP APIs, `otCoap*` and should not be used
+     * within the OpenThread core modules.
      *
      * If a response for a request is expected, respective function and context information should be provided.
      * If no response is expected, these arguments should be NULL pointers.
@@ -91,30 +119,13 @@ public:
      * @retval kErrorNoBufs        Failed to allocate retransmission data.
      * @retval kErrorInvalidState  DTLS connection was not initialized.
      */
-    Error SendMessage(Message                    &aMessage,
-                      ResponseHandler             aHandler      = nullptr,
-                      void                       *aContext      = nullptr,
-                      otCoapBlockwiseTransmitHook aTransmitHook = nullptr,
-                      otCoapBlockwiseReceiveHook  aReceiveHook  = nullptr);
-
-#else
-    /**
-     * Sends a CoAP message over secure DTLS session.
-     *
-     * If a response for a request is expected, respective function and context information should be provided.
-     * If no response is expected, these arguments should be nullptr pointers.
-     * If Message Id was not set in the header (equal to 0), this function will assign unique Message Id to the message.
-     *
-     * @param[in]  aMessage      A reference to the message to send.
-     * @param[in]  aHandler      A function pointer that shall be called on response reception or time-out.
-     * @param[in]  aContext      A pointer to arbitrary context information.
-     *
-     * @retval kErrorNone          Successfully sent CoAP message.
-     * @retval kErrorNoBufs        Failed to allocate retransmission data.
-     * @retval kErrorInvalidState  DTLS connection was not initialized.
-     */
-    Error SendMessage(Message &aMessage, ResponseHandler aHandler = nullptr, void *aContext = nullptr);
+    Error SendMessageWithResponseHandlerSeparateParams(Message                      &aMessage,
+                                                       ResponseHandlerSeparateParams aHandler,
+#if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
+                                                       BlockwiseTransmitHook aTransmitHook,
+                                                       BlockwiseReceiveHook  aReceiveHook,
 #endif
+                                                       void *aContext);
 
 protected:
     SecureSession(Instance &aInstance, Dtls::Transport &aDtlsTransport);

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -312,12 +312,9 @@ private:
 
         static void HandleConnected(ConnectEvent aEvent, void *aContext);
         void        HandleConnected(ConnectEvent aEvent);
-        static void HandleLeaderResponseToFwdTmf(void                *aContext,
-                                                 otMessage           *aMessage,
-                                                 const otMessageInfo *aMessageInfo,
-                                                 otError              aResult);
+        static void HandleLeaderResponseToFwdTmf(void *aContext, Coap::Msg *aMsg, otError aResult);
         void        HandleLeaderResponseToFwdTmf(const ForwardContext &aForwardContext,
-                                                 const Coap::Message  *aResponse,
+                                                 const Coap::Msg      *aResponse,
                                                  Error                 aResult);
         static bool HandleResource(CoapBase &aCoapBase, const char *aUriPath, Coap::Msg &aMsg);
         bool        HandleResource(const char *aUriPath, Coap::Msg &aMsg);

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -495,24 +495,13 @@ exit:
     return error;
 }
 
-void DatasetManager::HandleMgmtSetResponse(void                *aContext,
-                                           otMessage           *aMessage,
-                                           const otMessageInfo *aMessageInfo,
-                                           otError              aError)
+void DatasetManager::HandleMgmtSetResponse(Coap::Msg *aMsg, Error aError)
 {
-    static_cast<DatasetManager *>(aContext)->HandleMgmtSetResponse(AsCoapMessagePtr(aMessage),
-                                                                   AsCoreTypePtr(aMessageInfo), aError);
-}
-
-void DatasetManager::HandleMgmtSetResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aError)
-{
-    OT_UNUSED_VARIABLE(aMessageInfo);
-
     Error   error;
     uint8_t state = StateTlv::kPending;
 
     SuccessOrExit(error = aError);
-    VerifyOrExit(Tlv::Find<StateTlv>(*aMessage, state) == kErrorNone && state != StateTlv::kPending,
+    VerifyOrExit(Tlv::Find<StateTlv>(aMsg->mMessage, state) == kErrorNone && state != StateTlv::kPending,
                  error = kErrorParse);
 
     if (state == StateTlv::kReject)

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -286,12 +286,8 @@ private:
     void  SignalDatasetChange(void) const;
     void  SyncLocalWithLeader(const Dataset &aDataset);
     Error SendSetRequest(const Dataset &aDataset);
-    void  HandleMgmtSetResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aError);
 
-    static void HandleMgmtSetResponse(void                *aContext,
-                                      otMessage           *aMessage,
-                                      const otMessageInfo *aMessageInfo,
-                                      otError              aError);
+    DeclareTmfResponseHandlerIn(DatasetManager, HandleMgmtSetResponse);
 
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
     void  MoveKeysToSecureStorage(Dataset &aDataset) const;

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -258,10 +258,9 @@ Error JoinerRouter::SendJoinerEntrust(const Ip6::MessageInfo &aMessageInfo)
     message = PrepareJoinerEntrustMessage();
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
-    IgnoreError(Get<Tmf::Agent>().AbortTransaction(&JoinerRouter::HandleJoinerEntrustResponse, this));
+    IgnoreError(Get<Tmf::Agent>().AbortTransaction(HandleJoinerEntrustResponse, this));
 
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, aMessageInfo,
-                                                        &JoinerRouter::HandleJoinerEntrustResponse, this));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, aMessageInfo, HandleJoinerEntrustResponse, this));
 
     LogInfo("Sent %s (len= %d)", UriToString<kUriJoinerEntrust>(), message->GetLength());
     LogCert("[THCI] direction=send | type=JOIN_ENT.ntf");
@@ -304,13 +303,13 @@ exit:
     return message;
 }
 
-void JoinerRouter::HandleJoinerEntrustResponse(Coap::Message *aMessage, Error aResult)
+void JoinerRouter::HandleJoinerEntrustResponse(Coap::Msg *aMsg, Error aResult)
 {
     SendDelayedJoinerEntrust();
 
-    VerifyOrExit(aResult == kErrorNone && aMessage != nullptr);
+    VerifyOrExit(aResult == kErrorNone && aMsg != nullptr);
 
-    VerifyOrExit(aMessage->ReadCode() == Coap::kCodeChanged);
+    VerifyOrExit(aMsg->GetCode() == Coap::kCodeChanged);
 
     LogInfo("Receive %s response", UriToString<kUriJoinerEntrust>());
     LogCert("[THCI] direction=recv | type=JOIN_ENT.rsp");

--- a/src/core/thread/anycast_locator.cpp
+++ b/src/core/thread/anycast_locator.cpp
@@ -73,29 +73,18 @@ exit:
     return error;
 }
 
-void AnycastLocator::HandleResponse(void                *aContext,
-                                    otMessage           *aMessage,
-                                    const otMessageInfo *aMessageInfo,
-                                    otError              aError)
+void AnycastLocator::HandleResponse(Coap::Msg *aMsg, Error aError)
 {
-    static_cast<AnycastLocator *>(aContext)->HandleResponse(AsCoapMessagePtr(aMessage), AsCoreTypePtr(aMessageInfo),
-                                                            aError);
-}
-
-void AnycastLocator::HandleResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aError)
-{
-    OT_UNUSED_VARIABLE(aMessageInfo);
-
     uint16_t            rloc16  = Mle::kInvalidRloc16;
     const Ip6::Address *address = nullptr;
     Ip6::Address        meshLocalAddress;
 
     SuccessOrExit(aError);
-    OT_ASSERT(aMessage != nullptr);
+    OT_ASSERT(aMsg != nullptr);
 
     meshLocalAddress.SetPrefix(Get<Mle::Mle>().GetMeshLocalPrefix());
-    SuccessOrExit(Tlv::Find<ThreadMeshLocalEidTlv>(*aMessage, meshLocalAddress.GetIid()));
-    SuccessOrExit(Tlv::Find<ThreadRloc16Tlv>(*aMessage, rloc16));
+    SuccessOrExit(Tlv::Find<ThreadMeshLocalEidTlv>(aMsg->mMessage, meshLocalAddress.GetIid()));
+    SuccessOrExit(Tlv::Find<ThreadRloc16Tlv>(aMsg->mMessage, rloc16));
 
 #if OPENTHREAD_FTD
     Get<AddressResolver>().UpdateSnoopedCacheEntry(meshLocalAddress, rloc16, Get<Mac::Mac>().GetShortAddress());

--- a/src/core/thread/anycast_locator.hpp
+++ b/src/core/thread/anycast_locator.hpp
@@ -93,11 +93,9 @@ public:
     bool IsInProgress(void) const { return mCallback.IsSet(); }
 
 private:
-    static void HandleResponse(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo, otError aError);
-
-    void HandleResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aError);
-
     template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
+
+    DeclareTmfResponseHandlerIn(AnycastLocator, HandleResponse);
 
     Callback<LocatorCallback> mCallback;
 };

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -2414,7 +2414,7 @@ private:
 
     template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
-    DeclareTmfResponseHandlerFullParamIn(Mle, HandleAddressSolicitResponse);
+    DeclareTmfResponseHandlerIn(Mle, HandleAddressSolicitResponse);
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE
     void SignalDuaAddressEvent(const Child &aChild, const Ip6::Address &aOldDua) const;

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -155,17 +155,11 @@ private:
                          uint8_t               aAddressNum,
                          const uint32_t       *aTimeout,
                          Coap::ResponseHandler aResponseHandler,
-                         void                 *aResponseContext);
+                         void                 *aContext);
 
-    static void  HandleMlrResponse(void                *aContext,
-                                   otMessage           *aMessage,
-                                   const otMessageInfo *aMessageInfo,
-                                   otError              aResult);
-    void         HandleMlrResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
-    static Error ParseMlrResponse(Error          aResult,
-                                  Coap::Message *aMessage,
-                                  uint8_t       &aStatus,
-                                  AddressArray  &aFailedAddresses);
+    DeclareTmfResponseHandlerIn(MlrManager, HandleMlrResponse);
+
+    static Error ParseMlrResponse(Error aResult, Coap::Msg *aMsg, uint8_t &aStatus, AddressArray &aFailedAddresses);
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
     DeclareTmfResponseHandlerIn(MlrManager, HandleRegisterResponse);

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -242,9 +242,9 @@ void Notifier::HandleNotifierEvents(Events aEvents)
 
 void Notifier::HandleTimer(void) { SynchronizeServerData(); }
 
-void Notifier::HandleCoapResponse(Coap::Message *aMessage, Error aResult)
+void Notifier::HandleCoapResponse(Coap::Msg *aMsg, Error aResult)
 {
-    OT_UNUSED_VARIABLE(aMessage);
+    OT_UNUSED_VARIABLE(aMsg);
 
     mWaitingForResponse = false;
 

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -175,14 +175,8 @@ private:
     Error AppendChildTableIp6AddressList(Message &aMessage);
 #endif
 
-    static void HandleAnswerResponse(void                *aContext,
-                                     otMessage           *aMessage,
-                                     const otMessageInfo *aMessageInfo,
-                                     otError              aResult);
-    void        HandleAnswerResponse(Coap::Message          &aNextAnswer,
-                                     Coap::Message          *aResponse,
-                                     const Ip6::MessageInfo *aMessageInfo,
-                                     Error                   aResult);
+    static void HandleAnswerResponse(void *aContext, Coap::Msg *aMsg, Error aResult);
+    void        HandleAnswerResponse(Coap::Message &aNextAnswer, Coap::Msg *aResponse, Error aResult);
 #endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
     Error AppendBorderRouterIfAddrs(Message &aMessage);
@@ -281,10 +275,16 @@ private:
                       const Ip6::Address   &aDestination,
                       const uint8_t         aTlvTypes[],
                       uint8_t               aCount,
-                      Coap::ResponseHandler aHandler = nullptr,
-                      void                 *aContext = nullptr);
+                      Coap::ResponseHandler aHandler,
+                      void                 *aContext);
 
-    DeclareTmfResponseHandlerFullParamIn(Client, HandleGetResponse);
+    Error SendCommand(Uri                 aUri,
+                      Message::Priority   aPriority,
+                      const Ip6::Address &aDestination,
+                      const uint8_t       aTlvTypes[],
+                      uint8_t             aCount);
+
+    DeclareTmfResponseHandlerIn(Client, HandleGetResponse);
 
     template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 

--- a/src/core/thread/tmf.hpp
+++ b/src/core/thread/tmf.hpp
@@ -67,40 +67,18 @@ namespace Tmf {
  *
  * The `Type` class MUST implement the following member method which will be invoked by the `static` handler:
  *
- *   void MethodName(Coap::Message *aMessage, Error aResult);
+ *   void MethodName(Coap::Msg *aMsg, Error aResult);
  *
  * @param[in] Type        The class `Type` in which the TMF response handler is declared.
  * @param[in] MethodName  The handler method name.
  */
-#define DeclareTmfResponseHandlerIn(Type, MethodName)                                                               \
-    static void MethodName(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo, otError aResult) \
-    {                                                                                                               \
-        OT_UNUSED_VARIABLE(aMessageInfo);                                                                           \
-        static_cast<Type *>(aContext)->MethodName(AsCoapMessagePtr(aMessage), aResult);                             \
-    }                                                                                                               \
-                                                                                                                    \
-    void MethodName(Coap::Message *aMessage, Error aResult)
-
-/**
- * Declares a TMF/CoAP response handler with access to `MessageInfo` in a given class `Type`.
- *
- * This macro is a variant of `DeclareTmfResponseHandlerIn` and is intended for cases where the response handler needs
- * access to the full parameters including `Ip6::MessageInfo`.
- *
- * The `Type` class MUST implement the following member method which will be invoked by the `static` handler:
- *
- *   void MethodName(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
- *
- * @param[in] Type        The class `Type` in which the TMF response handler is declared.
- * @param[in] MethodName  The handler method name.
- */
-#define DeclareTmfResponseHandlerFullParamIn(Type, MethodName)                                                       \
-    static void MethodName(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo, otError aResult)  \
-    {                                                                                                                \
-        static_cast<Type *>(aContext)->MethodName(AsCoapMessagePtr(aMessage), AsCoreTypePtr(aMessageInfo), aResult); \
-    }                                                                                                                \
-                                                                                                                     \
-    void MethodName(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult)
+#define DeclareTmfResponseHandlerIn(Type, MethodName)                      \
+    static void MethodName(void *aContext, Coap::Msg *aMsg, Error aResult) \
+    {                                                                      \
+        static_cast<Type *>(aContext)->MethodName(aMsg, aResult);          \
+    }                                                                      \
+                                                                           \
+    void MethodName(Coap::Msg *aMsg, Error aResult)
 
 constexpr uint16_t kUdpPort = 61631; ///< TMF UDP Port
 

--- a/src/core/utils/history_tracker_server.cpp
+++ b/src/core/utils/history_tracker_server.cpp
@@ -257,34 +257,27 @@ void Server::PrepareMessageInfoForDest(const Ip6::Address &aDestination, Tmf::Me
     aMessageInfo.SetPeerAddr(aDestination);
 }
 
-void Server::HandleAnswerResponse(void                *aContext,
-                                  otMessage           *aMessage,
-                                  const otMessageInfo *aMessageInfo,
-                                  otError              aResult)
+void Server::HandleAnswerResponse(void *aContext, Coap::Msg *aMsg, Error aResult)
 {
     Coap::Message *nextAnswer = static_cast<Coap::Message *>(aContext);
 
     VerifyOrExit(nextAnswer != nullptr);
 
-    nextAnswer->Get<Server>().HandleAnswerResponse(*nextAnswer, AsCoapMessagePtr(aMessage), AsCoreTypePtr(aMessageInfo),
-                                                   aResult);
+    nextAnswer->Get<Server>().HandleAnswerResponse(*nextAnswer, aMsg, aResult);
 
 exit:
     return;
 }
 
-void Server::HandleAnswerResponse(Coap::Message          &aNextAnswer,
-                                  Coap::Message          *aResponse,
-                                  const Ip6::MessageInfo *aMessageInfo,
-                                  Error                   aResult)
+void Server::HandleAnswerResponse(Coap::Message &aNextAnswer, Coap::Msg *aResponse, Error aResult)
 {
     Error error = aResult;
 
     SuccessOrExit(error);
-    VerifyOrExit(aResponse != nullptr && aMessageInfo != nullptr, error = kErrorDrop);
-    VerifyOrExit(aResponse->ReadCode() == Coap::kCodeChanged, error = kErrorDrop);
+    VerifyOrExit(aResponse != nullptr, error = kErrorDrop);
+    VerifyOrExit(aResponse->GetCode() == Coap::kCodeChanged, error = kErrorDrop);
 
-    SendNextAnswer(aNextAnswer, aMessageInfo->GetPeerAddr());
+    SendNextAnswer(aNextAnswer, aResponse->mMessageInfo.GetPeerAddr());
 
 exit:
     if (error != kErrorNone)

--- a/src/core/utils/history_tracker_server.hpp
+++ b/src/core/utils/history_tracker_server.hpp
@@ -91,14 +91,8 @@ private:
     void  PrepareMessageInfoForDest(const Ip6::Address &aDestination, Tmf::MessageInfo &aMessageInfo) const;
     Error AppendNetworkInfo(Coap::Message *&aAnswer, AnswerInfo &aInfo, const RequestTlv &aRequestTlv);
 
-    static void HandleAnswerResponse(void                *aContext,
-                                     otMessage           *aMessage,
-                                     const otMessageInfo *aMessageInfo,
-                                     otError              aResult);
-    void        HandleAnswerResponse(Coap::Message          &aNextAnswer,
-                                     Coap::Message          *aResponse,
-                                     const Ip6::MessageInfo *aMessageInfo,
-                                     Error                   aResult);
+    static void HandleAnswerResponse(void *aContext, Coap::Msg *aMsg, Error aResult);
+    void        HandleAnswerResponse(Coap::Message &aNextAnswer, Coap::Msg *aResponse, Error aResult);
 
     template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 

--- a/src/core/utils/mesh_diag.cpp
+++ b/src/core/utils/mesh_diag.cpp
@@ -113,7 +113,7 @@ exit:
     return error;
 }
 
-void MeshDiag::HandleDiagGetResponse(Coap::Message *aMessage, Error aResult)
+void MeshDiag::HandleDiagGetResponse(Coap::Msg *aMsg, Error aResult)
 {
     Error           error;
     RouterInfo      routerInfo;
@@ -121,17 +121,17 @@ void MeshDiag::HandleDiagGetResponse(Coap::Message *aMessage, Error aResult)
     ChildIterator   childIterator;
 
     SuccessOrExit(aResult);
-    VerifyOrExit(aMessage != nullptr);
+    VerifyOrExit(aMsg != nullptr);
     VerifyOrExit(mState == kStateDiscoverTopology);
 
-    SuccessOrExit(routerInfo.ParseFrom(*aMessage));
+    SuccessOrExit(routerInfo.ParseFrom(aMsg->mMessage));
 
-    if (ip6AddrIterator.InitFrom(*aMessage) == kErrorNone)
+    if (ip6AddrIterator.InitFrom(aMsg->mMessage) == kErrorNone)
     {
         routerInfo.mIp6AddrIterator = &ip6AddrIterator;
     }
 
-    if (childIterator.InitFrom(*aMessage, routerInfo.mRloc16) == kErrorNone)
+    if (childIterator.InitFrom(aMsg->mMessage, routerInfo.mRloc16) == kErrorNone)
     {
         routerInfo.mChildIterator = &childIterator;
     }


### PR DESCRIPTION
This commit updates `Coap::ResponseHandler` to use a single `Coap::Msg` pointer instead of separate `Message` and `MessageInfo` pointers. The `Msg` class encapsulates both the CoAP message and its associated IP message info, simplifying the handler signature and usage.

It retains support for the legacy `otCoapResponseHandler` signature (which uses separate parameters) for the public API by introducing `SendMessageWithResponseHandlerSeparateParams`. This ensures that public APIs like `otCoapSendRequest` continue to work without breaking changes while allowing internal modules to benefit from the simplified interface.

It introduces `CoapBase::SendCallbacks` to consolidate the storage and invocation logic for different callback types, including the new `ResponseHandler`, the legacy `ResponseHandlerSeparateParams`, and block-wise transfer hooks.

All internal modules (MLE, MeshCoP, Network Data, etc.) are updated to define their response handlers using the new `ResponseHandler` signature with `Msg` input.