### PR TITLE
[mle] update `OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER` limit

### DIFF
--- a/src/core/config/mle.h
+++ b/src/core/config/mle.h
@@ -85,10 +85,13 @@
 /**
  * @def OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER
  *
- * The maximum number of IPv6 address registrations for MTD.
+ * The maximum number (as `uint16_t`) of IPv6 address registrations on an MTD with its parent.
+ *
+ * The default value is set to `0xffff` which is effectively as if no limit is set and requires an MTD child to register
+ * all its addresses.
  */
 #ifndef OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER
-#define OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER (OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD)
+#define OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER (0xffff)
 #endif
 
 /**

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3645,20 +3645,29 @@ Error Mle::TxMessage::AppendAddressRegistrationTlv(AddressRegistrationMode aMode
 {
     Error         error = kErrorNone;
     Tlv::Bookmark tlvBookmark;
-    uint8_t       counter = 0;
+    uint16_t      counter = 0;
+
+    static_assert(kMaxIpAddrsToRegisterOnMtd >= 1, "OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER MUST be at least 1");
 
     SuccessOrExit(error = Tlv::StartTlv(*this, Tlv::kAddressRegistration, tlvBookmark));
 
     // Prioritize ML-EID
     SuccessOrExit(error = AppendAddressRegistrationEntry(Get<Mle>().GetMeshLocalEid()));
-
-    // Continue to append the other addresses if not `kAppendMeshLocalOnly` mode
-    VerifyOrExit(aMode != kAppendMeshLocalOnly);
     counter++;
+
+    switch (aMode)
+    {
+    case kAppendAllAddresses:
+        break;
+    case kAppendMeshLocalOnly:
+        ExitNow();
+    }
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
     if (Get<ThreadNetif>().HasUnicastAddress(Get<DuaManager>().GetDomainUnicastAddress()))
     {
+        VerifyOrExit(counter < kMaxIpAddrsToRegisterOnMtd);
+
         // Prioritize DUA, compressed entry
         SuccessOrExit(error = AppendAddressRegistrationEntry(Get<DuaManager>().GetDomainUnicastAddress()));
         counter++;
@@ -3684,10 +3693,10 @@ Error Mle::TxMessage::AppendAddressRegistrationTlv(AddressRegistrationMode aMode
         }
 #endif
 
+        VerifyOrExit(counter < kMaxIpAddrsToRegisterOnMtd);
+
         SuccessOrExit(error = AppendAddressRegistrationEntry(addr.GetAddress()));
         counter++;
-        // only continue to append if there is available entry.
-        VerifyOrExit(counter < kMaxIpAddressesToRegister);
     }
 
     // Append external multicast addresses.  For sleepy end device,
@@ -3714,10 +3723,10 @@ Error Mle::TxMessage::AppendAddressRegistrationTlv(AddressRegistrationMode aMode
             }
 #endif
 
+            VerifyOrExit(counter < kMaxIpAddrsToRegisterOnMtd);
+
             SuccessOrExit(error = AppendAddressRegistrationEntry(addr.GetAddress()));
             counter++;
-            // only continue to append if there is available entry.
-            VerifyOrExit(counter < kMaxIpAddressesToRegister);
         }
     }
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1322,7 +1322,7 @@ private:
     static constexpr uint8_t  kMleHopLimit                   = 255;
     static constexpr uint8_t  kMleSecurityTagSize            = 4;
     static constexpr uint32_t kDefaultStoreFrameCounterAhead = OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD;
-    static constexpr uint8_t  kMaxIpAddressesToRegister      = OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER;
+    static constexpr uint16_t kMaxIpAddrsToRegisterOnMtd     = OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER;
     static constexpr uint32_t kDefaultChildTimeout           = OPENTHREAD_CONFIG_MLE_CHILD_TIMEOUT_DEFAULT;
     static constexpr uint32_t kDefaultCslTimeout             = OPENTHREAD_CONFIG_CSL_TIMEOUT;
 


### PR DESCRIPTION
This commit updates the default value of the configuration option `OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER` to `0xffff`. This effectively removes the limit on the number of IPv6 address registrations on an MTD with its parent by default, requiring an MTD child to register all its addresses.

It also fixes the logic in `AppendAddressRegistrationTlv()` to properly enforce the configured address limit. The limit check is now correctly performed before appending any new address. Previously if limit was set to an small value (say `2`) and DUA was present, we could potentially append extra unicast address.

It also changes the type of the constant `kMaxIpAddrsToRegisterOnMtd` (formerly `kMaxIpAddressesToRegister`) and the counter variable used in `Mle::TxMessage::AppendAddressRegistrationTlv()` from `uint8_t` to `uint16_t` to accommodate the new maximum value. A `static_assert` is added to ensure the configured limit is at least 1.