### PR TITLE
[diag] invoke SetDiagMode before setting channel/power

### DIFF
--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -491,19 +491,24 @@ Error Diags::ProcessStart(uint8_t aArgsLength, char *aArgs[])
     VerifyOrExit(!Get<ThreadNetif>().IsUp(), error = kErrorInvalidState);
 #endif
 
+    mStats.Clear();
+    IgnoreError(Get<Radio>().Enable());
+    Get<Radio>().SetDiagMode(true);
     otPlatDiagChannelSet(mChannel);
     otPlatDiagTxPowerSet(mTxPower);
 
-    IgnoreError(Get<Radio>().Enable());
     Get<Radio>().SetPromiscuous(true);
     Get<Mac::SubMac>().SetRxOnWhenIdle(true);
     otPlatAlarmMilliStop(&GetInstance());
     SuccessOrExit(error = Get<Radio>().Receive(mChannel));
     SuccessOrExit(error = Get<Radio>().SetTransmitPower(mTxPower));
-    Get<Radio>().SetDiagMode(true);
-    mStats.Clear();
 
 exit:
+    if (error != kErrorNone)
+    {
+        Get<Radio>().SetDiagMode(false);
+    }
+
     return error;
 }
 


### PR DESCRIPTION
In Host + RCP mode, running `diag start` from the host CLI may trigger RadioSpinel warnings: InvalidState, “Error processing result” / “Error waiting response”.

**Root cause**
Diags::ProcessStart sent channel / power commands before enabling diag mode. On Spinel, these are forwarded to the RCP (via `SPINEL_PROP_NEST_STREAM_MFG`), but the RCP only accepts other diag commands after start.
```    
    if (!IsEnabled() && !StringMatch(aArgs[0], "start"))
    {
        Output("diagnostics mode is disabled\r\n");
        ExitNow(error = kErrorInvalidState);
    }
```
As a result, early channel / power commands are rejected with InvalidState.

So, SetDiagMode should be invoked before setting channel/power.

