### PR TITLE
[spinel] fix writeable size in spinel logging

### DIFF
--- a/src/lib/spinel/logger.cpp
+++ b/src/lib/spinel/logger.cpp
@@ -524,7 +524,7 @@ void Logger::LogSpinelFrame(const uint8_t *aFrame, uint16_t aLength, bool aTx)
     case SPINEL_PROP_STREAM_DEBUG:
     {
         char          debugString[OPENTHREAD_LIB_SPINEL_NCP_LOG_MAX_SIZE + 1];
-        spinel_size_t stringLength = sizeof(debugString);
+        spinel_size_t stringLength = sizeof(debugString) - 1;
 
         unpacked = spinel_datatype_unpack_in_place(data, len, SPINEL_DATATYPE_DATA_S, debugString, &stringLength);
         assert(stringLength < sizeof(debugString));

--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -556,7 +556,7 @@ void RadioSpinel::HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, 
     else if (aKey == SPINEL_PROP_STREAM_DEBUG)
     {
         char         logStream[OPENTHREAD_CONFIG_NCP_SPINEL_LOG_MAX_SIZE + 1];
-        unsigned int len = sizeof(logStream);
+        unsigned int len = sizeof(logStream) - 1;
 
         unpacked = spinel_datatype_unpack_in_place(aBuffer, aLength, SPINEL_DATATYPE_DATA_S, logStream, &len);
         assert(len < sizeof(logStream));


### PR DESCRIPTION
There exists a NULL-byte OOB in the spinel logging. The initial stack buffer is initialized with an extra byte for the NULL-byte. However, the full size is passed into `spinel_datatype_unpack_in_place()` which interprets it as the valid writable size (`require_action(NULL != block_len_ptr && *block_len_ptr >= block_len, bail, (ret = -1, errno = EINVAL));`). 

When `block_len` is the length of the buffer, the NULL-byte write after the function call will be OOB.