### PR TITLE
[mle] implement three-way child update process

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1332,7 +1332,7 @@ Error Mle::SendChildUpdateResponse(const ChildUpdateResponseInfo &aInfo)
     Error      error = kErrorNone;
     TxMessage *message;
 
-    VerifyOrExit((message = NewMleMessage(kCommandChildUpdateResponse)) != nullptr, error = kErrorNoBufs);
+    VerifyOrExit((message = NewMleMessage(aInfo.mCommand)) != nullptr, error = kErrorNoBufs);
 
     for (uint8_t tlvType : aInfo.mTlvList)
     {
@@ -1401,6 +1401,17 @@ Error Mle::SendChildUpdateResponse(const ChildUpdateResponseInfo &aInfo)
             SuccessOrExit(error = message->AppendSupervisionIntervalTlvIfSleepyChild());
             break;
 
+        case Tlv::kMode:
+            SuccessOrExit(error = message->AppendModeTlv());
+            break;
+
+        case Tlv::kChallenge:
+            if (aInfo.mCommand == kCommandChildUpdateResponseAndRequest)
+            {
+                SuccessOrExit(error = message->AppendChallengeTlv(mPrevRoleRestorer.GetChallenge()));
+            }
+            break;
+
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
         case Tlv::kCslTimeout:
             if (Get<Mac::Mac>().IsCslEnabled())
@@ -1414,7 +1425,10 @@ Error Mle::SendChildUpdateResponse(const ChildUpdateResponseInfo &aInfo)
 
     SuccessOrExit(error = message->SendTo(aInfo.mDestination));
 
-    Log(kMessageSend, kTypeChildUpdateResponseAsChild, aInfo.mDestination);
+    Log(kMessageSend,
+        aInfo.mCommand == kCommandChildUpdateResponse ? kTypeChildUpdateResponseAsChild
+                                                      : kTypeChildUpdateResponseAndRequest,
+        aInfo.mDestination);
 
 exit:
     FreeMessageOnError(message, error);
@@ -1786,6 +1800,10 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
 
     case kCommandChildUpdateResponse:
         HandleChildUpdateResponse(rxInfo);
+        break;
+
+    case kCommandChildUpdateResponseAndRequest:
+        HandleChildUpdateResponseAndRequest(rxInfo);
         break;
 
 #if OPENTHREAD_FTD
@@ -2293,6 +2311,7 @@ void Mle::HandleChildUpdateRequestOnChild(RxInfo &aRxInfo)
 
     Log(kMessageReceive, kTypeChildUpdateRequestAsChild, aRxInfo.mMessageInfo.GetPeerAddr(), sourceAddress);
 
+    info.mCommand     = kCommandChildUpdateResponse;
     info.mDestination = aRxInfo.mMessageInfo.GetPeerAddr();
 
     info.mTlvList.Add(Tlv::kSourceAddress);
@@ -2371,6 +2390,24 @@ void Mle::HandleChildUpdateRequestOnChild(RxInfo &aRxInfo)
             break;
         default:
             ExitNow(error = kErrorParse);
+        }
+
+        if (!IsAttached() && mPrevRoleRestorer.IsRestoringChildRole() && IsRxOnWhenIdle() &&
+            aRxInfo.mMessage.ContainsTlv(Tlv::kThreeWayChildUpdate) && !info.mChallenge.IsEmpty())
+        {
+            // The use of "Child Update Response and Request" is
+            // restricted to when both the parent and the non-sleepy
+            // child are attempting to restore the link. The `mTlvList`
+            // is updated to include required TLVs for "Child Update
+            // Request". The parent is expected to already request the
+            // Address Registration TLV, but we add it again anyway
+            // (it will be ignored if already in the list).
+
+            info.mCommand = kCommandChildUpdateResponseAndRequest;
+
+            info.mTlvList.Add(Tlv::kAddressRegistration);
+            info.mTlvList.Add(Tlv::kMode);
+            info.mTlvList.Add(Tlv::kChallenge);
         }
     }
     else
@@ -2559,6 +2596,21 @@ exit:
     }
 
     LogProcessError(kTypeChildUpdateResponseAsChild, error);
+}
+
+void Mle::HandleChildUpdateResponseAndRequest(RxInfo &aRxInfo)
+{
+    Log(kMessageReceive, kTypeChildUpdateResponseAndRequest, aRxInfo.mMessageInfo.GetPeerAddr());
+
+    // A "Response and Request" is always processed as a response
+    // first. It is only processed as a request by parent nodes.
+
+    HandleChildUpdateResponse(aRxInfo);
+
+    if (IsRouterOrLeader())
+    {
+        HandleChildUpdateRequest(aRxInfo);
+    }
 }
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
@@ -2938,23 +2990,24 @@ const char *Mle::MessageActionToString(MessageAction aAction)
 
 const char *Mle::MessageTypeToString(MessageType aType)
 {
-#define MessageTypeMapList(_)                                   \
-    _(kTypeAdvertisement, "Advertisement")                      \
-    _(kTypeAnnounce, "Announce")                                \
-    _(kTypeChildIdRequest, "Child ID Request")                  \
-    _(kTypeChildIdRequestShort, "Child ID Request")             \
-    _(kTypeChildIdResponse, "Child ID Response")                \
-    _(kTypeChildUpdateRequestAsChild, "Child Update Request")   \
-    _(kTypeChildUpdateResponseAsChild, "Child Update Response") \
-    _(kTypeDataRequest, "Data Request")                         \
-    _(kTypeDataResponse, "Data Response")                       \
-    _(kTypeDiscoveryRequest, "Discovery Request")               \
-    _(kTypeDiscoveryResponse, "Discovery Response")             \
-    _(kTypeGenericDelayed, "delayed message")                   \
-    _(kTypeGenericUdp, "UDP")                                   \
-    _(kTypeParentRequestToRouters, "Parent Request")            \
-    _(kTypeParentRequestToRoutersReeds, "Parent Request")       \
-    _(kTypeParentResponse, "Parent Response")                   \
+#define MessageTypeMapList(_)                                                  \
+    _(kTypeAdvertisement, "Advertisement")                                     \
+    _(kTypeAnnounce, "Announce")                                               \
+    _(kTypeChildIdRequest, "Child ID Request")                                 \
+    _(kTypeChildIdRequestShort, "Child ID Request")                            \
+    _(kTypeChildIdResponse, "Child ID Response")                               \
+    _(kTypeChildUpdateRequestAsChild, "Child Update Request")                  \
+    _(kTypeChildUpdateResponseAsChild, "Child Update Response")                \
+    _(kTypeChildUpdateResponseAndRequest, "Child Update Response and Request") \
+    _(kTypeDataRequest, "Data Request")                                        \
+    _(kTypeDataResponse, "Data Response")                                      \
+    _(kTypeDiscoveryRequest, "Discovery Request")                              \
+    _(kTypeDiscoveryResponse, "Discovery Response")                            \
+    _(kTypeGenericDelayed, "delayed message")                                  \
+    _(kTypeGenericUdp, "UDP")                                                  \
+    _(kTypeParentRequestToRouters, "Parent Request")                           \
+    _(kTypeParentRequestToRoutersReeds, "Parent Request")                      \
+    _(kTypeParentResponse, "Parent Response")                                  \
     FtdMessageTypeMapList(_) LinkMetricsMessageTypeMapList(_) TimeSyncMessageTypeMapList(_) P2pMessageTypeMapList(_)
 
 #if OPENTHREAD_FTD
@@ -3591,6 +3644,11 @@ Error Mle::TxMessage::AppendLinkFrameCounterTlv(void)
 Error Mle::TxMessage::AppendMleFrameCounterTlv(void)
 {
     return Tlv::Append<MleFrameCounterTlv>(*this, Get<KeyManager>().GetMleFrameCounter());
+}
+
+Error Mle::TxMessage::AppendThreeWayChildUpdateTlv(void)
+{
+    return Tlv::AppendTlv(*this, Tlv::kThreeWayChildUpdate, nullptr, 0);
 }
 
 Error Mle::TxMessage::AppendAddress16Tlv(uint16_t aRloc16) { return Tlv::Append<Address16Tlv>(*this, aRloc16); }

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1488,6 +1488,7 @@ private:
         kTypeChildIdResponse,
         kTypeChildUpdateRequestAsChild,
         kTypeChildUpdateResponseAsChild,
+        kTypeChildUpdateResponseAndRequest,
         kTypeDataRequest,
         kTypeDataResponse,
         kTypeDiscoveryRequest,
@@ -1565,6 +1566,7 @@ private:
         Error AppendResponseTlv(const RxChallenge &aResponse);
         Error AppendLinkFrameCounterTlv(void);
         Error AppendMleFrameCounterTlv(void);
+        Error AppendThreeWayChildUpdateTlv(void);
         Error AppendAddress16Tlv(uint16_t aRloc16);
         Error AppendNetworkDataTlv(NetworkData::Type aType);
         Error AppendTlvRequestTlv(const uint8_t *aTlvs, uint8_t aTlvsLength);
@@ -1680,6 +1682,7 @@ private:
 
     struct ChildUpdateResponseInfo
     {
+        Command      mCommand;     // The response command.
         TlvList      mTlvList;     // The TLVs to include in the Child Update Response.
         RxChallenge  mChallenge;   // The received challenge from the Child Update Request (can be empty if none).
         Ip6::Address mDestination; // The destination address.
@@ -2326,6 +2329,7 @@ private:
     void       HandleChildUpdateRequestOnChild(RxInfo &aRxInfo);
     void       HandleChildUpdateResponse(RxInfo &aRxInfo);
     void       HandleChildUpdateResponseOnChild(RxInfo &aRxInfo);
+    void       HandleChildUpdateResponseAndRequest(RxInfo &aRxInfo);
     void       HandleDataResponse(RxInfo &aRxInfo);
     Error      HandleLeaderData(RxInfo &aRxInfo);
     uint32_t   GetAttachStartDelay(void) const;

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -2246,6 +2246,7 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
 
     VerifyOrExit(!mDetacher.IsDetaching());
 
+    info.mCommand     = kCommandChildUpdateResponse;
     info.mDestination = aRxInfo.mMessageInfo.GetPeerAddr();
 
     SuccessOrExit(error = aRxInfo.mMessage.ReadModeTlv(mode));
@@ -2442,7 +2443,15 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
 
     SendChildUpdateResponseToChild(child, info);
 
-    aRxInfo.mClass = RxInfo::kPeerMessage;
+    // If the message is a "Child Update Response and Request",
+    // the `mClass` may have already been set when processing it
+    // as a response. We only set it to `kPeerMessage` if it is
+    // still unknown.
+
+    if (aRxInfo.mClass == RxInfo::kUnknown)
+    {
+        aRxInfo.mClass = RxInfo::kPeerMessage;
+    }
 
 exit:
     LogProcessError(kTypeChildUpdateRequestOfChild, error);
@@ -3000,6 +3009,7 @@ Error Mle::SendChildUpdateRequestToChild(Child &aChild)
         }
 
         SuccessOrExit(error = message->AppendChallengeTlv(aChild.GetChallenge()));
+        SuccessOrExit(error = message->AppendThreeWayChildUpdateTlv());
     }
 
     destination.SetToLinkLocalAddress(aChild.GetExtAddress());

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -98,6 +98,7 @@ public:
         kPendingDataset        = 25, ///< Pending Operational Dataset TLV
         kDiscovery             = 26, ///< Thread Discovery TLV
         kSupervisionInterval   = 27, ///< Supervision Interval TLV
+        kThreeWayChildUpdate   = 28, ///< Three Way Child Update TLV
         kWakeupChannel         = 74, ///< Wakeup Channel TLV
         kCslChannel            = 80, ///< CSL Channel TLV
         kCslTimeout            = 85, ///< CSL Timeout TLV
@@ -228,6 +229,11 @@ typedef UintTlvInfo<Tlv::kCslTimeout, uint32_t> CslTimeoutTlv;
  * Defines XTAL Accuracy TLV constants and types.
  */
 typedef UintTlvInfo<Tlv::kXtalAccuracy, uint16_t> XtalAccuracyTlv;
+
+/**
+ * Defines Three Way Child Update TLV constants and types.
+ */
+typedef TlvInfo<Tlv::kThreeWayChildUpdate> ThreeWayChildUpdateTlv;
 
 #if !OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
 

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -166,6 +166,7 @@ enum Command : uint8_t
     kCommandLinkMetricsManagementRequest  = 18,  ///< Link Metrics Management Request command
     kCommandLinkMetricsManagementResponse = 19,  ///< Link Metrics Management Response command
     kCommandLinkProbe                     = 20,  ///< Link Probe command
+    kCommandChildUpdateResponseAndRequest = 21,  ///< Child Update Response and Request command
     kCommandTimeSync                      = 99,  ///< Time Sync command
     kCommandP2pLinkRequest                = 100, ///< P2P Link Request command
     kCommandP2pLinkAccept                 = 101, ///< P2P Link Accept command


### PR DESCRIPTION
This commit implements the three-way child update mechanism to efficiently restore links between a parent and a non-sleepy child.

- Introduces the new `kCommandChildUpdateResponseAndRequest` MLE command.
- Adds `Tlv::kThreeWayChildUpdate` to signal feature support from the parent to the child.
- Updates `Mle::SendChildUpdateRequestToChild()` to append the new TLV.
- Updates `Mle::HandleChildUpdateRequestOnChild()` to check for the TLV and construct a combined response and request by setting the command type to `kCommandChildUpdateResponseAndRequest` and requesting the necessary TLVs (`Tlv::kAddressRegistration`, `Tlv::kMode`, `Tlv::kChallenge`).
- Updates `Mle::SendChildUpdateResponse()` to properly format the message based on the command type, including `Tlv::kMode` and `Tlv::kChallenge` when appropriate.
- Adds `Mle::HandleChildUpdateResponseAndRequest()` to sequentially process both the response and the request components of the message.

---

Related to [SPEC-1457](https://threadgroup.atlassian.net/browse/SPEC-1457)
 Also related to https://github.com/openthread/openthread/issues/12008.

----

Validated the behavior by checking the logs, e.g.

Logs on the child, responding with "Update Response and Request"

```
00:00:24.788 [I] Mle-----------: Received msg from former parent, speeding up child role restoration
00:00:24.788 [I] Mle-----------: Allow extra Child Update attempts 2
00:00:24.788 [I] Mle-----------: Receive Child Update Request as child (fe80:0:0:0:4c57:7fe7:9599:4ff1,0x0000)
00:00:24.788 [I] Mle-----------: Send Child Update Response and Request (fe80:0:0:0:4c57:7fe7:9599:4ff1)
00:00:24.791 [I] Mle-----------: Receive Child Update Response as child (fe80:0:0:0:4c57:7fe7:9599:4ff1)
00:00:24.791 [N] Mle-----------: Role detached -> child
```

Logs on parent:

```
00:00:24.788 [I] Mle-----------: Send Child Update Request to child (fe80:0:0:0:68b4:b321:1bae:f6bf,0x0001)
00:00:24.789 [I] Mle-----------: Receive Child Update Response and Request (fe80:0:0:0:68b4:b321:1bae:f6bf)
00:00:24.789 [I] Mle-----------: Receive Child Update Response from child (fe80:0:0:0:68b4:b321:1bae:f6bf,0x0001)
00:00:24.789 [I] Mle-----------: Receive Child Update Request from child (fe80:0:0:0:68b4:b321:1bae:f6bf)
00:00:24.789 [I] Mle-----------: Send Child Update Response to child (fe80:0:0:0:68b4:b321:1bae:f6bf,0x0001)
00:00:24.789 [I] Notifier------: StateChanged (0x00000400) [Child+]
```
