### PR TITLE
[coap] decouple callback from queue iteration in `PendingRequests`

### DIFF
--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -873,6 +873,7 @@ private:
         };
 
         Error       AbortAllMatching(const Matcher &aMatcher);
+        void        FinalizeRemovedRequestsIn(MessageQueue &aQueue, Error aResult);
         void        RetransmitRequest(const Request &aRequest);
         static void HandleTimer(Timer &aTimer);
         void        HandleTimer(void);


### PR DESCRIPTION
This commit updates `PendingRequests::HandleTimer()` and `PendingRequests::AbortAllMatching()` to perform request finalization (which invokes user callbacks) outside of the main loop iterating over the `mRequestMessages` queue.

Iterating over `mRequestMessages` while invoking user callbacks is unsafe because the callback may modify the request queue (e.g., abort other transactions), potentially invalidating the iterator. This change protects against this by moving requests to be finalized into a separate local `MessageQueue`. The requests in the local queue are then finalized and freed after the main loop finishes.

----

~This PR contains the commit from https://github.com/openthread/openthread/pull/12527. Please check and review the last commit on this PR. Thanks.~ 