### PR TITLE
[nexus] use `OT_CFLAGS` for stricter build-time checks & fix warnings

### DIFF
--- a/tests/nexus/CMakeLists.txt
+++ b/tests/nexus/CMakeLists.txt
@@ -61,6 +61,7 @@ target_include_directories(ot-nexus-platform
 target_compile_options(ot-nexus-platform
     PRIVATE
         ${COMMON_COMPILE_OPTIONS}
+        ${OT_CFLAGS}
 )
 
 target_link_libraries(ot-nexus-platform
@@ -105,6 +106,7 @@ macro(ot_nexus_test name labels)
     target_compile_options(nexus_${name}
     PRIVATE
         ${COMMON_COMPILE_OPTIONS}
+        ${OT_CFLAGS}
     )
 
     add_test(NAME nexus_${name} COMMAND nexus_${name})

--- a/tests/nexus/platform/nexus_core.cpp
+++ b/tests/nexus/platform/nexus_core.cpp
@@ -40,9 +40,10 @@ Core *Core::sCore  = nullptr;
 bool  Core::sInUse = false;
 
 Core::Core(void)
-    : mNow(0)
-    , mCurNodeId(0)
+    : mCurNodeId(0)
     , mPendingAction(false)
+    , mNow(0)
+    , mActiveNode(nullptr)
 {
     const char *pcapFile;
 

--- a/tests/nexus/platform/nexus_core.hpp
+++ b/tests/nexus/platform/nexus_core.hpp
@@ -118,7 +118,7 @@ private:
     Node            *mActiveNode;
 };
 
-void Log(const char *aFormat, ...);
+void Log(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
 
 } // namespace Nexus
 } // namespace ot

--- a/tests/nexus/platform/nexus_misc.cpp
+++ b/tests/nexus/platform/nexus_misc.cpp
@@ -39,7 +39,8 @@
 namespace ot {
 namespace Nexus {
 
-static void LogVarArgs(Node *aActiveNode, const char *aFormat, va_list aArgs);
+static void LogVarArgs(Node *aActiveNode, const char *aFormat, va_list aArgs)
+    OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 0);
 
 extern "C" {
 

--- a/tests/nexus/platform/nexus_settings.cpp
+++ b/tests/nexus/platform/nexus_settings.cpp
@@ -74,12 +74,12 @@ Error Settings::Get(uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValue
     Error               error = kErrorNone;
     const Entry        *entry;
     const Entry::Value *value;
-    IndexMatcher        IndexMatcher(aIndex);
+    IndexMatcher        indexMatcher(aIndex);
 
     entry = mEntries.FindMatching(aKey);
     VerifyOrExit(entry != nullptr, error = kErrorNotFound);
 
-    value = entry->mValues.FindMatching(IndexMatcher);
+    value = entry->mValues.FindMatching(indexMatcher);
     VerifyOrExit(value != nullptr, error = kErrorNotFound);
 
     if (aValueLength != nullptr)
@@ -130,9 +130,8 @@ Error Settings::SetOrAdd(SetAddMode aMode, uint16_t aKey, const uint8_t *aValue,
 
 Error Settings::Delete(uint16_t aKey, int aIndex)
 {
-    Error         error = kErrorNone;
-    Entry        *entry;
-    Entry::Value *preValue;
+    Error  error = kErrorNone;
+    Entry *entry;
 
     entry = mEntries.FindMatching(aKey);
     VerifyOrExit(entry != nullptr, error = kErrorNotFound);

--- a/tests/nexus/test_5_1_8.cpp
+++ b/tests/nexus/test_5_1_8.cpp
@@ -54,7 +54,6 @@ static constexpr uint32_t kAttachAsChildTime = 10 * 1000;
  * All these values result in Link Quality 3 (highest).
  */
 static constexpr int8_t kRssiHigh = -20;
-static constexpr int8_t kRssiMid  = -40;
 static constexpr int8_t kRssiLow  = -60;
 
 void Test5_1_8(void)

--- a/tests/nexus/test_border_admitter.cpp
+++ b/tests/nexus/test_border_admitter.cpp
@@ -289,6 +289,8 @@ struct ResponseContext : public AdmitterInfo, public Clearable<ResponseContext>
 
 void HandleResponse(void *aContext, Coap::Msg *aMsg, Error aResult)
 {
+    OT_UNUSED_VARIABLE(aResult);
+
     ResponseContext *responseContext;
 
     VerifyOrQuit(aContext != nullptr);
@@ -338,7 +340,6 @@ bool HandleResource(void *aContext, Uri aUri, Coap::Msg &aMsg)
     AdmitterInfo            *info;
     Message                 *msgClone;
     uint16_t                 joinerPort;
-    uint16_t                 joinerRouterRloc;
     Ip6::InterfaceIdentifier joinerIid;
 
     VerifyOrQuit(aContext != nullptr);
@@ -376,7 +377,6 @@ bool HandleResource(void *aContext, Uri aUri, Coap::Msg &aMsg)
         break;
     }
 
-exit:
     return didHandle;
 }
 
@@ -1054,8 +1054,6 @@ void TestBorderAdmitterEnrollerInteraction(void)
 void TestBorderAdmitterCommissionerConflictAndPetitionerRetry(void)
 {
     static const char kEnrollerId[] = "TestEnroller1234";
-
-    static const uint8_t kEnrollerTimeoutInSec = 50;
 
     Core                   nexus;
     Node                  &admitter   = nexus.CreateNode();
@@ -1868,9 +1866,10 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
 
     for (uint8_t i = 0; i < kNumEnrollers; i++)
     {
-        Coap::Message           *message = AsCoapMessagePtr(recvContext[i].mRelayRxMsgs.GetHead());
         Ip6::InterfaceIdentifier readIid;
         uint16_t                 joinerRouterRloc;
+
+        message = AsCoapMessagePtr(recvContext[i].mRelayRxMsgs.GetHead());
 
         if ((modes[i] & MeshCoP::EnrollerModeTlv::kForwardJoinerRelayRx) == 0)
         {
@@ -1964,9 +1963,10 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
 
     for (uint8_t i = 0; i < kNumEnrollers; i++)
     {
-        Coap::Message           *message = AsCoapMessagePtr(recvContext[i].mRelayRxMsgs.GetHead());
         Ip6::InterfaceIdentifier readIid;
         uint16_t                 joinerRouterRloc;
+
+        message = AsCoapMessagePtr(recvContext[i].mRelayRxMsgs.GetHead());
 
         if (i != 0)
         {
@@ -2011,9 +2011,10 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
 
     for (uint8_t i = 0; i < kNumEnrollers; i++)
     {
-        Coap::Message           *message = AsCoapMessagePtr(recvContext[i].mRelayRxMsgs.GetHead());
         Ip6::InterfaceIdentifier readIid;
         uint16_t                 joinerRouterRloc;
+
+        message = AsCoapMessagePtr(recvContext[i].mRelayRxMsgs.GetHead());
 
         if ((modes[i] & MeshCoP::EnrollerModeTlv::kForwardJoinerRelayRx) == 0)
         {
@@ -2146,9 +2147,10 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
 
     for (uint8_t i = 0; i < kNumEnrollers; i++)
     {
-        Coap::Message           *message = AsCoapMessagePtr(recvContext[i].mRelayRxMsgs.GetHead());
         Ip6::InterfaceIdentifier readIid;
         uint16_t                 joinerRouterRloc;
+
+        message = AsCoapMessagePtr(recvContext[i].mRelayRxMsgs.GetHead());
 
         if (i != 0)
         {
@@ -2259,9 +2261,10 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
 
     for (uint8_t i = 0; i < kNumEnrollers; i++)
     {
-        Coap::Message           *message = AsCoapMessagePtr(recvContext[i].mRelayRxMsgs.GetHead());
         Ip6::InterfaceIdentifier readIid;
         uint16_t                 joinerRouterRloc;
+
+        message = AsCoapMessagePtr(recvContext[i].mRelayRxMsgs.GetHead());
 
         if (i != 0)
         {
@@ -2738,9 +2741,10 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
 
     for (uint8_t i = 0; i < kNumEnrollers; i++)
     {
-        Coap::Message           *message = AsCoapMessagePtr(recvContext[i].mRelayRxMsgs.GetHead());
         Ip6::InterfaceIdentifier readIid;
         uint16_t                 joinerRouterRloc;
+
+        message = AsCoapMessagePtr(recvContext[i].mRelayRxMsgs.GetHead());
 
         if (i != 2)
         {
@@ -3146,9 +3150,10 @@ void TestBorderAdmitterForwardingUdpProxy(void)
 
     for (uint8_t i = 0; i < kNumEnrollers; i++)
     {
-        Coap::Message *message = AsCoapMessagePtr(recvContext[i].mProxyRxMsgs.GetHead());
-        Ip6::Address   senderAddr;
-        OffsetRange    offsetRange;
+        Ip6::Address senderAddr;
+        OffsetRange  offsetRange;
+
+        message = AsCoapMessagePtr(recvContext[i].mProxyRxMsgs.GetHead());
 
         if ((modes[i] & MeshCoP::EnrollerModeTlv::kForwardUdpProxyRx) == 0)
         {
@@ -3227,12 +3232,9 @@ void ValidateAdmitterMdnsService(Node &aNode)
 
 void TestBorderAdmitterDnssdService(void)
 {
-    Core                             nexus;
-    Node                            &node1 = nexus.CreateNode();
-    Node                            &node2 = nexus.CreateNode();
-    Dns::Multicast::Core::Iterator  *iterator;
-    Dns::Multicast::Core::Service    service;
-    Dns::Multicast::Core::EntryState entryState;
+    Core  nexus;
+    Node &node1 = nexus.CreateNode();
+    Node &node2 = nexus.CreateNode();
 
     Log("------------------------------------------------------------------------------------------------------");
     Log("TestBorderAdmitterDnssdService");

--- a/tests/nexus/test_dtls.cpp
+++ b/tests/nexus/test_dtls.cpp
@@ -153,6 +153,8 @@ public:
 private:
     static MeshCoP::SecureSession *HandleAccept(void *aContext, const Ip6::MessageInfo &aMessageInfo)
     {
+        OT_UNUSED_VARIABLE(aMessageInfo);
+
         return static_cast<DtlsTransportAndSingleSession *>(aContext)->HandleAccept();
     }
 
@@ -196,6 +198,8 @@ private:
 
     static MeshCoP::SecureSession *HandleAccept(void *aContext, const Ip6::MessageInfo &aMessageInfo)
     {
+        OT_UNUSED_VARIABLE(aMessageInfo);
+
         DtlsTransportAndHeapSession *transport;
         HeapDtlsSession             *session;
 

--- a/tests/nexus/test_trel.cpp
+++ b/tests/nexus/test_trel.cpp
@@ -41,9 +41,8 @@ namespace Nexus {
 static constexpr uint32_t kInfraIfIndex   = 1;
 static constexpr uint16_t kMaxTxtDataSize = 128;
 
-static constexpr ot::Trel::Peer::DnssdState kDnssdResolved  = ot::Trel::Peer::kDnssdResolved;
-static constexpr ot::Trel::Peer::DnssdState kDnssdRemoved   = ot::Trel::Peer::kDnssdRemoved;
-static constexpr ot::Trel::Peer::DnssdState kDnssdResolving = ot::Trel::Peer::kDnssdResolving;
+static constexpr ot::Trel::Peer::DnssdState kDnssdResolved = ot::Trel::Peer::kDnssdResolved;
+static constexpr ot::Trel::Peer::DnssdState kDnssdRemoved  = ot::Trel::Peer::kDnssdRemoved;
 
 void TestTrelBasic(void)
 {
@@ -327,7 +326,7 @@ void TestTrelDelayedMdnsStartAndPeerRemovalDelay(void)
     peer = node1.Get<ot::Trel::PeerTable>().GetHead();
     VerifyOrQuit(peer != nullptr);
 
-    VerifyOrQuit(peer->GetDnssdState() == ot::Trel::Peer::kDnssdRemoved);
+    VerifyOrQuit(peer->GetDnssdState() == kDnssdRemoved);
     VerifyOrQuit(peer->GetExtPanId() == node2.Get<MeshCoP::NetworkIdentity>().GetExtPanId());
     VerifyOrQuit(peer->GetExtAddress() == node2.Get<Mac::Mac>().GetExtAddress());
     VerifyOrQuit(peer->GetServiceName() != nullptr);
@@ -404,7 +403,7 @@ void TestTrelDelayedMdnsStartAndPeerRemovalDelay(void)
     peer = node1.Get<ot::Trel::PeerTable>().GetHead();
     VerifyOrQuit(peer != nullptr);
 
-    VerifyOrQuit(peer->GetDnssdState() == ot::Trel::Peer::kDnssdRemoved);
+    VerifyOrQuit(peer->GetDnssdState() == kDnssdRemoved);
     VerifyOrQuit(peer->GetExtPanId() == node2.Get<MeshCoP::NetworkIdentity>().GetExtPanId());
     VerifyOrQuit(peer->GetExtAddress() == node2.Get<Mac::Mac>().GetExtAddress());
     VerifyOrQuit(peer->GetSockAddr().GetAddress() == node2.mMdns.mIfAddresses[0]);
@@ -653,7 +652,6 @@ void TestMultiServiceSameHost(void)
     Core                          nexus;
     Node                         &node             = nexus.CreateNode();
     Node                         &multiServiceNode = nexus.CreateNode();
-    const ot::Trel::Peer         *peer;
     Dns::Multicast::Core::Service services[3];
     uint8_t                       txtData[kMaxTxtDataSize];
     Ip6::Address                  address;
@@ -663,10 +661,10 @@ void TestMultiServiceSameHost(void)
 
     nexus.AdvanceTime(0);
 
-    for (Node &node : nexus.GetNodes())
+    for (Node &nodeEntry : nexus.GetNodes())
     {
-        node.GetInstance().SetLogLevel(kLogLevelInfo);
-        VerifyOrQuit(!node.Get<Dns::Multicast::Core>().IsEnabled());
+        nodeEntry.GetInstance().SetLogLevel(kLogLevelInfo);
+        VerifyOrQuit(!nodeEntry.Get<Dns::Multicast::Core>().IsEnabled());
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -740,24 +738,24 @@ void TestMultiServiceSameHost(void)
 
     VerifyOrQuit(node.Get<ot::Trel::PeerTable>().GetNumberOfPeers() == 3);
 
-    for (const ot::Trel::Peer &peer : node.Get<ot::Trel::PeerTable>())
+    for (const ot::Trel::Peer &peerEntry : node.Get<ot::Trel::PeerTable>())
     {
         bool found = false;
 
-        VerifyOrQuit(peer.GetDnssdState() == kDnssdResolved);
-        VerifyOrQuit(peer.GetServiceName() != nullptr);
-        VerifyOrQuit(peer.GetHostName() != nullptr);
-        VerifyOrQuit(StringStartsWith(peer.GetHostName(), "ot"));
-        VerifyOrQuit(StringEndsWith(peer.GetHostName(),
+        VerifyOrQuit(peerEntry.GetDnssdState() == kDnssdResolved);
+        VerifyOrQuit(peerEntry.GetServiceName() != nullptr);
+        VerifyOrQuit(peerEntry.GetHostName() != nullptr);
+        VerifyOrQuit(StringStartsWith(peerEntry.GetHostName(), "ot"));
+        VerifyOrQuit(StringEndsWith(peerEntry.GetHostName(),
                                     multiServiceNode.Get<Mac::Mac>().GetExtAddress().ToString().AsCString()));
 
-        VerifyOrQuit(peer.GetSockAddr().GetAddress() == multiServiceNode.mMdns.mIfAddresses[0]);
-        VerifyOrQuit(peer.GetHostAddresses().GetLength() == 1);
-        VerifyOrQuit(peer.GetHostAddresses()[0] == multiServiceNode.mMdns.mIfAddresses[0]);
+        VerifyOrQuit(peerEntry.GetSockAddr().GetAddress() == multiServiceNode.mMdns.mIfAddresses[0]);
+        VerifyOrQuit(peerEntry.GetHostAddresses().GetLength() == 1);
+        VerifyOrQuit(peerEntry.GetHostAddresses()[0] == multiServiceNode.mMdns.mIfAddresses[0]);
 
         for (const Dns::Multicast::Core::Service &service : services)
         {
-            if (StringMatch(peer.GetServiceName(), service.mServiceInstance))
+            if (StringMatch(peerEntry.GetServiceName(), service.mServiceInstance))
             {
                 found = true;
             }
@@ -778,28 +776,28 @@ void TestMultiServiceSameHost(void)
 
     VerifyOrQuit(node.Get<ot::Trel::PeerTable>().GetNumberOfPeers() == 3);
 
-    for (const ot::Trel::Peer &peer : node.Get<ot::Trel::PeerTable>())
+    for (const ot::Trel::Peer &peerEntry : node.Get<ot::Trel::PeerTable>())
     {
         bool found = false;
 
-        if (peer.GetDnssdState() != kDnssdResolved)
+        if (peerEntry.GetDnssdState() != kDnssdResolved)
         {
             continue;
         }
 
-        VerifyOrQuit(peer.GetServiceName() != nullptr);
-        VerifyOrQuit(peer.GetHostName() != nullptr);
-        VerifyOrQuit(StringStartsWith(peer.GetHostName(), "ot"));
-        VerifyOrQuit(StringEndsWith(peer.GetHostName(),
+        VerifyOrQuit(peerEntry.GetServiceName() != nullptr);
+        VerifyOrQuit(peerEntry.GetHostName() != nullptr);
+        VerifyOrQuit(StringStartsWith(peerEntry.GetHostName(), "ot"));
+        VerifyOrQuit(StringEndsWith(peerEntry.GetHostName(),
                                     multiServiceNode.Get<Mac::Mac>().GetExtAddress().ToString().AsCString()));
 
-        VerifyOrQuit(peer.GetSockAddr().GetAddress() == multiServiceNode.mMdns.mIfAddresses[0]);
-        VerifyOrQuit(peer.GetHostAddresses().GetLength() == 1);
-        VerifyOrQuit(peer.GetHostAddresses()[0] == multiServiceNode.mMdns.mIfAddresses[0]);
+        VerifyOrQuit(peerEntry.GetSockAddr().GetAddress() == multiServiceNode.mMdns.mIfAddresses[0]);
+        VerifyOrQuit(peerEntry.GetHostAddresses().GetLength() == 1);
+        VerifyOrQuit(peerEntry.GetHostAddresses()[0] == multiServiceNode.mMdns.mIfAddresses[0]);
 
         for (uint16_t index = 0; index < 2; index++)
         {
-            if (StringMatch(peer.GetServiceName(), services[index].mServiceInstance))
+            if (StringMatch(peerEntry.GetServiceName(), services[index].mServiceInstance))
             {
                 found = true;
             }
@@ -823,29 +821,29 @@ void TestMultiServiceSameHost(void)
 
     VerifyOrQuit(node.Get<ot::Trel::PeerTable>().GetNumberOfPeers() == 3);
 
-    for (const ot::Trel::Peer &peer : node.Get<ot::Trel::PeerTable>())
+    for (const ot::Trel::Peer &peerEntry : node.Get<ot::Trel::PeerTable>())
     {
         bool found = false;
 
-        if (peer.GetDnssdState() != kDnssdResolved)
+        if (peerEntry.GetDnssdState() != kDnssdResolved)
         {
             continue;
         }
 
-        VerifyOrQuit(peer.GetServiceName() != nullptr);
-        VerifyOrQuit(peer.GetHostName() != nullptr);
-        VerifyOrQuit(StringStartsWith(peer.GetHostName(), "ot"));
-        VerifyOrQuit(StringEndsWith(peer.GetHostName(),
+        VerifyOrQuit(peerEntry.GetServiceName() != nullptr);
+        VerifyOrQuit(peerEntry.GetHostName() != nullptr);
+        VerifyOrQuit(StringStartsWith(peerEntry.GetHostName(), "ot"));
+        VerifyOrQuit(StringEndsWith(peerEntry.GetHostName(),
                                     multiServiceNode.Get<Mac::Mac>().GetExtAddress().ToString().AsCString()));
 
-        VerifyOrQuit(peer.GetSockAddr().GetAddress() == multiServiceNode.mMdns.mIfAddresses[0]);
-        VerifyOrQuit(peer.GetHostAddresses().GetLength() == 2);
-        VerifyOrQuit(peer.GetHostAddresses()[0] == multiServiceNode.mMdns.mIfAddresses[0]);
-        VerifyOrQuit(peer.GetHostAddresses()[1] == multiServiceNode.mMdns.mIfAddresses[1]);
+        VerifyOrQuit(peerEntry.GetSockAddr().GetAddress() == multiServiceNode.mMdns.mIfAddresses[0]);
+        VerifyOrQuit(peerEntry.GetHostAddresses().GetLength() == 2);
+        VerifyOrQuit(peerEntry.GetHostAddresses()[0] == multiServiceNode.mMdns.mIfAddresses[0]);
+        VerifyOrQuit(peerEntry.GetHostAddresses()[1] == multiServiceNode.mMdns.mIfAddresses[1]);
 
         for (uint16_t index = 0; index < 2; index++)
         {
-            if (StringMatch(peer.GetServiceName(), services[index].mServiceInstance))
+            if (StringMatch(peerEntry.GetServiceName(), services[index].mServiceInstance))
             {
                 found = true;
             }


### PR DESCRIPTION
This commit updates `tests/nexus/CMakeLists.txt` to include `${OT_CFLAGS}` in `target_compile_options` for `ot-nexus-platform` and test executables. This enables stricter compiler warnings and errors during the build process.

It also addresses issues exposed by the new flags, including unused variables and constants, shadow variable declarations, and member variable initialization order in constructors.