### PR TITLE
[ip6] note MLE registration limit interaction with runtime pool mode

### DIFF
--- a/src/core/config/ip6.h
+++ b/src/core/config/ip6.h
@@ -59,6 +59,11 @@
  *
  * When this feature is enabled, the configs `OPENTHREAD_CONFIG_IP6_MAX_EXT_UCAST_ADDRS` and
  * `OPENTHREAD_CONFIG_IP6_MAX_EXT_MCAST_ADDRS` are no longer applicable or used.
+ *
+ * When using this feature, also consider setting `OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER`
+ * to `0xffff` (or at least as large as the total pool size passed to `otIp6Init()`). Otherwise,
+ * the MLE Address Registration TLV will still be capped at its compile-time default, silently
+ * dropping addresses beyond that limit even when the pools are larger.
  */
 #ifndef OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
 #define OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE 0


### PR DESCRIPTION
When `OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE` is used, the external unicast and multicast address pool sizes are determined at runtime. Without adjustment, the compile-time `OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER` cap silently discards address registrations beyond that limit, even when the runtime pools are larger.
    
These are independent settings; the stack does not enforce a relationship between them. This commit adds a documentation note to `OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE` advising that users set `OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER` to 0xffff (or at least as large as the sum of the unicast and multicast pool sizes) when using this feature.