### PR TITLE
[mle] bound attach backoff time during initial duration of SED being detached

### DIFF
--- a/src/core/config/mle.h
+++ b/src/core/config/mle.h
@@ -186,6 +186,33 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_INITIAL_MAX_INTERVAL
+ *
+ * Specifies the maximum backoff wait interval (in milliseconds) during the initial period after detach.
+ *
+ * During the initial period after detach (specified by `OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_INITIAL_PERIOD`),
+ * the backoff interval is clamped to this value. This allows more frequent attach attempts while a distressed
+ * parent stabilizes.
+ *
+ * Applicable only if attach backoff feature is enabled (see `OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_ENABLE`).
+ */
+#ifndef OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_INITIAL_MAX_INTERVAL
+#define OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_INITIAL_MAX_INTERVAL 60000 // 60 seconds = 1 minute
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_INITIAL_PERIOD
+ *
+ * Specifies the duration (in milliseconds) of the initial period after detach during which the backoff
+ * interval is clamped to `OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_INITIAL_MAX_INTERVAL`.
+ *
+ * Applicable only if attach backoff feature is enabled (see `OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_ENABLE`).
+ */
+#ifndef OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_INITIAL_PERIOD
+#define OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_INITIAL_PERIOD 300000 // 300 seconds = 5 minutes
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_DELAY_TO_RESET_BACKOFF_INTERVAL
  *
  * Specifies the delay wait interval (in milliseconds) used by attach backoff feature after a successful attach before

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -4606,6 +4606,11 @@ void Mle::Attacher::Attach(AttachMode aMode)
 
     if (Get<Mle>().IsDetached())
     {
+        if (mAttachCounter == 0)
+        {
+            mDetachTime = TimerMilli::GetNow();
+        }
+
         mAttachCounter++;
 
         if (mAttachCounter == 0)
@@ -4651,6 +4656,11 @@ uint32_t Mle::Attacher::GetStartDelay(void) const
         else
         {
             delay = Random::NonCrypto::AddJitter(kAttachBackoffMaxInterval, kAttachBackoffJitter);
+        }
+
+        if (TimerMilli::GetNow() - mDetachTime < kAttachBackoffInitialPeriod)
+        {
+            delay = Min(delay, kAttachBackoffInitialMaxInterval);
         }
     }
 #endif // OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_ENABLE

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1297,6 +1297,8 @@ private:
     static constexpr uint32_t kAttachBackoffMinInterval = OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_MINIMUM_INTERVAL;
     static constexpr uint32_t kAttachBackoffMaxInterval = OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_MAXIMUM_INTERVAL;
     static constexpr uint32_t kAttachBackoffJitter      = OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_JITTER_INTERVAL;
+    static constexpr uint32_t kAttachBackoffInitialMaxInterval = OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_INITIAL_MAX_INTERVAL;
+    static constexpr uint32_t kAttachBackoffInitialPeriod      = OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_INITIAL_PERIOD;
     static constexpr uint32_t kAttachBackoffDelayToResetCounter =
         OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_DELAY_TO_RESET_BACKOFF_INTERVAL;
 
@@ -1999,6 +2001,7 @@ private:
         uint8_t                 mChildIdRequestsRemaining;
         uint16_t                mAttachCounter;
         uint16_t                mAnnounceDelay;
+        TimeMilli               mDetachTime;
         TxChallenge             mParentRequestChallenge;
         ParentCandidate         mParentCandidate;
         AttachTimer             mTimer;


### PR DESCRIPTION
Bound the initial backoff time for SED attach to avoid large backoffs for parent distress events