### PR TITLE
[ip6] enforce single Hop-by-Hop Options header rule

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -809,6 +809,7 @@ Error Ip6::HandleExtensionHeaders(OwnedPtr<Message> &aMessagePtr,
 {
     Error           error = kErrorNone;
     ExtensionHeader extHeader;
+    bool            first = true;
 
     while (aReceive || aNextHeader == kProtoHopOpts)
     {
@@ -817,6 +818,9 @@ Error Ip6::HandleExtensionHeaders(OwnedPtr<Message> &aMessagePtr,
         switch (aNextHeader)
         {
         case kProtoHopOpts:
+            VerifyOrExit(first, error = kErrorDrop);
+            OT_FALL_THROUGH;
+
         case kProtoDstOpts:
             SuccessOrExit(error = HandleOptions(*aMessagePtr, aHeader, aReceive));
             break;
@@ -838,6 +842,7 @@ Error Ip6::HandleExtensionHeaders(OwnedPtr<Message> &aMessagePtr,
         }
 
         aNextHeader = extHeader.GetNextHeader();
+        first       = false;
     }
 
 exit:


### PR DESCRIPTION
RFC 8200 states that the Hop-by-Hop Options header MUST be the first extension header and can only occur once in a packet. This commit updates HandleExtensionHeaders to enforce this rule.

This fix prevents a potential infinite loop or exponential growth of messages when multiple Hop-by-Hop headers (each containing an MPL option) are processed. Previously, each MPL option could trigger its own retransmission, and if these options were evicted from the MPL SeedSet, they would be re-processed as new messages upon loopback, leading to exponential growth and eventually a timeout.