### PR TITLE
[cli] add `OutputResult()` in `Utils`

### DIFF
--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -121,6 +121,8 @@ class Interpreter : public OutputImplementer, public Utils
     friend class SrpClient;
     friend class SrpServer;
 #endif
+    friend class Utils;
+
     friend void otCliPlatLogv(otLogLevel, otLogRegion, const char *, va_list);
     friend void otCliAppendResult(otError aError);
     friend void otCliOutputBytes(const uint8_t *aBytes, uint8_t aLength);

--- a/src/cli/cli_dns.cpp
+++ b/src/cli/cli_dns.cpp
@@ -437,8 +437,6 @@ exit:
 
 //----------------------------------------------------------------------------------------------------------------------
 
-void Dns::OutputResult(otError aError) { GetInterpreter().OutputResult(aError); }
-
 otError Dns::GetDnsConfig(Arg aArgs[], otDnsQueryConfig *&aConfig)
 {
     // This method gets the optional DNS config from `aArgs[]`.

--- a/src/cli/cli_dns.hpp
+++ b/src/cli/cli_dns.hpp
@@ -101,7 +101,6 @@ private:
     template <CommandId kCommandId> otError Process(Arg aArgs[]);
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
-    void        OutputResult(otError aError);
     otError     GetDnsConfig(Arg aArgs[], otDnsQueryConfig *&aConfig);
     const char *DnsConfigServiceModeToString(otDnsServiceMode aMode) const;
     otError     ParseDnsServiceMode(const Arg &aArg, otDnsServiceMode &aMode) const;

--- a/src/cli/cli_history.cpp
+++ b/src/cli/cli_history.cpp
@@ -2026,8 +2026,6 @@ void History::HandleNetInfo(otError aError, const otHistoryTrackerNetworkInfo *a
     OutputResult(aError);
 }
 
-void History::OutputResult(otError aError) { GetInterpreter().OutputResult(aError); }
-
 #endif // #if OPENTHREAD_CONFIG_HISTORY_TRACKER_CLIENT_ENABLE
 
 otError History::Process(Arg aArgs[])

--- a/src/cli/cli_history.hpp
+++ b/src/cli/cli_history.hpp
@@ -101,7 +101,6 @@ private:
     void OutputNetInfoEntry(bool aIsList, const otHistoryTrackerNetworkInfo &aInfo, uint32_t aEntryAge);
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_CLIENT_ENABLE
-    void    OutputResult(otError aError);
     otError ParseQueryArgs(Arg       aArgs[],
                            bool     &aIsList,
                            uint16_t &aRloc16,

--- a/src/cli/cli_link_metrics.cpp
+++ b/src/cli/cli_link_metrics.cpp
@@ -594,8 +594,6 @@ const char *LinkMetrics::LinkMetricsStatusToStr(otLinkMetricsStatus aStatus)
     return str;
 }
 
-void LinkMetrics::OutputResult(otError aError) { GetInterpreter().OutputResult(aError); }
-
 } // namespace Cli
 } // namespace ot
 

--- a/src/cli/cli_link_metrics.hpp
+++ b/src/cli/cli_link_metrics.hpp
@@ -115,8 +115,6 @@ private:
 
     const char *LinkMetricsStatusToStr(otLinkMetricsStatus aStatus);
 
-    void OutputResult(otError aError);
-
     bool mQuerySync : 1;
     bool mConfigForwardTrackingSeriesSync : 1;
     bool mConfigEnhAckProbingSync : 1;

--- a/src/cli/cli_mesh_diag.cpp
+++ b/src/cli/cli_mesh_diag.cpp
@@ -548,8 +548,6 @@ exit:
     OutputResult(aError);
 }
 
-void MeshDiag::OutputResult(otError aError) { GetInterpreter().OutputResult(aError); }
-
 } // namespace Cli
 } // namespace ot
 

--- a/src/cli/cli_mesh_diag.hpp
+++ b/src/cli/cli_mesh_diag.hpp
@@ -104,8 +104,6 @@ private:
     void HandleMeshDiagQueryChildIp6Addrs(otError                    aError,
                                           uint16_t                   aChildRloc16,
                                           otMeshDiagIp6AddrIterator *aIp6AddrIterator);
-
-    void OutputResult(otError aError);
 };
 
 } // namespace Cli

--- a/src/cli/cli_ping.cpp
+++ b/src/cli/cli_ping.cpp
@@ -249,8 +249,6 @@ void PingSender::HandlePingStatistics(const otPingSenderStatistics *aStatistics)
     }
 }
 
-void PingSender::OutputResult(otError aError) { GetInterpreter().OutputResult(aError); }
-
 } // namespace Cli
 } // namespace ot
 

--- a/src/cli/cli_ping.hpp
+++ b/src/cli/cli_ping.hpp
@@ -81,8 +81,6 @@ private:
     static void HandlePingStatistics(const otPingSenderStatistics *aStatistics, void *aContext);
     void        HandlePingStatistics(const otPingSenderStatistics *aStatistics);
 
-    void OutputResult(otError aError);
-
     bool mPingIsAsync : 1;
 };
 

--- a/src/cli/cli_utils.cpp
+++ b/src/cli/cli_utils.cpp
@@ -64,6 +64,8 @@ Interpreter &Utils::GetInterpreter(void) { return static_cast<Interpreter &>(mIm
 
 const char *Utils::ToYesNo(bool aBool) { return aBool ? "yes" : "no"; }
 
+void Utils::OutputResult(otError aError) { GetInterpreter().OutputResult(aError); }
+
 void Utils::OutputFormat(const char *aFormat, ...)
 {
     va_list args;

--- a/src/cli/cli_utils.hpp
+++ b/src/cli/cli_utils.hpp
@@ -230,6 +230,16 @@ public:
     static const char *Uint64ToString(uint64_t aUint64, Uint64StringBuffer &aBuffer);
 
     /**
+     * Outputs the command result.
+     *
+     * This is called to end the current command. `OT_ERROR_PENDING` can be used to indicate command execution is
+     * continuing asynchronously.
+     *
+     * @param[in]  aError Error code value.
+     */
+    void OutputResult(otError aError);
+
+    /**
      * Delivers a formatted output string to the CLI console.
      *
      * @param[in]  aFormat  A pointer to the format string.


### PR DESCRIPTION
This commit add a `OutputResult()` wrapper method in the `Utils` base class.

Previously, several CLI sub-modules (`Dns`, `History`, `LinkMetrics`, `MeshDiag`, and `PingSender`) implemented their own `OutputResult()` wrappers that simply delegated to the `Interpreter`. Since all these sub-modules inherit from `Utils`, this functionality is now provided directly by the base class, removing redundant code and simplifying the sub-module implementations.

----

~This PR contains the commit from https://github.com/openthread/openthread/pull/13033.~
