### PR TITLE
[nexus] fix intermittent failures in 1.4 DNS and PIC tests

### DIFF
--- a/tests/nexus/test_1_4_DNS_TC_1.cpp
+++ b/tests/nexus/test_1_4_DNS_TC_1.cpp
@@ -158,7 +158,7 @@ void Test_1_4_DNS_TC_1(const char *aJsonFileName)
     r1.Join(br1);
     nexus.AdvanceTime(kJoinNetworkTime);
 
-    ed1.Join(r1);
+    ed1.Join(r1, Node::kAsFed);
     nexus.AdvanceTime(kJoinNetworkTime);
 
     // Setup BR_1 as Border Router

--- a/tests/nexus/test_1_4_DNS_TC_5.cpp
+++ b/tests/nexus/test_1_4_DNS_TC_5.cpp
@@ -287,7 +287,7 @@ void Test_1_4_DNS_TC_5(const char *aJsonFileName)
     br1.Form();
     nexus.AdvanceTime(kFormNetworkTime);
 
-    ed1.Join(br1);
+    ed1.Join(br1, Node::kAsFed);
     nexus.AdvanceTime(kJoinNetworkTime);
 
     br1.Get<BorderRouter::InfraIf>().Init(1, true);

--- a/tests/nexus/test_1_4_PIC_TC_1.cpp
+++ b/tests/nexus/test_1_4_PIC_TC_1.cpp
@@ -349,7 +349,7 @@ void Test_1_4_PIC_TC_1(void)
     r1.Join(br1);
     nexus.AdvanceTime(kJoinNetworkTime);
 
-    ed1.Join(r1);
+    ed1.Join(r1, Node::kAsFed);
     nexus.AdvanceTime(kJoinNetworkTime);
 
     Log("Step 4: BR_1 obtains OMR prefix via DHCPv6-PD");

--- a/tests/nexus/test_1_4_PIC_TC_3.cpp
+++ b/tests/nexus/test_1_4_PIC_TC_3.cpp
@@ -308,7 +308,7 @@ void Test_1_4_PIC_TC_3(void)
     r1.Join(br1);
     nexus.AdvanceTime(kJoinNetworkTime);
 
-    ed1.Join(r1);
+    ed1.Join(r1, Node::kAsFed);
     nexus.AdvanceTime(kJoinNetworkTime);
 
     Log("Step 4: BR_1 obtains OMR prefix via DHCPv6-PD");

--- a/tests/nexus/test_1_4_PIC_TC_4.cpp
+++ b/tests/nexus/test_1_4_PIC_TC_4.cpp
@@ -253,7 +253,7 @@ void Test_1_4_PIC_TC_4(void)
     r1.Join(br1);
     nexus.AdvanceTime(kJoinNetworkTime);
 
-    ed1.Join(r1);
+    ed1.Join(r1, Node::kAsFed);
     nexus.AdvanceTime(kJoinNetworkTime);
 
     Log("Step 4: BR_1 configures IPv4 address and NAT64 prefix");


### PR DESCRIPTION
This commit addresses intermittent failures in Nexus tests 1_4_DNS_TC_1, 1_4_DNS_TC_5, 1_4_PIC_TC_1, 1_4_PIC_TC_3, and 1_4_PIC_TC_4.

The issue was caused by the 'ed1' node occasionally upgrading its role from an End Device to a Router. When 'ed1' became a router, it would sometimes use its Routing Locator (RLOC) as the source address for DNS queries, whereas the verification scripts expected its Mesh Local Endpoint Identifier (MLEID), leading to packet verification failures.

To resolve this, 'ed1' is now explicitly joined as a Full End Device (FED) using 'Node::kAsFed' instead of the default Full Thread Device (FTD) mode. This prevents 'ed1' from becoming a router and ensures it maintains its End Device role throughout the test, providing stable addressing for verification.