### PR TITLE
[mlr] introduce `Mlr` namespace and rename types

### DIFF
--- a/src/core/api/backbone_router_ftd_api.cpp
+++ b/src/core/api/backbone_router_ftd_api.cpp
@@ -146,10 +146,10 @@ void otBackboneRouterConfigNextDuaRegistrationResponse(otInstance               
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
 void otBackboneRouterConfigNextMulticastListenerRegistrationResponse(otInstance *aInstance, uint8_t aStatus)
 {
-    OT_ASSERT(aStatus <= kMlrStatusMax);
+    OT_ASSERT(aStatus <= Mlr::kMaxStatusValue);
 
     AsCoreType(aInstance).Get<BackboneRouter::Manager>().ConfigNextMulticastListenerRegistrationResponse(
-        static_cast<MlrStatus>(aStatus));
+        static_cast<Mlr::Status>(aStatus));
 }
 
 void otBackboneRouterMulticastListenerClear(otInstance *aInstance)

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -260,8 +260,8 @@ otError otIp6RegisterMulticastListeners(otInstance                             *
                                         otIp6RegisterMulticastListenersCallback aCallback,
                                         void                                   *aContext)
 {
-    return AsCoreType(aInstance).Get<MlrManager>().RegisterMulticastListeners(AsCoreTypePtr(aAddresses), aAddressNum,
-                                                                              aTimeout, aCallback, aContext);
+    return AsCoreType(aInstance).Get<Mlr::Manager>().RegisterMulticastListeners(AsCoreTypePtr(aAddresses), aAddressNum,
+                                                                                aTimeout, aCallback, aContext);
 }
 #endif
 

--- a/src/core/backbone_router/bbr_leader.cpp
+++ b/src/core/backbone_router/bbr_leader.cpp
@@ -197,7 +197,7 @@ void Leader::UpdateBackboneRouterPrimary(void)
 #endif
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
-    Get<MlrManager>().HandleBackboneRouterPrimaryUpdate(state, mConfig);
+    Get<Mlr::Manager>().HandleBackboneRouterPrimaryUpdate(state, mConfig);
 #endif
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE)

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -58,7 +58,7 @@ Manager::Manager(Instance &aInstance)
     , mDuaResponseStatus(kDuaSuccess)
 #endif
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
-    , mMlrResponseStatus(kMlrSuccess)
+    , mMlrResponseStatus(Mlr::kStatusSuccess)
 #endif
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
     , mDuaResponseIsSpecified(false)
@@ -129,14 +129,14 @@ exit:
 
 void Manager::HandleMulticastListenerRegistration(const Coap::Msg &aMsg)
 {
-    Error     error     = kErrorNone;
-    bool      isPrimary = Get<Local>().IsPrimary();
-    MlrStatus status    = kMlrSuccess;
-    Config    config;
+    Error       error     = kErrorNone;
+    bool        isPrimary = Get<Local>().IsPrimary();
+    Mlr::Status status    = Mlr::kStatusSuccess;
+    Config      config;
 
     OffsetRange  offsetRange;
     Ip6::Address address;
-    Ip6::Address addresses[kMlrMaxIp6Addresses];
+    Ip6::Address addresses[Mlr::kMaxIp6Addresses];
     uint8_t      failedAddressNum  = 0;
     uint8_t      successAddressNum = 0;
     TimeMilli    expireTime;
@@ -147,12 +147,13 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Msg &aMsg)
 
     VerifyOrExit(aMsg.IsConfirmable(), error = kErrorParse);
 
-    VerifyOrExit(isPrimary, status = kMlrBbrNotPrimary);
+    VerifyOrExit(isPrimary, status = Mlr::kStatusBbrNotPrimary);
 
     VerifyOrExit(Tlv::FindTlvValueOffsetRange(aMsg.mMessage, Ip6AddressesTlv::kType, offsetRange) == kErrorNone,
                  error = kErrorParse);
-    VerifyOrExit(offsetRange.GetLength() % sizeof(Ip6::Address) == 0, status = kMlrGeneralFailure);
-    VerifyOrExit(offsetRange.GetLength() / sizeof(Ip6::Address) <= kMlrMaxIp6Addresses, status = kMlrGeneralFailure);
+    VerifyOrExit(offsetRange.GetLength() % sizeof(Ip6::Address) == 0, status = Mlr::kStatusGeneralFailure);
+    VerifyOrExit(offsetRange.GetLength() / sizeof(Ip6::Address) <= Mlr::kMaxIp6Addresses,
+                 status = Mlr::kStatusGeneralFailure);
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     // Required by Test Specification 5.10.22 MATN-TC-26, only for certification purpose
@@ -161,7 +162,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Msg &aMsg)
         mMlrResponseIsSpecified = false;
         status                  = mMlrResponseStatus;
 
-        if (status != kMlrSuccess)
+        if (status != Mlr::kStatusSuccess)
         {
             while (!offsetRange.IsEmpty())
             {
@@ -181,7 +182,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Msg &aMsg)
 
         VerifyOrExit((Get<NetworkData::Leader>().FindCommissioningSessionId(localSessionId) == kErrorNone) &&
                          (localSessionId == commissionerSessionId),
-                     status = kMlrGeneralFailure);
+                     status = Mlr::kStatusGeneralFailure);
 
         hasCommissionerSessionIdTlv = true;
     }
@@ -197,7 +198,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Msg &aMsg)
     }
     else
     {
-        VerifyOrExit(timeout < NumericLimits<uint32_t>::kMax, status = kMlrNoPersistent);
+        VerifyOrExit(timeout < NumericLimits<uint32_t>::kMax, status = Mlr::kStatusNoPersistent);
 
         if (timeout != 0)
         {
@@ -224,7 +225,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Msg &aMsg)
             mMulticastListenersTable.Remove(address);
 
             // Put successfully de-registered addresses at the end of `addresses`.
-            addresses[kMlrMaxIp6Addresses - (++successAddressNum)] = address;
+            addresses[Mlr::kMaxIp6Addresses - (++successAddressNum)] = address;
         }
         else
         {
@@ -236,15 +237,15 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Msg &aMsg)
                 failed = false;
                 break;
             case kErrorInvalidArgs:
-                if (status == kMlrSuccess)
+                if (status == Mlr::kStatusSuccess)
                 {
-                    status = kMlrInvalid;
+                    status = Mlr::kStatusInvalid;
                 }
                 break;
             case kErrorNoBufs:
-                if (status == kMlrSuccess)
+                if (status == Mlr::kStatusSuccess)
                 {
-                    status = kMlrNoResources;
+                    status = Mlr::kStatusNoResources;
                 }
                 break;
             default:
@@ -258,7 +259,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Msg &aMsg)
             else
             {
                 // Put successfully registered addresses at the end of `addresses`.
-                addresses[kMlrMaxIp6Addresses - (++successAddressNum)] = address;
+                addresses[Mlr::kMaxIp6Addresses - (++successAddressNum)] = address;
             }
         }
     }
@@ -271,13 +272,13 @@ exit:
 
     if (successAddressNum > 0)
     {
-        SendBackboneMulticastListenerRegistration(&addresses[kMlrMaxIp6Addresses - successAddressNum],
+        SendBackboneMulticastListenerRegistration(&addresses[Mlr::kMaxIp6Addresses - successAddressNum],
                                                   successAddressNum, timeout);
     }
 }
 
 void Manager::SendMulticastListenerRegistrationResponse(const Coap::Msg &aMsg,
-                                                        MlrStatus        aStatus,
+                                                        Mlr::Status      aStatus,
                                                         Ip6::Address    *aFailedAddresses,
                                                         uint8_t          aFailedAddressNum)
 {
@@ -320,7 +321,7 @@ void Manager::SendBackboneMulticastListenerRegistration(const Ip6::Address *aAdd
     Tlv::Bookmark     tlvBookmark;
     BackboneTmfAgent &backboneTmf = Get<BackboneRouter::BackboneTmfAgent>();
 
-    OT_ASSERT(aAddressNum >= kMlrMinIp6Addresses && aAddressNum <= kMlrMaxIp6Addresses);
+    OT_ASSERT(aAddressNum >= Mlr::kMinIp6Addresses && aAddressNum <= Mlr::kMaxIp6Addresses);
 
     message = backboneTmf.AllocateAndInitNonConfirmablePostMessage(kUriBackboneMlr);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
@@ -473,7 +474,7 @@ void Manager::ConfigNextDuaRegistrationResponse(const Ip6::InterfaceIdentifier *
 #endif
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
-void Manager::ConfigNextMulticastListenerRegistrationResponse(MlrStatus aStatus)
+void Manager::ConfigNextMulticastListenerRegistrationResponse(Mlr::Status aStatus)
 {
     mMlrResponseIsSpecified = true;
     mMlrResponseStatus      = aStatus;

--- a/src/core/backbone_router/bbr_manager.hpp
+++ b/src/core/backbone_router/bbr_manager.hpp
@@ -105,7 +105,7 @@ public:
      *
      * @param[in] aStatus  The status to respond.
      */
-    void ConfigNextMulticastListenerRegistrationResponse(MlrStatus aStatus);
+    void ConfigNextMulticastListenerRegistrationResponse(Mlr::Status aStatus);
 #endif
 #endif
 
@@ -173,7 +173,7 @@ private:
     void HandleMulticastListenerRegistration(const Coap::Msg &aMsg);
 
     void SendMulticastListenerRegistrationResponse(const Coap::Msg &aMsg,
-                                                   MlrStatus        aStatus,
+                                                   Mlr::Status      aStatus,
                                                    Ip6::Address    *aFailedAddresses,
                                                    uint8_t          aFailedAddressNum);
     void SendBackboneMulticastListenerRegistration(const Ip6::Address *aAddresses,
@@ -227,7 +227,7 @@ private:
     uint8_t                  mDuaResponseStatus;
 #endif
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
-    MlrStatus mMlrResponseStatus;
+    Mlr::Status mMlrResponseStatus;
 #endif
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
     bool mDuaResponseIsSpecified : 1;

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -138,7 +138,7 @@ void Notifier::EmitEvents(void)
     Get<MeshCoP::BorderAgent::Admitter>().HandleNotifierEvents(events);
 #endif
 #if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
-    Get<MlrManager>().HandleNotifierEvents(events);
+    Get<Mlr::Manager>().HandleNotifierEvents(events);
 #endif
 #if OPENTHREAD_CONFIG_DUA_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE)
     Get<DuaManager>().HandleNotifierEvents(events);

--- a/src/core/common/time_ticker.cpp
+++ b/src/core/common/time_ticker.cpp
@@ -114,7 +114,7 @@ void TimeTicker::HandleTimer(void)
 #if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
     if (mReceivers & Mask(kMlrManager))
     {
-        Get<MlrManager>().HandleTimeTick();
+        Get<Mlr::Manager>().HandleTimeTick();
     }
 #endif
 

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -766,7 +766,7 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
-    MlrManager mMlrManager;
+    Mlr::Manager mMlrManager;
 #endif
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE)
@@ -1256,7 +1256,7 @@ template <> inline BackboneRouter::BackboneTmfAgent &Instance::Get(void)
 #endif
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
-template <> inline MlrManager &Instance::Get(void) { return mMlrManager; }
+template <> inline Mlr::Manager &Instance::Get(void) { return mMlrManager; }
 #endif
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE)

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -615,8 +615,8 @@ void Netif::MulticastAddress::InitAsManualOrigin(void)
     mAddressOrigin = kOriginManual;
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
-    // Make sure `Clear()` sets the "MlrState" to `kMlrStateToRegister` value.
-    static_assert(kMlrStateToRegister == 0, "kMlrStateToRegister is not correct.");
+    // Make sure `Clear()` sets the "MlrState" to `Mlr::kStateToRegister` value.
+    static_assert(Mlr::kStateToRegister == 0, "Mlr::kStateToRegister is not correct.");
 #endif
 }
 
@@ -627,7 +627,7 @@ bool Netif::MulticastAddress::IsMlrCandidate(void) const
     return (GetOrigin() == kOriginManual) && GetAddress().IsMulticastLargerThanRealmLocal();
 }
 
-bool Netif::MulticastAddress::Matches(MlrState aMlrState) const
+bool Netif::MulticastAddress::Matches(Mlr::State aMlrState) const
 {
     return IsMlrCandidate() && (GetMlrState() == aMlrState);
 }

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -294,14 +294,14 @@ public:
          *
          * @returns The current Multicast Listener Registration state.
          */
-        MlrState GetMlrState(void) const { return static_cast<MlrState>(mData); }
+        Mlr::State GetMlrState(void) const { return static_cast<Mlr::State>(mData); }
 
         /**
          * Sets the Multicast Listener Registration (MLR) state.
          *
          * @param[in] aState  The new Multicast Listener Registration state.
          */
-        void SetMlrState(MlrState aState) { mData = aState; }
+        void SetMlrState(Mlr::State aState) { mData = aState; }
 
         /**
          * Indicates whether or not the address is an MLR candidate and matches a given MLR state.
@@ -311,7 +311,7 @@ public:
          * @retval TRUE  If the address is an MLR candidate and its state matches @p aMlrState.
          * @retval FALSE If the address is not an MLR candidate or its state does not match @p aMlrState.
          */
-        bool Matches(MlrState aMlrState) const;
+        bool Matches(Mlr::State aMlrState) const;
 #endif
 
     private:

--- a/src/core/thread/child.cpp
+++ b/src/core/thread/child.cpp
@@ -76,9 +76,9 @@ void Child::Info::SetFrom(const Child &aChild)
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 
-MlrState Child::Ip6AddrEntry::GetMlrState(const Child &aChild) const
+Mlr::State Child::Ip6AddrEntry::GetMlrState(const Child &aChild) const
 {
-    MlrState                   state = kMlrStateRegistering;
+    Mlr::State                 state = Mlr::kStateRegistering;
     Ip6AddressArray::IndexType index;
 
     OT_ASSERT(aChild.mIp6Addresses.IsInArrayBuffer(this));
@@ -87,18 +87,18 @@ MlrState Child::Ip6AddrEntry::GetMlrState(const Child &aChild) const
 
     if (aChild.mMlrToRegisterSet.Has(index))
     {
-        state = kMlrStateToRegister;
+        state = Mlr::kStateToRegister;
     }
     else if (aChild.mMlrRegisteredSet.Has(index))
     {
-        state = kMlrStateRegistered;
+        state = Mlr::kStateRegistered;
     }
 
     return state;
 }
 
 // NOLINTNEXTLINE(readability-make-member-function-const)
-void Child::Ip6AddrEntry::SetMlrState(MlrState aState, Child &aChild)
+void Child::Ip6AddrEntry::SetMlrState(Mlr::State aState, Child &aChild)
 {
     Ip6AddressArray::IndexType index;
 
@@ -106,8 +106,8 @@ void Child::Ip6AddrEntry::SetMlrState(MlrState aState, Child &aChild)
 
     index = aChild.mIp6Addresses.IndexOf(*this);
 
-    aChild.mMlrToRegisterSet.Update(index, aState == kMlrStateToRegister);
-    aChild.mMlrRegisteredSet.Update(index, aState == kMlrStateRegistered);
+    aChild.mMlrToRegisterSet.Update(index, aState == Mlr::kStateToRegister);
+    aChild.mMlrRegisteredSet.Update(index, aState == Mlr::kStateRegistered);
 }
 
 #endif // OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
@@ -292,7 +292,7 @@ bool Child::HasMlrRegisteredAddress(const Ip6::Address &aAddress) const
 
     entry = mIp6Addresses.FindMatching(aAddress);
     VerifyOrExit(entry != nullptr);
-    hasAddress = entry->GetMlrState(*this) == kMlrStateRegistered;
+    hasAddress = entry->GetMlrState(*this) == Mlr::kStateRegistered;
 
 exit:
     return hasAddress;

--- a/src/core/thread/child.hpp
+++ b/src/core/thread/child.hpp
@@ -108,7 +108,7 @@ public:
          *
          * @returns The MLR state of IPv6 address entry.
          */
-        MlrState GetMlrState(const Child &aChild) const;
+        Mlr::State GetMlrState(const Child &aChild) const;
 
         /**
          * Sets the MLR state of the IPv6 address entry.
@@ -116,7 +116,7 @@ public:
          * @param[in] aState    The MLR state.
          * @param[in] aChild    The child owning this address entry.
          */
-        void SetMlrState(MlrState aState, Child &aChild);
+        void SetMlrState(Mlr::State aState, Child &aChild);
 #endif
     };
 
@@ -353,28 +353,28 @@ public:
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     /**
-     * Returns if the Child has IPv6 address @p aAddress of MLR state `kMlrStateRegistered`.
+     * Returns if the Child has IPv6 address @p aAddress of MLR state `Mlr::kStateRegistered`.
      *
      * @param[in] aAddress  The IPv6 address.
      *
-     * @retval true   If the Child has IPv6 address @p aAddress of MLR state `kMlrStateRegistered`.
-     * @retval false  If the Child does not have IPv6 address @p aAddress of MLR state `kMlrStateRegistered`.
+     * @retval true   If the Child has IPv6 address @p aAddress of MLR state `Mlr::kStateRegistered`.
+     * @retval false  If the Child does not have IPv6 address @p aAddress of MLR state `Mlr::kStateRegistered`.
      */
     bool HasMlrRegisteredAddress(const Ip6::Address &aAddress) const;
 
     /**
-     * Returns if the Child has any IPv6 address of MLR state `kMlrStateRegistered`.
+     * Returns if the Child has any IPv6 address of MLR state `Mlr::kStateRegistered`.
      *
-     * @retval true   If the Child has any IPv6 address of MLR state `kMlrStateRegistered`.
-     * @retval false  If the Child does not have any IPv6 address of MLR state `kMlrStateRegistered`.
+     * @retval true   If the Child has any IPv6 address of MLR state `Mlr::kStateRegistered`.
+     * @retval false  If the Child does not have any IPv6 address of MLR state `Mlr::kStateRegistered`.
      */
     bool HasAnyMlrRegisteredAddress(void) const { return !mMlrRegisteredSet.IsEmpty(); }
 
     /**
-     * Returns if the Child has any IPv6 address of MLR state `kMlrStateToRegister`.
+     * Returns if the Child has any IPv6 address of MLR state `Mlr::kStateToRegister`.
      *
-     * @retval true   If the Child has any IPv6 address of MLR state `kMlrStateToRegister`.
-     * @retval false  If the Child does not have any IPv6 address of MLR state `kMlrStateToRegister`.
+     * @retval true   If the Child has any IPv6 address of MLR state `Mlr::kStateToRegister`.
+     * @retval false  If the Child does not have any IPv6 address of MLR state `Mlr::kStateToRegister`.
      */
     bool HasAnyMlrToRegisterAddress(void) const { return !mMlrToRegisterSet.IsEmpty(); }
 #endif // OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -1855,7 +1855,7 @@ Error Mle::ProcessAddressRegistrationTlv(RxInfo &aRxInfo, Child &aChild)
     Ip6::Address oldDua;
 #endif
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
-    MlrManager::MlrAddressArray oldMlrRegisteredAddresses;
+    Mlr::Manager::ChildAddressArray oldMlrRegisteredAddresses;
 #endif
 
     OT_UNUSED_VARIABLE(storedCount);
@@ -1881,7 +1881,7 @@ Error Mle::ProcessAddressRegistrationTlv(RxInfo &aRxInfo, Child &aChild)
                 continue;
             }
 
-            if (addrEntry.GetMlrState(aChild) == kMlrStateRegistered)
+            if (addrEntry.GetMlrState(aChild) == Mlr::kStateRegistered)
             {
                 IgnoreError(oldMlrRegisteredAddresses.PushBack(addrEntry));
             }
@@ -1995,7 +1995,7 @@ Error Mle::ProcessAddressRegistrationTlv(RxInfo &aRxInfo, Child &aChild)
 #endif
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
-    Get<MlrManager>().UpdateProxiedSubscriptions(aChild, oldMlrRegisteredAddresses);
+    Get<Mlr::Manager>().UpdateProxiedSubscriptions(aChild, oldMlrRegisteredAddresses);
 #endif
 
     if (count == 0)
@@ -3857,7 +3857,7 @@ void Mle::SetChildStateToValid(Child &aChild)
     IgnoreError(mChildTable.StoreChild(aChild));
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
-    Get<MlrManager>().UpdateProxiedSubscriptions(aChild, MlrManager::MlrAddressArray());
+    Get<Mlr::Manager>().UpdateProxiedSubscriptions(aChild, Mlr::Manager::ChildAddressArray());
 #endif
 
     mNeighborTable.Signal(NeighborTable::kChildAdded, aChild);

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -38,21 +38,22 @@
 #include "instance/instance.hpp"
 
 namespace ot {
+namespace Mlr {
 
 RegisterLogModule("MlrManager");
 
-MlrManager::MlrManager(Instance &aInstance)
+Manager::Manager(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mReregistrationDelay(0)
     , mSendDelay(0)
-    , mMlrPending(false)
+    , mPending(false)
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
     , mRegisterPending(false)
 #endif
 {
 }
 
-void MlrManager::HandleNotifierEvents(Events aEvents)
+void Manager::HandleNotifierEvents(Events aEvents)
 {
 #if OPENTHREAD_CONFIG_MLR_ENABLE
     if (aEvents.Contains(kEventIp6MulticastSubscribed))
@@ -68,8 +69,8 @@ void MlrManager::HandleNotifierEvents(Events aEvents)
     }
 }
 
-void MlrManager::HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState,
-                                                   const BackboneRouter::Config &aConfig)
+void Manager::HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState,
+                                                const BackboneRouter::Config &aConfig)
 {
     OT_UNUSED_VARIABLE(aConfig);
 
@@ -80,15 +81,15 @@ void MlrManager::HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State
 }
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
-void MlrManager::UpdateLocalSubscriptions(void)
+void Manager::UpdateLocalSubscriptions(void)
 {
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     // Check multicast addresses are newly listened against Children
     for (Ip6::Netif::MulticastAddress &addr : Get<ThreadNetif>().GetMulticastAddresses())
     {
-        if (addr.Matches(kMlrStateToRegister) && IsAddressMlrRegisteredByAnyChild(addr.GetAddress()))
+        if (addr.Matches(kStateToRegister) && IsAddressRegisteredByAnyChild(addr.GetAddress()))
         {
-            addr.SetMlrState(kMlrStateRegistered);
+            addr.SetMlrState(kStateRegistered);
         }
     }
 #endif
@@ -97,7 +98,7 @@ void MlrManager::UpdateLocalSubscriptions(void)
     ScheduleSend(0);
 }
 
-bool MlrManager::IsAddressMlrRegisteredByNetif(const Ip6::Address &aAddress) const
+bool Manager::IsAddressRegisteredByNetif(const Ip6::Address &aAddress) const
 {
     bool ret = false;
 
@@ -105,7 +106,7 @@ bool MlrManager::IsAddressMlrRegisteredByNetif(const Ip6::Address &aAddress) con
 
     for (const Ip6::Netif::MulticastAddress &addr : Get<ThreadNetif>().GetMulticastAddresses())
     {
-        if (addr.Matches(kMlrStateRegistered) && (addr.GetAddress() == aAddress))
+        if (addr.Matches(kStateRegistered) && (addr.GetAddress() == aAddress))
         {
             ret = true;
             break;
@@ -119,7 +120,7 @@ bool MlrManager::IsAddressMlrRegisteredByNetif(const Ip6::Address &aAddress) con
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 
-bool MlrManager::IsAddressMlrRegisteredByAnyChildExcept(const Ip6::Address &aAddress, const Child *aExceptChild) const
+bool Manager::IsAddressRegisteredByAnyChildExcept(const Ip6::Address &aAddress, const Child *aExceptChild) const
 {
     bool ret = false;
 
@@ -137,30 +138,30 @@ exit:
     return ret;
 }
 
-void MlrManager::UpdateProxiedSubscriptions(Child &aChild, const MlrAddressArray &aOldMlrRegisteredAddresses)
+void Manager::UpdateProxiedSubscriptions(Child &aChild, const ChildAddressArray &aOldRegisteredAddresses)
 {
     VerifyOrExit(aChild.IsStateValid());
 
     // Search the new multicast addresses and set its flag accordingly
     for (Child::Ip6AddrEntry &addrEntry : aChild.GetIp6Addresses())
     {
-        bool isMlrRegistered;
+        bool isRegistered;
 
         if (!addrEntry.IsMulticastLargerThanRealmLocal())
         {
             continue;
         }
 
-        isMlrRegistered = aOldMlrRegisteredAddresses.Contains(addrEntry);
+        isRegistered = aOldRegisteredAddresses.Contains(addrEntry);
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
         // Check if it's a new multicast address against parent Netif
-        isMlrRegistered = isMlrRegistered || IsAddressMlrRegisteredByNetif(addrEntry);
+        isRegistered = isRegistered || IsAddressRegisteredByNetif(addrEntry);
 #endif
         // Check if it's a new multicast address against other Children
-        isMlrRegistered = isMlrRegistered || IsAddressMlrRegisteredByAnyChildExcept(addrEntry, &aChild);
+        isRegistered = isRegistered || IsAddressRegisteredByAnyChildExcept(addrEntry, &aChild);
 
-        addrEntry.SetMlrState(isMlrRegistered ? kMlrStateRegistered : kMlrStateToRegister, aChild);
+        addrEntry.SetMlrState(isRegistered ? kStateRegistered : kStateToRegister, aChild);
     }
 
 exit:
@@ -175,16 +176,16 @@ exit:
 
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 
-void MlrManager::ScheduleSend(uint16_t aDelay)
+void Manager::ScheduleSend(uint16_t aDelay)
 {
-    OT_ASSERT(!mMlrPending || mSendDelay == 0);
+    OT_ASSERT(!mPending || mSendDelay == 0);
 
-    VerifyOrExit(!mMlrPending);
+    VerifyOrExit(!mPending);
 
     if (aDelay == 0)
     {
         mSendDelay = 0;
-        SendMlr();
+        Send();
     }
     else if (mSendDelay == 0 || mSendDelay > aDelay)
     {
@@ -196,7 +197,7 @@ exit:
     return;
 }
 
-void MlrManager::UpdateTimeTickerRegistration(void)
+void Manager::UpdateTimeTickerRegistration(void)
 {
     if (mSendDelay == 0 && mReregistrationDelay == 0)
     {
@@ -208,12 +209,12 @@ void MlrManager::UpdateTimeTickerRegistration(void)
     }
 }
 
-void MlrManager::SendMlr(void)
+void Manager::Send(void)
 {
     Error        error;
     AddressArray addresses;
 
-    VerifyOrExit(!mMlrPending, error = kErrorBusy);
+    VerifyOrExit(!mPending, error = kErrorBusy);
     VerifyOrExit(Get<Mle::Mle>().IsAttached(), error = kErrorInvalidState);
     VerifyOrExit(Get<Mle::Mle>().IsFullThreadDevice() || Get<Mle::Mle>().GetParent().IsThreadVersion1p1(),
                  error = kErrorInvalidState);
@@ -228,10 +229,10 @@ void MlrManager::SendMlr(void)
             break;
         }
 
-        if (addr.Matches(kMlrStateToRegister))
+        if (addr.Matches(kStateToRegister))
         {
             addresses.AddUnique(addr.GetAddress());
-            addr.SetMlrState(kMlrStateRegistering);
+            addr.SetMlrState(kStateRegistering);
         }
     }
 #endif
@@ -262,20 +263,19 @@ void MlrManager::SendMlr(void)
                 break;
             }
 
-            if (addrEntry.GetMlrState(child) == kMlrStateToRegister)
+            if (addrEntry.GetMlrState(child) == kStateToRegister)
             {
                 addresses.AddUnique(addrEntry);
-                addrEntry.SetMlrState(kMlrStateRegistering, child);
+                addrEntry.SetMlrState(kStateRegistering, child);
             }
         }
     }
 #endif
 
     VerifyOrExit(!addresses.IsEmpty(), error = kErrorNotFound);
-    SuccessOrExit(error =
-                      SendMlrMessage(addresses.GetArrayBuffer(), addresses.GetLength(), nullptr, HandleMlrResponse));
+    SuccessOrExit(error = SendMessage(addresses.GetArrayBuffer(), addresses.GetLength(), nullptr, HandleResponse));
 
-    mMlrPending = true;
+    mPending = true;
 
     // Generally Thread 1.2 Router would send MLR.req on behalf for MA (scope >=4) subscribed by its MTD child.
     // When Thread 1.2 MTD attaches to Thread 1.1 parent, 1.2 MTD should send MLR.req to PBBR itself.
@@ -288,7 +288,7 @@ void MlrManager::SendMlr(void)
 exit:
     if (error != kErrorNone)
     {
-        SetMulticastAddressMlrState(kMlrStateRegistering, kMlrStateToRegister);
+        SetMulticastAddressState(kStateRegistering, kStateToRegister);
 
         if (error == kErrorNoBufs)
         {
@@ -301,16 +301,16 @@ exit:
 }
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
-Error MlrManager::RegisterMulticastListeners(const Ip6::Address *aAddresses,
-                                             uint8_t             aAddressNum,
-                                             const uint32_t     *aTimeout,
-                                             MlrCallback         aCallback,
-                                             void               *aContext)
+Error Manager::RegisterMulticastListeners(const Ip6::Address *aAddresses,
+                                          uint8_t             aAddressNum,
+                                          const uint32_t     *aTimeout,
+                                          RegisterCallback    aCallback,
+                                          void               *aContext)
 {
     Error error;
 
     VerifyOrExit(aAddresses != nullptr, error = kErrorInvalidArgs);
-    VerifyOrExit(aAddressNum > 0 && aAddressNum <= kMlrMaxIp6Addresses, error = kErrorInvalidArgs);
+    VerifyOrExit(aAddressNum > 0 && aAddressNum <= kMaxIp6Addresses, error = kErrorInvalidArgs);
     VerifyOrExit(aContext == nullptr || aCallback != nullptr, error = kErrorInvalidArgs);
 #if !OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     VerifyOrExit(Get<MeshCoP::Commissioner>().IsActive(), error = kErrorInvalidState);
@@ -324,7 +324,7 @@ Error MlrManager::RegisterMulticastListeners(const Ip6::Address *aAddresses,
     // Only allow one outstanding registration if callback is specified.
     VerifyOrExit(!mRegisterPending, error = kErrorBusy);
 
-    SuccessOrExit(error = SendMlrMessage(aAddresses, aAddressNum, aTimeout, HandleRegisterResponse));
+    SuccessOrExit(error = SendMessage(aAddresses, aAddressNum, aTimeout, HandleRegisterResponse));
 
     mRegisterPending = true;
     mRegisterCallback.Set(aCallback, aContext);
@@ -333,7 +333,7 @@ exit:
     return error;
 }
 
-void MlrManager::HandleRegisterResponse(Coap::Msg *aMsg, Error aResult)
+void Manager::HandleRegisterResponse(Coap::Msg *aMsg, Error aResult)
 {
     uint8_t      status;
     Error        error;
@@ -341,17 +341,17 @@ void MlrManager::HandleRegisterResponse(Coap::Msg *aMsg, Error aResult)
 
     mRegisterPending = false;
 
-    error = ParseMlrResponse(aResult, aMsg, status, failedAddresses);
+    error = ParseResponse(aResult, aMsg, status, failedAddresses);
 
     mRegisterCallback.InvokeAndClearIfSet(error, status, failedAddresses.GetArrayBuffer(), failedAddresses.GetLength());
 }
 
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
 
-Error MlrManager::SendMlrMessage(const Ip6::Address         *aAddresses,
-                                 uint8_t                     aAddressNum,
-                                 const uint32_t             *aTimeout,
-                                 const Coap::ResponseHandler aResponseHandler)
+Error Manager::SendMessage(const Ip6::Address         *aAddresses,
+                           uint8_t                     aAddressNum,
+                           const uint32_t             *aTimeout,
+                           const Coap::ResponseHandler aResponseHandler)
 {
     OT_UNUSED_VARIABLE(aTimeout);
 
@@ -401,22 +401,22 @@ Error MlrManager::SendMlrMessage(const Ip6::Address         *aAddresses,
     LogInfo("Sent MLR.req: addressNum=%d", aAddressNum);
 
 exit:
-    LogInfoOnError(error, "SendMlrMessage()");
+    LogInfoOnError(error, "SendMessage()");
     FreeMessageOnError(message, error);
     return error;
 }
 
-void MlrManager::HandleMlrResponse(Coap::Msg *aMsg, Error aResult)
+void Manager::HandleResponse(Coap::Msg *aMsg, Error aResult)
 {
     uint8_t      status;
     Error        error;
     AddressArray failedAddresses;
 
-    error = ParseMlrResponse(aResult, aMsg, status, failedAddresses);
+    error = ParseResponse(aResult, aMsg, status, failedAddresses);
 
-    FinishMlr(error == kErrorNone && status == kMlrSuccess, failedAddresses);
+    Finish(error == kErrorNone && status == kStatusSuccess, failedAddresses);
 
-    if (error == kErrorNone && status == kMlrSuccess)
+    if (error == kErrorNone && status == kStatusSuccess)
     {
         // keep sending until all multicast addresses are registered.
         ScheduleSend(0);
@@ -439,12 +439,12 @@ void MlrManager::HandleMlrResponse(Coap::Msg *aMsg, Error aResult)
     }
 }
 
-Error MlrManager::ParseMlrResponse(Error aResult, Coap::Msg *aMsg, uint8_t &aStatus, AddressArray &aFailedAddresses)
+Error Manager::ParseResponse(Error aResult, Coap::Msg *aMsg, uint8_t &aStatus, AddressArray &aFailedAddresses)
 {
     Error       error;
     OffsetRange offsetRange;
 
-    aStatus = kMlrGeneralFailure;
+    aStatus = kStatusGeneralFailure;
 
     VerifyOrExit(aResult == kErrorNone && aMsg != nullptr, error = kErrorParse);
     VerifyOrExit(aMsg->GetCode() == Coap::kCodeChanged, error = kErrorParse);
@@ -454,7 +454,7 @@ Error MlrManager::ParseMlrResponse(Error aResult, Coap::Msg *aMsg, uint8_t &aSta
     if (Tlv::FindTlvValueOffsetRange(aMsg->mMessage, Ip6AddressesTlv::kType, offsetRange) == kErrorNone)
     {
         VerifyOrExit(offsetRange.GetLength() % sizeof(Ip6::Address) == 0, error = kErrorParse);
-        VerifyOrExit(offsetRange.GetLength() / sizeof(Ip6::Address) <= kMlrMaxIp6Addresses, error = kErrorParse);
+        VerifyOrExit(offsetRange.GetLength() / sizeof(Ip6::Address) <= kMaxIp6Addresses, error = kErrorParse);
 
         while (!offsetRange.IsEmpty())
         {
@@ -463,14 +463,14 @@ Error MlrManager::ParseMlrResponse(Error aResult, Coap::Msg *aMsg, uint8_t &aSta
         }
     }
 
-    VerifyOrExit(aFailedAddresses.IsEmpty() || aStatus != kMlrSuccess, error = kErrorParse);
+    VerifyOrExit(aFailedAddresses.IsEmpty() || aStatus != kStatusSuccess, error = kErrorParse);
 
 exit:
-    LogMlrResponse(aResult, error, aStatus, aFailedAddresses);
+    LogResponse(aResult, error, aStatus, aFailedAddresses);
     return aResult != kErrorNone ? aResult : error;
 }
 
-void MlrManager::SetMulticastAddressMlrState(MlrState aFromState, MlrState aToState)
+void Manager::SetMulticastAddressState(State aFromState, State aToState)
 {
 #if OPENTHREAD_CONFIG_MLR_ENABLE
     for (Ip6::Netif::MulticastAddress &addr : Get<ThreadNetif>().GetMulticastAddresses())
@@ -500,20 +500,20 @@ void MlrManager::SetMulticastAddressMlrState(MlrState aFromState, MlrState aToSt
 #endif
 }
 
-void MlrManager::FinishMlr(bool aSuccess, const AddressArray &aFailedAddresses)
+void Manager::Finish(bool aSuccess, const AddressArray &aFailedAddresses)
 {
-    OT_ASSERT(mMlrPending);
+    OT_ASSERT(mPending);
 
-    mMlrPending = false;
+    mPending = false;
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
     for (Ip6::Netif::MulticastAddress &addr : Get<ThreadNetif>().GetMulticastAddresses())
     {
-        if (addr.Matches(kMlrStateRegistering))
+        if (addr.Matches(kStateRegistering))
         {
             bool success = aSuccess || !aFailedAddresses.IsEmptyOrContains(addr.GetAddress());
 
-            addr.SetMlrState(success ? kMlrStateRegistered : kMlrStateToRegister);
+            addr.SetMlrState(success ? kStateRegistered : kStateToRegister);
         }
     }
 #endif
@@ -527,11 +527,11 @@ void MlrManager::FinishMlr(bool aSuccess, const AddressArray &aFailedAddresses)
                 continue;
             }
 
-            if (addrEntry.GetMlrState(child) == kMlrStateRegistering)
+            if (addrEntry.GetMlrState(child) == kStateRegistering)
             {
                 bool success = aSuccess || !aFailedAddresses.IsEmptyOrContains(addrEntry);
 
-                addrEntry.SetMlrState(success ? kMlrStateRegistered : kMlrStateToRegister, child);
+                addrEntry.SetMlrState(success ? kStateRegistered : kStateToRegister, child);
             }
         }
     }
@@ -541,11 +541,11 @@ void MlrManager::FinishMlr(bool aSuccess, const AddressArray &aFailedAddresses)
     CheckInvariants();
 }
 
-void MlrManager::HandleTimeTick(void)
+void Manager::HandleTimeTick(void)
 {
     if (mSendDelay > 0 && --mSendDelay == 0)
     {
-        SendMlr();
+        Send();
     }
 
     if (mReregistrationDelay > 0 && --mReregistrationDelay == 0)
@@ -556,11 +556,11 @@ void MlrManager::HandleTimeTick(void)
     UpdateTimeTickerRegistration();
 }
 
-void MlrManager::Reregister(void)
+void Manager::Reregister(void)
 {
     LogInfo("MLR Reregister!");
 
-    SetMulticastAddressMlrState(kMlrStateRegistered, kMlrStateToRegister);
+    SetMulticastAddressState(kStateRegistered, kStateToRegister);
     CheckInvariants();
 
     ScheduleSend(0);
@@ -569,12 +569,12 @@ void MlrManager::Reregister(void)
     UpdateReregistrationDelay(false);
 }
 
-void MlrManager::UpdateReregistrationDelay(bool aRereg)
+void Manager::UpdateReregistrationDelay(bool aRereg)
 {
-    bool needSendMlr = (Get<Mle::Mle>().IsFullThreadDevice() || Get<Mle::Mle>().GetParent().IsThreadVersion1p1()) &&
-                       Get<BackboneRouter::Leader>().HasPrimary();
+    bool needSend = (Get<Mle::Mle>().IsFullThreadDevice() || Get<Mle::Mle>().GetParent().IsThreadVersion1p1()) &&
+                    Get<BackboneRouter::Leader>().HasPrimary();
 
-    if (!needSendMlr)
+    if (!needSend)
     {
         mReregistrationDelay = 0;
     }
@@ -582,7 +582,7 @@ void MlrManager::UpdateReregistrationDelay(bool aRereg)
     {
         BackboneRouter::Config config;
         uint32_t               reregDelay;
-        uint32_t               effectiveMlrTimeout;
+        uint32_t               effectiveTimeout;
 
         IgnoreError(Get<BackboneRouter::Leader>().GetConfig(config));
 
@@ -596,8 +596,8 @@ void MlrManager::UpdateReregistrationDelay(bool aRereg)
         {
             // Calculate renewing period according to Thread Spec. 5.24.2.3.2
             // The random time t SHOULD be chosen such that (0.5* MLR-Timeout) < t < (MLR-Timeout – 9 seconds).
-            effectiveMlrTimeout = Max(config.mMlrTimeout, BackboneRouter::kMinMlrTimeout);
-            reregDelay = Random::NonCrypto::GetUint32InRange((effectiveMlrTimeout >> 1u) + 1, effectiveMlrTimeout - 9);
+            effectiveTimeout = Max(config.mMlrTimeout, BackboneRouter::kMinMlrTimeout);
+            reregDelay       = Random::NonCrypto::GetUint32InRange((effectiveTimeout >> 1u) + 1, effectiveTimeout - 9);
         }
 
         if (mReregistrationDelay == 0 || mReregistrationDelay > reregDelay)
@@ -608,11 +608,11 @@ void MlrManager::UpdateReregistrationDelay(bool aRereg)
 
     UpdateTimeTickerRegistration();
 
-    LogDebg("MlrManager::UpdateReregistrationDelay: rereg=%d, needSendMlr=%d, ReregDelay=%lu", aRereg, needSendMlr,
+    LogDebg("Manager::UpdateReregistrationDelay: rereg=%d, needSend=%d, ReregDelay=%lu", aRereg, needSend,
             ToUlong(mReregistrationDelay));
 }
 
-void MlrManager::LogMulticastAddresses(void)
+void Manager::LogMulticastAddresses(void)
 {
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)
     LogDebg("-------- Multicast Addresses --------");
@@ -648,7 +648,7 @@ void MlrManager::LogMulticastAddresses(void)
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)
 }
 
-void MlrManager::AddressArray::AddUnique(const Ip6::Address &aAddress)
+void Manager::AddressArray::AddUnique(const Ip6::Address &aAddress)
 {
     if (!Contains(aAddress))
     {
@@ -656,7 +656,7 @@ void MlrManager::AddressArray::AddUnique(const Ip6::Address &aAddress)
     }
 }
 
-void MlrManager::LogMlrResponse(Error aResult, Error aError, uint8_t aStatus, const AddressArray &aFailedAddresses)
+void Manager::LogResponse(Error aResult, Error aError, uint8_t aStatus, const AddressArray &aFailedAddresses)
 {
     OT_UNUSED_VARIABLE(aResult);
     OT_UNUSED_VARIABLE(aError);
@@ -664,7 +664,7 @@ void MlrManager::LogMlrResponse(Error aResult, Error aError, uint8_t aStatus, co
     OT_UNUSED_VARIABLE(aFailedAddresses);
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
-    if (aResult == kErrorNone && aError == kErrorNone && aStatus == kMlrSuccess)
+    if (aResult == kErrorNone && aError == kErrorNone && aStatus == kStatusSuccess)
     {
         LogInfo("Receive MLR.rsp OK");
     }
@@ -681,19 +681,19 @@ void MlrManager::LogMlrResponse(Error aResult, Error aError, uint8_t aStatus, co
 #endif
 }
 
-void MlrManager::CheckInvariants(void) const
+void Manager::CheckInvariants(void) const
 {
 #if OPENTHREAD_EXAMPLES_SIMULATION && OPENTHREAD_CONFIG_ASSERT_ENABLE
     uint16_t registeringNum = 0;
 
     OT_UNUSED_VARIABLE(registeringNum);
 
-    OT_ASSERT(!mMlrPending || mSendDelay == 0);
+    OT_ASSERT(!mPending || mSendDelay == 0);
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
     for (Ip6::Netif::MulticastAddress &addr : Get<ThreadNetif>().GetMulticastAddresses())
     {
-        if (addr.Matches(kMlrStateRegistering))
+        if (addr.Matches(kStateRegistering))
         {
             registeringNum++;
         }
@@ -709,15 +709,16 @@ void MlrManager::CheckInvariants(void) const
                 continue;
             }
 
-            registeringNum += (addrEntry.GetMlrState(child) == kMlrStateRegistering);
+            registeringNum += (addrEntry.GetMlrState(child) == kStateRegistering);
         }
     }
 #endif
 
-    OT_ASSERT(registeringNum == 0 || mMlrPending);
+    OT_ASSERT(registeringNum == 0 || mPending);
 #endif // OPENTHREAD_EXAMPLES_SIMULATION
 }
 
+} // namespace Mlr
 } // namespace ot
 
 #endif // OPENTHREAD_CONFIG_MLR_ENABLE

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -58,6 +58,7 @@
 #include "thread/tmf.hpp"
 
 namespace ot {
+namespace Mlr {
 
 /**
  * @addtogroup core-mlr
@@ -75,20 +76,20 @@ namespace ot {
 /**
  * Implements MLR management.
  */
-class MlrManager : public InstanceLocator, private NonCopyable
+class Manager : public InstanceLocator, private NonCopyable
 {
     friend class ot::Notifier;
     friend class ot::TimeTicker;
 
 public:
-    typedef otIp6RegisterMulticastListenersCallback MlrCallback;
+    typedef otIp6RegisterMulticastListenersCallback RegisterCallback;
 
     /**
      * Initializes the object.
      *
      * @param[in]  aInstance     A reference to the OpenThread instance.
      */
-    explicit MlrManager(Instance &aInstance);
+    explicit Manager(Instance &aInstance);
 
     /**
      * Notifies Primary Backbone Router status.
@@ -99,17 +100,17 @@ public:
     void HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState, const BackboneRouter::Config &aConfig);
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
-    static constexpr uint16_t kMaxMlrAddresses = OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD - 1; ///< Max MLR addresses
+    static constexpr uint16_t kMaxChildAddresses = OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD - 1; ///< Max MLR addresses
 
-    typedef Array<Ip6::Address, kMaxMlrAddresses> MlrAddressArray; ///< Registered MLR addresses array.
+    typedef Array<Ip6::Address, kMaxChildAddresses> ChildAddressArray; ///< Registered MLR addresses array.
 
     /**
      * Updates the Multicast Subscription Table according to the Child information.
      *
      * @param[in]  aChild                       A reference to the child information.
-     * @param[in]  aOldMlrRegisteredAddresses   Array of the Child's previously registered IPv6 addresses.
+     * @param[in]  aOldRegisteredAddresses   Array of the Child's previously registered IPv6 addresses.
      */
-    void UpdateProxiedSubscriptions(Child &aChild, const MlrAddressArray &aOldMlrRegisteredAddresses);
+    void UpdateProxiedSubscriptions(Child &aChild, const ChildAddressArray &aOldRegisteredAddresses);
 #endif
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
@@ -137,12 +138,12 @@ public:
     Error RegisterMulticastListeners(const Ip6::Address *aAddresses,
                                      uint8_t             aAddressNum,
                                      const uint32_t     *aTimeout,
-                                     MlrCallback         aCallback,
+                                     RegisterCallback    aCallback,
                                      void               *aContext);
 #endif
 
 private:
-    class AddressArray : public Array<Ip6::Address, kMlrMaxIp6Addresses>
+    class AddressArray : public Array<Ip6::Address, kMaxIp6Addresses>
     {
     public:
         bool IsEmptyOrContains(const Ip6::Address &aAddress) const { return IsEmpty() || Contains(aAddress); }
@@ -151,35 +152,36 @@ private:
 
     void HandleNotifierEvents(Events aEvents);
 
-    void  SendMlr(void);
-    Error SendMlrMessage(const Ip6::Address   *aAddresses,
-                         uint8_t               aAddressNum,
-                         const uint32_t       *aTimeout,
-                         Coap::ResponseHandler aResponseHandler);
+    void  Send(void);
+    Error SendMessage(const Ip6::Address   *aAddresses,
+                      uint8_t               aAddressNum,
+                      const uint32_t       *aTimeout,
+                      Coap::ResponseHandler aResponseHandler);
 
-    DeclareTmfResponseHandlerIn(MlrManager, HandleMlrResponse);
+    DeclareTmfResponseHandlerIn(Manager, HandleResponse);
 
-    static Error ParseMlrResponse(Error aResult, Coap::Msg *aMsg, uint8_t &aStatus, AddressArray &aFailedAddresses);
+    static Error ParseResponse(Error aResult, Coap::Msg *aMsg, uint8_t &aStatus, AddressArray &aFailedAddresses);
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
-    DeclareTmfResponseHandlerIn(MlrManager, HandleRegisterResponse);
+    DeclareTmfResponseHandlerIn(Manager, HandleRegisterResponse);
 #endif
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
     void UpdateLocalSubscriptions(void);
-    bool IsAddressMlrRegisteredByNetif(const Ip6::Address &aAddress) const;
+    bool IsAddressRegisteredByNetif(const Ip6::Address &aAddress) const;
 #endif
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
-    bool IsAddressMlrRegisteredByAnyChild(const Ip6::Address &aAddress) const
+    bool IsAddressRegisteredByAnyChild(const Ip6::Address &aAddress) const
     {
-        return IsAddressMlrRegisteredByAnyChildExcept(aAddress, nullptr);
+        return IsAddressRegisteredByAnyChildExcept(aAddress, nullptr);
     }
-    bool IsAddressMlrRegisteredByAnyChildExcept(const Ip6::Address &aAddress, const Child *aExceptChild) const;
+
+    bool IsAddressRegisteredByAnyChildExcept(const Ip6::Address &aAddress, const Child *aExceptChild) const;
 #endif
 
-    void SetMulticastAddressMlrState(MlrState aFromState, MlrState aToState);
-    void FinishMlr(bool aSuccess, const AddressArray &aFailedAddresses);
+    void SetMulticastAddressState(State aFromState, State aToState);
+    void Finish(bool aSuccess, const AddressArray &aFailedAddresses);
 
     void ScheduleSend(uint16_t aDelay);
     void UpdateTimeTickerRegistration(void);
@@ -189,21 +191,22 @@ private:
 
     void        LogMulticastAddresses(void);
     void        CheckInvariants(void) const;
-    static void LogMlrResponse(Error aResult, Error aError, uint8_t aStatus, const AddressArray &aFailedAddresses);
+    static void LogResponse(Error aResult, Error aError, uint8_t aStatus, const AddressArray &aFailedAddresses);
 
 #if (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE) && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
-    Callback<MlrCallback> mRegisterCallback;
+    Callback<RegisterCallback> mRegisterCallback;
 #endif
 
     uint32_t mReregistrationDelay;
     uint16_t mSendDelay;
 
-    bool mMlrPending : 1;
+    bool mPending : 1;
 #if (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE) && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
     bool mRegisterPending : 1;
 #endif
 };
 
+} // namespace Mlr
 } // namespace ot
 
 #endif // OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)

--- a/src/core/thread/mlr_types.hpp
+++ b/src/core/thread/mlr_types.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 namespace ot {
+namespace Mlr {
 
 /**
  * @addtogroup core-mlr
@@ -44,19 +45,19 @@ namespace ot {
  * @{
  */
 
-constexpr uint8_t kMlrMinIp6Addresses = 1;                        ///< Min number of addresses in IPv6 Addresses TLV.
-constexpr uint8_t kMlrMaxIp6Addresses = OT_IP6_MAX_MLR_ADDRESSES; ///< Max number of addresses in IPv6 Addresses TLV.
+constexpr uint8_t kMinIp6Addresses = 1;                        ///< Min number of addresses in IPv6 Addresses TLV.
+constexpr uint8_t kMaxIp6Addresses = OT_IP6_MAX_MLR_ADDRESSES; ///< Max number of addresses in IPv6 Addresses TLV.
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
 
 /**
- * Multicast Listener Registration state for multicast addresses.
+ * MLR registration state for a multicast address.
  */
-enum MlrState : uint8_t
+enum State : uint8_t
 {
-    kMlrStateToRegister,  ///< The multicast address is to be registered.
-    kMlrStateRegistering, ///< The multicast address is being registered.
-    kMlrStateRegistered,  ///< The multicast address is registered.
+    kStateToRegister,  ///< The multicast address is to be registered.
+    kStateRegistering, ///< The multicast address is being registered.
+    kStateRegistered,  ///< The multicast address is registered.
 };
 
 #endif // OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
@@ -64,17 +65,19 @@ enum MlrState : uint8_t
 /**
  * Multicast Listener Registration (MLR) Status values.
  */
-enum MlrStatus
+enum Status : uint8_t
 {
-    kMlrSuccess        = 0, ///< Successful (de)registration of all IPv6 addresses.
-    kMlrInvalid        = 2, ///< Invalid IPv6 address(es) in request.
-    kMlrNoPersistent   = 3, ///< This device does not support persistent registrations.
-    kMlrNoResources    = 4, ///< BBR resource shortage.
-    kMlrBbrNotPrimary  = 5, ///< BBR is not Primary at this moment.
-    kMlrGeneralFailure = 6, ///< Reason(s) for failure are not further specified.
-    kMlrStatusMax      = 6, ///< Max MLR status.
+    kStatusSuccess        = 0, ///< Successful (de)registration of all IPv6 addresses.
+    kStatusInvalid        = 2, ///< Invalid IPv6 address(es) in request.
+    kStatusNoPersistent   = 3, ///< This device does not support persistent registrations.
+    kStatusNoResources    = 4, ///< BBR resource shortage.
+    kStatusBbrNotPrimary  = 5, ///< BBR is not Primary at this moment.
+    kStatusGeneralFailure = 6, ///< Reason(s) for failure are not further specified.
 };
 
+constexpr uint8_t kMaxStatusValue = kStatusGeneralFailure;
+
+} // namespace Mlr
 } // namespace ot
 
 #endif // OT_CORE_THREAD_MLR_TYPES_HPP_

--- a/tests/nexus/test_1_2_MATN_TC_26.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_26.cpp
@@ -150,7 +150,7 @@ void TestMatnTc26(void)
      * - Pass Criteria:
      * - N/A
      */
-    br1.Get<BackboneRouter::Manager>().ConfigNextMulticastListenerRegistrationResponse(kMlrNoResources);
+    br1.Get<BackboneRouter::Manager>().ConfigNextMulticastListenerRegistrationResponse(Mlr::kStatusNoResources);
 
     Log("Step 2: The DUT must be configured to request registration of Multicast address MA1.");
 
@@ -214,7 +214,7 @@ void TestMatnTc26(void)
      * - Pass Criteria:
      * - N/A
      */
-    br1.Get<BackboneRouter::Manager>().ConfigNextMulticastListenerRegistrationResponse(kMlrGeneralFailure);
+    br1.Get<BackboneRouter::Manager>().ConfigNextMulticastListenerRegistrationResponse(Mlr::kStatusGeneralFailure);
 
     Log("Step 4 (cont.): Harness instructs the device to updates the network data (BBR Dataset).");
 

--- a/tests/nexus/test_1_2_MATN_TC_3.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_3.cpp
@@ -194,7 +194,7 @@ void TestMatnTc3(void)
      * - Pass Criteria:
      *   - N/A
      */
-    SuccessOrQuit(router.Get<MlrManager>().RegisterMulticastListeners(&ma1, 1, &kTimeoutZero, nullptr, nullptr));
+    SuccessOrQuit(router.Get<Mlr::Manager>().RegisterMulticastListeners(&ma1, 1, &kTimeoutZero, nullptr, nullptr));
     nexus.AdvanceTime(kMlrRegistrationTime);
 
     Log("---------------------------------------------------------------------------------------");


### PR DESCRIPTION
This commit introduces the `Mlr` namespace to encapsulate all Multicast Listener Registration related types and logic, improving overall code organization and readability.

The following primary renames were performed:
- `MlrManager` to `Mlr::Manager`
- `MlrState` to `Mlr::State`
- `MlrStatus` to `Mlr::Status`
- Constants like `kMlrSuccess` to `Mlr::kStatusSuccess`

Additionally, methods within the newly scoped `Mlr::Manager` class have been simplified by removing redundant `Mlr` prefixes (e.g., `SendMlr()` is now `Send()`, `FinishMlr()` is now `Finish()`).

External modules and tests have been updated to reference the new scoped names.