### PR TITLE
[nexus] add support for writing test_info.json

### DIFF
--- a/tests/nexus/platform/nexus_core.hpp
+++ b/tests/nexus/platform/nexus_core.hpp
@@ -56,6 +56,8 @@ public:
     TimeMilli GetNow(void) { return mNow; }
     void      AdvanceTime(uint32_t aDuration);
 
+    void SaveTestInfo(const char *aFilename);
+
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Used by platform implementation
 

--- a/tests/nexus/platform/nexus_node.hpp
+++ b/tests/nexus/platform/nexus_node.hpp
@@ -83,6 +83,9 @@ public:
     void GetTrelSockAddr(Ip6::SockAddr &aSockAddr) const;
 #endif
 
+    void        SetName(const char *aName) { IgnoreError(StringCopy(mName, aName)); }
+    const char *GetName(void) const { return mName; }
+
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     template <typename Type> Type &Get(void)
@@ -113,7 +116,9 @@ public:
     Node *mNext;
 
 private:
-    Node(void) = default;
+    Node(void) {}
+
+    char mName[32];
 };
 
 inline Node &AsNode(otInstance *aInstance) { return Node::From(aInstance); }

--- a/tests/nexus/test_5_1_1.cpp
+++ b/tests/nexus/test_5_1_1.cpp
@@ -106,6 +106,9 @@ void Test5_1_1(void)
     Node &leader = nexus.CreateNode();
     Node &router = nexus.CreateNode();
 
+    leader.SetName("LEADER");
+    router.SetName("ROUTER");
+
     nexus.AdvanceTime(0);
 
     Instance::SetLogLevel(kLogLevelInfo);
@@ -194,6 +197,8 @@ void Test5_1_1(void)
         router.Get<Mle::Mle>().GetLinkLocalAddress().ToString().AsCString());
     SendAndVerifyEchoRequest(nexus, leader, router, leaderReceivedEchoReply);
     Log("Router (as DUT) responded with Echo Reply successfully");
+
+    nexus.SaveTestInfo("test_5_1_1.json");
 }
 
 } // namespace Nexus


### PR DESCRIPTION
This commit adds support for writing test_info.json in the Nexus platform. The test_info.json file contains information about the test topology, including node names, roles, and addresses. This information is used by the packet verification framework to verify the behavior of the network.

Changes:
- Added `Core::SaveTestInfo` to `nexus_core.cpp` to write node information to JSON.
- Added `SetName` and `GetName` to `Node` class in `nexus_node.hpp`.
- Updated `test_5_1_1.cpp` to set node names and call `SaveTestInfo`.