### PR TITLE
[posix] add uart-exclusive option to enable flock / TIOCEXCL

### DIFF
--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -49,6 +49,7 @@
 #endif
 #include <stdarg.h>
 #include <stdlib.h>
+#include <sys/file.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -420,6 +421,27 @@ int HdlcInterface::OpenFile(const Url::Url &aRadioUrl)
     {
         perror("open uart failed");
         ExitNow();
+    }
+
+    if (aRadioUrl.HasParam("uart-exclusive"))
+    {
+        // Lock the device early to prevent concurrent access
+        if (flock(fd, LOCK_EX | LOCK_NB) == -1)
+        {
+            // LogCrit("flock failed: %s (device may already be in use)", strerror(errno));
+            perror("flock uart failed, device already in use");
+            close(fd);
+            fd = -1;
+            ExitNow();
+        }
+
+#ifdef TIOCEXCL
+        // Set exclusive access mode if supported by the platform
+        if (ioctl(fd, TIOCEXCL) == -1)
+        {
+            otLogWarnPlat("ioctl(TIOCEXCL) failed: %s", strerror(errno));
+        }
+#endif
     }
 
     if (isatty(fd))

--- a/src/posix/platform/radio_url.cpp
+++ b/src/posix/platform/radio_url.cpp
@@ -74,7 +74,8 @@ const char *otSysGetRadioUrlHelpString(void)
     "    uart-stop[=number-of-bits]     Uart stop bit, default is 1.\n"                              \
     "    uart-baudrate[=baudrate]       Uart baud rate, default is 115200.\n"                        \
     "    uart-flow-control              Enable flow control, disabled by default.\n"                 \
-    "    uart-reset                     Reset connection after hard resetting RCP(USB CDC ACM).\n"
+    "    uart-reset                     Reset connection after hard resetting RCP(USB CDC ACM).\n"   \
+    "    uart-exclusive                 Lock uart device using flock / TIOCEXCL.\n"
 
 #endif // OPENTHREAD_POSIX_CONFIG_RCP_BUS == OT_POSIX_RCP_BUS_SPI
 


### PR DESCRIPTION
When uart-exclusive is specified as a radio URL parameter, the UART device is locked using flock(LOCK_EX) to prevent concurrent access, and TIOCEXCL is set where supported.