### PR TITLE
[nexus] add `Node::FindMatchingAddress()` helper

### DIFF
--- a/tests/nexus/platform/nexus_node.cpp
+++ b/tests/nexus/platform/nexus_node.cpp
@@ -135,5 +135,26 @@ void Node::GetTrelSockAddr(Ip6::SockAddr &aSockAddr) const
 }
 #endif
 
+const Ip6::Address &Node::FindMatchingAddress(const char *aPrefix)
+{
+    Ip6::Prefix         prefix;
+    const Ip6::Address *matchedAddress = nullptr;
+
+    SuccessOrQuit(prefix.FromString(aPrefix));
+
+    for (const Ip6::Netif::UnicastAddress &unicastAddress : Get<ThreadNetif>().GetUnicastAddresses())
+    {
+        if (unicastAddress.GetAddress().MatchesPrefix(prefix))
+        {
+            matchedAddress = &unicastAddress.GetAddress();
+            break;
+        }
+    }
+
+    VerifyOrQuit(matchedAddress != nullptr, "no matching address found");
+
+    return *matchedAddress;
+}
+
 } // namespace Nexus
 } // namespace ot

--- a/tests/nexus/platform/nexus_node.hpp
+++ b/tests/nexus/platform/nexus_node.hpp
@@ -87,6 +87,11 @@ public:
     void GetTrelSockAddr(Ip6::SockAddr &aSockAddr) const;
 #endif
 
+    // Finds and returns the address on device matching the given `aPrefix`.
+    // It requires a matching prefix to be found, otherwise it is treated as
+    // a test failure (emits error message and exits the program.)
+    const Ip6::Address &FindMatchingAddress(const char *aPrefix);
+
     void        SetName(const char *aName) { mName.Clear().Append("%s", aName); }
     void        SetName(const char *aPrefix, uint16_t aIndex);
     const char *GetName(void) const { return mName.AsCString(); }

--- a/tests/nexus/test_5_2_5.cpp
+++ b/tests/nexus/test_5_2_5.cpp
@@ -62,29 +62,6 @@ static constexpr uint32_t kEchoResponseTime = 5000;
  */
 static constexpr uint16_t kRouterCount = 14;
 
-static Ip6::Address GetUnicastAddress(Node &aNode, const char *aPrefixString)
-{
-    Ip6::Prefix  prefix;
-    Ip6::Address address;
-    bool         found = false;
-
-    SuccessOrQuit(prefix.FromString(aPrefixString));
-
-    for (const Ip6::Netif::UnicastAddress &addr : aNode.Get<Ip6::Netif>().GetUnicastAddresses())
-    {
-        if (addr.GetAddress().MatchesPrefix(prefix))
-        {
-            address = addr.GetAddress();
-            found   = true;
-            break;
-        }
-    }
-
-    VerifyOrQuit(found, "did not get unicast address with prefix");
-
-    return address;
-}
-
 void Test5_2_5(void)
 {
     /**
@@ -287,7 +264,7 @@ void Test5_2_5(void)
      *   - The IPv6 Destination address MUST be the RLOC of the destination.
      *   - The DUT MUST send an ICMPv6 Echo Reply.
      */
-    nexus.SendAndVerifyEchoRequest(med1, GetUnicastAddress(reed1, "2001::/64"), 0, 64, kEchoResponseTime);
+    nexus.SendAndVerifyEchoRequest(med1, reed1.FindMatchingAddress("2001::/64"), 0, 64, kEchoResponseTime);
 
     Log("Step 8: MED_1 sends ICMPv6 Echo Request to REED_1 (DUT) using 2002:: EID.");
 
@@ -305,7 +282,7 @@ void Test5_2_5(void)
      *   - The IPv6 Destination address MUST be the RLOC of the destination.
      *   - The DUT MUST send an ICMPv6 Echo Reply.
      */
-    nexus.SendAndVerifyEchoRequest(med1, GetUnicastAddress(reed1, "2002::/64"), 0, 64, kEchoResponseTime);
+    nexus.SendAndVerifyEchoRequest(med1, reed1.FindMatchingAddress("2002::/64"), 0, 64, kEchoResponseTime);
 
     nexus.SaveTestInfo("test_5_2_5.json");
 }

--- a/tests/nexus/test_5_3_10.cpp
+++ b/tests/nexus/test_5_3_10.cpp
@@ -88,32 +88,6 @@ static constexpr char kPrefix1[] = "2003::/64";
  */
 static constexpr char kPrefix2[] = "2004::/64";
 
-/**
- * Get a unicast address of a node with a given prefix.
- */
-static Ip6::Address GetUnicastAddress(Node &aNode, const char *aPrefixString)
-{
-    Ip6::Prefix  prefix;
-    Ip6::Address address;
-    bool         found = false;
-
-    SuccessOrQuit(prefix.FromString(aPrefixString));
-
-    for (const Ip6::Netif::UnicastAddress &addr : aNode.Get<Ip6::Netif>().GetUnicastAddresses())
-    {
-        if (addr.GetAddress().MatchesPrefix(prefix))
-        {
-            address = addr.GetAddress();
-            found   = true;
-            break;
-        }
-    }
-
-    VerifyOrQuit(found, "did not get unicast address with prefix");
-
-    return address;
-}
-
 void Test5_3_10(void)
 {
     /**
@@ -238,7 +212,7 @@ void Test5_3_10(void)
      *     packet to Router_1.
      */
 
-    nexus.SendAndVerifyEchoRequest(med1, GetUnicastAddress(router1, kPrefix1), 0, kDefaultHopLimit, kEchoResponseTime);
+    nexus.SendAndVerifyEchoRequest(med1, router1.FindMatchingAddress(kPrefix1), 0, kDefaultHopLimit, kEchoResponseTime);
 
     Log("Step 4: Border Router");
 
@@ -256,7 +230,7 @@ void Test5_3_10(void)
      *   - The IPv6 Destination address MUST be the RLOC of the destination.
      */
 
-    nexus.SendAndVerifyEchoRequest(br, GetUnicastAddress(med1, kPrefix1), 0, kDefaultHopLimit, kEchoResponseTime);
+    nexus.SendAndVerifyEchoRequest(br, med1.FindMatchingAddress(kPrefix1), 0, kDefaultHopLimit, kEchoResponseTime);
 
     Log("Step 5: MED_1");
 
@@ -268,7 +242,7 @@ void Test5_3_10(void)
      *   - The DUT MUST forward the ICMPv6 Echo Reply to MED_1.
      */
 
-    nexus.SendAndVerifyEchoRequest(med1, GetUnicastAddress(router1, kPrefix1), 0, kDefaultHopLimit, kEchoResponseTime);
+    nexus.SendAndVerifyEchoRequest(med1, router1.FindMatchingAddress(kPrefix1), 0, kDefaultHopLimit, kEchoResponseTime);
 
     nexus.SaveTestInfo("test_5_3_10.json");
 
@@ -283,7 +257,7 @@ void Test5_3_10(void)
      *   - The DUT MUST send an Address Query Request to discover Router_1’s RLOC address.
      */
 
-    Ip6::Address router1Gua = GetUnicastAddress(router1, kPrefix1);
+    Ip6::Address router1Gua = router1.FindMatchingAddress(kPrefix1);
 
     router1.Reset();
     nexus.AdvanceTime(kRouterIdExpirationTimeInSec * 1000);
@@ -302,7 +276,7 @@ void Test5_3_10(void)
      *   - The DUT MUST NOT respond with an Address Notification message.
      */
 
-    Ip6::Address med1Gua = GetUnicastAddress(med1, kPrefix1);
+    Ip6::Address med1Gua = med1.FindMatchingAddress(kPrefix1);
 
     med1.Reset();
     nexus.AdvanceTime(dut.Get<Mle::Mle>().GetTimeout() * 1000);

--- a/tests/nexus/test_5_3_8.cpp
+++ b/tests/nexus/test_5_3_8.cpp
@@ -67,37 +67,6 @@ static constexpr uint16_t kEchoPayloadSize = 0;
 static constexpr uint8_t kEchoHopLimit = 64;
 
 /**
- * Get a unicast address matching a prefix.
- *
- * @param[in] aNode          The node to search.
- * @param[in] aPrefixString  The prefix to match.
- *
- * @returns The unicast address found.
- */
-static Ip6::Address GetUnicastAddress(Node &aNode, const char *aPrefixString)
-{
-    Ip6::Prefix  prefix;
-    Ip6::Address address;
-    bool         found = false;
-
-    SuccessOrQuit(prefix.FromString(aPrefixString));
-
-    for (const Ip6::Netif::UnicastAddress &addr : aNode.Get<Ip6::Netif>().GetUnicastAddresses())
-    {
-        if (addr.GetAddress().MatchesPrefix(prefix))
-        {
-            address = addr.GetAddress();
-            found   = true;
-            break;
-        }
-    }
-
-    VerifyOrQuit(found, "did not get unicast address with prefix");
-
-    return address;
-}
-
-/**
  * Add an on-mesh prefix to a node.
  *
  * @param[in] aNode          The node to add the prefix to.
@@ -251,7 +220,7 @@ void Test5_3_8(void)
      *   - MED_2 MUST respond with an ICMPv6 Echo Reply.
      */
 
-    nexus.SendAndVerifyEchoRequest(med1, GetUnicastAddress(med2, "2001::/64"), kEchoPayloadSize, kEchoHopLimit,
+    nexus.SendAndVerifyEchoRequest(med1, med2.FindMatchingAddress("2001::/64"), kEchoPayloadSize, kEchoHopLimit,
                                    kEchoResponseWaitTime);
 
     Log("---------------------------------------------------------------------------------------");
@@ -265,7 +234,7 @@ void Test5_3_8(void)
      *   - MED_2 MUST respond with an ICMPv6 Echo Reply.
      */
 
-    nexus.SendAndVerifyEchoRequest(med1, GetUnicastAddress(med2, "2002::/64"), kEchoPayloadSize, kEchoHopLimit,
+    nexus.SendAndVerifyEchoRequest(med1, med2.FindMatchingAddress("2002::/64"), kEchoPayloadSize, kEchoHopLimit,
                                    kEchoResponseWaitTime);
 
     Log("---------------------------------------------------------------------------------------");
@@ -279,7 +248,7 @@ void Test5_3_8(void)
      *   - MED_2 MUST respond with an ICMPv6 Echo Reply.
      */
 
-    nexus.SendAndVerifyEchoRequest(med1, GetUnicastAddress(med2, "2003::/64"), kEchoPayloadSize, kEchoHopLimit,
+    nexus.SendAndVerifyEchoRequest(med1, med2.FindMatchingAddress("2003::/64"), kEchoPayloadSize, kEchoHopLimit,
                                    kEchoResponseWaitTime);
 
     nexus.SaveTestInfo("test_5_3_8.json");

--- a/tests/nexus/test_5_3_9.cpp
+++ b/tests/nexus/test_5_3_9.cpp
@@ -92,29 +92,6 @@ static constexpr uint8_t kHopLimit = 64;
  */
 static constexpr uint32_t kSedPollPeriod = 100;
 
-static Ip6::Address GetGuaAddress(Node &aNode, const char *aPrefixString)
-{
-    Ip6::Prefix  prefix;
-    Ip6::Address address;
-    bool         found = false;
-
-    SuccessOrQuit(prefix.FromString(aPrefixString));
-
-    for (const Ip6::Netif::UnicastAddress &addr : aNode.Get<Ip6::Netif>().GetUnicastAddresses())
-    {
-        if (addr.GetAddress().MatchesPrefix(prefix))
-        {
-            address = addr.GetAddress();
-            found   = true;
-            break;
-        }
-    }
-
-    VerifyOrQuit(found, "did not get unicast address with prefix");
-
-    return address;
-}
-
 void Test5_3_9(void)
 {
     /**
@@ -228,7 +205,7 @@ void Test5_3_9(void)
      *     packet to SED_1.
      */
     Log("Step 3: SED_1");
-    nexus.SendAndVerifyEchoRequest(sed1, GetGuaAddress(router3, "2001::/64"), kEchoPayloadSize, kHopLimit,
+    nexus.SendAndVerifyEchoRequest(sed1, router3.FindMatchingAddress("2001::/64"), kEchoPayloadSize, kHopLimit,
                                    kEchoResponseTime);
 
     /**
@@ -245,7 +222,7 @@ void Test5_3_9(void)
      *   - The IPv6 Destination address MUST be the RLOC of the destination.
      */
     Log("Step 4: Router_1");
-    nexus.SendAndVerifyEchoRequest(router1, GetGuaAddress(sed1, "2001::/64"), kEchoPayloadSize, kHopLimit,
+    nexus.SendAndVerifyEchoRequest(router1, sed1.FindMatchingAddress("2001::/64"), kEchoPayloadSize, kHopLimit,
                                    kEchoResponseTime);
 
     /**
@@ -256,7 +233,7 @@ void Test5_3_9(void)
      *   - The DUT MUST forward the ICMPv6 Echo Reply to SED_1.
      */
     Log("Step 5: SED_1");
-    nexus.SendAndVerifyEchoRequest(sed1, GetGuaAddress(router3, "2001::/64"), kEchoPayloadSize, kHopLimit,
+    nexus.SendAndVerifyEchoRequest(sed1, router3.FindMatchingAddress("2001::/64"), kEchoPayloadSize, kHopLimit,
                                    kEchoResponseTime);
 
     /**
@@ -268,7 +245,7 @@ void Test5_3_9(void)
      *   - The DUT MUST send an Address Query to discover Router_3’s RLOC address.
      */
     Log("Step 6: Router_2 (DUT)");
-    Ip6::Address router3Gua = GetGuaAddress(router3, "2001::/64");
+    Ip6::Address router3Gua = router3.FindMatchingAddress("2001::/64");
     router3.Reset();
     nexus.AdvanceTime(kRouterIdTimeout);
 
@@ -284,7 +261,7 @@ void Test5_3_9(void)
      *   - The DUT MUST NOT respond with an Address Notification message.
      */
     Log("Step 7: SED_1");
-    Ip6::Address sed1Gua = GetGuaAddress(sed1, "2001::/64");
+    Ip6::Address sed1Gua = sed1.FindMatchingAddress("2001::/64");
     sed1.Reset();
     nexus.AdvanceTime(kChildTimeout);
 


### PR DESCRIPTION
This commit adds the `Node::FindMatchingAddress()` helper method to the `Nexus::Node` class. This method simplifies the process of finding a unicast address on a node that matches a given IPv6 prefix.