### PR TITLE
[net-diag] convert MAC and MLE counters TLVs to `SimpleTlvInfo`

### DIFF
--- a/src/core/thread/net_diag.cpp
+++ b/src/core/thread/net_diag.cpp
@@ -371,19 +371,19 @@ Error Server::AppendDiagTlv(uint8_t aTlvType, Message &aMessage)
 
     case Tlv::kMacCounters:
     {
-        MacCountersTlv tlv;
+        MacCountersTlvValue tlvValue;
 
-        tlv.Init(Get<Mac::Mac>().GetCounters());
-        error = tlv.AppendTo(aMessage);
+        tlvValue.InitFrom(Get<Mac::Mac>().GetCounters());
+        error = Tlv::Append<MacCountersTlv>(aMessage, tlvValue);
         break;
     }
 
     case Tlv::kMleCounters:
     {
-        MleCountersTlv tlv;
+        MleCountersTlvValue tlvValue;
 
-        tlv.Init(Get<Mle::Mle>().GetCounters());
-        error = tlv.AppendTo(aMessage);
+        tlvValue.InitFrom(Get<Mle::Mle>().GetCounters());
+        error = Tlv::Append<MleCountersTlv>(aMessage, tlvValue);
         break;
     }
 
@@ -1195,21 +1195,19 @@ Error Client::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator,
 
         case Tlv::kMacCounters:
         {
-            MacCountersTlv macCountersTlv;
+            MacCountersTlvValue tlvValue;
 
-            SuccessOrExit(error = aMessage.Read(offset, macCountersTlv));
-            VerifyOrExit(macCountersTlv.IsValid(), error = kErrorParse);
-            macCountersTlv.Read(aDiagTlv.mData.mMacCounters);
+            SuccessOrExit(error = tlvInfo.Read<MacCountersTlv>(aMessage, tlvValue));
+            tlvValue.Read(aDiagTlv.mData.mMacCounters);
             break;
         }
 
         case Tlv::kMleCounters:
         {
-            MleCountersTlv mleCoutersTlv;
+            MleCountersTlvValue tlvValue;
 
-            SuccessOrExit(error = aMessage.Read(offset, mleCoutersTlv));
-            VerifyOrExit(mleCoutersTlv.IsValid(), error = kErrorParse);
-            mleCoutersTlv.Read(aDiagTlv.mData.mMleCounters);
+            SuccessOrExit(error = tlvInfo.Read<MleCountersTlv>(aMessage, tlvValue));
+            tlvValue.Read(aDiagTlv.mData.mMleCounters);
             break;
         }
 

--- a/src/core/thread/net_diag_tlvs.cpp
+++ b/src/core/thread/net_diag_tlvs.cpp
@@ -214,13 +214,10 @@ void AnswerTlvValue::Init(uint16_t aIndex, IsLastFlag aIsLastFlag)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-// MacCountersTlv
+// MacCountersTlvValue
 
-void MacCountersTlv::Init(const Mac::Counters &aMacCounters)
+void MacCountersTlvValue::InitFrom(const Mac::Counters &aMacCounters)
 {
-    SetType(kMacCounters);
-    SetLength(sizeof(*this) - sizeof(Tlv));
-
     mIfInUnknownProtos  = BigEndian::HostSwap32(aMacCounters.mRxOther);
     mIfInErrors         = BigEndian::HostSwap32(aMacCounters.mRxErrNoFrame + aMacCounters.mRxErrUnknownNeighbor +
                                                 aMacCounters.mRxErrInvalidSrcAddr + aMacCounters.mRxErrSec +
@@ -235,7 +232,7 @@ void MacCountersTlv::Init(const Mac::Counters &aMacCounters)
     mIfOutDiscards      = BigEndian::HostSwap32(aMacCounters.mTxErrBusyChannel);
 }
 
-void MacCountersTlv::Read(MacCounters &aDiagMacCounters) const
+void MacCountersTlvValue::Read(MacCounters &aDiagMacCounters) const
 {
     aDiagMacCounters.mIfInUnknownProtos  = BigEndian::HostSwap32(mIfInUnknownProtos);
     aDiagMacCounters.mIfInErrors         = BigEndian::HostSwap32(mIfInErrors);
@@ -249,13 +246,10 @@ void MacCountersTlv::Read(MacCounters &aDiagMacCounters) const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-// MleCountersTlv
+// MleCountersTlvValue
 
-void MleCountersTlv::Init(const Mle::Counters &aMleCounters)
+void MleCountersTlvValue::InitFrom(const Mle::Counters &aMleCounters)
 {
-    SetType(kMleCounters);
-    SetLength(sizeof(*this) - sizeof(Tlv));
-
     mDisabledRole                  = BigEndian::HostSwap16(aMleCounters.mDisabledRole);
     mDetachedRole                  = BigEndian::HostSwap16(aMleCounters.mDetachedRole);
     mChildRole                     = BigEndian::HostSwap16(aMleCounters.mChildRole);
@@ -273,7 +267,7 @@ void MleCountersTlv::Init(const Mle::Counters &aMleCounters)
     mLeaderTime                    = BigEndian::HostSwap64(aMleCounters.mLeaderTime);
 }
 
-void MleCountersTlv::Read(MleCounters &aDiagMleCounters) const
+void MleCountersTlvValue::Read(MleCounters &aDiagMleCounters) const
 {
     aDiagMleCounters.mDisabledRole                  = BigEndian::HostSwap16(mDisabledRole);
     aDiagMleCounters.mDetachedRole                  = BigEndian::HostSwap16(mDetachedRole);

--- a/src/core/thread/net_diag_tlvs.hpp
+++ b/src/core/thread/net_diag_tlvs.hpp
@@ -330,31 +330,23 @@ typedef SimpleTlvInfo<Tlv::kLeaderData, LeaderDataTlvValue> LeaderDataTlv;
 typedef otNetworkDiagMacCounters MacCounters;
 
 /**
- * Implements Mac Counters TLV generation and parsing.
+ * Implements Mac Counters TLV value generation and parsing.
  */
 OT_TOOL_PACKED_BEGIN
-class MacCountersTlv : public Tlv, public TlvInfo<Tlv::kMacCounters>
+class MacCountersTlvValue
 {
 public:
     /**
-     * Initializes the TLV.
+     * Initializes the TLV value.
      *
      * @param[in] aMacCounters    The MAC counters to initialize the TLV with.
      */
-    void Init(const Mac::Counters &aMacCounters);
+    void InitFrom(const Mac::Counters &aMacCounters);
 
     /**
-     * Indicates whether or not the TLV appears to be well-formed.
+     * Reads the counters from the TLV value.
      *
-     * @retval TRUE   If the TLV appears to be well-formed.
-     * @retval FALSE  If the TLV does not appear to be well-formed.
-     */
-    bool IsValid(void) const { return GetLength() >= sizeof(*this) - sizeof(Tlv); }
-
-    /**
-     * Reads the counters from TLV.
-     *
-     * @param[out] aDiagMacCounters   A reference to `NetDiag::MacCounters` to populate.
+     * @param[out] aDiagMacCounters   A reference to `MacCounters` to populate.
      */
     void Read(MacCounters &aDiagMacCounters) const;
 
@@ -369,6 +361,11 @@ private:
     uint32_t mIfOutBroadcastPkts;
     uint32_t mIfOutDiscards;
 } OT_TOOL_PACKED_END;
+
+/**
+ * Defines Mac Counters  TLV constants and types.
+ */
+typedef SimpleTlvInfo<Tlv::kMacCounters, MacCountersTlvValue> MacCountersTlv;
 
 /**
  * Implements Child Table TLV Entry generation and parsing.
@@ -870,30 +867,21 @@ typedef SimpleTlvInfo<Tlv::kAnswer, AnswerTlvValue> AnswerTlv;
 typedef otNetworkDiagMleCounters MleCounters;
 
 /**
- * Implements MLE Counters TLV generation and parsing.
+ * Implements MLE Counters TLV value generation and parsing.
  */
 OT_TOOL_PACKED_BEGIN
-class MleCountersTlv : public Tlv, public TlvInfo<Tlv::kMleCounters>
+class MleCountersTlvValue
 {
 public:
     /**
-     * Initializes the TLV.
+     * Initializes the TLV value.
      *
      * @param[in] aMleCounters    The MLE counters to initialize the TLV with.
      */
-    void Init(const Mle::Counters &aMleCounters);
+    void InitFrom(const Mle::Counters &aMleCounters);
 
     /**
-     * Indicates whether or not the TLV appears to be well-formed.
-     *
-     * @retval TRUE   If the TLV appears to be well-formed.
-     * @retval FALSE  If the TLV does not appear to be well-formed.
-     */
-    bool IsValid(void) const { return GetLength() >= sizeof(*this) - sizeof(Tlv); }
-
-    /**
-     *
-     * Reads the counters from TLV.
+     * Reads the counters from TLV value
      *
      * @param[out] aDiagMleCounters   A reference to `NetDiag::MleCounters` to populate.
      */
@@ -916,6 +904,11 @@ private:
     uint64_t mRouterTime;                    // Milliseconds device has been in router role.
     uint64_t mLeaderTime;                    // Milliseconds device has been in leader role.
 } OT_TOOL_PACKED_END;
+
+/**
+ * Defines MLE Counters TLV constants and types.
+ */
+typedef SimpleTlvInfo<Tlv::kMleCounters, MleCountersTlvValue> MleCountersTlv;
 
 } // namespace NetDiag
 


### PR DESCRIPTION
This commit updates `MacCountersTlv` and `MleCountersTlv` to use the `SimpleTlvInfo` template. The original classes are replaced with `MacCountersTlvValue` and `MleCountersTlvValue` which only represent the TLV values. This helps simplify the TLV parsing and appending logic and more importantly allows the TLV value formats to be reused.