### PR TITLE
[ble] clean up message parsing in `BleSecure::HandleTransport()`

### DIFF
--- a/src/core/radio/ble_secure.cpp
+++ b/src/core/radio/ble_secure.cpp
@@ -633,38 +633,25 @@ Error BleSecure::HandleTransport(void *aContext, ot::Message &aMessage, const Ip
 
 Error BleSecure::HandleTransport(ot::Message &aMessage)
 {
-    otBleRadioPacket packet;
-    uint16_t         len    = aMessage.GetLength();
-    uint16_t         offset = 0;
-    Error            error  = kErrorNone;
+    Error       error = kErrorNone;
+    RadioPacket packet;
+    OffsetRange offsetRange;
 
-    while (len > 0)
+    offsetRange.InitFromMessageFullLength(aMessage);
+
+    while (!offsetRange.IsEmpty())
     {
-        if (len <= mMtuSize - kGattOverhead)
-        {
-            packet.mLength = len;
-        }
-        else
-        {
-            packet.mLength = mMtuSize - kGattOverhead;
-        }
+        packet.mLength = Min(offsetRange.GetLength(), Min<uint16_t>(mMtuSize - kGattOverhead, kPacketBufferSize));
 
-        if (packet.mLength > kPacketBufferSize)
-        {
-            packet.mLength = kPacketBufferSize;
-        }
-
-        IgnoreError(aMessage.Read(offset, mPacketBuffer, packet.mLength));
+        IgnoreError(aMessage.ReadAndAdvance(offsetRange, mPacketBuffer, packet.mLength));
         packet.mValue = mPacketBuffer;
         packet.mPower = OT_BLE_DEFAULT_POWER;
 
         SuccessOrExit(error = otPlatBleGattServerIndicate(&GetInstance(), kTxBleHandle, &packet));
-
-        len -= packet.mLength;
-        offset += packet.mLength;
     }
 
     aMessage.Free();
+
 exit:
     return error;
 }

--- a/src/core/radio/ble_secure.hpp
+++ b/src/core/radio/ble_secure.hpp
@@ -346,6 +346,8 @@ private:
         kNotAdvertising = 3, // Ble secure is started but not advertising.
     };
 
+    typedef otBleRadioPacket RadioPacket;
+
     static constexpr uint8_t  kInitialMtuSize   = OT_BLE_ATT_MTU_DEFAULT;
     static constexpr uint8_t  kMinMtuSize       = OT_BLE_ATT_MTU_MIN;
     static constexpr uint8_t  kMaxMtuSize       = OT_BLE_ATT_MTU_MAX;


### PR DESCRIPTION
This commit refactors `BleSecure::HandleTransport()` to use the `OffsetRange` and `Message::ReadAndAdvance()` helper methods. This replaces manual length and offset tracking, resulting in cleaner and safer message parsing logic.

Additionally:
- Simplified the payload length calculation by using nested `Min()` calls instead of multiple `if/else` blocks.
- Added a `RadioPacket` typedef in `BleSecure` to alias the public `otBleRadioPacket` structure, aligning with OpenThread's core namespace conventions.