### PR TITLE
[tmf] enforce link security for all TMF messages

### DIFF
--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -173,10 +173,16 @@ Error Agent::Filter(void *aContext, const Msg &aRxMsg) { return static_cast<Agen
 
 Error Agent::Filter(const Msg &aRxMsg) const
 {
-    return IsTmfMessage(aRxMsg.mMessageInfo.GetPeerAddr(), aRxMsg.mMessageInfo.GetSockAddr(),
-                        aRxMsg.mMessageInfo.GetSockPort())
-               ? kErrorNone
-               : kErrorNotTmf;
+    Error error = kErrorNone;
+
+    VerifyOrExit(IsTmfMessage(aRxMsg.mMessageInfo.GetPeerAddr(), aRxMsg.mMessageInfo.GetSockAddr(),
+                              aRxMsg.mMessageInfo.GetSockPort()),
+                 error = kErrorNotTmf);
+
+    VerifyOrExit(aRxMsg.mMessage.IsLinkSecurityEnabled(), error = kErrorSecurity);
+
+exit:
+    return error;
 }
 
 bool Agent::IsTmfMessage(const Ip6::Address &aSourceAddress, const Ip6::Address &aDestAddress, uint16_t aDestPort) const


### PR DESCRIPTION
This commit updates Tmf::Agent::Filter to require link-layer security for all incoming TMF requests.

Thread Management Framework (TMF) messages are used for network management and configuration. The Thread specification requires that all TMF messages be secured. While individual handlers often have specific checks, enforcing this at the TMF Agent level provides a consistent security layer for all TMF traffic.

For most TMF messages, security is provided by the Network Key. For commissioning-related messages (like Joiner Entrust), security is provided by the Key Encryption Key (KEK). In all cases, a valid TMF message must have link-layer security enabled.

This change prevents unauthenticated attackers from sending unsecured TMF messages to manipulate network state or configuration.