### PR TITLE
[nexus] add test 5.8.2 Key Increment Of 1

### DIFF
--- a/tests/nexus/CMakeLists.txt
+++ b/tests/nexus/CMakeLists.txt
@@ -155,6 +155,7 @@ ot_nexus_test(5_5_4_1 "cert;nexus")
 ot_nexus_test(5_5_4_2 "cert;nexus")
 ot_nexus_test(5_5_5 "cert;nexus")
 ot_nexus_test(5_5_7 "cert;nexus")
+ot_nexus_test(5_8_2 "cert;nexus")
 
 # Misc tests
 ot_nexus_test(border_admitter "core;nexus")

--- a/tests/nexus/run_nexus_tests.sh
+++ b/tests/nexus/run_nexus_tests.sh
@@ -85,6 +85,7 @@ DEFAULT_TESTS=(
     "5_5_4_2"
     "5_5_5"
     "5_5_7"
+    "5_8_2"
 )
 
 # Use provided arguments or the default test list

--- a/tests/nexus/test_5_8_2.cpp
+++ b/tests/nexus/test_5_8_2.cpp
@@ -1,0 +1,183 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+
+#include "platform/nexus_core.hpp"
+#include "platform/nexus_node.hpp"
+
+namespace ot {
+namespace Nexus {
+
+/**
+ * Time to advance for a node to form a network and become leader, in milliseconds.
+ */
+static constexpr uint32_t kFormNetworkTime = 13 * 1000;
+
+/**
+ * Time to advance for a node to join as a child and upgrade to a router, in milliseconds.
+ */
+static constexpr uint32_t kAttachToRouterTime = 200 * 1000;
+
+/**
+ * Time to advance for the network to stabilize.
+ */
+static constexpr uint32_t kStabilizationTime = 32 * 1000;
+
+/**
+ * Initial key sequence counter value.
+ */
+static constexpr uint32_t kInitialKeySequence = 0;
+
+void Test5_8_2(void)
+{
+    /**
+     * 5.8.2 Key Increment Of 1
+     *
+     * 5.8.2.1 Topology
+     * - Leader
+     * - Router_1 (DUT)
+     *
+     * 5.8.2.2 Purpose & Description
+     * The purpose of this test case is to verify that the DUT properly decrypts MAC and MLE packets secured with a key
+     *   index incremented by 1 and switches to the new key.
+     *
+     * Spec Reference                  | V1.1 Section | V1.3.0 Section
+     * --------------------------------|--------------|---------------
+     * MLE Message Security Processing | 7.3.1        | 7.3.1
+     */
+
+    Core nexus;
+
+    Node &leader  = nexus.CreateNode();
+    Node &router1 = nexus.CreateNode();
+
+    leader.SetName("LEADER");
+    router1.SetName("ROUTER_1");
+
+    nexus.AdvanceTime(0);
+
+    Instance::SetLogLevel(kLogLevelNote);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 1: Leader forms the network");
+
+    /**
+     * Step 1: Leader
+     * - Description: Forms the network. Starts the network using KeySequenceCounter = 0x00 (0).
+     * - Pass Criteria: N/A
+     */
+    leader.Get<KeyManager>().SetCurrentKeySequence(kInitialKeySequence, KeyManager::kForceUpdate);
+    leader.Form();
+    nexus.AdvanceTime(kFormNetworkTime);
+    VerifyOrQuit(leader.Get<Mle::Mle>().IsLeader());
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 2: Router_1 (DUT) attaches to the network");
+
+    /**
+     * Step 2: Router_1 (DUT)
+     * - Description: Automatically attaches to the network.
+     * - Pass Criteria:
+     *   - The DUT MUST send MLE Parent Request with MLE Auxiliary Security Header containing:
+     *     - Key ID Mode = 0x02 (2)
+     *     - Key Source = 0x00 (0)
+     *     - Key Index = 0x01 (1)
+     *   - The DUT MUST send MLE Child ID Request with MLE Auxiliary Security Header containing:
+     *     - Key ID Mode = 0x02 (2)
+     *     - Key Source = 0x00 (0)
+     *     - Key Index = 0x01 (1)
+     */
+    router1.Join(leader);
+    nexus.AdvanceTime(kAttachToRouterTime);
+    VerifyOrQuit(router1.Get<Mle::Mle>().IsRouter());
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 3: Leader sends ICMPv6 Echo Request to the DUT");
+
+    /**
+     * Step 3: Leader
+     * - Description: Harness instructs the device to send an ICMPv6 Echo Request to the DUT.
+     * - Pass Criteria:
+     *   - The DUT MUST respond with an ICMPv6 Echo Reply with MAC Auxiliary Security Header containing:
+     *     - Key ID Mode = 0x01 (1)
+     *     - Key Index = 0x01 (1)
+     */
+    nexus.SendAndVerifyEchoRequest(leader, router1.Get<Mle::Mle>().GetLinkLocalAddress());
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 4: Leader increments KeySequenceCounter by 1 to force a key switch");
+
+    /**
+     * Step 4: Leader
+     * - Description: Harness instructs the device to increment KeySequenceCounter by 1 to force a key switch. The DUT
+     *   is expected to set incoming frame counters to 0 for all existing devices and send subsequent MAC and MLE frames
+     *   with Key Index = 2.
+     * - Pass Criteria: N/A
+     */
+    leader.Get<KeyManager>().SetCurrentKeySequence(leader.Get<KeyManager>().GetCurrentKeySequence() + 1,
+                                                   KeyManager::kForceUpdate);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 5: Leader sends ICMPv6 Echo Request to the DUT");
+
+    /**
+     * Step 5: Leader
+     * - Description: Harness instructs the device to send an ICMPv6 Echo Request to the DUT.
+     * - Pass Criteria:
+     *   - The DUT MUST respond with an ICMPv6 Echo Reply with MAC Auxiliary security header containing:
+     *     - Key ID Mode = 0x01 (1)
+     *     - Key Index = 0x02 (2)
+     */
+    nexus.SendAndVerifyEchoRequest(leader, router1.Get<Mle::Mle>().GetLinkLocalAddress());
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 6: Router_1 (DUT) automatically reflects the Key Index update in its Advertisements");
+
+    /**
+     * Step 6: Router_1 (DUT)
+     * - Description: Automatically reflects the Key Index update in its Advertisements.
+     * - Pass Criteria:
+     *   - The DUT MUST send MLE Advertisements with MLE Auxiliary security header containing:
+     *     - Key ID Mode = 0x02 (2)
+     *     - Key Index = 0x02 (2)
+     */
+    nexus.AdvanceTime(kStabilizationTime);
+
+    nexus.SaveTestInfo("test_5_8_2.json");
+}
+
+} // namespace Nexus
+} // namespace ot
+
+int main(void)
+{
+    ot::Nexus::Test5_8_2();
+    printf("All tests passed\n");
+    return 0;
+}

--- a/tests/nexus/verify_5_8_2.py
+++ b/tests/nexus/verify_5_8_2.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import sys
+import os
+
+# Add the current directory to sys.path to find verify_utils
+CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(CUR_DIR)
+
+import verify_utils
+from pktverify import consts
+
+# Key ID Mode constants
+KEY_ID_MODE_1 = 1
+KEY_ID_MODE_2 = 2
+
+
+def _check_aux_sec(key_id_mode, key_index, key_source=None):
+
+    def _check(p):
+        return p.wpan.aux_sec.key_id_mode == key_id_mode and \
+               p.wpan.aux_sec.key_index == key_index and \
+               (key_source is None or \
+                p.wpan.aux_sec.key_source == key_source)
+
+    return _check
+
+
+def _verify_ping(pkts, src, dst, req_check=None, reply_check=None):
+    req_v = (pkts.filter_ping_request().filter_wpan_src64(src).filter_wpan_dst64(dst))
+
+    if req_check:
+        req_v = req_v.filter(req_check)
+
+    req_p = req_v.must_next()
+
+    reply_v = (pkts.filter_ping_reply(identifier=req_p.icmpv6.echo.identifier).filter(
+        f'frame.number > {req_p.number}').filter_wpan_src64(dst).filter_wpan_dst64(src))
+
+    if reply_check:
+        reply_v = reply_v.filter(reply_check)
+
+    reply_v.must_next()
+
+
+def verify(pv):
+    # 5.8.2 Key Increment Of 1
+    #
+    # 5.8.2.1 Topology
+    # - Leader
+    # - Router_1 (DUT)
+    #
+    # 5.8.2.2 Purpose & Description
+    # The purpose of this test case is to verify that the DUT properly decrypts MAC and MLE packets secured with a key
+    #   index incremented by 1 and switches to the new key.
+    #
+    # Spec Reference                  | V1.1 Section | V1.3.0 Section
+    # --------------------------------|--------------|---------------
+    # MLE Message Security Processing | 7.3.1        | 7.3.1
+
+    pkts = pv.pkts
+    pv.summary.show()
+
+    LEADER = pv.vars['LEADER']
+    ROUTER_1 = pv.vars['ROUTER_1']
+
+    # Step 1: Leader
+    # - Description: Forms the network. Starts the network using KeySequenceCounter = 0x00 (0).
+    # - Pass Criteria: N/A
+    print("Step 1: Leader forms the network")
+
+    # Step 2: Router_1 (DUT)
+    # - Description: Automatically attaches to the network.
+    # - Pass Criteria:
+    #   - The DUT MUST send MLE Parent Request with MLE Auxiliary Security Header containing:
+    #     - Key ID Mode = 0x02 (2)
+    #     - Key Source = 0x00 (0)
+    #     - Key Index = 0x01 (1)
+    #   - The DUT MUST send MLE Child ID Request with MLE Auxiliary Security Header containing:
+    #     - Key ID Mode = 0x02 (2)
+    #     - Key Source = 0x00 (0)
+    #     - Key Index = 0x01 (1)
+    print("Step 2: Router_1 (DUT) attaches to the network")
+    (pkts.filter_wpan_src64(ROUTER_1).filter_mle_cmd(consts.MLE_PARENT_REQUEST).filter(
+        _check_aux_sec(KEY_ID_MODE_2, 1, 0)).must_next())
+
+    (pkts.filter_wpan_src64(ROUTER_1).filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST).filter(
+        _check_aux_sec(KEY_ID_MODE_2, 1, 0)).must_next())
+
+    # Step 3: Leader
+    # - Description: Harness instructs the device to send an ICMPv6 Echo Request to the DUT.
+    # - Pass Criteria:
+    #   - The DUT MUST respond with an ICMPv6 Echo Reply with MAC Auxiliary Security Header containing:
+    #     - Key ID Mode = 0x01 (1)
+    #     - Key Index = 0x01 (1)
+    print("Step 3: Leader sends ICMPv6 Echo Request to the DUT")
+    _verify_ping(pkts, LEADER, ROUTER_1, reply_check=_check_aux_sec(KEY_ID_MODE_1, 1))
+
+    # Step 4: Leader
+    # - Description: Harness instructs the device to increment KeySequenceCounter by 1 to force a key switch. The DUT
+    #   is expected to set incoming frame counters to 0 for all existing devices and send subsequent MAC and MLE frames
+    #   with Key Index = 2.
+    # - Pass Criteria: N/A
+    print("Step 4: Leader increments KeySequenceCounter by 1 to force a key switch")
+
+    # Step 5: Leader
+    # - Description: Harness instructs the device to send an ICMPv6 Echo Request to the DUT.
+    # - Pass Criteria:
+    #   - The DUT MUST respond with an ICMPv6 Echo Reply with MAC Auxiliary security header containing:
+    #     - Key ID Mode = 0x01 (1)
+    #     - Key Index = 0x02 (2)
+    print("Step 5: Leader sends ICMPv6 Echo Request to the DUT")
+    _verify_ping(pkts,
+                 LEADER,
+                 ROUTER_1,
+                 req_check=_check_aux_sec(KEY_ID_MODE_1, 2),
+                 reply_check=_check_aux_sec(KEY_ID_MODE_1, 2))
+
+    # Step 6: Router_1 (DUT)
+    # - Description: Automatically reflects the Key Index update in its Advertisements.
+    # - Pass Criteria:
+    #   - The DUT MUST send MLE Advertisements with MLE Auxiliary security header containing:
+    #     - Key ID Mode = 0x02 (2)
+    #     - Key Index = 0x02 (2)
+    print("Step 6: Router_1 (DUT) automatically reflects the Key Index update in its Advertisements")
+    (pkts.filter_wpan_src64(ROUTER_1).filter_mle_cmd(consts.MLE_ADVERTISEMENT).filter(_check_aux_sec(KEY_ID_MODE_2,
+                                                                                                     2)).must_next())
+
+
+if __name__ == '__main__':
+    verify_utils.run_main(verify)

--- a/tests/scripts/thread-cert/pktverify/packet.py
+++ b/tests/scripts/thread-cert/pktverify/packet.py
@@ -106,6 +106,10 @@ class Packet(object):
     def dns(self) -> DnsLayer:
         return DnsLayer(self._packet, 'dns')
 
+    @property
+    def number(self) -> int:
+        return int(self._packet.number)
+
     def __getattr__(self, layer_name: str) -> Layer:
 
         real_layer_name = layer_name

--- a/tests/scripts/thread-cert/pktverify/utils.py
+++ b/tests/scripts/thread-cert/pktverify/utils.py
@@ -62,6 +62,7 @@ def make_filter_func(func: Union[str, Callable], **vars) -> Callable:
                     'eth': p.eth,
                     'icmpv6': p.icmpv6,
                     'udp': p.udp,
+                    'frame': p,
                     'thread_bl': p.thread_bl,
                     'thread_meshcop': p.thread_meshcop,
                     'Bytes': Bytes,


### PR DESCRIPTION
This commit adds a new Nexus test case for 'Key Increment Of 1' (5.8.2) as specified in the test specification.

Summary of changes:
- Implemented Nexus test 5.8.2:
    - Added tests/nexus/test_5_8_2.cpp: Sets up a network topology with a Leader and Router_1 (DUT). Verifies proper decryption of MAC and MLE packets secured with an incremented key index. Uses direct method calls and block comments.
    - Added tests/nexus/verify_5_8_2.py: PCAP verification script for test 5.8.2. Validates key index transitions in MLE Parent Request, Child ID Request, ICMPv6 Echo, and MLE Advertisements.
- Updated build and execution scripts:
    - Modified tests/nexus/CMakeLists.txt to build the new test.
    - Updated tests/nexus/run_nexus_tests.sh to include 5.8.2 in the default test list.