### PR TITLE
[border-router] add `Deprecate()` method in `OnLinkPrefix`

### DIFF
--- a/src/core/border_router/br_types.cpp
+++ b/src/core/border_router/br_types.cpp
@@ -72,6 +72,18 @@ void OnLinkPrefix::SetFrom(const PrefixTableEntry &aPrefixTableEntry)
     mLastUpdateTime    = TimerMilli::GetNow();
 }
 
+void OnLinkPrefix::Deprecate(void)
+{
+    TimeMilli twoHoursFromNow = TimerMilli::GetNow() + Time::SecToMsec(kTwoHoursLifetime);
+
+    mPreferredLifetime = 0;
+
+    if (GetExpireTime() > twoHoursFromNow)
+    {
+        mValidLifetime = Time::MsecToSec(twoHoursFromNow.DetermineRemainingDurationFrom(mLastUpdateTime));
+    }
+}
+
 bool OnLinkPrefix::IsDeprecated(void) const { return GetDeprecationTime() <= TimerMilli::GetNow(); }
 
 TimeMilli OnLinkPrefix::GetDeprecationTime(void) const { return CalculateExpirationTime(mPreferredLifetime); }
@@ -83,8 +95,6 @@ TimeMilli OnLinkPrefix::GetStaleTime(void) const
 
 void OnLinkPrefix::AdoptFlagsAndValidAndPreferredLifetimesFrom(const OnLinkPrefix &aPrefix)
 {
-    constexpr uint32_t kTwoHoursInSeconds = 2 * 3600;
-
     // Per RFC 4862 section 5.5.3.e:
     //
     // 1.  If the received Valid Lifetime is greater than 2 hours or
@@ -96,13 +106,13 @@ void OnLinkPrefix::AdoptFlagsAndValidAndPreferredLifetimesFrom(const OnLinkPrefi
     // 3.  Otherwise, reset the valid lifetime of the corresponding
     //     address to 2 hours.
 
-    if (aPrefix.mValidLifetime > kTwoHoursInSeconds || aPrefix.GetExpireTime() > GetExpireTime())
+    if (aPrefix.mValidLifetime > kTwoHoursLifetime || aPrefix.GetExpireTime() > GetExpireTime())
     {
         mValidLifetime = aPrefix.mValidLifetime;
     }
-    else if (GetExpireTime() > TimerMilli::GetNow() + TimeMilli::SecToMsec(kTwoHoursInSeconds))
+    else if (GetExpireTime() > TimerMilli::GetNow() + Time::SecToMsec(kTwoHoursLifetime))
     {
-        mValidLifetime = kTwoHoursInSeconds;
+        mValidLifetime = kTwoHoursLifetime;
     }
 
     mPreferredLifetime    = aPrefix.GetPreferredLifetime();

--- a/src/core/border_router/br_types.hpp
+++ b/src/core/border_router/br_types.hpp
@@ -227,9 +227,11 @@ public:
     uint32_t GetPreferredLifetime(void) const { return mPreferredLifetime; }
 
     /**
-     * Clears (sets to zero) the preferred lifetime of the prefix.
+     * Deprecates the prefix.
+     *
+     * Sets the preferred lifetime to zero and bounds the remaining valid lifetime to at most two hours from now.
      */
-    void ClearPreferredLifetime(void) { mPreferredLifetime = 0; }
+    void Deprecate(void);
 
     /**
      * Indicates whether the on-link prefix is deprecated.
@@ -279,7 +281,8 @@ public:
     bool IsFavoredOver(const Ip6::Prefix &aPrefix) const;
 
 private:
-    static constexpr uint32_t kFavoredMinPreferredLifetime = 1800; // In sec.
+    static constexpr uint32_t kTwoHoursLifetime            = 2 * Time::kOneHourInSec;
+    static constexpr uint32_t kFavoredMinPreferredLifetime = 30 * Time::kOneMinuteInSec;
     static constexpr uint8_t  kExpectedFavoredPrefixLength = 64;
 
     uint32_t mPreferredLifetime;

--- a/src/core/border_router/rx_ra_tracker.cpp
+++ b/src/core/border_router/rx_ra_tracker.cpp
@@ -727,7 +727,7 @@ void RxRaTracker::RemoveOrDeprecateOldEntries(TimeMilli aTimeThreshold)
         {
             if (entry.GetLastUpdateTime() <= aTimeThreshold)
             {
-                entry.ClearPreferredLifetime();
+                entry.Deprecate();
             }
         }
 
@@ -1096,10 +1096,7 @@ void RxRaTracker::HandleRouterTimer(void)
 
             for (OnLinkPrefix &entry : router.mOnLinkPrefixes)
             {
-                if (!entry.IsDeprecated())
-                {
-                    entry.ClearPreferredLifetime();
-                }
+                entry.Deprecate();
             }
 
             for (RoutePrefix &entry : router.mRoutePrefixes)


### PR DESCRIPTION
This commit introduces the `Deprecate()` method in the `OnLinkPrefix` class. This method properly deprecates an on-link prefix by setting its preferred lifetime to zero and bounding the remaining valid lifetime to a maximum of two hours from the current time.

Previously, `RxRaTracker` only called `ClearPreferredLifetime()`, which left the valid lifetime unchanged. By replacing `ClearPreferredLifetime()` with the new `Deprecate()` method, we ensure that the valid lifetime of deprecated prefixes is also bounded.

This change ensures that if a router is deemed unreachable, its on-link prefixes will live for a maximum of 2 more hours. This allows the state associated with an unreachable router to age out more quickly, even if the router had previously advertised the on-link prefix with long valid lifetime.