### PR TITLE
[tests] fix uninitialized memory in nexus test 1_3_DBR_TC_7A

### DIFF
--- a/tests/nexus/test_1_3_DBR_TC_7A.cpp
+++ b/tests/nexus/test_1_3_DBR_TC_7A.cpp
@@ -189,6 +189,7 @@ void Test_1_3_DBR_TC_7A(void)
     nexus.AddTestVar("PRE_1", kPre1Prefix);
 
     NetworkData::OnMeshPrefixConfig config;
+    config.Clear();
     SuccessOrQuit(AsCoreType(&config.mPrefix).FromString(kPre1Prefix));
     config.mPreference   = NetworkData::kRoutePreferenceHigh;
     config.mPreferred    = true;


### PR DESCRIPTION
The test `test_1_3_DBR_TC_7A` was failing occasionally due to uninitialized stack memory in `NetworkData::OnMeshPrefixConfig config`.

Because `OnMeshPrefixConfig` inherits from `otBorderRouterConfig` and does not automatically initialize its fields in its default constructor, declaring `NetworkData::OnMeshPrefixConfig config;` on the stack left its members (including `mDp` and `mNdDns` flags) with arbitrary stack garbage. If `mDp` (Domain Prefix flag) evaluated to true, it caused the registered `PRE_1` prefix to be erroneously processed as a Domain Prefix. Consequently, the border router did not include `PRE_1` as a Route Information Option (RIO) in its emitted Router Advertisements, causing packet verification to fail in Step 4.

This commit fixes the issue by explicitly initializing the `config` struct using `config.Clear()` right after declaration.