### PR TITLE
[nexus] add JSON writer to simplify `Nexus::Core::SaveTestInfo()`

### DIFF
--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -161,6 +161,17 @@ exit:
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+// NetworkKey
+
+NetworkKey::InfoString NetworkKey::ToString(void) const
+{
+    InfoString string;
+
+    string.AppendHexBytes(m8, kSize);
+    return string;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 // KeyManager
 
 KeyManager::KeyManager(Instance &aInstance)

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -138,7 +138,10 @@ OT_TOOL_PACKED_BEGIN
 class NetworkKey : public otNetworkKey, public Equatable<NetworkKey>, public Clearable<NetworkKey>
 {
 public:
-    static constexpr uint8_t kSize = OT_NETWORK_KEY_SIZE; ///< Size of the Thread Network Key (in bytes).
+    static constexpr uint8_t  kSize           = OT_NETWORK_KEY_SIZE; ///< Size of the Thread Network Key (in bytes).
+    static constexpr uint16_t kInfoStringSize = kSize * 2 + 1;       ///< Max chars for the info string (`ToString()`).
+
+    typedef String<kInfoStringSize> InfoString; ///< Fixed-length `String` object returned from `ToString()
 
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
     /**
@@ -149,6 +152,13 @@ public:
      */
     Error GenerateRandom(void) { return Random::Crypto::Fill(*this); }
 #endif
+
+    /**
+     * Converts the `NetworkKey` to a null-terminated string.
+     *
+     * @returns A `String` representing the `NetworkKey` (all bytes in hex format).
+     */
+    InfoString ToString(void) const;
 
 } OT_TOOL_PACKED_END;
 

--- a/src/core/thread/version.cpp
+++ b/src/core/thread/version.cpp
@@ -36,16 +36,21 @@
 namespace ot {
 
 #if OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_1
-const char kThreadVersionString[] = "1.1.1";
+const char kThreadVersionString[]      = "1.1.1";
+const char kThreadVersionStringShort[] = "1.1";
 #elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_2
-const char kThreadVersionString[] = "1.2.0";
+const char kThreadVersionString[]      = "1.2.0";
+const char kThreadVersionStringShort[] = "1.2";
 #elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_3
-const char kThreadVersionString[] = "1.3.0";
+const char kThreadVersionString[]      = "1.3.0";
+const char kThreadVersionStringShort[] = "1.3";
 #elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_3_1
 // Support projects on legacy "1.3.1" version, which is now "1.4"
-const char kThreadVersionString[] = "1.4.0";
+const char kThreadVersionString[]      = "1.4.0";
+const char kThreadVersionStringShort[] = "1.4";
 #elif OPENTHREAD_CONFIG_THREAD_VERSION == OT_THREAD_VERSION_1_4
-const char kThreadVersionString[] = "1.4.0";
+const char kThreadVersionString[]      = "1.4.0";
+const char kThreadVersionStringShort[] = "1.4";
 #else
 #error "The `OPENTHREAD_CONFIG_THREAD_VERSION` is not valid or supported"
 #endif

--- a/src/core/thread/version.hpp
+++ b/src/core/thread/version.hpp
@@ -49,7 +49,8 @@ constexpr uint16_t kThreadVersion1p3 = OT_THREAD_VERSION_1_3; ///< Thread Versio
 constexpr uint16_t kThreadVersion1p3p1 = OT_THREAD_VERSION_1_3_1; ///< Thread Version 1.3.1
 constexpr uint16_t kThreadVersion1p4   = OT_THREAD_VERSION_1_4;   ///< Thread Version 1.4
 
-extern const char kThreadVersionString[]; ///< Thread version as human-readable string.
+extern const char kThreadVersionString[];      ///< Thread version as human-readable string - full (e.g. "1.4.0")
+extern const char kThreadVersionStringShort[]; ///< Thread version as human-readable string - short (e.g. "1.3")
 
 } // namespace ot
 

--- a/tests/nexus/CMakeLists.txt
+++ b/tests/nexus/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(ot-nexus-platform
     platform/nexus_alarm.cpp
     platform/nexus_core.cpp
     platform/nexus_infra_if.cpp
+    platform/nexus_json.cpp
     platform/nexus_mdns.cpp
     platform/nexus_misc.cpp
     platform/nexus_node.cpp

--- a/tests/nexus/platform/nexus_core.cpp
+++ b/tests/nexus/platform/nexus_core.cpp
@@ -31,6 +31,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "nexus_json.hpp"
 #include "nexus_node.hpp"
 
 namespace ot {
@@ -61,151 +62,120 @@ Core::Core(void)
     }
 }
 
-void Core::SaveTestInfo(const char *aFilename)
+void Core::SaveTestInfo(const char *aFileName)
 {
-    FILE       *file = fopen(aFilename, "w");
-    Node       *tail = mNodes.GetTail();
-    const char *testcase;
-    const char *slash;
-    const char *dot;
-    const char *version;
-    int         testcaseLen;
+    Json::Writer jsonWriter;
 
-    VerifyOrExit(file != nullptr);
+    SuccessOrExit(jsonWriter.OpenFile(aFileName));
 
-    testcase = aFilename;
-    slash    = strrchr(aFilename, '/');
-
-    if (slash != nullptr)
-    {
-        testcase = slash + 1;
-    }
-
-    dot         = strrchr(testcase, '.');
-    testcaseLen = (dot != nullptr) ? static_cast<int>(dot - testcase) : static_cast<int>(strlen(testcase));
-
-    switch (otThreadGetVersion())
-    {
-    case OT_THREAD_VERSION_1_1:
-        version = "1.1";
-        break;
-    case OT_THREAD_VERSION_1_2:
-        version = "1.2";
-        break;
-    case OT_THREAD_VERSION_1_3:
-        version = "1.3";
-        break;
-    case OT_THREAD_VERSION_1_4:
-        version = "1.4";
-        break;
-    default:
-        version = "unknown";
-        break;
-    }
-
-    fprintf(file, "{\n");
-    fprintf(file, "  \"testcase\": \"%.*s\",\n", testcaseLen, testcase);
-    fprintf(file, "  \"pcap\": \"%s\",\n", getenv("OT_NEXUS_PCAP_FILE") ? getenv("OT_NEXUS_PCAP_FILE") : "");
+    jsonWriter.WriteNameValue("testcase", Json::ExtractTestName(aFileName).AsCString());
+    jsonWriter.WriteNameValue("pcap", getenv("OT_NEXUS_PCAP_FILE"));
 
     if (!mNodes.IsEmpty())
     {
-        NetworkKey                          networkKey;
-        Node                               &node = *mNodes.GetHead();
-        String<OT_NETWORK_KEY_SIZE * 2 + 1> keyString;
+        NetworkKey networkKey;
 
-        node.Get<KeyManager>().GetNetworkKey(networkKey);
-        keyString.AppendHexBytes(networkKey.m8, OT_NETWORK_KEY_SIZE);
-        fprintf(file, "  \"network_key\": \"%s\",\n", keyString.AsCString());
+        mNodes.GetHead()->Get<KeyManager>().GetNetworkKey(networkKey);
 
-        for (Node &leaderNode : mNodes)
+        jsonWriter.WriteNameValue("network_key", networkKey.ToString().AsCString());
+
+        for (Node &node : mNodes)
         {
-            if (leaderNode.Get<Mle::Mle>().IsLeader())
+            if (node.Get<Mle::Mle>().IsLeader())
             {
                 Ip6::Address aloc;
-                leaderNode.Get<Mle::Mle>().GetLeaderAloc(aloc);
-                fprintf(file, "  \"leader_aloc\": \"%s\",\n", aloc.ToString().AsCString());
+
+                node.Get<Mle::Mle>().GetLeaderAloc(aloc);
+                jsonWriter.WriteNameValue("leader_aloc", aloc.ToString().AsCString());
                 break;
             }
         }
     }
 
-    fprintf(file, "  \"topology\": {\n");
+    jsonWriter.BeginObject("topology");
+
     for (Node &node : mNodes)
     {
-        fprintf(file, "    \"%u\": {\"name\": \"%s\", \"version\": \"%s\"}%s\n", node.GetInstance().GetId(),
-                node.GetName() ? node.GetName() : "", version, (&node == tail) ? "" : ",");
+        jsonWriter.BeginObject(node.GetId());
+        jsonWriter.WriteNameValue("name", node.GetName());
+        jsonWriter.WriteNameValue("version", kThreadVersionStringShort);
+        jsonWriter.EndObject();
     }
-    fprintf(file, "  },\n");
+    jsonWriter.EndObject();
 
-    fprintf(file, "  \"extaddrs\": {\n");
+    jsonWriter.BeginObject("extaddrs");
+
     for (Node &node : mNodes)
     {
-        fprintf(file, "    \"%u\": \"%s\"%s\n", node.GetInstance().GetId(),
-                node.Get<Mac::Mac>().GetExtAddress().ToString().AsCString(), (&node == tail) ? "" : ",");
+        jsonWriter.WriteNameValue(node.GetId(), node.Get<Mac::Mac>().GetExtAddress().ToString().AsCString());
     }
-    fprintf(file, "  },\n");
 
-    fprintf(file, "  \"rloc16s\": {\n");
+    jsonWriter.EndObject();
+
+    jsonWriter.BeginObject("rloc16s");
+
     for (Node &node : mNodes)
     {
-        fprintf(file, "    \"%u\": \"0x%04x\"%s\n", node.GetInstance().GetId(), node.Get<Mle::Mle>().GetRloc16(),
-                (&node == tail) ? "" : ",");
+        constexpr uint16_t kRlocStringSize = 10;
+
+        String<kRlocStringSize> rlocString;
+
+        rlocString.Append("0x%04x", node.Get<Mle::Mle>().GetRloc16());
+        jsonWriter.WriteNameValue(node.GetId(), rlocString.AsCString());
     }
-    fprintf(file, "  },\n");
 
-    fprintf(file, "  \"mleids\": {\n");
+    jsonWriter.EndObject();
+
+    jsonWriter.BeginObject("mleids");
+
     for (Node &node : mNodes)
     {
-        fprintf(file, "    \"%u\": \"%s\"%s\n", node.GetInstance().GetId(),
-                node.Get<Mle::Mle>().GetMeshLocalEid().ToString().AsCString(), (&node == tail) ? "" : ",");
+        jsonWriter.WriteNameValue(node.GetId(), node.Get<Mle::Mle>().GetMeshLocalEid().ToString().AsCString());
     }
-    fprintf(file, "  },\n");
 
-    fprintf(file, "  \"rlocs\": {\n");
+    jsonWriter.EndObject();
+
+    jsonWriter.BeginObject("rlocs");
+
     for (Node &node : mNodes)
     {
-        fprintf(file, "    \"%u\": \"%s\"%s\n", node.GetInstance().GetId(),
-                node.Get<Mle::Mle>().GetMeshLocalRloc().ToString().AsCString(), (&node == tail) ? "" : ",");
+        jsonWriter.WriteNameValue(node.GetId(), node.Get<Mle::Mle>().GetMeshLocalRloc().ToString().AsCString());
     }
-    fprintf(file, "  },\n");
 
-    fprintf(file, "  \"ipaddrs\": {\n");
+    jsonWriter.EndObject();
+
+    jsonWriter.BeginObject("ipaddrs");
+
     for (Node &node : mNodes)
     {
-        bool first = true;
+        jsonWriter.BeginArray(node.GetId());
 
-        fprintf(file, "    \"%u\": [\n", node.GetInstance().GetId());
         for (const Ip6::Netif::UnicastAddress &addr : node.Get<ThreadNetif>().GetUnicastAddresses())
         {
-            if (!first)
-            {
-                fprintf(file, ",\n");
-            }
-            fprintf(file, "      \"%s\"", addr.GetAddress().ToString().AsCString());
-            first = false;
+            jsonWriter.WriteValue(addr.GetAddress().ToString().AsCString());
         }
-        fprintf(file, "\n    ]%s\n", (&node == tail) ? "" : ",");
-    }
-    fprintf(file, "  },\n");
 
-    fprintf(file, "  \"extra_vars\": {\n");
+        jsonWriter.EndArray();
+    }
+
+    jsonWriter.EndObject();
+
+    jsonWriter.BeginObject("extra_vars");
+
     if (!mNodes.IsEmpty())
     {
-        Node       &node = *mNodes.GetHead();
         Ip6::Prefix prefix;
 
-        prefix.Set(node.Get<Mle::Mle>().GetMeshLocalPrefix());
-        fprintf(file, "    \"mesh_local_prefix\": \"%s\"\n", prefix.ToString().AsCString());
+        prefix.Set(mNodes.GetHead()->Get<Mle::Mle>().GetMeshLocalPrefix());
+        jsonWriter.WriteNameValue("mesh_local_prefix", prefix.ToString().AsCString());
     }
-    fprintf(file, "  }\n");
 
-    fprintf(file, "}\n");
+    jsonWriter.EndObject();
+
+    jsonWriter.CloseFile();
 
 exit:
-    if (file != nullptr)
-    {
-        fclose(file);
-    }
+    return;
 }
 
 Core::~Core(void) { sInUse = false; }

--- a/tests/nexus/platform/nexus_core.hpp
+++ b/tests/nexus/platform/nexus_core.hpp
@@ -59,7 +59,7 @@ public:
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Test specific helper methods
 
-    void SaveTestInfo(const char *aFilename);
+    void SaveTestInfo(const char *aFileName);
     void SendAndVerifyEchoRequest(Node               &aSender,
                                   const Ip6::Address &aDestination,
                                   uint16_t            aPayloadSize     = 0,

--- a/tests/nexus/platform/nexus_json.cpp
+++ b/tests/nexus/platform/nexus_json.cpp
@@ -1,0 +1,182 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "nexus_json.hpp"
+
+namespace ot {
+namespace Nexus {
+namespace Json {
+
+TestNameString ExtractTestName(const char *aFileName)
+{
+    TestNameString testName;
+    const char    *start;
+    const char    *slash;
+    const char    *dot;
+
+    start = aFileName;
+    slash = strrchr(start, '/');
+
+    if (slash != nullptr)
+    {
+        start = slash + 1;
+    }
+
+    dot = strrchr(start, '.');
+
+    if (dot == nullptr)
+    {
+        testName.Append("%s", start);
+    }
+    else
+    {
+        testName.Append("%.*s", static_cast<int>(dot - start), start);
+    }
+
+    return testName;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+// Writer
+
+Writer::Writer(void)
+    : mFile(nullptr)
+    , mIndentation(0)
+    , mShouldWriteComma(false)
+{
+}
+
+Writer::~Writer(void) { CloseFile(); }
+
+Error Writer::OpenFile(const char *aFileName)
+{
+    Error error = kErrorNone;
+
+    if (mFile != nullptr)
+    {
+        CloseFile();
+    }
+
+    mFile = fopen(aFileName, "w");
+
+    VerifyOrExit(mFile != nullptr, error = kErrorFailed);
+
+    fprintf(mFile, "{");
+
+    mShouldWriteComma = false;
+    mIndentation      = kIndentSize;
+
+exit:
+    return error;
+}
+
+void Writer::CloseFile(void)
+{
+    VerifyOrExit(mFile != nullptr);
+
+    fprintf(mFile, "\n}\n");
+
+    fclose(mFile);
+    mFile             = nullptr;
+    mIndentation      = 0;
+    mShouldWriteComma = false;
+
+exit:
+    return;
+}
+
+void Writer::WriteIndentation(void) { fprintf(mFile, "%*s", mIndentation, ""); }
+
+void Writer::GoToNextLine(void) { fprintf(mFile, "%s\n", mShouldWriteComma ? "," : ""); }
+
+void Writer::Write(const char *aName, const char *aValue)
+{
+    VerifyOrExit(mFile != nullptr);
+
+    GoToNextLine();
+
+    WriteIndentation();
+
+    if (aName != nullptr)
+    {
+        fprintf(mFile, "\"%s\": ", aName);
+    }
+
+    fprintf(mFile, "\"%s\"", (aValue == nullptr) ? "" : aValue);
+
+    mShouldWriteComma = true;
+
+exit:
+    return;
+}
+
+void Writer::Write(Node::Id aNodeId, const char *aValue) { Write(Node::IdToString(aNodeId).AsCString(), aValue); }
+
+void Writer::Begin(const char *aName, char aBeginChar)
+{
+    VerifyOrExit(mFile != nullptr);
+
+    GoToNextLine();
+
+    WriteIndentation();
+    mIndentation += kIndentSize;
+
+    if (aName != nullptr)
+    {
+        fprintf(mFile, "\"%s\": ", aName);
+    }
+
+    fprintf(mFile, "%c", aBeginChar);
+
+    mShouldWriteComma = false;
+
+exit:
+    return;
+}
+
+void Writer::Begin(Node::Id aNodeId, char aBeginChar) { Begin(Node::IdToString(aNodeId).AsCString(), aBeginChar); }
+
+void Writer::End(char aEndChar)
+{
+    mShouldWriteComma = false;
+    GoToNextLine();
+
+    if (mIndentation >= kIndentSize)
+    {
+        mIndentation -= kIndentSize;
+    }
+
+    WriteIndentation();
+    fprintf(mFile, "%c", aEndChar);
+
+    mShouldWriteComma = true;
+}
+
+} // namespace Json
+} // namespace Nexus
+} // namespace ot

--- a/tests/nexus/platform/nexus_json.hpp
+++ b/tests/nexus/platform/nexus_json.hpp
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OT_NEXUS_PLATFORM_NEXUS_JSON_HPP_
+#define OT_NEXUS_PLATFORM_NEXUS_JSON_HPP_
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "nexus_node.hpp"
+
+namespace ot {
+namespace Nexus {
+namespace Json {
+
+constexpr uint16_t kTestNameStringSize = 32;
+
+using TestNameString = String<kTestNameStringSize>;
+
+TestNameString ExtractTestName(const char *aFileName);
+
+class Writer
+{
+public:
+    // Simple JSON writer (used by `Core::SaveTestInfo()`).
+
+    Writer(void);
+    ~Writer(void);
+
+    Error OpenFile(const char *aFileName);
+    void  CloseFile(void);
+
+    // If `aValue` is `nullptr`, empty string is ("") used.
+    void WriteNameValue(const char *aName, const char *aValue) { Write(aName, aValue); }
+    void WriteNameValue(Node::Id aNodeId, const char *aValue) { Write(aNodeId, aValue); }
+    void WriteValue(const char *aValue) { Write(/* aName */ nullptr, aValue); }
+
+    void BeginObject(const char *aName) { Begin(aName, '{'); }
+    void BeginObject(Node::Id aNodeId) { Begin(aNodeId, '{'); }
+    void EndObject(void) { End('}'); }
+
+    void BeginArray(const char *aName) { Begin(aName, '['); }
+    void BeginArray(Node::Id aNodeId) { Begin(aNodeId, '['); }
+    void EndArray(void) { End(']'); }
+
+private:
+    static constexpr uint16_t kIndentSize = 2;
+
+    void WriteIndentation(void);
+    void GoToNextLine(void);
+    void Write(const char *aName, const char *aValue);
+    void Write(Node::Id aNodeId, const char *aValue);
+    void Begin(const char *aName, char aBeginChar);
+    void Begin(Node::Id aNodeId, char aBeginChar);
+    void End(char aEndChar);
+
+    FILE    *mFile;
+    uint16_t mIndentation;
+    bool     mShouldWriteComma;
+};
+
+} // namespace Json
+} // namespace Nexus
+} // namespace ot
+
+#endif // OT_NEXUS_PLATFORM_NEXUS_JSON_HPP_

--- a/tests/nexus/platform/nexus_node.cpp
+++ b/tests/nexus/platform/nexus_node.cpp
@@ -32,6 +32,14 @@
 namespace ot {
 namespace Nexus {
 
+Node::IdString Node::IdToString(Id aId)
+{
+    IdString string;
+
+    string.Append("%lu", ToUlong(aId));
+    return string;
+}
+
 void Node::Reset(void)
 {
     Instance *instance = &GetInstance();

--- a/tests/nexus/platform/nexus_node.hpp
+++ b/tests/nexus/platform/nexus_node.hpp
@@ -66,6 +66,11 @@ class Node : public Platform, public Heap::Allocatable<Node>, public LinkedListE
     friend class Heap::Allocatable<Node>;
 
 public:
+    static constexpr uint16_t kIdStringSize = 12;
+
+    typedef String<kIdStringSize> IdString;
+    typedef uint32_t              Id;
+
     enum JoinMode : uint8_t
     {
         kAsFtd,
@@ -110,7 +115,9 @@ public:
         return *this;
     }
 
-    uint32_t GetId(void) { return GetInstance().GetId(); }
+    Id GetId(void) { return GetInstance().GetId(); }
+
+    static IdString IdToString(Id aId);
 
     static Node &From(otInstance *aInstance) { return static_cast<Node &>(*aInstance); }
 


### PR DESCRIPTION
This commit introduces a `Json::Writer` utility class in the nexus platform to simplify and standardize the generation of JSON output. The `Core::SaveTestInfo()` is updated to utilize this new `Writer`, replacing manual `fprintf` formatting with structured object and array creation methods.

Key changes include:
- `Json::Writer` to handle file I/O, indentation, and JSON syntax (braces, brackets, commas).
- `ExtractTestName()` to parse test case name from JSON file name.
- `NetworkKey::ToString()` to convert network key to string.
- `kThreadVersionStringShort` in `version.hpp` to provide short version as major.minor version strings (e.g., "1.4" instead of full "1.4.0").