### PR TITLE
[mle] delay child update tx to restore rx-on children

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -88,6 +88,8 @@ Mle::Mle(Instance &aInstance)
     , mChildRouterLinks(kChildRouterLinks)
     , mAlternateRloc16Timeout(0)
     , mLeaderUpgradeThreshold(kRouterUpgradeThreshold)
+    , mChildUpdateRestoreRetryTimeout(0)
+    , mChildUpdateRestoreRetryInterval(0)
     , mParentPriority(kParentPriorityUnspecified)
     , mPreviousPartitionIdRouter(0)
     , mPreviousPartitionId(0)
@@ -3194,6 +3196,35 @@ void Mle::DelayedSender::RemoveScheduledParentResponses(void)
     RemoveMatchingSchedules(kTypeParentResponse, destination);
 }
 
+void Mle::DelayedSender::ScheduleChildUpdateRequestToChild(const Child &aChild, uint32_t aDelay)
+{
+    Ip6::Address destination;
+    uint16_t     childRloc16;
+
+    destination.InitAsLinkLocalAddress(aChild.GetExtAddress());
+    RemoveMatchingSchedules(kTypeChildUpdateRequestOfChild, destination);
+
+    childRloc16 = aChild.GetRloc16();
+    AddSchedule(kTypeChildUpdateRequestOfChild, destination, aDelay, &childRloc16, sizeof(uint16_t));
+}
+
+bool Mle::DelayedSender::HasAnyScheduledChildUpdateRequestToChild(const Child &aChild) const
+{
+    Ip6::Address destination;
+
+    destination.InitAsLinkLocalAddress(aChild.GetExtAddress());
+
+    return HasMatchingSchedule(kTypeChildUpdateRequestOfChild, destination);
+}
+
+void Mle::DelayedSender::RemoveScheduledChildUpdateRequestToChild(const Child &aChild)
+{
+    Ip6::Address destination;
+
+    destination.InitAsLinkLocalAddress(aChild.GetExtAddress());
+    RemoveMatchingSchedules(kTypeChildUpdateRequestOfChild, destination);
+}
+
 void Mle::DelayedSender::ScheduleAdvertisement(const Ip6::Address &aDestination, uint32_t aDelay)
 {
     VerifyOrExit(!HasMatchingSchedule(kTypeAdvertisement, aDestination));
@@ -3356,6 +3387,22 @@ void Mle::DelayedSender::Execute(const Schedule &aSchedule)
 
         IgnoreError(aSchedule.Read(sizeof(Header), info));
         Get<Mle>().SendParentResponse(info);
+        break;
+    }
+
+    case kTypeChildUpdateRequestOfChild:
+    {
+        uint16_t rloc16;
+        Child   *child;
+
+        IgnoreError(aSchedule.Read(sizeof(Header), rloc16));
+        child = Get<ChildTable>().FindChild(rloc16, Child::kInStateValidOrRestoring);
+
+        if (child != nullptr)
+        {
+            IgnoreError(Get<Mle>().SendChildUpdateRequestToChild(*child));
+        }
+
         break;
     }
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1381,6 +1381,17 @@ private:
     static constexpr uint8_t  kDefaultLeaderWeight           = 64;
     static constexpr uint8_t  kAlternateRloc16Timeout        = 8; // Time to use alternate RLOC16 (in sec).
 
+    // Child Update Request constants (used by parent to restore
+    // former rx-on children upon its own role restoration). A gap
+    // (interval ± jitter) is used between "Child Update Request"
+    // transmissions. If no response is received, the requests are
+    // re-scheduled after `MinRetryInterval`, doubling the retry
+    // interval each time up to `MaxRetryInterval`.
+    static constexpr uint32_t kChildUpdateRestoreGapInterval      = 15; // in msec
+    static constexpr uint16_t kChildUpdateRestoreGapJitter        = 2;  // in msec
+    static constexpr uint8_t  kChildUpdateRestoreMinRetryInterval = 2;  // in sec
+    static constexpr uint8_t  kChildUpdateRestoreMaxRetryInterval = 64; // in sec
+
     // Threshold to accept a router upgrade request with reason
     // `kBorderRouterRequest` (number of BRs acting as router in
     // Network Data).
@@ -1774,9 +1785,13 @@ private:
 
         void ScheduleDataRequest(const Ip6::Address &aDestination, uint32_t aDelay);
         void ScheduleChildUpdateRequestToParent(uint32_t aDelay);
+        void RemoveScheduledChildUpdateRequestToParent(void);
 #if OPENTHREAD_FTD
         void ScheduleParentResponse(const ParentResponseInfo &aInfo, uint32_t aDelay);
         void RemoveScheduledParentResponses(void);
+        void ScheduleChildUpdateRequestToChild(const Child &aChild, uint32_t aDelay);
+        bool HasAnyScheduledChildUpdateRequestToChild(const Child &aChild) const;
+        void RemoveScheduledChildUpdateRequestToChild(const Child &aChild);
         void ScheduleAdvertisement(const Ip6::Address &aDestination, uint32_t aDelay);
         void ScheduleMulticastDataResponse(uint32_t aDelay);
         void ScheduleLinkRequest(const Router &aRouter, uint32_t aDelay);
@@ -1787,7 +1802,6 @@ private:
                                        const DiscoveryResponseInfo &aInfo,
                                        uint32_t                     aDelay);
 #endif
-        void RemoveScheduledChildUpdateRequestToParent(void);
 
         void HandleTimer(void);
         void GetQueueInfo(MessageQueue::Info &aQueueInfo) const { mSchedules.GetInfo(aQueueInfo); }
@@ -2545,6 +2559,7 @@ private:
     void     RemoveChildren(void);
     void     HandleAdvertiseTrickleTimer(void);
     void     HandleTimeTick(void);
+    void     ScheduleChildUpdateToRestoreNonSleepyChildren(void);
     void     HandleRouterTableEvent(RouterTable::Events aEvents);
 
     template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
@@ -2628,6 +2643,8 @@ private:
     uint8_t  mChildRouterLinks;
     uint8_t  mAlternateRloc16Timeout;
     uint8_t  mLeaderUpgradeThreshold;
+    uint8_t  mChildUpdateRestoreRetryTimeout;
+    uint8_t  mChildUpdateRestoreRetryInterval;
     int8_t   mParentPriority;
     uint32_t mPreviousPartitionIdRouter;
     uint32_t mPreviousPartitionId;

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -464,16 +464,76 @@ void Mle::SetStateRouterOrLeader(DeviceRole aRole, uint16_t aRloc16, LeaderStart
         Get<AddressResolver>().Clear();
     }
 
-    // Remove children that do not have a matching RLOC16
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValidOrRestoring))
     {
         if (RouterIdFromRloc16(child.GetRloc16()) != mRouterId)
         {
+            // Remove children that do not have a matching RLOC16
             RemoveNeighbor(child);
         }
     }
 
+    mChildUpdateRestoreRetryInterval = kChildUpdateRestoreMinRetryInterval;
+    ScheduleChildUpdateToRestoreNonSleepyChildren();
+
     LogNote("Partition ID 0x%lx", ToUlong(mLeaderData.GetPartitionId()));
+}
+
+void Mle::ScheduleChildUpdateToRestoreNonSleepyChildren(void)
+{
+    bool     hasUnrestoredChild = false;
+    uint32_t delay              = 0;
+    uint8_t  delayInSec;
+
+    VerifyOrExit(IsRouterOrLeader());
+
+    for (const Child &child : Get<ChildTable>().Iterate(Child::kInStateValidOrRestoring))
+    {
+        if (!child.IsRxOnWhenIdle() || !child.IsStateRestoring())
+        {
+            continue;
+        }
+
+        hasUnrestoredChild = true;
+
+        // If a previously scheduled "Child Update Request" is not yet
+        // sent, do not re-schedule.
+
+        if (mDelayedSender.HasAnyScheduledChildUpdateRequestToChild(child))
+        {
+            continue;
+        }
+
+        // Spread the "Child Update Request" transmissions to avoid a
+        // traffic burst and allow collection of responses from each
+        // child by adding a gap interval ± jitter (15 ± 2 msec) per
+        // child.
+
+        delay += Random::NonCrypto::AddJitter(kChildUpdateRestoreGapInterval, kChildUpdateRestoreGapJitter);
+        mDelayedSender.ScheduleChildUpdateRequestToChild(child, delay);
+    }
+
+    VerifyOrExit(hasUnrestoredChild);
+
+    // Set the retry timeout counter to the max of `delayInSec` and
+    // the current `RetryInterval`. On average, 15 msec is used per
+    // rx-on child, so if a device has 10 children, it will be ~150
+    // msec. For an extreme case of 512 children, the window will
+    // be ~7.7 seconds. We also double the current retry interval
+    // up to `MaxRetryInterval`.
+
+    delayInSec = static_cast<uint8_t>(DivideAndRoundUp(delay, Time::kOneSecondInMsec));
+
+    mChildUpdateRestoreRetryTimeout = Max<uint8_t>(mChildUpdateRestoreRetryInterval, delayInSec + 1);
+
+    mChildUpdateRestoreRetryInterval =
+        Min<uint8_t>(2 * mChildUpdateRestoreRetryInterval, kChildUpdateRestoreMaxRetryInterval);
+
+    LogInfo("Scheduled Child Update tx to restore rx-on children, retry timeout:%u, interval:%u",
+            mChildUpdateRestoreRetryTimeout, mChildUpdateRestoreRetryInterval);
+
+exit:
+    return;
 }
 
 void Mle::HandleAdvertiseTrickleTimer(TrickleTimer &aTimer) { aTimer.Get<Mle>().HandleAdvertiseTrickleTimer(); }
@@ -1676,9 +1736,22 @@ void Mle::HandleTimeTick(void)
             LogInfo("Child 0x%04x timeout expired", child.GetRloc16());
             RemoveNeighbor(child);
         }
-        else if (IsRouterOrLeader() && child.IsStateRestored())
+        else if (IsRouterOrLeader() && child.IsStateRestored() && !child.IsRxOnWhenIdle())
         {
             IgnoreError(SendChildUpdateRequestToChild(child));
+        }
+    }
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Retry restoring non-sleepy children (scheduling Child Update)
+
+    if (mChildUpdateRestoreRetryTimeout > 0)
+    {
+        mChildUpdateRestoreRetryTimeout--;
+
+        if (mChildUpdateRestoreRetryTimeout == 0)
+        {
+            ScheduleChildUpdateToRestoreNonSleepyChildren();
         }
     }
 
@@ -2856,6 +2929,8 @@ Error Mle::SendChildUpdateRequestToChild(Child &aChild)
     Ip6::Address destination;
     TxMessage   *message = nullptr;
 
+    VerifyOrExit(IsRouterOrLeader());
+
     if (!aChild.IsRxOnWhenIdle() && aChild.IsStateRestoring())
     {
         // No need to send the resync "Child Update Request"
@@ -2903,9 +2978,8 @@ Error Mle::SendChildUpdateRequestToChild(Child &aChild)
     destination.InitAsLinkLocalAddress(aChild.GetExtAddress());
     SuccessOrExit(error = message->SendTo(destination));
 
-    if (aChild.IsRxOnWhenIdle())
+    if (aChild.IsRxOnWhenIdle() && !aChild.IsStateValid())
     {
-        // only try to send a single Child Update Request message to an rx-on-when-idle child
         aChild.SetState(Child::kStateChildUpdateRequest);
     }
 
@@ -3122,21 +3196,25 @@ void Mle::RemoveNeighbor(Neighbor &aNeighbor)
     }
     else if (IsChildRloc16(aNeighbor.GetRloc16()))
     {
+        Child &child = static_cast<Child &>(aNeighbor);
+
         OT_ASSERT(mChildTable.Contains(aNeighbor));
+
+        mDelayedSender.RemoveScheduledChildUpdateRequestToChild(child);
 
         if (aNeighbor.IsStateValidOrRestoring())
         {
             mNeighborTable.Signal(NeighborTable::kChildRemoved, aNeighbor);
         }
 
-        Get<IndirectSender>().ClearAllMessagesForSleepyChild(static_cast<Child &>(aNeighbor));
+        Get<IndirectSender>().ClearAllMessagesForSleepyChild(child);
 
         if (aNeighbor.IsFullThreadDevice())
         {
             Get<AddressResolver>().RemoveEntriesForRloc16(aNeighbor.GetRloc16());
         }
 
-        mChildTable.RemoveStoredChild(static_cast<Child &>(aNeighbor));
+        mChildTable.RemoveStoredChild(child);
     }
     else if (aNeighbor.IsStateValid())
     {
@@ -3773,6 +3851,13 @@ void Mle::SetChildStateToValid(Child &aChild)
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     Get<Mlr::Manager>().UpdateChildRegistrations(aChild);
 #endif
+
+    // A "Child Update Request" may be scheduled to be sent to a
+    // child that we were trying to restore. If the child attaches
+    // again, any previously scheduled request to this child can be
+    // safely removed.
+
+    mDelayedSender.RemoveScheduledChildUpdateRequestToChild(aChild);
 
     mNeighborTable.Signal(NeighborTable::kChildAdded, aChild);
 


### PR DESCRIPTION
This commit introduces a mechanism to schedule and retry the transmission of "Child Update Request" messages to restore rx-on-when-idle (non-sleepy) children upon role restoration. It spreads the transmissions using a gap interval with jitter(15 ± 2 msec) to avoid traffic bursts. It also includes a retry mechanism starting with 2 seconds delay with exponential backoff up to a maximum interval of 64 seconds  if responses are not received.

The new `Mle::ScheduleChildUpdateToRestoreNonSleepyChildren` method is called when a router or leader role is assumed, and retries are managed within the `HandleTimeTick`. Sleepy children continue to be handled and recovered as before during time ticks.

----

Related to [SPEC-1456](https://threadgroup.atlassian.net/browse/SPEC-1456).