### PR TITLE
[key-manager] move initialization to `Instance::AfterInit`

### DIFF
--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -432,6 +432,8 @@ void Instance::AfterInit(void)
     mIsInitialized = true;
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
 
+    Get<KeyManager>().Init();
+
     // Restore datasets and network information
 
     Get<Settings>().Init();

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -179,21 +179,24 @@ KeyManager::KeyManager(Instance &aInstance)
     otPlatCryptoInit();
 
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
-    {
-        NetworkKey networkKey;
-
-        mNetworkKeyRef = Crypto::Storage::kInvalidKeyRef;
-        mPskcRef       = Crypto::Storage::kInvalidKeyRef;
-
-        IgnoreError(networkKey.GenerateRandom());
-        StoreNetworkKey(networkKey, /* aOverWriteExisting */ false);
-    }
+    mNetworkKeyRef = Crypto::Storage::kInvalidKeyRef;
+    mPskcRef       = Crypto::Storage::kInvalidKeyRef;
 #else
     IgnoreError(mNetworkKey.GenerateRandom());
     mPskc.Clear();
 #endif
 
     mMacFrameCounters.Reset();
+}
+
+void KeyManager::Init(void)
+{
+#if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
+    NetworkKey networkKey;
+
+    IgnoreError(networkKey.GenerateRandom());
+    StoreNetworkKey(networkKey, /* aOverWriteExisting */ false);
+#endif
 }
 
 void KeyManager::Start(void)

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -229,6 +229,15 @@ public:
     explicit KeyManager(Instance &aInstance);
 
     /**
+     * Initializes the `KeyManager`.
+     *
+     * This method is called after OpenThread `Instance` is fully initialized (from `Instance::AfterInit()`). This
+     * ensures that all `Instance` components (including `KeyManager`) have been constructed and are safe to interact
+     * with (e.g., to save a default key in `Crypto::Storage::KeyRefManager`).
+     */
+    void Init(void);
+
+    /**
      * Starts KeyManager rotation timer and sets guard timer to initial value.
      */
     void Start(void);


### PR DESCRIPTION
Currently, `KeyManager` generates and stores a random `NetworkKey` in its constructor when `OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE` is enabled. This invokes `StoreNetworkKey()`, which interacts with `KeyRefManager`. Accessing other components during construction can be unsafe if they are not yet fully initialized.

This commit introduces a `KeyManager::Init()` method to handle this initialization. This method is called from `Instance::AfterInit()`, ensuring that the `Instance` and all dependencies, such as `KeyRefManager`, are fully constructed before the `KeyManager` attempts to access them.

---

Should help address https://github.com/openthread/openthread/issues/12474 and https://github.com/openthread/openthread/issues/12208.