### PR TITLE
[nexus] improve robustness of test 5.2.1

### DIFF
--- a/tests/nexus/test_5_2_1.cpp
+++ b/tests/nexus/test_5_2_1.cpp
@@ -174,7 +174,7 @@ void Test5_2_1(void)
      */
     reed1.Join(dut);
     nexus.AdvanceTime(kAttachToChildTime);
-    VerifyOrQuit(reed1.Get<Mle::Mle>().IsChild());
+    VerifyOrQuit(reed1.Get<Mle::Mle>().IsAttached());
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 3: Router_1 (DUT)");


### PR DESCRIPTION
Changes 'IsChild()' check to 'IsAttached()' for REED_1 in test 5.2.1. REED_1 may quickly transition beyond the child state (e.g., to router) after attaching, causing 'IsChild()' to occasionally fail depending on the timing of the check. Using 'IsAttached()' ensures the node is successfully connected to the network regardless of its specific role.