### PR TITLE
[ci] clone ot-br-posix submodules recursively in CI/CD

### DIFF
--- a/.github/workflows/otbr-posix-dind.yml
+++ b/.github/workflows/otbr-posix-dind.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Clone ot-br-posix and replace openthread submodule
       run: |
         OPENTHREAD_DIR=$(pwd)
-        ./script/git-tool clone https://github.com/openthread/ot-br-posix.git --depth 1 /tmp/ot-br-posix
+        ./script/git-tool clone https://github.com/openthread/ot-br-posix.git --depth 1 --recurse-submodules --shallow-submodules /tmp/ot-br-posix
         cd /tmp/ot-br-posix
         rm -rf third_party/openthread/repo
         mkdir -p third_party/openthread/repo

--- a/script/git-tool
+++ b/script/git-tool
@@ -65,7 +65,8 @@ try_clone()
         shift
         git clone "$@" 2>&1
     else
-        dest_dir="$(git clone "$@" 2>&1 | tee | cut -d\' -f2)"
+        dest_dir="$(LC_ALL=C git clone "$@" 2>&1 | tee /dev/stderr | sed -n "s/^Cloning into '\([^']*\)'.*/\1/p")"
+        dest_dir="${dest_dir%%$'\n'*}"
 
         cd "${dest_dir}"
         apply_dependencies

--- a/script/test
+++ b/script/test
@@ -395,7 +395,7 @@ do_build_otbr_docker()
 
     (
         if [[ -z ${LOCAL_OTBR_DIR} ]]; then
-            ./script/git-tool clone https://github.com/openthread/ot-br-posix.git --depth 1 "${otbrdir}"
+            ./script/git-tool clone https://github.com/openthread/ot-br-posix.git --depth 1 --recurse-submodules --shallow-submodules "${otbrdir}"
         else
             rsync -r \
                 --exclude=third_party/openthread/repo \


### PR DESCRIPTION
When cloning the ot-br-posix repository to run the Docker-in-Docker integration tests, the clone was shallow and did not recursively check out nested submodules (such as cJSON and cpp-httplib). This led to build failures inside the Docker build container since libcjson is not pre-installed on the base build image.

This commit resolves the issue by:
1. Appending the `--recurse-submodules` flag to the git-tool clone calls in `otbr-posix-dind.yml` and `script/test`.
2. Updating `script/git-tool`'s destination directory parsing to robustly handle multi-line output from recursive submodule checkouts. The new pattern extracts the path exclusively from the first line using `sed` to prevent SIGPIPE or parsing errors.