### PR TITLE
[nexus] fix flakiness in test 5.5.4.1

### DIFF
--- a/tests/nexus/test_5_5_4_1.cpp
+++ b/tests/nexus/test_5_5_4_1.cpp
@@ -57,7 +57,7 @@ static constexpr uint32_t kResetTime = 300 * 1000;
 /**
  * Time to wait for network merge.
  */
-static constexpr uint32_t kMergeWaitTime = 200 * 1000;
+static constexpr uint32_t kMergeWaitTime = 300 * 1000;
 
 /**
  * The identifier used for Echo Request.


### PR DESCRIPTION
This commit addresses the occasional failure of Nexus test 5.5.4.1 by increasing the merge wait time and improving the robustness of the packet verification script.

Summary of changes:
- In test_5_5_4_1.cpp, increased kMergeWaitTime from 200s to 300s. This provides sufficient time for all nodes to synchronize their Mesh-Local Prefix and update their routing tables after the network partitions merge.
- In verify_5_5_4_1.py, updated Step 6 verification to filter ICMPv6 Echo Request and Reply packets by their specific identifier (0xabcd). This ensures that the verifier correctly identifies the packets from the intended test step and avoids matching stale or transient packets from earlier parts of the test.