### PR TITLE
[mle] consolidate `RouteTlv` definitions

### DIFF
--- a/src/core/thread/mle_tlvs.cpp
+++ b/src/core/thread/mle_tlvs.cpp
@@ -44,8 +44,6 @@ namespace Mle {
 //---------------------------------------------------------------------------------------------------------------------
 // RouteTlv
 
-#if !OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
-
 void RouteTlv::Init(void)
 {
     SetType(kRoute);
@@ -66,8 +64,6 @@ bool RouteTlv::IsValid(void) const
 exit:
     return isValid;
 }
-
-#endif // #if !OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
 
 //---------------------------------------------------------------------------------------------------------------------
 // ConnectivityTlvValue

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -229,8 +229,6 @@ typedef UintTlvInfo<Tlv::kCslTimeout, uint32_t> CslTimeoutTlv;
  */
 typedef UintTlvInfo<Tlv::kXtalAccuracy, uint16_t> XtalAccuracyTlv;
 
-#if !OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
-
 /**
  * Implements Route TLV generation and parsing.
  */
@@ -295,14 +293,28 @@ public:
      *
      * @returns The Route Data Entry Count.
      */
-    uint8_t GetRouteDataEntryCount(void) const { return GetLength() - sizeof(mRouterIdMask); }
+    uint8_t GetRouteDataEntryCount(void) const
+    {
+#if !OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
+        return GetLength() - sizeof(mRouterIdMask);
+#else
+        return (GetLength() - sizeof(mRouterIdMask)) * 2 / 3;
+#endif
+    }
 
     /**
      * Sets the Route Data entry count.
      *
      * @param[in]  aCount  The number of Route Data entries in the Route TLV.
      */
-    void SetRouteDataEntryCount(uint8_t aCount) { SetLength(sizeof(mRouterIdMask) + aCount); }
+    void SetRouteDataEntryCount(uint8_t aCount)
+    {
+#if !OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
+        SetLength(sizeof(mRouterIdMask) + aCount);
+#else
+        SetLength(sizeof(mRouterIdMask) + aCount + (aCount + 1) / 2);
+#endif
+    }
 
     /**
      * Returns the Route Cost value for a given Router index.
@@ -313,7 +325,11 @@ public:
      */
     uint8_t GetRouteCost(uint8_t aRouterIndex) const
     {
+#if !OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
         return ReadBits<uint8_t, kRouteCostMask>(mRouteData[aRouterIndex]);
+#else
+        return static_cast<uint8_t>(ReadBits<uint16_t, kRouteCostMask>(ReadEntry(aRouterIndex)));
+#endif
     }
 
     /**
@@ -325,7 +341,11 @@ public:
      */
     LinkQuality GetLinkQualityIn(uint8_t aRouterIndex) const
     {
+#if !OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
         return static_cast<LinkQuality>(ReadBits<uint8_t, kLinkQualityInMask>(mRouteData[aRouterIndex]));
+#else
+        return static_cast<LinkQuality>(ReadBits<uint16_t, kLinkQualityInMask>(ReadEntry(aRouterIndex)));
+#endif
     }
 
     /**
@@ -337,7 +357,11 @@ public:
      */
     LinkQuality GetLinkQualityOut(uint8_t aRouterIndex) const
     {
+#if !OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
         return static_cast<LinkQuality>(ReadBits<uint8_t, kLinkQualityOutMask>(mRouteData[aRouterIndex]));
+#else
+        return static_cast<LinkQuality>(ReadBits<uint16_t, kLinkQualityOutMask>(ReadEntry(aRouterIndex)));
+#endif
     }
 
     /**
@@ -350,14 +374,25 @@ public:
      */
     void SetRouteData(uint8_t aRouterIndex, LinkQuality aLinkQualityIn, LinkQuality aLinkQualityOut, uint8_t aRouteCost)
     {
+#if !OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
         mRouteData[aRouterIndex] = 0;
 
         WriteBits<uint8_t, kLinkQualityInMask>(mRouteData[aRouterIndex], aLinkQualityIn);
         WriteBits<uint8_t, kLinkQualityOutMask>(mRouteData[aRouterIndex], aLinkQualityOut);
         WriteBits<uint8_t, kRouteCostMask>(mRouteData[aRouterIndex], aRouteCost);
+#else
+        uint16_t data = 0;
+
+        WriteBits<uint16_t, kLinkQualityOutMask>(data, aLinkQualityOut);
+        WriteBits<uint16_t, kLinkQualityInMask>(data, aLinkQualityIn);
+        WriteBits<uint16_t, kRouteCostMask>(data, aRouteCost);
+
+        WriteEntry(aRouterIndex, data);
+#endif
     }
 
 private:
+#if !OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
     //   7   6   5   4   3   2   1   0
     // +---+---+---+---+---+---+---+---+
     // | LQOut | LQIn  |  Route Cost   |
@@ -367,152 +402,8 @@ private:
     static constexpr uint8_t kLinkQualityInMask  = 0x03 << 4;
     static constexpr uint8_t kRouteCostMask      = 0x0f << 0;
 
-    RouterIdMask mRouterIdMask;
-    uint8_t      mRouteData[kMaxRouterId + 1];
-} OT_TOOL_PACKED_END;
-
-#else // OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
-
-/**
- * Implements Route TLV generation and parsing.
- */
-OT_TOOL_PACKED_BEGIN
-class RouteTlv : public Tlv, public TlvInfo<Tlv::kRoute>
-{
-public:
-    /**
-     * Initializes the TLV.
-     */
-    void Init(void)
-    {
-        SetType(kRoute);
-        SetLength(sizeof(*this) - sizeof(Tlv));
-    }
-
-    /**
-     * Indicates whether or not the TLV appears to be well-formed.
-     *
-     * @retval TRUE   If the TLV appears to be well-formed.
-     * @retval FALSE  If the TLV does not appear to be well-formed.
-     */
-    bool IsValid(void) const { return GetLength() >= sizeof(RouterIdMask); }
-
-    /**
-     * Returns the Router ID Sequence value.
-     *
-     * @returns The Router ID Sequence value.
-     */
-    uint8_t GetRouterIdSequence(void) const { return mRouterIdMask.GetSequence(); }
-
-    /**
-     * Gets the Router ID Mask.
-     *
-     * @returns The Router ID Mask.
-     */
-    const RouterIdMask &GetRouterIdMask(void) const { return mRouterIdMask; }
-
-    /**
-     * Gets the Router ID Mask.
-     *
-     * @returns The Router ID Mask.
-     */
-    RouterIdMask &GetRouterIdMask(void) { return mRouterIdMask; }
-
-    /**
-     * Indicates whether or not a Router ID bit is set.
-     *
-     * @param[in]  aRouterId  The Router ID.
-     *
-     * @retval TRUE   If the Router ID bit is set.
-     * @retval FALSE  If the Router ID bit is not set.
-     */
-    bool IsRouterIdSet(uint8_t aRouterId) const { return mRouterIdMask.IsAllocated(aRouterId); }
-
-    /**
-     * Indicates whether the `RouteTlv` is a singleton, i.e., only one router is allocated.
-     *
-     * @retval TRUE   It is a singleton.
-     * @retval FALSE  It is not a singleton.
-     */
-    bool IsSingleton(void) const { return IsValid() && (mRouterIdMask.DetermineAllocatedCount() <= 1); }
-
-    /**
-     * Sets the Router ID bit.
-     *
-     * @param[in]  aRouterId  The Router ID bit to set.
-     */
-    void SetRouterId(uint8_t aRouterId) { mRouterIdMask.Add(aRouterId); }
-
-    /**
-     * Returns the number of Route Data entries in the Route TLV.
-     *
-     * @returns The Route Data Entry Count.
-     */
-    uint8_t GetRouteDataEntryCount(void) const { return (GetLength() - sizeof(mRouterIdMask)) * 2 / 3; }
-
-    /**
-     * Sets the Route Data entry count.
-     *
-     * @param[in]  aCount  The number of Route Data entries in the Route TLV.
-     */
-    void SetRouteDataEntryCount(uint8_t aCount) { SetLength(sizeof(mRouterIdMask) + aCount + (aCount + 1) / 2); }
-
-    /**
-     * Returns the Route Cost value for a given Router index.
-     *
-     * @param[in]  aRouterIndex  The Router index.
-     *
-     * @returns The Route Cost value for a given Router index.
-     */
-    uint8_t GetRouteCost(uint8_t aRouterIndex) const
-    {
-        return static_cast<uint8_t>(ReadBits<uint16_t, kRouteCostMask>(ReadEntry(aRouterIndex)));
-    }
-
-    /**
-     * Returns the Link Quality In value for a given Router index.
-     *
-     * @param[in]  aRouterIndex  The Router index.
-     *
-     * @returns The Link Quality In value for a given Router index.
-     */
-    LinkQuality GetLinkQualityIn(uint8_t aRouterIndex) const
-    {
-        return static_cast<LinkQuality>(ReadBits<uint16_t, kLinkQualityInMask>(ReadEntry(aRouterIndex)));
-    }
-
-    /**
-     * Returns the Link Quality Out value for a given Router index.
-     *
-     * @param[in]  aRouterIndex  The Router index.
-     *
-     * @returns The Link Quality Out value for a given Router index.
-     */
-    LinkQuality GetLinkQualityOut(uint8_t aRouterIndex) const
-    {
-        return static_cast<LinkQuality>(ReadBits<uint16_t, kLinkQualityOutMask>(ReadEntry(aRouterIndex)));
-    }
-
-    /**
-     * Sets the Route Data (Link Quality In/Out and Route Cost) for a given Router index.
-     *
-     * @param[in]  aRouterIndex    The Router index.
-     * @param[in]  aLinkQualityIn  The Link Quality In value.
-     * @param[in]  aLinkQualityOut The Link Quality Out value.
-     * @param[in]  aRouteCost      The Route Cost value.
-     */
-    void SetRouteData(uint8_t aRouterIndex, LinkQuality aLinkQualityIn, LinkQuality aLinkQualityOut, uint8_t aRouteCost)
-    {
-        uint16_t data = 0;
-
-        WriteBits<uint16_t, kLinkQualityOutMask>(data, aLinkQualityOut);
-        WriteBits<uint16_t, kLinkQualityInMask>(data, aLinkQualityIn);
-        WriteBits<uint16_t, kRouteCostMask>(data, aRouteCost);
-
-        WriteEntry(aRouterIndex, data);
-    }
-
-private:
+    static constexpr uint16_t kMaxRouteDataSize = kMaxRouterId + 1;
+#else
     // Under `LOG_ROUTES` feature, Route Data is 12 bits per route
     // (1.5 bytes). The first 4 bits are link qualities (out/in),
     // remaining 8 bits are for the route cost. The even and odd
@@ -524,6 +415,8 @@ private:
     static constexpr uint16_t kLinkQualityOutMask = 0x03 << 10;
     static constexpr uint16_t kLinkQualityInMask  = 0x03 << 8;
     static constexpr uint16_t kRouteCostMask      = 0xff << 0;
+
+    static constexpr uint16_t kMaxRouteDataSize = kMaxRouterId + 1 + kMaxRouterId / 2 + 1;
 
     uint16_t ReadEntry(uint8_t aRouterIndex) const
     {
@@ -560,12 +453,11 @@ private:
 
         BigEndian::WriteUint16(existing, &mRouteData[offset]);
     }
+#endif // OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
 
     RouterIdMask mRouterIdMask;
-    uint8_t      mRouteData[kMaxRouterId + 1 + kMaxRouterId / 2 + 1];
+    uint8_t      mRouteData[kMaxRouteDataSize];
 } OT_TOOL_PACKED_END;
-
-#endif // OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
 
 /**
  * Represents Leader Data TLV value.


### PR DESCRIPTION
This commit combines the two separate definitions of the `RouteTlv` class, which were previously conditionally compiled based on the `OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE` configuration, into a single unified class definition.

The `#if`/`#else` preprocessor directives are now localized within the specific getter and setter methods (e.g., `GetRouteDataEntryCount()`, `GetRouteCost()`, `SetRouteData()`) to handle the different routing data formats. This removes significant code duplication for shared methods such as `Init()`, `IsValid()`, `GetRouterIdSequence()`, and `IsSingleton()`.