### PR TITLE
[trel] defer channel check in `Link::ProcessReceivedPacket()`

### DIFF
--- a/src/core/radio/trel_link.cpp
+++ b/src/core/radio/trel_link.cpp
@@ -326,12 +326,10 @@ void Link::ProcessReceivedPacket(Packet &aPacket, const Ip6::SockAddr &aSockAddr
 
     if (type != Header::kTypeAck)
     {
-        // No need to check state or channel for a TREL ack packet.
-        // Note that TREL ack may be received much later than the tx
-        // and device can be on a different rx channel.
+        // We do not check the radio state for a TREL ACK packet, as it
+        // can be received much later than the transmission.
 
         VerifyOrExit((mState == kStateReceive) || (mState == kStateTransmit));
-        VerifyOrExit(aPacket.GetHeader().GetChannel() == mRxChannel);
     }
 
     if (mPanId != Mac::kPanIdBroadcast)
@@ -369,6 +367,14 @@ void Link::ProcessReceivedPacket(Packet &aPacket, const Ip6::SockAddr &aSockAddr
     {
         SendAck(aPacket);
     }
+
+    // Drop the packet if there is a channel mismatch. We perform this
+    // check after all other validations to ensure we still `SendAck()`.
+    // TREL ACKs are used to monitor the TREL link status between peers
+    // and should be sent even if the packet is sent on a different
+    // channel (e.g., an MLE Announce message).
+
+    VerifyOrExit(aPacket.GetHeader().GetChannel() == mRxChannel);
 
     mRxFrame.mPsdu    = aPacket.GetPayload();
     mRxFrame.mLength  = aPacket.GetPayloadLength();


### PR DESCRIPTION
This commit updates `Trel::Link::ProcessReceivedPacket()` to move channel mismatch validation until after the acknowledgment logic.

TREL ACKs serve as a mechanism to monitor link status between peers. By deferring the channel check, we ensure that TREL packets requiring an acknowledgment are correctly acknowledged at the TREL layer even if they are not further processed.

A primary use case is the MLE Announce message, which is sent on a different channel as a broadcast. At the TREL layer, this broadcast is converted to unicast TREL packet transmissions to each peer on the same PAN, with packets marked to request a TREL ACK. This change ensures the receiving TREL peer sends an ACK for such packets, maintaining link monitoring, while still dropping the packet at the TREL link layer due to the channel mismatch.

---

Should help address https://github.com/openthread/openthread/issues/13002.