### PR TITLE
[energy-scan] protect server state on allocation failure

### DIFF
--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -52,11 +52,12 @@ EnergyScanServer::EnergyScanServer(Instance &aInstance)
 
 template <> void EnergyScanServer::HandleTmf<kUriEnergyScan>(Coap::Msg &aMsg)
 {
-    uint8_t      count;
-    uint16_t     period;
-    uint16_t     scanDuration;
-    uint32_t     mask;
-    MeshCoP::Tlv tlv;
+    OwnedPtr<Coap::Message> newMessage;
+    uint8_t                 count;
+    uint16_t                period;
+    uint16_t                scanDuration;
+    uint32_t                mask;
+    MeshCoP::Tlv            tlv;
 
     VerifyOrExit(aMsg.IsPostRequest());
 
@@ -69,13 +70,13 @@ template <> void EnergyScanServer::HandleTmf<kUriEnergyScan>(Coap::Msg &aMsg)
     SuccessOrExit(MeshCoP::ChannelMaskTlv::FindIn(aMsg.mMessage, mask));
     VerifyOrExit(mask != 0);
 
-    mReportMessage.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnergyReport));
-    VerifyOrExit(mReportMessage != nullptr);
+    newMessage.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnergyReport));
+    VerifyOrExit(newMessage != nullptr);
 
-    SuccessOrExit(MeshCoP::ChannelMaskTlv::AppendTo(*mReportMessage, mask));
+    SuccessOrExit(MeshCoP::ChannelMaskTlv::AppendTo(*newMessage, mask));
 
     tlv.SetType(MeshCoP::Tlv::kEnergyList);
-    SuccessOrExit(mReportMessage->Append(tlv));
+    SuccessOrExit(newMessage->Append(tlv));
 
     mNumScanResults     = 0;
     mChannelMask        = mask;
@@ -83,14 +84,16 @@ template <> void EnergyScanServer::HandleTmf<kUriEnergyScan>(Coap::Msg &aMsg)
     mCount              = count;
     mPeriod             = period;
     mScanDuration       = scanDuration;
+    mCommissioner       = aMsg.mMessageInfo.GetPeerAddr();
+
+    mReportMessage = newMessage.PassOwnership();
     mTimer.Start(kScanDelay);
 
-    mCommissioner = aMsg.mMessageInfo.GetPeerAddr();
+    LogInfo("Received %s", UriToString<kUriEnergyScan>());
 
     if (aMsg.IsConfirmable() && !aMsg.mMessageInfo.GetSockAddr().IsMulticast())
     {
         SuccessOrExit(Get<Tmf::Agent>().SendAckResponse(aMsg));
-        LogInfo("Sent %s ack", UriToString<kUriEnergyScan>());
     }
 
 exit:


### PR DESCRIPTION
This commit updates `EnergyScanServer::HandleTmf<kUriEnergyScan>()` to use a local `OwnedPtr<Coap::Message>` when allocating and preparing the initial energy report message. Previously, the method directly modified `mReportMessage`, potentially leaving the object in an inconsistent state or leaking memory if subsequent `Append()` operations failed and exited early.

By building the message in a local `newMessage` first and only taking ownership using `PassOwnership()` after all operations succeed, we ensure the server's internal state remains consistent.