### PR TITLE
[message] enhance `Clone()` to support different reserved header size

### DIFF
--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -690,9 +690,13 @@ exit:
     return hasSame;
 }
 
-Message *Message::Clone(uint16_t aLength) const
+Message *Message::Clone(void) const { return Clone(GetLength()); }
+
+Message *Message::Clone(uint16_t aLength) const { return Clone(aLength, GetReserved()); }
+
+Message *Message::Clone(uint16_t aLength, uint16_t aReserveHeader) const
 {
-    Message *message = static_cast<Message *>(ot::Message::Clone(aLength));
+    Message *message = static_cast<Message *>(ot::Message::Clone(aLength, aReserveHeader));
 
     VerifyOrExit(message != nullptr);
 

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -827,10 +827,21 @@ public:
     Error AppendPayloadMarker(void);
 
     /**
+     * Creates a copy of the message.
+     *
+     * It allocates the new message from the same message pool as the original one and copies the entire payload. The
+     * `Type`, `SubType`, `LinkSecurity`, `Offset`, and `Priority` fields on the cloned message are also
+     * copied from the original one.
+     *
+     * @returns A pointer to the message or `nullptr` if insufficient message buffers are available.
+     */
+    Message *Clone(void) const;
+
+    /**
      * Creates a copy of this CoAP message.
      *
      * It allocates the new message from the same message pool as the original one and copies @p aLength octets
-     * of the payload. The `Type`, `SubType`, `LinkSecurity`, `Offset`, `InterfaceId`, and `Priority` fields on the
+     * of the payload. The `Type`, `SubType`, `LinkSecurity`, `Offset`, and `Priority` fields on the
      * cloned message are also copied from the original one.
      *
      * @param[in] aLength  Number of payload bytes to copy.
@@ -840,15 +851,17 @@ public:
     Message *Clone(uint16_t aLength) const;
 
     /**
-     * Creates a copy of the message.
+     * Creates a copy of the message using a given configuration.
      *
-     * It allocates the new message from the same message pool as the original one and copies the entire payload. The
-     * `Type`, `SubType`, `LinkSecurity`, `Offset`, `InterfaceId`, and `Priority` fields on the cloned message are also
-     * copied from the original one.
+     * It allocates the new message from the same message pool as the original one. The `Type`, `SubType`,
+     * `LinkSecurity`, `Offset`, and `Priority` fields on the cloned message are copied from the original one.
+     *
+     * @param[in] aLength         Number of message bytes to copy.
+     * @param[in] aReserveHeader  Number of header bytes to reserve in the new cloned message.
      *
      * @returns A pointer to the message or `nullptr` if insufficient message buffers are available.
      */
-    Message *Clone(void) const { return Clone(GetLength()); }
+    Message *Clone(uint16_t aLength, uint16_t aReserveHeader) const;
 
     /**
      * Returns a pointer to the next message after this as a `Coap::Message`.

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -70,6 +70,7 @@ struct otMessage
 
 namespace ot {
 
+class UnitTester;
 template <typename UintType> class CrcCalculator;
 
 namespace Crypto {
@@ -286,6 +287,7 @@ class Message : public otMessage, public Buffer, public GetProvider<Message>
     friend class MessagePool;
     friend class MessageQueue;
     friend class PriorityQueue;
+    friend class ot::UnitTester;
 
 public:
     /**
@@ -1065,26 +1067,39 @@ public:
     /**
      * Creates a copy of the message.
      *
-     * It allocates the new message from the same message pool as the original one and copies @p aLength octets
-     * of the payload. The `Type`, `SubType`, `LinkSecurity`, `Offset`, `InterfaceId`, and `Priority` fields on the
-     * cloned message are also copied from the original one.
+     * It allocates the new message from the same message pool as the original one and copies the entire payload. The
+     * `Type`, `SubType`, `LinkSecurity`, `Offset`, and `Priority` fields on the cloned message are also
+     * copied from the original one.
      *
-     * @param[in] aLength  Number of payload bytes to copy.
+     * @returns A pointer to the message or `nullptr` if insufficient message buffers are available.
+     */
+    Message *Clone(void) const;
+
+    /**
+     * Creates a copy of the message.
+     *
+     * It allocates the new message from the same message pool as the original one and copies @p aLength octets
+     * of the payload. The `Type`, `SubType`, `LinkSecurity`, `Offset`, and `Priority` fields on the cloned message
+     * are also copied from the original one.
+     *
+     * @param[in] aLength  Number of message bytes to copy.
      *
      * @returns A pointer to the message or nullptr if insufficient message buffers are available.
      */
     Message *Clone(uint16_t aLength) const;
 
     /**
-     * Creates a copy of the message.
+     * Creates a copy of the message using a given configuration.
      *
-     * It allocates the new message from the same message pool as the original one and copies the entire payload. The
-     * `Type`, `SubType`, `LinkSecurity`, `Offset`, `InterfaceId`, and `Priority` fields on the cloned message are also
-     * copied from the original one.
+     * It allocates the new message from the same message pool as the original one. The `Type`, `SubType`,
+     * `LinkSecurity`, `Offset`, and `Priority` fields on the cloned message are copied from the original one.
+     *
+     * @param[in] aLength         Number of message bytes to copy.
+     * @param[in] aReserveHeader  Number of header bytes to reserve in the new cloned message.
      *
      * @returns A pointer to the message or `nullptr` if insufficient message buffers are available.
      */
-    Message *Clone(void) const { return Clone(GetLength()); }
+    Message *Clone(uint16_t aLength, uint16_t aReserveHeader) const;
 
     /**
      * Returns the datagram tag used for 6LoWPAN fragmentation or the identification used for IPv6


### PR DESCRIPTION


This commit enhances the `Message::Clone()` method to support a custom configuration. This allows callers to specify a different length and reserved header size for the cloned message via the new overload `Clone(uint16_t aLength, uint16_t aReserveHeader)`.

The existing `Clone()` overloads have been updated to utilize this new configuration mechanism. Additionally,  `Coap::Message::Clone()` methods are updated to align with these changes.

A new unit test `TestCloning()` is added to `test_message.cpp` to verify the behavior of `Clone()` with various configurations.