### PR TITLE
[nexus] fix flaky test 5.2.3 by increasing downgrade threshold

### DIFF
--- a/tests/nexus/test_5_2_3.cpp
+++ b/tests/nexus/test_5_2_3.cpp
@@ -89,9 +89,11 @@ void Test5_2_3(void)
     Instance::SetLogLevel(kLogLevelNote);
 
     leader.Get<Mle::Mle>().SetRouterUpgradeThreshold(kMaxRouters);
+    leader.Get<Mle::Mle>().SetRouterDowngradeThreshold(kMaxRouters);
     for (uint8_t i = 0; i < kMaxRouters; i++)
     {
         routers[i]->Get<Mle::Mle>().SetRouterUpgradeThreshold(kMaxRouters);
+        routers[i]->Get<Mle::Mle>().SetRouterDowngradeThreshold(kMaxRouters);
     }
 
     // Topology:
@@ -179,7 +181,7 @@ void Test5_2_3(void)
     VerifyOrQuit(routers[kMaxRouters - 1]->Get<Mle::Mle>().IsChild());
 
     // Force Router 32 to try to become a router
-    routers[kMaxRouters - 1]->Get<Mle::Mle>().BecomeRouter(Mle::kReasonTooFewRouters);
+    SuccessOrQuit(routers[kMaxRouters - 1]->Get<Mle::Mle>().BecomeRouter(Mle::kReasonTooFewRouters));
 
     Log("---------------------------------------------------------------------------------------");
     /**


### PR DESCRIPTION
This commit fixes a flakiness in Nexus test 5.2.3 'Leader rejects CoAP Address Solicit (2-hops from Leader)'.

The test builds a topology with 32 routers (the maximum allowed). Occasionally, some routers would spontaneously downgrade to REEDs during the setup phase because the default Router Downgrade Threshold is 23. This led to failures when the test verified that all 31 joining nodes had become routers.

The fix sets both 'RouterUpgradeThreshold' and 'RouterDowngradeThreshold' to 'kMaxRouters' (32) for the leader and all routers, ensuring they remain in the router role throughout the test.

Additionally, this commit wraps the 'BecomeRouter' call with 'SuccessOrQuit' to resolve a compiler warning and ensure the operation's success is verified.

Summary of changes:
- Modified tests/nexus/test_5_2_3.cpp to set appropriate router thresholds and use SuccessOrQuit for role transition.