### PR TITLE
[udp] use `LinkedList::ContainsMatching()` in `IsPortInUse()`

### DIFF
--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -486,21 +486,7 @@ exit:
     return;
 }
 
-bool Udp::IsPortInUse(uint16_t aPort) const
-{
-    bool found = false;
-
-    for (const SocketHandle &socket : mSockets)
-    {
-        if (socket.GetSockName().GetPort() == aPort)
-        {
-            found = true;
-            break;
-        }
-    }
-
-    return found;
-}
+bool Udp::IsPortInUse(uint16_t aPort) const { return mSockets.ContainsMatching(aPort); }
 
 } // namespace Ip6
 } // namespace ot

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -162,6 +162,7 @@ public:
 #endif
 
     private:
+        bool Matches(uint16_t aSockPort) const { return GetSockName().GetPort() == aSockPort; }
         bool Matches(const MessageInfo &aMessageInfo) const;
 
         void HandleUdpReceive(Message &aMessage, const MessageInfo &aMessageInfo)


### PR DESCRIPTION
This commit simplifies `IsPortInUse()` by using `LinkedList` helper `ContainsMatching()` instead of manually iterating over the list of sockets. A `SocketHandle::Matches(uint16_t aSockPort)` is added to support this.