### PR TITLE
[coap] add `SendAckResponseIfUnicastRequest()`

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -420,6 +420,19 @@ Error CoapBase::SendAckResponse(const Msg &aRxMsg, Code aCode)
 
 Error CoapBase::SendAckResponse(const Msg &aRxMsg) { return SendAckResponse(aRxMsg, kCodeChanged); }
 
+Error CoapBase::SendAckResponseIfUnicastRequest(const Msg &aRxMsg, Error aError)
+{
+    Error error;
+
+    VerifyOrExit(aRxMsg.IsConfirmable(), error = kErrorInvalidArgs);
+    VerifyOrExit(!aRxMsg.mMessageInfo.GetSockAddr().IsMulticast(), error = kErrorInvalidArgs);
+
+    error = SendResponse(Message::MapErrorToCoapCode(aError), aRxMsg);
+
+exit:
+    return error;
+}
+
 Error CoapBase::SendEmptyMessage(Type aType, const Msg &aRxMsg)
 {
     Error    error   = kErrorNone;

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -651,6 +651,22 @@ public:
     Error SendAckResponse(const Msg &aRxMsg);
 
     /**
+     * Sends a CoAP ACK response without a payload mapping an `Error` to a CoAP Code.
+     *
+     * This method strictly ensures the @p aRxMsg is a confirmable request message and the request was not sent to
+     * a multicast address. It then sends a piggybacked ACK (`kTypeAck`) response containing a CoAP Code mapped
+     * from @p aError and matching token without a payload.
+     *
+     * @param[in]  aRxMsg          The received CoAP request message.
+     * @param[in]  aError          The error to map to a CoAP Code.
+     *
+     * @retval kErrorNone          Successfully enqueued the CoAP response message.
+     * @retval kErrorNoBufs        Insufficient buffers available to send the CoAP response.
+     * @retval kErrorInvalidArgs   The @p aRxMsg is not a confirmable request or was sent to a multicast address.
+     */
+    Error SendAckResponseIfUnicastRequest(const Msg &aRxMsg, Error aError);
+
+    /**
      * Aborts CoAP transactions associated with given handler and context.
      *
      * The associated response handler will be called with kErrorAbort.

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -684,6 +684,33 @@ exit:
     return hasSame;
 }
 
+Code Message::MapErrorToCoapCode(Error aError)
+{
+    Code code = kCodeInternalError;
+
+    switch (aError)
+    {
+    case kErrorNone:
+        code = kCodeChanged;
+        break;
+    case kErrorBusy:
+        code = kCodeServiceUnavailable;
+        break;
+    case kErrorParse:
+    case kErrorNotFound:
+    case kErrorInvalidArgs:
+        code = kCodeBadRequest;
+        break;
+    case kErrorNotImplemented:
+        code = kCodeNotImplemented;
+        break;
+    default:
+        break;
+    }
+
+    return code;
+}
+
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
 const char *Message::CodeToString(void) const
 {

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -813,6 +813,24 @@ public:
      */
     const Message *GetNextCoapMessage(void) const { return static_cast<const Message *>(GetNext()); }
 
+    /**
+     * Maps an `Error` to a CoAP Code.
+     *
+     * @param[in] aError  The error to map.
+     *
+     * @returns The corresponding CoAP Code.
+     *
+     * The following mappings are used:
+     * - `kErrorNone`           -> `kCodeChanged`
+     * - `kErrorBusy`           -> `kCodeServiceUnavailable`
+     * - `kErrorParse`          -> `kCodeBadRequest`
+     * - `kErrorNotFound`       -> `kCodeBadRequest`
+     * - `kErrorInvalidArgs`    -> `kCodeBadRequest`
+     * - `kErrorNotImplemented` -> `kCodeNotImplemented`
+     * - Any other error        -> `kCodeInternalError`
+     */
+    static Code MapErrorToCoapCode(Error aError);
+
 private:
     /*
      *

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -54,25 +54,22 @@ void AnnounceBeginServer::SendAnnounce(uint32_t aChannelMask, uint8_t aCount, ui
 
 template <> void AnnounceBeginServer::HandleTmf<kUriAnnounceBegin>(Coap::Msg &aMsg)
 {
+    Error    error;
     uint32_t mask;
     uint8_t  count;
     uint16_t period;
 
-    SuccessOrExit(MeshCoP::ChannelMaskTlv::FindIn(aMsg.mMessage, mask));
+    VerifyOrExit(!IsRunning(), error = kErrorBusy);
 
-    SuccessOrExit(Tlv::Find<MeshCoP::CountTlv>(aMsg.mMessage, count));
-    SuccessOrExit(Tlv::Find<MeshCoP::PeriodTlv>(aMsg.mMessage, period));
+    SuccessOrExit(error = MeshCoP::ChannelMaskTlv::FindIn(aMsg.mMessage, mask));
+
+    SuccessOrExit(error = Tlv::Find<MeshCoP::CountTlv>(aMsg.mMessage, count));
+    SuccessOrExit(error = Tlv::Find<MeshCoP::PeriodTlv>(aMsg.mMessage, period));
 
     SendAnnounce(mask, count, period);
 
-    if (aMsg.IsConfirmable() && !aMsg.mMessageInfo.GetSockAddr().IsMulticast())
-    {
-        SuccessOrExit(Get<Tmf::Agent>().SendAckResponse(aMsg));
-        LogInfo("Sent %s response", UriToString<kUriAnnounceBegin>());
-    }
-
 exit:
-    return;
+    IgnoreError(Get<Tmf::Agent>().SendAckResponseIfUnicastRequest(aMsg, error));
 }
 
 void AnnounceBeginServer::HandleTimer(Timer &aTimer)

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -50,29 +50,38 @@ EnergyScanServer::EnergyScanServer(Instance &aInstance)
 {
 }
 
+void EnergyScanServer::Stop(void)
+{
+    mReportMessage.Free();
+    mTimer.Stop();
+}
+
 template <> void EnergyScanServer::HandleTmf<kUriEnergyScan>(Coap::Msg &aMsg)
 {
+    Error                   error;
     OwnedPtr<Coap::Message> newMessage;
     uint8_t                 count;
     uint16_t                period;
     uint16_t                scanDuration;
     uint32_t                mask;
 
-    SuccessOrExit(Tlv::Find<MeshCoP::CountTlv>(aMsg.mMessage, count));
+    VerifyOrExit(!IsRunning(), error = kErrorBusy);
+
+    SuccessOrExit(error = Tlv::Find<MeshCoP::CountTlv>(aMsg.mMessage, count));
     count = Clamp(count, kMinCount, kMaxCount);
 
-    SuccessOrExit(Tlv::Find<MeshCoP::PeriodTlv>(aMsg.mMessage, period));
-    SuccessOrExit(Tlv::Find<MeshCoP::ScanDurationTlv>(aMsg.mMessage, scanDuration));
+    SuccessOrExit(error = Tlv::Find<MeshCoP::PeriodTlv>(aMsg.mMessage, period));
+    SuccessOrExit(error = Tlv::Find<MeshCoP::ScanDurationTlv>(aMsg.mMessage, scanDuration));
 
-    SuccessOrExit(MeshCoP::ChannelMaskTlv::FindIn(aMsg.mMessage, mask));
-    VerifyOrExit(mask != 0);
+    SuccessOrExit(error = MeshCoP::ChannelMaskTlv::FindIn(aMsg.mMessage, mask));
+    VerifyOrExit(mask != 0, error = kErrorInvalidArgs);
 
     newMessage.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriEnergyReport));
-    VerifyOrExit(newMessage != nullptr);
+    VerifyOrExit(newMessage != nullptr, error = kErrorNoBufs);
 
-    SuccessOrExit(MeshCoP::ChannelMaskTlv::AppendTo(*newMessage, mask));
+    SuccessOrExit(error = MeshCoP::ChannelMaskTlv::AppendTo(*newMessage, mask));
 
-    SuccessOrExit(Tlv::StartTlv(*newMessage, MeshCoP::Tlv::kEnergyList, mEnergyListTlvBookmark));
+    SuccessOrExit(error = Tlv::StartTlv(*newMessage, MeshCoP::Tlv::kEnergyList, mEnergyListTlvBookmark));
 
     mChannelMask        = mask;
     mChannelMaskCurrent = mChannelMask;
@@ -86,13 +95,8 @@ template <> void EnergyScanServer::HandleTmf<kUriEnergyScan>(Coap::Msg &aMsg)
 
     LogInfo("Received %s", UriToString<kUriEnergyScan>());
 
-    if (aMsg.IsConfirmable() && !aMsg.mMessageInfo.GetSockAddr().IsMulticast())
-    {
-        SuccessOrExit(Get<Tmf::Agent>().SendAckResponse(aMsg));
-    }
-
 exit:
-    return;
+    IgnoreError(Get<Tmf::Agent>().SendAckResponseIfUnicastRequest(aMsg, error));
 }
 
 void EnergyScanServer::HandleTimer(void)
@@ -104,7 +108,10 @@ void EnergyScanServer::HandleTimer(void)
         // grab the lowest channel to scan
         uint32_t channelMask = mChannelMaskCurrent & ~(mChannelMaskCurrent - 1);
 
-        IgnoreError(Get<Mac::Mac>().EnergyScan(channelMask, mScanDuration, HandleScanResult, this));
+        if (Get<Mac::Mac>().EnergyScan(channelMask, mScanDuration, HandleScanResult, this) != kErrorNone)
+        {
+            Stop();
+        }
     }
     else
     {
@@ -128,8 +135,7 @@ void EnergyScanServer::HandleScanResult(Mac::EnergyScanResult *aResult)
     {
         if (mReportMessage->Append<int8_t>(aResult->mMaxRssi) != kErrorNone)
         {
-            mReportMessage.Free();
-            ExitNow();
+            Stop();
         }
     }
     else
@@ -173,8 +179,7 @@ void EnergyScanServer::HandleNotifierEvents(Events aEvents)
     if (aEvents.Contains(kEventThreadNetdataChanged) && (mReportMessage != nullptr) &&
         Get<NetworkData::Leader>().FindBorderAgentRloc(borderAgentRloc) != kErrorNone)
     {
-        mReportMessage.Free();
-        mTimer.Stop();
+        Stop();
     }
 }
 

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -71,14 +71,13 @@ private:
 
     template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 
+    bool        IsRunning(void) const { return mReportMessage != nullptr; }
+    void        Stop(void);
     static void HandleScanResult(Mac::EnergyScanResult *aResult, void *aContext);
     void        HandleScanResult(Mac::EnergyScanResult *aResult);
-
-    void HandleTimer(void);
-
-    void HandleNotifierEvents(Events aEvents);
-
-    void SendReport(void);
+    void        HandleTimer(void);
+    void        HandleNotifierEvents(Events aEvents);
+    void        SendReport(void);
 
     using ScanTimer = TimerMilliIn<EnergyScanServer, &EnergyScanServer::HandleTimer>;
 

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -43,32 +43,31 @@ PanIdQueryServer::PanIdQueryServer(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mChannelMask(0)
     , mPanId(Mac::kPanIdBroadcast)
+    , mIsRunning(false)
     , mTimer(aInstance)
 {
 }
 
 template <> void PanIdQueryServer::HandleTmf<kUriPanIdQuery>(Coap::Msg &aMsg)
 {
+    Error    error;
     uint16_t panId;
     uint32_t mask;
 
-    SuccessOrExit(MeshCoP::ChannelMaskTlv::FindIn(aMsg.mMessage, mask));
+    VerifyOrExit(!mIsRunning, error = kErrorBusy);
 
-    SuccessOrExit(Tlv::Find<MeshCoP::PanIdTlv>(aMsg.mMessage, panId));
+    SuccessOrExit(error = MeshCoP::ChannelMaskTlv::FindIn(aMsg.mMessage, mask));
+
+    SuccessOrExit(error = Tlv::Find<MeshCoP::PanIdTlv>(aMsg.mMessage, panId));
 
     mChannelMask  = mask;
     mCommissioner = aMsg.mMessageInfo.GetPeerAddr();
     mPanId        = panId;
+    mIsRunning    = true;
     mTimer.Start(kScanDelay);
 
-    if (aMsg.IsConfirmable() && !aMsg.mMessageInfo.GetSockAddr().IsMulticast())
-    {
-        SuccessOrExit(Get<Tmf::Agent>().SendAckResponse(aMsg));
-        LogInfo("Sent %s ack", UriToString<kUriPanIdQuery>());
-    }
-
 exit:
-    return;
+    IgnoreError(Get<Tmf::Agent>().SendAckResponseIfUnicastRequest(aMsg, error));
 }
 
 void PanIdQueryServer::HandleScanResult(const ScanResult *aScanResult)
@@ -82,6 +81,7 @@ void PanIdQueryServer::HandleScanResult(const ScanResult *aScanResult)
     }
     else if (mChannelMask != 0)
     {
+        mIsRunning = false;
         SendConflict();
     }
 }
@@ -109,7 +109,11 @@ exit:
 
 void PanIdQueryServer::HandleTimer(void)
 {
-    IgnoreError(Get<Mac::Mac>().ActiveScan(mChannelMask, 0, HandleScanResult, this));
+    if (Get<Mac::Mac>().ActiveScan(mChannelMask, 0, HandleScanResult, this) != kErrorNone)
+    {
+        mIsRunning = false;
+    }
+
     mChannelMask = 0;
 }
 

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -76,8 +76,8 @@ private:
     Ip6::Address mCommissioner;
     uint32_t     mChannelMask;
     uint16_t     mPanId;
-
-    DelayTimer mTimer;
+    bool         mIsRunning;
+    DelayTimer   mTimer;
 };
 
 DeclareTmfHandler(PanIdQueryServer, kUriPanIdQuery);


### PR DESCRIPTION
This commit introduces `CoapBase::SendAckResponseIfUnicastRequest()`, which sends an ACK response with a CoAP Code mapped from an `Error` value, provided the original request was confirmable and not sent to a multicast address. It also adds `Message::MapErrorToCoapCode()` to handle the translation of common `Error` types into their appropriate CoAP Code equivalents (e.g., `kErrorBusy` to `kCodeServiceUnavailable`, or `kErrorParse` to `kCodeBadRequest`).

The TMF handlers in `AnnounceBeginServer`, `EnergyScanServer`, and `PanIdQueryServer` are updated to use this new method. Additionally, all three servers now explicitly reject new requests with `kErrorBusy` if they are already running an active scan or announce operation. The state tracking in `PanIdQueryServer` (`mIsRunning`) is also added to correctly check its running state when starting a query.