### PR TITLE
[mlr] move address count constants to `mlr_types.hpp`

### DIFF
--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -140,7 +140,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Msg &aMsg)
 
     OffsetRange  offsetRange;
     Ip6::Address address;
-    Ip6::Address addresses[Ip6AddressesTlv::kMaxAddresses];
+    Ip6::Address addresses[kMlrMaxIp6Addresses];
     uint8_t      failedAddressNum  = 0;
     uint8_t      successAddressNum = 0;
     TimeMilli    expireTime;
@@ -156,8 +156,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Msg &aMsg)
     VerifyOrExit(Tlv::FindTlvValueOffsetRange(aMsg.mMessage, Ip6AddressesTlv::kType, offsetRange) == kErrorNone,
                  error = kErrorParse);
     VerifyOrExit(offsetRange.GetLength() % sizeof(Ip6::Address) == 0, status = kMlrGeneralFailure);
-    VerifyOrExit(offsetRange.GetLength() / sizeof(Ip6::Address) <= Ip6AddressesTlv::kMaxAddresses,
-                 status = kMlrGeneralFailure);
+    VerifyOrExit(offsetRange.GetLength() / sizeof(Ip6::Address) <= kMlrMaxIp6Addresses, status = kMlrGeneralFailure);
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     // Required by Test Specification 5.10.22 MATN-TC-26, only for certification purpose
@@ -229,7 +228,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Msg &aMsg)
             mMulticastListenersTable.Remove(address);
 
             // Put successfully de-registered addresses at the end of `addresses`.
-            addresses[Ip6AddressesTlv::kMaxAddresses - (++successAddressNum)] = address;
+            addresses[kMlrMaxIp6Addresses - (++successAddressNum)] = address;
         }
         else
         {
@@ -263,7 +262,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Msg &aMsg)
             else
             {
                 // Put successfully registered addresses at the end of `addresses`.
-                addresses[Ip6AddressesTlv::kMaxAddresses - (++successAddressNum)] = address;
+                addresses[kMlrMaxIp6Addresses - (++successAddressNum)] = address;
             }
         }
     }
@@ -276,7 +275,7 @@ exit:
 
     if (successAddressNum > 0)
     {
-        SendBackboneMulticastListenerRegistration(&addresses[Ip6AddressesTlv::kMaxAddresses - successAddressNum],
+        SendBackboneMulticastListenerRegistration(&addresses[kMlrMaxIp6Addresses - successAddressNum],
                                                   successAddressNum, timeout);
     }
 }
@@ -325,7 +324,7 @@ void Manager::SendBackboneMulticastListenerRegistration(const Ip6::Address *aAdd
     Tlv::Bookmark     tlvBookmark;
     BackboneTmfAgent &backboneTmf = Get<BackboneRouter::BackboneTmfAgent>();
 
-    OT_ASSERT(aAddressNum >= Ip6AddressesTlv::kMinAddresses && aAddressNum <= Ip6AddressesTlv::kMaxAddresses);
+    OT_ASSERT(aAddressNum >= kMlrMinIp6Addresses && aAddressNum <= kMlrMaxIp6Addresses);
 
     message = backboneTmf.AllocateAndInitNonConfirmablePostMessage(kUriBackboneMlr);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);

--- a/src/core/backbone_router/bbr_manager.hpp
+++ b/src/core/backbone_router/bbr_manager.hpp
@@ -49,6 +49,7 @@
 #include "common/non_copyable.hpp"
 #include "net/netif.hpp"
 #include "thread/dua_manager.hpp"
+#include "thread/mlr_types.hpp"
 #include "thread/network_data.hpp"
 #include "thread/tmf.hpp"
 

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -310,7 +310,7 @@ Error MlrManager::RegisterMulticastListeners(const Ip6::Address *aAddresses,
     Error error;
 
     VerifyOrExit(aAddresses != nullptr, error = kErrorInvalidArgs);
-    VerifyOrExit(aAddressNum > 0 && aAddressNum <= Ip6AddressesTlv::kMaxAddresses, error = kErrorInvalidArgs);
+    VerifyOrExit(aAddressNum > 0 && aAddressNum <= kMlrMaxIp6Addresses, error = kErrorInvalidArgs);
     VerifyOrExit(aContext == nullptr || aCallback != nullptr, error = kErrorInvalidArgs);
 #if !OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     VerifyOrExit(Get<MeshCoP::Commissioner>().IsActive(), error = kErrorInvalidState);
@@ -455,8 +455,7 @@ Error MlrManager::ParseMlrResponse(Error aResult, Coap::Msg *aMsg, uint8_t &aSta
     if (Tlv::FindTlvValueOffsetRange(aMsg->mMessage, Ip6AddressesTlv::kType, offsetRange) == kErrorNone)
     {
         VerifyOrExit(offsetRange.GetLength() % sizeof(Ip6::Address) == 0, error = kErrorParse);
-        VerifyOrExit(offsetRange.GetLength() / sizeof(Ip6::Address) <= Ip6AddressesTlv::kMaxAddresses,
-                     error = kErrorParse);
+        VerifyOrExit(offsetRange.GetLength() / sizeof(Ip6::Address) <= kMlrMaxIp6Addresses, error = kErrorParse);
 
         while (!offsetRange.IsEmpty())
         {

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -53,6 +53,7 @@
 #include "common/timer.hpp"
 #include "net/netif.hpp"
 #include "thread/child.hpp"
+#include "thread/mlr_types.hpp"
 #include "thread/thread_tlvs.hpp"
 #include "thread/tmf.hpp"
 
@@ -141,7 +142,7 @@ public:
 #endif
 
 private:
-    class AddressArray : public Array<Ip6::Address, Ip6AddressesTlv::kMaxAddresses>
+    class AddressArray : public Array<Ip6::Address, kMlrMaxIp6Addresses>
     {
     public:
         bool IsEmptyOrContains(const Ip6::Address &aAddress) const { return IsEmpty() || Contains(aAddress); }

--- a/src/core/thread/mlr_types.hpp
+++ b/src/core/thread/mlr_types.hpp
@@ -44,6 +44,9 @@ namespace ot {
  * @{
  */
 
+constexpr uint8_t kMlrMinIp6Addresses = 1;                        ///< Min number of addresses in IPv6 Addresses TLV.
+constexpr uint8_t kMlrMaxIp6Addresses = OT_IP6_MAX_MLR_ADDRESSES; ///< Max number of addresses in IPv6 Addresses TLV.
+
 #if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
 
 /**

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -151,13 +151,7 @@ typedef TlvInfo<ThreadTlv::kThreadNetworkData> ThreadNetworkDataTlv;
 /**
  * Defines IPv6 Addresses TLV constants and types.
  */
-class Ip6AddressesTlv : public TlvInfo<ThreadTlv::kIp6Addresses>
-{
-public:
-    // Thread 1.2.0 5.19.13 limits the number of IPv6 addresses to [1, 15].
-    static constexpr uint8_t kMinAddresses = 1;
-    static constexpr uint8_t kMaxAddresses = OT_IP6_MAX_MLR_ADDRESSES;
-};
+typedef TlvInfo<ThreadTlv::kIp6Addresses> Ip6AddressesTlv;
 
 #endif // OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
 

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -329,7 +329,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_MLR_REQUEST>(v
 
     while (mDecoder.GetRemainingLengthInStruct())
     {
-        VerifyOrExit(addressesCount < Ip6AddressesTlv::kMaxAddresses, error = OT_ERROR_NO_BUFS);
+        VerifyOrExit(addressesCount < OT_IP6_MAX_MLR_ADDRESSES, error = OT_ERROR_NO_BUFS);
         SuccessOrExit(error = mDecoder.ReadIp6Address(addresses[addressesCount]));
         ++addressesCount;
     }


### PR DESCRIPTION
This commit moves the constants for the minimum and maximum number of IPv6 addresses allowed in a Multicast Listener Registration (MLR) request from the `Ip6AddressesTlv` class to `mlr_types.hpp`.

The new constants are named `kMlrMinIp6Addresses` and `kMlrMaxIp6Addresses`. This change decouples the protocol-specific limits from the TLV definition, which is more appropriate as these limits are specific to the MLR process rather than the TLV itself.

The `Ip6AddressesTlv` class is simplified to a `typedef` of `TlvInfo`. Call sites in `MlrManager`, `BackboneRouter::Manager`, and `NcpBase` are updated accordingly.