### PR TITLE
[bbr] improve Backbone Router callback and `Config` APIs

### DIFF
--- a/src/core/api/backbone_router_api.cpp
+++ b/src/core/api/backbone_router_api.cpp
@@ -46,7 +46,7 @@ otError otBackboneRouterGetPrimary(otInstance *aInstance, otBackboneRouterConfig
 {
     AssertPointerIsNotNull(aConfig);
 
-    return AsCoreType(aInstance).Get<BackboneRouter::Leader>().GetConfig(AsCoreType(aConfig));
+    return AsCoreType(aInstance).Get<BackboneRouter::Leader>().ReadConfig(AsCoreType(aConfig));
 }
 
 #endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)

--- a/src/core/backbone_router/bbr_leader.cpp
+++ b/src/core/backbone_router/bbr_leader.cpp
@@ -61,6 +61,17 @@ exit:
     return;
 }
 
+uint16_t Config::SelectRandomReregistrationDelay(void) const
+{
+    uint16_t delay = 1;
+
+    VerifyOrExit(mReregistrationDelay > 1);
+    delay = Random::NonCrypto::GetUint16InRange(1, mReregistrationDelay + 1);
+
+exit:
+    return delay;
+}
+
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 void Config::Log(const char *aTitle) const
 {
@@ -93,7 +104,7 @@ void Leader::Reset(void)
     mDomainPrefix.SetLength(0);
 }
 
-Error Leader::GetConfig(Config &aConfig) const
+Error Leader::ReadConfig(Config &aConfig) const
 {
     Error error = kErrorNone;
 
@@ -209,15 +220,15 @@ void Leader::UpdateBackboneRouterPrimary(void)
     mConfig = newConfig;
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    Get<BackboneRouter::Local>().HandleBackboneRouterPrimaryUpdate(state, mConfig);
+    Get<BackboneRouter::Local>().HandleBackboneRouterPrimaryUpdate(state);
 #endif
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
-    Get<Mlr::Manager>().HandleBackboneRouterPrimaryUpdate(state, mConfig);
+    Get<Mlr::Manager>().HandleBackboneRouterPrimaryUpdate(state);
 #endif
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE)
-    Get<DuaManager>().HandleBackboneRouterPrimaryUpdate(state, mConfig);
+    Get<DuaManager>().HandleBackboneRouterPrimaryUpdate(state);
 #endif
 
     OT_UNUSED_VARIABLE(state);

--- a/src/core/backbone_router/bbr_leader.hpp
+++ b/src/core/backbone_router/bbr_leader.hpp
@@ -132,6 +132,13 @@ public:
      */
     uint8_t GetSequenceNumber(void) const { return mSequenceNumber; }
 
+    /**
+     * Selects a random reregistration delay.
+     *
+     * @returns A random reregistration delay in seconds.
+     */
+    uint16_t SelectRandomReregistrationDelay(void) const;
+
 private:
     void AdjustMlrTimeout(void);
 
@@ -173,14 +180,21 @@ public:
     void Reset(void);
 
     /**
-     * Gets the Primary Backbone Router in the Thread Network.
+     * Gets the Primary Backbone Router configuration.
      *
-     * @param[out]  aConfig        The Primary Backbone Router information.
+     * @returns The Primary Backbone Router configuration.
+     */
+    const Config &GetConfig(void) const { return mConfig; }
+
+    /**
+     * Reads the Primary Backbone Router configuration in the Thread Network.
      *
-     * @retval kErrorNone          Successfully got the Primary Backbone Router information.
+     * @param[out]  aConfig        A reference to a `Config` to populate.
+     *
+     * @retval kErrorNone          Successfully read the Primary BBR config. @p aConfig is updated.
      * @retval kErrorNotFound      No Backbone Router in the Thread Network.
      */
-    Error GetConfig(Config &aConfig) const;
+    Error ReadConfig(Config &aConfig) const;
 
     /**
      * Gets the Backbone Router Service ID.

--- a/src/core/backbone_router/bbr_local.cpp
+++ b/src/core/backbone_router/bbr_local.cpp
@@ -237,14 +237,14 @@ exit:
     return;
 }
 
-void Local::HandleBackboneRouterPrimaryUpdate(Leader::State aState, const Config &aConfig)
+void Local::HandleBackboneRouterPrimaryUpdate(Leader::State aState)
 {
     OT_UNUSED_VARIABLE(aState);
 
     VerifyOrExit(IsEnabled() && Get<Mle::Mle>().IsAttached());
 
     // Wait some jitter before trying to Register.
-    if (aConfig.mServer16 == Mle::kInvalidRloc16)
+    if (!Get<Leader>().HasPrimary())
     {
         if (Get<Mle::Mle>().IsLeader())
         {
@@ -259,7 +259,7 @@ void Local::HandleBackboneRouterPrimaryUpdate(Leader::State aState, const Config
             Get<TimeTicker>().RegisterReceiver(TimeTicker::kBbrLocal);
         }
     }
-    else if (aConfig.mServer16 != Get<Mle::Mle>().GetRloc16())
+    else if (!Get<Mle::Mle>().HasRloc16(Get<Leader>().GetConfig().GetServer16()))
     {
         Reset();
     }
@@ -267,9 +267,9 @@ void Local::HandleBackboneRouterPrimaryUpdate(Leader::State aState, const Config
     {
         // Here original PBBR restores its Backbone Router Service from Thread Network,
         // Intentionally skips the state update as PBBR will refresh its service.
-        mSequenceNumber      = aConfig.mSequenceNumber;
-        mReregistrationDelay = aConfig.mReregistrationDelay;
-        mMlrTimeout          = aConfig.mMlrTimeout;
+        mSequenceNumber      = Get<Leader>().GetConfig().mSequenceNumber;
+        mReregistrationDelay = Get<Leader>().GetConfig().mReregistrationDelay;
+        mMlrTimeout          = Get<Leader>().GetConfig().mMlrTimeout;
         IncrementSequenceNumber();
         Get<Notifier>().Signal(kEventThreadBackboneRouterLocalChanged);
         IgnoreError(AddService(kForceRegistration));

--- a/src/core/backbone_router/bbr_local.hpp
+++ b/src/core/backbone_router/bbr_local.hpp
@@ -185,9 +185,8 @@ public:
      * Notifies Primary Backbone Router status.
      *
      * @param[in]  aState   The state or state change of Primary Backbone Router.
-     * @param[in]  aConfig  The Primary Backbone Router service.
      */
-    void HandleBackboneRouterPrimaryUpdate(Leader::State aState, const Config &aConfig);
+    void HandleBackboneRouterPrimaryUpdate(Leader::State aState);
 
     /**
      * Gets the Domain Prefix configuration.

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -129,11 +129,9 @@ exit:
 
 void Manager::HandleMulticastListenerRegistration(const Coap::Msg &aMsg)
 {
-    Error       error     = kErrorNone;
-    bool        isPrimary = Get<Local>().IsPrimary();
-    Mlr::Status status    = Mlr::kStatusSuccess;
-    Config      config;
-
+    Error        error     = kErrorNone;
+    bool         isPrimary = Get<Local>().IsPrimary();
+    Mlr::Status  status    = Mlr::kStatusSuccess;
     OffsetRange  offsetRange;
     Ip6::Address address;
     Ip6::Address addresses[Mlr::kMaxIp6Addresses];
@@ -191,9 +189,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Msg &aMsg)
 
     if (!processTimeoutTlv)
     {
-        IgnoreError(Get<Leader>().GetConfig(config));
-
-        timeout = config.mMlrTimeout;
+        timeout = Get<Leader>().GetConfig().GetMlrTimeout();
     }
     else
     {

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -255,12 +255,11 @@ void DuaManager::NotifyDuplicateDomainUnicastAddress(void)
 
 void DuaManager::UpdateReregistrationDelay(void)
 {
-    uint16_t               delay = 0;
-    BackboneRouter::Config config;
+    uint16_t delay;
 
-    VerifyOrExit(Get<BackboneRouter::Leader>().GetConfig(config) == kErrorNone);
+    VerifyOrExit(Get<BackboneRouter::Leader>().HasPrimary());
 
-    delay = config.mReregistrationDelay > 1 ? Random::NonCrypto::GetUint16InRange(1, config.mReregistrationDelay) : 1;
+    delay = Get<BackboneRouter::Leader>().GetConfig().SelectRandomReregistrationDelay();
 
     if (mDelay.mFields.mReregistrationDelay == 0 || mDelay.mFields.mReregistrationDelay > delay)
     {
@@ -333,11 +332,8 @@ exit:
     return;
 }
 
-void DuaManager::HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState,
-                                                   const BackboneRouter::Config &aConfig)
+void DuaManager::HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState)
 {
-    OT_UNUSED_VARIABLE(aConfig);
-
     if (aState == BackboneRouter::Leader::kStateAdded || aState == BackboneRouter::Leader::kStateToTriggerRereg)
     {
 #if OPENTHREAD_CONFIG_DUA_ENABLE

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -117,9 +117,8 @@ public:
      * Notifies Primary Backbone Router status.
      *
      * @param[in]  aState   The state or state change of Primary Backbone Router.
-     * @param[in]  aConfig  The Primary Backbone Router service.
      */
-    void HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState, const BackboneRouter::Config &aConfig);
+    void HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState);
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
 

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -68,11 +68,8 @@ void Manager::HandleNotifierEvents(Events aEvents)
     }
 }
 
-void Manager::HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState,
-                                                const BackboneRouter::Config &aConfig)
+void Manager::HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState)
 {
-    OT_UNUSED_VARIABLE(aConfig);
-
     RegistrationRequest request = kRenew;
 
     switch (aState)
@@ -471,11 +468,9 @@ exit:
         // If a registration attempt fails, retry it after a random
         // delay (same as re-registration delay).
 
-        BackboneRouter::Config config;
-
-        if (Get<BackboneRouter::Leader>().GetConfig(config) == kErrorNone)
+        if (Get<BackboneRouter::Leader>().HasPrimary())
         {
-            ScheduleSend(DetermineReregistrationDelay(config));
+            ScheduleSend(Get<BackboneRouter::Leader>().GetConfig().SelectRandomReregistrationDelay());
         }
     }
 }
@@ -572,18 +567,7 @@ void Manager::Reregister(void)
     ScheduleNextRegistration(kRenew);
 }
 
-uint16_t Manager::DetermineReregistrationDelay(const BackboneRouter::Config &aConfig)
-{
-    uint16_t delay = 1;
-
-    VerifyOrExit(aConfig.mReregistrationDelay > 1);
-    delay = Random::NonCrypto::GetUint16InRange(1, aConfig.mReregistrationDelay);
-
-exit:
-    return delay;
-}
-
-uint32_t Manager::DetermineRenewDelay(const BackboneRouter::Config &aConfig)
+uint32_t Manager::DetermineRenewDelay(void)
 {
     // As per Thread spec, the renew delay is randomly chosen
     // between (0.5 * MLR-Timeout) and (MLR-Timeout - 9 seconds).
@@ -591,15 +575,16 @@ uint32_t Manager::DetermineRenewDelay(const BackboneRouter::Config &aConfig)
     // potential retransmissions, and acknowledgment before the
     // actual timeout.
 
-    uint32_t timeout = Clamp<uint32_t>(aConfig.mMlrTimeout, BackboneRouter::kMinMlrTimeout, kLongRenewTimeout);
+    uint32_t timeout = Get<BackboneRouter::Leader>().GetConfig().GetMlrTimeout();
+
+    timeout = Clamp<uint32_t>(timeout, BackboneRouter::kMinMlrTimeout, kLongRenewTimeout);
 
     return Random::NonCrypto::GetUint32InRange((timeout / 2) + 1, timeout - kRenewGuardTime);
 }
 
 void Manager::ScheduleNextRegistration(RegistrationRequest aRequest)
 {
-    uint32_t               delay;
-    BackboneRouter::Config config;
+    uint32_t delay;
 
     if (!ShouldRegister())
     {
@@ -607,16 +592,14 @@ void Manager::ScheduleNextRegistration(RegistrationRequest aRequest)
         ExitNow();
     }
 
-    IgnoreError(Get<BackboneRouter::Leader>().GetConfig(config));
-
     switch (aRequest)
     {
     case kReregister:
-        delay = DetermineReregistrationDelay(config);
+        delay = Get<BackboneRouter::Leader>().GetConfig().SelectRandomReregistrationDelay();
         break;
 
     case kRenew:
-        delay = DetermineRenewDelay(config);
+        delay = DetermineRenewDelay();
         break;
 
     default:

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -95,9 +95,8 @@ public:
      * Notifies Primary Backbone Router status.
      *
      * @param[in]  aState   The state or state change of Primary Backbone Router.
-     * @param[in]  aConfig  The Primary Backbone Router service.
      */
-    void HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState, const BackboneRouter::Config &aConfig);
+    void HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State aState);
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     static constexpr uint16_t kMaxChildAddresses = OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD - 1; ///< Max MLR addresses
@@ -163,9 +162,9 @@ private:
 
     DeclareTmfResponseHandlerIn(Manager, HandleResponse);
 
-    static uint16_t DetermineReregistrationDelay(const BackboneRouter::Config &aConfig);
-    static uint32_t DetermineRenewDelay(const BackboneRouter::Config &aConfig);
-    static Error    ParseResponse(Error aResult, Coap::Msg *aMsg, uint8_t &aStatus, AddressArray &aFailedAddresses);
+    uint32_t DetermineRenewDelay(void);
+
+    static Error ParseResponse(Error aResult, Coap::Msg *aMsg, uint8_t &aStatus, AddressArray &aFailedAddresses);
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
     DeclareTmfResponseHandlerIn(Manager, HandleRegisterResponse);


### PR DESCRIPTION
This commit refactors and improves the Backbone Router callback and `Config` introducing new methods and encapsulating configuration-related logic.

Key changes:
- Added `Leader::GetConfig()` to provide direct access to the internal cached `Config` object.
- Renamed `Leader::GetConfig(Config &)` to `Leader::ReadConfig(Config &)` to better reflect its purpose.
- Added `Config::SelectRandomReregistrationDelay()` to encapsulate the logic for selecting a random re-registration delay.
- Simplified variosu `HandleBackboneRouterPrimaryUpdate()` callbacks to remove the parameter `aConfig`,  allowing these modules to use `Leader::GetConfig()` instead.

----

~This PR include commit from https://github.com/openthread/openthread/pull/13108. Please check and review the last commit. Thanks.~
