### PR TITLE
[key-manager] add `ClearKek()` to remove KEK when no longer needed

### DIFF
--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -184,6 +184,7 @@ void Joiner::Finish(Error aError)
     case kStateJoined:
         Get<Tmf::SecureAgent>().Disconnect();
         mTimer.Stop();
+        Get<KeyManager>().ClearKek();
 
         OT_FALL_THROUGH;
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -302,6 +302,8 @@ exit:
 
 void JoinerRouter::HandleJoinerEntrustResponse(Coap::Msg *aMsg, Error aResult)
 {
+    Get<KeyManager>().ClearKek();
+
     SendDelayedJoinerEntrust();
 
     VerifyOrExit(aResult == kErrorNone && aMsg != nullptr);

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -516,6 +516,12 @@ void KeyManager::SetKek(const Kek &aKek)
     mIsKekSet        = true;
 }
 
+void KeyManager::ClearKek(void)
+{
+    mKek.Clear();
+    mIsKekSet = false;
+}
+
 void KeyManager::SetSecurityPolicy(const SecurityPolicy &aSecurityPolicy)
 {
     SecurityPolicy newPolicy = aSecurityPolicy;

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -486,6 +486,11 @@ public:
     void SetKek(const uint8_t *aKekBytes) { SetKek(*reinterpret_cast<const Kek *>(aKekBytes)); }
 
     /**
+     * Clears the KEK.
+     */
+    void ClearKek(void);
+
+    /**
      * Returns the current KEK Frame Counter value.
      *
      * @returns The current KEK Frame Counter value.


### PR DESCRIPTION
This commit introduces the `KeyManager::ClearKek()` method, which clears the `Kek` and resets the `mIsKekSet` flag.

The KEK is a temporary key used during the commissioning and entrust phases. To improve security and key hygiene, this commit updates the `Joiner` and `JoinerRouter` to explicitly clear the KEK once these operations have concluded.

Specifically:
- `Joiner::Finish()` clears the KEK when finishing in `kStateEntrust` or `kStateJoined`.
- `JoinerRouter::HandleJoinerEntrustResponse()` clears the KEK immediately upon handling the entrust response, before scheduling any delayed entrusts (which set their own KEK from metadata).