### PR TITLE
[joiner] refresh ID from EUI-64 in `Start()` when discerner is empty

### DIFF
--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -128,6 +128,11 @@ Error Joiner::Start(const char      *aPskd,
 
     SuccessOrExit(error = Get<Tmf::SecureAgent>().Open(Ip6::NetifIdentifier::kNetifThreadInternal));
 
+    if (mDiscerner.IsEmpty())
+    {
+        SetIdFromIeeeEui64();
+    }
+
     // After this, if any of the steps fails, we need to cleanup
     // (free allocated message, stop seeker, close agent, etc).
     shouldCleanup = true;


### PR DESCRIPTION
This commit updates `Joiner::Start()` to explicitly call `SetIdFromIeeeEui64()` when `mDiscerner` is empty. This ensures that the Joiner ID is freshly derived from the current IEEE EUI-64 address, guaranteeing correctness even if the address was not ready during initialization or has changed since the instance was created.

----

Related earlier discussion/PR on this is here: https://github.com/openthread/openthread/pull/11200 (objective is to allow EUI64 change on the device even after `otInstance` initialization and ensure Joiner re-calculates the ID).