### PR TITLE
[nexus] fix false suppression of CHILD_REMOVED events

### DIFF
--- a/tests/nexus/platform/nexus_core.cpp
+++ b/tests/nexus/platform/nexus_core.cpp
@@ -35,6 +35,7 @@
 #include "nexus_node.hpp"
 #include "nexus_radio_model.hpp"
 #include "thread/child_table.hpp"
+#include "thread/mle.hpp"
 #include "thread/neighbor_table.hpp"
 
 namespace ot {
@@ -442,12 +443,11 @@ void Core::HandleNeighborTableChanged(otNeighborTableEvent aEvent, const otNeigh
         if (event == NeighborTable::kChildRemoved)
         {
             Instance &instance = *static_cast<Instance *>(aInfo->mInstance);
-            Neighbor *neighbor =
-                instance.Get<NeighborTable>().FindNeighbor(*extAddr, Neighbor::kInStateAnyExceptInvalid);
+            Neighbor *neighbor = instance.Get<NeighborTable>().FindNeighbor(*extAddr, Neighbor::kInStateValid);
 
-            if (neighbor != nullptr && !instance.Get<ChildTable>().Contains(*neighbor))
+            if (neighbor != nullptr)
             {
-                Log("Suppressing CHILD_REMOVED event because node is in router table");
+                Log("Suppressing CHILD_REMOVED event because neighbor link is established");
                 ExitNow();
             }
         }


### PR DESCRIPTION
The previous logic for suppressing CHILD_REMOVED events was flawed. It checked if the neighbor was not in the child table. However, since the callback is triggered after the child is removed, it was always false, leading to false suppression for all removed children.

This caused the parent node to never emit "link removed" events to the UI when children detached, leading to inconsistent link states (dashed lines) when only one direction was active.

This fix updates the logic to check if a neighbor entry exists in the neighbor table with an established link (kStateValid). This ensures we only suppress the event when the child has successfully transitioned to a router role and established a valid link.