### PR TITLE
[nexus] add test 5.2.3 Leader rejects Address Solicit (2-hops away)

### DIFF
--- a/tests/nexus/CMakeLists.txt
+++ b/tests/nexus/CMakeLists.txt
@@ -130,6 +130,7 @@ ot_nexus_test(5_1_11 "cert;nexus")
 ot_nexus_test(5_1_12 "cert;nexus")
 ot_nexus_test(5_1_13 "cert;nexus")
 ot_nexus_test(5_2_1 "cert;nexus")
+ot_nexus_test(5_2_3 "cert;nexus")
 
 # Misc tests
 ot_nexus_test(border_agent "core;nexus")

--- a/tests/nexus/platform/nexus_node.cpp
+++ b/tests/nexus/platform/nexus_node.cpp
@@ -103,6 +103,8 @@ void Node::AllowList(Node &aNode)
 
 void Node::UnallowList(Node &aNode) { Get<Mac::Filter>().RemoveAddress(aNode.Get<Mac::Mac>().GetExtAddress()); }
 
+void Node::SetName(const char *aPrefix, uint16_t aIndex) { mName.Clear().Append("%s %u", aPrefix, aIndex); }
+
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 void Node::GetTrelSockAddr(Ip6::SockAddr &aSockAddr) const
 {

--- a/tests/nexus/platform/nexus_node.hpp
+++ b/tests/nexus/platform/nexus_node.hpp
@@ -83,8 +83,9 @@ public:
     void GetTrelSockAddr(Ip6::SockAddr &aSockAddr) const;
 #endif
 
-    void        SetName(const char *aName) { IgnoreError(StringCopy(mName, aName)); }
-    const char *GetName(void) const { return mName; }
+    void        SetName(const char *aName) { mName.Clear().Append("%s", aName); }
+    void        SetName(const char *aPrefix, uint16_t aIndex);
+    const char *GetName(void) const { return mName.AsCString(); }
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -118,7 +119,7 @@ public:
 private:
     Node(void) {}
 
-    char mName[32];
+    String<32> mName;
 };
 
 inline Node &AsNode(otInstance *aInstance) { return Node::From(aInstance); }

--- a/tests/nexus/run_nexus_tests.sh
+++ b/tests/nexus/run_nexus_tests.sh
@@ -62,6 +62,7 @@ DEFAULT_TESTS=(
     "5_1_12"
     "5_1_13"
     "5_2_1"
+    "5_2_3"
 )
 
 # Use provided arguments or the default test list

--- a/tests/nexus/test_5_2_3.cpp
+++ b/tests/nexus/test_5_2_3.cpp
@@ -1,0 +1,210 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+
+#include "platform/nexus_core.hpp"
+#include "platform/nexus_node.hpp"
+
+namespace ot {
+namespace Nexus {
+
+/**
+ * 5.2.3 Leader rejects CoAP Address Solicit (2-hops from Leader)
+ *
+ * 5.2.3.1 Topology
+ * - Build a topology with the DUT as the Leader and have a total of 32 routers, including the Leader.
+ * - Attempt to attach a 33rd router, two hops from the leader.
+ *
+ * 5.2.3.2 Purpose & Description
+ * The purpose of this test case is to show that the DUT will only allow 32 active routers on the network and
+ * reject the Address Solicit Request from a 33rd router - that is 2-hops away - with a No Address Available status.
+ *
+ * Spec Reference                               | V1.1 Section    | V1.3.0 Section
+ * ---------------------------------------------|-----------------|-----------------
+ * Attaching to a Parent / Router ID Assignment | 4.7.1 / 5.9.10  | 4.5.1 / 5.9.10
+ */
+
+/**
+ * Time to advance for a node to form a network and become leader.
+ */
+static constexpr uint32_t kFormNetworkTime = 13 * 1000;
+
+/**
+ * Time to advance for a node to join as a child and upgrade to a router.
+ * This duration accounts for MLE attach process and ROUTER_SELECTION_JITTER.
+ */
+static constexpr uint32_t kAttachToRouterTime = 200 * 1000;
+
+/**
+ * Time to advance for a node to try to become a router.
+ */
+static constexpr uint32_t kWaitTime = 10 * 1000;
+
+static constexpr uint8_t kMaxRouters = 32;
+
+void Test5_2_3(void)
+{
+    Core nexus;
+
+    Node &leader = nexus.CreateNode();
+    Node *routers[kMaxRouters];
+
+    leader.SetName("Leader");
+
+    for (uint8_t i = 0; i < kMaxRouters; i++)
+    {
+        routers[i] = &nexus.CreateNode();
+        routers[i]->SetName("Router", i + 1);
+    }
+
+    nexus.AdvanceTime(0);
+
+    Instance::SetLogLevel(kLogLevelNote);
+
+    leader.Get<Mle::Mle>().SetRouterUpgradeThreshold(kMaxRouters);
+    for (uint8_t i = 0; i < kMaxRouters; i++)
+    {
+        routers[i]->Get<Mle::Mle>().SetRouterUpgradeThreshold(kMaxRouters);
+    }
+
+    // Topology:
+    // Leader <-> Router 1..31
+    // Router 32 <-> Router 1
+    for (uint8_t i = 0; i < kMaxRouters - 1; i++)
+    {
+        leader.AllowList(*routers[i]);
+        routers[i]->AllowList(leader);
+    }
+
+    routers[kMaxRouters - 1]->AllowList(*routers[0]);
+    routers[0]->AllowList(*routers[kMaxRouters - 1]);
+
+    Log("---------------------------------------------------------------------------------------");
+    /**
+     * Step 1: All
+     * - Description: Begin wireless sniffer and ensure topology is created and connectivity between nodes.
+     * - Pass Criteria: Topology is created, the DUT is the Leader of the network and there is a total of 32
+     *   active routers, including the Leader.
+     */
+    Log("Step 1: All");
+
+    leader.Form();
+    nexus.AdvanceTime(kFormNetworkTime);
+    VerifyOrQuit(leader.Get<Mle::Mle>().IsLeader());
+
+    for (uint8_t i = 0; i < kMaxRouters - 1; i++)
+    {
+        routers[i]->Join(leader);
+    }
+
+    nexus.AdvanceTime(kAttachToRouterTime);
+
+    for (uint8_t i = 0; i < kMaxRouters - 1; i++)
+    {
+        VerifyOrQuit(routers[i]->Get<Mle::Mle>().IsRouter());
+    }
+
+    Log("---------------------------------------------------------------------------------------");
+    /**
+     * Step 2: Router_31
+     * - Description: The harness causes Router_31 to attach to the network and send an Address Solicit Request to
+     *   become an active router.
+     * - Pass Criteria: N/A
+     */
+    Log("Step 2: Router_31");
+    // Handled in Step 1 for simplicity as Router 31 is one of the 31 routers joining the Leader.
+
+    Log("---------------------------------------------------------------------------------------");
+    /**
+     * Step 3: Leader (DUT)
+     * - Description: The DUT receives the Address Solicit Request and automatically replies with an Address
+     *   Solicit Response.
+     * - Pass Criteria:
+     *   - The DUT MUST reply to the Address Solicit Request with an Address Solicit Response containing:
+     *     - CoAP Response Code: 2.04 Changed
+     *     - CoAP Payload:
+     *       - Status TLV (value = Success)
+     *       - RLOC16 TLV
+     *       - Router Mask TLV
+     */
+    Log("Step 3: Leader (DUT)");
+    // Handled in Step 1.
+
+    Log("---------------------------------------------------------------------------------------");
+    /**
+     * Step 4: Leader (DUT)
+     * - Description: Automatically sends MLE Advertisements.
+     * - Pass Criteria: The DUT’s MLE Advertisements MUST contain the Route64 TLV with 32 assigned Router IDs.
+     */
+    Log("Step 4: Leader (DUT)");
+    // Handled in Step 1.
+
+    Log("---------------------------------------------------------------------------------------");
+    /**
+     * Step 5: Router_32
+     * - Description: The harness causes Router_32 to attach to any of the active routers, 2-hops from the leader,
+     *   and to send an Address Solicit Request to become an active router.
+     * - Pass Criteria: N/A
+     */
+    Log("Step 5: Router_32");
+    routers[kMaxRouters - 1]->Join(*routers[0]);
+    nexus.AdvanceTime(kAttachToRouterTime);
+    VerifyOrQuit(routers[kMaxRouters - 1]->Get<Mle::Mle>().IsChild());
+
+    // Force Router 32 to try to become a router
+    routers[kMaxRouters - 1]->Get<Mle::Mle>().BecomeRouter(Mle::kReasonTooFewRouters);
+
+    Log("---------------------------------------------------------------------------------------");
+    /**
+     * Step 6: Leader (DUT)
+     * - Description: The DUT receives the Address Solicit Request and automatically replies with an Address
+     *   Solicit Response.
+     * - Pass Criteria:
+     *   - The DUT MUST reply to the Address Solicit Request with an Address Solicit Response containing:
+     *     - CoAP Response Code: 2.04 Changed
+     *     - CoAP Payload:
+     *       - Status TLV (value = No Address Available)
+     */
+    Log("Step 6: Leader (DUT)");
+    nexus.AdvanceTime(kWaitTime);
+    VerifyOrQuit(routers[kMaxRouters - 1]->Get<Mle::Mle>().IsChild());
+
+    nexus.SaveTestInfo("test_5_2_3.json");
+}
+
+} // namespace Nexus
+} // namespace ot
+
+int main(void)
+{
+    ot::Nexus::Test5_2_3();
+    printf("All tests passed\n");
+    return 0;
+}

--- a/tests/nexus/verify_5_2_3.py
+++ b/tests/nexus/verify_5_2_3.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import sys
+import os
+
+# Add the current directory to sys.path to find verify_utils
+CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(CUR_DIR)
+
+import verify_utils
+from pktverify import consts
+
+
+def verify(pv):
+    # 5.2.3 Leader rejects CoAP Address Solicit (2-hops from Leader)
+    #
+    # 5.2.3.1 Topology
+    #   - Build a topology with the DUT as the Leader and have a total of 32 routers, including the Leader.
+    #   - Attempt to attach a 33rd router, two hops from the leader.
+    #
+    # 5.2.3.2 Purpose & Description
+    #   The purpose of this test case is to show that the DUT will only allow 32 active routers on the network and
+    #   reject the Address Solicit Request from a 33rd router - that is 2-hops away - with a No Address Available status.
+    #
+    #   Spec Reference                               | V1.1 Section    | V1.3.0 Section
+    #   ---------------------------------------------|-----------------|-----------------
+    #   Attaching to a Parent / Router ID Assignment | 4.7.1 / 5.9.10  | 4.5.1 / 5.9.10
+
+    pkts = pv.pkts
+    pv.summary.show()
+
+    MAX_ROUTERS = 32
+
+    LEADER = pv.vars['Leader']
+    ROUTER_31 = pv.vars['Router 31']
+    ROUTER_32 = pv.vars['Router 32']
+
+    # Step 1: All
+    # - Description: Begin wireless sniffer and ensure topology is created and connectivity between nodes.
+    # - Pass Criteria: Topology is created, the DUT is the Leader of the network and there is a total of 32
+    #   active routers, including the Leader.
+    print("Step 1: All")
+    pkts.filter_wpan_src64(LEADER).\
+        filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
+        filter(lambda p: consts.LEADER_DATA_TLV in p.mle.tlv.type).\
+        must_next()
+
+    # Step 2: Router_31
+    # - Description: The harness causes Router_31 to attach to the network and send an Address Solicit Request to
+    #   become an active router.
+    # - Pass Criteria: N/A
+    print("Step 2: Router_31")
+    pkts.filter_wpan_src64(ROUTER_31).\
+        filter_coap_request(consts.ADDR_SOL_URI).\
+        must_next()
+
+    # Step 3: Leader (DUT)
+    # - Description: The DUT receives the Address Solicit Request and automatically replies with an Address
+    #   Solicit Response.
+    # - Pass Criteria:
+    #   - The DUT MUST reply to the Address Solicit Request with an Address Solicit Response containing:
+    #     - CoAP Response Code: 2.04 Changed
+    #     - CoAP Payload:
+    #       - Status TLV (value = Success)
+    #       - RLOC16 TLV
+    #       - Router Mask TLV
+    print("Step 3: Leader (DUT)")
+    pkts.filter_wpan_src64(LEADER).\
+        filter_coap_ack(consts.ADDR_SOL_URI).\
+        filter(lambda p: {
+            consts.NL_STATUS_TLV,
+            consts.NL_RLOC16_TLV,
+            consts.NL_ROUTER_MASK_TLV
+        } <= set(p.coap.tlv.type) and\
+            p.coap.code == consts.COAP_CODE_ACK and\
+            p.coap.tlv.status == consts.ADDR_SOL_SUCCESS).\
+        must_next()
+
+    # Step 4: Leader (DUT)
+    # - Description: Automatically sends MLE Advertisements.
+    # - Pass Criteria: The DUT’s MLE Advertisements MUST contain the Route64 TLV with 32 assigned Router IDs.
+    print("Step 4: Leader (DUT)")
+    pkts.filter_wpan_src64(LEADER).\
+        filter_LLANMA().\
+        filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
+        filter(lambda p: consts.ROUTE64_TLV in p.mle.tlv.type and\
+               len(p.mle.tlv.route64.id_mask) == MAX_ROUTERS).\
+        must_next()
+
+    # Step 5: Router_32
+    # - Description: The harness causes Router_32 to attach to any of the active routers, 2-hops from the leader,
+    #   and to send an Address Solicit Request to become an active router.
+    # - Pass Criteria: N/A
+    print("Step 5: Router_32")
+    pkts.filter_wpan_src64(ROUTER_32).\
+        filter_coap_request(consts.ADDR_SOL_URI).\
+        must_next()
+
+    # Step 6: Leader (DUT)
+    # - Description: The DUT receives the Address Solicit Request and automatically replies with an Address
+    #   Solicit Response.
+    # - Pass Criteria:
+    #   - The DUT MUST reply to the Address Solicit Request with an Address Solicit Response containing:
+    #     - CoAP Response Code: 2.04 Changed
+    #     - CoAP Payload:
+    #       - Status TLV (value = No Address Available)
+    print("Step 6: Leader (DUT)")
+    pkts.filter_wpan_src64(LEADER).\
+        filter_coap_ack(consts.ADDR_SOL_URI).\
+        filter(lambda p: {
+            consts.NL_STATUS_TLV
+        } <= set(p.coap.tlv.type) and\
+            p.coap.code == consts.COAP_CODE_ACK and\
+            p.coap.tlv.status == consts.NL_NO_ADDRESS_AVAILABLE).\
+        must_next()
+
+
+if __name__ == '__main__':
+    verify_utils.run_main(verify)


### PR DESCRIPTION
Adds a new Nexus test case for 'Leader rejects CoAP Address Solicit (2-hops from Leader)' (5.2.3) as specified in the test specification.

Summary of changes:
- Implemented Nexus test 5.2.3:
    - Added test_5_2_3.cpp: Sets up a topology with a Leader, 31 routers (fully connected to Leader), and a 32nd router (Router 32) that is 2-hops away from the Leader via Router 1. Verifies that the Leader rejects the Address Solicit Request from the 33rd router with a 'No Address Available' status (1).
    - Added verify_5_2_3.py: PCAP verification script for test 5.2.3. Ensures the Address Solicit Request is sent by Router 32 to the Leader, and that the Leader responds with a CoAP ACK containing a Status TLV with value 1 (NL_NO_ADDRESS_AVAILABLE).
- Updated build and execution scripts:
    - Modified CMakeLists.txt to build the new 5.2.3 test executable.
    - Updated run_nexus_tests.sh to include 5.2.3 in the default test list.