### PR TITLE
[pktverify] remove excessive print output in Bytes comparison

### DIFF
--- a/tests/scripts/thread-cert/pktverify/bytes.py
+++ b/tests/scripts/thread-cert/pktverify/bytes.py
@@ -124,9 +124,7 @@ class Bytes(bytearray):
         elif not isinstance(other, Bytes):
             other = self.__class__(other)
 
-        eq = super().__eq__(other)
-        print("[%r %s %r]" % (self, "==" if eq else "!=", other), file=sys.stderr)
-        return eq
+        return super().__eq__(other)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit removes a debug print statement in the Bytes.__eq__ method that was causing excessive output to stderr during packet verification. The print statement was logging every byte comparison, leading to cluttered logs and potentially impacting performance or causing issues with log analysis.

- Removed print statement from Bytes.__eq__ in tests/scripts/thread-cert/pktverify/bytes.py.