### PR TITLE
OPENTHREAD-6583: MAC RX AES-CCM* decrypt via otPlatCryptoAesDecryptAn…

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (601)
+#define OPENTHREAD_API_VERSION (602)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/crypto.h
+++ b/include/openthread/platform/crypto.h
@@ -429,6 +429,61 @@ otError otPlatCryptoAesSetKey(otCryptoContext *aContext, const otCryptoKey *aKey
 otError otPlatCryptoAesEncrypt(otCryptoContext *aContext, const uint8_t *aInput, uint8_t *aOutput);
 
 /**
+ * Decrypt and verify the given AES-CCM* payload.
+ *
+ * @param[in]      aContext        AES context initialised with `otPlatCryptoAesSetKey()`.
+ * @param[in]      aNonce          Nonce (13 bytes, IEEE 802.15.4 CCM* format).
+ * @param[in]      aHeader         Additional authenticated data (MAC header).
+ * @param[in]      aHeaderLength   Length of @p aHeader in bytes.
+ * @param[in,out]  aPayload        Ciphertext on input; replaced with plaintext in place on success.
+ * @param[in]      aPayloadLength  Length of @p aPayload in bytes.
+ * @param[in]      aTag            MIC buffer of length @p aTagLength bytes.
+ * @param[in]      aTagLength      MIC length in bytes (4, 8, or 16).
+ *
+ * @retval OT_ERROR_NONE          Successfully decrypted and verified @p aPayload.
+ * @retval OT_ERROR_SECURITY      MIC verification failed.
+ * @retval OT_ERROR_INVALID_ARGS  @p aContext, @p aNonce, @p aPayload, or @p aTag was NULL.
+ * @retval OT_ERROR_FAILED        Other failure.
+ *
+ * @note This API is only used by OT core when `OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE` is enabled.
+ */
+otError otPlatCryptoAesDecryptAndVerify(otCryptoContext *aContext,
+                                        const uint8_t   *aNonce,
+                                        const void      *aHeader,
+                                        uint16_t         aHeaderLength,
+                                        void            *aPayload,
+                                        uint16_t         aPayloadLength,
+                                        const void      *aTag,
+                                        uint8_t          aTagLength);
+
+/**
+ * Encrypt and tag the given AES-CCM* payload.
+ *
+ * @param[in]      aContext        AES context initialised with `otPlatCryptoAesSetKey()`.
+ * @param[in]      aNonce          Nonce (13 bytes, IEEE 802.15.4 CCM* format).
+ * @param[in]      aHeader         Additional authenticated data (MAC header).
+ * @param[in]      aHeaderLength   Length of @p aHeader in bytes.
+ * @param[in,out]  aPayload        Plaintext on input; replaced with ciphertext in place on success.
+ * @param[in]      aPayloadLength  Length of @p aPayload in bytes.
+ * @param[out]     aTag            Buffer to receive the MIC; must be at least @p aTagLength bytes.
+ * @param[in]      aTagLength      MIC length in bytes (4, 8, or 16).
+ *
+ * @retval OT_ERROR_NONE          Successfully encrypted @p aPayload and generated MIC in @p aTag.
+ * @retval OT_ERROR_INVALID_ARGS  @p aContext, @p aNonce, @p aPayload, or @p aTag was NULL.
+ * @retval OT_ERROR_FAILED        Other failure.
+ *
+ * @note This API is only used by OT core when `OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE` is enabled.
+ */
+otError otPlatCryptoAesEncryptAndTag(otCryptoContext *aContext,
+                                     const uint8_t   *aNonce,
+                                     const void      *aHeader,
+                                     uint16_t         aHeaderLength,
+                                     void            *aPayload,
+                                     uint16_t         aPayloadLength,
+                                     void            *aTag,
+                                     uint8_t          aTagLength);
+
+/**
  * Free the AES context.
  *
  * @param[in]  aContext           Context for AES operation.

--- a/src/core/config/crypto.h
+++ b/src/core/config/crypto.h
@@ -68,6 +68,20 @@
 #define OPENTHREAD_CONFIG_CRYPTO_PLATFORM_ALLOCS_CONTEXT 0
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+ *
+ * Define to 1 to enable the platform AES-CCM* hook for MAC frame security.
+ *
+ * When enabled, `ProcessTransmitAesCcm()` and `ProcessReceiveAesCcm()` call
+ * `otPlatCryptoAesEncryptAndTag()` and `otPlatCryptoAesDecryptAndVerify()` respectively,
+ * allowing a platform to offload MAC frame AEAD to a hardware accelerator.
+ * When disabled (default), the OpenThread core `Crypto::AesCcm` engine is used.
+ */
+#ifndef OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+#define OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE 0
+#endif
+
 #if OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_PLATFORM
 
 /**

--- a/src/core/crypto/aes_ccm.cpp
+++ b/src/core/crypto/aes_ccm.cpp
@@ -297,5 +297,29 @@ void AesCcm::GenerateNonce(const Mac::ExtAddress &aAddress,
     aNonce[0] = aSecurityLevel;
 }
 
+#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+Error AesCcm::DecryptAndVerify(const uint8_t *aNonce,
+                               const void    *aHeader,
+                               uint16_t       aHeaderLength,
+                               void          *aPayload,
+                               uint16_t       aPayloadLength,
+                               const void    *aTag,
+                               uint8_t        aTagLength)
+{
+    return mEcb.DecryptAndVerify(aNonce, aHeader, aHeaderLength, aPayload, aPayloadLength, aTag, aTagLength);
+}
+
+Error AesCcm::EncryptAndTag(const uint8_t *aNonce,
+                            const void    *aHeader,
+                            uint16_t       aHeaderLength,
+                            void          *aPayload,
+                            uint16_t       aPayloadLength,
+                            void          *aTag,
+                            uint8_t        aTagLength)
+{
+    return mEcb.EncryptAndTag(aNonce, aHeader, aHeaderLength, aPayload, aPayloadLength, aTag, aTagLength);
+}
+#endif
+
 } // namespace Crypto
 } // namespace ot

--- a/src/core/crypto/aes_ccm.hpp
+++ b/src/core/crypto/aes_ccm.hpp
@@ -187,6 +187,53 @@ public:
                               uint8_t                aSecurityLevel,
                               uint8_t               *aNonce);
 
+#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+    /**
+     * Decrypts and verifies the given AES-CCM* payload via the platform hook.
+     *
+     * @param[in]      aNonce          Nonce (13 bytes, IEEE 802.15.4 CCM* format).
+     * @param[in]      aHeader         Additional authenticated data.
+     * @param[in]      aHeaderLength   Length of @p aHeader in bytes.
+     * @param[in,out]  aPayload        Ciphertext on input; replaced with plaintext in place on success.
+     * @param[in]      aPayloadLength  Length of @p aPayload in bytes.
+     * @param[in]      aTag            MIC buffer of length @p aTagLength bytes.
+     * @param[in]      aTagLength      MIC length in bytes (4, 8, or 16).
+     *
+     * @retval kErrorNone      Successfully decrypted and verified @p aPayload.
+     * @retval kErrorSecurity  MIC verification failed.
+     * @retval kErrorFailed    Platform operation failed.
+     */
+    Error DecryptAndVerify(const uint8_t *aNonce,
+                           const void    *aHeader,
+                           uint16_t       aHeaderLength,
+                           void          *aPayload,
+                           uint16_t       aPayloadLength,
+                           const void    *aTag,
+                           uint8_t        aTagLength);
+
+    /**
+     * Encrypts and tags the given AES-CCM* payload via the platform hook.
+     *
+     * @param[in]      aNonce          Nonce (13 bytes, IEEE 802.15.4 CCM* format).
+     * @param[in]      aHeader         Additional authenticated data.
+     * @param[in]      aHeaderLength   Length of @p aHeader in bytes.
+     * @param[in,out]  aPayload        Plaintext on input; replaced with ciphertext in place on success.
+     * @param[in]      aPayloadLength  Length of @p aPayload in bytes.
+     * @param[out]     aTag            Buffer to receive the MIC; must be at least @p aTagLength bytes.
+     * @param[in]      aTagLength      MIC length in bytes (4, 8, or 16).
+     *
+     * @retval kErrorNone    Successfully encrypted @p aPayload and generated MIC in @p aTag.
+     * @retval kErrorFailed  Platform operation failed.
+     */
+    Error EncryptAndTag(const uint8_t *aNonce,
+                        const void    *aHeader,
+                        uint16_t       aHeaderLength,
+                        void          *aPayload,
+                        uint16_t       aPayloadLength,
+                        void          *aTag,
+                        uint8_t        aTagLength);
+#endif
+
 private:
     AesEcb   mEcb;
     uint8_t  mBlock[AesEcb::kBlockSize];

--- a/src/core/crypto/aes_ecb.cpp
+++ b/src/core/crypto/aes_ecb.cpp
@@ -47,6 +47,32 @@ void AesEcb::Encrypt(const uint8_t aInput[kBlockSize], uint8_t aOutput[kBlockSiz
     SuccessOrAssert(otPlatCryptoAesEncrypt(&mContext, aInput, aOutput));
 }
 
+#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+Error AesEcb::DecryptAndVerify(const uint8_t *aNonce,
+                               const void    *aHeader,
+                               uint16_t       aHeaderLength,
+                               void          *aPayload,
+                               uint16_t       aPayloadLength,
+                               const void    *aTag,
+                               uint8_t        aTagLength)
+{
+    return otPlatCryptoAesDecryptAndVerify(&mContext, aNonce, aHeader, aHeaderLength, aPayload, aPayloadLength, aTag,
+                                           aTagLength);
+}
+
+Error AesEcb::EncryptAndTag(const uint8_t *aNonce,
+                            const void    *aHeader,
+                            uint16_t       aHeaderLength,
+                            void          *aPayload,
+                            uint16_t       aPayloadLength,
+                            void          *aTag,
+                            uint8_t        aTagLength)
+{
+    return otPlatCryptoAesEncryptAndTag(&mContext, aNonce, aHeader, aHeaderLength, aPayload, aPayloadLength, aTag,
+                                        aTagLength);
+}
+#endif
+
 AesEcb::~AesEcb(void) { SuccessOrAssert(otPlatCryptoAesFree(&mContext)); }
 
 } // namespace Crypto

--- a/src/core/crypto/aes_ecb.hpp
+++ b/src/core/crypto/aes_ecb.hpp
@@ -39,6 +39,7 @@
 #include <openthread/platform/crypto.h>
 
 #include "common/code_utils.hpp"
+#include "common/error.hpp"
 #include "crypto/context_size.hpp"
 #include "crypto/storage.hpp"
 
@@ -83,6 +84,57 @@ public:
      * @param[out]  aOutput  A pointer to the output buffer.
      */
     void Encrypt(const uint8_t aInput[kBlockSize], uint8_t aOutput[kBlockSize]);
+
+#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+    /**
+     * Decrypts and verifies the given AES-CCM* payload.
+     *
+     * Calls `otPlatCryptoAesDecryptAndVerify()` using the AES context set by `SetKey()`.
+     *
+     * @param[in]      aNonce          Nonce (13 bytes, IEEE 802.15.4 CCM* format).
+     * @param[in]      aHeader         Additional authenticated data.
+     * @param[in]      aHeaderLength   Length of @p aHeader in bytes.
+     * @param[in,out]  aPayload        Ciphertext on input; replaced with plaintext in place on success.
+     * @param[in]      aPayloadLength  Length of @p aPayload in bytes.
+     * @param[in]      aTag            MIC buffer of length @p aTagLength bytes.
+     * @param[in]      aTagLength      MIC length in bytes (4, 8, or 16).
+     *
+     * @retval kErrorNone      Successfully decrypted and verified @p aPayload.
+     * @retval kErrorSecurity  MIC verification failed.
+     * @retval kErrorFailed    Platform operation failed.
+     */
+    Error DecryptAndVerify(const uint8_t *aNonce,
+                           const void    *aHeader,
+                           uint16_t       aHeaderLength,
+                           void          *aPayload,
+                           uint16_t       aPayloadLength,
+                           const void    *aTag,
+                           uint8_t        aTagLength);
+
+    /**
+     * Encrypts and tags the given AES-CCM* payload.
+     *
+     * Calls `otPlatCryptoAesEncryptAndTag()` using the AES context set by `SetKey()`.
+     *
+     * @param[in]      aNonce          Nonce (13 bytes, IEEE 802.15.4 CCM* format).
+     * @param[in]      aHeader         Additional authenticated data.
+     * @param[in]      aHeaderLength   Length of @p aHeader in bytes.
+     * @param[in,out]  aPayload        Plaintext on input; replaced with ciphertext in place on success.
+     * @param[in]      aPayloadLength  Length of @p aPayload in bytes.
+     * @param[out]     aTag            Buffer to receive the MIC; must be at least @p aTagLength bytes.
+     * @param[in]      aTagLength      MIC length in bytes (4, 8, or 16).
+     *
+     * @retval kErrorNone    Successfully encrypted @p aPayload and generated MIC in @p aTag.
+     * @retval kErrorFailed  Platform operation failed.
+     */
+    Error EncryptAndTag(const uint8_t *aNonce,
+                        const void    *aHeader,
+                        uint16_t       aHeaderLength,
+                        void          *aPayload,
+                        uint16_t       aPayloadLength,
+                        void          *aTag,
+                        uint8_t        aTagLength);
+#endif
 
 private:
     ContextWith<kAesContextSize> mContext;

--- a/src/core/crypto/crypto_platform_mbedtls.cpp
+++ b/src/core/crypto/crypto_platform_mbedtls.cpp
@@ -152,6 +152,50 @@ exit:
     return error;
 }
 
+#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+// OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE is for hardware AEAD accelerators.
+// Platforms enabling it must supply these symbols; there is no software fallback.
+OT_TOOL_WEAK otError otPlatCryptoAesDecryptAndVerify(otCryptoContext *aContext,
+                                                     const uint8_t   *aNonce,
+                                                     const void      *aHeader,
+                                                     uint16_t         aHeaderLength,
+                                                     void            *aPayload,
+                                                     uint16_t         aPayloadLength,
+                                                     const void      *aTag,
+                                                     uint8_t          aTagLength)
+{
+    OT_UNUSED_VARIABLE(aContext);
+    OT_UNUSED_VARIABLE(aNonce);
+    OT_UNUSED_VARIABLE(aHeader);
+    OT_UNUSED_VARIABLE(aHeaderLength);
+    OT_UNUSED_VARIABLE(aPayload);
+    OT_UNUSED_VARIABLE(aPayloadLength);
+    OT_UNUSED_VARIABLE(aTag);
+    OT_UNUSED_VARIABLE(aTagLength);
+    return kErrorFailed;
+}
+
+OT_TOOL_WEAK otError otPlatCryptoAesEncryptAndTag(otCryptoContext *aContext,
+                                                  const uint8_t   *aNonce,
+                                                  const void      *aHeader,
+                                                  uint16_t         aHeaderLength,
+                                                  void            *aPayload,
+                                                  uint16_t         aPayloadLength,
+                                                  void            *aTag,
+                                                  uint8_t          aTagLength)
+{
+    OT_UNUSED_VARIABLE(aContext);
+    OT_UNUSED_VARIABLE(aNonce);
+    OT_UNUSED_VARIABLE(aHeader);
+    OT_UNUSED_VARIABLE(aHeaderLength);
+    OT_UNUSED_VARIABLE(aPayload);
+    OT_UNUSED_VARIABLE(aPayloadLength);
+    OT_UNUSED_VARIABLE(aTag);
+    OT_UNUSED_VARIABLE(aTagLength);
+    return kErrorFailed;
+}
+#endif // OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
 
 // HMAC implementations

--- a/src/core/crypto/crypto_platform_psa.cpp
+++ b/src/core/crypto/crypto_platform_psa.cpp
@@ -48,10 +48,12 @@
 #include "common/error.hpp"
 #include "common/new.hpp"
 #include "config/crypto.h"
+#include "crypto/aes_ccm.hpp"
 #include "crypto/ecdsa.hpp"
 #include "crypto/hmac_sha256.hpp"
 #include "crypto/storage.hpp"
 #include "instance/instance.hpp"
+#include "radio/radio.hpp"
 
 using namespace ot;
 using namespace Crypto;
@@ -388,6 +390,80 @@ OT_TOOL_WEAK otError otPlatCryptoAesFree(otCryptoContext *aContext)
 
     return kErrorNone;
 }
+
+#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+
+// Maximum ciphertext-plus-tag buffer for an IEEE 802.15.4 MAC frame (PSDU + max MIC).
+static constexpr uint16_t kMaxCcmCiphertextWithTagSize = Radio::kFrameMaxSize + AesCcm::kMaxTagLength;
+
+OT_TOOL_WEAK otError otPlatCryptoAesDecryptAndVerify(otCryptoContext *aContext,
+                                                     const uint8_t   *aNonce,
+                                                     const void      *aHeader,
+                                                     uint16_t         aHeaderLength,
+                                                     void            *aPayload,
+                                                     uint16_t         aPayloadLength,
+                                                     const void      *aTag,
+                                                     uint8_t          aTagLength)
+{
+    Error         error = kErrorNone;
+    psa_status_t  status;
+    psa_key_id_t *keyRef;
+    uint8_t       ciphertextWithTag[kMaxCcmCiphertextWithTagSize];
+    size_t        plaintextLen;
+
+    SuccessOrExit(error = ValidateContext(aContext, sizeof(psa_key_id_t)));
+    VerifyOrExit(aNonce != nullptr && aPayload != nullptr && aTag != nullptr, error = kErrorInvalidArgs);
+    VerifyOrExit(aPayloadLength + aTagLength <= sizeof(ciphertextWithTag), error = kErrorInvalidArgs);
+
+    memcpy(ciphertextWithTag, aPayload, aPayloadLength);
+    memcpy(ciphertextWithTag + aPayloadLength, aTag, aTagLength);
+
+    keyRef = static_cast<psa_key_id_t *>(aContext->mContext);
+    status =
+        psa_aead_decrypt(*keyRef, PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, aTagLength), aNonce, AesCcm::kNonceSize,
+                         static_cast<const uint8_t *>(aHeader), aHeaderLength, ciphertextWithTag,
+                         aPayloadLength + aTagLength, static_cast<uint8_t *>(aPayload), aPayloadLength, &plaintextLen);
+
+    error = (status == PSA_ERROR_INVALID_SIGNATURE) ? kErrorSecurity : PsaToOtError(status);
+
+exit:
+    return error;
+}
+
+OT_TOOL_WEAK otError otPlatCryptoAesEncryptAndTag(otCryptoContext *aContext,
+                                                  const uint8_t   *aNonce,
+                                                  const void      *aHeader,
+                                                  uint16_t         aHeaderLength,
+                                                  void            *aPayload,
+                                                  uint16_t         aPayloadLength,
+                                                  void            *aTag,
+                                                  uint8_t          aTagLength)
+{
+    Error         error = kErrorNone;
+    psa_status_t  status;
+    psa_key_id_t *keyRef;
+    uint8_t       ciphertextWithTag[kMaxCcmCiphertextWithTagSize];
+    size_t        ciphertextLen;
+
+    SuccessOrExit(error = ValidateContext(aContext, sizeof(psa_key_id_t)));
+    VerifyOrExit(aNonce != nullptr && aPayload != nullptr && aTag != nullptr, error = kErrorInvalidArgs);
+    VerifyOrExit(aPayloadLength + aTagLength <= sizeof(ciphertextWithTag), error = kErrorInvalidArgs);
+
+    keyRef = static_cast<psa_key_id_t *>(aContext->mContext);
+    status =
+        psa_aead_encrypt(*keyRef, PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, aTagLength), aNonce, AesCcm::kNonceSize,
+                         static_cast<const uint8_t *>(aHeader), aHeaderLength, static_cast<const uint8_t *>(aPayload),
+                         aPayloadLength, ciphertextWithTag, sizeof(ciphertextWithTag), &ciphertextLen);
+    SuccessOrExit(error = PsaToOtError(status));
+
+    memcpy(aPayload, ciphertextWithTag, aPayloadLength);
+    memcpy(aTag, ciphertextWithTag + aPayloadLength, aTagLength);
+
+exit:
+    return error;
+}
+
+#endif // OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
 
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
 

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1388,13 +1388,19 @@ void TxFrame::ProcessTransmitAesCcm(const ExtAddress &aExtAddress)
 
     Crypto::AesCcm::GenerateNonce(aExtAddress, frameCounter, securityLevel, nonce);
 
-    aesCcm.SetKey(GetAesKey());
-    tagLength = GetFooterLength() - GetFcsSize();
+    tagLength = static_cast<uint8_t>(GetFooterLength() - GetFcsSize());
 
+    aesCcm.SetKey(GetAesKey());
+
+#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+    SuccessOrExit(aesCcm.EncryptAndTag(nonce, GetHeader(), GetHeaderLength(), GetPayload(), GetPayloadLength(),
+                                       GetFooter(), tagLength));
+#else
     aesCcm.Init(GetHeaderLength(), GetPayloadLength(), tagLength, nonce, sizeof(nonce));
     aesCcm.Header(GetHeader(), GetHeaderLength());
     aesCcm.Payload(GetPayload(), GetPayload(), GetPayloadLength(), Crypto::AesCcm::kEncrypt);
     aesCcm.Finalize(GetFooter());
+#endif
 
     SetIsSecurityProcessed(true);
 
@@ -1624,11 +1630,11 @@ exit:
 Error RxFrame::ProcessReceiveAesCcm(const ExtAddress &aExtAddress, const KeyMaterial &aMacKey)
 {
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
+
     Error          error        = kErrorSecurity;
     uint32_t       frameCounter = 0;
     uint8_t        securityLevel;
     uint8_t        nonce[Crypto::AesCcm::kNonceSize];
-    uint8_t        tag[kMaxMicSize];
     uint8_t        tagLength;
     Crypto::AesCcm aesCcm;
 
@@ -1639,21 +1645,33 @@ Error RxFrame::ProcessReceiveAesCcm(const ExtAddress &aExtAddress, const KeyMate
 
     Crypto::AesCcm::GenerateNonce(aExtAddress, frameCounter, securityLevel, nonce);
 
+    tagLength = static_cast<uint8_t>(GetFooterLength() - GetFcsSize());
+
     aesCcm.SetKey(aMacKey);
-    tagLength = GetFooterLength() - GetFcsSize();
 
-    aesCcm.Init(GetHeaderLength(), GetPayloadLength(), tagLength, nonce, sizeof(nonce));
-    aesCcm.Header(GetHeader(), GetHeaderLength());
+#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    aesCcm.Payload(GetPayload(), GetPayload(), GetPayloadLength(), Crypto::AesCcm::kDecrypt);
-#else
-    // For fuzz tests, execute AES but do not alter the payload. A large
-    aesCcm.Payload(nullptr, GetPayload(), GetPayloadLength(), Crypto::AesCcm::kDecrypt);
+    SuccessOrExit(aesCcm.DecryptAndVerify(nonce, GetHeader(), GetHeaderLength(), GetPayload(), GetPayloadLength(),
+                                          GetFooter(), tagLength));
 #endif
-    aesCcm.Finalize(tag);
+#else
+    {
+        uint8_t tag[kMaxMicSize];
 
+        aesCcm.Init(GetHeaderLength(), GetPayloadLength(), tagLength, nonce, sizeof(nonce));
+        aesCcm.Header(GetHeader(), GetHeaderLength());
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    VerifyOrExit(memcmp(tag, GetFooter(), tagLength) == 0);
+        aesCcm.Payload(GetPayload(), GetPayload(), GetPayloadLength(), Crypto::AesCcm::kDecrypt);
+#else
+        // For fuzz tests, execute AES but do not alter the payload. A large
+        // payload would otherwise cause the fuzzer to time out.
+        aesCcm.Payload(nullptr, GetPayload(), GetPayloadLength(), Crypto::AesCcm::kDecrypt);
+#endif
+        aesCcm.Finalize(tag);
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        VerifyOrExit(memcmp(tag, GetFooter(), tagLength) == 0, error = kErrorSecurity);
+#endif
+    }
 #endif
 
     error = kErrorNone;

--- a/tests/unit/test_aes.cpp
+++ b/tests/unit/test_aes.cpp
@@ -254,6 +254,66 @@ void TestInPlaceAesCcmProcessing(void)
     testFreeInstance(instance);
 }
 
+#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+/**
+ * Verifies the platform AES-CCM* hook using the IEEE 802.15.4-2006 Annex C.2.3 test vector.
+ * Cross-checks encrypt-and-tag and decrypt-and-verify against the same known-good values used by
+ * TestMacCommandFrame(), and confirms that a corrupted MIC returns kErrorSecurity.
+ */
+void TestPlatformAesCcm(void)
+{
+    static constexpr uint16_t kHeaderLength  = 29;
+    static constexpr uint16_t kPayloadLength = 1;
+    static constexpr uint8_t  kTagLength     = 8;
+
+    static const uint8_t kKey[] = {
+        0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf,
+    };
+
+    static const uint8_t kNonce[] = {
+        0xAC, 0xDE, 0x48, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x05, 0x06,
+    };
+
+    static const uint8_t kHeader[] = {
+        0x2B, 0xDC, 0x84, 0x21, 0x43, 0x02, 0x00, 0x00, 0x00, 0x00, 0x48, 0xDE, 0xAC, 0xFF, 0xFF,
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x48, 0xDE, 0xAC, 0x06, 0x05, 0x00, 0x00, 0x00, 0x01,
+    };
+
+    static const uint8_t kPlaintext[]  = {0xCE};
+    static const uint8_t kCiphertext[] = {0xD8};
+    static const uint8_t kTag[]        = {0x4F, 0xDE, 0x52, 0x90, 0x61, 0xF9, 0xC6, 0xF1};
+
+    Instance      *instance = testInitInstance();
+    Crypto::AesCcm aesCcm;
+    uint8_t        payload[kPayloadLength];
+    uint8_t        tag[kTagLength];
+    uint8_t        corruptTag[kTagLength];
+
+    VerifyOrQuit(instance != nullptr);
+
+    aesCcm.SetKey(kKey, sizeof(kKey));
+
+    // Encrypt: plaintext in, ciphertext + MIC out.
+    memcpy(payload, kPlaintext, kPayloadLength);
+    SuccessOrQuit(aesCcm.EncryptAndTag(kNonce, kHeader, kHeaderLength, payload, kPayloadLength, tag, kTagLength));
+    VerifyOrQuit(memcmp(payload, kCiphertext, kPayloadLength) == 0);
+    VerifyOrQuit(memcmp(tag, kTag, kTagLength) == 0);
+
+    // Decrypt: ciphertext + MIC in, plaintext out (round-trip).
+    SuccessOrQuit(aesCcm.DecryptAndVerify(kNonce, kHeader, kHeaderLength, payload, kPayloadLength, tag, kTagLength));
+    VerifyOrQuit(memcmp(payload, kPlaintext, kPayloadLength) == 0);
+
+    // Corrupted MIC must return kErrorSecurity.
+    memcpy(payload, kCiphertext, kPayloadLength);
+    memcpy(corruptTag, kTag, kTagLength);
+    corruptTag[0] ^= 0xff;
+    VerifyOrQuit(aesCcm.DecryptAndVerify(kNonce, kHeader, kHeaderLength, payload, kPayloadLength, corruptTag,
+                                         kTagLength) == kErrorSecurity);
+
+    testFreeInstance(instance);
+}
+#endif // OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+
 } // namespace ot
 
 int main(void)
@@ -261,6 +321,9 @@ int main(void)
     ot::TestMacBeaconFrame();
     ot::TestMacCommandFrame();
     ot::TestInPlaceAesCcmProcessing();
+#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+    ot::TestPlatformAesCcm();
+#endif
     printf("All tests passed\n");
     return 0;
 }

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -40,6 +40,11 @@
 #include <openthread/platform/ble.h>
 #endif
 
+#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+#include <mbedtls/aes.h>
+#include <mbedtls/ccm.h>
+#endif
+
 constexpr uint16_t kFlashSwapSize = 2048;
 constexpr uint8_t  kFlashSwapNum  = 2;
 
@@ -121,6 +126,14 @@ bool sDiagMode = false;
 
 static otPlatDiagOutputCallback sOutputCallback        = nullptr;
 static void                    *sOutputCallbackContext = nullptr;
+
+#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+// Raw key bytes saved by the otPlatCryptoAesSetKey() override below.
+// mbedtls_aes_context stores only the scheduled round keys, not the original
+// key material, so we stash the bytes here for use by the software CCM hooks.
+static uint8_t sAesCcmKey[32];
+static size_t  sAesCcmKeyLen = 0;
+#endif
 
 extern "C" {
 
@@ -620,6 +633,121 @@ otError otPlatCryptoEcdsaVerifyUsingKeyRef(otCryptoKeyRef                    aKe
 }
 
 #endif // OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
+
+#if OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
+
+// Strong override of the weak mbedtls stub.  Schedules the key in the
+// mbedtls_aes_context for ECB use (existing behaviour) and also stashes the
+// raw bytes so the CCM hooks below can feed them into mbedtls_ccm_context.
+otError otPlatCryptoAesSetKey(otCryptoContext *aContext, const otCryptoKey *aKey)
+{
+    mbedtls_aes_context *ctx;
+
+    if (aContext == nullptr || aKey == nullptr || aKey->mKey == nullptr)
+    {
+        return OT_ERROR_INVALID_ARGS;
+    }
+
+    if (aContext->mContextSize < sizeof(mbedtls_aes_context))
+    {
+        return OT_ERROR_FAILED;
+    }
+
+    ctx = static_cast<mbedtls_aes_context *>(aContext->mContext);
+
+    if (mbedtls_aes_setkey_enc(ctx, aKey->mKey, aKey->mKeyLength * 8u) != 0)
+    {
+        return OT_ERROR_FAILED;
+    }
+
+    OT_ASSERT(aKey->mKeyLength <= sizeof(sAesCcmKey));
+    memcpy(sAesCcmKey, aKey->mKey, aKey->mKeyLength);
+    sAesCcmKeyLen = aKey->mKeyLength;
+
+    return OT_ERROR_NONE;
+}
+
+otError otPlatCryptoAesEncryptAndTag(otCryptoContext *aContext,
+                                     const uint8_t   *aNonce,
+                                     const void      *aHeader,
+                                     uint16_t         aHeaderLength,
+                                     void            *aPayload,
+                                     uint16_t         aPayloadLength,
+                                     void            *aTag,
+                                     uint8_t          aTagLength)
+{
+    otError             error = OT_ERROR_NONE;
+    mbedtls_ccm_context ccm;
+
+    OT_UNUSED_VARIABLE(aContext);
+
+    if (aNonce == nullptr || aPayload == nullptr || aTag == nullptr)
+    {
+        return OT_ERROR_INVALID_ARGS;
+    }
+
+    mbedtls_ccm_init(&ccm);
+
+    if (mbedtls_ccm_setkey(&ccm, MBEDTLS_CIPHER_ID_AES, sAesCcmKey, static_cast<unsigned int>(sAesCcmKeyLen * 8)) != 0)
+    {
+        error = OT_ERROR_FAILED;
+    }
+    else if (mbedtls_ccm_encrypt_and_tag(&ccm, aPayloadLength, aNonce, 13u, // IEEE 802.15.4 CCM* nonce length
+                                         static_cast<const uint8_t *>(aHeader), aHeaderLength,
+                                         static_cast<const uint8_t *>(aPayload), static_cast<uint8_t *>(aPayload),
+                                         static_cast<uint8_t *>(aTag), aTagLength) != 0)
+    {
+        error = OT_ERROR_FAILED;
+    }
+
+    mbedtls_ccm_free(&ccm);
+
+    return error;
+}
+
+otError otPlatCryptoAesDecryptAndVerify(otCryptoContext *aContext,
+                                        const uint8_t   *aNonce,
+                                        const void      *aHeader,
+                                        uint16_t         aHeaderLength,
+                                        void            *aPayload,
+                                        uint16_t         aPayloadLength,
+                                        const void      *aTag,
+                                        uint8_t          aTagLength)
+{
+    mbedtls_ccm_context ccm;
+    int                 ret;
+
+    OT_UNUSED_VARIABLE(aContext);
+
+    if (aNonce == nullptr || aPayload == nullptr || aTag == nullptr)
+    {
+        return OT_ERROR_INVALID_ARGS;
+    }
+
+    mbedtls_ccm_init(&ccm);
+
+    if (mbedtls_ccm_setkey(&ccm, MBEDTLS_CIPHER_ID_AES, sAesCcmKey, static_cast<unsigned int>(sAesCcmKeyLen * 8)) != 0)
+    {
+        mbedtls_ccm_free(&ccm);
+        return OT_ERROR_FAILED;
+    }
+
+    ret = mbedtls_ccm_auth_decrypt(&ccm, aPayloadLength, aNonce, 13u, // IEEE 802.15.4 CCM* nonce length
+                                   static_cast<const uint8_t *>(aHeader), aHeaderLength,
+                                   static_cast<const uint8_t *>(aPayload), static_cast<uint8_t *>(aPayload),
+                                   static_cast<const uint8_t *>(aTag), aTagLength);
+
+    mbedtls_ccm_free(&ccm);
+
+    if (ret == MBEDTLS_ERR_CCM_AUTH_FAILED)
+    {
+        return OT_ERROR_SECURITY;
+    }
+
+    return (ret == 0) ? OT_ERROR_NONE : OT_ERROR_FAILED;
+}
+
+#endif // OPENTHREAD_CONFIG_CRYPTO_PLATFORM_CCM_ENABLE
 
 otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
 {


### PR DESCRIPTION
Introduce a compile-time opt-in (OPENTHREAD_CONFIG_PLATFORM_SUPPORTS_CCM_ENABLE) to offload MAC-layer AES-CCM* encrypt and decrypt/verify to two new platform APIs (otPlatCryptoAesDecryptAndVerify / otPlatCryptoAesEncryptAndTag), replacing the software Crypto::AesCcm path in the TX and RX frame processing functions.