### PR TITLE
[posix] update `mdns-socket` to support one-shot multicast DNS queries

### DIFF
--- a/examples/platforms/simulation/mdns_socket.c
+++ b/examples/platforms/simulation/mdns_socket.c
@@ -351,7 +351,7 @@ void otPlatMdnsSendUnicast(otInstance *aInstance, otMessage *aMessage, const otP
         memset(&addr, 0, sizeof(addr));
         addr.sin_family = AF_INET;
         memcpy(&addr.sin_addr.s_addr, &ip4Addr, sizeof(otIp4Address));
-        addr.sin_port = htons(MDNS_PORT);
+        addr.sin_port = htons(aAddress->mPort);
 
         bytes = sendto(sMdnsFd4, buffer, length, 0, (struct sockaddr *)&addr, sizeof(addr));
 
@@ -363,7 +363,7 @@ void otPlatMdnsSendUnicast(otInstance *aInstance, otMessage *aMessage, const otP
 
         memset(&addr6, 0, sizeof(addr6));
         addr6.sin6_family = AF_INET6;
-        addr6.sin6_port   = htons(MDNS_PORT);
+        addr6.sin6_port   = htons(aAddress->mPort);
         memcpy(&addr6.sin6_addr, &aAddress->mAddress, sizeof(otIp6Address));
 
         bytes = sendto(sMdnsFd6, buffer, length, 0, (struct sockaddr *)&addr6, sizeof(addr6));
@@ -411,7 +411,7 @@ void platformMdnsSocketProcess(otInstance *aInstance, const fd_set *aReadFdSet)
 
         memset(&addrInfo, 0, sizeof(addrInfo));
         otIp4ToIp4MappedIp6Address((otIp4Address *)(&sockaddr.sin_addr.s_addr), &addrInfo.mAddress);
-        addrInfo.mPort         = MDNS_PORT;
+        addrInfo.mPort         = ntohs(sockaddr.sin_port);
         addrInfo.mInfraIfIndex = sInfraIfIndex;
 
         otPlatMdnsHandleReceive(aInstance, message, /* aInUnicast */ false, &addrInfo);
@@ -437,7 +437,7 @@ void platformMdnsSocketProcess(otInstance *aInstance, const fd_set *aReadFdSet)
 
         memset(&addrInfo, 0, sizeof(addrInfo));
         memcpy(&addrInfo.mAddress, &sockaddr6.sin6_addr, sizeof(otIp6Address));
-        addrInfo.mPort         = MDNS_PORT;
+        addrInfo.mPort         = ntohs(sockaddr6.sin6_port);
         addrInfo.mInfraIfIndex = sInfraIfIndex;
 
         otPlatMdnsHandleReceive(aInstance, message, /* aInUnicast */ false, &addrInfo);

--- a/src/posix/platform/mdns_socket.cpp
+++ b/src/posix/platform/mdns_socket.cpp
@@ -475,6 +475,7 @@ void MdnsSocket::ReceiveMessage(MsgType aMsgType)
         VerifyOrExit(rval >= 0, LogCrit("recvfrom() for IPv6 socket failed, errno: %s", strerror(errno)));
         length = static_cast<uint16_t>(rval);
         ReadIp6AddressFrom(&sockaddr6.sin6_addr, addrInfo.mAddress);
+        addrInfo.mPort = ntohs(sockaddr6.sin6_port);
         break;
 
     case kIp4Msg:
@@ -485,6 +486,7 @@ void MdnsSocket::ReceiveMessage(MsgType aMsgType)
         VerifyOrExit(rval >= 0, LogCrit("recvfrom() for IPv4 socket failed, errno: %s", strerror(errno)));
         length = static_cast<uint16_t>(rval);
         otIp4ToIp4MappedIp6Address((otIp4Address *)(&sockaddr.sin_addr.s_addr), &addrInfo.mAddress);
+        addrInfo.mPort = ntohs(sockaddr.sin_port);
         break;
     }
 
@@ -494,7 +496,6 @@ void MdnsSocket::ReceiveMessage(MsgType aMsgType)
     VerifyOrExit(message != nullptr);
     SuccessOrExit(otMessageAppend(message, buffer, length));
 
-    addrInfo.mPort         = kMdnsPort;
     addrInfo.mInfraIfIndex = mInfraIfIndex;
 
     otPlatMdnsHandleReceive(mInstance, message, /* aInUnicast */ false, &addrInfo);


### PR DESCRIPTION
This commit fixes the problem where OpenThread mDNS responder always sends responses to port 5353, ignoring the source port of the query.

According to RFC 6762, a mDNS responder should support one-shot multicast DNS queries by sending the response to the source address and source port of the query.

Changes:
- Captured the actual source port from incoming queries in Simulation and POSIX platforms.
- Updated otPlatMdnsSendUnicast in Simulation platform to use the provided destination port.
- Verified that legacy unicast responses correctly cap TTL to 10 seconds as required by RFC 6762 section 6.7.