### PR TITLE
[bbr-leader] remove `kDomainPrefixUnchanged` from `DomainPrefixEvent`

### DIFF
--- a/src/core/backbone_router/bbr_leader.cpp
+++ b/src/core/backbone_router/bbr_leader.cpp
@@ -112,11 +112,10 @@ const char *Leader::StateToString(State aState)
 
 const char *Leader::DomainPrefixEventToString(DomainPrefixEvent aEvent)
 {
-#define DomainPrefixEventMapList(_)        \
-    _(kDomainPrefixAdded, "Added")         \
-    _(kDomainPrefixRemoved, "Removed")     \
-    _(kDomainPrefixRefreshed, "Refreshed") \
-    _(kDomainPrefixUnchanged, "Unchanged")
+#define DomainPrefixEventMapList(_)    \
+    _(kDomainPrefixAdded, "Added")     \
+    _(kDomainPrefixRemoved, "Removed") \
+    _(kDomainPrefixRefreshed, "Refreshed")
 
     DefineEnumStringArray(DomainPrefixEventMapList);
 
@@ -225,16 +224,13 @@ void Leader::UpdateDomainPrefixConfig(void)
     {
         VerifyOrExit(HasDomainPrefix());
 
-        // Domain Prefix does not exist any more.
         mDomainPrefix.Clear();
         event = kDomainPrefixRemoved;
     }
-    else if (prefixConfig.GetPrefix() == mDomainPrefix)
-    {
-        event = kDomainPrefixUnchanged;
-    }
     else
     {
+        VerifyOrExit(prefixConfig.GetPrefix() != mDomainPrefix);
+
         event         = HasDomainPrefix() ? kDomainPrefixRefreshed : kDomainPrefixAdded;
         mDomainPrefix = prefixConfig.GetPrefix();
     }
@@ -250,12 +246,10 @@ void Leader::UpdateDomainPrefixConfig(void)
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE)
     Get<DuaManager>().HandleDomainPrefixUpdate(event);
-#else
-    OT_UNUSED_VARIABLE(event);
 #endif
 
 exit:
-    return;
+    OT_UNUSED_VARIABLE(event);
 }
 
 bool Leader::IsDomainUnicast(const Ip6::Address &aAddress) const

--- a/src/core/backbone_router/bbr_leader.hpp
+++ b/src/core/backbone_router/bbr_leader.hpp
@@ -76,7 +76,6 @@ enum DomainPrefixEvent : uint8_t
     kDomainPrefixAdded     = OT_BACKBONE_ROUTER_DOMAIN_PREFIX_ADDED,   ///< Domain Prefix Added.
     kDomainPrefixRemoved   = OT_BACKBONE_ROUTER_DOMAIN_PREFIX_REMOVED, ///< Domain Prefix Removed.
     kDomainPrefixRefreshed = OT_BACKBONE_ROUTER_DOMAIN_PREFIX_CHANGED, ///< Domain Prefix Changed.
-    kDomainPrefixUnchanged,                                            ///< Domain Prefix did not change.
 };
 
 /**
@@ -151,10 +150,7 @@ public:
      *
      * @retval A pointer to the Domain Prefix or nullptr if there is no Domain Prefix.
      */
-    const Ip6::Prefix *GetDomainPrefix(void) const
-    {
-        return (mDomainPrefix.GetLength() == 0) ? nullptr : &mDomainPrefix;
-    }
+    const Ip6::Prefix *GetDomainPrefix(void) const { return HasDomainPrefix() ? &mDomainPrefix : nullptr; }
 
     /**
      * Indicates whether or not the Domain Prefix is available in the Thread Network.
@@ -186,15 +182,13 @@ private:
     void LogBackboneRouterPrimary(State, const Config &) const {}
 #endif
 
-    Config      mConfig;       ///< Primary Backbone Router information.
-    Ip6::Prefix mDomainPrefix; ///< Domain Prefix in the Thread network.
+    Config      mConfig;
+    Ip6::Prefix mDomainPrefix;
 };
 
 } // namespace BackboneRouter
 
-/**
- * @}
- */
+DefineMapEnum(otBackboneRouterDomainPrefixEvent, BackboneRouter::DomainPrefixEvent);
 
 } // namespace ot
 

--- a/src/core/backbone_router/bbr_local.cpp
+++ b/src/core/backbone_router/bbr_local.cpp
@@ -374,10 +374,7 @@ exit:
 
 void Local::HandleDomainPrefixUpdate(DomainPrefixEvent aEvent)
 {
-    if (!IsEnabled())
-    {
-        ExitNow();
-    }
+    VerifyOrExit(IsEnabled());
 
     if (aEvent == kDomainPrefixRemoved || aEvent == kDomainPrefixRefreshed)
     {
@@ -390,11 +387,8 @@ void Local::HandleDomainPrefixUpdate(DomainPrefixEvent aEvent)
         Get<BackboneTmfAgent>().SubscribeMulticast(mAllDomainBackboneRouters);
     }
 
-    if (aEvent != kDomainPrefixUnchanged)
-    {
-        mDomainPrefixCallback.InvokeIfSet(static_cast<otBackboneRouterDomainPrefixEvent>(aEvent),
-                                          Get<Leader>().GetDomainPrefix());
-    }
+    mDomainPrefixCallback.InvokeIfSet(static_cast<otBackboneRouterDomainPrefixEvent>(aEvent),
+                                      Get<Leader>().GetDomainPrefix());
 
 exit:
     return;

--- a/src/core/backbone_router/ndproxy_table.cpp
+++ b/src/core/backbone_router/ndproxy_table.cpp
@@ -127,10 +127,8 @@ void NdProxyTable::Erase(NdProxy &aNdProxy) { aNdProxy.mValid = false; }
 
 void NdProxyTable::HandleDomainPrefixUpdate(DomainPrefixEvent aEvent)
 {
-    if (aEvent == kDomainPrefixAdded || aEvent == kDomainPrefixRemoved || aEvent == kDomainPrefixRefreshed)
-    {
-        Clear();
-    }
+    OT_UNUSED_VARIABLE(aEvent);
+    Clear();
 }
 
 void NdProxyTable::Clear(void)

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -92,12 +92,6 @@ void DuaManager::HandleDomainPrefixUpdate(BackboneRouter::DomainPrefixEvent aEve
 #if OPENTHREAD_CONFIG_DUA_ENABLE
     switch (aEvent)
     {
-    case BackboneRouter::kDomainPrefixUnchanged:
-        // In case removed for some reason e.g. the kDuaInvalid response from PBBR forcefully
-        VerifyOrExit(!Get<ThreadNetif>().HasUnicastAddress(GetDomainUnicastAddress()));
-
-        OT_FALL_THROUGH;
-
     case BackboneRouter::kDomainPrefixRefreshed:
     case BackboneRouter::kDomainPrefixAdded:
     {
@@ -108,7 +102,8 @@ void DuaManager::HandleDomainPrefixUpdate(BackboneRouter::DomainPrefixEvent aEve
         mDomainUnicastAddress.GetAddress().SetPrefix(*prefix);
     }
     break;
-    default:
+
+    case BackboneRouter::kDomainPrefixRemoved:
         ExitNow();
     }
 


### PR DESCRIPTION
This commit removes the `kDomainPrefixUnchanged` event from the `DomainPrefixEvent` enum and refactors the related logic in `BackboneRouter::Leader`. This value was redundant, as the manager should only report events when an actual change (addition, removal, or refresh) occurs in the Domain Prefix configuration.