### PR TITLE
[build] fix -Wimplicit-int-conversion errors with Clang 21

### DIFF
--- a/src/core/net/checksum.cpp
+++ b/src/core/net/checksum.cpp
@@ -86,7 +86,7 @@ void Checksum::WriteToMessage(uint16_t aOffset, Message &aMessage) const
 
     if (checksum != 0xffff)
     {
-        checksum = ~checksum;
+        checksum = static_cast<uint16_t>(~checksum);
     }
 
     checksum = BigEndian::HostSwap16(checksum);
@@ -241,7 +241,7 @@ void Checksum::UpdateIp4HeaderChecksum(Ip4::Header &aHeader)
 
     aHeader.SetChecksum(0);
     checksum.AddData(reinterpret_cast<const uint8_t *>(&aHeader), sizeof(aHeader));
-    aHeader.SetChecksum(~checksum.GetValue());
+    aHeader.SetChecksum(static_cast<uint16_t>(~checksum.GetValue()));
 }
 
 } // namespace ot

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -98,7 +98,7 @@ bool Prefix::ContainsPrefix(const NetworkPrefix &aSubPrefix) const
 void Prefix::Tidy(void)
 {
     uint8_t byteLength      = GetBytesSize();
-    uint8_t lastByteBitMask = ~(static_cast<uint8_t>(1 << (byteLength * 8 - mLength)) - 1);
+    uint8_t lastByteBitMask = static_cast<uint8_t>(~(static_cast<uint8_t>(1 << (byteLength * 8 - mLength)) - 1));
 
     if (byteLength != 0)
     {
@@ -375,7 +375,7 @@ void Address::CopyBits(uint8_t *aDst, const uint8_t *aSrc, uint8_t aNumBits)
         // ((0x80 >> 2) - 1) = (0b0010_0000 - 1) = 0b0001_1111
 
         aDst[numBytes] &= mask;
-        aDst[numBytes] |= (aSrc[numBytes] & ~mask);
+        aDst[numBytes] |= (aSrc[numBytes] & static_cast<uint8_t>(~mask));
     }
 }
 

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -85,7 +85,7 @@ int8_t RssAverager::GetAverage(void) const
 
     VerifyOrExit(mCount != 0, average = Radio::kInvalidRssi);
 
-    average = -static_cast<int8_t>(mAverage >> kPrecisionBitShift);
+    average = static_cast<int8_t>(-static_cast<int8_t>(mAverage >> kPrecisionBitShift));
 
     // Check for possible round up (e.g., average of -71.5 --> -72)
 

--- a/src/core/thread/neighbor_table.cpp
+++ b/src/core/thread/neighbor_table.cpp
@@ -230,7 +230,7 @@ Error NeighborTable::GetNextNeighborInfo(otNeighborInfoIterator &aIterator, Neig
 
     // Negative iterator value gives the current index into mRouters array
 
-    for (index = -aIterator; index <= Mle::kMaxRouterId; index++)
+    for (index = static_cast<int16_t>(-aIterator); index <= Mle::kMaxRouterId; index++)
     {
         Router *router = Get<RouterTable>().FindRouterById(static_cast<uint8_t>(index));
 
@@ -239,12 +239,12 @@ Error NeighborTable::GetNextNeighborInfo(otNeighborInfoIterator &aIterator, Neig
             aNeighInfo.SetFrom(*router);
             aNeighInfo.mIsChild = false;
             index++;
-            aIterator = -index;
+            aIterator = static_cast<otNeighborInfoIterator>(-index);
             ExitNow();
         }
     }
 
-    aIterator = -index;
+    aIterator = static_cast<otNeighborInfoIterator>(-index);
     error     = kErrorNotFound;
 
 exit:


### PR DESCRIPTION
C++ promotes narrow integer types to int before applying ~ or unary -, so the result is always int even when the variable being assigned to is narrower. Clang accepted this silently for years due to a bug in its range tracking ([LLVM #126846](https://github.com/llvm/llvm-project/pull/126846), fixed March 2025). Clang 21, now included in the latest Mac OS for example, includes a fix and flags these as errors.

Add <static_cast> to the destination type at each affected spot.