### PR TITLE
[address-resolver] simplify `SendAddressError()` and its usage

### DIFF
--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -686,7 +686,7 @@ void Manager::HandleDadBackboneAnswer(const Ip6::Address &aDua, const Ip6::Inter
         Ip6::Address dest;
 
         dest.SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), ndProxy->GetRloc16());
-        Get<AddressResolver>().SendAddressError(aDua, aMeshLocalIid, &dest);
+        Get<AddressResolver>().SendAddressError(aDua, aMeshLocalIid, dest);
     }
 
     ot::BackboneRouter::NdProxyTable::NotifyDadComplete(*ndProxy, duplicate);
@@ -739,7 +739,7 @@ void Manager::HandleProactiveBackboneNotification(const Ip6::Address            
     {
         // Duplicated address detected, send ADDR_ERR.ntf to ff03::2 in the Thread network
         BackboneRouter::NdProxyTable::Erase(*ndProxy);
-        Get<AddressResolver>().SendAddressError(aDua, aMeshLocalIid, nullptr);
+        Get<AddressResolver>().SendAddressError(aDua, aMeshLocalIid, Ip6::Address::GetRealmLocalAllRoutersMulticast());
     }
 
 exit:

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -678,19 +678,20 @@ template <> void AddressResolver::HandleTmf<kUriAddressNotify>(Coap::Msg &aMsg)
     entry = FindCacheEntry(target, list, prev);
     VerifyOrExit(entry != nullptr);
 
-    if (list == &mCachedList)
+    if ((list == &mCachedList) && entry->IsLastTransactionTimeValid())
     {
-        if (entry->IsLastTransactionTimeValid())
+        // Receiving multiple Address Notification for an EID from
+        // different mesh-local IIDs indicates address is in use
+        // by more than one device. Try to resolve the duplicate
+        // address by sending an Address Error message.
+
+        if (entry->GetMeshLocalIid() != meshLocalIid)
         {
-            // Receiving multiple Address Notification for an EID from
-            // different mesh-local IIDs indicates address is in use
-            // by more than one device. Try to resolve the duplicate
-            // address by sending an Address Error message.
-
-            VerifyOrExit(entry->GetMeshLocalIid() == meshLocalIid, SendAddressError(target, meshLocalIid, nullptr));
-
-            VerifyOrExit(lastTransactionTime < entry->GetLastTransactionTime());
+            SendAddressError(target, meshLocalIid, Ip6::Address::GetRealmLocalAllRoutersMulticast());
+            ExitNow();
         }
+
+        VerifyOrExit(lastTransactionTime < entry->GetLastTransactionTime());
     }
 
     entry->SetRloc16(rloc16);
@@ -717,7 +718,7 @@ exit:
 
 void AddressResolver::SendAddressError(const Ip6::Address             &aTarget,
                                        const Ip6::InterfaceIdentifier &aMeshLocalIid,
-                                       const Ip6::Address             *aDestination)
+                                       const Ip6::Address             &aDestination)
 {
     Error            error;
     Coap::Message   *message;
@@ -725,22 +726,13 @@ void AddressResolver::SendAddressError(const Ip6::Address             &aTarget,
 
     VerifyOrExit((message = Get<Tmf::Agent>().NewMessage()) != nullptr, error = kErrorNoBufs);
 
-    SuccessOrExit(error = message->Init(aDestination == nullptr ? Coap::kTypeNonConfirmable : Coap::kTypeConfirmable,
-                                        Coap::kCodePost));
-    SuccessOrExit(error = message->AppendUriPathOptions(PathForUri(kUriAddressError)));
+    SuccessOrExit(error = message->InitAsPost(aDestination, kUriAddressError));
     SuccessOrExit(error = message->AppendPayloadMarker());
 
     SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, aTarget));
     SuccessOrExit(error = Tlv::Append<ThreadMeshLocalEidTlv>(*message, aMeshLocalIid));
 
-    if (aDestination == nullptr)
-    {
-        messageInfo.SetSockAddrToRlocPeerAddrToRealmLocalAllRoutersMulticast();
-    }
-    else
-    {
-        messageInfo.SetSockAddrToRlocPeerAddrTo(*aDestination);
-    }
+    messageInfo.SetSockAddrToRlocPeerAddrTo(aDestination);
 
     SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo));
 
@@ -821,7 +813,7 @@ template <> void AddressResolver::HandleTmf<kUriAddressError>(Coap::Msg &aMsg)
             {
                 destination.SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), child.GetRloc16());
 
-                SendAddressError(target, meshLocalIid, &destination);
+                SendAddressError(target, meshLocalIid, destination);
                 ExitNow();
             }
         }

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -228,7 +228,7 @@ public:
      */
     void SendAddressError(const Ip6::Address             &aTarget,
                           const Ip6::InterfaceIdentifier &aMeshLocalIid,
-                          const Ip6::Address             *aDestination);
+                          const Ip6::Address             &aDestination);
 
 private:
     static constexpr uint16_t kCacheEntries = OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_ENTRIES;


### PR DESCRIPTION
This commit updates `AddressResolver::SendAddressError()` to accept the destination address as a `const Ip6::Address &` instead of a pointer. This allows the implementation to be simplified by using `Coap::Message::InitAsPost()`, which automatically determines the CoAP message type (confirmable vs. non-confirmable) based on whether the destination address is multicast.

All callers of `SendAddressError()` are updated accordingly. When sending to all routers, `GetRealmLocalAllRoutersMulticast()` is now explicitly passed.