### PR TITLE
[crypto] add `ContextWith` template to simplify context allocation

### DIFF
--- a/src/core/common/num_utils.hpp
+++ b/src/core/common/num_utils.hpp
@@ -272,7 +272,7 @@ exit:
  *
  * @return The result of division and rounding to the closest integer.
  */
-template <typename IntType> inline IntType DivideAndRoundToClosest(IntType aDividend, IntType aDivisor)
+template <typename IntType> inline constexpr IntType DivideAndRoundToClosest(IntType aDividend, IntType aDivisor)
 {
     return (aDividend + (aDivisor / 2)) / aDivisor;
 }
@@ -287,7 +287,7 @@ template <typename IntType> inline IntType DivideAndRoundToClosest(IntType aDivi
  *
  * @return The result of division and rounding up.
  */
-template <typename IntType> inline IntType DivideAndRoundUp(IntType aDividend, IntType aDivisor)
+template <typename IntType> inline constexpr IntType DivideAndRoundUp(IntType aDividend, IntType aDivisor)
 {
     return (aDividend + (aDivisor - 1)) / aDivisor;
 }

--- a/src/core/crypto/aes_ecb.cpp
+++ b/src/core/crypto/aes_ecb.cpp
@@ -38,17 +38,7 @@
 namespace ot {
 namespace Crypto {
 
-AesEcb::AesEcb(void)
-{
-#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_ALLOCS_CONTEXT
-    mContext.mContext     = nullptr;
-    mContext.mContextSize = 0;
-#else
-    mContext.mContext     = mContextStorage;
-    mContext.mContextSize = sizeof(mContextStorage);
-#endif
-    SuccessOrAssert(otPlatCryptoAesInit(&mContext));
-}
+AesEcb::AesEcb(void) { SuccessOrAssert(otPlatCryptoAesInit(&mContext)); }
 
 void AesEcb::SetKey(const Key &aKey) { SuccessOrAssert(otPlatCryptoAesSetKey(&mContext, &aKey)); }
 

--- a/src/core/crypto/aes_ecb.hpp
+++ b/src/core/crypto/aes_ecb.hpp
@@ -85,10 +85,7 @@ public:
     void Encrypt(const uint8_t aInput[kBlockSize], uint8_t aOutput[kBlockSize]);
 
 private:
-    otCryptoContext mContext;
-#if !OPENTHREAD_CONFIG_CRYPTO_PLATFORM_ALLOCS_CONTEXT
-    OT_DEFINE_ALIGNED_VAR(mContextStorage, kAesContextSize, uint64_t);
-#endif
+    ContextWith<kAesContextSize> mContext;
 };
 
 /**

--- a/src/core/crypto/hkdf_sha256.cpp
+++ b/src/core/crypto/hkdf_sha256.cpp
@@ -42,17 +42,7 @@
 namespace ot {
 namespace Crypto {
 
-HkdfSha256::HkdfSha256(void)
-{
-#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_ALLOCS_CONTEXT
-    mContext.mContext     = nullptr;
-    mContext.mContextSize = 0;
-#else
-    mContext.mContext     = mContextStorage;
-    mContext.mContextSize = sizeof(mContextStorage);
-#endif
-    SuccessOrAssert(otPlatCryptoHkdfInit(&mContext));
-}
+HkdfSha256::HkdfSha256(void) { SuccessOrAssert(otPlatCryptoHkdfInit(&mContext)); }
 
 HkdfSha256::~HkdfSha256(void) { SuccessOrAssert(otPlatCryptoHkdfDeinit(&mContext)); }
 

--- a/src/core/crypto/hkdf_sha256.hpp
+++ b/src/core/crypto/hkdf_sha256.hpp
@@ -42,6 +42,7 @@
 #include "common/code_utils.hpp"
 #include "crypto/context_size.hpp"
 #include "crypto/hmac_sha256.hpp"
+#include "crypto/storage.hpp"
 
 namespace ot {
 namespace Crypto {
@@ -93,10 +94,7 @@ public:
     void Expand(const uint8_t *aInfo, uint16_t aInfoLength, uint8_t *aOutputKey, uint16_t aOutputKeyLength);
 
 private:
-    otCryptoContext mContext;
-#if !OPENTHREAD_CONFIG_CRYPTO_PLATFORM_ALLOCS_CONTEXT
-    OT_DEFINE_ALIGNED_VAR(mContextStorage, kHkdfContextSize, uint64_t);
-#endif
+    ContextWith<kHkdfContextSize> mContext;
 };
 
 /**

--- a/src/core/crypto/hmac_sha256.cpp
+++ b/src/core/crypto/hmac_sha256.cpp
@@ -39,18 +39,7 @@
 namespace ot {
 namespace Crypto {
 
-HmacSha256::HmacSha256(void)
-{
-#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_ALLOCS_CONTEXT
-    mContext.mContext     = nullptr;
-    mContext.mContextSize = 0;
-#else
-    mContext.mContext     = mContextStorage;
-    mContext.mContextSize = sizeof(mContextStorage);
-#endif
-
-    SuccessOrAssert(otPlatCryptoHmacSha256Init(&mContext));
-}
+HmacSha256::HmacSha256(void) { SuccessOrAssert(otPlatCryptoHmacSha256Init(&mContext)); }
 
 HmacSha256::~HmacSha256(void) { SuccessOrAssert(otPlatCryptoHmacSha256Deinit(&mContext)); }
 

--- a/src/core/crypto/hmac_sha256.hpp
+++ b/src/core/crypto/hmac_sha256.hpp
@@ -123,10 +123,7 @@ public:
     void Finish(Hash &aHash);
 
 private:
-    otCryptoContext mContext;
-#if !OPENTHREAD_CONFIG_CRYPTO_PLATFORM_ALLOCS_CONTEXT
-    OT_DEFINE_ALIGNED_VAR(mContextStorage, kHmacSha256ContextSize, uint64_t);
-#endif
+    ContextWith<kHmacSha256ContextSize> mContext;
 };
 
 /**

--- a/src/core/crypto/sha256.cpp
+++ b/src/core/crypto/sha256.cpp
@@ -40,18 +40,7 @@
 namespace ot {
 namespace Crypto {
 
-Sha256::Sha256(void)
-{
-#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_ALLOCS_CONTEXT
-    mContext.mContext     = nullptr;
-    mContext.mContextSize = 0;
-#else
-    mContext.mContext     = mContextStorage;
-    mContext.mContextSize = sizeof(mContextStorage);
-#endif
-
-    SuccessOrAssert(otPlatCryptoSha256Init(&mContext));
-}
+Sha256::Sha256(void) { SuccessOrAssert(otPlatCryptoSha256Init(&mContext)); }
 
 Sha256::~Sha256(void) { SuccessOrAssert(otPlatCryptoSha256Deinit(&mContext)); }
 

--- a/src/core/crypto/sha256.hpp
+++ b/src/core/crypto/sha256.hpp
@@ -47,6 +47,7 @@
 #include "common/equatable.hpp"
 #include "common/type_traits.hpp"
 #include "crypto/context_size.hpp"
+#include "crypto/storage.hpp"
 
 namespace ot {
 
@@ -135,10 +136,7 @@ public:
     void Finish(Hash &aHash);
 
 private:
-    otCryptoContext mContext;
-#if !OPENTHREAD_CONFIG_CRYPTO_PLATFORM_ALLOCS_CONTEXT
-    OT_DEFINE_ALIGNED_VAR(mContextStorage, kSha256ContextSize, uint64_t);
-#endif
+    ContextWith<kSha256ContextSize> mContext;
 };
 
 /**

--- a/src/core/crypto/storage.hpp
+++ b/src/core/crypto/storage.hpp
@@ -44,6 +44,7 @@
 #include "common/error.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
+#include "common/num_utils.hpp"
 
 namespace ot {
 namespace Crypto {
@@ -264,6 +265,60 @@ inline bool HasKey(KeyRef aKeyRef) { return otPlatCryptoHasKey(aKeyRef); }
 #endif // OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
 
 /**
+ * Represents a crypto context.
+ */
+class Context : public otCryptoContext
+{
+public:
+    /**
+     * Gets the pointer to the context buffer.
+     *
+     * @returns A pointer to the context buffer.
+     */
+    void *GetContext(void) { return mContext; }
+
+    /**
+     * Gets the size of the context buffer.
+     *
+     * @returns The size of the context buffer in bytes.
+     */
+    uint16_t GetSize(void) const { return mContextSize; }
+
+    /**
+     * Sets the context buffer.
+     *
+     * @param[in] aContext A pointer to the context buffer.
+     * @param[in] aSize    The size of the context buffer in bytes.
+     */
+    void SetContext(void *aContext, uint16_t aSize) { mContext = aContext, mContextSize = aSize; }
+};
+
+/**
+ * Represents a crypto context with a locally allocated buffer.
+ *
+ * @tparam kContextSize The size of the context buffer in bytes.
+ */
+template <uint16_t kContextSize> class ContextWith : public Context
+{
+public:
+    /**
+     * Initializes the context and the locally allocated buffer.
+     */
+    ContextWith(void)
+    {
+        ClearAllBytes(*this);
+#if !OPENTHREAD_CONFIG_CRYPTO_PLATFORM_ALLOCS_CONTEXT
+        SetContext(mStorage, kContextSize);
+#endif
+    }
+
+private:
+#if !OPENTHREAD_CONFIG_CRYPTO_PLATFORM_ALLOCS_CONTEXT
+    uint64_t mStorage[DivideAndRoundUp<uint16_t>(kContextSize, sizeof(uint64_t))];
+#endif
+};
+
+/**
  * Represents a crypto key.
  *
  * The `Key` can represent a literal key (i.e., a pointer to a byte array containing the key along with a key length)
@@ -393,6 +448,7 @@ private:
 
 } // namespace Crypto
 
+DefineCoreType(otCryptoContext, Crypto::Context);
 DefineCoreType(otCryptoKey, Crypto::Key);
 
 } // namespace ot


### PR DESCRIPTION
This commit introduces the `Context` and `ContextWith<kContextSize>` helper classes in the `Crypto` namespace to wrap `otCryptoContext` and manage its storage allocation. `ContextWith<kContextSize>` handles the buffer allocation based on the configuration `OPENTHREAD_CONFIG_CRYPTO_PLATFORM_ALLOCS_CONTEXT`, automatically clearing and setting the buffer.

The `AesEcb`, `HkdfSha256`, `HmacSha256`, and `Sha256` classes are updated to use the new `ContextWith` template for their `mContext` members. This simplifies their initialization sequences and constructors.
