### PR TITLE
[config] default enable "key references" with PSA crypto

### DIFF
--- a/src/core/config/platform.h
+++ b/src/core/config/platform.h
@@ -34,6 +34,7 @@
 #ifndef OT_CORE_CONFIG_PLATFORM_H_
 #define OT_CORE_CONFIG_PLATFORM_H_
 
+#include "config/crypto.h"
 #include "config/srp_server.h"
 
 /**
@@ -156,7 +157,8 @@
  * Define to 1 if you want to enable key ref usage support as defined by platform.
  */
 #ifndef OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
-#define OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE 0
+#define OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE \
+    (OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_PSA)
 #endif
 
 /**

--- a/src/core/crypto/crypto_platform_psa.cpp
+++ b/src/core/crypto/crypto_platform_psa.cpp
@@ -58,6 +58,10 @@ using namespace Crypto;
 
 #if OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_PSA
 
+#if !OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
+#error "`OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE` is required when `CONFIG_CRYPTO_LIB_PSA` is selected"
+#endif
+
 //---------------------------------------------------------------------------------------------------------------------
 // Default/weak implementation of crypto platform APIs
 


### PR DESCRIPTION
This commit updates the default value of the
`OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE` configuration to be enabled automatically when `OPENTHREAD_CONFIG_CRYPTO_LIB` is set to `OPENTHREAD_CONFIG_CRYPTO_LIB_PSA`. Additionally, it adds a compile-time check in `crypto_platform_psa.cpp` to enforce this requirement. This ensures that the platform key references support is always enabled when the PSA crypto library is selected.