### PR TITLE
[nexus] extend `Node::Join()` to allow specifying network data type on SED

### DIFF
--- a/tests/nexus/platform/nexus_node.cpp
+++ b/tests/nexus/platform/nexus_node.cpp
@@ -66,7 +66,7 @@ void Node::Form(void)
 void Node::Join(Node &aNode, JoinMode aJoinMode)
 {
     MeshCoP::Dataset dataset;
-    Mle::DeviceMode  mode(0);
+    uint8_t          mode = 0;
 
     switch (aJoinMode)
     {
@@ -75,18 +75,20 @@ void Node::Join(Node &aNode, JoinMode aJoinMode)
         OT_FALL_THROUGH;
 
     case kAsFtd:
-        mode.Set(Mle::DeviceMode::kModeRxOnWhenIdle | Mle::DeviceMode::kModeFullThreadDevice |
-                 Mle::DeviceMode::kModeFullNetworkData);
+        mode = Mle::DeviceMode::kModeRxOnWhenIdle | Mle::DeviceMode::kModeFullThreadDevice |
+               Mle::DeviceMode::kModeFullNetworkData;
         break;
     case kAsMed:
-        mode.Set(Mle::DeviceMode::kModeRxOnWhenIdle | Mle::DeviceMode::kModeFullNetworkData);
+        mode = Mle::DeviceMode::kModeRxOnWhenIdle | Mle::DeviceMode::kModeFullNetworkData;
+        break;
+    case kAsSedWithFullNetData:
+        mode = Mle::DeviceMode::kModeFullNetworkData;
         break;
     case kAsSed:
-        mode.Set(Mle::DeviceMode::kModeFullNetworkData);
         break;
     }
 
-    SuccessOrQuit(Get<Mle::Mle>().SetDeviceMode(mode));
+    SuccessOrQuit(Get<Mle::Mle>().SetDeviceMode(Mle::DeviceMode(mode)));
 
     SuccessOrQuit(aNode.Get<MeshCoP::ActiveDatasetManager>().Read(dataset));
     Get<MeshCoP::ActiveDatasetManager>().SaveLocal(dataset);

--- a/tests/nexus/platform/nexus_node.hpp
+++ b/tests/nexus/platform/nexus_node.hpp
@@ -66,12 +66,19 @@ class Node : public Platform, public Heap::Allocatable<Node>, public LinkedListE
     friend class Heap::Allocatable<Node>;
 
 public:
+    // Defines the device role and Network Data request behavior
+    // during joining:
+    //
+    // - `kAsFtd`, `kAsFed`, and `kAsMed` all request full netdata.
+    // - `kAsSed` requests only stable netdata (default for SED).
+    // - `kAsSedWithFullNetData` explicitly request full netdata.
     enum JoinMode : uint8_t
     {
         kAsFtd,
         kAsFed,
         kAsMed,
         kAsSed,
+        kAsSedWithFullNetData,
     };
 
     void Reset(void);


### PR DESCRIPTION
This commit updates `Node::Join()` to allow specifying whether a node joining as an SED should request the full network data or only the stable subset via the `JoinMode` parameter.

Previously, `kAsSed` implicitly requested full network data. This change updates `kAsSed` to request only the stable subset (the default behavior for an SED). A new `kAsSedWithFullNetData` mode is introduced to explicitly request full network data when joining as an SED.

This change provides more flexibility in test scenarios, allowing validation of SEDs with different network data requirements.
