### PR TITLE
[nexus] update Node::SetName() to use underscore as separator

### DIFF
--- a/tests/nexus/platform/nexus_node.cpp
+++ b/tests/nexus/platform/nexus_node.cpp
@@ -125,7 +125,7 @@ void Node::SendEchoRequest(const Ip6::Address &aDestination,
     SuccessOrQuit(Get<Ip6::Icmp>().SendEchoRequest(*message, messageInfo, aIdentifier));
 }
 
-void Node::SetName(const char *aPrefix, uint16_t aIndex) { mName.Clear().Append("%s %u", aPrefix, aIndex); }
+void Node::SetName(const char *aPrefix, uint16_t aIndex) { mName.Clear().Append("%s_%u", aPrefix, aIndex); }
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 void Node::GetTrelSockAddr(Ip6::SockAddr &aSockAddr) const

--- a/tests/nexus/verify_5_2_3.py
+++ b/tests/nexus/verify_5_2_3.py
@@ -59,8 +59,8 @@ def verify(pv):
     MAX_ROUTERS = 32
 
     LEADER = pv.vars['Leader']
-    ROUTER_31 = pv.vars['Router 31']
-    ROUTER_32 = pv.vars['Router 32']
+    ROUTER_31 = pv.vars['Router_31']
+    ROUTER_32 = pv.vars['Router_32']
 
     # Step 1: All
     # - Description: Begin wireless sniffer and ensure topology is created and connectivity between nodes.

--- a/tests/nexus/verify_5_2_4.py
+++ b/tests/nexus/verify_5_2_4.py
@@ -64,9 +64,9 @@ def verify(pv):
     pv.summary.show()
 
     LEADER = pv.vars['Leader']
-    ROUTER_15 = pv.vars['Router 15']
-    REED_1 = pv.vars['REED 1']
-    MED_1 = pv.vars['MED 1']
+    ROUTER_15 = pv.vars['Router_15']
+    REED_1 = pv.vars['REED_1']
+    MED_1 = pv.vars['MED_1']
 
     # Step 1: All
     # - Description: Ensure topology is formed correctly without the DUT.


### PR DESCRIPTION
This commit updates the Nexus::Node::SetName(prefix, index) method to use an underscore ('_') instead of a space between the prefix and the index when generating the node name.

Corresponding verification scripts verify_5_2_3.py and verify_5_2_4.py are also updated to match the new naming convention when looking up nodes in the test environment.

All Nexus tests have been verified to pass with this change.