### PR TITLE
[tlv] add `Tlv::AppendTlvWithValueFromMessage()` helper

### DIFF
--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -253,24 +253,37 @@ template Error Tlv::AppendUintTlv<uint32_t>(Message &aMessage, uint8_t aType, ui
 
 Error Tlv::AppendEmptyTlv(Message &aMessage, uint8_t aType) { return AppendTlv(aMessage, aType, nullptr, 0); }
 
-Error Tlv::AppendTlv(Message &aMessage, uint8_t aType, const void *aValue, uint16_t aLength)
+Error Tlv::AppendTlvHeader(Message &aMessage, uint8_t aType, uint16_t aLength)
 {
-    Error       error = kErrorNone;
-    ExtendedTlv extTlv;
-    Tlv         tlv;
+    uint16_t size;
+
+    union
+    {
+        Tlv         tlv;
+        ExtendedTlv extTlv;
+    };
+
+    tlv.SetType(aType);
 
     if (aLength > kBaseTlvMaxLength)
     {
-        extTlv.SetType(aType);
         extTlv.SetLength(aLength);
-        SuccessOrExit(error = aMessage.Append(extTlv));
+        size = sizeof(ExtendedTlv);
     }
     else
     {
-        tlv.SetType(aType);
         tlv.SetLength(static_cast<uint8_t>(aLength));
-        SuccessOrExit(error = aMessage.Append(tlv));
+        size = sizeof(Tlv);
     }
+
+    return aMessage.AppendBytes(&tlv, size);
+}
+
+Error Tlv::AppendTlv(Message &aMessage, uint8_t aType, const void *aValue, uint16_t aLength)
+{
+    Error error;
+
+    SuccessOrExit(error = AppendTlvHeader(aMessage, aType, aLength));
 
     VerifyOrExit(aLength > 0);
     error = aMessage.AppendBytes(aValue, aLength);
@@ -279,16 +292,25 @@ exit:
     return error;
 }
 
+Error Tlv::AppendTlvWithValueFromMessage(Message           &aMessage,
+                                         uint8_t            aType,
+                                         const Message     &aValueMsg,
+                                         const OffsetRange &aValueMsgOffsetRange)
+{
+    Error error;
+
+    SuccessOrExit(error = AppendTlvHeader(aMessage, aType, aValueMsgOffsetRange.GetLength()));
+    error = aMessage.AppendBytesFromMessage(aValueMsg, aValueMsgOffsetRange);
+
+exit:
+    return error;
+}
+
 Error Tlv::StartTlv(Message &aMessage, uint8_t aType, Bookmark &aBookmark)
 {
-    Tlv tlv;
-
-    tlv.SetType(aType);
-    tlv.SetLength(0);
-
     aBookmark = aMessage.GetLength();
 
-    return aMessage.Append(tlv);
+    return AppendTlvHeader(aMessage, aType, 0);
 }
 
 Error Tlv::AdjustTlv(Message &aMessage, Bookmark aBookmark)

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -599,6 +599,25 @@ public:
     static Error AppendTlv(Message &aMessage, uint8_t aType, const void *aValue, uint16_t aLength);
 
     /**
+     * Appends a TLV with a given type and value read from another message.
+     *
+     * This method automatically formats the TLV as an Extended TLV if the length exceeds `kBaseTlvMaxLength` (254).
+     *
+     * @param[in] aMessage                The message to append the TLV to.
+     * @param[in] aType                   The TLV type to append.
+     * @param[in] aValueMsg               The message to read the TLV value from.
+     * @param[in] aValueMsgOffsetRange    The offset range in @p aValueMsg to read the value from.
+     *
+     * @retval kErrorNone     Successfully appended the TLV.
+     * @retval kErrorNoBufs   Insufficient available buffers to grow the message.
+     * @retval kErrorParse    Not enough bytes in @p aValueMsg to read the @p aValueMsgOffsetRange.
+     */
+    static Error AppendTlvWithValueFromMessage(Message           &aMessage,
+                                               uint8_t            aType,
+                                               const Message     &aValueMsg,
+                                               const OffsetRange &aValueMsgOffsetRange);
+
+    /**
      * Appends a TLV with a given type and value to a message.
      *
      * The TLV is appended as either a regular or an extended TLV based on the given @p aLength. If the length
@@ -820,6 +839,7 @@ protected:
     static const uint8_t kExtendedLength = 255; // Extended Length value.
 
 private:
+    static Error AppendTlvHeader(Message &aMessage, uint8_t aType, uint16_t aLength);
     static Error FindTlv(const Message &aMessage, uint8_t aType, void *aValue, uint16_t aLength);
     static Error FindStringTlv(const Message &aMessage, uint8_t aType, uint8_t aMaxStringLength, char *aValue);
     static Error AppendStringTlv(Message &aMessage, uint8_t aType, uint8_t aMaxStringLength, const char *aValue);

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -971,7 +971,7 @@ Error Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::MessageInfo 
     OT_UNUSED_VARIABLE(aMessageInfo);
 
     Error                   error = kErrorNone;
-    ExtendedTlv             tlv;
+    OffsetRange             offsetRange;
     OwnedPtr<Coap::Message> message;
     Kek                     kek;
 
@@ -989,10 +989,9 @@ Error Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::MessageInfo 
         SuccessOrExit(error = Tlv::Append<JoinerRouterKekTlv>(*message, kek));
     }
 
-    tlv.SetType(Tlv::kJoinerDtlsEncapsulation);
-    tlv.SetLength(aMessage.GetLength());
-    SuccessOrExit(error = message->Append(tlv));
-    SuccessOrExit(error = message->AppendBytesFromMessage(aMessage, 0, aMessage.GetLength()));
+    offsetRange.InitFromMessageFullLength(aMessage);
+    SuccessOrExit(
+        error = Tlv::AppendTlvWithValueFromMessage(*message, Tlv::kJoinerDtlsEncapsulation, aMessage, offsetRange));
 
     SuccessOrExit(error = Get<Tmf::Agent>().SendMessageToRloc(*message, mJoinerRloc));
     message.Release();

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -118,7 +118,6 @@ void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &a
 {
     Error          error;
     Coap::Message *message = nullptr;
-    ExtendedTlv    tlv;
     uint16_t       borderAgentRloc;
     OffsetRange    offsetRange;
 
@@ -134,11 +133,8 @@ void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &a
     SuccessOrExit(error = Tlv::Append<JoinerRouterLocatorTlv>(*message, Get<Mle::Mle>().GetRloc16()));
 
     offsetRange.InitFromMessageOffsetToEnd(aMessage);
-
-    tlv.SetType(Tlv::kJoinerDtlsEncapsulation);
-    tlv.SetLength(offsetRange.GetLength());
-    SuccessOrExit(error = message->Append(tlv));
-    SuccessOrExit(error = message->AppendBytesFromMessage(aMessage, offsetRange));
+    SuccessOrExit(
+        error = Tlv::AppendTlvWithValueFromMessage(*message, Tlv::kJoinerDtlsEncapsulation, aMessage, offsetRange));
 
     SuccessOrExit(error = Get<Tmf::Agent>().SendMessageToRloc(*message, borderAgentRloc));
 

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -693,26 +693,12 @@ Error TcatAgent::HandlePing(const Message     &aIncomingMessage,
                             const OffsetRange &aOffsetRange,
                             bool              &aResponse)
 {
-    Error           error = kErrorNone;
-    ot::ExtendedTlv extTlv;
-    ot::Tlv         tlv;
+    Error error;
 
     VerifyOrExit(aOffsetRange.GetLength() <= kPingPayloadMaxLength, error = kErrorParse);
 
-    if (aOffsetRange.GetLength() > ot::Tlv::kBaseTlvMaxLength)
-    {
-        extTlv.SetType(kTlvResponseWithPayload);
-        extTlv.SetLength(aOffsetRange.GetLength());
-        SuccessOrExit(error = aOutgoingMessage.Append(extTlv));
-    }
-    else
-    {
-        tlv.SetType(kTlvResponseWithPayload);
-        tlv.SetLength(static_cast<uint8_t>(aOffsetRange.GetLength()));
-        SuccessOrExit(error = aOutgoingMessage.Append(tlv));
-    }
-
-    SuccessOrExit(error = aOutgoingMessage.AppendBytesFromMessage(aIncomingMessage, aOffsetRange));
+    SuccessOrExit(error = Tlv::AppendTlvWithValueFromMessage(aOutgoingMessage, kTlvResponseWithPayload,
+                                                             aIncomingMessage, aOffsetRange));
     aResponse = true;
 
 exit:


### PR DESCRIPTION
This commit introduces a new helper method that allows appending a TLV by copying its value directly from a specified `OffsetRange` of another `Message`.

This helper automatically handles formatting the TLV as an Extended TLV if the length exceeds 254 bytes, eliminating the need for manual length checks and TLV header construction at the call sites.

Key changes:
- Added `Tlv::AppendTlvWithValueFromMessage()`.
- Refactored TLV header construction into a private helper `Tlv::AppendTlvHeader()` to share logic between `AppendTlv` variants and `StartTlv()`.
- Updated `Commissioner::SendRelayTransmit()` and  `JoinerRouter::HandleUdpReceive()` to use the new helper for
  `JoinerDtlsEncapsulation` TLVs.
- Updated `TcatAgent::HandlePing()` to use the new helper, significantly  simplifying the payload response generation.