### PR TITLE
[coap] rename message setup methods to use AllocateAndInit prefix

### DIFF
--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -279,7 +279,7 @@ void Manager::SendMulticastListenerRegistrationResponse(const Coap::Msg &aMsg,
     Error          error = kErrorNone;
     Coap::Message *message;
 
-    message = Get<Tmf::Agent>().NewResponseMessage(aMsg.mMessage);
+    message = Get<Tmf::Agent>().AllocateAndInitResponseFor(aMsg.mMessage);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(Tlv::Append<ThreadStatusTlv>(*message, aStatus));
@@ -317,7 +317,7 @@ void Manager::SendBackboneMulticastListenerRegistration(const Ip6::Address *aAdd
 
     OT_ASSERT(aAddressNum >= Ip6AddressesTlv::kMinAddresses && aAddressNum <= Ip6AddressesTlv::kMaxAddresses);
 
-    message = backboneTmf.NewNonConfirmablePostMessage(kUriBackboneMlr);
+    message = backboneTmf.AllocateAndInitNonConfirmablePostMessage(kUriBackboneMlr);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     addressesTlv.Init();
@@ -435,7 +435,7 @@ void Manager::SendDuaRegistrationResponse(const Coap::Msg &aMsg, const Ip6::Addr
     Error          error = kErrorNone;
     Coap::Message *message;
 
-    message = Get<Tmf::Agent>().NewResponseMessage(aMsg.mMessage);
+    message = Get<Tmf::Agent>().AllocateAndInitResponseFor(aMsg.mMessage);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(Tlv::Append<ThreadStatusTlv>(*message, aStatus));
@@ -508,7 +508,7 @@ Error Manager::SendBackboneQuery(const Ip6::Address &aDua, uint16_t aRloc16)
 
     VerifyOrExit(Get<Local>().IsPrimary(), error = kErrorInvalidState);
 
-    message = mBackboneTmfAgent.NewPriorityNonConfirmablePostMessage(kUriBackboneQuery);
+    message = mBackboneTmfAgent.AllocateAndInitPriorityNonConfirmablePostMessage(kUriBackboneQuery);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, aDua));

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -163,29 +163,32 @@ Message *CoapBase::NewPriorityMessage(void)
     return NewMessage(Message::Settings(kWithLinkSecurity, Message::kPriorityNet));
 }
 
-Message *CoapBase::NewPriorityConfirmablePostMessage(Uri aUri)
+Message *CoapBase::AllocateAndInitPriorityConfirmablePostMessage(Uri aUri)
 {
     return InitMessage(NewPriorityMessage(), kTypeConfirmable, aUri);
 }
 
-Message *CoapBase::NewConfirmablePostMessage(Uri aUri) { return InitMessage(NewMessage(), kTypeConfirmable, aUri); }
+Message *CoapBase::AllocateAndInitConfirmablePostMessage(Uri aUri)
+{
+    return InitMessage(NewMessage(), kTypeConfirmable, aUri);
+}
 
-Message *CoapBase::NewPriorityNonConfirmablePostMessage(Uri aUri)
+Message *CoapBase::AllocateAndInitPriorityNonConfirmablePostMessage(Uri aUri)
 {
     return InitMessage(NewPriorityMessage(), kTypeNonConfirmable, aUri);
 }
 
-Message *CoapBase::NewNonConfirmablePostMessage(Uri aUri)
+Message *CoapBase::AllocateAndInitNonConfirmablePostMessage(Uri aUri)
 {
     return InitMessage(NewMessage(), kTypeNonConfirmable, aUri);
 }
 
-Message *CoapBase::NewPriorityResponseMessage(const Message &aRequest)
+Message *CoapBase::AllocateAndInitPriorityResponseFor(const Message &aRequest)
 {
     return InitResponse(NewPriorityMessage(), aRequest);
 }
 
-Message *CoapBase::NewResponseMessage(const Message &aRequest) { return InitResponse(NewMessage(), aRequest); }
+Message *CoapBase::AllocateAndInitResponseFor(const Message &aRequest) { return InitResponse(NewMessage(), aRequest); }
 
 Message *CoapBase::InitMessage(Message *aMessage, Type aType, Uri aUri)
 {

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -380,7 +380,7 @@ public:
      *
      * @returns A pointer to the message or `nullptr` if failed to allocate message.
      */
-    Message *NewPriorityConfirmablePostMessage(Uri aUri);
+    Message *AllocateAndInitPriorityConfirmablePostMessage(Uri aUri);
 
     /**
      * Allocates and initializes a new CoAP Confirmable Post message with normal priority level.
@@ -394,7 +394,7 @@ public:
      *
      * @returns A pointer to the message or `nullptr` if failed to allocate message.
      */
-    Message *NewConfirmablePostMessage(Uri aUri);
+    Message *AllocateAndInitConfirmablePostMessage(Uri aUri);
 
     /**
      * Allocates and initializes a new CoAP Non-confirmable Post message with Network Control priority
@@ -409,7 +409,7 @@ public:
      *
      * @returns A pointer to the message or `nullptr` if failed to allocate message.
      */
-    Message *NewPriorityNonConfirmablePostMessage(Uri aUri);
+    Message *AllocateAndInitPriorityNonConfirmablePostMessage(Uri aUri);
 
     /**
      * Allocates and initializes a new CoAP Non-confirmable Post message with normal priority level.
@@ -423,7 +423,7 @@ public:
      *
      * @returns A pointer to the message or `nullptr` if failed to allocate message.
      */
-    Message *NewNonConfirmablePostMessage(Uri aUri);
+    Message *AllocateAndInitNonConfirmablePostMessage(Uri aUri);
 
     /**
      * Allocates and initializes a new CoAP response message with Network Control priority level for a
@@ -436,7 +436,7 @@ public:
      *
      * @returns A pointer to the message or `nullptr` if failed to allocate message.
      */
-    Message *NewPriorityResponseMessage(const Message &aRequest);
+    Message *AllocateAndInitPriorityResponseFor(const Message &aRequest);
 
     /**
      * Allocates and initializes a new CoAP response message with regular priority level for a given
@@ -449,7 +449,7 @@ public:
      *
      * @returns A pointer to the message or `nullptr` if failed to allocate message.
      */
-    Message *NewResponseMessage(const Message &aRequest);
+    Message *AllocateAndInitResponseFor(const Message &aRequest);
 
     /**
      * Sends a CoAP message with custom transmission parameters.

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -491,7 +491,7 @@ Error Manager::EvictActiveCommissioner(void)
     SuccessOrExit(error = Get<NetworkData::Leader>().FindBorderAgentRloc(baRloc16));
     SuccessOrExit(error = Get<NetworkData::Leader>().FindCommissioningSessionId(sessionId));
 
-    message.Reset(Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriLeaderKeepAlive));
+    message.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriLeaderKeepAlive));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<StateTlv>(*message, StateTlv::kReject));
@@ -690,7 +690,7 @@ Error Manager::CoapDtlsSession::ForwardToLeader(const Coap::Msg &aMsg, Uri aUri)
     forwardContext.Reset(ForwardContext::Allocate(*this, aMsg.mMessage, aUri));
     VerifyOrExit(!forwardContext.IsNull(), error = kErrorNoBufs);
 
-    message.Reset(Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(aUri));
+    message.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(aUri));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     offsetRange.InitFromMessageOffsetToEnd(aMsg.mMessage);
@@ -848,7 +848,7 @@ Error Manager::CoapDtlsSession::ForwardUdpProxy(const Message &aMessage, const I
 
     VerifyOrExit(aMessage.GetLength() > 0);
 
-    message.Reset(NewPriorityNonConfirmablePostMessage(kUriProxyRx));
+    message.Reset(AllocateAndInitPriorityNonConfirmablePostMessage(kUriProxyRx));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     offsetRange.InitFromMessageOffsetToEnd(aMessage);
@@ -887,7 +887,7 @@ Error Manager::CoapDtlsSession::ForwardUdpRelay(const Message &aMessage)
     OwnedPtr<Coap::Message> forwardMessage;
     Error                   error = kErrorNone;
 
-    forwardMessage.Reset(NewPriorityNonConfirmablePostMessage(kUriRelayRx));
+    forwardMessage.Reset(AllocateAndInitPriorityNonConfirmablePostMessage(kUriRelayRx));
     VerifyOrExit(forwardMessage != nullptr, error = kErrorNoBufs);
 
     error = ForwardToCommissioner(forwardMessage.PassOwnership(), aMessage);
@@ -1004,7 +1004,7 @@ void Manager::CoapDtlsSession::HandleTmfRelayTx(Coap::Msg &aMsg)
 
     SuccessOrExit(error = Tlv::Find<JoinerRouterLocatorTlv>(aMsg.mMessage, joinerRouterRloc));
 
-    message.Reset(Get<Tmf::Agent>().NewPriorityNonConfirmablePostMessage(kUriRelayTx));
+    message.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityNonConfirmablePostMessage(kUriRelayTx));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     offsetRange.InitFromMessageOffsetToEnd(aMsg.mMessage);

--- a/src/core/meshcop/border_agent_admitter.cpp
+++ b/src/core/meshcop/border_agent_admitter.cpp
@@ -575,7 +575,7 @@ void Admitter::CommissionerPetitioner::SendPetitionIfNoOtherCommissioner(void)
         ExitNow();
     }
 
-    message.Reset(Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriLeaderPetition));
+    message.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriLeaderPetition));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     writer.Append("otAdmitter");
@@ -707,7 +707,7 @@ Error Admitter::CommissionerPetitioner::SendKeepAlive(StateTlv::State aState)
     Error                   error = kErrorNone;
     OwnedPtr<Coap::Message> message;
 
-    message.Reset(Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriLeaderKeepAlive));
+    message.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriLeaderKeepAlive));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<StateTlv>(*message, aState));
@@ -807,7 +807,7 @@ void Admitter::CommissionerPetitioner::SendDataSet(void)
 
     IgnoreError(Get<Tmf::Agent>().AbortTransaction(HandleDataSetResponse, this));
 
-    message.Reset(Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriCommissionerSet));
+    message.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerSet));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<CommissionerSessionIdTlv>(*message, mSessionId));
@@ -1362,7 +1362,7 @@ void Manager::CoapDtlsSession::SendEnrollerResponse(Uri                  aUri,
 {
     OwnedPtr<Coap::Message> response;
 
-    response.Reset(NewPriorityResponseMessage(aRequest));
+    response.Reset(AllocateAndInitPriorityResponseFor(aRequest));
     VerifyOrExit(response != nullptr);
 
     SuccessOrExit(Tlv::Append<StateTlv>(*response, static_cast<uint8_t>(aResponseState)));
@@ -1390,7 +1390,7 @@ void Manager::CoapDtlsSession::SendEnrollerReportState(uint8_t aAdmitterState)
 {
     OwnedPtr<Coap::Message> message;
 
-    message.Reset(NewNonConfirmablePostMessage(kUriEnrollerReportState));
+    message.Reset(AllocateAndInitNonConfirmablePostMessage(kUriEnrollerReportState));
     VerifyOrExit(message != nullptr);
 
     SuccessOrExit(AppendAdmitterTlvs(*message, aAdmitterState));

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -606,7 +606,7 @@ Error Commissioner::SendMgmtCommissionerGetRequest(const uint8_t *aTlvs, uint8_t
     Error                   error = kErrorNone;
     OwnedPtr<Coap::Message> message;
 
-    message.Reset(Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriCommissionerGet));
+    message.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerGet));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     if (aLength > 0)
@@ -639,7 +639,7 @@ Error Commissioner::SendMgmtCommissionerSetRequest(const CommissioningDataset &a
     Error                   error = kErrorNone;
     OwnedPtr<Coap::Message> message;
 
-    message.Reset(Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriCommissionerSet));
+    message.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerSet));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     if (aDataset.IsLocatorSet())
@@ -701,7 +701,7 @@ Error Commissioner::SendPetition(void)
 
     mTransmitAttempts++;
 
-    message.Reset(Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriLeaderPetition));
+    message.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriLeaderPetition));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<CommissionerIdTlv>(*message, mCommissionerId));
@@ -769,7 +769,7 @@ void Commissioner::SendKeepAlive(uint16_t aSessionId)
     Error                   error = kErrorNone;
     OwnedPtr<Coap::Message> message;
 
-    message.Reset(Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriLeaderKeepAlive));
+    message.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriLeaderKeepAlive));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(
@@ -937,7 +937,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Message &aRequest, State
     Error          error = kErrorNone;
     Coap::Message *message;
 
-    message = Get<Tmf::SecureAgent>().NewPriorityResponseMessage(aRequest);
+    message = Get<Tmf::SecureAgent>().AllocateAndInitPriorityResponseFor(aRequest);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     message->SetOffset(message->GetLength());
@@ -981,7 +981,7 @@ Error Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::MessageInfo 
 
     Get<KeyManager>().ExtractKek(kek);
 
-    message.Reset(Get<Tmf::Agent>().NewPriorityNonConfirmablePostMessage(kUriRelayTx));
+    message.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityNonConfirmablePostMessage(kUriRelayTx));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<JoinerUdpPortTlv>(*message, mJoinerPort));

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -470,7 +470,8 @@ Error DatasetManager::SendSetRequest(const Dataset &aDataset)
 
     VerifyOrExit(!mMgmtPending, error = kErrorAlready);
 
-    message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(IsActiveDataset() ? kUriActiveSet : kUriPendingSet);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(IsActiveDataset() ? kUriActiveSet
+                                                                                                : kUriPendingSet);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = message->AppendBytes(aDataset.GetBytes(), aDataset.GetLength()));
@@ -561,7 +562,7 @@ Coap::Message *DatasetManager::ProcessGetRequest(const Coap::Message    &aReques
 
     IgnoreError(Read(dataset));
 
-    response = Get<Tmf::Agent>().NewPriorityResponseMessage(aRequest);
+    response = Get<Tmf::Agent>().AllocateAndInitPriorityResponseFor(aRequest);
     VerifyOrExit(response != nullptr, error = kErrorNoBufs);
 
     for (const Tlv *tlv = dataset.GetTlvsStart(); tlv < dataset.GetTlvsEnd(); tlv = tlv->GetNext())
@@ -695,7 +696,8 @@ Error DatasetManager::SendGetRequest(const Dataset::Components &aDatasetComponen
         tlvList.Add(aTlvTypes[index]);
     }
 
-    message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(IsActiveDataset() ? kUriActiveGet : kUriPendingGet);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(IsActiveDataset() ? kUriActiveGet
+                                                                                                : kUriPendingGet);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     if (!tlvList.IsEmpty())

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -236,7 +236,7 @@ void DatasetManager::SendSetOrReplaceResponse(const Coap::Msg &aMsg, StateTlv::S
     Error          error = kErrorNone;
     Coap::Message *message;
 
-    message = Get<Tmf::Agent>().NewPriorityResponseMessage(aMsg.mMessage);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityResponseFor(aMsg.mMessage);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<StateTlv>(*message, aState));

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -331,7 +331,7 @@ Error Joiner::PrepareJoinerFinalizeMessage(const char *aProvisioningUrl,
     Error                 error = kErrorNone;
     VendorStackVersionTlv vendorStackVersionTlv;
 
-    mFinalizeMessage = Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriJoinerFinalize);
+    mFinalizeMessage = Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriJoinerFinalize);
     VerifyOrExit(mFinalizeMessage != nullptr, error = kErrorNoBufs);
 
     mFinalizeMessage->SetOffset(mFinalizeMessage->GetLength());
@@ -452,7 +452,7 @@ void Joiner::SendJoinerEntrustResponse(const Coap::Msg &aMsg)
     Coap::Message   *message;
     Ip6::MessageInfo responseInfo(aMsg.mMessageInfo);
 
-    message = Get<Tmf::Agent>().NewPriorityResponseMessage(aMsg.mMessage);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityResponseFor(aMsg.mMessage);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     message->SetSubType(Message::kSubTypeJoinerEntrust);

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -126,7 +126,7 @@ void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &a
 
     SuccessOrExit(error = Get<NetworkData::Leader>().FindBorderAgentRloc(borderAgentRloc));
 
-    message = Get<Tmf::Agent>().NewPriorityNonConfirmablePostMessage(kUriRelayRx);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityNonConfirmablePostMessage(kUriRelayRx);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<JoinerUdpPortTlv>(*message, aMessageInfo.GetPeerPort()));
@@ -278,7 +278,7 @@ Coap::Message *JoinerRouter::PrepareJoinerEntrustMessage(void)
     Coap::Message *message = nullptr;
     Dataset        dataset;
 
-    message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriJoinerEntrust);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriJoinerEntrust);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     message->SetSubType(Message::kSubTypeJoinerEntrust);

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -86,7 +86,7 @@ void Leader::SendPetitionResponse(const Coap::Msg &aMsg, StateTlv::State aState)
     Error          error = kErrorNone;
     Coap::Message *message;
 
-    message = Get<Tmf::Agent>().NewPriorityResponseMessage(aMsg.mMessage);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityResponseFor(aMsg.mMessage);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<StateTlv>(*message, aState));
@@ -161,7 +161,7 @@ void Leader::SendKeepAliveResponse(const Coap::Msg &aMsg, StateTlv::State aState
     Error          error = kErrorNone;
     Coap::Message *message;
 
-    message = Get<Tmf::Agent>().NewPriorityResponseMessage(aMsg.mMessage);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityResponseFor(aMsg.mMessage);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<StateTlv>(*message, aState));
@@ -180,7 +180,7 @@ void Leader::SendDatasetChanged(const Ip6::Address &aAddress)
     Error          error = kErrorNone;
     Coap::Message *message;
 
-    message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriDatasetChanged);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriDatasetChanged);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, aAddress));

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -1119,7 +1119,7 @@ template <> void TcatAgent::HandleTmf<kUriTcatEnable>(Coap::Msg &aMsg)
     VerifyOrExit(aMsg.IsConfirmablePostRequest());
     LogInfo("Received %s from %s", UriToString<kUriTcatEnable>(),
             aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());
-    message = Get<Tmf::Agent>().NewResponseMessage(aMsg.mMessage);
+    message = Get<Tmf::Agent>().AllocateAndInitResponseFor(aMsg.mMessage);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Find<DelayTimerTlv>(aMsg.mMessage, delayTimerMs));

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -614,7 +614,7 @@ Error AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
     Error          error;
     Coap::Message *message;
 
-    message = Get<Tmf::Agent>().NewPriorityNonConfirmablePostMessage(kUriAddressQuery);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityNonConfirmablePostMessage(kUriAddressQuery);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, aEid));
@@ -874,7 +874,7 @@ void AddressResolver::SendAddressQueryResponse(const Ip6::Address             &a
     Error          error;
     Coap::Message *message;
 
-    message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriAddressNotify);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriAddressNotify);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, aTarget));

--- a/src/core/thread/anycast_locator.cpp
+++ b/src/core/thread/anycast_locator.cpp
@@ -53,7 +53,7 @@ Error AnycastLocator::Locate(const Ip6::Address &aAnycastAddress, LocatorCallbac
     VerifyOrExit((aCallback != nullptr) && Get<Mle::Mle>().IsAnycastLocator(aAnycastAddress),
                  error = kErrorInvalidArgs);
 
-    message = Get<Tmf::Agent>().NewConfirmablePostMessage(kUriAnycastLocate);
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriAnycastLocate);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     if (mCallback.IsSet())
@@ -101,7 +101,7 @@ template <> void AnycastLocator::HandleTmf<kUriAnycastLocate>(Coap::Msg &aMsg)
 
     VerifyOrExit(aMsg.IsConfirmablePostRequest());
 
-    message = Get<Tmf::Agent>().NewResponseMessage(aMsg.mMessage);
+    message = Get<Tmf::Agent>().AllocateAndInitResponseFor(aMsg.mMessage);
     VerifyOrExit(message != nullptr);
 
     SuccessOrExit(Tlv::Append<ThreadMeshLocalEidTlv>(*message, Get<Mle::Mle>().GetMeshLocalEid().GetIid()));

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -455,7 +455,7 @@ void DuaManager::PerformNextRegistration(void)
     }
 
     // Prepare DUA.req
-    message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriDuaRegistrationRequest);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriDuaRegistrationRequest);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
@@ -700,7 +700,7 @@ void DuaManager::SendAddressNotification(Ip6::Address &aAddress, DuaStatus aStat
     Coap::Message *message = nullptr;
     Error          error;
 
-    message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriDuaRegistrationNotify);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriDuaRegistrationNotify);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<ThreadStatusTlv>(*message, aStatus));

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -69,7 +69,7 @@ template <> void EnergyScanServer::HandleTmf<kUriEnergyScan>(Coap::Msg &aMsg)
     SuccessOrExit(MeshCoP::ChannelMaskTlv::FindIn(aMsg.mMessage, mask));
     VerifyOrExit(mask != 0);
 
-    mReportMessage.Reset(Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriEnergyReport));
+    mReportMessage.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnergyReport));
     VerifyOrExit(mReportMessage != nullptr);
 
     SuccessOrExit(MeshCoP::ChannelMaskTlv::AppendTo(*mReportMessage, mask));

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -3264,7 +3264,7 @@ Error Mle::SendAddressSolicit(RouterUpgradeReason aReason)
 
     VerifyOrExit(!mAddressSolicitPending);
 
-    message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriAddressSolicit);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriAddressSolicit);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<ThreadExtMacAddressTlv>(*message, Get<Mac::Mac>().GetExtAddress()));
@@ -3298,7 +3298,7 @@ void Mle::SendAddressRelease(void)
     Coap::Message *message;
     Ip6::Address   leaderRloc;
 
-    message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriAddressRelease);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriAddressRelease);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<ThreadRloc16Tlv>(*message, Rloc16FromRouterId(mRouterId)));
@@ -3576,7 +3576,7 @@ template <> void Mle::HandleTmf<kUriAddressSolicit>(Coap::Msg &aMsg)
 
     // Prepare and send response
 
-    response = Get<Tmf::Agent>().NewPriorityResponseMessage(aMsg.mMessage);
+    response = Get<Tmf::Agent>().AllocateAndInitPriorityResponseFor(aMsg.mMessage);
     VerifyOrExit(response != nullptr);
 
     SuccessOrExit(Tlv::Append<ThreadStatusTlv>(*response, info.mResponse));

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -363,7 +363,7 @@ Error MlrManager::SendMlrMessage(const Ip6::Address         *aAddresses,
 
     VerifyOrExit(Get<BackboneRouter::Leader>().HasPrimary(), error = kErrorInvalidState);
 
-    message = Get<Tmf::Agent>().NewConfirmablePostMessage(kUriMlr);
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriMlr);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     addressesTlv.Init();

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -574,7 +574,7 @@ Coap::Message *Leader::ProcessCommissionerGetRequest(const Coap::Message &aMessa
     Coap::Message *response = nullptr;
     OffsetRange    offsetRange;
 
-    response = Get<Tmf::Agent>().NewPriorityResponseMessage(aMessage);
+    response = Get<Tmf::Agent>().AllocateAndInitPriorityResponseFor(aMessage);
     VerifyOrExit(response != nullptr, error = kErrorNoBufs);
 
     if (Tlv::FindTlvValueOffsetRange(aMessage, MeshCoP::Tlv::kGet, offsetRange) == kErrorNone)

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -320,7 +320,7 @@ exit:
 
 void Leader::SendCommissioningSetResponse(const Coap::Msg &aMsg, MeshCoP::StateTlv::State aState)
 {
-    Coap::Message *message = Get<Tmf::Agent>().NewPriorityResponseMessage(aMsg.mMessage);
+    Coap::Message *message = Get<Tmf::Agent>().AllocateAndInitPriorityResponseFor(aMsg.mMessage);
 
     VerifyOrExit(message != nullptr);
     SuccessOrExit(Tlv::Append<MeshCoP::StateTlv>(*message, aState));

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -186,7 +186,7 @@ Error Notifier::SendServerDataNotification(uint16_t aOldRloc16, const NetworkDat
     Error          error = kErrorNone;
     Coap::Message *message;
 
-    message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriServerData);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriServerData);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     if (aNetworkData != nullptr)

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -585,7 +585,7 @@ void Server::SendAnswer(const Ip6::Address &aDestination, const Message &aReques
     AnswerTlv      answerTlv;
     uint16_t       queryId;
 
-    answer = Get<Tmf::Agent>().NewConfirmablePostMessage(kUriDiagnosticGetAnswer);
+    answer = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriDiagnosticGetAnswer);
     VerifyOrExit(answer != nullptr, error = kErrorNoBufs);
 
     IgnoreError(answer->SetPriority(aRequest.GetPriority()));
@@ -618,7 +618,7 @@ Error Server::AllocateAnswer(Coap::Message *&aAnswer, AnswerInfo &aInfo)
 
     Error error = kErrorNone;
 
-    aAnswer = Get<Tmf::Agent>().NewConfirmablePostMessage(kUriDiagnosticGetAnswer);
+    aAnswer = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriDiagnosticGetAnswer);
     VerifyOrExit(aAnswer != nullptr, error = kErrorNoBufs);
     IgnoreError(aAnswer->SetPriority(aInfo.mPriority));
 
@@ -916,7 +916,7 @@ template <> void Server::HandleTmf<kUriDiagnosticGetRequest>(Coap::Msg &aMsg)
     LogInfo("Received %s from %s", UriToString<kUriDiagnosticGetRequest>(),
             aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());
 
-    response = Get<Tmf::Agent>().NewResponseMessage(aMsg.mMessage);
+    response = Get<Tmf::Agent>().AllocateAndInitResponseFor(aMsg.mMessage);
     VerifyOrExit(response != nullptr, error = kErrorNoBufs);
 
     IgnoreError(response->SetPriority(aMsg.mMessage.GetPriority()));
@@ -1033,12 +1033,12 @@ Error Client::SendCommand(Uri                   aUri,
     switch (aUri)
     {
     case kUriDiagnosticGetQuery:
-        message = Get<Tmf::Agent>().NewNonConfirmablePostMessage(aUri);
+        message = Get<Tmf::Agent>().AllocateAndInitNonConfirmablePostMessage(aUri);
         break;
 
     case kUriDiagnosticGetRequest:
     case kUriDiagnosticReset:
-        message = Get<Tmf::Agent>().NewConfirmablePostMessage(aUri);
+        message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(aUri);
         break;
 
     default:

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -92,7 +92,7 @@ void PanIdQueryServer::SendConflict(void)
     Error          error = kErrorNone;
     Coap::Message *message;
 
-    message = Get<Tmf::Agent>().NewPriorityConfirmablePostMessage(kUriPanIdConflict);
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriPanIdConflict);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = MeshCoP::ChannelMaskTlv::AppendTo(*message, mChannelMask));

--- a/src/core/utils/history_tracker_client.cpp
+++ b/src/core/utils/history_tracker_client.cpp
@@ -83,7 +83,7 @@ Error Client::SendQuery(Tlv::Type aTlvType, uint16_t aMaxEntries, uint32_t aMaxE
 
     VerifyOrExit(Get<Mle::Mle>().IsAttached(), error = kErrorInvalidState);
 
-    message.Reset(Get<Tmf::Agent>().NewNonConfirmablePostMessage(kUriHistoryQuery));
+    message.Reset(Get<Tmf::Agent>().AllocateAndInitNonConfirmablePostMessage(kUriHistoryQuery));
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
     IgnoreError(message->SetPriority(Message::kPriorityLow));
 

--- a/src/core/utils/history_tracker_server.cpp
+++ b/src/core/utils/history_tracker_server.cpp
@@ -73,7 +73,7 @@ Error Server::AllocateAnswer(Coap::Message *&aAnswer, AnswerInfo &aInfo)
 
     Error error = kErrorNone;
 
-    aAnswer = Get<Tmf::Agent>().NewConfirmablePostMessage(kUriHistoryAnswer);
+    aAnswer = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriHistoryAnswer);
     VerifyOrExit(aAnswer != nullptr, error = kErrorNoBufs);
     IgnoreError(aAnswer->SetPriority(aInfo.mPriority));
 

--- a/tests/nexus/test_1_1_9_2_10.cpp
+++ b/tests/nexus/test_1_1_9_2_10.cpp
@@ -256,7 +256,7 @@ void Test9_2_10(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriPendingSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriPendingSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));

--- a/tests/nexus/test_1_1_9_2_12.cpp
+++ b/tests/nexus/test_1_1_9_2_12.cpp
@@ -227,7 +227,7 @@ void Test9_2_12(void)
         uint32_t channelMask = (1 << kPrimaryChannel);
 
         Tmf::Agent    &agent   = leader1.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriAnnounceBegin);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriAnnounceBegin);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(MeshCoP::Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, kCommissionerSessionId));

--- a/tests/nexus/test_1_1_9_2_13.cpp
+++ b/tests/nexus/test_1_1_9_2_13.cpp
@@ -102,7 +102,7 @@ static constexpr uint32_t kSedPollRate = 500;
 static void SendMgmtEnergyScanQuery(Node &aCommissioner, const Ip6::Address &aDestAddr, uint16_t aSessionId)
 {
     Tmf::Agent    &agent   = aCommissioner.Get<Tmf::Agent>();
-    Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriEnergyScan);
+    Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriEnergyScan);
 
     VerifyOrQuit(message != nullptr);
 

--- a/tests/nexus/test_1_1_9_2_15.cpp
+++ b/tests/nexus/test_1_1_9_2_15.cpp
@@ -138,7 +138,7 @@ void SendPendingSet(Node           &aCommissioner,
                     const uint16_t *aPanId = nullptr)
 {
     Tmf::Agent    &agent   = aCommissioner.Get<Tmf::Agent>();
-    Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriPendingSet);
+    Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriPendingSet);
     VerifyOrQuit(message != nullptr);
 
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, aSessionId));
@@ -526,7 +526,7 @@ void Test9_2_15(void)
 
     {
         Tmf::Agent    &agent   = leader.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveGet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriActiveGet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(agent.SendMessageTo(*message, dut.Get<Mle::Mle>().GetMeshLocalEid()));

--- a/tests/nexus/test_1_1_9_2_16.cpp
+++ b/tests/nexus/test_1_1_9_2_16.cpp
@@ -256,7 +256,7 @@ void Test9_2_16(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriPendingSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriPendingSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
@@ -409,7 +409,7 @@ void Test9_2_16(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriPendingSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriPendingSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
@@ -472,7 +472,7 @@ void Test9_2_16(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriActiveSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
@@ -613,7 +613,7 @@ void Test9_2_16(void)
 
     {
         Tmf::Agent    &agent   = leader.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveGet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriActiveGet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(agent.SendMessageToRloc(*message, router2.Get<Mle::Mle>().GetRloc16()));

--- a/tests/nexus/test_1_1_9_2_18.cpp
+++ b/tests/nexus/test_1_1_9_2_18.cpp
@@ -256,7 +256,7 @@ void Test9_2_18(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriActiveSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(
@@ -312,7 +312,7 @@ void Test9_2_18(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriPendingSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriPendingSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(
@@ -373,7 +373,7 @@ void Test9_2_18(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriPendingSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriPendingSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(

--- a/tests/nexus/test_1_1_9_2_2.cpp
+++ b/tests/nexus/test_1_1_9_2_2.cpp
@@ -138,7 +138,7 @@ void Test9_2_2(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriCommissionerSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerSet);
         VerifyOrQuit(message != nullptr);
 
         AppendSteeringDataTlv(*message);
@@ -181,7 +181,7 @@ void Test9_2_2(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriCommissionerSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
@@ -226,7 +226,7 @@ void Test9_2_2(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriCommissionerSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
@@ -259,7 +259,7 @@ void Test9_2_2(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriCommissionerSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
@@ -294,7 +294,7 @@ void Test9_2_2(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriCommissionerSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, kInvalidSessionId));
@@ -327,7 +327,7 @@ void Test9_2_2(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriCommissionerSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));

--- a/tests/nexus/test_1_1_9_2_4.cpp
+++ b/tests/nexus/test_1_1_9_2_4.cpp
@@ -338,7 +338,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriActiveSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
@@ -395,7 +395,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveGet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriActiveGet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));
@@ -440,7 +440,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriActiveSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
@@ -504,7 +504,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriActiveSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
@@ -573,7 +573,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriActiveSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
@@ -639,7 +639,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriActiveSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
@@ -701,7 +701,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriActiveSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, kInvalidSessionId));
@@ -762,7 +762,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriActiveSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
@@ -824,7 +824,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriActiveSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
@@ -888,7 +888,7 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriActiveSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));

--- a/tests/nexus/test_1_1_9_2_6.cpp
+++ b/tests/nexus/test_1_1_9_2_6.cpp
@@ -209,7 +209,7 @@ void Test9_2_6(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriCommissionerSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
@@ -294,7 +294,7 @@ void Test9_2_6(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriActiveSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriActiveSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));
@@ -496,7 +496,7 @@ void Test9_2_6(void)
 
     {
         Tmf::Agent    &agent   = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message = agent.NewPriorityConfirmablePostMessage(kUriPendingSet);
+        Coap::Message *message = agent.AllocateAndInitPriorityConfirmablePostMessage(kUriPendingSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, sessionId));

--- a/tests/nexus/test_1_1_9_2_7.cpp
+++ b/tests/nexus/test_1_1_9_2_7.cpp
@@ -272,7 +272,7 @@ void Test9_2_7(void)
         MeshCoP::Dataset       dataset;
         MeshCoP::Dataset::Info datasetInfo;
 
-        message = agent.NewPriorityConfirmablePostMessage(ot::kUriActiveSet);
+        message = agent.AllocateAndInitPriorityConfirmablePostMessage(ot::kUriActiveSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(router.Get<MeshCoP::ActiveDatasetManager>().Read(dataset));
@@ -399,7 +399,7 @@ void Test9_2_7(void)
         MeshCoP::Timestamp timestamp;
         timestamp.Clear();
 
-        message = agent.NewPriorityConfirmablePostMessage(ot::kUriPendingSet);
+        message = agent.AllocateAndInitPriorityConfirmablePostMessage(ot::kUriPendingSet);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(router.Get<MeshCoP::ActiveDatasetManager>().Read(dataset));
@@ -523,7 +523,7 @@ void Test9_2_7(void)
      */
     {
         Tmf::Agent    &agent     = commissioner.Get<Tmf::Agent>();
-        Coap::Message *message   = agent.NewPriorityConfirmablePostMessage(ot::kUriPendingSet);
+        Coap::Message *message   = agent.AllocateAndInitPriorityConfirmablePostMessage(ot::kUriPendingSet);
         uint16_t       sessionId = commissioner.Get<MeshCoP::Commissioner>().GetSessionId();
 
         VerifyOrQuit(message != nullptr);

--- a/tests/nexus/test_border_admitter.cpp
+++ b/tests/nexus/test_border_admitter.cpp
@@ -466,7 +466,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send an `EnrollerRegister` message from `enroller` to `admitter`");
 
-    message = enroller.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerRegister);
+    message = enroller.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerRegister);
     VerifyOrQuit(message != nullptr);
 
     mode = MeshCoP::EnrollerModeTlv::kForwardJoinerRelayRx | MeshCoP::EnrollerModeTlv::kForwardUdpProxyRx;
@@ -559,7 +559,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send an `EnrollerKeepAlive` message");
 
-    message = enroller.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
+    message = enroller.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
     VerifyOrQuit(message != nullptr);
 
     SuccessOrQuit(Tlv::Append<MeshCoP::StateTlv>(*message, MeshCoP::StateTlv::kAccept));
@@ -606,7 +606,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send an `EnrollerKeepAlive` message with an Enroller Mode TLV changing the mode");
 
-    message = enroller.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
+    message = enroller.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
     VerifyOrQuit(message != nullptr);
 
     mode = MeshCoP::EnrollerModeTlv::kForwardJoinerRelayRx;
@@ -645,7 +645,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send an `EnrollerKeepAlive` message with Steering Data TLV");
 
-    message = enroller.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
+    message = enroller.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
     VerifyOrQuit(message != nullptr);
 
     SuccessOrQuit(steeringData.Init(MeshCoP::SteeringData::kMaxLength));
@@ -737,7 +737,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Register as enroller again");
 
-    message = enroller.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerRegister);
+    message = enroller.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerRegister);
     VerifyOrQuit(message != nullptr);
 
     SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerId));
@@ -785,7 +785,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
     VerifyOrQuit(admitter.Get<Admitter>().IsPrimeAdmitter());
     VerifyOrQuit(admitter.Get<Admitter>().IsActiveCommissioner());
 
-    message = enroller.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
+    message = enroller.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
     VerifyOrQuit(message != nullptr);
 
     SuccessOrQuit(Tlv::Append<MeshCoP::StateTlv>(*message, MeshCoP::StateTlv::kReject));
@@ -811,7 +811,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Register as enroller again");
 
-    message = enroller.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerRegister);
+    message = enroller.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerRegister);
     VerifyOrQuit(message != nullptr);
 
     SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerId));
@@ -842,7 +842,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send an `EnrollerRegister` message while already registered, with different parameters");
 
-    message = enroller.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerRegister);
+    message = enroller.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerRegister);
     VerifyOrQuit(message != nullptr);
 
     mode = 0;
@@ -909,7 +909,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send an invalid `EnrollerKeepAlive` message without State TLV and validate that it is rejected");
 
-    message = enroller.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
+    message = enroller.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
     VerifyOrQuit(message != nullptr);
 
     responseContext.Clear();
@@ -947,7 +947,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
 
     for (uint16_t testIter = 0; testIter < 3; testIter++)
     {
-        message = enroller.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerRegister);
+        message = enroller.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerRegister);
         VerifyOrQuit(message != nullptr);
 
         // Skip one of the required TLVs for each `testIter`.
@@ -1000,7 +1000,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
         SuccessOrQuit(steeringData.Init(length));
         SuccessOrQuit(steeringData.UpdateBloomFilter(admitter.Get<Mac::Mac>().GetExtAddress()));
 
-        message = enroller.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerRegister);
+        message = enroller.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerRegister);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerId));
@@ -1026,7 +1026,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
 
     SuccessOrQuit(steeringData.Init(1));
 
-    message = enroller.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerRegister);
+    message = enroller.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerRegister);
     VerifyOrQuit(message != nullptr);
 
     SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerId));
@@ -1145,7 +1145,7 @@ void TestBorderAdmitterCommissionerConflictAndPetitionerRetry(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send an `EnrollerRegister` message from `enroller` to `admitter`");
 
-    message = enroller.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerRegister);
+    message = enroller.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerRegister);
     VerifyOrQuit(message != nullptr);
 
     mode = MeshCoP::EnrollerModeTlv::kForwardJoinerRelayRx | MeshCoP::EnrollerModeTlv::kForwardUdpProxyRx;
@@ -1243,7 +1243,7 @@ void TestBorderAdmitterCommissionerConflictAndPetitionerRetry(void)
     {
         nexus.AdvanceTime(20 * Time::kOneSecondInMsec);
 
-        message = enroller.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
+        message = enroller.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::StateTlv>(*message, MeshCoP::StateTlv::kAccept));
@@ -1457,7 +1457,8 @@ void TestBorderAdmitterMultipleEnrollers(void)
 
     for (uint8_t i = 0; i < kNumEnrollers; i++)
     {
-        message = enrollers[i]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerRegister);
+        message =
+            enrollers[i]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerRegister);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerIds[i]));
@@ -1539,7 +1540,8 @@ void TestBorderAdmitterMultipleEnrollers(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send a keep alive from first enroller with reject status (to unregister the enroller)");
 
-    message = enrollers[0]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
+    message =
+        enrollers[0]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
     VerifyOrQuit(message != nullptr);
 
     SuccessOrQuit(Tlv::Append<MeshCoP::StateTlv>(*message, MeshCoP::StateTlv::kReject));
@@ -1605,7 +1607,8 @@ void TestBorderAdmitterMultipleEnrollers(void)
 
     for (uint8_t i = 2; i < kNumEnrollers; i++)
     {
-        message = enrollers[i]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
+        message =
+            enrollers[i]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::StateTlv>(*message, MeshCoP::StateTlv::kAccept));
@@ -1779,7 +1782,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
 
     for (uint8_t i = 0; i < kNumEnrollers; i++)
     {
-        message = enrollers[i]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerRegister);
+        message =
+            enrollers[i]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerRegister);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerIds[i]));
@@ -1901,7 +1905,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send an `EnrollerJoinerAccept` message from `enrollers[0]` to `admitter` accepting `joiners[0]`");
 
-    message = enrollers[0]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerJoinerAccept);
+    message =
+        enrollers[0]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerJoinerAccept);
     VerifyOrQuit(message != nullptr);
 
     SuccessOrQuit(Tlv::Append<MeshCoP::JoinerIidTlv>(*message, joinerIids[0]));
@@ -2040,7 +2045,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
 
     for (uint8_t i = 0; i < kNumEnrollers; i++)
     {
-        message = enrollers[i]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
+        message =
+            enrollers[i]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::StateTlv>(*message, MeshCoP::StateTlv::kAccept));
@@ -2062,7 +2068,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send an `EnrollerJoinerAccept` message from `enrollers[0]` to `admitter` accepting `joiners[1]`");
 
-    message = enrollers[0]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerJoinerAccept);
+    message =
+        enrollers[0]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerJoinerAccept);
     VerifyOrQuit(message != nullptr);
 
     SuccessOrQuit(Tlv::Append<MeshCoP::JoinerIidTlv>(*message, joinerIids[1]));
@@ -2174,7 +2181,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("From `enrollers[1]` send `EnrollerJoinerAccept` for `joiners[1]`");
 
-    message = enrollers[1]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerJoinerAccept);
+    message =
+        enrollers[1]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerJoinerAccept);
     VerifyOrQuit(message != nullptr);
 
     SuccessOrQuit(Tlv::Append<MeshCoP::JoinerIidTlv>(*message, joinerIids[1]));
@@ -2288,7 +2296,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send an `EnrollerJoinerAccept` message again accepting `joiners[1]` from `enrollers[0]`");
 
-    message = enrollers[0]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerJoinerAccept);
+    message =
+        enrollers[0]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerJoinerAccept);
     VerifyOrQuit(message != nullptr);
 
     SuccessOrQuit(Tlv::Append<MeshCoP::JoinerIidTlv>(*message, joinerIids[1]));
@@ -2354,7 +2363,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send an `EnrollerJoinerRelease` message from `enrollers[0]` to `admitter` releasing `joiners[0]`");
 
-    message = enrollers[0]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerJoinerRelease);
+    message =
+        enrollers[0]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerJoinerRelease);
     VerifyOrQuit(message != nullptr);
 
     SuccessOrQuit(Tlv::Append<MeshCoP::JoinerIidTlv>(*message, joinerIids[0]));
@@ -2402,7 +2412,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send an `EnrollerJoinerRelease` message again releasing `joiners[0]` from `enrollers[0]`");
 
-    message = enrollers[0]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerJoinerRelease);
+    message =
+        enrollers[0]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerJoinerRelease);
     VerifyOrQuit(message != nullptr);
 
     SuccessOrQuit(Tlv::Append<MeshCoP::JoinerIidTlv>(*message, joinerIids[0]));
@@ -2421,7 +2432,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send an `EnrollerJoinerRelease` message releasing `joiners[1]` from `enrollers[0]`");
 
-    message = enrollers[0]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerJoinerRelease);
+    message =
+        enrollers[0]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerJoinerRelease);
     VerifyOrQuit(message != nullptr);
 
     SuccessOrQuit(Tlv::Append<MeshCoP::JoinerIidTlv>(*message, joinerIids[1]));
@@ -2440,7 +2452,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
 
     for (uint8_t j = 0; j < 2; j++)
     {
-        message = enrollers[2]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerJoinerAccept);
+        message = enrollers[2]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(
+            kUriEnrollerJoinerAccept);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::JoinerIidTlv>(*message, joinerIids[j]));
@@ -2508,7 +2521,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send an `EnrollerJoinerRelease` message from `enrollers[2]` with wildcard IID releasing all joiners");
 
-    message = enrollers[2]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerJoinerRelease);
+    message =
+        enrollers[2]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerJoinerRelease);
     VerifyOrQuit(message != nullptr);
 
     wildcardJoinerIid.Clear();
@@ -2546,7 +2560,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send an invalid `EnrollerJoinerAccept` message from enrollers[2] with wildcard IID");
 
-    message = enrollers[2]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerJoinerAccept);
+    message =
+        enrollers[2]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerJoinerAccept);
     VerifyOrQuit(message != nullptr);
 
     wildcardJoinerIid.Clear();
@@ -2568,7 +2583,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
 
     for (uint8_t j = 0; j < 2; j++)
     {
-        message = enrollers[2]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerJoinerAccept);
+        message = enrollers[2]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(
+            kUriEnrollerJoinerAccept);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::JoinerIidTlv>(*message, joinerIids[j]));
@@ -2644,7 +2660,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
 
         for (uint8_t i = 0; i < kNumEnrollers; i++)
         {
-            message = enrollers[i]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
+            message = enrollers[i]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(
+                kUriEnrollerKeepAlive);
             VerifyOrQuit(message != nullptr);
 
             SuccessOrQuit(Tlv::Append<MeshCoP::StateTlv>(*message, MeshCoP::StateTlv::kAccept));
@@ -2834,7 +2851,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
 
         for (uint8_t i = 0; i < kNumEnrollers; i++)
         {
-            message = enrollers[i]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
+            message = enrollers[i]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(
+                kUriEnrollerKeepAlive);
             VerifyOrQuit(message != nullptr);
 
             SuccessOrQuit(Tlv::Append<MeshCoP::StateTlv>(*message, MeshCoP::StateTlv::kAccept));
@@ -2895,7 +2913,8 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
 
         for (uint8_t i = 0; i < kNumEnrollers; i++)
         {
-            message = enrollers[i]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerKeepAlive);
+            message = enrollers[i]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(
+                kUriEnrollerKeepAlive);
             VerifyOrQuit(message != nullptr);
 
             SuccessOrQuit(Tlv::Append<MeshCoP::StateTlv>(*message, MeshCoP::StateTlv::kAccept));
@@ -3048,7 +3067,8 @@ void TestBorderAdmitterForwardingUdpProxy(void)
 
     for (uint8_t i = 0; i < kNumEnrollers; i++)
     {
-        message = enrollers[i]->Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriEnrollerRegister);
+        message =
+            enrollers[i]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnrollerRegister);
         VerifyOrQuit(message != nullptr);
 
         SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerIds[i]));
@@ -3116,7 +3136,7 @@ void TestBorderAdmitterForwardingUdpProxy(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Prepare a `DiagnosticGetQuery` message");
 
-    diagMessage = enrollers[0]->Get<Tmf::Agent>().NewNonConfirmablePostMessage(kUriDiagnosticGetQuery);
+    diagMessage = enrollers[0]->Get<Tmf::Agent>().AllocateAndInitNonConfirmablePostMessage(kUriDiagnosticGetQuery);
     VerifyOrQuit(diagMessage != nullptr);
     SuccessOrQuit(Tlv::Append<NetworkDiagnostic::TypeListTlv>(*diagMessage, kDiagTlvs, sizeof(kDiagTlvs)));
     diagMessage->WriteMessageId(0);
@@ -3124,7 +3144,7 @@ void TestBorderAdmitterForwardingUdpProxy(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Embed the `DiagnosticGetQuery` into `ProxyTx` message and send it from `enrollers[0]`");
 
-    message = enrollers[0]->Get<Tmf::SecureAgent>().NewPriorityNonConfirmablePostMessage(kUriProxyTx);
+    message = enrollers[0]->Get<Tmf::SecureAgent>().AllocateAndInitPriorityNonConfirmablePostMessage(kUriProxyTx);
     VerifyOrQuit(message != nullptr);
 
     udpEncapHeader.SetSourcePort(Tmf::kUdpPort);

--- a/tests/nexus/test_border_agent.cpp
+++ b/tests/nexus/test_border_agent.cpp
@@ -164,7 +164,7 @@ void TestBorderAgent(void)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     Log("Send `Commissioner Petition` TMF command to become full commissioner");
 
-    message = node1.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriCommissionerPetition);
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerPetition);
     VerifyOrQuit(message != nullptr);
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
     SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SendMessage(*message));
@@ -194,7 +194,7 @@ void TestBorderAgent(void)
     VerifyOrQuit(sessionInfo.mIsCommissioner);
     VerifyOrQuit(iter.GetNextSessionInfo(sessionInfo) == kErrorNotFound);
 
-    message = node1.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriCommissionerKeepAlive);
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerKeepAlive);
     VerifyOrQuit(message != nullptr);
     SuccessOrQuit(Tlv::Append<MeshCoP::StateTlv>(*message, MeshCoP::StateTlv::kAccept));
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
@@ -224,7 +224,7 @@ void TestBorderAgent(void)
 
     VerifyOrQuit(node1.Get<Tmf::SecureAgent>().IsConnected());
 
-    message = node1.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriCommissionerPetition);
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerPetition);
     VerifyOrQuit(message != nullptr);
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
     SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SendMessage(*message));
@@ -968,7 +968,7 @@ void TestHistoryTrackerBorderAgentEpskcEvent(void)
     epskcEvent = GetNewestEpskcEvent(node0);
     VerifyOrQuit(epskcEvent == OT_HISTORY_TRACKER_BORDER_AGENT_EPSKC_EVENT_CONNECTED);
 
-    message = node1.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriCommissionerPetition);
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerPetition);
     VerifyOrQuit(message != nullptr);
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
     SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SendMessage(*message));
@@ -1000,7 +1000,7 @@ void TestHistoryTrackerBorderAgentEpskcEvent(void)
     epskcEvent = GetNewestEpskcEvent(node0);
     VerifyOrQuit(epskcEvent == OT_HISTORY_TRACKER_BORDER_AGENT_EPSKC_EVENT_CONNECTED);
 
-    message = node1.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriCommissionerPetition);
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerPetition);
     VerifyOrQuit(message != nullptr);
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
     SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SendMessage(*message));
@@ -1009,7 +1009,7 @@ void TestHistoryTrackerBorderAgentEpskcEvent(void)
     epskcEvent = GetNewestEpskcEvent(node0);
     VerifyOrQuit(epskcEvent == OT_HISTORY_TRACKER_BORDER_AGENT_EPSKC_EVENT_PETITIONED);
 
-    message = node1.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriActiveGet);
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriActiveGet);
     VerifyOrQuit(message != nullptr);
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
     SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SendMessage(*message));
@@ -1041,7 +1041,7 @@ void TestHistoryTrackerBorderAgentEpskcEvent(void)
     epskcEvent = GetNewestEpskcEvent(node0);
     VerifyOrQuit(epskcEvent == OT_HISTORY_TRACKER_BORDER_AGENT_EPSKC_EVENT_CONNECTED);
 
-    message = node1.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriCommissionerPetition);
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerPetition);
     VerifyOrQuit(message != nullptr);
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
     SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SendMessage(*message));
@@ -1050,7 +1050,7 @@ void TestHistoryTrackerBorderAgentEpskcEvent(void)
     epskcEvent = GetNewestEpskcEvent(node0);
     VerifyOrQuit(epskcEvent == OT_HISTORY_TRACKER_BORDER_AGENT_EPSKC_EVENT_PETITIONED);
 
-    message = node1.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriActiveGet);
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriActiveGet);
     VerifyOrQuit(message != nullptr);
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
     SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SendMessage(*message));
@@ -1059,7 +1059,7 @@ void TestHistoryTrackerBorderAgentEpskcEvent(void)
     epskcEvent = GetNewestEpskcEvent(node0);
     VerifyOrQuit(epskcEvent == OT_HISTORY_TRACKER_BORDER_AGENT_EPSKC_EVENT_RETRIEVED_ACTIVE_DATASET);
 
-    message = node1.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriPendingGet);
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriPendingGet);
     VerifyOrQuit(message != nullptr);
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
     SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SendMessage(*message));
@@ -1090,7 +1090,7 @@ void TestHistoryTrackerBorderAgentEpskcEvent(void)
     epskcEvent = GetNewestEpskcEvent(node0);
     VerifyOrQuit(epskcEvent == OT_HISTORY_TRACKER_BORDER_AGENT_EPSKC_EVENT_CONNECTED);
 
-    message = node1.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriCommissionerPetition);
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerPetition);
     VerifyOrQuit(message != nullptr);
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
     SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SendMessage(*message));
@@ -1099,7 +1099,7 @@ void TestHistoryTrackerBorderAgentEpskcEvent(void)
     epskcEvent = GetNewestEpskcEvent(node0);
     VerifyOrQuit(epskcEvent == OT_HISTORY_TRACKER_BORDER_AGENT_EPSKC_EVENT_PETITIONED);
 
-    message = node1.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriActiveGet);
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriActiveGet);
     VerifyOrQuit(message != nullptr);
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
     SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SendMessage(*message));
@@ -1108,7 +1108,7 @@ void TestHistoryTrackerBorderAgentEpskcEvent(void)
     epskcEvent = GetNewestEpskcEvent(node0);
     VerifyOrQuit(epskcEvent == OT_HISTORY_TRACKER_BORDER_AGENT_EPSKC_EVENT_RETRIEVED_ACTIVE_DATASET);
 
-    message = node1.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriPendingGet);
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriPendingGet);
     VerifyOrQuit(message != nullptr);
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
     SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SendMessage(*message));
@@ -1139,7 +1139,7 @@ void TestHistoryTrackerBorderAgentEpskcEvent(void)
     epskcEvent = GetNewestEpskcEvent(node0);
     VerifyOrQuit(epskcEvent == OT_HISTORY_TRACKER_BORDER_AGENT_EPSKC_EVENT_CONNECTED);
 
-    message = node1.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriCommissionerPetition);
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerPetition);
     VerifyOrQuit(message != nullptr);
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
     SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SendMessage(*message));
@@ -1154,7 +1154,8 @@ void TestHistoryTrackerBorderAgentEpskcEvent(void)
         {
             break;
         }
-        message = node1.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriCommissionerKeepAlive);
+        message =
+            node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerKeepAlive);
         VerifyOrQuit(message != nullptr);
         SuccessOrQuit(Tlv::Append<MeshCoP::StateTlv>(*message, MeshCoP::StateTlv::kAccept));
         SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
@@ -1165,7 +1166,7 @@ void TestHistoryTrackerBorderAgentEpskcEvent(void)
         VerifyOrQuit(epskcEvent == OT_HISTORY_TRACKER_BORDER_AGENT_EPSKC_EVENT_KEEP_ALIVE);
     }
 
-    message = node1.Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriCommissionerKeepAlive);
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerKeepAlive);
     VerifyOrQuit(message != nullptr);
     SuccessOrQuit(Tlv::Append<MeshCoP::StateTlv>(*message, MeshCoP::StateTlv::kAccept));
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));


### PR DESCRIPTION
This commit updates the names of several message allocation methods in `CoapBase` to `AllocateAndInit*()`. This change helps to clearly differentiate these methods from the `NewPriorityMessage()` and `NetMessage()` overloads, which only allocate a new `Message`.

In contrast, the `AllocateAndInit` methods allocate the message and fully prepare it by initializing the CoAP header, appending the URI path option, the payload marker, leaving it ready for the payload. This change clarifies the design by explicitly indicating that these methods perform extra setup work.

All calls to these methods throughout the codebase have been updated to reflect the new names.