### PR TITLE
[instance] use `constexpr` for instance alignment size calculations

### DIFF
--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -44,11 +44,12 @@ namespace ot {
 #error "Exactly one of {OPENTHREAD_FTD, OPENTHREAD_MTD, OPENTHREAD_RADIO} MUST be set"
 #endif
 
+// Size of `ot::Instance` in `uint64_t` unit (aligned).
+constexpr size_t kInstanceSizeInUint64s = DivideAndRoundUp<size_t>(sizeof(Instance), sizeof(uint64_t));
+
 #if !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
-
-// Define the raw storage used for OpenThread instance (in single-instance case).
-OT_DEFINE_ALIGNED_VAR(gInstanceRaw, sizeof(Instance), uint64_t);
-
+// The raw storage used for OpenThread instance (in single-instance case)
+uint64_t gInstanceRaw[kInstanceSizeInUint64s];
 #endif
 
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE && OPENTHREAD_CONFIG_LOG_INSTANCE_AWARE_API_ENABLE
@@ -58,11 +59,10 @@ Instance *gActiveInstance = nullptr;
 
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE && OPENTHREAD_CONFIG_MULTIPLE_STATIC_INSTANCE_ENABLE
 
-#define INSTANCE_SIZE_ALIGNED OT_ALIGNED_VAR_SIZE(sizeof(ot::Instance), uint64_t)
-#define MULTI_INSTANCE_SIZE (OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_NUM * INSTANCE_SIZE_ALIGNED)
+constexpr size_t kMultiInstanceSizeInUint64s = (Instance::kNumStaticInstances * kInstanceSizeInUint64s);
 
 // Define the raw storage used for OpenThread instance (in multi-instance case).
-static uint64_t gMultiInstanceRaw[MULTI_INSTANCE_SIZE];
+static uint64_t gMultiInstanceRaw[kMultiInstanceSizeInUint64s];
 
 #endif
 
@@ -383,18 +383,19 @@ Instance &Instance::Get(void)
 }
 
 #else // #if !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
+
 #if OPENTHREAD_CONFIG_MULTIPLE_STATIC_INSTANCE_ENABLE
 
 Instance *Instance::InitMultiple(uint8_t aIdx)
 {
     size_t    bufferSize;
-    uint64_t *instanceBuffer = gMultiInstanceRaw + aIdx * INSTANCE_SIZE_ALIGNED;
+    uint64_t *instanceBuffer = gMultiInstanceRaw + aIdx * kInstanceSizeInUint64s;
     Instance *instance       = reinterpret_cast<Instance *>(instanceBuffer);
 
-    VerifyOrExit(aIdx < OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_NUM);
+    VerifyOrExit(aIdx < kNumStaticInstances);
     VerifyOrExit(!instance->mIsInitialized);
 
-    bufferSize = (&gMultiInstanceRaw[MULTI_INSTANCE_SIZE] - instanceBuffer) * sizeof(uint64_t);
+    bufferSize = (&gMultiInstanceRaw[kMultiInstanceSizeInUint64s] - instanceBuffer) * sizeof(uint64_t);
     instance   = Instance::Init(instanceBuffer, &bufferSize);
 
 exit:
@@ -403,13 +404,13 @@ exit:
 
 Instance &Instance::Get(uint8_t aIdx)
 {
-    void *instance = gMultiInstanceRaw + aIdx * INSTANCE_SIZE_ALIGNED;
+    void *instance = gMultiInstanceRaw + aIdx * kInstanceSizeInUint64s;
     return *static_cast<Instance *>(instance);
 }
 
 uint8_t Instance::GetIdx(Instance *aInstance)
 {
-    return static_cast<uint8_t>((reinterpret_cast<uint64_t *>(aInstance) - gMultiInstanceRaw) / INSTANCE_SIZE_ALIGNED);
+    return static_cast<uint8_t>((reinterpret_cast<uint64_t *>(aInstance) - gMultiInstanceRaw) / kInstanceSizeInUint64s);
 }
 
 #endif // #if OPENTHREAD_CONFIG_MULTIPLE_STATIC_INSTANCE_ENABLE
@@ -420,8 +421,11 @@ Instance *Instance::Init(void *aBuffer, size_t *aBufferSize)
 
     VerifyOrExit(aBufferSize != nullptr);
 
-    // Make sure the input buffer is big enough
-    VerifyOrExit(sizeof(Instance) <= *aBufferSize, *aBufferSize = sizeof(Instance));
+    if (sizeof(Instance) > *aBufferSize)
+    {
+        *aBufferSize = kInstanceSizeInUint64s * sizeof(uint64_t);
+        ExitNow();
+    }
 
     VerifyOrExit(aBuffer != nullptr);
 

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -210,6 +210,11 @@ public:
 
 #if OPENTHREAD_CONFIG_MULTIPLE_STATIC_INSTANCE_ENABLE
     /**
+     * Specifies number of static OpenThread instances.
+     */
+    static constexpr uint16_t kNumStaticInstances = OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_NUM;
+
+    /**
      * This static method initializes the OpenThread instance.
      *
      * This method utilizes static buffer to initialize the OpenThread instance.


### PR DESCRIPTION
This commit refactors the instance allocation logic in `Instance` to use `constexpr size_t` constants replacing the preprocessor macros (`OT_DEFINE_ALIGNED_VAR` and `OT_ALIGNED_VAR_SIZE`).

The new constants `kInstanceSizeInUint64s` and
`kMultiInstanceSizeInUint64s` provide better type safety and are more idiomatic C++. The raw storage arrays (`gInstanceRaw` and `gMultiInstanceRaw`) are now explicitly defined as `uint64_t` arrays using these calculated sizes.

Additionally, this commit introduces `kNumStaticInstances` to represent the configured number of multiple static instances.