### PR TITLE
[tests] prevent settings/flash retaining between unit tests

### DIFF
--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -33,6 +33,8 @@
 
 #include <stdio.h>
 #include <sys/time.h>
+#include <openthread/platform/flash.h>
+
 #ifdef OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
 #include <openthread/tcat.h>
 #include <openthread/platform/ble.h>
@@ -49,6 +51,12 @@ std::map<uint32_t, std::vector<std::vector<uint8_t>>> settings;
 ot::Instance *testInitInstance(void)
 {
     otInstance *instance = nullptr;
+
+    settings.clear();
+    for (uint8_t idx = 0; idx < FLASH_SWAP_NUM; idx++)
+    {
+        otPlatFlashErase(nullptr, idx);
+    }
 
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
 #if OPENTHREAD_CONFIG_MULTIPLE_STATIC_INSTANCE_ENABLE

--- a/tests/unit/test_tcat.cpp
+++ b/tests/unit/test_tcat.cpp
@@ -345,15 +345,17 @@ private:
                                           const TcatAgent::CertificateAuthorizationField aDeviceAuth,
                                           bool                                           aIsCommissionedAtStart)
     {
-        aAgent->mState                          = TcatAgent::kStateConnected;
+        // This mock function mimics the steps in TcatAgent::Connected() without requiring the actual TLS
+        // session object.
+        aAgent->ClearCommissionerState();
         aAgent->mCommissionerAuthorizationField = aCommAuth;
         aAgent->mDeviceAuthorizationField       = aDeviceAuth;
-        aAgent->mPskcVerified                   = false;
-        aAgent->mPskdVerified                   = false;
-        aAgent->mCommissionerHasExtendedPanId   = false;
-        aAgent->mCommissionerHasNetworkName     = false;
-        aAgent->mCommissionerHasDomainName      = false;
         aAgent->mIsCommissioned                 = aIsCommissionedAtStart;
+
+        aAgent->mNextState =
+            (aAgent->mState == TcatAgent::kStateActiveTemporary) ? TcatAgent::kStateStandby : TcatAgent::kStateActive;
+        aAgent->mState = TcatAgent::kStateConnected;
+        aAgent->NotifyStateChange();
     }
 
     // Mock condition: commissioner has or has not the given Extended Pan ID in its certificate.
@@ -545,6 +547,7 @@ public:
         // Mock TCAT Commissioner 4 connects to the Device - verify it only has access to class General by default.
         // The Device is commissioned already at start of the TCAT Link.
         // =======================================================================================================
+        instance->Get<ActiveDatasetManager>().SaveLocal(sFullDataset);
         memcpy(&sCommAuth, &kCommCert4AuthField, sizeof(sCommAuth));
         MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, true);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
@@ -740,22 +743,41 @@ public:
         VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
         VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
 
-        // Domain Name match
+        // Domain Name match - but Commissioning in general is still not authorized, due to missing Active Dataset.
+        // Hence the Network Name and XPAN ID checks cannot succeed in general. They will succeed now for the
+        // specific 'Set Active Dataset' command.
         MockDomainName(agent, true, &sCommDomainName);
-        VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning));
+        VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
         VerifyOrQuit(SetActiveDatasetAuthorized(agent, sFullDataset));
+
+        // the partial dataset cannot be written, because it lacks the required Network Name and XPAN ID combo.
         VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
 
         // PSKc proof
         agent->mPskcVerified = true;
-        VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassExtraction |
-                                                         kClassDecommissioning | kClassApplication));
+        VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
         VerifyOrQuit(SetActiveDatasetAuthorized(agent, sFullDataset));
         VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
 
-        // Try write a full dataset with differing XPAN ID
+        // Try write a full dataset with differing XPAN ID - this fails
         sFullDataset.mExtendedPanId.m8[2]++;
         VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+
+        // Test an equivalent case to above where the device does have a full dataset stored already, and the
+        // Commissioner connects. Now it has full access to all classes due to matching Network Name / XPAN ID combo.
+        sFullDataset = AsCoreType(&kFullDataset);
+        instance->Get<ActiveDatasetManager>().SaveLocal(sFullDataset);
+        MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, true);
+        agent->mPskdVerified = true;
+        agent->mPskcVerified = true;
+        MockNetworkName(agent, true, &sCommNetworkName);
+        MockExtPanId(agent, true, &sCommExtPanId);
+        MockDomainName(agent, true, &sCommDomainName);
+
+        VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassDecommissioning |
+                                                         kClassExtraction | kClassApplication));
+        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
 
         testFreeInstance(instance);
     }


### PR DESCRIPTION
Issue: state was retained between OT instances in the unit test platform, across tests. This commit adds settings and flash clearing as part of testInitInstance().