### PR TITLE
[posix] improve settings file resilience against corruption and power loss

### DIFF
--- a/src/posix/platform/settings_file.cpp
+++ b/src/posix/platform/settings_file.cpp
@@ -83,8 +83,9 @@ void SettingsFile::SetSettingsFileName(const char *aSettingsFileName)
 
 otError SettingsFile::Init(const char *aSettingsFileBaseName)
 {
-    otError     error     = OT_ERROR_NONE;
-    const char *directory = GetSettingsPath();
+    otError     error           = OT_ERROR_NONE;
+    const char *directory       = GetSettingsPath();
+    off_t       lastValidOffset = 0;
 
     OT_ASSERT(strlen(directory) < kMaxFileBasePathNameSize);
     OT_ASSERT((aSettingsFileBaseName != nullptr) && strlen(aSettingsFileBaseName) < kMaxFileBaseNameSize);
@@ -110,6 +111,8 @@ otError SettingsFile::Init(const char *aSettingsFileBaseName)
 
     for (off_t size = lseek(mSettingsFd, 0, SEEK_END), offset = lseek(mSettingsFd, 0, SEEK_SET); offset < size;)
     {
+        lastValidOffset = offset;
+
         uint16_t key;
         uint16_t length;
         ssize_t  rval;
@@ -127,7 +130,20 @@ otError SettingsFile::Init(const char *aSettingsFileBaseName)
 exit:
     if (error == OT_ERROR_PARSE)
     {
-        VerifyOrDie(ftruncate(mSettingsFd, 0) == 0, OT_EXIT_ERROR_ERRNO);
+        off_t fileSize = lseek(mSettingsFd, 0, SEEK_END);
+
+        if (lastValidOffset > 0)
+        {
+            otLogCritPlat("Settings file corrupt at offset %jd of %jd bytes, truncating to preserve %jd bytes of "
+                          "valid entries",
+                          (intmax_t)lastValidOffset, (intmax_t)fileSize, (intmax_t)lastValidOffset);
+        }
+        else
+        {
+            otLogCritPlat("Settings file corrupt from start (%jd bytes), truncating entire file", (intmax_t)fileSize);
+        }
+
+        VerifyOrDie(ftruncate(mSettingsFd, lastValidOffset) == 0, OT_EXIT_ERROR_ERRNO);
     }
 
     return error;

--- a/src/posix/platform/settings_file.cpp
+++ b/src/posix/platform/settings_file.cpp
@@ -405,6 +405,20 @@ void SettingsFile::SwapPersist(int aFd)
     VerifyOrDie(0 == fsync(aFd), OT_EXIT_ERROR_ERRNO);
     VerifyOrDie(0 == rename(swapFile, dataFile), OT_EXIT_ERROR_ERRNO);
 
+    // Best-effort: sync the parent directory so that the rename metadata
+    // reaches stable storage. Without this, a power loss between rename()
+    // and the next journal commit can lose the rename, leaving a partially-
+    // written swap file that causes a parse error on next Init().
+    {
+        int dirFd = open(GetSettingsPath(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+
+        if (dirFd >= 0)
+        {
+            fsync(dirFd);
+            close(dirFd);
+        }
+    }
+
     mSettingsFd = aFd;
 }
 


### PR DESCRIPTION
## Summary

Two improvements to the POSIX `SettingsFile` to reduce data loss from filesystem corruption and power loss, split into separate commits for independent review.

### Commit 1: truncate to last valid offset on parse error

When `Init()` encounters a corrupt entry (e.g., trailing garbage from an interrupted write), it currently truncates the **entire** file to 0, destroying all settings including the active operational dataset. This silently causes all paired Thread devices to become unreachable.

The parse loop already tracks the exact offset where corruption starts. This commit changes the truncation target from `0` to `lastValidOffset`:

- **`lastValidOffset > 0`**: preserves all entries that were successfully parsed before the corrupt entry. The active dataset (key `0x0001`) is typically one of the first entries written, so it survives trailing corruption. A critical log message is emitted stating how many bytes of valid data were preserved.
- **`lastValidOffset == 0`**: corruption starts at the beginning of the file, so no entries can be preserved. Behavior is identical to the original code (truncate to 0). A critical log message is emitted stating the entire file was truncated.

### Commit 2: fsync parent directory after rename in SwapPersist

`SwapPersist()` calls `fsync(fd)` on the data file but does not sync the parent directory after `rename()`. On journaling filesystems (ext4, overlayfs), the rename metadata may not reach stable storage before a power loss. This can leave the old swap file in place, which triggers a parse error on the next `Init()` — which, without commit 1, would then truncate the entire file to 0.

The added `fsync()` on the parent directory is best-effort (non-fatal) since the file data is already persisted; only the directory entry could lag behind.

## Motivation

Both issues were observed in production on embedded Linux devices (Yocto/overlayfs) where OTA updates trigger reboots that can interrupt the settings file persist cycle. The combination of (2) causing trailing corruption and (1) destroying the entire file on any parse error resulted in complete Thread network loss.

## Test plan

- [x] Verified on ARM embedded Linux (overlayfs on ext4): appending a garbage byte to the settings file, then restarting OpenThread, preserves all valid entries instead of truncating to 0
- [x] Unit tests for the key-length-value parser covering: valid files, trailing garbage (1 byte and 3 bytes), truncated mid-entry, entry length exceeding file size
- [x] Clean boot cycle: verified `.data` file is persisted correctly with directory fsync
- [x] Edge case: corruption at offset 0 (empty valid portion) — truncates to 0, same as original behavior