### PR TITLE
[time-sync] add compile-time check for TREL incompatibility

### DIFF
--- a/src/core/thread/time_sync_service.hpp
+++ b/src/core/thread/time_sync_service.hpp
@@ -38,6 +38,11 @@
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+#error "TIME_SYNC feature is not supported under RADIO_LINK_TREL. " \
+       "TIME_SYNC is an experimental feature that only works on 15.4 radio."
+#endif
+
 #include <openthread/network_time.h>
 
 #include "common/as_core_type.hpp"


### PR DESCRIPTION
This commit adds a compile-time check in `time_sync_service.hpp` to ensure that `OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE` is not enabled alongside `OPENTHREAD_CONFIG_TIME_SYNC_ENABLE`. The time synchronization feature is experimental and currently only supports IEEE 802.15.4 radio links. Attempting to use it over TREL is unsupported and will now result in a build failure.