### PR TITLE
[neighbor-table] introduce core `Iterator` type

### DIFF
--- a/src/core/thread/neighbor_table.cpp
+++ b/src/core/thread/neighbor_table.cpp
@@ -197,7 +197,7 @@ exit:
     return neighbor;
 }
 
-Error NeighborTable::GetNextNeighborInfo(otNeighborInfoIterator &aIterator, Neighbor::Info &aNeighInfo)
+Error NeighborTable::GetNextNeighborInfo(Iterator &aIterator, Neighbor::Info &aNeighInfo)
 {
     Error   error = kErrorNone;
     int16_t index;
@@ -239,12 +239,12 @@ Error NeighborTable::GetNextNeighborInfo(otNeighborInfoIterator &aIterator, Neig
             aNeighInfo.SetFrom(*router);
             aNeighInfo.mIsChild = false;
             index++;
-            aIterator = static_cast<otNeighborInfoIterator>(-index);
+            aIterator = static_cast<Iterator>(-index);
             ExitNow();
         }
     }
 
-    aIterator = static_cast<otNeighborInfoIterator>(-index);
+    aIterator = static_cast<Iterator>(-index);
     error     = kErrorNotFound;
 
 exit:
@@ -255,11 +255,11 @@ exit:
 
 #if OPENTHREAD_MTD
 
-Error NeighborTable::GetNextNeighborInfo(otNeighborInfoIterator &aIterator, Neighbor::Info &aNeighInfo)
+Error NeighborTable::GetNextNeighborInfo(Iterator &aIterator, Neighbor::Info &aNeighInfo)
 {
     Error error = kErrorNotFound;
 
-    VerifyOrExit(aIterator == OT_NEIGHBOR_INFO_ITERATOR_INIT);
+    VerifyOrExit(aIterator == kIteratorInit);
 
     aIterator++;
     VerifyOrExit(Get<Mle::Mle>().GetParent().IsStateValid());

--- a/src/core/thread/neighbor_table.hpp
+++ b/src/core/thread/neighbor_table.hpp
@@ -64,6 +64,16 @@ public:
     typedef otNeighborTableEntryInfo EntryInfo;
 
     /**
+     * Iterator used to iterate through neighbor table.
+     */
+    typedef otNeighborInfoIterator Iterator;
+
+    /**
+     * Initializer value for `Iterator`.
+     */
+    static constexpr Iterator kIteratorInit = OT_NEIGHBOR_INFO_ITERATOR_INIT;
+
+    /**
      * Defines the constants used in `NeighborTable::Callback` to indicate whether a child or router
      * neighbor is being added or removed.
      */
@@ -196,13 +206,13 @@ public:
      * the neighbor table.
      *
      * @param[in,out]  aIterator  A reference to the iterator context. To get the first neighbor entry
-                                  it should be set to OT_NEIGHBOR_INFO_ITERATOR_INIT.
+                                  it should be set to `kIteratorInit`.
      * @param[out]     aNeighInfo The neighbor information.
      *
      * @retval kErrorNone         Successfully found the next neighbor entry in table.
      * @retval kErrorNotFound     No subsequent neighbor entry exists in the table.
      */
-    Error GetNextNeighborInfo(otNeighborInfoIterator &aIterator, Neighbor::Info &aNeighInfo);
+    Error GetNextNeighborInfo(Iterator &aIterator, Neighbor::Info &aNeighInfo);
 
     /**
      * Registers the "neighbor table changed" callback function.
@@ -233,6 +243,8 @@ private:
 
     Callback mCallback;
 };
+
+DefineMapEnum(otNeighborTableEvent, NeighborTable::Event);
 
 } // namespace ot
 

--- a/src/core/utils/link_metrics_manager.cpp
+++ b/src/core/utils/link_metrics_manager.cpp
@@ -124,8 +124,8 @@ void LinkMetricsManager::Update(void)
 // This method updates the Link Metrics Subject in the subject list. It adds new neighbors to the list.
 void LinkMetricsManager::UpdateSubjects(void)
 {
-    Neighbor::Info         neighborInfo;
-    otNeighborInfoIterator iterator = OT_NEIGHBOR_INFO_ITERATOR_INIT;
+    Neighbor::Info          neighborInfo;
+    NeighborTable::Iterator iterator = NeighborTable::kIteratorInit;
 
     while (Get<NeighborTable>().GetNextNeighborInfo(iterator, neighborInfo) == kErrorNone)
     {


### PR DESCRIPTION
This commit introduces `NeighborTable::Iterator` and `NeighborTable::kIteratorInit` as core type aliases for the public `otNeighborInfoIterator` and its initializer `OT_NEIGHBOR_INFO_ITERATOR_INIT`.