### PR TITLE
[nexus] clear last parent ID on router/leader role change

### DIFF
--- a/tests/nexus/platform/nexus_core.cpp
+++ b/tests/nexus/platform/nexus_core.cpp
@@ -594,6 +594,11 @@ void Core::HandleStateChanged(otChangedFlags aFlags, void *aContext)
         }
         break;
     }
+    case Mle::kRoleRouter:
+    case Mle::kRoleLeader:
+        node->SetLastParentId(0xffff);
+        break;
+
     default:
         break;
     }


### PR DESCRIPTION
In `Nexus::Core::HandleStateChanged`, the `lastParentId` was not cleared when a device transitioned to the Router or Leader role. This could cause stale parent associations to persist, leading to incorrect link state reporting in the visualizer during subsequent role transitions (e.g., when a former Leader merges into a partition and becomes a Child/REED).

This fix clears `lastParentId` (sets it to `0xffff`) when the device becomes a Router or Leader, ensuring a fresh state for parent tracking.