### PR TITLE
[nexus] add error handling to SetRouterEligible calls

### DIFF
--- a/tests/nexus/test_5_1_10.cpp
+++ b/tests/nexus/test_5_1_10.cpp
@@ -165,7 +165,7 @@ void Test5_1_10(void)
      *     - Version TLV
      */
 
-    dut.Get<Mle::Mle>().SetRouterEligible(false);
+    SuccessOrQuit(dut.Get<Mle::Mle>().SetRouterEligible(false));
     dut.Join(leader);
 
     /**

--- a/tests/nexus/test_5_1_11.cpp
+++ b/tests/nexus/test_5_1_11.cpp
@@ -186,7 +186,7 @@ void Test5_1_11(void)
      *     - Scan Mask TLV = 0x80 (active Routers)
      *     - Version TLV
      */
-    dut.Get<Mle::Mle>().SetRouterEligible(false);
+    SuccessOrQuit(dut.Get<Mle::Mle>().SetRouterEligible(false));
     dut.Join(leader);
 
     Log("---------------------------------------------------------------------------------------");

--- a/tests/nexus/test_5_1_8.cpp
+++ b/tests/nexus/test_5_1_8.cpp
@@ -176,7 +176,7 @@ void Test5_1_8(void)
      *     - Scan Mask TLV = 0x80 (Active Routers)
      *     - Version TLV
      */
-    dut.Get<Mle::Mle>().SetRouterEligible(false);
+    SuccessOrQuit(dut.Get<Mle::Mle>().SetRouterEligible(false));
     dut.Join(router3, Node::kAsFed); // We use router3 as the dataset source, but it will scan and find all
 
     Log("---------------------------------------------------------------------------------------");

--- a/tests/nexus/test_5_1_9.cpp
+++ b/tests/nexus/test_5_1_9.cpp
@@ -187,7 +187,7 @@ void Test5_1_9(void)
      *     - Version TLV
      */
     Log("Step 3: Router_2 (DUT) begins attach process");
-    dut.Get<Mle::Mle>().SetRouterEligible(false);
+    SuccessOrQuit(dut.Get<Mle::Mle>().SetRouterEligible(false));
     dut.Join(reed1); // reed1 is just a placeholder here, it will scan.
 
     /**


### PR DESCRIPTION
Adds SuccessOrQuit() around SetRouterEligible() calls in Nexus tests to properly handle potential errors and ensure test robustness.

Summary of changes:
- Modified tests/nexus/test_5_1_8.cpp, test_5_1_9.cpp, test_5_1_10.cpp, and test_5_1_11.cpp to wrap SetRouterEligible(false) calls in SuccessOrQuit().
- Verified that tests build and pass correctly with these changes.