### PR TITLE
[nexus] fix intermittent failure in Test 5.5.5

### DIFF
--- a/tests/nexus/test_5_5_5.cpp
+++ b/tests/nexus/test_5_5_5.cpp
@@ -47,7 +47,7 @@ static constexpr uint32_t kAttachToRouterTime = 200 * 1000;
 /**
  * Time to advance for an isolated router to detect isolation and re-attach, in milliseconds.
  */
-static constexpr uint32_t kReattachTime = 120 * 1000;
+static constexpr uint32_t kReattachTime = 140 * 1000;
 
 /**
  * Time to advance for a node to join as a child.

--- a/tests/nexus/verify_5_5_5.py
+++ b/tests/nexus/verify_5_5_5.py
@@ -138,7 +138,8 @@ def verify(pv):
     #       - Status TLV
     #       - RLOC16 TLV (optional)
     print("Step 7: REED_1 (DUT)")
-    pkts.filter_wpan_src64(REED_1).\
+    pkts.range(step4_start, cascade=False).\
+      filter_wpan_src64(REED_1).\
       filter_coap_request(consts.ADDR_SOL_URI).\
       filter(lambda p: {
         consts.NL_MAC_EXTENDED_ADDRESS_TLV,
@@ -157,7 +158,8 @@ def verify(pv):
     #     - Source Address TLV
     #     - Version TLV
     print("Step 8: REED_1 (DUT)")
-    link_req = pkts.filter_wpan_src64(REED_1).\
+    link_req = pkts.range(step4_start, cascade=False).\
+      filter_wpan_src64(REED_1).\
       filter_LLANMA().\
       filter_mle_cmd(consts.MLE_LINK_REQUEST).\
       filter(lambda p: {


### PR DESCRIPTION
This commit fixes an intermittent failure in Nexus Test 5.5.5 where the verification script failed to find the Address Solicit Request.

The failure was caused by two main factors:
1. Re-attachment timing: The original 120s re-attachment window in the C++ test was occasionally too short for Router 1 to detect isolation, perform a new parent search, and complete attachment, especially when combined with protocol jitter and router timeout.
2. Packet ordering: The Python verification script searched for the Address Solicit Request only after the Child ID Request. However, due to randomized router selection jitter, the DUT (REED 1) could occasionally send the Address Solicit Request before Router 1 had finished its attachment process.

To fix this:
- Increased kReattachTime from 120s to 140s in the C++ test to provide a safer margin for re-attachment.
- Updated the verification script to search for the Address Solicit Request and Link Request starting from the beginning of the re-attachment process (Step 4), using cascade=False to maintain the sequential search index for other mandatory packets.

Verified by running multiple repeated iterations of the test.