### PR TITLE
[nexus] fix duplicate alarm firing in simulation core

### DIFF
--- a/tests/nexus/platform/nexus_core.cpp
+++ b/tests/nexus/platform/nexus_core.cpp
@@ -270,6 +270,7 @@ void Core::Process(Node &aNode)
 
     if (aNode.mAlarm.ShouldTrigger(mNow))
     {
+        aNode.mAlarm.mScheduled = false;
         otPlatAlarmMilliFired(&aNode.GetInstance());
     }
 }


### PR DESCRIPTION
This commit fixes an issue in the Nexus simulation core where alarms could fire multiple times at the same simulation timestamp. This occurred because the `mScheduled` flag was not cleared upon firing, and if the simulation time remained static (e.g., due to pending tasklets), the `ShouldTrigger` condition would remain true across multiple iterations of the simulation loop.

By clearing the `mScheduled` flag before invoking the fired callback, we ensure that each scheduled alarm triggers exactly once unless it is explicitly rescheduled by the stack. This improvement stabilizes Nexus tests (such as 6.2.2) that were previously flaky due to this non-deterministic behavior.