### PR TITLE
[cli] consolidate `otInstance` pointer in `OutputImplementer`

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -75,8 +75,8 @@ Interpreter *Interpreter::sInterpreter = nullptr;
 static OT_DEFINE_ALIGNED_VAR(sInterpreterRaw, sizeof(Interpreter), uint64_t);
 
 Interpreter::Interpreter(Instance *aInstance, otCliOutputCallback aCallback, void *aContext)
-    : OutputImplementer(aCallback, aContext)
-    , Utils(aInstance, *this)
+    : OutputImplementer(aInstance, aCallback, aContext)
+    , Utils(static_cast<OutputImplementer &>(*this))
     , mCommandIsPending(false)
     , mInternalDebugCommand(false)
 #if OPENTHREAD_CONFIG_CLI_PROMPT_ENABLE
@@ -87,62 +87,62 @@ Interpreter::Interpreter(Instance *aInstance, otCliOutputCallback aCallback, voi
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
     , mSntpQueryingInProgress(false)
 #endif
-    , mDataset(aInstance, *this)
-    , mNetworkData(aInstance, *this)
-    , mUdp(aInstance, *this)
+    , mDataset(*this)
+    , mNetworkData(*this)
+    , mUdp(*this)
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
-    , mMacFilter(aInstance, *this)
+    , mMacFilter(*this)
 #endif
 #if OPENTHREAD_CLI_DNS_ENABLE
-    , mDns(aInstance, *this)
+    , mDns(*this)
 #endif
 #if OPENTHREAD_CONFIG_MULTICAST_DNS_ENABLE && OPENTHREAD_CONFIG_MULTICAST_DNS_PUBLIC_API_ENABLE
-    , mMdns(aInstance, *this)
+    , mMdns(*this)
 #endif
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    , mBa(aInstance, *this)
+    , mBa(*this)
 #endif
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-    , mBbr(aInstance, *this)
+    , mBbr(*this)
 #endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-    , mBr(aInstance, *this)
+    , mBr(*this)
 #endif
 #if OPENTHREAD_CONFIG_TCP_ENABLE && OPENTHREAD_CONFIG_CLI_TCP_ENABLE
-    , mTcp(aInstance, *this)
+    , mTcp(*this)
 #endif
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
-    , mCoap(aInstance, *this)
+    , mCoap(*this)
 #endif
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-    , mCoapSecure(aInstance, *this)
+    , mCoapSecure(*this)
 #endif
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-    , mCommissioner(aInstance, *this)
+    , mCommissioner(*this)
 #endif
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
-    , mJoiner(aInstance, *this)
+    , mJoiner(*this)
 #endif
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
-    , mSrpClient(aInstance, *this)
+    , mSrpClient(*this)
 #endif
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
-    , mSrpServer(aInstance, *this)
+    , mSrpServer(*this)
 #endif
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    , mHistory(aInstance, *this)
+    , mHistory(*this)
 #endif
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
-    , mLinkMetrics(aInstance, *this)
+    , mLinkMetrics(*this)
 #endif
 #if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE && OPENTHREAD_CONFIG_CLI_BLE_SECURE_ENABLE
-    , mTcat(aInstance, *this)
+    , mTcat(*this)
 #endif
 #if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
-    , mPing(aInstance, *this)
+    , mPing(*this)
 #endif
 #if OPENTHREAD_CONFIG_MESH_DIAG_ENABLE && OPENTHREAD_FTD
-    , mMeshDiag(aInstance, *this)
+    , mMeshDiag(*this)
 #endif
 #if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_ENABLE
     , mLocateInProgress(false)

--- a/src/cli/cli_ba.hpp
+++ b/src/cli/cli_ba.hpp
@@ -55,11 +55,10 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    Ba(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Utils(aInstance, aOutputImplementer)
+    explicit Ba(OutputImplementer &aOutputImplementer)
+        : Utils(aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_bbr.hpp
+++ b/src/cli/cli_bbr.hpp
@@ -56,11 +56,10 @@ public:
     /**
      * Constructor.
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    Bbr(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Utils(aInstance, aOutputImplementer)
+    explicit Bbr(OutputImplementer &aOutputImplementer)
+        : Utils(aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_br.hpp
+++ b/src/cli/cli_br.hpp
@@ -61,11 +61,10 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    Br(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Utils(aInstance, aOutputImplementer)
+    explicit Br(OutputImplementer &aOutputImplementer)
+        : Utils(aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -44,8 +44,8 @@
 namespace ot {
 namespace Cli {
 
-Coap::Coap(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Utils(aInstance, aOutputImplementer)
+Coap::Coap(OutputImplementer &aOutputImplementer)
+    : Utils(aOutputImplementer)
     , mUseDefaultRequestTxParameters(true)
     , mUseDefaultResponseTxParameters(true)
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE

--- a/src/cli/cli_coap.hpp
+++ b/src/cli/cli_coap.hpp
@@ -54,10 +54,9 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    Coap(otInstance *aInstance, OutputImplementer &aOutputImplementer);
+    explicit Coap(OutputImplementer &aOutputImplementer);
 
     /**
      * Processes a CLI sub-command.

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -46,8 +46,8 @@
 namespace ot {
 namespace Cli {
 
-CoapSecure::CoapSecure(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Utils(aInstance, aOutputImplementer)
+CoapSecure::CoapSecure(OutputImplementer &aOutputImplementer)
+    : Utils(aOutputImplementer)
     , mShutdownFlag(false)
     , mUseCertificate(false)
     , mPskLength(0)

--- a/src/cli/cli_coap_secure.hpp
+++ b/src/cli/cli_coap_secure.hpp
@@ -60,10 +60,9 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    CoapSecure(otInstance *aInstance, OutputImplementer &aOutputImplementer);
+    explicit CoapSecure(OutputImplementer &aOutputImplementer);
 
     /**
      * Processes a CLI sub-command.

--- a/src/cli/cli_commissioner.hpp
+++ b/src/cli/cli_commissioner.hpp
@@ -54,11 +54,10 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    Commissioner(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Utils(aInstance, aOutputImplementer)
+    explicit Commissioner(OutputImplementer &aOutputImplementer)
+        : Utils(aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -51,8 +51,8 @@ namespace Cli {
 class Dataset : private Utils
 {
 public:
-    Dataset(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Utils(aInstance, aOutputImplementer)
+    explicit Dataset(OutputImplementer &aOutputImplementer)
+        : Utils(aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_dns.hpp
+++ b/src/cli/cli_dns.hpp
@@ -68,11 +68,10 @@ public:
     /**
      * Constructor.
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    Dns(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Utils(aInstance, aOutputImplementer)
+    explicit Dns(OutputImplementer &aOutputImplementer)
+        : Utils(aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_history.hpp
+++ b/src/cli/cli_history.hpp
@@ -55,11 +55,10 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    History(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Utils(aInstance, aOutputImplementer)
+    explicit History(OutputImplementer &aOutputImplementer)
+        : Utils(aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_joiner.hpp
+++ b/src/cli/cli_joiner.hpp
@@ -54,11 +54,10 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    Joiner(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Utils(aInstance, aOutputImplementer)
+    explicit Joiner(OutputImplementer &aOutputImplementer)
+        : Utils(aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_link_metrics.cpp
+++ b/src/cli/cli_link_metrics.cpp
@@ -44,8 +44,8 @@
 namespace ot {
 namespace Cli {
 
-LinkMetrics::LinkMetrics(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Utils(aInstance, aOutputImplementer)
+LinkMetrics::LinkMetrics(OutputImplementer &aOutputImplementer)
+    : Utils(aOutputImplementer)
     , mQuerySync(false)
     , mConfigForwardTrackingSeriesSync(false)
     , mConfigEnhAckProbingSync(false)

--- a/src/cli/cli_link_metrics.hpp
+++ b/src/cli/cli_link_metrics.hpp
@@ -55,10 +55,9 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    LinkMetrics(otInstance *aInstance, OutputImplementer &aOutputImplementer);
+    explicit LinkMetrics(OutputImplementer &aOutputImplementer);
 
     /**
      * Processes a CLI sub-command.

--- a/src/cli/cli_mac_filter.hpp
+++ b/src/cli/cli_mac_filter.hpp
@@ -55,11 +55,10 @@ public:
     /**
      * Constructor.
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    MacFilter(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Utils(aInstance, aOutputImplementer)
+    explicit MacFilter(OutputImplementer &aOutputImplementer)
+        : Utils(aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_mdns.hpp
+++ b/src/cli/cli_mdns.hpp
@@ -55,11 +55,10 @@ public:
     /**
      * Constructor.
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    Mdns(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Utils(aInstance, aOutputImplementer)
+    explicit Mdns(OutputImplementer &aOutputImplementer)
+        : Utils(aOutputImplementer)
         , mInfraIfIndex(0)
         , mRequestId(0)
         , mWaitingForCallback(false)

--- a/src/cli/cli_mesh_diag.cpp
+++ b/src/cli/cli_mesh_diag.cpp
@@ -44,8 +44,8 @@
 namespace ot {
 namespace Cli {
 
-MeshDiag::MeshDiag(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Utils(aInstance, aOutputImplementer)
+MeshDiag::MeshDiag(OutputImplementer &aOutputImplementer)
+    : Utils(aOutputImplementer)
 {
 }
 

--- a/src/cli/cli_mesh_diag.hpp
+++ b/src/cli/cli_mesh_diag.hpp
@@ -54,10 +54,9 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    MeshDiag(otInstance *aInstance, OutputImplementer &aOutputImplementer);
+    explicit MeshDiag(OutputImplementer &aOutputImplementer);
 
     /**
      * Processes a CLI sub-command.

--- a/src/cli/cli_network_data.cpp
+++ b/src/cli/cli_network_data.cpp
@@ -43,12 +43,12 @@
 namespace ot {
 namespace Cli {
 
-NetworkData::NetworkData(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Utils(aInstance, aOutputImplementer)
+NetworkData::NetworkData(OutputImplementer &aOutputImplementer)
+    : Utils(aOutputImplementer)
 {
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_SIGNAL_NETWORK_DATA_FULL
     mFullCallbackWasCalled = false;
-    otBorderRouterSetNetDataFullCallback(aInstance, HandleNetdataFull, this);
+    otBorderRouterSetNetDataFullCallback(GetInstancePtr(), HandleNetdataFull, this);
 #endif
 }
 

--- a/src/cli/cli_network_data.hpp
+++ b/src/cli/cli_network_data.hpp
@@ -63,10 +63,9 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    NetworkData(otInstance *aInstance, OutputImplementer &aOutputImplementer);
+    explicit NetworkData(OutputImplementer &aOutputImplementer);
 
     /**
      * Processes a CLI sub-command.

--- a/src/cli/cli_ping.cpp
+++ b/src/cli/cli_ping.cpp
@@ -44,8 +44,8 @@
 namespace ot {
 namespace Cli {
 
-PingSender::PingSender(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Utils(aInstance, aOutputImplementer)
+PingSender::PingSender(OutputImplementer &aOutputImplementer)
+    : Utils(aOutputImplementer)
     , mPingIsAsync(false)
 {
 }

--- a/src/cli/cli_ping.hpp
+++ b/src/cli/cli_ping.hpp
@@ -55,10 +55,9 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    PingSender(otInstance *aInstance, OutputImplementer &aOutputImplementer);
+    explicit PingSender(OutputImplementer &aOutputImplementer);
 
     /**
      * Processes a CLI sub-command.

--- a/src/cli/cli_srp_client.cpp
+++ b/src/cli/cli_srp_client.cpp
@@ -57,8 +57,8 @@ exit:
     return error;
 }
 
-SrpClient::SrpClient(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Utils(aInstance, aOutputImplementer)
+SrpClient::SrpClient(OutputImplementer &aOutputImplementer)
+    : Utils(aOutputImplementer)
     , mCallbackEnabled(false)
 {
     otSrpClientSetCallback(GetInstancePtr(), SrpClient::HandleCallback, this);

--- a/src/cli/cli_srp_client.hpp
+++ b/src/cli/cli_srp_client.hpp
@@ -56,10 +56,9 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    SrpClient(otInstance *aInstance, OutputImplementer &aOutputImplementer);
+    explicit SrpClient(OutputImplementer &aOutputImplementer);
 
     /**
      * Processes a CLI sub-command.

--- a/src/cli/cli_srp_server.hpp
+++ b/src/cli/cli_srp_server.hpp
@@ -54,11 +54,10 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    SrpServer(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Utils(aInstance, aOutputImplementer)
+    explicit SrpServer(OutputImplementer &aOutputImplementer)
+        : Utils(aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_tcat.hpp
+++ b/src/cli/cli_tcat.hpp
@@ -50,11 +50,10 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    Tcat(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-        : Utils(aInstance, aOutputImplementer)
+    explicit Tcat(OutputImplementer &aOutputImplementer)
+        : Utils(aOutputImplementer)
         , mSelectedCert(0)
     {
     }

--- a/src/cli/cli_tcp.cpp
+++ b/src/cli/cli_tcp.cpp
@@ -62,8 +62,8 @@ const int TcpExample::sCipherSuites[] = {MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8,
                                          MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8, 0};
 #endif
 
-TcpExample::TcpExample(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Utils(aInstance, aOutputImplementer)
+TcpExample::TcpExample(OutputImplementer &aOutputImplementer)
+    : Utils(aOutputImplementer)
     , mInitialized(false)
     , mEndpointConnected(false)
     , mEndpointConnectedFastOpen(false)

--- a/src/cli/cli_tcp.hpp
+++ b/src/cli/cli_tcp.hpp
@@ -68,10 +68,9 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    TcpExample(otInstance *aInstance, OutputImplementer &aOutputImplementer);
+    explicit TcpExample(OutputImplementer &aOutputImplementer);
 
     /**
      * Processes a CLI sub-command.

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -43,8 +43,8 @@
 namespace ot {
 namespace Cli {
 
-UdpExample::UdpExample(otInstance *aInstance, OutputImplementer &aOutputImplementer)
-    : Utils(aInstance, aOutputImplementer)
+UdpExample::UdpExample(OutputImplementer &aOutputImplementer)
+    : Utils(aOutputImplementer)
     , mLinkSecurityEnabled(true)
 {
     ClearAllBytes(mSocket);

--- a/src/cli/cli_udp.hpp
+++ b/src/cli/cli_udp.hpp
@@ -52,10 +52,9 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aInstance            The OpenThread Instance.
      * @param[in]  aOutputImplementer   An `OutputImplementer`.
      */
-    UdpExample(otInstance *aInstance, OutputImplementer &aOutputImplementer);
+    explicit UdpExample(OutputImplementer &aOutputImplementer);
 
     /**
      * Processes a CLI sub-command.

--- a/src/cli/cli_utils.cpp
+++ b/src/cli/cli_utils.cpp
@@ -50,8 +50,9 @@ namespace Cli {
 
 const char Utils::kUnknownString[] = "unknown";
 
-OutputImplementer::OutputImplementer(otCliOutputCallback aCallback, void *aCallbackContext)
-    : mCallback(aCallback)
+OutputImplementer::OutputImplementer(otInstance *aInstance, otCliOutputCallback aCallback, void *aCallbackContext)
+    : mInstance(aInstance)
+    , mCallback(aCallback)
     , mCallbackContext(aCallbackContext)
 #if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
     , mOutputLength(0)

--- a/src/cli/cli_utils.hpp
+++ b/src/cli/cli_utils.hpp
@@ -88,7 +88,7 @@ public:
      * @param[in] aCallback           A pointer to an `otCliOutputCallback` to deliver strings to the CLI console.
      * @param[in] aCallbackContext    An arbitrary context to pass in when invoking @p aCallback.
      */
-    OutputImplementer(otCliOutputCallback aCallback, void *aCallbackContext);
+    OutputImplementer(otInstance *aInstance, otCliOutputCallback aCallback, void *aCallbackContext);
 
 #if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
     void SetEmittingCommandOutput(bool aEmittingOutput) { mEmittingCommandOutput = aEmittingOutput; }
@@ -101,6 +101,7 @@ private:
 
     void OutputV(const char *aFormat, va_list aArguments) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 0);
 
+    otInstance         *mInstance;
     otCliOutputCallback mCallback;
     void               *mCallbackContext;
 #if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
@@ -181,12 +182,10 @@ public:
     /**
      * Initializes the `Utils` object.
      *
-     * @param[in] aInstance           A pointer to OpenThread instance.
      * @param[in] aImplementer        An `OutputImplementer`.
      */
-    Utils(otInstance *aInstance, OutputImplementer &aImplementer)
-        : mInstance(aInstance)
-        , mImplementer(aImplementer)
+    explicit Utils(OutputImplementer &aImplementer)
+        : mImplementer(aImplementer)
     {
     }
 
@@ -195,7 +194,7 @@ public:
      *
      * @returns The pointer to the OpenThread instance.
      */
-    otInstance *GetInstancePtr(void) { return mInstance; }
+    otInstance *GetInstancePtr(void) { return mImplementer.mInstance; }
 
     /**
      * Converts a boolean to "yes" or "no" string.
@@ -759,6 +758,9 @@ protected:
 
 private:
     static constexpr uint16_t kInputOutputLogStringSize = OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LOG_STRING_SIZE;
+
+    Utils(const Utils &)            = delete;
+    Utils &operator=(const Utils &) = delete;
 
     void OutputTableHeader(uint8_t aNumColumns, const char *const aTitles[], const uint8_t aWidths[]);
     void OutputTableSeparator(uint8_t aNumColumns, const uint8_t aWidths[]);


### PR DESCRIPTION
This commit refactors the CLI sub-modules to avoid passing and storing the `otInstance` pointer redundantly.

Previously, the `otInstance` pointer was passed to the constructor of every CLI sub-module (e.g., `Dataset`, `PingSender`, `Coap`) and stored within the `Utils` base class.

This change moves the `otInstance` pointer down to the `OutputImplementer` base class. The `Utils` class now retrieves the instance pointer directly from its associated `OutputImplementer` reference (`mImplementer.mInstance`).

This simplifies the constructors of all CLI sub-modules and reduces memory overhead by ensuring only a single `otInstance` pointer is kept within the CLI interpreter hierarchy.