### PR TITLE
[nexus] set RSSI in simulated ACK frames

### DIFF
--- a/tests/nexus/platform/nexus_core.cpp
+++ b/tests/nexus/platform/nexus_core.cpp
@@ -889,9 +889,25 @@ void Core::ProcessRadio(Node &aNode)
         }
 
         ackFrame.UpdateFcs();
-        mPcap.WriteFrame(ackFrame, mNow);
 
-        otPlatRadioTxDone(&aNode.GetInstance(), &aNode.mRadio.mTxFrame, &ackFrame, kErrorNone);
+        {
+            int16_t ackRssi = RadioModel::CalculateRssi(*ackNode, aNode);
+
+            ackFrame.mInfo.mRxInfo.mRssi      = ClampToInt8(ackRssi);
+            ackFrame.mInfo.mRxInfo.mLqi       = kDefaultRxLqi;
+            ackFrame.mInfo.mRxInfo.mTimestamp = mNow;
+
+            mPcap.WriteFrame(ackFrame, mNow);
+
+            if (RadioModel::ShouldDropPacket(ackRssi))
+            {
+                otPlatRadioTxDone(&aNode.GetInstance(), &aNode.mRadio.mTxFrame, nullptr, kErrorNoAck);
+            }
+            else
+            {
+                otPlatRadioTxDone(&aNode.GetInstance(), &aNode.mRadio.mTxFrame, &ackFrame, kErrorNone);
+            }
+        }
     }
     else
     {


### PR DESCRIPTION
Set the RSSI field in simulated MAC ACK frames in nexus_core.cpp.

Previously, the simulator did not populate the mRssi field in the mInfo.mRxInfo structure of simulated ACK frames passed to otPlatRadioTxDone. This caused OpenThread to ignore the RSSI of ACKs, preventing the parentRss average from updating on successful data polls from Sleepy End Devices (SEDs).

Now, the RSSI from the parent to the child is calculated using the radio model and clamped to int8_t before being assigned to the ACK frame.