### PR TITLE
[srp-adv-proxy] clear name on `ExtractLabels()` failure in `AdvertisingProxy`

### DIFF
--- a/src/core/net/srp_advertising_proxy.cpp
+++ b/src/core/net/srp_advertising_proxy.cpp
@@ -1152,7 +1152,10 @@ void AdvertisingProxy::UnregisterKey(const char *aName, const char *aServiceType
 
 void AdvertisingProxy::CopyNameAndRemoveDomain(DnsName &aName, const char *aFullName)
 {
-    IgnoreError(Dns::Name::ExtractLabels(aFullName, Get<Server>().GetDomain(), aName, sizeof(aName)));
+    if (Dns::Name::ExtractLabels(aFullName, Get<Server>().GetDomain(), aName, sizeof(aName)) != kErrorNone)
+    {
+        aName[0] = kNullChar;
+    }
 }
 
 void AdvertisingProxy::HandleRegistered(otInstance *aInstance, otPlatDnssdRequestId aRequestId, otError aError)


### PR DESCRIPTION
This commit updates `AdvertisingProxy::CopyNameAndRemoveDomain()` to properly handle potential errors returned by `Dns::Name::ExtractLabels()`.

Previously, any error returned by `ExtractLabels()` was ignored, which could leave the output name buffer in an indeterminate state. With this change, if extracting the labels fails, the name buffer is explicitly cleared by setting its first character to `kNullChar`.

This prevents subsequent code from using uninitialized or partially written data in the event of a parsing or buffer size error.