### PR TITLE
[coap] add new helpers to finalize requests

### DIFF
--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -853,7 +853,9 @@ private:
     Message    *CopyAndEnqueueMessage(const Message &aMessage, uint16_t aCopyLength, const Metadata &aMetadata);
     void        DequeueMessage(Message &aMessage);
     Message    *FindRelatedRequest(const Msg &aMsg, Metadata &aMetadata);
-    void        FinalizeCoapTransaction(Message &aRequest, const Metadata &aMetadata, Msg *aResponse, Error aResult);
+    void        FinalizeRequest(Message &aRequest, const Metadata &aMetadata, Msg &aResponse);
+    void        FinalizeRequestWithError(Message &aRequest, const Metadata &aMetadata, Error aResult);
+    void        Finalize(Message &aRequest, const Metadata &aMetadata, Msg *aResponse, Error aResult);
     bool        InvokeResponseFallback(Msg &aRxMsg) const;
     void        ProcessReceivedRequest(Msg &aRxMsg);
     void        ProcessReceivedResponse(Msg &aRxMsg);


### PR DESCRIPTION
This commit replaces `FinalizeCoapTransaction()` with `Finalize()`, `FinalizeRequest()`, and `FinalizeRequestWithError()`.

`FinalizeRequest()` is used when a valid response is received. `FinalizeRequestWithError()` handles error scenarios such as timeouts or aborts. `Finalize()` serves as the common implementation used by the other two.

This commit also updates usage in `coap.cpp` to use the specific helper method matching the completion state, simplifying the code.