### PR TITLE
[github-actions] remove wireshark PPA from nexus workflow

### DIFF
--- a/.github/workflows/nexus.yml
+++ b/.github/workflows/nexus.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         sudo add-apt-repository -y ppa:wireshark-dev/stable
         sudo apt-get update
-        sudo DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y ninja-build tshark
+        sudo DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y ninja-build tshark=4.6.*
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
 
     - name: Build Nexus


### PR DESCRIPTION
This commit removes the wireshark-dev/stable PPA from the Nexus workflow. The PPA is no longer necessary as tshark is available in the default Ubuntu repositories.