### PR TITLE
[backtrace] add crash callback

### DIFF
--- a/src/posix/platform/backtrace.cpp
+++ b/src/posix/platform/backtrace.cpp
@@ -156,6 +156,7 @@ static void signalCritical(int sig, siginfo_t *info, void *ucontext)
 
     otLogCritPlat("------------------ END OF CRASH ------------------");
 
+    otSysCrashCallback();
     resetSignalActions();
     raise(sig);
 }

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -330,6 +330,11 @@ void otSysTrelDeinit(void);
  */
 void otSysSetRcpRestorationEnabled(bool aEnabled);
 
+/**
+ * Called when openthread has crashed
+ */
+inline __attribute__((weak)) void otSysCrashCallback(void) {}
+
 #ifdef __cplusplus
 } // end of extern "C"
 #endif


### PR DESCRIPTION
This commit adds `otSysCrashCallback()` function which will be called when openthread has crashed. It does nothing by default. 

Users can define this function according to their needs.