### PR TITLE
[dns] make name compression per-instance and enforce mDNS check

### DIFF
--- a/include/openthread/dns.h
+++ b/include/openthread/dns.h
@@ -39,6 +39,7 @@
 #include <stdint.h>
 
 #include <openthread/error.h>
+#include <openthread/instance.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -157,17 +158,23 @@ otError otDnsEncodeTxtData(const otDnsTxtEntry *aTxtEntries,
 /**
  * Enables/disables the "DNS name compression" mode.
  *
- * By default DNS name compression is enabled. When disabled, DNS names are appended as full and never compressed. This
- * is applicable to OpenThread's DNS and SRP client/server modules.
+ * By default, DNS name compression is enabled. When disabled, DNS names are appended in full and are never compressed.
+ * This applies to OpenThread's DNS and SRP client/server modules.
+ *
+ * DNS name compression cannot be disabled if the OpenThread mDNS module is enabled. Enabling the mDNS module will
+ * automatically enable name compression if it was previously disabled. Attempting to disable compression while the mDNS
+ * module is active will return `OT_ERROR_NOT_CAPABLE`.
  *
  * This is intended for testing only and available when `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` config is enabled.
  *
- * Note that in the case `OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE` is used, this mode applies to all OpenThread
- * instances (i.e., calling this function enables/disables the compression mode on all OpenThread instances).
- *
+ * @param[in] aInstance  A pointer to an OpenThread instance.
  * @param[in] aEnabled   TRUE to enable the "DNS name compression" mode, FALSE to disable.
+ *
+ * @retval OT_ERROR_NONE          The "DNS name compression" mode is updated.
+ * @retval OT_ERROR_NOT_CAPABLE   The "DNS name compression" mode cannot be disabled since OpenThread mDNS module is
+ *                                enabled.
  */
-void otDnsSetNameCompressionEnabled(bool aEnabled);
+otError otDnsSetNameCompressionEnabled(otInstance *aInstance, bool aEnabled);
 
 /**
  * Indicates whether the "DNS name compression" mode is enabled or not.
@@ -176,7 +183,7 @@ void otDnsSetNameCompressionEnabled(bool aEnabled);
  *
  * @returns TRUE if the "DNS name compression" mode is enabled, FALSE otherwise.
  */
-bool otDnsIsNameCompressionEnabled(void);
+bool otDnsIsNameCompressionEnabled(otInstance *aInstance);
 
 /**
  * @}

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (578)
+#define OPENTHREAD_API_VERSION (579)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1875,9 +1875,11 @@ Done
 
 Enable/Disable the "DNS name compression" mode.
 
-By default DNS name compression is enabled. When disabled, DNS names are appended as full and never compressed. This is applicable to OpenThread's DNS and SRP client/server modules.
+By default, DNS name compression is enabled. When disabled, DNS names are appended in full and are never compressed. This applies to OpenThread's DNS and SRP client/server modules.
 
-This is intended for testing only and available under `REFERENCE_DEVICE` config.
+DNS name compression cannot be disabled if the OpenThread mDNS module is enabled. Enabling the mDNS module will automatically enable name compression if it was previously disabled. Attempting to disable compression while the mDNS module is active will fail.
+
+This is intended for testing only and requires `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE`.
 
 Get the current "DNS name compression" mode.
 

--- a/src/cli/cli_dns.cpp
+++ b/src/cli/cli_dns.cpp
@@ -44,30 +44,12 @@ namespace Cli {
 
 template <> otError Dns::Process<Cmd("compression")>(Arg aArgs[])
 {
-    otError error = OT_ERROR_NONE;
-
     /**
      * @cli dns compression
      * @code
      * dns compression
      * Enabled
      * @endcode
-     * @cparam dns compression [@ca{enable|disable}]
-     * @par api_copy
-     * #otDnsIsNameCompressionEnabled
-     * @par
-     * By default DNS name compression is enabled. When disabled,
-     * DNS names are appended as full and never compressed. This
-     * is applicable to OpenThread's DNS and SRP client/server
-     * modules."
-     * `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is required.
-     */
-    if (aArgs[0].IsEmpty())
-    {
-        OutputEnabledDisabledStatus(otDnsIsNameCompressionEnabled());
-    }
-    /**
-     * @cli dns compression (enable,disable)
      * @code
      * dns compression enable
      * Enabled
@@ -81,25 +63,20 @@ template <> otError Dns::Process<Cmd("compression")>(Arg aArgs[])
      * @endcode
      * @cparam dns compression [@ca{enable|disable}]
      * @par
-     * Set the "DNS name compression" mode.
+     * Gets or sets the "DNS name compression" mode.
      * @par
-     * By default DNS name compression is enabled. When disabled,
-     * DNS names are appended as full and never compressed. This
-     * is applicable to OpenThread's DNS and SRP client/server
-     * modules."
-     * `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is required.
+     * This is intended for testing only and requires `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE`.
+     * @par
+     * By default, DNS name compression is enabled. When disabled, DNS names are appended in full and are never
+     * compressed. This applies to OpenThread's DNS and SRP client/server modules.
+     * @par
+     * DNS name compression cannot be disabled if the OpenThread mDNS module is enabled. Enabling the mDNS module will
+     * automatically enable name compression if it was previously disabled. Attempting to disable compression while the
+     * mDNS module is active will return an error.
+     * @sa otDnsIsNameCompressionEnabled
      * @sa otDnsSetNameCompressionEnabled
      */
-    else
-    {
-        bool enable;
-
-        SuccessOrExit(error = ParseEnableOrDisable(aArgs[0], enable));
-        otDnsSetNameCompressionEnabled(enable);
-    }
-
-exit:
-    return error;
+    return ProcessEnableDisable(aArgs, otDnsIsNameCompressionEnabled, otDnsSetNameCompressionEnabled);
 }
 
 #endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE

--- a/src/core/api/dns_api.cpp
+++ b/src/core/api/dns_api.cpp
@@ -69,9 +69,15 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-void otDnsSetNameCompressionEnabled(bool aEnabled) { Instance::SetDnsNameCompressionEnabled(aEnabled); }
+otError otDnsSetNameCompressionEnabled(otInstance *aInstance, bool aEnabled)
+{
+    return AsCoreType(aInstance).SetDnsNameCompressionEnabled(aEnabled);
+}
 
-bool otDnsIsNameCompressionEnabled(void) { return Instance::IsDnsNameCompressionEnabled(); }
+bool otDnsIsNameCompressionEnabled(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).IsDnsNameCompressionEnabled();
+}
 #endif
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE

--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -66,9 +66,6 @@ static uint64_t gMultiInstanceRaw[MULTI_INSTANCE_SIZE];
 OT_DEFINE_ALIGNED_VAR(sHeapRaw, sizeof(Utils::Heap), uint64_t);
 Utils::Heap *Instance::sHeap{nullptr};
 #endif
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-bool Instance::sDnsNameCompressionEnabled = true;
-#endif
 #endif
 
 #if OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE
@@ -299,6 +296,9 @@ Instance::Instance(void)
 #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
     , mNat64Translator(*this)
 #endif
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+    , mDnsNameCompressionEnabled(true)
+#endif
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 #if OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
     , mLinkRaw(*this)
@@ -513,6 +513,26 @@ Error Instance::ErasePersistentInfo(void)
 exit:
     return error;
 }
+
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+Error Instance::SetDnsNameCompressionEnabled(bool aEnabled)
+{
+    Error error = kErrorNone;
+
+#if OPENTHREAD_CONFIG_MULTICAST_DNS_ENABLE
+    if (Get<Dns::Multicast::Core>().IsEnabled())
+    {
+        VerifyOrExit(aEnabled, error = kErrorNotCapable);
+    }
+#endif
+
+    mDnsNameCompressionEnabled = aEnabled;
+    ExitNow();
+
+exit:
+    return error;
+}
+#endif
 
 void Instance::GetBufferInfo(BufferInfo &aInfo)
 {

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -371,23 +371,31 @@ public:
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     /**
-     * Enables/disables the "DNS name compressions" mode.
+     * Enables/disables the "DNS name compression" mode.
      *
-     * By default DNS name compression is enabled. When disabled, DNS names are appended as full and never compressed.
-     * This is applicable to OpenThread's DNS and SRP client/server modules.
+     * By default, DNS name compression is enabled. When disabled, DNS names are appended in full and are never
+     * compressed. This applies to OpenThread's DNS and SRP client/server modules.
+     *
+     * DNS name compression cannot be disabled if the OpenThread mDNS module is enabled. Enabling the mDNS module will
+     * automatically enable name compression if it was previously disabled. Attempting to disable compression while the
+     * mDNS module is active will return `kErrorNotCapable`.
      *
      * This is intended for testing only and available under a `REFERENCE_DEVICE` config.
      *
      * @param[in] aEnabled   TRUE to enable the "DNS name compression" mode, FALSE to disable.
+     *
+     * @retval kErrorNone         The "DNS name compression" mode is updated.
+     * @retval kErrorNotCapable   The "DNS name compression" mode cannot be disabled since OpenThread mDNS module is
+     *                            enabled.
      */
-    static void SetDnsNameCompressionEnabled(bool aEnabled) { sDnsNameCompressionEnabled = aEnabled; }
+    Error SetDnsNameCompressionEnabled(bool aEnabled);
 
     /**
      * Indicates whether the "DNS name compression" mode is enabled or not.
      *
-     * @returns TRUE if the "DNS name compressions" mode is enabled, FALSE otherwise.
+     * @returns TRUE if the "DNS name compression" mode is enabled, FALSE otherwise.
      */
-    static bool IsDnsNameCompressionEnabled(void) { return sDnsNameCompressionEnabled; }
+    bool IsDnsNameCompressionEnabled(void) { return mDnsNameCompressionEnabled; }
 #endif
 
     /**
@@ -448,10 +456,6 @@ private:
 
 #if (OPENTHREAD_MTD || OPENTHREAD_FTD) && !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
     static Utils::Heap *sHeap;
-#endif
-
-#if (OPENTHREAD_MTD || OPENTHREAD_FTD) && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    static bool sDnsNameCompressionEnabled;
 #endif
 
     //-----------------------------------------------------------------------------------------------------------------
@@ -758,6 +762,10 @@ private:
 
 #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
     Nat64::Translator mNat64Translator;
+#endif
+
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+    bool mDnsNameCompressionEnabled;
 #endif
 
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD

--- a/src/core/net/dns_types.cpp
+++ b/src/core/net/dns_types.cpp
@@ -285,7 +285,7 @@ Error Name::AppendPointerLabel(uint16_t aOffset, Message &aMessage)
     uint16_t value;
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    if (!Instance::IsDnsNameCompressionEnabled())
+    if (!aMessage.GetInstance().IsDnsNameCompressionEnabled())
     {
         // If "DNS name compression" mode is disabled, instead of
         // appending the pointer label, read the name from the message

--- a/src/core/net/mdns.cpp
+++ b/src/core/net/mdns.cpp
@@ -141,6 +141,10 @@ Error Core::SetEnabled(bool aEnable, uint32_t aInfraIfIndex, Requester aRequeste
     {
         LogInfo("%snabling on infra-if-index %lu", (aRequester == kRequesterAuto) ? "Auto-e" : "E",
                 ToUlong(mInfraIfIndex));
+
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+        SuccessOrAssert(GetInstance().SetDnsNameCompressionEnabled(true));
+#endif
     }
     else
     {


### PR DESCRIPTION
This commit updates the DNS name compression setting to be a per-instance property rather than a global static variable.

The `otDnsSetNameCompressionEnabled()` and `otDnsIsNameCompressionEnabled()` C APIs are updated to take an `otInstance` pointer. Internally, the `Instance` class now uses the `mDnsNameCompressionEnabled` member variable instead of the static `sDnsNameCompressionEnabled`.

Additionally, this commit enforces that DNS name compression cannot be disabled when the OpenThread mDNS module is active. The `otDnsSetNameCompressionEnabled()` function now returns an `otError` and will return `OT_ERROR_NOT_CAPABLE` if a user attempts to disable compression while mDNS is enabled. When the mDNS module is enabled, it automatically sets name compression to true.

The CLI command and related documentation are updated to reflect these changes.

----

Should help address an issue discovered by fuzzer (disabling compression while using mDNS, e.g. trel use-case).