### PR TITLE
[nexus] add helpers for sending and validating ICMPv6 echo exchange

### DIFF
--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -51,6 +51,8 @@ Message *Icmp::NewMessage(void) { return Get<Ip6>().NewMessage(sizeof(Header)); 
 
 Error Icmp::RegisterHandler(Handler &aHandler) { return mHandlers.Add(aHandler); }
 
+Error Icmp::UnregisterHandler(Handler &aHandler) { return mHandlers.Remove(aHandler); }
+
 Error Icmp::SendEchoRequest(Message &aMessage, const MessageInfo &aMessageInfo, uint16_t aIdentifier)
 {
     Error       error = kErrorNone;

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -237,6 +237,16 @@ public:
     Error RegisterHandler(Handler &aHandler);
 
     /**
+     * Unregisters an ICMPv6 handler.
+     *
+     * @param[in] aHandler  The ICMPv6 handler.
+     *
+     * @retval kErrorNone      The handler was successfully removed from the list.
+     * @retval kErrorNotFound  Could not find the handler in the list.
+     */
+    Error UnregisterHandler(Handler &aHandler);
+
+    /**
      * Sends an ICMPv6 Echo Request message.
      *
      * @param[in]  aMessage      A reference to the Echo Request payload.

--- a/tests/nexus/platform/nexus_core.hpp
+++ b/tests/nexus/platform/nexus_core.hpp
@@ -56,7 +56,15 @@ public:
     TimeMilli GetNow(void) { return mNow; }
     void      AdvanceTime(uint32_t aDuration);
 
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Test specific helper methods
+
     void SaveTestInfo(const char *aFilename);
+    void SendAndVerifyEchoRequest(Node               &aSender,
+                                  const Ip6::Address &aDestination,
+                                  uint16_t            aPayloadSize     = 0,
+                                  uint8_t             aHopLimit        = 64,
+                                  uint32_t            aResponseTimeout = 1000);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Used by platform implementation
@@ -77,12 +85,26 @@ private:
         kSendAckFramePending,
     };
 
+    struct IcmpEchoResponseContext
+    {
+        IcmpEchoResponseContext(Node &aNode, uint16_t aIdentifier);
+
+        Node    &mNode;
+        uint16_t mIdentifier;
+        bool     mResponseReceived;
+    };
+
     void Process(Node &aNode);
     void ProcessRadio(Node &aNode);
     void ProcessMdns(Node &aNode);
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
     void ProcessTrel(Node &aNode);
 #endif
+
+    static void HandleIcmpResponse(void                *aContext,
+                                   otMessage           *aMessage,
+                                   const otMessageInfo *aMessageInfo,
+                                   const otIcmp6Header *aIcmpHeader);
 
     static Core *sCore;
     static bool  sInUse;

--- a/tests/nexus/platform/nexus_node.cpp
+++ b/tests/nexus/platform/nexus_node.cpp
@@ -103,6 +103,28 @@ void Node::AllowList(Node &aNode)
 
 void Node::UnallowList(Node &aNode) { Get<Mac::Filter>().RemoveAddress(aNode.Get<Mac::Mac>().GetExtAddress()); }
 
+void Node::SendEchoRequest(const Ip6::Address &aDestination,
+                           uint16_t            aIdentifier,
+                           uint16_t            aPayloadSize,
+                           uint8_t             aHopLimit)
+{
+    Message         *message;
+    Ip6::MessageInfo messageInfo;
+
+    message = Get<Ip6::Icmp>().NewMessage();
+    VerifyOrQuit(message != nullptr);
+
+    SuccessOrQuit(message->SetLength(aPayloadSize));
+
+    messageInfo.SetPeerAddr(aDestination);
+    messageInfo.SetHopLimit(aHopLimit);
+
+    Log("Sending Echo Request from Node %lu (%s) to %s (payload-size:%u)", ToUlong(GetId()), GetName(),
+        aDestination.ToString().AsCString(), aPayloadSize);
+
+    SuccessOrQuit(Get<Ip6::Icmp>().SendEchoRequest(*message, messageInfo, aIdentifier));
+}
+
 void Node::SetName(const char *aPrefix, uint16_t aIndex) { mName.Clear().Append("%s %u", aPrefix, aIndex); }
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE

--- a/tests/nexus/platform/nexus_node.hpp
+++ b/tests/nexus/platform/nexus_node.hpp
@@ -79,6 +79,10 @@ public:
     void Join(Node &aNode, JoinMode aJoinMode = kAsFtd);
     void AllowList(Node &aNode);
     void UnallowList(Node &aNode);
+    void SendEchoRequest(const Ip6::Address &aDestination,
+                         uint16_t            aIdentifier,
+                         uint16_t            aPayloadSize = 0,
+                         uint8_t             aHopLimit    = 64);
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
     void GetTrelSockAddr(Ip6::SockAddr &aSockAddr) const;
 #endif

--- a/tests/nexus/test_5_1_2.cpp
+++ b/tests/nexus/test_5_1_2.cpp
@@ -64,17 +64,6 @@ static constexpr uint32_t kChildTimeoutWaitTime = (kChildTimeout + 2) * 1000;
  */
 static constexpr uint32_t kEchoRequestWaitTime = 5 * 1000;
 
-static void SendEchoRequest(Node &aSender, const Ip6::Address &aPeerAddr, uint16_t aIdentifier)
-{
-    Message         *message = aSender.Get<Ip6::Icmp>().NewMessage();
-    Ip6::MessageInfo messageInfo;
-
-    VerifyOrQuit(message != nullptr);
-    messageInfo.SetPeerAddr(aPeerAddr);
-    messageInfo.SetHopLimit(64);
-    SuccessOrQuit(aSender.Get<Ip6::Icmp>().SendEchoRequest(*message, messageInfo, aIdentifier));
-}
-
 void Test5_1_2(void)
 {
     /**
@@ -167,7 +156,7 @@ void Test5_1_2(void)
      * Leader automatically attempts to perform address resolution by sending an Address Query Request
      * - Pass Criteria: N/A
      */
-    SendEchoRequest(leader, med.Get<Mle::Mle>().GetMeshLocalEid(), 0x1234);
+    leader.SendEchoRequest(med.Get<Mle::Mle>().GetMeshLocalEid(), 0x1234);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 4: Router_1 (DUT)");
@@ -188,7 +177,7 @@ void Test5_1_2(void)
      * Leader automatically attempts to perform address resolution by sending an Address Query Request
      * - Pass Criteria: N/A
      */
-    SendEchoRequest(leader, sed.Get<Mle::Mle>().GetMeshLocalEid(), 0x5678);
+    leader.SendEchoRequest(sed.Get<Mle::Mle>().GetMeshLocalEid(), 0x5678);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 7: Router_1 (DUT)");

--- a/tests/nexus/test_5_2_4.cpp
+++ b/tests/nexus/test_5_2_4.cpp
@@ -61,24 +61,9 @@ static constexpr uint32_t kReedAdvertisementMaxJitter = 60 * 1000;
 static constexpr uint32_t kWaitTime = kReedAdvertisementInterval + kReedAdvertisementMaxJitter;
 
 /**
- * Time to wait for ICMPv6 Echo Response.
- */
-static constexpr uint32_t kEchoResponseTime = 1000;
-
-/**
  * Number of routers in the topology besides the leader.
  */
 static constexpr uint16_t kNumRouters = 15;
-
-/**
- * Hop limit for ICMPv6 Echo Request.
- */
-static constexpr uint8_t kEchoHopLimit = 64;
-
-/**
- * Echo Request Identifier.
- */
-static constexpr uint16_t kEchoIdentifier = 0x1234;
 
 void Test5_2_4(void)
 {
@@ -281,18 +266,7 @@ void Test5_2_4(void)
      *   Leader.
      * - Pass Criteria: The Leader MUST respond with an ICMPv6 Echo Reply.
      */
-    {
-        Message         *message = med1.Get<Ip6::Icmp>().NewMessage();
-        Ip6::MessageInfo messageInfo;
-
-        VerifyOrQuit(message != nullptr);
-        messageInfo.SetPeerAddr(leader.Get<Mle::Mle>().GetMeshLocalEid());
-        messageInfo.SetHopLimit(kEchoHopLimit);
-
-        SuccessOrQuit(med1.Get<Ip6::Icmp>().SendEchoRequest(*message, messageInfo, kEchoIdentifier));
-    }
-
-    nexus.AdvanceTime(kEchoResponseTime);
+    nexus.SendAndVerifyEchoRequest(med1, leader.Get<Mle::Mle>().GetMeshLocalEid());
 
     nexus.SaveTestInfo("test_5_2_4.json");
 }


### PR DESCRIPTION
This commit adds helper methods in Nexus to simplify ICMPv6 echo exchanges:
- `Node::SendEchoRequest()`: sends an ICMPv6 Echo Request with configurable parameters such as payload size and hop limit.
- `Core::SendAndVerifyEchoRequest()`: sends an Echo Request and validates the matching Echo Reply within a timeout.

This commit also update various certification tests to use these helpers, removing duplicate local utility functions.