### PR TITLE
[tlv] define `Tlv::AppendTlvHeader()` public and use it in core

### DIFF
--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -551,6 +551,21 @@ public:
     }
 
     /**
+     * Appends a TLV header to a message.
+     *
+     * This method automatically formats the header as a standard TLV header or an extended one based on the
+     * @p aLength value.
+     *
+     * @param[in] aMessage  The message to append the TLV header to.
+     * @param[in] aType     The TLV type to append.
+     * @param[in] aLength   The length of the TLV value.
+     *
+     * @retval kErrorNone    Successfully appended the TLV header.
+     * @retval kErrorNoBufs  Could not add the TLV header due to insufficient buffer space.
+     */
+    static Error AppendTlvHeader(Message &aMessage, uint8_t aType, uint16_t aLength);
+
+    /**
      * Appends an empty TLV (no value) with a given type to a message.
      *
      * On success this method grows the message by the size of the TLV.
@@ -839,7 +854,6 @@ protected:
     static const uint8_t kExtendedLength = 255; // Extended Length value.
 
 private:
-    static Error AppendTlvHeader(Message &aMessage, uint8_t aType, uint16_t aLength);
     static Error FindTlv(const Message &aMessage, uint8_t aType, void *aValue, uint16_t aLength);
     static Error FindStringTlv(const Message &aMessage, uint8_t aType, uint8_t aMaxStringLength, char *aValue);
     static Error AppendStringTlv(Message &aMessage, uint8_t aType, uint8_t aMaxStringLength, const char *aValue);

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -903,7 +903,6 @@ Error Manager::CoapDtlsSession::ForwardUdpProxy(const Message &aMessage, const I
 {
     Error                     error = kErrorNone;
     OwnedPtr<Coap::Message>   message;
-    ExtendedTlv               extTlv;
     UdpEncapsulationTlvHeader udpEncapHeader;
     OffsetRange               offsetRange;
 
@@ -914,13 +913,11 @@ Error Manager::CoapDtlsSession::ForwardUdpProxy(const Message &aMessage, const I
 
     offsetRange.InitFromMessageOffsetToEnd(aMessage);
 
-    extTlv.SetType(Tlv::kUdpEncapsulation);
-    extTlv.SetLength(sizeof(UdpEncapsulationTlvHeader) + offsetRange.GetLength());
-
     udpEncapHeader.SetSourcePort(aMessageInfo.GetPeerPort());
     udpEncapHeader.SetDestinationPort(aMessageInfo.GetSockPort());
 
-    SuccessOrExit(error = message->Append(extTlv));
+    SuccessOrExit(error = Tlv::AppendTlvHeader(*message, Tlv::kUdpEncapsulation,
+                                               sizeof(UdpEncapsulationTlvHeader) + offsetRange.GetLength()));
     SuccessOrExit(error = message->Append(udpEncapHeader));
     SuccessOrExit(error = message->AppendBytesFromMessage(aMessage, offsetRange));
 

--- a/tests/nexus/test_border_admitter.cpp
+++ b/tests/nexus/test_border_admitter.cpp
@@ -3196,7 +3196,6 @@ void TestBorderAdmitterForwardingUdpProxy(void)
     uint16_t                           sessionId;
     uint16_t                           rloc16;
     MeshCoP::UdpEncapsulationTlvHeader udpEncapHeader;
-    ExtendedTlv                        extTlv;
 
     Log("------------------------------------------------------------------------------------------------------");
     Log("TestBorderAdmitterForwardingUdpProxy");
@@ -3360,10 +3359,8 @@ void TestBorderAdmitterForwardingUdpProxy(void)
     udpEncapHeader.SetSourcePort(Tmf::kUdpPort);
     udpEncapHeader.SetDestinationPort(Tmf::kUdpPort);
 
-    extTlv.SetType(MeshCoP::Tlv::kUdpEncapsulation);
-    extTlv.SetLength(sizeof(udpEncapHeader) + diagMessage->GetLength());
-
-    SuccessOrQuit(message->Append(extTlv));
+    SuccessOrQuit(Tlv::AppendTlvHeader(*message, MeshCoP::Tlv::kUdpEncapsulation,
+                                       sizeof(udpEncapHeader) + diagMessage->GetLength()));
     SuccessOrQuit(message->Append(udpEncapHeader));
     SuccessOrQuit(message->AppendBytesFromMessage(*diagMessage, 0, diagMessage->GetLength()));
     diagMessage->Free();


### PR DESCRIPTION
This commit makes `Tlv::AppendTlvHeader()` public and updates call sites to use it. This method automatically handles the formatting of the TLV header as either a standard TLV header or an extended one based on the provided length.