### PR TITLE
[core] Add `otDatasetIsConnectivityAffected` API

### DIFF
--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -634,6 +634,26 @@ void otDatasetConvertToTlvs(const otOperationalDataset *aDataset, otOperationalD
 otError otDatasetUpdateTlvs(const otOperationalDataset *aDataset, otOperationalDatasetTlvs *aDatasetTlvs);
 
 /**
+ * This method checks if applying the given dataset can impact the Thread network connectivity.
+ *
+ * Changes in any of the following fields (if presents) of the dataset can impact the Thread network connectivity:
+ * - Channel
+ * - Mesh-Local Prefix
+ * - PAN ID
+ * - Network Key
+ * - Security Policy fields:
+ *   - R bit (when changed from 1 to 0)
+ *   - NCR bit (when changed from 0 to 1)
+ *   - VR field (when increasing the value VR)
+ *
+ * @param[in] aDatasetOld  The pointer to old Operational Dataset.
+ * @param[in] aDatasetNew  The pointer to new Operational Dataset.
+ *
+ * @retval true   The given dataset can impact the network connectivity.
+ * @retval false  The given dataset does not impact the network connectivity.
+ */
+bool otDatasetIsConnectivityAffected(const otOperationalDataset *aDatasetOld, const otOperationalDataset *aDatasetNew);
+/**
  * @}
  */
 

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (596)
+#define OPENTHREAD_API_VERSION (597)
 
 /**
  * @addtogroup api-instance

--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -228,3 +228,53 @@ otError otDatasetUpdateTlvs(const otOperationalDataset *aDataset, otOperationalD
 exit:
     return error;
 }
+
+bool otDatasetIsConnectivityAffected(const otOperationalDataset *aDatasetOld, const otOperationalDataset *aDatasetNew)
+{
+    bool ret = true;
+
+    AssertPointerIsNotNull(aDatasetOld);
+    AssertPointerIsNotNull(aDatasetNew);
+
+    const MeshCoP::Dataset::Info &datasetOld = AsCoreType(aDatasetOld);
+    const MeshCoP::Dataset::Info &datasetNew = AsCoreType(aDatasetNew);
+
+    if (datasetOld.IsPresent<MeshCoP::Dataset::kChannel>() && datasetNew.IsPresent<MeshCoP::Dataset::kChannel>())
+    {
+        VerifyOrExit(datasetOld.Get<MeshCoP::Dataset::kChannel>() == datasetNew.Get<MeshCoP::Dataset::kChannel>());
+    }
+
+    if (datasetOld.IsPresent<MeshCoP::Dataset::kPanId>() && datasetNew.IsPresent<MeshCoP::Dataset::kPanId>())
+    {
+        VerifyOrExit(datasetOld.Get<MeshCoP::Dataset::kPanId>() == datasetNew.Get<MeshCoP::Dataset::kPanId>());
+    }
+
+    if (datasetOld.IsPresent<MeshCoP::Dataset::kNetworkKey>() && datasetNew.IsPresent<MeshCoP::Dataset::kNetworkKey>())
+    {
+        VerifyOrExit(datasetOld.Get<MeshCoP::Dataset::kNetworkKey>() ==
+                     datasetNew.Get<MeshCoP::Dataset::kNetworkKey>());
+    }
+
+    if (datasetOld.IsPresent<MeshCoP::Dataset::kMeshLocalPrefix>() &&
+        datasetNew.IsPresent<MeshCoP::Dataset::kMeshLocalPrefix>())
+    {
+        VerifyOrExit(datasetOld.Get<MeshCoP::Dataset::kMeshLocalPrefix>() ==
+                     datasetNew.Get<MeshCoP::Dataset::kMeshLocalPrefix>());
+    }
+
+    if (datasetOld.IsPresent<MeshCoP::Dataset::kSecurityPolicy>() &&
+        datasetNew.IsPresent<MeshCoP::Dataset::kSecurityPolicy>())
+    {
+        SecurityPolicy policyOld = datasetOld.Get<MeshCoP::Dataset::kSecurityPolicy>();
+        SecurityPolicy policyNew = datasetNew.Get<MeshCoP::Dataset::kSecurityPolicy>();
+
+        VerifyOrExit(!policyOld.mRoutersEnabled || policyNew.mRoutersEnabled);
+        VerifyOrExit(policyOld.mNonCcmRoutersEnabled || !policyNew.mNonCcmRoutersEnabled);
+        VerifyOrExit(!(policyOld.mVersionThresholdForRouting < policyNew.mVersionThresholdForRouting));
+    }
+
+    ret = false;
+
+exit:
+    return ret;
+}

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -49,16 +49,13 @@ Error DatasetManager::ProcessSetOrReplaceRequest(MgmtCommand          aCommand,
                                                  const Coap::Message &aMessage,
                                                  RequestInfo         &aInfo) const
 {
-    Error              error = kErrorParse;
-    Dataset            dataset;
-    OffsetRange        offsetRange;
-    Timestamp          activeTimestamp;
-    ChannelTlvValue    channelValue;
-    uint16_t           sessionId;
-    Ip6::NetworkPrefix meshLocalPrefix;
-    NetworkKey         networkKey;
-    uint16_t           panId;
-    uint32_t           delayTimer;
+    Error       error = kErrorParse;
+    Dataset     dataset;
+    OffsetRange offsetRange;
+    Timestamp   activeTimestamp;
+    NetworkKey  localNetworkKey;
+    uint16_t    sessionId;
+    uint32_t    delayTimer;
 
     aInfo.Clear();
 
@@ -86,34 +83,29 @@ Error DatasetManager::ProcessSetOrReplaceRequest(MgmtCommand          aCommand,
     // Determine whether the new Dataset affects connectivity
     // or network key.
 
-    if ((dataset.Read<ChannelTlv>(channelValue) == kErrorNone) &&
-        (channelValue.GetChannel() != Get<Mac::Mac>().GetPanChannel()))
+    Dataset::Info localDatasetInfo;
+    localDatasetInfo.Clear();
+    Get<KeyManager>().GetNetworkKey(localNetworkKey);
+
+    localDatasetInfo.Set<Dataset::kChannel>(Get<Mac::Mac>().GetPanChannel());
+    localDatasetInfo.Set<Dataset::kPanId>(Get<Mac::Mac>().GetPanId());
+    localDatasetInfo.Set<Dataset::kMeshLocalPrefix>(Get<Mle::Mle>().GetMeshLocalPrefix());
+    localDatasetInfo.Set<Dataset::kNetworkKey>(localNetworkKey);
+    localDatasetInfo.Set<Dataset::kSecurityPolicy>(Get<KeyManager>().GetSecurityPolicy());
+
+    Dataset::Info datasetInfo;
+    datasetInfo.Clear();
+    dataset.ConvertTo(datasetInfo);
+
+    if (datasetInfo.IsPresent<Dataset::kNetworkKey>() &&
+        datasetInfo.Get<Dataset::kNetworkKey>() != localDatasetInfo.Get<Dataset::kNetworkKey>())
     {
-        aInfo.mAffectsConnectivity = true;
+        aInfo.mAffectsNetworkKey = true;
     }
 
-    if ((dataset.Read<PanIdTlv>(panId) == kErrorNone) && (panId != Get<Mac::Mac>().GetPanId()))
+    if (otDatasetIsConnectivityAffected(&localDatasetInfo, &datasetInfo))
     {
         aInfo.mAffectsConnectivity = true;
-    }
-
-    if ((dataset.Read<MeshLocalPrefixTlv>(meshLocalPrefix) == kErrorNone) &&
-        (meshLocalPrefix != Get<Mle::Mle>().GetMeshLocalPrefix()))
-    {
-        aInfo.mAffectsConnectivity = true;
-    }
-
-    if (dataset.Read<NetworkKeyTlv>(networkKey) == kErrorNone)
-    {
-        NetworkKey localNetworkKey;
-
-        Get<KeyManager>().GetNetworkKey(localNetworkKey);
-
-        if (networkKey != localNetworkKey)
-        {
-            aInfo.mAffectsConnectivity = true;
-            aInfo.mAffectsNetworkKey   = true;
-        }
     }
 
     // Check active timestamp rollback. If there is no change to


### PR DESCRIPTION
This function checks if applying the given dataset can impact the Thread network connectivity.

Changes in any of the following fields (if presents) of the dataset can impact the Thread network connectivity (based on Section "8.7.4. Updating the Active Operational Dataset" of Thread spec):
- Channel
- Mesh-Local Prefix
- PAN ID
- Network Key
- Security Policy fields:
  - R bit (when changed from 1 to 0)
  - NCR bit (when changed from 0 to 1)
  - VR field (when increasing the value VR)