### PR TITLE
[border-router] stop DHCPv6-PD when stopping RoutingManager

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -965,7 +965,7 @@ private:
 
         void               SetEnabled(bool aEnabled);
         void               Start(void) { Evaluate(); }
-        void               Stop(void) { Evaluate(); }
+        void               Stop(void) { SetState(kDhcp6PdStateStopped); }
         bool               HasPrefix(void) const { return !mPrefix.IsEmpty(); }
         bool               HasConflict(void) const { return mOnLinkPrefixConflict || mRoutePrefixConflict; }
         const Ip6::Prefix &GetPrefix(void) const { return mPrefix.GetPrefix(); }


### PR DESCRIPTION
`PdPrefixManager::Stop` currently depends on the `RoutingManager` state. Since it is called before `mIsRunning` is set to false (which happens at the end of the function), `PdPrefixManager` still sees `RoutingManager` as active. This leads to an incorrect PD state transition from IDLE back to RUNNING in certain scenarios such as when the infra interface is lost and the OMR prefix is removed from the interface, consequently triggering an unintended DHCPv6-PD request.

This commit resolves this state ordering issue by directly setting `PdPrefixManager` state to `kDhcp6PdStateStopped` when stopping the `RoutingManager`.