### PR TITLE
[nexus] fix intermittent failure in test 6.1.2

### DIFF
--- a/tests/nexus/test_6_1_2.cpp
+++ b/tests/nexus/test_6_1_2.cpp
@@ -115,6 +115,7 @@ void RunTest6_1_2(Topology aTopology, const char *aJsonFile)
     VerifyOrQuit(leader.Get<Mle::Mle>().IsLeader());
 
     reed.Join(leader);
+    reed.Get<Mle::Mle>().SetRouterUpgradeThreshold(0);
     nexus.AdvanceTime(kReedToRouterTime);
     VerifyOrQuit(reed.Get<Mle::Mle>().IsChild());
 


### PR DESCRIPTION
This commit fixes an intermittent failure in Nexus test 6.1.2 by setting the REED's router upgrade threshold to 0.

By default, a REED may attempt to upgrade to a Router if the number of active routers in the network is below a certain threshold. In this test scenario, we want to ensure the REED remains a child until the appropriate point in the test sequence. Setting the threshold to 0 prevents premature promotion due to low router count, ensuring more deterministic test behavior.