### PR TITLE
[mesh forwarder] selective retransmission of fragments on failed indirect transmissions

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -239,6 +239,7 @@ set(COMMON_SOURCES
     thread/discover_scanner.cpp
     thread/dua_manager.cpp
     thread/energy_scan_server.cpp
+    thread/frag_cache_retransmit.cpp
     thread/indirect_sender.cpp
     thread/key_manager.cpp
     thread/link_metrics.cpp

--- a/src/core/config/mesh_forwarder.h
+++ b/src/core/config/mesh_forwarder.h
@@ -198,6 +198,41 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE
+ *
+ * Define as 1 to enable the fragment cache retransmission feature.
+ *
+ * When enabled, a parent router that fails to deliver a fragmented message to a sleepy child will cache
+ * the message and send a CoAP notification to the mesh source. When the source receives an MRP retry
+ * matching the cached message (by UDP checksum and flow 5-tuple), it redirects retransmission to the
+ * caching router instead of forwarding the full message through the mesh again. This saves airtime on
+ * multi-hop paths. If the notification is lost, normal retransmission proceeds as a failsafe.
+ */
+#ifndef OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE
+#define OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE 0
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_MESH_FRAG_CACHE_MAX_ENTRIES
+ *
+ * Specifies the maximum number of cached messages per router for fragment cache retransmission.
+ * Each entry holds a cloned message (~1280 bytes) so this directly impacts RAM usage.
+ */
+#ifndef OPENTHREAD_CONFIG_MESH_FRAG_CACHE_MAX_ENTRIES
+#define OPENTHREAD_CONFIG_MESH_FRAG_CACHE_MAX_ENTRIES 3
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_MESH_FRAG_CACHE_TIMEOUT
+ *
+ * Specifies the cache expiry timeout in seconds for fragment cache retransmission entries.
+ * Cached messages are freed after this timeout if no resend request is received.
+ */
+#ifndef OPENTHREAD_CONFIG_MESH_FRAG_CACHE_TIMEOUT
+#define OPENTHREAD_CONFIG_MESH_FRAG_CACHE_TIMEOUT 30
+#endif
+
+/**
  * @}
  */
 

--- a/src/core/thread/frag_cache_retransmit.cpp
+++ b/src/core/thread/frag_cache_retransmit.cpp
@@ -1,0 +1,443 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "frag_cache_retransmit.hpp"
+
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE
+
+#include "instance/instance.hpp"
+#include "thread/address_resolver.hpp"
+#include "thread/mesh_forwarder.hpp"
+#include "thread/mle.hpp"
+#include "thread/tmf.hpp"
+
+namespace ot {
+
+RegisterLogModule("FragCache");
+
+FragCacheRetransmit::FragCacheRetransmit(Instance &aInstance)
+    : InstanceLocator(aInstance)
+    , mCacheTimer(aInstance, FragCacheRetransmit::HandleCacheTimer, this)
+    , mRedirectTimer(aInstance, FragCacheRetransmit::HandleRedirectTimer, this)
+{
+    memset(mCacheEntries, 0, sizeof(mCacheEntries));
+    memset(mRedirectEntries, 0, sizeof(mRedirectEntries));
+}
+
+bool FragCacheRetransmit::ExtractFlowId(const Message &aMessage, FlowId &aFlowId) const
+{
+    Ip6::Headers headers;
+
+    SuccessOrExit(headers.ParseFrom(aMessage));
+    VerifyOrExit(headers.IsUdp());
+
+    aFlowId.mUdpChecksum = headers.GetChecksum();
+    aFlowId.mDstAddr     = headers.GetDestinationAddress();
+    aFlowId.mDstPort     = headers.GetDestinationPort();
+    aFlowId.mSrcPort     = headers.GetSourcePort();
+    aFlowId.mChildRloc16 = 0; // Set by caller
+
+    return true;
+
+exit:
+    return false;
+}
+
+// --- CachingTable (at parent/failing router) ---
+
+FragCacheRetransmit::CacheEntry *FragCacheRetransmit::FindCacheEntry(const FlowId &aFlowId)
+{
+    for (CacheEntry &entry : mCacheEntries)
+    {
+        if (entry.mValid &&
+            entry.mFlowId.mUdpChecksum == aFlowId.mUdpChecksum &&
+            entry.mFlowId.mDstAddr == aFlowId.mDstAddr &&
+            entry.mFlowId.mDstPort == aFlowId.mDstPort &&
+            entry.mFlowId.mSrcPort == aFlowId.mSrcPort &&
+            (aFlowId.mChildRloc16 == 0 || entry.mFlowId.mChildRloc16 == aFlowId.mChildRloc16))
+        {
+            return &entry;
+        }
+    }
+
+    return nullptr;
+}
+
+FragCacheRetransmit::CacheEntry *FragCacheRetransmit::AllocateCacheEntry(void)
+{
+    CacheEntry *oldest = nullptr;
+
+    for (CacheEntry &entry : mCacheEntries)
+    {
+        if (!entry.mValid)
+        {
+            return &entry;
+        }
+
+        if (oldest == nullptr || entry.mExpireTime < oldest->mExpireTime)
+        {
+            oldest = &entry;
+        }
+    }
+
+    // Evict oldest entry
+    if (oldest != nullptr && oldest->mMessage != nullptr)
+    {
+        oldest->mMessage->Free();
+        oldest->mMessage = nullptr;
+        oldest->mValid   = false;
+    }
+
+    return oldest;
+}
+
+void FragCacheRetransmit::HandleIndirectTxFailure(Message &aMessage, Child &aChild)
+{
+    FlowId     flowId;
+    CacheEntry *entry;
+
+    VerifyOrExit(ExtractFlowId(aMessage, flowId));
+
+    flowId.mChildRloc16 = aChild.GetRloc16();
+
+    // Don't cache duplicates
+    VerifyOrExit(FindCacheEntry(flowId) == nullptr);
+
+    entry = AllocateCacheEntry();
+    VerifyOrExit(entry != nullptr);
+
+    entry->mMessage = aMessage.Clone();
+    VerifyOrExit(entry->mMessage != nullptr);
+
+    entry->mValid             = true;
+    entry->mFlowId            = flowId;
+    entry->mExpireTime        = TimerMilli::GetNow() + kCacheTimeoutMs;
+
+    // Resolve mesh source RLOC16 from the IPv6 source address via address cache
+    {
+        Ip6::Headers headers;
+        uint16_t     srcRloc16 = Mle::kInvalidRloc16;
+
+        if (headers.ParseFrom(aMessage) == kErrorNone)
+        {
+            const Ip6::Address &srcAddr = headers.GetSourceAddress();
+
+            if (srcAddr.GetIid().IsLocator())
+            {
+                srcRloc16 = srcAddr.GetIid().GetLocator();
+            }
+            else
+            {
+                srcRloc16 = Get<AddressResolver>().LookUp(srcAddr);
+            }
+        }
+
+        VerifyOrExit(srcRloc16 != Mle::kInvalidRloc16);
+        entry->mMeshSourceRloc16 = srcRloc16;
+    }
+
+    mCacheTimer.FireAtIfEarlier(entry->mExpireTime);
+
+    LogNote("Cached msg for child 0x%04x, checksum 0x%04x, notifying source 0x%04x",
+            flowId.mChildRloc16, flowId.mUdpChecksum, entry->mMeshSourceRloc16);
+
+    SendNotification(flowId, entry->mMeshSourceRloc16);
+
+exit:
+    return;
+}
+
+void FragCacheRetransmit::SendNotification(const FlowId &aFlowId, uint16_t aMeshSourceRloc16)
+{
+    Error              error;
+    Coap::Message     *message;
+
+    message = Get<Tmf::Agent>().AllocateAndInitNonConfirmablePostMessage(kUriFragCacheNotify);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    SuccessOrExit(error = message->Append(aFlowId));
+
+    {
+        Ip6::Address dest;
+        dest.SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aMeshSourceRloc16);
+        SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, dest));
+    }
+    message = nullptr;
+
+    LogNote("Sent FragCacheNotify to 0x%04x", aMeshSourceRloc16);
+
+exit:
+    FreeMessage(message);
+}
+
+void FragCacheRetransmit::HandleNotify(Coap::Msg &aMsg)
+{
+    FlowId         flowId;
+    RedirectEntry *entry;
+
+    SuccessOrExit(aMsg.mMessage.Read(aMsg.mMessage.GetOffset(), flowId));
+
+    entry = AllocateRedirectEntry();
+    VerifyOrExit(entry != nullptr);
+
+    entry->mValid               = true;
+    entry->mUdpChecksum         = flowId.mUdpChecksum;
+    entry->mDstAddr             = flowId.mDstAddr;
+    entry->mDstPort             = flowId.mDstPort;
+    entry->mSrcPort             = flowId.mSrcPort;
+    entry->mCachingRouterRloc16 = aMsg.mMessageInfo.GetPeerAddr().GetIid().GetLocator();
+    entry->mExpireTime          = TimerMilli::GetNow() + kCacheTimeoutMs;
+
+    mRedirectTimer.FireAtIfEarlier(entry->mExpireTime);
+
+    LogNote("Received FragCacheNotify from 0x%04x, checksum 0x%04x",
+            entry->mCachingRouterRloc16, flowId.mUdpChecksum);
+
+exit:
+    return;
+}
+
+// --- RedirectTable (at source router) ---
+
+FragCacheRetransmit::RedirectEntry *FragCacheRetransmit::FindRedirectEntry(uint16_t      aChecksum,
+                                                                          const Ip6::Address &aDstAddr,
+                                                                          uint16_t      aDstPort,
+                                                                          uint16_t      aSrcPort)
+{
+    for (RedirectEntry &entry : mRedirectEntries)
+    {
+        if (entry.mValid &&
+            entry.mUdpChecksum == aChecksum &&
+            entry.mDstAddr == aDstAddr &&
+            entry.mDstPort == aDstPort &&
+            entry.mSrcPort == aSrcPort)
+        {
+            return &entry;
+        }
+    }
+
+    return nullptr;
+}
+
+FragCacheRetransmit::RedirectEntry *FragCacheRetransmit::AllocateRedirectEntry(void)
+{
+    for (RedirectEntry &entry : mRedirectEntries)
+    {
+        if (!entry.mValid)
+        {
+            return &entry;
+        }
+    }
+
+    // Evict oldest
+    RedirectEntry *oldest = &mRedirectEntries[0];
+
+    for (RedirectEntry &entry : mRedirectEntries)
+    {
+        if (entry.mExpireTime < oldest->mExpireTime)
+        {
+            oldest = &entry;
+        }
+    }
+
+    oldest->mValid = false;
+    return oldest;
+}
+
+bool FragCacheRetransmit::ShouldRedirect(const Message &aMessage, uint16_t &aCachingRouterRloc)
+{
+    Ip6::Headers   headers;
+    RedirectEntry *entry;
+
+    SuccessOrExit(headers.ParseFrom(aMessage));
+    VerifyOrExit(headers.IsUdp());
+
+    entry = FindRedirectEntry(headers.GetChecksum(), headers.GetDestinationAddress(),
+                              headers.GetDestinationPort(), headers.GetSourcePort());
+    VerifyOrExit(entry != nullptr);
+
+    aCachingRouterRloc = entry->mCachingRouterRloc16;
+
+    LogNote("Redirect match: checksum 0x%04x → caching router 0x%04x",
+            headers.GetChecksum(), aCachingRouterRloc);
+
+    // Remove the entry (one-shot redirect)
+    entry->mValid = false;
+
+    return true;
+
+exit:
+    return false;
+}
+
+void FragCacheRetransmit::SendRedirect(uint16_t aCachingRouterRloc, const Message &aMessage)
+{
+    Error          error;
+    Coap::Message *message = nullptr;
+    FlowId         flowId;
+
+    VerifyOrExit(ExtractFlowId(aMessage, flowId));
+
+    message = Get<Tmf::Agent>().AllocateAndInitNonConfirmablePostMessage(kUriFragCacheResend);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    SuccessOrExit(error = message->Append(flowId));
+
+    {
+        Ip6::Address dest;
+        dest.SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aCachingRouterRloc);
+        SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, dest));
+    }
+    message = nullptr;
+
+    LogNote("Sent FragCacheResend to 0x%04x", aCachingRouterRloc);
+
+exit:
+    FreeMessage(message);
+}
+
+void FragCacheRetransmit::HandleResend(Coap::Msg &aMsg)
+{
+    FlowId      flowId;
+    CacheEntry *entry;
+
+    SuccessOrExit(aMsg.mMessage.Read(aMsg.mMessage.GetOffset(), flowId));
+
+    entry = FindCacheEntry(flowId);
+    VerifyOrExit(entry != nullptr);
+
+    LogNote("Received FragCacheResend, retransmitting cached msg for child 0x%04x", flowId.mChildRloc16);
+
+    RetransmitCachedMessage(*entry);
+
+exit:
+    return;
+}
+
+void FragCacheRetransmit::RetransmitCachedMessage(CacheEntry &aEntry)
+{
+    Message *clone;
+    Child   *child;
+
+    VerifyOrExit(aEntry.mMessage != nullptr);
+
+    child = Get<ChildTable>().FindChild(aEntry.mFlowId.mChildRloc16, Child::kInStateAnyExceptInvalid);
+    VerifyOrExit(child != nullptr);
+
+    clone = aEntry.mMessage->Clone();
+    VerifyOrExit(clone != nullptr);
+
+    // Reset for fresh transmission with new datagram tag
+    clone->SetOffset(0);
+    clone->SetDatagramTag(0);
+
+    Get<MeshForwarder>().SendMessage(OwnedPtr<Message>(clone));
+
+    LogNote("Retransmitted cached msg to child 0x%04x", aEntry.mFlowId.mChildRloc16);
+
+    // Remove cache entry after retransmission
+    aEntry.mMessage->Free();
+    aEntry.mMessage = nullptr;
+    aEntry.mValid   = false;
+
+exit:
+    return;
+}
+
+// --- Timer handlers ---
+
+void FragCacheRetransmit::HandleCacheTimer(Timer &aTimer)
+{
+    static_cast<FragCacheRetransmit *>(static_cast<TimerMilliContext &>(aTimer).GetContext())->HandleCacheTimer();
+}
+
+void FragCacheRetransmit::HandleCacheTimer(void)
+{
+    NextFireTime nextTime;
+
+    for (CacheEntry &entry : mCacheEntries)
+    {
+        if (!entry.mValid)
+        {
+            continue;
+        }
+
+        if (nextTime.GetNow() >= entry.mExpireTime)
+        {
+            LogNote("Cache entry expired for child 0x%04x, checksum 0x%04x",
+                    entry.mFlowId.mChildRloc16, entry.mFlowId.mUdpChecksum);
+
+            if (entry.mMessage != nullptr)
+            {
+                entry.mMessage->Free();
+                entry.mMessage = nullptr;
+            }
+
+            entry.mValid = false;
+        }
+        else
+        {
+            nextTime.UpdateIfEarlier(entry.mExpireTime);
+        }
+    }
+
+    mCacheTimer.FireAt(nextTime);
+}
+
+void FragCacheRetransmit::HandleRedirectTimer(Timer &aTimer)
+{
+    static_cast<FragCacheRetransmit *>(static_cast<TimerMilliContext &>(aTimer).GetContext())->HandleRedirectTimer();
+}
+
+void FragCacheRetransmit::HandleRedirectTimer(void)
+{
+    NextFireTime nextTime;
+
+    for (RedirectEntry &entry : mRedirectEntries)
+    {
+        if (!entry.mValid)
+        {
+            continue;
+        }
+
+        if (nextTime.GetNow() >= entry.mExpireTime)
+        {
+            entry.mValid = false;
+        }
+        else
+        {
+            nextTime.UpdateIfEarlier(entry.mExpireTime);
+        }
+    }
+
+    mRedirectTimer.FireAt(nextTime);
+}
+
+} // namespace ot
+
+#endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE

--- a/src/core/thread/frag_cache_retransmit.hpp
+++ b/src/core/thread/frag_cache_retransmit.hpp
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FRAG_CACHE_RETRANSMIT_HPP_
+#define FRAG_CACHE_RETRANSMIT_HPP_
+
+#include "openthread-core-config.h"
+
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE
+
+#include "common/locator.hpp"
+#include "common/message.hpp"
+#include "common/non_copyable.hpp"
+#include "common/timer.hpp"
+#include "coap/coap.hpp"
+#include "net/ip6.hpp"
+#include "thread/child.hpp"
+
+namespace ot {
+
+class FragCacheRetransmit : public InstanceLocator, private NonCopyable
+{
+public:
+    explicit FragCacheRetransmit(Instance &aInstance);
+
+    void HandleIndirectTxFailure(Message &aMessage, Child &aChild);
+
+    bool ShouldRedirect(const Message &aMessage, uint16_t &aCachingRouterRloc);
+
+    void SendRedirect(uint16_t aCachingRouterRloc, const Message &aMessage);
+
+    void HandleNotify(Coap::Msg &aMsg);
+
+    void HandleResend(Coap::Msg &aMsg);
+
+private:
+    static constexpr uint16_t kMaxCacheEntries    = OPENTHREAD_CONFIG_MESH_FRAG_CACHE_MAX_ENTRIES;
+    static constexpr uint32_t kCacheTimeoutMs     = OPENTHREAD_CONFIG_MESH_FRAG_CACHE_TIMEOUT * 1000;
+    static constexpr uint16_t kMaxRedirectEntries = 8;
+
+    OT_TOOL_PACKED_BEGIN
+    struct FlowId
+    {
+        uint16_t       mUdpChecksum;
+        Ip6::Address   mDstAddr;
+        uint16_t       mDstPort;
+        uint16_t       mSrcPort;
+        uint16_t       mChildRloc16;
+    } OT_TOOL_PACKED_END;
+
+    struct CacheEntry
+    {
+        bool           mValid;
+        FlowId         mFlowId;
+        uint16_t       mMeshSourceRloc16;
+        Message       *mMessage;
+        TimeMilli      mExpireTime;
+    };
+
+    struct RedirectEntry
+    {
+        bool           mValid;
+        uint16_t       mUdpChecksum;
+        Ip6::Address   mDstAddr;
+        uint16_t       mDstPort;
+        uint16_t       mSrcPort;
+        uint16_t       mCachingRouterRloc16;
+        TimeMilli      mExpireTime;
+    };
+
+    bool ExtractFlowId(const Message &aMessage, FlowId &aFlowId) const;
+    void SendNotification(const FlowId &aFlowId, uint16_t aMeshSourceRloc16);
+    void RetransmitCachedMessage(CacheEntry &aEntry);
+
+    CacheEntry    *FindCacheEntry(const FlowId &aFlowId);
+    CacheEntry    *AllocateCacheEntry(void);
+    RedirectEntry *FindRedirectEntry(uint16_t aChecksum, const Ip6::Address &aDstAddr, uint16_t aDstPort, uint16_t aSrcPort);
+    RedirectEntry *AllocateRedirectEntry(void);
+
+    static void HandleCacheTimer(Timer &aTimer);
+    void        HandleCacheTimer(void);
+    static void HandleRedirectTimer(Timer &aTimer);
+    void        HandleRedirectTimer(void);
+
+    CacheEntry        mCacheEntries[kMaxCacheEntries];
+    RedirectEntry     mRedirectEntries[kMaxRedirectEntries];
+    TimerMilliContext  mCacheTimer;
+    TimerMilliContext  mRedirectTimer;
+};
+
+} // namespace ot
+
+#endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE
+
+#endif // FRAG_CACHE_RETRANSMIT_HPP_

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -450,6 +450,13 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
     {
         // The indirect tx of this message to the child is done.
 
+#if OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE
+        if (!aChild.GetIndirectTxSuccess())
+        {
+            Get<MeshForwarder>().GetFragCacheRetransmit().HandleIndirectTxFailure(*message, aChild);
+        }
+#endif
+
         Error        txError    = aError;
         uint16_t     childIndex = Get<ChildTable>().GetChildIndex(aChild);
         Mac::Address macDest;

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -82,6 +82,9 @@ MeshForwarder::MeshForwarder(Instance &aInstance)
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
     , mIndirectSender(aInstance)
 #endif
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE
+    , mFragCacheRetransmit(aInstance)
+#endif
     , mDataPollSender(aInstance)
 {
 #if OPENTHREAD_CONFIG_TX_QUEUE_STATISTICS_ENABLE

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -57,6 +57,10 @@
 #include "thread/network_data_leader.hpp"
 #include "thread/thread_link_info.hpp"
 
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE
+#include "thread/frag_cache_retransmit.hpp"
+#endif
+
 namespace ot {
 
 namespace Mle {
@@ -267,6 +271,12 @@ public:
      *                       `kErrorNoAck` to indicate an ack timeout.
      */
     void HandleDeferredAck(Neighbor &aNeighbor, Error aError);
+#endif
+
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
+
+    FragCacheRetransmit &GetFragCacheRetransmit(void) { return mFragCacheRetransmit; }
 #endif
 
 private:
@@ -572,6 +582,10 @@ private:
 
 #if OPENTHREAD_FTD
     FwdFrameInfoArray mFwdFrameInfoArray;
+#endif
+
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE
+    FragCacheRetransmit mFragCacheRetransmit;
 #endif
 
     DataPollSender mDataPollSender;

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -48,6 +48,20 @@ void MeshForwarder::SendMessage(OwnedPtr<Message> aMessagePtr)
     message.SetOffset(0);
     message.SetDatagramTag(0);
     message.SetTimestampToNow();
+
+#if OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE
+    {
+        uint16_t cachingRouterRloc;
+
+        if (mFragCacheRetransmit.ShouldRedirect(message, cachingRouterRloc))
+        {
+            mFragCacheRetransmit.SendRedirect(cachingRouterRloc, message);
+            message.Free();
+            ExitNow();
+        }
+    }
+#endif
+
     mSendQueue.Enqueue(message);
 
     switch (message.GetType())
@@ -940,6 +954,20 @@ exit:
 #endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
 
 // LCOV_EXCL_STOP
+
+#if OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE
+
+template <> void MeshForwarder::HandleTmf<kUriFragCacheNotify>(Coap::Msg &aMsg)
+{
+    mFragCacheRetransmit.HandleNotify(aMsg);
+}
+
+template <> void MeshForwarder::HandleTmf<kUriFragCacheResend>(Coap::Msg &aMsg)
+{
+    mFragCacheRetransmit.HandleResend(aMsg);
+}
+
+#endif // OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE
 
 } // namespace ot
 

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -135,6 +135,11 @@ bool Agent::HandleResource(const char *aUriPath, Msg &aMsg)
         Case(kUriDiagnosticGetQuery, NetworkDiagnostic::Server);
         Case(kUriDiagnosticReset, NetworkDiagnostic::Server);
 
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE
+        Case(kUriFragCacheNotify, MeshForwarder);
+        Case(kUriFragCacheResend, MeshForwarder);
+#endif
+
 #if OPENTHREAD_CONFIG_TMF_NETDIAG_CLIENT_ENABLE
         Case(kUriDiagnosticGetAnswer, NetworkDiagnostic::Client);
 #endif

--- a/src/core/thread/uri_paths.cpp
+++ b/src/core/thread/uri_paths.cpp
@@ -95,6 +95,8 @@ struct Entry
     _("d/dg", kUriDiagnosticGetRequest, "DiagGetRequest")         \
     _("d/dq", kUriDiagnosticGetQuery, "DiagGetQuery")             \
     _("d/dr", kUriDiagnosticReset, "DiagReset")                   \
+    _("f/n", kUriFragCacheNotify, "FragCacheNotify")              \
+    _("f/r", kUriFragCacheResend, "FragCacheResend")              \
     _("h/an", kUriHistoryAnswer, "HistAnswer")                    \
     _("h/qy", kUriHistoryQuery, "HistQuery")                      \
     _("n/dn", kUriDuaRegistrationNotify, "DuaRegNotify")          \

--- a/src/core/thread/uri_paths.hpp
+++ b/src/core/thread/uri_paths.hpp
@@ -88,6 +88,8 @@ enum Uri : uint8_t
     kUriDiagnosticGetRequest,   ///< Network Diagnostic Get Request ("d/dg")
     kUriDiagnosticGetQuery,     ///< Network Diagnostic Get Query ("d/dq")
     kUriDiagnosticReset,        ///< Network Diagnostic Reset ("d/dr")
+    kUriFragCacheNotify,        ///< Fragment Cache Notify ("f/n")
+    kUriFragCacheResend,        ///< Fragment Cache Resend ("f/r")
     kUriHistoryAnswer,          ///< History Answer ("h/an")
     kUriHistoryQuery,           ///< History Query ("h/qy")
     kUriDuaRegistrationNotify,  ///< DUA Registration Notification ("n/dn")


### PR DESCRIPTION
Adds fragment cache retransmission support (OPENTHREAD_CONFIG_MESH_FRAG_CACHE_RETRANSMIT_ENABLE). When indirect TX to a sleepy child fails, the parent router caches the message and notifies the mesh source via CoAP. On retry, the source redirects retransmission to the caching router instead of forwarding through the full mesh path again, saving multi-hop airtime.