### PR TITLE
[nexus] stabilize reed_address_solicit_rejected test

### DIFF
--- a/tests/nexus/test_reed_address_solicit_rejected.cpp
+++ b/tests/nexus/test_reed_address_solicit_rejected.cpp
@@ -76,7 +76,11 @@ void TestReedAddressSolicitRejected(void)
         reed.Get<NetworkData::Notifier>().HandleServerDataUpdated();
     }
 
-    nexus.AdvanceTime(5 * 1000);
+    // REED sends a Server Data Notification to the leader, the leader
+    // updates its network data and broadcasts the update to the
+    // network. We advance time enough to ensure all these steps are
+    // completed.
+    nexus.AdvanceTime(15 * 1000);
 
     Log("Step 3: Verify REED has the Service ALOC");
     {


### PR DESCRIPTION
This commit stabilizes the Nexus reed_address_solicit_rejected test by increasing the wait time for network data synchronization from 5 seconds to 15 seconds.

The test was occasionally failing because the 5-second wait was sometimes insufficient for the REED's service registration to reach the leader and for the updated network data to be broadcast back to the REED. Increasing the delay to 15 seconds provides more robust buffer for these network events.

Verified by running the test 50 times in a loop without failures.