### PR TITLE
[mdns] simplify and limit multi-packet rx message lists

### DIFF
--- a/src/core/net/mdns.cpp
+++ b/src/core/net/mdns.cpp
@@ -4963,6 +4963,8 @@ void Core::MultiPacketRxMessages::AddNew(OwnedPtr<RxMessage> &aRxMessagePtr)
 
     mRxMsgEntries.RemoveMatching(aRxMessagePtr->GetSenderAddress());
 
+    VerifyOrExit(mRxMsgEntries.CountAllEntries() < kMaxRxMsgEntries);
+
     newEntry = RxMsgEntry::Allocate(GetInstance());
     VerifyOrExit(newEntry != nullptr);
 
@@ -5022,20 +5024,12 @@ exit:
 
 void Core::MultiPacketRxMessages::RxMsgEntry::Add(OwnedPtr<RxMessage> &aRxMessagePtr)
 {
-    uint16_t numMsgs = 0;
+    // If a subsequent received `RxMessage` is also marked as
+    // truncated, we again delay the process time. To avoid
+    // continuous delay and piling up of messages in the list,
+    // we limit the number of messages.
 
-    for (const RxMessage &rxMsg : mRxMessages)
-    {
-        // If a subsequent received `RxMessage` is also marked as
-        // truncated, we again delay the process time. To avoid
-        // continuous delay and piling up of messages in the list,
-        // we limit the number of messages.
-
-        numMsgs++;
-        VerifyOrExit(numMsgs < kMaxNumMessages);
-
-        OT_UNUSED_VARIABLE(rxMsg);
-    }
+    VerifyOrExit(mRxMessages.CountAllEntries() < kMaxNumMessagesPerEntry);
 
     mProcessTime = TimerMilli::GetNow();
 

--- a/src/core/net/mdns.hpp
+++ b/src/core/net/mdns.hpp
@@ -1660,13 +1660,15 @@ private:
     private:
         static constexpr uint32_t kMinProcessDelay = 400; // msec
         static constexpr uint32_t kMaxProcessDelay = 500; // msec
-        static constexpr uint16_t kMaxNumMessages  = 10;
+        static constexpr uint16_t kMaxRxMsgEntries = 64;
 
         struct RxMsgEntry : public InstanceLocator,
                             public LinkedListEntry<RxMsgEntry>,
                             public Heap::Allocatable<RxMsgEntry>,
                             private NonCopyable
         {
+            static constexpr uint16_t kMaxNumMessagesPerEntry = 10;
+
             explicit RxMsgEntry(Instance &aInstance);
 
             bool Matches(const AddressInfo &aAddress) const;


### PR DESCRIPTION
This commit simplifies the logic for limiting the number of messages tracked in `MultiPacketRxMessages`.

It introduces a new cap, `kMaxRxMsgEntries` (set to 64), to restrict the total number of unique `RxMsgEntry` items being tracked, preventing unbounded memory growth. Additionally, the existing message limit per entry is renamed from `kMaxNumMessages` to `kMaxNumMessagesPerEntry` and moved within the `RxMsgEntry` scope. The manual `for` loop used to count existing messages in `RxMsgEntry::Add` is replaced with a clean check using `CountAllEntries()`.