### PR TITLE
[energy-scan] use `Tlv::StartTlv()` and `Tlv::EndTlv()`

### DIFF
--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -57,7 +57,6 @@ template <> void EnergyScanServer::HandleTmf<kUriEnergyScan>(Coap::Msg &aMsg)
     uint16_t                period;
     uint16_t                scanDuration;
     uint32_t                mask;
-    MeshCoP::Tlv            tlv;
 
     SuccessOrExit(Tlv::Find<MeshCoP::CountTlv>(aMsg.mMessage, count));
     count = Clamp(count, kMinCount, kMaxCount);
@@ -73,10 +72,8 @@ template <> void EnergyScanServer::HandleTmf<kUriEnergyScan>(Coap::Msg &aMsg)
 
     SuccessOrExit(MeshCoP::ChannelMaskTlv::AppendTo(*newMessage, mask));
 
-    tlv.SetType(MeshCoP::Tlv::kEnergyList);
-    SuccessOrExit(newMessage->Append(tlv));
+    SuccessOrExit(Tlv::StartTlv(*newMessage, MeshCoP::Tlv::kEnergyList, mEnergyListTlvBookmark));
 
-    mNumScanResults     = 0;
     mChannelMask        = mask;
     mChannelMaskCurrent = mChannelMask;
     mCount              = count;
@@ -102,7 +99,7 @@ void EnergyScanServer::HandleTimer(void)
 {
     VerifyOrExit(mReportMessage != nullptr);
 
-    if (mCount)
+    if (mCount != 0)
     {
         // grab the lowest channel to scan
         uint32_t channelMask = mChannelMaskCurrent & ~(mChannelMaskCurrent - 1);
@@ -134,17 +131,6 @@ void EnergyScanServer::HandleScanResult(Mac::EnergyScanResult *aResult)
             mReportMessage.Free();
             ExitNow();
         }
-
-        mNumScanResults++;
-
-        if (mNumScanResults == NumericLimits<uint8_t>::kMax)
-        {
-            // If we reach the max length that fit in the Energy List
-            // TLV we send the current set of energy scan data.
-
-            mCount = 0;
-            mTimer.Start(kReportDelay);
-        }
     }
     else
     {
@@ -157,14 +143,7 @@ void EnergyScanServer::HandleScanResult(Mac::EnergyScanResult *aResult)
             mCount--;
         }
 
-        if (mCount)
-        {
-            mTimer.Start(mPeriod);
-        }
-        else
-        {
-            mTimer.Start(kReportDelay);
-        }
+        mTimer.Start((mCount > 0) ? mPeriod : kReportDelay);
     }
 
 exit:
@@ -173,12 +152,9 @@ exit:
 
 void EnergyScanServer::SendReport(void)
 {
-    Error    error = kErrorNone;
-    uint16_t offset;
+    Error error;
 
-    // Update the Energy List TLV length in Report message
-    offset = mReportMessage->GetLength() - mNumScanResults - sizeof(uint8_t);
-    mReportMessage->Write(offset, mNumScanResults);
+    SuccessOrExit(error = Tlv::EndTlv(*mReportMessage, mEnergyListTlvBookmark));
 
     SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*mReportMessage, mCommissioner));
     mReportMessage.Release();

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -88,7 +88,7 @@ private:
     uint16_t                mPeriod;
     uint16_t                mScanDuration;
     uint8_t                 mCount;
-    uint8_t                 mNumScanResults;
+    Tlv::Bookmark           mEnergyListTlvBookmark;
     OwnedPtr<Coap::Message> mReportMessage;
     ScanTimer               mTimer;
 };


### PR DESCRIPTION
This commit updates `EnergyScanServer` to use `Tlv::StartTlv()` and `Tlv::EndTlv()` when constructing the Energy List TLV for the report message. By leveraging a `Tlv::Bookmark` (`mEnergyListTlvBookmark`), the server no longer needs to manually track the number of scan results (`mNumScanResults`) and calculate the exact offset to update the TLV length.

Furthermore, `Tlv::EndTlv()` automatically manages the conversion to an Extended TLV if the payload size exceeds the maximum length of a standard TLV.