### PR TITLE
[mac] enforce KeyIdMode1 for CSL synchronization processing

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2490,7 +2490,12 @@ void Mac::ProcessCsl(const RxFrame &aFrame, const Address &aSrcAddr)
     CslNeighbor *neighbor = nullptr;
     const CslIe *csl;
 
+    uint8_t keyIdMode;
+
     VerifyOrExit(aFrame.IsVersion2015() && aFrame.GetSecurityEnabled());
+
+    IgnoreError(aFrame.GetKeyIdMode(keyIdMode));
+    VerifyOrExit(keyIdMode == Frame::kKeyIdMode1);
 
     csl = aFrame.GetCslIe();
     VerifyOrExit(csl != nullptr);


### PR DESCRIPTION
This commit updates `Mac::ProcessCsl` to explicitly verify that CSL IE data frames are secured using `KeyIdMode1` (utilizing the network key and per-neighbor frame counter freshness checks).