### PR TITLE
[nexus] fix intermittent failure in test 5.5.5

### DIFF
--- a/tests/nexus/test_5_5_5.cpp
+++ b/tests/nexus/test_5_5_5.cpp
@@ -169,6 +169,7 @@ void Test5_5_5(void)
      * - Pass Criteria: N/A
      */
     r[3]->Reset();
+    SuccessOrQuit(r[1]->Get<Mle::Mle>().SetRouterEligible(false));
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 4: Router_1");


### PR DESCRIPTION
This commit fixes an intermittent failure in Nexus test 5.5.5. The failure occurred when Router_1 performed a late upgrade from child to router after re-attaching to the DUT. This caused a mismatch between the RLOC16 in the captured ping packets and the RLOC16 saved in the test info JSON at the end of the test.

Changes:
- Disabled router eligibility for Router_1 in test_5_5_5.cpp after it becomes isolated. This ensures it remains a child of the DUT and maintains a consistent RLOC16 for the duration of the test.