### PR TITLE
[border-router] detect DHCPv6-PD prefix conflict with on-link prefixes

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -961,8 +961,10 @@ private:
         void               Start(void) { Evaluate(); }
         void               Stop(void) { Evaluate(); }
         bool               HasPrefix(void) const { return !mPrefix.IsEmpty(); }
+        bool               HasConflictWithOnLinkPrefixes(void) const { return mConflicted; }
         const Ip6::Prefix &GetPrefix(void) const { return mPrefix.GetPrefix(); }
         State              GetState(void) const { return mState; }
+        void               CheckConflictWithOnLinkPrefixes(void);
 
         void  ProcessPrefixesFromRa(const InfraIf::Icmp6Packet &aRaPacket);
         void  ProcessPrefix(const Dhcp6PdPrefix &aPrefix);
@@ -1000,6 +1002,7 @@ private:
 #endif
 
         State         mState;
+        bool          mConflicted;
         uint32_t      mNumPlatformPioProcessed;
         uint32_t      mNumPlatformRaReceived;
         TimeMilli     mLastPlatformRaTime;

--- a/src/core/border_router/rx_ra_tracker.cpp
+++ b/src/core/border_router/rx_ra_tracker.cpp
@@ -856,6 +856,16 @@ void RxRaTracker::Evaluate(void)
         mEventTask.Post();
     }
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Check for possible conflict between delegated DHCPv6-PD prefix
+    // and any of the observed on-link prefixes. This protects against
+    // DHCPv6-PD server misbehavior (assigning same prefix to multiple
+    // requesters).
+
+    Get<RoutingManager>().mPdPrefixManager.CheckConflictWithOnLinkPrefixes();
+#endif
+
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Schedule timers
 
@@ -1169,6 +1179,26 @@ bool RxRaTracker::IsAddressOnLink(const Ip6::Address &aAddress) const
         {
             isOnLink = aAddress.MatchesPrefix(onLinkPrefix.GetPrefix());
             VerifyOrExit(!isOnLink);
+        }
+    }
+
+exit:
+    return isOnLink;
+}
+
+bool RxRaTracker::IsPrefixOnLink(const Ip6::Prefix &aPrefix) const
+{
+    bool isOnLink = false;
+
+    for (const Router &router : mRouters)
+    {
+        for (const OnLinkPrefix &onLinkPrefix : router.mOnLinkPrefixes)
+        {
+            if (aPrefix == onLinkPrefix.GetPrefix())
+            {
+                isOnLink = true;
+                ExitNow();
+            }
         }
     }
 

--- a/src/core/border_router/rx_ra_tracker.hpp
+++ b/src/core/border_router/rx_ra_tracker.hpp
@@ -307,6 +307,16 @@ public:
      */
     bool IsAddressReachableThroughExplicitRoute(const Ip6::Address &aAddress) const;
 
+    /**
+     * Indicates whether a given prefix is seen as an on-link prefix in any tracked RA.
+     *
+     * @param[in] aPrefix  The IPv6 prefix to check.
+     *
+     * @retval TRUE   The prefix is on-link.
+     * @retval FALSE  The prefix is not on-link.
+     */
+    bool IsPrefixOnLink(const Ip6::Prefix &aPrefix) const;
+
     // Callbacks notifying of changes
     void HandleLocalOnLinkPrefixChanged(void);
 


### PR DESCRIPTION
This commit updates `RoutingManager` to detect if a delegated DHCPv6 PD prefix conflicts with any on-link prefix advertised on the infrastructure link.

This protects against potential DHCPv6 server misbehavior and bugs where the same prefix might be assigned to multiple requesters.

If a conflict is detected, the delegated PD prefix is marked as conflicted and is no longer used as the OMR prefix. Instead, we revert to using the locally generated OMR prefix. If the conflict is resolved, the delegated PD prefix is used again.

A new unit test `TestDhcp6PdConflict()` is added to verify this behavior.

---

Related to [SPEC-1446](https://threadgroup.atlassian.net/browse/SPEC-1446).