### PR TITLE
[routing-manager] fix minor style issues in `StateToString()`

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -2271,9 +2271,9 @@ const char *RoutingManager::RoutePublisher::StateToString(State aState)
     _(kPublishDefault, "def-route")   \
     _(kPublishUla, "ula")
 
-    DefineEnumStringArray(RoutePublisherStateMapList)
+    DefineEnumStringArray(RoutePublisherStateMapList);
 
-        return kStrings[aState];
+    return kStrings[aState];
 }
 
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE


### PR DESCRIPTION
This commit fixes minor coding style issues in
`RoutingManager::RoutePublisher::StateToString()`. It adds a missing semicolon after the `DefineEnumStringArray()` macro and corrects the indentation of the return statement.