### PR TITLE
[bbr] fix overflow in `Config::SelectRandomReregistrationDelay()`

### DIFF
--- a/src/core/backbone_router/bbr_leader.cpp
+++ b/src/core/backbone_router/bbr_leader.cpp
@@ -66,7 +66,7 @@ uint16_t Config::SelectRandomReregistrationDelay(void) const
     uint16_t delay = 1;
 
     VerifyOrExit(mReregistrationDelay > 1);
-    delay = Random::NonCrypto::GetUint16InRange(1, mReregistrationDelay + 1);
+    delay = 1 + Random::NonCrypto::GetUint16InRange(0, mReregistrationDelay);
 
 exit:
     return delay;


### PR DESCRIPTION
This commit fixes a potential `uint16_t` overflow in `Config::SelectRandomReregistrationDelay()` which could occur if `mReregistrationDelay` was set to the maximum `uint16_t` value.

The `Random::NonCrypto::GetUint16InRange(lower, upper)` function includes the lower bound but excludes the upper bound. Previously, the code called `GetUint16InRange(1, mReregistrationDelay + 1)`, which would overflow the upper bound if `mReregistrationDelay` was `0xffff`. The logic is updated to `1 + GetUint16InRange(0, mReregistrationDelay)`, which safely produces a random value in the range `[1, mReregistrationDelay]` without overflow.