### PR TITLE
[nexus] fix intermittent failures in test 7.1.7

### DIFF
--- a/tests/nexus/test_7_1_7.cpp
+++ b/tests/nexus/test_7_1_7.cpp
@@ -69,6 +69,11 @@ static const char kPrefix1[] = "2001:db8:1::/64";
  */
 static const char kPrefix2[] = "2001:db8:2::/64";
 
+/**
+ * SED poll period, in milliseconds.
+ */
+static constexpr uint32_t kSedPollPeriod = 500;
+
 void Test7_1_7(const char *aJsonFile)
 {
     /**
@@ -138,6 +143,8 @@ void Test7_1_7(const char *aJsonFile)
     router2.Join(leader, Node::kAsFtd);
     med1.Join(leader, Node::kAsMed);
     sed1.Join(leader, Node::kAsSed);
+
+    SuccessOrQuit(sed1.Get<DataPollSender>().SetExternalPollPeriod(kSedPollPeriod));
 
     nexus.AdvanceTime(kAttachToRouterTime);
 
@@ -492,6 +499,8 @@ void Test7_1_7(const char *aJsonFile)
      *       - Stable Flag set.
      *       - compression flag set to 0.
      */
+
+    nexus.AdvanceTime(kStabilizationTime);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 18: Leader (DUT)");


### PR DESCRIPTION
This commit fixes intermittent failures in Nexus test 7.1.7 by improving test stability and making the verification script more robust.

Implementation details:
- tests/nexus/test_7_1_7.cpp: Added a 500ms external poll period for SED_1 to ensure it remains active and reachable during the test. Added a stabilization delay after Step 17 to ensure network data updates are fully propagated.
- tests/nexus/verify_7_1_7.py: Added source filtering for the Leader (DUT) in network data update checks to avoid matching packets from other nodes. Used Border Router sub-TLV count checks to reliably distinguish between initial prefix additions and subsequent removals. Wrapped CoAP ACK verification in save_index() blocks to prevent advancing the search index past concurrent MLE messages.