### PR TITLE
[nexus] remove redundant CoAP ACK code checks in verify scripts

### DIFF
--- a/tests/nexus/verify_5_1_1.py
+++ b/tests/nexus/verify_5_1_1.py
@@ -229,7 +229,6 @@ def verify(pv):
                           consts.NL_RLOC16_TLV,
                           consts.NL_ROUTER_MASK_TLV
                           } <= set(p.coap.tlv.type) and\
-               p.coap.code == consts.COAP_CODE_ACK and\
                p.coap.tlv.status == 0\
                ).\
         must_next()

--- a/tests/nexus/verify_5_1_5.py
+++ b/tests/nexus/verify_5_1_5.py
@@ -121,7 +121,6 @@ def verify(pv):
             consts.NL_RLOC16_TLV,
             consts.NL_ROUTER_MASK_TLV
         } <= set(p.coap.tlv.type) and
-            p.coap.code == consts.COAP_CODE_ACK and
             p.coap.tlv.status == 0).\
         must_next()
 
@@ -167,7 +166,6 @@ def verify(pv):
             consts.NL_RLOC16_TLV,
             consts.NL_ROUTER_MASK_TLV
         } <= set(p.coap.tlv.type) and
-            p.coap.code == consts.COAP_CODE_ACK and
             p.coap.tlv.status == 0).\
         must_next()
 

--- a/tests/nexus/verify_5_1_6.py
+++ b/tests/nexus/verify_5_1_6.py
@@ -74,7 +74,6 @@ def verify(pv):
                           consts.NL_RLOC16_TLV,
                           consts.NL_ROUTER_MASK_TLV
                           } <= set(p.coap.tlv.type) and\
-               p.coap.code == consts.COAP_CODE_ACK and\
                p.coap.tlv.status == 0
                ).\
         must_next()

--- a/tests/nexus/verify_5_2_3.py
+++ b/tests/nexus/verify_5_2_3.py
@@ -99,7 +99,6 @@ def verify(pv):
             consts.NL_RLOC16_TLV,
             consts.NL_ROUTER_MASK_TLV
         } <= set(p.coap.tlv.type) and\
-            p.coap.code == consts.COAP_CODE_ACK and\
             p.coap.tlv.status == consts.ADDR_SOL_SUCCESS).\
         must_next()
 
@@ -137,7 +136,6 @@ def verify(pv):
         filter(lambda p: {
             consts.NL_STATUS_TLV
         } <= set(p.coap.tlv.type) and\
-            p.coap.code == consts.COAP_CODE_ACK and\
             p.coap.tlv.status == consts.NL_NO_ADDRESS_AVAILABLE).\
         must_next()
 

--- a/tests/nexus/verify_5_2_6.py
+++ b/tests/nexus/verify_5_2_6.py
@@ -114,7 +114,6 @@ def verify(pv):
     print("Step 4: Leader - Receives Address Release message and automatically sends a 2.04 Changed CoAP response.")
     pkts.filter_wpan_src64(LEADER).\
         filter_coap_ack(consts.ADDR_REL_URI).\
-        filter(lambda p: p.coap.code == consts.COAP_CODE_ACK).\
         must_next()
 
     # Step 5: Leader


### PR DESCRIPTION
This commit removes redundant `p.coap.code == consts.COAP_CODE_ACK` checks in several Nexus test verification scripts.

The `filter_coap_ack()` function in the `pktverify` framework already filters for CoAP ACK messages, which involves checking the message type and the CoAP code. Therefore, adding a manual filter for the same CoAP code is redundant and can be removed for conciseness.

Summary of changes:
- tests/nexus/verify_5_1_1.py: Remove redundant CoAP ACK code check.
- tests/nexus/verify_5_1_5.py: Remove redundant CoAP ACK code checks.
- tests/nexus/verify_5_1_6.py: Remove redundant CoAP ACK code check.
- tests/nexus/verify_5_2_3.py: Remove redundant CoAP ACK code checks.
- tests/nexus/verify_5_2_6.py: Remove redundant CoAP ACK code check.