### PR TITLE
[nexus] refine CHILD_REMOVED event suppression

### DIFF
--- a/tests/nexus/platform/nexus_core.cpp
+++ b/tests/nexus/platform/nexus_core.cpp
@@ -37,7 +37,6 @@
 #include "nexus_radio_model.hpp"
 #include "thread/child_table.hpp"
 #include "thread/mle.hpp"
-#include "thread/neighbor_table.hpp"
 
 namespace ot {
 namespace Nexus {
@@ -464,11 +463,10 @@ void Core::HandleNeighborTableChanged(otNeighborTableEvent aEvent, const otNeigh
         if (event == NeighborTable::kChildRemoved)
         {
             Instance &instance = *static_cast<Instance *>(aInfo->mInstance);
-            Neighbor *neighbor = instance.Get<NeighborTable>().FindNeighbor(*extAddr, Neighbor::kInStateValid);
 
-            if (neighbor != nullptr)
+            if (instance.Get<RouterTable>().FindRouter(*extAddr) != nullptr)
             {
-                Log("Suppressing CHILD_REMOVED event because neighbor link is established");
+                Log("Suppressing CHILD_REMOVED event because neighbor is a valid router");
                 ExitNow();
             }
         }


### PR DESCRIPTION
Refine the event suppression logic in nexus_core.cpp when handling NeighborTable::kChildRemoved events.

Previously, any valid neighbor found would suppress the event. Now, it only suppresses the event if the node is found in the Router table. This ensures that removal events for Sleepy End Devices (SEDs) are not suppressed, allowing the link to disappear in the visualizer as expected.