### PR TITLE
[nexus] add `OT_NEXUS_BUILD_TESTS` cmake option

### DIFF
--- a/tests/nexus/CMakeLists.txt
+++ b/tests/nexus/CMakeLists.txt
@@ -47,7 +47,11 @@ set(COMMON_COMPILE_OPTIONS
     -DOPENTHREAD_CONFIG_USE_STD_NEW=1
 )
 
+option(OT_NEXUS_BUILD_TESTS "Build Nexus test executables" ON)
 option(OT_NEXUS_GRPC "Enable Nexus gRPC" OFF)
+
+message(STATUS "OT_NEXUS_BUILD_TESTS=\"${OT_NEXUS_BUILD_TESTS}\"")
+message(STATUS "OT_NEXUS_GRPC=\"${OT_NEXUS_GRPC}\"")
 
 if(OT_NEXUS_GRPC AND NOT EMSCRIPTEN)
     find_package(gRPC CONFIG REQUIRED)
@@ -175,33 +179,39 @@ macro(ot_nexus_test name labels)
     # file `test_{name}.cpp`. The `labels` argument assigns categories to the
     # test, allowing us to run specific subsets using `ctest -L {label}`.
 
-    add_executable(nexus_${name}
-        test_${name}.cpp ${ARGN}
-    )
+    if(OT_NEXUS_BUILD_TESTS)
 
-    target_include_directories(nexus_${name}
-    PRIVATE
-        ${COMMON_INCLUDES}
-    )
+        add_executable(nexus_${name}
+            test_${name}.cpp ${ARGN}
+        )
 
-    target_link_libraries(nexus_${name}
-    PRIVATE
-        ${COMMON_LIBS}
-    )
+        target_include_directories(nexus_${name}
+        PRIVATE
+            ${COMMON_INCLUDES}
+        )
 
-    target_compile_options(nexus_${name}
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-        ${OT_CFLAGS}
-    )
+        target_link_libraries(nexus_${name}
+        PRIVATE
+            ${COMMON_LIBS}
+        )
 
-    add_test(NAME nexus_${name} COMMAND nexus_${name})
+        target_compile_options(nexus_${name}
+        PRIVATE
+            ${COMMON_COMPILE_OPTIONS}
+            ${OT_CFLAGS}
+        )
 
-    set_tests_properties(nexus_${name} PROPERTIES LABELS "${labels}")
+        add_test(NAME nexus_${name} COMMAND nexus_${name})
+
+        set_tests_properties(nexus_${name} PROPERTIES LABELS "${labels}")
+
+    endif()
+
 endmacro()
 
 
 #----------------------------------------------------------------------------------------------------------------------
+
 # Cert tests
 ot_nexus_test(1_1_5_1_1 "cert;nexus")
 ot_nexus_test(1_1_5_1_2 "cert;nexus")

--- a/tests/nexus/build.sh
+++ b/tests/nexus/build.sh
@@ -45,6 +45,7 @@ else
 fi
 
 long_routes=OFF
+build_tests=ON
 
 case $1 in
     trel)
@@ -59,6 +60,11 @@ case $1 in
         fifteenfour=ON
         wasm=OFF
         long_routes=ON
+        ;;
+    no_tests)
+        fifteenfour=ON
+        wasm=OFF
+        build_tests=OFF
         ;;
     *)
         fifteenfour=ON
@@ -81,6 +87,7 @@ CMAKE_ARGS=(
     -DOT_APP_RCP=OFF
     -DOT_15_4="${fifteenfour}"
     -DOT_MLE_LONG_ROUTES="${long_routes}"
+    -DOT_NEXUS_BUILD_TESTS="${build_tests}"
     -DOT_PROJECT_CONFIG="${top_srcdir}/tests/nexus/openthread-core-nexus-config.h"
 )
 


### PR DESCRIPTION
This commit introduces a new CMake option `OT_NEXUS_BUILD_TESTS` (defaulting to `ON`) to control whether the individual Nexus test executables are built.

When developing or debugging the OpenThread core stack within the Nexus framework, building the large number of certification tests can be time-consuming. This option allows developers to skip building the tests and only compile the `ot-nexus-platform` library and OT core.

The check is implemented inside the `ot_nexus_test` macro to ensure all test definitions automatically respect the flag without requiring large conditional blocks in the `CMakeLists.txt` file.

Additionally, a `no_tests` argument is added to `tests/nexus/build.sh` to easily invoke this configuration from the command line.

----

It can help shave off ~10 seconds. A full Nexus build takes ~31 seconds, and a build with `no_tests` takes `~21` seconds (tested on an M4 MacBook Pro).