### PR TITLE
[github-actions] replace snap with apt-get for shfmt installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,10 +59,9 @@ jobs:
     - name: Bootstrap
       run: |
         sudo apt-get update
-        sudo apt-get --no-install-recommends install -y shellcheck iwyu
+        sudo apt-get --no-install-recommends install -y shellcheck iwyu shfmt
         sudo bash script/install-llvm.sh
         python3 -m pip install yapf==0.43.0
-        sudo snap install shfmt
         npm install prettier@2.0.4
     - name: Check
       run: |

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -52,7 +52,7 @@ install_packages_pretty_format()
     python3 -m pip install mdv || echo 'WARNING: could not install mdv, which is required to post markdown size report for OpenThread.'
 
     # add shfmt for shell pretty
-    command -v shfmt || sudo apt-get install shfmt || echo 'WARNING: could not install shfmt, which is useful if you plan to contribute shell scripts to the OpenThread project.'
+    command -v shfmt || sudo apt-get --no-install-recommends install -y shfmt || echo 'WARNING: could not install shfmt, which is useful if you plan to contribute shell scripts to the OpenThread project.'
 
     sudo apt-get --no-install-recommends install -y iwyu || echo 'WARNING: iwyu, which is useful to ensure applying the IWYU rules.'
 }


### PR DESCRIPTION
The 'pretty' job was failing intermittently with 'error: unable to contact snap store' when attempting to install shfmt.

This change replaces the snap installation of shfmt with apt-get in the GitHub Actions build workflow. Using apt-get is more reliable in CI environments and avoids external dependencies on the Snap Store.

Additionally, script/bootstrap is updated to use consistent flags (-y and --no-install-recommends) when installing shfmt via apt-get.