### PR TITLE
[pktverify] improve CoAP TLV disambiguation in packet verification

### DIFF
--- a/tests/nexus/verify_9_2_1.py
+++ b/tests/nexus/verify_9_2_1.py
@@ -41,14 +41,14 @@ from pktverify.null_field import nullField
 
 
 # Monkey-patch CoapTlvParser to parse MeshCoP TLVs in CoAP payload
-def meshcop_coap_tlv_parse(t, v):
+def meshcop_coap_tlv_parse(t, v, layer=None):
     kvs = []
     if t == consts.NM_COMMISSIONER_SESSION_ID_TLV:
-        kvs.append(('commissioner_session_id', str(struct.unpack('>H', v)[0])))
+        kvs.append(('comm_sess_id', str(struct.unpack('>H', v)[0])))
     elif t == consts.NM_STEERING_DATA_TLV:
         kvs.append(('steering_data', v.hex()))
     elif t == consts.NM_BORDER_AGENT_LOCATOR_TLV:
-        kvs.append(('border_agent_locator', str(struct.unpack('>H', v)[0])))
+        kvs.append(('border_agent_rloc16', hex(struct.unpack('>H', v)[0])))
     elif t == consts.TLV_REQUEST_TLV:
         kvs.append(('tlv_request', v.hex()))
     return kvs
@@ -77,11 +77,11 @@ def verify(pv):
     from pktverify import layer_fields
     layer_fields._LAYER_FIELDS['coap.tlv.tlv_request'] = layer_fields._bytes
 
-    def new_parse(t, v):
+    def new_parse(t, v, layer=None):
         if t in (consts.NM_COMMISSIONER_SESSION_ID_TLV, consts.NM_STEERING_DATA_TLV,
                  consts.NM_BORDER_AGENT_LOCATOR_TLV, consts.TLV_REQUEST_TLV):
-            return meshcop_coap_tlv_parse(t, v)
-        return old_parse(t, v)
+            return meshcop_coap_tlv_parse(t, v, layer=layer)
+        return old_parse(t, v, layer=layer)
 
     verify_utils.CoapTlvParser.parse = staticmethod(new_parse)
 


### PR DESCRIPTION
This commit implements a more robust mechanism to differentiate between overlapping TLV types in CoAP payloads, specifically for TLV type 8, which is used for both NM_STEERING_DATA_TLV (MeshCoP) and DG_IPV6_ADDRESS_LIST_TLV (Diagnostic).

The logic previously relied solely on TLV length, which was fragile and caused 16-byte Steering Data TLVs to be misinterpreted.

Key changes:
- Enhanced CoapTlvParser.parse() and CoapLayer to accept and pass the CoapLayer instance as context during parsing.
- Added a 'uri_path' property to CoapLayer for easier access to the CoAP URI path (recon).
- Updated thread_coap_tlv_parse in verify_utils.py to use the URI path to correctly identify Diagnostic TLVs (if URI starts with '/d/') vs. MeshCoP or other Thread TLVs.
- Updated verify_9_2_1.py monkey-patches to match the new parser signature.