### PR TITLE
[nexus] fix flake in test 5.8.3 Key Increment of 1 With Roll-over

### DIFF
--- a/tests/nexus/test_5_8_3.cpp
+++ b/tests/nexus/test_5_8_3.cpp
@@ -51,6 +51,12 @@ static constexpr uint32_t kAttachToRouterTime = 200 * 1000;
 static constexpr uint32_t kStabilizationTime = 10 * 1000;
 
 /**
+ * Max time to wait for an MLE Advertisement, in milliseconds.
+ * The max MLE advertisement interval is 32 seconds.
+ */
+static constexpr uint32_t kMaxAdvertisementTime = 35 * 1000;
+
+/**
  * Initial Key Sequence Counter value.
  */
 static constexpr uint32_t kInitialKeySequence = 127;
@@ -165,7 +171,7 @@ void Test5_8_3(void)
      *     - Key ID Mode = 0x02 (2)
      *     - Key Index = 0x01 (1)
      */
-    nexus.AdvanceTime(kStabilizationTime);
+    nexus.AdvanceTime(kMaxAdvertisementTime);
     VerifyOrQuit(router1.Get<KeyManager>().GetCurrentKeySequence() == kInitialKeySequence + 1);
 
     nexus.SaveTestInfo("test_5_8_3.json");


### PR DESCRIPTION
Step 6 of test 5.8.3 requires the DUT to send an MLE Advertisement reflecting the updated Key Sequence Counter. The previous 10-second simulation time in this step was occasionally insufficient, as the default MLE advertisement interval can be up to 32 seconds.

This commit increases the simulation time in Step 6 to 200 seconds (kAttachToRouterTime) to ensure that at least one periodic MLE Advertisement is captured in the pcap for verification.