### PR TITLE
[mlr] extract registration criteria into `ShouldRegister()` helper

### DIFF
--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -209,16 +209,28 @@ void Manager::UpdateTimeTickerRegistration(void)
     }
 }
 
+bool Manager::ShouldRegister(void) const
+{
+    bool shouldRegister = false;
+
+    VerifyOrExit(Get<Mle::Mle>().IsFullThreadDevice() || Get<Mle::Mle>().GetParent().IsThreadVersion1p1());
+    VerifyOrExit(Get<BackboneRouter::Leader>().HasPrimary());
+
+    shouldRegister = true;
+
+exit:
+    return shouldRegister;
+}
+
 void Manager::Send(void)
 {
     Error        error;
     AddressArray addresses;
 
     VerifyOrExit(!mPending, error = kErrorBusy);
+
     VerifyOrExit(Get<Mle::Mle>().IsAttached(), error = kErrorInvalidState);
-    VerifyOrExit(Get<Mle::Mle>().IsFullThreadDevice() || Get<Mle::Mle>().GetParent().IsThreadVersion1p1(),
-                 error = kErrorInvalidState);
-    VerifyOrExit(Get<BackboneRouter::Leader>().HasPrimary(), error = kErrorInvalidState);
+    VerifyOrExit(ShouldRegister(), error = kErrorInvalidState);
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
     // Append Netif multicast addresses
@@ -568,8 +580,7 @@ void Manager::Reregister(void)
 
 void Manager::UpdateReregistrationDelay(bool aRereg)
 {
-    bool needSend = (Get<Mle::Mle>().IsFullThreadDevice() || Get<Mle::Mle>().GetParent().IsThreadVersion1p1()) &&
-                    Get<BackboneRouter::Leader>().HasPrimary();
+    bool needSend = ShouldRegister();
 
     if (!needSend)
     {

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -150,8 +150,8 @@ private:
         void AddUnique(const Ip6::Address &aAddress);
     };
 
-    void HandleNotifierEvents(Events aEvents);
-
+    void  HandleNotifierEvents(Events aEvents);
+    bool  ShouldRegister(void) const;
     void  Send(void);
     Error SendMessage(const Ip6::Address   *aAddresses,
                       uint8_t               aAddressNum,


### PR DESCRIPTION
This commit introduces a new private helper method, `ShouldRegister()`, to the `Manager` class. This method consolidates the checks required to determine if the device should perform MLR.