### PR TITLE
[nexus] fix unused variable warning in otPlatRadioTransmit

### DIFF
--- a/tests/nexus/platform/nexus_radio.cpp
+++ b/tests/nexus/platform/nexus_radio.cpp
@@ -140,6 +140,8 @@ otRadioFrame *otPlatRadioGetTransmitBuffer(otInstance *aInstance) { return &AsNo
 
 otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
 {
+    OT_UNUSED_VARIABLE(aFrame);
+
     Error  error = kErrorNone;
     Radio &radio = AsNode(aInstance).mRadio;
 


### PR DESCRIPTION
This commit fixes a compiler warning in nexus_radio.cpp where the aFrame parameter in otPlatRadioTransmit was considered unused in non-debug builds. The variable is only used within an OT_ASSERT.

Using OT_UNUSED_VARIABLE is the standard OpenThread pattern to address unused parameters and ensure clean builds across different compilers and build configurations.