### PR TITLE
[cli] fix `BlockwiseTransmitHook` to be stateless

### DIFF
--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -1176,8 +1176,7 @@ otError Coap::BlockwiseTransmitHook(void     *aContext,
 
 otError Coap::BlockwiseTransmitHook(uint8_t *aBlock, uint32_t aPosition, uint16_t *aBlockLength, bool *aMore)
 {
-    static uint32_t blockCount = 0;
-    OT_UNUSED_VARIABLE(aPosition);
+    uint32_t blockCount = aPosition / *aBlockLength;
 
     // Send a random payload
     otRandomNonCryptoFillBuffer(aBlock, *aBlockLength);
@@ -1189,15 +1188,13 @@ otError Coap::BlockwiseTransmitHook(uint8_t *aBlock, uint32_t aPosition, uint16_
         OutputBytesLine(&aBlock[i * 16], 16);
     }
 
-    if (blockCount == mBlockCount - 1)
+    if (blockCount >= mBlockCount - 1)
     {
-        blockCount = 0;
-        *aMore     = false;
+        *aMore = false;
     }
     else
     {
         *aMore = true;
-        blockCount++;
     }
 
     return OT_ERROR_NONE;


### PR DESCRIPTION
This commit updates `Coap::BlockwiseTransmitHook` to calculate the current block count based on the block position (`aPosition`) and block length (`*aBlockLength`), rather than relying on a `static` variable.

The previous implementation used a `static uint32_t blockCount` to track the progress of the block-wise transfer. This approach caused issues when multiple transfers occurred concurrently or when the process persisted across test retries (as in the simulation environment). In such cases, the static variable could become out of sync, leading to incorrect transfer termination or infinite loops.

By deriving `blockCount` from `aPosition`, the hook becomes stateless and correctly handles retransmissions and concurrent transfers.