### PR TITLE
[mle] use entry count instead of byte length in `RouteTlv`

### DIFF
--- a/src/core/thread/mle_tlvs.cpp
+++ b/src/core/thread/mle_tlvs.cpp
@@ -61,7 +61,7 @@ bool RouteTlv::IsValid(void) const
     VerifyOrExit(GetLength() >= sizeof(mRouterIdMask));
 
     VerifyOrExit(mRouterIdMask.IsValid());
-    isValid = (GetRouteDataLength() >= mRouterIdMask.DetermineAllocatedCount());
+    isValid = (GetRouteDataEntryCount() >= mRouterIdMask.DetermineAllocatedCount());
 
 exit:
     return isValid;

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -291,18 +291,18 @@ public:
     bool IsSingleton(void) const { return IsValid() && (mRouterIdMask.DetermineAllocatedCount() <= 1); }
 
     /**
-     * Returns the Route Data Length value.
+     * Returns the number of Route Data entries in the Route TLV.
      *
-     * @returns The Route Data Length value.
+     * @returns The Route Data Entry Count.
      */
-    uint8_t GetRouteDataLength(void) const { return GetLength() - sizeof(mRouterIdMask); }
+    uint8_t GetRouteDataEntryCount(void) const { return GetLength() - sizeof(mRouterIdMask); }
 
     /**
-     * Sets the Route Data Length value.
+     * Sets the Route Data entry count.
      *
-     * @param[in]  aLength  The Route Data Length value.
+     * @param[in]  aCount  The number of Route Data entries in the Route TLV.
      */
-    void SetRouteDataLength(uint8_t aLength) { SetLength(sizeof(mRouterIdMask) + aLength); }
+    void SetRouteDataEntryCount(uint8_t aCount) { SetLength(sizeof(mRouterIdMask) + aCount); }
 
     /**
      * Returns the Route Cost value for a given Router index.
@@ -437,18 +437,18 @@ public:
     void SetRouterId(uint8_t aRouterId) { mRouterIdMask.Add(aRouterId); }
 
     /**
-     * Returns the Route Data Length value.
+     * Returns the number of Route Data entries in the Route TLV.
      *
-     * @returns The Route Data Length value in bytes
+     * @returns The Route Data Entry Count.
      */
-    uint8_t GetRouteDataLength(void) const { return GetLength() - sizeof(mRouterIdMask); }
+    uint8_t GetRouteDataEntryCount(void) const { return (GetLength() - sizeof(mRouterIdMask)) * 2 / 3; }
 
     /**
-     * Sets the Route Data Length value.
+     * Sets the Route Data entry count.
      *
-     * @param[in]  aLength  The Route Data Length value in number of router entries
+     * @param[in]  aCount  The number of Route Data entries in the Route TLV.
      */
-    void SetRouteDataLength(uint8_t aLength) { SetLength(sizeof(mRouterIdMask) + aLength + (aLength + 1) / 2); }
+    void SetRouteDataEntryCount(uint8_t aCount) { SetLength(sizeof(mRouterIdMask) + aCount + (aCount + 1) / 2); }
 
     /**
      * Returns the Route Cost value for a given Router index.

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -841,7 +841,7 @@ void RouterTable::FillRouteTlv(Mle::RouteTlv &aRouteTlv, const Neighbor *aNeighb
         routerIndex++;
     }
 
-    aRouteTlv.SetRouteDataLength(routerIndex);
+    aRouteTlv.SetRouteDataEntryCount(routerIndex);
 }
 
 void RouterTable::HandleTimeTick(void)


### PR DESCRIPTION
This commit renames `GetRouteDataLength()` and `SetRouteDataLength()` to `GetRouteDataEntryCount()` and `SetRouteDataEntryCount()` in the `RouteTlv` class.

When `OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE` is enabled, the route data entries use a packed format (12 bits or 1.5 bytes per entry). Consequently, the byte length of the route data field in the TLV is no longer equal to the number of route entries.

This change ensures that `GetRouteDataEntryCount()` correctly calculates the number of entries from the TLV length and `SetRouteDataEntryCount()` sets the TLV length correctly based on the entry count.