### PR TITLE
[cli] add `ToYesNo()` helper to convert boolean to string

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3614,9 +3614,9 @@ template <> otError Interpreter::Process<Cmd("deviceprops")>(Arg aArgs[])
         const otDeviceProperties *props = otThreadGetDeviceProperties(GetInstancePtr());
 
         OutputLine("PowerSupply      : %s", Stringify(props->mPowerSupply, kPowerSupplyStrings));
-        OutputLine("IsBorderRouter   : %s", props->mIsBorderRouter ? "yes" : "no");
-        OutputLine("SupportsCcm      : %s", props->mSupportsCcm ? "yes" : "no");
-        OutputLine("IsUnstable       : %s", props->mIsUnstable ? "yes" : "no");
+        OutputLine("IsBorderRouter   : %s", ToYesNo(props->mIsBorderRouter));
+        OutputLine("SupportsCcm      : %s", ToYesNo(props->mSupportsCcm));
+        OutputLine("IsUnstable       : %s", ToYesNo(props->mIsUnstable));
         OutputLine("WeightAdjustment : %d", props->mLeaderWeightAdjustment);
     }
     /**
@@ -7770,7 +7770,7 @@ void Interpreter::OutputEnhRoute(uint8_t aIndentSize, const otNetworkDiagEnhRout
             continue;
         }
 
-        OutputFormat(" HasLink:%-3s LinkQualityOut:%u LinkQualityIn:%u ", routeData.mHasLink ? "yes" : "no",
+        OutputFormat(" HasLink:%-3s LinkQualityOut:%u LinkQualityIn:%u ", ToYesNo(routeData.mHasLink),
                      routeData.mLinkQualityOut, routeData.mLinkQualityIn);
 
         if (routeData.mNextHop == kInvalidRouterId)

--- a/src/cli/cli_ba.cpp
+++ b/src/cli/cli_ba.cpp
@@ -179,8 +179,8 @@ template <> otError Ba::Process<Cmd("sessions")>(Arg aArgs[])
     {
         otIp6SockAddrToString(&info.mPeerSockAddr, sockAddrString, sizeof(sockAddrString));
 
-        OutputLine("%s connected:%s commissioner:%s lifetime:%s", sockAddrString, info.mIsConnected ? "yes" : "no",
-                   info.mIsCommissioner ? "yes" : "no", Uint64ToString(info.mLifetime, lifetimeString));
+        OutputLine("%s connected:%s commissioner:%s lifetime:%s", sockAddrString, ToYesNo(info.mIsConnected),
+                   ToYesNo(info.mIsCommissioner), Uint64ToString(info.mLifetime, lifetimeString));
     }
 exit:
     return error;

--- a/src/cli/cli_br.cpp
+++ b/src/cli/cli_br.cpp
@@ -86,7 +86,7 @@ template <> otError Br::Process<Cmd("infraif")>(Arg aArgs[])
 
     VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
     SuccessOrExit(error = otBorderRoutingGetInfraIfInfo(GetInstancePtr(), &ifIndex, &isRunning));
-    OutputLine("if-index:%lu, is-running:%s", ToUlong(ifIndex), isRunning ? "yes" : "no");
+    OutputLine("if-index:%lu, is-running:%s", ToUlong(ifIndex), ToYesNo(isRunning));
 
 exit:
     return error;
@@ -214,9 +214,9 @@ template <> otError Br::Process<Cmd("multiail")>(Arg aArgs[])
      */
     else if (aArgs[0] == "state")
     {
-        OutputLine("Enabled: %s", otBorderRoutingIsMultiAilDetectionEnabled(GetInstancePtr()) ? "yes" : "no");
-        OutputLine("Running: %s", otBorderRoutingIsMultiAilDetectionRunning(GetInstancePtr()) ? "yes" : "no");
-        OutputLine("Detected: %s", otBorderRoutingIsMultiAilDetected(GetInstancePtr()) ? "yes" : "no");
+        OutputLine("Enabled: %s", ToYesNo(otBorderRoutingIsMultiAilDetectionEnabled(GetInstancePtr())));
+        OutputLine("Running: %s", ToYesNo(otBorderRoutingIsMultiAilDetectionRunning(GetInstancePtr())));
+        OutputLine("Detected: %s", ToYesNo(otBorderRoutingIsMultiAilDetected(GetInstancePtr())));
     }
     /**
      * @cli br multiail (enable, disable)
@@ -767,7 +767,7 @@ template <> otError Br::Process<Cmd("prefixtable")>(Arg aArgs[])
         char string[OT_IP6_PREFIX_STRING_SIZE];
 
         otIp6PrefixToString(&entry.mPrefix, string, sizeof(string));
-        OutputFormat("prefix:%s, on-link:%s, ms-since-rx:%lu, lifetime:%lu, ", string, entry.mIsOnLink ? "yes" : "no",
+        OutputFormat("prefix:%s, on-link:%s, ms-since-rx:%lu, lifetime:%lu, ", string, ToYesNo(entry.mIsOnLink),
                      ToUlong(entry.mMsecSinceLastUpdate), ToUlong(entry.mValidLifetime));
 
         if (entry.mIsOnLink)
@@ -1010,7 +1010,7 @@ void Br::OutputRouterInfo(const otBorderRoutingRouterEntry &aEntry, RouterOutput
         otConvertDurationInSecondsToString(aEntry.mAge, ageString, sizeof(ageString));
 
         OutputFormat(" ms-since-rx:%lu reachable:%s age:%s", ToUlong(aEntry.mMsecSinceLastUpdate),
-                     aEntry.mIsReachable ? "yes" : "no", ageString);
+                     ToYesNo(aEntry.mIsReachable), ageString);
 
         if (aEntry.mIsLocalDevice)
         {

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -336,7 +336,7 @@ otError CoapSecure::ProcessIsRequest(Arg aArgs[], bool (*IsChecker)(otInstance *
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
-    OutputLine("%s", IsChecker(GetInstancePtr()) ? "yes" : "no");
+    OutputLine("%s", ToYesNo(IsChecker(GetInstancePtr())));
 
 exit:
     return error;

--- a/src/cli/cli_dns.cpp
+++ b/src/cli/cli_dns.cpp
@@ -139,8 +139,7 @@ template <> otError Dns::Process<Cmd("config")>(Arg aArgs[])
         OutputSockAddrLine(defaultConfig->mServerSockAddr);
         OutputLine("ResponseTimeout: %lu ms", ToUlong(defaultConfig->mResponseTimeout));
         OutputLine("MaxTxAttempts: %u", defaultConfig->mMaxTxAttempts);
-        OutputLine("RecursionDesired: %s",
-                   (defaultConfig->mRecursionFlag == OT_DNS_FLAG_RECURSION_DESIRED) ? "yes" : "no");
+        OutputLine("RecursionDesired: %s", ToYesNo(defaultConfig->mRecursionFlag == OT_DNS_FLAG_RECURSION_DESIRED));
         OutputLine("ServiceMode: %s", DnsConfigServiceModeToString(defaultConfig->mServiceMode));
 #if OPENTHREAD_CONFIG_DNS_CLIENT_NAT64_ENABLE
         OutputLine("Nat64Mode: %s", (defaultConfig->mNat64Mode == OT_DNS_NAT64_ALLOW) ? "allow" : "disallow");

--- a/src/cli/cli_history.cpp
+++ b/src/cli/cli_history.cpp
@@ -183,7 +183,7 @@ template <> otError History::Process<Cmd("ipaddr")>(Arg aArgs[])
             OutputLine("%s -> event:%s address:%s prefixlen:%d origin:%s scope:%d preferred:%s valid:%s rloc:%s",
                        ageString, Stringify(info->mEvent, kSimpleEventStrings), addressString, info->mPrefixLength,
                        Interpreter::AddressOriginToString(info->mAddressOrigin), info->mScope,
-                       info->mPreferred ? "yes" : "no", info->mValid ? "yes" : "no", info->mRloc ? "yes" : "no");
+                       ToYesNo(info->mPreferred), ToYesNo(info->mValid), ToYesNo(info->mRloc));
         }
     }
 
@@ -1195,7 +1195,7 @@ void History::OutputRxTxEntryListFormat(const otHistoryTrackerMessageInfo &aInfo
 
     OutputLine("%s", ageString);
     OutputFormat(kIndentSize, "type:%s len:%u checksum:0x%04x sec:%s prio:%s ", MessageTypeToString(aInfo),
-                 aInfo.mPayloadLength, aInfo.mChecksum, aInfo.mLinkSecurity ? "yes" : "no",
+                 aInfo.mPayloadLength, aInfo.mChecksum, ToYesNo(aInfo.mLinkSecurity),
                  MessagePriorityToString(aInfo.mPriority));
     if (aIsRx)
     {
@@ -1203,7 +1203,7 @@ void History::OutputRxTxEntryListFormat(const otHistoryTrackerMessageInfo &aInfo
     }
     else
     {
-        OutputFormat("tx-success:%s", aInfo.mTxSuccess ? "yes" : "no");
+        OutputFormat("tx-success:%s", ToYesNo(aInfo.mTxSuccess));
     }
 
     OutputLine(" %s:0x%04x radio:%s", aIsRx ? "from" : "to", aInfo.mNeighborRloc16, RadioTypeToString(aInfo));
@@ -1223,7 +1223,7 @@ void History::OutputRxTxEntryTableFormat(const otHistoryTrackerMessageInfo &aInf
     otHistoryTrackerEntryAgeToString(aEntryAge, ageString, sizeof(ageString));
 
     OutputFormat("| %20s | %-16.16s | %5u | 0x%04x | %3s | %4s | ", "", MessageTypeToString(aInfo),
-                 aInfo.mPayloadLength, aInfo.mChecksum, aInfo.mLinkSecurity ? "yes" : "no",
+                 aInfo.mPayloadLength, aInfo.mChecksum, ToYesNo(aInfo.mLinkSecurity),
                  MessagePriorityToString(aInfo.mPriority));
 
     if (aIsRx)
@@ -1696,7 +1696,7 @@ template <> otError History::Process<Cmd("omrprefix")>(Arg aArgs[])
         otIp6PrefixToString(&info->mOmrPrefix, prefixString, sizeof(prefixString));
 
         OutputLine(isList ? "%s -> omr-prefix:%s prf:%s is-local:%s" : "| %20s | %-48s | %-6s | %-6s |", ageString,
-                   prefixString, PreferenceToString(info->mPreference), info->mIsLocal ? "yes" : "no");
+                   prefixString, PreferenceToString(info->mPreference), ToYesNo(info->mIsLocal));
     }
 
 exit:
@@ -1766,7 +1766,7 @@ template <> otError History::Process<Cmd("onlinkprefix")>(Arg aArgs[])
         otIp6PrefixToString(&info->mOnLinkPrefix, prefixString, sizeof(prefixString));
 
         OutputLine(isList ? "%s -> on-link-prefix:%s is-local:%s" : "| %20s | %-48s | %-6s |", ageString, prefixString,
-                   info->mIsLocal ? "yes" : "no");
+                   ToYesNo(info->mIsLocal));
     }
 
 exit:

--- a/src/cli/cli_mdns.cpp
+++ b/src/cli/cli_mdns.cpp
@@ -200,8 +200,8 @@ void Mdns::OutputState(otMdnsEntryState aState)
 
 void Mdns::OutputCacheInfo(const otMdnsCacheInfo &aInfo)
 {
-    OutputLine(kIndentSize, "active: %s", aInfo.mIsActive ? "yes" : "no");
-    OutputLine(kIndentSize, "cached-results: %s", aInfo.mHasCachedResults ? "yes" : "no");
+    OutputLine(kIndentSize, "active: %s", ToYesNo(aInfo.mIsActive));
+    OutputLine(kIndentSize, "cached-results: %s", ToYesNo(aInfo.mHasCachedResults));
 }
 
 template <> otError Mdns::Process<Cmd("register")>(Arg aArgs[])

--- a/src/cli/cli_mesh_diag.cpp
+++ b/src/cli/cli_mesh_diag.cpp
@@ -460,8 +460,8 @@ void MeshDiag::HandleMeshDiagQueryChildTableResult(otError aError, const otMeshD
     OutputLine(kIndentSize, "timeout:%lu age:%lu supvn:%u q-msg:%u", ToUlong(aChildEntry->mTimeout),
                ToUlong(aChildEntry->mAge), aChildEntry->mSupervisionInterval, aChildEntry->mQueuedMessageCount);
 
-    OutputLine(kIndentSize, "rx-on:%s type:%s full-net:%s", aChildEntry->mRxOnWhenIdle ? "yes" : "no",
-               aChildEntry->mDeviceTypeFtd ? "ftd" : "mtd", aChildEntry->mFullNetData ? "yes" : "no");
+    OutputLine(kIndentSize, "rx-on:%s type:%s full-net:%s", ToYesNo(aChildEntry->mRxOnWhenIdle),
+               aChildEntry->mDeviceTypeFtd ? "ftd" : "mtd", ToYesNo(aChildEntry->mFullNetData));
 
     OutputLine(kIndentSize, "rss - ave:%d last:%d margin:%d", aChildEntry->mAverageRssi, aChildEntry->mLastRssi,
                aChildEntry->mLinkMargin);
@@ -476,9 +476,8 @@ void MeshDiag::HandleMeshDiagQueryChildTableResult(otError aError, const otMeshD
     otConvertDurationInSecondsToString(aChildEntry->mConnectionTime, string, sizeof(string));
     OutputLine(kIndentSize, "conn-time:%s", string);
 
-    OutputLine(kIndentSize, "csl - sync:%s period:%u timeout:%lu channel:%u",
-               aChildEntry->mCslSynchronized ? "yes" : "no", aChildEntry->mCslPeriod, ToUlong(aChildEntry->mCslTimeout),
-               aChildEntry->mCslChannel);
+    OutputLine(kIndentSize, "csl - sync:%s period:%u timeout:%lu channel:%u", ToYesNo(aChildEntry->mCslSynchronized),
+               aChildEntry->mCslPeriod, ToUlong(aChildEntry->mCslTimeout), aChildEntry->mCslChannel);
 
 exit:
     OutputResult(aError);

--- a/src/cli/cli_network_data.cpp
+++ b/src/cli/cli_network_data.cpp
@@ -935,7 +935,7 @@ template <> otError NetworkData::Process<Cmd("full")>(Arg aArgs[])
      */
     if (aArgs[0].IsEmpty())
     {
-        OutputLine(mFullCallbackWasCalled ? "yes" : "no");
+        OutputLine("%s", ToYesNo(mFullCallbackWasCalled));
     }
     /**
      * @cli netdata full reset

--- a/src/cli/cli_utils.cpp
+++ b/src/cli/cli_utils.cpp
@@ -60,6 +60,8 @@ OutputImplementer::OutputImplementer(otCliOutputCallback aCallback, void *aCallb
 {
 }
 
+const char *Utils::ToYesNo(bool aBool) { return aBool ? "yes" : "no"; }
+
 void Utils::OutputFormat(const char *aFormat, ...)
 {
     va_list args;

--- a/src/cli/cli_utils.hpp
+++ b/src/cli/cli_utils.hpp
@@ -198,6 +198,15 @@ public:
     otInstance *GetInstancePtr(void) { return mInstance; }
 
     /**
+     * Converts a boolean to "yes" or "no" string.
+     *
+     * @param[in] aBool  A boolean value to convert.
+     *
+     * @returns The converted string representation of @p aBool ("yes" for TRUE and "no" for FALSE).
+     */
+    static const char *ToYesNo(bool aBool);
+
+    /**
      * Represents a buffer which is used when converting a `uint64` value to string in decimal format.
      */
     struct Uint64StringBuffer


### PR DESCRIPTION
This commit introduces a new helper method `Utils::ToYesNo()` in the CLI module to convert boolean values into "yes" or "no" strings.

Previously, this conversion was performed using inline ternary operators (e.g., `val ? "yes" : "no"`) scattered throughout the CLI implementation. This change replaces these instances with the new helper method, improving code readability and consistency.