### PR TITLE
[cli] enhance `batracker agents` to display parsed txt data

### DIFF
--- a/include/openthread/border_agent_txt_data.h
+++ b/include/openthread/border_agent_txt_data.h
@@ -184,6 +184,61 @@ typedef struct otBorderAgentTxtDataInfo
 otError otBorderAgentTxtDataParse(const uint8_t *aTxtData, uint16_t aTxtDataLength, otBorderAgentTxtDataInfo *aInfo);
 
 /**
+ * Converts a given Connection Mode in a Border Agent State Bitmap to a human-readable string.
+ *
+ * Requires `OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE`.
+ *
+ * @param[in] aConnMode   The Connection Mode to convert.
+ *
+ * @return The string representation of @p aConnMode.
+ */
+const char *otBorderAgentConnModeToString(otBorderAgentConnMode aConnMode);
+
+/**
+ * Converts a given Thread Interface State in a Border Agent State Bitmap to a human-readable string.
+ *
+ * Requires `OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE`.
+ *
+ * @param[in] aIfState   The Thread Interface State to convert.
+ *
+ * @return The string representation of @p aIfState.
+ */
+const char *otBorderAgentIfStateToString(otBorderAgentThreadIfState aIfState);
+
+/**
+ * Converts a given Availability Status in a Border Agent State Bitmap to a human-readable string.
+ *
+ * Requires `OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE`.
+ *
+ * @param[in] aAvailability   The Availability Status to convert.
+ *
+ * @return The string representation of @p aAvailability.
+ */
+const char *otBorderAgentAvailabilityToString(otBorderAgentAvailability aAvailability);
+
+/**
+ * Converts a given Thread Role in a Border Agent State Bitmap to a human-readable string.
+ *
+ * Requires `OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE`.
+ *
+ * @param[in] aRole   The Thread Role to convert.
+ *
+ * @return The string representation of @p aRole.
+ */
+const char *otBorderAgentThreadRoleToString(otBorderAgentThreadRole aRole);
+
+/**
+ * Converts a given Multi-AIL State in a Border Agent State Bitmap to a human-readable string.
+ *
+ * Requires `OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE`.
+ *
+ * @param[in] aState   The Multi-AIL State to convert.
+ *
+ * @return The string representation of @p aState.
+ */
+const char *otBorderAgentMultiAilStateToString(otBorderAgentMultiAilState aState);
+
+/**
  * @}
  *
  */

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (578)
+#define OPENTHREAD_API_VERSION (579)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -752,7 +752,7 @@ running
 Done
 ```
 
-### batracker agents
+### batracker agents [rawtxt]
 
 Requires `OPENTHREAD_CONFIG_BORDER_AGENT_TRACKER_ENABLE`.
 
@@ -761,13 +761,54 @@ Outputs the list of discovered Border Agents. Information per Agent:
 - Service name
 - Port number
 - Host name
-- TXT data (key/value pairs per line)
+- TXT data (parsed human-readable information, or raw key/value pairs)
 - Host addresses
 - Milliseconds since agent was first discovered
 - Milliseconds since the last change to agent info (port, addresses, TXT data)
 
+By default, if `OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE` is enabled, the TXT data is parsed and displayed in a human-readable format.
+
+The optional `rawtxt` argument forces the output of TXT data in its raw format (key/value pairs), even when the parser is enabled. If the parser is disabled, the raw format is always used.
+
 ```bash
 > batracker agents
+ServiceName: OTBR-by-Google-a7215b46a4f1fd
+    Port: 49154
+    Host: otbe345eefb12f7f9c
+    TxtData:
+        RecordVersion: 1
+        AgentId: e12f639deb66987e11a7215cd123
+        ThreadVersion: 1.4.0
+        NetworkName: ota7215b46a4f1fd
+        ExtendedPanId: 16dd92d88a32e63f
+        ActiveTimestamp: 1771558107
+        PartitionId: 0x10930b04
+        DomainName: DefaultDomain
+        BbrSeqNum: 23
+        BbrPort: 61631
+        OmrPrefix: fd70:ad65:47d9:1::/64
+        ExtAddress: 8e5d342e265b279c
+        VendorName: Google
+        ModelName: OTBR
+        StateBitmap:
+            ConnMode: pskc
+            ThreadIfState: active
+            Availability: high
+            ThreadRole: leader
+            BbrIsActive: yes
+            BbrIsPrimary: yes
+            EpskcSupported: yes
+            MultiAilState: not-detected
+            AdmitterSupported: yes
+    Address(es):
+        fd7c:af54:fada:4dcc:6aec:8aff:fe0d:e90b
+    MilliSecondsSinceDiscovered: 3523
+    MilliSecondsSinceLastChange: 3523
+Done
+```
+
+```bash
+> batracker agents rawtxt
 ServiceName: OTBR-by-Google-be345eefb12f7f9c
     Port: 49152
     Host: otbe345eefb12f7f9c

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -492,6 +492,42 @@ template <> otError Interpreter::Process<Cmd("batracker")>(Arg aArgs[])
      * @cli batracker agents
      * @code
      * batracker agents
+     * ServiceName: OTBR-by-Google-a7215b46a4f1fd
+     *     Port: 49154
+     *     Host: otbe345eefb12f7f9c
+     *     TxtData:
+     *         RecordVersion: 1
+     *         AgentId: e12f639deb66987e11a7215cd123
+     *         ThreadVersion: 1.4.0
+     *         NetworkName: ota7215b46a4f1fd
+     *         ExtendedPanId: 16dd92d88a32e63f
+     *         ActiveTimestamp: 1771558107
+     *         PartitionId: 0x10930b04
+     *         DomainName: DefaultDomain
+     *         BbrSeqNum: 23
+     *         BbrPort: 61631
+     *         OmrPrefix: fd70:ad65:47d9:1::/64
+     *         ExtAddress: 8e5d342e265b279c
+     *         VendorName: Google
+     *         ModelName: OTBR
+     *         StateBitmap:
+     *             ConnMode: pskc
+     *             ThreadIfState: active
+     *             Availability: high
+     *             ThreadRole: leader
+     *             BbrIsActive: yes
+     *             BbrIsPrimary: yes
+     *             EpskcSupported: yes
+     *             MultiAilState: not-detected
+     *             AdmitterSupported: yes
+     *     Address(es):
+     *         fd7c:af54:fada:4dcc:6aec:8aff:fe0d:e90b
+     *     MilliSecondsSinceDiscovered: 3523
+     *     MilliSecondsSinceLastChange: 3523
+     * Done
+     * @endcode
+     * @code
+     * batracker agents rawtxt
      * ServiceName: OTBR-by-Google-be345eefb12f7f9c
      *     Port: 49152
      *     Host: otbe345eefb12f7f9c
@@ -512,20 +548,45 @@ template <> otError Interpreter::Process<Cmd("batracker")>(Arg aArgs[])
      *     MilliSecondsSinceLastChange: 5237
      * Done
      * @endcode
+     * @cparam batracker agents [@ca{rawtxt}]
      * @par
-     * Outputs the list of discovered border agents. Information per agent:
+     * Outputs the list of discovered border agents. Information per agent includes:
      * - Service name
      * - Port number
      * - Host name
-     * - TXT data (key/value pairs per line)
+     * - TXT data (parsed human-readable information, or raw key/value pairs)
      * - Host addresses
      * - Milliseconds since agent was first discovered
      * - Milliseconds since the last change to agent info (port, addresses, TXT data)
+     * @par
+     * By default, if `OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE` is enabled, the TXT data is parsed and
+     * displayed in a human-readable format.
+     * @par
+     * The optional `rawtxt` argument forces the output of TXT data in its raw format (key/value pairs), even when the
+     * parser is enabled. If the parser is disabled, the raw format is always used.
+     * @sa otBorderAgentTxtDataParse
+     * @sa otBorderAgentTxtDataInfo
      */
     else if (aArgs[0] == "agents")
     {
         otBorderAgentTrackerIterator  iterator;
         otBorderAgentTrackerAgentInfo agent;
+        bool                          rawTxtData;
+
+#if OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE
+        if (!aArgs[1].IsEmpty())
+        {
+            VerifyOrExit(aArgs[1] == "rawtxt", error = OT_ERROR_INVALID_ARGS);
+            rawTxtData = true;
+        }
+        else
+        {
+            rawTxtData = false;
+        }
+#else
+        VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+        rawTxtData = true;
+#endif
 
         otBorderAgentTrackerInitIterator(GetInstancePtr(), &iterator);
 
@@ -537,15 +598,31 @@ template <> otError Interpreter::Process<Cmd("batracker")>(Arg aArgs[])
 
             OutputFormat(kIndentSize, "TxtData:");
 
-            if (agent.mTxtData != nullptr)
+            if (agent.mTxtData == nullptr)
+            {
+                OutputLine(" (null)");
+            }
+            else if (rawTxtData)
             {
                 OutputNewLine();
                 OutputDnsTxtData(kIndentSize * 2, agent.mTxtData, agent.mTxtDataLength);
             }
+#if OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE
             else
             {
-                OutputLine(" (null)");
+                otBorderAgentTxtDataInfo txtInfo;
+
+                if (otBorderAgentTxtDataParse(agent.mTxtData, agent.mTxtDataLength, &txtInfo) != OT_ERROR_NONE)
+                {
+                    OutputLine(" (parse error) - use `rawtxt`");
+                }
+                else
+                {
+                    OutputNewLine();
+                    OutputBorderAgentTxtDataInfo(kIndentSize * 2, txtInfo);
+                }
             }
+#endif
 
             OutputFormat(kIndentSize, "Address(es):");
 
@@ -576,10 +653,108 @@ template <> otError Interpreter::Process<Cmd("batracker")>(Arg aArgs[])
         error = OT_ERROR_INVALID_ARGS;
     }
 
+exit:
     return error;
 }
 
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_TRACKER_ENABLE
+
+#if OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE
+void Interpreter::OutputBorderAgentTxtDataInfo(uint8_t aIndentSize, const otBorderAgentTxtDataInfo &aInfo)
+{
+    if (aInfo.mHasRecordVersion)
+    {
+        OutputLine(aIndentSize, "RecordVersion: %s", aInfo.mRecordVersion);
+    }
+
+    if (aInfo.mHasAgentId)
+    {
+        OutputFormat(aIndentSize, "AgentId: ");
+        OutputBytesLine(aInfo.mAgentId.mId);
+    }
+
+    if (aInfo.mHasThreadVersion)
+    {
+        OutputLine(aIndentSize, "ThreadVersion: %s", aInfo.mThreadVersion);
+    }
+
+    if (aInfo.mHasNetworkName)
+    {
+        OutputLine(aIndentSize, "NetworkName: %s", aInfo.mNetworkName.m8);
+    }
+
+    if (aInfo.mHasExtendedPanId)
+    {
+        OutputFormat(aIndentSize, "ExtendedPanId: ");
+        OutputBytesLine(aInfo.mExtendedPanId.m8);
+    }
+
+    if (aInfo.mHasActiveTimestamp)
+    {
+        OutputFormat(aIndentSize, "ActiveTimestamp: ");
+        OutputUint64Line(aInfo.mActiveTimestamp.mSeconds);
+    }
+
+    if (aInfo.mHasPartitionId)
+    {
+        OutputLine(aIndentSize, "PartitionId: 0x%lx", ToUlong(aInfo.mPartitionId));
+    }
+
+    if (aInfo.mHasDomainName)
+    {
+        OutputLine(aIndentSize, "DomainName: %s", aInfo.mDomainName.m8);
+    }
+
+    if (aInfo.mHasBbrSeqNum)
+    {
+        OutputLine(aIndentSize, "BbrSeqNum: %u", aInfo.mBbrSeqNum);
+    }
+
+    if (aInfo.mHasBbrPort)
+    {
+        OutputLine(aIndentSize, "BbrPort: %u", aInfo.mBbrPort);
+    }
+
+    if (aInfo.mHasOmrPrefix)
+    {
+        OutputFormat(aIndentSize, "OmrPrefix: ");
+        OutputIp6PrefixLine(aInfo.mOmrPrefix);
+    }
+
+    if (aInfo.mHasExtAddress)
+    {
+        OutputFormat(aIndentSize, "ExtAddress: ");
+        OutputExtAddressLine(aInfo.mExtAddress);
+    }
+
+    if (aInfo.mHasVendorName)
+    {
+        OutputLine(aIndentSize, "VendorName: %s", aInfo.mVendorName);
+    }
+
+    if (aInfo.mHasModelName)
+    {
+        OutputLine(aIndentSize, "ModelName: %s", aInfo.mModelName);
+    }
+
+    if (aInfo.mHasStateBitmap)
+    {
+        uint8_t indent = aIndentSize + kIndentSize;
+
+        OutputLine(aIndentSize, "StateBitmap:");
+
+        OutputLine(indent, "ConnMode: %s", otBorderAgentConnModeToString(aInfo.mStateBitmap.mConnMode));
+        OutputLine(indent, "ThreadIfState: %s", otBorderAgentIfStateToString(aInfo.mStateBitmap.mThreadIfState));
+        OutputLine(indent, "Availability: %s", otBorderAgentAvailabilityToString(aInfo.mStateBitmap.mAvailability));
+        OutputLine(indent, "ThreadRole: %s", otBorderAgentThreadRoleToString(aInfo.mStateBitmap.mThreadRole));
+        OutputLine(indent, "BbrIsActive: %s", ToYesNo(aInfo.mStateBitmap.mBbrIsActive));
+        OutputLine(indent, "BbrIsPrimary: %s", ToYesNo(aInfo.mStateBitmap.mBbrIsPrimary));
+        OutputLine(indent, "EpskcSupported: %s", ToYesNo(aInfo.mStateBitmap.mEpskcSupported));
+        OutputLine(indent, "MultiAilState: %s", otBorderAgentMultiAilStateToString(aInfo.mStateBitmap.mMultiAilState));
+        OutputLine(indent, "AdmitterSupported: %s", ToYesNo(aInfo.mStateBitmap.mAdmitterSupported));
+    }
+}
+#endif // OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 template <> otError Interpreter::Process<Cmd("br")>(Arg aArgs[]) { return mBr.Process(aArgs); }

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -273,6 +273,10 @@ private:
     void OutputChildTableEntry(uint8_t aIndentSize, const otNetworkDiagChildEntry &aChildEntry);
 #endif
 
+#if OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE
+    void OutputBorderAgentTxtDataInfo(uint8_t aIndentSize, const otBorderAgentTxtDataInfo &aInfo);
+#endif
+
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
     void OutputTrelCounters(const otTrelCounters &aCounters);
 #endif

--- a/src/core/api/border_agent_txt_data_api.cpp
+++ b/src/core/api/border_agent_txt_data_api.cpp
@@ -48,4 +48,29 @@ otError otBorderAgentTxtDataParse(const uint8_t *aTxtData, uint16_t aTxtDataLeng
     return AsCoreType(aInfo).ParseFrom(aTxtData, aTxtDataLength);
 }
 
+const char *otBorderAgentConnModeToString(otBorderAgentConnMode aConnMode)
+{
+    return MeshCoP::BorderAgent::TxtData::ConnModeToString(aConnMode);
+}
+
+const char *otBorderAgentIfStateToString(otBorderAgentThreadIfState aIfState)
+{
+    return MeshCoP::BorderAgent::TxtData::IfStateToString(aIfState);
+}
+
+const char *otBorderAgentAvailabilityToString(otBorderAgentAvailability aAvailability)
+{
+    return MeshCoP::BorderAgent::TxtData::AvailabilityToString(aAvailability);
+}
+
+const char *otBorderAgentThreadRoleToString(otBorderAgentThreadRole aRole)
+{
+    return MeshCoP::BorderAgent::TxtData::RoleToString(aRole);
+}
+
+const char *otBorderAgentMultiAilStateToString(otBorderAgentMultiAilState aState)
+{
+    return MeshCoP::BorderAgent::TxtData::MultiAilStateToString(aState);
+}
+
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE

--- a/src/core/meshcop/border_agent_txt_data.cpp
+++ b/src/core/meshcop/border_agent_txt_data.cpp
@@ -444,6 +444,68 @@ void TxtData::StateBitmap::Parse(uint32_t aBitmap, Info &aInfo)
     aInfo.mAdmitterSupported = aBitmap & kFlagAdmitterSupported;
 }
 
+const char *TxtData::ConnModeToString(ConnMode aConnMode)
+{
+#define ConnModeMapList(_)           \
+    _(kConnModeDisabled, "disabled") \
+    _(kConnModePskc, "pskc")         \
+    _(kConnModePskd, "pskd")         \
+    _(kConnModeVendor, "vendor")     \
+    _(kConnModeX509, "x509")
+
+    DefineEnumStringArray(ConnModeMapList);
+
+    return (static_cast<uint8_t>(aConnMode) < GetArrayLength(kStrings)) ? kStrings[aConnMode] : "invalid";
+}
+
+const char *TxtData::IfStateToString(IfState aIfState)
+{
+#define IfStateMapList(_)           \
+    _(kThreadIfNotInit, "not-init") \
+    _(kThreadIfInit, "init")        \
+    _(kThreadIfActive, "active")
+
+    DefineEnumStringArray(IfStateMapList);
+
+    return (static_cast<uint8_t>(aIfState) < GetArrayLength(kStrings)) ? kStrings[aIfState] : "invalid";
+}
+
+const char *TxtData::AvailabilityToString(Availability aAvailability)
+{
+#define AvailabilityMapList(_)       \
+    _(kAvailabilityInfreq, "infreq") \
+    _(kAvailabilityHigh, "high")
+
+    DefineEnumStringArray(AvailabilityMapList);
+
+    return (static_cast<uint8_t>(aAvailability) < GetArrayLength(kStrings)) ? kStrings[aAvailability] : "invalid";
+}
+
+const char *TxtData::RoleToString(Role aRole)
+{
+#define RoleMapList(_)                            \
+    _(kRoleDisabledDetached, "disabled-detached") \
+    _(kRoleChild, "child")                        \
+    _(kRoleRouter, "router")                      \
+    _(kRoleLeader, "leader")
+
+    DefineEnumStringArray(RoleMapList);
+
+    return (static_cast<uint8_t>(aRole) < GetArrayLength(kStrings)) ? kStrings[aRole] : "invalid";
+}
+
+const char *TxtData::MultiAilStateToString(MultiAilState aState)
+{
+#define MultiAilStateMapList(_)             \
+    _(kMultiAilDisabled, "disabled")        \
+    _(kMultiAilNotDetected, "not-detected") \
+    _(kMultiAilDetected, "detected")
+
+    DefineEnumStringArray(MultiAilStateMapList);
+
+    return (static_cast<uint8_t>(aState) < GetArrayLength(kStrings)) ? kStrings[aState] : "invalid";
+}
+
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE
 
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE || OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE

--- a/src/core/meshcop/border_agent_txt_data.hpp
+++ b/src/core/meshcop/border_agent_txt_data.hpp
@@ -154,6 +154,51 @@ public:
         }
     };
 
+    /**
+     * Converts a given Connection Mode in a Border Agent State Bitmap to a human-readable string.
+     *
+     * @param[in] aConnMode   The Connection Mode to convert.
+     *
+     * @return The string representation of @p aConnMode.
+     */
+    static const char *ConnModeToString(ConnMode aConnMode);
+
+    /**
+     * Converts a given Thread Interface State in a Border Agent State Bitmap to a human-readable string.
+     *
+     * @param[in] aIfState   The Thread Interface State to convert.
+     *
+     * @return The string representation of @p aIfState.
+     */
+    static const char *IfStateToString(IfState aIfState);
+
+    /**
+     * Converts a given Availability Status in a Border Agent State Bitmap to a human-readable string.
+     *
+     * @param[in] aAvailability   The Availability Status to convert.
+     *
+     * @return The string representation of @p aAvailability.
+     */
+    static const char *AvailabilityToString(Availability aAvailability);
+
+    /**
+     * Converts a given Thread Role in a Border Agent State Bitmap to a human-readable string.
+     *
+     * @param[in] aRole   The Thread Role to convert.
+     *
+     * @return The string representation of @p aRole.
+     */
+    static const char *RoleToString(Role aRole);
+
+    /**
+     * Converts a given Multi-AIL State in a Border Agent State Bitmap to a human-readable string.
+     *
+     * @param[in] aState   The Multi-AIL State to convert.
+     *
+     * @return The string representation of @p aState.
+     */
+    static const char *MultiAilStateToString(MultiAilState aState);
+
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_TXT_DATA_PARSER_ENABLE
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE


### PR DESCRIPTION
This commit enhances the `batracker agents` command to display parsed, human-readable information from the Border Agent TXT data by default. This allows users to easily inspect the Border Agent State Bitmap (Connection Mode, Thread Interface Status, Availability, Role, etc.) and other fields like Thread Version, Network Name, Vendor Name, or Vendor Model without manually decoding the raw bytes.

The `rawtxt` argument is introduced to optionally display the TXT data in the raw key/value pair format.

To support this, new public APIs are added to convert Border Agent State Bitmap enum values to their string representations.