### PR TITLE
[tmf] introduce specialized `SendMessageTo()` methods in `Tmf::Agent`

### DIFF
--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -100,8 +100,8 @@ otError otDatasetSendMgmtActiveGet(otInstance                           *aInstan
                                    uint8_t                               aLength,
                                    const otIp6Address                   *aAddress)
 {
-    return AsCoreType(aInstance).Get<MeshCoP::ActiveDatasetManager>().SendGetRequest(AsCoreType(aDatasetComponents),
-                                                                                     aTlvTypes, aLength, aAddress);
+    return AsCoreType(aInstance).Get<MeshCoP::ActiveDatasetManager>().SendGetRequest(
+        AsCoreType(aDatasetComponents), aTlvTypes, aLength, AsCoreTypePtr(aAddress));
 }
 
 otError otDatasetSendMgmtActiveSet(otInstance                 *aInstance,
@@ -121,8 +121,8 @@ otError otDatasetSendMgmtPendingGet(otInstance                           *aInsta
                                     uint8_t                               aLength,
                                     const otIp6Address                   *aAddress)
 {
-    return AsCoreType(aInstance).Get<MeshCoP::PendingDatasetManager>().SendGetRequest(AsCoreType(aDatasetComponents),
-                                                                                      aTlvTypes, aLength, aAddress);
+    return AsCoreType(aInstance).Get<MeshCoP::PendingDatasetManager>().SendGetRequest(
+        AsCoreType(aDatasetComponents), aTlvTypes, aLength, AsCoreTypePtr(aAddress));
 }
 
 otError otDatasetSendMgmtPendingSet(otInstance                 *aInstance,

--- a/src/core/meshcop/announce_begin_client.cpp
+++ b/src/core/meshcop/announce_begin_client.cpp
@@ -51,9 +51,8 @@ Error AnnounceBeginClient::SendRequest(uint32_t            aChannelMask,
                                        uint16_t            aPeriod,
                                        const Ip6::Address &aAddress)
 {
-    Error            error = kErrorNone;
-    Tmf::MessageInfo messageInfo(GetInstance());
-    Coap::Message   *message = nullptr;
+    Error          error   = kErrorNone;
+    Coap::Message *message = nullptr;
 
     VerifyOrExit(Get<MeshCoP::Commissioner>().IsActive(), error = kErrorInvalidState);
     VerifyOrExit((message = Get<Tmf::Agent>().NewPriorityMessage()) != nullptr, error = kErrorNoBufs);
@@ -69,9 +68,7 @@ Error AnnounceBeginClient::SendRequest(uint32_t            aChannelMask,
     SuccessOrExit(error = Tlv::Append<MeshCoP::CountTlv>(*message, aCount));
     SuccessOrExit(error = Tlv::Append<MeshCoP::PeriodTlv>(*message, aPeriod));
 
-    messageInfo.SetSockAddrToRlocPeerAddrTo(aAddress);
-
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, aAddress));
 
     LogInfo("Sent %s", UriToString<kUriAnnounceBegin>());
 

--- a/src/core/meshcop/border_agent_admitter.cpp
+++ b/src/core/meshcop/border_agent_admitter.cpp
@@ -894,15 +894,12 @@ exit:
 
 Error Admitter::CommissionerPetitioner::SendToLeader(OwnedPtr<Coap::Message> aMessage, Coap::ResponseHandler aHandler)
 {
-    Error            error;
-    Tmf::MessageInfo messageInfo(GetInstance());
-
-    messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
+    Error error;
 
     // On success the message ownership is transferred.
 
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*aMessage, messageInfo, aHandler,
-                                                        (aHandler != nullptr) ? this : nullptr));
+    SuccessOrExit(
+        error = Get<Tmf::Agent>().SendMessageToLeaderAloc(*aMessage, aHandler, (aHandler != nullptr) ? this : nullptr));
     aMessage.Release();
 
 exit:

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -212,7 +212,7 @@ public:
     Error SendGetRequest(const Dataset::Components &aDatasetComponents,
                          const uint8_t             *aTlvTypes,
                          uint8_t                    aLength,
-                         const otIp6Address        *aAddress) const;
+                         const Ip6::Address        *aAddress) const;
 
     /**
      * Processes a MGMT_GET request message and prepares the response.

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -54,9 +54,8 @@ Error EnergyScanClient::SendQuery(uint32_t                           aChannelMas
                                   otCommissionerEnergyReportCallback aCallback,
                                   void                              *aContext)
 {
-    Error            error = kErrorNone;
-    Tmf::MessageInfo messageInfo(GetInstance());
-    Coap::Message   *message = nullptr;
+    Error          error   = kErrorNone;
+    Coap::Message *message = nullptr;
 
     VerifyOrExit(Get<MeshCoP::Commissioner>().IsActive(), error = kErrorInvalidState);
     VerifyOrExit((message = Get<Tmf::Agent>().NewPriorityMessage()) != nullptr, error = kErrorNoBufs);
@@ -73,8 +72,7 @@ Error EnergyScanClient::SendQuery(uint32_t                           aChannelMas
     SuccessOrExit(error = Tlv::Append<MeshCoP::PeriodTlv>(*message, aPeriod));
     SuccessOrExit(error = Tlv::Append<MeshCoP::ScanDurationTlv>(*message, aScanDuration));
 
-    messageInfo.SetSockAddrToRlocPeerAddrTo(aAddress);
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, aAddress));
 
     LogInfo("Sent %s", UriToString<kUriEnergyScan>());
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -116,12 +116,11 @@ void JoinerRouter::SetJoinerUdpPort(uint16_t aJoinerUdpPort)
 
 void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    Error            error;
-    Coap::Message   *message = nullptr;
-    Tmf::MessageInfo messageInfo(GetInstance());
-    ExtendedTlv      tlv;
-    uint16_t         borderAgentRloc;
-    OffsetRange      offsetRange;
+    Error          error;
+    Coap::Message *message = nullptr;
+    ExtendedTlv    tlv;
+    uint16_t       borderAgentRloc;
+    OffsetRange    offsetRange;
 
     LogInfo("JoinerRouter::HandleUdpReceive");
 
@@ -141,9 +140,7 @@ void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &a
     SuccessOrExit(error = message->Append(tlv));
     SuccessOrExit(error = message->AppendBytesFromMessage(aMessage, offsetRange));
 
-    messageInfo.SetSockAddrToRlocPeerAddrTo(borderAgentRloc);
-
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageToRloc(*message, borderAgentRloc));
 
     LogInfo("Sent %s", UriToString<kUriRelayRx>());
 

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -177,15 +177,13 @@ exit:
 
 void Leader::SendDatasetChanged(const Ip6::Address &aAddress)
 {
-    Error            error = kErrorNone;
-    Tmf::MessageInfo messageInfo(GetInstance());
-    Coap::Message   *message;
+    Error          error = kErrorNone;
+    Coap::Message *message;
 
     message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriDatasetChanged);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
-    messageInfo.SetSockAddrToRlocPeerAddrTo(aAddress);
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, aAddress));
 
     LogInfo("Sent %s", UriToString<kUriDatasetChanged>());
 

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -52,9 +52,8 @@ Error PanIdQueryClient::SendQuery(uint16_t                            aPanId,
                                   otCommissionerPanIdConflictCallback aCallback,
                                   void                               *aContext)
 {
-    Error            error = kErrorNone;
-    Tmf::MessageInfo messageInfo(GetInstance());
-    Coap::Message   *message = nullptr;
+    Error          error   = kErrorNone;
+    Coap::Message *message = nullptr;
 
     VerifyOrExit(Get<MeshCoP::Commissioner>().IsActive(), error = kErrorInvalidState);
     VerifyOrExit((message = Get<Tmf::Agent>().NewPriorityMessage()) != nullptr, error = kErrorNoBufs);
@@ -69,8 +68,7 @@ Error PanIdQueryClient::SendQuery(uint16_t                            aPanId,
 
     SuccessOrExit(error = Tlv::Append<MeshCoP::PanIdTlv>(*message, aPanId));
 
-    messageInfo.SetSockAddrToRlocPeerAddrTo(aAddress);
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, aAddress));
 
     LogInfo("Sent %s", UriToString<kUriPanIdQuery>());
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -611,18 +611,15 @@ exit:
 
 Error AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
 {
-    Error            error;
-    Coap::Message   *message;
-    Tmf::MessageInfo messageInfo(GetInstance());
+    Error          error;
+    Coap::Message *message;
 
     message = Get<Tmf::Agent>().NewPriorityNonConfirmablePostMessage(kUriAddressQuery);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, aEid));
 
-    messageInfo.SetSockAddrToRlocPeerAddrToRealmLocalAllRoutersMulticast();
-
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, Ip6::Address::GetRealmLocalAllRoutersMulticast()));
 
     LogInfo("Sent %s for %s", UriToString<kUriAddressQuery>(), aEid.ToString().AsCString());
 
@@ -720,9 +717,8 @@ void AddressResolver::SendAddressError(const Ip6::Address             &aTarget,
                                        const Ip6::InterfaceIdentifier &aMeshLocalIid,
                                        const Ip6::Address             &aDestination)
 {
-    Error            error;
-    Coap::Message   *message;
-    Tmf::MessageInfo messageInfo(GetInstance());
+    Error          error;
+    Coap::Message *message;
 
     VerifyOrExit((message = Get<Tmf::Agent>().NewMessage()) != nullptr, error = kErrorNoBufs);
 
@@ -732,9 +728,7 @@ void AddressResolver::SendAddressError(const Ip6::Address             &aTarget,
     SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, aTarget));
     SuccessOrExit(error = Tlv::Append<ThreadMeshLocalEidTlv>(*message, aMeshLocalIid));
 
-    messageInfo.SetSockAddrToRlocPeerAddrTo(aDestination);
-
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, aDestination));
 
     LogInfo("Sent %s for target %s", UriToString<kUriAddressError>(), aTarget.ToString().AsCString());
 
@@ -877,9 +871,8 @@ void AddressResolver::SendAddressQueryResponse(const Ip6::Address             &a
                                                const uint32_t                 *aLastTransactionTime,
                                                const Ip6::Address             &aDestination)
 {
-    Error            error;
-    Coap::Message   *message;
-    Tmf::MessageInfo messageInfo(GetInstance());
+    Error          error;
+    Coap::Message *message;
 
     message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriAddressNotify);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
@@ -893,9 +886,7 @@ void AddressResolver::SendAddressQueryResponse(const Ip6::Address             &a
         SuccessOrExit(error = Tlv::Append<ThreadLastTransactionTimeTlv>(*message, *aLastTransactionTime));
     }
 
-    messageInfo.SetSockAddrToRlocPeerAddrTo(aDestination);
-
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, aDestination));
 
     LogInfo("Sent %s for target %s", UriToString<kUriAddressNotify>(), aTarget.ToString().AsCString());
 

--- a/src/core/thread/anycast_locator.cpp
+++ b/src/core/thread/anycast_locator.cpp
@@ -47,9 +47,8 @@ AnycastLocator::AnycastLocator(Instance &aInstance)
 
 Error AnycastLocator::Locate(const Ip6::Address &aAnycastAddress, LocatorCallback aCallback, void *aContext)
 {
-    Error            error   = kErrorNone;
-    Coap::Message   *message = nullptr;
-    Tmf::MessageInfo messageInfo(GetInstance());
+    Error          error   = kErrorNone;
+    Coap::Message *message = nullptr;
 
     VerifyOrExit((aCallback != nullptr) && Get<Mle::Mle>().IsAnycastLocator(aAnycastAddress),
                  error = kErrorInvalidArgs);
@@ -62,9 +61,7 @@ Error AnycastLocator::Locate(const Ip6::Address &aAnycastAddress, LocatorCallbac
         IgnoreError(Get<Tmf::Agent>().AbortTransaction(HandleResponse, this));
     }
 
-    messageInfo.SetSockAddrToRlocPeerAddrTo(aAnycastAddress);
-
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo, HandleResponse, this));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, aAnycastAddress, HandleResponse, this));
 
     mCallback.Set(aCallback, aContext);
 

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -172,17 +172,14 @@ exit:
 
 void EnergyScanServer::SendReport(void)
 {
-    Error            error = kErrorNone;
-    Tmf::MessageInfo messageInfo(GetInstance());
-    uint16_t         offset;
+    Error    error = kErrorNone;
+    uint16_t offset;
 
     // Update the Energy List TLV length in Report message
     offset = mReportMessage->GetLength() - mNumScanResults - sizeof(uint8_t);
     mReportMessage->Write(offset, mNumScanResults);
 
-    messageInfo.SetSockAddrToRlocPeerAddrTo(mCommissioner);
-
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*mReportMessage, messageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*mReportMessage, mCommissioner));
     mReportMessage.Release();
 
     LogInfo("Sent %s", UriToString<kUriEnergyReport>());

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -358,10 +358,10 @@ Error MlrManager::SendMlrMessage(const Ip6::Address         *aAddresses,
 {
     OT_UNUSED_VARIABLE(aTimeout);
 
-    Error            error   = kErrorNone;
-    Coap::Message   *message = nullptr;
-    Tmf::MessageInfo messageInfo(GetInstance());
-    Ip6AddressesTlv  addressesTlv;
+    Error           error   = kErrorNone;
+    Coap::Message  *message = nullptr;
+    Ip6::Address    destAddr;
+    Ip6AddressesTlv addressesTlv;
 
     VerifyOrExit(Get<BackboneRouter::Leader>().HasPrimary(), error = kErrorInvalidState);
 
@@ -393,17 +393,14 @@ Error MlrManager::SendMlrMessage(const Ip6::Address         *aAddresses,
         uint8_t pbbrServiceId;
 
         SuccessOrExit(error = Get<BackboneRouter::Leader>().GetServiceId(pbbrServiceId));
-        Get<Mle::Mle>().GetServiceAloc(pbbrServiceId, messageInfo.GetPeerAddr());
+        Get<Mle::Mle>().GetServiceAloc(pbbrServiceId, destAddr);
     }
     else
     {
-        messageInfo.GetPeerAddr().SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(),
-                                                      Get<BackboneRouter::Leader>().GetServer16());
+        destAddr.SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), Get<BackboneRouter::Leader>().GetServer16());
     }
 
-    messageInfo.SetSockAddrToRloc();
-
-    error = Get<Tmf::Agent>().SendMessage(*message, messageInfo, aResponseHandler, aContext);
+    error = Get<Tmf::Agent>().SendMessageTo(*message, destAddr, aResponseHandler, aContext);
 
     LogInfo("Sent MLR.req: addressNum=%d", aAddressNum);
 

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -183,9 +183,8 @@ exit:
 
 Error Notifier::SendServerDataNotification(uint16_t aOldRloc16, const NetworkData *aNetworkData)
 {
-    Error            error = kErrorNone;
-    Coap::Message   *message;
-    Tmf::MessageInfo messageInfo(GetInstance());
+    Error          error = kErrorNone;
+    Coap::Message *message;
 
     message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriServerData);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
@@ -205,8 +204,7 @@ Error Notifier::SendServerDataNotification(uint16_t aOldRloc16, const NetworkDat
         SuccessOrExit(error = Tlv::Append<ThreadRloc16Tlv>(*message, aOldRloc16));
     }
 
-    messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo, HandleCoapResponse, this));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageToLeaderAloc(*message, HandleCoapResponse, this));
 
     LogInfo("Sent %s", UriToString<kUriServerData>());
 

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -147,7 +147,6 @@ private:
     Error AppendIp6AddressList(Message &aMessage);
     Error AppendMacCounters(Message &aMessage);
     Error AppendRequestedTlvs(const Message &aRequest, Message &aResponse);
-    void  PrepareMessageInfoForDest(const Ip6::Address &aDestination, Tmf::MessageInfo &aMessageInfo) const;
 
 #if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
     Error AppendRequestedTlvsForTcat(const Message &aRequest, Message &aResponse, OffsetRange &aOffsetRange);

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -89,9 +89,8 @@ void PanIdQueryServer::HandleScanResult(const ScanResult *aScanResult)
 
 void PanIdQueryServer::SendConflict(void)
 {
-    Error            error = kErrorNone;
-    Tmf::MessageInfo messageInfo(GetInstance());
-    Coap::Message   *message;
+    Error          error = kErrorNone;
+    Coap::Message *message;
 
     message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriPanIdConflict);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
@@ -100,9 +99,7 @@ void PanIdQueryServer::SendConflict(void)
 
     SuccessOrExit(error = Tlv::Append<MeshCoP::PanIdTlv>(*message, mPanId));
 
-    messageInfo.SetSockAddrToRlocPeerAddrTo(mCommissioner);
-
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, mCommissioner));
 
     LogInfo("Sent %s", UriToString<kUriPanIdConflict>());
 

--- a/src/core/thread/tmf.hpp
+++ b/src/core/thread/tmf.hpp
@@ -83,66 +83,9 @@ namespace Tmf {
 
 constexpr uint16_t kUdpPort = 61631; ///< TMF UDP Port
 
-typedef Coap::Message Message; ///< A TMF message.
-typedef Coap::Msg     Msg;     ///< A TMF message along with its `Ip6::MessageInfo`.
-
-/**
- * Represents message information for a TMF message.
- *
- * This is sub-class of `Ip6::MessageInfo` intended for use when sending TMF messages.
- */
-class MessageInfo : public InstanceLocator, public Ip6::MessageInfo
-{
-public:
-    /**
-     * Initializes the `MessageInfo`.
-     *
-     * The peer port is set to `Tmf::kUdpPort` and all other properties are cleared (set to zero).
-     *
-     * @param[in] aInstance    The OpenThread instance.
-     */
-    explicit MessageInfo(Instance &aInstance)
-        : InstanceLocator(aInstance)
-    {
-        SetPeerPort(kUdpPort);
-    }
-
-    /**
-     * Sets the local socket address to mesh-local RLOC address.
-     */
-    void SetSockAddrToRloc(void);
-
-    /**
-     * Sets the local socket address to RLOC address and the peer socket address to leader ALOC.
-     */
-    void SetSockAddrToRlocPeerAddrToLeaderAloc(void);
-
-    /**
-     * Sets the local socket address to RLOC address and the peer socket address to leader RLOC.
-     */
-    void SetSockAddrToRlocPeerAddrToLeaderRloc(void);
-
-    /**
-     * Sets the local socket address to RLOC address and the peer socket address to realm-local all
-     * routers multicast address.
-     */
-    void SetSockAddrToRlocPeerAddrToRealmLocalAllRoutersMulticast(void);
-
-    /**
-     * Sets the local socket address to RLOC address and the peer socket address to a router RLOC based on
-     * a given RLOC16.
-     *
-     * @param[in] aRloc16     The RLOC16 to use for peer address.
-     */
-    void SetSockAddrToRlocPeerAddrTo(uint16_t aRloc16);
-
-    /**
-     * Sets the local socket address to RLOC address and the peer socket address to a given address.
-     *
-     * @param[in] aPeerAddress  The peer address.
-     */
-    void SetSockAddrToRlocPeerAddrTo(const Ip6::Address &aPeerAddress);
-};
+typedef Coap::Message         Message;         ///< A TMF message.
+typedef Coap::Msg             Msg;             ///< A TMF message along with its `Ip6::MessageInfo`.
+typedef Coap::ResponseHandler ResponseHandler; ///< A TMF message response handler function pointer.
 
 /**
  * Implements functionality of the Thread TMF agent.
@@ -184,6 +127,103 @@ public:
     bool IsTmfMessage(const Ip6::Address &aSourceAddress, const Ip6::Address &aDestAddress, uint16_t aDestPort) const;
 
     /**
+     * Sends a TMF message to a given destination address.
+     *
+     * @param[in]  aMessage      The message to send.
+     * @param[in]  aDest         The destination IPv6 address.
+     *
+     * @retval kErrorNone    Successfully sent the message.
+     * @retval kErrorNoBufs  Insufficient buffers available to send the message.
+     */
+    Error SendMessageTo(Message &aMessage, const Ip6::Address &aDest);
+
+    /**
+     * Sends a TMF message to a given destination address.
+     *
+     * @param[in]  aMessage      The message to send.
+     * @param[in]  aDest         The destination IPv6 address.
+     * @param[in]  aHandler      The `ResponseHandler` callback function.
+     * @param[in]  aContext      A pointer to arbitrary context information used with @p aHandler.
+     *
+     * @retval kErrorNone    Successfully sent the message.
+     * @retval kErrorNoBufs  Insufficient buffers available to send the message.
+     */
+    Error SendMessageTo(Message &aMessage, const Ip6::Address &aDest, ResponseHandler aHandler, void *aContext);
+
+    /**
+     * Sends a TMF message to a given destination address and allows multicast loop.
+     *
+     * @param[in]  aMessage      The message to send.
+     * @param[in]  aDest         The destination IPv6 address.
+     *
+     * @retval kErrorNone    Successfully sent the message.
+     * @retval kErrorNoBufs  Insufficient buffers available to send the message.
+     */
+    Error SendMessageAllowMulticastLoop(Message &aMessage, const Ip6::Address &aDest);
+
+    /**
+     * Sends a TMF message to a given destination address and allows multicast loop.
+     *
+     * @param[in]  aMessage      The message to send.
+     * @param[in]  aDest         The destination IPv6 address.
+     * @param[in]  aHandler      The `ResponseHandler` callback function.
+     * @param[in]  aContext      A pointer to arbitrary context information used with @p aHandler.
+     *
+     * @retval kErrorNone    Successfully sent the message.
+     * @retval kErrorNoBufs  Insufficient buffers available to send the message.
+     */
+    Error SendMessageAllowMulticastLoop(Message            &aMessage,
+                                        const Ip6::Address &aDest,
+                                        ResponseHandler     aHandler,
+                                        void               *aContext);
+
+    /**
+     * Sends a TMF message to a router RLOC based on a given RLOC16.
+     *
+     * @param[in]  aMessage      The message to send.
+     * @param[in]  aRloc16       The RLOC16 to use for peer address.
+     *
+     * @retval kErrorNone    Successfully sent the message.
+     * @retval kErrorNoBufs  Insufficient buffers available to send the message.
+     */
+    Error SendMessageToRloc(Message &aMessage, uint16_t aRloc16);
+
+    /**
+     * Sends a TMF message to a router RLOC based on a given RLOC16.
+     *
+     * @param[in]  aMessage      The message to send.
+     * @param[in]  aRloc16       The RLOC16 to use for peer address.
+     * @param[in]  aHandler      The `ResponseHandler` callback function.
+     * @param[in]  aContext      A pointer to arbitrary context information used with @p aHandler.
+     *
+     * @retval kErrorNone    Successfully sent the message.
+     * @retval kErrorNoBufs  Insufficient buffers available to send the message.
+     */
+    Error SendMessageToRloc(Message &aMessage, uint16_t aRloc16, ResponseHandler aHandler, void *aContext);
+
+    /**
+     * Sends a TMF message to the Leader ALOC.
+     *
+     * @param[in]  aMessage      The message to send.
+     *
+     * @retval kErrorNone    Successfully sent the message.
+     * @retval kErrorNoBufs  Insufficient buffers available to send the message.
+     */
+    Error SendMessageToLeaderAloc(Message &aMessage);
+
+    /**
+     * Sends a TMF message to the Leader ALOC.
+     *
+     * @param[in]  aMessage      The message to send.
+     * @param[in]  aHandler      The `ResponseHandler` callback function.
+     * @param[in]  aContext      A pointer to arbitrary context information used with @p aHandler.
+     *
+     * @retval kErrorNone    Successfully sent the message.
+     * @retval kErrorNoBufs  Insufficient buffers available to send the message.
+     */
+    Error SendMessageToLeaderAloc(Message &aMessage, ResponseHandler aHandler, void *aContext);
+
+    /**
      * Converts a TMF message priority to IPv6 header DSCP value.
      *
      * @param[in] aPriority  The message priority to convert.
@@ -204,6 +244,12 @@ public:
 private:
     template <Uri kUri> void HandleTmf(Msg &aMsg);
 
+    void         PrepareMessageInfo(Ip6::MessageInfo &aMessageInfo) const;
+    Error        Send(Message            &aMessage,
+                      const Ip6::Address &aDest,
+                      bool                aAllowMulticastLoop,
+                      ResponseHandler     aHandler,
+                      void               *aContext);
     static bool  HandleResource(CoapBase &aCoapBase, const char *aUriPath, Msg &aMsg);
     bool         HandleResource(const char *aUriPath, Msg &aMsg);
     static Error Filter(void *aContext, const Msg &aRxMsg);

--- a/src/core/utils/history_tracker_client.cpp
+++ b/src/core/utils/history_tracker_client.cpp
@@ -79,7 +79,6 @@ Error Client::SendQuery(Tlv::Type aTlvType, uint16_t aMaxEntries, uint32_t aMaxE
 {
     Error                   error = kErrorNone;
     OwnedPtr<Coap::Message> message;
-    Tmf::MessageInfo        messageInfo(GetInstance());
     RequestTlv              requestTlv;
 
     VerifyOrExit(Get<Mle::Mle>().IsAttached(), error = kErrorInvalidState);
@@ -94,10 +93,7 @@ Error Client::SendQuery(Tlv::Type aTlvType, uint16_t aMaxEntries, uint32_t aMaxE
     requestTlv.Init(aTlvType, aMaxEntries, aMaxEntryAge);
     SuccessOrExit(error = message->Append(requestTlv));
 
-    messageInfo.SetSockAddrToRloc();
-    messageInfo.GetPeerAddr().SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aRloc16);
-
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageToRloc(*message, aRloc16));
     message.Release();
 
     LogInfo("Sent %s for TLV %u to 0x%04x", UriToString<kUriHistoryQuery>(), aTlvType, aRloc16);

--- a/src/core/utils/history_tracker_server.hpp
+++ b/src/core/utils/history_tracker_server.hpp
@@ -88,7 +88,6 @@ private:
     void  PrepareAndSendAnswers(const Ip6::Address &aDestination, const Message &aRequest);
     Error CheckAnswerLength(Coap::Message *&aAnswer, AnswerInfo &aInfo);
     void  SendNextAnswer(Coap::Message &aAnswer, const Ip6::Address &aDestination);
-    void  PrepareMessageInfoForDest(const Ip6::Address &aDestination, Tmf::MessageInfo &aMessageInfo) const;
     Error AppendNetworkInfo(Coap::Message *&aAnswer, AnswerInfo &aInfo, const RequestTlv &aRequestTlv);
 
     static void HandleAnswerResponse(void *aContext, Coap::Msg *aMsg, Error aResult);

--- a/tests/nexus/test_9_2_10.cpp
+++ b/tests/nexus/test_9_2_10.cpp
@@ -276,9 +276,7 @@ void Test9_2_10(void)
         SuccessOrQuit(Tlv::Append<MeshCoP::ChannelTlv>(*message, MeshCoP::ChannelTlvValue(0, kSecondaryChannel)));
         SuccessOrQuit(Tlv::Append<MeshCoP::PanIdTlv>(*message, kSecondaryPanId));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     Log("---------------------------------------------------------------------------------------");

--- a/tests/nexus/test_9_2_12.cpp
+++ b/tests/nexus/test_9_2_12.cpp
@@ -235,10 +235,7 @@ void Test9_2_12(void)
         SuccessOrQuit(MeshCoP::Tlv::Append<MeshCoP::CountTlv>(*message, kAnnounceCount));
         SuccessOrQuit(MeshCoP::Tlv::Append<MeshCoP::PeriodTlv>(*message, kAnnouncePeriod));
 
-        Tmf::MessageInfo messageInfo(leader1.GetInstance());
-        messageInfo.SetPeerAddr(router1.Get<Mle::Mle>().GetMeshLocalRloc());
-
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageTo(*message, router1.Get<Mle::Mle>().GetMeshLocalRloc()));
     }
     nexus.AdvanceTime(kResponseTime);
 

--- a/tests/nexus/test_9_2_13.cpp
+++ b/tests/nexus/test_9_2_13.cpp
@@ -112,9 +112,7 @@ static void SendMgmtEnergyScanQuery(Node &aCommissioner, const Ip6::Address &aDe
     SuccessOrQuit(Tlv::Append<MeshCoP::PeriodTlv>(*message, kScanPeriod));
     SuccessOrQuit(Tlv::Append<MeshCoP::ScanDurationTlv>(*message, kScanDuration));
 
-    Tmf::MessageInfo messageInfo(aCommissioner.GetInstance());
-    messageInfo.SetPeerAddr(aDestAddr);
-    SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+    SuccessOrQuit(agent.SendMessageTo(*message, aDestAddr));
 }
 
 void Test9_2_13(void)

--- a/tests/nexus/test_9_2_15.cpp
+++ b/tests/nexus/test_9_2_15.cpp
@@ -166,9 +166,7 @@ void SendPendingSet(Node           &aCommissioner,
         SuccessOrQuit(Tlv::Append<MeshCoP::PanIdTlv>(*message, *aPanId));
     }
 
-    Tmf::MessageInfo messageInfo(aCommissioner.GetInstance());
-    messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-    SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+    SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
 }
 
 void Test9_2_15(void)
@@ -531,9 +529,7 @@ void Test9_2_15(void)
         Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveGet);
         VerifyOrQuit(message != nullptr);
 
-        Tmf::MessageInfo messageInfo(leader.GetInstance());
-        messageInfo.SetPeerAddr(dut.Get<Mle::Mle>().GetMeshLocalEid());
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageTo(*message, dut.Get<Mle::Mle>().GetMeshLocalEid()));
     }
 
     Log("---------------------------------------------------------------------------------------");

--- a/tests/nexus/test_9_2_16.cpp
+++ b/tests/nexus/test_9_2_16.cpp
@@ -282,9 +282,7 @@ void Test9_2_16(void)
         }
         SuccessOrQuit(Tlv::Append<MeshCoP::DelayTimerTlv>(*message, kDelayTimerStep3));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     Log("---------------------------------------------------------------------------------------");
@@ -439,9 +437,7 @@ void Test9_2_16(void)
         SuccessOrQuit(Tlv::Append<MeshCoP::PanIdTlv>(*message, kPanIdStep11));
         SuccessOrQuit(Tlv::Append<MeshCoP::DelayTimerTlv>(*message, kDelayTimerStep11));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     Log("---------------------------------------------------------------------------------------");
@@ -493,9 +489,7 @@ void Test9_2_16(void)
             SuccessOrQuit(Tlv::Append<MeshCoP::PskcTlv>(*message, pskc));
         }
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     Log("---------------------------------------------------------------------------------------");
@@ -622,9 +616,7 @@ void Test9_2_16(void)
         Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveGet);
         VerifyOrQuit(message != nullptr);
 
-        Tmf::MessageInfo messageInfo(leader.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrTo(router2.Get<Mle::Mle>().GetRloc16());
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToRloc(*message, router2.Get<Mle::Mle>().GetRloc16()));
     }
 
     Log("---------------------------------------------------------------------------------------");

--- a/tests/nexus/test_9_2_18.cpp
+++ b/tests/nexus/test_9_2_18.cpp
@@ -264,9 +264,7 @@ void Test9_2_18(void)
             dataset.SetFrom(activeDatasetInfo);
             SuccessOrQuit(message->AppendBytes(dataset.GetBytes(), dataset.GetLength()));
         }
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
     nexus.AdvanceTime(kStabilizationTime);
 
@@ -321,9 +319,7 @@ void Test9_2_18(void)
             dataset.SetFrom(pendingDatasetInfo1);
             SuccessOrQuit(message->AppendBytes(dataset.GetBytes(), dataset.GetLength()));
         }
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
     nexus.AdvanceTime(kStabilizationTime);
 
@@ -383,9 +379,7 @@ void Test9_2_18(void)
             dataset.SetFrom(pendingDatasetInfo2);
             SuccessOrQuit(message->AppendBytes(dataset.GetBytes(), dataset.GetLength()));
         }
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
     nexus.AdvanceTime(kStabilizationTime);
 

--- a/tests/nexus/test_9_2_2.cpp
+++ b/tests/nexus/test_9_2_2.cpp
@@ -143,9 +143,7 @@ void Test9_2_2(void)
 
         AppendSteeringDataTlv(*message);
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     /**
@@ -190,9 +188,7 @@ void Test9_2_2(void)
 
         AppendSteeringDataTlv(*message);
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     /**
@@ -236,9 +232,7 @@ void Test9_2_2(void)
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
         SuccessOrQuit(Tlv::Append<MeshCoP::BorderAgentLocatorTlv>(*message, kBorderAgentRloc));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     /**
@@ -274,9 +268,7 @@ void Test9_2_2(void)
 
         SuccessOrQuit(Tlv::Append<MeshCoP::BorderAgentLocatorTlv>(*message, kBorderAgentRloc));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     /**
@@ -309,9 +301,7 @@ void Test9_2_2(void)
 
         AppendSteeringDataTlv(*message);
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     /**
@@ -346,9 +336,7 @@ void Test9_2_2(void)
 
         SuccessOrQuit(Tlv::Append<MeshCoP::ChannelTlv>(*message, Mle::ChannelTlvValue(11)));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     /**

--- a/tests/nexus/test_9_2_4.cpp
+++ b/tests/nexus/test_9_2_4.cpp
@@ -363,9 +363,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
         SuccessOrQuit(
             Tlv::AppendTlv(*message, MeshCoP::Tlv::kSecurityPolicy, kSecurityPolicy, sizeof(kSecurityPolicy)));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     Log("---------------------------------------------------------------------------------------");
@@ -400,9 +398,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
         Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveGet);
         VerifyOrQuit(message != nullptr);
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     Log("---------------------------------------------------------------------------------------");
@@ -470,9 +466,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
         SuccessOrQuit(
             Tlv::AppendTlv(*message, MeshCoP::Tlv::kSecurityPolicy, kSecurityPolicy, sizeof(kSecurityPolicy)));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     Log("---------------------------------------------------------------------------------------");
@@ -541,9 +535,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
         SuccessOrQuit(
             Tlv::AppendTlv(*message, MeshCoP::Tlv::kSecurityPolicy, kSecurityPolicy, sizeof(kSecurityPolicy)));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     Log("---------------------------------------------------------------------------------------");
@@ -611,9 +603,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
         SuccessOrQuit(Tlv::AppendTlv(*message, MeshCoP::Tlv::kSecurityPolicy, kSecurityPolicyStep10,
                                      sizeof(kSecurityPolicyStep10)));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     Log("---------------------------------------------------------------------------------------");
@@ -675,9 +665,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
         SuccessOrQuit(Tlv::AppendTlv(*message, MeshCoP::Tlv::kSecurityPolicy, kSecurityPolicyStep10,
                                      sizeof(kSecurityPolicyStep10)));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     Log("---------------------------------------------------------------------------------------");
@@ -738,9 +726,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
         SuccessOrQuit(Tlv::AppendTlv(*message, MeshCoP::Tlv::kSecurityPolicy, kSecurityPolicyStep10,
                                      sizeof(kSecurityPolicyStep10)));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     Log("---------------------------------------------------------------------------------------");
@@ -801,9 +787,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
         SuccessOrQuit(Tlv::AppendTlv(*message, MeshCoP::Tlv::kSecurityPolicy, kSecurityPolicyStep10,
                                      sizeof(kSecurityPolicyStep10)));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     Log("---------------------------------------------------------------------------------------");
@@ -867,9 +851,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
         SuccessOrQuit(
             Tlv::AppendTlv(*message, MeshCoP::Tlv::kSteeringData, kSteeringDataStep18, sizeof(kSteeringDataStep18)));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     Log("---------------------------------------------------------------------------------------");
@@ -932,9 +914,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
                                      sizeof(kSecurityPolicyStep10)));
         SuccessOrQuit(Tlv::AppendTlv(*message, kFutureTlvType, kFutureTlvValue, sizeof(kFutureTlvValue)));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     Log("---------------------------------------------------------------------------------------");

--- a/tests/nexus/test_9_2_6.cpp
+++ b/tests/nexus/test_9_2_6.cpp
@@ -220,9 +220,7 @@ void Test9_2_6(void)
                 Tlv::Append<MeshCoP::SteeringDataTlv>(*message, steeringData.GetData(), steeringData.GetLength()));
         }
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
     nexus.AdvanceTime(kResponseTime);
 
@@ -308,9 +306,7 @@ void Test9_2_6(void)
         SuccessOrQuit(Tlv::Append<MeshCoP::NetworkNameTlv>(*message, kNetworkName));
         SuccessOrQuit(Tlv::Append<MeshCoP::PskcTlv>(*message, AsCoreType(reinterpret_cast<const otPskc *>(kPskc))));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
     nexus.AdvanceTime(kResponseTime);
 
@@ -516,9 +512,7 @@ void Test9_2_6(void)
         SuccessOrQuit(Tlv::Append<MeshCoP::DelayTimerTlv>(*message, kDelayTimerTime));
         SuccessOrQuit(Tlv::Append<MeshCoP::ChannelTlv>(*message, Mle::ChannelTlvValue(kSecondaryChannel)));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
     nexus.AdvanceTime(kResponseTime);
 

--- a/tests/nexus/test_9_2_7.cpp
+++ b/tests/nexus/test_9_2_7.cpp
@@ -291,9 +291,7 @@ void Test9_2_7(void)
         SuccessOrQuit(updatedDataset.WriteTlvsFrom(datasetInfo));
         SuccessOrQuit(message->AppendBytes(updatedDataset.GetBytes(), updatedDataset.GetLength()));
 
-        Tmf::MessageInfo messageInfo(router.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     nexus.AdvanceTime(kResponseTime);
@@ -417,9 +415,7 @@ void Test9_2_7(void)
 
         SuccessOrQuit(message->AppendBytes(dataset.GetBytes(), dataset.GetLength()));
 
-        Tmf::MessageInfo messageInfo(router.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     // Wait for acceptance and retransmissions if needed
@@ -550,9 +546,7 @@ void Test9_2_7(void)
         SuccessOrQuit(Tlv::Append<MeshCoP::ChannelTlv>(*message, MeshCoP::ChannelTlvValue(0, kSecondaryChannel)));
         SuccessOrQuit(Tlv::Append<MeshCoP::PanIdTlv>(*message, kPanIdStep17));
 
-        Tmf::MessageInfo messageInfo(commissioner.GetInstance());
-        messageInfo.SetSockAddrToRlocPeerAddrToLeaderAloc();
-        SuccessOrQuit(agent.SendMessage(*message, messageInfo));
+        SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
     }
 
     Log("---------------------------------------------------------------------------------------");


### PR DESCRIPTION
This commit introduces new helper methods in the `Tmf::Agent` class (`SendMessageTo()`, `SendMessageToRloc()`, `SendMessageToLeaderAloc()`, and `SendMessageAllowMulticastLoop()`) to simplify the transmission of TMF messages.

Previously, callers of `Tmf::Agent::SendMessage()` were required to manually configure a `Tmf::MessageInfo` object with the appropriate socket and peer address information before sending a message. This led to repetitive code across the various modules utilizing TMF.

By incorporating these address resolution and message info preparation steps directly into `Tmf::Agent`, this change significantly reduces boilerplate code. All existing calls to `SendMessage()` have been updated to use the new flavors.