### PR TITLE
[netdata-publisher] remove entry immediately when desired num is zero

### DIFF
--- a/src/core/thread/network_data_publisher.hpp
+++ b/src/core/thread/network_data_publisher.hpp
@@ -379,7 +379,7 @@ private:
     private:
         void               Add(void);
         void               Remove(State aNextState);
-        void               LogUpdateTime(void) const;
+        void               LogUpdateTime(TimeMilli aNow) const;
         static const char *StateToString(State aState);
 
         TimeMilli mUpdateTime;

--- a/tests/scripts/thread-cert/test_netdata_publisher.py
+++ b/tests/scripts/thread-cert/test_netdata_publisher.py
@@ -464,10 +464,11 @@ class NetDataPublisher(thread_cert.TestCase):
 
         # Verify that publishing an anycast entry will update the
         # limit for the server data unicast address entry and all are
-        # removed.
+        # removed quickly. We validate this by waiting for a short
+        # time (15 msec) after publishing anycast.
 
         leader.netdata_publish_dnssrp_anycast(ANYCAST_SEQ_NUM)
-        self.simulator.go(WAIT_TIME)
+        self.simulator.go(15)
         services = leader.get_services()
         self.assertEqual(len(services), 1)
         self.verify_anycast_services(services)


### PR DESCRIPTION
Update `Publisher::Entry::UpdateState()` to support quickly removing a published entry when the desired number of entries is explicitly set to zero. In this case, we bypass the random removal delay and remove the entry immediately. This situation helps with SRP/DNS unicast entries, where if any service data unicast or anycast entry is seen, we set the desired number to zero and want to quickly remove any previously added server data unicast entry.