### PR TITLE
[nexus] use `kAsFed` in `Node::Join`

### DIFF
--- a/tests/nexus/test_5_1_10.cpp
+++ b/tests/nexus/test_5_1_10.cpp
@@ -165,8 +165,7 @@ void Test5_1_10(void)
      *     - Version TLV
      */
 
-    SuccessOrQuit(dut.Get<Mle::Mle>().SetRouterEligible(false));
-    dut.Join(leader);
+    dut.Join(leader, Node::kAsFed);
 
     /**
      * Step 4: Router_1, Router_2

--- a/tests/nexus/test_5_1_11.cpp
+++ b/tests/nexus/test_5_1_11.cpp
@@ -186,8 +186,7 @@ void Test5_1_11(void)
      *     - Scan Mask TLV = 0x80 (active Routers)
      *     - Version TLV
      */
-    SuccessOrQuit(dut.Get<Mle::Mle>().SetRouterEligible(false));
-    dut.Join(leader);
+    dut.Join(leader, Node::kAsFed);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 4: Router_2");

--- a/tests/nexus/test_5_1_8.cpp
+++ b/tests/nexus/test_5_1_8.cpp
@@ -175,7 +175,6 @@ void Test5_1_8(void)
      *     - Scan Mask TLV = 0x80 (Active Routers)
      *     - Version TLV
      */
-    SuccessOrQuit(dut.Get<Mle::Mle>().SetRouterEligible(false));
     dut.Join(router3, Node::kAsFed); // We use router3 as the dataset source, but it will scan and find all
 
     Log("---------------------------------------------------------------------------------------");

--- a/tests/nexus/test_5_1_9.cpp
+++ b/tests/nexus/test_5_1_9.cpp
@@ -187,8 +187,7 @@ void Test5_1_9(void)
      *     - Version TLV
      */
     Log("Step 3: Router_2 (DUT) begins attach process");
-    SuccessOrQuit(dut.Get<Mle::Mle>().SetRouterEligible(false));
-    dut.Join(reed1); // reed1 is just a placeholder here, it will scan.
+    dut.Join(reed1, Node::kAsFed); // reed1 is just a placeholder here, it will scan.
 
     /**
      * Step 4: REED_2, REED_1

--- a/tests/nexus/test_dtls.cpp
+++ b/tests/nexus/test_dtls.cpp
@@ -254,13 +254,11 @@ void TestDtlsSingleSession(void)
     nexus.AdvanceTime(50 * Time::kOneSecondInMsec);
     VerifyOrQuit(node0.Get<Mle::Mle>().IsLeader());
 
-    SuccessOrQuit(node1.Get<Mle::Mle>().SetRouterEligible(false));
-    node1.Join(node0);
+    node1.Join(node0, Node::kAsFed);
     nexus.AdvanceTime(20 * Time::kOneSecondInMsec);
     VerifyOrQuit(node1.Get<Mle::Mle>().IsChild());
 
-    SuccessOrQuit(node2.Get<Mle::Mle>().SetRouterEligible(false));
-    node2.Join(node0);
+    node2.Join(node0, Node::kAsFed);
     nexus.AdvanceTime(20 * Time::kOneSecondInMsec);
     VerifyOrQuit(node2.Get<Mle::Mle>().IsChild());
 
@@ -496,13 +494,11 @@ void TestDtlsMultiSession(void)
     nexus.AdvanceTime(50 * Time::kOneSecondInMsec);
     VerifyOrQuit(node0.Get<Mle::Mle>().IsLeader());
 
-    SuccessOrQuit(node1.Get<Mle::Mle>().SetRouterEligible(false));
-    node1.Join(node0);
+    node1.Join(node0, Node::kAsFed);
     nexus.AdvanceTime(20 * Time::kOneSecondInMsec);
     VerifyOrQuit(node1.Get<Mle::Mle>().IsChild());
 
-    SuccessOrQuit(node2.Get<Mle::Mle>().SetRouterEligible(false));
-    node2.Join(node0);
+    node2.Join(node0, Node::kAsFed);
     nexus.AdvanceTime(20 * Time::kOneSecondInMsec);
     VerifyOrQuit(node2.Get<Mle::Mle>().IsChild());
 


### PR DESCRIPTION
Updates various Nexus test cases to utilize the `kAsFed` `JoinMode` when calling `Node::Join`. Previously, these tests manually called `Mle::SetRouterEligible(false)` before joining to configure the device as a Full End Device (FED). Using the `kAsFed` parameter simplifies the test code and leverages the existing logic within `Node::Join` to handle the configuration.