### PR TITLE
[cli][tcat] initialize TCAT from CLI with proper vendor app URL

### DIFF
--- a/src/cli/cli_tcat.cpp
+++ b/src/cli/cli_tcat.cpp
@@ -28,17 +28,15 @@
 
 #include "openthread-core-config.h"
 
-#include "cli/cli_utils.hpp"
-
 #include "cli/cli_tcat.hpp"
+#include "cli/cli_utils.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/string.hpp"
 
 #include <openthread/ble_secure.h>
-
-#include <mbedtls/oid.h>
 #include <openthread/error.h>
+#include <openthread/netdiag.h>
 #include <openthread/tcat.h>
 #include <openthread/platform/ble.h>
 
@@ -123,7 +121,6 @@ otTcatGeneralDeviceId    sGeneralDeviceId;
 
 const char kPskdVendor[]              = "JJJJJJ";
 const char kInstallVendor[]           = "InstallCode";
-const char kUrl[]                     = "dummy_url";
 const char kApplicationServiceName1[] = "echo";
 const char kApplicationServiceName2[] = "discard";
 
@@ -356,7 +353,7 @@ template <> otError Tcat::Process<Cmd("start")>(Arg aArgs[])
 
     ClearAllBytes(mVendorInfo);
     mVendorInfo.mPskdString                 = kPskdVendor;
-    mVendorInfo.mProvisioningUrl            = kUrl;
+    mVendorInfo.mProvisioningUrl            = otThreadGetVendorAppUrl(GetInstancePtr());
     mVendorInfo.mInstallCode                = kInstallVendor;
     mVendorInfo.mApplicationServiceName[0]  = kApplicationServiceName1;
     mVendorInfo.mApplicationServiceName[1]  = kApplicationServiceName2;

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -48,11 +48,8 @@ RegisterLogModule("TcatAgent");
 
 bool TcatAgent::VendorInfo::IsValid(void) const
 {
-    return (mProvisioningUrl == nullptr ||
-            (IsValidUtf8String(mProvisioningUrl) &&
-             (static_cast<uint8_t>(StringLength(mProvisioningUrl, kProvisioningUrlMaxLength)) <
-              kProvisioningUrlMaxLength))) &&
-           mPskdString != nullptr;
+    // Note: mProvisioningUrl can be nullptr, if not present
+    return mPskdString != nullptr && Tlv::ValidateStringValue<ProvisioningUrlTlv>(mProvisioningUrl) == kErrorNone;
 }
 
 TcatAgent::TcatAgent(Instance &aInstance)
@@ -825,10 +822,10 @@ Error TcatAgent::HandleGetProvisioningUrl(Message &aOutgoingMessage, bool &aResp
     uint16_t length;
 
     VerifyOrExit(mVendorInfo != nullptr, error = kErrorInvalidState);
-    VerifyOrExit(mVendorInfo->mProvisioningUrl != nullptr, error = kErrorInvalidState);
+    VerifyOrExit(mVendorInfo->mProvisioningUrl != nullptr, error = kErrorNotImplemented);
 
     length = StringLength(mVendorInfo->mProvisioningUrl, kProvisioningUrlMaxLength);
-    VerifyOrExit(length > 0 && length <= Tlv::kBaseTlvMaxLength, error = kErrorNotFound);
+    VerifyOrExit(length > 0, error = kErrorNotImplemented);
 
     SuccessOrExit(error =
                       Tlv::AppendTlv(aOutgoingMessage, kTlvResponseWithPayload, mVendorInfo->mProvisioningUrl, length));

--- a/src/core/meshcop/tcat_agent.hpp
+++ b/src/core/meshcop/tcat_agent.hpp
@@ -38,6 +38,7 @@
 
 #if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
 
+#include <openthread/netdiag.h>
 #include <openthread/tcat.h>
 #include <openthread/platform/ble.h>
 
@@ -473,7 +474,7 @@ private:
     uint8_t CheckAuthorizationRequirements(CommandClassFlags aFlagsChecked, Dataset::Info *aDatasetInfo) const;
 
     static constexpr uint16_t kPingPayloadMaxLength      = 512;
-    static constexpr uint16_t kProvisioningUrlMaxLength  = 64;
+    static constexpr uint16_t kProvisioningUrlMaxLength  = OT_NETWORK_DIAGNOSTIC_MAX_VENDOR_APP_URL_TLV_LENGTH;
     static constexpr uint16_t kMaxPskdLength             = OT_JOINER_MAX_PSKD_LENGTH;
     static constexpr uint16_t kTcatMaxDeviceIdSize       = OT_TCAT_MAX_DEVICEID_SIZE;
     static constexpr uint16_t kInstallCodeMaxSize        = 255;

--- a/tests/scripts/expect/cli-tcat.exp
+++ b/tests/scripts/expect/cli-tcat.exp
@@ -90,9 +90,9 @@ expect_line "\tLEN:\t8"
 expect_line "\tVALUE:\t0xef1398c2fd504b67"
 
 send "provisioning_url\n"
-expect_line "\tTYPE:\tRESPONSE_W_PAYLOAD"
-expect_line "\tLEN:\t9"
-expect_line "\tVALUE:\t0x64756d6d795f75726c"
+expect_line "\tTYPE:\tRESPONSE_W_STATUS"
+expect_line "\tLEN:\t1"
+expect_line "\tVALUE:\t0x01"
 
 send "get_apps\n"
 expect_line "\tApplication 1 is UDP service: echo"


### PR DESCRIPTION
This updates the TCAT CLI to use the configured 'vendor app URL' by default as the TCAT Provisioning URL, instead of a dummy value. It also updates the max length of this URL to the configured vendor app URL max length as agreed by JIRA BHC-769. Also 2 related minor validation fixes in TCAT agent code.