### PR TITLE
[nexus] clear OnMeshPrefixConfig before use in tests

### DIFF
--- a/tests/nexus/test_5_6_1.cpp
+++ b/tests/nexus/test_5_6_1.cpp
@@ -139,6 +139,7 @@ void Test5_6_1(void)
         {
             NetworkData::OnMeshPrefixConfig config;
 
+            config.Clear();
             SuccessOrQuit(config.GetPrefix().FromString(prefixInfo.mPrefix));
             config.mStable       = prefixInfo.mIsStable;
             config.mOnMesh       = true;

--- a/tests/nexus/test_6_3_2.cpp
+++ b/tests/nexus/test_6_3_2.cpp
@@ -153,6 +153,7 @@ void RunTest6_3_2(Topology aTopology, const char *aJsonFile)
     {
         NetworkData::OnMeshPrefixConfig config;
 
+        config.Clear();
         SuccessOrQuit(config.GetPrefix().FromString("2001::/64"));
         config.mStable       = true;
         config.mOnMesh       = true;
@@ -237,6 +238,7 @@ void RunTest6_3_2(Topology aTopology, const char *aJsonFile)
     {
         NetworkData::OnMeshPrefixConfig config;
 
+        config.Clear();
         SuccessOrQuit(config.GetPrefix().FromString("2002::/64"));
         config.mStable       = true;
         config.mOnMesh       = true;


### PR DESCRIPTION
This commit ensures that the NetworkData::OnMeshPrefixConfig structure is cleared using config.Clear() before it is used in Nexus tests.

Since OnMeshPrefixConfig is a local variable on the stack, its fields can contain garbage values if not explicitly initialized. The core validity check OnMeshPrefixConfig::IsValid() fails if both mDhcp and mSlaac are set to true, which can happen with uninitialized memory.

Updated tests:
- tests/nexus/test_6_3_2.cpp: Fixed RunTest6_3_2.
- tests/nexus/test_5_6_1.cpp: Fixed RunTest5_6_1.