### PR TITLE
[tests] use `constexpr` for constants in unit tests

### DIFF
--- a/tests/unit/test_child.cpp
+++ b/tests/unit/test_child.cpp
@@ -39,10 +39,7 @@ namespace ot {
 
 static Instance *sInstance;
 
-enum
-{
-    kMaxChildIp6Addresses = OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD,
-};
+constexpr uint16_t kMaxChildIp6Addresses = OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD;
 
 void VerifyChildIp6Addresses(const Child &aChild, uint8_t aAddressListLength, const Ip6::Address aAddressList[])
 {

--- a/tests/unit/test_child_table.cpp
+++ b/tests/unit/test_child_table.cpp
@@ -40,10 +40,7 @@ namespace ot {
 
 static Instance *sInstance;
 
-enum
-{
-    kMaxChildren = OPENTHREAD_CONFIG_MLE_MAX_CHILDREN,
-};
+constexpr uint16_t kMaxChildren = OPENTHREAD_CONFIG_MLE_MAX_CHILDREN;
 
 struct TestChild
 {

--- a/tests/unit/test_dns.cpp
+++ b/tests/unit/test_dns.cpp
@@ -42,11 +42,8 @@ namespace ot {
 
 void TestDnsName(void)
 {
-    enum
-    {
-        kMaxSize       = 300,
-        kMaxNameLength = Dns::Name::kMaxNameSize - 1,
-    };
+    static constexpr uint16_t kMaxSize       = 300;
+    static constexpr uint16_t kMaxNameLength = Dns::Name::kMaxNameSize - 1;
 
     struct TestName
     {
@@ -635,19 +632,14 @@ void TestDnsName(void)
 
 void TestDnsCompressedName(void)
 {
-    enum
-    {
-        kHeaderOffset   = 10,
-        kGuardBlockSize = 20,
-        kMaxBufferSize  = 100,
-        kLabelSize      = 64,
-        kNameSize       = 256,
-
-        kName2EncodedSize = 4 + 2,  // encoded "FOO" + pointer label (2 bytes)
-        kName3EncodedSize = 2,      // pointer label (2 bytes)
-        kName4EncodedSize = 15 + 2, // encoded "Human.Readable" + pointer label (2 bytes).
-
-    };
+    static constexpr uint8_t  kHeaderOffset     = 10;
+    static constexpr uint8_t  kGuardBlockSize   = 20;
+    static constexpr uint16_t kMaxBufferSize    = 100;
+    static constexpr uint16_t kLabelSize        = 64;
+    static constexpr uint16_t kNameSize         = 256;
+    static constexpr uint16_t kName2EncodedSize = 4 + 2;  // encoded "FOO" + pointer label (2 bytes)
+    static constexpr uint16_t kName3EncodedSize = 2;      // pointer label (2 bytes)
+    static constexpr uint16_t kName4EncodedSize = 15 + 2; // encoded "Human.Readable" + pointer label (2 bytes).
 
     const char kName[]          = "F.ISI.ARPA";
     const char kLabel1[]        = "FOO";
@@ -1155,19 +1147,16 @@ void TestDnsCompressedName(void)
 
 void TestHeaderAndResourceRecords(void)
 {
-    enum
-    {
-        kHeaderOffset    = 0,
-        kQuestionCount   = 1,
-        kAnswerCount     = 2,
-        kAdditionalCount = 6,
-        kTtl             = 7200,
-        kTxtTtl          = 7300,
-        kSrvPort         = 1234,
-        kSrvPriority     = 1,
-        kSrvWeight       = 2,
-        kMaxSize         = 600,
-    };
+    static constexpr uint8_t  kHeaderOffset    = 0;
+    static constexpr uint16_t kQuestionCount   = 1;
+    static constexpr uint16_t kAnswerCount     = 2;
+    static constexpr uint16_t kAdditionalCount = 6;
+    static constexpr uint32_t kTtl             = 7200;
+    static constexpr uint32_t kTxtTtl          = 7300;
+    static constexpr uint16_t kSrvPort         = 1234;
+    static constexpr uint16_t kSrvPriority     = 1;
+    static constexpr uint16_t kSrvWeight       = 2;
+    static constexpr uint16_t kMaxSize         = 600;
 
     const char    kMessageString[]  = "DnsMessage";
     const char    kDomainName[]     = "example.com.";

--- a/tests/unit/test_hdlc.cpp
+++ b/tests/unit/test_hdlc.cpp
@@ -38,20 +38,16 @@
 namespace ot {
 namespace Ncp {
 
-enum
-{
-    kBufferSize        = 1500,  // Frame buffer size
-    kMaxFrameLength    = 500,   // Maximum allowed frame length (used when randomly generating frames)
-    kFuzzTestIteration = 50000, // Number of iteration during fuzz test (randomly generating frames)
-    kFrameHeaderSize   = 4,     // Frame header size
+constexpr uint16_t kBufferSize        = 1500;  // Frame buffer size
+constexpr uint16_t kMaxFrameLength    = 500;   // Maximum allowed frame length (used when randomly generating frames)
+constexpr uint32_t kFuzzTestIteration = 50000; // Number of iteration during fuzz test (randomly generating frames)
+constexpr uint16_t kFrameHeaderSize   = 4;     // Frame header size
 
-    kFlagXOn        = 0x11,
-    kFlagXOff       = 0x13,
-    kFlagSequence   = 0x7e, ///< HDLC Flag value
-    kEscapeSequence = 0x7d, ///< HDLC Escape value
-    kFlagSpecial    = 0xf8,
-
-};
+constexpr uint8_t kFlagXOn        = 0x11;
+constexpr uint8_t kFlagXOff       = 0x13;
+constexpr uint8_t kFlagSequence   = 0x7e; // HDLC Flag value
+constexpr uint8_t kEscapeSequence = 0x7d; // HDLC Escape value
+constexpr uint8_t kFlagSpecial    = 0xf8;
 
 static const uint8_t sOpenThreadText[] = "OpenThread Rocks";
 static const uint8_t sHelloText[]      = "Hello there!";

--- a/tests/unit/test_hkdf_sha256.cpp
+++ b/tests/unit/test_hkdf_sha256.cpp
@@ -52,11 +52,8 @@ struct TestVector
 
 void TestHkdfSha256(void)
 {
-    enum
-    {
-        kMaxOuttKey = 128,
-        kFillByte   = 0x77,
-    };
+    static constexpr uint16_t kMaxOuttKey = 128;
+    static constexpr uint8_t  kFillByte   = 0x77;
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Test Case #1: RFC-5869 Appendix A.1

--- a/tests/unit/test_link_quality.cpp
+++ b/tests/unit/test_link_quality.cpp
@@ -38,20 +38,17 @@ namespace ot {
 
 static Instance *sInstance;
 
-enum
-{
-    kMaxRssValue = 0,
-    kMinRssValue = -128,
+constexpr int8_t kMaxRssValue = 0;
+constexpr int8_t kMinRssValue = -128;
 
-    kStringBuffferSize = 80,
+constexpr uint16_t kStringBuffferSize = 80;
 
-    kRssAverageMaxDiff = 16,
-    kNumRssAdds        = 300,
+constexpr uint8_t  kRssAverageMaxDiff = 16;
+constexpr uint16_t kNumRssAdds        = 300;
 
-    kRawAverageBitShift = 3,
-    kRawAverageMultiple = (1 << kRawAverageBitShift),
-    kRawAverageBitMask  = (1 << kRawAverageBitShift) - 1,
-};
+constexpr uint8_t kRawAverageBitShift = 3;
+constexpr uint8_t kRawAverageMultiple = (1 << kRawAverageBitShift);
+constexpr uint8_t kRawAverageBitMask  = (1 << kRawAverageBitShift) - 1;
 
 #define MIN_RSS(_rss1, _rss2) (((_rss1) < (_rss2)) ? (_rss1) : (_rss2))
 #define MAX_RSS(_rss1, _rss2) (((_rss1) < (_rss2)) ? (_rss2) : (_rss1))

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -1856,12 +1856,9 @@ void TestLowpanIphc(void)
 
 void TestLowpanMeshHeader(void)
 {
-    enum
-    {
-        kMaxFrameSize = 127,
-        kSourceAddr   = 0x100,
-        kDestAddr     = 0x200,
-    };
+    static constexpr uint16_t kMaxFrameSize = 127;
+    static constexpr uint16_t kSourceAddr   = 0x100;
+    static constexpr uint16_t kDestAddr     = 0x200;
 
     const uint8_t kMeshHeader1[] = {0xb1, 0x01, 0x00, 0x02, 0x00};       // src:0x100, dest:0x200, hop:0x1
     const uint8_t kMeshHeader2[] = {0xbf, 0x20, 0x01, 0x00, 0x02, 0x00}; // src:0x100, dest:0x200, hop:0x20

--- a/tests/unit/test_multipan_rcp_instances.cpp
+++ b/tests/unit/test_multipan_rcp_instances.cpp
@@ -41,18 +41,9 @@
 using namespace ot;
 using namespace ot::Ncp;
 
-enum
-{
-    kTestBufferSize = 800
-};
+constexpr uint16_t kTestBufferSize = 800;
 
-enum
-{
-    kTestMacScanChannelMask = 0x01
-};
-
-OT_TOOL_PACKED_BEGIN
-struct RadioMessage
+OT_TOOL_PACKED_BEGIN struct RadioMessage
 {
     uint8_t mChannel;
     uint8_t mPsdu[OT_RADIO_FRAME_MAX_SIZE];

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -40,11 +40,8 @@
 #include <openthread/platform/ble.h>
 #endif
 
-enum
-{
-    FLASH_SWAP_SIZE = 2048,
-    FLASH_SWAP_NUM  = 2,
-};
+constexpr uint16_t kFlashSwapSize = 2048;
+constexpr uint8_t  kFlashSwapNum  = 2;
 
 std::map<uint32_t, std::vector<std::vector<uint8_t>>> settings;
 
@@ -53,7 +50,7 @@ ot::Instance *testInitInstance(void)
     otInstance *instance = nullptr;
 
     settings.clear();
-    for (uint8_t idx = 0; idx < FLASH_SWAP_NUM; idx++)
+    for (uint8_t idx = 0; idx < kFlashSwapNum; idx++)
     {
         otPlatFlashErase(nullptr, idx);
     }
@@ -388,7 +385,7 @@ OT_TOOL_WEAK void otPlatSettingsWipe(otInstance *) { settings.clear(); }
 
 uint8_t *GetFlash(void)
 {
-    static uint8_t sFlash[FLASH_SWAP_SIZE * FLASH_SWAP_NUM];
+    static uint8_t sFlash[kFlashSwapSize * kFlashSwapNum];
     static bool    sInitialized;
 
     if (!sInitialized)
@@ -402,28 +399,28 @@ uint8_t *GetFlash(void)
 
 OT_TOOL_WEAK void otPlatFlashInit(otInstance *) {}
 
-OT_TOOL_WEAK uint32_t otPlatFlashGetSwapSize(otInstance *) { return FLASH_SWAP_SIZE; }
+OT_TOOL_WEAK uint32_t otPlatFlashGetSwapSize(otInstance *) { return kFlashSwapSize; }
 
 OT_TOOL_WEAK void otPlatFlashErase(otInstance *, uint8_t aSwapIndex)
 {
     uint32_t address;
 
-    VerifyOrQuit(aSwapIndex < FLASH_SWAP_NUM, "aSwapIndex invalid");
+    VerifyOrQuit(aSwapIndex < kFlashSwapNum, "aSwapIndex invalid");
 
-    address = aSwapIndex ? FLASH_SWAP_SIZE : 0;
+    address = aSwapIndex ? kFlashSwapSize : 0;
 
-    memset(GetFlash() + address, 0xff, FLASH_SWAP_SIZE);
+    memset(GetFlash() + address, 0xff, kFlashSwapSize);
 }
 
 OT_TOOL_WEAK void otPlatFlashRead(otInstance *, uint8_t aSwapIndex, uint32_t aOffset, void *aData, uint32_t aSize)
 {
     uint32_t address;
 
-    VerifyOrQuit(aSwapIndex < FLASH_SWAP_NUM, "aSwapIndex invalid");
-    VerifyOrQuit(aSize <= FLASH_SWAP_SIZE, "aSize invalid");
-    VerifyOrQuit(aOffset <= (FLASH_SWAP_SIZE - aSize), "aOffset + aSize invalid");
+    VerifyOrQuit(aSwapIndex < kFlashSwapNum, "aSwapIndex invalid");
+    VerifyOrQuit(aSize <= kFlashSwapSize, "aSize invalid");
+    VerifyOrQuit(aOffset <= (kFlashSwapSize - aSize), "aOffset + aSize invalid");
 
-    address = aSwapIndex ? FLASH_SWAP_SIZE : 0;
+    address = aSwapIndex ? kFlashSwapSize : 0;
 
     memcpy(aData, GetFlash() + address + aOffset, aSize);
 }
@@ -436,11 +433,11 @@ OT_TOOL_WEAK void otPlatFlashWrite(otInstance *,
 {
     uint32_t address;
 
-    VerifyOrQuit(aSwapIndex < FLASH_SWAP_NUM, "aSwapIndex invalid");
-    VerifyOrQuit(aSize <= FLASH_SWAP_SIZE, "aSize invalid");
-    VerifyOrQuit(aOffset <= (FLASH_SWAP_SIZE - aSize), "aOffset + aSize invalid");
+    VerifyOrQuit(aSwapIndex < kFlashSwapNum, "aSwapIndex invalid");
+    VerifyOrQuit(aSize <= kFlashSwapSize, "aSize invalid");
+    VerifyOrQuit(aOffset <= (kFlashSwapSize - aSize), "aOffset + aSize invalid");
 
-    address = aSwapIndex ? FLASH_SWAP_SIZE : 0;
+    address = aSwapIndex ? kFlashSwapSize : 0;
 
     for (uint32_t index = 0; index < aSize; index++)
     {

--- a/tests/unit/test_spinel_buffer.cpp
+++ b/tests/unit/test_spinel_buffer.cpp
@@ -43,12 +43,10 @@ namespace Spinel {
 // This module implements unit-test for Spinel::Buffer class.
 
 // Test related constants:
-enum
-{
-    kTestBufferSize       = 800,
-    kTestIterationAttemps = 10000,
-    kTagArraySize         = 1000,
-};
+
+constexpr uint16_t kTestBufferSize       = 800;
+constexpr uint16_t kTestIterationAttemps = 10000;
+constexpr uint16_t kTagArraySize         = 1000;
 
 //  Messages used for building frames...
 static const uint8_t sOpenThreadText[] = "OpenThread Rocks";
@@ -68,15 +66,13 @@ struct CallbackContext
 
 CallbackContext sContext;
 
-enum
-{
-    kNumPrios = 2, // Number of priority levels.
+constexpr uint8_t kNumPrios = 2; // Number of priority levels.
 
-    kTestFrame1Size = sizeof(sMottoText) + sizeof(sMysteryText) + sizeof(sMottoText) + sizeof(sHelloText),
-    kTestFrame2Size = sizeof(sMysteryText) + sizeof(sHelloText) + sizeof(sOpenThreadText),
-    kTestFrame3Size = sizeof(sMysteryText),
-    kTestFrame4Size = sizeof(sOpenThreadText),
-};
+constexpr uint16_t kTestFrame1Size =
+    sizeof(sMottoText) + sizeof(sMysteryText) + sizeof(sMottoText) + sizeof(sHelloText);
+constexpr uint16_t kTestFrame2Size = sizeof(sMysteryText) + sizeof(sHelloText) + sizeof(sOpenThreadText);
+constexpr uint16_t kTestFrame3Size = sizeof(sMysteryText);
+constexpr uint16_t kTestFrame4Size = sizeof(sOpenThreadText);
 
 Spinel::Buffer::FrameTag sTagHistoryArray[kNumPrios][kTagArraySize];
 uint32_t                 sTagHistoryHead[kNumPrios] = {0};
@@ -870,16 +866,13 @@ void TestBuffer(void)
  * Handle the cases where buffer gets full or empty.
  */
 
-enum
-{
-    kFuzTestBufferSize            = 2000,   // Size of the buffer used during fuzz testing
-    kFuzTestIterationAttempts     = 500000, // Number of iterations  to run
-    kLensArraySize                = 500,    // Size of "Lengths" array.
-    kMaxFrameLen                  = 400,    // Maximum frame length
-    kReadProbability              = 50,     // Probability (in percent) to randomly choose to read vs write frame
-    kHighPriorityProbability      = 20,     // Probability (in percent) to write a high priority frame
-    kUseTrueRandomNumberGenerator = 1,      // To use true random number generator or not.
-};
+constexpr uint16_t kFuzTestBufferSize            = 2000;   // Size of the buffer used during fuzz testing
+constexpr uint32_t kFuzTestIterationAttempts     = 500000; // Number of iterations to run
+constexpr uint16_t kLensArraySize                = 500;    // Size of "Lengths" array.
+constexpr uint16_t kMaxFrameLen                  = 400;    // Maximum frame length
+constexpr uint8_t  kReadProbability              = 50;     // Probability to randomly choose to read vs write frame
+constexpr uint8_t  kHighPriorityProbability      = 20;     // Probability to write a high priority frame
+constexpr bool     kUseTrueRandomNumberGenerator = true;   // To use true random number generator or not.
 
 uint8_t  sFrameBuffer[kNumPrios][kFuzTestBufferSize];
 uint32_t sFrameBufferTailIndex[kNumPrios] = {0};

--- a/tests/unit/test_spinel_decoder.cpp
+++ b/tests/unit/test_spinel_decoder.cpp
@@ -35,10 +35,7 @@
 namespace ot {
 namespace Spinel {
 
-enum
-{
-    kTestBufferSize = 800,
-};
+constexpr uint16_t kTestBufferSize = 800;
 
 void TestDecoder(void)
 {

--- a/tests/unit/test_spinel_encoder.cpp
+++ b/tests/unit/test_spinel_encoder.cpp
@@ -35,10 +35,7 @@
 namespace ot {
 namespace Spinel {
 
-enum
-{
-    kTestBufferSize = 800,
-};
+constexpr uint16_t kTestBufferSize = 800;
 
 otError ReadFrame(Spinel::Buffer &aNcpBuffer, uint8_t *aFrame, uint16_t &aFrameLen)
 {

--- a/tests/unit/test_string.cpp
+++ b/tests/unit/test_string.cpp
@@ -36,10 +36,7 @@
 
 namespace ot {
 
-enum
-{
-    kStringSize = 10,
-};
+constexpr uint16_t kStringSize = 10;
 
 template <uint16_t kSize> void PrintString(const char *aName, const String<kSize> aString)
 {

--- a/tests/unit/test_timer.cpp
+++ b/tests/unit/test_timer.cpp
@@ -37,14 +37,10 @@
 
 namespace ot {
 
-enum
-{
-    kCallCountIndexAlarmStop = 0,
-    kCallCountIndexAlarmStart,
-    kCallCountIndexTimerHandler,
-
-    kCallCountIndexMax
-};
+constexpr uint16_t kCallCountIndexAlarmStop    = 0;
+constexpr uint16_t kCallCountIndexAlarmStart   = 1;
+constexpr uint16_t kCallCountIndexTimerHandler = 2;
+constexpr uint16_t kCallCountIndexMax          = 3;
 
 uint32_t sNow;
 uint32_t sPlatT0;

--- a/tests/unit/test_util.cpp
+++ b/tests/unit/test_util.cpp
@@ -32,10 +32,7 @@
 
 void DumpBuffer(const char *aTextMessage, const uint8_t *aBuffer, uint16_t aBufferLength)
 {
-    enum
-    {
-        kBytesPerLine = 16, // Number of bytes per line.
-    };
+    static constexpr uint16_t kBytesPerLine = 16; // Number of bytes per line.
 
     char     charBuff[kBytesPerLine + 1];
     uint16_t counter;


### PR DESCRIPTION
This commit refactors various unit tests to use `constexpr` for defining constants instead of anonymous `enum` types.

Using `constexpr` is the modern and preferred approach in C++, as it provides explicit types for constants and improves code clarity and type safety.