### PR TITLE
[nexus] isolate both leaders during Step 2 in announce flap test

### DIFF
--- a/tests/nexus/test_announce_no_flap_on_unmergeable_partitions.cpp
+++ b/tests/nexus/test_announce_no_flap_on_unmergeable_partitions.cpp
@@ -118,10 +118,11 @@ void Test(void)
         Log("---------------------------------------------------------------------------------------");
         Log("Step 2: LEADER_NEW forms its own partition with the newer Active Timestamp (isolated)");
 
-        // Isolate LEADER_NEW (empty allowlist drops all RX) so it cannot
-        // hear LEADER_OLD and is forced to form its own partition rather
-        // than attach as a child.
+        // Isolate both nodes so they cannot hear each other. This prevents
+        // LEADER_OLD from attempting to attach to LEADER_NEW, and forces
+        // LEADER_NEW to form its own partition.
         leaderNew.Get<Mac::Filter>().SetMode(Mac::Filter::kModeAllowlist);
+        leaderOld.Get<Mac::Filter>().SetMode(Mac::Filter::kModeAllowlist);
 
         timestamp.SetSeconds(kTimestampNew);
         datasetInfo.Set<MeshCoP::Dataset::kActiveTimestamp>(timestamp);


### PR DESCRIPTION
Fixes an intermittent failure in the
`nexus_announce_no_flap_on_unmergeable_partitions` test.

Previously, only LEADER_NEW was isolated (by enabling allowlist mode with an empty address list) in Step 2. Because LEADER_OLD still had allowlist mode disabled, it could receive advertisements from LEADER_NEW. If LEADER_NEW's randomly allocated partition ID happened to be larger than LEADER_OLD's, LEADER_OLD would see it as a "better partition" and initiate a transition to child to attach to LEADER_NEW.

Although this attempt would initially fail in Step 2 (since LEADER_NEW dropped all RX), it kept retrying. In Step 3, when the allowlist was opened on both sides, the queued/retried attach attempt from LEADER_OLD succeeded, making it a child and causing the Leader assertion to fail.

Isolating both nodes during Step 2 ensures that LEADER_OLD never hears LEADER_NEW's initial good-link advertisements. When Step 3 begins, it only hears LEADER_NEW through the weak link and correctly rejects the advertisements, keeping both nodes stable leaders of separate partitions.