### PR TITLE
[mle] check router role allowed before sending multicast adv

### DIFF
--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -539,7 +539,14 @@ exit:
     return;
 }
 
-void Mle::SendMulticastAdvertisement(void) { SendAdvertisement(Ip6::Address::GetLinkLocalAllNodesMulticast()); }
+void Mle::SendMulticastAdvertisement(void)
+{
+    VerifyOrExit(IsRouterRoleAllowed());
+    SendAdvertisement(Ip6::Address::GetLinkLocalAllNodesMulticast());
+
+exit:
+    return;
+}
 
 void Mle::ScheduleUnicastAdvertisementTo(const Router &aRouter)
 {


### PR DESCRIPTION
This commit updates `Mle::SendMulticastAdvertisement()` to verify that the router role is allowed by calling `IsRouterRoleAllowed()` before proceeding to send the multicast MLE advertisement.

---

~This PR currently contain the commit from https://github.com/openthread/openthread/pull/12854. Please read and review the last commit in this PR. Thanks.~ 

Addresses #12873. 
