### PR TITLE
[meshcop] add TMF command to retrieve ephemeral key (ePSKc)

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -37,6 +37,9 @@
 
 #include "instance/instance.hpp"
 #include "meshcop/border_agent_txt_data.hpp"
+#if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+#include "meshcop/border_agent_ephemeral_key.hpp"
+#endif
 
 namespace ot {
 namespace MeshCoP {
@@ -642,6 +645,11 @@ bool Manager::CoapDtlsSession::HandleResource(const char *aUriPath, Coap::Msg &a
     case kUriCommissionerKeepAlive:
         HandleTmfCommissionerKeepAlive(aMsg);
         break;
+#if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+    case kUriCommissionerEpskc:
+        HandleTmfCommissionerEpskc(aMsg);
+        break;
+#endif
     case kUriRelayTx:
         HandleTmfRelayTx(aMsg);
         break;
@@ -712,6 +720,43 @@ void Manager::CoapDtlsSession::HandleTmfCommissionerKeepAlive(Coap::Msg &aMsg)
 exit:
     return;
 }
+
+#if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+void Manager::CoapDtlsSession::HandleTmfCommissionerEpskc(Coap::Msg &aMsg)
+{
+    Error                    error = kErrorNone;
+    OwnedPtr<Coap::Message>  response;
+    EphemeralKeyManager::Tap tap;
+
+    VerifyOrExit(IsActiveCommissioner(), error = kErrorInvalidState);
+
+    Log<kUriCommissionerEpskc>(kReceive);
+
+    SuccessOrExit(error = tap.GenerateRandom());
+    SuccessOrExit(error = Get<EphemeralKeyManager>().Start(tap.mTap, 0, 0));
+
+    response.Reset(Get<Tmf::Agent>().AllocateAndInitPriorityResponseFor(aMsg.mMessage));
+    VerifyOrExit(response != nullptr, error = kErrorNoBufs);
+
+    SuccessOrExit(error = response->AppendPayloadMarker());
+    SuccessOrExit(error = response->AppendBytes(tap.mTap, EphemeralKeyManager::Tap::kLength));
+
+    SuccessOrExit(error = SendMessage(response.PassOwnership()));
+    Log<kUriCommissionerEpskc>(kSend, " response");
+
+exit:
+    if (error != kErrorNone)
+    {
+        Coap::Token token;
+
+        LogWarn("Failed to handle %s: %s", UriToString<kUriCommissionerEpskc>(), ErrorToString(error));
+        if (aMsg.mMessage.ReadToken(token) == kErrorNone)
+        {
+            SendErrorMessage(error, token);
+        }
+    }
+}
+#endif
 
 Error Manager::CoapDtlsSession::ForwardToLeader(const Coap::Msg &aMsg, Uri aUri)
 {

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -313,6 +313,9 @@ private:
         Error ForwardUdpRelay(const Message &aMessage);
         Error ForwardUdpProxy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
         void  HandleTmfCommissionerKeepAlive(Coap::Msg &aMsg);
+#if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+        void HandleTmfCommissionerEpskc(Coap::Msg &aMsg);
+#endif
         void  HandleTmfRelayTx(Coap::Msg &aMsg);
         void  HandleTmfProxyTx(Coap::Msg &aMsg);
         void  HandleTmfDatasetGet(Coap::Message &aMessage, Uri aUri);

--- a/src/core/thread/uri_paths.cpp
+++ b/src/core/thread/uri_paths.cpp
@@ -67,6 +67,7 @@ struct Entry
     _("c/ar", kUriActiveReplace, "ActiveReplace")                 \
     _("c/as", kUriActiveSet, "ActiveSet")                         \
     _("c/ca", kUriCommissionerKeepAlive, "CommrKeepAlive")        \
+    _("c/ce", kUriCommissionerEpskc, "CommrEpskc")                \
     _("c/cg", kUriCommissionerGet, "CommrGet")                    \
     _("c/cp", kUriCommissionerPetition, "CommrPetition")          \
     _("c/cs", kUriCommissionerSet, "CommrSet")                    \

--- a/src/core/thread/uri_paths.hpp
+++ b/src/core/thread/uri_paths.hpp
@@ -60,6 +60,7 @@ enum Uri : uint8_t
     kUriActiveReplace,          ///< MGMT_ACTIVE_REPLACE ("c/ar")
     kUriActiveSet,              ///< MGMT_ACTIVE_SET ("c/as")
     kUriCommissionerKeepAlive,  ///< Commissioner Keep Alive ("c/ca")
+    kUriCommissionerEpskc,      ///< Commissioner EPSKc ("c/ce")
     kUriCommissionerGet,        ///< MGMT_COMMISSIONER_GET ("c/cg")
     kUriCommissionerPetition,   ///< Commissioner Petition ("c/cp")
     kUriCommissionerSet,        ///< MGMT_COMMISSIONER_SET ("c/cs")
@@ -139,6 +140,7 @@ template <> const char *UriToString<kUriActiveGet>(void);
 template <> const char *UriToString<kUriActiveReplace>(void);
 template <> const char *UriToString<kUriActiveSet>(void);
 template <> const char *UriToString<kUriCommissionerKeepAlive>(void);
+template <> const char *UriToString<kUriCommissionerEpskc>(void);
 template <> const char *UriToString<kUriCommissionerGet>(void);
 template <> const char *UriToString<kUriCommissionerPetition>(void);
 template <> const char *UriToString<kUriCommissionerSet>(void);

--- a/tests/nexus/test_border_agent.cpp
+++ b/tests/nexus/test_border_agent.cpp
@@ -826,6 +826,107 @@ void TestBorderAgentEphemeralKeyTapGeneration(void)
     VerifyOrQuit(tap.Validate() == kErrorInvalidArgs);
 }
 
+#if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+struct EpskcResponseContext
+{
+    bool mReceived;
+    char mTap[EphemeralKeyManager::Tap::kLength + 1];
+};
+
+static void HandleEpskcResponse(void *aContext, Coap::Msg *aMsg, Error aResult)
+{
+    EpskcResponseContext *context = static_cast<EpskcResponseContext *>(aContext);
+
+    context->mReceived = true;
+    VerifyOrQuit(aResult == kErrorNone);
+    VerifyOrQuit(aMsg != nullptr);
+
+    uint16_t length = aMsg->mMessage.DetermineLengthAfterOffset();
+
+    VerifyOrQuit(length == EphemeralKeyManager::Tap::kLength);
+    
+    OffsetRange offsetRange;
+    offsetRange.InitFromMessageOffsetToEnd(aMsg->mMessage);
+    for (uint16_t i = 0; i < length; i++)
+    {
+        SuccessOrQuit(aMsg->mMessage.Read(offsetRange, context->mTap[i]));
+        offsetRange.AdvanceOffset(sizeof(char));
+    }
+    context->mTap[length] = '\0';
+}
+
+void TestBorderAgentEpskcRetrieval(void)
+{
+    Core                     nexus;
+    Node                    &node0 = nexus.CreateNode();
+    Node                    &node1 = nexus.CreateNode();
+    Ip6::SockAddr            sockAddr;
+    Pskc                     pskc;
+    Coap::Message           *message;
+    EpskcResponseContext     responseContext;
+
+    Log("------------------------------------------------------------------------------------------------------");
+    Log("TestBorderAgentEpskcRetrieval");
+
+    nexus.AdvanceTime(0);
+
+    node0.Form();
+    nexus.AdvanceTime(50 * Time::kOneSecondInMsec);
+    VerifyOrQuit(node0.Get<Mle::Mle>().IsLeader());
+
+    SuccessOrQuit(node1.Get<Mac::Mac>().SetPanChannel(node0.Get<Mac::Mac>().GetPanChannel()));
+    node1.Get<Mac::Mac>().SetPanId(node0.Get<Mac::Mac>().GetPanId());
+    node1.Get<ThreadNetif>().Up();
+
+    sockAddr.SetAddress(node0.Get<Mle::Mle>().GetLinkLocalAddress());
+    sockAddr.SetPort(node0.Get<Manager>().GetUdpPort());
+
+    node0.Get<KeyManager>().GetPskc(pskc);
+    SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SetPsk(pskc.m8, Pskc::kSize));
+    SuccessOrQuit(node1.Get<Tmf::SecureAgent>().Open(0));
+    SuccessOrQuit(node1.Get<Tmf::SecureAgent>().Connect(sockAddr));
+
+    nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
+    VerifyOrQuit(node1.Get<Tmf::SecureAgent>().IsConnected());
+
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerPetition);
+    VerifyOrQuit(message != nullptr);
+    SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
+    SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SendMessage(*message));
+
+    nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
+    VerifyOrQuit(node0.Get<Manager>().GetCounters().mPskcCommissionerPetitions == 1);
+
+    responseContext.mReceived = false;
+    ClearAllBytes(responseContext.mTap);
+
+    message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerEpskc);
+    VerifyOrQuit(message != nullptr);
+    SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SendMessage(*message, HandleEpskcResponse, &responseContext));
+
+    nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
+    VerifyOrQuit(responseContext.mReceived);
+    Log("Retrieved TAP: %s", responseContext.mTap);
+
+    node1.Get<Tmf::SecureAgent>().Close();
+    nexus.AdvanceTime(3 * Time::kOneSecondInMsec);
+    VerifyOrQuit(!node1.Get<Tmf::SecureAgent>().IsConnected());
+
+    // Now connect again using the retrieved TAP
+    sockAddr.SetPort(node0.Get<EphemeralKeyManager>().GetUdpPort());
+    SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SetPsk(reinterpret_cast<const uint8_t *>(responseContext.mTap),
+                                                       EphemeralKeyManager::Tap::kLength));
+    SuccessOrQuit(node1.Get<Tmf::SecureAgent>().Open(0));
+    SuccessOrQuit(node1.Get<Tmf::SecureAgent>().Connect(sockAddr));
+
+    nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
+    VerifyOrQuit(node1.Get<Tmf::SecureAgent>().IsConnected());
+    VerifyOrQuit(node0.Get<EphemeralKeyManager>().GetState() == EphemeralKeyManager::kStateConnected);
+
+    node1.Get<Tmf::SecureAgent>().Close();
+}
+#endif
+
 EpskcEvent GetNewestEpskcEvent(Node &aNode)
 {
     const EpskcEvent *epskcEvent = nullptr;
@@ -2574,6 +2675,9 @@ int main(void)
     ot::Nexus::TestBorderAgent();
     ot::Nexus::TestBorderAgentEphemeralKey();
     ot::Nexus::TestBorderAgentEphemeralKeyTapGeneration();
+#if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+    ot::Nexus::TestBorderAgentEpskcRetrieval();
+#endif
     ot::Nexus::TestHistoryTrackerBorderAgentEpskcEvent();
     ot::Nexus::TestBorderAgentTxtDataCallback();
     ot::Nexus::TestBorderAgentServiceRegistration();

--- a/tests/nexus/test_border_agent.cpp
+++ b/tests/nexus/test_border_agent.cpp
@@ -870,14 +870,17 @@ void TestBorderAgentEpskcRetrieval(void)
 
     nexus.AdvanceTime(0);
 
+    // 1. Form the topology: node0 acts as Leader and Border Agent.
     node0.Form();
     nexus.AdvanceTime(50 * Time::kOneSecondInMsec);
     VerifyOrQuit(node0.Get<Mle::Mle>().IsLeader());
 
+    // Configure node1 to be on the same channel/panid but not attached.
     SuccessOrQuit(node1.Get<Mac::Mac>().SetPanChannel(node0.Get<Mac::Mac>().GetPanChannel()));
     node1.Get<Mac::Mac>().SetPanId(node0.Get<Mac::Mac>().GetPanId());
     node1.Get<ThreadNetif>().Up();
 
+    // 2. Establish a DTLS connection from Node 1 to Node 0 (Border Agent) using PSKc.
     sockAddr.SetAddress(node0.Get<Mle::Mle>().GetLinkLocalAddress());
     sockAddr.SetPort(node0.Get<Manager>().GetUdpPort());
 
@@ -889,6 +892,7 @@ void TestBorderAgentEpskcRetrieval(void)
     nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
     VerifyOrQuit(node1.Get<Tmf::SecureAgent>().IsConnected());
 
+    // 3. Send `Commissioner Petition` TMF command to become full commissioner.
     message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerPetition);
     VerifyOrQuit(message != nullptr);
     SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
@@ -897,6 +901,7 @@ void TestBorderAgentEpskcRetrieval(void)
     nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
     VerifyOrQuit(node0.Get<Manager>().GetCounters().mPskcCommissionerPetitions == 1);
 
+    // 4. Send the new TMF command to retrieve the ePSKc (TAP).
     responseContext.mReceived = false;
     ClearAllBytes(responseContext.mTap);
 
@@ -908,11 +913,12 @@ void TestBorderAgentEpskcRetrieval(void)
     VerifyOrQuit(responseContext.mReceived);
     Log("Retrieved TAP: %s", responseContext.mTap);
 
+    // 5. Disconnect the initial session.
     node1.Get<Tmf::SecureAgent>().Close();
     nexus.AdvanceTime(3 * Time::kOneSecondInMsec);
     VerifyOrQuit(!node1.Get<Tmf::SecureAgent>().IsConnected());
 
-    // Now connect again using the retrieved TAP
+    // 6. Connect again using the retrieved TAP on the ephemeral port.
     sockAddr.SetPort(node0.Get<EphemeralKeyManager>().GetUdpPort());
     SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SetPsk(reinterpret_cast<const uint8_t *>(responseContext.mTap),
                                                        EphemeralKeyManager::Tap::kLength));

--- a/tests/nexus/test_border_agent.cpp
+++ b/tests/nexus/test_border_agent.cpp
@@ -844,7 +844,7 @@ static void HandleEpskcResponse(void *aContext, Coap::Msg *aMsg, Error aResult)
     uint16_t length = aMsg->mMessage.DetermineLengthAfterOffset();
 
     VerifyOrQuit(length == EphemeralKeyManager::Tap::kLength);
-    
+
     OffsetRange offsetRange;
     offsetRange.InitFromMessageOffsetToEnd(aMsg->mMessage);
     for (uint16_t i = 0; i < length; i++)
@@ -857,13 +857,13 @@ static void HandleEpskcResponse(void *aContext, Coap::Msg *aMsg, Error aResult)
 
 void TestBorderAgentEpskcRetrieval(void)
 {
-    Core                     nexus;
-    Node                    &node0 = nexus.CreateNode();
-    Node                    &node1 = nexus.CreateNode();
-    Ip6::SockAddr            sockAddr;
-    Pskc                     pskc;
-    Coap::Message           *message;
-    EpskcResponseContext     responseContext;
+    Core                 nexus;
+    Node                &node0 = nexus.CreateNode();
+    Node                &node1 = nexus.CreateNode();
+    Ip6::SockAddr        sockAddr;
+    Pskc                 pskc;
+    Coap::Message       *message;
+    EpskcResponseContext responseContext;
 
     Log("------------------------------------------------------------------------------------------------------");
     Log("TestBorderAgentEpskcRetrieval");


### PR DESCRIPTION
This commit adds a new TMF command c/ce that allows an authenticated commissioner (connected using PSKc using meshcop/DTLS) to request the Border Agent to open a credential sharing window and retrieve the generated ephemeral key (ePSKc/TAP).

Upon receiving the request, the Border Agent:
- Verifies that the requester is the active commissioner.
- Generates a random 9-digit TAP (Thread Administration Passcode).
- Starts the EphemeralKeyManager with the generated TAP.
- Returns the TAP string as the payload in the CoAP response.

A new Nexus test case TestBorderAgentEpskcRetrieval is added in test_border_agent.cpp to validate this behavior by connecting as a commissioner, retrieving the TAP, and then verifying that a new session can be established using the retrieved TAP.