### PR TITLE
[posix] fix ICMPv6 RA length calculation in tryProcessIcmp6RaMessage()

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -1182,7 +1182,7 @@ static otError tryProcessIcmp6RaMessage(otInstance *aInstance, const uint8_t *da
     otDumpInfoPlat("", data, static_cast<size_t>(length));
 #endif
 
-    raLength = length + (ra - data);
+    raLength = length - (ra - data);
     otPlatBorderRoutingProcessIcmp6Ra(aInstance, ra, raLength);
 
 exit:


### PR DESCRIPTION
There exists a stack OOB read in `tryProcessIcmp6RaMessage()`. The bug originates from the posix packet processing in `processTransmit()`. When an ICMPv6 RA packet is sent, this triggers `tryProcessIcmp6RaMessage()`, which calculates:
`raLength = length + (ra - data)`

However, the length passed is the packet size, which can go up to the `char packet[kMaxIp6Size];` stack buffer size. The correct calculation is `raLength = length - (ra - data)`.

This small mistake can make `raLength` larger than the total stack buffer size, causing a read OOB during RA processing in `otPlatBorderRoutingProcessIcmp6Ra()`.