### PR TITLE
[cli] track all CLI interpreters for callback dispatching

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -71,6 +71,8 @@
 namespace ot {
 namespace Cli {
 
+Interpreter *Interpreter::sInterpreterList = nullptr;
+
 Interpreter::Interpreter(Instance *aInstance, otCliOutputCallback aCallback, void *aContext)
     : OutputImplementer(aCallback, aContext)
     , Utils(aInstance, *this)
@@ -146,6 +148,18 @@ Interpreter::Interpreter(Instance *aInstance, otCliOutputCallback aCallback, voi
 #endif
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD
 {
+    if (!DoesInterpreterListContain(*this))
+    {
+        // Add it to the list if not already present. We check if it
+        // is already present to support cases where the same
+        // interpreter instance is re-initialized without being
+        // finalized first. While such usage is not recommended, we
+        // still want to support it.
+
+        mNext            = sInterpreterList;
+        sInterpreterList = this;
+    }
+
 #if (OPENTHREAD_FTD || OPENTHREAD_MTD) && OPENTHREAD_CONFIG_CLI_REGISTER_IP6_RECV_CALLBACK
     otIp6SetReceiveCallback(GetInstancePtr(), &Interpreter::HandleIp6Receive, this);
 #endif
@@ -156,6 +170,50 @@ Interpreter::Interpreter(Instance *aInstance, otCliOutputCallback aCallback, voi
     ClearAllBytes(mUserCommands);
 
     OutputPrompt();
+}
+
+bool Interpreter::DoesInterpreterListContain(Interpreter &aInterpreter)
+{
+    bool contains = false;
+
+    for (Interpreter *cur = sInterpreterList; cur != nullptr; cur = cur->mNext)
+    {
+        if (cur == &aInterpreter)
+        {
+            contains = true;
+            break;
+        }
+    }
+
+    return contains;
+}
+
+Interpreter::~Interpreter(void)
+{
+    if (sInterpreterList == this)
+    {
+        sInterpreterList = mNext;
+    }
+    else
+    {
+        for (Interpreter *cur = sInterpreterList; cur != nullptr; cur = cur->mNext)
+        {
+            if (cur->mNext == this)
+            {
+                cur->mNext = mNext;
+                break;
+            }
+        }
+    }
+
+    mNext = nullptr;
+
+#if OPENTHREAD_CONFIG_CLI_STATIC_INTERPRETER_ENABLE
+    if (sInterpreter == this)
+    {
+        sInterpreter = nullptr;
+    }
+#endif
 }
 
 void Interpreter::OutputResult(otError aError)

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -142,6 +142,18 @@ public:
      */
     explicit Interpreter(Instance *aInstance, otCliOutputCallback aCallback, void *aContext);
 
+    /**
+     * Destructor
+     */
+    ~Interpreter(void);
+
+    /**
+     * Gets the head of the linked list of all initialized CLI interpreters.
+     *
+     * @returns A pointer to the first CLI interpreter, or `nullptr` if none are initialized.
+     */
+    static Interpreter *GetInterpreterList(void) { return sInterpreterList; }
+
 #if OPENTHREAD_CONFIG_CLI_STATIC_INTERPRETER_ENABLE
     /**
      * Returns a reference to the static CLI interpreter.
@@ -392,6 +404,8 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
+    static bool DoesInterpreterListContain(Interpreter &aInterpreter);
+
     struct UserCommandsEntry
     {
         const otCliCommand *mCommands;
@@ -399,6 +413,9 @@ private:
         void               *mContext;
     };
 
+    static Interpreter *sInterpreterList;
+
+    Interpreter      *mNext;
     UserCommandsEntry mUserCommands[kMaxUserCommandEntries];
     bool              mCommandIsPending;
     bool              mInternalDebugCommand;

--- a/src/cli/cli_mdns.cpp
+++ b/src/cli/cli_mdns.cpp
@@ -446,9 +446,13 @@ exit:
 
 void Mdns::HandleRegisterationDone(otInstance *aInstance, otMdnsRequestId aRequestId, otError aError)
 {
-    OT_UNUSED_VARIABLE(aInstance);
-
-    Interpreter::GetInterpreter().mMdns.HandleRegisterationDone(aRequestId, aError);
+    for (Interpreter *intprtr = Interpreter::GetInterpreterList(); intprtr != nullptr; intprtr = intprtr->mNext)
+    {
+        if (intprtr->GetInstancePtr() == aInstance)
+        {
+            intprtr->mMdns.HandleRegisterationDone(aRequestId, aError);
+        }
+    }
 }
 
 void Mdns::HandleRegisterationDone(otMdnsRequestId aRequestId, otError aError)
@@ -733,9 +737,13 @@ exit:
 
 void Mdns::HandleBrowseResult(otInstance *aInstance, const otMdnsBrowseResult *aResult)
 {
-    OT_UNUSED_VARIABLE(aInstance);
-
-    Interpreter::GetInterpreter().mMdns.HandleBrowseResult(*aResult);
+    for (Interpreter *intprtr = Interpreter::GetInterpreterList(); intprtr != nullptr; intprtr = intprtr->mNext)
+    {
+        if (intprtr->GetInstancePtr() == aInstance)
+        {
+            intprtr->mMdns.HandleBrowseResult(*aResult);
+        }
+    }
 }
 
 void Mdns::HandleBrowseResult(const otMdnsBrowseResult &aResult)
@@ -789,9 +797,13 @@ exit:
 
 void Mdns::HandleSrvResult(otInstance *aInstance, const otMdnsSrvResult *aResult)
 {
-    OT_UNUSED_VARIABLE(aInstance);
-
-    Interpreter::GetInterpreter().mMdns.HandleSrvResult(*aResult);
+    for (Interpreter *intprtr = Interpreter::GetInterpreterList(); intprtr != nullptr; intprtr = intprtr->mNext)
+    {
+        if (intprtr->GetInstancePtr() == aInstance)
+        {
+            intprtr->mMdns.HandleSrvResult(*aResult);
+        }
+    }
 }
 
 void Mdns::HandleSrvResult(const otMdnsSrvResult &aResult)
@@ -843,9 +855,13 @@ exit:
 
 void Mdns::HandleTxtResult(otInstance *aInstance, const otMdnsTxtResult *aResult)
 {
-    OT_UNUSED_VARIABLE(aInstance);
-
-    Interpreter::GetInterpreter().mMdns.HandleTxtResult(*aResult);
+    for (Interpreter *intprtr = Interpreter::GetInterpreterList(); intprtr != nullptr; intprtr = intprtr->mNext)
+    {
+        if (intprtr->GetInstancePtr() == aInstance)
+        {
+            intprtr->mMdns.HandleTxtResult(*aResult);
+        }
+    }
 }
 
 void Mdns::HandleTxtResult(const otMdnsTxtResult &aResult)
@@ -893,9 +909,13 @@ exit:
 
 void Mdns::HandleIp6AddressResult(otInstance *aInstance, const otMdnsAddressResult *aResult)
 {
-    OT_UNUSED_VARIABLE(aInstance);
-
-    Interpreter::GetInterpreter().mMdns.HandleAddressResult(*aResult, kIp6Address);
+    for (Interpreter *intprtr = Interpreter::GetInterpreterList(); intprtr != nullptr; intprtr = intprtr->mNext)
+    {
+        if (intprtr->GetInstancePtr() == aInstance)
+        {
+            intprtr->mMdns.HandleAddressResult(*aResult, kIp6Address);
+        }
+    }
 }
 
 void Mdns::HandleAddressResult(const otMdnsAddressResult &aResult, IpAddressType aType)
@@ -946,9 +966,13 @@ exit:
 
 void Mdns::HandleIp4AddressResult(otInstance *aInstance, const otMdnsAddressResult *aResult)
 {
-    OT_UNUSED_VARIABLE(aInstance);
-
-    Interpreter::GetInterpreter().mMdns.HandleAddressResult(*aResult, kIp4Address);
+    for (Interpreter *intprtr = Interpreter::GetInterpreterList(); intprtr != nullptr; intprtr = intprtr->mNext)
+    {
+        if (intprtr->GetInstancePtr() == aInstance)
+        {
+            intprtr->mMdns.HandleAddressResult(*aResult, kIp4Address);
+        }
+    }
 }
 
 template <> otError Mdns::Process<Cmd("recordquerier")>(Arg aArgs[])
@@ -992,9 +1016,13 @@ exit:
 
 void Mdns::HandleRecordResult(otInstance *aInstance, const otMdnsRecordResult *aResult)
 {
-    OT_UNUSED_VARIABLE(aInstance);
-
-    Interpreter::GetInterpreter().mMdns.HandleRecordResult(*aResult);
+    for (Interpreter *intprtr = Interpreter::GetInterpreterList(); intprtr != nullptr; intprtr = intprtr->mNext)
+    {
+        if (intprtr->GetInstancePtr() == aInstance)
+        {
+            intprtr->mMdns.HandleRecordResult(*aResult);
+        }
+    }
 }
 
 void Mdns::HandleRecordResult(const otMdnsRecordResult &aResult)


### PR DESCRIPTION
This commit introduces a linked list (`sInterpreterList`) to track all initialized `Interpreter` instances.

Previously, static callbacks in the CLI (such as those in the `Mdns` module) relied on `Interpreter::GetInterpreter()` which assumed a global singleton. With the introduction of multi-interpreter support, these callbacks must route responses to the specific interpreter associated with the `otInstance` that triggered the event.

The `Interpreter` constructor now inserts the instance into `sInterpreterList`, and the destructor removes it. Static C callbacks are updated to iterate through this list, matching the `otInstance` pointer to find the correct `Interpreter` and delegate the result.