### PR TITLE
[test] separate size report workflow

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -1,0 +1,70 @@
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+name: Size Check
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.repository == 'openthread/openthread' && github.run_id) || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  size-check:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Run
+      env:
+        PR_BODY: "${{ github.event.pull_request.body }}"
+        PR_NUMBER: "${{ github.event.pull_request.number }}"
+      run: |
+        ./script/check-size
+        cat /tmp/ot-size-report/report_pr >> $GITHUB_STEP_SUMMARY
+        echo "${{ github.event.pull_request.number }}" > /tmp/ot-size-report/pr_number
+    - name: Upload report
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: report_pr
+        path: /tmp/ot-size-report

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2020, The OpenThread Authors.
+#  Copyright (c) 2026, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -26,59 +26,22 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-name: Size
+name: Size Report
 
 on:
-  push:
-    branches-ignore:
-      - 'dependabot/**'
-  pull_request_target:
-    branches:
-      - 'main'
+  workflow_run:
+    workflows: ["Size Check"]
+    types:
+      - completed
 
 permissions:
   contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.repository == 'openthread/openthread' && github.run_id) || github.ref }}
-  cancel-in-progress: true
+  pull-requests: write
 
 jobs:
 
-  size-check:
-    runs-on: ubuntu-24.04
-    steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
-      with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - name: Fetch Pull Request ref
-      if: ${{ github.event_name == 'pull_request_target' }}
-      run: |
-        git fetch --depth 2 origin pull/${{ github.event.pull_request.number }}/merge
-        echo "OT_SHA_NEW=$(git rev-parse FETCH_HEAD)" >> $GITHUB_ENV
-    - name: Run
-      env:
-        PR_BODY: "${{ github.event.pull_request.body }}"
-        PR_NUMBER: "${{ github.event.pull_request.number }}"
-      run: |
-        ./script/check-size
-        cat /tmp/ot-size-report/report_pr >> $GITHUB_STEP_SUMMARY
-    - name: Upload report
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: report_pr
-        path: /tmp/ot-size-report/report_pr
-
-
   size-report:
-    needs:
-    - size-check
-    permissions:
-      pull-requests: write
-    if: github.event_name == 'pull_request_target'
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04
     steps:
     - name: Download report
@@ -86,6 +49,8 @@ jobs:
       with:
         name: report_pr
         path: /tmp/ot-size-report
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Post Report
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
@@ -95,15 +60,17 @@ jobs:
           const fs = require('fs')
 
           const report = fs.readFileSync('/tmp/ot-size-report/report_pr', 'utf8');
+          const pr_number = parseInt(fs.readFileSync('/tmp/ot-size-report/pr_number', 'utf8').trim());
+
           const params = {
-              issue_number: context.issue.number,
+              issue_number: pr_number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: report,
           }
 
           const response = await github.rest.issues.listComments({
-            issue_number: context.issue.number,
+            issue_number: pr_number,
             owner: context.repo.owner,
             repo: context.repo.repo,
           });


### PR DESCRIPTION
This commit breaks the size report workflow into two workflows so that we can use `pull-request` to collect the data.