### PR TITLE
[github-actions] run DinD test with and without mDNSResponder

### DIFF
--- a/.github/workflows/otbr-posix-dind.yml
+++ b/.github/workflows/otbr-posix-dind.yml
@@ -47,6 +47,10 @@ jobs:
 
   dind-dns-sd:
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        mdns: ["", "--mdnsresponder"]
     env:
       PR_BODY: "${{ github.event.pull_request.body }}"
     steps:
@@ -84,4 +88,4 @@ jobs:
           -w /usr/src/ot-br-posix \
           -e DOCKER_HOST=unix:///var/run/docker.sock \
           otbr-dind-runner \
-          bash -c "dockerd --host=unix:///var/run/docker.sock >/dev/null 2>&1 & ./tests/scripts/test_dind_dns_sd.sh"
+          bash -c "dockerd --host=unix:///var/run/docker.sock >/dev/null 2>&1 & ./tests/scripts/test_dind_dns_sd.sh ${{ matrix.mdns }}"


### PR DESCRIPTION
Update `otbr-posix-dind.yml` workflow to run the DinD integration test using a matrix strategy that covers both the default mDNS implementation and `mDNSResponder`.

This mirrors the testing matrix used in `ot-br-posix` repository's `docker-test.yml` workflow.