### PR TITLE
[coap] simplify URI path parsing in block-wise requests

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -707,6 +707,8 @@ void CoapBase::ProcessReceivedRequest(Msg &aRxMsg)
         ExitNow();
     }
 
+    SuccessOrExit(error = aRxMsg.mMessage.ReadUriPathOptions(uriPath));
+
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
     {
         bool didHandle = false;
@@ -714,8 +716,6 @@ void CoapBase::ProcessReceivedRequest(Msg &aRxMsg)
         SuccessOrExit(error = ProcessBlockwiseRequest(aRxMsg, uriPath, didHandle));
         VerifyOrExit(!didHandle);
     }
-#else
-    SuccessOrExit(error = aRxMsg.mMessage.ReadUriPathOptions(uriPath));
 #endif
 
     if ((mResourceHandler != nullptr) && mResourceHandler(*this, uriPath, aRxMsg))
@@ -896,11 +896,10 @@ exit:
     return error;
 }
 
-Error CoapBase::ProcessBlockwiseRequest(Msg &aRxMsg, Message::UriPathStringBuffer &aUriPath, bool &aDidHandle)
+Error CoapBase::ProcessBlockwiseRequest(Msg &aRxMsg, const Message::UriPathStringBuffer &aUriPath, bool &aDidHandle)
 {
     Error            error = kErrorNone;
     Option::Iterator iterator;
-    char            *curUriPath        = aUriPath;
     uint8_t          blockOptionType   = 0;
     uint32_t         totalTransferSize = 0;
 
@@ -910,18 +909,6 @@ Error CoapBase::ProcessBlockwiseRequest(Msg &aRxMsg, Message::UriPathStringBuffe
     {
         switch (iterator.GetOption()->GetNumber())
         {
-        case kOptionUriPath:
-            if (curUriPath != aUriPath)
-            {
-                *curUriPath++ = '/';
-            }
-
-            VerifyOrExit(curUriPath + iterator.GetOption()->GetLength() < GetArrayEnd(aUriPath), error = kErrorParse);
-
-            IgnoreError(iterator.ReadOptionValue(curUriPath));
-            curUriPath += iterator.GetOption()->GetLength();
-            break;
-
         case kOptionBlock1:
             blockOptionType += 1;
             break;
@@ -941,8 +928,6 @@ Error CoapBase::ProcessBlockwiseRequest(Msg &aRxMsg, Message::UriPathStringBuffe
 
         SuccessOrExit(error = iterator.Advance());
     }
-
-    curUriPath[0] = kNullChar;
 
     for (const ResourceBlockWise &resource : mBlockWiseResources)
     {

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -929,7 +929,7 @@ private:
 
     Error ProcessBlockwiseSend(Msg &aMsg, const SendCallbacks &aCallbacks);
     Error ProcessBlockwiseResponse(Msg &aRxMsg, Request &aRequest);
-    Error ProcessBlockwiseRequest(Msg &aRxMsg, Message::UriPathStringBuffer &aUriPath, bool &aDidHandle);
+    Error ProcessBlockwiseRequest(Msg &aRxMsg, const Message::UriPathStringBuffer &aUriPath, bool &aDidHandle);
     void  FreeLastBlockResponse(void);
     Error CacheLastBlockResponse(Message *aResponse);
     Error PrepareNextBlockRequest(uint16_t         aBlockOptionNumber,


### PR DESCRIPTION
This commit simplifies the handling of URI paths during the processing of block-wise CoAP requests, effectively removing duplicated code.

Previously, `CoapBase::ProcessBlockwiseRequest()` manually iterated through CoAP options to parse and construct the URI path string. This logic was redundant as the same functionality is provided by the `Message::ReadUriPathOptions()` method.

By calling `ReadUriPathOptions()` earlier in the request processing flow within `CoapBase::ProcessReceivedRequest()`, we can populate the `uriPath` string buffer and simply pass it down. Consequently, the `aUriPath` parameter in `ProcessBlockwiseRequest()` has been updated to a `const Message::UriPathStringBuffer &` to reflect its new role as a read-only input. This change leads to cleaner, more cohesive code.