### PR TITLE
[array] add `DoesArrayContain()` helper function

### DIFF
--- a/src/core/common/array.hpp
+++ b/src/core/common/array.hpp
@@ -98,6 +98,38 @@ template <typename Type, uint16_t kArrayLength> inline const Type *GetArrayEnd(c
 }
 
 /**
+ * Indicates whether a given array contains a match to a given item.
+ *
+ * The template arguments are expected to be deduced by the compiler allowing  callers to simply use
+ * `DoesArrayContain(aArray, aItem)`.
+ *
+ * @tparam  Type          The array element type.
+ * @tparam  kArrayLength  The array length.
+ *
+ * @param[in] aArray  A reference to the array to search in.
+ * @param[in] aItem   The item to search for.
+ *
+ * @retval TRUE   The array contains @p aItem.
+ * @retval FALSE  The array does not contain @p aItem.
+ */
+template <typename Type, uint16_t kArrayLength>
+inline bool DoesArrayContain(const Type (&aArray)[kArrayLength], const Type &aItem)
+{
+    bool contains = false;
+
+    for (const Type &entry : aArray)
+    {
+        if (entry == aItem)
+        {
+            contains = true;
+            break;
+        }
+    }
+
+    return contains;
+}
+
+/**
  * Represents an array of elements with a fixed max size.
  *
  * @tparam Type        The array element type.

--- a/src/core/meshcop/border_agent_admitter.cpp
+++ b/src/core/meshcop/border_agent_admitter.cpp
@@ -1200,18 +1200,8 @@ Error Manager::CoapDtlsSession::ReadSteeringDataTlv(const Message &aMessage, Ste
     // Ensure the read steering data has a valid length. A length of
     // one byte is only allowed to indicate `PermitsAllJoiners()`.
 
-    error = kErrorInvalidArgs;
-
-    for (uint8_t validLength : Admitter::kEnrollerValidSteeringDataLengths)
-    {
-        if (aSteeringData.GetLength() == validLength)
-        {
-            error = kErrorNone;
-            break;
-        }
-    }
-
-    SuccessOrExit(error);
+    VerifyOrExit(DoesArrayContain(Admitter::kEnrollerValidSteeringDataLengths, aSteeringData.GetLength()),
+                 error = kErrorInvalidArgs);
 
     if (aSteeringData.GetLength() == 1)
     {

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -35,17 +35,15 @@
 
 #include "instance/instance.hpp"
 
-using IcmpType = ot::Ip6::Icmp::Header::Type;
-
-static const IcmpType kForwardIcmpTypes[] = {
-    IcmpType::kTypeDstUnreach,       IcmpType::kTypePacketToBig, IcmpType::kTypeTimeExceeded,
-    IcmpType::kTypeParameterProblem, IcmpType::kTypeEchoRequest, IcmpType::kTypeEchoReply,
-};
-
 namespace ot {
 namespace Ip6 {
 
 RegisterLogModule("Ip6");
+
+const uint8_t Ip6::kForwardIcmpTypes[] = {
+    Icmp::Header::kTypeDstUnreach,       Icmp::Header::kTypePacketToBig, Icmp::Header::kTypeTimeExceeded,
+    Icmp::Header::kTypeParameterProblem, Icmp::Header::kTypeEchoRequest, Icmp::Header::kTypeEchoReply,
+};
 
 Ip6::Ip6(Instance &aInstance)
     : InstanceLocator(aInstance)
@@ -1298,20 +1296,8 @@ Error Ip6::HandleDatagram(OwnedPtr<Message> aMessagePtr, bool aIsReassembled)
 
             SuccessOrExit(error = aMessagePtr->Read(aMessagePtr->GetOffset(), icmpType));
 
-            error = kErrorDrop;
-
-            for (IcmpType type : kForwardIcmpTypes)
-            {
-                if (icmpType == type)
-                {
-                    error = kErrorNone;
-                    break;
-                }
-            }
-
-            SuccessOrExit(error);
+            VerifyOrExit(DoesArrayContain(kForwardIcmpTypes, icmpType), error = kErrorDrop);
         }
-
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
         if (mTmfOriginFilterEnabled)
 #endif

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -371,6 +371,8 @@ private:
     void UpdateBorderRoutingCounters(const Header &aHeader, uint16_t aMessageLength, bool aIsInbound);
 #endif
 
+    static const uint8_t kForwardIcmpTypes[];
+
     using SendQueueTask = TaskletIn<Ip6, &Ip6::HandleSendQueue>;
 
     bool mReceiveFilterEnabled;


### PR DESCRIPTION
This commit introduces the `DoesArrayContain()` template function to check if a given item is present in a fixed-size C array. The template arguments are deduced by the compiler, allowing callers to simply use `DoesArrayContain(aArray, aItem)`.

It also updates `Manager::CoapDtlsSession::ReadSteeringDataTlv()` and `Ip6::HandleDatagram()` to use this new helper function instead of using manual `for` loops to iterate over `kEnrollerValidSteeringDataLengths` and `kForwardIcmpTypes` arrays respectively.