### PR TITLE
[mle] Added `RouterUpgradeReasonFlagsTlv` to Address Solicit requests

### DIFF
--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -509,12 +509,22 @@ uint8_t otThreadGetRouterDowngradeThreshold(otInstance *aInstance);
 void otThreadSetRouterDowngradeThreshold(otInstance *aInstance, uint8_t aThreshold);
 
 /**
+ * For backwards compatibility, the maximum router selection jitter that can be set or fetched through Thread API
+ * functions is limited to 255 seconds.  This maximum will be returned if the actual value is larger.
+ */
+#define OT_API_MAX_ROUTER_SELECTION_JITTER (255)
+
+/**
  * Get the ROUTER_SELECTION_JITTER parameter used in the REED/Router role.
+ *
+ * Note: This is limited to returning a maximum of 255 seconds if the actual
+ * jitter set is higher than this maximum.
  *
  * @param[in]  aInstance   A pointer to an OpenThread instance.
  *
- * @returns The ROUTER_SELECTION_JITTER value.
+ * @returns The ROUTER_SELECTION_JITTER value (or max 255 seconds).
  *
+ * @sa OT_API_MAX_ROUTER_SELECTION_JITTER
  * @sa otThreadSetRouterSelectionJitter
  */
 uint8_t otThreadGetRouterSelectionJitter(otInstance *aInstance);
@@ -526,7 +536,7 @@ uint8_t otThreadGetRouterSelectionJitter(otInstance *aInstance);
  * this API will render a production application non-compliant with the Thread Specification.
  *
  * @param[in]  aInstance      A pointer to an OpenThread instance.
- * @param[in]  aRouterJitter  The ROUTER_SELECTION_JITTER value.
+ * @param[in]  aRouterJitter  The ROUTER_SELECTION_JITTER value (max 255 seconds).
  *
  * @sa otThreadGetRouterSelectionJitter
  */

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -176,7 +176,8 @@ exit:
 
 otError otThreadBecomeRouter(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<Mle::Mle>().BecomeRouter(Mle::kReasonHaveChildIdRequest);
+    return AsCoreType(aInstance).Get<Mle::Mle>().BecomeRouter(
+        Mle::RouterUpgradeReasonFlags::kUpgradeReasonHaveChildIdRequestFlag);
 }
 
 otError otThreadBecomeLeader(otInstance *aInstance)

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -196,12 +196,15 @@ void otThreadSetRouterDowngradeThreshold(otInstance *aInstance, uint8_t aThresho
 
 uint8_t otThreadGetRouterSelectionJitter(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<Mle::Mle>().GetRouterSelectionJitter();
+    uint16_t routerSelectionJitter = AsCoreType(aInstance).Get<Mle::Mle>().GetRouterSelectionJitter();
+    return (routerSelectionJitter > OT_API_MAX_ROUTER_SELECTION_JITTER) ? OT_API_MAX_ROUTER_SELECTION_JITTER
+                                                                        : static_cast<uint8_t>(routerSelectionJitter);
 }
 
 void otThreadSetRouterSelectionJitter(otInstance *aInstance, uint8_t aRouterJitter)
 {
-    AsCoreType(aInstance).Get<Mle::Mle>().SetRouterSelectionJitter(aRouterJitter);
+    // Values within a uint8_t range should not cause errors, so they are ignored to maintain backwards compatibility
+    IgnoreError(AsCoreType(aInstance).Get<Mle::Mle>().SetRouterSelectionJitter(aRouterJitter));
 }
 
 otError otThreadGetChildInfoById(otInstance *aInstance, uint16_t aChildId, otChildInfo *aChildInfo)

--- a/src/core/backbone_router/bbr_local.cpp
+++ b/src/core/backbone_router/bbr_local.cpp
@@ -288,7 +288,7 @@ void Local::HandleTimeTick(void)
     // Delay registration while router role transition is pending
     // (i.e., device may soon switch from REED to router role).
 
-    VerifyOrExit(!Get<Mle::Mle>().IsRouterRoleTransitionPending());
+    VerifyOrExit(!Get<Mle::Mle>().IsRouterRoleTransitioning());
 
     if (mRegistrationTimeout > 0)
     {

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -319,10 +319,15 @@ void DuaManager::HandleNotifierEvents(Events aEvents)
             // Wait for link establishment with neighboring routers.
             UpdateRegistrationDelay(kNewRouterRegistrationDelay);
         }
-        else if (Get<Mle::Mle>().WillBecomeRouterSoon())
+        else
         {
-            // Will check again in case the device decides to stay REED when jitter timeout expires.
-            UpdateRegistrationDelay(Get<Mle::Mle>().GetRouterRoleTransitionTimeout() + kNewRouterRegistrationDelay + 1);
+            int8_t routerTransitionTimeRemaining = Get<Mle::Mle>().GetTimeUntilBecomingRouterIfSoon();
+            if (routerTransitionTimeRemaining >= 0)
+            {
+                // Will check again in case the device decides to stay REED when jitter timeout expires.
+                UpdateRegistrationDelay(static_cast<uint8_t>(routerTransitionTimeRemaining) +
+                                        kNewRouterRegistrationDelay + 1);
+            }
         }
 #endif
     }
@@ -432,10 +437,16 @@ void DuaManager::PerformNextRegistration(void)
     // Only send DUA.req when necessary
 #if OPENTHREAD_CONFIG_DUA_ENABLE
 #if OPENTHREAD_FTD
-    if (!Get<Mle::Mle>().IsRouterOrLeader() && Get<Mle::Mle>().WillBecomeRouterSoon())
+    if (!Get<Mle::Mle>().IsRouterOrLeader())
     {
-        UpdateRegistrationDelay(Get<Mle::Mle>().GetRouterRoleTransitionTimeout() + kNewRouterRegistrationDelay + 1);
-        ExitNow();
+        int8_t routerTransitionTimeRemaining = Get<Mle::Mle>().GetTimeUntilBecomingRouterIfSoon();
+        if (routerTransitionTimeRemaining >= 0)
+        {
+            // Will check again in case the device decides to stay REED when jitter timeout expires.
+            UpdateRegistrationDelay(static_cast<uint8_t>(routerTransitionTimeRemaining) + kNewRouterRegistrationDelay +
+                                    1);
+            ExitNow();
+        }
     }
 #endif
     VerifyOrExit(Get<Mle::Mle>().IsFullThreadDevice() || Get<Mle::Mle>().GetParent().IsThreadVersion1p1());

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -90,8 +90,14 @@ Mle::Mle(Instance &aInstance)
     , mThreadVersionCheckEnabled(true)
 #endif
     , mNetworkIdTimeout(kNetworkIdTimeout)
+
     , mRouterUpgradeThreshold(kRouterUpgradeThreshold)
     , mRouterDowngradeThreshold(kRouterDowngradeThreshold)
+    , mRouterUpgradeDelayMinimum(kRouterTransitionMinimumDefault)
+    , mRouterUpgradeDelayJitter(kRouterTransitionJitterDefault)
+    , mRouterDowngradeDelayMinimum(kRouterTransitionMinimumDefault)
+    , mRouterDowngradeDelayJitter(kRouterTransitionJitterDefault)
+
     , mPreviousPartitionRouterIdSequence(0)
     , mPreviousPartitionIdTimeout(0)
     , mChildRouterLinks(kChildRouterLinks)
@@ -6103,7 +6109,7 @@ void Mle::AnnounceHandler::HandleAnnounceAttachSuccess(void)
     mState = kStateToInformPreviousChannel;
 
 #if OPENTHREAD_FTD
-    if (Get<Mle>().IsFullThreadDevice() && !Get<Mle>().IsRouter() && Get<Mle>().IsRouterRoleTransitionPending())
+    if (Get<Mle>().IsFullThreadDevice() && !Get<Mle>().IsRouter() && Get<Mle>().IsRouterRoleTransitioning())
     {
         ExitNow();
     }

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -785,6 +785,24 @@ public:
     bool IsRouterRoleAllowed(void) const { return mRouterRoleAllowed; }
 
     /**
+     * Start a router upgrade role transition with saved timing parameters.
+     */
+    void StartRouterRoleUpgradeTransition(void)
+    {
+        mRouterRoleTransition.StartTransition(mRouterUpgradeDelayMinimum, mRouterUpgradeDelayJitter,
+                                              RouterRoleTransition::kUpgrading);
+    }
+
+    /**
+     * Start a router downgrade role transition with saved timing parameters.
+     */
+    void StartRouterRoleDowngradeTransition(void)
+    {
+        mRouterRoleTransition.StartTransition(mRouterDowngradeDelayMinimum, mRouterDowngradeDelayJitter,
+                                              RouterRoleTransition::kDowngrading);
+    }
+
+    /**
      * Indicates whether a node is the only router on the network.
      *
      * @retval TRUE   It is the only router in the network.
@@ -924,26 +942,43 @@ public:
     void SetNetworkIdTimeout(uint8_t aTimeout) { mNetworkIdTimeout = aTimeout; }
 
     /**
-     * Returns the ROUTER_SELECTION_JITTER value.
+     * Returns the ROUTER_SELECTION_JITTER value for upgrade transitions.
      *
-     * @returns The ROUTER_SELECTION_JITTER value in seconds.
+     * Note: This currently gets only the upgrade jitter, though the setter also sets the downgrade
+     * jitter to the same value.
+     *
+     * @returns The ROUTER_SELECTION_JITTER value for upgrade transitions in seconds.
      */
-    uint8_t GetRouterSelectionJitter(void) const { return mRouterRoleTransition.GetJitter(); }
+    uint16_t GetRouterSelectionJitter(void) const { return mRouterUpgradeDelayJitter; }
 
     /**
-     * Sets the ROUTER_SELECTION_JITTER value.
+     * Sets the ROUTER_SELECTION_JITTER value for upgrade and downgrade transitions (0 to 1200 seconds).
      *
-     * @param[in] aRouterJitter  The router selection jitter value (in seconds).
+     * @param[in] aRouterJitter  The router selection jitter value for upgrade and downgrade transitions (in seconds).
      */
-    void SetRouterSelectionJitter(uint8_t aRouterJitter) { mRouterRoleTransition.SetJitter(aRouterJitter); }
+    Error SetRouterSelectionJitter(uint16_t aRouterJitter);
 
     /**
-     * Indicates whether or not router role transition (upgrade from REED or downgrade to REED) is pending.
+     * Indicates whether or not a router role transition (or address solicit) is in progress
      *
-     * @retval TRUE    Router role transition is pending.
-     * @retval FALSE   Router role transition is not pending
+     * @retval TRUE    Router role is transitioning or an address solicit is currently pending.
+     * @retval FALSE   Router role is not transitioning.
      */
-    bool IsRouterRoleTransitionPending(void) const { return mRouterRoleTransition.IsPending(); }
+    bool IsRouterRoleTransitioning(void) const
+    {
+        return mRouterRoleTransition.IsTransitioning() || mAddressSolicitPending;
+    }
+
+    /**
+     * Indicates whether or not a router role upgrade transition should be performed.
+     *
+     * @retval TRUE    The upgrade attempt is pending.
+     * @retval FALSE   The upgrade attempt is not currently pending.
+     */
+    bool IsRouterRoleUpgradePending(void) const
+    {
+        return mRouterRoleTransition.IsUpgradePending() && !mAddressSolicitPending;
+    }
 
     /**
      * Returns the current timeout delay in seconds till router role transition (upgrade from REED or downgrade to
@@ -951,7 +986,7 @@ public:
      *
      * @returns The timeout in seconds till router role transition, or zero if not pending role transition.
      */
-    uint8_t GetRouterRoleTransitionTimeout(void) const { return mRouterRoleTransition.GetTimeout(); }
+    uint16_t GetRouterRoleTransitionTimeout(void) const { return mRouterRoleTransition.GetTimeout(); }
 
     /**
      * Returns the ROUTER_UPGRADE_THRESHOLD value.
@@ -1017,12 +1052,12 @@ public:
     Error SetChildRouterLinks(uint8_t aChildRouterLinks);
 
     /**
-     * Returns if the REED is expected to become Router soon.
+     * Returns the time remaining if the REED is expected to become Router soon (within 10s).
      *
-     * @retval TRUE   If the REED is going to become a Router soon.
-     * @retval FALSE  If the REED is not going to become a Router soon.
+     * @retval 0-10   Time remaining, if the REED is going to become a Router soon.
+     * @retval -1     If the REED is not going to become a Router soon.
      */
-    bool WillBecomeRouterSoon(void) const;
+    int8_t GetTimeUntilBecomingRouterIfSoon(void) const;
 
     /**
      * Removes a link to a neighbor.
@@ -1344,14 +1379,17 @@ private:
     static constexpr uint32_t kMaxLeaderToRouterTimeout      = 90000;  // (in msec)
     static constexpr uint8_t  kMinDowngradeNeighbors         = 7;
     static constexpr uint8_t  kNetworkIdTimeout              = 120; // (in sec)
-    static constexpr uint8_t  kRouterSelectionJitter         = 120; // (in sec)
-    static constexpr uint8_t  kRouterDowngradeThreshold      = 23;
-    static constexpr uint8_t  kRouterUpgradeThreshold        = 16;
     static constexpr uint16_t kDiscoveryMaxJitter            = 250; // Max jitter delay Discovery Responses (in msec).
     static constexpr uint16_t kUnsolicitedDataResponseJitter = 500; // Max delay for unsol Data Response (in msec).
     static constexpr uint8_t  kLeaderDowngradeExtraDelay     = 10;  // Extra delay to downgrade leader (in sec).
     static constexpr uint8_t  kDefaultLeaderWeight           = 64;
     static constexpr uint8_t  kAlternateRloc16Timeout        = 8; // Time to use alternate RLOC16 (in sec).
+
+    static constexpr uint8_t  kRouterUpgradeThreshold         = 16;
+    static constexpr uint8_t  kRouterDowngradeThreshold       = 23;
+    static constexpr uint16_t kRouterTransitionMinimumDefault = 0;    ///< (in sec) Default transition delay minimum
+    static constexpr uint16_t kRouterTransitionJitterDefault  = 120;  ///< (in sec) Default transition delay jitter
+    static constexpr uint16_t kRouterTransitionDelayMax       = 1200; ///< (in sec) Maximum transition delay
 
     // Threshold to accept a router upgrade request with reason
     // `kBorderRouterRequest` (number of BRs acting as router in
@@ -2219,18 +2257,32 @@ private:
     public:
         RouterRoleTransition(void);
 
-        bool    IsPending(void) const { return (mTimeout != 0); }
-        void    StartTimeout(void);
-        void    StopTimeout(void) { mTimeout = 0; }
-        void    IncreaseTimeout(uint8_t aIncrement) { mTimeout += aIncrement; }
-        uint8_t GetTimeout(void) const { return mTimeout; }
-        bool    HandleTimeTick(void);
-        uint8_t GetJitter(void) const { return mJitter; }
-        void    SetJitter(uint8_t aJitter) { mJitter = aJitter; }
+        enum Transition : uint8_t
+        {
+            kNotTransitioning = 0,
+            kUpgrading        = 1,
+            kDowngrading      = 2
+        };
+
+        bool IsTransitioning(void) const { return mTransition != kNotTransitioning; }
+        bool IsUpgrading(void) const { return mTransition == kUpgrading; }
+        bool IsDowngrading(void) const { return mTransition == kDowngrading; }
+
+        bool IsUpgradePending(void) const { return IsUpgrading() && mTimeout == 0; }
+        bool IsDowngradePending(void) const { return IsDowngrading() && mTimeout == 0; }
+
+        void ClearTransition(void);
+        void StartTransition(uint16_t   aRouterTransitionMinimum,
+                             uint16_t   aRouterTransitionJitter,
+                             Transition aTransitionType);
+
+        void     IncreaseTimeout(uint8_t aIncrement) { mTimeout += aIncrement; }
+        uint16_t GetTimeout(void) const { return mTimeout; }
+        void     HandleTimeTick(void);
 
     private:
-        uint8_t mTimeout;
-        uint8_t mJitter;
+        uint16_t   mTimeout;
+        Transition mTransition;
     };
 
 #endif
@@ -2558,8 +2610,14 @@ private:
     uint8_t mRouterId;
     uint8_t mPreviousRouterId;
     uint8_t mNetworkIdTimeout;
-    uint8_t mRouterUpgradeThreshold;
-    uint8_t mRouterDowngradeThreshold;
+
+    uint8_t  mRouterUpgradeThreshold;
+    uint8_t  mRouterDowngradeThreshold;
+    uint16_t mRouterUpgradeDelayMinimum;
+    uint16_t mRouterUpgradeDelayJitter;
+    uint16_t mRouterDowngradeDelayMinimum;
+    uint16_t mRouterDowngradeDelayJitter;
+
     uint8_t mLeaderWeight;
     uint8_t mPreviousPartitionRouterIdSequence;
     uint8_t mPreviousPartitionIdTimeout;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -813,13 +813,15 @@ public:
     /**
      * Generates an Address Solicit request for a Router ID.
      *
-     * @param[in]  aReason  The reason for requesting a Router ID.
+     * @param[in] aReasonFlags Bitmap of reasons causing the attempt to upgrade to a router.
      *
      * @retval kErrorNone           Successfully generated an Address Solicit message.
+     * @retval kErrorBusy           An Address Solicit Request is already in progress.
      * @retval kErrorNotCapable     Device is not capable of becoming a router
      * @retval kErrorInvalidState   Thread is not enabled
+     * @retval kErrorInvalidArgs    An invalid aReasonFlags was provided.
      */
-    Error BecomeRouter(RouterUpgradeReason aReason);
+    Error BecomeRouter(RouterUpgradeReasonFlags aReasonFlags);
 
     /**
      * Specifies the leader weight check behavior used in `BecomeLeader()`.
@@ -1769,7 +1771,14 @@ private:
 
         Mac::ExtAddress mExtAddress;
         uint16_t        mRequestedRloc16;
-        uint8_t         mReason;
+        /**
+         * Single reason given in the Status TLV for backwards compatibility
+         */
+        RouterUpgradeReasonFlags::StatusTlvEnum mStatusTlvReason;
+        /**
+         * mReasonFlags can indicate multiple upgrade reasons, or kUpgradeReasonFlagsNone if omitted.
+         */
+        RouterUpgradeReasonFlags mReasonFlags;
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
         uint16_t mXtalAccuracy;
 #endif
@@ -2491,7 +2500,7 @@ private:
     Error    ReadAndProcessRouteTlvOnFtdChild(RxInfo &aRxInfo, uint8_t aParentId);
     void     StopAdvertiseTrickleTimer(void);
     uint32_t DetermineAdvertiseIntervalMax(void) const;
-    Error    SendAddressSolicit(RouterUpgradeReason aReason);
+    Error    SendAddressSolicit(RouterUpgradeReasonFlags aReasonFlags);
     void     ProcessAddressSolicit(AddrSolicitInfo &aInfo);
     void     SendAddressRelease(void);
     void     SendMulticastAdvertisement(void);
@@ -2543,18 +2552,21 @@ private:
     bool ShouldBeginDowngradeTimer(uint8_t aNeighborId, const RouteTlv &aRouteTlv) const;
 
     /**
-     * Determine if a router upgrade transition should occur or timer should be started.
+     * Get the upgrade reason flags that apply, if a router upgrade transition or its timer should be started.
      *
      * Note: This checks all upgrade conditions both when the timer is started and when the upgrade is attempted but
      * does not check `HasNeighborWithGoodLinkQuality()`, so that the runtime required by that check will only
      * apply just before making the attempt to upgrade.
      *
-     * @retval TRUE   Upgrade conditions may apply.
-     * @retval FALSE  The device should not upgrade.
+     * @param[in] aImmediateUpgradeReason A reason to upgrade immediately or kUpgradeReasonFlagsNone by default
+     *
+     * @returns RouterUpgradeReasonFlags with one or more flags set or kUpgradeReasonFlagsNone,
+     * if no upgrade should be started
      *
      * @sa HasNeighborWithGoodLinkQuality
      */
-    bool ShouldUpgrade(void) const;
+    RouterUpgradeReasonFlags GetUpgradeReasons(RouterUpgradeReasonFlags::ReasonBitmapEnum aImmediateUpgradeReason =
+                                                   RouterUpgradeReasonFlags::kUpgradeReasonFlagsNone) const;
 
     bool NeighborHasComparableConnectivity(uint8_t aNeighborId, const RouteTlv &aRouteTlv) const;
 
@@ -2575,7 +2587,7 @@ private:
     static void HandleAdvertiseTrickleTimer(TrickleTimer &aTimer);
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
-    const char *RouterUpgradeReasonToString(uint8_t aReason);
+    const char *RouterUpgradeReasonToString(RouterUpgradeReasonFlags::StatusTlvEnum aStatusTlvReason);
 #endif
 
 #endif // OPENTHREAD_FTD

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -2518,11 +2518,49 @@ private:
     void     SetChildStateToValid(Child &aChild);
     bool     HasChildren(void);
     void     RemoveChildren(void);
-    bool     ShouldDowngrade(uint8_t aNeighborId, const RouteTlv &aRouteTlv) const;
-    bool     NeighborHasComparableConnectivity(const RouteTlv &aRouteTlv, uint8_t aNeighborId) const;
-    void     HandleAdvertiseTrickleTimer(void);
-    void     HandleTimeTick(void);
-    void     HandleRouterTableEvent(RouterTable::Events aEvents);
+
+    /**
+     * Determine if a router downgrade transition should occur or timer should be started.
+     *
+     * Note: Checks all downgrade conditions except having comparable connectivity to a neighbor router both when
+     * the timer is started and when the downgrade is performed.
+     *
+     * @retval TRUE   Downgrade conditions may apply for the Router role.
+     * @retval FALSE  The device should not downgrade or is not in the Router role.
+     *
+     * @sa ShouldBeginDowngradeTimer
+     */
+    bool ShouldRouterDowngrade(void) const;
+
+    /**
+     * Determine if a router downgrade transition timer should be started.
+     *
+     * Note: Checks all conditions known when handling advertisments.
+     *
+     * @retval TRUE   The unit should begin its downgrade timer.
+     * @retval FALSE  The device should not downgrade.
+     */
+    bool ShouldBeginDowngradeTimer(uint8_t aNeighborId, const RouteTlv &aRouteTlv) const;
+
+    /**
+     * Determine if a router upgrade transition should occur or timer should be started.
+     *
+     * Note: This checks all upgrade conditions both when the timer is started and when the upgrade is attempted but
+     * does not check `HasNeighborWithGoodLinkQuality()`, so that the runtime required by that check will only
+     * apply just before making the attempt to upgrade.
+     *
+     * @retval TRUE   Upgrade conditions may apply.
+     * @retval FALSE  The device should not upgrade.
+     *
+     * @sa HasNeighborWithGoodLinkQuality
+     */
+    bool ShouldUpgrade(void) const;
+
+    bool NeighborHasComparableConnectivity(uint8_t aNeighborId, const RouteTlv &aRouteTlv) const;
+
+    void HandleAdvertiseTrickleTimer(void);
+    void HandleTimeTick(void);
+    void HandleRouterTableEvent(RouterTable::Events aEvents);
 
     template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
 

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -131,7 +131,7 @@ void Mle::UpdateRouterRoleAllowed(UpdateRouterRoleAllowedReason aReason)
     // Take action based on the current role, the new `mRouterRoleAllowed`,
     // and the reason for the change.
 
-    if (IsChild() && mRouterRoleAllowed && (aReason == kReasonConfigParameterChanged))
+    if (IsChild() && mRouterRoleAllowed && (aReason == kReasonConfigParameterChanged) && ShouldUpgrade())
     {
         StartRouterRoleUpgradeTransition();
     }
@@ -343,11 +343,12 @@ void Mle::HandleChildStart(void)
 {
     mAddressSolicitRejected = false;
 
-    if (IsRouterRoleAllowed())
+    if (ShouldUpgrade())
     {
         // As a REED, re-start the timer to check for a role upgrade when re-attaching as a Child
         StartRouterRoleUpgradeTransition();
     }
+    // If the REED shouldn't upgrade, then it may begin sending advertisements on the next time tick.
 
     StopLeader();
     Get<TimeTicker>().RegisterReceiver(TimeTicker::kMle);
@@ -1310,7 +1311,7 @@ Error Mle::HandleAdvertisementOnFtd(RxInfo &aRxInfo, uint16_t aSourceAddress, co
                 ExitNow(error = kErrorDetached);
             }
 
-            if (mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold)
+            if (ShouldUpgrade())
             {
                 if (!IsRouterRoleTransitioning())
                 {
@@ -1348,7 +1349,7 @@ Error Mle::HandleAdvertisementOnFtd(RxInfo &aRxInfo, uint16_t aSourceAddress, co
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Update routers as a router or leader.
 
-    if (ShouldDowngrade(routerId, routeTlv))
+    if (ShouldBeginDowngradeTimer(routerId, routeTlv))
     {
         // Downgrade conditions have been met after an advertisement from another active router
         StartRouterRoleDowngradeTransition();
@@ -1623,7 +1624,7 @@ void Mle::HandleTimeTick(void)
         else if (IsRouterRoleUpgradePending())
         {
             // An upgrade should be performed, if the conditions to upgrade still apply
-            if (mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold && HasNeighborWithGoodLinkQuality())
+            if (ShouldUpgrade() && HasNeighborWithGoodLinkQuality())
             {
                 IgnoreError(BecomeRouter(kReasonTooFewRouters));
                 // Any attempt to become a router will also clear the current role transition
@@ -1649,7 +1650,7 @@ void Mle::HandleTimeTick(void)
         if (mRouterRoleTransition.IsDowngradePending())
         {
             bool roleAllowed           = IsRouterRoleAllowed();
-            bool shouldRouterDowngrade = IsRouter() && mRouterTable.GetActiveRouterCount() > mRouterDowngradeThreshold;
+            bool shouldRouterDowngrade = ShouldRouterDowngrade();
             if (!roleAllowed || shouldRouterDowngrade)
             {
                 if (IsRouter())
@@ -3830,58 +3831,23 @@ void Mle::FillConnectivityTlvValue(ConnectivityTlvValue &aTlvValue) const
     aTlvValue.InitFrom(connectivity);
 }
 
-bool Mle::ShouldDowngrade(uint8_t aNeighborId, const RouteTlv &aRouteTlv) const
+bool Mle::ShouldBeginDowngradeTimer(uint8_t aNeighborId, const RouteTlv &aRouteTlv) const
 {
     // Determine whether all conditions are satisfied for the router
     // to downgrade after receiving info for a neighboring router
     // with Router ID `aNeighborId` along with its `aRouteTlv`.
 
-    bool    shouldDowngrade   = false;
-    uint8_t activeRouterCount = mRouterTable.GetActiveRouterCount();
-    uint8_t count;
+    bool shouldDowngrade = false;
 
-    VerifyOrExit(IsRouter());
     VerifyOrExit(mRouterTable.IsAllocated(aNeighborId));
-    VerifyOrExit(!mBlockDowngrade);
 
     // Return false, to let an existing downgrade transition continue
     VerifyOrExit(!mRouterRoleTransition.IsDowngrading());
 
-    VerifyOrExit(activeRouterCount > mRouterDowngradeThreshold);
+    VerifyOrExit(ShouldRouterDowngrade());
 
-    // Check that we have at least `kMinDowngradeNeighbors`
-    // neighboring routers with two-way link quality of 2 or better.
-
-    count = 0;
-
-    for (const Router &router : mRouterTable)
-    {
-        if (!router.IsStateValid() || (router.GetTwoWayLinkQuality() < kLinkQuality2))
-        {
-            continue;
-        }
-
-        count++;
-
-        if (count >= kMinDowngradeNeighbors)
-        {
-            break;
-        }
-    }
-
-    VerifyOrExit(count >= kMinDowngradeNeighbors);
-
-    // Check that we have fewer children than three times the number
-    // of excess routers (defined as the difference between number of
-    // active routers and `mRouterDowngradeThreshold`).
-
-    count = activeRouterCount - mRouterDowngradeThreshold;
-    VerifyOrExit(mChildTable.GetNumChildren(Child::kInStateValid) < count * 3);
-
-    // Check that the neighbor has as good or better-quality links to
-    // same routers.
-
-    VerifyOrExit(NeighborHasComparableConnectivity(aRouteTlv, aNeighborId));
+    // Check that the neighbor has as good or better-quality links to the same routers.
+    VerifyOrExit(NeighborHasComparableConnectivity(aNeighborId, aRouteTlv));
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTER_REQUEST_ROUTER_ROLE
     // Check if we are eligible to be router due to being a BR.
@@ -3894,7 +3860,61 @@ exit:
     return shouldDowngrade;
 }
 
-bool Mle::NeighborHasComparableConnectivity(const RouteTlv &aRouteTlv, uint8_t aNeighborId) const
+bool Mle::ShouldRouterDowngrade(void) const
+{
+    uint8_t count;
+    uint8_t excessRouters;
+    bool    shouldDowngrade   = false;
+    uint8_t activeRouterCount = mRouterTable.GetActiveRouterCount();
+
+    // Only kRoleRouter may downgrade.
+    // kRoleLeader may not downgrade due to these conditions, and other roles are not applicable.
+    VerifyOrExit(IsRouter());
+
+    VerifyOrExit(!mBlockDowngrade);
+    VerifyOrExit(activeRouterCount > mRouterDowngradeThreshold);
+
+    excessRouters = (activeRouterCount > mRouterDowngradeThreshold) ? activeRouterCount - mRouterDowngradeThreshold : 0;
+    VerifyOrExit(mChildTable.GetNumChildren(Child::kInStateValid) < excessRouters * 3);
+
+    // Check that we have at least `kMinDowngradeNeighbors`
+    // neighboring routers with two-way link quality of 2 or better.
+    count = 0;
+    for (const Router &router : mRouterTable)
+    {
+        if (!router.IsStateValid() || (router.GetTwoWayLinkQuality() < kLinkQuality2))
+        {
+            continue;
+        }
+        count++;
+        if (count >= kMinDowngradeNeighbors)
+        {
+            break;
+        }
+    }
+    VerifyOrExit(count >= kMinDowngradeNeighbors);
+
+    shouldDowngrade = true;
+exit:
+    return shouldDowngrade;
+}
+
+bool Mle::ShouldUpgrade(void) const
+{
+    bool shouldUpgrade = false;
+
+    VerifyOrExit(IsRouterRoleAllowed());
+
+    if (mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold)
+    {
+        shouldUpgrade = true;
+    }
+
+exit:
+    return shouldUpgrade;
+}
+
+bool Mle::NeighborHasComparableConnectivity(uint8_t aNeighborId, const RouteTlv &aRouteTlv) const
 {
     // Check whether the neighboring router with Router ID `aNeighborId`
     // (along with its `aRouteTlv`) has as good or better-quality links

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -131,7 +131,8 @@ void Mle::UpdateRouterRoleAllowed(UpdateRouterRoleAllowedReason aReason)
     // Take action based on the current role, the new `mRouterRoleAllowed`,
     // and the reason for the change.
 
-    if (IsChild() && mRouterRoleAllowed && (aReason == kReasonConfigParameterChanged) && ShouldUpgrade())
+    if (IsChild() && mRouterRoleAllowed && (aReason == kReasonConfigParameterChanged) &&
+        GetUpgradeReasons().HasReason())
     {
         StartRouterRoleUpgradeTransition();
     }
@@ -217,9 +218,12 @@ void Mle::SetDeviceProperties(const DeviceProperties &aDeviceProperties)
 }
 #endif
 
-Error Mle::BecomeRouter(RouterUpgradeReason aReason)
+Error Mle::BecomeRouter(RouterUpgradeReasonFlags aReasonFlags)
 {
     Error error = kErrorNone;
+
+    VerifyOrExit(!mAddressSolicitPending, error = kErrorBusy);
+    VerifyOrExit(aReasonFlags.HasReason(), error = kErrorInvalidArgs);
 
     switch (mRole)
     {
@@ -238,11 +242,11 @@ Error Mle::BecomeRouter(RouterUpgradeReason aReason)
 
     VerifyOrExit(IsRouterRoleAllowed(), error = kErrorNotCapable);
 
-    LogInfo("Attempt to become router, reason:%s", RouterUpgradeReasonToString(aReason));
+    LogInfo("Attempt to become router with reason flags: (0x%02x)", aReasonFlags.AsUint8());
 
     Get<MeshForwarder>().SetRxOnWhenIdle(true);
 
-    error = SendAddressSolicit(aReason);
+    error = SendAddressSolicit(aReasonFlags);
 
 exit:
     // The upgrade attempt was completed.
@@ -343,7 +347,7 @@ void Mle::HandleChildStart(void)
 {
     mAddressSolicitRejected = false;
 
-    if (ShouldUpgrade())
+    if (GetUpgradeReasons().HasReason())
     {
         // As a REED, re-start the timer to check for a role upgrade when re-attaching as a Child
         StartRouterRoleUpgradeTransition();
@@ -375,7 +379,7 @@ void Mle::HandleChildStart(void)
     case kSamePartition:
         if (HasChildren())
         {
-            IgnoreError(BecomeRouter(kReasonHaveChildIdRequest));
+            IgnoreError(BecomeRouter(RouterUpgradeReasonFlags::kUpgradeReasonHaveChildIdRequestFlag));
         }
 
         break;
@@ -408,7 +412,7 @@ void Mle::HandleChildStart(void)
     case kBetterPartition:
         if (HasChildren() && mPreviousPartitionIdRouter != mLeaderData.GetPartitionId())
         {
-            IgnoreError(BecomeRouter(kReasonParentPartitionChange));
+            IgnoreError(BecomeRouter(RouterUpgradeReasonFlags::kUpgradeReasonParentPartitionChangeFlag));
         }
 
         break;
@@ -1311,7 +1315,7 @@ Error Mle::HandleAdvertisementOnFtd(RxInfo &aRxInfo, uint16_t aSourceAddress, co
                 ExitNow(error = kErrorDetached);
             }
 
-            if (ShouldUpgrade())
+            if (GetUpgradeReasons().HasReason())
             {
                 if (!IsRouterRoleTransitioning())
                 {
@@ -1623,10 +1627,11 @@ void Mle::HandleTimeTick(void)
         }
         else if (IsRouterRoleUpgradePending())
         {
+            RouterUpgradeReasonFlags upgradeReasons = GetUpgradeReasons();
             // An upgrade should be performed, if the conditions to upgrade still apply
-            if (ShouldUpgrade() && HasNeighborWithGoodLinkQuality())
+            if (upgradeReasons.HasReason() && HasNeighborWithGoodLinkQuality())
             {
-                IgnoreError(BecomeRouter(kReasonTooFewRouters));
+                IgnoreError(BecomeRouter(upgradeReasons));
                 // Any attempt to become a router will also clear the current role transition
             }
             else
@@ -2289,7 +2294,7 @@ void Mle::HandleChildIdRequest(RxInfo &aRxInfo)
     {
     case kRoleChild:
         child->SetState(Neighbor::kStateChildIdRequest);
-        IgnoreError(BecomeRouter(kReasonHaveChildIdRequest));
+        IgnoreError(BecomeRouter(RouterUpgradeReasonFlags::kUpgradeReasonHaveChildIdRequestFlag));
         break;
 
     case kRoleRouter:
@@ -3354,13 +3359,16 @@ void Mle::SetRouterId(uint8_t aRouterId)
     mPreviousRouterId = mRouterId;
 }
 
-Error Mle::SendAddressSolicit(RouterUpgradeReason aReason)
+Error Mle::SendAddressSolicit(RouterUpgradeReasonFlags aReasonFlags)
 {
     Error          error   = kErrorNone;
     Coap::Message *message = nullptr;
     Ip6::Address   leaderRloc;
 
+    RouterUpgradeReasonFlags::StatusTlvEnum statusTlvReason;
+
     VerifyOrExit(!mAddressSolicitPending);
+    SuccessOrExit(error = aReasonFlags.AsStatusTlvReason(statusTlvReason));
 
     message = Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriAddressSolicit);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
@@ -3372,7 +3380,8 @@ Error Mle::SendAddressSolicit(RouterUpgradeReason aReason)
         SuccessOrExit(error = Tlv::Append<ThreadRloc16Tlv>(*message, Rloc16FromRouterId(mPreviousRouterId)));
     }
 
-    SuccessOrExit(error = Tlv::Append<ThreadStatusTlv>(*message, aReason));
+    SuccessOrExit(error = Tlv::Append<ThreadStatusTlv>(*message, static_cast<uint8_t>(statusTlvReason)));
+    SuccessOrExit(error = Tlv::Append<RouterUpgradeReasonFlagsTlv>(*message, aReasonFlags));
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     SuccessOrExit(error = Tlv::Append<XtalAccuracyTlv>(*message, otPlatTimeGetXtalAccuracy()));
@@ -3384,6 +3393,9 @@ Error Mle::SendAddressSolicit(RouterUpgradeReason aReason)
     mAddressSolicitPending = true;
 
     Log(kMessageSend, kTypeAddressSolicit, leaderRloc);
+
+    LogInfo("Sending AddrSolicit (statusTlvReason: %s, flags: 0x%02x)", RouterUpgradeReasonToString(statusTlvReason),
+            aReasonFlags.AsUint8());
 
 exit:
     FreeMessageOnError(message, error);
@@ -3582,12 +3594,19 @@ Error Mle::AddrSolicitInfo::ParseFrom(const Coap::Msg &aMsg)
 {
     // Parses a `kUriAddressSolicit` request message.
 
-    Error error;
+    Error   error;
+    uint8_t statusTlvReason;
 
     VerifyOrExit(aMsg.IsConfirmable(), error = kErrorParse);
 
     SuccessOrExit(error = Tlv::Find<ThreadExtMacAddressTlv>(aMsg.mMessage, mExtAddress));
-    SuccessOrExit(error = Tlv::Find<ThreadStatusTlv>(aMsg.mMessage, mReason));
+    SuccessOrExit(error = Tlv::Find<ThreadStatusTlv>(aMsg.mMessage, statusTlvReason));
+    mStatusTlvReason = static_cast<RouterUpgradeReasonFlags::StatusTlvEnum>(statusTlvReason);
+    if (Tlv::Find<RouterUpgradeReasonFlagsTlv>(aMsg.mMessage, mReasonFlags) != kErrorNone)
+    {
+        // For backwards compatibility, RouterUpgradeReasonFlagsTlv may be omitted.
+        mReasonFlags = RouterUpgradeReasonFlags(RouterUpgradeReasonFlags::kUpgradeReasonFlagsNone);
+    }
 
     switch (Tlv::Find<ThreadRloc16Tlv>(aMsg.mMessage, mRequestedRloc16))
     {
@@ -3625,7 +3644,8 @@ void Mle::ProcessAddressSolicit(AddrSolicitInfo &aInfo)
     aInfo.mResponse = kAddrSolicitNoAddressAvailable;
     aInfo.mRouter   = nullptr;
 
-    LogInfo("AddrSolicit Reason: %s", RouterUpgradeReasonToString(aInfo.mReason));
+    LogInfo("Received AddrSolicit (reason: %s, flags: 0x%02x)", RouterUpgradeReasonToString(aInfo.mStatusTlvReason),
+            aInfo.mReasonFlags.AsUint8());
 
     if (aInfo.mRequestedRloc16 != kInvalidRloc16)
     {
@@ -3644,17 +3664,17 @@ void Mle::ProcessAddressSolicit(AddrSolicitInfo &aInfo)
         ExitNow();
     }
 
-    switch (aInfo.mReason)
+    switch (aInfo.mStatusTlvReason)
     {
-    case kReasonTooFewRouters:
+    case RouterUpgradeReasonFlags::kReasonTooFewRouters:
         VerifyOrExit(mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold);
         break;
 
-    case kReasonHaveChildIdRequest:
-    case kReasonParentPartitionChange:
+    case RouterUpgradeReasonFlags::kReasonHaveChildIdRequest:
+    case RouterUpgradeReasonFlags::kReasonParentPartitionChange:
         break;
 
-    case kReasonBorderRouterRequest:
+    case RouterUpgradeReasonFlags::kReasonBorderRouterRequest:
         if ((mRouterTable.GetActiveRouterCount() >= mRouterUpgradeThreshold) &&
             (Get<NetworkData::Leader>().CountBorderRouters(NetworkData::kRouterRoleOnly) >=
              kRouterUpgradeBorderRouterRequestThreshold))
@@ -3899,19 +3919,24 @@ exit:
     return shouldDowngrade;
 }
 
-bool Mle::ShouldUpgrade(void) const
+RouterUpgradeReasonFlags Mle::GetUpgradeReasons(
+    RouterUpgradeReasonFlags::ReasonBitmapEnum aImmediateUpgradeReason) const
 {
-    bool shouldUpgrade = false;
+    RouterUpgradeReasonFlags reasonFlags(RouterUpgradeReasonFlags::kUpgradeReasonFlagsNone);
 
     VerifyOrExit(IsRouterRoleAllowed());
 
+    reasonFlags |= aImmediateUpgradeReason;
+
+    // Additional reasons that do not upgrade immediately
     if (mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold)
     {
-        shouldUpgrade = true;
+        reasonFlags |= RouterUpgradeReasonFlags::kUpgradeReasonTooFewRoutersFlag;
     }
+    // Future changes will include additional changes here for kUpgradeReasonManagedRouterFlag
 
 exit:
-    return shouldUpgrade;
+    return reasonFlags;
 }
 
 bool Mle::NeighborHasComparableConnectivity(uint8_t aNeighborId, const RouteTlv &aRouteTlv) const
@@ -4061,24 +4086,26 @@ exit:
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
-const char *Mle::RouterUpgradeReasonToString(uint8_t aReason)
+const char *Mle::RouterUpgradeReasonToString(RouterUpgradeReasonFlags::StatusTlvEnum aStatusTlvReason)
 {
-    const char *str = "Unknown";
+    const char *str;
 
-    switch (aReason)
+    switch (aStatusTlvReason)
     {
-    case kReasonTooFewRouters:
+    case RouterUpgradeReasonFlags::kReasonTooFewRouters:
         str = "TooFewRouters";
         break;
-    case kReasonHaveChildIdRequest:
+    case RouterUpgradeReasonFlags::kReasonHaveChildIdRequest:
         str = "HaveChildIdRequest";
         break;
-    case kReasonParentPartitionChange:
+    case RouterUpgradeReasonFlags::kReasonParentPartitionChange:
         str = "ParentPartitionChange";
         break;
-    case kReasonBorderRouterRequest:
+    case RouterUpgradeReasonFlags::kReasonBorderRouterRequest:
         str = "BorderRouterRequest";
         break;
+    default:
+        str = "Unknown";
     }
 
     return str;

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -133,7 +133,7 @@ void Mle::UpdateRouterRoleAllowed(UpdateRouterRoleAllowedReason aReason)
 
     if (IsChild() && mRouterRoleAllowed && (aReason == kReasonConfigParameterChanged))
     {
-        mRouterRoleTransition.StartTimeout();
+        StartRouterRoleUpgradeTransition();
     }
 
     if (IsRouterOrLeader())
@@ -161,8 +161,8 @@ void Mle::UpdateRouterRoleAllowed(UpdateRouterRoleAllowedReason aReason)
             break;
 
         case kReasonSecurityPolicyChanged:
-            VerifyOrExit(!mRouterRoleTransition.IsPending());
-            mRouterRoleTransition.StartTimeout();
+            VerifyOrExit(!mRouterRoleTransition.IsDowngrading());
+            StartRouterRoleDowngradeTransition();
 
             if (IsLeader())
             {
@@ -241,11 +241,13 @@ Error Mle::BecomeRouter(RouterUpgradeReason aReason)
     LogInfo("Attempt to become router, reason:%s", RouterUpgradeReasonToString(aReason));
 
     Get<MeshForwarder>().SetRxOnWhenIdle(true);
-    mRouterRoleTransition.StopTimeout();
 
     error = SendAddressSolicit(aReason);
 
 exit:
+    // The upgrade attempt was completed.
+    // Future upgrade attempts may be re-started when receiving advertisements.
+    mRouterRoleTransition.ClearTransition();
     return error;
 }
 
@@ -341,7 +343,11 @@ void Mle::HandleChildStart(void)
 {
     mAddressSolicitRejected = false;
 
-    mRouterRoleTransition.StartTimeout();
+    if (IsRouterRoleAllowed())
+    {
+        // As a REED, re-start the timer to check for a role upgrade when re-attaching as a Child
+        StartRouterRoleUpgradeTransition();
+    }
 
     StopLeader();
     Get<TimeTicker>().RegisterReceiver(TimeTicker::kMle);
@@ -1304,9 +1310,19 @@ Error Mle::HandleAdvertisementOnFtd(RxInfo &aRxInfo, uint16_t aSourceAddress, co
                 ExitNow(error = kErrorDetached);
             }
 
-            if (!mRouterRoleTransition.IsPending() && (mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold))
+            if (mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold)
             {
-                mRouterRoleTransition.StartTimeout();
+                if (!IsRouterRoleTransitioning())
+                {
+                    // Upgrade conditions have been met after an advertisement from a child's parent and the
+                    // upgrade is not yet scheduled.
+                    StartRouterRoleUpgradeTransition();
+                }
+            }
+            else
+            {
+                // Clear the transition timer if the reason to upgrade no longer applies
+                mRouterRoleTransition.ClearTransition();
             }
 
             mRouterTable.UpdateRouterOnFtdChild(routeTlv, routerId);
@@ -1332,9 +1348,10 @@ Error Mle::HandleAdvertisementOnFtd(RxInfo &aRxInfo, uint16_t aSourceAddress, co
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Update routers as a router or leader.
 
-    if (IsRouter() && ShouldDowngrade(routerId, routeTlv))
+    if (ShouldDowngrade(routerId, routeTlv))
     {
-        mRouterRoleTransition.StartTimeout();
+        // Downgrade conditions have been met after an advertisement from another active router
+        StartRouterRoleDowngradeTransition();
     }
 
     router = mRouterTable.FindRouterById(routerId);
@@ -1588,54 +1605,76 @@ void Mle::HandleTimeTick(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Role transitions
 
-    if (mRouterRoleTransition.HandleTimeTick())
+    mRouterRoleTransition.HandleTimeTick();
+
+    switch (mRole)
     {
-        // `mRouterRoleTransition.HandleTimeTick()` returns `true`
-        // if role transition timeout expires.
+    case kRoleDisabled:
+    case kRoleDetached:
+        break;
 
-        switch (mRole)
+    case kRoleChild:
+        if (!IsRouterRoleAllowed() || mRouterRoleTransition.IsDowngrading())
         {
-        case kRoleDisabled:
-        case kRoleDetached:
-            break;
-
-        case kRoleChild:
+            // This device is a FED or a downgrade transition was not completed before a role change.
+            // Clear the transition if in progress and skip starting REED advertisements.
+            mRouterRoleTransition.ClearTransition();
+        }
+        else if (IsRouterRoleUpgradePending())
+        {
+            // An upgrade should be performed, if the conditions to upgrade still apply
             if (mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold && HasNeighborWithGoodLinkQuality())
             {
                 IgnoreError(BecomeRouter(kReasonTooFewRouters));
+                // Any attempt to become a router will also clear the current role transition
             }
             else
             {
+                // Since the conditions to upgrade no longer apply, clear the upgrade transition
+                mRouterRoleTransition.ClearTransition();
+                // Also ensure that the actions to perform at the completion of a router role transition are still done
                 mAnnounceHandler.HandleRouterRoleTransitionAttemptDone();
             }
-
-            if (!mAdvertiseTrickleTimer.IsRunning())
-            {
-                SendMulticastAdvertisement();
-
-                mAdvertiseTrickleTimer.Start(TrickleTimer::kModePlainTimer, kReedAdvIntervalMin, kReedAdvIntervalMax);
-            }
-
-            break;
-
-        case kRoleRouter:
-            if (mRouterTable.GetActiveRouterCount() > mRouterDowngradeThreshold)
-            {
-                LogNote("Downgrade to REED");
-                mAttacher.Attach(kDowngradeToReed);
-            }
-
-            OT_FALL_THROUGH;
-
-        case kRoleLeader:
-            if (!IsRouterRoleAllowed())
-            {
-                LogInfo("Router role no longer allowed");
-                IgnoreError(BecomeDetached());
-            }
-
-            break;
         }
+        else if (!IsRouterRoleTransitioning() && !mAdvertiseTrickleTimer.IsRunning())
+        {
+            // REEDs should start sending REED advertisements when no longer waiting to transitioning roles
+            SendMulticastAdvertisement();
+            mAdvertiseTrickleTimer.Start(TrickleTimer::kModePlainTimer, kReedAdvIntervalMin, kReedAdvIntervalMax);
+        }
+        break;
+
+    case kRoleRouter:
+    case kRoleLeader:
+        if (mRouterRoleTransition.IsDowngradePending())
+        {
+            bool roleAllowed           = IsRouterRoleAllowed();
+            bool shouldRouterDowngrade = IsRouter() && mRouterTable.GetActiveRouterCount() > mRouterDowngradeThreshold;
+            if (!roleAllowed || shouldRouterDowngrade)
+            {
+                if (IsRouter())
+                {
+                    // Perform re-attachment to downgrade from the kRoleRouter role
+                    LogNote("Downgrade from Router to REED (allowed:%d, downgrade: %d)", roleAllowed,
+                            shouldRouterDowngrade);
+                    mAttacher.Attach(kDowngradeToReed);
+                }
+                else // IsLeader()
+                {
+                    // Only use detachment to downgrade from the kRoleLeader role
+                    LogInfo("Downgrade from Leader to REED (Router role no longer allowed).");
+                    IgnoreError(BecomeDetached());
+                }
+            }
+            // Clear the timer on a successful downgrade, or if the downgrade transition is no longer applicable
+            mRouterRoleTransition.ClearTransition();
+        }
+        else if (mRouterRoleTransition.IsUpgrading())
+        {
+            // Upgrading is not applicable to active routers
+            mRouterRoleTransition.ClearTransition();
+        }
+        break;
     }
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3495,6 +3534,16 @@ exit:
     mAnnounceHandler.HandleRouterRoleTransitionAttemptDone();
 }
 
+Error Mle::SetRouterSelectionJitter(uint16_t aRouterJitter)
+{
+    Error error = kErrorNone;
+    VerifyOrExit(aRouterJitter <= kRouterTransitionDelayMax, error = kErrorInvalidArgs);
+    mRouterUpgradeDelayJitter   = aRouterJitter;
+    mRouterDowngradeDelayJitter = aRouterJitter;
+exit:
+    return error;
+}
+
 Error Mle::SetChildRouterLinks(uint8_t aChildRouterLinks)
 {
     Error error = kErrorNone;
@@ -3505,21 +3554,24 @@ exit:
     return error;
 }
 
-bool Mle::WillBecomeRouterSoon(void) const
+int8_t Mle::GetTimeUntilBecomingRouterIfSoon(void) const
 {
     static constexpr uint8_t kMaxDelay = 10;
 
-    bool willBecomeRouter = false;
+    uint16_t currentTimeout   = mRouterRoleTransition.GetTimeout();
+    int8_t   willBecomeRouter = -1;
 
     VerifyOrExit(IsRouterRoleAllowed() && IsChild());
     VerifyOrExit(!mAddressSolicitRejected);
 
-    if (!mAddressSolicitPending)
+    if (mAddressSolicitPending)
     {
-        VerifyOrExit(mRouterRoleTransition.IsPending() && mRouterRoleTransition.GetTimeout() <= kMaxDelay);
+        ExitNow(willBecomeRouter = 0);
     }
 
-    willBecomeRouter = true;
+    VerifyOrExit(mRouterRoleTransition.IsUpgrading());
+    VerifyOrExit(currentTimeout <= kMaxDelay);
+    willBecomeRouter = static_cast<int8_t>(currentTimeout);
 
 exit:
     return willBecomeRouter;
@@ -3792,7 +3844,8 @@ bool Mle::ShouldDowngrade(uint8_t aNeighborId, const RouteTlv &aRouteTlv) const
     VerifyOrExit(mRouterTable.IsAllocated(aNeighborId));
     VerifyOrExit(!mBlockDowngrade);
 
-    VerifyOrExit(!mRouterRoleTransition.IsPending());
+    // Return false, to let an existing downgrade transition continue
+    VerifyOrExit(!mRouterRoleTransition.IsDowngrading());
 
     VerifyOrExit(activeRouterCount > mRouterDowngradeThreshold);
 
@@ -4018,22 +4071,42 @@ const char *Mle::RouterUpgradeReasonToString(uint8_t aReason)
 
 Mle::RouterRoleTransition::RouterRoleTransition(void)
     : mTimeout(0)
-    , mJitter(kRouterSelectionJitter)
+    , mTransition(kNotTransitioning)
 {
 }
 
-void Mle::RouterRoleTransition::StartTimeout(void) { mTimeout = 1 + Random::NonCrypto::GetUint8InRange(0, mJitter); }
-
-bool Mle::RouterRoleTransition::HandleTimeTick(void)
+void Mle::RouterRoleTransition::ClearTransition(void)
 {
-    bool expired = false;
+    mTimeout    = 0;
+    mTransition = kNotTransitioning;
+}
 
-    VerifyOrExit(mTimeout > 0);
-    mTimeout--;
-    expired = (mTimeout == 0);
+void Mle::RouterRoleTransition::StartTransition(uint16_t   aRouterTransitionMinimum,
+                                                uint16_t   aRouterTransitionJitter,
+                                                Transition aTransitionType)
+{
+    uint16_t minimumDelay = Min<uint16_t>(aRouterTransitionMinimum, kRouterTransitionDelayMax);
+    if (aRouterTransitionJitter == 0)
+    {
+        mTimeout = minimumDelay;
+    }
+    else
+    {
+        // Note: GetUint16InRange() returns a value in the range [minimumDelay, delayUpperLimit)
+        uint16_t delayUpperLimit = static_cast<uint16_t>(Min<uint32_t>(
+            static_cast<uint32_t>(minimumDelay) + aRouterTransitionJitter + 1, kRouterTransitionDelayMax + 1));
+        mTimeout                 = Random::NonCrypto::GetUint16InRange(minimumDelay, delayUpperLimit);
+    }
 
-exit:
-    return expired;
+    mTransition = aTransitionType;
+}
+
+void Mle::RouterRoleTransition::HandleTimeTick(void)
+{
+    if (mTimeout > 0)
+    {
+        mTimeout--;
+    }
 }
 
 } // namespace Mle

--- a/src/core/thread/mle_types.cpp
+++ b/src/core/thread/mle_types.cpp
@@ -45,6 +45,42 @@ namespace ot {
 namespace Mle {
 
 //---------------------------------------------------------------------------------------------------------------------
+// RouterUpgradeReasonFlags
+
+#if OPENTHREAD_FTD
+otError RouterUpgradeReasonFlags::AsStatusTlvReason(StatusTlvEnum &aStatusTlvReason) const
+{
+    otError error = kErrorNone;
+
+    // Select a single reason to report in the Status TLV prioritized in reverse bit order
+    if ((mRouterUpgradeReasonFlags & kUpgradeReasonBorderRouterRequestFlag) != 0)
+    {
+        aStatusTlvReason = RouterUpgradeReasonFlags::kReasonBorderRouterRequest;
+    }
+    else if ((mRouterUpgradeReasonFlags & kUpgradeReasonParentPartitionChangeFlag) != 0)
+    {
+        aStatusTlvReason = RouterUpgradeReasonFlags::kReasonParentPartitionChange;
+    }
+    else if ((mRouterUpgradeReasonFlags & kUpgradeReasonHaveChildIdRequestFlag) != 0)
+    {
+        aStatusTlvReason = RouterUpgradeReasonFlags::kReasonHaveChildIdRequest;
+    }
+    else if ((mRouterUpgradeReasonFlags & kUpgradeReasonTooFewRoutersFlag) != 0)
+    {
+        aStatusTlvReason = RouterUpgradeReasonFlags::kReasonTooFewRouters;
+    }
+    else
+    {
+        ExitNow(error = kErrorInvalidArgs);
+    }
+
+exit:
+    return error;
+}
+static_assert(sizeof(RouterUpgradeReasonFlags) == 1, "sizeof(RouterUpgradeReasonFlags) must be 1");
+#endif
+
+//---------------------------------------------------------------------------------------------------------------------
 // DeviceMode
 
 void DeviceMode::Get(ModeConfig &aModeConfig) const

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -173,18 +173,68 @@ enum Command : uint8_t
     kCommandP2pLinkTearDown               = 103, ///< P2P Link Tear Down command
 };
 
+#if OPENTHREAD_FTD
 /**
- * Represents the reason to attempt to upgrade to router role (used in `BecomeRouter()`).
+ * Bitmap of reasons to attempt to upgrade to router role (used in `BecomeRouter()`) and sent in the
+ * RouterUpgradeReasonDetailTlv of Address Solicit Requests.
  *
- * The enumeration values correspond to the status values in `ThreadStatusTlv` in a TMF Address Solicit Request message.
+ * @sa RouterUpgradeStatusTlvReason
+ * @sa RouterUpgradeReasonDetailTlv
  */
-enum RouterUpgradeReason : uint8_t
+OT_TOOL_PACKED_BEGIN
+class RouterUpgradeReasonFlags
 {
-    kReasonTooFewRouters         = 2, ///< Too few routers.
-    kReasonHaveChildIdRequest    = 3, ///< Have pending Child ID Request.
-    kReasonParentPartitionChange = 4, ///< Parent Partition change.
-    kReasonBorderRouterRequest   = 5, ///< Device is Border Router.
-};
+public:
+    enum ReasonBitmapEnum : uint8_t
+    {
+        kUpgradeReasonFlagsNone                 = 0x00,      ///< No Upgrade reasons are pending
+        kUpgradeReasonTooFewRoutersFlag         = (1U << 0), ///< Too few routers
+        kUpgradeReasonHaveChildIdRequestFlag    = (1U << 1), ///< Pending Child ID Request
+        kUpgradeReasonParentPartitionChangeFlag = (1U << 2), ///< Parent Partition change
+        kUpgradeReasonBorderRouterRequestFlag   = (1U << 3), ///< Border Router
+        // (1U << 4) Reserved for adding kUpgradeReasonManagedRouterFlag in future changes
+    };
+    enum StatusTlvEnum : uint8_t
+    {
+        kReasonTooFewRouters         = 2, ///< Too few routers.  Only used if no other bits are set.
+        kReasonHaveChildIdRequest    = 3, ///< Have pending Child ID Request.
+        kReasonParentPartitionChange = 4, ///< Parent Partition change.
+        kReasonBorderRouterRequest   = 5, ///< Device is Border Router.
+    };
+
+    RouterUpgradeReasonFlags() = default;
+    RouterUpgradeReasonFlags(ReasonBitmapEnum aReason)
+        : mRouterUpgradeReasonFlags(aReason)
+    {
+    }
+
+    /**
+     * Checks if the reason indicates an upgrade should occur
+     *
+     * @param[in] aUpgradeReasonValue  The `ReasonBitmapEnum` to compare with.
+     *
+     * @retval TRUE  The two values are equal.
+     * @retval FALSE The two values are not equal.
+     */
+    bool HasReason(void) const { return mRouterUpgradeReasonFlags != static_cast<uint8_t>(kUpgradeReasonFlagsNone); }
+
+    void operator|=(ReasonBitmapEnum other) { mRouterUpgradeReasonFlags |= static_cast<uint8_t>(other); }
+
+    /**
+     * Convert multiple flags into a single backwards-compatible reason to use in the Status TLV or logging.
+     *
+     * @param[out] aStatusTlvReason The reference to the status TLV reason to update.
+     *
+     * @retval kErrorNone        Successfully updated the reason.
+     * @retval kErrorInvalidArgs The current value of the flags was not valid.
+     */
+    otError AsStatusTlvReason(StatusTlvEnum &aStatusTlvReason) const;
+    uint8_t AsUint8(void) { return mRouterUpgradeReasonFlags; }
+
+private:
+    uint8_t mRouterUpgradeReasonFlags;
+} OT_TOOL_PACKED_END;
+#endif
 
 /**
  * Specifies the leader role start mode.

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -346,7 +346,8 @@ void Notifier::HandleTimeTick(void)
         {
             LogInfo("Requesting router role as BR");
             mDidRequestRouterRoleUpgrade = true;
-            IgnoreError(Get<Mle::Mle>().BecomeRouter(Mle::kReasonBorderRouterRequest));
+            IgnoreError(
+                Get<Mle::Mle>().BecomeRouter(Mle::RouterUpgradeReasonFlags::kUpgradeReasonBorderRouterRequestFlag));
         }
     }
 exit:

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -154,7 +154,7 @@ Error Notifier::UpdateInconsistentData(void)
     // Don't send this Server Data Notification if the device is going
     // to upgrade to Router.
 
-    if (Get<Mle::Mle>().WillBecomeRouterSoon())
+    if (Get<Mle::Mle>().GetTimeUntilBecomingRouterIfSoon() >= 0)
     {
         ExitNow(error = kErrorInvalidState);
     }

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -57,20 +57,21 @@ public:
      */
     enum Type : uint8_t
     {
-        kTarget                = 0,  ///< Target EID TLV
-        kExtMacAddress         = 1,  ///< Extended MAC Address TLV
-        kRloc16                = 2,  ///< RLOC16 TLV
-        kMeshLocalEid          = 3,  ///< ML-EID TLV
-        kStatus                = 4,  ///< Status TLV
-        kLastTransactionTime   = 6,  ///< Time Since Last Transaction TLV
-        kRouterMask            = 7,  ///< Router Mask TLV
-        kNdOption              = 8,  ///< ND Option TLV
-        kNdData                = 9,  ///< ND Data TLV
-        kThreadNetworkData     = 10, ///< Thread Network Data TLV
-        kTimeout               = 11, ///< Timeout TLV
-        kNetworkName           = 12, ///< Network Name TLV
-        kIp6Addresses          = 14, ///< IPv6 Addresses TLV
-        kCommissionerSessionId = 15, ///< Commissioner Session ID TLV
+        kTarget                   = 0,  ///< Target EID TLV
+        kExtMacAddress            = 1,  ///< Extended MAC Address TLV
+        kRloc16                   = 2,  ///< RLOC16 TLV
+        kMeshLocalEid             = 3,  ///< ML-EID TLV
+        kStatus                   = 4,  ///< Status TLV
+        kLastTransactionTime      = 6,  ///< Time Since Last Transaction TLV
+        kRouterMask               = 7,  ///< Router Mask TLV
+        kNdOption                 = 8,  ///< ND Option TLV
+        kNdData                   = 9,  ///< ND Data TLV
+        kThreadNetworkData        = 10, ///< Thread Network Data TLV
+        kTimeout                  = 11, ///< Timeout TLV
+        kNetworkName              = 12, ///< Network Name TLV
+        kIp6Addresses             = 14, ///< IPv6 Addresses TLV
+        kCommissionerSessionId    = 15, ///< Commissioner Session ID TLV
+        kRouterUpgradeReasonFlags = 16, ///< Router Upgrade Reason Flags TLV
     };
 
     /**
@@ -160,6 +161,15 @@ public:
 };
 
 #endif // OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
+
+#if OPENTHREAD_FTD
+/**
+ * Defines Router Upgrade Reason Flags TLV bitmap.
+ *
+ * Includes flags for possible router upgrade reasons.
+ */
+typedef SimpleTlvInfo<ThreadTlv::kRouterUpgradeReasonFlags, Mle::RouterUpgradeReasonFlags> RouterUpgradeReasonFlagsTlv;
+#endif
 
 } // namespace ot
 

--- a/tests/nexus/test_1_1_5_1_5.cpp
+++ b/tests/nexus/test_1_1_5_1_5.cpp
@@ -101,7 +101,7 @@ void Test5_1_5(void)
     nexus.AdvanceTime(kFormNetworkTime);
     VerifyOrQuit(leader.Get<Mle::Mle>().IsLeader());
 
-    router1.Get<Mle::Mle>().SetRouterSelectionJitter(1);
+    VerifyOrQuit(router1.Get<Mle::Mle>().SetRouterSelectionJitter(1) == kErrorNone);
     router1.Join(leader);
     nexus.AdvanceTime(kAttachToRouterTime);
     VerifyOrQuit(router1.Get<Mle::Mle>().IsRouter());

--- a/tests/nexus/test_1_1_5_2_3.cpp
+++ b/tests/nexus/test_1_1_5_2_3.cpp
@@ -179,7 +179,8 @@ void Test5_2_3(void)
     VerifyOrQuit(routers[kMaxRouters - 1]->Get<Mle::Mle>().IsChild());
 
     // Force Router 32 to try to become a router
-    SuccessOrQuit(routers[kMaxRouters - 1]->Get<Mle::Mle>().BecomeRouter(Mle::kReasonTooFewRouters));
+    SuccessOrQuit(routers[kMaxRouters - 1]->Get<Mle::Mle>().BecomeRouter(
+        Mle::RouterUpgradeReasonFlags::kUpgradeReasonTooFewRoutersFlag));
 
     Log("---------------------------------------------------------------------------------------");
     /**

--- a/tests/nexus/test_1_1_7_1_6.cpp
+++ b/tests/nexus/test_1_1_7_1_6.cpp
@@ -363,7 +363,7 @@ void Test7_1_6(void)
      */
 
     SuccessOrQuit(router1.Get<Mle::Mle>().SetRouterEligible(true));
-    SuccessOrQuit(router1.Get<Mle::Mle>().BecomeRouter(Mle::kReasonTooFewRouters));
+    SuccessOrQuit(router1.Get<Mle::Mle>().BecomeRouter(Mle::RouterUpgradeReasonFlags::kUpgradeReasonTooFewRoutersFlag));
     nexus.AdvanceTime(kStabilizationTime);
 
     {

--- a/tests/nexus/test_1_1_9_2_11.cpp
+++ b/tests/nexus/test_1_1_9_2_11.cpp
@@ -203,12 +203,13 @@ void Test9_2_11(void)
     commissioner.Join(leader);
     nexus.AdvanceTime(kJoinTime);
     VerifyOrQuit(commissioner.Get<Mle::Mle>().IsAttached());
-    SuccessOrQuit(commissioner.Get<Mle::Mle>().BecomeRouter(Mle::kReasonTooFewRouters));
+    SuccessOrQuit(
+        commissioner.Get<Mle::Mle>().BecomeRouter(Mle::RouterUpgradeReasonFlags::kUpgradeReasonTooFewRoutersFlag));
 
     router1.Join(leader);
     nexus.AdvanceTime(kJoinTime);
     VerifyOrQuit(router1.Get<Mle::Mle>().IsAttached());
-    SuccessOrQuit(router1.Get<Mle::Mle>().BecomeRouter(Mle::kReasonTooFewRouters));
+    SuccessOrQuit(router1.Get<Mle::Mle>().BecomeRouter(Mle::RouterUpgradeReasonFlags::kUpgradeReasonTooFewRoutersFlag));
 
     nexus.AdvanceTime(kFormNetworkTime);
     VerifyOrQuit(commissioner.Get<Mle::Mle>().IsRouter());

--- a/tests/nexus/test_reed_address_solicit_rejected.cpp
+++ b/tests/nexus/test_reed_address_solicit_rejected.cpp
@@ -99,7 +99,7 @@ void TestReedAddressSolicitRejected(void)
 
     Log("Step 4: Force REED to try to become a router");
     reed.Get<Mle::Mle>().SetRouterUpgradeThreshold(16);
-    reed.Get<Mle::Mle>().SetRouterSelectionJitter(120);
+    VerifyOrQuit(reed.Get<Mle::Mle>().SetRouterSelectionJitter(120) == kErrorNone);
 
     // We advance time enough to cover jitter and router upgrade attempt.
     nexus.AdvanceTime(130 * 1000);

--- a/tests/nexus/test_router_downgrade_on_sec_policy_change.cpp
+++ b/tests/nexus/test_router_downgrade_on_sec_policy_change.cpp
@@ -53,8 +53,8 @@ void TestRouterDowngradeOnSecPolicyChange(void)
     Node &leader = nexus.CreateNode();
     Node &router = nexus.CreateNode();
 
-    leader.Get<Mle::Mle>().SetRouterSelectionJitter(10);
-    router.Get<Mle::Mle>().SetRouterSelectionJitter(10);
+    VerifyOrQuit(leader.Get<Mle::Mle>().SetRouterSelectionJitter(10) == kErrorNone);
+    VerifyOrQuit(router.Get<Mle::Mle>().SetRouterSelectionJitter(10) == kErrorNone);
 
     nexus.AdvanceTime(0);
 

--- a/tests/nexus/test_router_reattach.cpp
+++ b/tests/nexus/test_router_reattach.cpp
@@ -73,7 +73,7 @@ void TestRouterReattach(void)
     {
         nodes[i]->Get<Mle::Mle>().SetRouterUpgradeThreshold(32);
         nodes[i]->Get<Mle::Mle>().SetRouterDowngradeThreshold(32);
-        nodes[i]->Get<Mle::Mle>().SetRouterSelectionJitter(1);
+        VerifyOrQuit(nodes[i]->Get<Mle::Mle>().SetRouterSelectionJitter(1) == kErrorNone);
         nodes[i]->Join(*nodes[0]);
         nexus.AdvanceTime(kAttachToRouterTime);
         Log("Node %u role: %s", i + 1, nodes[i]->GetExtendedRoleString());
@@ -85,7 +85,7 @@ void TestRouterReattach(void)
     nodes[1]->Reset();
     nodes[1]->Get<Mle::Mle>().SetRouterUpgradeThreshold(32);
     nodes[1]->Get<Mle::Mle>().SetRouterDowngradeThreshold(32);
-    nodes[1]->Get<Mle::Mle>().SetRouterSelectionJitter(3);
+    VerifyOrQuit(nodes[1]->Get<Mle::Mle>().SetRouterSelectionJitter(3) == kErrorNone);
 
     // Re-enable and start
     Log("Step 4: Restarting Node 2");

--- a/tests/nexus/test_srp_scale.cpp
+++ b/tests/nexus/test_srp_scale.cpp
@@ -159,7 +159,7 @@ void TestSrpScale(void)
     {
         routers[i] = &nexus.CreateNode();
         routers[i]->SetName("router", i + 1);
-        routers[i]->Get<Mle::Mle>().SetRouterSelectionJitter(1);
+        VerifyOrQuit(routers[i]->Get<Mle::Mle>().SetRouterSelectionJitter(1) == kErrorNone);
         routers[i]->Join(leader);
     }
 

--- a/tests/nexus/verify_1_1_5_3_6.py
+++ b/tests/nexus/verify_1_1_5_3_6.py
@@ -66,17 +66,26 @@ def verify(pv):
     #   - Description: Ensure topology is formed correctly.
     #   - Pass Criteria: N/A
     print("Step 1: All")
-    pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
+    leader_pkt = pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
         filter_wpan_src64(LEADER).\
         must_next()
+    leader_child_id = leader_pkt.mle.tlv.source_addr & 0x1FF
+    # The leader should only advertise as a router
+    assert leader_child_id == 0
     router1_pkt = pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
         filter_wpan_src64(ROUTER_1).\
         must_next()
     router1_id = (router1_pkt.mle.tlv.source_addr >> 10)
+    router1_child_id = router1_pkt.mle.tlv.source_addr & 0x1FF
+    # Router 1 should only advertise as a router
+    assert router1_child_id == 0
     router2_pkt = pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
         filter_wpan_src64(ROUTER_2).\
         must_next()
     router2_id = (router2_pkt.mle.tlv.source_addr >> 10)
+    router2_child_id = router2_pkt.mle.tlv.source_addr & 0x1FF
+    # Router 2 should only advertise as a router
+    assert router2_child_id == 0
 
     # Step 2: Router_2
     #
@@ -111,13 +120,16 @@ def verify(pv):
     #   - Description: Harness re-enables the device and waits for it to reattach and upgrade to a
     #     router.
     #   - Pass Criteria:
-    #     - The DUT MUST reset the MLE Advertisement trickle timer and send an Advertisement.
+    #     - The DUT MUST reset the MLE Advertisement trickle timer and send a Router Advertisement.
     print("Step 5: Router_2")
     # Verify Router 2 becomes router again (sends advertisement) and get its new ID
     router2_rejoin_pkt = pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT).\
         filter_wpan_src64(ROUTER_2).\
         must_next()
     router2_id_reattached = (router2_rejoin_pkt.mle.tlv.source_addr >> 10)
+    router2_child_id_reattached = router2_rejoin_pkt.mle.tlv.source_addr & 0x1FF
+    # Router 2 should only advertise as a router
+    assert router2_child_id_reattached == 0
 
     # Verify Leader sends advertisement after Router 2 re-joins
     pkts.filter_mle_cmd(consts.MLE_ADVERTISEMENT).\


### PR DESCRIPTION
This commit adds a TLV to Address Solicit requests that can indicate multiple
upgrade reasons.  This prepares for upcoming changes to support a Managed
Router configuration feature, which will add a "managed router" upgrade
reason in future changes.

Key changes:
* New `kRouterUpgradeReasonFlags` TLV type defined to 16 per SPEC-1279
* `RouterUpgradeReasonFlags` class created to manage the backwards-compatible reason
and new bitmap for the upgrade reasons.
* Calls to `BecomeRouter()` and `SendAddressSolicit()`have been updated to use the new
RouterUpgradeReasonFlags class as the upgrade reason, which is converted to/from the
legacy reason when constructing or handling the address solicit request
* The new TLV is optionally parsed from address solicit message data,
and if not found is set to `kUpgradeReasonFlagsNone`
* Additional valid-state verifications were added to the top of `BecomeRouter()`,
which can return additional error codes
* Address solicit logging has been updated to print the string of the
single backwards-compatible value and hexadecimal value of the new bitmap.
* `Mle::ShouldUpgrade()` has been updated to `Mle::GetUpgradeReasons()`

----

This PR currently contains the commits from #12976 and #12977. Please check and review only the HEAD commit in this PR.