### PR TITLE
[joiner] fix potential message leak when `Start()` fails

### DIFF
--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -358,17 +358,12 @@ Error Joiner::PrepareJoinerFinalizeMessage(const char *aProvisioningUrl,
     }
 
 exit:
-    if (error != kErrorNone)
-    {
-        FreeJoinerFinalizeMessage();
-    }
-
     return error;
 }
 
 void Joiner::FreeJoinerFinalizeMessage(void)
 {
-    VerifyOrExit(mState == kStateIdle && mFinalizeMessage != nullptr);
+    VerifyOrExit(mFinalizeMessage != nullptr);
 
     mFinalizeMessage->Free();
     mFinalizeMessage = nullptr;


### PR DESCRIPTION
This commit updates `FreeJoinerFinalizeMessage()` to remove the state check, allowing the message to be freed regardless of the current state. It also removes the redundant cleanup in
`PrepareJoinerFinalizeMessage()` since `Joiner::Start()` handles the cleanup upon error.

The `Joiner::Start()` method allocates the Joiner Finalize message and then transitions the state to `kStateDiscover` before starting the Seeker. If starting the Seeker fails, the exit label performs cleanup, including calling `FreeJoinerFinalizeMessage()`. Previously, `FreeJoinerFinalizeMessage()` checked that the state was `kStateIdle` before freeing the message. Since the state had already been updated to `kStateDiscover`, the message would not be freed, leading to a message leak on failure.