### PR TITLE
[border-agent] add support for Commissioner ePSKc TMF command

### DIFF
--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -303,6 +303,8 @@ typedef enum otMeshcopTlvType
     OT_MESHCOP_TLV_SCAN_DURATION            = 56,  ///< meshcop Scan Duration TLV
     OT_MESHCOP_TLV_ENERGY_LIST              = 57,  ///< meshcop Energy List TLV
     OT_MESHCOP_TLV_THREAD_DOMAIN_NAME       = 59,  ///< meshcop Thread Domain Name TLV
+    OT_MESHCOP_TLV_EPSKC_KEY                = 72,  ///< meshcop Ephemeral Key TLV
+    OT_MESHCOP_TLV_EPSKC_TIMEOUT            = 73,  ///< meshcop Ephemeral Key Timeout TLV
     OT_MESHCOP_TLV_WAKEUP_CHANNEL           = 74,  ///< meshcop Wake-up Channel TLV
     OT_MESHCOP_TLV_ADMITTER_STATE           = 90,  ///< meshcop Admitter State TLV
     OT_MESHCOP_TLV_ENROLLER_ID              = 91,  ///< meshcop Enroller ID TLV

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (605)
+#define OPENTHREAD_API_VERSION (606)
 
 /**
  * @addtogroup api-instance

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -699,6 +699,7 @@ Code Message::MapErrorToCoapCode(Error aError)
     case kErrorParse:
     case kErrorNotFound:
     case kErrorInvalidArgs:
+    case kErrorInvalidState:
         code = kCodeBadRequest;
         break;
     case kErrorNotImplemented:

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -655,6 +655,11 @@ bool Manager::CoapDtlsSession::HandleResource(const char *aUriPath, Coap::Msg &a
     case kUriCommissionerKeepAlive:
         HandleTmfCommissionerKeepAlive(aMsg);
         break;
+#if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+    case kUriCommissionerEpskc:
+        HandleTmfCommissionerEpskc(aMsg);
+        break;
+#endif
     case kUriRelayTx:
         HandleTmfRelayTx(aMsg);
         break;
@@ -725,6 +730,84 @@ void Manager::CoapDtlsSession::HandleTmfCommissionerKeepAlive(Coap::Msg &aMsg)
 exit:
     return;
 }
+
+#if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+void Manager::CoapDtlsSession::HandleTmfCommissionerEpskc(Coap::Msg &aMsg)
+{
+    Error                    error           = kErrorNone;
+    bool                     shouldAppendKey = false;
+    OwnedPtr<Coap::Message>  response;
+    StateTlv::State          responseState;
+    EpskcKeyTlv::StringType  keyString;
+    EphemeralKeyManager::Tap tap;
+    uint32_t                 timeout;
+    uint16_t                 port;
+
+    VerifyOrExit(aMsg.IsConfirmable());
+
+    VerifyOrExit(IsActiveCommissioner(), error = kErrorInvalidState);
+
+    Log<kUriCommissionerEpskc>(kReceive);
+
+    switch (error = Tlv::Find<EpskcKeyTlv>(aMsg.mMessage, keyString))
+    {
+    case kErrorNone:
+        break;
+    case kErrorNotFound:
+        SuccessOrExit(error = tap.GenerateRandom());
+        IgnoreError(StringCopy(keyString, tap.mTap));
+        shouldAppendKey = true;
+        break;
+    default:
+        ExitNow();
+    }
+
+    switch (error = Tlv::Find<EpskcTimeoutTlv>(aMsg.mMessage, timeout))
+    {
+    case kErrorNone:
+        break;
+    case kErrorNotFound:
+        timeout = 0;
+        break;
+    default:
+        ExitNow();
+    }
+
+    switch (error = Tlv::Find<CommissionerUdpPortTlv>(aMsg.mMessage, port))
+    {
+    case kErrorNone:
+        break;
+    case kErrorNotFound:
+        port = 0;
+        break;
+    default:
+        ExitNow();
+    }
+
+    responseState = (Get<EphemeralKeyManager>().Start(keyString, timeout, port) == kErrorNone) ? StateTlv::kAccept
+                                                                                               : StateTlv::kReject;
+
+    response.Reset(AllocateAndInitResponseFor(aMsg.mMessage));
+    VerifyOrExit(response != nullptr, error = kErrorNoBufs);
+
+    SuccessOrExit(error = Tlv::Append<StateTlv>(*response, static_cast<uint8_t>(responseState)));
+
+    if ((responseState == StateTlv::kAccept) && shouldAppendKey)
+    {
+        SuccessOrExit(error = Tlv::Append<EpskcKeyTlv>(*response, keyString));
+    }
+
+    SuccessOrExit(error = SendMessage(response.PassOwnership()));
+
+    Log<kUriCommissionerEpskc>(kSend, " response");
+
+exit:
+    if (error != kErrorNone)
+    {
+        IgnoreError(SendAckResponseIfUnicastRequest(aMsg, error));
+    }
+}
+#endif
 
 Error Manager::CoapDtlsSession::ForwardToLeader(const Coap::Msg &aMsg, Uri aUri)
 {

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -315,6 +315,9 @@ private:
         Error ForwardUdpRelay(const Message &aMessage);
         Error ForwardUdpProxy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
         void  HandleTmfCommissionerKeepAlive(Coap::Msg &aMsg);
+#if OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE
+        void HandleTmfCommissionerEpskc(Coap::Msg &aMsg);
+#endif
         void  HandleTmfRelayTx(Coap::Msg &aMsg);
         void  HandleTmfProxyTx(Coap::Msg &aMsg);
         void  HandleTmfDatasetGet(Coap::Message &aMessage, Uri aUri);

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -36,6 +36,7 @@
 
 #include "openthread-core-config.h"
 
+#include <openthread/border_agent_ephemeral_key.h>
 #include <openthread/commissioner.h>
 #include <openthread/dataset.h>
 #include <openthread/platform/radio.h>
@@ -112,6 +113,8 @@ public:
         kScanDuration            = OT_MESHCOP_TLV_SCAN_DURATION,            ///< Scan Duration TLV
         kEnergyList              = OT_MESHCOP_TLV_ENERGY_LIST,              ///< Energy List TLV
         kThreadDomainName        = OT_MESHCOP_TLV_THREAD_DOMAIN_NAME,       ///< Thread Domain Name TLV
+        kEpskcKey                = OT_MESHCOP_TLV_EPSKC_KEY,                ///< Ephemeral PSKc Key TLV
+        kEpskcTimeout            = OT_MESHCOP_TLV_EPSKC_TIMEOUT,            ///< Ephemeral PSKc Timeout TLV
         kWakeupChannel           = OT_MESHCOP_TLV_WAKEUP_CHANNEL,           ///< Wakeup Channel TLV
         kAdmitterState           = OT_MESHCOP_TLV_ADMITTER_STATE,           ///< Admitter State TLV
         kEnrollerId              = OT_MESHCOP_TLV_ENROLLER_ID,              ///< Enroller ID TLV
@@ -125,6 +128,11 @@ public:
      * Max length of Provisioning URL TLV.
      */
     static constexpr uint8_t kMaxProvisioningUrlLength = OT_PROVISIONING_URL_MAX_SIZE;
+
+    /**
+     * Max length of Ephemeral Key TLV.
+     */
+    static constexpr uint8_t kMaxEpskcKeyLength = OT_BORDER_AGENT_MAX_EPHEMERAL_KEY_LENGTH;
 
     static constexpr uint8_t kMaxCommissionerIdLength   = 64; ///< Max length of Commissioner ID TLV.
     static constexpr uint8_t kMaxEnrollerIdLength       = 64; ///< Max length of Enroller ID TLV.
@@ -260,6 +268,16 @@ typedef UintTlvInfo<Tlv::kPanId, uint16_t> PanIdTlv;
  * Defines Extended PAN ID TLV constants and types.
  */
 typedef SimpleTlvInfo<Tlv::kExtendedPanId, ExtendedPanId> ExtendedPanIdTlv;
+
+/**
+ * Defines Ephemeral PSKc Key TLV constants and types
+ */
+typedef StringTlvInfo<Tlv::kEpskcKey, Tlv::kMaxEpskcKeyLength> EpskcKeyTlv;
+
+/**
+ * Defines Ephemeral PSKc Timeout TLV constants and types.
+ */
+typedef UintTlvInfo<Tlv::kEpskcTimeout, uint32_t> EpskcTimeoutTlv;
 
 /**
  * Implements Network Name TLV generation and parsing.

--- a/src/core/thread/uri_paths.cpp
+++ b/src/core/thread/uri_paths.cpp
@@ -65,6 +65,7 @@ struct Entry
     _("c/ar", kUriActiveReplace, "ActiveReplace")                 \
     _("c/as", kUriActiveSet, "ActiveSet")                         \
     _("c/ca", kUriCommissionerKeepAlive, "CommrKeepAlive")        \
+    _("c/ce", kUriCommissionerEpskc, "CommrEpskc")                \
     _("c/cg", kUriCommissionerGet, "CommrGet")                    \
     _("c/cp", kUriCommissionerPetition, "CommrPetition")          \
     _("c/cs", kUriCommissionerSet, "CommrSet")                    \

--- a/src/core/thread/uri_paths.hpp
+++ b/src/core/thread/uri_paths.hpp
@@ -58,6 +58,7 @@ enum Uri : uint8_t
     kUriActiveReplace,         ///< MGMT_ACTIVE_REPLACE ("c/ar")
     kUriActiveSet,             ///< MGMT_ACTIVE_SET ("c/as")
     kUriCommissionerKeepAlive, ///< Commissioner Keep Alive ("c/ca")
+    kUriCommissionerEpskc,     ///< Commissioner ePSKc ("c/ce")
     kUriCommissionerGet,       ///< MGMT_COMMISSIONER_GET ("c/cg")
     kUriCommissionerPetition,  ///< Commissioner Petition ("c/cp")
     kUriCommissionerSet,       ///< MGMT_COMMISSIONER_SET ("c/cs")
@@ -133,6 +134,7 @@ template <> const char *UriToString<kUriActiveGet>(void);
 template <> const char *UriToString<kUriActiveReplace>(void);
 template <> const char *UriToString<kUriActiveSet>(void);
 template <> const char *UriToString<kUriCommissionerKeepAlive>(void);
+template <> const char *UriToString<kUriCommissionerEpskc>(void);
 template <> const char *UriToString<kUriCommissionerGet>(void);
 template <> const char *UriToString<kUriCommissionerPetition>(void);
 template <> const char *UriToString<kUriCommissionerSet>(void);

--- a/tests/nexus/test_border_agent.cpp
+++ b/tests/nexus/test_border_agent.cpp
@@ -826,6 +826,185 @@ void TestBorderAgentEphemeralKeyTapGeneration(void)
     VerifyOrQuit(tap.Validate() == kErrorInvalidArgs);
 }
 
+struct EpskcResponseContext : public Clearable<EpskcResponseContext>
+{
+    static void HandleResponse(void *aContext, Coap::Msg *aMsg, Error aResult)
+    {
+        static_cast<EpskcResponseContext *>(aContext)->HandleResponse(aMsg, aResult);
+    }
+
+    void HandleResponse(Coap::Msg *aMsg, Error aResult)
+    {
+        VerifyOrQuit(!mReceived);
+
+        mReceived = true;
+        mError    = aResult;
+
+        SuccessOrExit(aResult);
+
+        VerifyOrQuit(aMsg != nullptr);
+
+        SuccessOrQuit(Tlv::Find<MeshCoP::StateTlv>(aMsg->mMessage, mResponseState));
+
+        switch (Tlv::Find<MeshCoP::EpskcKeyTlv>(aMsg->mMessage, mKeyString))
+        {
+        case kErrorNone:
+            mHasKey = true;
+            break;
+        case kErrorNotFound:
+            break;
+        default:
+            VerifyOrQuit(false);
+        }
+
+    exit:
+        return;
+    }
+
+    bool                             mReceived;
+    bool                             mHasKey;
+    Error                            mError;
+    uint8_t                          mResponseState;
+    MeshCoP::EpskcKeyTlv::StringType mKeyString;
+};
+
+void TestBorderAgentCommissionerEpskcTmfCommand(void)
+{
+    static constexpr uint8_t kAppendKeyFlag     = 1 << 0;
+    static constexpr uint8_t kAppendTimeoutFlag = 1 << 1;
+    static constexpr uint8_t kAppendPortFlag    = 1 << 2;
+
+    static const char     kKey[]   = "ephemeral_key";
+    static const uint32_t kTimeout = 7 * Time::kOneMinuteInMsec;
+    static const uint16_t kPort    = 12346;
+
+    Core                 nexus;
+    Node                &node0 = nexus.CreateNode();
+    Node                &node1 = nexus.CreateNode();
+    Ip6::SockAddr        sockAddr;
+    Pskc                 pskc;
+    Coap::Message       *message;
+    EpskcResponseContext context;
+
+    Log("------------------------------------------------------------------------------------------------------");
+    Log("TestBorderAgentCommissionerEpskcTmfCommand");
+
+    nexus.AdvanceTime(0);
+
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    Log("Form topology");
+
+    node0.Form();
+    nexus.AdvanceTime(50 * Time::kOneSecondInMsec);
+    VerifyOrQuit(node0.Get<Mle::Mle>().IsLeader());
+
+    SuccessOrQuit(node1.Get<Mac::Mac>().SetPanChannel(node0.Get<Mac::Mac>().GetPanChannel()));
+    node1.Get<Mac::Mac>().SetPanId(node0.Get<Mac::Mac>().GetPanId());
+    node1.Get<ThreadNetif>().Up();
+
+    for (uint16_t iter = 0; iter <= 7; iter++)
+    {
+        bool appendKey     = (iter & kAppendKeyFlag);
+        bool appendTimeout = (iter & kAppendTimeoutFlag);
+        bool appendPort    = (iter & kAppendPortFlag);
+
+        Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  - - - - - - - - - - - - - - - ");
+        Log("Starting iter %u (appendKey:%u, appendTimeout:%u, appendPort:%u)", iter, appendKey, appendTimeout,
+            appendPort);
+
+        Log("Establish a DTLS session using PSKc from `node1` to `node0` (Border Agent)");
+
+        sockAddr.SetAddress(node0.Get<Mle::Mle>().GetLinkLocalAddress());
+        sockAddr.SetPort(node0.Get<Manager>().GetUdpPort());
+
+        node0.Get<KeyManager>().GetPskc(pskc);
+        SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SetPsk(pskc.m8, Pskc::kSize));
+        SuccessOrQuit(node1.Get<Tmf::SecureAgent>().Open(0));
+        SuccessOrQuit(node1.Get<Tmf::SecureAgent>().Connect(sockAddr));
+
+        nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
+        VerifyOrQuit(node1.Get<Tmf::SecureAgent>().IsConnected());
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        Log("Send `kUriCommissionerPetition` TMF command to become full commissioner.");
+
+        message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerPetition);
+        VerifyOrQuit(message != nullptr);
+        SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerIdTlv>(*message, "node1"));
+        SuccessOrQuit(node1.Get<Tmf::SecureAgent>().SendMessage(*message));
+
+        nexus.AdvanceTime(1 * Time::kOneSecondInMsec);
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        Log("Send TMF command `kUriCommissionerEpskc` to start ephemeral key session");
+
+        context.Clear();
+
+        message = node1.Get<Tmf::SecureAgent>().AllocateAndInitPriorityConfirmablePostMessage(kUriCommissionerEpskc);
+        VerifyOrQuit(message != nullptr);
+
+        if (appendKey)
+        {
+            SuccessOrQuit(Tlv::Append<MeshCoP::EpskcKeyTlv>(*message, kKey));
+        }
+
+        if (appendTimeout)
+        {
+            SuccessOrQuit(Tlv::Append<MeshCoP::EpskcTimeoutTlv>(*message, kTimeout));
+        }
+
+        if (appendPort)
+        {
+            SuccessOrQuit(Tlv::Append<MeshCoP::CommissionerUdpPortTlv>(*message, kPort));
+        }
+
+        SuccessOrQuit(
+            node1.Get<Tmf::SecureAgent>().SendMessage(*message, EpskcResponseContext::HandleResponse, &context));
+
+        nexus.AdvanceTime(Time::kOneSecondInMsec);
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        Log("Validate the `kUriCommissionerEpskc` response");
+
+        VerifyOrQuit(context.mReceived);
+
+        SuccessOrQuit(context.mError);
+        VerifyOrQuit(context.mResponseState == MeshCoP::StateTlv::kAccept);
+
+        VerifyOrQuit(context.mHasKey == !appendKey);
+
+        if (context.mHasKey)
+        {
+            Log("  TAP in response: %s", context.mKeyString);
+        }
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        Log("Validate the port number used by `EphemeralKeyManager`");
+
+        Log("  UdpPort: %u", node0.Get<EphemeralKeyManager>().GetUdpPort());
+
+        if (appendPort)
+        {
+            VerifyOrQuit(node0.Get<EphemeralKeyManager>().GetUdpPort() == kPort);
+        }
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        Log("Check that EphemeralKeyManager is active for the requested timeout interval");
+
+        VerifyOrQuit(node0.Get<EphemeralKeyManager>().GetState() == EphemeralKeyManager::kStateStarted);
+        nexus.AdvanceTime(appendTimeout ? kTimeout : EphemeralKeyManager::kDefaultTimeout);
+        nexus.AdvanceTime(5);
+        VerifyOrQuit(node0.Get<EphemeralKeyManager>().GetState() == EphemeralKeyManager::kStateStopped);
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        Log("Disconnect");
+
+        node1.Get<Tmf::SecureAgent>().Close();
+        nexus.AdvanceTime(3 * Time::kOneSecondInMsec);
+        VerifyOrQuit(!node1.Get<Tmf::SecureAgent>().IsConnected());
+    }
+}
+
 EpskcEvent GetNewestEpskcEvent(Node &aNode)
 {
     const EpskcEvent *epskcEvent = nullptr;
@@ -2795,6 +2974,7 @@ int main(void)
     ot::Nexus::TestBorderAgent();
     ot::Nexus::TestBorderAgentEphemeralKey();
     ot::Nexus::TestBorderAgentEphemeralKeyTapGeneration();
+    ot::Nexus::TestBorderAgentCommissionerEpskcTmfCommand();
     ot::Nexus::TestHistoryTrackerBorderAgentEpskcEvent();
     ot::Nexus::TestBorderAgentTxtDataCallback();
     ot::Nexus::TestBorderAgentServiceRegistration();


### PR DESCRIPTION
This commit adds support for the `kUriCommissionerEpskc` ("c/ce") TMF command to `BorderAgent`, allowing a commissioner to request the start of an ephemeral key session.

The caller can optionally provide an ephemeral key string, a timeout interval, or a UDP port in the TMF request. If the key is omitted, a cryptographically secure random Thread Administration One-Time Passcode (TAP) is generated, used, and returned in the TMF response. If the timeout or UDP port is not provided, default values defined by `otBorderAgentEphemeralKeyStart` are used.

The implementation includes:
- defining two new MeshCoP TLVs: Ephemeral PSKc Key TLV and Ephemeral PSKc Timeout TLV.
- adding a test case in Nexus `test_border_agent` to validate the new command with various TLV combinations.

----

Related to [SPEC-1467](https://threadgroup.atlassian.net/browse/SPEC-1467)