### PR TITLE
[cli] replace static `Interpreter::GetInterpreter()` calls

### DIFF
--- a/src/cli/cli_br.cpp
+++ b/src/cli/cli_br.cpp
@@ -1200,7 +1200,7 @@ template <> otError Br::Process<Cmd("counters")>(Arg aArgs[])
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
-    Interpreter::GetInterpreter().OutputBorderRouterCounters();
+    GetInterpreter().OutputBorderRouterCounters();
 
 exit:
     return error;

--- a/src/cli/cli_dns.cpp
+++ b/src/cli/cli_dns.cpp
@@ -437,7 +437,7 @@ exit:
 
 //----------------------------------------------------------------------------------------------------------------------
 
-void Dns::OutputResult(otError aError) { Interpreter::GetInterpreter().OutputResult(aError); }
+void Dns::OutputResult(otError aError) { GetInterpreter().OutputResult(aError); }
 
 otError Dns::GetDnsConfig(Arg aArgs[], otDnsQueryConfig *&aConfig)
 {

--- a/src/cli/cli_history.cpp
+++ b/src/cli/cli_history.cpp
@@ -2026,7 +2026,7 @@ void History::HandleNetInfo(otError aError, const otHistoryTrackerNetworkInfo *a
     OutputResult(aError);
 }
 
-void History::OutputResult(otError aError) { Interpreter::GetInterpreter().OutputResult(aError); }
+void History::OutputResult(otError aError) { GetInterpreter().OutputResult(aError); }
 
 #endif // #if OPENTHREAD_CONFIG_HISTORY_TRACKER_CLIENT_ENABLE
 

--- a/src/cli/cli_link_metrics.cpp
+++ b/src/cli/cli_link_metrics.cpp
@@ -594,7 +594,7 @@ const char *LinkMetrics::LinkMetricsStatusToStr(otLinkMetricsStatus aStatus)
     return str;
 }
 
-void LinkMetrics::OutputResult(otError aError) { Interpreter::GetInterpreter().OutputResult(aError); }
+void LinkMetrics::OutputResult(otError aError) { GetInterpreter().OutputResult(aError); }
 
 } // namespace Cli
 } // namespace ot

--- a/src/cli/cli_mdns.cpp
+++ b/src/cli/cli_mdns.cpp
@@ -456,7 +456,7 @@ void Mdns::HandleRegisterationDone(otMdnsRequestId aRequestId, otError aError)
     if (mWaitingForCallback && (aRequestId == mRequestId))
     {
         mWaitingForCallback = false;
-        Interpreter::GetInterpreter().OutputResult(aError);
+        GetInterpreter().OutputResult(aError);
     }
     else
     {

--- a/src/cli/cli_mesh_diag.cpp
+++ b/src/cli/cli_mesh_diag.cpp
@@ -548,7 +548,7 @@ exit:
     OutputResult(aError);
 }
 
-void MeshDiag::OutputResult(otError aError) { Interpreter::GetInterpreter().OutputResult(aError); }
+void MeshDiag::OutputResult(otError aError) { GetInterpreter().OutputResult(aError); }
 
 } // namespace Cli
 } // namespace ot

--- a/src/cli/cli_ping.cpp
+++ b/src/cli/cli_ping.cpp
@@ -249,7 +249,7 @@ void PingSender::HandlePingStatistics(const otPingSenderStatistics *aStatistics)
     }
 }
 
-void PingSender::OutputResult(otError aError) { Interpreter::GetInterpreter().OutputResult(aError); }
+void PingSender::OutputResult(otError aError) { GetInterpreter().OutputResult(aError); }
 
 } // namespace Cli
 } // namespace ot

--- a/src/cli/cli_utils.cpp
+++ b/src/cli/cli_utils.cpp
@@ -60,6 +60,8 @@ OutputImplementer::OutputImplementer(otCliOutputCallback aCallback, void *aCallb
 {
 }
 
+Interpreter &Utils::GetInterpreter(void) { return static_cast<Interpreter &>(mImplementer); }
+
 const char *Utils::ToYesNo(bool aBool) { return aBool ? "yes" : "no"; }
 
 void Utils::OutputFormat(const char *aFormat, ...)

--- a/src/cli/cli_utils.hpp
+++ b/src/cli/cli_utils.hpp
@@ -73,28 +73,24 @@ constexpr static CommandId Cmd(const char *aString)
 }
 
 class Utils;
+class Interpreter;
 
 /**
- * Implements the basic output functions.
+ * Implements the basic output functions acting as a base class for `Interpreter`.
  */
 class OutputImplementer
 {
     friend class Utils;
 
 public:
-    /**
-     * Initializes the `OutputImplementer` object.
-     *
-     * @param[in] aCallback           A pointer to an `otCliOutputCallback` to deliver strings to the CLI console.
-     * @param[in] aCallbackContext    An arbitrary context to pass in when invoking @p aCallback.
-     */
-    OutputImplementer(otCliOutputCallback aCallback, void *aCallbackContext);
-
 #if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
     void SetEmittingCommandOutput(bool aEmittingOutput) { mEmittingCommandOutput = aEmittingOutput; }
 #else
     void SetEmittingCommandOutput(bool) {}
 #endif
+
+protected:
+    OutputImplementer(otCliOutputCallback aCallback, void *aCallbackContext);
 
 private:
     static constexpr uint16_t kInputOutputLogStringSize = OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LOG_STRING_SIZE;
@@ -196,6 +192,13 @@ public:
      * @returns The pointer to the OpenThread instance.
      */
     otInstance *GetInstancePtr(void) { return mInstance; }
+
+    /**
+     * Returns the associated CLI `Interpreter`.
+     *
+     * @returns A reference to the associated CLI `Interpreter`.
+     */
+    Interpreter &GetInterpreter(void);
 
     /**
      * Converts a boolean to "yes" or "no" string.


### PR DESCRIPTION
This commit updates the CLI sub-modules to use a new, non-static `GetInterpreter()` method provided by the `Utils` base class, rather than relying on the static `Interpreter::GetInterpreter()` which returns a global singleton.

The `Utils::GetInterpreter()` method downcasts its associated `OutputImplementer` reference to the specific `Interpreter` instance it belongs to. `OutputImplementer` is a base class of `Interpreter`.

This change is a step towards adding support for multiple CLI interpreters (per OpenThread instance).

Additionally, the `OutputImplementer` constructor is made `protected` as it is intended to serve as a base class.