### PR TITLE
[nexus] replace IgnoreError with SuccessOrQuit in Nexus tests

### DIFF
--- a/tests/nexus/test_5_1_10.cpp
+++ b/tests/nexus/test_5_1_10.cpp
@@ -146,8 +146,8 @@ void Test5_1_10(void)
     router1.AllowList(dut);
     router2.AllowList(dut);
 
-    IgnoreError(dut.Get<Mac::Filter>().AddRssIn(router2.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality2));
-    IgnoreError(router2.Get<Mac::Filter>().AddRssIn(dut.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality2));
+    SuccessOrQuit(dut.Get<Mac::Filter>().AddRssIn(router2.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality2));
+    SuccessOrQuit(router2.Get<Mac::Filter>().AddRssIn(dut.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality2));
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 3: Router_3 (DUT)");

--- a/tests/nexus/test_5_1_5.cpp
+++ b/tests/nexus/test_5_1_5.cpp
@@ -133,7 +133,7 @@ void Test5_1_5(void)
      *   - Router_1 automatically sends a link request, re-attaches and requests its original Router ID.
      * - Pass Criteria: N/A
      */
-    IgnoreError(router1.Get<Mle::Mle>().Start());
+    SuccessOrQuit(router1.Get<Mle::Mle>().Start());
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 4: Leader (DUT)");
@@ -179,7 +179,7 @@ void Test5_1_5(void)
      *   - Router_1 reattaches and requests its most recent Router ID.
      * - Pass Criteria: N/A
      */
-    IgnoreError(router1.Get<Mle::Mle>().Start());
+    SuccessOrQuit(router1.Get<Mle::Mle>().Start());
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 7: Leader (DUT)");

--- a/tests/nexus/test_5_1_9.cpp
+++ b/tests/nexus/test_5_1_9.cpp
@@ -151,17 +151,17 @@ void Test5_1_9(void)
      */
     Log("Step 2: Harness configures the RSSI");
 
-    IgnoreError(leader.Get<Mac::Filter>().AddRssIn(router1.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
-    IgnoreError(leader.Get<Mac::Filter>().AddRssIn(reed1.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
-    IgnoreError(leader.Get<Mac::Filter>().AddRssIn(reed2.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
+    SuccessOrQuit(leader.Get<Mac::Filter>().AddRssIn(router1.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
+    SuccessOrQuit(leader.Get<Mac::Filter>().AddRssIn(reed1.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
+    SuccessOrQuit(leader.Get<Mac::Filter>().AddRssIn(reed2.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
 
-    IgnoreError(router1.Get<Mac::Filter>().AddRssIn(leader.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
-    IgnoreError(router1.Get<Mac::Filter>().AddRssIn(reed1.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
+    SuccessOrQuit(router1.Get<Mac::Filter>().AddRssIn(leader.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
+    SuccessOrQuit(router1.Get<Mac::Filter>().AddRssIn(reed1.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
 
-    IgnoreError(reed1.Get<Mac::Filter>().AddRssIn(leader.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
-    IgnoreError(reed1.Get<Mac::Filter>().AddRssIn(router1.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
+    SuccessOrQuit(reed1.Get<Mac::Filter>().AddRssIn(leader.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
+    SuccessOrQuit(reed1.Get<Mac::Filter>().AddRssIn(router1.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
 
-    IgnoreError(reed2.Get<Mac::Filter>().AddRssIn(leader.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
+    SuccessOrQuit(reed2.Get<Mac::Filter>().AddRssIn(leader.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
 
     // Setup DUT connectivity (only to REEDs)
     dut.AllowList(reed1);
@@ -169,10 +169,10 @@ void Test5_1_9(void)
     dut.AllowList(reed2);
     reed2.AllowList(dut);
 
-    IgnoreError(dut.Get<Mac::Filter>().AddRssIn(reed1.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
-    IgnoreError(dut.Get<Mac::Filter>().AddRssIn(reed2.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
-    IgnoreError(reed1.Get<Mac::Filter>().AddRssIn(dut.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
-    IgnoreError(reed2.Get<Mac::Filter>().AddRssIn(dut.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
+    SuccessOrQuit(dut.Get<Mac::Filter>().AddRssIn(reed1.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
+    SuccessOrQuit(dut.Get<Mac::Filter>().AddRssIn(reed2.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
+    SuccessOrQuit(reed1.Get<Mac::Filter>().AddRssIn(dut.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
+    SuccessOrQuit(reed2.Get<Mac::Filter>().AddRssIn(dut.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
 
     /**
      * Step 3: Router_2 (DUT)

--- a/tests/nexus/test_5_6_4.cpp
+++ b/tests/nexus/test_5_6_4.cpp
@@ -156,22 +156,22 @@ void Test5_6_4(void)
         NetworkData::OnMeshPrefixConfig config;
 
         config.Clear();
-        IgnoreError(config.GetPrefix().FromString(kPrefix1));
+        SuccessOrQuit(config.GetPrefix().FromString(kPrefix1));
         config.mStable       = true;
         config.mOnMesh       = true;
         config.mPreferred    = true;
         config.mSlaac        = true;
         config.mDefaultRoute = true;
-        IgnoreError(router1.Get<NetworkData::Local>().AddOnMeshPrefix(config));
+        SuccessOrQuit(router1.Get<NetworkData::Local>().AddOnMeshPrefix(config));
 
         config.Clear();
-        IgnoreError(config.GetPrefix().FromString(kPrefix2));
+        SuccessOrQuit(config.GetPrefix().FromString(kPrefix2));
         config.mStable       = false;
         config.mOnMesh       = true;
         config.mPreferred    = true;
         config.mSlaac        = true;
         config.mDefaultRoute = true;
-        IgnoreError(router1.Get<NetworkData::Local>().AddOnMeshPrefix(config));
+        SuccessOrQuit(router1.Get<NetworkData::Local>().AddOnMeshPrefix(config));
 
         router1.Get<NetworkData::Notifier>().HandleServerDataUpdated();
     }

--- a/tests/nexus/test_6_1_5.cpp
+++ b/tests/nexus/test_6_1_5.cpp
@@ -161,8 +161,8 @@ void Test6_1_5(void)
     router1.AllowList(sed1);
     reed2.AllowList(sed1);
 
-    IgnoreError(sed1.Get<Mac::Filter>().AddRssIn(reed2.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality2));
-    IgnoreError(reed2.Get<Mac::Filter>().AddRssIn(sed1.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality2));
+    SuccessOrQuit(sed1.Get<Mac::Filter>().AddRssIn(reed2.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality2));
+    SuccessOrQuit(reed2.Get<Mac::Filter>().AddRssIn(sed1.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality2));
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 3: Automatically begins attach process by sending a multicast MLE Parent Request.");

--- a/tests/nexus/test_7_1_2.cpp
+++ b/tests/nexus/test_7_1_2.cpp
@@ -134,24 +134,24 @@ void Test7_1_2(void)
         NetworkData::OnMeshPrefixConfig config;
 
         config.Clear();
-        IgnoreError(static_cast<Ip6::Address &>(config.mPrefix.mPrefix).FromString(kPrefix1));
+        SuccessOrQuit(static_cast<Ip6::Address &>(config.mPrefix.mPrefix).FromString(kPrefix1));
         config.mPrefix.mLength = kPrefixLength;
         config.mStable         = true;
         config.mOnMesh         = true;
         config.mPreferred      = true;
         config.mSlaac          = true;
         config.mDefaultRoute   = true;
-        IgnoreError(router1.Get<NetworkData::Local>().AddOnMeshPrefix(config));
+        SuccessOrQuit(router1.Get<NetworkData::Local>().AddOnMeshPrefix(config));
 
         config.Clear();
-        IgnoreError(static_cast<Ip6::Address &>(config.mPrefix.mPrefix).FromString(kPrefix2));
+        SuccessOrQuit(static_cast<Ip6::Address &>(config.mPrefix.mPrefix).FromString(kPrefix2));
         config.mPrefix.mLength = kPrefixLength;
         config.mStable         = false;
         config.mOnMesh         = true;
         config.mPreferred      = true;
         config.mSlaac          = true;
         config.mDefaultRoute   = true;
-        IgnoreError(router1.Get<NetworkData::Local>().AddOnMeshPrefix(config));
+        SuccessOrQuit(router1.Get<NetworkData::Local>().AddOnMeshPrefix(config));
     }
 
     router1.Join(leader);

--- a/tests/nexus/test_7_1_8.cpp
+++ b/tests/nexus/test_7_1_8.cpp
@@ -157,22 +157,22 @@ void Test7_1_8(const char *aJsonFile)
         NetworkData::OnMeshPrefixConfig config;
 
         config.Clear();
-        IgnoreError(config.GetPrefix().FromString(kPrefix1));
+        SuccessOrQuit(config.GetPrefix().FromString(kPrefix1));
         config.mStable       = true;
         config.mDefaultRoute = true;
         config.mSlaac        = true;
         config.mOnMesh       = true;
         config.mPreferred    = true;
-        IgnoreError(fed1.Get<NetworkData::Local>().AddOnMeshPrefix(config));
+        SuccessOrQuit(fed1.Get<NetworkData::Local>().AddOnMeshPrefix(config));
 
         config.Clear();
-        IgnoreError(config.GetPrefix().FromString(kPrefix2));
+        SuccessOrQuit(config.GetPrefix().FromString(kPrefix2));
         config.mStable       = false;
         config.mDefaultRoute = true;
         config.mSlaac        = true;
         config.mOnMesh       = true;
         config.mPreferred    = true;
-        IgnoreError(fed1.Get<NetworkData::Local>().AddOnMeshPrefix(config));
+        SuccessOrQuit(fed1.Get<NetworkData::Local>().AddOnMeshPrefix(config));
 
         fed1.Get<NetworkData::Notifier>().HandleServerDataUpdated();
     }


### PR DESCRIPTION
This commit replaces instances of IgnoreError with SuccessOrQuit in several Nexus test files to ensure that errors from core methods are properly handled and cause test failure if they occur.

Modified files:
- tests/nexus/test_5_1_5.cpp
- tests/nexus/test_5_1_9.cpp
- tests/nexus/test_5_1_10.cpp
- tests/nexus/test_5_6_4.cpp
- tests/nexus/test_6_1_5.cpp
- tests/nexus/test_7_1_2.cpp
- tests/nexus/test_7_1_8.cpp