### PR TITLE
[coap] optimize retransmission timer scheduling

### DIFF
--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -847,7 +847,6 @@ private:
 
     Message    *InitMessage(Message *aMessage, Type aType, Uri aUri);
     Message    *InitResponse(Message *aMessage, const Message &aRequest);
-    void        ScheduleRetransmissionTimer(void);
     static void HandleRetransmissionTimer(Timer &aTimer);
     void        HandleRetransmissionTimer(void);
     void        ClearRequests(const Ip6::Address *aAddress);


### PR DESCRIPTION

This commit optimizes the CoAP retransmission timer logic by removing the `ScheduleRetransmissionTimer()` method, which iterated over all pending requests to determine the next fire time.

The logic is updated as follows:
- `HandleRetransmissionTimer()` now determines the next fire time while iterating over the `mPendingRequests` list to process retransmissions. This avoids a redundant second pass over the list.
- `NextFireTime` is used to track the earliest fire time.
- `CopyAndEnqueueMessage()` uses `Timer::FireAtIfEarlier()` to update the timer only if the new message's fire time is earlier than the current schedule.
- `DequeueMessage()` no longer triggers a schedule update. If the dequeued message was the next to expire, the timer will fire, perform no actions, and then reschedule itself.