### PR TITLE
[nexus] add test 7.1.3 Network data propagation - Border Router as Leader

### DIFF
--- a/tests/nexus/CMakeLists.txt
+++ b/tests/nexus/CMakeLists.txt
@@ -180,6 +180,7 @@ ot_nexus_test(6_6_1 "cert;nexus")
 ot_nexus_test(6_6_2 "cert;nexus")
 ot_nexus_test(7_1_1 "cert;nexus")
 ot_nexus_test(7_1_2 "cert;nexus")
+ot_nexus_test(7_1_3 "cert;nexus")
 
 # Misc tests
 ot_nexus_test(border_admitter "core;nexus")

--- a/tests/nexus/run_nexus_tests.sh
+++ b/tests/nexus/run_nexus_tests.sh
@@ -116,6 +116,7 @@ DEFAULT_TESTS=(
     "6_6_2"
     "7_1_1"
     "7_1_2"
+    "7_1_3"
 )
 
 # Use provided arguments or the default test list

--- a/tests/nexus/test_7_1_3.cpp
+++ b/tests/nexus/test_7_1_3.cpp
@@ -1,0 +1,243 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+
+#include "platform/nexus_core.hpp"
+#include "platform/nexus_node.hpp"
+
+namespace ot {
+namespace Nexus {
+
+/**
+ * Time to advance for a node to form a network and become leader, in milliseconds.
+ */
+static constexpr uint32_t kFormNetworkTime = 13 * 1000;
+
+/**
+ * Time to advance for a node to join as a child and upgrade to a router, in milliseconds.
+ */
+static constexpr uint32_t kAttachToRouterTime = 200 * 1000;
+
+/**
+ * Time to advance for the network to stabilize after routers have attached.
+ */
+static constexpr uint32_t kStabilizationTime = 10 * 1000;
+
+/**
+ * Time to advance for a child to register its address.
+ */
+static constexpr uint32_t kChildUpdateWaitTime = 10 * 1000;
+
+void Test7_1_3(const char *aJsonFile)
+{
+    /**
+     * 7.1.3 Network data propagation - Border Router as Leader of Thread network; advertises new network data
+     *   information after network is formed
+     *
+     * 7.1.3.1 Topology
+     * - MED_1 is configured to require complete network data. (Mode TLV)
+     * - SED_1 is configured to request only stable network data. (Mode TLV)
+     *
+     * 7.1.3.2 Purpose & Description
+     * The purpose of this test case is to verify that global prefix information can be set on the DUT, which is acting
+     *   as a Leader in the Thread network. The DUT must also demonstrate that it correctly sets the Network Data
+     *   (stable/non-stable) and propagates it properly in an already formed network.
+     *
+     * Spec Reference                                     | V1.1 Section       | V1.3.0 Section
+     * ---------------------------------------------------|--------------------|--------------------
+     * Thread Network Data / Stable Thread Network Data / | 5.13 / 5.14 / 5.15 | 5.13 / 5.14 / 5.15
+     *   Network Data and Propagation                     |                    |
+     */
+
+    Core nexus;
+
+    Node &leader  = nexus.CreateNode();
+    Node &router1 = nexus.CreateNode();
+    Node &med1    = nexus.CreateNode();
+    Node &sed1    = nexus.CreateNode();
+
+    leader.SetName("LEADER");
+    router1.SetName("ROUTER_1");
+    med1.SetName("MED_1");
+    sed1.SetName("SED_1");
+
+    /** Use AllowList to specify links between nodes. */
+    leader.AllowList(router1);
+    router1.AllowList(leader);
+
+    leader.AllowList(med1);
+    med1.AllowList(leader);
+
+    leader.AllowList(sed1);
+    sed1.AllowList(leader);
+
+    nexus.AdvanceTime(0);
+
+    Instance::SetLogLevel(kLogLevelNote);
+
+    /**
+     * Step 1: All
+     * - Description: Ensure topology is formed correctly.
+     * - Pass Criteria: N/A
+     */
+    Log("Step 1: Ensure topology is formed correctly.");
+    leader.Form();
+    nexus.AdvanceTime(kFormNetworkTime);
+    VerifyOrQuit(leader.Get<Mle::Mle>().IsLeader());
+
+    router1.Join(leader, Node::kAsFtd);
+    med1.Join(leader, Node::kAsMed);
+    sed1.Join(leader, Node::kAsSed);
+    nexus.AdvanceTime(kAttachToRouterTime);
+
+    VerifyOrQuit(router1.Get<Mle::Mle>().IsFullThreadDevice());
+    VerifyOrQuit(med1.Get<Mle::Mle>().IsAttached());
+    VerifyOrQuit(sed1.Get<Mle::Mle>().IsAttached());
+
+    nexus.AdvanceTime(kStabilizationTime);
+
+    /**
+     * Step 2: Leader (DUT)
+     * - Description: User configures the DUT with the following On-Mesh Prefix Set:
+     *   - Prefix 1: P_prefix=2001::/64 P_stable=1 P_on_mesh=1 P_preferred=1 P_slaac=1 P_default=1
+     *   - Prefix 2: P_prefix=2002::/64 P_stable=0 P_on_mesh=1 P_preferred=1 P_slaac=1 P_default=1
+     * - Pass Criteria: N/A
+     */
+    Log("Step 2: Leader (DUT) configures On-Mesh Prefixes.");
+    {
+        NetworkData::OnMeshPrefixConfig config;
+
+        config.Clear();
+        SuccessOrQuit(config.GetPrefix().FromString("2001::/64"));
+        config.mStable       = true;
+        config.mOnMesh       = true;
+        config.mPreferred    = true;
+        config.mSlaac        = true;
+        config.mDefaultRoute = true;
+        SuccessOrQuit(leader.Get<NetworkData::Local>().AddOnMeshPrefix(config));
+
+        config.Clear();
+        SuccessOrQuit(config.GetPrefix().FromString("2002::/64"));
+        config.mStable       = false;
+        config.mOnMesh       = true;
+        config.mPreferred    = true;
+        config.mSlaac        = true;
+        config.mDefaultRoute = true;
+        SuccessOrQuit(leader.Get<NetworkData::Local>().AddOnMeshPrefix(config));
+
+        leader.Get<NetworkData::Notifier>().HandleServerDataUpdated();
+    }
+
+    /**
+     * Step 3: Leader (DUT)
+     * - Description: Automatically sends the new network data to neighbors and rx-on-while-idle Children (MED_1).
+     * - Pass Criteria: The DUT MUST send a multicast MLE Data Response with the new network information, which includes
+     *   the following TLVs:
+     *   - Network Data TLV
+     *     - At least two Prefix TLVs (Prefix 1 and Prefix 2):
+     *       - 6LoWPAN ID sub-TLV
+     *       - Border Router sub-TLV
+     */
+    Log("Step 3: Leader (DUT) automatically sends the new network data to neighbors and rx-on-while-idle Children.");
+    nexus.AdvanceTime(kStabilizationTime);
+
+    /**
+     * Step 4: MED_1
+     * - Description: Automatically sends the global address configured to its parent (the DUT), via the Address
+     *   Registration TLV included in its Child Update Request keep-alive message.
+     * - Pass Criteria: N/A
+     */
+    Log("Step 4: MED_1 automatically sends the global address configured to its parent.");
+    nexus.AdvanceTime(kChildUpdateWaitTime);
+
+    /**
+     * Step 5: Leader (DUT)
+     * - Description: Automatically sends MLE Child Update Response to MED_1.
+     * - Pass Criteria: The DUT MUST unicast MLE Child Update Response to MED_1, containing the following TLVs:
+     *   - Source Address TLV
+     *   - Address Registration TLV (Echoes back the addresses MED_1 has configured)
+     *   - Mode TLV
+     */
+    Log("Step 5: Leader (DUT) automatically sends MLE Child Update Response to MED_1.");
+    nexus.AdvanceTime(kChildUpdateWaitTime);
+
+    /**
+     * Step 6: Leader (DUT)
+     * - Description: Automatically sends notification of new network data to SED_1. Depending upon the DUT's device
+     *   implementation, two different behavior paths (A,B) are allowable.
+     * - Pass Criteria:
+     *   - Path A: The DUT MUST unicast MLE Child Update Request to SED_1, including the following TLVs:
+     *     - Source Address TLV
+     *     - Leader Data TLV
+     *     - Network Data TLV
+     *     - Active Timestamp TLV
+     *     - Goto step 7
+     *   - Path B: The DUT MUST unicast MLE Data Response to SED_1, including the following TLVs:
+     *     - Source Address TLV
+     *     - Leader Data TLV
+     *     - Network Data TLV
+     *     - Active Timestamp TLV
+     *     - Goto step 7
+     */
+    Log("Step 6: Leader (DUT) automatically sends notification of new network data to SED_1.");
+    nexus.AdvanceTime(kAttachToRouterTime);
+
+    /**
+     * Step 7: SED_1
+     * - Description: After receiving the MLE Data Response or MLE Child Update Request, automatically sends the global
+     *   address configured to its parent (DUT), via the Address Registration TLV as part of the Child Update Request
+     *   command.
+     * - Pass Criteria: N/A
+     */
+    Log("Step 7: SED_1 automatically sends the global address configured to its parent.");
+    nexus.AdvanceTime(kChildUpdateWaitTime);
+
+    /**
+     * Step 8: Leader (DUT)
+     * - Description: Automatically sends MLE Child Update Response to SED_1.
+     * - Pass Criteria: The DUT MUST unicast MLE Child Update Response to SED_1, including the following TLVs:
+     *   - Source Address TLV
+     *   - Address Registration TLV (Echoes back the addresses SED_1 has configured)
+     *   - Mode TLV
+     */
+    Log("Step 8: Leader (DUT) automatically sends MLE Child Update Response to SED_1.");
+    nexus.AdvanceTime(kChildUpdateWaitTime);
+
+    nexus.SaveTestInfo(aJsonFile);
+}
+
+} /* namespace Nexus */
+} /* namespace ot */
+
+int main(int argc, char *argv[])
+{
+    ot::Nexus::Test7_1_3((argc > 2) ? argv[2] : "test_7_1_3.json");
+    printf("All tests passed\n");
+    return 0;
+}

--- a/tests/nexus/verify_7_1_3.py
+++ b/tests/nexus/verify_7_1_3.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import sys
+import os
+
+# Add the current directory to sys.path to find verify_utils
+CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(CUR_DIR)
+
+import verify_utils
+from pktverify import consts
+from pktverify.addrs import Ipv6Addr
+from pktverify.null_field import nullField
+
+
+def verify(pv):
+    # 7.1.3 Network data propagation - Border Router as Leader of Thread network; advertises new network data
+    #   information after network is formed
+    #
+    # 7.1.3.1 Topology
+    # - MED_1 is configured to require complete network data. (Mode TLV)
+    # - SED_1 is configured to request only stable network data. (Mode TLV)
+    #
+    # 7.1.3.2 Purpose & Description
+    # The purpose of this test case is to verify that global prefix information can be set on the DUT, which is acting
+    #   as a Leader in the Thread network. The DUT must also demonstrate that it correctly sets the Network Data
+    #   (stable/non-stable) and propagates it properly in an already formed network.
+    #
+    # Spec Reference                                     | V1.1 Section       | V1.3.0 Section
+    # ---------------------------------------------------|--------------------|--------------------
+    # Thread Network Data / Stable Thread Network Data / | 5.13 / 5.14 / 5.15 | 5.13 / 5.14 / 5.15
+    #   Network Data and Propagation                     |                    |
+
+    pkts = pv.pkts
+    pv.summary.show()
+
+    LEADER = pv.vars['LEADER']
+    MED_1 = pv.vars['MED_1']
+    SED_1 = pv.vars['SED_1']
+
+    PREFIX_1 = Ipv6Addr("2001::")
+    PREFIX_2 = Ipv6Addr("2002::")
+
+    # Step 1: All
+    # - Description: Ensure topology is formed correctly.
+    # - Pass Criteria: N/A
+    print("Step 1: Ensure topology is formed correctly.")
+
+    # Step 2: Leader (DUT)
+    # - Description: User configures the DUT with the following On-Mesh Prefix Set:
+    #   - Prefix 1: P_prefix=2001::/64 P_stable=1 P_on_mesh=1 P_preferred=1 P_slaac=1 P_default=1
+    #   - Prefix 2: P_prefix=2002::/64 P_stable=0 P_on_mesh=1 P_preferred=1 P_slaac=1 P_default=1
+    # - Pass Criteria: N/A
+    print("Step 2: Leader (DUT) configures On-Mesh Prefixes.")
+
+    # Step 3: Leader (DUT)
+    # - Description: Automatically sends the new network data to neighbors and rx-on-while-idle Children (MED_1).
+    # - Pass Criteria: The DUT MUST send a multicast MLE Data Response with the new network information, which includes
+    #   the following TLVs:
+    #   - Network Data TLV
+    #     - At least two Prefix TLVs (Prefix 1 and Prefix 2):
+    #       - 6LoWPAN ID sub-TLV
+    #       - Border Router sub-TLV
+    print("Step 3: Leader (DUT) automatically sends the new network data to neighbors and rx-on-while-idle Children.")
+    pkts.filter_wpan_src64(LEADER).\
+        filter_LLANMA().\
+        filter_mle_cmd(consts.MLE_DATA_RESPONSE).\
+        filter(lambda p: p.thread_nwd.tlv.prefix is not nullField and {
+                          PREFIX_1,
+                          PREFIX_2
+                          } <= set(p.thread_nwd.tlv.prefix)).\
+        must_next()
+
+    # Step 4: MED_1
+    # - Description: Automatically sends the global address configured to its parent (the DUT), via the Address
+    #   Registration TLV included in its Child Update Request keep-alive message.
+    # - Pass Criteria: N/A
+    print("Step 4: MED_1 automatically sends the global address configured to its parent.")
+    pkts.filter_wpan_src64(MED_1).\
+        filter_wpan_dst64(LEADER).\
+        filter_mle_cmd(consts.MLE_CHILD_UPDATE_REQUEST).\
+        filter(lambda p: {
+                          consts.ADDRESS_REGISTRATION_TLV
+                          } <= set(p.mle.tlv.type)).\
+        must_next()
+
+    # Step 5: Leader (DUT)
+    # - Description: Automatically sends MLE Child Update Response to MED_1.
+    # - Pass Criteria: The DUT MUST unicast MLE Child Update Response to MED_1, containing the following TLVs:
+    #   - Source Address TLV
+    #   - Address Registration TLV (Echoes back the addresses MED_1 has configured)
+    #   - Mode TLV
+    print("Step 5: Leader (DUT) automatically sends MLE Child Update Response to MED_1.")
+    pkts.filter_wpan_src64(LEADER).\
+        filter_wpan_dst64(MED_1).\
+        filter_mle_cmd(consts.MLE_CHILD_UPDATE_RESPONSE).\
+        filter(lambda p: {
+                          consts.SOURCE_ADDRESS_TLV,
+                          consts.ADDRESS_REGISTRATION_TLV,
+                          consts.MODE_TLV
+                          } <= set(p.mle.tlv.type)).\
+        must_next()
+
+    # Step 6: Leader (DUT)
+    # - Description: Automatically sends notification of new network data to SED_1. Depending upon the DUT's device
+    #   implementation, two different behavior paths (A,B) are allowable.
+    # - Pass Criteria:
+    #   - Path A: The DUT MUST unicast MLE Child Update Request to SED_1, including the following TLVs:
+    #     - Source Address TLV
+    #     - Leader Data TLV
+    #     - Network Data TLV
+    #     - Active Timestamp TLV
+    #     - Goto step 7
+    #   - Path B: The DUT MUST unicast MLE Data Response to SED_1, including the following TLVs:
+    #     - Source Address TLV
+    #     - Leader Data TLV
+    #     - Network Data TLV
+    #     - Active Timestamp TLV
+    #     - Goto step 7
+    print("Step 6: Leader (DUT) automatically sends notification of new network data to SED_1.")
+    pkts.filter_wpan_src64(LEADER).\
+        filter_wpan_dst64(SED_1).\
+        filter_mle_cmd2(consts.MLE_CHILD_UPDATE_REQUEST, consts.MLE_DATA_RESPONSE).\
+        filter(lambda p: {
+                          consts.SOURCE_ADDRESS_TLV,
+                          consts.LEADER_DATA_TLV,
+                          consts.NETWORK_DATA_TLV,
+                          consts.ACTIVE_TIMESTAMP_TLV
+                          } <= set(p.mle.tlv.type)).\
+        filter(lambda p: p.thread_nwd.tlv.prefix is not nullField and
+                         PREFIX_1 in p.thread_nwd.tlv.prefix and
+                         PREFIX_2 not in p.thread_nwd.tlv.prefix).\
+        must_next()
+
+    # Step 7: SED_1
+    # - Description: After receiving the MLE Data Response or MLE Child Update Request, automatically sends the global
+    #   address configured to its parent (DUT), via the Address Registration TLV as part of the Child Update Request
+    #   command.
+    # - Pass Criteria: N/A
+    print("Step 7: SED_1 automatically sends the global address configured to its parent.")
+    pkts.filter_wpan_src64(SED_1).\
+        filter_wpan_dst64(LEADER).\
+        filter_mle_cmd(consts.MLE_CHILD_UPDATE_REQUEST).\
+        filter(lambda p: {
+                          consts.ADDRESS_REGISTRATION_TLV
+                          } <= set(p.mle.tlv.type)).\
+        must_next()
+
+    # Step 8: Leader (DUT)
+    # - Description: Automatically sends MLE Child Update Response to SED_1.
+    # - Pass Criteria: The DUT MUST unicast MLE Child Update Response to SED_1, including the following TLVs:
+    #   - Source Address TLV
+    #   - Address Registration TLV (Echoes back the addresses SED_1 has configured)
+    #   - Mode TLV
+    print("Step 8: Leader (DUT) automatically sends MLE Child Update Response to SED_1.")
+    pkts.filter_wpan_src64(LEADER).\
+        filter_wpan_dst64(SED_1).\
+        filter_mle_cmd(consts.MLE_CHILD_UPDATE_RESPONSE).\
+        filter(lambda p: {
+                          consts.SOURCE_ADDRESS_TLV,
+                          consts.ADDRESS_REGISTRATION_TLV,
+                          consts.MODE_TLV
+                          } <= set(p.mle.tlv.type)).\
+        must_next()
+
+
+if __name__ == '__main__':
+    verify_utils.run_main(verify)


### PR DESCRIPTION
This commit adds a new Nexus test case 7.1.3 which verifies that global prefix information can be set on the DUT (Leader) and that the DUT correctly sets and propagates the Network Data (stable/non-stable) to neighbors and children in an already formed network.

The test setup uses a Leader (DUT) configured as a Border Router with both stable (2001::/64) and non-stable (2002::/64) prefixes. It verifies that neighbors and MED_1 (requesting complete data) receive both prefixes via MLE Data Response, while SED_1 (requesting only stable data) receives only the stable prefix via MLE Child Update Request.

Summary of changes:
- Created tests/nexus/test_7_1_3.cpp:
    - Implements test logic using direct core method calls.
    - Sets log level to note.
    - Configures AllowList for Leader-Router1, Leader-MED1, and Leader-SED1 links.
    - Includes 1-line log outputs for each test step.
    - Adheres to requested block comment formatting.
- Created tests/nexus/verify_7_1_3.py:
    - Implements pcap-based verification of PASS criteria.
    - Validates selective prefix propagation based on child mode.
    - Verifies MLE Child ID and Child Update exchanges.
    - Follows requested Python filter formatting style.
- Updated tests/nexus/CMakeLists.txt to build the new test.
- Updated tests/nexus/run_nexus_tests.sh to add 7_1_3 to the default test list.