### PR TITLE
[nexus] update tshark to 4.6.2 or later

### DIFF
--- a/.github/workflows/nexus.yml
+++ b/.github/workflows/nexus.yml
@@ -59,6 +59,7 @@ jobs:
 
     - name: Bootstrap
       run: |
+        sudo add-apt-repository -y ppa:wireshark-dev/stable
         sudo apt-get update
         sudo DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y ninja-build tshark
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt


### PR DESCRIPTION
This commit updates the Nexus workflow to install TShark version 4.6.2 or later by adding the 'wireshark-dev/stable' PPA. This is required to support modern Wireshark features in Nexus tests.