### PR TITLE
[cli] make user commands list a static member

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -74,6 +74,8 @@ namespace Cli {
 Interpreter *Interpreter::sInterpreter = nullptr;
 static OT_DEFINE_ALIGNED_VAR(sInterpreterRaw, sizeof(Interpreter), uint64_t);
 
+Interpreter::UserCommandsEntry Interpreter::sUserCommands[kMaxUserCommandEntries];
+
 Interpreter::Interpreter(Instance *aInstance, otCliOutputCallback aCallback, void *aContext)
     : OutputImplementer(aCallback, aContext)
     , Utils(aInstance, *this)
@@ -155,8 +157,6 @@ Interpreter::Interpreter(Instance *aInstance, otCliOutputCallback aCallback, voi
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
     otDiagSetOutputCallback(GetInstancePtr(), &Interpreter::HandleDiagOutput, this);
 #endif
-
-    ClearAllBytes(mUserCommands);
 
     OutputPrompt();
 }
@@ -380,7 +380,7 @@ otError Interpreter::ProcessUserCommands(Arg aArgs[])
 {
     otError error = OT_ERROR_INVALID_COMMAND;
 
-    for (const UserCommandsEntry &entry : mUserCommands)
+    for (const UserCommandsEntry &entry : sUserCommands)
     {
         for (uint8_t i = 0; i < entry.mLength; i++)
         {
@@ -402,7 +402,7 @@ otError Interpreter::SetUserCommands(const otCliCommand *aCommands, uint8_t aLen
 {
     otError error = OT_ERROR_FAILED;
 
-    for (UserCommandsEntry &entry : mUserCommands)
+    for (UserCommandsEntry &entry : sUserCommands)
     {
         if (entry.mCommands == nullptr)
         {
@@ -8810,7 +8810,7 @@ otError Interpreter::ProcessCommand(Arg aArgs[])
     {
         OutputCommandTable(kCommands);
 
-        for (const UserCommandsEntry &entry : mUserCommands)
+        for (const UserCommandsEntry &entry : sUserCommands)
         {
             for (uint8_t i = 0; i < entry.mLength; i++)
             {

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -355,14 +355,22 @@ private:
 
     struct UserCommandsEntry
     {
+        UserCommandsEntry(void)
+            : mCommands(nullptr)
+            , mLength(0)
+            , mContext(nullptr)
+        {
+        }
+
         const otCliCommand *mCommands;
         uint8_t             mLength;
         void               *mContext;
     };
 
-    UserCommandsEntry mUserCommands[kMaxUserCommandEntries];
-    bool              mCommandIsPending;
-    bool              mInternalDebugCommand;
+    static UserCommandsEntry sUserCommands[kMaxUserCommandEntries];
+
+    bool mCommandIsPending;
+    bool mInternalDebugCommand;
 #if OPENTHREAD_CONFIG_CLI_PROMPT_ENABLE
     bool mPromptEnabled;
 #endif


### PR DESCRIPTION
This commit changes the `mUserCommands` array in the `Interpreter` class to be a static member, `sUserCommands`.

By making the user commands list static, the registered CLI commands can persist across different instances of the `Interpreter`. This is useful in scenarios where multiple CLI interpreters may be used.