### PR TITLE
[mle] trigger `Child Update Request` for restoring children upon RX

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1391,6 +1391,7 @@ private:
     static constexpr uint16_t kChildUpdateRestoreGapJitter        = 2;  // in msec
     static constexpr uint8_t  kChildUpdateRestoreMinRetryInterval = 2;  // in sec
     static constexpr uint8_t  kChildUpdateRestoreMaxRetryInterval = 64; // in sec
+    static constexpr uint32_t kChildUpdateRestoreAfterRxMaxDelay  = 10; // in msec
 
     // Threshold to accept a router upgrade request with reason
     // `kBorderRouterRequest` (number of BRs acting as router in

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -2250,11 +2250,17 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
         ExitNow();
     }
 
-    // Ignore "Child Update Request" from a child that is present in the
-    // child table but it is not yet in valid state. For example, a
-    // child which is being restored (due to parent reset) or is in the
-    // middle of the attach process (in `kStateParentRequest` or
-    // `kStateChildIdRequest`).
+    // If the child is in the restoring state (due to parent reset), we
+    // schedule a "Child Update Request" to the child after a short random
+    // delay. We ignore "Child Update Request" if the child is not yet in
+    // a valid state (e.g., it is in the middle of the attach process).
+
+    if (child->IsStateRestoring() && child->IsRxOnWhenIdle())
+    {
+        mDelayedSender.ScheduleChildUpdateRequestToChild(*child,
+                                                         GenerateRandomDelay(kChildUpdateRestoreAfterRxMaxDelay));
+        ExitNow();
+    }
 
     VerifyOrExit(child->IsStateValid());
 


### PR DESCRIPTION
This commit updates `Mle::HandleChildUpdateRequestOnParent()` to trigger a `Child Update Request` upon receiving a request from a child that is in the restoring state.

If a parent node is reset, it needs to restore its link with its former children by sending a `Child Update Request` and receiving a response. The parent performs this upon restoring its previous role by scheduling a `Child Update Request` to all non-sleepy children. If no response is received, the parent retries sending the request with an increasing retry delay.

If the child was also reset, it may not respond to the parent's initial request while booting up, but instead send its own `Child Update Request` to the parent once ready. Previously, the parent would ignore such requests from the child if it was in the restoring state. This commit updates the parent to schedule its own `Child Update Request` transmission to the child upon receiving a request from it. This allows for faster recovery in cases where both the parent and child were rebooted and are attempting to restore the link.

----

This PR currently contains the commit from #12840. Please check and review the last commit in this PR. Thanks. 