### PR TITLE
[mle] Refactor for `Mle::RouterRoleTransition`

### DIFF
--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -509,12 +509,22 @@ uint8_t otThreadGetRouterDowngradeThreshold(otInstance *aInstance);
 void otThreadSetRouterDowngradeThreshold(otInstance *aInstance, uint8_t aThreshold);
 
 /**
+ * For backwards compatibility, the maximum router selection jitter that can be set or fetched through Thread API
+ * functions is limited to 255 seconds.  This maximum will be returned if the actual value is larger.
+ */
+#define OT_API_MAX_ROUTER_SELECTION_JITTER (255)
+
+/**
  * Get the ROUTER_SELECTION_JITTER parameter used in the REED/Router role.
+ *
+ * Note: This is limited to returning a maximum of 255 seconds if the actual
+ * jitter set is higher than this maximum.
  *
  * @param[in]  aInstance   A pointer to an OpenThread instance.
  *
- * @returns The ROUTER_SELECTION_JITTER value.
+ * @returns The ROUTER_SELECTION_JITTER value (or max 255 seconds).
  *
+ * @sa OT_API_MAX_ROUTER_SELECTION_JITTER
  * @sa otThreadSetRouterSelectionJitter
  */
 uint8_t otThreadGetRouterSelectionJitter(otInstance *aInstance);
@@ -526,7 +536,7 @@ uint8_t otThreadGetRouterSelectionJitter(otInstance *aInstance);
  * this API will render a production application non-compliant with the Thread Specification.
  *
  * @param[in]  aInstance      A pointer to an OpenThread instance.
- * @param[in]  aRouterJitter  The ROUTER_SELECTION_JITTER value.
+ * @param[in]  aRouterJitter  The ROUTER_SELECTION_JITTER value (max 255 seconds).
  *
  * @sa otThreadGetRouterSelectionJitter
  */

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -196,12 +196,15 @@ void otThreadSetRouterDowngradeThreshold(otInstance *aInstance, uint8_t aThresho
 
 uint8_t otThreadGetRouterSelectionJitter(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<Mle::Mle>().GetRouterSelectionJitter();
+    uint16_t routerSelectionJitter = AsCoreType(aInstance).Get<Mle::Mle>().GetRouterSelectionJitter();
+    return (routerSelectionJitter > OT_API_MAX_ROUTER_SELECTION_JITTER) ? OT_API_MAX_ROUTER_SELECTION_JITTER
+                                                                        : static_cast<uint8_t>(routerSelectionJitter);
 }
 
 void otThreadSetRouterSelectionJitter(otInstance *aInstance, uint8_t aRouterJitter)
 {
-    AsCoreType(aInstance).Get<Mle::Mle>().SetRouterSelectionJitter(aRouterJitter);
+    // Values within a uint8_t range should not cause errors, so they are ignored to maintain backwards compatibility
+    IgnoreError(AsCoreType(aInstance).Get<Mle::Mle>().SetRouterSelectionJitter(aRouterJitter));
 }
 
 otError otThreadGetChildInfoById(otInstance *aInstance, uint16_t aChildId, otChildInfo *aChildInfo)

--- a/src/core/backbone_router/bbr_local.cpp
+++ b/src/core/backbone_router/bbr_local.cpp
@@ -288,7 +288,7 @@ void Local::HandleTimeTick(void)
     // Delay registration while router role transition is pending
     // (i.e., device may soon switch from REED to router role).
 
-    VerifyOrExit(!Get<Mle::Mle>().IsRouterRoleTransitionPending());
+    VerifyOrExit(!Get<Mle::Mle>().IsRouterRoleTransitioning());
 
     if (mRegistrationTimeout > 0)
     {

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -319,10 +319,15 @@ void DuaManager::HandleNotifierEvents(Events aEvents)
             // Wait for link establishment with neighboring routers.
             UpdateRegistrationDelay(kNewRouterRegistrationDelay);
         }
-        else if (Get<Mle::Mle>().WillBecomeRouterSoon())
+        else
         {
-            // Will check again in case the device decides to stay REED when jitter timeout expires.
-            UpdateRegistrationDelay(Get<Mle::Mle>().GetRouterRoleTransitionTimeout() + kNewRouterRegistrationDelay + 1);
+            int8_t routerTransitionTimeRemaining = Get<Mle::Mle>().GetTimeUntilBecomingRouterIfSoon();
+            if (routerTransitionTimeRemaining >= 0)
+            {
+                // Will check again in case the device decides to stay REED when jitter timeout expires.
+                UpdateRegistrationDelay(static_cast<uint8_t>(routerTransitionTimeRemaining) +
+                                        kNewRouterRegistrationDelay + 1);
+            }
         }
 #endif
     }
@@ -432,10 +437,16 @@ void DuaManager::PerformNextRegistration(void)
     // Only send DUA.req when necessary
 #if OPENTHREAD_CONFIG_DUA_ENABLE
 #if OPENTHREAD_FTD
-    if (!Get<Mle::Mle>().IsRouterOrLeader() && Get<Mle::Mle>().WillBecomeRouterSoon())
+    if (!Get<Mle::Mle>().IsRouterOrLeader())
     {
-        UpdateRegistrationDelay(Get<Mle::Mle>().GetRouterRoleTransitionTimeout() + kNewRouterRegistrationDelay + 1);
-        ExitNow();
+        int8_t routerTransitionTimeRemaining = Get<Mle::Mle>().GetTimeUntilBecomingRouterIfSoon();
+        if (routerTransitionTimeRemaining >= 0)
+        {
+            // Will check again in case the device decides to stay REED when jitter timeout expires.
+            UpdateRegistrationDelay(static_cast<uint8_t>(routerTransitionTimeRemaining) + kNewRouterRegistrationDelay +
+                                    1);
+            ExitNow();
+        }
     }
 #endif
     VerifyOrExit(Get<Mle::Mle>().IsFullThreadDevice() || Get<Mle::Mle>().GetParent().IsThreadVersion1p1());

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -90,8 +90,14 @@ Mle::Mle(Instance &aInstance)
     , mThreadVersionCheckEnabled(true)
 #endif
     , mNetworkIdTimeout(kNetworkIdTimeout)
+
     , mRouterUpgradeThreshold(kRouterUpgradeThreshold)
     , mRouterDowngradeThreshold(kRouterDowngradeThreshold)
+    , mRouterUpgradeDelayMinimum(kRouterTransitionMinimumDefault)
+    , mRouterUpgradeDelayJitter(kRouterTransitionJitterDefault)
+    , mRouterDowngradeDelayMinimum(kRouterTransitionMinimumDefault)
+    , mRouterDowngradeDelayJitter(kRouterTransitionJitterDefault)
+
     , mPreviousPartitionRouterIdSequence(0)
     , mPreviousPartitionIdTimeout(0)
     , mChildRouterLinks(kChildRouterLinks)
@@ -6103,7 +6109,7 @@ void Mle::AnnounceHandler::HandleAnnounceAttachSuccess(void)
     mState = kStateToInformPreviousChannel;
 
 #if OPENTHREAD_FTD
-    if (Get<Mle>().IsFullThreadDevice() && !Get<Mle>().IsRouter() && Get<Mle>().IsRouterRoleTransitionPending())
+    if (Get<Mle>().IsFullThreadDevice() && !Get<Mle>().IsRouter() && Get<Mle>().IsRouterRoleTransitioning())
     {
         ExitNow();
     }

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -785,6 +785,24 @@ public:
     bool IsRouterRoleAllowed(void) const { return mRouterRoleAllowed; }
 
     /**
+     * Start a router upgrade role transition with saved timing parameters.
+     */
+    void StartRouterRoleUpgradeTransition(void)
+    {
+        mRouterRoleTransition.StartTransition(mRouterUpgradeDelayMinimum, mRouterUpgradeDelayJitter,
+                                              RouterRoleTransition::kUpgrading);
+    }
+
+    /**
+     * Start a router downgrade role transition with saved timing parameters.
+     */
+    void StartRouterRoleDowngradeTransition(void)
+    {
+        mRouterRoleTransition.StartTransition(mRouterDowngradeDelayMinimum, mRouterDowngradeDelayJitter,
+                                              RouterRoleTransition::kDowngrading);
+    }
+
+    /**
      * Indicates whether a node is the only router on the network.
      *
      * @retval TRUE   It is the only router in the network.
@@ -924,26 +942,43 @@ public:
     void SetNetworkIdTimeout(uint8_t aTimeout) { mNetworkIdTimeout = aTimeout; }
 
     /**
-     * Returns the ROUTER_SELECTION_JITTER value.
+     * Returns the ROUTER_SELECTION_JITTER value for upgrade transitions.
      *
-     * @returns The ROUTER_SELECTION_JITTER value in seconds.
+     * Note: This currently gets only the upgrade jitter, though the setter also sets the downgrade
+     * jitter to the same value.
+     *
+     * @returns The ROUTER_SELECTION_JITTER value for upgrade transitions in seconds.
      */
-    uint8_t GetRouterSelectionJitter(void) const { return mRouterRoleTransition.GetJitter(); }
+    uint16_t GetRouterSelectionJitter(void) const { return mRouterUpgradeDelayJitter; }
 
     /**
-     * Sets the ROUTER_SELECTION_JITTER value.
+     * Sets the ROUTER_SELECTION_JITTER value for upgrade and downgrade transitions (0 to 1200 seconds).
      *
-     * @param[in] aRouterJitter  The router selection jitter value (in seconds).
+     * @param[in] aRouterJitter  The router selection jitter value for upgrade and downgrade transitions (in seconds).
      */
-    void SetRouterSelectionJitter(uint8_t aRouterJitter) { mRouterRoleTransition.SetJitter(aRouterJitter); }
+    Error SetRouterSelectionJitter(uint16_t aRouterJitter);
 
     /**
-     * Indicates whether or not router role transition (upgrade from REED or downgrade to REED) is pending.
+     * Indicates whether or not a router role transition (or address solicit) is in progress
      *
-     * @retval TRUE    Router role transition is pending.
-     * @retval FALSE   Router role transition is not pending
+     * @retval TRUE    Router role is transitioning or an address solicit is currently pending.
+     * @retval FALSE   Router role is not transitioning.
      */
-    bool IsRouterRoleTransitionPending(void) const { return mRouterRoleTransition.IsPending(); }
+    bool IsRouterRoleTransitioning(void) const
+    {
+        return mRouterRoleTransition.IsTransitioning() || mAddressSolicitPending;
+    }
+
+    /**
+     * Indicates whether or not a router role upgrade transition should be performed.
+     *
+     * @retval TRUE    The upgrade attempt is pending.
+     * @retval FALSE   The upgrade attempt is not currently pending.
+     */
+    bool IsRouterRoleUpgradePending(void) const
+    {
+        return mRouterRoleTransition.IsUpgradePending() && !mAddressSolicitPending;
+    }
 
     /**
      * Returns the current timeout delay in seconds till router role transition (upgrade from REED or downgrade to
@@ -951,7 +986,7 @@ public:
      *
      * @returns The timeout in seconds till router role transition, or zero if not pending role transition.
      */
-    uint8_t GetRouterRoleTransitionTimeout(void) const { return mRouterRoleTransition.GetTimeout(); }
+    uint16_t GetRouterRoleTransitionTimeout(void) const { return mRouterRoleTransition.GetTimeout(); }
 
     /**
      * Returns the ROUTER_UPGRADE_THRESHOLD value.
@@ -1017,12 +1052,12 @@ public:
     Error SetChildRouterLinks(uint8_t aChildRouterLinks);
 
     /**
-     * Returns if the REED is expected to become Router soon.
+     * Returns the time remaining if the REED is expected to become Router soon (within 10s).
      *
-     * @retval TRUE   If the REED is going to become a Router soon.
-     * @retval FALSE  If the REED is not going to become a Router soon.
+     * @retval 0-10   Time remaining, if the REED is going to become a Router soon.
+     * @retval -1     If the REED is not going to become a Router soon.
      */
-    bool WillBecomeRouterSoon(void) const;
+    int8_t GetTimeUntilBecomingRouterIfSoon(void) const;
 
     /**
      * Removes a link to a neighbor.
@@ -1344,14 +1379,17 @@ private:
     static constexpr uint32_t kMaxLeaderToRouterTimeout      = 90000;  // (in msec)
     static constexpr uint8_t  kMinDowngradeNeighbors         = 7;
     static constexpr uint8_t  kNetworkIdTimeout              = 120; // (in sec)
-    static constexpr uint8_t  kRouterSelectionJitter         = 120; // (in sec)
-    static constexpr uint8_t  kRouterDowngradeThreshold      = 23;
-    static constexpr uint8_t  kRouterUpgradeThreshold        = 16;
     static constexpr uint16_t kDiscoveryMaxJitter            = 250; // Max jitter delay Discovery Responses (in msec).
     static constexpr uint16_t kUnsolicitedDataResponseJitter = 500; // Max delay for unsol Data Response (in msec).
     static constexpr uint8_t  kLeaderDowngradeExtraDelay     = 10;  // Extra delay to downgrade leader (in sec).
     static constexpr uint8_t  kDefaultLeaderWeight           = 64;
     static constexpr uint8_t  kAlternateRloc16Timeout        = 8; // Time to use alternate RLOC16 (in sec).
+
+    static constexpr uint8_t  kRouterUpgradeThreshold         = 16;
+    static constexpr uint8_t  kRouterDowngradeThreshold       = 23;
+    static constexpr uint16_t kRouterTransitionMinimumDefault = 0;    ///< (in sec) Default transition delay minimum
+    static constexpr uint16_t kRouterTransitionJitterDefault  = 120;  ///< (in sec) Default transition delay jitter
+    static constexpr uint16_t kRouterTransitionDelayMax       = 1200; ///< (in sec) Maximum transition delay
 
     // Threshold to accept a router upgrade request with reason
     // `kBorderRouterRequest` (number of BRs acting as router in
@@ -2219,18 +2257,32 @@ private:
     public:
         RouterRoleTransition(void);
 
-        bool    IsPending(void) const { return (mTimeout != 0); }
-        void    StartTimeout(void);
-        void    StopTimeout(void) { mTimeout = 0; }
-        void    IncreaseTimeout(uint8_t aIncrement) { mTimeout += aIncrement; }
-        uint8_t GetTimeout(void) const { return mTimeout; }
-        bool    HandleTimeTick(void);
-        uint8_t GetJitter(void) const { return mJitter; }
-        void    SetJitter(uint8_t aJitter) { mJitter = aJitter; }
+        enum Transition : uint8_t
+        {
+            kNotTransitioning = 0,
+            kUpgrading        = 1,
+            kDowngrading      = 2
+        };
+
+        bool IsTransitioning(void) const { return mTransition != kNotTransitioning; }
+        bool IsUpgrading(void) const { return mTransition == kUpgrading; }
+        bool IsDowngrading(void) const { return mTransition == kDowngrading; }
+
+        bool IsUpgradePending(void) const { return IsUpgrading() && mTimeout == 0; }
+        bool IsDowngradePending(void) const { return IsDowngrading() && mTimeout == 0; }
+
+        void ClearTransition(void);
+        void StartTransition(uint16_t   aRouterTransitionMinimum,
+                             uint16_t   aRouterTransitionJitter,
+                             Transition aTransitionType);
+
+        void     IncreaseTimeout(uint8_t aIncrement) { mTimeout += aIncrement; }
+        uint16_t GetTimeout(void) const { return mTimeout; }
+        void     HandleTimeTick(void);
 
     private:
-        uint8_t mTimeout;
-        uint8_t mJitter;
+        uint16_t   mTimeout;
+        Transition mTransition;
     };
 
 #endif
@@ -2558,8 +2610,14 @@ private:
     uint8_t mRouterId;
     uint8_t mPreviousRouterId;
     uint8_t mNetworkIdTimeout;
-    uint8_t mRouterUpgradeThreshold;
-    uint8_t mRouterDowngradeThreshold;
+
+    uint8_t  mRouterUpgradeThreshold;
+    uint8_t  mRouterDowngradeThreshold;
+    uint16_t mRouterUpgradeDelayMinimum;
+    uint16_t mRouterUpgradeDelayJitter;
+    uint16_t mRouterDowngradeDelayMinimum;
+    uint16_t mRouterDowngradeDelayJitter;
+
     uint8_t mLeaderWeight;
     uint8_t mPreviousPartitionRouterIdSequence;
     uint8_t mPreviousPartitionIdTimeout;

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -133,7 +133,7 @@ void Mle::UpdateRouterRoleAllowed(UpdateRouterRoleAllowedReason aReason)
 
     if (IsChild() && mRouterRoleAllowed && (aReason == kReasonConfigParameterChanged))
     {
-        mRouterRoleTransition.StartTimeout();
+        StartRouterRoleUpgradeTransition();
     }
 
     if (IsRouterOrLeader())
@@ -161,8 +161,8 @@ void Mle::UpdateRouterRoleAllowed(UpdateRouterRoleAllowedReason aReason)
             break;
 
         case kReasonSecurityPolicyChanged:
-            VerifyOrExit(!mRouterRoleTransition.IsPending());
-            mRouterRoleTransition.StartTimeout();
+            VerifyOrExit(!mRouterRoleTransition.IsDowngrading());
+            StartRouterRoleDowngradeTransition();
 
             if (IsLeader())
             {
@@ -241,11 +241,13 @@ Error Mle::BecomeRouter(RouterUpgradeReason aReason)
     LogInfo("Attempt to become router, reason:%s", RouterUpgradeReasonToString(aReason));
 
     Get<MeshForwarder>().SetRxOnWhenIdle(true);
-    mRouterRoleTransition.StopTimeout();
 
     error = SendAddressSolicit(aReason);
 
 exit:
+    // The upgrade attempt was completed.
+    // Future upgrade attempts may be re-started when receiving advertisements.
+    mRouterRoleTransition.ClearTransition();
     return error;
 }
 
@@ -341,7 +343,11 @@ void Mle::HandleChildStart(void)
 {
     mAddressSolicitRejected = false;
 
-    mRouterRoleTransition.StartTimeout();
+    if (IsRouterRoleAllowed())
+    {
+        // As a REED, re-start the timer to check for a role upgrade when re-attaching as a Child
+        StartRouterRoleUpgradeTransition();
+    }
 
     StopLeader();
     Get<TimeTicker>().RegisterReceiver(TimeTicker::kMle);
@@ -1304,9 +1310,19 @@ Error Mle::HandleAdvertisementOnFtd(RxInfo &aRxInfo, uint16_t aSourceAddress, co
                 ExitNow(error = kErrorDetached);
             }
 
-            if (!mRouterRoleTransition.IsPending() && (mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold))
+            if (mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold)
             {
-                mRouterRoleTransition.StartTimeout();
+                if (!IsRouterRoleTransitioning())
+                {
+                    // Upgrade conditions have been met after an advertisement from a child's parent and the
+                    // upgrade is not yet scheduled.
+                    StartRouterRoleUpgradeTransition();
+                }
+            }
+            else
+            {
+                // Clear the transition timer if the reason to upgrade no longer applies
+                mRouterRoleTransition.ClearTransition();
             }
 
             mRouterTable.UpdateRouterOnFtdChild(routeTlv, routerId);
@@ -1332,9 +1348,10 @@ Error Mle::HandleAdvertisementOnFtd(RxInfo &aRxInfo, uint16_t aSourceAddress, co
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Update routers as a router or leader.
 
-    if (IsRouter() && ShouldDowngrade(routerId, routeTlv))
+    if (ShouldDowngrade(routerId, routeTlv))
     {
-        mRouterRoleTransition.StartTimeout();
+        // Downgrade conditions have been met after an advertisement from another active router
+        StartRouterRoleDowngradeTransition();
     }
 
     router = mRouterTable.FindRouterById(routerId);
@@ -1588,54 +1605,76 @@ void Mle::HandleTimeTick(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Role transitions
 
-    if (mRouterRoleTransition.HandleTimeTick())
+    mRouterRoleTransition.HandleTimeTick();
+
+    switch (mRole)
     {
-        // `mRouterRoleTransition.HandleTimeTick()` returns `true`
-        // if role transition timeout expires.
+    case kRoleDisabled:
+    case kRoleDetached:
+        break;
 
-        switch (mRole)
+    case kRoleChild:
+        if (!IsRouterRoleAllowed() || mRouterRoleTransition.IsDowngrading())
         {
-        case kRoleDisabled:
-        case kRoleDetached:
-            break;
-
-        case kRoleChild:
+            // This device is a FED or a downgrade transition was not completed before a role change.
+            // Clear the transition if in progress and skip starting REED advertisements.
+            mRouterRoleTransition.ClearTransition();
+        }
+        else if (IsRouterRoleUpgradePending())
+        {
+            // An upgrade should be performed, if the conditions to upgrade still apply
             if (mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold && HasNeighborWithGoodLinkQuality())
             {
                 IgnoreError(BecomeRouter(kReasonTooFewRouters));
+                // Any attempt to become a router will also clear the current role transition
             }
             else
             {
+                // Since the conditions to upgrade no longer apply, clear the upgrade transition
+                mRouterRoleTransition.ClearTransition();
+                // Also ensure that the actions to perform at the completion of a router role transition are still done
                 mAnnounceHandler.HandleRouterRoleTransitionAttemptDone();
             }
-
-            if (!mAdvertiseTrickleTimer.IsRunning())
-            {
-                SendMulticastAdvertisement();
-
-                mAdvertiseTrickleTimer.Start(TrickleTimer::kModePlainTimer, kReedAdvIntervalMin, kReedAdvIntervalMax);
-            }
-
-            break;
-
-        case kRoleRouter:
-            if (mRouterTable.GetActiveRouterCount() > mRouterDowngradeThreshold)
-            {
-                LogNote("Downgrade to REED");
-                mAttacher.Attach(kDowngradeToReed);
-            }
-
-            OT_FALL_THROUGH;
-
-        case kRoleLeader:
-            if (!IsRouterRoleAllowed())
-            {
-                LogInfo("Router role no longer allowed");
-                IgnoreError(BecomeDetached());
-            }
-
-            break;
         }
+        else if (!IsRouterRoleTransitioning() && !mAdvertiseTrickleTimer.IsRunning())
+        {
+            // REEDs should start sending REED advertisements when no longer waiting to transitioning roles
+            SendMulticastAdvertisement();
+            mAdvertiseTrickleTimer.Start(TrickleTimer::kModePlainTimer, kReedAdvIntervalMin, kReedAdvIntervalMax);
+        }
+        break;
+
+    case kRoleRouter:
+    case kRoleLeader:
+        if (mRouterRoleTransition.IsDowngradePending())
+        {
+            bool roleAllowed           = IsRouterRoleAllowed();
+            bool shouldRouterDowngrade = IsRouter() && mRouterTable.GetActiveRouterCount() > mRouterDowngradeThreshold;
+            if (!roleAllowed || shouldRouterDowngrade)
+            {
+                if (IsRouter())
+                {
+                    // Perform re-attachment to downgrade from the kRoleRouter role
+                    LogNote("Downgrade from Router to REED (allowed:%d, downgrade: %d)", roleAllowed,
+                            shouldRouterDowngrade);
+                    mAttacher.Attach(kDowngradeToReed);
+                }
+                else // IsLeader()
+                {
+                    // Only use detachment to downgrade from the kRoleLeader role
+                    LogInfo("Downgrade from Leader to REED (Router role no longer allowed).");
+                    IgnoreError(BecomeDetached());
+                }
+            }
+            // Clear the timer on a successful downgrade, or if the downgrade transition is no longer applicable
+            mRouterRoleTransition.ClearTransition();
+        }
+        else if (mRouterRoleTransition.IsUpgrading())
+        {
+            // Upgrading is not applicable to active routers
+            mRouterRoleTransition.ClearTransition();
+        }
+        break;
     }
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3495,6 +3534,16 @@ exit:
     mAnnounceHandler.HandleRouterRoleTransitionAttemptDone();
 }
 
+Error Mle::SetRouterSelectionJitter(uint16_t aRouterJitter)
+{
+    Error error = kErrorNone;
+    VerifyOrExit(aRouterJitter <= kRouterTransitionDelayMax, error = kErrorInvalidArgs);
+    mRouterUpgradeDelayJitter   = aRouterJitter;
+    mRouterDowngradeDelayJitter = aRouterJitter;
+exit:
+    return error;
+}
+
 Error Mle::SetChildRouterLinks(uint8_t aChildRouterLinks)
 {
     Error error = kErrorNone;
@@ -3505,21 +3554,24 @@ exit:
     return error;
 }
 
-bool Mle::WillBecomeRouterSoon(void) const
+int8_t Mle::GetTimeUntilBecomingRouterIfSoon(void) const
 {
     static constexpr uint8_t kMaxDelay = 10;
 
-    bool willBecomeRouter = false;
+    uint16_t currentTimeout   = mRouterRoleTransition.GetTimeout();
+    int8_t   willBecomeRouter = -1;
 
     VerifyOrExit(IsRouterRoleAllowed() && IsChild());
     VerifyOrExit(!mAddressSolicitRejected);
 
-    if (!mAddressSolicitPending)
+    if (mAddressSolicitPending)
     {
-        VerifyOrExit(mRouterRoleTransition.IsPending() && mRouterRoleTransition.GetTimeout() <= kMaxDelay);
+        ExitNow(willBecomeRouter = 0);
     }
 
-    willBecomeRouter = true;
+    VerifyOrExit(mRouterRoleTransition.IsUpgrading());
+    VerifyOrExit(currentTimeout <= kMaxDelay);
+    willBecomeRouter = static_cast<int8_t>(currentTimeout);
 
 exit:
     return willBecomeRouter;
@@ -3792,7 +3844,8 @@ bool Mle::ShouldDowngrade(uint8_t aNeighborId, const RouteTlv &aRouteTlv) const
     VerifyOrExit(mRouterTable.IsAllocated(aNeighborId));
     VerifyOrExit(!mBlockDowngrade);
 
-    VerifyOrExit(!mRouterRoleTransition.IsPending());
+    // Return false, to let an existing downgrade transition continue
+    VerifyOrExit(!mRouterRoleTransition.IsDowngrading());
 
     VerifyOrExit(activeRouterCount > mRouterDowngradeThreshold);
 
@@ -4018,22 +4071,42 @@ const char *Mle::RouterUpgradeReasonToString(uint8_t aReason)
 
 Mle::RouterRoleTransition::RouterRoleTransition(void)
     : mTimeout(0)
-    , mJitter(kRouterSelectionJitter)
+    , mTransition(kNotTransitioning)
 {
 }
 
-void Mle::RouterRoleTransition::StartTimeout(void) { mTimeout = 1 + Random::NonCrypto::GetUint8InRange(0, mJitter); }
-
-bool Mle::RouterRoleTransition::HandleTimeTick(void)
+void Mle::RouterRoleTransition::ClearTransition(void)
 {
-    bool expired = false;
+    mTimeout    = 0;
+    mTransition = kNotTransitioning;
+}
 
-    VerifyOrExit(mTimeout > 0);
-    mTimeout--;
-    expired = (mTimeout == 0);
+void Mle::RouterRoleTransition::StartTransition(uint16_t   aRouterTransitionMinimum,
+                                                uint16_t   aRouterTransitionJitter,
+                                                Transition aTransitionType)
+{
+    uint16_t minimumDelay = Min<uint16_t>(aRouterTransitionMinimum, kRouterTransitionDelayMax);
+    if (aRouterTransitionJitter == 0)
+    {
+        mTimeout = minimumDelay;
+    }
+    else
+    {
+        // Note: GetUint16InRange() returns a value in the range [minimumDelay, delayUpperLimit)
+        uint16_t delayUpperLimit = static_cast<uint16_t>(Min<uint32_t>(
+            static_cast<uint32_t>(minimumDelay) + aRouterTransitionJitter + 1, kRouterTransitionDelayMax + 1));
+        mTimeout                 = Random::NonCrypto::GetUint16InRange(minimumDelay, delayUpperLimit);
+    }
 
-exit:
-    return expired;
+    mTransition = aTransitionType;
+}
+
+void Mle::RouterRoleTransition::HandleTimeTick(void)
+{
+    if (mTimeout > 0)
+    {
+        mTimeout--;
+    }
 }
 
 } // namespace Mle

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -154,7 +154,7 @@ Error Notifier::UpdateInconsistentData(void)
     // Don't send this Server Data Notification if the device is going
     // to upgrade to Router.
 
-    if (Get<Mle::Mle>().WillBecomeRouterSoon())
+    if (Get<Mle::Mle>().GetTimeUntilBecomingRouterIfSoon() >= 0)
     {
         ExitNow(error = kErrorInvalidState);
     }

--- a/tests/nexus/test_1_1_5_1_5.cpp
+++ b/tests/nexus/test_1_1_5_1_5.cpp
@@ -101,7 +101,7 @@ void Test5_1_5(void)
     nexus.AdvanceTime(kFormNetworkTime);
     VerifyOrQuit(leader.Get<Mle::Mle>().IsLeader());
 
-    router1.Get<Mle::Mle>().SetRouterSelectionJitter(1);
+    VerifyOrQuit(router1.Get<Mle::Mle>().SetRouterSelectionJitter(1) == kErrorNone);
     router1.Join(leader);
     nexus.AdvanceTime(kAttachToRouterTime);
     VerifyOrQuit(router1.Get<Mle::Mle>().IsRouter());

--- a/tests/nexus/test_reed_address_solicit_rejected.cpp
+++ b/tests/nexus/test_reed_address_solicit_rejected.cpp
@@ -99,7 +99,7 @@ void TestReedAddressSolicitRejected(void)
 
     Log("Step 4: Force REED to try to become a router");
     reed.Get<Mle::Mle>().SetRouterUpgradeThreshold(16);
-    reed.Get<Mle::Mle>().SetRouterSelectionJitter(120);
+    VerifyOrQuit(reed.Get<Mle::Mle>().SetRouterSelectionJitter(120) == kErrorNone);
 
     // We advance time enough to cover jitter and router upgrade attempt.
     nexus.AdvanceTime(130 * 1000);

--- a/tests/nexus/test_router_downgrade_on_sec_policy_change.cpp
+++ b/tests/nexus/test_router_downgrade_on_sec_policy_change.cpp
@@ -53,8 +53,8 @@ void TestRouterDowngradeOnSecPolicyChange(void)
     Node &leader = nexus.CreateNode();
     Node &router = nexus.CreateNode();
 
-    leader.Get<Mle::Mle>().SetRouterSelectionJitter(10);
-    router.Get<Mle::Mle>().SetRouterSelectionJitter(10);
+    VerifyOrQuit(leader.Get<Mle::Mle>().SetRouterSelectionJitter(10) == kErrorNone);
+    VerifyOrQuit(router.Get<Mle::Mle>().SetRouterSelectionJitter(10) == kErrorNone);
 
     nexus.AdvanceTime(0);
 

--- a/tests/nexus/test_router_reattach.cpp
+++ b/tests/nexus/test_router_reattach.cpp
@@ -73,7 +73,7 @@ void TestRouterReattach(void)
     {
         nodes[i]->Get<Mle::Mle>().SetRouterUpgradeThreshold(32);
         nodes[i]->Get<Mle::Mle>().SetRouterDowngradeThreshold(32);
-        nodes[i]->Get<Mle::Mle>().SetRouterSelectionJitter(1);
+        VerifyOrQuit(nodes[i]->Get<Mle::Mle>().SetRouterSelectionJitter(1) == kErrorNone);
         nodes[i]->Join(*nodes[0]);
         nexus.AdvanceTime(kAttachToRouterTime);
         Log("Node %u role: %s", i + 1, nodes[i]->GetExtendedRoleString());
@@ -85,7 +85,7 @@ void TestRouterReattach(void)
     nodes[1]->Reset();
     nodes[1]->Get<Mle::Mle>().SetRouterUpgradeThreshold(32);
     nodes[1]->Get<Mle::Mle>().SetRouterDowngradeThreshold(32);
-    nodes[1]->Get<Mle::Mle>().SetRouterSelectionJitter(3);
+    VerifyOrQuit(nodes[1]->Get<Mle::Mle>().SetRouterSelectionJitter(3) == kErrorNone);
 
     // Re-enable and start
     Log("Step 4: Restarting Node 2");

--- a/tests/nexus/test_srp_scale.cpp
+++ b/tests/nexus/test_srp_scale.cpp
@@ -159,7 +159,7 @@ void TestSrpScale(void)
     {
         routers[i] = &nexus.CreateNode();
         routers[i]->SetName("router", i + 1);
-        routers[i]->Get<Mle::Mle>().SetRouterSelectionJitter(1);
+        VerifyOrQuit(routers[i]->Get<Mle::Mle>().SetRouterSelectionJitter(1) == kErrorNone);
         routers[i]->Join(leader);
     }
 

--- a/tests/nexus/verify_1_1_5_3_6.py
+++ b/tests/nexus/verify_1_1_5_3_6.py
@@ -66,17 +66,26 @@ def verify(pv):
     #   - Description: Ensure topology is formed correctly.
     #   - Pass Criteria: N/A
     print("Step 1: All")
-    pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
+    leader_pkt = pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
         filter_wpan_src64(LEADER).\
         must_next()
+    leader_child_id = leader_pkt.mle.tlv.source_addr & 0x1FF
+    # The leader should only advertise as a router
+    assert leader_child_id == 0
     router1_pkt = pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
         filter_wpan_src64(ROUTER_1).\
         must_next()
     router1_id = (router1_pkt.mle.tlv.source_addr >> 10)
+    router1_child_id = router1_pkt.mle.tlv.source_addr & 0x1FF
+    # Router 1 should only advertise as a router
+    assert router1_child_id == 0
     router2_pkt = pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
         filter_wpan_src64(ROUTER_2).\
         must_next()
     router2_id = (router2_pkt.mle.tlv.source_addr >> 10)
+    router2_child_id = router2_pkt.mle.tlv.source_addr & 0x1FF
+    # Router 2 should only advertise as a router
+    assert router2_child_id == 0
 
     # Step 2: Router_2
     #
@@ -111,13 +120,16 @@ def verify(pv):
     #   - Description: Harness re-enables the device and waits for it to reattach and upgrade to a
     #     router.
     #   - Pass Criteria:
-    #     - The DUT MUST reset the MLE Advertisement trickle timer and send an Advertisement.
+    #     - The DUT MUST reset the MLE Advertisement trickle timer and send a Router Advertisement.
     print("Step 5: Router_2")
     # Verify Router 2 becomes router again (sends advertisement) and get its new ID
     router2_rejoin_pkt = pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
         filter_wpan_src64(ROUTER_2).\
         must_next()
     router2_id_reattached = (router2_rejoin_pkt.mle.tlv.source_addr >> 10)
+    router2_child_id_reattached = router2_rejoin_pkt.mle.tlv.source_addr & 0x1FF
+    # Router 2 should only advertise as a router
+    assert router2_child_id_reattached == 0
 
     # Verify Leader sends advertisement after Router 2 re-joins
     pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT).\


### PR DESCRIPTION
This commit refactors the router role transition timer to support transitions longer than 255 seconds with independently defined upgrade and downgrade thresholds.  This prepares for upcoming changes to support a Managed Router configuration feature.

Key changes:
- Refactor of `RouterRoleTransition`, using a new `Transition` enum and transition checking methods to clarify which transition type is in progress or pending, or when the transition should be cleared.
- Minimum and jitter variables for upgrade and downgrade transitions were created or moved to the Mle class, replacing `RouterRoleTransition::mJitter`. These are initialized to the previous defaults (0s and 120s, respectively).
- The role transition timer will now only start when the router role is allowed, due to how the transition timer is now checked differently in `Mle::HandleTimeTick()`.
- The role transition upgrade timer will also be canceled when conditions to upgrade no longer apply.
- When downgrading from kRoleRouter role due to `!IsRouterRoleAllowed()`, the normal steps for a downgrade reattachment are performed instead of detachment, for a more graceful downgrade transition
- `Mle::SetRouterSelectionJitter()` now takes a uint16 and returns Error instead of void, which is ignored for `otThreadSetRouterSelectionJitter()` to maintain the current API.  This prepares for new API calls to be added in upcoming changes to support a Managed Router configuration feature, which will support the new range.
- `Mle::GetRouterSelectionJitter()` now returns a uint16 and gets only `mRouterUpgradeDelayJitter`, but can currently be expected to match the downgrade jitter when set with `Mle::SetRouterSelectionJitter()`
- Uses of `WillBecomeRouterSoon()` now return the time remaining to simplify conditions where it was used for DUA (due to the uint16 type changes)
- `otThreadGetRouterSelectionJitter()` and `otThreadSetRouterSelectionJitter()` remain limited to a maximum jitter get/set of 255 (with a new limit in the api defined as `OT_API_MAX_ROUTER_SELECTION_JITTER`) to maintain the previous API, which will become deprecated in future changes that implement Managed Router configuration, where the new parameters will be separately configurable.
- Multiple tests were updated to also verify the new return code of `SetRouterSelectionJitter()`
- `verify_1_1_5_3_6.py` was updated to more strictly check that advertisements in this test are only from router RLOC16 source addresses.