### PR TITLE
[instance] fix typo in `mIsLogLevelOverridden` member variable

### DIFF
--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -323,7 +323,7 @@ Instance::Instance(void)
 #if OPENTHREAD_CONFIG_LOG_LEVEL_OVERRIDE_ENABLE
     , mOriginalLogLevel(kLogLevelNone)
     , mOverrideLogLevel(kLogLevelNone)
-    , mIsLogLevelOverriden(false)
+    , mIsLogLevelOverridden(false)
 #endif
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
     , mIsLogLevelSet(false)
@@ -601,7 +601,7 @@ Error Instance::SetLogLevel(LogLevel aLogLevel)
     ExitNow(error = kErrorNotCapable);
 #else
 #if OPENTHREAD_CONFIG_LOG_LEVEL_OVERRIDE_ENABLE
-    if (mIsLogLevelOverriden)
+    if (mIsLogLevelOverridden)
     {
         mOriginalLogLevel = aLogLevel;
         aLogLevel         = Max(aLogLevel, mOverrideLogLevel);
@@ -632,10 +632,10 @@ void Instance::OverrideLogLevel(LogLevel aLogLevel)
 {
     LogLevel logLevel;
 
-    if (!mIsLogLevelOverriden)
+    if (!mIsLogLevelOverridden)
     {
-        mOriginalLogLevel    = GetLogLevel();
-        mIsLogLevelOverriden = true;
+        mOriginalLogLevel     = GetLogLevel();
+        mIsLogLevelOverridden = true;
     }
 
     mOverrideLogLevel = aLogLevel;
@@ -652,8 +652,8 @@ exit:
 
 void Instance::RestoreLogLevel(void)
 {
-    VerifyOrExit(mIsLogLevelOverriden);
-    mIsLogLevelOverriden = false;
+    VerifyOrExit(mIsLogLevelOverridden);
+    mIsLogLevelOverridden = false;
     IgnoreError(SetLogLevel(mOriginalLogLevel));
 
 exit:

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -902,7 +902,7 @@ private:
 #if OPENTHREAD_CONFIG_LOG_LEVEL_OVERRIDE_ENABLE
     LogLevel mOriginalLogLevel;
     LogLevel mOverrideLogLevel;
-    bool     mIsLogLevelOverriden;
+    bool     mIsLogLevelOverridden;
 #endif
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
     bool mIsLogLevelSet;


### PR DESCRIPTION
This commit fixes a spelling error in `Instance` class where `mIsLogLevelOverriden` was misspelled. It has been corrected to `mIsLogLevelOverridden`.