### PR TITLE
[otns] use `Coap::Message::UriPathStringBuffer` in `EmitCoapStatus`

### DIFF
--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -199,10 +199,10 @@ void Otns::EmitCoapStatus(const char             *aAction,
                           const Ip6::MessageInfo &aMessageInfo,
                           Error                  *aError) const
 {
-    Error            error;
-    char             uriPath[Coap::Message::kMaxReceivedUriPath + 1];
-    StatusString     string;
-    Coap::HeaderInfo header;
+    Error                              error;
+    Coap::Message::UriPathStringBuffer uriPath;
+    StatusString                       string;
+    Coap::HeaderInfo                   header;
 
     SuccessOrExit(error = aMessage.ParseHeaderInfo(header));
     SuccessOrExit(error = aMessage.ReadUriPathOptions(uriPath));


### PR DESCRIPTION
This commit updates the `Otns::EmitCoapStatus()` method to use the `Coap::Message::UriPathStringBuffer` typedef for the `uriPath` local variable, replacing an explicit character array definition. This improves code consistency and matches the expected parameter type of the `Coap::Message::ReadUriPathOptions()` method.