### PR TITLE
[coap] add new `AllocateAndInitPostMessageTo()` helper methods

### DIFF
--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -632,10 +632,8 @@ Error Manager::SendBackboneAnswer(const Ip6::Address             &aDstAddr,
     Coap::Message   *message = nullptr;
     Ip6::MessageInfo messageInfo;
 
-    VerifyOrExit((message = mBackboneTmfAgent.NewPriorityMessage()) != nullptr, error = kErrorNoBufs);
-
-    SuccessOrExit(error = message->InitAsPost(aDstAddr, kUriBackboneAnswer));
-    SuccessOrExit(error = message->AppendPayloadMarker());
+    message = mBackboneTmfAgent.AllocateAndInitPriorityPostMessageTo(kUriBackboneAnswer, aDstAddr);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, aDua));
 

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -183,6 +183,16 @@ Message *CoapBase::AllocateAndInitNonConfirmablePostMessage(Uri aUri)
     return InitMessage(NewMessage(), kTypeNonConfirmable, aUri);
 }
 
+Message *CoapBase::AllocateAndInitPostMessageTo(Uri aUri, const Ip6::Address &aDestination)
+{
+    return InitMessage(NewMessage(), aDestination.IsMulticast() ? kTypeNonConfirmable : kTypeConfirmable, aUri);
+}
+
+Message *CoapBase::AllocateAndInitPriorityPostMessageTo(Uri aUri, const Ip6::Address &aDestination)
+{
+    return InitMessage(NewPriorityMessage(), aDestination.IsMulticast() ? kTypeNonConfirmable : kTypeConfirmable, aUri);
+}
+
 Message *CoapBase::AllocateAndInitPriorityResponseFor(const Message &aRequest)
 {
     return InitResponse(NewPriorityMessage(), aRequest);

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -397,8 +397,7 @@ public:
     Message *AllocateAndInitConfirmablePostMessage(Uri aUri);
 
     /**
-     * Allocates and initializes a new CoAP Non-confirmable Post message with Network Control priority
-     * level.
+     * Allocates and initializes a new CoAP Non-confirmable Post message with Network Control priority level.
      *
      * The CoAP header is initialized as `kTypeNonConfirmable` and `kCodePost` with a given URI and a randomly
      * generated token (of default length). This method also sets the payload marker (calling `AppendPayloadMarker()`).
@@ -424,6 +423,42 @@ public:
      * @returns A pointer to the message or `nullptr` if failed to allocate message.
      */
     Message *AllocateAndInitNonConfirmablePostMessage(Uri aUri);
+
+    /**
+     * Allocates and initializes a new CoAP Post message with normal priority level.
+     *
+     * If the provided @p aDestination address is multicast, the message will be Non-Confirmable. Otherwise, it will be
+     * Confirmable.
+     *
+     * The CoAP header is initialized as either `kTypeNonConfirmable` or `kTypeConfirmable` and `kCodePost` with the
+     * given URI and a randomly generated token (of default length). This method also sets the payload marker (calling
+     * `AppendPayloadMarker()`). Even if the message has no payload, calling `AppendPayloadMarker()` is harmless, since
+     * `SendMessage()` will check and remove the payload marker when there is no payload.
+     *
+     * @param[in] aUri         The URI.
+     * @param[in] aDestination The destination IPv6 address.
+     *
+     * @returns A pointer to the message or `nullptr` if failed to allocate message.
+     */
+    Message *AllocateAndInitPostMessageTo(Uri aUri, const Ip6::Address &aDestination);
+
+    /**
+     * Allocates and initializes a new CoAP Post message with Network Control priority level.
+     *
+     * If the provided @p aDestination address is multicast, the message will be Non-Confirmable. Otherwise, it will be
+     * Confirmable.
+     *
+     * The CoAP header is initialized as either `kTypeNonConfirmable` or `kTypeConfirmable` and `kCodePost` with the
+     * given URI and a randomly generated token (of default length). This method also sets the payload marker (calling
+     * `AppendPayloadMarker()`). Even if the message has no payload, calling `AppendPayloadMarker()` is harmless, since
+     * `SendMessage()` will check and remove the payload marker when there is no payload.
+     *
+     * @param[in] aUri         The URI.
+     * @param[in] aDestination The destination IPv6 address.
+     *
+     * @returns A pointer to the message or `nullptr` if failed to allocate message.
+     */
+    Message *AllocateAndInitPriorityPostMessageTo(Uri aUri, const Ip6::Address &aDestination);
 
     /**
      * Allocates and initializes a new CoAP response message with Network Control priority level for a

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -131,11 +131,6 @@ exit:
     return error;
 }
 
-Error Message::InitAsPost(const Ip6::Address &aDestination, Uri aUri)
-{
-    return Init(aDestination.IsMulticast() ? kTypeNonConfirmable : kTypeConfirmable, kCodePost, aUri);
-}
-
 Error Message::InitAsResponse(Type aType, Code aCode, const Message &aRequest)
 {
     Error error;

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -486,23 +486,6 @@ public:
     Error Init(Type aType, Code aCode, Uri aUri);
 
     /**
-     * Initializes a CoAP POST message, appends a URI Path, and adds a random token.
-     *
-     * This method erases any previously written content in the message.
-     *
-     * The CoAP Type is determined from the destination IPv6 address: `kTypeNonConfirmable` for multicast and
-     * `kTypeConfirmable` otherwise. The Message ID is set to zero. A random token of default length
-     * (`Token::kDefaultLength`) is generated and added.
-     *
-     * @param[in] aDestination  The message destination IPv6 address, used to determine the CoAP Type.
-     * @param[in] aUri          The URI string.
-     *
-     * @retval kErrorNone    Successfully initialized the message and appended the URI-path option.
-     * @retval kErrorNoBufs  Could not grow the message to append the option.
-     */
-    Error InitAsPost(const Ip6::Address &aDestination, Uri aUri);
-
-    /**
      * Initializes a CoAP message as a response to a request message.
      *
      * This method erases any previously written content in the message. The Message ID and Token are copied from the

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -1013,10 +1013,9 @@ Error Commissioner::SendAnnounceBeginRequest(uint32_t            aChannelMask,
     Coap::Message *message = nullptr;
 
     VerifyOrExit(IsActive(), error = kErrorInvalidState);
-    VerifyOrExit((message = Get<Tmf::Agent>().NewPriorityMessage()) != nullptr, error = kErrorNoBufs);
 
-    SuccessOrExit(error = message->InitAsPost(aAddress, kUriAnnounceBegin));
-    SuccessOrExit(error = message->AppendPayloadMarker());
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityPostMessageTo(kUriAnnounceBegin, aAddress);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<CommissionerSessionIdTlv>(*message, GetSessionId()));
 
@@ -1046,10 +1045,9 @@ Error Commissioner::SendEnergyScanQuery(uint32_t                           aChan
     Coap::Message *message = nullptr;
 
     VerifyOrExit(IsActive(), error = kErrorInvalidState);
-    VerifyOrExit((message = Get<Tmf::Agent>().NewPriorityMessage()) != nullptr, error = kErrorNoBufs);
 
-    SuccessOrExit(error = message->InitAsPost(aAddress, kUriEnergyScan));
-    SuccessOrExit(error = message->AppendPayloadMarker());
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityPostMessageTo(kUriEnergyScan, aAddress);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<CommissionerSessionIdTlv>(*message, GetSessionId()));
 
@@ -1103,10 +1101,9 @@ Error Commissioner::SendPanIdQuery(uint16_t                            aPanId,
     Coap::Message *message = nullptr;
 
     VerifyOrExit(IsActive(), error = kErrorInvalidState);
-    VerifyOrExit((message = Get<Tmf::Agent>().NewPriorityMessage()) != nullptr, error = kErrorNoBufs);
 
-    SuccessOrExit(error = message->InitAsPost(aAddress, kUriPanIdQuery));
-    SuccessOrExit(error = message->AppendPayloadMarker());
+    message = Get<Tmf::Agent>().AllocateAndInitPriorityPostMessageTo(kUriPanIdQuery, aAddress);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<CommissionerSessionIdTlv>(*message, GetSessionId()));
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -720,10 +720,8 @@ void AddressResolver::SendAddressError(const Ip6::Address             &aTarget,
     Error          error;
     Coap::Message *message;
 
-    VerifyOrExit((message = Get<Tmf::Agent>().NewMessage()) != nullptr, error = kErrorNoBufs);
-
-    SuccessOrExit(error = message->InitAsPost(aDestination, kUriAddressError));
-    SuccessOrExit(error = message->AppendPayloadMarker());
+    message = Get<Tmf::Agent>().AllocateAndInitPostMessageTo(kUriAddressError, aDestination);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, aTarget));
     SuccessOrExit(error = Tlv::Append<ThreadMeshLocalEidTlv>(*message, aMeshLocalIid));


### PR DESCRIPTION
This commit introduces `AllocateAndInitPostMessageTo()` and `AllocateAndInitPriorityPostMessageTo()` methods in `CoapBase`. These methods simplify the creation of CoAP POST messages by combining the allocation, initialization, and appending of the payload marker into a single call. The message type (Confirmable vs. Non-Confirmable) is automatically determined based on whether the destination address is multicast.

The previous `InitAsPost()` method in `Coap::Message` is removed, and all callers in `BbrManager`, `Commissioner`, and `AddressResolver` are updated to use the new helper methods.