### PR TITLE
[mac] remove redundant `ExtAddress::operator==()`

### DIFF
--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -75,8 +75,6 @@ void ExtAddress::SetFromIid(const Ip6::InterfaceIdentifier &aIid)
 
 #endif
 
-bool ExtAddress::operator==(const ExtAddress &aOther) const { return (memcmp(m8, aOther.m8, sizeof(m8)) == 0); }
-
 ExtAddress::InfoString ExtAddress::ToString(void) const
 {
     InfoString string;

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -221,16 +221,6 @@ public:
     }
 
     /**
-     * Overloads operator `==` to evaluate whether or not two `ExtAddress` instances are equal.
-     *
-     * @param[in]  aOther  The other `ExtAddress` instance to compare with.
-     *
-     * @retval TRUE   If the two `ExtAddress` instances are equal.
-     * @retval FALSE  If the two `ExtAddress` instances are not equal.
-     */
-    bool operator==(const ExtAddress &aOther) const;
-
-    /**
      * Converts an address to a string.
      *
      * @returns An `InfoString` containing the string representation of the Extended Address.


### PR DESCRIPTION
The `ExtAddress` class inherits from `Equatable<ExtAddress>`, which already provides an `operator==` implementation that compares the object's memory content.