### PR TITLE
[cli] make `otPlatLogOutput` weak to allow application override

### DIFF
--- a/src/cli/cli_logging.cpp
+++ b/src/cli/cli_logging.cpp
@@ -42,7 +42,7 @@
 #if OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_APP
 
 #if OPENTHREAD_CONFIG_LOG_INSTANCE_AWARE_API_ENABLE
-extern "C" void otPlatLogOutput(otInstance *aInstance, otLogLevel aLogLevel, const char *aLogLine)
+extern "C" OT_TOOL_WEAK void otPlatLogOutput(otInstance *aInstance, otLogLevel aLogLevel, const char *aLogLine)
 {
     OT_UNUSED_VARIABLE(aInstance);
     otPlatLog(aLogLevel, OT_LOG_REGION_CORE, "%s", aLogLine);


### PR DESCRIPTION
Make `otPlatLogOutput()` `OT_TOOL_WEAK` in `cli_logging.cpp` so that applications can provide their own strong definition to customize instance-aware log output behaviour.