### PR TITLE
[mle] encapsulate router ID sequence and mask in `RouterIdMask`

### DIFF
--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -1111,7 +1111,7 @@ Error Mle::ProcessRouteTlv(const RouteTlv &aRouteTlv, RxInfo &aRxInfo)
         neighborRloc16 = aRxInfo.mNeighbor->GetRloc16();
     }
 
-    mRouterTable.UpdateRouterIdSet(aRouteTlv.GetRouterIdSequence(), aRouteTlv.GetRouterIdMask());
+    mRouterTable.UpdateRouterIdMask(aRouteTlv.GetRouterIdMask());
 
     if (IsAttached() && !mRouterTable.IsAllocated(RouterIdFromRloc16(GetRloc16())))
     {
@@ -3375,11 +3375,11 @@ exit:
 
 void Mle::HandleAddressSolicitResponse(Coap::Msg *aMsg, Error aResult)
 {
-    uint8_t             status;
-    uint16_t            rloc16;
-    ThreadRouterMaskTlv routerMaskTlv;
-    uint8_t             routerId;
-    Router             *router;
+    uint8_t      status;
+    uint16_t     rloc16;
+    RouterIdMask routerIdMask;
+    uint8_t      routerId;
+    Router      *router;
 
     mAddressSolicitPending = false;
 
@@ -3411,8 +3411,8 @@ void Mle::HandleAddressSolicitResponse(Coap::Msg *aMsg, Error aResult)
     SuccessOrExit(Tlv::Find<ThreadRloc16Tlv>(aMsg->mMessage, rloc16));
     routerId = RouterIdFromRloc16(rloc16);
 
-    SuccessOrExit(Tlv::FindTlv(aMsg->mMessage, routerMaskTlv));
-    VerifyOrExit(routerMaskTlv.IsValid());
+    SuccessOrExit(Tlv::Find<ThreadRouterMaskTlv>(aMsg->mMessage, routerIdMask));
+    VerifyOrExit(routerIdMask.IsValid());
 
     SetAlternateRloc16(GetRloc16());
 
@@ -3429,7 +3429,7 @@ void Mle::HandleAddressSolicitResponse(Coap::Msg *aMsg, Error aResult)
 
     mRouterTable.ClearNeighbors();
 
-    mRouterTable.UpdateRouterIdSet(routerMaskTlv.GetIdSequence(), routerMaskTlv.GetAssignedRouterIdMask());
+    mRouterTable.UpdateRouterIdMask(routerIdMask);
 
     router = mRouterTable.FindRouterById(routerId);
     VerifyOrExit(router != nullptr);
@@ -3655,15 +3655,12 @@ template <> void Mle::HandleTmf<kUriAddressSolicit>(Coap::Msg &aMsg)
 
     if (info.mRouter != nullptr)
     {
-        ThreadRouterMaskTlv routerMaskTlv;
+        RouterIdMask routerIdMask;
 
         SuccessOrExit(Tlv::Append<ThreadRloc16Tlv>(*response, info.mRouter->GetRloc16()));
 
-        routerMaskTlv.Init();
-        routerMaskTlv.SetIdSequence(mRouterTable.GetRouterIdSequence());
-        mRouterTable.GetRouterIdSet(routerMaskTlv.GetAssignedRouterIdMask());
-
-        SuccessOrExit(routerMaskTlv.AppendTo(*response));
+        mRouterTable.GetRouterIdMask(routerIdMask);
+        SuccessOrExit(Tlv::Append<ThreadRouterMaskTlv>(*response, routerIdMask));
     }
 
     SuccessOrExit(Get<Tmf::Agent>().SendMessage(*response, aMsg.mMessageInfo));

--- a/src/core/thread/mle_tlvs.cpp
+++ b/src/core/thread/mle_tlvs.cpp
@@ -56,15 +56,12 @@ void RouteTlv::Init(void)
 
 bool RouteTlv::IsValid(void) const
 {
-    bool    isValid = false;
-    uint8_t numAllocatedIds;
+    bool isValid = false;
 
-    VerifyOrExit(GetLength() >= sizeof(mRouterIdSequence) + sizeof(mRouterIdMask));
+    VerifyOrExit(GetLength() >= sizeof(mRouterIdMask));
 
-    numAllocatedIds = mRouterIdMask.GetNumberOfAllocatedIds();
-    VerifyOrExit(numAllocatedIds <= kMaxRouters);
-
-    isValid = (GetRouteDataLength() >= numAllocatedIds);
+    VerifyOrExit(mRouterIdMask.IsValid());
+    isValid = (GetRouteDataLength() >= mRouterIdMask.DetermineAllocatedCount());
 
 exit:
     return isValid;

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -256,36 +256,31 @@ public:
      *
      * @returns The Router ID Sequence value.
      */
-    uint8_t GetRouterIdSequence(void) const { return mRouterIdSequence; }
-
-    /**
-     * Sets the Router ID Sequence value.
-     *
-     * @param[in]  aSequence  The Router ID Sequence value.
-     */
-    void SetRouterIdSequence(uint8_t aSequence) { mRouterIdSequence = aSequence; }
+    uint8_t GetRouterIdSequence(void) const { return mRouterIdMask.GetSequence(); }
 
     /**
      * Gets the Router ID Mask.
+     *
+     * @returns The Router ID Mask.
      */
-    const RouterIdSet &GetRouterIdMask(void) const { return mRouterIdMask; }
+    const RouterIdMask &GetRouterIdMask(void) const { return mRouterIdMask; }
 
     /**
-     * Sets the Router ID Mask.
+     * Gets the Router ID Mask.
      *
-     * @param[in]  aRouterIdSet The Router ID Mask to set.
+     * @returns The Router ID Mask.
      */
-    void SetRouterIdMask(const RouterIdSet &aRouterIdSet) { mRouterIdMask = aRouterIdSet; }
+    RouterIdMask &GetRouterIdMask(void) { return mRouterIdMask; }
 
     /**
      * Indicates whether or not a Router ID bit is set.
      *
-     * @param[in]  aRouterId  The Router ID bit.
+     * @param[in]  aRouterId  The Router ID.
      *
      * @retval TRUE   If the Router ID bit is set.
      * @retval FALSE  If the Router ID bit is not set.
      */
-    bool IsRouterIdSet(uint8_t aRouterId) const { return mRouterIdMask.Contains(aRouterId); }
+    bool IsRouterIdSet(uint8_t aRouterId) const { return mRouterIdMask.IsAllocated(aRouterId); }
 
     /**
      * Indicates whether the `RouteTlv` is a singleton, i.e., only one router is allocated.
@@ -293,21 +288,21 @@ public:
      * @retval TRUE   It is a singleton.
      * @retval FALSE  It is not a singleton.
      */
-    bool IsSingleton(void) const { return IsValid() && (mRouterIdMask.GetNumberOfAllocatedIds() <= 1); }
+    bool IsSingleton(void) const { return IsValid() && (mRouterIdMask.DetermineAllocatedCount() <= 1); }
 
     /**
      * Returns the Route Data Length value.
      *
      * @returns The Route Data Length value.
      */
-    uint8_t GetRouteDataLength(void) const { return GetLength() - sizeof(mRouterIdSequence) - sizeof(mRouterIdMask); }
+    uint8_t GetRouteDataLength(void) const { return GetLength() - sizeof(mRouterIdMask); }
 
     /**
      * Sets the Route Data Length value.
      *
      * @param[in]  aLength  The Route Data Length value.
      */
-    void SetRouteDataLength(uint8_t aLength) { SetLength(sizeof(mRouterIdSequence) + sizeof(mRouterIdMask) + aLength); }
+    void SetRouteDataLength(uint8_t aLength) { SetLength(sizeof(mRouterIdMask) + aLength); }
 
     /**
      * Returns the Route Cost value for a given Router index.
@@ -365,9 +360,8 @@ private:
     static constexpr uint8_t kRouteCostOffset      = 0;
     static constexpr uint8_t kRouteCostMask        = 0xf << kRouteCostOffset;
 
-    uint8_t     mRouterIdSequence;
-    RouterIdSet mRouterIdMask;
-    uint8_t     mRouteData[kMaxRouterId + 1];
+    RouterIdMask mRouterIdMask;
+    uint8_t      mRouteData[kMaxRouterId + 1];
 } OT_TOOL_PACKED_END;
 
 #else // OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
@@ -394,33 +388,28 @@ public:
      * @retval TRUE   If the TLV appears to be well-formed.
      * @retval FALSE  If the TLV does not appear to be well-formed.
      */
-    bool IsValid(void) const { return GetLength() >= sizeof(mRouterIdSequence) + sizeof(mRouterIdMask); }
+    bool IsValid(void) const { return GetLength() >= sizeof(RouterIdMask); }
 
     /**
      * Returns the Router ID Sequence value.
      *
      * @returns The Router ID Sequence value.
      */
-    uint8_t GetRouterIdSequence(void) const { return mRouterIdSequence; }
-
-    /**
-     * Sets the Router ID Sequence value.
-     *
-     * @param[in]  aSequence  The Router ID Sequence value.
-     */
-    void SetRouterIdSequence(uint8_t aSequence) { mRouterIdSequence = aSequence; }
+    uint8_t GetRouterIdSequence(void) const { return mRouterIdMask.GetSequence(); }
 
     /**
      * Gets the Router ID Mask.
+     *
+     * @returns The Router ID Mask.
      */
-    const RouterIdSet &GetRouterIdMask(void) const { return mRouterIdMask; }
+    const RouterIdMask &GetRouterIdMask(void) const { return mRouterIdMask; }
 
     /**
-     * Sets the Router ID Mask.
+     * Gets the Router ID Mask.
      *
-     * @param[in]  aRouterIdSet The Router ID Mask to set.
+     * @returns The Router ID Mask.
      */
-    void SetRouterIdMask(const RouterIdSet &aRouterIdSet) { mRouterIdMask = aRouterIdSet; }
+    RouterIdMask &GetRouterIdMask(void) { return mRouterIdMask; }
 
     /**
      * Indicates whether or not a Router ID bit is set.
@@ -430,7 +419,7 @@ public:
      * @retval TRUE   If the Router ID bit is set.
      * @retval FALSE  If the Router ID bit is not set.
      */
-    bool IsRouterIdSet(uint8_t aRouterId) const { return mRouterIdMask.Contains(aRouterId); }
+    bool IsRouterIdSet(uint8_t aRouterId) const { return mRouterIdMask.IsAllocated(aRouterId); }
 
     /**
      * Indicates whether the `RouteTlv` is a singleton, i.e., only one router is allocated.
@@ -438,7 +427,7 @@ public:
      * @retval TRUE   It is a singleton.
      * @retval FALSE  It is not a singleton.
      */
-    bool IsSingleton(void) const { return IsValid() && (mRouterIdMask.GetNumberOfAllocatedIds() <= 1); }
+    bool IsSingleton(void) const { return IsValid() && (mRouterIdMask.DetermineAllocatedCount() <= 1); }
 
     /**
      * Sets the Router ID bit.
@@ -452,17 +441,14 @@ public:
      *
      * @returns The Route Data Length value in bytes
      */
-    uint8_t GetRouteDataLength(void) const { return GetLength() - sizeof(mRouterIdSequence) - sizeof(mRouterIdMask); }
+    uint8_t GetRouteDataLength(void) const { return GetLength() - sizeof(mRouterIdMask); }
 
     /**
      * Sets the Route Data Length value.
      *
      * @param[in]  aLength  The Route Data Length value in number of router entries
      */
-    void SetRouteDataLength(uint8_t aLength)
-    {
-        SetLength(sizeof(mRouterIdSequence) + sizeof(mRouterIdMask) + aLength + (aLength + 1) / 2);
-    }
+    void SetRouteDataLength(uint8_t aLength) { SetLength(sizeof(mRouterIdMask) + aLength + (aLength + 1) / 2); }
 
     /**
      * Returns the Route Cost value for a given Router index.
@@ -574,8 +560,7 @@ private:
             ((aLinkQuality << (kLinkQualityOutOffset - offset)) & (kLinkQualityOutMask >> offset));
     }
 
-    uint8_t     mRouterIdSequence;
-    RouterIdSet mRouterIdMask;
+    RouterIdMask mRouterIdMask;
     // Since we do hold 12 (compressible to 11) bits of data per router, each entry occupies 1.5 bytes,
     // consecutively. First 4 bits are link qualities, remaining 8 bits are route cost.
     uint8_t mRouteData[kMaxRouterId + 1 + kMaxRouterId / 2 + 1];

--- a/src/core/thread/mle_types.cpp
+++ b/src/core/thread/mle_types.cpp
@@ -145,18 +145,25 @@ uint8_t DeviceProperties::CalculateLeaderWeight(void) const
 #endif // #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MLE_DEVICE_PROPERTY_LEADER_WEIGHT_ENABLE
 
 //---------------------------------------------------------------------------------------------------------------------
-// RouterIdSet
+// RouterIdMask
 
-uint8_t RouterIdSet::GetNumberOfAllocatedIds(void) const
+uint8_t RouterIdMask::DetermineAllocatedCount(void) const
 {
     uint8_t count = 0;
 
-    for (uint8_t byte : mRouterIdSet)
+    for (uint8_t byte : mMask)
     {
         count += CountBitsInMask(byte);
     }
 
     return count;
+}
+
+Error RouterIdMask::AppendMaskTo(Message &aMessage) const { return aMessage.AppendBytes(mMask, kMaskSize); }
+
+Error RouterIdMask::ReadMaskFrom(const Message &aMessage, const OffsetRange &aOffsetRange)
+{
+    return aMessage.Read(aOffsetRange, mMask, kMaskSize);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -622,45 +622,99 @@ public:
     void SetLeaderRouterId(uint8_t aRouterId) { mLeaderRouterId = aRouterId; }
 };
 
+/**
+ * Represents a Router ID Sequence and Mask.
+ *
+ * This type is defined as packed and is used in `RouteTlv` and `ThreadRouterMaskTlv`.
+ */
 OT_TOOL_PACKED_BEGIN
-class RouterIdSet : public Equatable<RouterIdSet>, public Clearable<RouterIdSet>
+class RouterIdMask : public Clearable<RouterIdMask>
 {
 public:
     /**
-     * Indicates whether or not a Router ID bit is set.
+     * The size of the Router ID mask in bytes.
+     */
+    static constexpr uint8_t kMaskSize = BytesForBitSize(kMaxRouterId + 1);
+
+    /**
+     * Indicates whether or not the mask is valid (count of allocated Router IDs is within the limit).
+     *
+     * @retval TRUE   If the mask is valid.
+     * @retval FALSE  If the mask is not valid.
+     */
+    bool IsValid(void) const { return (DetermineAllocatedCount() <= kMaxRouters); }
+
+    /**
+     * Gets the Router ID Sequence number associated with the mask.
+     *
+     * @returns The Router ID Sequence number.
+     */
+    uint8_t GetSequence(void) const { return mSequence; }
+
+    /**
+     * Sets the Router ID Sequence value.
+     *
+     * @param[in]  aSequence  The Router ID Sequence value.
+     */
+    void SetSequence(uint8_t aSequence) { mSequence = aSequence; }
+
+    /**
+     * Indicates whether or not a Router ID bit is set in the mask.
      *
      * @param[in]  aRouterId  The Router ID.
      *
-     * @retval TRUE   If the Router ID bit is set.
-     * @retval FALSE  If the Router ID bit is not set.
+     * @retval TRUE   If the Router ID bit is set in the mask.
+     * @retval FALSE  If the Router ID bit is not set in the mask.
      */
-    bool Contains(uint8_t aRouterId) const { return (mRouterIdSet[aRouterId / 8] & MaskFor(aRouterId)) != 0; }
+    bool IsAllocated(uint8_t aRouterId) const { return (mMask[aRouterId / 8] & MaskFor(aRouterId)) != 0; }
 
     /**
-     * Sets a given Router ID.
+     * Sets a given Router ID in the mask.
      *
      * @param[in]  aRouterId  The Router ID to set.
      */
-    void Add(uint8_t aRouterId) { mRouterIdSet[aRouterId / 8] |= MaskFor(aRouterId); }
+    void Add(uint8_t aRouterId) { mMask[aRouterId / 8] |= MaskFor(aRouterId); }
 
     /**
-     * Removes a given Router ID.
+     * Removes a given Router ID from the mask.
      *
      * @param[in]  aRouterId  The Router ID to remove.
      */
-    void Remove(uint8_t aRouterId) { mRouterIdSet[aRouterId / 8] &= ~MaskFor(aRouterId); }
+    void Remove(uint8_t aRouterId) { mMask[aRouterId / 8] &= ~MaskFor(aRouterId); }
 
     /**
-     * Calculates the number of allocated Router IDs in the set.
+     * Calculates the number of allocated Router IDs in the mask.
      *
-     * @returns The number of allocated Router IDs in the set.
+     * @returns The number of allocated Router IDs in the mask.
      */
-    uint8_t GetNumberOfAllocatedIds(void) const;
+    uint8_t DetermineAllocatedCount(void) const;
+
+    /**
+     * Appends the Router ID mask (excluding the sequence) to a message.
+     *
+     * @param[in]  aMessage  The message to append to.
+     *
+     * @retval kErrorNone    Successfully appended the mask.
+     * @retval kErrorNoBufs  Insufficient available buffers to grow the message.
+     */
+    Error AppendMaskTo(Message &aMessage) const;
+
+    /**
+     * Reads the Router ID mask (excluding the sequence) from a message within a given offset range.
+     *
+     * @param[in]  aMessage      The message to read from.
+     * @param[in]  aOffsetRange  The offset range to read from.
+     *
+     * @retval kErrorNone   Successfully read the mask.
+     * @retval kErrorParse  Not enough bytes remaining in the message to read the mask.
+     */
+    Error ReadMaskFrom(const Message &aMessage, const OffsetRange &aOffsetRange);
 
 private:
     static uint8_t MaskFor(uint8_t aRouterId) { return (0x80 >> (aRouterId % 8)); }
 
-    uint8_t mRouterIdSet[BytesForBitSize(kMaxRouterId + 1)];
+    uint8_t mSequence;
+    uint8_t mMask[kMaskSize];
 } OT_TOOL_PACKED_END;
 
 class TxChallenge;

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -105,20 +105,20 @@ Error Server::AppendEnhancedRoute(Message &aMessage)
 {
     Error                 error = kErrorNone;
     Tlv::Bookmark         tlvBookmark;
-    Mle::RouterIdSet      routerIdSet;
+    Mle::RouterIdMask     routerIdMask;
     EnhancedRouteTlvEntry entry;
 
     VerifyOrExit(Get<Mle::Mle>().IsRouterOrLeader());
 
-    Get<RouterTable>().GetRouterIdSet(routerIdSet);
+    Get<RouterTable>().GetRouterIdMask(routerIdMask);
 
     SuccessOrExit(error = Tlv::StartTlv(aMessage, Tlv::kEnhancedRoute, tlvBookmark));
 
-    SuccessOrExit(error = aMessage.Append(routerIdSet));
+    SuccessOrExit(error = routerIdMask.AppendMaskTo(aMessage));
 
     for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
     {
-        if (!routerIdSet.Contains(routerId))
+        if (!routerIdMask.IsAllocated(routerId))
         {
             continue;
         }
@@ -1038,11 +1038,11 @@ static void ParseRoute(const RouteTlv &aRouteTlv, otNetworkDiagRoute &aNetworkDi
 
 static Error ParseEnhancedRoute(const Message &aMessage, uint16_t aOffset, otNetworkDiagEnhRoute &aNetworkDiagEnhRoute)
 {
-    Error            error;
-    OffsetRange      offsetRange;
-    Tlv              tlv;
-    Mle::RouterIdSet routerIdSet;
-    uint8_t          index;
+    Error             error;
+    OffsetRange       offsetRange;
+    Tlv               tlv;
+    Mle::RouterIdMask routerIdMask;
+    uint8_t           index;
 
     SuccessOrExit(error = aMessage.Read(aOffset, tlv));
 
@@ -1052,8 +1052,8 @@ static Error ParseEnhancedRoute(const Message &aMessage, uint16_t aOffset, otNet
     aOffset += sizeof(tlv);
     offsetRange.Init(aOffset, tlv.GetLength());
 
-    SuccessOrExit(error = aMessage.Read(offsetRange, routerIdSet));
-    offsetRange.AdvanceOffset(sizeof(routerIdSet));
+    SuccessOrExit(error = routerIdMask.ReadMaskFrom(aMessage, offsetRange));
+    offsetRange.AdvanceOffset(Mle::RouterIdMask::kMaskSize);
 
     index = 0;
 
@@ -1061,7 +1061,7 @@ static Error ParseEnhancedRoute(const Message &aMessage, uint16_t aOffset, otNet
     {
         EnhancedRouteTlvEntry entry;
 
-        if (!routerIdSet.Contains(routerId))
+        if (!routerIdMask.IsAllocated(routerId))
         {
             continue;
         }

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -522,19 +522,19 @@ uint16_t RouterTable::GetNextHop(uint16_t aDestRloc16) const
     return nextHopRloc16;
 }
 
-void RouterTable::UpdateRouterIdSet(uint8_t aRouterIdSequence, const Mle::RouterIdSet &aRouterIdSet)
+void RouterTable::UpdateRouterIdMask(const Mle::RouterIdMask &aRouterIdMask)
 {
     bool shouldAdd = false;
 
-    mRouterIdSequence            = aRouterIdSequence;
+    mRouterIdSequence            = aRouterIdMask.GetSequence();
     mRouterIdSequenceLastUpdated = TimerMilli::GetNow();
 
     // Remove all previously allocated routers that are now removed in
-    // new `aRouterIdSet`.
+    // new `aRouterIdMask`.
 
     for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
     {
-        if (IsAllocated(routerId) == aRouterIdSet.Contains(routerId))
+        if (IsAllocated(routerId) == aRouterIdMask.IsAllocated(routerId))
         {
             continue;
         }
@@ -556,11 +556,11 @@ void RouterTable::UpdateRouterIdSet(uint8_t aRouterIdSequence, const Mle::Router
 
     VerifyOrExit(shouldAdd);
 
-    // Now add all new routers in `aRouterIdSet`.
+    // Now add all new routers in `aRouterIdMask`.
 
     for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
     {
-        if (!IsAllocated(routerId) && aRouterIdSet.Contains(routerId))
+        if (!IsAllocated(routerId) && aRouterIdMask.IsAllocated(routerId))
         {
             AddRouter(routerId);
         }
@@ -574,9 +574,9 @@ exit:
 
 void RouterTable::UpdateRoutes(const Mle::RouteTlv &aRouteTlv, uint8_t aNeighborId)
 {
-    Router          *neighbor;
-    Mle::RouterIdSet finitePathCostIdSet;
-    uint8_t          linkCostToNeighbor;
+    Router           *neighbor;
+    Mle::RouterIdMask finitePathCostIds;
+    uint8_t           linkCostToNeighbor;
 
     neighbor = FindRouterById(aNeighborId);
     VerifyOrExit(neighbor != nullptr);
@@ -586,13 +586,13 @@ void RouterTable::UpdateRoutes(const Mle::RouteTlv &aRouteTlv, uint8_t aNeighbor
     // cost changed from finite to infinite or vice versa to decide
     // whether to reset the  MLE Advertisement interval.
 
-    finitePathCostIdSet.Clear();
+    finitePathCostIds.Clear();
 
     for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
     {
         if (GetPathCost(Mle::Rloc16FromRouterId(routerId)) < Mle::kMaxRouteCost)
         {
-            finitePathCostIdSet.Add(routerId);
+            finitePathCostIds.Add(routerId);
         }
     }
 
@@ -701,7 +701,7 @@ void RouterTable::UpdateRoutes(const Mle::RouteTlv &aRouteTlv, uint8_t aNeighbor
 
     for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
     {
-        bool oldCostFinite = finitePathCostIdSet.Contains(routerId);
+        bool oldCostFinite = finitePathCostIds.IsAllocated(routerId);
         bool newCostFinite = (GetPathCost(Mle::Rloc16FromRouterId(routerId)) < Mle::kMaxRouteCost);
 
         if (newCostFinite != oldCostFinite)
@@ -746,13 +746,25 @@ void RouterTable::UpdateRouterOnFtdChild(const Mle::RouteTlv &aRouteTlv, uint8_t
     }
 }
 
+void RouterTable::GetRouterIdMask(Mle::RouterIdMask &aRouterIdMask) const
+{
+    aRouterIdMask.Clear();
+    aRouterIdMask.SetSequence(GetRouterIdSequence());
+
+    for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
+    {
+        if (IsAllocated(routerId))
+        {
+            aRouterIdMask.Add(routerId);
+        }
+    }
+}
+
 void RouterTable::FillRouteTlv(Mle::RouteTlv &aRouteTlv, const Neighbor *aNeighbor) const
 {
-    uint8_t          routerIdSequence = mRouterIdSequence;
-    Mle::RouterIdSet routerIdSet;
-    uint8_t          routerIndex;
+    uint8_t routerIndex;
 
-    mRouterIdMap.GetAsRouterIdSet(routerIdSet);
+    GetRouterIdMask(aRouteTlv.GetRouterIdMask());
 
     if ((aNeighbor != nullptr) && Mle::IsRouterRloc16(aNeighbor->GetRloc16()))
     {
@@ -779,21 +791,18 @@ void RouterTable::FillRouteTlv(Mle::RouteTlv &aRouteTlv, const Neighbor *aNeighb
                     continue;
                 }
 
-                if (routerIdSet.Contains(routerId))
+                if (aRouteTlv.GetRouterIdMask().IsAllocated(routerId))
                 {
-                    routerIdSet.Remove(routerId);
+                    aRouteTlv.GetRouterIdMask().Remove(routerId);
                     routerCount--;
                 }
             }
 
             // Ensure that the neighbor will process the current
             // Route64 TLV in a subsequent message exchange
-            routerIdSequence -= kLinkAcceptSequenceRollback;
+            aRouteTlv.GetRouterIdMask().SetSequence(GetRouterIdSequence() - kLinkAcceptSequenceRollback);
         }
     }
-
-    aRouteTlv.SetRouterIdSequence(routerIdSequence);
-    aRouteTlv.SetRouterIdMask(routerIdSet);
 
     routerIndex = 0;
 
@@ -801,7 +810,7 @@ void RouterTable::FillRouteTlv(Mle::RouteTlv &aRouteTlv, const Neighbor *aNeighb
     {
         uint16_t routerRloc16;
 
-        if (!routerIdSet.Contains(routerId))
+        if (!aRouteTlv.GetRouterIdMask().IsAllocated(routerId))
         {
             continue;
         }
@@ -872,19 +881,6 @@ exit:
     return error;
 }
 #endif
-
-void RouterTable::RouterIdMap::GetAsRouterIdSet(Mle::RouterIdSet &aRouterIdSet) const
-{
-    aRouterIdSet.Clear();
-
-    for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
-    {
-        if (IsAllocated(routerId))
-        {
-            aRouterIdSet.Add(routerId);
-        }
-    }
-}
 
 void RouterTable::RouterIdMap::HandleTimeTick(void)
 {

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -339,12 +339,11 @@ public:
     bool IsAllocated(uint8_t aRouterId) const { return mRouterIdMap.IsAllocated(aRouterId); }
 
     /**
-     * Updates the Router ID allocation set.
+     * Updates the allocated Router ID mask.
      *
-     * @param[in]  aRouterIdSequence  The Router ID Sequence.
-     * @param[in]  aRouterIdSet       The Router ID Set.
+     * @param[in]  aRouterIdMask      The Router ID Mask.
      */
-    void UpdateRouterIdSet(uint8_t aRouterIdSequence, const Mle::RouterIdSet &aRouterIdSet);
+    void UpdateRouterIdMask(const Mle::RouterIdMask &aRouterIdMask);
 
     /**
      * Updates the routes based on a received `RouteTlv` from a neighboring router.
@@ -365,11 +364,11 @@ public:
     void UpdateRouterOnFtdChild(const Mle::RouteTlv &aRouteTlv, uint8_t aParentId);
 
     /**
-     * Gets the allocated Router ID set.
+     * Gets the allocated Router ID Mask.
      *
-     * @param[out]  aRouterIdSet   A reference to output the allocated Router ID set.
+     * @param[out]  aRouterIdMask   A reference to output the allocated Router ID Mask.
      */
-    void GetRouterIdSet(Mle::RouterIdSet &aRouterIdSet) const { return mRouterIdMap.GetAsRouterIdSet(aRouterIdSet); }
+    void GetRouterIdMask(Mle::RouterIdMask &aRouterIdMask) const;
 
     /**
      * Fills a Route TLV.
@@ -462,7 +461,6 @@ private:
         void    SetIndex(uint8_t aRouterId, uint8_t aIndex) { mIndexes[aRouterId] = kAllocatedFlag | aIndex; }
         bool    CanAllocate(uint8_t aRouterId) const { return (mIndexes[aRouterId] == 0); }
         void    Release(uint8_t aRouterId) { mIndexes[aRouterId] = kReuseDelay; }
-        void    GetAsRouterIdSet(Mle::RouterIdSet &aRouterIdSet) const;
         void    HandleTimeTick(void);
 
     private:

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -137,69 +137,9 @@ typedef UintTlvInfo<ThreadTlv::kCommissionerSessionId, uint16_t> ThreadCommissio
 typedef UintTlvInfo<ThreadTlv::kStatus, uint8_t> ThreadStatusTlv;
 
 /**
- * Implements Router Mask TLV generation and parsing.
+ * Defines Router Mask TLV  constants and types.
  */
-OT_TOOL_PACKED_BEGIN
-class ThreadRouterMaskTlv : public ThreadTlv, public TlvInfo<ThreadTlv::kRouterMask>
-{
-public:
-    /**
-     * Initializes the TLV.
-     */
-    void Init(void)
-    {
-        SetType(kRouterMask);
-        SetLength(sizeof(*this) - sizeof(ThreadTlv));
-        mAssignedRouterIdMask.Clear();
-    }
-
-    /**
-     * Indicates whether or not the TLV appears to be well-formed.
-     *
-     * @retval TRUE   If the TLV appears to be well-formed.
-     * @retval FALSE  If the TLV does not appear to be well-formed.
-     */
-    bool IsValid(void) const { return GetLength() >= sizeof(*this) - sizeof(ThreadTlv); }
-
-    /**
-     * Returns the ID Sequence value.
-     *
-     * @returns The ID Sequence value.
-     */
-    uint8_t GetIdSequence(void) const { return mIdSequence; }
-
-    /**
-     * Sets the ID Sequence value.
-     *
-     * @param[in]  aSequence  The ID Sequence value.
-     */
-    void SetIdSequence(uint8_t aSequence) { mIdSequence = aSequence; }
-
-    /**
-     * Gets the Assigned Router ID Mask.
-     *
-     * @returns The Assigned Router ID Mask.
-     */
-    const Mle::RouterIdSet &GetAssignedRouterIdMask(void) const { return mAssignedRouterIdMask; }
-
-    /**
-     * Gets the Assigned Router ID Mask.
-     *
-     * @returns The Assigned Router ID Mask.
-     */
-    Mle::RouterIdSet &GetAssignedRouterIdMask(void) { return mAssignedRouterIdMask; }
-
-    /**
-     * Sets the Assigned Router ID Mask.
-     *
-     * @param[in]  aRouterIdSet A reference to the Assigned Router ID Mask.
-     */
-    void SetAssignedRouterIdMask(const Mle::RouterIdSet &aRouterIdSet) { mAssignedRouterIdMask = aRouterIdSet; }
-
-private:
-    uint8_t          mIdSequence;
-    Mle::RouterIdSet mAssignedRouterIdMask;
-} OT_TOOL_PACKED_END;
+typedef SimpleTlvInfo<ThreadTlv::kRouterMask, Mle::RouterIdMask> ThreadRouterMaskTlv;
 
 /**
  * Defines Thread Network Data TLV constants and types.

--- a/src/core/utils/mesh_diag.cpp
+++ b/src/core/utils/mesh_diag.cpp
@@ -88,13 +88,13 @@ Error MeshDiag::DiscoverTopology(const DiscoverConfig &aConfig, DiscoverCallback
         tlvs[tlvsLength++] = ChildTableTlv::kType;
     }
 
-    Get<RouterTable>().GetRouterIdSet(mDiscover.mExpectedRouterIdSet);
+    Get<RouterTable>().GetRouterIdMask(mDiscover.mExpectedRouterIds);
 
     for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
     {
         Ip6::Address destination;
 
-        if (!mDiscover.mExpectedRouterIdSet.Contains(routerId))
+        if (!mDiscover.mExpectedRouterIds.IsAllocated(routerId))
         {
             continue;
         }
@@ -136,9 +136,9 @@ void MeshDiag::HandleDiagGetResponse(Coap::Msg *aMsg, Error aResult)
         routerInfo.mChildIterator = &childIterator;
     }
 
-    mDiscover.mExpectedRouterIdSet.Remove(routerInfo.mRouterId);
+    mDiscover.mExpectedRouterIds.Remove(routerInfo.mRouterId);
 
-    if (mDiscover.mExpectedRouterIdSet.GetNumberOfAllocatedIds() == 0)
+    if (mDiscover.mExpectedRouterIds.DetermineAllocatedCount() == 0)
     {
         error  = kErrorNone;
         mState = kStateIdle;

--- a/src/core/utils/mesh_diag.hpp
+++ b/src/core/utils/mesh_diag.hpp
@@ -260,7 +260,7 @@ private:
     struct DiscoverInfo
     {
         Callback<DiscoverCallback> mCallback;
-        Mle::RouterIdSet           mExpectedRouterIdSet;
+        Mle::RouterIdMask          mExpectedRouterIds;
     };
 
     struct QueryChildTableInfo


### PR DESCRIPTION
This commit updates the `RouterIdSet` class, renaming it to `RouterIdMask` and expanding it to encapsulate both the router ID sequence number and the bitmask. This allows simplifying the definition of `ThreadRouterMaskTlv` and `RouteTlv`.