### PR TITLE
[nexus] add helper to allow link between nodes in nexus

### DIFF
--- a/tests/nexus/platform/nexus_node.cpp
+++ b/tests/nexus/platform/nexus_node.cpp
@@ -251,5 +251,17 @@ bool Node::Matches(const Ip6::Address &aAddress, AddressNetif aNetif) const
     return matches;
 }
 
+void AllowLinkBetween(Node &aFirstNode, Node &aSecondNode)
+{
+    aFirstNode.AllowList(aSecondNode);
+    aSecondNode.AllowList(aFirstNode);
+}
+
+void UnallowLinkBetween(Node &aFirstNode, Node &aSecondNode)
+{
+    aFirstNode.UnallowList(aSecondNode);
+    aSecondNode.UnallowList(aFirstNode);
+}
+
 } // namespace Nexus
 } // namespace ot

--- a/tests/nexus/platform/nexus_node.hpp
+++ b/tests/nexus/platform/nexus_node.hpp
@@ -205,6 +205,9 @@ public:
 
 inline Node &AsNode(otInstance *aInstance) { return Node::From(aInstance); }
 
+void AllowLinkBetween(Node &aFirstNode, Node &aSecondNode);
+void UnallowLinkBetween(Node &aFirstNode, Node &aSecondNode);
+
 } // namespace Nexus
 
 template <> inline Nexus::Node        &Instance::Get(void) { return Nexus::AsNode(this); }

--- a/tests/nexus/test_1_1_5_1_10.cpp
+++ b/tests/nexus/test_1_1_5_1_10.cpp
@@ -106,15 +106,9 @@ void Test5_1_10(void)
      * - Pass Criteria: N/A
      */
 
-    /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    leader.AllowList(router2);
-
-    router1.AllowList(leader);
-    router1.AllowList(router2);
-
-    router2.AllowList(leader);
-    router2.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, router2);
+    AllowLinkBetween(router1, router2);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -140,11 +134,8 @@ void Test5_1_10(void)
      */
 
     /** Restricted topology for DUT. */
-    dut.AllowList(router1);
-    dut.AllowList(router2);
-
-    router1.AllowList(dut);
-    router2.AllowList(dut);
+    AllowLinkBetween(dut, router1);
+    AllowLinkBetween(dut, router2);
 
     SuccessOrQuit(dut.Get<Mac::Filter>().AddRssIn(router2.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality2));
     SuccessOrQuit(router2.Get<Mac::Filter>().AddRssIn(dut.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality2));

--- a/tests/nexus/test_1_1_5_1_11.cpp
+++ b/tests/nexus/test_1_1_5_1_11.cpp
@@ -100,39 +100,11 @@ void Test5_1_11(void)
 
     nexus.AdvanceTime(0);
 
-    /**
-     * Use AllowList feature to restrict the topology.
-     */
-
-    /**
-     * Leader <-> REED_1
-     */
-    leader.AllowList(reed1);
-    reed1.AllowList(leader);
-
-    /**
-     * Leader <-> Router_2
-     */
-    leader.AllowList(router2);
-    router2.AllowList(leader);
-
-    /**
-     * REED_1 <-> DUT
-     */
-    reed1.AllowList(dut);
-    dut.AllowList(reed1);
-
-    /**
-     * Router_2 <-> DUT
-     */
-    router2.AllowList(dut);
-    dut.AllowList(router2);
-
-    /**
-     * REED_1 <-> Router_2 (to ensure they can see each other if needed, though not strictly required by topology)
-     */
-    reed1.AllowList(router2);
-    router2.AllowList(reed1);
+    AllowLinkBetween(leader, reed1);
+    AllowLinkBetween(leader, router2);
+    AllowLinkBetween(reed1, dut);
+    AllowLinkBetween(router2, dut);
+    AllowLinkBetween(reed1, router2);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: Leader, REED_1, Router_2");

--- a/tests/nexus/test_1_1_5_1_12.cpp
+++ b/tests/nexus/test_1_1_5_1_12.cpp
@@ -78,12 +78,10 @@ void Test5_1_12(void)
     dut.SetName("DUT");
 
     // Leader <-> Router_2
-    leader.AllowList(router2);
-    router2.AllowList(leader);
+    AllowLinkBetween(leader, router2);
 
     // Leader <-> DUT
-    leader.AllowList(dut);
-    dut.AllowList(leader);
+    AllowLinkBetween(leader, dut);
 
     nexus.AdvanceTime(0);
 
@@ -133,8 +131,7 @@ void Test5_1_12(void)
      * - Description: Harness enables communication between Router_1 (DUT) and Router_2.
      * - Pass Criteria: N/A
      */
-    dut.AllowList(router2);
-    router2.AllowList(dut);
+    AllowLinkBetween(dut, router2);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 4: The DUT and Router_2 automatically exchange unicast Link Request and unicast Link Accept messages.");

--- a/tests/nexus/test_1_1_5_1_13.cpp
+++ b/tests/nexus/test_1_1_5_1_13.cpp
@@ -82,9 +82,7 @@ void Test5_1_13(void)
 
     nexus.AdvanceTime(0);
 
-    // Use AllowList feature to restrict the topology.
-    leader.AllowList(router);
-    router.AllowList(leader);
+    AllowLinkBetween(leader, router);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: All");
@@ -127,7 +125,7 @@ void Test5_1_13(void)
      * - Pass Criteria: N/A
      */
     router.Reset();
-    router.AllowList(leader);
+    AllowLinkBetween(router, leader);
     router.Get<ThreadNetif>().Up();
     SuccessOrQuit(router.Get<Mle::Mle>().Start());
 

--- a/tests/nexus/test_1_1_5_1_2.cpp
+++ b/tests/nexus/test_1_1_5_1_2.cpp
@@ -98,15 +98,9 @@ void Test5_1_2(void)
 
     nexus.AdvanceTime(0);
 
-    // Use AllowList feature to restrict the topology.
-    leader.AllowList(router);
-    router.AllowList(leader);
-
-    router.AllowList(med);
-    med.AllowList(router);
-
-    router.AllowList(sed);
-    sed.AllowList(router);
+    AllowLinkBetween(leader, router);
+    AllowLinkBetween(router, med);
+    AllowLinkBetween(router, sed);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: All");

--- a/tests/nexus/test_1_1_5_1_3.cpp
+++ b/tests/nexus/test_1_1_5_1_3.cpp
@@ -121,15 +121,9 @@ void Test5_1_3(void)
      * - Pass Criteria: N/A
      */
 
-    /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    leader.AllowList(router2);
-    router2.AllowList(leader);
-
-    router1.AllowList(router2);
-    router2.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, router2);
+    AllowLinkBetween(router1, router2);
 
     leader.Get<Mle::Mle>().SetPreferredLeaderPartitionId(kMaxPartitionId);
     leader.Form();

--- a/tests/nexus/test_1_1_5_1_4.cpp
+++ b/tests/nexus/test_1_1_5_1_4.cpp
@@ -117,15 +117,9 @@ void Test5_1_4(void)
      * - Pass Criteria: N/A
      */
 
-    /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    leader.AllowList(router2);
-    router2.AllowList(leader);
-
-    router1.AllowList(router2);
-    router2.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, router2);
+    AllowLinkBetween(router1, router2);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_1_5.cpp
+++ b/tests/nexus/test_1_1_5_1_5.cpp
@@ -95,9 +95,7 @@ void Test5_1_5(void)
      * - Pass Criteria: N/A
      */
 
-    /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_1_6.cpp
+++ b/tests/nexus/test_1_1_5_1_6.cpp
@@ -72,9 +72,7 @@ void Test5_1_6(void)
     leader.SetName("LEADER");
     router.SetName("ROUTER");
 
-    // Use AllowList feature to restrict the topology
-    leader.AllowList(router);
-    router.AllowList(leader);
+    AllowLinkBetween(leader, router);
 
     nexus.AdvanceTime(0);
 

--- a/tests/nexus/test_1_1_5_1_7.cpp
+++ b/tests/nexus/test_1_1_5_1_7.cpp
@@ -106,12 +106,11 @@ static void CreateNodes(Core &aNexus, Node *aNodes[], uint16_t aCount, const cha
     }
 }
 
-static void AllowListNodes(Node &aRouter, Node *aNodes[], uint16_t aCount)
+static void AllowLinkBetweenNodes(Node &aRouter, Node *aNodes[], uint16_t aCount)
 {
     for (uint16_t i = 0; i < aCount; i++)
     {
-        aRouter.AllowList(*aNodes[i]);
-        aNodes[i]->AllowList(aRouter);
+        AllowLinkBetween(aRouter, *aNodes[i]);
     }
 }
 
@@ -160,12 +159,9 @@ void Test5_1_7(void)
 
     nexus.AdvanceTime(0);
 
-    // Use AllowList feature to restrict the topology.
-    leader.AllowList(router);
-    router.AllowList(leader);
-
-    AllowListNodes(router, meds, kNumMeds);
-    AllowListNodes(router, seds, kNumSeds);
+    AllowLinkBetween(leader, router);
+    AllowLinkBetweenNodes(router, meds, kNumMeds);
+    AllowLinkBetweenNodes(router, seds, kNumSeds);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: Leader, Router_1 (DUT), Children");

--- a/tests/nexus/test_1_1_5_1_8.cpp
+++ b/tests/nexus/test_1_1_5_1_8.cpp
@@ -96,19 +96,9 @@ void Test5_1_8(void)
 
     nexus.AdvanceTime(0);
 
-    // Use AllowList feature to restrict the topology.
-    // L <-> R3
-    // R3 <-> R1
-    // R1 <-> R2
-    // DUT hears R1, R2, R3
-    leader.AllowList(router3);
-    router3.AllowList(leader);
-
-    router3.AllowList(router1);
-    router1.AllowList(router3);
-
-    router1.AllowList(router2);
-    router2.AllowList(router1);
+    AllowLinkBetween(leader, router3);
+    AllowLinkBetween(router3, router1);
+    AllowLinkBetween(router1, router2);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: Leader, Router_1, Router_2, Router_3");
@@ -144,11 +134,8 @@ void Test5_1_8(void)
      *   a link quality of 3 (highest).
      * - Pass Criteria: N/A
      */
-    dut.AllowList(router2);
-    dut.AllowList(router3);
-
-    router2.AllowList(dut);
-    router3.AllowList(dut);
+    AllowLinkBetween(dut, router2);
+    AllowLinkBetween(dut, router3);
 
     // Harness configures the RSSI to prefer Router 3.
     // All values below enable Link Quality 3 (highest).

--- a/tests/nexus/test_1_1_5_1_9.cpp
+++ b/tests/nexus/test_1_1_5_1_9.cpp
@@ -114,17 +114,10 @@ void Test5_1_9(void)
      */
     Log("Step 1: Setup the topology without the DUT");
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    leader.AllowList(reed1);
-    reed1.AllowList(leader);
-
-    leader.AllowList(reed2);
-    reed2.AllowList(leader);
-
-    router1.AllowList(reed1);
-    reed1.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, reed1);
+    AllowLinkBetween(leader, reed2);
+    AllowLinkBetween(router1, reed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -164,10 +157,8 @@ void Test5_1_9(void)
     SuccessOrQuit(reed2.Get<Mac::Filter>().AddRssIn(leader.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
 
     // Setup DUT connectivity (only to REEDs)
-    dut.AllowList(reed1);
-    reed1.AllowList(dut);
-    dut.AllowList(reed2);
-    reed2.AllowList(dut);
+    AllowLinkBetween(dut, reed1);
+    AllowLinkBetween(dut, reed2);
 
     SuccessOrQuit(dut.Get<Mac::Filter>().AddRssIn(reed1.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));
     SuccessOrQuit(dut.Get<Mac::Filter>().AddRssIn(reed2.Get<Mac::Mac>().GetExtAddress(), kLq3Rssi));

--- a/tests/nexus/test_1_1_5_2_1.cpp
+++ b/tests/nexus/test_1_1_5_2_1.cpp
@@ -83,15 +83,9 @@ void Test5_2_1(void)
     reed1.SetName("REED_1");
     med1.SetName("MED_1");
 
-    // Establish topology using AllowList
-    dut.AllowList(leader);
-    leader.AllowList(dut);
-
-    dut.AllowList(reed1);
-    reed1.AllowList(dut);
-
-    reed1.AllowList(med1);
-    med1.AllowList(reed1);
+    AllowLinkBetween(dut, leader);
+    AllowLinkBetween(dut, reed1);
+    AllowLinkBetween(reed1, med1);
 
     nexus.AdvanceTime(0);
 

--- a/tests/nexus/test_1_1_5_2_3.cpp
+++ b/tests/nexus/test_1_1_5_2_3.cpp
@@ -101,12 +101,10 @@ void Test5_2_3(void)
     // Router 32 <-> Router 1
     for (uint8_t i = 0; i < kMaxRouters - 1; i++)
     {
-        leader.AllowList(*routers[i]);
-        routers[i]->AllowList(leader);
+        AllowLinkBetween(leader, *routers[i]);
     }
 
-    routers[kMaxRouters - 1]->AllowList(*routers[0]);
-    routers[0]->AllowList(*routers[kMaxRouters - 1]);
+    AllowLinkBetween(*routers[kMaxRouters - 1], *routers[0]);
 
     Log("---------------------------------------------------------------------------------------");
     /**

--- a/tests/nexus/test_1_1_5_2_4.cpp
+++ b/tests/nexus/test_1_1_5_2_4.cpp
@@ -109,20 +109,14 @@ void Test5_2_4(void)
 
     SuccessOrQuit(Instance::SetGlobalLogLevel(kLogLevelNote));
 
-    /** Use AllowList feature to restrict the topology. */
     for (uint16_t i = 0; i < kNumRouters; i++)
     {
-        leader.AllowList(*routers[i]);
-        routers[i]->AllowList(leader);
+        AllowLinkBetween(leader, *routers[i]);
     }
 
-    /** Router 15 and REED_1 (DUT) have a link */
-    routers[kNumRouters - 1]->AllowList(reed1);
-    reed1.AllowList(*routers[kNumRouters - 1]);
+    AllowLinkBetween(*routers[kNumRouters - 1], reed1);
 
-    /** REED_1 (DUT) and MED_1 have a link. */
-    reed1.AllowList(med1);
-    med1.AllowList(reed1);
+    AllowLinkBetween(reed1, med1);
 
     Log("Step 1: Ensure topology is formed correctly without the DUT.");
 

--- a/tests/nexus/test_1_1_5_2_5.cpp
+++ b/tests/nexus/test_1_1_5_2_5.cpp
@@ -112,23 +112,14 @@ void Test5_2_5(void)
     nexus.AdvanceTime(0);
     SuccessOrQuit(Instance::SetGlobalLogLevel(kLogLevelNote));
 
-    /**
-     * Use AllowList feature to restrict the topology.
-     */
     for (uint16_t i = 0; i < kRouterCount; i++)
     {
-        leader.AllowList(*routers[i]);
-        routers[i]->AllowList(leader);
+        AllowLinkBetween(leader, *routers[i]);
     }
 
-    leader.AllowList(br);
-    br.AllowList(leader);
-
-    leader.AllowList(med1);
-    med1.AllowList(leader);
-
-    routers[0]->AllowList(reed1);
-    reed1.AllowList(*routers[0]);
+    AllowLinkBetween(leader, br);
+    AllowLinkBetween(leader, med1);
+    AllowLinkBetween(*routers[0], reed1);
 
     Log("Step 1: Configure the Leader to be a DHCPv6 Border Router for prefix 2001::");
 

--- a/tests/nexus/test_1_1_5_3_10.cpp
+++ b/tests/nexus/test_1_1_5_3_10.cpp
@@ -135,10 +135,10 @@ void Test5_3_10(void)
     nexus.AdvanceTime(kFormNetworkTime);
     VerifyOrQuit(leader.Get<Mle::Mle>().IsLeader());
 
-    leader.AllowList(br);
-    br.AllowList(leader);
+    AllowLinkBetween(leader, br);
 
     br.Join(leader);
+
     nexus.AdvanceTime(kAttachToRouterTime);
     VerifyOrQuit(br.Get<Mle::Mle>().IsRouter());
 
@@ -167,17 +167,10 @@ void Test5_3_10(void)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    leader.AllowList(dut);
-    dut.AllowList(leader);
-
-    router1.AllowList(dut);
-    dut.AllowList(router1);
-
-    dut.AllowList(med1);
-    med1.AllowList(dut);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, dut);
+    AllowLinkBetween(router1, dut);
+    AllowLinkBetween(dut, med1);
 
     router1.Join(leader);
     dut.Join(leader);

--- a/tests/nexus/test_1_1_5_3_11.cpp
+++ b/tests/nexus/test_1_1_5_3_11.cpp
@@ -110,12 +110,8 @@ void Test5_3_11(void)
      * - Pass Criteria: N/A
      */
 
-    /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    router1.AllowList(med1);
-    med1.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, med1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_3_2.cpp
+++ b/tests/nexus/test_1_1_5_3_2.cpp
@@ -95,14 +95,9 @@ void Test5_3_2(void)
      */
     Log("Step 1: All");
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    router1.AllowList(dut);
-    dut.AllowList(router1);
-
-    dut.AllowList(sed1);
-    sed1.AllowList(dut);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, dut);
+    AllowLinkBetween(dut, sed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_3_3.cpp
+++ b/tests/nexus/test_1_1_5_3_3.cpp
@@ -121,24 +121,19 @@ void Test5_3_3(void)
      */
 
     /** Link between Leader and Router 1 */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
 
     /** Link between Leader and Router 2 (DUT) */
-    leader.AllowList(dut);
-    dut.AllowList(leader);
+    AllowLinkBetween(leader, dut);
 
     /** Link between Leader and Router 3 */
-    leader.AllowList(router3);
-    router3.AllowList(leader);
+    AllowLinkBetween(leader, router3);
 
     /** Link between Router 2 (DUT) and Router 3 */
-    dut.AllowList(router3);
-    router3.AllowList(dut);
+    AllowLinkBetween(dut, router3);
 
     /** Link between Router 2 (DUT) and MED 1 */
-    dut.AllowList(med1);
-    med1.AllowList(dut);
+    AllowLinkBetween(dut, med1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_3_4.cpp
+++ b/tests/nexus/test_1_1_5_3_4.cpp
@@ -111,21 +111,12 @@ void Test5_3_4(void)
      * - Pass Criteria: N/A
      */
 
-    /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    for (Node *med : meds)
-    {
-        leader.AllowList(*med);
-    }
-
-    router1.AllowList(leader);
-    router1.AllowList(sed1);
-
-    sed1.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, sed1);
 
     for (Node *med : meds)
     {
-        med->AllowList(leader);
+        AllowLinkBetween(leader, *med);
     }
 
     leader.Form();

--- a/tests/nexus/test_1_1_5_3_5.cpp
+++ b/tests/nexus/test_1_1_5_3_5.cpp
@@ -117,17 +117,10 @@ void Test5_3_5(void)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(dut);
-    leader.AllowList(router2);
-
-    dut.AllowList(leader);
-    dut.AllowList(router2);
-    dut.AllowList(router3);
-
-    router2.AllowList(leader);
-    router2.AllowList(dut);
-
-    router3.AllowList(dut);
+    AllowLinkBetween(leader, dut);
+    AllowLinkBetween(leader, router2);
+    AllowLinkBetween(dut, router2);
+    AllowLinkBetween(dut, router3);
 
     /** Leader and Router 2 Link Quality 3 */
     SuccessOrQuit(leader.Get<Mac::Filter>().AddRssIn(router2.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality3));

--- a/tests/nexus/test_1_1_5_3_6.cpp
+++ b/tests/nexus/test_1_1_5_3_6.cpp
@@ -92,15 +92,8 @@ void Test5_3_6(void)
      *   - Pass Criteria: N/A
      */
 
-    /**
-     * Use AllowList to specify links between nodes. There is a link between the following node pairs:
-     * - Leader (DUT) and Router 1
-     * - Router 1 and Router 2
-     */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-    router1.AllowList(router2);
-    router2.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, router2);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_3_7.cpp
+++ b/tests/nexus/test_1_1_5_3_7.cpp
@@ -115,21 +115,14 @@ void Test5_3_7(void)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(router1);
-    leader.AllowList(router2);
-    leader.AllowList(med2);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, router2);
+    AllowLinkBetween(leader, med2);
 
-    router1.AllowList(leader);
-    router1.AllowList(router2);
-    router1.AllowList(med1);
+    AllowLinkBetween(router1, router2);
+    AllowLinkBetween(router1, med1);
 
-    router2.AllowList(leader);
-    router2.AllowList(router1);
-    router2.AllowList(sed1);
-
-    med1.AllowList(router1);
-    med2.AllowList(leader);
-    sed1.AllowList(router2);
+    AllowLinkBetween(router2, sed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_3_8.cpp
+++ b/tests/nexus/test_1_1_5_3_8.cpp
@@ -125,15 +125,9 @@ void Test5_3_8(void)
 
     SuccessOrQuit(Instance::SetGlobalLogLevel(kLogLevelNote));
 
-    /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(br);
-    br.AllowList(leader);
-
-    leader.AllowList(med1);
-    med1.AllowList(leader);
-
-    leader.AllowList(med2);
-    med2.AllowList(leader);
+    AllowLinkBetween(leader, br);
+    AllowLinkBetween(leader, med1);
+    AllowLinkBetween(leader, med2);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: Border Router");

--- a/tests/nexus/test_1_1_5_3_9.cpp
+++ b/tests/nexus/test_1_1_5_3_9.cpp
@@ -164,14 +164,10 @@ void Test5_3_9(void)
      * - Pass Criteria: N/A
      */
     Log("Step 2: All");
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-    leader.AllowList(dut);
-    dut.AllowList(leader);
-    leader.AllowList(router3);
-    router3.AllowList(leader);
-    dut.AllowList(sed1);
-    sed1.AllowList(dut);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, dut);
+    AllowLinkBetween(leader, router3);
+    AllowLinkBetween(dut, sed1);
 
     router1.Join(leader);
     dut.Join(leader);

--- a/tests/nexus/test_1_1_5_5_2.cpp
+++ b/tests/nexus/test_1_1_5_5_2.cpp
@@ -114,11 +114,8 @@ void Test5_5_2(void)
      */
     Log("Step 1: All");
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    router1.AllowList(med1);
-    med1.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, med1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_5_3.cpp
+++ b/tests/nexus/test_1_1_5_5_3.cpp
@@ -110,17 +110,11 @@ void Test5_5_3(void)
      *   - Pass Criteria: N/A
      */
 
-    leader.AllowList(router1);
-    leader.AllowList(router2);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, router2);
 
-    router1.AllowList(leader);
-    router1.AllowList(med2);
-
-    router2.AllowList(leader);
-    router2.AllowList(med3);
-
-    med2.AllowList(router1);
-    med3.AllowList(router2);
+    AllowLinkBetween(router1, med2);
+    AllowLinkBetween(router2, med3);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -328,8 +322,7 @@ void Test5_5_3(void)
      *           - RLOC16 TLV (optional)
      */
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
 
     nexus.AdvanceTime(kWaitPeriod);
 

--- a/tests/nexus/test_1_1_5_5_4_1.cpp
+++ b/tests/nexus/test_1_1_5_5_4_1.cpp
@@ -115,18 +115,10 @@ void Test5_5_4_1(void)
      * - Pass Criteria: N/A.
      */
 
-    dut.AllowList(router1);
-    dut.AllowList(router2);
-
-    router1.AllowList(dut);
-    router1.AllowList(router3);
-
-    router2.AllowList(dut);
-    router2.AllowList(router4);
-
-    router3.AllowList(router1);
-
-    router4.AllowList(router2);
+    AllowLinkBetween(dut, router1);
+    AllowLinkBetween(dut, router2);
+    AllowLinkBetween(router1, router3);
+    AllowLinkBetween(router2, router4);
 
     dut.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_5_4_2.cpp
+++ b/tests/nexus/test_1_1_5_5_4_2.cpp
@@ -121,15 +121,10 @@ void Test5_5_4_2(void)
      */
     Log("Step 1: All");
 
-    /** Use AllowList to specify links between nodes. */
-    leader.AllowList(router1);
-    leader.AllowList(router2);
-    router1.AllowList(leader);
-    router1.AllowList(router3);
-    router2.AllowList(leader);
-    router2.AllowList(router4);
-    router3.AllowList(router1);
-    router4.AllowList(router2);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, router2);
+    AllowLinkBetween(router1, router3);
+    AllowLinkBetween(router2, router4);
 
     /** Set NETWORK_ID_TIMEOUT of Router_3 to 55 seconds. */
     router3.Get<Mle::Mle>().SetNetworkIdTimeout(kRouter3NetworkIdTimeout);

--- a/tests/nexus/test_1_1_5_5_5.cpp
+++ b/tests/nexus/test_1_1_5_5_5.cpp
@@ -110,19 +110,15 @@ void Test5_5_5(void)
      * - Pass Criteria: N/A
      */
 
-    /** Configure AllowList for specific links. */
     for (uint16_t i = 2; i <= 15; i++)
     {
-        leader.AllowList(*r[i]);
-        r[i]->AllowList(leader);
+        AllowLinkBetween(leader, *r[i]);
     }
 
-    r[1]->AllowList(*r[3]);
-    r[3]->AllowList(*r[1]);
+    AllowLinkBetween(*r[1], *r[3]);
 
     /** DUT links. */
-    dut.AllowList(*r[2]);
-    r[2]->AllowList(dut);
+    AllowLinkBetween(dut, *r[2]);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -181,8 +177,7 @@ void Test5_5_5(void)
      * - Pass Criteria: N/A
      */
     SuccessOrQuit(dut.Get<Mle::Mle>().SetRouterEligible(true));
-    dut.AllowList(*r[1]);
-    r[1]->AllowList(dut);
+    AllowLinkBetween(dut, *r[1]);
     nexus.AdvanceTime(kReattachTime);
 
     Log("---------------------------------------------------------------------------------------");

--- a/tests/nexus/test_1_1_5_5_7.cpp
+++ b/tests/nexus/test_1_1_5_5_7.cpp
@@ -105,13 +105,9 @@ void Test5_5_7(void)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(router1);
-    leader.AllowList(router2);
-    leader.AllowList(router3);
-
-    router1.AllowList(leader);
-    router2.AllowList(leader);
-    router3.AllowList(leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, router2);
+    AllowLinkBetween(leader, router3);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_6_1.cpp
+++ b/tests/nexus/test_1_1_5_6_1.cpp
@@ -85,19 +85,9 @@ void Test5_6_1(void)
     const char *kPrefix3 = "2003::/64";
     const char *kPrefix4 = "2004::/64";
 
-    /**
-     * - Use AllowList to specify links between nodes. There is a link between the following node pairs:
-     *   - Router 1 (DUT) and Leader
-     *   - Router 1 (DUT) and MED 1
-     *   - Router 1 (DUT) and SED 1
-     */
-    router1.AllowList(leader);
-    router1.AllowList(med1);
-    router1.AllowList(sed1);
-
-    leader.AllowList(router1);
-    med1.AllowList(router1);
-    sed1.AllowList(router1);
+    AllowLinkBetween(router1, leader);
+    AllowLinkBetween(router1, med1);
+    AllowLinkBetween(router1, sed1);
 
     nexus.AdvanceTime(0);
 

--- a/tests/nexus/test_1_1_5_6_2.cpp
+++ b/tests/nexus/test_1_1_5_6_2.cpp
@@ -88,19 +88,9 @@ void Test5_6_2(void)
     const char *kPrefix1 = "2001::/64";
     const char *kPrefix2 = "2002::/64";
 
-    /**
-     * - Use AllowList to specify links between nodes. There is a link between the following node pairs:
-     *   - Leader (DUT) and Router 1
-     *   - Leader (DUT) and MED 1
-     *   - Leader (DUT) and SED 1
-     */
-    leader.AllowList(router1);
-    leader.AllowList(med1);
-    leader.AllowList(sed1);
-
-    router1.AllowList(leader);
-    med1.AllowList(leader);
-    sed1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, med1);
+    AllowLinkBetween(leader, sed1);
 
     nexus.AdvanceTime(0);
 

--- a/tests/nexus/test_1_1_5_6_3.cpp
+++ b/tests/nexus/test_1_1_5_6_3.cpp
@@ -106,15 +106,9 @@ void Test5_6_3(void)
      *   - Pass Criteria: N/A
      */
 
-    /** Use AllowList to specify links between nodes. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    router1.AllowList(med1);
-    med1.AllowList(router1);
-
-    router1.AllowList(sed1);
-    sed1.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, med1);
+    AllowLinkBetween(router1, sed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_6_4.cpp
+++ b/tests/nexus/test_1_1_5_6_4.cpp
@@ -109,13 +109,9 @@ void Test5_6_4(void)
      * - Pass Criteria: N/A
      */
 
-    dut.AllowList(router1);
-    dut.AllowList(med1);
-    dut.AllowList(sed1);
-
-    router1.AllowList(dut);
-    med1.AllowList(dut);
-    sed1.AllowList(dut);
+    AllowLinkBetween(dut, router1);
+    AllowLinkBetween(dut, med1);
+    AllowLinkBetween(dut, sed1);
 
     dut.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_6_5.cpp
+++ b/tests/nexus/test_1_1_5_6_5.cpp
@@ -99,19 +99,9 @@ void Test5_6_5(void)
      * - Pass Criteria: N/A
      */
 
-    /**
-     * Use AllowList to specify links between nodes. There is a link between the following node pairs:
-     * - Leader (DUT) and Router 1
-     * - Leader (DUT) and MED 1
-     * - Leader (DUT) and SED 1
-     */
-    leader.AllowList(router1);
-    leader.AllowList(med1);
-    leader.AllowList(sed1);
-
-    router1.AllowList(leader);
-    med1.AllowList(leader);
-    sed1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, med1);
+    AllowLinkBetween(leader, sed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_6_6.cpp
+++ b/tests/nexus/test_1_1_5_6_6.cpp
@@ -96,19 +96,9 @@ void Test5_6_6(void)
     const char *kPrefix2 = "2002::/64";
     const char *kPrefix3 = "2003::/64";
 
-    /**
-     * - Use AllowList to specify links between nodes. There is a link between the following node pairs:
-     * - Leader (DUT) and Router 1
-     * - Leader (DUT) and MED 1
-     * - Leader (DUT) and SED 1
-     */
-    leader.AllowList(router1);
-    leader.AllowList(med1);
-    leader.AllowList(sed1);
-
-    router1.AllowList(leader);
-    med1.AllowList(leader);
-    sed1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, med1);
+    AllowLinkBetween(leader, sed1);
 
     nexus.AdvanceTime(0);
 

--- a/tests/nexus/test_1_1_5_6_7.cpp
+++ b/tests/nexus/test_1_1_5_6_7.cpp
@@ -137,40 +137,23 @@ void Test5_6_7(void)
      * - Pass Criteria: N/A.
      */
 
-    leader.AllowList(r1);
-    leader.AllowList(r2);
-    leader.AllowList(r3);
-    leader.AllowList(r4);
-    leader.AllowList(r5);
-    leader.AllowList(r6);
-    leader.AllowList(r7);
-    leader.AllowList(r8);
-    leader.AllowList(r9);
-    leader.AllowList(r10);
-    leader.AllowList(r11);
-    leader.AllowList(r12);
-    leader.AllowList(r13);
-    leader.AllowList(r14);
-    leader.AllowList(r15);
+    AllowLinkBetween(leader, r1);
+    AllowLinkBetween(leader, r2);
+    AllowLinkBetween(leader, r3);
+    AllowLinkBetween(leader, r4);
+    AllowLinkBetween(leader, r5);
+    AllowLinkBetween(leader, r6);
+    AllowLinkBetween(leader, r7);
+    AllowLinkBetween(leader, r8);
+    AllowLinkBetween(leader, r9);
+    AllowLinkBetween(leader, r10);
+    AllowLinkBetween(leader, r11);
+    AllowLinkBetween(leader, r12);
+    AllowLinkBetween(leader, r13);
+    AllowLinkBetween(leader, r14);
+    AllowLinkBetween(leader, r15);
 
-    r1.AllowList(leader);
-    r1.AllowList(dut);
-    r2.AllowList(leader);
-    r3.AllowList(leader);
-    r4.AllowList(leader);
-    r5.AllowList(leader);
-    r6.AllowList(leader);
-    r7.AllowList(leader);
-    r8.AllowList(leader);
-    r9.AllowList(leader);
-    r10.AllowList(leader);
-    r11.AllowList(leader);
-    r12.AllowList(leader);
-    r13.AllowList(leader);
-    r14.AllowList(leader);
-    r15.AllowList(leader);
-
-    dut.AllowList(r1);
+    AllowLinkBetween(dut, r1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -221,8 +204,7 @@ void Test5_6_7(void)
      *   will fail because the DUT will go through (re) attachment when it emerges.
      * - Pass Criteria: N/A.
      */
-    dut.UnallowList(r1);
-    r1.UnallowList(dut);
+    UnallowLinkBetween(dut, r1);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 4: Leader");
@@ -272,8 +254,7 @@ void Test5_6_7(void)
      * - Pass Criteria: N/A.
      */
     nexus.AdvanceTime(kRfIsolationTime);
-    dut.AllowList(r1);
-    r1.AllowList(dut);
+    AllowLinkBetween(dut, r1);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 7: All");

--- a/tests/nexus/test_1_1_5_6_9.cpp
+++ b/tests/nexus/test_1_1_5_6_9.cpp
@@ -118,15 +118,11 @@ void Test5_6_9(void)
      * - Router 1 (DUT) and MED 1
      * - Router 1 (DUT) and SED 1
      */
-    leader.AllowList(router1);
-    leader.AllowList(router2);
-    router1.AllowList(leader);
-    router2.AllowList(leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, router2);
 
-    router1.AllowList(med1);
-    router1.AllowList(sed1);
-    med1.AllowList(router1);
-    sed1.AllowList(router1);
+    AllowLinkBetween(router1, med1);
+    AllowLinkBetween(router1, sed1);
 
     nexus.AdvanceTime(0);
 

--- a/tests/nexus/test_1_1_5_7_1.cpp
+++ b/tests/nexus/test_1_1_5_7_1.cpp
@@ -99,18 +99,11 @@ void Test5_7_1(void)
      */
     Log("Step 1: All");
 
-    /** Use AllowList to specify links between nodes. */
-    dut.AllowList(leader);
-    dut.AllowList(fed1);
-    dut.AllowList(med1);
-    dut.AllowList(sed1);
-    dut.AllowList(reed1);
-
-    leader.AllowList(dut);
-    fed1.AllowList(dut);
-    med1.AllowList(dut);
-    sed1.AllowList(dut);
-    reed1.AllowList(dut);
+    AllowLinkBetween(dut, leader);
+    AllowLinkBetween(dut, fed1);
+    AllowLinkBetween(dut, med1);
+    AllowLinkBetween(dut, sed1);
+    AllowLinkBetween(dut, reed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_7_2.cpp
+++ b/tests/nexus/test_1_1_5_7_2.cpp
@@ -134,15 +134,12 @@ void Test5_7_2(void)
      * - Pass Criteria: N/A
      */
 
-    /** Use AllowList to specify links between nodes. */
     for (uint8_t i = 0; i < kNumRouters; i++)
     {
-        leader.AllowList(*routers[i]);
-        routers[i]->AllowList(leader);
+        AllowLinkBetween(leader, *routers[i]);
     }
 
-    reed1.AllowList(*routers[0]);
-    routers[0]->AllowList(reed1);
+    AllowLinkBetween(reed1, *routers[0]);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_7_3.cpp
+++ b/tests/nexus/test_1_1_5_7_3.cpp
@@ -151,18 +151,10 @@ void Test5_7_3(void)
      * - Pass Criteria: N/A.
      */
 
-    /** Use AllowList to specify links between nodes. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    router1.AllowList(fed1);
-    fed1.AllowList(router1);
-
-    router1.AllowList(med1);
-    med1.AllowList(router1);
-
-    router1.AllowList(sed1);
-    sed1.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, fed1);
+    AllowLinkBetween(router1, med1);
+    AllowLinkBetween(router1, sed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_5_8_4.cpp
+++ b/tests/nexus/test_1_1_5_8_4.cpp
@@ -107,12 +107,8 @@ void Test5_8_4(void)
      * - Pass Criteria: N/A.
      */
 
-    /** Use AllowList to specify links between nodes. */
-    leader.AllowList(commr1);
-    commr1.AllowList(leader);
-
-    leader.AllowList(commr2);
-    commr2.AllowList(leader);
+    AllowLinkBetween(leader, commr1);
+    AllowLinkBetween(leader, commr2);
 
     /** Partition is formed with all Security Policy TLV bits set to 1. */
     {

--- a/tests/nexus/test_1_1_6_1_2.cpp
+++ b/tests/nexus/test_1_1_6_1_2.cpp
@@ -107,8 +107,7 @@ void RunTest6_1_2(Topology aTopology, const char *aJsonFile)
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: All");
 
-    leader.AllowList(reed);
-    reed.AllowList(leader);
+    AllowLinkBetween(leader, reed);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -136,8 +135,7 @@ void RunTest6_1_2(Topology aTopology, const char *aJsonFile)
     Log("---------------------------------------------------------------------------------------");
     Log("Step 2: ED_1 / SED_1 (DUT)");
 
-    reed.AllowList(dut);
-    dut.AllowList(reed);
+    AllowLinkBetween(reed, dut);
 
     if (aTopology == kTopologyA)
     {

--- a/tests/nexus/test_1_1_6_1_3.cpp
+++ b/tests/nexus/test_1_1_6_1_3.cpp
@@ -134,23 +134,12 @@ void RunTest6_1_3(Topology aTopology, const char *aJsonFile)
      *   - Pass Criteria: N/A
      */
 
-    /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    leader.AllowList(router2);
-    leader.AllowList(router3);
-
-    router1.AllowList(leader);
-    router1.AllowList(router3);
-
-    router2.AllowList(leader);
-    router2.AllowList(dut);
-
-    router3.AllowList(leader);
-    router3.AllowList(router1);
-    router3.AllowList(dut);
-
-    dut.AllowList(router2);
-    dut.AllowList(router3);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, router2);
+    AllowLinkBetween(leader, router3);
+    AllowLinkBetween(router1, router3);
+    AllowLinkBetween(router2, dut);
+    AllowLinkBetween(router3, dut);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_6_1_4.cpp
+++ b/tests/nexus/test_1_1_6_1_4.cpp
@@ -132,31 +132,12 @@ void Test6_1_4(void)
      * - Pass Criteria: N/A
      */
 
-    /**
-     * Use AllowList to specify links between nodes. There is a link between the following node pairs:
-     * - Leader and Router 1
-     * - Leader and Router 2
-     * - Leader and Router 3
-     * - Router 1 and Router 3
-     * - Router 2 and SED 1 (DUT)
-     * - Router 3 and SED 1 (DUT)
-     */
-    leader.AllowList(router1);
-    leader.AllowList(router2);
-    leader.AllowList(router3);
-
-    router1.AllowList(leader);
-    router1.AllowList(router3);
-
-    router2.AllowList(leader);
-    router2.AllowList(dut);
-
-    router3.AllowList(leader);
-    router3.AllowList(router1);
-    router3.AllowList(dut);
-
-    dut.AllowList(router2);
-    dut.AllowList(router3);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, router2);
+    AllowLinkBetween(leader, router3);
+    AllowLinkBetween(router1, router3);
+    AllowLinkBetween(router2, dut);
+    AllowLinkBetween(router3, dut);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_6_1_5.cpp
+++ b/tests/nexus/test_1_1_6_1_5.cpp
@@ -124,12 +124,8 @@ void Test6_1_5(void)
      * - Pass Criteria: N/A
      */
 
-    /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    leader.AllowList(reed2);
-
-    router1.AllowList(leader);
-    reed2.AllowList(leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, reed2);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -155,11 +151,8 @@ void Test6_1_5(void)
      */
 
     /** Restricted topology for DUT. */
-    sed1.AllowList(router1);
-    sed1.AllowList(reed2);
-
-    router1.AllowList(sed1);
-    reed2.AllowList(sed1);
+    AllowLinkBetween(sed1, router1);
+    AllowLinkBetween(sed1, reed2);
 
     SuccessOrQuit(sed1.Get<Mac::Filter>().AddRssIn(reed2.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality2));
     SuccessOrQuit(reed2.Get<Mac::Filter>().AddRssIn(sed1.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality2));

--- a/tests/nexus/test_1_1_6_1_6.cpp
+++ b/tests/nexus/test_1_1_6_1_6.cpp
@@ -132,11 +132,8 @@ void RunTest6_1_6(Topology aTopology, const char *aJsonFile)
      */
     Log("Step 1: All");
 
-    leader.AllowList(router1);
-    leader.AllowList(reed1);
-
-    router1.AllowList(leader);
-    reed1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, reed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -158,11 +155,8 @@ void RunTest6_1_6(Topology aTopology, const char *aJsonFile)
      */
     Log("Step 2: Router_1");
 
-    dut.AllowList(router1);
-    dut.AllowList(reed1);
-
-    router1.AllowList(dut);
-    reed1.AllowList(dut);
+    AllowLinkBetween(dut, router1);
+    AllowLinkBetween(dut, reed1);
 
     SuccessOrQuit(dut.Get<Mac::Filter>().AddRssIn(router1.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality1));
     SuccessOrQuit(router1.Get<Mac::Filter>().AddRssIn(dut.Get<Mac::Mac>().GetExtAddress(), kRssiLinkQuality1));

--- a/tests/nexus/test_1_1_6_1_7.cpp
+++ b/tests/nexus/test_1_1_6_1_7.cpp
@@ -102,18 +102,10 @@ void RunTest6_1_7(const char *aJsonFile)
      * - Pass Criteria: N/A
      */
 
-    /** Use AllowList feature to specify links between nodes. */
-    leader.AllowList(router1);
-    leader.AllowList(router2);
-
-    router1.AllowList(leader);
-    router1.AllowList(router3);
-
-    router2.AllowList(leader);
-    router2.AllowList(router3);
-
-    router3.AllowList(router1);
-    router3.AllowList(router2);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, router2);
+    AllowLinkBetween(router1, router3);
+    AllowLinkBetween(router2, router3);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -139,8 +131,7 @@ void RunTest6_1_7(const char *aJsonFile)
      * - Pass Criteria:
      *   - The DUT MUST unicast MLE Child ID Request to the Leader.
      */
-    dut.AllowList(leader);
-    leader.AllowList(dut);
+    AllowLinkBetween(dut, leader);
 
     dut.Join(leader, Node::kAsFed);
     nexus.AdvanceTime(kAttachToLeaderTime);
@@ -159,13 +150,9 @@ void RunTest6_1_7(const char *aJsonFile)
      *     - Source Address TLV
      *     - Version TLV
      */
-    dut.AllowList(router1);
-    dut.AllowList(router2);
-    dut.AllowList(router3);
-
-    router1.AllowList(dut);
-    router2.AllowList(dut);
-    router3.AllowList(dut);
+    AllowLinkBetween(dut, router1);
+    AllowLinkBetween(dut, router2);
+    AllowLinkBetween(dut, router3);
 
     nexus.AdvanceTime(kLinkRequestTime);
 

--- a/tests/nexus/test_1_1_6_2_1.cpp
+++ b/tests/nexus/test_1_1_6_2_1.cpp
@@ -98,10 +98,8 @@ void RunTest6_2_1(Topology aTopology, const char *aJsonFile)
      */
     Log("Step 1: All");
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-    router1.AllowList(dut);
-    dut.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, dut);
 
     leader.Form();
 

--- a/tests/nexus/test_1_1_6_2_2.cpp
+++ b/tests/nexus/test_1_1_6_2_2.cpp
@@ -134,14 +134,10 @@ void RunTest_6_2_2(Topology aTopology, const char *aJsonFile)
      * - Description: Ensure topology is formed correctly. Ensure that the DUT successfully attached to Router_1.
      * - Pass Criteria: N/A
      */
-    leader.AllowList(router1);
-    leader.AllowList(router2);
-    router1.AllowList(leader);
-    router1.AllowList(router2);
-    router1.AllowList(dut);
-    router2.AllowList(leader);
-    router2.AllowList(router1);
-    dut.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, router2);
+    AllowLinkBetween(router1, router2);
+    AllowLinkBetween(router1, dut);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_6_3_1.cpp
+++ b/tests/nexus/test_1_1_6_3_1.cpp
@@ -148,10 +148,8 @@ void RunTest6_3_1(Topology aTopology, const char *aJsonFile)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-    router1.AllowList(dut);
-    dut.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, dut);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -228,8 +226,7 @@ void RunTest6_3_1(Topology aTopology, const char *aJsonFile)
          */
     }
 
-    leader.AllowList(dut);
-    dut.AllowList(leader);
+    AllowLinkBetween(leader, dut);
 
     nexus.AdvanceTime(kDetectParentLossTime);
 

--- a/tests/nexus/test_1_1_6_3_2.cpp
+++ b/tests/nexus/test_1_1_6_3_2.cpp
@@ -100,12 +100,7 @@ void RunTest6_3_2(Topology aTopology, const char *aJsonFile)
         break;
     }
 
-    /**
-     * Use AllowList to specify links between nodes. There is a link between the following node pairs:
-     * - Leader and SED 1 (DUT)
-     */
-    leader.AllowList(dut);
-    dut.AllowList(leader);
+    AllowLinkBetween(leader, dut);
 
     nexus.AdvanceTime(0);
 
@@ -259,8 +254,7 @@ void RunTest6_3_2(Topology aTopology, const char *aJsonFile)
      *   RF isolation, the test will fail because the DUT will go through re-attachment when it emerges.)
      * - Pass Criteria: N/A
      */
-    leader.AllowList(dut);
-    dut.AllowList(leader);
+    AllowLinkBetween(leader, dut);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 10: MED_1 (DUT)");

--- a/tests/nexus/test_1_1_6_4_1.cpp
+++ b/tests/nexus/test_1_1_6_4_1.cpp
@@ -134,8 +134,7 @@ void RunTest6_4_1(Topology aTopology, const char *aJsonFile)
      * - Description: Ensure topology is formed correctly.
      * - Pass Criteria: N/A
      */
-    leader.AllowList(dut);
-    dut.AllowList(leader);
+    AllowLinkBetween(leader, dut);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_6_4_2.cpp
+++ b/tests/nexus/test_1_1_6_4_2.cpp
@@ -126,11 +126,8 @@ void RunTest6_4_2(Topology aTopology, const char *aJsonFile)
      * - Pass Criteria: N/A
      */
 
-    /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-    router1.AllowList(dut);
-    dut.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, dut);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_6_5_1.cpp
+++ b/tests/nexus/test_1_1_6_5_1.cpp
@@ -123,8 +123,7 @@ void RunTest6_5_1(Topology aTopology, const char *aJsonFile)
      */
     Log("Step 1: All");
 
-    leader.AllowList(dut);
-    dut.AllowList(leader);
+    AllowLinkBetween(leader, dut);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_6_5_2.cpp
+++ b/tests/nexus/test_1_1_6_5_2.cpp
@@ -133,10 +133,8 @@ void RunTest_6_5_2(Topology aTopology, const char *aJsonFile)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-    router1.AllowList(dut);
-    dut.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, dut);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -232,8 +230,7 @@ void RunTest_6_5_2(Topology aTopology, const char *aJsonFile)
     /**
      * Enable link between Leader and DUT so it can re-attach to Leader.
      */
-    leader.AllowList(dut);
-    dut.AllowList(leader);
+    AllowLinkBetween(leader, dut);
 
     /**
      * Wait for the DUT to realize synchronization failed and start a new attach process.

--- a/tests/nexus/test_1_1_6_5_3.cpp
+++ b/tests/nexus/test_1_1_6_5_3.cpp
@@ -139,10 +139,8 @@ void RunTest6_5_3(Topology aTopology, const char *aJsonFile)
      */
     Log("Step 1: All");
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-    router1.AllowList(dut);
-    dut.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, dut);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_6_6_1.cpp
+++ b/tests/nexus/test_1_1_6_6_1.cpp
@@ -131,8 +131,7 @@ void RunTest6_6_1(Topology aTopology, const char *aJsonFile)
      * - Description: Harness instructs the device to form the network using thrKeySequenceCounter = 0.
      * - Pass Criteria: N/A
      */
-    leader.AllowList(dut);
-    dut.AllowList(leader);
+    AllowLinkBetween(leader, dut);
 
     leader.Get<KeyManager>().SetCurrentKeySequence(kInitialKeySequence,
                                                    KeyManager::kForceUpdate | KeyManager::kGuardTimerUnchanged);

--- a/tests/nexus/test_1_1_6_6_2.cpp
+++ b/tests/nexus/test_1_1_6_6_2.cpp
@@ -131,8 +131,7 @@ void RunTest6_6_2(Topology aTopology, const char *aJsonFile)
      * - Description: Harness instructs the device to form the network using thrKeySequenceCounter = 0x7F (127).
      * - Pass Criteria: N/A
      */
-    leader.AllowList(dut);
-    dut.AllowList(leader);
+    AllowLinkBetween(leader, dut);
 
     leader.Form();
     leader.Get<KeyManager>().SetCurrentKeySequence(kInitialKeySequence,

--- a/tests/nexus/test_1_1_7_1_1.cpp
+++ b/tests/nexus/test_1_1_7_1_1.cpp
@@ -83,14 +83,9 @@ void Test7_1_1(const char *aJsonFile)
     med1.SetName("MED_1");
     sed1.SetName("SED_1");
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    leader.AllowList(med1);
-    med1.AllowList(leader);
-
-    leader.AllowList(sed1);
-    sed1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, med1);
+    AllowLinkBetween(leader, sed1);
 
     nexus.AdvanceTime(0);
 

--- a/tests/nexus/test_1_1_7_1_2.cpp
+++ b/tests/nexus/test_1_1_7_1_2.cpp
@@ -126,9 +126,7 @@ void Test7_1_2(void)
      */
     Log("Step 2: Router_1 (DUT)");
 
-    /** Use AllowList feature to specify links between nodes. */
-    router1.AllowList(leader);
-    leader.AllowList(router1);
+    AllowLinkBetween(router1, leader);
 
     {
         NetworkData::OnMeshPrefixConfig config;
@@ -182,9 +180,7 @@ void Test7_1_2(void)
      */
     Log("Step 5: MED_1");
 
-    /** Use AllowList feature to specify links between nodes. */
-    med1.AllowList(router1);
-    router1.AllowList(med1);
+    AllowLinkBetween(med1, router1);
 
     /**
      * Step 6: Router_1 (DUT)
@@ -206,9 +202,7 @@ void Test7_1_2(void)
      */
     Log("Step 7: SED_1");
 
-    /** Use AllowList feature to specify links between nodes. */
-    sed1.AllowList(router1);
-    router1.AllowList(sed1);
+    AllowLinkBetween(sed1, router1);
 
     /**
      * Step 8: Router_1 (DUT)

--- a/tests/nexus/test_1_1_7_1_3.cpp
+++ b/tests/nexus/test_1_1_7_1_3.cpp
@@ -87,15 +87,9 @@ void Test7_1_3(const char *aJsonFile)
     med1.SetName("MED_1");
     sed1.SetName("SED_1");
 
-    /** Use AllowList to specify links between nodes. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    leader.AllowList(med1);
-    med1.AllowList(leader);
-
-    leader.AllowList(sed1);
-    sed1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, med1);
+    AllowLinkBetween(leader, sed1);
 
     nexus.AdvanceTime(0);
 

--- a/tests/nexus/test_1_1_7_1_4.cpp
+++ b/tests/nexus/test_1_1_7_1_4.cpp
@@ -89,15 +89,9 @@ void Test7_1_4(const char *aJsonFile)
     med1.SetName("MED_1");
     sed1.SetName("SED_1");
 
-    /** Use AllowList to specify links between nodes. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    router1.AllowList(med1);
-    med1.AllowList(router1);
-
-    router1.AllowList(sed1);
-    sed1.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, med1);
+    AllowLinkBetween(router1, sed1);
 
     nexus.AdvanceTime(0);
 

--- a/tests/nexus/test_1_1_7_1_5.cpp
+++ b/tests/nexus/test_1_1_7_1_5.cpp
@@ -91,14 +91,9 @@ void Test7_1_5(void)
      */
     Log("Step 1: All");
 
-    /** Use AllowList feature to restrict the topology. */
-    router1.AllowList(leader);
-    router1.AllowList(med1);
-    router1.AllowList(sed1);
-
-    leader.AllowList(router1);
-    med1.AllowList(router1);
-    sed1.AllowList(router1);
+    AllowLinkBetween(router1, leader);
+    AllowLinkBetween(router1, med1);
+    AllowLinkBetween(router1, sed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_7_1_6.cpp
+++ b/tests/nexus/test_1_1_7_1_6.cpp
@@ -120,15 +120,10 @@ void Test7_1_6(void)
      * - Pass Criteria: N/A.
      */
 
-    dut.AllowList(router1);
-    dut.AllowList(router2);
-    dut.AllowList(med1);
-    dut.AllowList(sed1);
-
-    router1.AllowList(dut);
-    router2.AllowList(dut);
-    med1.AllowList(dut);
-    sed1.AllowList(dut);
+    AllowLinkBetween(dut, router1);
+    AllowLinkBetween(dut, router2);
+    AllowLinkBetween(dut, med1);
+    AllowLinkBetween(dut, sed1);
 
     dut.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -330,8 +325,7 @@ void Test7_1_6(void)
      * - Pass Criteria: N/A.
      */
 
-    dut.AllowList(router1);
-    router1.AllowList(dut);
+    AllowLinkBetween(dut, router1);
     router1.Join(dut, Node::kAsFed);
     nexus.AdvanceTime(kAttachToRouterTime);
 

--- a/tests/nexus/test_1_1_7_1_7.cpp
+++ b/tests/nexus/test_1_1_7_1_7.cpp
@@ -122,18 +122,10 @@ void Test7_1_7(const char *aJsonFile)
      * - Pass Criteria: N/A.
      */
 
-    /** Use AllowList to specify links between nodes. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    leader.AllowList(router2);
-    router2.AllowList(leader);
-
-    leader.AllowList(med1);
-    med1.AllowList(leader);
-
-    leader.AllowList(sed1);
-    sed1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, router2);
+    AllowLinkBetween(leader, med1);
+    AllowLinkBetween(leader, sed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -282,8 +274,7 @@ void Test7_1_7(const char *aJsonFile)
 
     nexus.AdvanceTime(kStabilizationTime);
 
-    router2.UnallowList(leader);
-    leader.UnallowList(router2);
+    UnallowLinkBetween(router2, leader);
 
     nexus.AdvanceTime(kPartitionStartWaitTime);
 
@@ -327,8 +318,7 @@ void Test7_1_7(const char *aJsonFile)
      * - Pass Criteria: N/A.
      */
 
-    router2.AllowList(leader);
-    leader.AllowList(router2);
+    AllowLinkBetween(router2, leader);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 10: Router_2");

--- a/tests/nexus/test_1_1_7_1_8.cpp
+++ b/tests/nexus/test_1_1_7_1_8.cpp
@@ -118,12 +118,8 @@ void Test7_1_8(const char *aJsonFile)
      * - Pass Criteria: N/A.
      */
 
-    /** Use AllowList feature to specify links between nodes. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    router1.AllowList(fed1);
-    fed1.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, fed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_9_2_1.cpp
+++ b/tests/nexus/test_1_1_9_2_1.cpp
@@ -109,9 +109,7 @@ void RunTest9_2_1(Topology aTopology, const char *aJsonFile)
      * - Description: Ensure topology is formed correctly.
      * - Pass Criteria: N/A.
      */
-
-    leader.AllowList(commissioner);
-    commissioner.AllowList(leader);
+    AllowLinkBetween(leader, commissioner);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_9_2_10.cpp
+++ b/tests/nexus/test_1_1_9_2_10.cpp
@@ -181,17 +181,10 @@ void Test9_2_10(void)
      * - Pass Criteria: N/A.
      */
 
-    commissioner.AllowList(leader);
-    leader.AllowList(commissioner);
-
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    router1.AllowList(med1);
-    med1.AllowList(router1);
-
-    router1.AllowList(sed1);
-    sed1.AllowList(router1);
+    AllowLinkBetween(commissioner, leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, med1);
+    AllowLinkBetween(router1, sed1);
 
     {
         MeshCoP::Dataset::Info datasetInfo;
@@ -486,19 +479,14 @@ void Test9_2_10(void)
      */
 
     router1.Get<Mac::Filter>().ClearAddresses();
-    router1.AllowList(med1);
-    router1.AllowList(sed1);
-
     med1.Get<Mac::Filter>().ClearAddresses();
-    med1.AllowList(router1);
-
     sed1.Get<Mac::Filter>().ClearAddresses();
-    sed1.AllowList(router1);
+    AllowLinkBetween(router1, med1);
+    AllowLinkBetween(router1, sed1);
 
     leader.Get<Mac::Filter>().ClearAddresses();
     commissioner.Get<Mac::Filter>().ClearAddresses();
-    commissioner.AllowList(leader);
-    leader.AllowList(commissioner);
+    AllowLinkBetween(leader, commissioner);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 14: Router_1");
@@ -570,8 +558,7 @@ void Test9_2_10(void)
 
     nexus.AdvanceTime(kIsolationTime - kDelayTimerTime);
 
-    router1.AllowList(leader);
-    leader.AllowList(router1);
+    AllowLinkBetween(router1, leader);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 19: Router_1");

--- a/tests/nexus/test_1_1_9_2_11.cpp
+++ b/tests/nexus/test_1_1_9_2_11.cpp
@@ -178,14 +178,10 @@ void Test9_2_11(void)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(commissioner);
-    leader.AllowList(router1);
-    commissioner.AllowList(leader);
-    router1.AllowList(leader);
-    router1.AllowList(med1);
-    router1.AllowList(sed1);
-    med1.AllowList(router1);
-    sed1.AllowList(router1);
+    AllowLinkBetween(leader, commissioner);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, med1);
+    AllowLinkBetween(router1, sed1);
 
     {
         MeshCoP::Dataset::Info datasetInfo;

--- a/tests/nexus/test_1_1_9_2_12.cpp
+++ b/tests/nexus/test_1_1_9_2_12.cpp
@@ -124,18 +124,10 @@ void Test9_2_12(void)
 
     SuccessOrQuit(Instance::SetGlobalLogLevel(kLogLevelNote));
 
-    /** Use AllowList feature to specify links between nodes. */
-    leader2.AllowList(med1);
-    med1.AllowList(leader2);
-
-    leader1.AllowList(router1);
-    router1.AllowList(leader1);
-
-    router1.AllowList(leader2);
-    leader2.AllowList(router1);
-
-    router1.AllowList(med1);
-    med1.AllowList(router1);
+    AllowLinkBetween(leader2, med1);
+    AllowLinkBetween(leader1, router1);
+    AllowLinkBetween(router1, leader2);
+    AllowLinkBetween(router1, med1);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: All");

--- a/tests/nexus/test_1_1_9_2_13.cpp
+++ b/tests/nexus/test_1_1_9_2_13.cpp
@@ -162,18 +162,10 @@ void Test9_2_13(void)
      * - Pass Criteria: N/A.
      */
 
-    /** Set up AllowList for links. */
-    leader1.AllowList(commissioner);
-    commissioner.AllowList(leader1);
-
-    leader1.AllowList(router1);
-    router1.AllowList(leader1);
-
-    router1.AllowList(fed1);
-    fed1.AllowList(router1);
-
-    leader2.AllowList(sed2);
-    sed2.AllowList(leader2);
+    AllowLinkBetween(leader1, commissioner);
+    AllowLinkBetween(leader1, router1);
+    AllowLinkBetween(router1, fed1);
+    AllowLinkBetween(leader2, sed2);
 
     Ip6::Prefix        prefix;
     Ip6::NetworkPrefix networkPrefix;

--- a/tests/nexus/test_1_1_9_2_14.cpp
+++ b/tests/nexus/test_1_1_9_2_14.cpp
@@ -117,15 +117,9 @@ void Test9_2_14(void)
      *   - Pass Criteria: N/A
      */
 
-    leader1.AllowList(router1);
-    leader1.AllowList(commissioner);
-
-    router1.AllowList(leader1);
-    router1.AllowList(leader2);
-
-    commissioner.AllowList(leader1);
-
-    leader2.AllowList(router1);
+    AllowLinkBetween(leader1, router1);
+    AllowLinkBetween(leader1, commissioner);
+    AllowLinkBetween(router1, leader2);
 
     {
         MeshCoP::Dataset::Info datasetInfo;

--- a/tests/nexus/test_1_1_9_2_15.cpp
+++ b/tests/nexus/test_1_1_9_2_15.cpp
@@ -215,11 +215,8 @@ void Test9_2_15(void)
      * - Pass Criteria: N/A
      */
 
-    commissioner.AllowList(leader);
-    leader.AllowList(commissioner);
-
-    leader.AllowList(router1);
-    router1.AllowList(leader);
+    AllowLinkBetween(commissioner, leader);
+    AllowLinkBetween(leader, router1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -254,8 +251,7 @@ void Test9_2_15(void)
      * - Leader and Router 1
      * - Router 1 and Router 2
      */
-    dut.AllowList(router1);
-    router1.AllowList(dut);
+    AllowLinkBetween(dut, router1);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 3: Commissioner");

--- a/tests/nexus/test_1_1_9_2_16.cpp
+++ b/tests/nexus/test_1_1_9_2_16.cpp
@@ -201,14 +201,9 @@ void Test9_2_16(void)
      * - Pass Criteria: N/A
      */
 
-    commissioner.AllowList(leader);
-    leader.AllowList(commissioner);
-
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    router1.AllowList(router2);
-    router2.AllowList(router1);
+    AllowLinkBetween(commissioner, leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, router2);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_9_2_17.cpp
+++ b/tests/nexus/test_1_1_9_2_17.cpp
@@ -152,18 +152,13 @@ void Test9_2_17(void)
      *   Advertisements on separate channels.
      */
 
-    leader1.AllowList(dut);
-    dut.AllowList(leader1);
-
-    leader2.AllowList(dut);
-    dut.AllowList(leader2);
+    AllowLinkBetween(leader1, dut);
 
     // Leader 1 <-> DUT is allowed.
     // Leader 2 <-> DUT is initially blocked by radio channel and different PAN ID, but here we also use AllowList.
     // We start with Leader 2 being reachable but on different channel.
     // Actually, to fully control connectivity as per spec, we'll unallow Leader 2 for now.
-    leader2.UnallowList(dut);
-    dut.UnallowList(leader2);
+    UnallowLinkBetween(leader2, dut);
 
     dut.Get<Mle::Mle>().SetTimeout(20);
 
@@ -237,8 +232,7 @@ void Test9_2_17(void)
     leader1.Get<Mle::Mle>().Stop();
     leader1.Get<ThreadNetif>().Down();
 
-    leader2.AllowList(dut);
-    dut.AllowList(leader2);
+    AllowLinkBetween(leader2, dut);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 3: DUT");

--- a/tests/nexus/test_1_1_9_2_18.cpp
+++ b/tests/nexus/test_1_1_9_2_18.cpp
@@ -152,19 +152,10 @@ void Test9_2_18(void)
      * - Description: Ensure topology is formed correctly.
      * - Pass Criteria: N/A
      */
-
-    /** Use AllowList feature to specify links between nodes. */
-    commissioner.AllowList(leader);
-    leader.AllowList(commissioner);
-
-    router1.AllowList(leader);
-    leader.AllowList(router1);
-
-    router1.AllowList(med1);
-    med1.AllowList(router1);
-
-    router1.AllowList(sed1);
-    sed1.AllowList(router1);
+    AllowLinkBetween(commissioner, leader);
+    AllowLinkBetween(router1, leader);
+    AllowLinkBetween(router1, med1);
+    AllowLinkBetween(router1, sed1);
 
     MeshCoP::Dataset::Info datasetInfo;
     SuccessOrQuit(datasetInfo.GenerateRandom(leader.GetInstance()));

--- a/tests/nexus/test_1_1_9_2_19.cpp
+++ b/tests/nexus/test_1_1_9_2_19.cpp
@@ -130,8 +130,7 @@ void RunTest9_2_19(Topology aTopology, const char *aJsonFile)
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: All");
 
-    leader.AllowList(commissioner);
-    commissioner.AllowList(leader);
+    AllowLinkBetween(leader, commissioner);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_9_2_2.cpp
+++ b/tests/nexus/test_1_1_9_2_2.cpp
@@ -108,8 +108,7 @@ void Test9_2_2(void)
      */
     Log("Step 1: All");
 
-    leader.AllowList(commissioner);
-    commissioner.AllowList(leader);
+    AllowLinkBetween(leader, commissioner);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_9_2_3.cpp
+++ b/tests/nexus/test_1_1_9_2_3.cpp
@@ -112,8 +112,7 @@ void RunTest9_2_3(Topology aTopology, const char *aJsonFile)
      * - Pass Criteria: N/A.
      */
 
-    leader.AllowList(commissioner);
-    commissioner.AllowList(leader);
+    AllowLinkBetween(leader, commissioner);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_9_2_4.cpp
+++ b/tests/nexus/test_1_1_9_2_4.cpp
@@ -268,12 +268,11 @@ void RunTest9_2_4(Topology aTopology, const char *aJsonFile)
 
     /**
      * Step 1: All
-     * - Description: Ensure topology is formed correctly.
+     * - Description: Ensure topology is formed correctly
      * - Pass Criteria: N/A.
      */
 
-    leader.AllowList(commissioner);
-    commissioner.AllowList(leader);
+    AllowLinkBetween(leader, commissioner);
 
     {
         MeshCoP::Dataset::Info datasetInfo;

--- a/tests/nexus/test_1_1_9_2_5.cpp
+++ b/tests/nexus/test_1_1_9_2_5.cpp
@@ -124,8 +124,7 @@ void Test9_2_5(void)
      * - Pass Criteria: N/A.
      */
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_1_9_2_6.cpp
+++ b/tests/nexus/test_1_1_9_2_6.cpp
@@ -150,14 +150,10 @@ void Test9_2_6(void)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(commissioner);
-    leader.AllowList(router1);
-    commissioner.AllowList(leader);
-    router1.AllowList(leader);
-    router1.AllowList(med1);
-    router1.AllowList(sed1);
-    med1.AllowList(router1);
-    sed1.AllowList(router1);
+    AllowLinkBetween(leader, commissioner);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, med1);
+    AllowLinkBetween(router1, sed1);
 
     {
         MeshCoP::Dataset::Info datasetInfo;

--- a/tests/nexus/test_1_1_9_2_7.cpp
+++ b/tests/nexus/test_1_1_9_2_7.cpp
@@ -165,8 +165,7 @@ void Test9_2_7(void)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(commissioner);
-    commissioner.AllowList(leader);
+    AllowLinkBetween(leader, commissioner);
 
     {
         MeshCoP::Dataset::Info datasetInfo;
@@ -212,8 +211,7 @@ void Test9_2_7(void)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(router);
-    router.AllowList(leader);
+    AllowLinkBetween(leader, router);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 3: Router");

--- a/tests/nexus/test_1_1_9_2_8.cpp
+++ b/tests/nexus/test_1_1_9_2_8.cpp
@@ -158,17 +158,10 @@ void Test9_2_8(void)
      * - Pass Criteria: N/A.
      */
 
-    commissioner.AllowList(leader);
-    leader.AllowList(commissioner);
-
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    leader.AllowList(med1);
-    med1.AllowList(leader);
-
-    leader.AllowList(sed1);
-    sed1.AllowList(leader);
+    AllowLinkBetween(commissioner, leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, med1);
+    AllowLinkBetween(leader, sed1);
 
     {
         MeshCoP::Dataset::Info dataset;
@@ -339,9 +332,9 @@ void Test9_2_8(void)
      *     PANID: 0xAFCE).
      */
 
-    router1.AllowList(leader);
-    med1.AllowList(leader);
-    sed1.AllowList(leader);
+    AllowLinkBetween(router1, leader);
+    AllowLinkBetween(med1, leader);
+    AllowLinkBetween(sed1, leader);
 
     SuccessOrQuit(router1.Get<Mle::Mle>().SetDeviceMode(Mle::DeviceMode(Mle::DeviceMode::kModeRxOnWhenIdle |
                                                                         Mle::DeviceMode::kModeFullThreadDevice |

--- a/tests/nexus/test_1_1_9_2_9.cpp
+++ b/tests/nexus/test_1_1_9_2_9.cpp
@@ -220,14 +220,9 @@ void Test9_2_9(void)
      * - Pass Criteria: N/A
      */
 
-    commissioner.AllowList(leader);
-    leader.AllowList(commissioner);
-
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    router1.AllowList(router2);
-    router2.AllowList(router1);
+    AllowLinkBetween(commissioner, leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, router2);
 
     leader.Get<Mac::Mac>().SetPanId(kPanIdFace);
     leader.Form();
@@ -326,8 +321,7 @@ void Test9_2_9(void)
     Log("---------------------------------------------------------------------------------------");
     Log("Step 4: Leader");
 
-    router1.UnallowList(router2);
-    router2.UnallowList(router1);
+    UnallowLinkBetween(router1, router2);
 
     /**
      * Step 4: Leader
@@ -393,8 +387,7 @@ void Test9_2_9(void)
     Log("---------------------------------------------------------------------------------------");
     Log("Step 6: Router_1");
 
-    router1.AllowList(router2);
-    router2.AllowList(router1);
+    AllowLinkBetween(router1, router2);
 
     /**
      * Step 6: Router_1
@@ -464,10 +457,8 @@ void Test9_2_9(void)
      * - Pass Criteria: N/A
      */
 
-    leader.UnallowList(router1);
-    leader.UnallowList(router2);
-    router1.UnallowList(leader);
-    router2.UnallowList(leader);
+    UnallowLinkBetween(leader, router1);
+    UnallowLinkBetween(leader, router2);
 
     nexus.AdvanceTime(kRfIsolationTime);
 
@@ -681,8 +672,7 @@ void Test9_2_9(void)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
 
     nexus.AdvanceTime(300000); // 300s to ensure merge and dataset sync.
 

--- a/tests/nexus/test_1_2_BBR_TC_3.cpp
+++ b/tests/nexus/test_1_2_BBR_TC_3.cpp
@@ -124,8 +124,7 @@ void TestBbrTc3(void)
      * - Pass Criteria:
      *   - N/A
      */
-    br1.AllowList(br2);
-    br2.AllowList(br1);
+    AllowLinkBetween(br1, br2);
 
     br1.Get<BorderRouter::InfraIf>().Init(kInfraIfIndex, true);
     br1.Get<BorderRouter::RoutingManager>().Init();

--- a/tests/nexus/test_1_2_LP_5_2_1.cpp
+++ b/tests/nexus/test_1_2_LP_5_2_1.cpp
@@ -125,24 +125,10 @@ void Test1_2_LP_5_2_1(void)
     sed2.SetName("SED_2");
     sed3.SetName("SED_3");
 
-    /**
-     * - Use AllowList to specify links between nodes. There is a link between the following node pairs:
-     *   - Leader (DUT) and Router 1
-     *   - Leader (DUT) and SED 1
-     *   - Leader (DUT) and SED 2
-     *   - Leader (DUT) and SED 3
-     */
-    dut.AllowList(router1);
-    router1.AllowList(dut);
-
-    dut.AllowList(sed1);
-    sed1.AllowList(dut);
-
-    dut.AllowList(sed2);
-    sed2.AllowList(dut);
-
-    dut.AllowList(sed3);
-    sed3.AllowList(dut);
+    AllowLinkBetween(dut, router1);
+    AllowLinkBetween(dut, sed1);
+    AllowLinkBetween(dut, sed2);
+    AllowLinkBetween(dut, sed3);
 
     nexus.AdvanceTime(0);
 

--- a/tests/nexus/test_1_2_LP_5_3_1.cpp
+++ b/tests/nexus/test_1_2_LP_5_3_1.cpp
@@ -111,12 +111,8 @@ void Test1_2_LP_5_3_1(void)
      * - Pass Criteria: N/A.
      */
 
-    /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    leader.AllowList(ssed1);
-
-    router1.AllowList(leader);
-    ssed1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, ssed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_LP_5_3_2.cpp
+++ b/tests/nexus/test_1_2_LP_5_3_2.cpp
@@ -206,12 +206,8 @@ void Test1_2_LP_5_3_2(void)
      */
     Log("Step 1: All");
 
-    /** Use AllowList feature to restrict the topology. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    router1.AllowList(ssed1);
-    ssed1.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, ssed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_LP_5_3_3.cpp
+++ b/tests/nexus/test_1_2_LP_5_3_3.cpp
@@ -145,16 +145,8 @@ void Test1_2_LP_5_3_3(void)
      */
     Log("Step 1: All");
 
-    /**
-     * Use AllowList to specify links between nodes. There is a link between the following node pairs:
-     * - Leader (DUT) and Router 1
-     * - Leader (DUT) and SSED 1
-     */
-    dut.AllowList(router1);
-    router1.AllowList(dut);
-
-    dut.AllowList(ssed1);
-    ssed1.AllowList(dut);
+    AllowLinkBetween(dut, router1);
+    AllowLinkBetween(dut, ssed1);
 
     dut.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_LP_5_3_4.cpp
+++ b/tests/nexus/test_1_2_LP_5_3_4.cpp
@@ -108,12 +108,8 @@ void Test1_2_LP_5_3_4(void)
      * - Pass Criteria: N/A.
      */
 
-    leader.AllowList(router1);
-    leader.AllowList(ssed1);
-
-    router1.AllowList(leader);
-
-    ssed1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(leader, ssed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_LP_5_3_5.cpp
+++ b/tests/nexus/test_1_2_LP_5_3_5.cpp
@@ -170,13 +170,11 @@ void Test1_2_LP_5_3_5(void)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(router1);
-    router1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
 
     for (Node *ssed : sseds)
     {
-        router1.AllowList(*ssed);
-        ssed->AllowList(router1);
+        AllowLinkBetween(router1, *ssed);
     }
 
     leader.Form();

--- a/tests/nexus/test_1_2_LP_5_3_6.cpp
+++ b/tests/nexus/test_1_2_LP_5_3_6.cpp
@@ -136,11 +136,8 @@ void Test1_2_LP_5_3_6(void)
      */
     Log("Step 1: All");
 
-    /** Use AllowList feature to specify links between nodes. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-    router1.AllowList(ssed1);
-    ssed1.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, ssed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_LP_5_3_7.cpp
+++ b/tests/nexus/test_1_2_LP_5_3_7.cpp
@@ -135,11 +135,8 @@ void Test1_2_LP_5_3_7(void)
      *   Description: Topology formation: Leader, DUT, SSED_1.
      *   Pass Criteria: N/A.
      */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-
-    router1.AllowList(ssed1);
-    ssed1.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, ssed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_LP_5_3_8.cpp
+++ b/tests/nexus/test_1_2_LP_5_3_8.cpp
@@ -174,11 +174,8 @@ void Test5_3_8(void)
      * - Pass Criteria: N/A.
      */
 
-    /** Use AllowList feature to specify links between nodes. */
-    leader.AllowList(router1);
-    router1.AllowList(leader);
-    router1.AllowList(ssed1);
-    ssed1.AllowList(router1);
+    AllowLinkBetween(leader, router1);
+    AllowLinkBetween(router1, ssed1);
 
     {
         MeshCoP::Dataset::Info datasetInfo;

--- a/tests/nexus/test_1_2_LP_7_1_1.cpp
+++ b/tests/nexus/test_1_2_LP_7_1_1.cpp
@@ -153,10 +153,8 @@ void Test1_2_LP_7_1_1(void)
      * - Pass Criteria: N/A.
      */
 
-    leader.AllowList(sed1);
-    leader.AllowList(ssed1);
-    sed1.AllowList(leader);
-    ssed1.AllowList(leader);
+    AllowLinkBetween(leader, sed1);
+    AllowLinkBetween(leader, ssed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_LP_7_1_2.cpp
+++ b/tests/nexus/test_1_2_LP_7_1_2.cpp
@@ -145,10 +145,8 @@ void Test1_2_LP_7_1_2(void)
      * - Pass Criteria: N/A
      */
 
-    leader.AllowList(sed1);
-    leader.AllowList(ssed1);
-    sed1.AllowList(leader);
-    ssed1.AllowList(leader);
+    AllowLinkBetween(leader, sed1);
+    AllowLinkBetween(leader, ssed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_LP_7_2_1.cpp
+++ b/tests/nexus/test_1_2_LP_7_2_1.cpp
@@ -189,10 +189,8 @@ void Test1_2_LP_7_2_1(void)
      * - Pass Criteria: N/A
      */
     Log("Step 1: Topology formation: DUT, SED_1, SSED_1.");
-    leader.AllowList(sed1);
-    leader.AllowList(ssed1);
-    sed1.AllowList(leader);
-    ssed1.AllowList(leader);
+    AllowLinkBetween(leader, sed1);
+    AllowLinkBetween(leader, ssed1);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_LP_7_2_2.cpp
+++ b/tests/nexus/test_1_2_LP_7_2_2.cpp
@@ -201,18 +201,12 @@ void Test1_2_LP_7_2_2(void)
      * - Pass Criteria: N/A.
      */
     Log("Step 1: Topology formation: DUT, SED_1, SED_2, SED_3, SSED_1, SSED_2, SSED_3.");
-    leader.AllowList(sed1);
-    leader.AllowList(sed2);
-    leader.AllowList(sed3);
-    leader.AllowList(ssed1);
-    leader.AllowList(ssed2);
-    leader.AllowList(ssed3);
-    sed1.AllowList(leader);
-    sed2.AllowList(leader);
-    sed3.AllowList(leader);
-    ssed1.AllowList(leader);
-    ssed2.AllowList(leader);
-    ssed3.AllowList(leader);
+    AllowLinkBetween(leader, sed1);
+    AllowLinkBetween(leader, sed2);
+    AllowLinkBetween(leader, sed3);
+    AllowLinkBetween(leader, ssed1);
+    AllowLinkBetween(leader, ssed2);
+    AllowLinkBetween(leader, ssed3);
 
     leader.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_1.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_1.cpp
@@ -135,8 +135,7 @@ void TestMatnTc1(void)
      * - Pass Criteria:
      *   - N/A
      */
-    br1.AllowList(router);
-    router.AllowList(br1);
+    AllowLinkBetween(br1, router);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_10.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_10.cpp
@@ -133,12 +133,9 @@ void TestMatnTc10(void)
      * - Pass Criteria:
      *   - N/A
      */
-    br1.AllowList(router);
-    br1.AllowList(br2);
-    router.AllowList(br1);
-    router.AllowList(br2);
-    br2.AllowList(br1);
-    br2.AllowList(router);
+    AllowLinkBetween(br1, router);
+    AllowLinkBetween(br1, br2);
+    AllowLinkBetween(router, br2);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_12.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_12.cpp
@@ -132,8 +132,7 @@ void TestMatnTc12(void)
      * - Pass Criteria:
      *   - N/A
      */
-    br1.AllowList(router);
-    router.AllowList(br1);
+    AllowLinkBetween(br1, router);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_15.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_15.cpp
@@ -112,17 +112,10 @@ void TestMatnTc15(void)
      *   - N/A
      */
 
-    br1.AllowList(br2);
-    br1.AllowList(router);
-
-    br2.AllowList(br1);
-    br2.AllowList(router);
-
-    router.AllowList(br1);
-    router.AllowList(br2);
-    router.AllowList(dut);
-
-    dut.AllowList(router);
+    AllowLinkBetween(br1, br2);
+    AllowLinkBetween(br1, router);
+    AllowLinkBetween(br2, router);
+    AllowLinkBetween(router, dut);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_16.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_16.cpp
@@ -143,8 +143,7 @@ void TestMatnTc16(void)
      */
     Log("Step 0: Topology formation – BR_1 (DUT), Router");
 
-    br1.AllowList(router);
-    router.AllowList(br1);
+    AllowLinkBetween(br1, router);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_19.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_19.cpp
@@ -148,14 +148,10 @@ void TestMatnTc19(void)
      *   - N/A
      */
 
-    br1.AllowList(br2);
-    br1.AllowList(router);
-    br2.AllowList(br1);
-    br2.AllowList(router);
-    router.AllowList(br1);
-    router.AllowList(br2);
-    router.AllowList(mtd);
-    mtd.AllowList(router);
+    AllowLinkBetween(br1, br2);
+    AllowLinkBetween(br1, router);
+    AllowLinkBetween(br2, router);
+    AllowLinkBetween(router, mtd);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_2.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_2.cpp
@@ -124,12 +124,9 @@ void TestMatnTc2(void)
      * - Pass Criteria:
      *   - N/A
      */
-    br1.AllowList(br2);
-    br1.AllowList(td);
-    br2.AllowList(br1);
-    br2.AllowList(td);
-    td.AllowList(br1);
-    td.AllowList(br2);
+    AllowLinkBetween(br1, br2);
+    AllowLinkBetween(br1, td);
+    AllowLinkBetween(br2, td);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_20.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_20.cpp
@@ -115,18 +115,10 @@ void TestMatnTc20(void)
      *   - N/A
      */
 
-    /** Use AllowList to specify links between nodes. */
-    br1.AllowList(br2);
-    br1.AllowList(router);
-
-    br2.AllowList(br1);
-    br2.AllowList(router);
-
-    router.AllowList(br1);
-    router.AllowList(br2);
-    router.AllowList(med);
-
-    med.AllowList(router);
+    AllowLinkBetween(br1, br2);
+    AllowLinkBetween(br1, router);
+    AllowLinkBetween(br2, router);
+    AllowLinkBetween(router, med);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_21.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_21.cpp
@@ -176,12 +176,9 @@ void TestMatnTc21(void)
      */
     Log("Step 0: Topology formation – BR_1, BR_2, Router");
 
-    br1.AllowList(br2);
-    br1.AllowList(router);
-    br2.AllowList(br1);
-    br2.AllowList(router);
-    router.AllowList(br1);
-    router.AllowList(br2);
+    AllowLinkBetween(br1, br2);
+    AllowLinkBetween(br1, router);
+    AllowLinkBetween(br2, router);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_22.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_22.cpp
@@ -123,10 +123,8 @@ void TestMatnTc22(void)
      */
     Log("Step 0: Topology formation – BR_1. Topology addition – TD (DUT_Router and DUT_FED). DUTs register MA1.");
 
-    br1.AllowList(dut1);
-    dut1.AllowList(br1);
-    br1.AllowList(dut2);
-    dut2.AllowList(br1);
+    AllowLinkBetween(br1, dut1);
+    AllowLinkBetween(br1, dut2);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_23.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_23.cpp
@@ -108,12 +108,9 @@ void TestMatnTc23(void)
      */
     Log("Step 0: Topology formation - BR_1, BR_2, TD (DUT)");
 
-    br1.AllowList(br2);
-    br1.AllowList(td);
-    br2.AllowList(br1);
-    br2.AllowList(td);
-    td.AllowList(br1);
-    td.AllowList(br2);
+    AllowLinkBetween(br1, br2);
+    AllowLinkBetween(br1, td);
+    AllowLinkBetween(br2, td);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_26.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_26.cpp
@@ -114,8 +114,7 @@ void TestMatnTc26(void)
      * - Pass Criteria:
      * - N/A
      */
-    br1.AllowList(td);
-    td.AllowList(br1);
+    AllowLinkBetween(br1, td);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_3.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_3.cpp
@@ -133,12 +133,9 @@ void TestMatnTc3(void)
      * - Pass Criteria:
      *   - N/A
      */
-    br1.AllowList(br2);
-    br1.AllowList(router);
-    br2.AllowList(br1);
-    br2.AllowList(router);
-    router.AllowList(br1);
-    router.AllowList(br2);
+    AllowLinkBetween(br1, br2);
+    AllowLinkBetween(br1, router);
+    AllowLinkBetween(br2, router);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_4.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_4.cpp
@@ -139,12 +139,10 @@ void Test1_2_MATN_TC_4(void)
      * - Pass Criteria:
      *   - N/A
      */
-    br1.AllowList(br2);
-    br1.AllowList(router);
-    br2.AllowList(br1);
-    br2.AllowList(router);
-    router.AllowList(br1);
-    router.AllowList(br2);
+
+    AllowLinkBetween(br1, br2);
+    AllowLinkBetween(br1, router);
+    AllowLinkBetween(br2, router);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_5.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_5.cpp
@@ -139,12 +139,9 @@ void TestMatnTc5(void)
      */
     Log("Step 0: Topology formation – BR_1 (DUT)");
 
-    br1.AllowList(br2);
-    br1.AllowList(router);
-    br2.AllowList(br1);
-    br2.AllowList(router);
-    router.AllowList(br1);
-    router.AllowList(br2);
+    AllowLinkBetween(br1, br2);
+    AllowLinkBetween(br1, router);
+    AllowLinkBetween(br2, router);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_7.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_7.cpp
@@ -145,12 +145,9 @@ void TestMatnTc7(void)
      *   - N/A
      */
 
-    br1.AllowList(br2);
-    br1.AllowList(router);
-    br2.AllowList(br1);
-    br2.AllowList(router);
-    router.AllowList(br1);
-    router.AllowList(br2);
+    AllowLinkBetween(br1, br2);
+    AllowLinkBetween(br1, router);
+    AllowLinkBetween(br2, router);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_2_MATN_TC_9.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_9.cpp
@@ -115,12 +115,10 @@ void TestMatnTc9(void)
      * - Pass Criteria:
      *   - N/A
      */
-    br1.AllowList(router);
-    br1.AllowList(br2);
-    router.AllowList(br1);
-    router.AllowList(br2);
-    br2.AllowList(br1);
-    br2.AllowList(router);
+
+    AllowLinkBetween(br1, br2);
+    AllowLinkBetween(br1, router);
+    AllowLinkBetween(br2, router);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_3_DBR_TC_10.cpp
+++ b/tests/nexus/test_1_3_DBR_TC_10.cpp
@@ -207,11 +207,8 @@ void Test_1_3_DBR_TC_10(const char *aJsonFileName)
      */
     Log("Step 2: Router_1 and ED_1 enable and form topology.");
 
-    br1.AllowList(router1);
-    router1.AllowList(br1);
-
-    router1.AllowList(ed1);
-    ed1.AllowList(router1);
+    AllowLinkBetween(br1, router1);
+    AllowLinkBetween(router1, ed1);
 
     router1.Join(br1);
     nexus.AdvanceTime(kJoinNetworkTime);

--- a/tests/nexus/test_1_3_DBR_TC_2.cpp
+++ b/tests/nexus/test_1_3_DBR_TC_2.cpp
@@ -124,7 +124,8 @@ void Test_1_3_DBR_TC_2(void)
      * - Pass Criteria: N/A
      */
 
-    br2.AllowList(br1);
+    AllowLinkBetween(br1, br2);
+    AllowLinkBetween(ed1, br1);
 
     br2.Form();
     nexus.AdvanceTime(kFormNetworkTime);
@@ -159,9 +160,6 @@ void Test_1_3_DBR_TC_2(void)
      * - Description (DBR-1.2): Enable: turn on device.
      * - Pass Criteria: N/A
      */
-
-    br1.AllowList(br2);
-    br1.AllowList(ed1);
 
     br1.Join(br2);
     nexus.AdvanceTime(kJoinNetworkTime);
@@ -214,7 +212,6 @@ void Test_1_3_DBR_TC_2(void)
      *     Network Data that is sent to the Child ED 1.
      */
 
-    ed1.AllowList(br1);
     ed1.Join(br1, Node::kAsFed);
     nexus.AdvanceTime(kJoinNetworkTime);
 

--- a/tests/nexus/test_1_3_DBR_TC_3.cpp
+++ b/tests/nexus/test_1_3_DBR_TC_3.cpp
@@ -201,12 +201,10 @@ void Test_1_3_DBR_TC_3(void)
     SuccessOrQuit(br2.Get<BorderRouter::RoutingManager>().GetOmrPrefix(omrPrefix2));
     nexus.AddTestVar("OMR_PREFIX_2", omrPrefix2.ToString().AsCString());
 
-    br1.AllowList(ed1);
-    ed1.AllowList(br1);
+    AllowLinkBetween(br1, ed1);
     ed1.Join(br1, Node::kAsFed);
 
-    br2.AllowList(ed2);
-    ed2.AllowList(br2);
+    AllowLinkBetween(br2, ed2);
     ed2.Join(br2, Node::kAsFed);
 
     nexus.AdvanceTime(kJoinNetworkTime);

--- a/tests/nexus/test_1_3_DBR_TC_6.cpp
+++ b/tests/nexus/test_1_3_DBR_TC_6.cpp
@@ -166,8 +166,7 @@ void Test_1_3_DBR_TC_6(void)
 
     br1.Get<BorderRouter::InfraIf>().Init(kInfraIfIndex, true);
 
-    br1.AllowList(br2);
-    br2.AllowList(br1);
+    AllowLinkBetween(br1, br2);
 
     br1.Join(br2);
     nexus.AdvanceTime(kJoinNetworkTime);
@@ -180,8 +179,7 @@ void Test_1_3_DBR_TC_6(void)
     Log("---------------------------------------------------------------------------------------");
     Log("Step 2b: Device: ED 1 Description (DBR-1.6): Harness enables device.");
 
-    ed1.AllowList(br1);
-    br1.AllowList(ed1);
+    AllowLinkBetween(ed1, br1);
 
     ed1.Join(br1, Node::kAsFed);
     nexus.AdvanceTime(kJoinNetworkTime);

--- a/tests/nexus/test_1_3_DBR_TC_8.cpp
+++ b/tests/nexus/test_1_3_DBR_TC_8.cpp
@@ -281,10 +281,8 @@ void Test_1_3_DBR_TC_8(void)
      */
     Log("Step 1: BR_2 becomes Leader and registers OMR_1.");
 
-    br1.AllowList(br2);
-    br1.AllowList(ed1);
-    br2.AllowList(br1);
-    ed1.AllowList(br1);
+    AllowLinkBetween(br1, br2);
+    AllowLinkBetween(br1, ed1);
 
     br2.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_3_DIAG_TC_1.cpp
+++ b/tests/nexus/test_1_3_DIAG_TC_1.cpp
@@ -109,28 +109,11 @@ void TestDiagTc1(const char *aJsonFileName)
 
     SuccessOrQuit(Instance::SetGlobalLogLevel(kLogLevelNote));
 
-    /**
-     * In cpp, use AllowList to specify links between nodes. There is a link between the following node pairs:
-     * - Router_1 and Leader
-     * - Router_1 and FED_1
-     * - Router_1 and MED_1
-     * - Router_1 and SED_1
-     * - Router_1 and REED_1
-     */
-    router1.AllowList(leader);
-    leader.AllowList(router1);
-
-    router1.AllowList(fed1);
-    fed1.AllowList(router1);
-
-    router1.AllowList(med1);
-    med1.AllowList(router1);
-
-    router1.AllowList(sed1);
-    sed1.AllowList(router1);
-
-    router1.AllowList(reed1);
-    reed1.AllowList(router1);
+    AllowLinkBetween(router1, leader);
+    AllowLinkBetween(router1, fed1);
+    AllowLinkBetween(router1, med1);
+    AllowLinkBetween(router1, sed1);
+    AllowLinkBetween(router1, reed1);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: Enable the devices in order. Leader configures its Network Data with an OMR prefix.");

--- a/tests/nexus/test_1_3_DIAG_TC_2.cpp
+++ b/tests/nexus/test_1_3_DIAG_TC_2.cpp
@@ -85,15 +85,8 @@ void TestDiagTc2(const char *aJsonFile)
 
     SuccessOrQuit(Instance::SetGlobalLogLevel(kLogLevelNote));
 
-    /**
-     * - Leader_1 and Router_1
-     * - Router_1 and TD_1
-     */
-    leader1.AllowList(router1);
-    router1.AllowList(leader1);
-
-    router1.AllowList(td1);
-    td1.AllowList(router1);
+    AllowLinkBetween(leader1, router1);
+    AllowLinkBetween(router1, td1);
 
     Log("---------------------------------------------------------------------------------------");
     Log("Step 1: Enable the devices in order. Leader configures its Network Data with an OMR prefix.");

--- a/tests/nexus/test_1_3_DPR_TC_2.cpp
+++ b/tests/nexus/test_1_3_DPR_TC_2.cpp
@@ -146,8 +146,7 @@ void Test_1_3_DPR_TC_2(void)
      *   - N/A
      */
 
-    br1.AllowList(ed1);
-    ed1.AllowList(br1);
+    AllowLinkBetween(br1, ed1);
 
     br1.Form();
 
@@ -240,11 +239,9 @@ void Test_1_3_DPR_TC_2(void)
      *   - N/A
      */
 
-    br2.AllowList(ed2);
-    ed2.AllowList(br2);
+    AllowLinkBetween(br2, ed2);
 
-    br1.UnallowList(br2);
-    br2.UnallowList(br1);
+    UnallowLinkBetween(br1, br2);
     br1.UnallowList(ed2);
     ed1.UnallowList(br2);
     ed1.UnallowList(ed2);

--- a/tests/nexus/test_1_3_GEN_TC_1.cpp
+++ b/tests/nexus/test_1_3_GEN_TC_1.cpp
@@ -96,15 +96,8 @@ void Test_1_3_GEN_TC_1(Topology aTopology, const char *aJsonFileName)
     router1.SetName("Router_1");
     ed1.SetName("ED_1");
 
-    /**
-     * In the cpp, use AllowList to specify links between nodes. There is a link between the following node pairs:
-     * - BR_1 and Router_1
-     * - Router_1 and ED_1
-     */
-    br1.AllowList(router1);
-    router1.AllowList(br1);
-    router1.AllowList(ed1);
-    ed1.AllowList(router1);
+    AllowLinkBetween(br1, router1);
+    AllowLinkBetween(router1, ed1);
 
     nexus.AdvanceTime(0);
 

--- a/tests/nexus/test_1_3_SRPC_TC_1.cpp
+++ b/tests/nexus/test_1_3_SRPC_TC_1.cpp
@@ -154,18 +154,10 @@ void Test_1_3_SRPC_TC_1(const char *aJsonFileName)
      *   - N/A
      */
 
-    /** Use AllowList to specify links between nodes. */
-    br1.AllowList(br2);
-    br1.AllowList(router1);
-
-    br2.AllowList(br1);
-    br2.AllowList(router1);
-
-    router1.AllowList(br1);
-    router1.AllowList(br2);
-    router1.AllowList(ed1);
-
-    ed1.AllowList(router1);
+    AllowLinkBetween(br1, br2);
+    AllowLinkBetween(br1, router1);
+    AllowLinkBetween(br2, router1);
+    AllowLinkBetween(router1, ed1);
 
     br1.Join(router1);
     nexus.AdvanceTime(kAttachToRouterTime * 2);

--- a/tests/nexus/test_1_4_DNS_TC_1.cpp
+++ b/tests/nexus/test_1_4_DNS_TC_1.cpp
@@ -147,12 +147,10 @@ void Test_1_4_DNS_TC_1(const char *aJsonFileName)
     Log("Step 1: Topology: Start Eth_1, BR_1, Router_1, and ED_1.");
 
     // BR_1 and Router_1
-    br1.AllowList(r1);
-    r1.AllowList(br1);
+    AllowLinkBetween(br1, r1);
 
     // Router_1 and ED_1
-    r1.AllowList(ed1);
-    ed1.AllowList(r1);
+    AllowLinkBetween(r1, ed1);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_4_DNS_TC_3.cpp
+++ b/tests/nexus/test_1_4_DNS_TC_3.cpp
@@ -226,10 +226,8 @@ void Test_1_4_DNS_TC_3(const char *aJsonFileName)
     eth1.mInfraIf.SetUdpHook(HandleUdpHook);
     eth2.mInfraIf.SetUdpHook(HandleUdpHook);
 
-    br1.AllowList(router1);
-    router1.AllowList(br1);
-    router1.AllowList(ed1);
-    ed1.AllowList(router1);
+    AllowLinkBetween(br1, router1);
+    AllowLinkBetween(router1, ed1);
 
     SuccessOrQuit(gua1Prefix.FromString(kGua1Prefix));
     SuccessOrQuit(eth1Addr.FromString(kEth1Addr));

--- a/tests/nexus/test_1_4_DNS_TC_5.cpp
+++ b/tests/nexus/test_1_4_DNS_TC_5.cpp
@@ -266,8 +266,7 @@ void Test_1_4_DNS_TC_5(const char *aJsonFileName)
     sEth1Node = &eth1;
     eth1.mInfraIf.SetUdpHook(HandleUdpHook);
 
-    br1.AllowList(ed1);
-    ed1.AllowList(br1);
+    AllowLinkBetween(br1, ed1);
 
     SuccessOrQuit(eth1Addr.FromString(kEth1Addr));
     SuccessOrQuit(br1AilAddr.FromString(kBr1AilAddr));

--- a/tests/nexus/test_1_4_PIC_TC_1.cpp
+++ b/tests/nexus/test_1_4_PIC_TC_1.cpp
@@ -331,10 +331,9 @@ void Test_1_4_PIC_TC_1(void)
      *   - Pass Criteria:
      *     - N/A
      */
-    br1.AllowList(r1);
-    r1.AllowList(br1);
-    r1.AllowList(ed1);
-    ed1.AllowList(r1);
+
+    AllowLinkBetween(br1, r1);
+    AllowLinkBetween(r1, ed1);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_4_PIC_TC_3.cpp
+++ b/tests/nexus/test_1_4_PIC_TC_3.cpp
@@ -292,10 +292,8 @@ void Test_1_4_PIC_TC_3(void)
      *   - Pass Criteria:
      *     - N/A
      */
-    br1.AllowList(r1);
-    r1.AllowList(br1);
-    r1.AllowList(ed1);
-    ed1.AllowList(r1);
+    AllowLinkBetween(br1, r1);
+    AllowLinkBetween(r1, ed1);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_4_PIC_TC_4.cpp
+++ b/tests/nexus/test_1_4_PIC_TC_4.cpp
@@ -236,10 +236,9 @@ void Test_1_4_PIC_TC_4(void)
      *   - Description (PIC-10.4): Enable
      *   - Pass Criteria: N/A
      */
-    br1.AllowList(r1);
-    r1.AllowList(br1);
-    r1.AllowList(ed1);
-    ed1.AllowList(r1);
+
+    AllowLinkBetween(br1, r1);
+    AllowLinkBetween(r1, ed1);
 
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_4_TREL_TC_1.cpp
+++ b/tests/nexus/test_1_4_TREL_TC_1.cpp
@@ -95,10 +95,8 @@ void Test1_4_Trel_Tc_1(void)
     SuccessOrQuit(br.Get<Dns::Multicast::Core>().SetEnabled(true, kInfraIfIndex));
     SuccessOrQuit(router1.Get<Dns::Multicast::Core>().SetEnabled(true, kInfraIfIndex));
 
-    br.AllowList(router1);
-    br.AllowList(router2);
-    router1.AllowList(br);
-    router2.AllowList(br);
+    AllowLinkBetween(br, router1);
+    AllowLinkBetween(br, router2);
 
     br.Form();
     nexus.AdvanceTime(kFormNetworkTime);

--- a/tests/nexus/test_1_4_TREL_TC_2.cpp
+++ b/tests/nexus/test_1_4_TREL_TC_2.cpp
@@ -106,24 +106,19 @@ void Test_1_4_TREL_TC_2(void)
     Log("Step 1: Form the topology");
 
     // Leader <-> Router_1 (DUT)
-    leader.AllowList(router1);
-    router1.AllowList(leader);
+    AllowLinkBetween(leader, router1);
 
     // Leader <-> Router_2
-    leader.AllowList(router2);
-    router2.AllowList(leader);
+    AllowLinkBetween(leader, router2);
 
     // Router_1 (DUT) <-> Router_3
-    router1.AllowList(router3);
-    router3.AllowList(router1);
+    AllowLinkBetween(router1, router3);
 
     // Router_1 (DUT) <-> Router_4
-    router1.AllowList(router4);
-    router4.AllowList(router1);
+    AllowLinkBetween(router1, router4);
 
     // Router_1 (DUT) <-> ED_1
-    router1.AllowList(ed1);
-    ed1.AllowList(router1);
+    AllowLinkBetween(router1, ed1);
 
     // Enable TREL (mDNS) on all TREL nodes.
     SuccessOrQuit(router1.Get<Dns::Multicast::Core>().SetEnabled(true, kInfraIfIndex));

--- a/tests/nexus/test_1_4_TREL_TC_3.cpp
+++ b/tests/nexus/test_1_4_TREL_TC_3.cpp
@@ -92,10 +92,8 @@ void Test_1_4_TREL_TC_3(void)
      */
     Log("Step 1: Form the topology. Wait for Router to become Thread router. ED MUST attach to the DUT as its parent.");
 
-    br.AllowList(router);
-    router.AllowList(br);
-    br.AllowList(ed);
-    ed.AllowList(br);
+    AllowLinkBetween(br, router);
+    AllowLinkBetween(br, ed);
 
     SuccessOrQuit(br.Get<Dns::Multicast::Core>().SetEnabled(true, kInfraIfIndex));
     SuccessOrQuit(router.Get<Dns::Multicast::Core>().SetEnabled(true, kInfraIfIndex));

--- a/tests/nexus/test_1_4_TREL_TC_4.cpp
+++ b/tests/nexus/test_1_4_TREL_TC_4.cpp
@@ -127,13 +127,8 @@ void Test_1_4_TREL_TC_4(void)
      *   - ED MUST attach to the DUT as its parent.
      */
 
-    /** Use AllowList feature to specify links between nodes. */
-    br.AllowList(router);
-    br.AllowList(ed);
-
-    router.AllowList(br);
-
-    ed.AllowList(br);
+    AllowLinkBetween(br, router);
+    AllowLinkBetween(br, ed);
 
     SuccessOrQuit(br.Get<Dns::Multicast::Core>().SetEnabled(true, kInfraIfIndex));
     SuccessOrQuit(router.Get<Dns::Multicast::Core>().SetEnabled(true, kInfraIfIndex));

--- a/tests/nexus/test_mle_blocking_downgrade.cpp
+++ b/tests/nexus/test_mle_blocking_downgrade.cpp
@@ -66,28 +66,16 @@ void TestMleBlockingDowngrade(void)
     Log("---------------------------------------------------------------------------------------");
     Log("Form initial topology");
 
-    leader.AllowList(dut);
-    dut.AllowList(leader);
-
-    leader.AllowList(newRouter);
-    newRouter.AllowList(leader);
-
-    child.AllowList(dut);
-    dut.AllowList(child);
-
-    child.AllowList(newRouter);
-    newRouter.AllowList(child);
+    AllowLinkBetween(leader, dut);
+    AllowLinkBetween(leader, newRouter);
+    AllowLinkBetween(child, dut);
+    AllowLinkBetween(child, newRouter);
 
     for (Node *router : routers)
     {
-        leader.AllowList(*router);
-        router->AllowList(leader);
-
-        dut.AllowList(*router);
-        router->AllowList(dut);
-
-        newRouter.AllowList(*router);
-        router->AllowList(newRouter);
+        AllowLinkBetween(leader, *router);
+        AllowLinkBetween(dut, *router);
+        AllowLinkBetween(newRouter, *router);
     }
 
     leader.Form();


### PR DESCRIPTION
Added `Core::AllowLinkBetween()` and `Core::UnallowLinkBetween()` helper methods to the Nexus test platform. These methods simplify establishing bidirectional links between nodes in simulation tests by handling the reciprocal `AllowList()` calls in a single step.

Updated various Nexus test cases to utilize these new helpers, replacing manual bidirectional `AllowList()` calls. This change reduces verbosity and ensures consistency in how links are established in the test topology.