### PR TITLE
[github-actions] remove redundant GCC 11 PPA repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,11 +283,6 @@ jobs:
     - name: Bootstrap
       run: |
         sudo apt-get update
-        case ${{ matrix.gcc_ver }} in
-          11)
-            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-            ;;
-        esac
         sudo apt-get --no-install-recommends install -y gcc-${{ matrix.gcc_ver }} g++-${{ matrix.gcc_ver }} ninja-build libreadline-dev libncurses-dev
     - name: Build
       run: |


### PR DESCRIPTION
This commit removes the manual addition of the
'ubuntu-toolchain-r/test' PPA for GCC 11 in the build workflow. The PPA is no longer necessary as the required GCC versions are available in the default Ubuntu repositories used by the GitHub Actions environment.