### PR TITLE
[github-actions] reduce multiply runs of pkt verification tests

### DIFF
--- a/.github/workflows/simulation-1.1.yml
+++ b/.github/workflows/simulation-1.1.yml
@@ -53,7 +53,7 @@ jobs:
       THREAD_VERSION: 1.1
       VIRTUAL_TIME: 1
       OT_VT_USE_UNIX_SOCKET: 1
-      MULTIPLY: 3
+      MULTIPLY: 1
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1

--- a/.github/workflows/simulation-1.4.yml
+++ b/.github/workflows/simulation-1.4.yml
@@ -207,7 +207,7 @@ jobs:
       PACKET_VERIFICATION: 1
       THREAD_VERSION: 1.4
       INTER_OP_BBR: 1
-      MULTIPLY: 3
+      MULTIPLY: 1
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1


### PR DESCRIPTION
This commit updates the `simulation-1.1.yml` and `simulation-1.4.yml` workflows to reduce the `MULTIPLY` environment variable from 3 to 1 for the packet verification job. This change avoids running the packet verification tests multiple times, which helps optimize the CI execution time.