### PR TITLE
[child] add runtime per-child IPv6 address pool for FTDs

### DIFF
--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -126,6 +126,43 @@ jobs:
         path: tmp/coverage.info
         retention-days: 1
 
+  toranj-cli-ip6-ext-addr-pool:
+    name: toranj-cli-ip6-ext-addr-pool
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.12'
+        cache: pip
+    - name: Bootstrap
+      run: |
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y ninja-build
+        python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
+    - name: Build
+      run: |
+        mkdir -p build/toranj-ip6-pool
+        cd build/toranj-ip6-pool
+        cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=ON \
+            -DOT_THREAD_VERSION=1.4 -DOT_APP_CLI=ON -DOT_APP_NCP=OFF -DOT_APP_RCP=OFF \
+            -DOT_15_4=ON -DOT_TREL=OFF \
+            -DOT_PROJECT_CONFIG=../../tests/toranj/openthread-core-toranj-config-ip6-pool-test.h \
+            ../..
+        ninja ot-cli-ftd
+    - name: Run
+      run: |
+        cd tests/toranj/cli
+        top_builddir=$(pwd)/../../../build/toranj-ip6-pool \
+            python3 test-ip6-ext-addr-pool-child-table.py
+
   toranj-unittest:
     name: toranj-unittest
     runs-on: ubuntu-24.04

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (590)
+#define OPENTHREAD_API_VERSION (591)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -912,6 +912,32 @@ void otThreadGetNextHopAndPathCost(otInstance *aInstance,
  * @}
  */
 
+/**
+ * Sets the maximum number of IPv6 address entries per child on an FTD.
+ *
+ * Requires `OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE` and `OPENTHREAD_FTD`.
+ *
+ * When `OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE` is enabled on an FTD, the
+ * compile-time `OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD` is inert. Instead, IPv6 address
+ * entries are individually heap-allocated on demand as children register addresses. Each
+ * child is independently capped at `aAddrsPerChild` entries, ensuring no single child can
+ * exhaust address storage at the expense of others.
+ *
+ * Must be called before `otThreadSetEnabled()`. If it has not been called,
+ * `otThreadSetEnabled()` returns `OT_ERROR_INVALID_STATE`.
+ *
+ * This function can only be called once. Subsequent calls return `OT_ERROR_ALREADY`.
+ *
+ * @param[in] aInstance      A pointer to an OpenThread instance.
+ * @param[in] aAddrsPerChild Maximum number of IPv6 address entries per child.
+ *
+ * @retval OT_ERROR_NONE             Successfully set the per-child address capacity.
+ * @retval OT_ERROR_ALREADY          The capacity has already been set.
+ * @retval OT_ERROR_INVALID_ARGS     @p aAddrsPerChild is 0.
+ * @retval OT_ERROR_NOT_IMPLEMENTED  Feature is not enabled (`OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE` is 0).
+ */
+otError otChildTableInit(otInstance *aInstance, uint16_t aAddrsPerChild);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3392,6 +3392,11 @@ otError Interpreter::ProcessIfconfigInit(Arg aArgs[])
     unicastPool   = nullptr;
     multicastPool = nullptr;
 
+#if OPENTHREAD_FTD
+    // On an FTD, also set the per-child address capacity to match the unicast + multicast pool size.
+    IgnoreError(otChildTableInit(GetInstancePtr(), static_cast<uint16_t>(unicastPoolSize + multicastPoolSize)));
+#endif
+
 exit:
     otHeapFree(unicastPool);
     otHeapFree(multicastPool);

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -393,6 +393,15 @@ otError otThreadSetEnabled(otInstance *aInstance, bool aEnabled)
 
 uint16_t otThreadGetVersion(void) { return kThreadVersion; }
 
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+otError otChildTableInit(otInstance *aInstance, uint16_t aAddrsPerChild)
+{
+    return AsCoreType(aInstance).Get<ChildTable>().Init(aAddrsPerChild);
+}
+#else
+otError otChildTableInit(otInstance *, uint16_t) { return kErrorNotImplemented; }
+#endif
+
 bool otThreadIsSingleton(otInstance *aInstance)
 {
     bool isSingleton = false;

--- a/src/core/config/mle.h
+++ b/src/core/config/mle.h
@@ -77,6 +77,10 @@
  * @def OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD
  *
  * The maximum number of supported IPv6 address registrations per child.
+ *
+ * On an FTD, this controls the compile-time size of the per-child address storage in each `Child`
+ * entry. When `OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE` is set, all sizing is determined
+ * at runtime via `otChildTableInit()` and this config is not used for FTD child table sizing.
  */
 #ifndef OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD
 #define OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD 4

--- a/src/core/thread/child.cpp
+++ b/src/core/thread/child.cpp
@@ -76,6 +76,20 @@ void Child::Info::SetFrom(const Child &aChild)
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+
+MlrState Child::Ip6AddrEntry::GetMlrState(const Child & /* aChild */) const
+{
+    return static_cast<MlrState>(mMlrState);
+}
+
+void Child::Ip6AddrEntry::SetMlrState(MlrState aState, Child & /* aChild */)
+{
+    mMlrState = static_cast<uint8_t>(aState);
+}
+
+#else // !OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+
 MlrState Child::Ip6AddrEntry::GetMlrState(const Child &aChild) const
 {
     MlrState                   state = kMlrStateRegistering;
@@ -110,6 +124,8 @@ void Child::Ip6AddrEntry::SetMlrState(MlrState aState, Child &aChild)
     aChild.mMlrRegisteredSet.Update(index, aState == kMlrStateRegistered);
 }
 
+#endif // OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+
 #endif // OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -126,10 +142,23 @@ void Child::Clear(void)
 void Child::ClearIp6Addresses(void)
 {
     mMeshLocalIid.Clear();
+
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+    // Free all heap-allocated entries in the per-child linked list.
+    while (!mIp6Addresses.IsEmpty())
+    {
+        Ip6AddrEntry *entry = mIp6Addresses.GetHead();
+        mIp6Addresses.Pop();
+        Get<ChildTable>().FreeIp6AddrEntry(*entry);
+    }
+
+    mIp6AddrCount = 0;
+#else
     mIp6Addresses.Clear();
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     mMlrToRegisterSet.Clear();
     mMlrRegisteredSet.Clear();
+#endif
 #endif
 }
 
@@ -173,10 +202,26 @@ Error Child::GetNextIp6Address(AddressIterator &aIterator, Ip6::Address &aAddres
         }
     }
 
-    VerifyOrExit(aIterator - 1 < mIp6Addresses.GetLength(), error = kErrorNotFound);
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+    {
+        const Ip6AddrEntry *entry = mIp6Addresses.GetHead();
+        AddressIterator     idx   = 1;
 
+        while (entry != nullptr && idx < aIterator)
+        {
+            entry = entry->GetNext();
+            idx++;
+        }
+
+        VerifyOrExit(entry != nullptr, error = kErrorNotFound);
+        aAddress = *entry;
+        aIterator++;
+    }
+#else
+    VerifyOrExit(aIterator - 1 < mIp6Addresses.GetLength(), error = kErrorNotFound);
     aAddress = mIp6Addresses[static_cast<Ip6AddressArray::IndexType>(aIterator - 1)];
     aIterator++;
+#endif
 
 exit:
     return error;
@@ -195,8 +240,23 @@ Error Child::AddIp6Address(const Ip6::Address &aAddress)
         ExitNow();
     }
 
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+    VerifyOrExit(!mIp6Addresses.ContainsMatching(aAddress), error = kErrorAlready);
+    VerifyOrExit(mIp6AddrCount < Get<ChildTable>().GetIp6AddrCapacity(), error = kErrorNoBufs);
+    {
+        Ip6AddrEntry *entry = Get<ChildTable>().AllocIp6AddrEntry();
+        VerifyOrExit(entry != nullptr, error = kErrorNoBufs);
+        static_cast<Ip6::Address &>(*entry) = aAddress;
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+        entry->mMlrState = static_cast<uint8_t>(kMlrStateRegistering);
+#endif
+        mIp6Addresses.Push(*entry);
+        mIp6AddrCount++;
+    }
+#else
     VerifyOrExit(!mIp6Addresses.ContainsMatching(aAddress), error = kErrorAlready);
     error = mIp6Addresses.PushBack(static_cast<const Ip6AddrEntry &>(aAddress));
+#endif
 
 exit:
     return error;
@@ -218,6 +278,14 @@ Error Child::RemoveIp6Address(const Ip6::Address &aAddress)
         ExitNow();
     }
 
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+    entry = mIp6Addresses.FindMatching(aAddress);
+    VerifyOrExit(entry != nullptr);
+    SuccessOrAssert(mIp6Addresses.Remove(*entry));
+    Get<ChildTable>().FreeIp6AddrEntry(*entry);
+    mIp6AddrCount--;
+    error = kErrorNone;
+#else
     entry = mIp6Addresses.FindMatching(aAddress);
     VerifyOrExit(entry != nullptr);
 
@@ -240,6 +308,7 @@ Error Child::RemoveIp6Address(const Ip6::Address &aAddress)
 
     mIp6Addresses.Remove(*entry);
     error = kErrorNone;
+#endif // OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
 
 exit:
     return error;

--- a/src/core/thread/child.hpp
+++ b/src/core/thread/child.hpp
@@ -43,8 +43,10 @@ namespace ot {
 
 #if OPENTHREAD_FTD
 
+#if !OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
 #if OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD < 2
 #error OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD should be at least set to 2.
+#endif
 #endif
 
 /**
@@ -55,10 +57,15 @@ class Child : public CslNeighbor
 public:
     static constexpr uint8_t kMaxRequestTlvs = 6;
 
+#if !OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
     /**
      * Maximum number of registered IPv6 addresses per child (excluding the mesh-local EID).
+     *
+     * Not used when `OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE` is set; per-child address
+     * capacity is then determined at runtime by the value passed to `otChildTableInit()`.
      */
     static constexpr uint16_t kNumIp6Addresses = OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD - 1;
+#endif
 
     /**
      * Represents the iterator for registered IPv6 address list of an MTD child.
@@ -88,6 +95,9 @@ public:
      * Represents an IPv6 address entry registered by an MTD child.
      */
     class Ip6AddrEntry : public Ip6::Address
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+                       , public LinkedListEntry<Ip6AddrEntry>
+#endif
     {
     public:
         /**
@@ -118,14 +128,34 @@ public:
          */
         void SetMlrState(MlrState aState, Child &aChild);
 #endif
+
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+    private:
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+        uint8_t mMlrState;
+#endif
+        Ip6AddrEntry *mNext;
+
+        friend class Child;
+        friend class LinkedList<Ip6AddrEntry>;
+        friend class LinkedListEntry<Ip6AddrEntry>;
+#endif
     };
 
     /**
-     * Represents an array of IPv6 address entries registered by an MTD child.
+     * Represents the collection of IPv6 address entries registered by an MTD child.
      *
-     * This array does not include the mesh-local EID.
+     * When `OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE` is enabled this is a
+     * `LinkedList<Ip6AddrEntry>` whose entries are individually heap-allocated on demand.
+     * Each child is independently capped at the value passed to `otChildTableInit()`.
+     *
+     * When disabled this is a compile-time-sized `Array<Ip6AddrEntry, kNumIp6Addresses>`.
      */
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+    typedef LinkedList<Ip6AddrEntry> Ip6AddressArray;
+#else
     typedef Array<Ip6AddrEntry, kNumIp6Addresses> Ip6AddressArray;
+#endif
 
     /**
      * Initializes the `Child` object.
@@ -368,7 +398,21 @@ public:
      * @retval true   If the Child has any IPv6 address of MLR state `kMlrStateRegistered`.
      * @retval false  If the Child does not have any IPv6 address of MLR state `kMlrStateRegistered`.
      */
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+    bool HasAnyMlrRegisteredAddress(void) const
+    {
+        for (const Ip6AddrEntry &entry : mIp6Addresses)
+        {
+            if (entry.mMlrState == static_cast<uint8_t>(kMlrStateRegistered))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+#else
     bool HasAnyMlrRegisteredAddress(void) const { return !mMlrRegisteredSet.IsEmpty(); }
+#endif
 
     /**
      * Returns if the Child has any IPv6 address of MLR state `kMlrStateToRegister`.
@@ -376,17 +420,36 @@ public:
      * @retval true   If the Child has any IPv6 address of MLR state `kMlrStateToRegister`.
      * @retval false  If the Child does not have any IPv6 address of MLR state `kMlrStateToRegister`.
      */
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+    bool HasAnyMlrToRegisterAddress(void) const
+    {
+        for (const Ip6AddrEntry &entry : mIp6Addresses)
+        {
+            if (entry.mMlrState == static_cast<uint8_t>(kMlrStateToRegister))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+#else
     bool HasAnyMlrToRegisterAddress(void) const { return !mMlrToRegisterSet.IsEmpty(); }
+#endif
 #endif // OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 
 private:
+#if !OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
     typedef BitSet<kNumIp6Addresses> ChildIp6AddressSet;
+#endif
 
     uint32_t mTimeout;
 
     Ip6::InterfaceIdentifier mMeshLocalIid;
     Ip6AddressArray          mIp6Addresses;
-#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+    uint16_t mIp6AddrCount;
+#endif
+#if !OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     ChildIp6AddressSet mMlrToRegisterSet;
     ChildIp6AddressSet mMlrRegisteredSet;
 #endif

--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -35,6 +35,7 @@
 
 #if OPENTHREAD_FTD
 
+#include "common/heap.hpp"
 #include "instance/instance.hpp"
 
 namespace ot {
@@ -81,6 +82,9 @@ ChildTable::ChildTable(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mNextChildId(Mle::kMaxChildId)
     , mMaxChildrenAllowed(kMaxChildren)
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+    , mIp6AddrCapacity(0)
+#endif
 {
     for (Child &child : mChildren)
     {
@@ -96,6 +100,28 @@ void ChildTable::Clear(void)
         child.Clear();
     }
 }
+
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+Error ChildTable::Init(uint16_t aAddrsPerChild)
+{
+    Error error = kErrorNone;
+
+    VerifyOrExit(aAddrsPerChild != 0, error = kErrorInvalidArgs);
+    VerifyOrExit(mIp6AddrCapacity == 0, error = kErrorAlready);
+
+    mIp6AddrCapacity = aAddrsPerChild;
+
+exit:
+    return error;
+}
+
+Child::Ip6AddrEntry *ChildTable::AllocIp6AddrEntry(void)
+{
+    return static_cast<Child::Ip6AddrEntry *>(Heap::CAlloc(1, sizeof(Child::Ip6AddrEntry)));
+}
+
+void ChildTable::FreeIp6AddrEntry(Child::Ip6AddrEntry &aEntry) { Heap::Free(&aEntry); }
+#endif
 
 Child *ChildTable::GetChildAtIndex(uint16_t aChildIndex)
 {

--- a/src/core/thread/child_table.hpp
+++ b/src/core/thread/child_table.hpp
@@ -108,6 +108,62 @@ public:
      */
     void Clear(void);
 
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+    /**
+     * Sets the maximum number of IPv6 address entries per child.
+     *
+     * Requires `OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE`.
+     *
+     * Each child is independently capped at `aAddrsPerChild` heap-allocated entries,
+     * ensuring that no single child can exhaust address storage at the expense of others.
+     * This satisfies the Thread specification requirement that a parent MUST support at
+     * least four IPv6 addresses per MTD child.
+     *
+     * Must be called before `otThreadSetEnabled()`. If it has not been called,
+     * `otThreadSetEnabled()` returns `OT_ERROR_INVALID_STATE`.
+     *
+     * This function can only be called once. Subsequent calls return `OT_ERROR_ALREADY`.
+     *
+     * @param[in] aAddrsPerChild  Maximum IPv6 address entries per child.
+     *
+     * @retval kErrorNone         Successfully set the per-child address capacity.
+     * @retval kErrorAlready      The capacity has already been set.
+     * @retval kErrorInvalidArgs  @p aAddrsPerChild is 0.
+     */
+    Error Init(uint16_t aAddrsPerChild);
+
+    /**
+     * Indicates whether the per-child address capacity has been set via `Init()`.
+     *
+     * @retval TRUE   Initialized.
+     * @retval FALSE  Not yet initialized.
+     */
+    bool IsInitialized(void) const { return mIp6AddrCapacity != 0; }
+
+    /**
+     * Returns the per-child IPv6 address capacity set by `Init()`.
+     *
+     * @returns Maximum number of IPv6 address entries per child.
+     */
+    uint16_t GetIp6AddrCapacity(void) const { return mIp6AddrCapacity; }
+
+    /**
+     * Heap-allocates one `Ip6AddrEntry`.
+     *
+     * The caller is responsible for enforcing the per-child limit before calling this.
+     *
+     * @returns A pointer to an allocated entry, or `nullptr` if heap allocation fails.
+     */
+    Child::Ip6AddrEntry *AllocIp6AddrEntry(void);
+
+    /**
+     * Frees a heap-allocated `Ip6AddrEntry`.
+     *
+     * @param[in] aEntry  The entry to free.
+     */
+    void FreeIp6AddrEntry(Child::Ip6AddrEntry &aEntry);
+#endif
+
     /**
      * Returns the child table index for a given `Child` instance.
      *
@@ -340,6 +396,9 @@ private:
     uint16_t mNextChildId;
     uint16_t mMaxChildrenAllowed;
     Child    mChildren[kMaxChildren];
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+    uint16_t mIp6AddrCapacity;
+#endif
 };
 
 } // namespace ot

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -46,6 +46,9 @@
 #include "coap/coap_message.hpp"
 #include "common/array.hpp"
 #include "common/callback.hpp"
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+#include "common/heap_array.hpp"
+#endif
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
@@ -98,9 +101,13 @@ public:
     void HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState, const BackboneRouter::Config &aConfig);
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+#if OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+    typedef Heap::Array<Ip6::Address> MlrAddressArray; ///< Registered MLR addresses array (heap-allocated, runtime-sized).
+#else
     static constexpr uint16_t kMaxMlrAddresses = OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD - 1; ///< Max MLR addresses
 
     typedef Array<Ip6::Address, kMaxMlrAddresses> MlrAddressArray; ///< Registered MLR addresses array.
+#endif
 
     /**
      * Updates the Multicast Subscription Table according to the Child information.

--- a/tests/toranj/cli/test-ip6-ext-addr-pool-child-table.py
+++ b/tests/toranj/cli/test-ip6-ext-addr-pool-child-table.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+
+from cli import verify
+from cli import verify_within
+import cli
+import ipaddress
+import time
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test description:
+#
+# Validate FTD-side behaviour when `OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE` is set:
+#
+# `ifconfig init <ucast> <mcast>` on an FTD initialises both the netif address pools and the
+# shared per-child address pool (ucast + mcast slots per child) via `otChildTableInit`. A SED
+# child then registers UCAST_POOL_SIZE external unicast addresses, and all of them must appear
+# in the parent FTD's child-IP table, proving the runtime-allocated per-child `LinkedList` pool
+# stores entries correctly.
+#
+# Network topology
+#
+#    leader (FTD) --- sed (sleepy end device)
+#
+
+test_name = __file__[:-3] if __file__.endswith('.py') else __file__
+print('-' * 120)
+print('Starting \'{}\''.format(test_name))
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Creating `cli.Node` instances
+
+speedup = 40
+cli.Node.set_time_speedup_factor(speedup)
+
+leader = cli.Node()
+sed = cli.Node()
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test Implementation
+
+UCAST_POOL_SIZE = 6
+MCAST_POOL_SIZE = 6
+
+leader.cli('ifconfig init', UCAST_POOL_SIZE, MCAST_POOL_SIZE)
+leader.form('ip6-ext-pool-ftd')
+verify(leader.get_state() == 'leader')
+
+sed.cli('ifconfig init', UCAST_POOL_SIZE, MCAST_POOL_SIZE)
+sed.set_child_timeout(300)
+sed.set_pollperiod(500)
+sed.join(leader, cli.JOIN_TYPE_SLEEPY_END_DEVICE)
+verify(sed.get_state() == 'child')
+verify(len(leader.get_child_table()) == 1)
+
+# Add UCAST_POOL_SIZE external unicast addresses on the SED using a distinct /64 prefix.
+UCAST_PREFIX = 'fd00:abcd::'
+ucast_addrs = ['{}{}'.format(UCAST_PREFIX, i + 1) for i in range(UCAST_POOL_SIZE)]
+for addr in ucast_addrs:
+    sed.add_ip_addr(addr)
+
+# Allow time for the SED to send a Child Update Request and the leader to process it.
+time.sleep(2.0 / speedup)
+
+
+def _norm(addr_str):
+    return str(ipaddress.ip_address(addr_str.lower()))
+
+
+def check_all_child_addrs_registered():
+    child_ip_entries = leader.get_child_ip()
+    # Output format: "rloc16: address" per line.
+    registered_addrs = [_norm(entry.split(': ', 1)[1]) for entry in child_ip_entries if ': ' in entry]
+    for addr in ucast_addrs:
+        verify(_norm(addr) in registered_addrs)
+
+
+verify_within(check_all_child_addrs_registered, 5)
+
+# -----------------------------------------------------------------------------------------------------------------------
+print('\'{}\' passed.'.format(test_name))

--- a/tests/toranj/openthread-core-toranj-config-ip6-pool-test.h
+++ b/tests/toranj/openthread-core-toranj-config-ip6-pool-test.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * Simulation toranj config variant with IP6 runtime external address pool
+ * enabled, used for the ip6-ext-addr-pool toranj tests.
+ */
+
+#ifndef OT_TORANJ_OPENTHREAD_CORE_TORANJ_CONFIG_IP6_POOL_TEST_H_
+#define OT_TORANJ_OPENTHREAD_CORE_TORANJ_CONFIG_IP6_POOL_TEST_H_
+
+/* Pull in the standard simulation toranj config first. */
+#include "openthread-core-toranj-config-simulation.h"
+
+/* Override the pool flag that the simulation config sets to 0. */
+#undef OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE
+#define OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE 1
+
+/* Enable the CLI 'ifconfig init' and 'thread childtableinit' commands (testing-only). */
+#define OPENTHREAD_CONFIG_CLI_IFCONFIG_INIT_ENABLE 1
+
+#endif /* OT_TORANJ_OPENTHREAD_CORE_TORANJ_CONFIG_IP6_POOL_TEST_H_ */


### PR DESCRIPTION
When MTDs in a network are configured with runtime IPv6 address pools via `OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE`, the parent FTD must also adapt; otherwise its compile-time per-child address storage silently drops registrations that exceed its enforced compile-time limit.
    
This commit extends `OPENTHREAD_CONFIG_IP6_INIT_EXT_ADDR_POOL_ENABLE` to govern FTD child table sizing:
    
- `Child::mIp6Addresses` becomes a `LinkedList<Ip6AddrEntry>` whose entries are individually heap-allocated on demand; each child is independently capped at `aAddrsPerChild` entries.
    
- `otChildTableInit(aInstance, aAddrsPerChild)` is a new public FTD API that applications may call before starting the Thread network to set a custom per-child capacity. Returns `OT_ERROR_NOT_IMPLEMENTED` when the feature is disabled.
    
- On CLI builds, `ifconfig init <ucast> <mcast>` on an FTD automatically calls `otChildTableInit` with ucast+mcast slots per child.
