### PR TITLE
Fix/log level get linking error

### DIFF
--- a/script/check-simulation-build-cmake
+++ b/script/check-simulation-build-cmake
@@ -271,11 +271,32 @@ build_multi_radio_links()
     ./script/cmake-build simulation -DOT_LOG_LEVEL=DEBG \
         -DOT_TREL=ON -DOT_15_4=ON
 }
+
+build_spinel_only()
+{
+    # Build only the spinel-related library targets.
+    reset_source
+    OT_CMAKE_NINJA_TARGET="openthread-radio-spinel openthread-spinel-ncp openthread-spinel-rcp openthread-hdlc openthread-platform" \
+        "$(dirname "$0")"/cmake-build simulation \
+        -DOT_APP_CLI=OFF \
+        -DOT_APP_NCP=OFF \
+        -DOT_APP_RCP=OFF
+
+    # Link test: verify spinel-only files link into a final executable.
+    reset_source
+    OT_CMAKE_NINJA_TARGET="ot-test-spinel-only-link" \
+        "$(dirname "$0")"/cmake-build simulation \
+        -DOT_APP_CLI=OFF \
+        -DOT_APP_NCP=OFF \
+        -DOT_APP_RCP=OFF
+}
+
 main()
 {
     build_all_features
     build_nest_common
     build_multi_radio_links
+    build_spinel_only
 }
 
 main "$@"

--- a/src/core/api/logging_api.cpp
+++ b/src/core/api/logging_api.cpp
@@ -43,7 +43,9 @@ otLogLevel otLoggingGetLevel(void)
 {
     LogLevel level;
 
-#if !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
+#if !OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE
+    level = static_cast<LogLevel>(OPENTHREAD_CONFIG_LOG_LEVEL);
+#elif !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
     level = Instance::Get().GetLogLevel();
 #else
     level = Instance::GetGlobalLogLevel();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,3 +45,5 @@ endif()
 if(OT_PLATFORM STREQUAL "nexus")
     add_subdirectory(nexus)
 endif()
+
+add_subdirectory(spinel-only)

--- a/tests/spinel-only/CMakeLists.txt
+++ b/tests/spinel-only/CMakeLists.txt
@@ -1,0 +1,104 @@
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+# Spinel-only link test
+#
+# Verifies that the Spinel/HDLC libraries plus a minimal set of OT core
+# files can link into a final executable *without* the full Thread stack.
+# This mirrors the ESP-IDF OPENTHREAD_SPINEL_ONLY build mode used by the
+# Zigbee gateway and catches linker errors (e.g. unwanted Instance::Get()
+# references) that static-library-only builds cannot detect.
+#
+# The target is EXCLUDE_FROM_ALL so it is only built when explicitly
+# requested via ninja target name.
+
+add_library(openthread-spinel-only-core STATIC EXCLUDE_FROM_ALL
+    ${PROJECT_SOURCE_DIR}/src/core/api/error_api.cpp
+    ${PROJECT_SOURCE_DIR}/src/core/api/logging_api.cpp
+    ${PROJECT_SOURCE_DIR}/src/core/common/error.cpp
+    ${PROJECT_SOURCE_DIR}/src/core/common/log.cpp
+    ${PROJECT_SOURCE_DIR}/src/core/common/string.cpp
+)
+
+target_include_directories(openthread-spinel-only-core
+    PUBLIC
+        ${PROJECT_SOURCE_DIR}/include
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/src
+        ${PROJECT_SOURCE_DIR}/src/core
+        ${PROJECT_SOURCE_DIR}/src/include
+        ${PROJECT_SOURCE_DIR}/examples/platforms/simulation
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_compile_definitions(openthread-spinel-only-core PRIVATE
+    OPENTHREAD_FTD=0
+    OPENTHREAD_MTD=0
+    OPENTHREAD_RADIO=0
+    OPENTHREAD_PROJECT_CORE_CONFIG_FILE="openthread-core-spinel-only-config.h"
+    OPENTHREAD_PLATFORM_CORE_CONFIG_FILE="openthread-core-simulation-config.h"
+    OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE=0
+)
+
+target_compile_options(openthread-spinel-only-core PRIVATE
+    ${OT_CFLAGS}
+)
+
+add_executable(ot-test-spinel-only-link EXCLUDE_FROM_ALL
+    platform_stubs.c
+    mac_frame_stubs.cpp
+)
+
+target_include_directories(ot-test-spinel-only-link PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_SOURCE_DIR}/src/core
+    ${PROJECT_SOURCE_DIR}/src/include
+    ${PROJECT_SOURCE_DIR}/examples/platforms/simulation
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_compile_definitions(ot-test-spinel-only-link PRIVATE
+    OPENTHREAD_FTD=0
+    OPENTHREAD_MTD=0
+    OPENTHREAD_RADIO=0
+    OPENTHREAD_PROJECT_CORE_CONFIG_FILE="openthread-core-spinel-only-config.h"
+    OPENTHREAD_PLATFORM_CORE_CONFIG_FILE="openthread-core-simulation-config.h"
+    OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE=0
+)
+
+target_link_libraries(ot-test-spinel-only-link PRIVATE
+    -Wl,--whole-archive
+    -Wl,--allow-multiple-definition
+    openthread-radio-spinel
+    openthread-spinel-rcp
+    openthread-hdlc
+    openthread-platform
+    openthread-spinel-only-core
+    -Wl,--no-whole-archive
+)

--- a/tests/spinel-only/mac_frame_stubs.cpp
+++ b/tests/spinel-only/mac_frame_stubs.cpp
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "openthread-core-config.h"
+#include "mac/mac_frame.hpp"
+
+namespace ot {
+namespace Mac {
+
+void Frame::SetFrameCounter(uint32_t) {}
+void Frame::SetKeyId(uint8_t) {}
+
+} // namespace Mac
+} // namespace ot

--- a/tests/spinel-only/openthread-core-spinel-only-config.h
+++ b/tests/spinel-only/openthread-core-spinel-only-config.h
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * @file
+ *   Project config for the spinel-only link test. Mirrors the key settings
+ *   used by ESP-IDF when building OpenThread in OPENTHREAD_SPINEL_ONLY mode
+ *   (no full Thread stack, only the Spinel/HDLC transport libraries).
+ *
+ *   In spinel-only mode no ot::Instance object is compiled, so all code paths
+ *   that call Instance::Get() must be avoided.
+ */
+
+#ifndef OPENTHREAD_CORE_SPINEL_ONLY_CONFIG_H_
+#define OPENTHREAD_CORE_SPINEL_ONLY_CONFIG_H_
+
+/*
+ * Disable uptime prepending in logs. The uptime feature requires
+ * ot::Instance and its UptimeTracker, neither of which exist in a
+ * spinel-only build.
+ */
+#define OPENTHREAD_CONFIG_LOG_PREPEND_UPTIME 0
+
+#endif /* OPENTHREAD_CORE_SPINEL_ONLY_CONFIG_H_ */

--- a/tests/spinel-only/platform_stubs.c
+++ b/tests/spinel-only/platform_stubs.c
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Minimal platform stubs for the spinel-only link test.
+ *
+ * These satisfy the platform-layer symbols referenced by the Spinel/HDLC
+ * libraries and the minimal OT core files.  They are never executed; their
+ * sole purpose is to let the linker succeed.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
+#include <openthread/link.h>
+#include <openthread/logging.h>
+#include <openthread/platform/logging.h>
+#include <openthread/platform/time.h>
+
+uint64_t otPlatTimeGet(void) { return 0; }
+
+void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
+{
+    (void)aLogLevel;
+    (void)aLogRegion;
+    (void)aFormat;
+}
+
+void otPlatAssertFail(const char *aFilename, int aLineNumber)
+{
+    (void)aFilename;
+    (void)aLineNumber;
+    abort();
+}
+
+uint32_t otLinkGetFrameCounter(otInstance *aInstance)
+{
+    (void)aInstance;
+    return 0;
+}
+
+int main(void) { return 0; }


### PR DESCRIPTION
## Summary

This MR contains two closely related changes:

1.  **Fix**: Remove unnecessary `Instance::Get()` call in `otLoggingGetLevel()` when log level is a compile-time constant. This issue is involved by https://github.com/openthread/openthread/pull/12740

Spinel is an independent protocol, and OpenThread should support building in a spinel-only mode, where only the Spinel/HDLC transport layers are included without the full Thread stack. In ESP-IDF, this mode is used by other stacks (e.g., Zigbee), where only the Spinel transport libraries are compiled and the full OpenThread stack — including the `ot::Instance` object — is not present.

In such configurations, any code path that references `Instance::Get()` will lead to a linker error, since the singleton instance is never instantiated.

Previously, `otLoggingGetLevel()` unconditionally called `Instance::Get().GetLogLevel()` in single-instance mode, even when OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE is set to 0. In this case, `GetLogLevel()` simply returns the compile-time constant OPENTHREAD_CONFIG_LOG_LEVEL, making the call to `Instance::Get()` unnecessary. This introduced an unintended hard dependency on `Instance::Get()`, which breaks spinel-only builds.

2.  **Test**: Add a spinel-only link test to CI that catches linker errors caused by unwanted `Instance::Get()` dependencies and to help safeguard spinel-only builds.
