### PR TITLE
[build] fix LLVM compilation issues

### DIFF
--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -406,7 +406,8 @@ otError otMacFrameProcessTxSfd(otRadioFrame *aFrame, uint64_t aRadioTime, otRadi
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     if (static_cast<Mac::Frame *>(aFrame)->Has<Mac::CslIe>()) // CSL IE should be filled for every transmit attempt
     {
-        otMacFrameSetCslIe(aFrame, aRadioContext->mCslPeriod, ComputeCslPhase(aRadioTime, aRadioContext));
+        otMacFrameSetCslIe(aFrame, aRadioContext->mCslPeriod,
+                           ComputeCslPhase(static_cast<uint32_t>(aRadioTime), aRadioContext));
     }
 #endif
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE

--- a/src/cli/cli_ping.cpp
+++ b/src/cli/cli_ping.cpp
@@ -233,8 +233,8 @@ void PingSender::HandlePingStatistics(const otPingSenderStatistics *aStatistics)
 
     if (aStatistics->mReceivedCount != 0)
     {
-        uint32_t avgRoundTripTime =
-            1000 * static_cast<uint64_t>(aStatistics->mTotalRoundTripTime) / aStatistics->mReceivedCount;
+        uint32_t avgRoundTripTime = static_cast<uint32_t>(
+            1000 * static_cast<uint64_t>(aStatistics->mTotalRoundTripTime) / aStatistics->mReceivedCount);
 
         OutputFormat(" Round-trip min/avg/max = %u/%u.%03u/%u ms.", aStatistics->mMinRoundTripTime,
                      static_cast<uint16_t>(avgRoundTripTime / 1000), static_cast<uint16_t>(avgRoundTripTime % 1000),


### PR DESCRIPTION
This PR includes:
- Fixed a Clang `-Wshorten-64-to-32` warning in `mac_frame.cpp` by explicitly casting `aRadioTime` to `uint32_t` at the `ComputeCslPhase()` call site, preserving the intended 32-bit timer and wraparound behavior.
- Fixed a Clang `-Wshorten-64-to-32` warning in `cli_ping.cpp` by changing `avgRoundTripTime` to `uint64_t`, matching the computation type and avoiding implicit narrowing.