### PR TITLE
[array] add `Add()` method

### DIFF
--- a/src/core/common/array.hpp
+++ b/src/core/common/array.hpp
@@ -347,6 +347,17 @@ public:
     Type *PopBack(void) { return IsEmpty() ? nullptr : &mElements[--mLength]; }
 
     /**
+     * Adds an entry to the array if it is not already present.
+     *
+     * @param[in]  aEntry  The entry to add.
+     *
+     * @retval kErrorNone     Successfully added the entry to the array.
+     * @retval kErrorAlready  The entry is already present in the array.
+     * @retval kErrorNoBufs   The array is full.
+     */
+    Error Add(const Type &aEntry) { return Contains(aEntry) ? kErrorAlready : PushBack(aEntry); }
+
+    /**
      * Returns the index of an element in the array.
      *
      * The @p aElement MUST be from the array, otherwise the behavior of this method is undefined.

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -47,15 +47,11 @@ Notifier::Notifier(Instance &aInstance)
 
 Error Notifier::RegisterCallback(StateChangedCallback aCallback, void *aContext)
 {
-    Error            error = kErrorNone;
     ExternalCallback newCallback;
 
     newCallback.Set(aCallback, aContext);
-    VerifyOrExit(!mExternalCallbacks.Contains(newCallback), error = kErrorAlready);
-    error = mExternalCallbacks.PushBack(newCallback);
 
-exit:
-    return error;
+    return mExternalCallbacks.Add(newCallback);
 }
 
 void Notifier::RemoveCallback(StateChangedCallback aCallback, void *aContext)

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -723,14 +723,6 @@ exit:
     return error;
 }
 
-void DatasetManager::TlvList::Add(uint8_t aTlvType)
-{
-    if (!Contains(aTlvType))
-    {
-        IgnoreError(PushBack(aTlvType));
-    }
-}
-
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
 
 const DatasetManager::SecurelyStoredTlv DatasetManager::kSecurelyStoredTlvs[] = {

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include "common/callback.hpp"
+#include "common/code_utils.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/timer.hpp"
@@ -234,7 +235,7 @@ private:
     {
     public:
         TlvList(void) = default;
-        void Add(uint8_t aTlvType);
+        void Add(uint8_t aTlvType) { IgnoreError(Array::Add(aTlvType)); }
     };
 
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -1782,18 +1782,21 @@ exit:
 
 void Client::RecordServerAsLimitedToSingleQuestion(const Ip6::Address &aServerAddress)
 {
+    uint8_t randomIndex;
+
     VerifyOrExit(!aServerAddress.IsUnspecified());
 
-    VerifyOrExit(!mLimitedQueryServers.Contains(aServerAddress));
-
-    if (mLimitedQueryServers.IsFull())
+    switch (mLimitedQueryServers.Add(aServerAddress))
     {
-        uint8_t randomIndex = Random::NonCrypto::GetUint8InRange(0, mLimitedQueryServers.GetMaxSize());
-
+    case kErrorNone:
+    case kErrorAlready:
+        break;
+    default:
+        randomIndex = Random::NonCrypto::GetUint8InRange(0, mLimitedQueryServers.GetLength());
         mLimitedQueryServers.Remove(mLimitedQueryServers[randomIndex]);
+        IgnoreError(mLimitedQueryServers.PushBack(aServerAddress));
+        break;
     }
-
-    IgnoreError(mLimitedQueryServers.PushBack(aServerAddress));
 
 exit:
     return;

--- a/src/core/net/ip6_filter.cpp
+++ b/src/core/net/ip6_filter.cpp
@@ -101,7 +101,31 @@ exit:
     return error;
 }
 
-Error Filter::UpdateUnsecurePorts(Action aAction, uint16_t aPort)
+Error Filter::AddUnsecurePort(uint16_t aPort)
+{
+    Error error;
+
+    VerifyOrExit(aPort != 0, error = kErrorInvalidArgs);
+
+    error = mUnsecurePorts.Add(aPort);
+
+    switch (error)
+    {
+    case kErrorNone:
+        LogInfo("Added unsecure port %u", aPort);
+        break;
+    case kErrorAlready:
+        error = kErrorNone;
+        break;
+    default:
+        break;
+    }
+
+exit:
+    return error;
+}
+
+Error Filter::RemoveUnsecurePort(uint16_t aPort)
 {
     Error     error = kErrorNone;
     uint16_t *entry;
@@ -110,18 +134,10 @@ Error Filter::UpdateUnsecurePorts(Action aAction, uint16_t aPort)
 
     entry = mUnsecurePorts.Find(aPort);
 
-    if (aAction == kAdd)
-    {
-        VerifyOrExit(entry == nullptr);
-        SuccessOrExit(error = mUnsecurePorts.PushBack(aPort));
-    }
-    else
-    {
-        VerifyOrExit(entry != nullptr, error = kErrorNotFound);
-        mUnsecurePorts.Remove(*entry);
-    }
+    VerifyOrExit(entry != nullptr, error = kErrorNotFound);
+    mUnsecurePorts.Remove(*entry);
 
-    LogInfo("%s unsecure port %d", (aAction == kAdd) ? "Added" : "Removed", aPort);
+    LogInfo("Removed unsecure port %u", aPort);
 
 exit:
     return error;

--- a/src/core/net/ip6_filter.hpp
+++ b/src/core/net/ip6_filter.hpp
@@ -88,7 +88,7 @@ public:
      * @retval kErrorInvalidArgs  The port is invalid (value 0 is reserved for internal use).
      * @retval kErrorNoBufs       The unsecure port list is full.
      */
-    Error AddUnsecurePort(uint16_t aPort) { return UpdateUnsecurePorts(kAdd, aPort); }
+    Error AddUnsecurePort(uint16_t aPort);
 
     /**
      * Removes a port from the allowed unsecure port list.
@@ -99,7 +99,7 @@ public:
      * @retval kErrorInvalidArgs  The port is invalid (value 0 is reserved for internal use).
      * @retval kErrorNotFound     The port was not found in the unsecure port list.
      */
-    Error RemoveUnsecurePort(uint16_t aPort) { return UpdateUnsecurePorts(kRemove, aPort); }
+    Error RemoveUnsecurePort(uint16_t aPort);
 
     /**
      * Checks whether a port is in the unsecure port list.
@@ -133,14 +133,6 @@ public:
 
 private:
     static constexpr uint16_t kMaxUnsecurePorts = 2;
-
-    enum Action : uint8_t
-    {
-        kAdd,
-        kRemove,
-    };
-
-    Error UpdateUnsecurePorts(Action aAction, uint16_t aPort);
 
     Array<uint16_t, kMaxUnsecurePorts> mUnsecurePorts;
 };

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3153,15 +3153,14 @@ void Mle::HandleWakeupFrame(const Mac::WakeupInfo &aWakeupInfo)
 
 void Mle::TlvList::Add(uint8_t aTlvType)
 {
-    VerifyOrExit(!Contains(aTlvType));
-
-    if (PushBack(aTlvType) != kErrorNone)
+    switch (Array::Add(aTlvType))
     {
-        LogWarn("Failed to include TLV %d", aTlvType);
+    case kErrorNone:
+    case kErrorAlready:
+        break;
+    default:
+        LogWarn("Failed to include TLV %u", aTlvType);
     }
-
-exit:
-    return;
 }
 
 void Mle::TlvList::AddElementsFrom(const TlvList &aTlvList)

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -649,14 +649,6 @@ void MlrManager::LogMulticastAddresses(void)
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)
 }
 
-void MlrManager::AddressArray::AddUnique(const Ip6::Address &aAddress)
-{
-    if (!Contains(aAddress))
-    {
-        IgnoreError(PushBack(aAddress));
-    }
-}
-
 void MlrManager::LogMlrResponse(Error aResult, Error aError, uint8_t aStatus, const AddressArray &aFailedAddresses)
 {
     OT_UNUSED_VARIABLE(aResult);

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -146,7 +146,7 @@ private:
     {
     public:
         bool IsEmptyOrContains(const Ip6::Address &aAddress) const { return IsEmpty() || Contains(aAddress); }
-        void AddUnique(const Ip6::Address &aAddress);
+        void AddUnique(const Ip6::Address &aAddress) { IgnoreError(Add(aAddress)); }
     };
 
     void HandleNotifierEvents(Events aEvents);

--- a/tests/nexus/platform/nexus_radio.cpp
+++ b/tests/nexus/platform/nexus_radio.cpp
@@ -176,29 +176,20 @@ void otPlatRadioEnableSrcMatch(otInstance *aInstance, bool aEnable)
 
 otError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, otShortAddress aShortAddress)
 {
-    Error  error = kErrorNone;
-    Radio &radio = AsNode(aInstance).mRadio;
+    Error error = AsNode(aInstance).mRadio.mSrcMatchShortEntries.Add(aShortAddress);
 
-    VerifyOrExit(!radio.mSrcMatchShortEntries.Contains(aShortAddress));
-    error = radio.mSrcMatchShortEntries.PushBack(aShortAddress);
-
-exit:
-    return error;
+    return (error == kErrorAlready) ? kErrorNone : error;
 }
 
 otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
-    Error           error = kErrorNone;
-    Radio          &radio = AsNode(aInstance).mRadio;
+    Error           error;
     Mac::ExtAddress extAddress;
 
     extAddress.Set(aExtAddress->m8, Mac::ExtAddress::kReverseByteOrder);
+    error = AsNode(aInstance).mRadio.mSrcMatchExtEntries.Add(extAddress);
 
-    VerifyOrExit(!radio.mSrcMatchExtEntries.Contains(extAddress));
-    error = radio.mSrcMatchExtEntries.PushBack(extAddress);
-
-exit:
-    return error;
+    return (error == kErrorAlready) ? kErrorNone : error;
 }
 
 otError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, otShortAddress aShortAddress)


### PR DESCRIPTION
This commit introduces the `Add()` method to the `Array` class, which appends an entry only if it is not already present in the array. It returns `kErrorAlready` if the entry is already present, `kErrorNone` on successful addition, and `kErrorNoBufs` if the array is full.

Various parts of the codebase, including `Notifier`, `DatasetManager`, `Dns::Client`, `Ip6::Filter`, `Mle::TlvList`, `MlrManager`, and Nexus `Radio`, are updated to use this new method instead of manually checking `Contains()` before calling `PushBack()`.