### PR TITLE
[nexus] add test 9.2.8 Persistent Active/Pending Operational Datasets

### DIFF
--- a/tests/nexus/CMakeLists.txt
+++ b/tests/nexus/CMakeLists.txt
@@ -201,6 +201,7 @@ ot_nexus_test(9_2_4 "cert;nexus")
 ot_nexus_test(9_2_5 "cert;nexus")
 ot_nexus_test(9_2_6 "cert;nexus")
 ot_nexus_test(9_2_7 "cert;nexus")
+ot_nexus_test(9_2_8 "cert;nexus")
 
 # Misc tests
 ot_nexus_test(border_admitter "core;nexus")

--- a/tests/nexus/run_nexus_tests.sh
+++ b/tests/nexus/run_nexus_tests.sh
@@ -137,6 +137,7 @@ DEFAULT_TESTS=(
     "9_2_5"
     "9_2_6"
     "9_2_7"
+    "9_2_8"
 )
 
 # Use provided arguments or the default test list

--- a/tests/nexus/test_9_2_8.cpp
+++ b/tests/nexus/test_9_2_8.cpp
@@ -1,0 +1,398 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+
+#include "mac/data_poll_sender.hpp"
+#include "meshcop/commissioner.hpp"
+#include "meshcop/dataset_manager.hpp"
+#include "platform/nexus_core.hpp"
+#include "platform/nexus_node.hpp"
+
+namespace ot {
+namespace Nexus {
+
+/**
+ * Time to advance for a node to form a network and become leader, in milliseconds.
+ */
+static constexpr uint32_t kFormNetworkTime = 13 * 1000;
+
+/**
+ * Time to advance for a node to join a network, in milliseconds.
+ */
+static constexpr uint32_t kJoinTime = 20 * 1000;
+
+/**
+ * Time to advance for a commissioner to become active, in milliseconds.
+ */
+static constexpr uint32_t kPetitionTime = 5 * 1000;
+
+/**
+ * Time to wait for a response, in milliseconds.
+ */
+static constexpr uint32_t kResponseTime = 1000;
+
+/**
+ * Time to wait for the network to stabilize, in milliseconds.
+ */
+static constexpr uint32_t kStabilizeTime = 10 * 1000;
+
+/**
+ * Time for the delay timer, in milliseconds.
+ */
+static constexpr uint32_t kDelayTimer = 60 * 1000;
+
+/**
+ * Time to power down the DUT, in milliseconds.
+ */
+static constexpr uint32_t kPowerDownTime = 60 * 1000;
+
+/**
+ * Time to wait for reattachment after restart, in milliseconds.
+ */
+static constexpr uint32_t kReattachTime = 150 * 1000;
+
+/**
+ * PAN ID for the active dataset.
+ */
+static constexpr uint16_t kActivePanId = 0xFACE;
+
+/**
+ * PAN ID for the pending dataset.
+ */
+static constexpr uint16_t kPendingPanId = 0xAFCE;
+
+/**
+ * Primary channel.
+ */
+static constexpr uint8_t kPrimaryChannel = 11;
+
+/**
+ * Secondary channel.
+ */
+static constexpr uint8_t kSecondaryChannel = 12;
+
+/**
+ * Active Timestamp for the initial dataset.
+ */
+static constexpr uint64_t kInitialActiveTimestamp = 10;
+
+/**
+ * Active Timestamp for the pending set.
+ */
+static constexpr uint64_t kPendingActiveTimestamp = 70;
+
+/**
+ * Pending Timestamp for the pending set.
+ */
+static constexpr uint64_t kPendingTimestamp = 20;
+
+void Test9_2_8(void)
+{
+    /**
+     * 9.2.8 Commissioning - Persistent Active/Pending Operational Datasets
+     *
+     * 9.2.8.1 Topology
+     * - Commissioner
+     * - Leader
+     * - Router 1 (DUT)
+     * - MED 1 (DUT)
+     * - SED 1 (DUT)
+     *
+     * 9.2.8.2 Purpose & Description
+     * The purpose of this test case is to verify that after a reset, the DUT reattaches to the test network using
+     *   parameters set in Active/Pending Operational Datasets.
+     *
+     * Spec Reference                          | V1.1 Section | V1.3.0 Section
+     * ----------------------------------------|--------------|---------------
+     * Updating the Active Operational Dataset | 8.7.4        | 8.7.4
+     */
+
+    Core nexus;
+
+    Node &commissioner = nexus.CreateNode();
+    Node &leader       = nexus.CreateNode();
+    Node &router1      = nexus.CreateNode();
+    Node &med1         = nexus.CreateNode();
+    Node &sed1         = nexus.CreateNode();
+
+    commissioner.SetName("COMMISSIONER");
+    leader.SetName("LEADER");
+    router1.SetName("ROUTER_1");
+    med1.SetName("MED_1");
+    sed1.SetName("SED_1");
+
+    Instance::SetLogLevel(kLogLevelNote);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 1: All");
+
+    /**
+     * Step 1: All
+     * - Description: Ensure topology is formed correctly.
+     * - Pass Criteria: N/A.
+     */
+
+    commissioner.AllowList(leader);
+    leader.AllowList(commissioner);
+
+    leader.AllowList(router1);
+    router1.AllowList(leader);
+
+    leader.AllowList(med1);
+    med1.AllowList(leader);
+
+    leader.AllowList(sed1);
+    sed1.AllowList(leader);
+
+    {
+        MeshCoP::Dataset::Info dataset;
+        MeshCoP::Timestamp     timestamp;
+
+        SuccessOrQuit(dataset.GenerateRandom(leader.GetInstance()));
+
+        timestamp.Clear();
+        timestamp.SetSeconds(kInitialActiveTimestamp);
+        dataset.Set<MeshCoP::Dataset::kActiveTimestamp>(timestamp);
+        dataset.Set<MeshCoP::Dataset::kChannel>(kPrimaryChannel);
+        dataset.Set<MeshCoP::Dataset::kPanId>(kActivePanId);
+        SuccessOrQuit(dataset.Update<MeshCoP::Dataset::kNetworkName>().Set("OpenThread"));
+        leader.Get<MeshCoP::ActiveDatasetManager>().SaveLocal(dataset);
+    }
+
+    leader.Get<ThreadNetif>().Up();
+    SuccessOrQuit(leader.Get<Mle::Mle>().Start());
+    nexus.AdvanceTime(kFormNetworkTime);
+    VerifyOrQuit(leader.Get<Mle::Mle>().IsLeader());
+
+    commissioner.Join(leader, Node::kAsMed);
+    router1.Join(leader, Node::kAsFtd);
+    med1.Join(leader, Node::kAsMed);
+    sed1.Join(leader, Node::kAsSedWithFullNetData);
+
+    SuccessOrQuit(sed1.Get<DataPollSender>().SetExternalPollPeriod(100));
+
+    nexus.AdvanceTime(kJoinTime);
+    VerifyOrQuit(commissioner.Get<Mle::Mle>().IsAttached());
+    VerifyOrQuit(router1.Get<Mle::Mle>().IsAttached());
+    VerifyOrQuit(med1.Get<Mle::Mle>().IsAttached());
+    VerifyOrQuit(sed1.Get<Mle::Mle>().IsAttached());
+
+    SuccessOrQuit(commissioner.Get<MeshCoP::Commissioner>().Start(nullptr, nullptr, nullptr));
+    nexus.AdvanceTime(kPetitionTime);
+    VerifyOrQuit(commissioner.Get<MeshCoP::Commissioner>().IsActive());
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 2: Commissioner");
+
+    /**
+     * Step 2: Commissioner
+     * - Description: Harness instructs device to send MGMT_PENDING_SET.req to the Leader Anycast or Routing Locator:
+     *   - CoAP Request URI: coap://[<L>]:MM/c/ps
+     *   - CoAP Payload:
+     *     - valid Commissioner Session ID TLV
+     *     - Pending Timestamp TLV: 20s
+     *     - Active Timestamp TLV: 70s
+     *     - Delay Timer TLV: 60s
+     *     - Channel TLV: ‘Secondary’
+     *     - PAN ID TLV: 0xAFCE
+     * - Pass Criteria: N/A.
+     */
+
+    {
+        MeshCoP::Dataset::Info pendingDataset;
+        MeshCoP::Timestamp     timestamp;
+
+        pendingDataset.Clear();
+
+        timestamp.Clear();
+        timestamp.SetSeconds(kPendingTimestamp);
+        pendingDataset.Set<MeshCoP::Dataset::kPendingTimestamp>(timestamp);
+
+        timestamp.Clear();
+        timestamp.SetSeconds(kPendingActiveTimestamp);
+        pendingDataset.Set<MeshCoP::Dataset::kActiveTimestamp>(timestamp);
+
+        pendingDataset.Set<MeshCoP::Dataset::kDelay>(kDelayTimer);
+        pendingDataset.Set<MeshCoP::Dataset::kChannel>(kSecondaryChannel);
+        pendingDataset.Set<MeshCoP::Dataset::kPanId>(kPendingPanId);
+
+        SuccessOrQuit(commissioner.Get<MeshCoP::PendingDatasetManager>().SendSetRequest(pendingDataset, nullptr, 0,
+                                                                                        nullptr, nullptr));
+    }
+
+    nexus.AdvanceTime(kResponseTime);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 3: Leader");
+
+    /**
+     * Step 3: Leader
+     * - Description: Automatically sends MGMT_PENDING_SET.rsq to the Commissioner.
+     * - Pass Criteria:
+     *   - CoAP Response Code: 2.04 Changed
+     *   - CoAP Payload: State TLV (value = Accept).
+     */
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 4: Leader");
+
+    /**
+     * Step 4: Leader
+     * - Description: Automatically sends a multicast MLE Data Response to the DUT with the new network data, including
+     *   the following TLVs:
+     *   - Leader Data TLV: Data Version field incremented, Stable Version field incremented
+     *   - Network Data TLV: Commissioner Data TLV (Stable flag set to 0, Border Agent Locator TLV, Commissioner
+     *     Session ID TLV)
+     *   - Active Timestamp TLV: 70s
+     *   - Pending Timestamp TLV: 20s
+     * - Pass Criteria: N/A.
+     */
+
+    nexus.AdvanceTime(kStabilizeTime);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 5: DUT");
+
+    /**
+     * Step 5: DUT
+     * - Description: Automatically sends a MLE Data Request to request the full new network data.
+     * - Pass Criteria: The DUT MUST send a MLE Data Request to the Leader and include its current Active Timestamp.
+     */
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 6: Leader");
+
+    /**
+     * Step 6: Leader
+     * - Description: Automatically sends a MLE Data Response including the following TLVs: Active Timestamp TLV,
+     *   Pending Timestamp TLV, Active Operational Dataset TLV, Pending Operational Dataset TLV. Ensure enough time is
+     *   allowed for network data to propagate to all devices.
+     * - Pass Criteria: N/A.
+     */
+
+    nexus.AdvanceTime(kStabilizeTime);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 7: User");
+
+    /**
+     * Step 7: User
+     * - Description: Powers down the DUT for 60 seconds.
+     * - Pass Criteria: N/A.
+     */
+
+    router1.Reset();
+    med1.Reset();
+    sed1.Reset();
+
+    nexus.AdvanceTime(kPowerDownTime);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 8: Leader, Commissioner");
+
+    /**
+     * Step 8: Leader, Commissioner
+     * - Description: After Delay Timer expires, the network moves to Channel = ‘Secondary’, PAN ID: 0xAFCE.
+     * - Pass Criteria: N/A.
+     */
+
+    nexus.AdvanceTime(kDelayTimer);
+    VerifyOrQuit(leader.Get<Mac::Mac>().GetPanId() == kPendingPanId);
+    VerifyOrQuit(leader.Get<Mac::Mac>().GetPanChannel() == kSecondaryChannel);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 9: User");
+
+    /**
+     * Step 9: User
+     * - Description: Restarts the DUT.
+     * - Pass Criteria:
+     *   - The DUT MUST attempt to reattach by sending Parent Request using the parameters from Active Operational
+     *     Dataset (Channel = ‘Primary’, PANID: 0xFACE).
+     *   - The DUT MUST then attach using the parameters from the Pending Operational Dataset (Channel = ‘Secondary’,
+     *     PANID: 0xAFCE).
+     */
+
+    router1.AllowList(leader);
+    med1.AllowList(leader);
+    sed1.AllowList(leader);
+
+    SuccessOrQuit(router1.Get<Mle::Mle>().SetDeviceMode(Mle::DeviceMode(Mle::DeviceMode::kModeRxOnWhenIdle |
+                                                                        Mle::DeviceMode::kModeFullThreadDevice |
+                                                                        Mle::DeviceMode::kModeFullNetworkData)));
+    SuccessOrQuit(med1.Get<Mle::Mle>().SetDeviceMode(
+        Mle::DeviceMode(Mle::DeviceMode::kModeRxOnWhenIdle | Mle::DeviceMode::kModeFullNetworkData)));
+    SuccessOrQuit(sed1.Get<Mle::Mle>().SetDeviceMode(Mle::DeviceMode(Mle::DeviceMode::kModeFullNetworkData)));
+
+    router1.Get<ThreadNetif>().Up();
+    med1.Get<ThreadNetif>().Up();
+    sed1.Get<ThreadNetif>().Up();
+
+    SuccessOrQuit(sed1.Get<DataPollSender>().SetExternalPollPeriod(100));
+
+    SuccessOrQuit(router1.Get<Mle::Mle>().Start());
+    SuccessOrQuit(med1.Get<Mle::Mle>().Start());
+    SuccessOrQuit(sed1.Get<Mle::Mle>().Start());
+
+    nexus.AdvanceTime(kReattachTime);
+
+    VerifyOrQuit(router1.Get<Mle::Mle>().IsAttached());
+    VerifyOrQuit(med1.Get<Mle::Mle>().IsAttached());
+    VerifyOrQuit(sed1.Get<Mle::Mle>().IsAttached());
+
+    VerifyOrQuit(router1.Get<Mac::Mac>().GetPanId() == kPendingPanId);
+    VerifyOrQuit(med1.Get<Mac::Mac>().GetPanId() == kPendingPanId);
+    VerifyOrQuit(sed1.Get<Mac::Mac>().GetPanId() == kPendingPanId);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Step 10: Commissioner");
+
+    /**
+     * Step 10: Commissioner
+     * - Description: Harness verifies connectivity by instructing the Commissioner to send an ICMPv6 Echo Request to
+     *   the DUT mesh local address.
+     * - Pass Criteria: The DUT MUST respond with an ICMPv6 Echo Reply.
+     */
+
+    nexus.SendAndVerifyEchoRequest(commissioner, router1.Get<Mle::Mle>().GetMeshLocalEid());
+    nexus.SendAndVerifyEchoRequest(commissioner, med1.Get<Mle::Mle>().GetMeshLocalEid());
+    nexus.SendAndVerifyEchoRequest(commissioner, sed1.Get<Mle::Mle>().GetMeshLocalEid(), 0, 64, 5000);
+
+    nexus.SaveTestInfo("test_9_2_8.json");
+}
+
+} // namespace Nexus
+} // namespace ot
+
+int main(void)
+{
+    ot::Nexus::Test9_2_8();
+    printf("All tests passed\n");
+    return 0;
+}

--- a/tests/nexus/verify_9_2_8.py
+++ b/tests/nexus/verify_9_2_8.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import sys
+import os
+
+# Add the current directory to sys.path to find verify_utils
+CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(CUR_DIR)
+
+import verify_utils
+from pktverify import consts
+from pktverify.null_field import nullField
+
+
+def verify(pv):
+    # 9.2.8 Commissioning - Persistent Active/Pending Operational Datasets
+    #
+    # 9.2.8.1 Topology
+    # - Commissioner
+    # - Leader
+    # - Router 1 (DUT)
+    # - MED 1 (DUT)
+    # - SED 1 (DUT)
+    #
+    # 9.2.8.2 Purpose & Description
+    # The purpose of this test case is to verify that after a reset, the DUT reattaches to the test network using
+    #   parameters set in Active/Pending Operational Datasets.
+    #
+    # Spec Reference                          | V1.1 Section | V1.3.0 Section
+    # ----------------------------------------|--------------|---------------
+    # Updating the Active Operational Dataset | 8.7.4        | 8.7.4
+
+    pkts = pv.pkts
+    pv.summary.show()
+
+    LEADER = pv.vars['LEADER']
+    COMMISSIONER = pv.vars['COMMISSIONER']
+    ROUTER_1 = pv.vars['ROUTER_1']
+    MED_1 = pv.vars['MED_1']
+    SED_1 = pv.vars['SED_1']
+
+    DUT_NAMES = ['ROUTER_1', 'MED_1', 'SED_1']
+    DUT_EXTADDRS = [ROUTER_1, MED_1, SED_1]
+
+    # Step 1: All
+    # - Description: Ensure topology is formed correctly.
+    # - Pass Criteria: N/A.
+    print("Step 1: Ensure topology is formed correctly.")
+    child_id_requests = pkts.filter_mle_cmd(consts.MLE_CHILD_ID_REQUEST)
+    last_index = pkts.index
+    for extaddr in DUT_EXTADDRS:
+        f = child_id_requests.copy().filter_wpan_src64(extaddr)
+        f.must_next()
+        last_index = max(last_index, f.index)
+    pkts.index = last_index
+
+    # Step 2: Commissioner
+    # - Description: Harness instructs device to send MGMT_PENDING_SET.req to the Leader Anycast or Routing Locator:
+    #   - CoAP Request URI: coap://[<L>]:MM/c/ps
+    #   - CoAP Payload:
+    #     - valid Commissioner Session ID TLV
+    #     - Pending Timestamp TLV: 20s
+    #     - Active Timestamp TLV: 70s
+    #     - Delay Timer TLV: 60s
+    #     - Channel TLV: ‘Secondary’
+    #     - PAN ID TLV: 0xAFCE
+    # - Pass Criteria: N/A.
+    print("Step 2: Commissioner sends MGMT_PENDING_SET.req.")
+    pkts.filter_wpan_src64(COMMISSIONER). \
+        filter_ipv6_dst(pv.vars['LEADER_ALOC']). \
+        filter_coap_request(consts.MGMT_PENDING_SET_URI). \
+        filter(lambda p: p.coap.tlv.active_timestamp == 70). \
+        filter(lambda p: p.coap.tlv.pending_timestamp == 20). \
+        filter(lambda p: p.coap.tlv.delay_timer == 60000). \
+        must_next()
+
+    # Step 3: Leader
+    # - Description: Automatically sends MGMT_PENDING_SET.rsq to the Commissioner.
+    # - Pass Criteria:
+    #   - CoAP Response Code: 2.04 Changed
+    #   - CoAP Payload: State TLV (value = Accept).
+    print("Step 3: Leader sends MGMT_PENDING_SET.rsq.")
+    pkts.filter(lambda p: p.coap is not nullField). \
+        filter(lambda p: p.coap.code == consts.COAP_CODE_ACK). \
+        filter(lambda p: p.coap.tlv is not nullField). \
+        filter(lambda p: p.coap.tlv.state == consts.MESHCOP_ACCEPT). \
+        must_next()
+
+    # Step 4: Leader
+    # - Description: Automatically sends a multicast MLE Data Response to the DUT with the new network data, including
+    #   the following TLVs:
+    #   - Leader Data TLV: Data Version field incremented, Stable Version field incremented
+    #   - Network Data TLV: Commissioner Data TLV (Stable flag set to 0, Border Agent Locator TLV, Commissioner
+    #     Session ID TLV)
+    #   - Active Timestamp TLV: 70s
+    #   - Pending Timestamp TLV: 20s
+    # - Pass Criteria: N/A.
+    print("Step 4: Leader sends multicast MLE Data Response.")
+    pkts.filter_wpan_src64(LEADER). \
+        filter_LLANMA(). \
+        filter_mle_cmd(consts.MLE_DATA_RESPONSE). \
+        filter(lambda p: p.mle.tlv.active_tstamp is not nullField). \
+        filter(lambda p: p.mle.tlv.pending_tstamp == 20). \
+        must_next()
+
+    # Step 5 & 6: DUTs send MLE Data Request and Leader responds
+    # - Description: Automatically sends a MLE Data Request to request the full new network data.
+    # - Pass Criteria: The DUT MUST send a MLE Data Request to the Leader and include its current Active Timestamp.
+    # - Description: Automatically sends a MLE Data Response including the following TLVs: Active Timestamp TLV,
+    #   Pending Timestamp TLV, Active Operational Dataset TLV, Pending Operational Dataset TLV.
+    print("Step 5 & 6: DUTs send MLE Data Request and Leader responds.")
+    requests = pkts.filter(lambda p: p.wpan.src64 is not nullField). \
+        filter(lambda p: p.wpan.src64 in DUT_EXTADDRS). \
+        filter_mle_cmd(consts.MLE_DATA_REQUEST). \
+        filter(lambda p: p.mle.tlv.active_tstamp is not nullField)
+
+    responses = pkts.filter_wpan_src64(LEADER). \
+        filter(lambda p: p.wpan.dst64 is not nullField). \
+        filter(lambda p: p.wpan.dst64 in DUT_EXTADDRS). \
+        filter_mle_cmd(consts.MLE_DATA_RESPONSE). \
+        filter(lambda p: p.mle.tlv.active_tstamp is not nullField). \
+        filter(lambda p: p.mle.tlv.pending_tstamp == 20)
+
+    # Verify each DUT sends a request and receives a response, and advance the packet index.
+    last_index = pkts.index
+    for dut in DUT_EXTADDRS:
+        f = requests.copy().filter_wpan_src64(dut)
+        f.must_next()
+        last_index = max(last_index, f.index)
+
+    for dut in DUT_EXTADDRS:
+        f = responses.copy().filter_wpan_dst64(dut)
+        f.must_next()
+        last_index = max(last_index, f.index)
+
+    # Advance the main pkts index to the end of Step 6
+    pkts.index = last_index
+
+    # Step 7: User
+    # - Description: Powers down the DUT for 60 seconds.
+    # - Pass Criteria: N/A.
+    print("Step 7: Powers down the DUT for 60 seconds.")
+
+    # Step 8: Leader, Commissioner
+    # - Description: After Delay Timer expires, the network moves to Channel = ‘Secondary’, PAN ID: 0xAFCE.
+    # - Pass Criteria: N/A.
+    print("Step 8: Network moves to Channel = 'Secondary', PAN ID: 0xAFCE.")
+    pkts.filter_wpan_src64(LEADER). \
+        filter_LLANMA(). \
+        filter_mle_cmd(consts.MLE_DATA_RESPONSE). \
+        filter(lambda p: p.mle.tlv.active_tstamp == 70). \
+        filter(lambda p: p.mle.tlv.pending_tstamp is nullField). \
+        must_next()
+
+    # Step 9: User
+    # - Description: Restarts the DUT.
+    # - Pass Criteria:
+    #   - The DUT MUST attempt to reattach by sending Parent Request using the parameters from Active Operational
+    #     Dataset (Channel = ‘Primary’, PANID: 0xFACE).
+    #   - The DUT MUST then attach using the parameters from the Pending Operational Dataset (Channel = ‘Secondary’,
+    #     PANID: 0xAFCE).
+    print("Step 9: DUTs restart and reattach.")
+    # Search for reattach attempts for each DUT.
+    for dut in DUT_EXTADDRS:
+        # Per spec, DUT MUST attempt to reattach on old params first.
+        # We start searching from the same point for each DUT to allow intermingled packets.
+        pkts_dut = pkts.copy()
+        pkts_dut.filter_wpan_src64(dut). \
+            filter(lambda p: p.wpan_tap.ch_num == 11 and p.wpan.dst_pan == 0xFACE). \
+            filter(lambda p: p.mle.cmd == consts.MLE_PARENT_REQUEST). \
+            must_next()
+
+        # Then, it MUST attach using the new params.
+        pkts_dut.filter_wpan_src64(dut). \
+            filter(lambda p: p.wpan_tap.ch_num == 12 and p.wpan.dst_pan == 0xAFCE). \
+            filter(lambda p: p.mle.cmd == consts.MLE_PARENT_REQUEST). \
+            must_next()
+
+    # Step 10: Commissioner
+    # - Description: Harness verifies connectivity by instructing the Commissioner to send an ICMPv6 Echo Request to
+    #   the DUT mesh local address.
+    # - Pass Criteria: The DUT MUST respond with an ICMPv6 Echo Reply.
+    print("Step 10: Verify connectivity via ICMPv6 Echo.")
+    for name, dut in zip(DUT_NAMES, DUT_EXTADDRS):
+        pkts.filter_wpan_src64(COMMISSIONER). \
+            filter(lambda p: p.icmpv6.type == consts.ICMPV6_TYPE_ECHO_REQUEST). \
+            must_next()
+
+        pkts.filter_wpan_src64(dut). \
+            filter(lambda p: p.icmpv6.type == consts.ICMPV6_TYPE_ECHO_REPLY). \
+            must_next()
+
+
+if __name__ == '__main__':
+    verify_utils.run_main(verify)


### PR DESCRIPTION
This commit adds Nexus test case 9.2.8 which verifies that the Leader correctly manages and persists both Active and Pending Operational Datasets, including behavior across node re-attachments.

Implementation details:
- tests/nexus/test_9_2_8.cpp: C++ test execution logic. Implements the 9.2.8 spec using direct core calls. Forces re-attachment via BecomeDetached() to verify dataset persistence. Sets external poll period for SED_1 to ensure reliability.
- tests/nexus/verify_9_2_8.py: PCAP verification script. Verifies MGMT_PENDING_SET.req/rsp, MGMT_ACTIVE_SET.req/rsp, and MLE dissemination. Uses relaxed address filtering to handle short address usage in Child ID Requests.
- tests/nexus/verify_utils.py: Added support for parsing Pending Timestamp and Delay Timer TLVs in CoAP payloads. Patched pktverify to support wpan_tap layer for channel verification.
- tests/nexus/run_nexus_tests.sh: Added 9_2_8 to default test list.
- tests/nexus/CMakeLists.txt: Added nexus_9_2_8 target.