### PR TITLE
[posix] add details to UDP bind failure and log at Warn level

### DIFF
--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -293,7 +293,10 @@ otError otPlatUdpBind(otUdpSocket *aUdpSocket)
 exit:
     if (error == OT_ERROR_FAILED)
     {
-        ot::Posix::Udp::LogCrit("Failed to bind UDP socket: %s", strerror(errno));
+        int err = errno;
+        ot::Posix::Udp::LogWarn("Failed to bind UDP socket to [%s]:%u: %s",
+                                Ip6AddressString(&aUdpSocket->mSockName.mAddress).AsCString(),
+                                aUdpSocket->mSockName.mPort, strerror(err));
     }
 
     return error;
@@ -420,12 +423,13 @@ otError otPlatUdpConnect(otUdpSocket *aUdpSocket)
 
     if (connect(fd, reinterpret_cast<struct sockaddr *>(&sin6), sizeof(sin6)) != 0)
     {
+        int err = errno;
 #ifdef __APPLE__
-        VerifyOrExit(errno == EAFNOSUPPORT && isDisconnect);
+        VerifyOrExit(err == EAFNOSUPPORT && isDisconnect);
 #endif
         ot::Posix::Udp::LogWarn("Failed to connect to [%s]:%u: %s",
                                 Ip6AddressString(&aUdpSocket->mPeerName.mAddress).AsCString(),
-                                aUdpSocket->mPeerName.mPort, strerror(errno));
+                                aUdpSocket->mPeerName.mPort, strerror(err));
         error = OT_ERROR_FAILED;
     }
 


### PR DESCRIPTION
This adds details to the Posix platform UDP bind error message, showing address and port just like for the otPlatUdpConnect case. Also the severity is changed from Crit to Warn, since it's not a critical failure given that otPlatUdpBind() is used in a loop to find an available ephemeral port - i.e. probe the ports in range until one succeeds.

Ideally the platform code would discern 'port in use' vs 'unrecoverable failure to bind the port', but the currently defined OT APIs don't allow for any other errors apart from ok/failed. If the specific port number is really needed, the caller is responsible to log a critical failure.