### PR TITLE
[meshcop] add `GenerateRandom()` to `ExtendedPanId` class

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -71,7 +71,7 @@ Error Dataset::Info::GenerateRandom(Instance &aInstance)
 
     SuccessOrExit(error = AsCoreType(&mNetworkKey).GenerateRandom());
     SuccessOrExit(error = AsCoreType(&mPskc).GenerateRandom());
-    SuccessOrExit(error = Random::Crypto::Fill(mExtendedPanId));
+    SuccessOrExit(error = AsCoreType(&mExtendedPanId).GenerateRandom());
     SuccessOrExit(error = AsCoreType(&mMeshLocalPrefix).GenerateRandomUla());
 
     nameWriter.Append("%s-%04x", NetworkName::kNetworkNameInit, mPanId);

--- a/src/core/meshcop/extended_panid.cpp
+++ b/src/core/meshcop/extended_panid.cpp
@@ -51,6 +51,8 @@ ExtendedPanId::InfoString ExtendedPanId::ToString(void) const
     return string;
 }
 
+Error ExtendedPanId::GenerateRandom(void) { return Random::Crypto::Fill(*this); }
+
 ExtendedPanIdManager::ExtendedPanIdManager(Instance &aInstance)
     : InstanceLocator(aInstance)
 {

--- a/src/core/meshcop/extended_panid.hpp
+++ b/src/core/meshcop/extended_panid.hpp
@@ -69,6 +69,14 @@ public:
      */
     InfoString ToString(void) const;
 
+    /**
+     * Generates a cryptographically secure random sequence to populate the Extended PAN Identifier.
+     *
+     * @retval kErrorNone     Successfully generated a random Extended PAN ID.
+     * @retval kErrorFailed   Failed to generate random sequence.
+     */
+    Error GenerateRandom(void);
+
 } OT_TOOL_PACKED_END;
 
 class ExtendedPanIdManager : public InstanceLocator, private NonCopyable


### PR DESCRIPTION
This commit adds a `GenerateRandom()` method to the `ExtendedPanId` class, enabling the generation of a cryptographically secure random Extended PAN Identifier.