### PR TITLE
[tcat][ble] update BLE API and related TCAT agent change to re-enable advertising after disconnect

### DIFF
--- a/examples/platforms/simulation/ble.c
+++ b/examples/platforms/simulation/ble.c
@@ -49,6 +49,7 @@ static uint8_t sBleBuffer[PLAT_BLE_MSG_DATA_MAX];
 static int  sFd              = -1;
 static bool sIsConnected     = false;
 static bool sIsDisconnecting = false;
+static bool sIsEnabled       = false;
 
 static const uint16_t kPortBase = 10000;
 static uint16_t       sPort     = 0;
@@ -108,28 +109,31 @@ otError otPlatBleGetAdvertisementBuffer(otInstance *aInstance, uint8_t **aAdvert
 otError otPlatBleEnable(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
-    initFds();
+    if (!sIsEnabled)
+    {
+        initFds();
+        sIsEnabled       = true;
+        sIsConnected     = false;
+        sIsDisconnecting = false;
+    }
     return OT_ERROR_NONE;
 }
 
 otError otPlatBleDisable(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
-    deinitFds();
-    sIsConnected     = false;
-    sIsDisconnecting = false;
+    if (sIsEnabled)
+    {
+        deinitFds();
+        sIsEnabled = false;
+    }
     return OT_ERROR_NONE;
 }
 
 otError otPlatBleGapAdvStart(otInstance *aInstance, uint16_t aInterval)
 {
     OT_UNUSED_VARIABLE(aInstance);
-    if (sIsDisconnecting) // finalize the disconnection of the TCAT client
-    {
-        sIsConnected     = false;
-        sIsDisconnecting = false;
-    }
-    if (sIsConnected)
+    if (sIsConnected || !sIsEnabled)
     {
         return OT_ERROR_INVALID_STATE;
     }
@@ -140,21 +144,24 @@ otError otPlatBleGapAdvStart(otInstance *aInstance, uint16_t aInterval)
 otError otPlatBleGapAdvStop(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
+    if (!sIsEnabled)
+    {
+        return OT_ERROR_INVALID_STATE;
+    }
     otLogDebgPlat("BLE adv stop");
     return OT_ERROR_NONE;
 }
 
 otError otPlatBleGapDisconnect(otInstance *aInstance)
 {
-    if (!sIsConnected && !sIsDisconnecting)
+    OT_UNUSED_VARIABLE(aInstance);
+    if (!sIsConnected)
     {
         return OT_ERROR_INVALID_STATE;
     }
-    if (!sIsDisconnecting) // check, to avoid reentrant calls
-    {
-        sIsDisconnecting = true;
-        otPlatBleGapOnDisconnected(aInstance, 0);
-    }
+    // Only flag the disconnection here. The 'disconnected' event is delivered asynchronously
+    // by platformBleProcess() (via otPlatBleGapOnDisconnected), per API contract.
+    sIsDisconnecting = true;
     return OT_ERROR_NONE;
 }
 
@@ -189,7 +196,6 @@ void platformBleDeinit(void) { deinitFds(); }
 
 void platformBleUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, struct timeval *aTimeout, int *aMaxFd)
 {
-    OT_UNUSED_VARIABLE(aTimeout);
     OT_UNUSED_VARIABLE(aWriteFdSet);
 
     if (aReadFdSet != NULL && sFd != -1)
@@ -201,6 +207,13 @@ void platformBleUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, struct time
             *aMaxFd = sFd;
         }
     }
+
+    // A pending disconnection must be delivered promptly; ensure the main loop does not block.
+    if (sIsDisconnecting && aTimeout != NULL)
+    {
+        aTimeout->tv_sec  = 0;
+        aTimeout->tv_usec = 0;
+    }
 }
 
 void platformBleProcess(otInstance *aInstance, const fd_set *aReadFdSet, const fd_set *aWriteFdSet)
@@ -208,6 +221,14 @@ void platformBleProcess(otInstance *aInstance, const fd_set *aReadFdSet, const f
     OT_UNUSED_VARIABLE(aWriteFdSet);
 
     otEXPECT(sFd != -1);
+
+    // Deliver a pending disconnection (requested earlier via otPlatBleGapDisconnect)
+    if (sIsDisconnecting)
+    {
+        sIsConnected = false;
+        otPlatBleGapOnDisconnected(aInstance, 0);
+        sIsDisconnecting = false;
+    }
 
     if (FD_ISSET(sFd, aReadFdSet))
     {
@@ -244,6 +265,7 @@ void platformBleProcess(otInstance *aInstance, const fd_set *aReadFdSet, const f
             DieNow(OT_EXIT_FAILURE);
         }
     }
+
 exit:
     return;
 }
@@ -287,6 +309,10 @@ otError otPlatBleGapAdvSetData(otInstance *aInstance, uint8_t *aAdvertisementDat
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aAdvertisementData);
     OT_UNUSED_VARIABLE(aAdvertisementLen);
+    if (!sIsEnabled)
+    {
+        return OT_ERROR_INVALID_STATE;
+    }
     return OT_ERROR_NONE;
 }
 
@@ -295,13 +321,17 @@ otError otPlatBleGapAdvUpdateData(otInstance *aInstance, uint8_t *aAdvertisement
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aAdvertisementData);
     OT_UNUSED_VARIABLE(aAdvertisementLen);
+    if (!sIsEnabled)
+    {
+        return OT_ERROR_INVALID_STATE;
+    }
     return OT_ERROR_NONE;
 }
 
 bool otPlatBleSupportsMultiRadio(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
-    return false;
+    return true;
 }
 
 #endif // OPENTHREAD_CONFIG_BLE_TCAT_ENABLE

--- a/examples/platforms/simulation/ble.c
+++ b/examples/platforms/simulation/ble.c
@@ -28,12 +28,15 @@
 
 #include "platform-simulation.h"
 
+#if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
+
 #include <errno.h>
 
 #include <stdio.h>
 #include <stdlib.h>
 
 #include <openthread/error.h>
+#include <openthread/logging.h>
 #include <openthread/tcat.h>
 #include <openthread/platform/ble.h>
 
@@ -43,7 +46,9 @@
 #define PLAT_BLE_MSG_DATA_MAX 2048
 static uint8_t sBleBuffer[PLAT_BLE_MSG_DATA_MAX];
 
-static int sFd = -1;
+static int  sFd              = -1;
+static bool sIsConnected     = false;
+static bool sIsDisconnecting = false;
 
 static const uint16_t kPortBase = 10000;
 static uint16_t       sPort     = 0;
@@ -109,27 +114,47 @@ otError otPlatBleEnable(otInstance *aInstance)
 
 otError otPlatBleDisable(otInstance *aInstance)
 {
-    deinitFds();
     OT_UNUSED_VARIABLE(aInstance);
+    deinitFds();
+    sIsConnected     = false;
+    sIsDisconnecting = false;
     return OT_ERROR_NONE;
 }
 
 otError otPlatBleGapAdvStart(otInstance *aInstance, uint16_t aInterval)
 {
     OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(aInterval);
+    if (sIsDisconnecting) // finalize the disconnection of the TCAT client
+    {
+        sIsConnected     = false;
+        sIsDisconnecting = false;
+    }
+    if (sIsConnected)
+    {
+        return OT_ERROR_INVALID_STATE;
+    }
+    otLogDebgPlat("BLE adv start (interval %u)", aInterval);
     return OT_ERROR_NONE;
 }
 
 otError otPlatBleGapAdvStop(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
+    otLogDebgPlat("BLE adv stop");
     return OT_ERROR_NONE;
 }
 
 otError otPlatBleGapDisconnect(otInstance *aInstance)
 {
-    OT_UNUSED_VARIABLE(aInstance);
+    if (!sIsConnected && !sIsDisconnecting)
+    {
+        return OT_ERROR_INVALID_STATE;
+    }
+    if (!sIsDisconnecting) // check, to avoid reentrant calls
+    {
+        sIsDisconnecting = true;
+        otPlatBleGapOnDisconnected(aInstance, 0);
+    }
     return OT_ERROR_NONE;
 }
 
@@ -193,6 +218,14 @@ void platformBleProcess(otInstance *aInstance, const fd_set *aReadFdSet, const f
         if (rval > 0)
         {
             otBleRadioPacket myPacket;
+
+            if (!sIsConnected)
+            {
+                sIsConnected = true;
+                otLogDebgPlat("BLE client connected");
+                otPlatBleGapOnConnected(aInstance, 0);
+            }
+
             myPacket.mValue  = sBleBuffer;
             myPacket.mLength = (uint16_t)rval;
             myPacket.mPower  = 0;
@@ -215,6 +248,22 @@ exit:
     return;
 }
 
+/* Weak stubs for callbacks defined in the FTD/MTD core library, not available for RCP targets. */
+
+OT_TOOL_WEAK void otPlatBleGapOnConnected(otInstance *aInstance, uint16_t aConnectionId)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aConnectionId);
+    assert(false);
+}
+
+OT_TOOL_WEAK void otPlatBleGapOnDisconnected(otInstance *aInstance, uint16_t aConnectionId)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aConnectionId);
+    assert(false);
+}
+
 OT_TOOL_WEAK void otPlatBleGattServerOnWriteRequest(otInstance             *aInstance,
                                                     uint16_t                aHandle,
                                                     const otBleRadioPacket *aPacket)
@@ -223,9 +272,6 @@ OT_TOOL_WEAK void otPlatBleGattServerOnWriteRequest(otInstance             *aIns
     OT_UNUSED_VARIABLE(aHandle);
     OT_UNUSED_VARIABLE(aPacket);
     assert(false);
-    /* In case of rcp there is a problem with linking to otPlatBleGattServerOnWriteRequest
-     * which is available in FTD/MTD library.
-     */
 }
 
 void otPlatBleGetLinkCapabilities(otInstance *aInstance, otBleLinkCapabilities *aBleLinkCapabilities)
@@ -257,3 +303,5 @@ bool otPlatBleSupportsMultiRadio(otInstance *aInstance)
     OT_UNUSED_VARIABLE(aInstance);
     return false;
 }
+
+#endif // OPENTHREAD_CONFIG_BLE_TCAT_ENABLE

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (603)
+#define OPENTHREAD_API_VERSION (604)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/ble.h
+++ b/include/openthread/platform/ble.h
@@ -276,6 +276,10 @@ extern void otPlatBleGapOnDisconnected(otInstance *aInstance, uint16_t aConnecti
  * The BLE device shall use the Remote User Terminated Connection (0x13) reason
  * code when disconnecting from the peer BLE device.
  *
+ * This function only triggers the disconnection procedure. When OT_ERROR_NONE is returned,
+ * the platform MUST report completion of the disconnection asynchronously, by invoking
+ * otPlatBleGapOnDisconnected().
+ *
  * @param[in] aInstance  The OpenThread instance structure.
  *
  * @retval OT_ERROR_NONE           Disconnection procedure has been started.

--- a/include/openthread/platform/ble.h
+++ b/include/openthread/platform/ble.h
@@ -74,10 +74,10 @@ extern "C" {
 #define OT_BLE_ADV_INTERVAL_MAX 0x4000
 
 /**
- * Default interval for advertising packet (ms).
+ * Default interval for advertising packet in OT_BLE_ADV_INTERVAL_UNIT units (100 ms).
  */
 
-#define OT_BLE_ADV_INTERVAL_DEFAULT 100
+#define OT_BLE_ADV_INTERVAL_DEFAULT 160
 
 /**
  * Unit used to calculate interval duration (0.625ms).
@@ -104,13 +104,13 @@ extern "C" {
 #define OT_BLE_ATT_MTU_DEFAULT 23
 
 /**
- * Default power value for BLE.
+ * Default Tx power value for BLE in dBm.
  */
 
 #define OT_BLE_DEFAULT_POWER 0
 
 /**
- * TOBLE service UUID
+ * ToBLE service UUID (a GATT service UUID for Thread over BLE)
  */
 
 #define OT_TOBLE_SERVICE_UUID 0xfffb
@@ -130,7 +130,7 @@ typedef struct otBleLinkCapabilities
  */
 typedef struct otBleRadioPacket
 {
-    uint8_t *mValue;  ///< The value of an attribute
+    uint8_t *mValue;  ///< Pointer to the packet data
     uint16_t mLength; ///< Length of the @p mValue.
     int8_t   mPower;  ///< Transmit/receive power in dBm.
 } otBleRadioPacket;
@@ -171,18 +171,16 @@ otError otPlatBleDisable(otInstance *aInstance);
  * @section Bluetooth Low Energy GAP.
  ***************************************************************************/
 /**
- * Gets BLE Advertising buffer.
+ * Gets a platform-provided buffer for BLE advertising data.
  *
  * @note This function shall be used only for BLE Peripheral role.
- * Returned buffer should have enough space to fit max advertisement
- * defined by specification.
+ * The platform must provide a buffer of at least @p OT_TCAT_ADVERTISEMENT_MAX_LEN bytes.
  *
- * @param[in] aInstance          The OpenThread instance structure.
- * @param[in] aAdvertisementData The formatted TCAT advertisement frame.
- * @param[in] aAdvertisementLen  The TCAT advertisement frame length.
+ * @param[in]  aInstance             The OpenThread instance structure.
+ * @param[out] aAdvertisementBuffer  A pointer to be set to the platform-provided advertisement buffer.
  *
- * @retval OT_ERROR_NONE           Advertising procedure has been started.
- * @retval OT_ERROR_NO_BUFS        No bufferspace available.
+ * @retval OT_ERROR_NONE      Successfully retrieved the advertisement buffer.
+ * @retval OT_ERROR_NO_BUFS   No buffer space available.
  */
 otError otPlatBleGetAdvertisementBuffer(otInstance *aInstance, uint8_t **aAdvertisementBuffer);
 
@@ -190,12 +188,13 @@ otError otPlatBleGetAdvertisementBuffer(otInstance *aInstance, uint8_t **aAdvert
  * Sets BLE Advertising data.
  *
  * @note This function shall be used only for BLE Peripheral role.
+ * It shall only be called while advertising is not active.
  *
  * @param[in] aInstance          The OpenThread instance structure.
  * @param[in] aAdvertisementData The formatted TCAT advertisement frame.
- * @param[in] aAdvertisementLen  The TCAT advertisement frame length.
+ * @param[in] aAdvertisementLen  The length of the @p aAdvertisementData frame.
  *
- * @retval OT_ERROR_NONE           Advertising procedure has been started.
+ * @retval OT_ERROR_NONE           Advertising data set successfully.
  * @retval OT_ERROR_INVALID_STATE  BLE Device is in invalid state.
  * @retval OT_ERROR_INVALID_ARGS   Invalid value has been supplied.
  */
@@ -205,12 +204,13 @@ otError otPlatBleGapAdvSetData(otInstance *aInstance, uint8_t *aAdvertisementDat
  * Updates BLE Advertising data.
  *
  * @note This function shall be used only for BLE Peripheral role.
+ * It shall only be called while advertising is active.
  *
  * @param[in] aInstance          The OpenThread instance structure.
  * @param[in] aAdvertisementData The formatted TCAT advertisement frame.
- * @param[in] aAdvertisementLen  The TCAT advertisement frame length.
+ * @param[in] aAdvertisementLen  The length of the @p aAdvertisementData frame.
  *
- * @retval OT_ERROR_NONE           Advertising procedure has been started.
+ * @retval OT_ERROR_NONE           Advertising data updated successfully.
  * @retval OT_ERROR_FAILED         Update of data failed.
  * @retval OT_ERROR_INVALID_ARGS   Invalid value has been supplied.
  */
@@ -222,6 +222,8 @@ otError otPlatBleGapAdvUpdateData(otInstance *aInstance, uint8_t *aAdvertisement
  * The BLE device shall use undirected advertising with no filter applied.
  * A single BLE Advertising packet must be sent on all advertising
  * channels (37, 38 and 39).
+ * The advertising shall remain active until either otPlatBleGapAdvStop() is
+ * called or a BLE Central Device connects (otPlatBleGapOnConnected()).
  *
  * @note This function shall be used only for BLE Peripheral role.
  *
@@ -272,7 +274,7 @@ extern void otPlatBleGapOnDisconnected(otInstance *aInstance, uint16_t aConnecti
  * Disconnects BLE connection.
  *
  * The BLE device shall use the Remote User Terminated Connection (0x13) reason
- * code when disconnecting from the peer BLE device..
+ * code when disconnecting from the peer BLE device.
  *
  * @param[in] aInstance  The OpenThread instance structure.
  *
@@ -315,7 +317,7 @@ extern void otPlatBleGattOnMtuUpdate(otInstance *aInstance, uint16_t aMtu);
  *
  * @param[in] aInstance   The OpenThread instance structure.
  * @param[in] aHandle     The handle of the attribute to be indicated.
- * @param[in] aPacket     A pointer to the packet contains value to be indicated.
+ * @param[in] aPacket     A pointer to the packet containing the value to be indicated.
  *
  * @retval OT_ERROR_NONE           ATT Handle Value Indication has been sent.
  * @retval OT_ERROR_INVALID_STATE  BLE Device is in invalid state.
@@ -332,22 +334,24 @@ otError otPlatBleGattServerIndicate(otInstance *aInstance, uint16_t aHandle, con
  *
  * @param[in] aInstance   The OpenThread instance structure.
  * @param[in] aHandle     The handle of the attribute to be written.
- * @param[in] aPacket     A pointer to the packet contains value to be written to the attribute.
+ * @param[in] aPacket     A pointer to the packet containing the value to be written to the attribute.
  */
 extern void otPlatBleGattServerOnWriteRequest(otInstance *aInstance, uint16_t aHandle, const otBleRadioPacket *aPacket);
 
 /**
- * Function to retrieve from platform BLE link capabilities.
+ * Retrieve BLE link capabilities from the platform.
  *
  * @param[in]   aInstance             The OpenThread instance structure.
- * @param[out]  aBleLinkCapabilities  The pointer to retrieve the BLE ling capabilities.
+ * @param[out]  aBleLinkCapabilities  The pointer to retrieve the BLE link capabilities into.
  */
 void otPlatBleGetLinkCapabilities(otInstance *aInstance, otBleLinkCapabilities *aBleLinkCapabilities);
 
 /**
- * Function to retrieve from platform multiradio support of BLE and IEEE.
+ * Check if the platform has multi-radio support for BLE and IEEE 802.15.4.
  *
- * @param[in] aInstance             The OpenThread instance structure.
+ * @param[in] aInstance The OpenThread instance structure.
+ *
+ * @returns TRUE if the platform supports simultaneous BLE and IEEE 802.15.4 operation, FALSE otherwise.
  */
 bool otPlatBleSupportsMultiRadio(otInstance *aInstance);
 /**

--- a/include/openthread/platform/ble.h
+++ b/include/openthread/platform/ble.h
@@ -257,8 +257,8 @@ otError otPlatBleGapAdvStart(otInstance *aInstance, uint16_t aInterval);
 otError otPlatBleGapAdvStop(otInstance *aInstance);
 
 /**
- * The BLE driver calls this method to notify OpenThread that a BLE Central Device has
- * been connected.
+ * The BLE driver calls this function to notify OpenThread that a BLE Central Device has
+ * been connected. The BLE driver MUST stop advertising before calling this function.
  *
  * @param[in]  aInstance     The OpenThread instance structure.
  * @param[in]  aConnectionId The identifier of the open connection.
@@ -266,8 +266,9 @@ otError otPlatBleGapAdvStop(otInstance *aInstance);
 extern void otPlatBleGapOnConnected(otInstance *aInstance, uint16_t aConnectionId);
 
 /**
- * The BLE driver calls this method to notify OpenThread that the BLE Central Device
- * has been disconnected.
+ * The BLE driver calls this function to notify OpenThread that the BLE Central Device
+ * has been disconnected. The BLE driver MUST NOT start advertising before or after this
+ * call: this is controlled explicitly via otPlatBleGapAdvStart().
  *
  * @param[in]  aInstance     The OpenThread instance structure.
  * @param[in]  aConnectionId The identifier of the closed connection.
@@ -307,7 +308,7 @@ otError otPlatBleGapDisconnect(otInstance *aInstance);
 otError otPlatBleGattMtuGet(otInstance *aInstance, uint16_t *aMtu);
 
 /**
- * The BLE driver calls this method to notify OpenThread that ATT_MTU has been updated.
+ * The BLE driver calls this function to notify OpenThread that ATT_MTU has been updated.
  *
  * @param[in]  aInstance     The OpenThread instance structure.
  * @param[in]  aMtu          The updated ATT_MTU value. It MUST be >=OT_BLE_ATT_MTU_MIN.
@@ -335,7 +336,7 @@ extern void otPlatBleGattOnMtuUpdate(otInstance *aInstance, uint16_t aMtu);
 otError otPlatBleGattServerIndicate(otInstance *aInstance, uint16_t aHandle, const otBleRadioPacket *aPacket);
 
 /**
- * The BLE driver calls this method to notify OpenThread that an ATT Write Request
+ * The BLE driver calls this function to notify OpenThread that an ATT Write Request
  * packet has been received.
  *
  * @note This function shall be used only for GATT Server.

--- a/include/openthread/platform/ble.h
+++ b/include/openthread/platform/ble.h
@@ -196,6 +196,7 @@ otError otPlatBleGetAdvertisementBuffer(otInstance *aInstance, uint8_t **aAdvert
  *
  * @retval OT_ERROR_NONE           Advertising data set successfully.
  * @retval OT_ERROR_INVALID_STATE  BLE Device is in invalid state.
+ * @retval OT_ERROR_FAILED         Setting of data failed.
  * @retval OT_ERROR_INVALID_ARGS   Invalid value has been supplied.
  */
 otError otPlatBleGapAdvSetData(otInstance *aInstance, uint8_t *aAdvertisementData, uint16_t aAdvertisementLen);
@@ -211,6 +212,7 @@ otError otPlatBleGapAdvSetData(otInstance *aInstance, uint8_t *aAdvertisementDat
  * @param[in] aAdvertisementLen  The length of the @p aAdvertisementData frame.
  *
  * @retval OT_ERROR_NONE           Advertising data updated successfully.
+ * @retval OT_ERROR_INVALID_STATE  BLE Device is in invalid state.
  * @retval OT_ERROR_FAILED         Update of data failed.
  * @retval OT_ERROR_INVALID_ARGS   Invalid value has been supplied.
  */
@@ -224,11 +226,13 @@ otError otPlatBleGapAdvUpdateData(otInstance *aInstance, uint8_t *aAdvertisement
  * channels (37, 38 and 39).
  * The advertising shall remain active until either otPlatBleGapAdvStop() is
  * called or a BLE Central Device connects (otPlatBleGapOnConnected()).
+ * The BLE platform is not obliged to exactly match the requested interval
+ * between subsequent advertising packets: it is a requested/desired value.
  *
  * @note This function shall be used only for BLE Peripheral role.
  *
  * @param[in] aInstance  The OpenThread instance structure.
- * @param[in] aInterval  The interval between subsequent advertising packets
+ * @param[in] aInterval  The requested interval between subsequent advertising packets
  *                       in OT_BLE_ADV_INTERVAL_UNIT units.
  *                       Shall be within OT_BLE_ADV_INTERVAL_MIN and
  *                       OT_BLE_ADV_INTERVAL_MAX range or OT_BLE_ADV_INTERVAL_DEFAULT

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -140,6 +140,10 @@ void Notifier::EmitEvents(void)
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_BORDER_AGENT_ADMITTER_ENABLE
     Get<MeshCoP::BorderAgent::Admitter>().HandleNotifierEvents(events);
 #endif
+#if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
+    Get<Ble::BleSecure>().HandleNotifierEvents(events);
+    Get<MeshCoP::TcatAgent>().HandleNotifierEvents(events);
+#endif
 #if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
     Get<Mlr::Manager>().HandleNotifierEvents(events);
 #endif
@@ -189,9 +193,6 @@ void Notifier::EmitEvents(void)
 #endif
 #if OPENTHREAD_CONFIG_LINK_METRICS_MANAGER_ENABLE
     Get<Utils::LinkMetricsManager>().HandleNotifierEvents(events);
-#endif
-#if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
-    Get<MeshCoP::TcatAgent>().HandleNotifierEvents(events);
 #endif
 
     for (ExternalCallback &callback : mExternalCallbacks)

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -1069,8 +1069,7 @@ void TcatAgent::HandleTimer(void)
 // internally called when TcatAgent state changes: perform any required actions.
 void TcatAgent::NotifyStateChange(void)
 {
-    Get<Ble::BleSecure>().NotifySendAdvertisements(mState == kStateActive || mState == kStateActiveTemporary ||
-                                                   mState == kStateConnected);
+    Get<Ble::BleSecure>().NotifySendAdvertisements(mState == kStateActive || mState == kStateActiveTemporary);
 }
 
 void TcatAgent::HandleNotifierEvents(Events aEvents)

--- a/src/core/radio/ble_secure.cpp
+++ b/src/core/radio/ble_secure.cpp
@@ -180,14 +180,22 @@ void BleSecure::Disconnect(void)
 
     if (mBleState == kConnected)
     {
-        // request platform to close BLE. Once this closing is done, #HandleBleDisconnected will
-        // be called by the platform, which will call BleSecure::Disconnect again.
-        IgnoreError(otPlatBleGapDisconnect(&GetInstance()));
+        // Request the platform to close the BLE connection. When the platform signals completion
+        // (asynchronously) it calls otPlatBleGapOnDisconnected() -> #HandleBleDisconnected(), which
+        // in turn calls this method again - now with mBleState no longer kConnected - to invoke below
+        // mConnectCallback and update the advertisement data. We therefore return early here when
+        // the platform accepted the request, to avoid invoking the callback (and updating the
+        // advertisement data) twice. If the platform did not start the disconnection, no completion
+        // callback will follow and we handle mConnectCallback directly below.
+        VerifyOrExit(otPlatBleGapDisconnect(&GetInstance()) != kErrorNone);
     }
 
     mConnectCallback.InvokeIfSet(&GetInstance(), false, false);
     // Update advertisement data
     IgnoreError(NotifyAdvertisementChanged());
+
+exit:
+    return;
 }
 
 Error BleSecure::NotifyAdvertisementChanged(void)

--- a/src/core/radio/ble_secure.cpp
+++ b/src/core/radio/ble_secure.cpp
@@ -56,7 +56,7 @@ BleSecure::BleSecure(Instance &aInstance)
     , mSendMessage(nullptr)
     , mTransmitTask(aInstance)
     , mBleState(kStopped)
-    , mBleAdvRequestedState(kAdvertising)
+    , mBleAdvRequestedState(kStopped)
     , mMtuSize(kInitialMtuSize)
 {
 }
@@ -223,7 +223,7 @@ Error BleSecure::SetRequestedBleAdvertisementsState(void)
         SuccessOrExit(error = otPlatBleGapAdvStart(&GetInstance(), OT_BLE_ADV_INTERVAL_DEFAULT));
         mBleState = kAdvertising;
     }
-    else if (mBleAdvRequestedState == kNotAdvertising && mBleState == kAdvertising)
+    else if (mBleAdvRequestedState != kAdvertising && mBleState == kAdvertising)
     {
         SuccessOrExit(error = otPlatBleGapAdvStop(&GetInstance()));
         mBleState = kNotAdvertising;
@@ -398,14 +398,12 @@ void BleSecure::HandleBleDisconnected(uint16_t aConnectionId)
 {
     OT_UNUSED_VARIABLE(aConnectionId);
 
-    // kAdvertising is the state that the BLE stack will automatically assume, after a BLE client disconnects.
-    mBleState = kAdvertising;
+    mBleState = kNotAdvertising; // per otPlatBleGapAdvStart() API, advertising stopped already when client connected.
     mMtuSize  = kInitialMtuSize;
 
     Disconnect(); // Stop TLS connection and update advertisement data
 
-    // if a different BLE advertising state was requested earlier while a BLE client was connected,
-    // then now's the time to fulfill the request.
+    // Resume advertising (or fulfill a different advertising state requested while a client was connected).
     IgnoreError(SetRequestedBleAdvertisementsState());
 }
 

--- a/src/core/radio/ble_secure.cpp
+++ b/src/core/radio/ble_secure.cpp
@@ -196,10 +196,19 @@ Error BleSecure::NotifyAdvertisementChanged(void)
     uint16_t advertisementLen  = 0;
     uint8_t *advertisementData = nullptr;
 
-    VerifyOrExit(mBleState == kAdvertising);
+    VerifyOrExit(mBleState != kStopped);
     SuccessOrExit(error = otPlatBleGetAdvertisementBuffer(&GetInstance(), &advertisementData));
     SuccessOrExit(error = Get<MeshCoP::TcatAgent>().GetAdvertisementData(advertisementLen, advertisementData));
-    SuccessOrExit(error = otPlatBleGapAdvUpdateData(&GetInstance(), advertisementData, advertisementLen));
+
+    if (mBleState == kAdvertising)
+    {
+        SuccessOrExit(error = otPlatBleGapAdvUpdateData(&GetInstance(), advertisementData, advertisementLen));
+    }
+    else
+    {
+        // Any other state: update buffered data for when advertising resumes.
+        SuccessOrExit(error = otPlatBleGapAdvSetData(&GetInstance(), advertisementData, advertisementLen));
+    }
 
 exit:
     return error;

--- a/src/core/radio/ble_secure.cpp
+++ b/src/core/radio/ble_secure.cpp
@@ -56,7 +56,7 @@ BleSecure::BleSecure(Instance &aInstance)
     , mSendMessage(nullptr)
     , mTransmitTask(aInstance)
     , mBleState(kStopped)
-    , mBleAdvRequestedState(kStopped)
+    , mIsBleAdvRequested(false)
     , mMtuSize(kInitialMtuSize)
 {
 }
@@ -86,9 +86,9 @@ Error BleSecure::Start(ConnectCallback aConnectHandler, ReceiveCallback aReceive
     mTls.SetConnectCallback(HandleTlsConnectEvent, this);
 
     // attempt to start BLE advertising only if everything else succeeded.
-    mBleState             = kNotAdvertising;
-    mBleAdvRequestedState = kAdvertising;
-    error                 = SetRequestedBleAdvertisementsState();
+    mBleState          = kNotAdvertising;
+    mIsBleAdvRequested = true;
+    error              = SetRequestedBleAdvertisementsState();
 
 exit:
     if (error != kErrorNone && error != kErrorAlready)
@@ -118,9 +118,9 @@ void BleSecure::Stop(void)
     // Even if stop-advertisements or disable BLE would fail, we continue closing TLS and stopping TCAT agent.
     IgnoreError(otPlatBleGapAdvStop(&GetInstance()));
     IgnoreError(otPlatBleDisable(&GetInstance()));
-    mBleState             = kStopped;
-    mBleAdvRequestedState = kStopped;
-    mMtuSize              = kInitialMtuSize;
+    mBleState          = kStopped;
+    mIsBleAdvRequested = false;
+    mMtuSize           = kInitialMtuSize;
 
     mTls.Close();
     Get<MeshCoP::TcatAgent>().Stop();
@@ -214,9 +214,17 @@ exit:
     return error;
 }
 
+void BleSecure::HandleNotifierEvents(Events aEvents)
+{
+    if (aEvents.ContainsAny(kEventActiveDatasetChanged | kEventThreadRoleChanged))
+    {
+        IgnoreError(NotifyAdvertisementChanged());
+    }
+}
+
 void BleSecure::NotifySendAdvertisements(bool aSendAdvertisements)
 {
-    mBleAdvRequestedState = aSendAdvertisements ? kAdvertising : kNotAdvertising;
+    mIsBleAdvRequested = aSendAdvertisements;
     IgnoreError(SetRequestedBleAdvertisementsState());
 }
 
@@ -227,12 +235,12 @@ Error BleSecure::SetRequestedBleAdvertisementsState(void)
     Error error = kErrorNone;
 
     // Must not make GapAdv platform calls when kStopped, or kConnected.
-    if (mBleAdvRequestedState == kAdvertising && mBleState == kNotAdvertising)
+    if (mIsBleAdvRequested && mBleState == kNotAdvertising)
     {
         SuccessOrExit(error = otPlatBleGapAdvStart(&GetInstance(), OT_BLE_ADV_INTERVAL_DEFAULT));
         mBleState = kAdvertising;
     }
-    else if (mBleAdvRequestedState != kAdvertising && mBleState == kAdvertising)
+    else if (!mIsBleAdvRequested && mBleState == kAdvertising)
     {
         SuccessOrExit(error = otPlatBleGapAdvStop(&GetInstance()));
         mBleState = kNotAdvertising;

--- a/src/core/radio/ble_secure.hpp
+++ b/src/core/radio/ble_secure.hpp
@@ -35,6 +35,7 @@
 
 #include <openthread/ble_secure.h>
 
+#include "common/notifier.hpp"
 #include "meshcop/meshcop.hpp"
 #include "meshcop/secure_transport.hpp"
 #include "meshcop/tcat_agent.hpp"
@@ -54,6 +55,8 @@ namespace Ble {
 
 class BleSecure : public InstanceLocator, public MeshCoP::Tls::Extension, private NonCopyable
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * Pointer to call when the secure BLE connection state changes.
@@ -356,6 +359,8 @@ private:
     static constexpr uint16_t kTxBleHandle      = 0;   // Characteristics Handle for TX (not used)
     static constexpr uint16_t kTlsDataMaxSize   = 800; // Maximum size of data chunks sent with mTls.Send(..)
 
+    void HandleNotifierEvents(Events aEvents);
+
     static void HandleTlsConnectEvent(MeshCoP::Tls::ConnectEvent aEvent, void *aContext);
     void        HandleTlsConnectEvent(MeshCoP::Tls::ConnectEvent aEvent);
 
@@ -381,7 +386,7 @@ private:
     TxTask                    mTransmitTask;
     uint8_t                   mPacketBuffer[kPacketBufferSize];
     BleState                  mBleState;
-    BleState                  mBleAdvRequestedState;
+    bool                      mIsBleAdvRequested;
     uint16_t                  mMtuSize;
 };
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -319,10 +319,6 @@ void Mle::SetRole(DeviceRole aRole)
         break;
     }
 
-#if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
-    IgnoreError(Get<Ble::BleSecure>().NotifyAdvertisementChanged());
-#endif
-
     // If the previous state is disabled, the parent can be in kStateRestored.
     if (!IsChild() && oldRole != kRoleDisabled)
     {

--- a/tests/scripts/expect/cli-tcat-decommission.exp
+++ b/tests/scripts/expect/cli-tcat-decommission.exp
@@ -53,6 +53,9 @@ send "thread start\n"
 expect_line "\tTYPE:\tRESPONSE_W_STATUS"
 expect_line "\tVALUE:\t0x00"
 
+send "disconnect\n"
+expect_line "Done"
+
 dispose_tcat_client 1
 
 switch_node 1

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -35,7 +35,7 @@
 #include <sys/time.h>
 #include <openthread/platform/flash.h>
 
-#ifdef OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
+#if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
 #include <openthread/tcat.h>
 #include <openthread/platform/ble.h>
 #endif
@@ -800,7 +800,7 @@ OT_TOOL_WEAK otPlatMcuPowerState otPlatGetMcuPowerState(otInstance *aInstance) {
 
 OT_TOOL_WEAK otError otPlatSetMcuPowerState(otInstance *aInstance, otPlatMcuPowerState aState) { return OT_ERROR_NONE; }
 #endif // OPENTHREAD_CONFIG_NCP_ENABLE_MCU_POWER_STATE_CONTROL
-#ifdef OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
+#if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
 
 uint8_t  sPlatBleLastAdvSetData[OT_TCAT_ADVERTISEMENT_MAX_LEN];
 uint16_t sPlatBleLastAdvSetDataLen = 0;
@@ -842,7 +842,9 @@ otError otPlatBleGapAdvStop(otInstance *aInstance)
 
 otError otPlatBleGapDisconnect(otInstance *aInstance)
 {
-    OT_UNUSED_VARIABLE(aInstance);
+    // Honor the platform contract: report completion of the disconnection via the callback.
+    // Normally this call is done asynchronously, but for unit testing purposes we make the reentrant call.
+    otPlatBleGapOnDisconnected(aInstance, 0);
     return OT_ERROR_NONE;
 }
 

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -801,6 +801,10 @@ OT_TOOL_WEAK otPlatMcuPowerState otPlatGetMcuPowerState(otInstance *aInstance) {
 OT_TOOL_WEAK otError otPlatSetMcuPowerState(otInstance *aInstance, otPlatMcuPowerState aState) { return OT_ERROR_NONE; }
 #endif // OPENTHREAD_CONFIG_NCP_ENABLE_MCU_POWER_STATE_CONTROL
 #ifdef OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
+
+uint8_t  sPlatBleLastAdvSetData[OT_TCAT_ADVERTISEMENT_MAX_LEN];
+uint16_t sPlatBleLastAdvSetDataLen = 0;
+
 otError otPlatBleEnable(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
@@ -875,17 +879,19 @@ bool otPlatBleSupportsMultiRadio(otInstance *aInstance)
 otError otPlatBleGapAdvSetData(otInstance *aInstance, uint8_t *aAdvertisementData, uint16_t aAdvertisementLen)
 {
     OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(aAdvertisementData);
-    OT_UNUSED_VARIABLE(aAdvertisementLen);
+    if (aAdvertisementData == nullptr || aAdvertisementLen > OT_TCAT_ADVERTISEMENT_MAX_LEN)
+    {
+        return OT_ERROR_INVALID_ARGS;
+    }
+    memcpy(sPlatBleLastAdvSetData, aAdvertisementData, aAdvertisementLen);
+    sPlatBleLastAdvSetDataLen = aAdvertisementLen;
+
     return OT_ERROR_NONE;
 }
 
 otError otPlatBleGapAdvUpdateData(otInstance *aInstance, uint8_t *aAdvertisementData, uint16_t aAdvertisementLen)
 {
-    OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(aAdvertisementData);
-    OT_UNUSED_VARIABLE(aAdvertisementLen);
-    return OT_ERROR_NONE;
+    return otPlatBleGapAdvSetData(aInstance, aAdvertisementData, aAdvertisementLen);
 }
 
 #endif // OPENTHREAD_CONFIG_BLE_TCAT_ENABLE

--- a/tests/unit/test_platform.h
+++ b/tests/unit/test_platform.h
@@ -57,4 +57,16 @@ ot::Instance *testInitAdditionalInstance(uint8_t id);
 #endif
 void testFreeInstance(otInstance *aInstance);
 
+#if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
+#include <openthread/tcat.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern uint8_t  sPlatBleLastAdvSetData[OT_TCAT_ADVERTISEMENT_MAX_LEN];
+extern uint16_t sPlatBleLastAdvSetDataLen;
+#ifdef __cplusplus
+}
+#endif
+#endif
+
 #endif // OT_UNIT_TEST_PLATFORM_H_

--- a/tests/unit/test_tcat.cpp
+++ b/tests/unit/test_tcat.cpp
@@ -36,6 +36,7 @@
 #include <openthread/ble_secure.h>
 
 #include "cli/cli_dataset.hpp"
+#include "radio/ble_secure.hpp"
 
 #define OT_TCAT_X509_CERT                                                \
     "-----BEGIN CERTIFICATE-----\n"                                      \
@@ -267,6 +268,8 @@ static Instance *TestInitInstanceTcat(void)
     memcpy(&sCommExtPanId, &kExtPanId, sizeof(sCommExtPanId));
     memcpy(&sCommAuth, &kCommCert1AuthField, sizeof(sCommAuth));
     memcpy(&sDeviceAuth, &kDeviceCert1AuthField, sizeof(sDeviceAuth));
+    sPlatBleLastAdvSetDataLen = 0;
+    memset(sPlatBleLastAdvSetData, 0, OT_TCAT_ADVERTISEMENT_MAX_LEN);
 
     return instance;
 }
@@ -332,6 +335,46 @@ void TestTcatConnectionAndCertAttributes(void)
     VerifyOrQuit(otBleSecureIsTcatAgentStarted(instance));
     otBleSecureStop(instance);
     VerifyOrQuit(!otBleSecureIsTcatAgentStarted(instance));
+
+    testFreeInstance(instance);
+}
+
+void TestTcatAdvertisementUpdates(void)
+{
+    TestBleSecure ble;
+    Instance     *instance = TestInitInstanceTcat();
+    uint8_t       advDataSnapshot[OT_TCAT_ADVERTISEMENT_MAX_LEN];
+    uint16_t      advDataSnapshotLen;
+
+    VerifyOrQuit(sPlatBleLastAdvSetDataLen == 0, "Adv data should be unset before BleSecure start");
+
+    SuccessOrQuit(otBleSecureStart(instance, HandleBleSecureConnect, nullptr, true, &ble));
+    SuccessOrQuit(otBleSecureTcatStart(instance, nullptr));
+
+    VerifyOrQuit(sPlatBleLastAdvSetDataLen > 0, "Adv data should be set after BleSecure start");
+    advDataSnapshotLen = sPlatBleLastAdvSetDataLen;
+    memcpy(advDataSnapshot, sPlatBleLastAdvSetData, advDataSnapshotLen);
+
+    otPlatBleGapOnConnected(instance, kConnectionId);
+    SuccessOrQuit(otBleSecureConnect(instance));
+
+    // BLE connect and initiating TLS does not change the adv data.
+    VerifyOrQuit(sPlatBleLastAdvSetDataLen == advDataSnapshotLen &&
+                     memcmp(sPlatBleLastAdvSetData, advDataSnapshot, advDataSnapshotLen) == 0,
+                 "Adv data changed unexpectedly after BLE connect");
+    advDataSnapshotLen = sPlatBleLastAdvSetDataLen;
+    memcpy(advDataSnapshot, sPlatBleLastAdvSetData, advDataSnapshotLen);
+
+    // Commissioner sets dataset, then disconnects
+    instance->Get<ActiveDatasetManager>().SaveLocal(sPartialDataset);
+    otBleSecureDisconnect(instance);
+
+    // Adv is changed due to the partial dataset now being advertised in the S flag.
+    VerifyOrQuit(sPlatBleLastAdvSetDataLen == advDataSnapshotLen, "Adv data length changed unexpectedly");
+    VerifyOrQuit(memcmp(sPlatBleLastAdvSetData, advDataSnapshot, advDataSnapshotLen) != 0,
+                 "Adv data did not change after disconnect, which it should due to S flag");
+
+    otBleSecureStop(instance);
 
     testFreeInstance(instance);
 }
@@ -834,6 +877,7 @@ int main(void)
     ot::MeshCoP::UnitTester::TestTcatCommissioner1AuthWithDeviceRequirements();
     ot::MeshCoP::UnitTester::TestTcatCommissioner2AuthWithDeviceRequirements();
     ot::MeshCoP::UnitTester::TestTcatCommissioner4AuthWithExistingPartialDataset();
+    ot::MeshCoP::TestTcatAdvertisementUpdates();
     printf("All tests passed\n");
 #else
     printf("TCAT feature is not enabled\n");

--- a/tests/unit/test_tcat.cpp
+++ b/tests/unit/test_tcat.cpp
@@ -194,6 +194,7 @@ public:
     TestBleSecure(void)
         : mIsConnected(false)
         , mIsBleConnectionOpen(false)
+        , mConnectCallbackCount(0)
     {
     }
 
@@ -201,14 +202,18 @@ public:
     {
         mIsConnected         = aConnected;
         mIsBleConnectionOpen = aBleConnectionOpen;
+        mConnectCallbackCount++;
     }
 
-    bool IsConnected(void) const { return mIsConnected; }
-    bool IsBleConnectionOpen(void) const { return mIsBleConnectionOpen; }
+    bool     IsConnected(void) const { return mIsConnected; }
+    bool     IsBleConnectionOpen(void) const { return mIsBleConnectionOpen; }
+    uint32_t GetConnectCallbackCount(void) const { return mConnectCallbackCount; }
+    void     ResetConnectCallbackCount(void) { mConnectCallbackCount = 0; }
 
 private:
-    bool mIsConnected;
-    bool mIsBleConnectionOpen;
+    bool     mIsConnected;
+    bool     mIsBleConnectionOpen;
+    uint32_t mConnectCallbackCount;
 };
 
 static void HandleBleSecureConnect(otInstance *aInstance, bool aConnected, bool aBleConnectionOpen, void *aContext)
@@ -306,8 +311,11 @@ void TestTcatConnectionAndCertAttributes(void)
     // Validate connection callbacks when calling `otBleSecureDisconnect()`
     otPlatBleGapOnConnected(instance, kConnectionId);
     VerifyOrQuit(!ble.IsConnected() && ble.IsBleConnectionOpen());
+    ble.ResetConnectCallbackCount();
     otBleSecureDisconnect(instance);
     VerifyOrQuit(!ble.IsConnected() && !ble.IsBleConnectionOpen());
+    // Regression test: a locally-initiated disconnect must invoke the connect callback exactly once.
+    VerifyOrQuit(ble.GetConnectCallbackCount() == 1);
 
     // Validate TLS connection can be started (as client) only when peer is BLE-connected
     otPlatBleGapOnConnected(instance, kConnectionId);


### PR DESCRIPTION
Note: consists of 3 separate commits, each with commit comment of the particular change.

This fixes some ble.h issues and makes explicit that BLE advertising will stop once a client connects. The TCAT agent is updated to re-enable advertising after a client disconnects (in the default case). This fixes an issue observed in cert tests. For easier testing in the future, debug log messages are added for the simulation BLE platform.

The simulation platform (ble.c) is improved to act more like a real BLE platform, by now supporting
client connection state and calling of otPlatBleGapOnConnected() and otPlatBleGapOnDisconnected().
