### PR TITLE
[cli] handle duplicate registration in `Interpreter::SetUserCommands()`

### DIFF
--- a/include/openthread/cli.h
+++ b/include/openthread/cli.h
@@ -99,11 +99,11 @@ void otCliInputLine(char *aBuf);
  * Set a user command table.
  *
  * @param[in]  aUserCommands  A pointer to an array with user commands.
- * @param[in]  aLength        @p aUserCommands length.
- * @param[in]  aContext       @p The context passed to the handler.
+ * @param[in]  aLength        The @p aUserCommands length.
+ * @param[in]  aContext       The context passed to the handler.
  *
- * @retval OT_ERROR_NONE    Successfully updated command table with commands from @p aUserCommands.
- * @retval OT_ERROR_FAILED  Maximum number of command entries have already been set.
+ * @retval OT_ERROR_NONE     Successfully updated command table with commands from @p aUserCommands.
+ * @retval OT_ERROR_NO_BUFS  Maximum number of command entries have already been set.
  */
 otError otCliSetUserCommands(const otCliCommand *aUserCommands, uint8_t aLength, void *aContext);
 

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (593)
+#define OPENTHREAD_API_VERSION (594)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -400,21 +400,28 @@ otError Interpreter::ProcessUserCommands(Arg aArgs[])
 
 otError Interpreter::SetUserCommands(const otCliCommand *aCommands, uint8_t aLength, void *aContext)
 {
-    otError error = OT_ERROR_FAILED;
+    otError error = OT_ERROR_NONE;
 
     for (UserCommandsEntry &entry : mUserCommands)
     {
+        if (entry.mCommands == aCommands)
+        {
+            // Ignore if already registered.
+            ExitNow();
+        }
+
         if (entry.mCommands == nullptr)
         {
             entry.mCommands = aCommands;
             entry.mLength   = aLength;
             entry.mContext  = aContext;
-
-            error = OT_ERROR_NONE;
-            break;
+            ExitNow();
         }
     }
 
+    error = OT_ERROR_NO_BUFS;
+
+exit:
     return error;
 }
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -176,10 +176,10 @@ public:
      *
      * @param[in]  aCommands  A pointer to an array with user commands.
      * @param[in]  aLength    @p aUserCommands length.
-     * @param[in]  aContext   @p aUserCommands length.
+     * @param[in]  aContext   Context to use when invoking the command handler.
      *
-     * @retval OT_ERROR_NONE    Successfully updated command table with commands from @p aCommands.
-     * @retval OT_ERROR_FAILED  No available UserCommandsEntry to register requested user commands.
+     * @retval OT_ERROR_NONE     Successfully updated command table with commands from @p aCommands.
+     * @retval OT_ERROR_NO_BUFS  No available `UserCommandsEntry` to register the requested user commands.
      */
     otError SetUserCommands(const otCliCommand *aCommands, uint8_t aLength, void *aContext);
 


### PR DESCRIPTION
This commit updates the `Interpreter::SetUserCommands()` method to detect if a set of CLI commands is already registered. If a duplicate registration is detected, the method now returns `OT_ERROR_NONE` and exits early without consuming an additional slot in the user commands table. It also ensures that `OT_ERROR_FAILED` is only returned when there are no available slots for a new registration.