### PR TITLE
[nexus] fix intermittent failure in dns_client_config_auto_start test

### DIFF
--- a/tests/nexus/test_dns_client_config_auto_start.cpp
+++ b/tests/nexus/test_dns_client_config_auto_start.cpp
@@ -48,7 +48,7 @@ static constexpr uint32_t kJoinNetworkTime = 10 * 1000;
 /**
  * Time to advance for the network to stabilize, in milliseconds.
  */
-static constexpr uint32_t kStabilizationTime = 15 * 1000;
+static constexpr uint32_t kStabilizationTime = 200 * 1000;
 
 /**
  * Default DNS server address for testing.


### PR DESCRIPTION
This commit fixes an intermittent failure in the Nexus test 'dns_client_config_auto_start'. The test was occasionally failing because the REED node was not upgrading to the Router role within the previous 15-second stabilization period.

The Router role transition can take up to 120 seconds due to the default 'ROUTER_SELECTION_JITTER' parameter. This commit increases 'kStabilizationTime' to 200 seconds to ensure the node has ample time to become a router before the test proceeds to verify its DNS configuration.