### PR TITLE
[test] fix and enhance `test_coap_block.py`

### DIFF
--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -3093,20 +3093,20 @@ class NodeImpl:
         else:
             timeout = 5
 
-        self._expect(r'coap request from ([\da-f:]+)(?: OBS=(\d+))?'
-                     r'(?: with payload: ([\da-f]+))?\b',
-                     timeout=timeout)
-        (source, observe, payload) = self.pexpect.match.groups()
+        self._expect(
+            r'coap request from ([\da-f:]+) (GET|PUT|DELETE|POST)(?: OBS=(\d+))?'
+            r'(?: with payload: ([\da-f]+))?\b',
+            timeout=timeout)
+        (source, method, observe, payload) = self.pexpect.match.groups()
+
         source = source.decode('UTF-8')
+        method = method.decode('UTF-8')
 
         if observe is not None:
             observe = int(observe, base=10)
 
-        if payload is not None:
-            payload = binascii.a2b_hex(payload).decode('UTF-8')
-
         # Return the values received
-        return dict(source=source, observe=observe, payload=payload)
+        return dict(source=source, observe=observe, payload=payload, method=method)
 
     def coap_wait_subscribe(self):
         """


### PR DESCRIPTION
This commit fixes and enhances `test_coap_block.py`. Previously, the test masked failures by using multiple trials and suppressing exceptions. It appeared to pass even though an incorrect regex match in `coap_wait_request()` caused it to consistently fail.

The regex in `coap_wait_request()` is updated to correctly match CLI output and capture the CoAP method (GET, PUT, POST, DELETE).

The test script is enhanced by:

- Removing trial/retry logic and exception suppression that masked previous failures.
- Verifying both request and response messages for GET, PUT, and POST.
- Validating source IPv6 addresses in requests and responses.
- Ensuring the payload presence matches the expected behavior for each CoAP method.