### PR TITLE
[logging] introduce `Log{Level}OnError` macros and update core

### DIFF
--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -133,10 +133,7 @@ void InfraIf::HandledReceived(uint32_t aIfIndex, const Ip6::Address &aSource, co
     }
 
 exit:
-    if (error != kErrorNone)
-    {
-        LogDebg("Dropped ICMPv6 message: %s", ErrorToString(error));
-    }
+    LogDebgOnError(error, "process ICMPv6 msg");
 }
 
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
@@ -158,10 +155,7 @@ void InfraIf::DiscoverNat64PrefixDone(uint32_t aIfIndex, const Ip6::Prefix &aPre
     Get<RoutingManager>().HandlePlatformDiscoveredNat64PrefixDone(aPrefix);
 
 exit:
-    if (error != kErrorNone)
-    {
-        LogDebg("Failed to handle discovered NAT64 synthetic addresses: %s", ErrorToString(error));
-    }
+    LogDebgOnError(error, "handle discovered NAT64 synthetic addresses");
 }
 
 #endif // OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
@@ -229,10 +223,7 @@ void InfraIf::HandleDhcp6Received(Message &aMessage, uint32_t aInfraIfIndex)
     Get<Dhcp6PdClient>().HandleReceived(aMessage);
 
 exit:
-    if (error != kErrorNone)
-    {
-        LogDebg("Dropped DHCPv6 message: %s", ErrorToString(error));
-    }
+    LogDebgOnError(error, "process DHCPv6 msg");
 }
 
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_ENABLE

--- a/src/core/border_router/rx_ra_tracker.cpp
+++ b/src/core/border_router/rx_ra_tracker.cpp
@@ -1876,7 +1876,7 @@ void RxRaTracker::RsSender::HandleTimer(void)
     }
     else
     {
-        LogCrit("RsSender: Failed to send RS %u/%u: %s", mTxCount + 1, kMaxTxCount, ErrorToString(error));
+        LogCritOnError(error, "send RS %u/%u", mTxCount + 1, kMaxTxCount);
 
         // Note that `mTxCount` is intentionally not incremented
         // if the tx fails.

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -891,15 +891,11 @@ void CoapBase::ProcessReceivedRequest(Msg &aRxMsg)
     error = kErrorNotFound;
 
 exit:
+    LogInfoOnError(error, "process request");
 
-    if (error != kErrorNone)
+    if (error == kErrorNotFound && !aRxMsg.mMessageInfo.GetSockAddr().IsMulticast())
     {
-        LogInfo("Failed to process request: %s", ErrorToString(error));
-
-        if (error == kErrorNotFound && !aRxMsg.mMessageInfo.GetSockAddr().IsMulticast())
-        {
-            IgnoreError(SendNotFound(aRxMsg));
-        }
+        IgnoreError(SendNotFound(aRxMsg));
     }
 }
 

--- a/src/core/common/log.hpp
+++ b/src/core/common/log.hpp
@@ -107,8 +107,20 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in]  ...   Arguments for the format specification.
  */
 #define LogCrit(...) Logger::LogAtLevel<kLogLevelCrit>(kLogModuleName, __VA_ARGS__)
+
+/**
+ * Emits an error log message at critical log level if there is an error.
+ *
+ * The emitted log will use the the following format "Failed to {aFormattedText} - {ErrorToString(aError)}", and will
+ * be emitted only if there is an error, i.e., @p aError is not `kErrorNone`.
+ *
+ * @param[in] aError       The error to check and log.
+ * @param[in] ...          Arguments for the format specification.
+ */
+#define LogCritOnError(aError, ...) Logger::LogOnError<kLogLevelCrit>(kLogModuleName, aError, __VA_ARGS__)
 #else
 #define LogCrit(...)
+#define LogCritOnError(aError, ...) OT_UNUSED_VARIABLE(aError)
 #endif
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
@@ -118,8 +130,21 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in]  ...   Arguments for the format specification.
  */
 #define LogWarn(...) Logger::LogAtLevel<kLogLevelWarn>(kLogModuleName, __VA_ARGS__)
+
+/**
+ * Emits an error log message at warning log level if there is an error.
+ *
+ * The emitted log will use the the following format "Failed to {aFormattedText} - {ErrorToString(aError)}", and will
+ * be emitted only if there is an error, i.e., @p aError is not `kErrorNone`.
+ *
+ * @param[in] aError       The error to check and log.
+ * @param[in] ...          Arguments for the format specification.
+ */
+#define LogWarnOnError(aError, ...) Logger::LogOnError<kLogLevelWarn>(kLogModuleName, aError, __VA_ARGS__)
+
 #else
 #define LogWarn(...)
+#define LogWarnOnError(aError, ...) OT_UNUSED_VARIABLE(aError)
 #endif
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
@@ -129,8 +154,21 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in]  ...   Arguments for the format specification.
  */
 #define LogNote(...) Logger::LogAtLevel<kLogLevelNote>(kLogModuleName, __VA_ARGS__)
+
+/**
+ * Emits an error log message at note log level if there is an error.
+ *
+ * The emitted log will use the the following format "Failed to {aFormattedText} - {ErrorToString(aError)}", and will
+ * be emitted only if there is an error, i.e., @p aError is not `kErrorNone`.
+ *
+ * @param[in] aError       The error to check and log.
+ * @param[in] ...          Arguments for the format specification.
+ */
+#define LogNoteOnError(aError, ...) Logger::LogOnError<kLogLevelNote>(kLogModuleName, aError, __VA_ARGS__)
+
 #else
 #define LogNote(...)
+#define LogNoteOnError(aError, ...) OT_UNUSED_VARIABLE(aError)
 #endif
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
@@ -140,8 +178,21 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in]  ...   Arguments for the format specification.
  */
 #define LogInfo(...) Logger::LogAtLevel<kLogLevelInfo>(kLogModuleName, __VA_ARGS__)
+
+/**
+ * Emits an error log message at info log level if there is an error.
+ *
+ * The emitted log will use the the following format "Failed to {aFormattedText} - {ErrorToString(aError)}", and will
+ * be emitted only if there is an error, i.e., @p aError is not `kErrorNone`.
+ *
+ * @param[in] aError       The error to check and log.
+ * @param[in] ...          Arguments for the format specification.
+ */
+#define LogInfoOnError(aError, ...) Logger::LogOnError<kLogLevelInfo>(kLogModuleName, aError, __VA_ARGS__)
+
 #else
 #define LogInfo(...)
+#define LogInfoOnError(aError, ...) OT_UNUSED_VARIABLE(aError)
 #endif
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)
@@ -151,23 +202,21 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in]  ...   Arguments for the format specification.
  */
 #define LogDebg(...) Logger::LogAtLevel<kLogLevelDebg>(kLogModuleName, __VA_ARGS__)
-#else
-#define LogDebg(...)
-#endif
 
-#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
 /**
- * Emits an error log message at warning log level if there is an error.
+ * Emits an error log message at debug log level if there is an error.
  *
- * The emitted log will use the the following format "Failed to {aText}: {ErrorToString(aError)}", and will be emitted
- * only if there is an error, i.e., @p aError is not `kErrorNone`.
+ * The emitted log will use the the following format "Failed to {aFormattedText} - {ErrorToString(aError)}", and will
+ * be emitted only if there is an error, i.e., @p aError is not `kErrorNone`.
  *
  * @param[in] aError       The error to check and log.
- * @param[in] aText        The text to include in the log.
+ * @param[in] ...          Arguments for the format specification.
  */
-#define LogWarnOnError(aError, aText) Logger::LogOnError(kLogModuleName, aError, aText)
+#define LogDebgOnError(aError, ...) Logger::LogOnError<kLogLevelDebg>(kLogModuleName, aError, __VA_ARGS__)
+
 #else
-#define LogWarnOnError(aError, aText)
+#define LogDebg(...)
+#define LogDebgOnError(aError, ...) OT_UNUSED_VARIABLE(aError)
 #endif
 
 #if OT_SHOULD_LOG
@@ -312,12 +361,12 @@ public:
     static void LogAtLevel(const char *aModuleName, const char *aFormat, ...)
         OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 3);
 
+    template <LogLevel kLogLevel>
+    static void LogOnError(const char *aModuleName, Error aError, const char *aFormat, ...)
+        OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(3, 4);
+
     static void LogVarArgs(const char *aModuleName, LogLevel aLogLevel, const char *aFormat, va_list aArgs)
         OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(3, 0);
-
-#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
-    static void LogOnError(const char *aModuleName, Error aError, const char *aText);
-#endif
 
 #if OPENTHREAD_CONFIG_LOG_PKT_DUMP
     static constexpr uint8_t kStringLineLength = 80;
@@ -338,6 +387,10 @@ public:
     template <LogLevel kLogLevel>
     static void DumpAtLevel(const char *aModuleName, const char *aText, const void *aData, uint16_t aDataLength);
 #endif
+
+private:
+    static void Log(const char *aModuleName, LogLevel aLogLevel, Error aError, const char *aFormat, va_list aArgs)
+        OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(4, 0);
 };
 
 extern template void Logger::LogAtLevel<kLogLevelNone>(const char *aModuleName, const char *aFormat, ...);
@@ -346,6 +399,13 @@ extern template void Logger::LogAtLevel<kLogLevelWarn>(const char *aModuleName, 
 extern template void Logger::LogAtLevel<kLogLevelNote>(const char *aModuleName, const char *aFormat, ...);
 extern template void Logger::LogAtLevel<kLogLevelInfo>(const char *aModuleName, const char *aFormat, ...);
 extern template void Logger::LogAtLevel<kLogLevelDebg>(const char *aModuleName, const char *aFormat, ...);
+
+extern template void Logger::LogOnError<kLogLevelNone>(const char *aModuleName, Error aError, const char *aFormat, ...);
+extern template void Logger::LogOnError<kLogLevelCrit>(const char *aModuleName, Error aError, const char *aFormat, ...);
+extern template void Logger::LogOnError<kLogLevelWarn>(const char *aModuleName, Error aError, const char *aFormat, ...);
+extern template void Logger::LogOnError<kLogLevelNote>(const char *aModuleName, Error aError, const char *aFormat, ...);
+extern template void Logger::LogOnError<kLogLevelInfo>(const char *aModuleName, Error aError, const char *aFormat, ...);
+extern template void Logger::LogOnError<kLogLevelDebg>(const char *aModuleName, Error aError, const char *aFormat, ...);
 
 #if OPENTHREAD_CONFIG_LOG_PKT_DUMP
 extern template void Logger::DumpAtLevel<kLogLevelNone>(const char *aModuleName,

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1345,9 +1345,7 @@ void Mac::HandleTransmitDone(TxFrame &aFrame, RxFrame *aAckFrame, Error aError)
 
             if (requiredRadios.Contains(radio) && (aError != kErrorNone))
             {
-                LogDebg("Frame tx failed on required radio link %s with error %s", RadioTypeToString(radio),
-                        ErrorToString(aError));
-
+                LogDebgOnError(aError, "tx frame on required radio link %s", RadioTypeToString(radio));
                 mTxError = aError;
             }
         }

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -258,20 +258,15 @@ Error SubMac::RadioSleep(void)
 {
     Error error = kErrorNone;
 
-    VerifyOrExit(ShouldHandleTransitionToSleep());
+    if (ShouldHandleTransitionToSleep())
+    {
+        SuccessOrExit(error = Get<Radio>().Sleep());
+    }
 
-    error = Get<Radio>().Sleep();
+    SetState(kStateSleep);
 
 exit:
-    if (error != kErrorNone)
-    {
-        LogWarn("RadioSleep() failed, error: %s", ErrorToString(error));
-    }
-    else
-    {
-        SetState(kStateSleep);
-    }
-
+    LogWarnOnError(error, "RadioSleep()");
     return error;
 }
 
@@ -290,15 +285,12 @@ Error SubMac::Receive(uint8_t aChannel)
         error = Get<Radio>().Receive(aChannel);
     }
 
-    if (error != kErrorNone)
-    {
-        LogWarn("RadioReceive() failed, error: %s", ErrorToString(error));
-        ExitNow();
-    }
+    SuccessOrExit(error);
 
     SetState(kStateReceive);
 
 exit:
+    LogWarnOnError(error, "RadioReceive()");
     return error;
 }
 

--- a/src/core/meshcop/border_agent_tracker.cpp
+++ b/src/core/meshcop/border_agent_tracker.cpp
@@ -156,7 +156,7 @@ void Tracker::HandleBrowseResult(const Dnssd::BrowseResult &aResult)
     }
 
 exit:
-    LogOnError(error, "add new agent", aResult.mServiceInstance);
+    LogWarnOnError(error, "add new agent %s", aResult.mServiceInstance);
 }
 
 void Tracker::HandleSrvResult(otInstance *aInstance, const otPlatDnssdSrvResult *aResult)
@@ -241,22 +241,6 @@ bool Tracker::NameMatch(const Heap::String &aHeapString, const char *aName)
     return !aHeapString.IsNull() && StringMatch(aHeapString.AsCString(), aName, kStringCaseInsensitiveMatch);
 }
 
-#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
-
-void Tracker::LogOnError(Error aError, const char *aText, const char *aName)
-{
-    if (aError != kErrorNone)
-    {
-        LogWarn("Error %s - Failed to %s - %s", ErrorToString(aError), aText, (aName != nullptr) ? aName : "");
-    }
-}
-
-#else
-
-void Tracker::LogOnError(Error, const char *, const char *) {}
-
-#endif
-
 const char *Tracker::StateToString(State aState)
 {
 #define StateMapList(_)                   \
@@ -316,7 +300,7 @@ Error Tracker::Host::SetNameAndStartAddrResolver(const char *aHostName)
     Get<Dnssd>().StartIp6AddressResolver(AddressResolver(mName.AsCString()));
 
 exit:
-    LogOnError(error, "set host name", aHostName);
+    LogWarnOnError(error, "set host name %s", aHostName);
     return error;
 }
 
@@ -348,7 +332,7 @@ void Tracker::Host::SetAddresses(const Dnssd::AddressResult &aResult)
     }
 
 exit:
-    LogOnError(error, "set host addresses", mName.AsCString());
+    LogWarnOnError(error, "set host addresses on %s", mName.AsCString());
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -460,7 +444,7 @@ void Tracker::Agent::SetTxtData(const uint8_t *aData, uint16_t aDataLength)
     SetUpdateTimeToNow();
 
 exit:
-    LogOnError(error, "set TXT data", mServiceName.AsCString());
+    LogWarnOnError(error, "set TXT data on %s", mServiceName.AsCString());
 }
 
 void Tracker::Agent::ClearTxtData(void)

--- a/src/core/meshcop/border_agent_tracker.hpp
+++ b/src/core/meshcop/border_agent_tracker.hpp
@@ -225,7 +225,6 @@ private:
     static void HandleAddressResult(otInstance *aInstance, const otPlatDnssdAddressResult *aResult);
 
     static bool        NameMatch(const Heap::String &aHeapString, const char *aName);
-    static void        LogOnError(Error aError, const char *aText, const char *aName);
     static const char *StateToString(State aState);
 
     static const char kServiceType[];

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -183,12 +183,7 @@ Error DatasetManager::ApplyConfiguration(const Dataset &aDataset) const
             uint8_t channel = static_cast<uint8_t>(cur->ReadValueAs<ChannelTlv>().GetChannel());
 
             error = Get<Mac::Mac>().SetPanChannel(channel);
-
-            if (error != kErrorNone)
-            {
-                LogCrit("Failed to set PAN channel to %u when applying dataset: %s", channel, ErrorToString(error));
-            }
-
+            LogCritOnError(error, "set PAN channel to %u when applying dataset", channel);
             break;
         }
 
@@ -198,10 +193,7 @@ Error DatasetManager::ApplyConfiguration(const Dataset &aDataset) const
             uint8_t channel = static_cast<uint8_t>(cur->ReadValueAs<WakeupChannelTlv>().GetChannel());
             error           = Get<Mac::Mac>().SetWakeupChannel(channel);
 
-            if (error != kErrorNone)
-            {
-                LogCrit("Failed to set wake-up channel to %u when applying dataset: %s", channel, ErrorToString(error));
-            }
+            LogCritOnError(error, "set wake-up channel to %u when applying dataset", channel);
 #endif
             break;
         }

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -1653,7 +1653,7 @@ void Server::ResetUpstreamQueryTransaction(UpstreamQueryTransaction &aTxn, Error
     else
     {
         mCounters.mUpstreamDnsCounters.mFailures++;
-        LogWarn("Upstream query transaction %d closed: %s.", index, ErrorToString(aError));
+        LogWarnOnError(aError, "handle upstream query transaction %d", index);
     }
     aTxn.Reset();
 }

--- a/src/core/net/mdns.cpp
+++ b/src/core/net/mdns.cpp
@@ -4271,12 +4271,7 @@ Error Core::RxMessage::Init(Instance          &aInstance,
     mMessagePtr = aMessagePtr.PassOwnership();
 
 exit:
-    if (error != kErrorNone)
-    {
-        LogInfo("Failed to parse message from %s, error:%s", aSenderAddress.GetAddress().ToString().AsCString(),
-                ErrorToString(error));
-    }
-
+    LogInfoOnError(error, "parse message from %s", aSenderAddress.GetAddress().ToString().AsCString());
     return error;
 }
 

--- a/src/core/net/srp_advertising_proxy.cpp
+++ b/src/core/net/srp_advertising_proxy.cpp
@@ -956,10 +956,7 @@ void AdvertisingProxy::RegisterHost(Host &aHost)
     Get<Dnssd>().RegisterHost(hostInfo, aHost.mAdvId, HandleRegistered);
 
 exit:
-    if (error != kErrorNone)
-    {
-        LogWarn("Error %s registering host '%s'", ErrorToString(error), hostName);
-    }
+    LogWarnOnError(error, "register host '%s'", hostName);
 }
 
 void AdvertisingProxy::UnregisterHost(Host &aHost)
@@ -1030,11 +1027,7 @@ void AdvertisingProxy::RegisterService(Service &aService)
     Get<Dnssd>().RegisterService(serviceInfo, aService.mAdvId, HandleRegistered);
 
 exit:
-    if (error != kErrorNone)
-    {
-        LogWarn("Error %s registering service '%s' '%s'", ErrorToString(error), aService.GetInstanceLabel(),
-                serviceName);
-    }
+    LogWarnOnError(error, "register service '%s' '%s'", aService.GetInstanceLabel(), serviceName);
 }
 
 void AdvertisingProxy::UnregisterService(Service &aService)

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -384,8 +384,7 @@ Error Client::Start(const Ip6::SockAddr &aServerSockAddr, Requester aRequester)
 
     if (error != kErrorNone)
     {
-        LogInfo("Failed to connect to server %s: %s", aServerSockAddr.GetAddress().ToString().AsCString(),
-                ErrorToString(error));
+        LogInfoOnError(error, "connect to server %s", aServerSockAddr.GetAddress().ToString().AsCString());
         IgnoreError(mSocket.Close());
         ExitNow();
     }
@@ -1049,7 +1048,7 @@ exit:
         // continue to retry using the `mRetryWaitInterval` (which keeps
         // growing on each failure).
 
-        LogInfo("Failed to send update: %s", ErrorToString(error));
+        LogInfoOnError(error, "send update");
 
         SetState(kStateToRetry);
 
@@ -1928,10 +1927,7 @@ void Client::ProcessResponse(Message &aMessage)
     UpdateState();
 
 exit:
-    if (error != kErrorNone)
-    {
-        LogInfo("Failed to process response %s", ErrorToString(error));
-    }
+    LogInfoOnError(error, "process response");
 }
 
 void Client::SelectNewMessageId(void)

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -1573,7 +1573,7 @@ void Server::InformUpdateHandlerOrCommit(Error aError, Host &aHost, const Messag
     }
     else
     {
-        LogInfo("Error %s processing received SRP update", ErrorToString(aError));
+        LogInfoOnError(aError, "process received SRP update");
     }
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 

--- a/src/core/radio/ble_secure.cpp
+++ b/src/core/radio/ble_secure.cpp
@@ -591,7 +591,7 @@ exit:
         // mSendMessage is most likely not initialized; so appending a GeneralError status TLV to mSendMessage would
         // fail also. In this case it's not possible to recover TLV integrity and client/server sync.
         // It's handled by logging the error and (necessarily) closing the secure connection.
-        LogCrit("HandleTlsReceive: %s", ErrorToString(error));
+        LogCritOnError(error, "HandleTlsReceive");
         Disconnect();
     }
 }

--- a/src/core/radio/trel_peer_discoverer.cpp
+++ b/src/core/radio/trel_peer_discoverer.cpp
@@ -315,8 +315,7 @@ void PeerDiscoverer::HandleRegisterDone(Error aError)
     }
     else
     {
-        LogInfo("Failed to register DNS-SD service with name:%s, Error:%s", mServiceName.GetName(),
-                ErrorToString(aError));
+        LogInfoOnError(aError, "register DNS-SD service with name:%s", mServiceName.GetName());
         UnregisterService();
 
         // Generate a new name (appending a suffix index to the name)

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -747,12 +747,8 @@ void AddressResolver::SendAddressError(const Ip6::Address             &aTarget,
     LogInfo("Sent %s for target %s", UriToString<kUriAddressError>(), aTarget.ToString().AsCString());
 
 exit:
-
-    if (error != kErrorNone)
-    {
-        FreeMessage(message);
-        LogInfo("Failed to send %s: %s", UriToString<kUriAddressError>(), ErrorToString(error));
-    }
+    FreeMessageOnError(message, error);
+    LogInfoOnError(error, "send %s", UriToString<kUriAddressError>());
 }
 
 #endif // OPENTHREAD_FTD
@@ -829,11 +825,7 @@ template <> void AddressResolver::HandleTmf<kUriAddressError>(Coap::Msg &aMsg)
 #endif // OPENTHREAD_FTD
 
 exit:
-
-    if (error != kErrorNone)
-    {
-        LogWarn("Error %s when processing %s", ErrorToString(error), UriToString<kUriAddressError>());
-    }
+    LogWarnOnError(error, "process %s", UriToString<kUriAddressError>());
 }
 
 #if OPENTHREAD_FTD

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -826,12 +826,9 @@ void MeshForwarder::GetForwardFramePriority(RxInfo &aRxInfo, Message::Priority &
     error = GetFramePriority(aRxInfo, aPriority);
 
 exit:
-    if (error != kErrorNone)
-    {
-        LogInfo("Failed to get forwarded frame priority, error:%s, %s", ErrorToString(error),
-                aRxInfo.ToString().AsCString());
-    }
-    else if (isFragment)
+    LogInfoOnError(error, "get forwarded frame priority %s", aRxInfo.ToString().AsCString());
+
+    if ((error == kErrorNone) && isFragment)
     {
         UpdateFragmentPriority(fragmentHeader, aRxInfo.mFrameData.GetLength(), aRxInfo.GetSrcAddr().GetShort(),
                                aPriority);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2856,13 +2856,13 @@ void Mle::LogError(MessageAction aAction, MessageType aType, Error aError)
     {
         if (aAction == kMessageReceive && (aError == kErrorDrop || aError == kErrorNoRoute))
         {
-            LogInfo("Failed to %s %s%s: %s", "process", MessageTypeToString(aType),
-                    MessageTypeActionToSuffixString(aType, aAction), ErrorToString(aError));
+            LogInfoOnError(aError, "%s %s%s", "process", MessageTypeToString(aType),
+                           MessageTypeActionToSuffixString(aType, aAction));
         }
         else
         {
-            LogWarn("Failed to %s %s%s: %s", aAction == kMessageSend ? "send" : "process", MessageTypeToString(aType),
-                    MessageTypeActionToSuffixString(aType, aAction), ErrorToString(aError));
+            LogWarnOnError(aError, "%s %s%s", aAction == kMessageSend ? "send" : "process", MessageTypeToString(aType),
+                           MessageTypeActionToSuffixString(aType, aAction));
         }
     }
 }

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -1947,8 +1947,8 @@ Error Mle::ProcessAddressRegistrationTlv(RxInfo &aRxInfo, Child &aChild)
         }
         else
         {
-            LogWarn("Error %s adding IPv6 address %s to child 0x%04x", ErrorToString(error),
-                    address.ToString().AsCString(), aChild.GetRloc16());
+            LogWarnOnError(error, "add IPv6 address %s to child 0x%04x", address.ToString().AsCString(),
+                           aChild.GetRloc16());
         }
 
         if (address.IsMulticast())

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -408,7 +408,7 @@ Error MlrManager::SendMlrMessage(const Ip6::Address         *aAddresses,
     LogInfo("Sent MLR.req: addressNum=%d", aAddressNum);
 
 exit:
-    LogInfo("SendMlrMessage(): %s", ErrorToString(error));
+    LogInfoOnError(error, "SendMlrMessage()");
     FreeMessageOnError(message, error);
     return error;
 }


### PR DESCRIPTION
This commit introduces a new set of logging macros, `LogCritOnError`, `LogWarnOnError`, `LogNoteOnError`, `LogInfoOnError`, and `LogDebgOnError`, to provide a consistent and streamlined way to log errors across the codebase.

The new macros automatically prepend "Failed to " and append the error string (using `ErrorToString()`) to the log message, reducing boilerplate code and ensuring a uniform log format. These macros only emit a log if the provided `Error` is not `kErrorNone`.

This change improves code readability and maintainability by consolidating error logging logic into the logging framework.