### PR TITLE
[joiner] require link security for Joiner Entrust

### DIFF
--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -421,7 +421,8 @@ template <> void Joiner::HandleTmf<kUriJoinerEntrust>(Coap::Msg &aMsg)
     Error         error;
     Dataset::Info datasetInfo;
 
-    VerifyOrExit(mState == kStateEntrust && aMsg.IsConfirmable(), error = kErrorDrop);
+    VerifyOrExit(mState == kStateEntrust && aMsg.IsConfirmable() && aMsg.mMessage.IsLinkSecurityEnabled(),
+                 error = kErrorDrop);
 
     LogInfo("Received %s", UriToString<kUriJoinerEntrust>());
     LogCert("[THCI] direction=recv | type=JOIN_ENT.ntf");


### PR DESCRIPTION
This commit adds an explicit check in Joiner::HandleTmf<kUriJoinerEntrust> to verify that the received message has link-layer security enabled.

According to the Thread specification, the Joiner Entrust message MUST be protected by link-layer security using the Key Encryption Key (KEK). Previously, this check was missing, allowing an unauthenticated attacker to send unsecured Joiner Entrust messages. Such messages could inject invalid network configuration, causing the device to fail to attach to the correct network after a reboot.

By verifying IsLinkSecurityEnabled(), we ensure that the message was successfully decrypted using the KEK (since the network key is not yet known by the Joiner), thus authenticating the sender as the valid Commissioner or Joiner Router.