### PR TITLE
[coap] update `GetType()` to return `Type` enum instead of `uint8_t`

### DIFF
--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -279,7 +279,7 @@ public:
      *
      * @returns The Type value.
      */
-    uint8_t GetType(void) const { return mType; }
+    Type GetType(void) const { return mType; }
 
     /**
      * Returns the Code value.
@@ -418,7 +418,7 @@ public:
     bool RequireResetOnError(void) { return IsConfirmable() || IsNonConfirmable(); }
 
 private:
-    uint8_t  mType;
+    Type     mType;
     uint8_t  mCode;
     uint16_t mMessageId;
     Token    mToken;
@@ -878,7 +878,7 @@ private:
 
         uint8_t  GetVersion(void) const { return ReadBits<uint8_t, kVersionMask>(mVersionTypeToken); }
         void     SetVersion(uint8_t aVersion) { WriteBits<uint8_t, kVersionMask>(mVersionTypeToken, aVersion); }
-        uint8_t  GetType(void) const { return ReadBits<uint8_t, kTypeMask>(mVersionTypeToken); }
+        Type     GetType(void) const { return static_cast<Type>(ReadBits<uint8_t, kTypeMask>(mVersionTypeToken)); }
         void     SetType(Type aType) { WriteBits<uint8_t, kTypeMask>(mVersionTypeToken, aType); }
         uint8_t  GetCode(void) const { return mCode; }
         void     SetCode(Code aCode) { mCode = aCode; }


### PR DESCRIPTION
Update the `GetType()` methods to return the `Type` enumeration instead of a raw `uint8_t`. This improves type safety and clarifies the return type for callers. The `mType` member variable is also updated from `uint8_t` to `Type`.

Generally, when parsing header fields, we do not map the value directly to an `enum` since the enum may not cover all possible values present in a received header. However, in this case, the `Type` field in the CoAP header is a 2-bit value, and all four possible values are explicitly defined and accounted for in the `Type` enumeration. Therefore, we can safely cast the read bits to the `Type` enum.