### PR TITLE
[mle] handle invalid leader mask in HandleAddressSolicitResponse

### DIFF
--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -3363,6 +3363,7 @@ void Mle::HandleAddressSolicitResponse(Coap::Msg *aMsg, Error aResult)
 
     SuccessOrExit(Tlv::Find<ThreadRouterMaskTlv>(aMsg->mMessage, routerIdMask));
     VerifyOrExit(routerIdMask.IsValid());
+    VerifyOrExit(routerIdMask.IsAllocated(GetLeaderId()));
 
     SetAlternateRloc16(GetRloc16());
 


### PR DESCRIPTION
This commit resolves an issue in HandleAddressSolicitResponse where a malformed or invalid leader-supplied Router ID Mask omitting the leader ID could trigger an assertion.

When a node receives an Address Solicit Response, it installs the new router ID mask. If the leader's router ID is missing from the mask, the Router entry for the leader is removed from the local router table. Subsequently, when the node tries to ensure it has a valid next hop and cost towards the leader, `mRouterTable.GetLeader()` returns `nullptr`, leading to an `OT_ASSERT(leader != nullptr)` failure or a null-pointer write when assertions are disabled.

This is resolved by safely verifying that the leader's router ID is indeed present in the received router ID mask before applying the routing update, ensuring `GetLeader()` is guaranteed to find it.