### PR TITLE
[routing-manager] defer OMR prefix removal with a randomized delay

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -995,6 +995,11 @@ void RoutingManager::OmrPrefixManager::Evaluate(void)
             break;
         }
 
+        case kToRemove:
+            // No favored prefix; cancel the pending removal and re-add our local prefix.
+            AddLocalToNetData();
+            break;
+
         case kAdded:
         case kToAdd:
             break;
@@ -1013,7 +1018,29 @@ void RoutingManager::OmrPrefixManager::Evaluate(void)
     // we remove our local prefix if it is added or scheduled to be added.
 
     SetFavoredPrefix(favoredPrefix);
-    RemoveLocalFromNetData();
+
+    switch (mLocalInNetDataState)
+    {
+    case kAdded:
+    {
+        uint32_t delay = Random::NonCrypto::GenerateInClosedRange(kMinDelayToRemove, kMaxDelayToRemove);
+
+        mLocalInNetDataState = kToRemove;
+        mTimer.Start(delay);
+        LogInfo("Will remove %s from NetData in %lu msec", LocalToString().AsCString(), ToUlong(delay));
+        break;
+    }
+
+    case kToAdd:
+        // Prefix not yet in Network Data; cancel the pending add.
+        mTimer.Stop();
+        mLocalInNetDataState = kNotAdded;
+        break;
+
+    case kToRemove:
+    case kNotAdded:
+        break;
+    }
 
 exit:
     return;
@@ -1021,11 +1048,18 @@ exit:
 
 void RoutingManager::OmrPrefixManager::HandleTimer(void)
 {
-    VerifyOrExit(mLocalInNetDataState == kToAdd);
-    AddLocalToNetData();
-
-exit:
-    return;
+    switch (mLocalInNetDataState)
+    {
+    case kToAdd:
+        AddLocalToNetData();
+        break;
+    case kToRemove:
+        RemoveLocalFromNetData();
+        break;
+    case kNotAdded:
+    case kAdded:
+        break;
+    }
 }
 
 bool RoutingManager::OmrPrefixManager::ShouldAdvertiseLocalAsRio(void) const
@@ -1113,6 +1147,8 @@ void RoutingManager::OmrPrefixManager::RemoveLocalFromNetData(void)
     switch (mLocalInNetDataState)
     {
     case kAdded:
+    case kToRemove:
+        mTimer.Stop();
         IgnoreError(Get<NetworkData::Local>().RemoveOnMeshPrefix(mLocalPrefix.GetPrefix()));
         Get<NetworkData::Notifier>().HandleServerDataUpdated();
         LogInfo("Removed %s from NetData", LocalToString().AsCString());

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -643,9 +643,14 @@ private:
 #endif
 
     private:
-        // All times are in msec
-        static constexpr uint32_t kMinDelayToAdd  = 250;
-        static constexpr uint32_t kMaxDelayToAdd  = kMinDelayToAdd + 3500;
+        // All times are in msec.
+        static constexpr uint32_t kMinDelayToAdd = 250;
+        static constexpr uint32_t kMaxDelayToAdd =
+            kMinDelayToAdd + OPENTHREAD_CONFIG_NETDATA_PUBLISHER_MAX_DELAY_TO_ADD;
+        static constexpr uint32_t kMinDelayToRemove =
+            kMaxDelayToAdd; // never remove before the peer's add window closes
+        static constexpr uint32_t kMaxDelayToRemove = OPENTHREAD_CONFIG_NETDATA_PUBLISHER_MAX_DELAY_TO_REMOVE;
+        static_assert(kMinDelayToRemove <= kMaxDelayToRemove, "kMinDelayToRemove must be <= kMaxDelayToRemove");
         static constexpr uint32_t kRetryDelay     = 1500;
         static constexpr uint16_t kRetryJitter    = 150;
         static constexpr uint16_t kInfoStringSize = 85;
@@ -664,6 +669,7 @@ private:
             kNotAdded,
             kToAdd,
             kAdded,
+            kToRemove,
         };
 
         void       SetFavoredPrefix(const OmrPrefix &aOmrPrefix);


### PR DESCRIPTION
When `OmrPrefixManager` yields to a more-favored peer prefix, `RemoveLocalFromNetData()` is called immediately, producing back-to-back Network Data version bumps.

According to the OMR section in Thread spec, cooperative (preference-based) removal should use a randomized delay, and not an immediate withdrawal.

This change adds `kToRemove` to `LocalPrefixState` completing the delayed-removal path in #12753.