### PR TITLE
[mle] Use IsRouterEligible() to replace additional checks

### DIFF
--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -116,6 +116,7 @@ exit:
 Error Mle::SetRouterEligible(bool aEligible)
 {
     Error error = kErrorNone;
+    bool  newEligibleState;
 
     if (!IsFullThreadDevice())
     {
@@ -126,6 +127,9 @@ Error Mle::SetRouterEligible(bool aEligible)
 
     mRouterEligible = aEligible;
 
+    // The new eligible state may be affected by both mRouterEligible and the security policy
+    newEligibleState = IsRouterEligible();
+
     switch (mRole)
     {
     case kRoleDisabled:
@@ -133,17 +137,17 @@ Error Mle::SetRouterEligible(bool aEligible)
         break;
 
     case kRoleChild:
-        if (mRouterEligible)
+        if (newEligibleState)
         {
             mRouterRoleTransition.StartTimeout();
         }
 
-        Get<Mac::Mac>().SetBeaconEnabled(mRouterEligible);
+        Get<Mac::Mac>().SetBeaconEnabled(newEligibleState);
         break;
 
     case kRoleRouter:
     case kRoleLeader:
-        if (!mRouterEligible)
+        if (!newEligibleState)
         {
             IgnoreError(BecomeDetached());
         }
@@ -314,7 +318,7 @@ void Mle::HandleChildStart(void)
     StopLeader();
     Get<TimeTicker>().RegisterReceiver(TimeTicker::kMle);
 
-    if (mRouterEligible)
+    if (IsRouterEligible())
     {
         Get<Mac::Mac>().SetBeaconEnabled(true);
     }
@@ -1563,7 +1567,7 @@ void Mle::HandleTimeTick(void)
         break;
 
     case kRoleChild:
-        if (roleTransitionTimeoutExpired)
+        if (IsRouterEligible() && roleTransitionTimeoutExpired)
         {
             if (mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold && HasNeighborWithGoodLinkQuality())
             {

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -141,6 +141,10 @@ Error Mle::SetRouterEligible(bool aEligible)
         {
             mRouterRoleTransition.StartTimeout();
         }
+        else
+        {
+            mRouterRoleTransition.StopTimeout();
+        }
 
         Get<Mac::Mac>().SetBeaconEnabled(newEligibleState);
         break;
@@ -318,10 +322,7 @@ void Mle::HandleChildStart(void)
     StopLeader();
     Get<TimeTicker>().RegisterReceiver(TimeTicker::kMle);
 
-    if (IsRouterEligible())
-    {
-        Get<Mac::Mac>().SetBeaconEnabled(true);
-    }
+    Get<Mac::Mac>().SetBeaconEnabled(IsRouterEligible());
 
     Get<ThreadNetif>().SubscribeAllRoutersMulticast();
 
@@ -1584,8 +1585,6 @@ void Mle::HandleTimeTick(void)
 
                 mAdvertiseTrickleTimer.Start(TrickleTimer::kModePlainTimer, kReedAdvIntervalMin, kReedAdvIntervalMax);
             }
-
-            ExitNow();
         }
 
         OT_FALL_THROUGH;
@@ -1599,7 +1598,8 @@ void Mle::HandleTimeTick(void)
             mAttacher.Attach(kSamePartition);
         }
 
-        if (roleTransitionTimeoutExpired && mRouterTable.GetActiveRouterCount() > mRouterDowngradeThreshold)
+        if (roleTransitionTimeoutExpired && !IsChild() &&
+            mRouterTable.GetActiveRouterCount() > mRouterDowngradeThreshold)
         {
             LogNote("Downgrade to REED");
             mAttacher.Attach(kDowngradeToReed);
@@ -1608,7 +1608,7 @@ void Mle::HandleTimeTick(void)
         OT_FALL_THROUGH;
 
     case kRoleLeader:
-        if (roleTransitionTimeoutExpired && !IsRouterEligible())
+        if (roleTransitionTimeoutExpired && !IsChild() && !IsRouterEligible())
         {
             LogInfo("No longer router eligible");
             IgnoreError(BecomeDetached());

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -141,10 +141,8 @@ Error Mle::SetRouterEligible(bool aEligible)
         {
             mRouterRoleTransition.StartTimeout();
         }
-        else
-        {
-            mRouterRoleTransition.StopTimeout();
-        }
+        // If the role transition timeout is running, it will be ignored when !IsRouterEligible()
+        // in Mle::HandleTimeTick()
 
         Get<Mac::Mac>().SetBeaconEnabled(newEligibleState);
         break;
@@ -317,6 +315,8 @@ void Mle::HandleChildStart(void)
 {
     mAddressSolicitRejected = false;
 
+    // Currently, this always starts the timer to attempt an upgrade, whether the conditions apply
+    // for an upgrade or not, which may be updated in future changes to the router role transition.
     mRouterRoleTransition.StartTimeout();
 
     StopLeader();
@@ -1568,7 +1568,15 @@ void Mle::HandleTimeTick(void)
         break;
 
     case kRoleChild:
-        if (IsRouterEligible() && roleTransitionTimeoutExpired)
+        if (!IsRouterEligible())
+        {
+            // This device is a FED.
+            // Skip the role transition check and do not start the REED advertisement timer.
+            // REED advertisements are stopped in Mle::HandleAdvertiseTrickleTimer() when a FED.
+            // A FED also doesn't need to check the leader's age.
+            break;
+        }
+        else if (roleTransitionTimeoutExpired)
         {
             if (mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold && HasNeighborWithGoodLinkQuality())
             {
@@ -1579,14 +1587,20 @@ void Mle::HandleTimeTick(void)
                 mAnnounceHandler.HandleRouterRoleTransitionAttemptDone();
             }
 
+            // Currently, a REED will begin advertising after the first role transition attempt,
+            // which may advertise even if an address solicit is in progress.
             if (!mAdvertiseTrickleTimer.IsRunning())
             {
                 SendMulticastAdvertisement();
 
                 mAdvertiseTrickleTimer.Start(TrickleTimer::kModePlainTimer, kReedAdvIntervalMin, kReedAdvIntervalMax);
             }
+
+            // Break to ensure that a downgrade is not attempted below right after an attempt to upgrade
+            break;
         }
 
+        // REEDs should process the leader age below when they have not just attempted to upgrade to router role.
         OT_FALL_THROUGH;
 
     case kRoleRouter:
@@ -1598,8 +1612,7 @@ void Mle::HandleTimeTick(void)
             mAttacher.Attach(kSamePartition);
         }
 
-        if (roleTransitionTimeoutExpired && !IsChild() &&
-            mRouterTable.GetActiveRouterCount() > mRouterDowngradeThreshold)
+        if (roleTransitionTimeoutExpired && mRouterTable.GetActiveRouterCount() > mRouterDowngradeThreshold)
         {
             LogNote("Downgrade to REED");
             mAttacher.Attach(kDowngradeToReed);
@@ -1608,7 +1621,7 @@ void Mle::HandleTimeTick(void)
         OT_FALL_THROUGH;
 
     case kRoleLeader:
-        if (roleTransitionTimeoutExpired && !IsChild() && !IsRouterEligible())
+        if (roleTransitionTimeoutExpired && !IsRouterEligible())
         {
             LogInfo("No longer router eligible");
             IgnoreError(BecomeDetached());


### PR DESCRIPTION
This commit uses IsRouterEligible() instead of directly using mRouterEligible for eligibility checks in additional cases where checking the security policy may be important.  This prepares for a future Router Configuration Management feature where router eligibility may be configured and persist across resets separately from the status in the security policy.