### PR TITLE
[ip6] expose static multicast address getters and remove wrapper methods

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -494,7 +494,6 @@ void RoutingManager::SendRouterAdvertisement(RouterAdvTxMode aRaTxMode)
     Error                     error = kErrorNone;
     RouterAdvert::TxMessage   raMsg;
     RouterAdvert::Header      header;
-    Ip6::Address              destAddress;
     InfraIf::Icmp6Packet      packet;
     InfraIf::LinkLayerAddress linkAddr;
 
@@ -545,12 +544,11 @@ void RoutingManager::SendRouterAdvertisement(RouterAdvTxMode aRaTxMode)
     // Exit when the size of packet is less than the size of header.
     VerifyOrExit(raMsg.ContainsAnyOptions());
 
-    destAddress.SetToLinkLocalAllNodesMulticast();
     raMsg.GetAsPacket(packet);
 
     mTxRaInfo.IncrementTxCountAndSaveHash(packet);
 
-    SuccessOrExit(error = Get<InfraIf>().Send(packet, destAddress));
+    SuccessOrExit(error = Get<InfraIf>().Send(packet, Ip6::Address::GetLinkLocalAllNodesMulticast()));
 
     mTxRaInfo.mLastTxTime = TimerMilli::GetNow();
     Get<Ip6::Ip6>().GetBorderRoutingCounters().mRaTxSuccess++;

--- a/src/core/border_router/rx_ra_tracker.cpp
+++ b/src/core/border_router/rx_ra_tracker.cpp
@@ -1825,7 +1825,6 @@ void RxRaTracker::RsSender::Stop(void) { mTimer.Stop(); }
 
 Error RxRaTracker::RsSender::SendRs(void)
 {
-    Ip6::Address              destAddress;
     RouterSolicitHeader       rsHdr;
     TxMessage                 rsMsg;
     InfraIf::LinkLayerAddress linkAddr;
@@ -1840,9 +1839,8 @@ Error RxRaTracker::RsSender::SendRs(void)
     }
 
     rsMsg.GetAsPacket(packet);
-    destAddress.SetToLinkLocalAllRoutersMulticast();
 
-    error = Get<InfraIf>().Send(packet, destAddress);
+    error = Get<InfraIf>().Send(packet, Ip6::Address::GetLinkLocalAllRoutersMulticast());
 
     if (error == kErrorNone)
     {

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -266,7 +266,7 @@ void Client::Solicit(uint16_t aRloc16)
     SuccessOrExit(error = AppendRapidCommitOption(*message));
 
 #if OPENTHREAD_ENABLE_DHCP6_MULTICAST_SOLICIT
-    messageInfo.GetPeerAddr().SetToRealmLocalAllRoutersMulticast();
+    messageInfo.SetPeerAddr(Ip6::Address::GetRealmLocalAllRoutersMulticast());
 #else
     messageInfo.GetPeerAddr().SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aRloc16);
 #endif

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -212,7 +212,7 @@ Error Ip6::PrepareMulticastToLargerThanRealmLocal(Message &aMessage, const Heade
     tunnelHeader.SetHopLimit(kDefaultHopLimit);
     tunnelHeader.SetPayloadLength(aHeader.GetPayloadLength() + sizeof(tunnelHeader));
     tunnelHeader.SetSource(Get<Mle::Mle>().GetMeshLocalRloc());
-    tunnelHeader.GetDestination().SetToRealmLocalAllMplForwarders();
+    tunnelHeader.SetDestination(Address::GetRealmLocalAllMplForwarders());
     tunnelHeader.SetNextHeader(kProtoIp6);
 
     SuccessOrExit(error = AddMplOption(aMessage, tunnelHeader));

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -325,29 +325,9 @@ bool Address::IsLinkLocalMulticast(void) const { return IsMulticast() && (GetSco
 
 bool Address::IsLinkLocalUnicastOrMulticast(void) const { return IsLinkLocalUnicast() || IsLinkLocalMulticast(); }
 
-bool Address::IsLinkLocalAllNodesMulticast(void) const { return (*this == GetLinkLocalAllNodesMulticast()); }
-
-void Address::SetToLinkLocalAllNodesMulticast(void) { *this = GetLinkLocalAllNodesMulticast(); }
-
-bool Address::IsLinkLocalAllRoutersMulticast(void) const { return (*this == GetLinkLocalAllRoutersMulticast()); }
-
-void Address::SetToLinkLocalAllRoutersMulticast(void) { *this = GetLinkLocalAllRoutersMulticast(); }
-
 bool Address::IsRealmLocalMulticast(void) const { return IsMulticast() && (GetScope() == kRealmLocalScope); }
 
 bool Address::IsMulticastLargerThanRealmLocal(void) const { return IsMulticast() && (GetScope() > kRealmLocalScope); }
-
-bool Address::IsRealmLocalAllNodesMulticast(void) const { return (*this == GetRealmLocalAllNodesMulticast()); }
-
-void Address::SetToRealmLocalAllNodesMulticast(void) { *this = GetRealmLocalAllNodesMulticast(); }
-
-bool Address::IsRealmLocalAllRoutersMulticast(void) const { return (*this == GetRealmLocalAllRoutersMulticast()); }
-
-void Address::SetToRealmLocalAllRoutersMulticast(void) { *this = GetRealmLocalAllRoutersMulticast(); }
-
-bool Address::IsRealmLocalAllMplForwarders(void) const { return (*this == GetRealmLocalAllMplForwarders()); }
-
-void Address::SetToRealmLocalAllMplForwarders(void) { *this = GetRealmLocalAllMplForwarders(); }
 
 bool Address::IsIp4Mapped(void) const
 {

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -621,32 +621,6 @@ public:
     bool IsLinkLocalUnicastOrMulticast(void) const;
 
     /**
-     * Indicates whether or not the IPv6 address is a link-local all nodes multicast address (ff02::01).
-     *
-     * @retval TRUE   If the IPv6 address is a link-local all nodes multicast address.
-     * @retval FALSE  If the IPv6 address is not a link-local all nodes multicast address.
-     */
-    bool IsLinkLocalAllNodesMulticast(void) const;
-
-    /**
-     * Sets the IPv6 address to the link-local all nodes multicast address (ff02::01).
-     */
-    void SetToLinkLocalAllNodesMulticast(void);
-
-    /**
-     * Indicates whether or not the IPv6 address is a link-local all routers multicast address (ff02::02).
-     *
-     * @retval TRUE   If the IPv6 address is a link-local all routers multicast address.
-     * @retval FALSE  If the IPv6 address is not a link-local all routers multicast address.
-     */
-    bool IsLinkLocalAllRoutersMulticast(void) const;
-
-    /**
-     * Sets the IPv6 address to the link-local all routers multicast address (ff02::02).
-     */
-    void SetToLinkLocalAllRoutersMulticast(void);
-
-    /**
      * Indicates whether or not the IPv6 address is a realm-local multicast address.
      *
      * @retval TRUE   If the IPv6 address is a realm-local multicast address.
@@ -655,51 +629,47 @@ public:
     bool IsRealmLocalMulticast(void) const;
 
     /**
-     * Indicates whether or not the IPv6 address is a realm-local all nodes multicast address (ff03::01).
-     *
-     * @retval TRUE   If the IPv6 address is a realm-local all nodes multicast address.
-     * @retval FALSE  If the IPv6 address is not a realm-local all nodes multicast address.
-     */
-    bool IsRealmLocalAllNodesMulticast(void) const;
-
-    /**
-     * Sets the IPv6 address to the realm-local all nodes multicast address (ff03::01)
-     */
-    void SetToRealmLocalAllNodesMulticast(void);
-
-    /**
-     * Indicates whether or not the IPv6 address is a realm-local all routers multicast address (ff03::02).
-     *
-     * @retval TRUE   If the IPv6 address is a realm-local all routers multicast address.
-     * @retval FALSE  If the IPv6 address is not a realm-local all routers multicast address.
-     */
-    bool IsRealmLocalAllRoutersMulticast(void) const;
-
-    /**
-     * Sets the IPv6 address to the realm-local all routers multicast address (ff03::02).
-     */
-    void SetToRealmLocalAllRoutersMulticast(void);
-
-    /**
-     * Indicates whether or not the IPv6 address is a realm-local all MPL forwarders address (ff03::fc).
-     *
-     * @retval TRUE   If the IPv6 address is a realm-local all MPL forwarders address.
-     * @retval FALSE  If the IPv6 address is not a realm-local all MPL forwarders address.
-     */
-    bool IsRealmLocalAllMplForwarders(void) const;
-
-    /**
-     * Sets the the IPv6 address to the realm-local all MPL forwarders address (ff03::fc).
-     */
-    void SetToRealmLocalAllMplForwarders(void);
-
-    /**
      * Indicates whether or not the IPv6 address is multicast larger than realm local.
      *
      * @retval TRUE   If the IPv6 address is multicast larger than realm local.
      * @retval FALSE  If the IPv6 address is not multicast or the scope is not larger than realm local.
      */
     bool IsMulticastLargerThanRealmLocal(void) const;
+
+    /**
+     * Returns the link-local all nodes multicast address (ff02::01).
+     *
+     * @returns The link-local all nodes multicast address.
+     */
+    static const Address &GetLinkLocalAllNodesMulticast(void);
+
+    /**
+     * Returns the link-local all routers multicast address (ff02::02)
+     *
+     * @returns The link-local all routers multicast address.
+     */
+    static const Address &GetLinkLocalAllRoutersMulticast(void);
+
+    /**
+     * Returns the realm-local all nodes multicast address (ff03::01)
+     *
+     * @returns The realm-local all nodes multicast address.
+     */
+    static const Address &GetRealmLocalAllNodesMulticast(void);
+
+    /**
+     * Returns the realm-local all routers multicast address (ff03::02).
+     *
+     * @returns The realm-local all routers multicast address.
+     */
+    static const Address &GetRealmLocalAllRoutersMulticast(void);
+
+    /**
+     * Returns the realm-local all MPL forwarders address (ff03::fc).
+     *
+     * @returns The realm-local all MPL forwarders address.
+     */
+    static const Address &GetRealmLocalAllMplForwarders(void);
 
     /**
      * Sets the IPv6 address to a Routing Locator (RLOC) IPv6 address with a given Network Prefix and
@@ -950,12 +920,6 @@ private:
     void SetToLocator(const NetworkPrefix &aNetworkPrefix, uint16_t aLocator);
     void ToString(StringWriter &aWriter) const;
     void AppendHexWords(StringWriter &aWriter, uint8_t aLength) const;
-
-    static const Address &GetLinkLocalAllNodesMulticast(void);
-    static const Address &GetLinkLocalAllRoutersMulticast(void);
-    static const Address &GetRealmLocalAllNodesMulticast(void);
-    static const Address &GetRealmLocalAllRoutersMulticast(void);
-    static const Address &GetRealmLocalAllMplForwarders(void);
 
     static void CopyBits(uint8_t *aDst, const uint8_t *aSrc, uint8_t aNumBits);
 

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -64,7 +64,6 @@ Error DiscoverScanner::Discover(const Mac::ChannelMask &aScanChannels,
     Error                             error   = kErrorNone;
     Mle::TxMessage                   *message = nullptr;
     Tlv::Bookmark                     tlvBookmark;
-    Ip6::Address                      destination;
     MeshCoP::DiscoveryRequestTlvValue discoveryRequestTlvValue;
 
     VerifyOrExit(Get<ThreadNetif>().IsUp(), error = kErrorInvalidState);
@@ -131,9 +130,7 @@ Error DiscoverScanner::Discover(const Mac::ChannelMask &aScanChannels,
 
     message->RegisterTxCallback(HandleDiscoveryRequestFrameTxDone, this);
 
-    destination.SetToLinkLocalAllRoutersMulticast();
-
-    SuccessOrExit(error = message->SendTo(destination));
+    SuccessOrExit(error = message->SendTo(Ip6::Address::GetLinkLocalAllRoutersMulticast()));
 
     if ((aPanId == Mac::kPanIdBroadcast) && (Get<Mac::Mac>().GetPanId() == Mac::kPanIdBroadcast))
     {
@@ -156,7 +153,7 @@ Error DiscoverScanner::Discover(const Mac::ChannelMask &aScanChannels,
         Get<MeshForwarder>().SetRxOnWhenIdle(true);
     }
 
-    Mle::Log(Mle::kMessageSend, Mle::kTypeDiscoveryRequest, destination);
+    Mle::Log(Mle::kMessageSend, Mle::kTypeDiscoveryRequest, Ip6::Address::GetLinkLocalAllRoutersMulticast());
 
 exit:
     FreeMessageOnError(message, error);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1368,11 +1368,7 @@ exit:
 
 void Mle::SendAnnounce(uint8_t aChannel, AnnounceMode aMode)
 {
-    Ip6::Address destination;
-
-    destination.SetToLinkLocalAllNodesMulticast();
-
-    SendAnnounce(aChannel, destination, aMode);
+    SendAnnounce(aChannel, Ip6::Address::GetLinkLocalAllNodesMulticast(), aMode);
 }
 
 void Mle::SendAnnounce(uint8_t aChannel, const Ip6::Address &aDestination, AnnounceMode aMode)
@@ -3194,13 +3190,9 @@ exit:
 
 void Mle::DelayedSender::ScheduleMulticastDataResponse(uint32_t aDelay)
 {
-    Ip6::Address destination;
-
-    destination.SetToLinkLocalAllNodesMulticast();
-
     Get<MeshForwarder>().RemoveDataResponseMessages();
-    RemoveMatchingSchedules(kTypeDataResponse, destination);
-    AddSchedule(kTypeDataResponse, destination, aDelay, nullptr, 0);
+    RemoveMatchingSchedules(kTypeDataResponse, Ip6::Address::GetLinkLocalAllNodesMulticast());
+    AddSchedule(kTypeDataResponse, Ip6::Address::GetLinkLocalAllNodesMulticast(), aDelay, nullptr, 0);
 }
 
 void Mle::DelayedSender::ScheduleLinkRequest(const Router &aRouter, uint32_t aDelay)
@@ -4904,7 +4896,7 @@ void Mle::Attacher::SendParentRequest(ParentRequestType aType)
     else
 #endif
     {
-        destination.SetToLinkLocalAllRoutersMulticast();
+        destination = Ip6::Address::GetLinkLocalAllRoutersMulticast();
     }
 
     SuccessOrExit(error = message->SendTo(destination));

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -498,13 +498,7 @@ exit:
     return;
 }
 
-void Mle::SendMulticastAdvertisement(void)
-{
-    Ip6::Address destination;
-
-    destination.SetToLinkLocalAllNodesMulticast();
-    SendAdvertisement(destination);
-}
+void Mle::SendMulticastAdvertisement(void) { SendAdvertisement(Ip6::Address::GetLinkLocalAllNodesMulticast()); }
 
 void Mle::ScheduleUnicastAdvertisementTo(const Router &aRouter)
 {
@@ -615,7 +609,7 @@ void Mle::SendLinkRequest(Router *aRouter)
     {
         mPrevRoleRestorer.GenerateRandomChallenge();
         SuccessOrExit(error = message->AppendChallengeTlv(mPrevRoleRestorer.GetChallenge()));
-        destination.SetToLinkLocalAllRoutersMulticast();
+        destination = Ip6::Address::GetLinkLocalAllRoutersMulticast();
     }
     else
     {
@@ -3104,12 +3098,10 @@ exit:
 
 void Mle::SendMulticastDataResponse(void)
 {
-    Ip6::Address destination;
-    TlvList      tlvList;
+    TlvList tlvList;
 
-    destination.SetToLinkLocalAllNodesMulticast();
     tlvList.Add(Tlv::kNetworkData);
-    SendDataResponse(destination, tlvList);
+    SendDataResponse(Ip6::Address::GetLinkLocalAllNodesMulticast(), tlvList);
 }
 
 void Mle::SendDataResponse(const Ip6::Address &aDestination, const TlvList &aTlvList, const Message *aRequestMessage)
@@ -3913,7 +3905,7 @@ Error Mle::SendTimeSync(void)
 
     message->SetTimeSync(true);
 
-    destination.SetToLinkLocalAllNodesMulticast();
+    destination = Ip6::Address::GetLinkLocalAllNodesMulticast();
     SuccessOrExit(error = message->SendTo(destination));
 
     Log(kMessageSend, kTypeTimeSync, destination);

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -58,7 +58,7 @@ void MessageInfo::SetSockAddrToRlocPeerAddrToLeaderRloc(void)
 void MessageInfo::SetSockAddrToRlocPeerAddrToRealmLocalAllRoutersMulticast(void)
 {
     SetSockAddrToRloc();
-    GetPeerAddr().SetToRealmLocalAllRoutersMulticast();
+    SetPeerAddr(Ip6::Address::GetRealmLocalAllRoutersMulticast());
 }
 
 void MessageInfo::SetSockAddrToRlocPeerAddrTo(uint16_t aRloc16)

--- a/tests/nexus/test_5_3_1.cpp
+++ b/tests/nexus/test_5_3_1.cpp
@@ -101,12 +101,6 @@ void Test5_3_1(void)
     nexus.AdvanceTime(kAttachToRouterTime);
     VerifyOrQuit(dut.Get<Mle::Mle>().IsRouter());
 
-    Ip6::Address allNodesMulticast;
-    allNodesMulticast.SetToLinkLocalAllNodesMulticast();
-
-    Ip6::Address allRoutersMulticast;
-    allRoutersMulticast.SetToLinkLocalAllRoutersMulticast();
-
     const Ip6::Address &dutAddr = dut.Get<Mle::Mle>().GetLinkLocalAddress();
 
     Log("---------------------------------------------------------------------------------------");
@@ -140,7 +134,7 @@ void Test5_3_1(void)
      *   multicast address (FF02::1)
      * - Pass Criteria: The DUT MUST respond with an ICMPv6 Echo Reply
      */
-    nexus.SendAndVerifyEchoRequest(leader, allNodesMulticast, kEchoPayloadSize);
+    nexus.SendAndVerifyEchoRequest(leader, Ip6::Address::GetLinkLocalAllNodesMulticast(), kEchoPayloadSize);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 5: Leader sends fragmented Echo Request to All Nodes multicast address");
@@ -151,7 +145,7 @@ void Test5_3_1(void)
      *   multicast address (FF02::1)
      * - Pass Criteria: The DUT MUST respond with an ICMPv6 Echo Reply
      */
-    nexus.SendAndVerifyEchoRequest(leader, allNodesMulticast, kFragmentedEchoPayloadSize);
+    nexus.SendAndVerifyEchoRequest(leader, Ip6::Address::GetLinkLocalAllNodesMulticast(), kFragmentedEchoPayloadSize);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 6: Leader sends Echo Request to All Routers multicast address");
@@ -162,7 +156,7 @@ void Test5_3_1(void)
      *   multicast address (FF02::2)
      * - Pass Criteria: The DUT MUST respond with an ICMPv6 Echo Reply
      */
-    nexus.SendAndVerifyEchoRequest(leader, allRoutersMulticast, kEchoPayloadSize);
+    nexus.SendAndVerifyEchoRequest(leader, Ip6::Address::GetLinkLocalAllRoutersMulticast(), kEchoPayloadSize);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 7: Leader sends fragmented Echo Request to All Routers multicast address");
@@ -173,7 +167,7 @@ void Test5_3_1(void)
      *   All-Routers multicast address (FF02::2)
      * - Pass Criteria: The DUT MUST respond with an ICMPv6 Echo Reply
      */
-    nexus.SendAndVerifyEchoRequest(leader, allRoutersMulticast, kFragmentedEchoPayloadSize);
+    nexus.SendAndVerifyEchoRequest(leader, Ip6::Address::GetLinkLocalAllRoutersMulticast(), kFragmentedEchoPayloadSize);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 8: Leader sends Echo Request to All Thread Nodes multicast address");

--- a/tests/nexus/test_5_3_2.cpp
+++ b/tests/nexus/test_5_3_2.cpp
@@ -149,11 +149,7 @@ void Test5_3_2(void)
      *   - The DUT MUST NOT forward the ICMPv6 Echo Request to SED_1.
      */
     Log("Step 4: Leader");
-    {
-        Ip6::Address multicastAddr;
-        multicastAddr.SetToRealmLocalAllNodesMulticast();
-        nexus.SendAndVerifyEchoRequest(leader, multicastAddr);
-    }
+    nexus.SendAndVerifyEchoRequest(leader, Ip6::Address::GetRealmLocalAllNodesMulticast());
 
     /**
      * Step 5: Leader
@@ -164,11 +160,7 @@ void Test5_3_2(void)
      *   - The DUT MUST NOT forward the ICMPv6 Echo Request to SED_1.
      */
     Log("Step 5: Leader");
-    {
-        Ip6::Address multicastAddr;
-        multicastAddr.SetToRealmLocalAllNodesMulticast();
-        nexus.SendAndVerifyEchoRequest(leader, multicastAddr, kLargePayloadSize);
-    }
+    nexus.SendAndVerifyEchoRequest(leader, Ip6::Address::GetRealmLocalAllNodesMulticast(), kLargePayloadSize);
 
     /**
      * Step 6: Leader
@@ -179,11 +171,7 @@ void Test5_3_2(void)
      *   - The DUT MUST NOT forward the ICMPv6 Echo Request to SED_1.
      */
     Log("Step 6: Leader");
-    {
-        Ip6::Address multicastAddr;
-        multicastAddr.SetToRealmLocalAllRoutersMulticast();
-        nexus.SendAndVerifyEchoRequest(leader, multicastAddr);
-    }
+    nexus.SendAndVerifyEchoRequest(leader, Ip6::Address::GetRealmLocalAllRoutersMulticast());
 
     /**
      * Step 7: Leader
@@ -194,11 +182,7 @@ void Test5_3_2(void)
      *   - The DUT MUST NOT forward the ICMPv6 Echo Request to SED_1.
      */
     Log("Step 7: Leader");
-    {
-        Ip6::Address multicastAddr;
-        multicastAddr.SetToRealmLocalAllRoutersMulticast();
-        nexus.SendAndVerifyEchoRequest(leader, multicastAddr, kLargePayloadSize);
-    }
+    nexus.SendAndVerifyEchoRequest(leader, Ip6::Address::GetRealmLocalAllRoutersMulticast(), kLargePayloadSize);
 
     /**
      * Step 8: Leader


### PR DESCRIPTION
This commit updates `Ip6::Address` to expose `static` getter methods for common multicast addresses (e.g., `GetLinkLocalAllNodesMulticast()`) as public API.

Consequentially, the wrapper `SetTo...` and `Is...` methods for these multicast addresses are removed. Callers are updated to use the `static` getters directly. This change simplifies usage by allowing direct access to the constant address instances, often eliminating the need for local `Ip6::Address` variables.