### PR TITLE
[nexus] add test 5.2.1 REED Attach

### DIFF
--- a/tests/nexus/CMakeLists.txt
+++ b/tests/nexus/CMakeLists.txt
@@ -129,6 +129,7 @@ ot_nexus_test(5_1_10 "cert;nexus")
 ot_nexus_test(5_1_11 "cert;nexus")
 ot_nexus_test(5_1_12 "cert;nexus")
 ot_nexus_test(5_1_13 "cert;nexus")
+ot_nexus_test(5_2_1 "cert;nexus")
 
 # Misc tests
 ot_nexus_test(border_agent "core;nexus")

--- a/tests/nexus/run_nexus_tests.sh
+++ b/tests/nexus/run_nexus_tests.sh
@@ -61,6 +61,7 @@ DEFAULT_TESTS=(
     "5_1_11"
     "5_1_12"
     "5_1_13"
+    "5_2_1"
 )
 
 # Use provided arguments or the default test list

--- a/tests/nexus/test_5_2_1.cpp
+++ b/tests/nexus/test_5_2_1.cpp
@@ -1,0 +1,276 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+
+#include "platform/nexus_core.hpp"
+#include "platform/nexus_node.hpp"
+
+namespace ot {
+namespace Nexus {
+
+/**
+ * Time to advance for a node to form a network and become leader.
+ */
+static constexpr uint32_t kFormNetworkTime = 13 * 1000;
+
+/**
+ * Time to advance for a node to join as a child and upgrade to a router.
+ * This duration accounts for MLE attach process and ROUTER_SELECTION_JITTER.
+ */
+static constexpr uint32_t kAttachToRouterTime = 200 * 1000;
+
+/**
+ * Time to advance for a node to join as a child.
+ */
+static constexpr uint32_t kAttachToChildTime = 10 * 1000;
+
+/**
+ * Time to wait for ICMPv6 Echo Reply.
+ */
+static constexpr uint32_t kEchoResponseTime = 1000;
+
+static void HandleEchoReply(void                *aContext,
+                            otMessage           *aMessage,
+                            const otMessageInfo *aMessageInfo,
+                            const otIcmp6Header *aIcmpHeader)
+{
+    OT_UNUSED_VARIABLE(aMessage);
+    OT_UNUSED_VARIABLE(aMessageInfo);
+
+    if (aIcmpHeader->mType == OT_ICMP6_TYPE_ECHO_REPLY)
+    {
+        *static_cast<bool *>(aContext) = true;
+    }
+}
+
+static void SendAndVerifyEchoRequest(Core               &aNexus,
+                                     Node               &aSender,
+                                     const Ip6::Address &aReceiverAddr,
+                                     bool               &aReceivedEchoReply)
+{
+    Message         *message = aSender.Get<Ip6::Icmp>().NewMessage();
+    Ip6::MessageInfo messageInfo;
+    Error            error = kErrorNone;
+
+    VerifyOrQuit(message != nullptr);
+
+    messageInfo.SetPeerAddr(aReceiverAddr);
+    messageInfo.SetHopLimit(64);
+
+    aReceivedEchoReply = false;
+
+    error = aSender.Get<Ip6::Icmp>().SendEchoRequest(*message, messageInfo, 0x1234);
+    if (error != kErrorNone)
+    {
+        message->Free();
+        SuccessOrQuit(error);
+    }
+
+    aNexus.AdvanceTime(kEchoResponseTime);
+    VerifyOrQuit(aReceivedEchoReply, "Echo Reply not received");
+}
+
+void Test5_2_1(void)
+{
+    /**
+     * 5.2.1 REED Attach
+     *
+     * 5.2.1.1 Topology
+     * - Leader
+     * - Router_1 (DUT)
+     * - REED_1
+     * - MED_1
+     *
+     * 5.2.1.2 Purpose & Description
+     * The purpose of this test case is to show that the DUT is able to attach a REED and forward address solicits
+     *   two hops away from the Leader.
+     *
+     * Spec Reference                               | V1.1 Section    | V1.3.0 Section
+     * ---------------------------------------------|-----------------|---------------
+     * Attaching to a Parent / Router ID Assignment | 4.7.1 / 5.9.10  | 4.5.1 / 5.9.10
+     */
+
+    Core nexus;
+
+    Node &leader = nexus.CreateNode();
+    Node &dut    = nexus.CreateNode();
+    Node &reed1  = nexus.CreateNode();
+    Node &med1   = nexus.CreateNode();
+
+    leader.SetName("LEADER");
+    dut.SetName("DUT");
+    reed1.SetName("REED_1");
+    med1.SetName("MED_1");
+
+    // Establish topology using AllowList
+    dut.AllowList(leader);
+    leader.AllowList(dut);
+
+    dut.AllowList(reed1);
+    reed1.AllowList(dut);
+
+    reed1.AllowList(med1);
+    med1.AllowList(reed1);
+
+    nexus.AdvanceTime(0);
+
+    Instance::SetLogLevel(kLogLevelInfo);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 1: Router_1 (DUT)");
+
+    /**
+     * Step 1: Router_1 (DUT)
+     * - Description: Attach to Leader and sends properly formatted MLE advertisements.
+     * - Pass Criteria:
+     *   - The DUT MUST send properly formatted MLE Advertisements.
+     *   - MLE Advertisements MUST be sent with an IP Hop Limit of 255 to the Link-Local All Nodes multicast address
+     *     (FF02::1).
+     *   - The following TLVs MUST be present in MLE Advertisements:
+     *     - Source Address TLV
+     *     - Leader Data TLV
+     *     - Route64 TLV
+     */
+    leader.Form();
+    nexus.AdvanceTime(kFormNetworkTime);
+    dut.Join(leader);
+    nexus.AdvanceTime(kAttachToRouterTime);
+    VerifyOrQuit(dut.Get<Mle::Mle>().IsRouter());
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 2: REED_1");
+
+    /**
+     * Step 2: REED_1
+     * - Description: Attach REED_1 to DUT; REED_1 automatically sends MLE Parent Request.
+     * - Pass Criteria: N/A
+     */
+    reed1.Join(dut);
+    nexus.AdvanceTime(kAttachToChildTime);
+    VerifyOrQuit(reed1.Get<Mle::Mle>().IsChild());
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 3: Router_1 (DUT)");
+
+    /**
+     * Step 3: Router_1 (DUT)
+     * - Description: Automatically sends an MLE Parent Response.
+     * - Pass Criteria:
+     *   - The DUT MUST respond with a MLE Parent Response.
+     *   - The following TLVs MUST be present in the MLE Parent Response:
+     *     - Challenge TLV
+     *     - Connectivity TLV
+     *     - Leader Data TLV
+     *     - Link-layer Frame Counter TLV
+     *     - Link Margin TLV
+     *     - Response TLV
+     *     - Source Address TLV
+     *     - Version TLV
+     *     - MLE Frame Counter TLV (optional)
+     */
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 4: Router_1 (DUT)");
+
+    /**
+     * Step 4: Router_1 (DUT)
+     * - Description: Automatically sends an MLE Child ID Response.
+     * - Pass Criteria:
+     *   - The DUT MUST send a MLE Child ID Response.
+     *   - The following TLVs MUST be present in the Child ID Response:
+     *     - Address16 TLV
+     *     - Leader Data TLV
+     *     - Network Data TLV
+     *     - Source Address TLV
+     *     - Route64 TLV (optional)
+     */
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 6: MED_1");
+
+    /**
+     * Step 6: MED_1
+     * - Description: The harness attaches MED_1 to REED_1.
+     * - Pass Criteria: N/A
+     */
+    med1.Join(reed1, Node::kAsMed);
+    nexus.AdvanceTime(kAttachToChildTime);
+    VerifyOrQuit(med1.Get<Mle::Mle>().IsChild());
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 7: REED_1");
+
+    /**
+     * Step 7: REED_1
+     * - Description: Automatically sends an Address Solicit Request to DUT.
+     * - Pass Criteria: N/A
+     */
+    nexus.AdvanceTime(kAttachToRouterTime);
+    VerifyOrQuit(reed1.Get<Mle::Mle>().IsRouter());
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 8: Router_1 (DUT)");
+
+    /**
+     * Step 8: Router_1 (DUT)
+     * - Description: Automatically forwards Address Solicit Request to Leader, and forwards Leader's Address Solicit
+     *     Response to REED_1.
+     * - Pass Criteria:
+     *   - The DUT MUST forward the Address Solicit Request to the Leader.
+     *   - The DUT MUST forward the Leader's Address Solicit Response to REED_1.
+     */
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 9: Leader");
+
+    /**
+     * Step 9: Leader
+     * - Description: Harness verifies connectivity by instructing the device to send an ICMPv6 Echo Request to REED_1.
+     * - Pass Criteria:
+     *   - REED_1 responds with ICMPv6 Echo Reply.
+     */
+    bool               reed1ReceivedEchoReply = false;
+    Ip6::Icmp::Handler leaderIcmpHandler(HandleEchoReply, &reed1ReceivedEchoReply);
+    leader.Get<Ip6::Icmp>().RegisterHandler(leaderIcmpHandler);
+
+    SendAndVerifyEchoRequest(nexus, leader, reed1.Get<Mle::Mle>().GetMeshLocalEid(), reed1ReceivedEchoReply);
+
+    nexus.SaveTestInfo("test_5_2_1.json");
+}
+
+} // namespace Nexus
+} // namespace ot
+
+int main(void)
+{
+    ot::Nexus::Test5_2_1();
+    printf("All tests passed\n");
+    return 0;
+}

--- a/tests/nexus/verify_5_2_1.py
+++ b/tests/nexus/verify_5_2_1.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import sys
+import os
+
+# Add the current directory to sys.path to find verify_utils
+CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(CUR_DIR)
+
+import verify_utils
+from pktverify import consts
+
+
+def verify(pv):
+    # 5.2.1 REED Attach
+    #
+    # 5.2.1.1 Topology
+    # - Leader
+    # - Router_1 (DUT)
+    # - REED_1
+    # - MED_1
+    #
+    # 5.2.1.2 Purpose & Description
+    # The purpose of this test case is to show that the DUT is able to attach a REED and forward address solicits
+    #   two hops away from the Leader.
+    #
+    # Spec Reference                               | V1.1 Section    | V1.3.0 Section
+    # ---------------------------------------------|-----------------|---------------
+    # Attaching to a Parent / Router ID Assignment | 4.7.1 / 5.9.10  | 4.5.1 / 5.9.10
+
+    pkts = pv.pkts
+    pv.summary.show()
+
+    LEADER = pv.vars['LEADER']
+    LEADER_RLOC16 = pv.vars['LEADER_RLOC16']
+    DUT = pv.vars['DUT']
+    DUT_RLOC16 = pv.vars['DUT_RLOC16']
+    REED_1 = pv.vars['REED_1']
+    MED_1 = pv.vars['MED_1']
+
+    # Step 1: Router_1 (DUT)
+    # - Description: Attach to Leader and sends properly formatted MLE advertisements.
+    # - Pass Criteria:
+    #   - The DUT MUST send properly formatted MLE Advertisements.
+    #   - MLE Advertisements MUST be sent with an IP Hop Limit of 255 to the Link-Local All Nodes multicast address
+    #     (FF02::1).
+    #   - The following TLVs MUST be present in MLE Advertisements:
+    #     - Source Address TLV
+    #     - Leader Data TLV
+    #     - Route64 TLV
+    print("Step 1: Router_1 (DUT)")
+    pkts.filter_wpan_src64(DUT).\
+        filter_LLANMA().\
+        filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
+        filter(lambda p: {
+                          consts.SOURCE_ADDRESS_TLV,
+                          consts.LEADER_DATA_TLV,
+                          consts.ROUTE64_TLV
+                          } <= set(p.mle.tlv.type) and\
+               p.ipv6.hlim == 255).\
+        must_next()
+
+    # Step 2: REED_1
+    # - Description: Attach REED_1 to DUT; REED_1 automatically sends MLE Parent Request.
+    # - Pass Criteria: N/A
+    print("Step 2: REED_1")
+    pkts.filter_wpan_src64(REED_1).\
+        filter_LLARMA().\
+        filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
+        must_next()
+
+    # Step 3: Router_1 (DUT)
+    # - Description: Automatically sends an MLE Parent Response.
+    # - Pass Criteria:
+    #   - The DUT MUST respond with a MLE Parent Response.
+    #   - The following TLVs MUST be present in the MLE Parent Response:
+    #     - Challenge TLV
+    #     - Connectivity TLV
+    #     - Leader Data TLV
+    #     - Link-layer Frame Counter TLV
+    #     - Link Margin TLV
+    #     - Response TLV
+    #     - Source Address TLV
+    #     - Version TLV
+    #     - MLE Frame Counter TLV (optional)
+    print("Step 3: Router_1 (DUT)")
+    pkts.filter_wpan_src64(DUT).\
+        filter_wpan_dst64(REED_1).\
+        filter_mle_cmd(consts.MLE_PARENT_RESPONSE).\
+        filter(lambda p: {
+                          consts.CHALLENGE_TLV,
+                          consts.CONNECTIVITY_TLV,
+                          consts.LEADER_DATA_TLV,
+                          consts.LINK_LAYER_FRAME_COUNTER_TLV,
+                          consts.LINK_MARGIN_TLV,
+                          consts.RESPONSE_TLV,
+                          consts.SOURCE_ADDRESS_TLV,
+                          consts.VERSION_TLV
+                          } <= set(p.mle.tlv.type)).\
+        must_next()
+
+    # Step 4: Router_1 (DUT)
+    # - Description: Automatically sends an MLE Child ID Response.
+    # - Pass Criteria:
+    #   - The DUT MUST send a MLE Child ID Response.
+    #   - The following TLVs MUST be present in the Child ID Response:
+    #     - Address16 TLV
+    #     - Leader Data TLV
+    #     - Network Data TLV
+    #     - Source Address TLV
+    #     - Route64 TLV (optional)
+    print("Step 4: Router_1 (DUT)")
+    pkts.filter_wpan_src64(DUT).\
+        filter_wpan_dst64(REED_1).\
+        filter_mle_cmd(consts.MLE_CHILD_ID_RESPONSE).\
+        filter(lambda p: {
+                          consts.ADDRESS16_TLV,
+                          consts.LEADER_DATA_TLV,
+                          consts.NETWORK_DATA_TLV,
+                          consts.SOURCE_ADDRESS_TLV
+                          } <= set(p.mle.tlv.type)).\
+        must_next()
+
+    # Step 6: MED_1
+    # - Description: The harness attaches MED_1 to REED_1.
+    # - Pass Criteria: N/A
+    print("Step 6: MED_1")
+    pkts.filter_wpan_src64(MED_1).\
+        filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
+        must_next()
+
+    # Step 7: REED_1
+    # - Description: Automatically sends an Address Solicit Request to DUT.
+    # - Pass Criteria: N/A
+    print("Step 7: REED_1")
+    _pkt_sol = pkts.filter_wpan_src64(REED_1).\
+        filter_wpan_dst16(DUT_RLOC16).\
+        filter_coap_request(consts.ADDR_SOL_URI).\
+        must_next()
+
+    # Step 8: Router_1 (DUT)
+    # - Description: Automatically forwards Address Solicit Request to Leader, and forwards Leader's Address Solicit
+    #     Response to REED_1.
+    # - Pass Criteria:
+    #   - The DUT MUST forward the Address Solicit Request to the Leader.
+    #   - The DUT MUST forward the Leader's Address Solicit Response to REED_1.
+    print("Step 8: Router_1 (DUT)")
+    pkts.filter_wpan_src16(DUT_RLOC16).\
+        filter_wpan_dst16(LEADER_RLOC16).\
+        filter_coap_request(consts.ADDR_SOL_URI).\
+        must_next()
+
+    pkts.filter_wpan_src16(LEADER_RLOC16).\
+        filter_wpan_dst16(DUT_RLOC16).\
+        filter_coap_ack(consts.ADDR_SOL_URI).\
+        must_next()
+
+    pkts.filter_wpan_src16(DUT_RLOC16).\
+        filter_wpan_dst16(_pkt_sol.wpan.src16).\
+        filter_coap_ack(consts.ADDR_SOL_URI).\
+        must_next()
+
+    # Step 9: Leader
+    # - Description: Harness verifies connectivity by instructing the device to send an ICMPv6 Echo Request to REED_1.
+    # - Pass Criteria:
+    #   - REED_1 responds with ICMPv6 Echo Reply.
+    print("Step 9: Leader")
+    _pkt_ping = pkts.filter_ping_request().\
+        filter_wpan_src64(LEADER).\
+        must_next()
+
+    pkts.filter_ping_reply(identifier=_pkt_ping.icmpv6.echo.identifier).\
+        filter_wpan_src64(REED_1).\
+        must_next()
+
+
+if __name__ == '__main__':
+    verify_utils.run_main(verify)


### PR DESCRIPTION
Adds a new Nexus test case for 'REED Attach' (5.2.1) as specified in the test specification.

Summary of changes:
- Implemented Nexus test 5.2.1:
    - Added test_5_2_1.cpp: Sets up a Leader, REED_1, and MED_1 (DUT) topology. Ensures REED_1 upgrades to a Router when the DUT attaches. Verifies connectivity from the Leader to the DUT via REED_1 using ICMP Echo.
    - Added verify_5_2_1.py: PCAP verification script for test 5.2.1, ensuring MLE Parent Requests, Address Solicit/Responses, and ICMP Echo Request/Replies are correctly exchanged and forwarded.
- Updated build and execution scripts:
    - Modified CMakeLists.txt to build the new 5.2.1 test executable.
    - Updated run_nexus_tests.sh to include 5.2.1 in the default test list.