### PR TITLE
[spinel] add libopenthread-radio-spinel GN library

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -101,6 +101,11 @@ group("libopenthread-spinel-rcp") {
   deps = [ "src/lib/spinel:libopenthread-spinel-rcp" ]
 }
 
+group("libopenthread-radio-spinel") {
+  public_deps = [ "src/lib/spinel:spinel-api" ]
+  deps = [ "src/lib/spinel:libopenthread-radio-spinel" ]
+}
+
 if (current_os == "fuchsia") {
   group("lib-ot-core") {
     public_deps = [

--- a/src/lib/spinel/BUILD.gn
+++ b/src/lib/spinel/BUILD.gn
@@ -85,6 +85,25 @@ static_library("libopenthread-spinel-ncp") {
   ]
 }
 
+static_library("libopenthread-radio-spinel") {
+  sources = spinel_sources
+  public_deps = [
+    ":spinel-api",
+    "../../core:libopenthread_core_headers",
+    "../platform:libopenthread-platform",
+  ]
+
+  defines = [
+    "OPENTHREAD_FTD=0",
+    "OPENTHREAD_MTD=0",
+    "OPENTHREAD_RADIO=0",
+  ]
+
+  public_configs = [
+    ":spinel_config_openthread_message_disable",
+  ]
+}
+
 static_library("libopenthread-spinel-rcp") {
   sources = spinel_sources
   public_deps = [


### PR DESCRIPTION
**Context**

For NXP RTs/rw61x platforms running Matter over Thread, we rely on the RCP architecture to generate the radio-spinel libraries used on the host side. However, on these platforms we also need to support FTD or MTD builds.
The current Matter dependency for rw61x RCP is defined here:
https://github.com/project-chip/connectedhomeip/blob/master/third_party/openthread/platforms/nxp/rt/rw61x/BUILD.gn#L187

**Issue**

Following this OpenThread change:
https://github.com/openthread/openthread/pull/12121/changes#diff-d7acea6210a7cc323c71038bc347fc751c62b8f13566c9dcdbc212328c8efa44
it is no longer possible to build libopenthread-spinel-rcp while also enabling OPENTHREAD_FTD or OPENTHREAD_MTD.
This is due to conflicting defines: OPENTHREAD_FTD, OPENTHREAD_MTD, and OPENTHREAD_RADIO now being explicitly forced by the library:
defines = [  "OPENTHREAD_FTD=0",  "OPENTHREAD_MTD=0",  "OPENTHREAD_RADIO=1",]
As a result, applications cannot build a configuration that uses spinel sources, and FTD or MTD configuration

Without spinel sources, the Matter build fails due to include restrictions such as:
openthread/ot-nxp/src/common/spinel/radio.cpp:44:11: Include not allowed.
#include "lib/spinel/spinel.h"

**Proposal**

Introduce two additional static libraries:

libopenthread-spinel-rcp-ftd
libopenthread-spinel-rcp-mtd

These variants would combine spinel sources, and either the openthread_ftd_config or openthread_mtd_config,

allowing platforms such as rw61x to build Thread FTD/MTD devices that still depend on the RCP spinel components.