### PR TITLE
[nexus] remove redundant cast in `SendMlrRequest()`

### DIFF
--- a/tests/nexus/test_1_2_MATN_TC_21.cpp
+++ b/tests/nexus/test_1_2_MATN_TC_21.cpp
@@ -111,7 +111,7 @@ void SendMlrRequest(Node &aSource, const Ip6::Address &aDestination, const void 
     Coap::Message *message = aSource.Get<Tmf::Agent>().AllocateAndInitPriorityConfirmablePostMessage(kUriMlr);
     VerifyOrQuit(message != nullptr);
 
-    SuccessOrQuit(Tlv::Append<Ip6AddressesTlv>(*message, static_cast<const uint8_t *>(aAddressesData), aDataLength));
+    SuccessOrQuit(Tlv::Append<Ip6AddressesTlv>(*message, aAddressesData, aDataLength));
 
     SuccessOrQuit(aSource.Get<Tmf::Agent>().SendMessageTo(*message, aDestination));
 }


### PR DESCRIPTION
This commit removes a redundant `static_cast<const uint8_t *>` when calling `Tlv::Append<Ip6AddressesTlv>()` in `SendMlrRequest()` in `test_1_2_MATN_TC_21.cpp`. Since the method accepts `const void *` as its value argument, the explicit cast is unnecessary and can be safely removed to simplify the code.