### PR TITLE
[tests] fix build error in nexus_discover_scan test

### DIFF
--- a/tests/nexus/test_discover_scan.cpp
+++ b/tests/nexus/test_discover_scan.cpp
@@ -149,7 +149,7 @@ void TestDiscoverScanRequestCallback(void)
     result = &resultContext.mScanResults[0];
 
     VerifyOrQuit(AsCoreType(&result->mExtAddress) == leader.Get<Mac::Mac>().GetExtAddress());
-    VerifyOrQuit(AsCoreType(&result->mExtendedPanId) == leader.Get<MeshCoP::ExtendedPanIdManager>().GetExtPanId());
+    VerifyOrQuit(AsCoreType(&result->mExtendedPanId) == leader.Get<MeshCoP::NetworkIdentity>().GetExtPanId());
     VerifyOrQuit(result->mPanId == leader.Get<Mac::Mac>().GetPanId());
     VerifyOrQuit(result->mChannel == leader.Get<Mac::Mac>().GetPanChannel());
     VerifyOrQuit(result->mDiscover);


### PR DESCRIPTION
This commit updates `tests/nexus/test_discover_scan.cpp` to use `MeshCoP::NetworkIdentity` instead of `MeshCoP::ExtendedPanIdManager`. The latter was renamed in the core codebase, leading to a build failure in the nexus discovery scan test.