### PR TITLE
[mlr] extract `AddressArray` and add `FindIn()` to `Ip6AddressesTlv`

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -729,6 +729,7 @@ openthread_core_files = [
   "thread/mle_types.hpp",
   "thread/mlr_manager.cpp",
   "thread/mlr_manager.hpp",
+  "thread/mlr_types.cpp",
   "thread/mlr_types.hpp",
   "thread/neighbor.cpp",
   "thread/neighbor.hpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -255,6 +255,7 @@ set(COMMON_SOURCES
     thread/mle_tlvs.cpp
     thread/mle_types.cpp
     thread/mlr_manager.cpp
+    thread/mlr_types.cpp
     thread/neighbor.cpp
     thread/neighbor_table.cpp
     thread/network_data.cpp

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -451,8 +451,7 @@ void Manager::HandleResponse(Coap::Msg *aMsg, Error aResult)
 
 Error Manager::ParseResponse(Error aResult, Coap::Msg *aMsg, uint8_t &aStatus, AddressArray &aFailedAddresses)
 {
-    Error       error = aResult;
-    OffsetRange offsetRange;
+    Error error = aResult;
 
     aStatus = kStatusGeneralFailure;
     aFailedAddresses.Clear();
@@ -463,17 +462,16 @@ Error Manager::ParseResponse(Error aResult, Coap::Msg *aMsg, uint8_t &aStatus, A
 
     SuccessOrExit(error = Tlv::Find<ThreadStatusTlv>(aMsg->mMessage, aStatus));
 
-    if (Tlv::FindTlvValueOffsetRange(aMsg->mMessage, Ip6AddressesTlv::kType, offsetRange) == kErrorNone)
+    switch (error = Ip6AddressesTlv::FindIn(aMsg->mMessage, aFailedAddresses))
     {
-        while (!offsetRange.IsEmpty())
-        {
-            Ip6::Address address;
-
-            SuccessOrExit(error = aMsg->mMessage.Read(offsetRange, address));
-            offsetRange.AdvanceOffset(sizeof(Ip6::Address));
-
-            SuccessOrExit(error = aFailedAddresses.AddUnique(address));
-        }
+    case kErrorNone:
+        break;
+    case kErrorNotFound:
+        error = kErrorNone;
+        aFailedAddresses.Clear();
+        break;
+    default:
+        ExitNow();
     }
 
     if (aStatus == kStatusSuccess)
@@ -724,18 +722,6 @@ void Manager::LogMulticastAddresses(void)
 #endif
 
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)
-}
-
-Error Manager::AddressArray::AddUnique(const Ip6::Address &aAddress)
-{
-    Error error = kErrorNone;
-
-    if (!Contains(aAddress))
-    {
-        error = PushBack(aAddress);
-    }
-
-    return error;
 }
 
 } // namespace Mlr

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -152,12 +152,6 @@ private:
         kRenew,
     };
 
-    class AddressArray : public Array<Ip6::Address, kMaxIp6Addresses>
-    {
-    public:
-        Error AddUnique(const Ip6::Address &aAddress);
-    };
-
     void  HandleNotifierEvents(Events aEvents);
     bool  ShouldRegister(void) const;
     void  Send(void);

--- a/src/core/thread/mlr_types.cpp
+++ b/src/core/thread/mlr_types.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2026, The OpenThread Authors.
+ *  Copyright (c) 2020-2026, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -28,51 +28,25 @@
 
 /**
  * @file
- *   This file implements methods for generating and processing Thread Network Layer TLVs.
+ *   This file implements MLR types.
  */
 
-#include "thread_tlvs.hpp"
+#include "mlr_types.hpp"
 
 namespace ot {
+namespace Mlr {
 
-#if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
-
-Error Ip6AddressesTlv::AppendTo(Message &aMessage, const Ip6::Address *aAddresses, uint16_t aNumAddresses)
+Error AddressArray::AddUnique(const Ip6::Address &aAddress)
 {
-    Error         error;
-    Tlv::Bookmark tlvBookmark;
+    Error error = kErrorNone;
 
-    SuccessOrExit(error = Tlv::StartTlv(aMessage, kType, tlvBookmark));
-    SuccessOrExit(error = aMessage.AppendBytes(aAddresses, aNumAddresses * sizeof(Ip6::Address)));
-    error = Tlv::EndTlv(aMessage, tlvBookmark);
-
-exit:
-    return error;
-}
-
-Error Ip6AddressesTlv::FindIn(const Message &aMessage, Mlr::AddressArray &aAddresses)
-{
-    Error       error;
-    OffsetRange offsetRange;
-
-    aAddresses.Clear();
-
-    SuccessOrExit(error = Tlv::FindTlvValueOffsetRange(aMessage, kType, offsetRange));
-
-    while (!offsetRange.IsEmpty())
+    if (!Contains(aAddress))
     {
-        Ip6::Address address;
-
-        SuccessOrExit(error = aMessage.Read(offsetRange, address));
-        offsetRange.AdvanceOffset(sizeof(Ip6::Address));
-
-        SuccessOrExit(error = aAddresses.AddUnique(address));
+        error = PushBack(aAddress);
     }
 
-exit:
     return error;
 }
 
-#endif // OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
-
+} // namespace Mlr
 } // namespace ot

--- a/src/core/thread/mlr_types.hpp
+++ b/src/core/thread/mlr_types.hpp
@@ -36,6 +36,10 @@
 
 #include "openthread-core-config.h"
 
+#include "common/array.hpp"
+#include "common/error.hpp"
+#include "net/ip6_address.hpp"
+
 namespace ot {
 namespace Mlr {
 
@@ -76,6 +80,23 @@ enum Status : uint8_t
 };
 
 constexpr uint8_t kMaxStatusValue = kStatusGeneralFailure;
+
+/**
+ * Represents an array of IPv6 addresses.
+ */
+class AddressArray : public Array<Ip6::Address, kMaxIp6Addresses>
+{
+public:
+    /**
+     * Adds an IPv6 address to the array if it is not already present.
+     *
+     * @param[in] aAddress  The IPv6 address to add.
+     *
+     * @retval kErrorNone    Successfully added the address or it was already present.
+     * @retval kErrorNoBufs  The array is full.
+     */
+    Error AddUnique(const Ip6::Address &aAddress);
+};
 
 } // namespace Mlr
 } // namespace ot

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -42,6 +42,7 @@
 #include "meshcop/network_name.hpp"
 #include "net/ip6_address.hpp"
 #include "thread/mle_types.hpp"
+#include "thread/mlr_types.hpp"
 
 namespace ot {
 
@@ -165,6 +166,19 @@ public:
      * @retval kErrorNoBufs   Insufficient available buffers to grow the message.
      */
     static Error AppendTo(Message &aMessage, const Ip6::Address *aAddresses, uint16_t aNumAddresses);
+
+    /**
+     * Finds and parses the IPv6 Addresses TLV from a given message.
+     *
+     * @param[in]  aMessage    The message to parse.
+     * @param[out] aAddresses  An `AddressArray` to output the parsed IPv6 addresses.
+     *
+     * @retval kErrorNone       Successfully found and parsed the TLV.
+     * @retval kErrorNotFound   Could not find the TLV in the message.
+     * @retval kErrorParse      Failed to parse the TLV.
+     * @retval kErrorNoBufs     There are more addresses in the TLV than can fit in `aAddresses`.
+     */
+    static Error FindIn(const Message &aMessage, Mlr::AddressArray &aAddresses);
 
     Ip6AddressesTlv(void) = delete;
 };


### PR DESCRIPTION
This commit moves the `AddressArray` class out of the `Mlr::Manager` and into a dedicated `mlr_types.hpp` file as `Mlr::AddressArray`. This decouples the type from the manager, making it available for broader use across the module.

Additionally, the logic for parsing the `Ip6AddressesTlv` is extracted from `Mlr::Manager::ParseResponse()` into a new `FindIn()` method on the TLV class itself. This centralizes the TLV parsing logic within the TLV class, which is more idiomatic. The `FindIn()` method also provides a safety guarantee by clearing the output `AddressArray` if parsing fails.

The build system configurations (`BUILD.gn` and `CMakeLists.txt`) are updated to include the newly added `mlr_types.cpp` file. Doxygen documentation is also provided for the new types and methods.