### PR TITLE
[tests] add helper to allow link between nodes in nexus

### DIFF
--- a/tests/nexus/platform/nexus_core.cpp
+++ b/tests/nexus/platform/nexus_core.cpp
@@ -418,6 +418,18 @@ void Core::ProcessTrel(Node &aNode)
 
 //---------------------------------------------------------------------------------------------------------------------
 
+void Core::AllowLinkBetween(Node &aFirstNode, Node &aSecondNode)
+{
+    aFirstNode.AllowList(aSecondNode);
+    aSecondNode.AllowList(aFirstNode);
+}
+
+void Core::UnallowLinkBetween(Node &aFirstNode, Node &aSecondNode)
+{
+    aFirstNode.UnallowList(aSecondNode);
+    aSecondNode.UnallowList(aFirstNode);
+}
+
 Core::IcmpEchoResponseContext::IcmpEchoResponseContext(Node &aNode, uint16_t aIdentifier)
     : mNode(aNode)
     , mIdentifier(aIdentifier)

--- a/tests/nexus/platform/nexus_core.hpp
+++ b/tests/nexus/platform/nexus_core.hpp
@@ -59,6 +59,9 @@ public:
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Test specific helper methods
 
+    void AllowLinkBetween(Node &aFirstNode, Node &aSecondNode);
+    void UnallowLinkBetween(Node &aFirstNode, Node &aSecondNode);
+
     void SaveTestInfo(const char *aFilename);
     void SendAndVerifyEchoRequest(Node               &aSender,
                                   const Ip6::Address &aDestination,

--- a/tests/nexus/test_5_1_10.cpp
+++ b/tests/nexus/test_5_1_10.cpp
@@ -107,14 +107,9 @@ void Test5_1_10(void)
      */
 
     /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    leader.AllowList(router2);
-
-    router1.AllowList(leader);
-    router1.AllowList(router2);
-
-    router2.AllowList(leader);
-    router2.AllowList(router1);
+    nexus.AllowLinkBetween(leader, router1);
+    nexus.AllowLinkBetween(leader, router2);
+    nexus.AllowLinkBetween(router1, router2);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -140,11 +135,8 @@ void Test5_1_10(void)
      */
 
     /** Restricted topology for DUT. */
-    dut.AllowList(router1);
-    dut.AllowList(router2);
-
-    router1.AllowList(dut);
-    router2.AllowList(dut);
+    nexus.AllowLinkBetween(dut, router1);
+    nexus.AllowLinkBetween(dut, router2);
 
     IgnoreError(dut.Get<Mac::Filter>().AddRssIn(router2.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality2));
     IgnoreError(router2.Get<Mac::Filter>().AddRssIn(dut.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality2));

--- a/tests/nexus/test_5_1_11.cpp
+++ b/tests/nexus/test_5_1_11.cpp
@@ -107,32 +107,27 @@ void Test5_1_11(void)
     /**
      * Leader <-> REED_1
      */
-    leader.AllowList(reed1);
-    reed1.AllowList(leader);
+    nexus.AllowLinkBetween(leader, reed1);
 
     /**
      * Leader <-> Router_2
      */
-    leader.AllowList(router2);
-    router2.AllowList(leader);
+    nexus.AllowLinkBetween(leader, router2);
 
     /**
      * REED_1 <-> DUT
      */
-    reed1.AllowList(dut);
-    dut.AllowList(reed1);
+    nexus.AllowLinkBetween(reed1, dut);
 
     /**
      * Router_2 <-> DUT
      */
-    router2.AllowList(dut);
-    dut.AllowList(router2);
+    nexus.AllowLinkBetween(router2, dut);
 
     /**
      * REED_1 <-> Router_2 (to ensure they can see each other if needed, though not strictly required by topology)
      */
-    reed1.AllowList(router2);
-    router2.AllowList(reed1);
+    nexus.AllowLinkBetween(reed1, router2);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: Leader, REED_1, Router_2");

--- a/tests/nexus/test_5_1_12.cpp
+++ b/tests/nexus/test_5_1_12.cpp
@@ -78,12 +78,10 @@ void Test5_1_12(void)
     dut.SetName("DUT");
 
     // Leader <-> Router_2
-    leader.AllowList(router2);
-    router2.AllowList(leader);
+    nexus.AllowLinkBetween(leader, router2);
 
     // Leader <-> DUT
-    leader.AllowList(dut);
-    dut.AllowList(leader);
+    nexus.AllowLinkBetween(leader, dut);
 
     nexus.AdvanceTime(0);
 
@@ -133,8 +131,7 @@ void Test5_1_12(void)
      * - Description: Harness enables communication between Router_1 (DUT) and Router_2.
      * - Pass Criteria: N/A
      */
-    dut.AllowList(router2);
-    router2.AllowList(dut);
+    nexus.AllowLinkBetween(dut, router2);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 4: The DUT and Router_2 automatically exchange unicast Link Request and unicast Link Accept messages.");

--- a/tests/nexus/test_5_1_13.cpp
+++ b/tests/nexus/test_5_1_13.cpp
@@ -83,8 +83,7 @@ void Test5_1_13(void)
     nexus.AdvanceTime(0);
 
     // Use AllowList feature to restrict the topology.
-    leader.AllowList(router);
-    router.AllowList(leader);
+    nexus.AllowLinkBetween(leader, router);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: All");
@@ -127,7 +126,7 @@ void Test5_1_13(void)
      * - Pass Criteria: N/A
      */
     router.Reset();
-    router.AllowList(leader);
+    nexus.AllowLinkBetween(router, leader);
     router.Get<ThreadNetif>().Up();
     SuccessOrQuit(router.Get<Mle::Mle>().Start());
 

--- a/tests/nexus/test_5_1_2.cpp
+++ b/tests/nexus/test_5_1_2.cpp
@@ -99,14 +99,9 @@ void Test5_1_2(void)
     nexus.AdvanceTime(0);
 
     // Use AllowList feature to restrict the topology.
-    leader.AllowList(router);
-    router.AllowList(leader);
-
-    router.AllowList(med);
-    med.AllowList(router);
-
-    router.AllowList(sed);
-    sed.AllowList(router);
+    nexus.AllowLinkBetween(leader, router);
+    nexus.AllowLinkBetween(router, med);
+    nexus.AllowLinkBetween(router, sed);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: All");

--- a/tests/nexus/test_5_1_3.cpp
+++ b/tests/nexus/test_5_1_3.cpp
@@ -122,14 +122,9 @@ void Test5_1_3(void)
      */
 
     /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    leader.AllowList(router2);
-    router2.AllowList(leader);
-
-    router1.AllowList(router2);
-    router2.AllowList(router1);
+    nexus.AllowLinkBetween(leader, router1);
+    nexus.AllowLinkBetween(leader, router2);
+    nexus.AllowLinkBetween(router1, router2);
 
     leader.Get<Mle::Mle>().SetPreferredLeaderPartitionId(kMaxPartitionId);
     leader.Form();

--- a/tests/nexus/test_5_1_4.cpp
+++ b/tests/nexus/test_5_1_4.cpp
@@ -118,14 +118,9 @@ void Test5_1_4(void)
      */
 
     /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    leader.AllowList(router2);
-    router2.AllowList(leader);
-
-    router1.AllowList(router2);
-    router2.AllowList(router1);
+    nexus.AllowLinkBetween(leader, router1);
+    nexus.AllowLinkBetween(leader, router2);
+    nexus.AllowLinkBetween(router1, router2);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_5_1_5.cpp
+++ b/tests/nexus/test_5_1_5.cpp
@@ -96,8 +96,7 @@ void Test5_1_5(void)
      */
 
     /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
+    nexus.AllowLinkBetween(leader, router1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_5_1_6.cpp
+++ b/tests/nexus/test_5_1_6.cpp
@@ -73,8 +73,7 @@ void Test5_1_6(void)
     router.SetName("ROUTER");
 
     // Use AllowList feature to restrict the topology
-    leader.AllowList(router);
-    router.AllowList(leader);
+    nexus.AllowLinkBetween(leader, router);
 
     nexus.AdvanceTime(0);
 

--- a/tests/nexus/test_5_1_7.cpp
+++ b/tests/nexus/test_5_1_7.cpp
@@ -110,12 +110,11 @@ static void CreateNodes(Core &aNexus, Node *aNodes[], uint16_t aCount, const cha
     }
 }
 
-static void AllowListNodes(Node &aRouter, Node *aNodes[], uint16_t aCount)
+static void AllowLinkBetweenNodes(Core &aNexus, Node &aRouter, Node *aNodes[], uint16_t aCount)
 {
     for (uint16_t i = 0; i < aCount; i++)
     {
-        aRouter.AllowList(*aNodes[i]);
-        aNodes[i]->AllowList(aRouter);
+        aNexus.AllowLinkBetween(aRouter, *aNodes[i]);
     }
 }
 
@@ -165,11 +164,10 @@ void Test5_1_7(void)
     nexus.AdvanceTime(0);
 
     // Use AllowList feature to restrict the topology.
-    leader.AllowList(router);
-    router.AllowList(leader);
+    nexus.AllowLinkBetween(leader, router);
 
-    AllowListNodes(router, meds, kNumMeds);
-    AllowListNodes(router, seds, kNumSeds);
+    AllowLinkBetweenNodes(nexus, router, meds, kNumMeds);
+    AllowLinkBetweenNodes(nexus, router, seds, kNumSeds);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: Leader, Router_1 (DUT), Children");

--- a/tests/nexus/test_5_1_8.cpp
+++ b/tests/nexus/test_5_1_8.cpp
@@ -101,14 +101,9 @@ void Test5_1_8(void)
     // R3 <-> R1
     // R1 <-> R2
     // DUT hears R1, R2, R3
-    leader.AllowList(router3);
-    router3.AllowList(leader);
-
-    router3.AllowList(router1);
-    router1.AllowList(router3);
-
-    router1.AllowList(router2);
-    router2.AllowList(router1);
+    nexus.AllowLinkBetween(leader, router3);
+    nexus.AllowLinkBetween(router3, router1);
+    nexus.AllowLinkBetween(router1, router2);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: Leader, Router_1, Router_2, Router_3");
@@ -144,11 +139,8 @@ void Test5_1_8(void)
      *   a link quality of 3 (highest).
      * - Pass Criteria: N/A
      */
-    dut.AllowList(router2);
-    dut.AllowList(router3);
-
-    router2.AllowList(dut);
-    router3.AllowList(dut);
+    nexus.AllowLinkBetween(dut, router2);
+    nexus.AllowLinkBetween(dut, router3);
 
     // Harness configures the RSSI to prefer Router 3.
     // All values below enable Link Quality 3 (highest).

--- a/tests/nexus/test_5_1_9.cpp
+++ b/tests/nexus/test_5_1_9.cpp
@@ -114,17 +114,10 @@ void Test5_1_9(void)
      */
     Log("Step 1: Setup the topology without the DUT");
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    leader.AllowList(reed1);
-    reed1.AllowList(leader);
-
-    leader.AllowList(reed2);
-    reed2.AllowList(leader);
-
-    router1.AllowList(reed1);
-    reed1.AllowList(router1);
+    nexus.AllowLinkBetween(leader, router1);
+    nexus.AllowLinkBetween(leader, reed1);
+    nexus.AllowLinkBetween(leader, reed2);
+    nexus.AllowLinkBetween(router1, reed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -164,10 +157,8 @@ void Test5_1_9(void)
     IgnoreError(reed2.Get<Mac::Filter>().AddRssIn(leader.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
 
     // Setup DUT connectivity (only to REEDs)
-    dut.AllowList(reed1);
-    reed1.AllowList(dut);
-    dut.AllowList(reed2);
-    reed2.AllowList(dut);
+    nexus.AllowLinkBetween(dut, reed1);
+    nexus.AllowLinkBetween(dut, reed2);
 
     IgnoreError(dut.Get<Mac::Filter>().AddRssIn(reed1.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
     IgnoreError(dut.Get<Mac::Filter>().AddRssIn(reed2.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));

--- a/tests/nexus/test_5_2_1.cpp
+++ b/tests/nexus/test_5_2_1.cpp
@@ -84,14 +84,9 @@ void Test5_2_1(void)
     med1.SetName("MED_1");
 
     // Establish topology using AllowList
-    dut.AllowList(leader);
-    leader.AllowList(dut);
-
-    dut.AllowList(reed1);
-    reed1.AllowList(dut);
-
-    reed1.AllowList(med1);
-    med1.AllowList(reed1);
+    nexus.AllowLinkBetween(dut, leader);
+    nexus.AllowLinkBetween(dut, reed1);
+    nexus.AllowLinkBetween(reed1, med1);
 
     nexus.AdvanceTime(0);
 

--- a/tests/nexus/test_5_2_3.cpp
+++ b/tests/nexus/test_5_2_3.cpp
@@ -101,12 +101,10 @@ void Test5_2_3(void)
     // Router 32 <-> Router 1
     for (uint8_t i = 0; i < kMaxRouters - 1; i++)
     {
-        leader.AllowList(*routers[i]);
-        routers[i]->AllowList(leader);
+        nexus.AllowLinkBetween(leader, *routers[i]);
     }
 
-    routers[kMaxRouters - 1]->AllowList(*routers[0]);
-    routers[0]->AllowList(*routers[kMaxRouters - 1]);
+    nexus.AllowLinkBetween(*routers[kMaxRouters - 1], *routers[0]);
 
     Log("---------------------------------------------------------------------------------------");
     /**

--- a/tests/nexus/test_5_2_4.cpp
+++ b/tests/nexus/test_5_2_4.cpp
@@ -112,17 +112,14 @@ void Test5_2_4(void)
     /** Use AllowList feature to restrict the topology. */
     for (uint16_t i = 0; i < kNumRouters; i++)
     {
-        leader.AllowList(*routers[i]);
-        routers[i]->AllowList(leader);
+        nexus.AllowLinkBetween(leader, *routers[i]);
     }
 
     /** Router 15 and REED_1 (DUT) have a link */
-    routers[kNumRouters - 1]->AllowList(reed1);
-    reed1.AllowList(*routers[kNumRouters - 1]);
+    nexus.AllowLinkBetween(*routers[kNumRouters - 1], reed1);
 
     /** REED_1 (DUT) and MED_1 have a link. */
-    reed1.AllowList(med1);
-    med1.AllowList(reed1);
+    nexus.AllowLinkBetween(reed1, med1);
 
     Log("Step 1: Ensure topology is formed correctly without the DUT.");
 

--- a/tests/nexus/test_5_2_5.cpp
+++ b/tests/nexus/test_5_2_5.cpp
@@ -117,18 +117,12 @@ void Test5_2_5(void)
      */
     for (uint16_t i = 0; i < kRouterCount; i++)
     {
-        leader.AllowList(*routers[i]);
-        routers[i]->AllowList(leader);
+        nexus.AllowLinkBetween(leader, *routers[i]);
     }
 
-    leader.AllowList(br);
-    br.AllowList(leader);
-
-    leader.AllowList(med1);
-    med1.AllowList(leader);
-
-    routers[0]->AllowList(reed1);
-    reed1.AllowList(*routers[0]);
+    nexus.AllowLinkBetween(leader, br);
+    nexus.AllowLinkBetween(leader, med1);
+    nexus.AllowLinkBetween(*routers[0], reed1);
 
     Log("Step 1: Configure the Leader to be a DHCPv6 Border Router for prefix 2001::");
 

--- a/tests/nexus/test_5_3_10.cpp
+++ b/tests/nexus/test_5_3_10.cpp
@@ -140,10 +140,10 @@ void Test5_3_10(void)
     nexus.AdvanceTime(kFormNetworkTime);
     VerifyOrQuit(leader.Get<Mle::Mle>().IsLeader());
 
-    leader.AllowList(br);
-    br.AllowList(leader);
+    nexus.AllowLinkBetween(leader, br);
 
     br.Join(leader);
+
     nexus.AdvanceTime(kAttachToRouterTime);
     VerifyOrQuit(br.Get<Mle::Mle>().IsRouter());
 
@@ -172,17 +172,10 @@ void Test5_3_10(void)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    leader.AllowList(dut);
-    dut.AllowList(leader);
-
-    router1.AllowList(dut);
-    dut.AllowList(router1);
-
-    dut.AllowList(med1);
-    med1.AllowList(dut);
+    nexus.AllowLinkBetween(leader, router1);
+    nexus.AllowLinkBetween(leader, dut);
+    nexus.AllowLinkBetween(router1, dut);
+    nexus.AllowLinkBetween(dut, med1);
 
     router1.Join(leader);
     dut.Join(leader);

--- a/tests/nexus/test_5_3_11.cpp
+++ b/tests/nexus/test_5_3_11.cpp
@@ -111,11 +111,8 @@ void Test5_3_11(void)
      */
 
     /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    router1.AllowList(med1);
-    med1.AllowList(router1);
+    nexus.AllowLinkBetween(leader, router1);
+    nexus.AllowLinkBetween(router1, med1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_5_3_2.cpp
+++ b/tests/nexus/test_5_3_2.cpp
@@ -95,14 +95,9 @@ void Test5_3_2(void)
      */
     Log("Step 1: All");
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    router1.AllowList(dut);
-    dut.AllowList(router1);
-
-    dut.AllowList(sed1);
-    sed1.AllowList(dut);
+    nexus.AllowLinkBetween(leader, router1);
+    nexus.AllowLinkBetween(router1, dut);
+    nexus.AllowLinkBetween(dut, sed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_5_3_3.cpp
+++ b/tests/nexus/test_5_3_3.cpp
@@ -121,24 +121,19 @@ void Test5_3_3(void)
      */
 
     /** Link between Leader and Router 1 */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
+    nexus.AllowLinkBetween(leader, router1);
 
     /** Link between Leader and Router 2 (DUT) */
-    leader.AllowList(dut);
-    dut.AllowList(leader);
+    nexus.AllowLinkBetween(leader, dut);
 
     /** Link between Leader and Router 3 */
-    leader.AllowList(router3);
-    router3.AllowList(leader);
+    nexus.AllowLinkBetween(leader, router3);
 
     /** Link between Router 2 (DUT) and Router 3 */
-    dut.AllowList(router3);
-    router3.AllowList(dut);
+    nexus.AllowLinkBetween(dut, router3);
 
     /** Link between Router 2 (DUT) and MED 1 */
-    dut.AllowList(med1);
-    med1.AllowList(dut);
+    nexus.AllowLinkBetween(dut, med1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_5_3_4.cpp
+++ b/tests/nexus/test_5_3_4.cpp
@@ -112,20 +112,11 @@ void Test5_3_4(void)
      */
 
     /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
+    nexus.AllowLinkBetween(leader, router1);
+    nexus.AllowLinkBetween(router1, sed1);
     for (Node *med : meds)
     {
-        leader.AllowList(*med);
-    }
-
-    router1.AllowList(leader);
-    router1.AllowList(sed1);
-
-    sed1.AllowList(router1);
-
-    for (Node *med : meds)
-    {
-        med->AllowList(leader);
+        nexus.AllowLinkBetween(leader, *med);
     }
 
     leader.Form();

--- a/tests/nexus/test_5_3_5.cpp
+++ b/tests/nexus/test_5_3_5.cpp
@@ -117,17 +117,10 @@ void Test5_3_5(void)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(dut);
-    leader.AllowList(router2);
-
-    dut.AllowList(leader);
-    dut.AllowList(router2);
-    dut.AllowList(router3);
-
-    router2.AllowList(leader);
-    router2.AllowList(dut);
-
-    router3.AllowList(dut);
+    nexus.AllowLinkBetween(leader, dut);
+    nexus.AllowLinkBetween(leader, router2);
+    nexus.AllowLinkBetween(dut, router2);
+    nexus.AllowLinkBetween(dut, router3);
 
     /** Leader and Router 2 Link Quality 3 */
     SuccessOrQuit(leader.Get<Mac::Filter>().AddRssIn(router2.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality3));

--- a/tests/nexus/test_5_3_6.cpp
+++ b/tests/nexus/test_5_3_6.cpp
@@ -97,10 +97,8 @@ void Test5_3_6(void)
      * - Leader (DUT) and Router 1
      * - Router 1 and Router 2
      */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-    router1.AllowList(router2);
-    router2.AllowList(router1);
+    nexus.AllowLinkBetween(leader, router1);
+    nexus.AllowLinkBetween(router1, router2);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_5_3_7.cpp
+++ b/tests/nexus/test_5_3_7.cpp
@@ -115,21 +115,14 @@ void Test5_3_7(void)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(router1);
-    leader.AllowList(router2);
-    leader.AllowList(med2);
+    nexus.AllowLinkBetween(leader, router1);
+    nexus.AllowLinkBetween(leader, router2);
+    nexus.AllowLinkBetween(leader, med2);
 
-    router1.AllowList(leader);
-    router1.AllowList(router2);
-    router1.AllowList(med1);
+    nexus.AllowLinkBetween(router1, router2);
+    nexus.AllowLinkBetween(router1, med1);
 
-    router2.AllowList(leader);
-    router2.AllowList(router1);
-    router2.AllowList(sed1);
-
-    med1.AllowList(router1);
-    med2.AllowList(leader);
-    sed1.AllowList(router2);
+    nexus.AllowLinkBetween(router2, sed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_5_3_8.cpp
+++ b/tests/nexus/test_5_3_8.cpp
@@ -126,14 +126,9 @@ void Test5_3_8(void)
     Instance::SetLogLevel(kLogLevelNote);
 
     /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(br);
-    br.AllowList(leader);
-
-    leader.AllowList(med1);
-    med1.AllowList(leader);
-
-    leader.AllowList(med2);
-    med2.AllowList(leader);
+    nexus.AllowLinkBetween(leader, br);
+    nexus.AllowLinkBetween(leader, med1);
+    nexus.AllowLinkBetween(leader, med2);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: Border Router");

--- a/tests/nexus/test_5_3_9.cpp
+++ b/tests/nexus/test_5_3_9.cpp
@@ -164,14 +164,10 @@ void Test5_3_9(void)
      * - Pass Criteria: N/A
      */
     Log("Step 2: All");
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-    leader.AllowList(dut);
-    dut.AllowList(leader);
-    leader.AllowList(router3);
-    router3.AllowList(leader);
-    dut.AllowList(sed1);
-    sed1.AllowList(dut);
+    nexus.AllowLinkBetween(leader, router1);
+    nexus.AllowLinkBetween(leader, dut);
+    nexus.AllowLinkBetween(leader, router3);
+    nexus.AllowLinkBetween(dut, sed1);
 
     router1.Join(leader);
     dut.Join(leader);

--- a/tests/nexus/test_5_5_2.cpp
+++ b/tests/nexus/test_5_5_2.cpp
@@ -114,11 +114,8 @@ void Test5_5_2(void)
      */
     Log("Step 1: All");
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    router1.AllowList(med1);
-    med1.AllowList(router1);
+    nexus.AllowLinkBetween(leader, router1);
+    nexus.AllowLinkBetween(router1, med1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_5_5_3.cpp
+++ b/tests/nexus/test_5_5_3.cpp
@@ -110,17 +110,11 @@ void Test5_5_3(void)
      *   - Pass Criteria: N/A
      */
 
-    leader.AllowList(router1);
-    leader.AllowList(router2);
+    nexus.AllowLinkBetween(leader, router1);
+    nexus.AllowLinkBetween(leader, router2);
 
-    router1.AllowList(leader);
-    router1.AllowList(med2);
-
-    router2.AllowList(leader);
-    router2.AllowList(med3);
-
-    med2.AllowList(router1);
-    med3.AllowList(router2);
+    nexus.AllowLinkBetween(router1, med2);
+    nexus.AllowLinkBetween(router2, med3);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -328,8 +322,7 @@ void Test5_5_3(void)
      *           - RLOC16 TLV (optional)
      */
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
+    nexus.AllowLinkBetween(leader, router1);
 
     nexus.AdvanceTime(kWaitPeriod);
 

--- a/tests/nexus/test_5_5_4_1.cpp
+++ b/tests/nexus/test_5_5_4_1.cpp
@@ -115,18 +115,10 @@ void Test5_5_4_1(void)
      * - Pass Criteria: N/A.
      */
 
-    dut.AllowList(router1);
-    dut.AllowList(router2);
-
-    router1.AllowList(dut);
-    router1.AllowList(router3);
-
-    router2.AllowList(dut);
-    router2.AllowList(router4);
-
-    router3.AllowList(router1);
-
-    router4.AllowList(router2);
+    nexus.AllowLinkBetween(dut, router1);
+    nexus.AllowLinkBetween(dut, router2);
+    nexus.AllowLinkBetween(router1, router3);
+    nexus.AllowLinkBetween(router2, router4);
 
     dut.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_5_5_4_2.cpp
+++ b/tests/nexus/test_5_5_4_2.cpp
@@ -122,14 +122,10 @@ void Test5_5_4_2(void)
     Log("Step 1: All");
 
     /** Use AllowList to specify links between nodes. */
-    leader.AllowList(router1);
-    leader.AllowList(router2);
-    router1.AllowList(leader);
-    router1.AllowList(router3);
-    router2.AllowList(leader);
-    router2.AllowList(router4);
-    router3.AllowList(router1);
-    router4.AllowList(router2);
+    nexus.AllowLinkBetween(leader, router1);
+    nexus.AllowLinkBetween(leader, router2);
+    nexus.AllowLinkBetween(router1, router3);
+    nexus.AllowLinkBetween(router2, router4);
 
     /** Set NETWORK_ID_TIMEOUT of Router_3 to 55 seconds. */
     router3.Get<Mle::Mle>().SetNetworkIdTimeout(kRouter3NetworkIdTimeout);

--- a/tests/nexus/test_5_5_5.cpp
+++ b/tests/nexus/test_5_5_5.cpp
@@ -113,16 +113,13 @@ void Test5_5_5(void)
     /** Configure AllowList for specific links. */
     for (uint16_t i = 2; i <= 15; i++)
     {
-        leader.AllowList(*r[i]);
-        r[i]->AllowList(leader);
+        nexus.AllowLinkBetween(leader, *r[i]);
     }
 
-    r[1]->AllowList(*r[3]);
-    r[3]->AllowList(*r[1]);
+    nexus.AllowLinkBetween(*r[1], *r[3]);
 
     /** DUT links. */
-    dut.AllowList(*r[2]);
-    r[2]->AllowList(dut);
+    nexus.AllowLinkBetween(dut, *r[2]);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -180,8 +177,7 @@ void Test5_5_5(void)
      * - Pass Criteria: N/A
      */
     SuccessOrQuit(dut.Get<Mle::Mle>().SetRouterEligible(true));
-    dut.AllowList(*r[1]);
-    r[1]->AllowList(dut);
+    nexus.AllowLinkBetween(dut, *r[1]);
     nexus.AdvanceTime(kReattachTime);
 
     Log("---------------------------------------------------------------------------------------");

--- a/tests/nexus/test_5_5_7.cpp
+++ b/tests/nexus/test_5_5_7.cpp
@@ -105,13 +105,9 @@ void Test5_5_7(void)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(router1);
-    leader.AllowList(router2);
-    leader.AllowList(router3);
-
-    router1.AllowList(leader);
-    router2.AllowList(leader);
-    router3.AllowList(leader);
+    nexus.AllowLinkBetween(leader, router1);
+    nexus.AllowLinkBetween(leader, router2);
+    nexus.AllowLinkBetween(leader, router3);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_5_7_1.cpp
+++ b/tests/nexus/test_5_7_1.cpp
@@ -100,17 +100,12 @@ void Test5_7_1(void)
     Log("Step 1: All");
 
     /** Use AllowList to specify links between nodes. */
-    dut.AllowList(leader);
-    dut.AllowList(fed1);
-    dut.AllowList(med1);
-    dut.AllowList(sed1);
-    dut.AllowList(reed1);
 
-    leader.AllowList(dut);
-    fed1.AllowList(dut);
-    med1.AllowList(dut);
-    sed1.AllowList(dut);
-    reed1.AllowList(dut);
+    nexus.AllowLinkBetween(dut, leader);
+    nexus.AllowLinkBetween(dut, fed1);
+    nexus.AllowLinkBetween(dut, med1);
+    nexus.AllowLinkBetween(dut, sed1);
+    nexus.AllowLinkBetween(dut, reed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_6_1_2.cpp
+++ b/tests/nexus/test_6_1_2.cpp
@@ -107,8 +107,7 @@ void RunTest6_1_2(Topology aTopology, const char *aJsonFile)
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: All");
 
-    leader.AllowList(reed);
-    reed.AllowList(leader);
+    nexus.AllowLinkBetween(leader, reed);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -136,8 +135,7 @@ void RunTest6_1_2(Topology aTopology, const char *aJsonFile)
     Log("---------------------------------------------------------------------------------------");
     Log("Step 2: ED_1 / SED_1 (DUT)");
 
-    reed.AllowList(dut);
-    dut.AllowList(reed);
+    nexus.AllowLinkBetween(reed, dut);
 
     if (aTopology == kTopologyA)
     {


### PR DESCRIPTION
Added `Core::AllowLinkBetween()` and `Core::UnallowLinkBetween()` helper methods to the Nexus test platform. These methods simplify establishing bidirectional links between nodes in simulation tests by handling the reciprocal `AllowList()` calls in a single step.

Updated various Nexus test cases to utilize these new helpers, replacing manual bidirectional `AllowList()` calls. This change reduces verbosity and ensures consistency in how links are established in the test topology.