### PR TITLE
[cli] remove invalid log when tx buffer is full

### DIFF
--- a/examples/apps/cli/cli_uart.cpp
+++ b/examples/apps/cli/cli_uart.cpp
@@ -342,7 +342,6 @@ static int CliUartOutput(void *aContext, const char *aFormat, va_list aArguments
                 else
                 {
                     // Flush did not succeed, so abandon buffered output.
-                    otLogWarnPlat("Failed to output CLI: %s", otThreadErrorToString(error));
                     break;
                 }
             }


### PR DESCRIPTION
In CliUartOutput, if otPlatUartFlush() fails when trying to send buffered output to make room for new output, it logs a warning using otLogWarnPlat. However, this warning is added to the same full buffer, which does not help and can cause further issues.

This commit removes the offending log line as suggested in issue https://github.com/openthread/openthread/issues/7478.

Resolves: https://github.com/openthread/openthread/issues/7478