### PR TITLE
[srp] always send Update Lease (UL) option in success response

### DIFF
--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -727,8 +727,9 @@ void Server::CommitSrpUpdate(Error                    aError,
 exit:
     if (aMessageInfo != nullptr)
     {
-        if (aError == kErrorNone && (grantedLease != hostLease || grantedKeyLease != hostKeyLease))
+        if (aError == kErrorNone)
         {
+            // RFC 9664: server MUST echo the Update Lease option in any successful (RCODE=0) response.
             SendResponse(aDnsHeader, grantedLease, grantedKeyLease, useShortLease, *aMessageInfo);
         }
         else

--- a/tests/unit/test_srp_server.cpp
+++ b/tests/unit/test_srp_server.cpp
@@ -967,11 +967,11 @@ void TestUpdateLeaseShortVariant(void)
     VerifyOrQuit(service1.GetState() == Srp::Client::kRemoved);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    // Register the service again, but this time change it to request
-    // a lease time that is larger than the `LeaseConfig.mMinLease` of
-    // 27 hours. This ensures that server needs to include the Lease
-    // Option in its response (since it need to grant a different
-    // lease interval).
+    // Register the service again, but this time request a lease time
+    // larger than the server's `LeaseConfig.mMaxLease` of 27 hours, so
+    // the server grants a different (clamped) interval. Validate that
+    // the client adopts the granted lease from the Update Lease
+    // Option in the response.
 
     service1.mLease    = 100u * 3600; // 100 hours >= 27 hours.
     service1.mKeyLease = 110u * 3600;


### PR DESCRIPTION
Per RFC 9664, the UL option is always included in a success response (RCODE=0). Comment in test_srp_server is updated also to avoid suggesting the opposite.