### PR TITLE
[ip6] restrict MPL option processing to Hop-by-Hop header

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -489,7 +489,7 @@ exit:
     return error;
 }
 
-Error Ip6::HandleOptions(Message &aMessage, const Header &aHeader, bool &aReceive)
+Error Ip6::HandleOptions(Message &aMessage, const Header &aHeader, bool &aReceive, bool aIsHopByHop)
 {
     Error          error        = kErrorNone;
     bool           hasMplOption = false;
@@ -516,7 +516,7 @@ Error Ip6::HandleOptions(Message &aMessage, const Header &aHeader, bool &aReceiv
             continue;
         }
 
-        if (option.GetType() == MplOption::kType)
+        if (aIsHopByHop && (option.GetType() == MplOption::kType))
         {
             VerifyOrExit(!hasMplOption, error = kErrorDrop);
             hasMplOption = true;
@@ -817,10 +817,11 @@ Error Ip6::HandleExtensionHeaders(OwnedPtr<Message> &aMessagePtr,
         {
         case kProtoHopOpts:
             VerifyOrExit(first, error = kErrorDrop);
-            OT_FALL_THROUGH;
+            SuccessOrExit(error = HandleOptions(*aMessagePtr, aHeader, aReceive, /* aIsHopByHop */ true));
+            break;
 
         case kProtoDstOpts:
-            SuccessOrExit(error = HandleOptions(*aMessagePtr, aHeader, aReceive));
+            SuccessOrExit(error = HandleOptions(*aMessagePtr, aHeader, aReceive, /* aIsHopByHop */ false));
             break;
 
         case kProtoFragment:

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -362,7 +362,7 @@ private:
     Error PrepareMulticastToLargerThanRealmLocal(Message &aMessage, const Header &aHeader);
     Error InsertMplOption(Message &aMessage, Header &aHeader);
     Error RemoveMplOption(Message &aMessage);
-    Error HandleOptions(Message &aMessage, const Header &aHeader, bool &aReceive);
+    Error HandleOptions(Message &aMessage, const Header &aHeader, bool &aReceive, bool aIsHopByHop);
     Error Receive(Header            &aIp6Header,
                   OwnedPtr<Message> &aMessagePtr,
                   uint8_t            aIpProto,


### PR DESCRIPTION
RFC 7731 Section 4 specifies that the MPL Option MUST only reside within a Hop-by-Hop Options extension header. However, previously, Ip6::HandleOptions processed MplOption::kType regardless of whether the enclosing header was Hop-by-Hop or Destination Options.

This commit fixes the issue by adding a boolean parameter to Ip6::HandleOptions indicating if the enclosing header is Hop-by-Hop. MplOption::kType is now only processed if this parameter is true. If the MPL Option is encountered in a Destination Options header, it is treated as unrecognized, and because its type action mandates discarding the packet, the datagram is dropped safely.