### PR TITLE
[mle] treat failed attach after Parent Response differently to avoid excessive backoff

### DIFF
--- a/src/core/config/mle.h
+++ b/src/core/config/mle.h
@@ -186,6 +186,23 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_PARENT_REACHABLE_INTERVAL
+ *
+ * Specifies the maximum backoff wait interval (in milliseconds) used when a Child ID Request was sent to a parent with
+ * good link quality (link quality 2 or 3) but no Child ID Response was received. This caps the exponential backoff
+ * growth, ensuring the device retries sooner when the parent is likely reachable but the attach handshake did not
+ * complete (e.g., due to channel congestion).
+ *
+ * The cap is applied as `min(normal_backoff_delay, this_value)`. It only takes effect when the computed exponential
+ * backoff exceeds this value.
+ *
+ * Applicable only if attach backoff feature is enabled (see `OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_ENABLE`).
+ */
+#ifndef OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_PARENT_REACHABLE_INTERVAL
+#define OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_PARENT_REACHABLE_INTERVAL 60000 // 60 seconds = 1 minute
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_DELAY_TO_RESET_BACKOFF_INTERVAL
  *
  * Specifies the delay wait interval (in milliseconds) used by attach backoff feature after a successful attach before

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -307,6 +307,7 @@ void Mle::SetRole(DeviceRole aRole)
     if ((oldRole == kRoleDetached) && IsAttached())
     {
         mLastAttachTime = Get<UptimeTracker>().GetUptimeInSeconds();
+        LogNote("Successfully attached after %u attempt(s)", mAttacher.GetAttachCounter());
     }
 
     UpdateRoleTimeCounters(oldRole);
@@ -4490,6 +4491,7 @@ void Mle::PrevRoleRestorer::SendMulticastLinkRequest(void)
 Mle::Attacher::Attacher(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mReceivedResponseFromParent(false)
+    , mShouldCapBackoff(false)
     , mState(kStateIdle)
     , mMode(kAnyPartition)
     , mReattachMode(kReattachModeStop)
@@ -4603,6 +4605,7 @@ void Mle::Attacher::Attach(AttachMode aMode)
     }
 
     mTimer.Start(GetStartDelay());
+    mShouldCapBackoff = false;
 
     if (Get<Mle>().IsDetached())
     {
@@ -4654,6 +4657,11 @@ uint32_t Mle::Attacher::GetStartDelay(void) const
         }
     }
 #endif // OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_ENABLE
+
+    if (mShouldCapBackoff)
+    {
+        delay = Min(delay, kAttachBackoffParentReachableInterval);
+    }
 
     jitter = Random::NonCrypto::GetUint32InRange(0, kAttachStartJitter);
 
@@ -4803,6 +4811,7 @@ void Mle::Attacher::HandleTimer(void)
     if (HasAcceptableParentCandidate() && (SendChildIdRequest() == kErrorNone))
     {
         SetState(kStateChildIdRequest);
+        mShouldCapBackoff = (mParentCandidate.GetTwoWayLinkQuality() >= kLinkQuality2);
         mChildIdRequestsRemaining--;
         delay = Random::NonCrypto::AddJitter(kChildIdResponseTimeout, kChildIdResponseJitter);
         ExitNow();
@@ -5454,6 +5463,8 @@ void Mle::Attacher::HandleChildIdResponse(RxInfo &aRxInfo)
     VerifyOrExit(aRxInfo.IsNeighborStateValid(), error = kErrorSecurity);
 
     VerifyOrExit(mState == kStateChildIdRequest);
+
+    mShouldCapBackoff = false;
 
     SuccessOrExit(error = Tlv::Find<Address16Tlv>(aRxInfo.mMessage, shortAddress));
     VerifyOrExit(RouterIdMatch(sourceAddress, shortAddress), error = kErrorRejected);

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1299,6 +1299,8 @@ private:
     static constexpr uint32_t kAttachBackoffJitter      = OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_JITTER_INTERVAL;
     static constexpr uint32_t kAttachBackoffDelayToResetCounter =
         OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_DELAY_TO_RESET_BACKOFF_INTERVAL;
+    static constexpr uint32_t kAttachBackoffParentReachableInterval =
+        OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_PARENT_REACHABLE_INTERVAL;
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Number of Parent Requests in first and next attach cycles
@@ -1933,6 +1935,7 @@ private:
         void             Attach(AttachMode aMode);
         void             CancelAttachOnRoleChange(void);
         void             ResetAttachCounter(void) { mAttachCounter = 0; }
+        uint16_t         GetAttachCounter(void) const { return mAttachCounter; }
         AttachMode       GetAttachMode(void) const { return mMode; }
         ParentCandidate &GetParentCandidate(void) { return mParentCandidate; }
         void             ClearParentCandidate(void) { mParentCandidate.Clear(); }
@@ -1990,6 +1993,7 @@ private:
         using AttachTimer = TimerMilliIn<Mle, &Mle::HandleAttacherTimer>;
 
         bool                    mReceivedResponseFromParent : 1;
+        bool                    mShouldCapBackoff : 1;
         State                   mState;
         AttachMode              mMode;
         ReattachMode            mReattachMode;


### PR DESCRIPTION
When a SED receives a Parent Response but fails to complete the attach (Child ID Response never received), the current exponential backoff treats this identically to "no parent found". This is problematic in some scenarios — e.g., a parent reboots and large number of children try to reattach simultaneously, where Child ID failures can happen, and backoff ramps exponentially even though the parent comes back and becomes available.