### PR TITLE
[mle] fix child state handling in ProcessAddressRegistrationTlv

### DIFF
--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -1872,8 +1872,6 @@ Error Mle::ProcessAddressRegistrationTlv(RxInfo &aRxInfo, Child &aChild)
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     if (aChild.HasAnyMlrRegisteredAddress())
     {
-        OT_ASSERT(aChild.IsStateValid());
-
         for (const Child::Ip6AddrEntry &addrEntry : aChild.GetIp6Addresses())
         {
             if (!addrEntry.IsMulticastLargerThanRealmLocal())


### PR DESCRIPTION
This commit removes an overly strict `OT_ASSERT` on child state validity inside `ProcessAddressRegistrationTlv`.

When a valid child transitions to a link-reestablishment state (e.g., `kStateChildUpdateRequest` or `kStateChildIdRequest`) with registered MLR addresses, its MLR registered set is preserved. The subsequent processing of the Child Update Response or Child ID Request causes `ProcessAddressRegistrationTlv` to be invoked while the child is not yet back in `kStateValid`, which triggers the assertion on the parent router/leader.

Since the parsing logic and `MlrManager` handle non-valid child states gracefully, this assertion is deleted.