### PR TITLE
[tmf] remove redundant `SetSockPortToTmf()` calls

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -520,7 +520,6 @@ Error Manager::EvictActiveCommissioner(void)
     SuccessOrExit(error = Tlv::Append<CommissionerSessionIdTlv>(*message, sessionId));
 
     messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-    messageInfo.SetSockPortToTmf();
 
     error = Get<Tmf::Agent>().SendMessage(message.PassOwnership(), messageInfo);
 
@@ -722,7 +721,6 @@ Error Manager::CoapDtlsSession::ForwardToLeader(const Coap::Msg &aMsg, Uri aUri)
     SuccessOrExit(error = message->AppendBytesFromMessage(aMsg.mMessage, offsetRange));
 
     messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-    messageInfo.SetSockPortToTmf();
 
     SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(message.PassOwnership(), messageInfo,
                                                         HandleLeaderResponseToFwdTmf, forwardContext.Get()));
@@ -1039,7 +1037,6 @@ void Manager::CoapDtlsSession::HandleTmfRelayTx(Coap::Msg &aMsg)
     SuccessOrExit(error = message->AppendBytesFromMessage(aMsg.mMessage, offsetRange));
 
     messageInfo.SetSockAddrToRlocPeerAddrTo(joinerRouterRloc);
-    messageInfo.SetSockPortToTmf();
 
     SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(message.PassOwnership(), messageInfo));
 

--- a/src/core/thread/tmf.hpp
+++ b/src/core/thread/tmf.hpp
@@ -108,11 +108,6 @@ public:
     }
 
     /**
-     * Sets the local socket port to TMF port.
-     */
-    void SetSockPortToTmf(void) { SetSockPort(kUdpPort); }
-
-    /**
      * Sets the local socket address to mesh-local RLOC address.
      */
     void SetSockAddrToRloc(void);


### PR DESCRIPTION
This commit removes calls to `SetSockPortToTmf()` from the Border Agent prior to sending messages via `Tmf::Agent`. Setting the local socket port is unnecessary because the `Tmf::Agent` is already bound to the TMF port number when sending CoAP messages.

Additionally, since these removals eliminate the last uses of the `SetSockPortToTmf()` method within the codebase, the method itself has been completely removed from `Tmf::MessageInfo` class to clean up dead code.