### PR TITLE
[ip6] make `Ip6::Address::AppendHexWords` alignment-safe

### DIFF
--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -628,7 +628,7 @@ void Address::ToString(char *aBuffer, uint16_t aSize) const
 
 void Address::ToString(StringWriter &aWriter) const
 {
-    AppendHexWords(aWriter, static_cast<uint8_t>(GetArrayLength(mFields.m16)));
+    AppendHexWords(aWriter, static_cast<uint8_t>(GetArrayLength(mFields.m8) / 2));
 }
 
 void Address::AppendHexWords(StringWriter &aWriter, uint8_t aLength) const
@@ -643,7 +643,7 @@ void Address::AppendHexWords(StringWriter &aWriter, uint8_t aLength) const
             aWriter.Append(":");
         }
 
-        aWriter.Append("%x", BigEndian::HostSwap16(mFields.m16[index]));
+        aWriter.Append("%x", BigEndian::ReadUint16(&mFields.m8[index * 2]));
     }
 }
 


### PR DESCRIPTION
This commit updates the `Ip6::Address::AppendHexWords()` implementation to use `BigEndian::ReadUint16` for alignment-safe access to address components.