### PR TITLE
[border-router] fix stop behavior in `PdPrefixManager`

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -2531,6 +2531,15 @@ exit:
     return;
 }
 
+void RoutingManager::PdPrefixManager::Stop(void)
+{
+    VerifyOrExit(mState != kDhcp6PdStateDisabled);
+    SetState(kDhcp6PdStateStopped);
+
+exit:
+    return;
+}
+
 void RoutingManager::PdPrefixManager::Evaluate(void)
 {
     VerifyOrExit(mState != kDhcp6PdStateDisabled);

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -965,7 +965,7 @@ private:
 
         void               SetEnabled(bool aEnabled);
         void               Start(void) { Evaluate(); }
-        void               Stop(void) { Evaluate(); }
+        void               Stop(void);
         bool               HasPrefix(void) const { return !mPrefix.IsEmpty(); }
         bool               HasConflict(void) const { return mOnLinkPrefixConflict || mRoutePrefixConflict; }
         const Ip6::Prefix &GetPrefix(void) const { return mPrefix.GetPrefix(); }


### PR DESCRIPTION
Previously, `PdPrefixManager::Stop()` was implemented as a call to `Evaluate()`. The `Evaluate()` method calls `UpdateState()`, which checks `RoutingManager::IsRunning()` to determine if the state should be switched to `kDhcp6PdStateStopped`.

However, `RoutingManager::Stop()` calls `PdPrefixManager::Stop()` before updating its own running state (setting `mIsRunning` to `false`). As a result, `PdPrefixManager` would incorrectly remain in `Running` or `Idle` state instead of stopping.

This commit updates `PdPrefixManager::Stop()` to explicitly set the state to `kDhcp6PdStateStopped`.

----

Thanks to @xiaom-GitHub for finding and reporting this (see https://github.com/openthread/openthread/pull/12441).