### PR TITLE
[mesh-forwarder] enhance EID-RLOC cache updates

### DIFF
--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -669,6 +669,7 @@ void MeshForwarder::UpdateEidRlocCacheAndStaleChild(RxInfo &aRxInfo)
 {
     Neighbor *neighbor;
 
+    VerifyOrExit(aRxInfo.IsLinkSecurityEnabled());
     VerifyOrExit(!aRxInfo.GetDstAddr().IsBroadcast() && aRxInfo.GetSrcAddr().IsShort());
 
     SuccessOrExit(aRxInfo.ParseIp6Headers());


### PR DESCRIPTION
Gate `MeshForwarder::UpdateEidRlocCacheAndStaleChild` on link security, ensuring that the received frame has security enabled.

Adding the link security check ensures that only fully authenticated data frames (successfully decrypted and verified at the MAC layer) can influence the EID-to-RLOC cache and the child table states.