### PR TITLE
[meshcop] add `FindIn()` and `AppendTo()` for `SteeringDataTlv`

### DIFF
--- a/src/core/meshcop/border_agent_admitter.cpp
+++ b/src/core/meshcop/border_agent_admitter.cpp
@@ -813,7 +813,7 @@ void Admitter::CommissionerPetitioner::SendDataSet(void)
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = Tlv::Append<CommissionerSessionIdTlv>(*message, mSessionId));
-    SuccessOrExit(error = Tlv::Append<SteeringDataTlv>(*message, mSteeringData.GetData(), mSteeringData.GetLength()));
+    SuccessOrExit(error = SteeringDataTlv::AppendTo(*message, mSteeringData));
 
     if (mJoinerUdpPort != 0)
     {
@@ -1193,10 +1193,9 @@ exit:
 
 Error Manager::CoapDtlsSession::ReadSteeringDataTlv(const Message &aMessage, SteeringData &aSteeringData)
 {
-    Error       error;
-    OffsetRange offsetRange;
+    Error error;
 
-    SuccessOrExit(error = Tlv::FindTlvValueOffsetRange(aMessage, Tlv::kSteeringData, offsetRange));
+    SuccessOrExit(error = SteeringDataTlv::FindIn(aMessage, aSteeringData));
 
     // Ensure the read steering data has a valid length. A length of
     // one byte is only allowed to indicate `PermitsAllJoiners()`.
@@ -1205,7 +1204,7 @@ Error Manager::CoapDtlsSession::ReadSteeringDataTlv(const Message &aMessage, Ste
 
     for (uint8_t validLength : Admitter::kEnrollerValidSteeringDataLengths)
     {
-        if (offsetRange.GetLength() == validLength)
+        if (aSteeringData.GetLength() == validLength)
         {
             error = kErrorNone;
             break;
@@ -1213,9 +1212,6 @@ Error Manager::CoapDtlsSession::ReadSteeringDataTlv(const Message &aMessage, Ste
     }
 
     SuccessOrExit(error);
-
-    IgnoreError(aSteeringData.Init(static_cast<uint8_t>(offsetRange.GetLength())));
-    aMessage.ReadBytes(offsetRange, aSteeringData.GetData());
 
     if (aSteeringData.GetLength() == 1)
     {

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -652,7 +652,7 @@ Error Commissioner::SendMgmtCommissionerSetRequest(const CommissioningDataset &a
     {
         const SteeringData &steeringData = aDataset.GetSteeringData();
 
-        SuccessOrExit(error = Tlv::Append<SteeringDataTlv>(*message, steeringData.GetData(), steeringData.GetLength()));
+        SuccessOrExit(error = SteeringDataTlv::AppendTo(*message, steeringData));
     }
 
     if (aDataset.IsJoinerUdpPortSet())

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -65,6 +65,19 @@ Error SteeringDataTlv::CopyTo(SteeringData &aSteeringData) const
     return aSteeringData.Init(GetSteeringDataLength(), mSteeringData);
 }
 
+Error SteeringDataTlv::FindIn(const Message &aMessage, SteeringData &aSteeringData)
+{
+    Error       error;
+    OffsetRange offsetRange;
+
+    SuccessOrExit(error = Tlv::FindTlvValueOffsetRange(aMessage, Tlv::kSteeringData, offsetRange));
+    SuccessOrExit(error = aSteeringData.Init(ClampToUint8(offsetRange.GetLength())));
+    error = aMessage.Read(offsetRange, aSteeringData.GetData(), aSteeringData.GetLength());
+
+exit:
+    return error;
+}
+
 bool SecurityPolicyTlv::IsValid(void) const
 {
     return GetLength() >= sizeof(mRotationTime) && GetFlagsLength() >= kThread11FlagsLength;

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -370,6 +370,34 @@ public:
      */
     Error CopyTo(SteeringData &aSteeringData) const;
 
+    /**
+     * Searches within a given message for Steering Data TLV, parses and validates the TLV value and returns the
+     * read Steering Data.
+     *
+     * @param[in]  aMessage       The message to search in.
+     * @param[out] aSteeringData  A reference to return the read Steering Data.
+     *
+     * @retval kErrorNone         Found the TLV, successfully parsed its value, @p aSteeringData is updated.
+     * @retval kErrorNotFound     No Steering Data TLV found in the @p aMessage.
+     * @retval kErrorParse        Found the TLV, but failed to parse it (e.g. not enough bytes in message).
+     * @retval kErrorInvalidArgs  Found the TLV, but TLV length is not valid for Steering Data (e.g., larger than max).
+     */
+    static Error FindIn(const Message &aMessage, SteeringData &aSteeringData);
+
+    /**
+     * Append a Steering Data TLV to a given message.
+     *
+     * @param[in] aMessage        The message to append to.
+     * @param[in] aSteeringData   The Steering Data value.
+     *
+     * @retval kErrorNone          Successfully appended the TLV to @p aMessage.
+     * @retval kErrorNoBufs        Insufficient available buffers to grow the message.
+     */
+    static Error AppendTo(Message &aMessage, const SteeringData &aSteeringData)
+    {
+        return Tlv::Append<SteeringDataTlv>(aMessage, aSteeringData.GetData(), aSteeringData.GetLength());
+    }
+
 private:
     uint8_t mSteeringData[SteeringData::kMaxLength];
 } OT_TOOL_PACKED_END;

--- a/src/core/meshcop/steering_data.hpp
+++ b/src/core/meshcop/steering_data.hpp
@@ -43,6 +43,7 @@
 #include "common/code_utils.hpp"
 #include "common/equatable.hpp"
 #include "common/error.hpp"
+#include "common/message.hpp"
 #include "common/string.hpp"
 #include "mac/mac_types.hpp"
 

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -318,7 +318,7 @@ void DiscoverScanner::HandleDiscoveryResponse(Mle::RxInfo &aRxInfo) const
     ScanResult                         result;
     OffsetRange                        offsetRange;
     MeshCoP::DiscoveryResponseTlvValue respTlvValue;
-    MeshCoP::SteeringDataTlv           steeringDataTlv;
+    MeshCoP::SteeringData              steeringData;
 
     Mle::Log(Mle::kMessageReceive, Mle::kTypeDiscoveryResponse, aRxInfo.mMessageInfo.GetPeerAddr());
 
@@ -363,19 +363,14 @@ void DiscoverScanner::HandleDiscoveryResponse(Mle::RxInfo &aRxInfo) const
         ExitNow(error = kErrorParse);
     }
 
-    switch (Tlv::FindTlv(aRxInfo.mMessage, steeringDataTlv))
+    switch (MeshCoP::SteeringDataTlv::FindIn(aRxInfo.mMessage, steeringData))
     {
     case kErrorNone:
-        if (steeringDataTlv.IsValid())
+        AsCoreType(&result.mSteeringData) = steeringData;
+
+        if (mEnableFiltering)
         {
-            MeshCoP::SteeringData &steeringData = AsCoreType(&result.mSteeringData);
-
-            IgnoreError(steeringDataTlv.CopyTo(steeringData));
-
-            if (mEnableFiltering)
-            {
-                VerifyOrExit(steeringData.Contains(mFilterIndexes));
-            }
+            VerifyOrExit(steeringData.Contains(mFilterIndexes));
         }
 
         break;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -4015,7 +4015,7 @@ Error Mle::TxMessage::AppendSteeringDataTlv(void)
         SuccessOrExit(Get<NetworkData::Leader>().FindSteeringData(steeringData));
     }
 
-    error = Tlv::Append<MeshCoP::SteeringDataTlv>(*this, steeringData.GetData(), steeringData.GetLength());
+    error = MeshCoP::SteeringDataTlv::AppendTo(*this, steeringData);
 
 exit:
     return error;

--- a/tests/nexus/test_1_1_9_2_2.cpp
+++ b/tests/nexus/test_1_1_9_2_2.cpp
@@ -69,7 +69,7 @@ static void AppendSteeringDataTlv(Coap::Message &aMessage)
     MeshCoP::SteeringData steeringData;
 
     steeringData.SetToPermitAllJoiners();
-    SuccessOrQuit(Tlv::Append<MeshCoP::SteeringDataTlv>(aMessage, steeringData.GetData(), steeringData.GetLength()));
+    SuccessOrQuit(MeshCoP::SteeringDataTlv::AppendTo(aMessage, steeringData));
 }
 
 void Test9_2_2(void)

--- a/tests/nexus/test_1_1_9_2_6.cpp
+++ b/tests/nexus/test_1_1_9_2_6.cpp
@@ -216,8 +216,7 @@ void Test9_2_6(void)
         {
             MeshCoP::SteeringData steeringData;
             steeringData.SetToPermitAllJoiners();
-            SuccessOrQuit(
-                Tlv::Append<MeshCoP::SteeringDataTlv>(*message, steeringData.GetData(), steeringData.GetLength()));
+            SuccessOrQuit(MeshCoP::SteeringDataTlv::AppendTo(*message, steeringData));
         }
 
         SuccessOrQuit(agent.SendMessageToLeaderAloc(*message));

--- a/tests/nexus/test_border_admitter.cpp
+++ b/tests/nexus/test_border_admitter.cpp
@@ -475,7 +475,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
 
     SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerId));
     SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerModeTlv>(*message, mode));
-    SuccessOrQuit(Tlv::Append<MeshCoP::SteeringDataTlv>(*message, steeringData.GetData(), steeringData.GetLength()));
+    SuccessOrQuit(MeshCoP::SteeringDataTlv::AppendTo(*message, steeringData));
 
     responseContext.Clear();
     SuccessOrQuit(enroller.Get<Tmf::SecureAgent>().SendMessage(*message, HandleResponse, &responseContext));
@@ -652,7 +652,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
     SuccessOrQuit(steeringData.UpdateBloomFilter(admitter.Get<Mac::Mac>().GetExtAddress()));
 
     SuccessOrQuit(Tlv::Append<MeshCoP::StateTlv>(*message, MeshCoP::StateTlv::kAccept));
-    SuccessOrQuit(Tlv::Append<MeshCoP::SteeringDataTlv>(*message, steeringData.GetData(), steeringData.GetLength()));
+    SuccessOrQuit(MeshCoP::SteeringDataTlv::AppendTo(*message, steeringData));
 
     responseContext.Clear();
     SuccessOrQuit(enroller.Get<Tmf::SecureAgent>().SendMessage(*message, HandleResponse, &responseContext));
@@ -742,7 +742,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
 
     SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerId));
     SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerModeTlv>(*message, mode));
-    SuccessOrQuit(Tlv::Append<MeshCoP::SteeringDataTlv>(*message, steeringData.GetData(), steeringData.GetLength()));
+    SuccessOrQuit(MeshCoP::SteeringDataTlv::AppendTo(*message, steeringData));
 
     responseContext.Clear();
     SuccessOrQuit(enroller.Get<Tmf::SecureAgent>().SendMessage(*message, HandleResponse, &responseContext));
@@ -816,7 +816,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
 
     SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerId));
     SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerModeTlv>(*message, mode));
-    SuccessOrQuit(Tlv::Append<MeshCoP::SteeringDataTlv>(*message, steeringData.GetData(), steeringData.GetLength()));
+    SuccessOrQuit(MeshCoP::SteeringDataTlv::AppendTo(*message, steeringData));
 
     responseContext.Clear();
     SuccessOrQuit(enroller.Get<Tmf::SecureAgent>().SendMessage(*message, HandleResponse, &responseContext));
@@ -851,7 +851,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
 
     SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerIdAlt));
     SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerModeTlv>(*message, mode));
-    SuccessOrQuit(Tlv::Append<MeshCoP::SteeringDataTlv>(*message, steeringData.GetData(), steeringData.GetLength()));
+    SuccessOrQuit(MeshCoP::SteeringDataTlv::AppendTo(*message, steeringData));
 
     responseContext.Clear();
     SuccessOrQuit(enroller.Get<Tmf::SecureAgent>().SendMessage(*message, HandleResponse, &responseContext));
@@ -964,8 +964,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
 
         if (testIter != 2)
         {
-            SuccessOrQuit(
-                Tlv::Append<MeshCoP::SteeringDataTlv>(*message, steeringData.GetData(), steeringData.GetLength()));
+            SuccessOrQuit(MeshCoP::SteeringDataTlv::AppendTo(*message, steeringData));
         }
 
         responseContext.Clear();
@@ -1005,8 +1004,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
 
         SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerId));
         SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerModeTlv>(*message, mode));
-        SuccessOrQuit(
-            Tlv::Append<MeshCoP::SteeringDataTlv>(*message, steeringData.GetData(), steeringData.GetLength()));
+        SuccessOrQuit(MeshCoP::SteeringDataTlv::AppendTo(*message, steeringData));
 
         responseContext.Clear();
         SuccessOrQuit(enroller.Get<Tmf::SecureAgent>().SendMessage(*message, HandleResponse, &responseContext));
@@ -1031,7 +1029,7 @@ void TestBorderAdmitterEnrollerInteraction(void)
 
     SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerId));
     SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerModeTlv>(*message, mode));
-    SuccessOrQuit(Tlv::Append<MeshCoP::SteeringDataTlv>(*message, steeringData.GetData(), steeringData.GetLength()));
+    SuccessOrQuit(MeshCoP::SteeringDataTlv::AppendTo(*message, steeringData));
 
     responseContext.Clear();
     SuccessOrQuit(enroller.Get<Tmf::SecureAgent>().SendMessage(*message, HandleResponse, &responseContext));
@@ -1154,7 +1152,7 @@ void TestBorderAdmitterCommissionerConflictAndPetitionerRetry(void)
 
     SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerId));
     SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerModeTlv>(*message, mode));
-    SuccessOrQuit(Tlv::Append<MeshCoP::SteeringDataTlv>(*message, steeringData.GetData(), steeringData.GetLength()));
+    SuccessOrQuit(MeshCoP::SteeringDataTlv::AppendTo(*message, steeringData));
 
     SuccessOrQuit(enroller.Get<Tmf::SecureAgent>().SendMessage(*message));
 
@@ -1465,8 +1463,7 @@ void TestBorderAdmitterMultipleEnrollers(void)
 
         SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerIds[i]));
         SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerModeTlv>(*message, mode));
-        SuccessOrQuit(
-            Tlv::Append<MeshCoP::SteeringDataTlv>(*message, steeringData[i].GetData(), steeringData[i].GetLength()));
+        SuccessOrQuit(MeshCoP::SteeringDataTlv::AppendTo(*message, steeringData[i]));
 
         responseContexts[i].Clear();
         SuccessOrQuit(
@@ -1790,8 +1787,7 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
 
         SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerIds[i]));
         SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerModeTlv>(*message, modes[i]));
-        SuccessOrQuit(
-            Tlv::Append<MeshCoP::SteeringDataTlv>(*message, steeringData.GetData(), steeringData.GetLength()));
+        SuccessOrQuit(MeshCoP::SteeringDataTlv::AppendTo(*message, steeringData));
 
         responseContexts[i].Clear();
         SuccessOrQuit(
@@ -3288,8 +3284,7 @@ void TestBorderAdmitterForwardingUdpProxy(void)
 
         SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerIdTlv>(*message, kEnrollerIds[i]));
         SuccessOrQuit(Tlv::Append<MeshCoP::EnrollerModeTlv>(*message, modes[i]));
-        SuccessOrQuit(
-            Tlv::Append<MeshCoP::SteeringDataTlv>(*message, steeringData.GetData(), steeringData.GetLength()));
+        SuccessOrQuit(MeshCoP::SteeringDataTlv::AppendTo(*message, steeringData));
 
         responseContexts[i].Clear();
         SuccessOrQuit(


### PR DESCRIPTION
This commit introduces static helper methods `SteeringDataTlv::FindIn()` and `SteeringDataTlv::AppendTo()` to simplify the handling of steering data in `Message` objects.

`SteeringDataTlv::FindIn()` encapsulates the pattern of searching for a `SteeringDataTlv` in a `Message` and reading its value into a `SteeringData` object. `SteeringDataTlv::AppendTo()` provides a unified way to append steering data to a `Message`, including a validity check. Additionally, `SteeringData::ReadFrom()` is added to read steering data from a `Message` at a given `OffsetRange`.

These helpers are adopted across core modules (MeshCoP, MLE, Discovery) and various Nexus tests, replacing manual TLV manipulation with a cleaner and safer helper methods.