### PR TITLE
[nexus] format packet verification chains in verify_5_*.py scripts

### DIFF
--- a/tests/nexus/verify_5_1_1.py
+++ b/tests/nexus/verify_5_1_1.py
@@ -72,16 +72,16 @@ def verify(pv):
     #     - Route64 TLV
     #     - Source Address TLV
     print("Step 1: Leader is sending properly formatted MLE Advertisements.")
-    pkts.filter_wpan_src64(LEADER).\
-        filter_LLANMA().\
-        filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_LLANMA() \
+        .filter_mle_cmd(consts.MLE_ADVERTISEMENT) \
+        .filter(lambda p: {
                           consts.LEADER_DATA_TLV,
                           consts.ROUTE64_TLV,
                           consts.SOURCE_ADDRESS_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.ipv6.hlim == 255).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.ipv6.hlim == 255) \
+        .must_next()
 
     # Step 2: Router_1
     # - Description: Automatically begins the attach process by sending a multicast MLE Parent Request.
@@ -93,19 +93,19 @@ def verify(pv):
     #     - Scan Mask TLV = 0x80 (Active Routers)
     #     - Version TLV
     print("Step 2: Router sends a MLE Parent Request")
-    pkts.filter_wpan_src64(ROUTER).\
-        filter_LLARMA().\
-        filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(ROUTER) \
+        .filter_LLARMA() \
+        .filter_mle_cmd(consts.MLE_PARENT_REQUEST) \
+        .filter(lambda p: {
                           consts.CHALLENGE_TLV,
                           consts.MODE_TLV,
                           consts.SCAN_MASK_TLV,
                           consts.VERSION_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.ipv6.hlim == 255 and\
-               p.mle.tlv.scan_mask.r == 1 and\
-               p.mle.tlv.scan_mask.e == 0).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.ipv6.hlim == 255 and \
+               p.mle.tlv.scan_mask.r == 1 and \
+               p.mle.tlv.scan_mask.e == 0) \
+        .must_next()
 
     # Step 3: Leader
     # - Description: Automatically responds with a MLE Parent Response.
@@ -121,10 +121,10 @@ def verify(pv):
     #     - Version TLV
     #     - MLE Frame Counter TLV (optional)
     print("Step 3: Leader responds with a MLE Parent Response.")
-    pkts.filter_wpan_src64(LEADER).\
-        filter_wpan_dst64(ROUTER).\
-        filter_mle_cmd(consts.MLE_PARENT_RESPONSE).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_wpan_dst64(ROUTER) \
+        .filter_mle_cmd(consts.MLE_PARENT_RESPONSE) \
+        .filter(lambda p: {
                           consts.CHALLENGE_TLV,
                           consts.CONNECTIVITY_TLV,
                           consts.LEADER_DATA_TLV,
@@ -133,8 +133,8 @@ def verify(pv):
                           consts.RESPONSE_TLV,
                           consts.SOURCE_ADDRESS_TLV,
                           consts.VERSION_TLV
-                           } <= set(p.mle.tlv.type)).\
-               must_next()
+                           } <= set(p.mle.tlv.type)) \
+        .must_next()
 
     # Step 4: Router_1
     # - Description: Automatically responds to the MLE Parent Response by sending a MLE Child ID Request.
@@ -153,10 +153,10 @@ def verify(pv):
     #   - The following TLV MUST NOT be present in the MLE Child ID Request:
     #     - Address Registration TLV
     print("Step 4: Router sends a MLE Child ID Request.")
-    _pkt = pkts.filter_wpan_src64(ROUTER).\
-        filter_wpan_dst64(LEADER).\
-        filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST).\
-        filter(lambda p: {
+    _pkt = pkts.filter_wpan_src64(ROUTER) \
+        .filter_wpan_dst64(LEADER) \
+        .filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST) \
+        .filter(lambda p: {
                           consts.LINK_LAYER_FRAME_COUNTER_TLV,
                           consts.MODE_TLV,
                           consts.RESPONSE_TLV,
@@ -165,10 +165,10 @@ def verify(pv):
                           consts.ADDRESS16_TLV,
                           consts.NETWORK_DATA_TLV,
                           consts.VERSION_TLV
-                } <= set(p.mle.tlv.type) and\
-               p.mle.tlv.addr16 is nullField and\
-               p.thread_nwd.tlv.type is nullField).\
-               must_next()
+                } <= set(p.mle.tlv.type) and \
+               p.mle.tlv.addr16 is nullField and \
+               p.thread_nwd.tlv.type is nullField) \
+        .must_next()
     _pkt.must_not_verify(lambda p: (consts.ADDRESS_REGISTRATION_TLV) in p.mle.tlv.type)
 
     # Step 5: Leader
@@ -181,16 +181,16 @@ def verify(pv):
     #     - Source Address TLV
     #     - Route64 TLV (if requested)
     print("Step 5: Leader responds with a Child ID Response.")
-    pkts.filter_wpan_src64(LEADER).\
-        filter_wpan_dst64(ROUTER).\
-        filter_mle_cmd(consts.MLE_CHILD_ID_RESPONSE).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_wpan_dst64(ROUTER) \
+        .filter_mle_cmd(consts.MLE_CHILD_ID_RESPONSE) \
+        .filter(lambda p: {
                           consts.ADDRESS16_TLV,
                           consts.LEADER_DATA_TLV,
                           consts.NETWORK_DATA_TLV,
                           consts.SOURCE_ADDRESS_TLV
-                          } <= set(p.mle.tlv.type)).\
-               must_next()
+                          } <= set(p.mle.tlv.type)) \
+        .must_next()
 
     # Step 6: Router_1
     # - Description: Automatically sends an Address Solicit Request.
@@ -201,15 +201,15 @@ def verify(pv):
     #       - MAC Extended Address TLV
     #       - Status TLV
     print("Step 6: Router sends an Address Solicit Request.")
-    _pkt = pkts.filter_wpan_src64(ROUTER).\
-        filter_wpan_dst16(LEADER_RLOC16).\
-        filter_coap_request(consts.ADDR_SOL_URI).\
-        filter(lambda p: {
+    _pkt = pkts.filter_wpan_src64(ROUTER) \
+        .filter_wpan_dst16(LEADER_RLOC16) \
+        .filter_coap_request(consts.ADDR_SOL_URI) \
+        .filter(lambda p: {
                           consts.NL_MAC_EXTENDED_ADDRESS_TLV,
                           consts.NL_STATUS_TLV
-                          } <= set(p.coap.tlv.type)\
-               ).\
-       must_next()
+                          } <= set(p.coap.tlv.type) \
+               ) \
+        .must_next()
 
     # Step 7: Leader
     # - Description: Automatically sends an Address Solicit Response.
@@ -221,18 +221,18 @@ def verify(pv):
     #       - RLOC16 TLV
     #       - Router Mask TLV
     print("Step 7: Leader sends an Address Solicit Response.")
-    pkts.filter_wpan_src64(LEADER).\
-        filter_wpan_dst16(_pkt.wpan.src16).\
-        filter_coap_ack(consts.ADDR_SOL_URI).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_wpan_dst16(_pkt.wpan.src16) \
+        .filter_coap_ack(consts.ADDR_SOL_URI) \
+        .filter(lambda p: {
                           consts.NL_STATUS_TLV,
                           consts.NL_RLOC16_TLV,
                           consts.NL_ROUTER_MASK_TLV
-                          } <= set(p.coap.tlv.type) and\
-               p.coap.code == consts.COAP_CODE_ACK and\
-               p.coap.tlv.status == 0\
-               ).\
-        must_next()
+                          } <= set(p.coap.tlv.type) and \
+               p.coap.code == consts.COAP_CODE_ACK and \
+               p.coap.tlv.status == 0 \
+               ) \
+        .must_next()
 
     # Step 8: Router_1
     # - Description: Automatically multicasts a Link Request Message (optional).
@@ -244,17 +244,17 @@ def verify(pv):
     #     - Version TLV
     #     - TLV Request TLV: Link Margin
     print("Step 8: Router MAY send a multicast Link Request Message (optional).")
-    link_request = pkts.filter_wpan_src64(ROUTER).\
-        filter_LLANMA().\
-        filter_mle_cmd(consts.MLE_LINK_REQUEST).\
-        filter(lambda p: {
+    link_request = pkts.filter_wpan_src64(ROUTER) \
+        .filter_LLANMA() \
+        .filter_mle_cmd(consts.MLE_LINK_REQUEST) \
+        .filter(lambda p: {
                           consts.CHALLENGE_TLV,
                           consts.LEADER_DATA_TLV,
                           consts.SOURCE_ADDRESS_TLV,
                           consts.VERSION_TLV,
                           consts.TLV_REQUEST_TLV
-                          } <= set(p.mle.tlv.type)).\
-        next()
+                          } <= set(p.mle.tlv.type)) \
+        .next()
 
     # Step 9: Leader
     # - Description: Automatically unicasts a Link Accept message (conditional).
@@ -270,18 +270,18 @@ def verify(pv):
     #     - MLE Frame Counter TLV (optional)
     if link_request:
         print("Step 9: Leader responds with a Link Accept message.")
-        pkts.filter_wpan_src64(LEADER).\
-            filter_wpan_dst64(ROUTER).\
-            filter_mle_cmd(consts.MLE_LINK_ACCEPT).\
-            filter(lambda p: {
+        pkts.filter_wpan_src64(LEADER) \
+            .filter_wpan_dst64(ROUTER) \
+            .filter_mle_cmd(consts.MLE_LINK_ACCEPT) \
+            .filter(lambda p: {
                               consts.LEADER_DATA_TLV,
                               consts.LINK_LAYER_FRAME_COUNTER_TLV,
                               consts.LINK_MARGIN_TLV,
                               consts.RESPONSE_TLV,
                               consts.SOURCE_ADDRESS_TLV,
                               consts.VERSION_TLV
-                              } <= set(p.mle.tlv.type)).\
-            must_next()
+                              } <= set(p.mle.tlv.type)) \
+            .must_next()
     else:
         print("Step 9: Link Request not sent, skipping Link Accept verification.")
 
@@ -293,39 +293,39 @@ def verify(pv):
     #     - Route64 TLV
     #     - Source Address TLV
     print("Step 10: Router is sending properly formatted MLE Advertisements.")
-    pkts.filter_wpan_src64(ROUTER).\
-        filter_LLANMA().\
-        filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(ROUTER) \
+        .filter_LLANMA() \
+        .filter_mle_cmd(consts.MLE_ADVERTISEMENT) \
+        .filter(lambda p: {
                           consts.LEADER_DATA_TLV,
                           consts.ROUTE64_TLV,
                           consts.SOURCE_ADDRESS_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.ipv6.hlim == 255).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.ipv6.hlim == 255) \
+        .must_next()
 
     # Step 11: Leader Or Router_1 (not the DUT)
     # - Description: Harness verifies connectivity by instructing the reference device to send a ICMPv6 Echo Request to the DUT link-local address.
     # - Pass Criteria:
     #   - The DUT MUST respond with ICMPv6 Echo Reply
     print("Step 11: ICMPv6 Echo Request/Reply")
-    _pkt = pkts.filter_ping_request().\
-        filter_wpan_src64(ROUTER).\
-        filter_wpan_dst64(LEADER).\
-        must_next()
-    pkts.filter_ping_reply(identifier=_pkt.icmpv6.echo.identifier).\
-        filter_wpan_src64(LEADER).\
-        filter_wpan_dst64(ROUTER).\
-        must_next()
+    _pkt = pkts.filter_ping_request() \
+        .filter_wpan_src64(ROUTER) \
+        .filter_wpan_dst64(LEADER) \
+        .must_next()
+    pkts.filter_ping_reply(identifier=_pkt.icmpv6.echo.identifier) \
+        .filter_wpan_src64(LEADER) \
+        .filter_wpan_dst64(ROUTER) \
+        .must_next()
 
-    _pkt = pkts.filter_ping_request().\
-        filter_wpan_src64(LEADER).\
-        filter_wpan_dst64(ROUTER).\
-        must_next()
-    pkts.filter_ping_reply(identifier=_pkt.icmpv6.echo.identifier).\
-        filter_wpan_src64(ROUTER).\
-        filter_wpan_dst64(LEADER).\
-        must_next()
+    _pkt = pkts.filter_ping_request() \
+        .filter_wpan_src64(LEADER) \
+        .filter_wpan_dst64(ROUTER) \
+        .must_next()
+    pkts.filter_ping_reply(identifier=_pkt.icmpv6.echo.identifier) \
+        .filter_wpan_src64(ROUTER) \
+        .filter_wpan_dst64(LEADER) \
+        .must_next()
 
 
 if __name__ == '__main__':

--- a/tests/nexus/verify_5_1_10.py
+++ b/tests/nexus/verify_5_1_10.py
@@ -88,19 +88,19 @@ def verify(pv):
     #       - Scan Mask TLV (Router bit = 1, REED bit = 0)
     #       - Version TLV
     print("Step 3: Router_3 (DUT)")
-    pkts.filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
-        filter_LLARMA().\
-        filter_wpan_src64(DUT).\
-        filter(lambda p: {
+    pkts.filter_mle_cmd(consts.MLE_PARENT_REQUEST) \
+        .filter_LLARMA() \
+        .filter_wpan_src64(DUT) \
+        .filter(lambda p: {
                           consts.MODE_TLV,
                           consts.CHALLENGE_TLV,
                           consts.SCAN_MASK_TLV,
                           consts.VERSION_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.ipv6.hlim == 255 and\
-               p.mle.tlv.scan_mask.r == 1 and\
-               p.mle.tlv.scan_mask.e == 0).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.ipv6.hlim == 255 and \
+               p.mle.tlv.scan_mask.r == 1 and \
+               p.mle.tlv.scan_mask.e == 0) \
+        .must_next()
 
     # Step 4: Router_1, Router_2
     # - Description: Leader, Router_1, and Router_2 each send MLE Parent Response.
@@ -125,10 +125,10 @@ def verify(pv):
     #       - Link-layer Frame Counter TLV
     #       - Exclude Address Registration TLV
     print("Step 5: Router_3 (DUT)")
-    pkt = pkts.filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST).\
-        filter_wpan_src64(DUT).\
-        filter_wpan_dst64(ROUTER_1).\
-        filter(lambda p: {
+    pkt = pkts.filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST) \
+        .filter_wpan_src64(DUT) \
+        .filter_wpan_dst64(ROUTER_1) \
+        .filter(lambda p: {
                           consts.MODE_TLV,
                           consts.RESPONSE_TLV,
                           consts.TIMEOUT_TLV,
@@ -137,11 +137,11 @@ def verify(pv):
                           consts.LINK_LAYER_FRAME_COUNTER_TLV,
                           consts.ADDRESS16_TLV,
                           consts.NETWORK_DATA_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.ipv6.hlim == 255 and\
-               p.mle.tlv.addr16 is nullField and\
-               p.thread_nwd.tlv.type is nullField).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.ipv6.hlim == 255 and \
+               p.mle.tlv.addr16 is nullField and \
+               p.thread_nwd.tlv.type is nullField) \
+        .must_next()
     pkt.must_not_verify(lambda p: (consts.ADDRESS_REGISTRATION_TLV) in p.mle.tlv.type)
 
 

--- a/tests/nexus/verify_5_1_11.py
+++ b/tests/nexus/verify_5_1_11.py
@@ -87,28 +87,28 @@ def verify(pv):
     #     - Scan Mask TLV = 0x80 (active Routers)
     #     - Version TLV
     print("Step 3: Router_1 (DUT) sends MLE Parent Request to active Routers")
-    pkts.filter_wpan_src64(DUT).\
-        filter_LLARMA().\
-        filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(DUT) \
+        .filter_LLARMA() \
+        .filter_mle_cmd(consts.MLE_PARENT_REQUEST) \
+        .filter(lambda p: {
                           consts.CHALLENGE_TLV,
                           consts.MODE_TLV,
                           consts.SCAN_MASK_TLV,
                           consts.VERSION_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.ipv6.hlim == 255 and\
-               p.mle.tlv.scan_mask.r == 1 and\
-               p.mle.tlv.scan_mask.e == 0).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.ipv6.hlim == 255 and \
+               p.mle.tlv.scan_mask.r == 1 and \
+               p.mle.tlv.scan_mask.e == 0) \
+        .must_next()
 
     # Step 4: Router_2
     # - Description: Automatically responds to DUT with MLE Parent Response.
     # - Pass Criteria: N/A
     print("Step 4: Router_2 responds with MLE Parent Response")
-    pkts.filter_wpan_src64(ROUTER_2).\
-        filter_wpan_dst64(DUT).\
-        filter_mle_cmd(consts.MLE_PARENT_RESPONSE).\
-        must_next()
+    pkts.filter_wpan_src64(ROUTER_2) \
+        .filter_wpan_dst64(DUT) \
+        .filter_mle_cmd(consts.MLE_PARENT_RESPONSE) \
+        .must_next()
 
     # Step 5: Router_1 (DUT)
     # - Description: Automatically sends another MLE Parent Request - to Routers and REEDs - when it doesn’t see the
@@ -121,19 +121,19 @@ def verify(pv):
     #     - Scan Mask TLV = 0xC0 (Routers and REEDs)
     #     - Version TLV
     print("Step 5: Router_1 (DUT) sends MLE Parent Request to Routers and REEDs")
-    pkts.filter_wpan_src64(DUT).\
-        filter_LLARMA().\
-        filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(DUT) \
+        .filter_LLARMA() \
+        .filter_mle_cmd(consts.MLE_PARENT_REQUEST) \
+        .filter(lambda p: {
                           consts.CHALLENGE_TLV,
                           consts.MODE_TLV,
                           consts.SCAN_MASK_TLV,
                           consts.VERSION_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.ipv6.hlim == 255 and\
-               p.mle.tlv.scan_mask.r == 1 and\
-               p.mle.tlv.scan_mask.e == 1).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.ipv6.hlim == 255 and \
+               p.mle.tlv.scan_mask.r == 1 and \
+               p.mle.tlv.scan_mask.e == 1) \
+        .must_next()
 
     # Step 6: Router_1 (DUT)
     # - Description: Automatically sends MLE Child ID Request to REED_1 due to its better link quality.
@@ -149,10 +149,10 @@ def verify(pv):
     #   - The following TLV MUST NOT be present in the Child ID Request:
     #     - Address Registration TLV
     print("Step 6: Router_1 (DUT) sends MLE Child ID Request to REED_1")
-    pkt = pkts.filter_wpan_src64(DUT).\
-        filter_wpan_dst64(REED_1).\
-        filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST).\
-        filter(lambda p: {
+    pkt = pkts.filter_wpan_src64(DUT) \
+        .filter_wpan_dst64(REED_1) \
+        .filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST) \
+        .filter(lambda p: {
                           consts.LINK_LAYER_FRAME_COUNTER_TLV,
                           consts.MODE_TLV,
                           consts.RESPONSE_TLV,
@@ -161,10 +161,10 @@ def verify(pv):
                           consts.VERSION_TLV,
                           consts.ADDRESS16_TLV,
                           consts.NETWORK_DATA_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.mle.tlv.addr16 is nullField and\
-               p.thread_nwd.tlv.type is nullField).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.mle.tlv.addr16 is nullField and \
+               p.thread_nwd.tlv.type is nullField) \
+        .must_next()
     pkt.must_not_verify(lambda p: (consts.ADDRESS_REGISTRATION_TLV) in p.mle.tlv.type)
 
 

--- a/tests/nexus/verify_5_1_12.py
+++ b/tests/nexus/verify_5_1_12.py
@@ -74,16 +74,16 @@ def verify(pv):
     #     - Route64 TLV
     #     - Source Address TLV
     print("Step 2: Router_1 (DUT) transmits MLE advertisements.")
-    pkts.filter_wpan_src64(DUT).\
-        filter_LLANMA().\
-        filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(DUT) \
+        .filter_LLANMA() \
+        .filter_mle_cmd(consts.MLE_ADVERTISEMENT) \
+        .filter(lambda p: {
                           consts.LEADER_DATA_TLV,
                           consts.ROUTE64_TLV,
                           consts.SOURCE_ADDRESS_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.ipv6.hlim == 255).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.ipv6.hlim == 255) \
+        .must_next()
 
     # Step 3: Test Harness
     # - Description: Harness enables communication between Router_1 (DUT) and Router_2.
@@ -116,21 +116,21 @@ def verify(pv):
 
     # In this test, DUT should send Link Request to Router_2 when it hears Router_2's advertisement
     # It might also send Link Accept and Request if it heard a Link Request from Router_2 first.
-    pkts.filter_wpan_src64(DUT).\
-        filter_wpan_dst64(ROUTER_2).\
-        filter(lambda p: p.mle.cmd in [consts.MLE_LINK_REQUEST, consts.MLE_LINK_ACCEPT_AND_REQUEST] and\
+    pkts.filter_wpan_src64(DUT) \
+        .filter_wpan_dst64(ROUTER_2) \
+        .filter(lambda p: p.mle.cmd in [consts.MLE_LINK_REQUEST, consts.MLE_LINK_ACCEPT_AND_REQUEST] and \
                {
                 consts.CHALLENGE_TLV,
                 consts.LEADER_DATA_TLV,
                 consts.TLV_REQUEST_TLV,
                 consts.SOURCE_ADDRESS_TLV,
                 consts.VERSION_TLV
-                } <= set(p.mle.tlv.type)).\
-        must_next()
+                } <= set(p.mle.tlv.type)) \
+        .must_next()
 
-    pkts.filter_wpan_src64(ROUTER_2).\
-        filter_wpan_dst64(DUT).\
-        filter(lambda p: p.mle.cmd in [consts.MLE_LINK_ACCEPT, consts.MLE_LINK_ACCEPT_AND_REQUEST] and\
+    pkts.filter_wpan_src64(ROUTER_2) \
+        .filter_wpan_dst64(DUT) \
+        .filter(lambda p: p.mle.cmd in [consts.MLE_LINK_ACCEPT, consts.MLE_LINK_ACCEPT_AND_REQUEST] and \
                {
                 consts.LEADER_DATA_TLV,
                 consts.LINK_LAYER_FRAME_COUNTER_TLV,
@@ -138,8 +138,8 @@ def verify(pv):
                 consts.RESPONSE_TLV,
                 consts.SOURCE_ADDRESS_TLV,
                 consts.VERSION_TLV
-                } <= set(p.mle.tlv.type)).\
-        must_next()
+                } <= set(p.mle.tlv.type)) \
+        .must_next()
 
 
 if __name__ == '__main__':

--- a/tests/nexus/verify_5_1_13.py
+++ b/tests/nexus/verify_5_1_13.py
@@ -77,30 +77,30 @@ def verify(pv):
     print("Step 2: Router_1 / Leader")
 
     # Leader Advertisements
-    pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
-        filter_LLANMA().\
-        filter_wpan_src64(LEADER).\
-        filter(lambda p: {
+    pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT) \
+        .filter_LLANMA() \
+        .filter_wpan_src64(LEADER) \
+        .filter(lambda p: {
                           consts.LEADER_DATA_TLV,
                           consts.ROUTE64_TLV,
                           consts.SOURCE_ADDRESS_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.ipv6.hlim == 255 and\
-               p.mle.tlv.route64.id_mask is not nullField).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.ipv6.hlim == 255 and \
+               p.mle.tlv.route64.id_mask is not nullField) \
+        .must_next()
 
     # Router_1 Advertisements
-    pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
-        filter_LLANMA().\
-        filter_wpan_src64(ROUTER_1).\
-        filter(lambda p: {
+    pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT) \
+        .filter_LLANMA() \
+        .filter_wpan_src64(ROUTER_1) \
+        .filter(lambda p: {
                           consts.LEADER_DATA_TLV,
                           consts.ROUTE64_TLV,
                           consts.SOURCE_ADDRESS_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.ipv6.hlim == 255 and\
-               p.mle.tlv.route64.id_mask is not nullField).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.ipv6.hlim == 255 and \
+               p.mle.tlv.route64.id_mask is not nullField) \
+        .must_next()
 
     # Step 3: Router_1
     # - Description: Harness silently resets the device.
@@ -122,19 +122,19 @@ def verify(pv):
 
     # Note: Address16 and Route64 TLVs are requested in TLV Request TLV, and Wireshark dissects their types into
     # mle.tlv.type list. We also verify that they are NOT present as top-level TLVs (since the router has reset).
-    pkt_lq = pkts.filter_mle_cmd(consts.MLE_LINK_REQUEST).\
-        filter_LLARMA().\
-        filter_wpan_src64(ROUTER_1).\
-        filter(lambda p: {
+    pkt_lq = pkts.filter_mle_cmd(consts.MLE_LINK_REQUEST) \
+        .filter_LLARMA() \
+        .filter_wpan_src64(ROUTER_1) \
+        .filter(lambda p: {
                           consts.CHALLENGE_TLV,
                           consts.TLV_REQUEST_TLV,
                           consts.VERSION_TLV,
                           consts.ADDRESS16_TLV,
                           consts.ROUTE64_TLV
-                          } <= set(p.mle.tlv.type)).\
-        must_next()
+                          } <= set(p.mle.tlv.type)) \
+        .must_next()
 
-    pkt_lq.must_verify(lambda p: p.mle.tlv.addr16 is nullField and\
+    pkt_lq.must_verify(lambda p: p.mle.tlv.addr16 is nullField and \
                                  p.mle.tlv.route64.id_mask is nullField)
 
     # Step 5: Leader
@@ -156,10 +156,10 @@ def verify(pv):
 
     ROUTER_1_RLOC16 = pv.vars['ROUTER_1_RLOC16']
 
-    pkt_la = pkts.filter_mle_cmd2(consts.MLE_LINK_ACCEPT, consts.MLE_LINK_ACCEPT_AND_REQUEST).\
-        filter_wpan_src64(LEADER).\
-        filter_wpan_dst64(ROUTER_1).\
-        filter(lambda p: p.sniff_timestamp - pkt_lq.sniff_timestamp < consts.MLE_MAX_RESPONSE_DELAY + 0.1 and\
+    pkt_la = pkts.filter_mle_cmd2(consts.MLE_LINK_ACCEPT, consts.MLE_LINK_ACCEPT_AND_REQUEST) \
+        .filter_wpan_src64(LEADER) \
+        .filter_wpan_dst64(ROUTER_1) \
+        .filter(lambda p: p.sniff_timestamp - pkt_lq.sniff_timestamp < consts.MLE_MAX_RESPONSE_DELAY + 0.1 and \
                          {
                           consts.ADDRESS16_TLV,
                           consts.LEADER_DATA_TLV,
@@ -168,10 +168,10 @@ def verify(pv):
                           consts.ROUTE64_TLV,
                           consts.SOURCE_ADDRESS_TLV,
                           consts.VERSION_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.mle.tlv.addr16 == ROUTER_1_RLOC16 and\
-               p.mle.tlv.route64.id_mask is not nullField).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.mle.tlv.addr16 == ROUTER_1_RLOC16 and \
+               p.mle.tlv.route64.id_mask is not nullField) \
+        .must_next()
 
     if pkt_la.mle.cmd == consts.MLE_LINK_ACCEPT_AND_REQUEST:
         pkt_la.must_verify(lambda p: consts.CHALLENGE_TLV in p.mle.tlv.type)

--- a/tests/nexus/verify_5_1_2.py
+++ b/tests/nexus/verify_5_1_2.py
@@ -78,35 +78,35 @@ def verify(pv):
     # - Description: Harness instructs the Leader to send an ICMPv6 Echo Request to MED_1. As part of the process, the Leader automatically attempts to perform address resolution by sending an Address Query Request
     # - Pass Criteria: N/A
     print("Step 3: Leader sends Address Query for MED_1")
-    pkts.filter_wpan_src64(LEADER).\
-        filter_coap_request(consts.ADDR_QRY_URI).\
-        filter(lambda p: p.coap.tlv.target_eid == pv.vars['MED_1_MLEID']).\
-        must_next()
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_coap_request(consts.ADDR_QRY_URI) \
+        .filter(lambda p: p.coap.tlv.target_eid == pv.vars['MED_1_MLEID']) \
+        .must_next()
 
     # Step 4: Router_1 (DUT)
     # - Description: Does not respond to Address Query Request
     # - Pass Criteria: The DUT MUST NOT respond with an Address Notification Message
     print("Step 4: Router_1 (DUT) MUST NOT respond with an Address Notification Message")
-    pkts.filter_wpan_src64(ROUTER_1).\
-        filter_coap_request(consts.ADDR_NTF_URI).\
-        must_not_next()
+    pkts.filter_wpan_src64(ROUTER_1) \
+        .filter_coap_request(consts.ADDR_NTF_URI) \
+        .must_not_next()
 
     # Step 6: Leader
     # - Description: Harness instructs the Leader to send an ICMPv6 Echo Request to SED_1. As part of the process, the Leader automatically attempts to perform address resolution by sending an Address Query Request
     # - Pass Criteria: N/A
     print("Step 6: Leader sends Address Query for SED_1")
-    pkts.filter_wpan_src64(LEADER).\
-        filter_coap_request(consts.ADDR_QRY_URI).\
-        filter(lambda p: p.coap.tlv.target_eid == pv.vars['SED_1_MLEID']).\
-        must_next()
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_coap_request(consts.ADDR_QRY_URI) \
+        .filter(lambda p: p.coap.tlv.target_eid == pv.vars['SED_1_MLEID']) \
+        .must_next()
 
     # Step 7: Router_1 (DUT)
     # - Description: Does not to Address Query Request
     # - Pass Criteria: The DUT MUST NOT respond with an Address Notification Message
     print("Step 7: Router_1 (DUT) MUST NOT respond with an Address Notification Message")
-    pkts.filter_wpan_src64(ROUTER_1).\
-        filter_coap_request(consts.ADDR_NTF_URI).\
-        must_not_next()
+    pkts.filter_wpan_src64(ROUTER_1) \
+        .filter_coap_request(consts.ADDR_NTF_URI) \
+        .must_not_next()
 
 
 if __name__ == '__main__':

--- a/tests/nexus/verify_5_1_3.py
+++ b/tests/nexus/verify_5_1_3.py
@@ -86,10 +86,10 @@ def verify(pv):
     #   Leader of P2
     # - Pass Criteria: N/A
     print("Step 4: Router_2 becomes leader of a new partition (P2).")
-    pkts.filter_wpan_src64(ROUTER_2).\
-        filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
-        filter(lambda p: p.mle.tlv.leader_data.partition_id != P1_ID).\
-        must_next()
+    pkts.filter_wpan_src64(ROUTER_2) \
+        .filter_mle_cmd(consts.MLE_ADVERTISEMENT) \
+        .filter(lambda p: p.mle.tlv.leader_data.partition_id != P1_ID) \
+        .must_next()
 
     # Step 5: Router_1 (DUT)
     # - Description: Times out after 120 seconds and automatically attempts to reattach to original partition (P1)
@@ -104,19 +104,19 @@ def verify(pv):
     #   - The DUT MUST make two separate attempts to reconnect to its original partition (P1) in this manner.
     print("Step 5: Router_1 attempts to reattach to original partition (P1).")
     for _ in range(2):
-        pkts.filter_wpan_src64(ROUTER_1).\
-            filter_LLARMA().\
-            filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
-            filter(lambda p: {
+        pkts.filter_wpan_src64(ROUTER_1) \
+            .filter_LLARMA() \
+            .filter_mle_cmd(consts.MLE_PARENT_REQUEST) \
+            .filter(lambda p: {
                               consts.CHALLENGE_TLV,
                               consts.MODE_TLV,
                               consts.SCAN_MASK_TLV,
                               consts.VERSION_TLV
-                              } <= set(p.mle.tlv.type) and\
-                   p.ipv6.hlim == 255 and\
-                   p.mle.tlv.scan_mask.r == 1 and\
-                   p.mle.tlv.scan_mask.e == 1).\
-            must_next()
+                              } <= set(p.mle.tlv.type) and \
+                   p.ipv6.hlim == 255 and \
+                   p.mle.tlv.scan_mask.r == 1 and \
+                   p.mle.tlv.scan_mask.e == 1) \
+            .must_next()
 
     # Step 6: Router_1 (DUT)
     # - Description: Automatically attempts to attach to any other partition
@@ -128,16 +128,16 @@ def verify(pv):
     #     - Scan Mask TLV
     #     - Version TLV
     print("Step 6: Router_1 attempts to attach to any other partition.")
-    pkts.filter_wpan_src64(ROUTER_1).\
-        filter_LLARMA().\
-        filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(ROUTER_1) \
+        .filter_LLARMA() \
+        .filter_mle_cmd(consts.MLE_PARENT_REQUEST) \
+        .filter(lambda p: {
                           consts.CHALLENGE_TLV,
                           consts.MODE_TLV,
                           consts.SCAN_MASK_TLV,
                           consts.VERSION_TLV
-                          } <= set(p.mle.tlv.type)).\
-        must_next()
+                          } <= set(p.mle.tlv.type)) \
+        .must_next()
 
     # Step 7: Router_1 (DUT)
     # - Description: Automatically attaches to Router_2’s partition (P2)
@@ -154,19 +154,19 @@ def verify(pv):
     #   - The following TLV MUST NOT be present in the Child ID Request:
     #     - Address Registration TLV
     print("Step 7: Router_1 sends a Child ID Request to Router_2.")
-    pkts.filter_wpan_src64(ROUTER_1).\
-        filter_wpan_dst64(ROUTER_2).\
-        filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(ROUTER_1) \
+        .filter_wpan_dst64(ROUTER_2) \
+        .filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST) \
+        .filter(lambda p: {
                           consts.LINK_LAYER_FRAME_COUNTER_TLV,
                           consts.MODE_TLV,
                           consts.RESPONSE_TLV,
                           consts.TIMEOUT_TLV,
                           consts.TLV_REQUEST_TLV,
                           consts.VERSION_TLV
-                } <= set(p.mle.tlv.type)).\
-        filter(lambda p: consts.ADDRESS_REGISTRATION_TLV not in p.mle.tlv.type).\
-        must_next()
+                } <= set(p.mle.tlv.type)) \
+        .filter(lambda p: consts.ADDRESS_REGISTRATION_TLV not in p.mle.tlv.type) \
+        .must_next()
 
     # Step 8: Router_1 (DUT)
     # - Description: Automatically sends Address Solicit Request
@@ -179,22 +179,22 @@ def verify(pv):
     #       - Status TLV
     #       - RLOC16 TLV (optional)
     print("Step 8: Router_1 sends an Address Solicit Request to Router_2 (new leader).")
-    pkts.filter_wpan_src64(ROUTER_1).\
-        filter_coap_request(consts.ADDR_SOL_URI).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(ROUTER_1) \
+        .filter_coap_request(consts.ADDR_SOL_URI) \
+        .filter(lambda p: {
                           consts.NL_MAC_EXTENDED_ADDRESS_TLV,
                           consts.NL_STATUS_TLV
-                          } <= set(p.coap.tlv.type)\
-               ).\
-       must_next()
+                          } <= set(p.coap.tlv.type) \
+               ) \
+        .must_next()
 
     # Step 9: Router_2
     # - Description: Automatically responds with Address Solicit Response Message
     # - Pass Criteria: N/A
     print("Step 9: Router_2 responds with Address Solicit Response.")
-    pkts.filter_wpan_src64(ROUTER_2).\
-        filter_coap_ack(consts.ADDR_SOL_URI).\
-        must_next()
+    pkts.filter_wpan_src64(ROUTER_2) \
+        .filter_coap_ack(consts.ADDR_SOL_URI) \
+        .must_next()
 
 
 if __name__ == '__main__':

--- a/tests/nexus/verify_5_1_4.py
+++ b/tests/nexus/verify_5_1_4.py
@@ -99,19 +99,19 @@ def verify(pv):
     #   - The DUT MUST make two separate attempts to reconnect to its current Partition in this manner.
     print("Step 5: Router_1 attempts to reattach to original partition.")
     for _ in range(2):
-        pkts.filter_wpan_src64(ROUTER_1).\
-            filter_LLARMA().\
-            filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
-            filter(lambda p: {
+        pkts.filter_wpan_src64(ROUTER_1) \
+            .filter_LLARMA() \
+            .filter_mle_cmd(consts.MLE_PARENT_REQUEST) \
+            .filter(lambda p: {
                               consts.CHALLENGE_TLV,
                               consts.MODE_TLV,
                               consts.SCAN_MASK_TLV,
                               consts.VERSION_TLV
-                              } <= set(p.mle.tlv.type) and\
-                   p.ipv6.hlim == 255 and\
-                   p.mle.tlv.scan_mask.r == 1 and\
-                   p.mle.tlv.scan_mask.e == 1).\
-            must_next()
+                              } <= set(p.mle.tlv.type) and \
+                   p.ipv6.hlim == 255 and \
+                   p.mle.tlv.scan_mask.r == 1 and \
+                   p.mle.tlv.scan_mask.e == 1) \
+            .must_next()
 
     # Step 6: Router_1 (DUT)
     # - Description: Automatically attempts to attach to any other partition
@@ -123,16 +123,16 @@ def verify(pv):
     #     - Scan Mask TLV
     #     - Version TLV
     print("Step 6: Router_1 attempts to attach to any other partition.")
-    pkts.filter_wpan_src64(ROUTER_1).\
-        filter_LLARMA().\
-        filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(ROUTER_1) \
+        .filter_LLARMA() \
+        .filter_mle_cmd(consts.MLE_PARENT_REQUEST) \
+        .filter(lambda p: {
                           consts.CHALLENGE_TLV,
                           consts.MODE_TLV,
                           consts.SCAN_MASK_TLV,
                           consts.VERSION_TLV
-                          } <= set(p.mle.tlv.type)).\
-        must_next()
+                          } <= set(p.mle.tlv.type)) \
+        .must_next()
 
     # Step 7: Router_1 (DUT)
     # - Description: Automatically creates a new partition with different Partition ID, initial VN_version, initial
@@ -149,23 +149,23 @@ def verify(pv):
     #     - Initial VN_version & VN_stable_version different from the original
     #     - Initial ID sequence number different from the original
     print("Step 8: Router_2 attaches to Router_1 (DUT) and receives MLE Parent Response.")
-    pkts.filter_wpan_src64(ROUTER_1).\
-        filter_wpan_dst64(ROUTER_2).\
-        filter_mle_cmd(consts.MLE_PARENT_RESPONSE).\
-        filter(lambda p: p.mle.tlv.leader_data.partition_id != P1_ID).\
-        filter(lambda p: (p.mle.tlv.leader_data.data_version != original_leader_data.data_version) or
-               (p.mle.tlv.leader_data.stable_data_version != original_leader_data.stable_data_version)).\
-        must_next()
+    pkts.filter_wpan_src64(ROUTER_1) \
+        .filter_wpan_dst64(ROUTER_2) \
+        .filter_mle_cmd(consts.MLE_PARENT_RESPONSE) \
+        .filter(lambda p: p.mle.tlv.leader_data.partition_id != P1_ID) \
+        .filter(lambda p: (p.mle.tlv.leader_data.data_version != original_leader_data.data_version) or
+               (p.mle.tlv.leader_data.stable_data_version != original_leader_data.stable_data_version)) \
+        .must_next()
 
     # Step 9: Router_2
     # - Description: Automatically sends MLE Child ID Request
     # - Pass Criteria:
     #   - The DUT MUST send a properly formatted Child ID Response to Router_2 (See 5.1.1 Attaching for pass criteria)
     print("Step 9: Router_1 sends Child ID Response to Router_2.")
-    pkts.filter_wpan_src64(ROUTER_1).\
-        filter_wpan_dst64(ROUTER_2).\
-        filter_mle_cmd(consts.MLE_CHILD_ID_RESPONSE).\
-        must_next()
+    pkts.filter_wpan_src64(ROUTER_1) \
+        .filter_wpan_dst64(ROUTER_2) \
+        .filter_mle_cmd(consts.MLE_CHILD_ID_RESPONSE) \
+        .must_next()
 
     # Step 10: Router_1 (DUT)
     # - Description: Automatically sends Address Solicit Response Message
@@ -178,12 +178,12 @@ def verify(pv):
     #     - RLOC16 TLV
     #     - Router Mask TLV
     print("Step 10: Router_1 sends Address Solicit Response to Router_2.")
-    pkts.filter_wpan_src64(ROUTER_1).\
-        filter_coap_ack(consts.ADDR_SOL_URI).\
-        filter(lambda p: {consts.NL_STATUS_TLV, consts.NL_RLOC16_TLV, consts.NL_ROUTER_MASK_TLV} <=
+    pkts.filter_wpan_src64(ROUTER_1) \
+        .filter_coap_ack(consts.ADDR_SOL_URI) \
+        .filter(lambda p: {consts.NL_STATUS_TLV, consts.NL_RLOC16_TLV, consts.NL_ROUTER_MASK_TLV} <=
                set(p.coap.tlv.type) and
-               p.coap.tlv.status == 0).\
-        must_next()
+               p.coap.tlv.status == 0) \
+        .must_next()
 
 
 if __name__ == '__main__':

--- a/tests/nexus/verify_5_1_6.py
+++ b/tests/nexus/verify_5_1_6.py
@@ -66,31 +66,31 @@ def verify(pv):
     # - Pass Criteria: N/A
     print("Step 0: Verify topology is formed correctly")
     pv.verify_attached('ROUTER')
-    pkts.copy().filter_wpan_src64(LEADER).\
-        filter_coap_ack(consts.ADDR_SOL_URI).\
-        filter(lambda p: {
+    pkts.copy().filter_wpan_src64(LEADER) \
+        .filter_coap_ack(consts.ADDR_SOL_URI) \
+        .filter(lambda p: {
                           consts.NL_STATUS_TLV,
                           consts.NL_RLOC16_TLV,
                           consts.NL_ROUTER_MASK_TLV
-                          } <= set(p.coap.tlv.type) and\
-               p.coap.code == consts.COAP_CODE_ACK and\
+                          } <= set(p.coap.tlv.type) and \
+               p.coap.code == consts.COAP_CODE_ACK and \
                p.coap.tlv.status == 0
-               ).\
-        must_next()
+               ) \
+        .must_next()
 
     # Step 1: Leader
     # - Description: Harness instructs the Leader to send a ' helper ping' (ICMPv6 Echo Request) to the DUT
     # - Pass Criteria:
     #   - The DUT MUST respond with an ICMPv6 Echo Reply
     print("Step 1: Leader sends a ' helper ping' (ICMPv6 Echo Request) to the DUT")
-    _pkt = pkts.filter_ping_request().\
-        filter_wpan_src64(LEADER).\
-        filter_wpan_dst64(ROUTER).\
-        must_next()
-    pkts.filter_ping_reply(identifier=_pkt.icmpv6.echo.identifier).\
-        filter_wpan_src64(ROUTER).\
-        filter_wpan_dst64(LEADER).\
-        must_next()
+    _pkt = pkts.filter_ping_request() \
+        .filter_wpan_src64(LEADER) \
+        .filter_wpan_dst64(ROUTER) \
+        .must_next()
+    pkts.filter_ping_reply(identifier=_pkt.icmpv6.echo.identifier) \
+        .filter_wpan_src64(ROUTER) \
+        .filter_wpan_dst64(LEADER) \
+        .must_next()
 
     # Step 2: Leader
     # - Description: Harness instructs the Leader to remove the Router ID of Router_1 (the DUT)
@@ -105,25 +105,25 @@ def verify(pv):
     print("Step 3: Router_1 (DUT) automatically re-attaches")
 
     # MLE Parent Request
-    pkts.filter_wpan_src64(ROUTER).\
-        filter_LLARMA().\
-        filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(ROUTER) \
+        .filter_LLARMA() \
+        .filter_mle_cmd(consts.MLE_PARENT_REQUEST) \
+        .filter(lambda p: {
                           consts.CHALLENGE_TLV,
                           consts.MODE_TLV,
                           consts.SCAN_MASK_TLV,
                           consts.VERSION_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.ipv6.hlim == 255 and\
-               p.mle.tlv.scan_mask.r == 1 and\
-               p.mle.tlv.scan_mask.e == 0).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.ipv6.hlim == 255 and \
+               p.mle.tlv.scan_mask.r == 1 and \
+               p.mle.tlv.scan_mask.e == 0) \
+        .must_next()
 
     # MLE Child ID Request
-    _pkt = pkts.filter_wpan_src64(ROUTER).\
-        filter_wpan_dst64(LEADER).\
-        filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST).\
-        filter(lambda p: {
+    _pkt = pkts.filter_wpan_src64(ROUTER) \
+        .filter_wpan_dst64(LEADER) \
+        .filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST) \
+        .filter(lambda p: {
                           consts.LINK_LAYER_FRAME_COUNTER_TLV,
                           consts.MODE_TLV,
                           consts.RESPONSE_TLV,
@@ -132,36 +132,36 @@ def verify(pv):
                           consts.ADDRESS16_TLV,
                           consts.NETWORK_DATA_TLV,
                           consts.VERSION_TLV
-                } <= set(p.mle.tlv.type) and\
-               p.mle.tlv.addr16 is nullField and\
-               p.thread_nwd.tlv.type is nullField).\
-               must_next()
+                } <= set(p.mle.tlv.type) and \
+               p.mle.tlv.addr16 is nullField and \
+               p.thread_nwd.tlv.type is nullField) \
+        .must_next()
     _pkt.must_not_verify(lambda p: (consts.ADDRESS_REGISTRATION_TLV) in p.mle.tlv.type)
 
     # Address Solicit Request
-    pkts.filter_wpan_src64(ROUTER).\
-        filter_wpan_dst16(LEADER_RLOC16).\
-        filter_coap_request(consts.ADDR_SOL_URI).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(ROUTER) \
+        .filter_wpan_dst16(LEADER_RLOC16) \
+        .filter_coap_request(consts.ADDR_SOL_URI) \
+        .filter(lambda p: {
                           consts.NL_MAC_EXTENDED_ADDRESS_TLV,
                           consts.NL_STATUS_TLV
                           } <= set(p.coap.tlv.type)
-               ).\
-       must_next()
+               ) \
+        .must_next()
 
     # Step 4: Leader
     # - Description: Harness verifies connectivity by instructing the Leader to send an ICMPv6 Echo Request to the DUT
     # - Pass Criteria:
     #   - The DUT MUST respond with an ICMPv6 Echo Reply
     print("Step 4: Leader sends an ICMPv6 Echo Request to the DUT")
-    _pkt = pkts.filter_ping_request().\
-        filter_wpan_src64(LEADER).\
-        filter_wpan_dst64(ROUTER).\
-        must_next()
-    pkts.filter_ping_reply(identifier=_pkt.icmpv6.echo.identifier).\
-        filter_wpan_src64(ROUTER).\
-        filter_wpan_dst64(LEADER).\
-        must_next()
+    _pkt = pkts.filter_ping_request() \
+        .filter_wpan_src64(LEADER) \
+        .filter_wpan_dst64(ROUTER) \
+        .must_next()
+    pkts.filter_ping_reply(identifier=_pkt.icmpv6.echo.identifier) \
+        .filter_wpan_src64(ROUTER) \
+        .filter_wpan_dst64(LEADER) \
+        .must_next()
 
 
 if __name__ == '__main__':

--- a/tests/nexus/verify_5_1_7.py
+++ b/tests/nexus/verify_5_1_7.py
@@ -72,23 +72,23 @@ def verify_ping_forwarding(pv, start_idx, children_rloc16, children_mleid, base_
         f = pkts.range(start_idx).copy()
 
         # Router to child
-        f.filter_ping_request(identifier=base_echo_id + i).\
-            filter_wpan_src16(ROUTER_1_RLOC16).\
-            filter_wpan_dst16(child_rloc16).\
-            filter_ipv6_dst(child_mleid).\
-            must_next()
+        f.filter_ping_request(identifier=base_echo_id + i) \
+            .filter_wpan_src16(ROUTER_1_RLOC16) \
+            .filter_wpan_dst16(child_rloc16) \
+            .filter_ipv6_dst(child_mleid) \
+            .must_next()
 
         # Child to Router
-        f.filter_ping_reply(identifier=base_echo_id + i).\
-            filter_wpan_src16(child_rloc16).\
-            filter_wpan_dst16(ROUTER_1_RLOC16).\
-            must_next()
+        f.filter_ping_reply(identifier=base_echo_id + i) \
+            .filter_wpan_src16(child_rloc16) \
+            .filter_wpan_dst16(ROUTER_1_RLOC16) \
+            .must_next()
 
         # Router to Leader
-        f.filter_ping_reply(identifier=base_echo_id + i).\
-            filter_wpan_src16(ROUTER_1_RLOC16).\
-            filter_wpan_dst16(LEADER_RLOC16).\
-            must_next()
+        f.filter_ping_reply(identifier=base_echo_id + i) \
+            .filter_wpan_src16(ROUTER_1_RLOC16) \
+            .filter_wpan_dst16(LEADER_RLOC16) \
+            .must_next()
 
         max_idx = max(max_idx, f.index)
 
@@ -140,18 +140,18 @@ def verify(pv):
 
     for child in children:
         # Parent Response
-        f = start_pkts.copy().\
-            filter_wpan_src64(ROUTER_1).\
-            filter_wpan_dst64(child).\
-            filter_mle_cmd(consts.MLE_PARENT_RESPONSE)
+        f = start_pkts.copy() \
+        .filter_wpan_src64(ROUTER_1) \
+        .filter_wpan_dst64(child) \
+        .filter_mle_cmd(consts.MLE_PARENT_RESPONSE)
         f.must_next()
         max_idx = max(max_idx, f.index)
 
         # Child ID Response
-        f = start_pkts.copy().\
-            filter_wpan_src64(ROUTER_1).\
-            filter_wpan_dst64(child).\
-            filter_mle_cmd(consts.MLE_CHILD_ID_RESPONSE)
+        f = start_pkts.copy() \
+        .filter_wpan_src64(ROUTER_1) \
+        .filter_wpan_dst64(child) \
+        .filter_mle_cmd(consts.MLE_CHILD_ID_RESPONSE)
         f.must_next()
         max_idx = max(max_idx, f.index)
 
@@ -169,12 +169,12 @@ def verify(pv):
 
     # Leader sends all requests to Router first (identifiers 1001..1004)
     for i, med_mleid in enumerate(MEDS_MLEID):
-        pkts.filter_ping_request(identifier=MED_ECHO_ID + i).\
-            filter_wpan_src16(LEADER_RLOC16).\
-            filter_wpan_dst16(ROUTER_1_RLOC16).\
-            filter_ipv6_dst(med_mleid).\
-            filter(lambda p: p.ipv6.plen == SMALL_DATAGRAM_SIZE - IPV6_HEADER_SIZE).\
-            must_next()
+        pkts.filter_ping_request(identifier=MED_ECHO_ID + i) \
+            .filter_wpan_src16(LEADER_RLOC16) \
+            .filter_wpan_dst16(ROUTER_1_RLOC16) \
+            .filter_ipv6_dst(med_mleid) \
+            .filter(lambda p: p.ipv6.plen == SMALL_DATAGRAM_SIZE - IPV6_HEADER_SIZE) \
+            .must_next()
 
     # Verify Router forwards to MEDs and receives replies (allow interleaving with requests)
     pkts.index = verify_ping_forwarding(pv, step2_start_idx, MEDS_RLOC16, MEDS_MLEID, MED_ECHO_ID)
@@ -193,21 +193,21 @@ def verify(pv):
 
     # Leader sends all requests to Router first (identifiers 2001..2006)
     # SED_1 (1280 octets)
-    pkts.filter_ping_request(identifier=SED_ECHO_ID).\
-        filter_wpan_src16(LEADER_RLOC16).\
-        filter_wpan_dst16(ROUTER_1_RLOC16).\
-        filter_ipv6_dst(SEDS_MLEID[0]).\
-        filter(lambda p: p.ipv6.plen == LARGE_DATAGRAM_SIZE - IPV6_HEADER_SIZE).\
-        must_next()
+    pkts.filter_ping_request(identifier=SED_ECHO_ID) \
+        .filter_wpan_src16(LEADER_RLOC16) \
+        .filter_wpan_dst16(ROUTER_1_RLOC16) \
+        .filter_ipv6_dst(SEDS_MLEID[0]) \
+        .filter(lambda p: p.ipv6.plen == LARGE_DATAGRAM_SIZE - IPV6_HEADER_SIZE) \
+        .must_next()
 
     # SED_2..6 (106 octets)
     for i in range(1, NUM_SEDS):
-        pkts.filter_ping_request(identifier=SED_ECHO_ID + i).\
-            filter_wpan_src16(LEADER_RLOC16).\
-            filter_wpan_dst16(ROUTER_1_RLOC16).\
-            filter_ipv6_dst(SEDS_MLEID[i]).\
-            filter(lambda p: p.ipv6.plen == SMALL_DATAGRAM_SIZE - IPV6_HEADER_SIZE).\
-            must_next()
+        pkts.filter_ping_request(identifier=SED_ECHO_ID + i) \
+            .filter_wpan_src16(LEADER_RLOC16) \
+            .filter_wpan_dst16(ROUTER_1_RLOC16) \
+            .filter_ipv6_dst(SEDS_MLEID[i]) \
+            .filter(lambda p: p.ipv6.plen == SMALL_DATAGRAM_SIZE - IPV6_HEADER_SIZE) \
+            .must_next()
 
     # Verify Router forwards to SEDs and receives replies (allow interleaving)
     pkts.index = verify_ping_forwarding(pv, step3_start_idx, SEDS_RLOC16, SEDS_MLEID, SED_ECHO_ID)

--- a/tests/nexus/verify_5_1_8.py
+++ b/tests/nexus/verify_5_1_8.py
@@ -71,9 +71,9 @@ def verify(pv):
     # - Pass Criteria: N/A
     print("Step 1: Leader, Router_1, Router_2, Router_3")
     for node in [LEADER, ROUTER_1, ROUTER_2, ROUTER_3]:
-        pkts.filter_wpan_src64(node).\
-            filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
-            must_next()
+        pkts.filter_wpan_src64(node) \
+            .filter_mle_cmd(consts.MLE_ADVERTISEMENT) \
+            .must_next()
 
     # Step 2: Test Harness
     # - Description: Harness configures the RSSI between Router_1, Router_2, and Router_3 and Router_4 (DUT) to enable
@@ -92,30 +92,30 @@ def verify(pv):
     #     - Scan Mask TLV = 0x80 (Active Routers)
     #     - Version TLV
     print("Step 3: Router_4 (DUT)")
-    pkts.filter_wpan_src64(DUT).\
-        filter_LLARMA().\
-        filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
-        filter(lambda p: {consts.CHALLENGE_TLV, consts.MODE_TLV, consts.SCAN_MASK_TLV, consts.VERSION_TLV} <= set(p.mle.tlv.type)).\
-        filter(lambda p: p.ipv6.hlim == 255).\
-        filter(lambda p: p.mle.tlv.scan_mask.r == 1).\
-        filter(lambda p: p.mle.tlv.scan_mask.e == 0).\
-        must_next()
+    pkts.filter_wpan_src64(DUT) \
+        .filter_LLARMA() \
+        .filter_mle_cmd(consts.MLE_PARENT_REQUEST) \
+        .filter(lambda p: {consts.CHALLENGE_TLV, consts.MODE_TLV, consts.SCAN_MASK_TLV, consts.VERSION_TLV} <= set(p.mle.tlv.type)) \
+        .filter(lambda p: p.ipv6.hlim == 255) \
+        .filter(lambda p: p.mle.tlv.scan_mask.r == 1) \
+        .filter(lambda p: p.mle.tlv.scan_mask.e == 0) \
+        .must_next()
 
     # Step 4: Router_2, Router_3
     # - Description: Each device automatically responds to the DUT with MLE Parent Response.
     # - Pass Criteria: N/A
     print("Step 4: Router_2, Router_3")
     _start_idx = pkts.index
-    pkts.filter_wpan_src64(ROUTER_2).\
-        filter_wpan_dst64(DUT).\
-        filter_mle_cmd(consts.MLE_PARENT_RESPONSE).\
-        must_next()
+    pkts.filter_wpan_src64(ROUTER_2) \
+        .filter_wpan_dst64(DUT) \
+        .filter_mle_cmd(consts.MLE_PARENT_RESPONSE) \
+        .must_next()
 
-    pkts.range(_start_idx).\
-        filter_wpan_src64(ROUTER_3).\
-        filter_wpan_dst64(DUT).\
-        filter_mle_cmd(consts.MLE_PARENT_RESPONSE).\
-        must_next()
+    pkts.range(_start_idx) \
+        .filter_wpan_src64(ROUTER_3) \
+        .filter_wpan_dst64(DUT) \
+        .filter_mle_cmd(consts.MLE_PARENT_RESPONSE) \
+        .must_next()
 
     # Step 5: Router_4 (DUT)
     # - Description: Automatically sends a MLE Child ID Request to Router_3 due to better connectivity.
@@ -133,19 +133,19 @@ def verify(pv):
     print("Step 5: Router_4 (DUT)")
     # We must reset the range to find Child ID Request because Step 4 might have advanced past it
     # depending on which Parent Response came last.
-    child_id_req = pkts.range(_start_idx).\
-        filter_wpan_src64(DUT).\
-        filter_wpan_dst64(ROUTER_3).\
-        filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST).\
-        filter(lambda p: {
+    child_id_req = pkts.range(_start_idx) \
+        .filter_wpan_src64(DUT) \
+        .filter_wpan_dst64(ROUTER_3) \
+        .filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST) \
+        .filter(lambda p: {
             consts.LINK_LAYER_FRAME_COUNTER_TLV,
             consts.MODE_TLV,
             consts.RESPONSE_TLV,
             consts.TIMEOUT_TLV,
             consts.TLV_REQUEST_TLV,
             consts.VERSION_TLV
-        } <= set(p.mle.tlv.type)).\
-        must_next()
+        } <= set(p.mle.tlv.type)) \
+        .must_next()
 
     child_id_req.must_not_verify(lambda p: consts.ADDRESS_REGISTRATION_TLV in p.mle.tlv.type)
 

--- a/tests/nexus/verify_5_1_9.py
+++ b/tests/nexus/verify_5_1_9.py
@@ -72,12 +72,12 @@ def verify(pv):
     #   advertisements.
     # - Pass Criteria: N/A
     print("Step 1: Setup the topology without the DUT")
-    pkts.filter_wpan_src64(LEADER).\
-        filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
-        must_next()
-    pkts.filter_wpan_src64(ROUTER_1).\
-        filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
-        must_next()
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_mle_cmd(consts.MLE_ADVERTISEMENT) \
+        .must_next()
+    pkts.filter_wpan_src64(ROUTER_1) \
+        .filter_mle_cmd(consts.MLE_ADVERTISEMENT) \
+        .must_next()
 
     # Step 2: Test Harness
     # - Description: Harness configures the RSSI between Leader, Router_1, Router_2 (DUT), REED_1, and REED_2 to enable
@@ -86,19 +86,19 @@ def verify(pv):
     print("Step 2: Harness configures the RSSI")
 
     # Step 3: Router_2 (DUT)
-    pkts.filter_wpan_src64(DUT).\
-        filter_LLARMA().\
-        filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(DUT) \
+        .filter_LLARMA() \
+        .filter_mle_cmd(consts.MLE_PARENT_REQUEST) \
+        .filter(lambda p: {
                           consts.MODE_TLV,
                           consts.CHALLENGE_TLV,
                           consts.SCAN_MASK_TLV,
                           consts.VERSION_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.ipv6.hlim == 255 and\
-               p.mle.tlv.scan_mask.r == 1 and\
-               p.mle.tlv.scan_mask.e == 0).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.ipv6.hlim == 255 and \
+               p.mle.tlv.scan_mask.r == 1 and \
+               p.mle.tlv.scan_mask.e == 0) \
+        .must_next()
     lstart = pkts.index
 
     # Step 4: REED_2, REED_1
@@ -119,29 +119,29 @@ def verify(pv):
     #   - The Key Identifier Mode of the Security Control field of the MAC frame Auxiliary Security Header MUST be set
     #     to '0x02'
     print("Step 5: Router_2 (DUT) sends MLE Parent Request with Scan Mask set to Routers and REEDs")
-    pkts.filter_wpan_src64(DUT).\
-        filter_LLARMA().\
-        filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(DUT) \
+        .filter_LLARMA() \
+        .filter_mle_cmd(consts.MLE_PARENT_REQUEST) \
+        .filter(lambda p: {
                           consts.CHALLENGE_TLV,
                           consts.MODE_TLV,
                           consts.SCAN_MASK_TLV,
                           consts.VERSION_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.ipv6.hlim == 255 and\
-               p.mle.tlv.scan_mask.r == 1 and\
-               p.mle.tlv.scan_mask.e == 1 and\
-               p.wpan.aux_sec.key_id_mode == 0x02).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.ipv6.hlim == 255 and \
+               p.mle.tlv.scan_mask.r == 1 and \
+               p.mle.tlv.scan_mask.e == 1 and \
+               p.wpan.aux_sec.key_id_mode == 0x02) \
+        .must_next()
     lend = pkts.index
 
     # Verify Step 4: No Parent Response from REEDs between Step 3 and Step 5
     for reed in [REED_1, REED_2]:
-        pkts.range(lstart, lend).\
-            filter_wpan_src64(reed).\
-            filter_wpan_dst64(DUT).\
-            filter_mle_cmd(consts.MLE_PARENT_RESPONSE).\
-            must_not_next()
+        pkts.range(lstart, lend) \
+            .filter_wpan_src64(reed) \
+            .filter_wpan_dst64(DUT) \
+            .filter_mle_cmd(consts.MLE_PARENT_RESPONSE) \
+            .must_not_next()
 
     # Step 6: REED_1, REED_2
     # - Description: Each device automatically responds to DUT with MLE Parent Response. REED_1 reports more high
@@ -154,10 +154,10 @@ def verify(pv):
 
     def find_parent_response(src64):
         pkts.index = _index
-        pkt = pkts.filter_wpan_src64(src64).\
-            filter_wpan_dst64(DUT).\
-            filter_mle_cmd(consts.MLE_PARENT_RESPONSE).\
-            filter(lambda p: {
+        pkt = pkts.filter_wpan_src64(src64) \
+            .filter_wpan_dst64(DUT) \
+            .filter_mle_cmd(consts.MLE_PARENT_RESPONSE) \
+            .filter(lambda p: {
                               consts.CHALLENGE_TLV,
                               consts.CONNECTIVITY_TLV,
                               consts.LEADER_DATA_TLV,
@@ -166,9 +166,9 @@ def verify(pv):
                               consts.RESPONSE_TLV,
                               consts.SOURCE_ADDRESS_TLV,
                               consts.VERSION_TLV
-                              } <= set(p.mle.tlv.type) and\
-                   p.wpan.aux_sec.key_id_mode == 0x02).\
-            must_next()
+                              } <= set(p.mle.tlv.type) and \
+                   p.wpan.aux_sec.key_id_mode == 0x02) \
+            .must_next()
         return pkt, pkts.index
 
     p_reed1, index1 = find_parent_response(REED_1)
@@ -197,18 +197,18 @@ def verify(pv):
     #   - The following TLV MUST NOT be present in the Child ID Request:
     #     - Address Registration TLV
     print("Step 7: Router_2 (DUT) sends a MLE Child ID Request to REED_1")
-    _pkt = pkts.filter_wpan_src64(DUT).\
-        filter_wpan_dst64(REED_1).\
-        filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST).\
-        filter(lambda p: {
+    _pkt = pkts.filter_wpan_src64(DUT) \
+        .filter_wpan_dst64(REED_1) \
+        .filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST) \
+        .filter(lambda p: {
                           consts.LINK_LAYER_FRAME_COUNTER_TLV,
                           consts.MODE_TLV,
                           consts.RESPONSE_TLV,
                           consts.TIMEOUT_TLV,
                           consts.TLV_REQUEST_TLV,
                           consts.VERSION_TLV
-                          } <= set(p.mle.tlv.type)).\
-        must_next()
+                          } <= set(p.mle.tlv.type)) \
+        .must_next()
     _pkt.must_not_verify(lambda p: consts.ADDRESS_REGISTRATION_TLV in p.mle.tlv.type)
 
 

--- a/tests/nexus/verify_5_2_1.py
+++ b/tests/nexus/verify_5_2_1.py
@@ -76,25 +76,25 @@ def verify(pv):
     #     - Leader Data TLV
     #     - Route64 TLV
     print("Step 1: Router_1 (DUT)")
-    pkts.filter_wpan_src64(DUT).\
-        filter_LLANMA().\
-        filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(DUT) \
+        .filter_LLANMA() \
+        .filter_mle_cmd(consts.MLE_ADVERTISEMENT) \
+        .filter(lambda p: {
                           consts.SOURCE_ADDRESS_TLV,
                           consts.LEADER_DATA_TLV,
                           consts.ROUTE64_TLV
-                          } <= set(p.mle.tlv.type) and\
-               p.ipv6.hlim == 255).\
-        must_next()
+                          } <= set(p.mle.tlv.type) and \
+               p.ipv6.hlim == 255) \
+        .must_next()
 
     # Step 2: REED_1
     # - Description: Attach REED_1 to DUT; REED_1 automatically sends MLE Parent Request.
     # - Pass Criteria: N/A
     print("Step 2: REED_1")
-    pkts.filter_wpan_src64(REED_1).\
-        filter_LLARMA().\
-        filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
-        must_next()
+    pkts.filter_wpan_src64(REED_1) \
+        .filter_LLARMA() \
+        .filter_mle_cmd(consts.MLE_PARENT_REQUEST) \
+        .must_next()
 
     # Step 3: Router_1 (DUT)
     # - Description: Automatically sends an MLE Parent Response.
@@ -111,10 +111,10 @@ def verify(pv):
     #     - Version TLV
     #     - MLE Frame Counter TLV (optional)
     print("Step 3: Router_1 (DUT)")
-    pkts.filter_wpan_src64(DUT).\
-        filter_wpan_dst64(REED_1).\
-        filter_mle_cmd(consts.MLE_PARENT_RESPONSE).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(DUT) \
+        .filter_wpan_dst64(REED_1) \
+        .filter_mle_cmd(consts.MLE_PARENT_RESPONSE) \
+        .filter(lambda p: {
                           consts.CHALLENGE_TLV,
                           consts.CONNECTIVITY_TLV,
                           consts.LEADER_DATA_TLV,
@@ -123,8 +123,8 @@ def verify(pv):
                           consts.RESPONSE_TLV,
                           consts.SOURCE_ADDRESS_TLV,
                           consts.VERSION_TLV
-                          } <= set(p.mle.tlv.type)).\
-        must_next()
+                          } <= set(p.mle.tlv.type)) \
+        .must_next()
 
     # Step 4: Router_1 (DUT)
     # - Description: Automatically sends an MLE Child ID Response.
@@ -137,33 +137,33 @@ def verify(pv):
     #     - Source Address TLV
     #     - Route64 TLV (optional)
     print("Step 4: Router_1 (DUT)")
-    pkts.filter_wpan_src64(DUT).\
-        filter_wpan_dst64(REED_1).\
-        filter_mle_cmd(consts.MLE_CHILD_ID_RESPONSE).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(DUT) \
+        .filter_wpan_dst64(REED_1) \
+        .filter_mle_cmd(consts.MLE_CHILD_ID_RESPONSE) \
+        .filter(lambda p: {
                           consts.ADDRESS16_TLV,
                           consts.LEADER_DATA_TLV,
                           consts.NETWORK_DATA_TLV,
                           consts.SOURCE_ADDRESS_TLV
-                          } <= set(p.mle.tlv.type)).\
-        must_next()
+                          } <= set(p.mle.tlv.type)) \
+        .must_next()
 
     # Step 6: MED_1
     # - Description: The harness attaches MED_1 to REED_1.
     # - Pass Criteria: N/A
     print("Step 6: MED_1")
-    pkts.filter_wpan_src64(MED_1).\
-        filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
-        must_next()
+    pkts.filter_wpan_src64(MED_1) \
+        .filter_mle_cmd(consts.MLE_PARENT_REQUEST) \
+        .must_next()
 
     # Step 7: REED_1
     # - Description: Automatically sends an Address Solicit Request to DUT.
     # - Pass Criteria: N/A
     print("Step 7: REED_1")
-    _pkt_sol = pkts.filter_wpan_src64(REED_1).\
-        filter_wpan_dst16(DUT_RLOC16).\
-        filter_coap_request(consts.ADDR_SOL_URI).\
-        must_next()
+    _pkt_sol = pkts.filter_wpan_src64(REED_1) \
+        .filter_wpan_dst16(DUT_RLOC16) \
+        .filter_coap_request(consts.ADDR_SOL_URI) \
+        .must_next()
 
     # Step 8: Router_1 (DUT)
     # - Description: Automatically forwards Address Solicit Request to Leader, and forwards Leader's Address Solicit
@@ -172,33 +172,33 @@ def verify(pv):
     #   - The DUT MUST forward the Address Solicit Request to the Leader.
     #   - The DUT MUST forward the Leader's Address Solicit Response to REED_1.
     print("Step 8: Router_1 (DUT)")
-    pkts.filter_wpan_src16(DUT_RLOC16).\
-        filter_wpan_dst16(LEADER_RLOC16).\
-        filter_coap_request(consts.ADDR_SOL_URI).\
-        must_next()
+    pkts.filter_wpan_src16(DUT_RLOC16) \
+        .filter_wpan_dst16(LEADER_RLOC16) \
+        .filter_coap_request(consts.ADDR_SOL_URI) \
+        .must_next()
 
-    pkts.filter_wpan_src16(LEADER_RLOC16).\
-        filter_wpan_dst16(DUT_RLOC16).\
-        filter_coap_ack(consts.ADDR_SOL_URI).\
-        must_next()
+    pkts.filter_wpan_src16(LEADER_RLOC16) \
+        .filter_wpan_dst16(DUT_RLOC16) \
+        .filter_coap_ack(consts.ADDR_SOL_URI) \
+        .must_next()
 
-    pkts.filter_wpan_src16(DUT_RLOC16).\
-        filter_wpan_dst16(_pkt_sol.wpan.src16).\
-        filter_coap_ack(consts.ADDR_SOL_URI).\
-        must_next()
+    pkts.filter_wpan_src16(DUT_RLOC16) \
+        .filter_wpan_dst16(_pkt_sol.wpan.src16) \
+        .filter_coap_ack(consts.ADDR_SOL_URI) \
+        .must_next()
 
     # Step 9: Leader
     # - Description: Harness verifies connectivity by instructing the device to send an ICMPv6 Echo Request to REED_1.
     # - Pass Criteria:
     #   - REED_1 responds with ICMPv6 Echo Reply.
     print("Step 9: Leader")
-    _pkt_ping = pkts.filter_ping_request().\
-        filter_wpan_src64(LEADER).\
-        must_next()
+    _pkt_ping = pkts.filter_ping_request() \
+        .filter_wpan_src64(LEADER) \
+        .must_next()
 
-    pkts.filter_ping_reply(identifier=_pkt_ping.icmpv6.echo.identifier).\
-        filter_wpan_src64(REED_1).\
-        must_next()
+    pkts.filter_ping_reply(identifier=_pkt_ping.icmpv6.echo.identifier) \
+        .filter_wpan_src64(REED_1) \
+        .must_next()
 
 
 if __name__ == '__main__':

--- a/tests/nexus/verify_5_2_3.py
+++ b/tests/nexus/verify_5_2_3.py
@@ -67,19 +67,19 @@ def verify(pv):
     # - Pass Criteria: Topology is created, the DUT is the Leader of the network and there is a total of 32
     #   active routers, including the Leader.
     print("Step 1: All")
-    pkts.filter_wpan_src64(LEADER).\
-        filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
-        filter(lambda p: consts.LEADER_DATA_TLV in p.mle.tlv.type).\
-        must_next()
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_mle_cmd(consts.MLE_ADVERTISEMENT) \
+        .filter(lambda p: consts.LEADER_DATA_TLV in p.mle.tlv.type) \
+        .must_next()
 
     # Step 2: Router_31
     # - Description: The harness causes Router_31 to attach to the network and send an Address Solicit Request to
     #   become an active router.
     # - Pass Criteria: N/A
     print("Step 2: Router_31")
-    pkts.filter_wpan_src64(ROUTER_31).\
-        filter_coap_request(consts.ADDR_SOL_URI).\
-        must_next()
+    pkts.filter_wpan_src64(ROUTER_31) \
+        .filter_coap_request(consts.ADDR_SOL_URI) \
+        .must_next()
 
     # Step 3: Leader (DUT)
     # - Description: The DUT receives the Address Solicit Request and automatically replies with an Address
@@ -92,36 +92,36 @@ def verify(pv):
     #       - RLOC16 TLV
     #       - Router Mask TLV
     print("Step 3: Leader (DUT)")
-    pkts.filter_wpan_src64(LEADER).\
-        filter_coap_ack(consts.ADDR_SOL_URI).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_coap_ack(consts.ADDR_SOL_URI) \
+        .filter(lambda p: {
             consts.NL_STATUS_TLV,
             consts.NL_RLOC16_TLV,
             consts.NL_ROUTER_MASK_TLV
-        } <= set(p.coap.tlv.type) and\
-            p.coap.code == consts.COAP_CODE_ACK and\
-            p.coap.tlv.status == consts.ADDR_SOL_SUCCESS).\
-        must_next()
+        } <= set(p.coap.tlv.type) and \
+            p.coap.code == consts.COAP_CODE_ACK and \
+            p.coap.tlv.status == consts.ADDR_SOL_SUCCESS) \
+        .must_next()
 
     # Step 4: Leader (DUT)
     # - Description: Automatically sends MLE Advertisements.
     # - Pass Criteria: The DUT’s MLE Advertisements MUST contain the Route64 TLV with 32 assigned Router IDs.
     print("Step 4: Leader (DUT)")
-    pkts.filter_wpan_src64(LEADER).\
-        filter_LLANMA().\
-        filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
-        filter(lambda p: consts.ROUTE64_TLV in p.mle.tlv.type and\
-               len(p.mle.tlv.route64.id_mask) == MAX_ROUTERS).\
-        must_next()
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_LLANMA() \
+        .filter_mle_cmd(consts.MLE_ADVERTISEMENT) \
+        .filter(lambda p: consts.ROUTE64_TLV in p.mle.tlv.type and \
+               len(p.mle.tlv.route64.id_mask) == MAX_ROUTERS) \
+        .must_next()
 
     # Step 5: Router_32
     # - Description: The harness causes Router_32 to attach to any of the active routers, 2-hops from the leader,
     #   and to send an Address Solicit Request to become an active router.
     # - Pass Criteria: N/A
     print("Step 5: Router_32")
-    pkts.filter_wpan_src64(ROUTER_32).\
-        filter_coap_request(consts.ADDR_SOL_URI).\
-        must_next()
+    pkts.filter_wpan_src64(ROUTER_32) \
+        .filter_coap_request(consts.ADDR_SOL_URI) \
+        .must_next()
 
     # Step 6: Leader (DUT)
     # - Description: The DUT receives the Address Solicit Request and automatically replies with an Address
@@ -132,14 +132,14 @@ def verify(pv):
     #     - CoAP Payload:
     #       - Status TLV (value = No Address Available)
     print("Step 6: Leader (DUT)")
-    pkts.filter_wpan_src64(LEADER).\
-        filter_coap_ack(consts.ADDR_SOL_URI).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_coap_ack(consts.ADDR_SOL_URI) \
+        .filter(lambda p: {
             consts.NL_STATUS_TLV
-        } <= set(p.coap.tlv.type) and\
-            p.coap.code == consts.COAP_CODE_ACK and\
-            p.coap.tlv.status == consts.NL_NO_ADDRESS_AVAILABLE).\
-        must_next()
+        } <= set(p.coap.tlv.type) and \
+            p.coap.code == consts.COAP_CODE_ACK and \
+            p.coap.tlv.status == consts.NL_NO_ADDRESS_AVAILABLE) \
+        .must_next()
 
 
 if __name__ == '__main__':

--- a/tests/nexus/verify_5_2_4.py
+++ b/tests/nexus/verify_5_2_4.py
@@ -78,10 +78,10 @@ def verify(pv):
     # - Pass Criteria: The DUT MUST NOT attempt to become an active router by sending an Address Solicit Request.
     print("Step 2: The DUT MUST NOT attempt to become an active router.")
     # We verify it joins as a child and NO Address Solicit Request is sent before Step 9.
-    pkts.filter_wpan_src64(REED_1).\
-        filter_wpan_dst64(ROUTER_15).\
-        filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST).\
-        must_next()
+    pkts.filter_wpan_src64(REED_1) \
+        .filter_wpan_dst64(ROUTER_15) \
+        .filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST) \
+        .must_next()
 
     # Step 3: REED_1 (DUT)
     # - Description: Automatically sends MLE Advertisements.
@@ -95,15 +95,15 @@ def verify(pv):
     #   - The following TLV MUST NOT be present in the MLE Advertisement:
     #     - Route64 TLV
     print("Step 3: The DUT MUST send properly formatted MLE Advertisements.")
-    _pkt = pkts.filter_wpan_src64(REED_1).\
-        filter_LLANMA().\
-        filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
-        filter(lambda p: {
+    _pkt = pkts.filter_wpan_src64(REED_1) \
+        .filter_LLANMA() \
+        .filter_mle_cmd(consts.MLE_ADVERTISEMENT) \
+        .filter(lambda p: {
                           consts.LEADER_DATA_TLV,
                           consts.SOURCE_ADDRESS_TLV
                           } <= set(p.mle.tlv.type) and
-               p.ipv6.hlim == 255).\
-        must_next()
+               p.ipv6.hlim == 255) \
+        .must_next()
     _pkt.must_not_verify(lambda p: (consts.ROUTE64_TLV) in p.mle.tlv.type)
 
     # Step 4: Wait
@@ -117,28 +117,28 @@ def verify(pv):
     # - Pass Criteria: The DUT MUST send a second MLE Advertisement after REED_ADVERTISEMENT_INTERVAL+JITTER where
     #   JITTER <= REED_ADVERTISEMENT_MAX_JITTER.
     print("Step 5: The DUT MUST send a second MLE Advertisement.")
-    pkts.filter_wpan_src64(REED_1).\
-        filter_LLANMA().\
-        filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
-        must_next()
+    pkts.filter_wpan_src64(REED_1) \
+        .filter_LLANMA() \
+        .filter_mle_cmd(consts.MLE_ADVERTISEMENT) \
+        .must_next()
 
     # Step 6: MED_1
     # - Description: Automatically sends multicast MLE Parent Request.
     # - Pass Criteria: N/A
     print("Step 6: MED_1 sends multicast MLE Parent Request.")
-    pkts.filter_wpan_src64(MED_1).\
-        filter_LLARMA().\
-        filter_mle_cmd(consts.MLE_PARENT_REQUEST).\
-        must_next()
+    pkts.filter_wpan_src64(MED_1) \
+        .filter_LLARMA() \
+        .filter_mle_cmd(consts.MLE_PARENT_REQUEST) \
+        .must_next()
 
     # Step 7: REED_1 (DUT)
     # - Description: Automatically sends MLE Parent Response.
     # - Pass Criteria: The DUT MUST reply with a properly formatted MLE Parent Response.
     print("Step 7: The DUT MUST reply with a properly formatted MLE Parent Response.")
-    pkts.filter_wpan_src64(REED_1).\
-        filter_wpan_dst64(MED_1).\
-        filter_mle_cmd(consts.MLE_PARENT_RESPONSE).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(REED_1) \
+        .filter_wpan_dst64(MED_1) \
+        .filter_mle_cmd(consts.MLE_PARENT_RESPONSE) \
+        .filter(lambda p: {
                           consts.CHALLENGE_TLV,
                           consts.CONNECTIVITY_TLV,
                           consts.LEADER_DATA_TLV,
@@ -147,17 +147,17 @@ def verify(pv):
                           consts.RESPONSE_TLV,
                           consts.SOURCE_ADDRESS_TLV,
                           consts.VERSION_TLV
-                           } <= set(p.mle.tlv.type)).\
-        must_next()
+                           } <= set(p.mle.tlv.type)) \
+        .must_next()
 
     # Step 8: MED_1
     # - Description: Automatically sends MLE Child ID Request to the DUT.
     # - Pass Criteria: N/A
     print("Step 8: MED_1 sends MLE Child ID Request to the DUT.")
-    pkts.filter_wpan_src64(MED_1).\
-        filter_wpan_dst64(REED_1).\
-        filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST).\
-        must_next()
+    pkts.filter_wpan_src64(MED_1) \
+        .filter_wpan_dst64(REED_1) \
+        .filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST) \
+        .must_next()
 
     # Step 9: REED_1 (DUT)
     # - Description: Automatically sends an Address Solicit Request to the Leader.
@@ -169,13 +169,13 @@ def verify(pv):
     #       - Status TLV
     #       - RLOC16 TLV (optional)
     print("Step 9: The DUT MUST send an Address Solicit Request to the Leader.")
-    pkts.filter_wpan_src64(REED_1).\
-        filter_coap_request(consts.ADDR_SOL_URI).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(REED_1) \
+        .filter_coap_request(consts.ADDR_SOL_URI) \
+        .filter(lambda p: {
                           consts.NL_MAC_EXTENDED_ADDRESS_TLV,
                           consts.NL_STATUS_TLV
-                          } <= set(p.coap.tlv.type)).\
-        must_next()
+                          } <= set(p.coap.tlv.type)) \
+        .must_next()
 
     # Step 10: REED_1 (DUT)
     # - Description: Optionally, automatically sends a Multicast Link Request after receiving an Address Solicit
@@ -190,44 +190,44 @@ def verify(pv):
     #     - Version TLV
     print("Step 10: The DUT MAY send a Multicast Link Request.")
     # We use next() since it's optional
-    pkts.filter_wpan_src64(REED_1).\
-        filter_LLARMA().\
-        filter_mle_cmd(consts.MLE_LINK_REQUEST).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(REED_1) \
+        .filter_LLARMA() \
+        .filter_mle_cmd(consts.MLE_LINK_REQUEST) \
+        .filter(lambda p: {
                           consts.CHALLENGE_TLV,
                           consts.LEADER_DATA_TLV,
                           consts.SOURCE_ADDRESS_TLV,
                           consts.TLV_REQUEST_TLV,
                           consts.VERSION_TLV
-                          } <= set(p.mle.tlv.type)).\
-        next()
+                          } <= set(p.mle.tlv.type)) \
+        .next()
 
     # Step 11: REED_1 (DUT)
     # - Description: Automatically sends MLE Child ID Response to MED_1.
     # - Pass Criteria: The DUTs MLE Child ID Response MUST be properly formatted with MED_1’s new 16-bit address.
     print("Step 11: The DUT MUST send MLE Child ID Response to MED_1.")
-    pkts.filter_wpan_src64(REED_1).\
-        filter_wpan_dst64(MED_1).\
-        filter_mle_cmd(consts.MLE_CHILD_ID_RESPONSE).\
-        filter(lambda p: {
+    pkts.filter_wpan_src64(REED_1) \
+        .filter_wpan_dst64(MED_1) \
+        .filter_mle_cmd(consts.MLE_CHILD_ID_RESPONSE) \
+        .filter(lambda p: {
                           consts.ADDRESS16_TLV,
                           consts.LEADER_DATA_TLV,
                           consts.NETWORK_DATA_TLV,
                           consts.SOURCE_ADDRESS_TLV
-                          } <= set(p.mle.tlv.type)).\
-        must_next()
+                          } <= set(p.mle.tlv.type)) \
+        .must_next()
 
     # Step 12: MED_1
     # - Description: The harness verifies connectivity by instructing the device to send an ICMPv6 Echo Request to the
     #   Leader.
     # - Pass Criteria: The Leader MUST respond with an ICMPv6 Echo Reply.
     print("Step 12: Harness verifies connectivity by sending an ICMPv6 Echo Request.")
-    _pkt = pkts.filter_ping_request().\
-        filter_wpan_src64(MED_1).\
-        must_next()
-    pkts.filter_ping_reply(identifier=_pkt.icmpv6.echo.identifier).\
-        filter_ipv6_dst(_pkt.ipv6.src).\
-        must_next()
+    _pkt = pkts.filter_ping_request() \
+        .filter_wpan_src64(MED_1) \
+        .must_next()
+    pkts.filter_ping_reply(identifier=_pkt.icmpv6.echo.identifier) \
+        .filter_ipv6_dst(_pkt.ipv6.src) \
+        .must_next()
 
 
 if __name__ == '__main__':

--- a/tests/nexus/verify_5_3_2.py
+++ b/tests/nexus/verify_5_3_2.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import sys
+import os
+
+# Add the current directory to sys.path to find verify_utils
+CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(CUR_DIR)
+
+import verify_utils
+from pktverify import consts
+from pktverify.addrs import Ipv6Addr
+
+
+def verify(pv):
+    # 5.3.2 Realm-Local Addressing
+    #
+    # 5.3.2.1 Topology
+    # - Leader
+    # - Router 1
+    # - Router 2 (DUT)
+    # - SED 1
+    #
+    # 5.3.2.2 Purpose & Description
+    # The purpose of this test case is to validate the Realm-Local addresses that the DUT configures.
+    #
+    # Spec Reference   | V1.1 Section | V1.3.0 Section
+    # -----------------|--------------|---------------
+    # Realm-Local Scope| 5.2.3.2      | 5.2.1.2
+
+    pkts = pv.pkts
+    pv.summary.show()
+
+    LEADER = pv.vars['LEADER']
+    DUT = pv.vars['DUT']
+    SED_1 = pv.vars['SED_1']
+    DUT_MLEID = pv.vars['DUT_MLEID']
+    LEADER_MLEID = pv.vars['LEADER_MLEID']
+    DUT_RLOC16 = pv.vars['DUT_RLOC16']
+    SED_1_RLOC16 = pv.vars['SED_1_RLOC16']
+
+    mesh_local_prefix_str = pv.vars['mesh_local_prefix']
+    prefix = mesh_local_prefix_str.split('/')[0]
+    # ff33:00:40:prefix:00000001
+    realm_local_all_thread_nodes = Ipv6Addr(
+        bytearray([0xff, 0x33, 0x00, 64]) + Ipv6Addr(prefix)[:8] + bytearray([0, 0, 0, 1]))
+
+    ECHO_ID = 0x1234
+
+    # Step 1: All
+    # - Description: Build the topology as described and begin the wireless sniffer.
+    # - Pass Criteria: N/A
+    print("Step 1: All")
+    pkts.filter_wpan_src64(LEADER).filter_mle_cmd(consts.MLE_ADVERTISEMENT).must_next()
+    pkts.filter_wpan_src64(DUT).filter_mle_cmd(consts.MLE_ADVERTISEMENT).must_next()
+
+    # Step 2: Leader
+    # - Description: Harness instructs the device to send an ICMPv6 Echo Request to the DUT ML-EID.
+    # - Pass Criteria: The DUT MUST respond with an ICMPv6 Echo Reply.
+    print("Step 2: Leader")
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_ipv6_dst(DUT_MLEID) \
+        .filter_ping_request(identifier=ECHO_ID) \
+        .must_next()
+    pkts.filter_wpan_src64(DUT) \
+        .filter_ipv6_dst(LEADER_MLEID) \
+        .filter_ping_reply(identifier=ECHO_ID) \
+        .must_next()
+
+    # Step 3: Leader
+    # - Description: Harness instructs the device to send a fragmented ICMPv6 Echo Request to the DUT ML-EID.
+    # - Pass Criteria: The DUT MUST respond with an ICMPv6 Echo Reply.
+    print("Step 3: Leader")
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_ipv6_dst(DUT_MLEID) \
+        .filter_ping_request(identifier=ECHO_ID) \
+        .filter(lambda p: hasattr(p, 'lowpan') and hasattr(p.lowpan, 'fragment')) \
+        .must_next()
+    pkts.filter_wpan_src64(DUT) \
+        .filter_ipv6_dst(LEADER_MLEID) \
+        .filter_ping_reply(identifier=ECHO_ID) \
+        .must_next()
+
+    # Step 4: Leader
+    # - Description: Harness instructs the device to send an ICMPv6 Echo Request to the Realm-Local All-Nodes
+    #   multicast address (FF03::1).
+    # - Pass Criteria:
+    #   - The DUT MUST respond with an ICMPv6 Echo Reply.
+    #   - The DUT MUST NOT forward the ICMPv6 Echo Request to SED_1.
+    print("Step 4: Leader")
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_ipv6_dst(consts.REALM_LOCAL_ALL_NODES_ADDRESS) \
+        .filter_ping_request(identifier=ECHO_ID) \
+        .must_next()
+    pkts.filter_wpan_src64(DUT) \
+        .filter_ipv6_dst(LEADER_MLEID) \
+        .filter_ping_reply(identifier=ECHO_ID) \
+        .must_next()
+    pkts.copy().filter_wpan_src64(DUT) \
+        .filter_wpan_dst64(SED_1) \
+        .filter_ipv6_dst(consts.REALM_LOCAL_ALL_NODES_ADDRESS) \
+        .must_not_next()
+
+    # Step 5: Leader
+    # - Description: Harness instructs the device to send a fragmented ICMPv6 Echo Request to the Realm-Local
+    #   All-Nodes multicast address (FF03::1).
+    # - Pass Criteria:
+    #   - The DUT MUST respond with an ICMPv6 Echo Reply.
+    #   - The DUT MUST NOT forward the ICMPv6 Echo Request to SED_1.
+    print("Step 5: Leader")
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_ipv6_dst(consts.REALM_LOCAL_ALL_NODES_ADDRESS) \
+        .filter_ping_request(identifier=ECHO_ID) \
+        .filter(lambda p: hasattr(p, 'lowpan') and hasattr(p.lowpan, 'fragment')) \
+        .must_next()
+    pkts.filter_wpan_src64(DUT) \
+        .filter_ipv6_dst(LEADER_MLEID) \
+        .filter_ping_reply(identifier=ECHO_ID) \
+        .must_next()
+    pkts.copy().filter_wpan_src64(DUT) \
+        .filter_wpan_dst64(SED_1) \
+        .filter_ipv6_dst(consts.REALM_LOCAL_ALL_NODES_ADDRESS) \
+        .must_not_next()
+
+    # Step 6: Leader
+    # - Description: Harness instructs the device to send an ICMPv6 Echo Request to the Realm-Local All-Routers
+    #   multicast address (FF03::2).
+    # - Pass Criteria:
+    #   - The DUT MUST respond with an ICMPv6 Echo Reply.
+    #   - The DUT MUST NOT forward the ICMPv6 Echo Request to SED_1.
+    print("Step 6: Leader")
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_ipv6_dst(consts.REALM_LOCAL_ALL_ROUTERS_ADDRESS) \
+        .filter_ping_request(identifier=ECHO_ID) \
+        .must_next()
+    pkts.filter_wpan_src64(DUT) \
+        .filter_ipv6_dst(LEADER_MLEID) \
+        .filter_ping_reply(identifier=ECHO_ID) \
+        .must_next()
+    pkts.copy().filter_wpan_src64(DUT) \
+        .filter_wpan_dst64(SED_1) \
+        .filter_ipv6_dst(consts.REALM_LOCAL_ALL_ROUTERS_ADDRESS) \
+        .must_not_next()
+
+    # Step 7: Leader
+    # - Description: Harness instructs the device to send a fragmented ICMPv6 Echo Request to the Realm-Local
+    #   All-Routers multicast address (FF03::2).
+    # - Pass Criteria:
+    #   - The DUT MUST respond with an ICMPv6 Echo Reply.
+    #   - The DUT MUST NOT forward the ICMPv6 Echo Request to SED_1.
+    print("Step 7: Leader")
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_ipv6_dst(consts.REALM_LOCAL_ALL_ROUTERS_ADDRESS) \
+        .filter_ping_request(identifier=ECHO_ID) \
+        .filter(lambda p: hasattr(p, 'lowpan') and hasattr(p.lowpan, 'fragment')) \
+        .must_next()
+    pkts.filter_wpan_src64(DUT) \
+        .filter_ipv6_dst(LEADER_MLEID) \
+        .filter_ping_reply(identifier=ECHO_ID) \
+        .must_next()
+    pkts.copy().filter_wpan_src64(DUT) \
+        .filter_wpan_dst64(SED_1) \
+        .filter_ipv6_dst(consts.REALM_LOCAL_ALL_ROUTERS_ADDRESS) \
+        .must_not_next()
+
+    # Step 8: Leader
+    # - Description: Harness instructs the device to send a Fragmented ICMPv6 Echo Request to the Realm-Local All
+    #   Thread Nodes multicast address.
+    # - Pass Criteria:
+    #   - The Realm-Local All Thread Nodes multicast address MUST be a realm-local Unicast Prefix-Based Multicast
+    #     Address [RFC 3306], with:
+    #     - flgs set to 3 (P = 1 and T = 1)
+    #     - scop set to 3
+    #     - plen set to the Mesh Local Prefix length
+    #     - network prefix set to the Mesh Local Prefix
+    #     - group ID set to 1
+    #   - The DUT MUST use IEEE 802.15.4 indirect transmissions to forward packet to SED_1.
+    print("Step 8: Leader")
+    pkts.filter_wpan_src64(LEADER) \
+        .filter_ipv6_dst(realm_local_all_thread_nodes) \
+        .filter_ping_request(identifier=ECHO_ID) \
+        .filter(lambda p: hasattr(p, 'lowpan') and hasattr(p.lowpan, 'fragment')) \
+        .must_next()
+    pkts.filter(lambda p: p.wpan.src16 == SED_1_RLOC16) \
+        .filter_wpan_cmd(consts.WPAN_DATA_REQUEST) \
+        .must_next()
+    # DUT forwards the packet to SED_1 responding to the Data Request.
+    # We use RLOC16 filters because decryption might fail for these packets.
+    pkts.filter(lambda p: p.wpan.src16 == DUT_RLOC16 and p.wpan.dst16 == SED_1_RLOC16) \
+        .must_next()
+    # SED_1 sends Echo Reply (unicast to Leader).
+    # Unicast packets are usually mapped and decrypted correctly if mapping was learned.
+    pkts.filter(lambda p: p.wpan.src16 == SED_1_RLOC16) \
+        .filter_ipv6_dst(LEADER_MLEID) \
+        .filter_ping_reply(identifier=ECHO_ID) \
+        .must_next()
+
+
+if __name__ == '__main__':
+    verify_utils.run_main(verify)


### PR DESCRIPTION
This commit standardizes the code style for packet verification chains across all 'tests/nexus/verify_5_*.py' scripts to match the pattern established in 'tests/nexus/verify_5_3_2.py'.

Key formatting changes include:
- Replaced the trailing '.\' pattern with ' \' (space and backslash).
- Moved the leading dot ('.') for chained method calls to the beginning of the next line.
- Standardized the indentation of chained '.filter' and other packet processing calls to be the base indentation plus 4 spaces.
- Ensured a space exists before all trailing backslashes at the end of a line for consistent appearance.

These changes improve readability and maintainability of the Nexus verification scripts by ensuring a uniform style throughout the test suite.