### PR TITLE
[network data] add coalescing logic for batched network data updates

### DIFF
--- a/src/core/config/border_router.h
+++ b/src/core/config/border_router.h
@@ -88,6 +88,36 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_ENABLE
+ *
+ * Define as 1 to enable coalescing of Network Data changes on the Leader.
+ *
+ * When enabled, the Leader defers propagation of Network Data updates
+ * by a short settling period (@sa OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_DELAY).
+ * Rapid successive changes (e.g., during network formation) are batched
+ * into a single propagation event, reducing multicast traffic on the mesh.
+ *
+ * When disabled (default), each Network Data change is propagated immediately
+ * as per the baseline Thread specification behavior.
+ */
+#ifndef OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_ENABLE
+#define OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_ENABLE 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_DELAY
+ *
+ * Specifies the settling delay in milliseconds for Network Data coalescing
+ * on the Leader. The timer restarts on each new change, so propagation
+ * occurs after this duration of no new changes.
+ *
+ * Only used when OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_ENABLE is 1.
+ */
+#ifndef OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_DELAY
+#define OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_DELAY 1000
+#endif
+
+/**
  * @}
  */
 

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -50,6 +50,9 @@ Leader::Leader(Instance &aInstance)
     , mWaitingForNetDataSync(false)
     , mContextIds(aInstance)
     , mTimer(aInstance)
+#if OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_ENABLE
+    , mCoalesceTimer(aInstance)
+#endif
 #endif
 {
     Reset();
@@ -689,6 +692,13 @@ void Leader::SignalNetDataChanged(void)
     mMaxLength = Max(mMaxLength, GetLength());
     Get<ot::Notifier>().Signal(kEventThreadNetdataChanged);
 }
+
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_ENABLE
+void Leader::HandleCoalesceTimer(void)
+{
+    SignalNetDataChanged();
+}
+#endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -461,6 +461,9 @@ private:
 
 #if OPENTHREAD_FTD
     static constexpr uint32_t kMaxNetDataSyncWait = 60 * 1000; // Maximum time to wait for netdata sync in msec.
+#if OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_ENABLE
+    static constexpr uint32_t kCoalesceDelay = OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_DELAY;
+#endif
     static constexpr uint8_t  kMinServiceId       = 0x00;
     static constexpr uint8_t  kMaxServiceId       = 0x0f;
 
@@ -621,12 +624,19 @@ private:
     void IncrementVersions(bool aIncludeStable);
     void IncrementVersions(const ChangedFlags &aFlags);
 
+#if OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_ENABLE
+    void HandleCoalesceTimer(void);
+#endif
+
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_SIGNAL_NETWORK_DATA_FULL
     void CheckForNetDataGettingFull(const NetworkData &aNetworkData, uint16_t aOldRloc16);
     void MarkAsClone(void);
 #endif
 
-    using UpdateTimer = TimerMilliIn<Leader, &Leader::HandleTimer>;
+    using UpdateTimer    = TimerMilliIn<Leader, &Leader::HandleTimer>;
+#if OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_ENABLE
+    using CoalesceTimer  = TimerMilliIn<Leader, &Leader::HandleCoalesceTimer>;
+#endif
 #endif // OPENTHREAD_FTD
 
     uint8_t mStableVersion;
@@ -641,6 +651,9 @@ private:
     bool        mWaitingForNetDataSync;
     ContextIds  mContextIds;
     UpdateTimer mTimer;
+#if OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_ENABLE
+    CoalesceTimer mCoalesceTimer;
+#endif
 #endif
 };
 

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -92,7 +92,16 @@ void Leader::IncrementVersions(bool aIncludeStable)
     }
 
     mVersion++;
+
+#if OPENTHREAD_CONFIG_LEADER_NETDATA_COALESCE_ENABLE
+    // Coalesce rapid Network Data changes into a single propagation.
+    // Restart the timer on each change so that we wait for a settling
+    // period after the last change before propagating.
+    mCoalesceTimer.Start(kCoalesceDelay);
+#else
     SignalNetDataChanged();
+#endif
+
     ExitNow();
 
 exit:


### PR DESCRIPTION
When this feature is enabled, the leader defers Network Data propagation by restarting a 1-second settling timer on each change, so rapid successive updates are batched into a single update reducing MLE traffic on the mesh                         
