### PR TITLE
[posix] handle RCP disconnection (EOF from read())

### DIFF
--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -189,7 +189,11 @@ void HdlcInterface::Read(void)
     {
         Decode(buffer, static_cast<uint16_t>(rval));
     }
-    else if ((rval < 0) && (errno != EAGAIN) && (errno != EINTR))
+    else if (rval == 0)
+    {
+        DieNowWithMessage("RCP device disconnected (EOF)", OT_EXIT_FAILURE);
+    }
+    else if ((errno != EAGAIN) && (errno != EWOULDBLOCK) && (errno != EINTR))
     {
         DieNow(OT_EXIT_ERROR_ERRNO);
     }


### PR DESCRIPTION
When unplugging a USB RCP, a read from the device file handle will see EOF. Treat this as a fatal error, just like an unexpected read error.