### PR TITLE
[nexus] fix occasional failure in anycast test

### DIFF
--- a/tests/nexus/test_anycast.cpp
+++ b/tests/nexus/test_anycast.cpp
@@ -49,7 +49,7 @@ static constexpr uint32_t kAttachToRouterTime = 200 * 1000;
 /**
  * Time to advance for the network to stabilize after nodes have attached.
  */
-static constexpr uint32_t kStabilizationTime = 30 * 1000;
+static constexpr uint32_t kStabilizationTime = 60 * 1000;
 
 static void AddPrefix(Node &aNode, const char *aPrefixString, const char *aFlags)
 {
@@ -162,14 +162,19 @@ void TestAnycast(void)
     VerifyOrQuit(r1.Get<Mle::Mle>().IsLeader());
 
     r2.Join(r1);
-    r3.Join(r1);
-    r4.Join(r1);
-    r5.Join(r1);
-
     nexus.AdvanceTime(kAttachToRouterTime);
     VerifyOrQuit(r2.Get<Mle::Mle>().IsRouter());
+
+    r3.Join(r2);
+    nexus.AdvanceTime(kAttachToRouterTime);
     VerifyOrQuit(r3.Get<Mle::Mle>().IsRouter());
+
+    r4.Join(r3);
+    nexus.AdvanceTime(kAttachToRouterTime);
     VerifyOrQuit(r4.Get<Mle::Mle>().IsRouter());
+
+    r5.Join(r4);
+    nexus.AdvanceTime(kAttachToRouterTime);
     VerifyOrQuit(r5.Get<Mle::Mle>().IsRouter());
 
     const char *kPrefix      = "2001:dead:beef:cafe::/64";


### PR DESCRIPTION
This commit addresses a race condition in the Nexus 'anycast' test by ensuring that nodes join the network sequentially in the deep line topology (R1-R2-R3-R4-R5).

Previously, parallel join attempts could trigger MLE attach backoffs and lead to discovery collisions, causing nodes at the end of the chain to fail to become routers within the allotted time.

The stabilization time is also increased to allow sufficient time for Network Data updates and Anycast Locator (ALOC) registrations to propagate across multiple hops.

Verified by running the test 100 times consecutively without failure.