### PR TITLE
[network-data] reject Context ID 0 in `ContextTlv::IsValid()`

### DIFF
--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -1128,7 +1128,10 @@ public:
      * @retval TRUE   If the TLV appears to be well-formed.
      * @retval FALSE  If the TLV does not appear to be well-formed.
      */
-    bool IsValid(void) const { return GetLength() >= sizeof(*this) - sizeof(NetworkDataTlv); }
+    bool IsValid(void) const
+    {
+        return (GetLength() >= sizeof(*this) - sizeof(NetworkDataTlv)) && (GetContextId() != 0);
+    }
 
     /**
      * Indicates whether or not the Compress flag is set.


### PR DESCRIPTION
This commit updates the `ContextTlv::IsValid()` method to reject Context TLVs that specify a Context ID of zero.

According to the Thread specification, Context ID 0 is reserved for the Mesh-Local Prefix and should not be distributed in the Network Data. Adding this check ensures that such invalid TLVs are correctly identified as malformed and dropped during Network Data processing.