### PR TITLE
[bit-set] cast bitwise NOT in FlipBits to uint8_t

### DIFF
--- a/src/core/common/bit_set.cpp
+++ b/src/core/common/bit_set.cpp
@@ -67,7 +67,7 @@ void BitSetUtils::FlipBits(uint8_t *aTargetMask, uint16_t aSize, uint16_t aNumBi
 {
     for (uint16_t i = 0; i < aSize; i++)
     {
-        aTargetMask[i] = ~aTargetMask[i];
+        aTargetMask[i] = static_cast<uint8_t>(~aTargetMask[i]);
     }
 
     Tidy(aTargetMask, aSize, aNumBits);
@@ -106,7 +106,7 @@ void BitSetUtils::Subtract(uint8_t *aTargetMask, const uint8_t *aMask, uint16_t 
 {
     for (uint16_t i = 0; i < aSize; i++)
     {
-        aTargetMask[i] &= (~aMask[i]);
+        aTargetMask[i] &= static_cast<uint8_t>(~aMask[i]);
     }
 }
 


### PR DESCRIPTION
Explicitly cast the result of the bitwise NOT operator ~ to uint8_t in BitSetUtils::FlipBits to resolve a build error under AppleClang.

In C++, using the bitwise NOT operator on a uint8_t value promotes it to an int. Assigning the promoted int back to uint8_t triggers an implicit conversion warning/error (-Wimplicit-int-conversion) under newer compiler versions, which fails the build when compiled with -Werror.