### PR TITLE
[ip6] rename methods fully initializing an `Ip6::Address/Prefix`

### DIFF
--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -191,7 +191,7 @@ bool otIp6IsLinkLocalUnicast(const otIp6Address *aAddress) { return AsCoreType(a
 
 void otIp6FormLinkLocalAddressFromExtAddress(const otExtAddress *aExtAddress, otIp6Address *aAddress)
 {
-    AsCoreType(aAddress).SetToLinkLocalAddress(AsCoreType(aExtAddress));
+    AsCoreType(aAddress).InitAsLinkLocalAddress(AsCoreType(aExtAddress));
 }
 
 void otIp6ExtractExtAddressFromIp6AddressIid(const otIp6Address *aAddress, otExtAddress *aExtAddress)

--- a/src/core/api/nat64_api.cpp
+++ b/src/core/api/nat64_api.cpp
@@ -142,7 +142,7 @@ otError otIp4FromIp4MappedIp6Address(const otIp6Address *aIp6Address, otIp4Addre
 
 void otIp4ToIp4MappedIp6Address(const otIp4Address *aIp4Address, otIp6Address *aIp6Address)
 {
-    AsCoreType(aIp6Address).SetToIp4Mapped(AsCoreType(aIp4Address));
+    AsCoreType(aIp6Address).InitAsIp4Mapped(AsCoreType(aIp4Address));
 }
 
 otError otIp4AddressFromString(const char *aString, otIp4Address *aAddress)

--- a/src/core/backbone_router/bbr_local.cpp
+++ b/src/core/backbone_router/bbr_local.cpp
@@ -57,7 +57,7 @@ Local::Local(Instance &aInstance)
 
     // Primary Backbone Router Aloc
     mBbrPrimaryAloc.InitAsThreadOriginMeshLocal();
-    mBbrPrimaryAloc.GetAddress().GetIid().SetToLocator(Mle::Aloc16::ForPrimaryBackboneRouter());
+    mBbrPrimaryAloc.GetAddress().GetIid().InitAsLocator(Mle::Aloc16::ForPrimaryBackboneRouter());
 
     // All Network Backbone Routers Multicast Address.
     mAllNetworkBackboneRouters.Clear();

--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -278,7 +278,7 @@ Error InfraIf::LinkLayerAddress::ConvertToIid(Ip6::InterfaceIdentifier &aIid) co
         ExitNow(error = kErrorNotCapable);
     }
 
-    aIid.SetFromExtAddress(extAddress);
+    aIid.InitFromExtAddress(extAddress);
 
 exit:
     return error;

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -224,7 +224,7 @@ void RoutingManager::LoadOrGenerateRandomBrUlaPrefix(void)
 
         SuccessOrAssert(randomUlaPrefix.GenerateRandomUla());
 
-        mBrUlaPrefix.Set(randomUlaPrefix);
+        mBrUlaPrefix.InitFrom(randomUlaPrefix);
         mBrUlaPrefix.SetSubnetId(0);
         mBrUlaPrefix.SetLength(kBrUlaPrefixLength);
 

--- a/src/core/meshcop/border_agent_txt_data.cpp
+++ b/src/core/meshcop/border_agent_txt_data.cpp
@@ -544,7 +544,7 @@ bool TxtData::Info::ReadOmrPrefix(const Dns::TxtEntry &aEntry, Ip6::Prefix &aPre
     VerifyOrExit(length <= Ip6::Prefix::kMaxLength);
     VerifyOrExit(aEntry.mValueLength >= sizeof(uint8_t) + Ip6::Prefix::SizeForLength(length));
 
-    aPrefix.Set(&aEntry.mValue[1], length);
+    aPrefix.InitFrom(&aEntry.mValue[1], length);
     didRead = true;
 
 exit:

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -168,7 +168,7 @@ template <> void JoinerRouter::HandleTmf<kUriRelayTx>(Coap::Msg &aMsg)
 
     SuccessOrExit(error = message->AppendBytesFromMessage(aMsg.mMessage, offsetRange));
 
-    messageInfo.GetPeerAddr().SetToLinkLocalAddress(joinerIid);
+    messageInfo.GetPeerAddr().InitAsLinkLocalAddress(joinerIid);
     messageInfo.SetPeerPort(joinerPort);
 
     SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));

--- a/src/core/meshcop/seeker.cpp
+++ b/src/core/meshcop/seeker.cpp
@@ -279,7 +279,7 @@ Error Seeker::SetUpNextConnection(Ip6::SockAddr &aSockAddr)
 
     aSockAddr.Clear();
     aSockAddr.SetPort(entry.mJoinerUdpPort);
-    aSockAddr.GetAddress().SetToLinkLocalAddress(entry.mExtAddr);
+    aSockAddr.GetAddress().InitAsLinkLocalAddress(entry.mExtAddr);
 
 exit:
     return error;

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -268,7 +268,7 @@ void Client::Solicit(uint16_t aRloc16)
 #if OPENTHREAD_ENABLE_DHCP6_MULTICAST_SOLICIT
     messageInfo.SetPeerAddr(Ip6::Address::GetRealmLocalAllRoutersMulticast());
 #else
-    messageInfo.GetPeerAddr().SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aRloc16);
+    messageInfo.GetPeerAddr().InitAsRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aRloc16);
 #endif
     messageInfo.SetSockAddr(Get<Mle::Mle>().GetMeshLocalRloc());
     messageInfo.mPeerPort = kDhcpServerPort;

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -402,7 +402,7 @@ Error Server::AppendIaAddressOption(Message               &aMessage,
 
     option.Init();
     option.GetAddress().SetPrefix(aPrefix.mFields.m8, OT_IP6_PREFIX_BITSIZE);
-    option.GetAddress().GetIid().SetFromExtAddress(aClientAddress);
+    option.GetAddress().GetIid().InitFromExtAddress(aClientAddress);
     option.SetPreferredLifetime(IaAddressOption::kDefaultPreferredLifetime);
     option.SetValidLifetime(IaAddressOption::kDefaultValidLifetime);
     SuccessOrExit(error = aMessage.Append(option));

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -152,7 +152,7 @@ private:
             mPrefix = aPrefix;
 
             mAloc.InitAsThreadOrigin();
-            mAloc.GetAddress().SetToAnycastLocator(aMeshLocalPrefix, (Ip6::Address::kAloc16Mask << 8) + aContextId);
+            mAloc.GetAddress().InitAsAnycastLocator(aMeshLocalPrefix, (Ip6::Address::kAloc16Mask << 8) + aContextId);
             mAloc.mMeshLocal = true;
         }
 

--- a/src/core/net/dhcp6_types.cpp
+++ b/src/core/net/dhcp6_types.cpp
@@ -304,7 +304,7 @@ void IaPrefixOption::GetPrefix(Ip6::Prefix &aPrefix) const
 {
     uint8_t length = Min(GetPrefixLength(), Ip6::Prefix::kMaxLength);
 
-    aPrefix.Set(mPrefix.mFields.m8, length);
+    aPrefix.InitFrom(mPrefix.mFields.m8, length);
     aPrefix.Tidy();
 }
 

--- a/src/core/net/ip4_types.cpp
+++ b/src/core/net/ip4_types.cpp
@@ -72,7 +72,7 @@ Error Address::ExtractFromIp4MappedIp6Address(const Ip6::Address &aIp6Address)
     Error error = kErrorNone;
 
     VerifyOrExit(aIp6Address.IsIp4Mapped(), error = kErrorParse);
-    SetBytes(&aIp6Address.GetBytes()[12]);
+    InitFrom(&aIp6Address.GetBytes()[12]);
 
 exit:
     return error;

--- a/src/core/net/ip4_types.hpp
+++ b/src/core/net/ip4_types.hpp
@@ -110,12 +110,12 @@ public:
     const uint8_t *GetBytes(void) const { return mFields.m8; }
 
     /**
-     * Sets the IPv4 address from a given byte array.
+     * Initializes the IPv4 address from a given byte array.
      *
      * @param[in] aBuffer    Pointer to an array containing the IPv4 address. `kSize` bytes from the buffer
      *                       are copied to form the IPv4 address.
      */
-    void SetBytes(const uint8_t *aBuffer) { memcpy(mFields.m8, aBuffer, kSize); }
+    void InitFrom(const uint8_t *aBuffer) { memcpy(mFields.m8, aBuffer, kSize); }
 
     /**
      * Sets the IPv4 address from a given IPv4-mapped IPv6 address.

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -48,7 +48,7 @@ Error NetworkPrefix::GenerateRandomUla(void)
     return Random::Crypto::FillBuffer(&m8[1], kSize - 1);
 }
 
-Error NetworkPrefix::SetFrom(const Prefix &aPrefix)
+Error NetworkPrefix::InitFrom(const Prefix &aPrefix)
 {
     Error error = kErrorNone;
 
@@ -62,7 +62,7 @@ exit:
 //---------------------------------------------------------------------------------------------------------------------
 // Prefix methods
 
-void Prefix::Set(const uint8_t *aPrefix, uint8_t aLength)
+void Prefix::InitFrom(const uint8_t *aPrefix, uint8_t aLength)
 {
     memcpy(mPrefix.mFields.m8, aPrefix, SizeForLength(aLength));
     mLength = aLength;
@@ -227,9 +227,9 @@ bool InterfaceIdentifier::IsReservedSubnetAnycast(void) const
 
 void InterfaceIdentifier::GenerateRandom(void) { SuccessOrAssert(Random::Crypto::Fill(*this)); }
 
-void InterfaceIdentifier::SetBytes(const uint8_t *aBuffer) { memcpy(mFields.m8, aBuffer, kSize); }
+void InterfaceIdentifier::InitFrom(const uint8_t *aBuffer) { memcpy(mFields.m8, aBuffer, kSize); }
 
-void InterfaceIdentifier::SetFromExtAddress(const Mac::ExtAddress &aExtAddress)
+void InterfaceIdentifier::InitFromExtAddress(const Mac::ExtAddress &aExtAddress)
 {
     Mac::ExtAddress addr;
 
@@ -238,7 +238,7 @@ void InterfaceIdentifier::SetFromExtAddress(const Mac::ExtAddress &aExtAddress)
     addr.CopyTo(mFields.m8);
 }
 
-void InterfaceIdentifier::SetToLocator(uint16_t aLocator)
+void InterfaceIdentifier::InitAsLocator(uint16_t aLocator)
 {
     // Locator IID pattern `0000:00ff:fe00:xxxx`
     mFields.m32[0] = BigEndian::HostSwap32(0x000000ff);
@@ -307,14 +307,14 @@ bool Address::IsLinkLocalUnicast(void) const
     return (mFields.m16[0] & BigEndian::HostSwap16(0xffc0)) == BigEndian::HostSwap16(0xfe80);
 }
 
-void Address::SetToLinkLocalAddress(const Mac::ExtAddress &aExtAddress)
+void Address::InitAsLinkLocalAddress(const Mac::ExtAddress &aExtAddress)
 {
     mFields.m32[0] = BigEndian::HostSwap32(0xfe800000);
     mFields.m32[1] = 0;
-    GetIid().SetFromExtAddress(aExtAddress);
+    GetIid().InitFromExtAddress(aExtAddress);
 }
 
-void Address::SetToLinkLocalAddress(const InterfaceIdentifier &aIid)
+void Address::InitAsLinkLocalAddress(const InterfaceIdentifier &aIid)
 {
     mFields.m32[0] = BigEndian::HostSwap32(0xfe800000);
     mFields.m32[1] = 0;
@@ -334,7 +334,7 @@ bool Address::IsIp4Mapped(void) const
     return (mFields.m32[0] == 0) && (mFields.m32[1] == 0) && (mFields.m32[2] == BigEndian::HostSwap32(0xffff));
 }
 
-void Address::SetToIp4Mapped(const Ip4::Address &aIp4Address)
+void Address::InitAsIp4Mapped(const Ip4::Address &aIp4Address)
 {
     Clear();
     mFields.m16[5] = 0xffff;
@@ -385,10 +385,10 @@ void Address::SetMulticastNetworkPrefix(const uint8_t *aPrefix, uint8_t aPrefixL
     mFields.m8[kMulticastNetworkPrefixLengthOffset] = aPrefixLength;
 }
 
-void Address::SetToLocator(const NetworkPrefix &aNetworkPrefix, uint16_t aLocator)
+void Address::InitAsLocator(const NetworkPrefix &aNetworkPrefix, uint16_t aLocator)
 {
     SetPrefix(aNetworkPrefix);
-    GetIid().SetToLocator(aLocator);
+    GetIid().InitAsLocator(aLocator);
 }
 
 uint8_t Address::GetScope(void) const

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -83,14 +83,14 @@ public:
     Error GenerateRandomUla(void);
 
     /**
-     * Sets the Network Prefix from a given `Prefix`.
+     * Initializes the Network Prefix from a given `Prefix`.
      *
      * @param[in] aPrefix  The prefix to use to set the Network Prefix.
      *
      * @retval kErrorNone          Successfully set the Network Prefix from @p aPrefix.
      * @retval kErrorInvalidArgs   The @p aPrefix length is not valid (must be `kLength`).
      */
-    Error SetFrom(const Prefix &aPrefix);
+    Error InitFrom(const Prefix &aPrefix);
 
 } OT_TOOL_PACKED_END;
 
@@ -140,19 +140,19 @@ public:
     uint8_t GetBytesSize(void) const { return SizeForLength(mLength); }
 
     /**
-     * Sets the prefix.
+     * Initializes the prefix.
      *
      * @param[in] aPrefix  A pointer to buffer containing the prefix bytes.
      * @param[in] aLength  The length or prefix in bits.
      */
-    void Set(const uint8_t *aPrefix, uint8_t aLength);
+    void InitFrom(const uint8_t *aPrefix, uint8_t aLength);
 
     /**
-     * Sets the prefix from a given Network Prefix.
+     * Initializes the prefix from a given Network Prefix.
      *
      * @param[in] aNetworkPrefix    A Network Prefix.
      */
-    void Set(const NetworkPrefix &aNetworkPrefix) { Set(aNetworkPrefix.m8, NetworkPrefix::kLength); }
+    void InitFrom(const NetworkPrefix &aNetworkPrefix) { InitFrom(aNetworkPrefix.m8, NetworkPrefix::kLength); }
 
     /**
      * Sets the subnet ID of the prefix.
@@ -394,27 +394,27 @@ public:
     const uint8_t *GetBytes(void) const { return mFields.m8; }
 
     /**
-     * Sets the Interface Identifier from a given byte array.
+     * Initializes the Interface Identifier from a given byte array.
      *
      * @param[in] aBuffer    Pointer to an array containing the Interface Identifier. `kSize` bytes from the buffer
      *                       are copied to form the Interface Identifier.
      */
-    void SetBytes(const uint8_t *aBuffer);
+    void InitFrom(const uint8_t *aBuffer);
 
     /**
-     * Sets the Interface Identifier from a given IEEE 802.15.4 Extended Address.
+     * Initializes the Interface Identifier from a given IEEE 802.15.4 Extended Address.
      *
      * @param[in] aExtAddress  An Extended Address.
      */
-    void SetFromExtAddress(const Mac::ExtAddress &aExtAddress);
+    void InitFromExtAddress(const Mac::ExtAddress &aExtAddress);
 
     /**
-     * Sets the Interface Identifier to Routing/Anycast Locator pattern `0000:00ff:fe00:xxxx` with a given
+     * Initializes the Interface Identifier to Routing/Anycast Locator pattern `0000:00ff:fe00:xxxx` with a given
      * locator (RLOC16 or ALOC16) value.
      *
      * @param[in]  aLocator    RLOC16 or ALOC16.
      */
-    void SetToLocator(uint16_t aLocator);
+    void InitAsLocator(uint16_t aLocator);
 
     /**
      * Indicates whether or not the Interface Identifier matches the locator pattern `0000:00ff:fe00:xxxx`.
@@ -470,7 +470,7 @@ public:
     /**
      * Sets the Interface Identifier (IID) address locator field.
      *
-     * Unlike `SetToLocator()`, this method only changes the last 2 bytes of the IID and keeps the rest of the address
+     * Unlike `InitAsLocator()`, this method only changes the last 2 bytes of the IID and keeps the rest of the address
      * as before.
      *
      * @param[in]  aLocator   RLOC16 or ALOC16.
@@ -539,12 +539,12 @@ public:
     const uint8_t *GetBytes(void) const { return mFields.m8; }
 
     /**
-     * Sets the IPv6 address from a given byte array.
+     * Initializes the IPv6 address from a given byte array.
      *
      * @param[in] aBuffer    Pointer to an array containing the IPv6 address. `kSize` bytes from the buffer
      *                       are copied to form the IPv6 address.
      */
-    void SetBytes(const uint8_t *aBuffer) { memcpy(mFields.m8, aBuffer, kSize); }
+    void InitFrom(const uint8_t *aBuffer) { memcpy(mFields.m8, aBuffer, kSize); }
 
     /**
      * Indicates whether or not the IPv6 address is the Unspecified Address.
@@ -571,19 +571,19 @@ public:
     bool IsLinkLocalUnicast(void) const;
 
     /**
-     * Sets the IPv6 address to a Link-Local address with Interface Identifier generated from a given
-     * MAC Extended Address.
+     * Initializes the IPv6 address as a Link-Local address with Interface Identifier generated from a given MAC
+     * Extended Address.
      *
      * @param[in]  aExtAddress  A MAC Extended Address (used to generate the IID).
      */
-    void SetToLinkLocalAddress(const Mac::ExtAddress &aExtAddress);
+    void InitAsLinkLocalAddress(const Mac::ExtAddress &aExtAddress);
 
     /**
-     * Sets the IPv6 address to a Link-Local address with a given Interface Identifier.
+     * Initializes the IPv6 address to a Link-Local address with a given Interface Identifier.
      *
      * @param[in]  aIid   An Interface Identifier.
      */
-    void SetToLinkLocalAddress(const InterfaceIdentifier &aIid);
+    void InitAsLinkLocalAddress(const InterfaceIdentifier &aIid);
 
     /**
      * Indicates whether or not the IPv6 address is multicast address.
@@ -661,27 +661,27 @@ public:
     static const Address &GetRealmLocalAllMplForwarders(void);
 
     /**
-     * Sets the IPv6 address to a Routing Locator (RLOC) IPv6 address with a given Network Prefix and
-     * RLOC16 value.
+     * Initializes the IPv6 address to a Routing Locator (RLOC) IPv6 address with a given Network Prefix and RLOC16
+     * value.
      *
      * @param[in]  aNetworkPrefix    A Network Prefix.
      * @param[in]  aRloc16           A RLOC16 value.
      */
-    void SetToRoutingLocator(const NetworkPrefix &aNetworkPrefix, uint16_t aRloc16)
+    void InitAsRoutingLocator(const NetworkPrefix &aNetworkPrefix, uint16_t aRloc16)
     {
-        SetToLocator(aNetworkPrefix, aRloc16);
+        InitAsLocator(aNetworkPrefix, aRloc16);
     }
 
     /**
-     * Sets the IPv6 address to a Anycast Locator (ALOC) IPv6 address with a given Network Prefix and
-     * ALOC16 value.
+     * Initializes the IPv6 address to a Anycast Locator (ALOC) IPv6 address with a given Network Prefix and ALOC16
+     * value.
      *
      * @param[in]  aNetworkPrefix    A Network Prefix.
      * @param[in]  aAloc16           A ALOC16 value.
      */
-    void SetToAnycastLocator(const NetworkPrefix &aNetworkPrefix, uint16_t aAloc16)
+    void InitAsAnycastLocator(const NetworkPrefix &aNetworkPrefix, uint16_t aAloc16)
     {
-        SetToLocator(aNetworkPrefix, aAloc16);
+        InitAsLocator(aNetworkPrefix, aAloc16);
     }
 
     /**
@@ -697,11 +697,11 @@ public:
     bool IsIp4Mapped(void) const;
 
     /**
-     * Sets the IPv6 address to follow the IPv4-mapped IPv6 address for a given IPv4 address.
+     * Initializes the IPv6 address to follow the IPv4-mapped IPv6 address for a given IPv4 address.
      *
      * @param[in] aIp4Address  An IPv4 address.
      */
-    void SetToIp4Mapped(const Ip4::Address &aIp4Address);
+    void InitAsIp4Mapped(const Ip4::Address &aIp4Address);
 
     /**
      * Returns the Network Prefix of the IPv6 address (most significant 64 bits of the address).
@@ -719,7 +719,7 @@ public:
      * @param[in]  aLength  The length of prefix in bits.
      * @param[out] aPrefix  A reference to a prefix to output the fetched prefix.
      */
-    void GetPrefix(uint8_t aLength, Prefix &aPrefix) const { aPrefix.Set(mFields.m8, aLength); }
+    void GetPrefix(uint8_t aLength, Prefix &aPrefix) const { aPrefix.InitFrom(mFields.m8, aLength); }
 
     /**
      * Indicates whether the IPv6 address matches a given prefix.
@@ -908,7 +908,7 @@ private:
     static constexpr uint8_t kMulticastNetworkPrefixLengthOffset = 3; // Prefix-Based Multicast Address (RFC3306)
     static constexpr uint8_t kMulticastNetworkPrefixOffset       = 4; // Prefix-Based Multicast Address (RFC3306)
 
-    void SetToLocator(const NetworkPrefix &aNetworkPrefix, uint16_t aLocator);
+    void InitAsLocator(const NetworkPrefix &aNetworkPrefix, uint16_t aLocator);
     void ToString(StringWriter &aWriter) const;
     void AppendHexWords(StringWriter &aWriter, uint8_t aLength) const;
 

--- a/src/core/net/mdns.cpp
+++ b/src/core/net/mdns.cpp
@@ -7242,7 +7242,7 @@ void Core::Ip4AddrCache::ProcessResponseRecord(const Message &aMessage, uint16_t
     SuccessOrExit(aMessage.Read(aRecordOffset, aRecord));
     VerifyOrExit(aRecord.GetLength() >= sizeof(Ip4::Address));
 
-    address.SetToIp4Mapped(aRecord.GetAddress());
+    address.InitAsIp4Mapped(aRecord.GetAddress());
 
     AddNewResponseAddress(address, aRecord.GetTtl(), aRecord.GetClass() & kClassCacheFlushFlag);
 

--- a/src/core/net/nd6.cpp
+++ b/src/core/net/nd6.cpp
@@ -96,7 +96,7 @@ void PrefixInfoOption::SetPrefix(const Prefix &aPrefix)
     mPrefix       = AsCoreType(&aPrefix.mPrefix);
 }
 
-void PrefixInfoOption::GetPrefix(Prefix &aPrefix) const { aPrefix.Set(mPrefix.GetBytes(), mPrefixLength); }
+void PrefixInfoOption::GetPrefix(Prefix &aPrefix) const { aPrefix.InitFrom(mPrefix.GetBytes(), mPrefixLength); }
 
 bool PrefixInfoOption::IsValid(void) const
 {
@@ -131,7 +131,7 @@ void RouteInfoOption::SetPrefix(const Prefix &aPrefix)
     memcpy(GetPrefixBytes(), aPrefix.GetBytes(), aPrefix.GetBytesSize());
 }
 
-void RouteInfoOption::GetPrefix(Prefix &aPrefix) const { aPrefix.Set(GetPrefixBytes(), mPrefixLength); }
+void RouteInfoOption::GetPrefix(Prefix &aPrefix) const { aPrefix.InitFrom(GetPrefixBytes(), mPrefixLength); }
 
 bool RouteInfoOption::IsValid(void) const
 {
@@ -234,7 +234,7 @@ Error Nat64PrefixOption::GetPrefix(Prefix &aPrefix) const
 
     VerifyOrExit(prefixLengthCode < GetArrayLength(kPrefixLengths), error = kErrorParse);
 
-    aPrefix.Set(mPrefixMsb, kPrefixLengths[prefixLengthCode]);
+    aPrefix.InitFrom(mPrefixMsb, kPrefixLengths[prefixLengthCode]);
 
 exit:
     return error;

--- a/src/core/net/nd_agent.cpp
+++ b/src/core/net/nd_agent.cpp
@@ -103,7 +103,7 @@ void Agent::UpdateService(void)
             uint16_t aloc16 = Mle::Aloc16::FromNdAgentContextId(lowpanContext.GetContextId());
 
             mAloc.InitAsThreadOrigin();
-            mAloc.GetAddress().SetToAnycastLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aloc16);
+            mAloc.GetAddress().InitAsAnycastLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aloc16);
             mAloc.mMeshLocal = true;
             Get<ThreadNetif>().AddUnicastAddress(mAloc);
             ExitNow();

--- a/src/core/net/slaac_address.cpp
+++ b/src/core/net/slaac_address.cpp
@@ -439,7 +439,7 @@ Error Slaac::GenerateIid(Netif::UnicastAddress &aAddress, uint8_t &aDadCounter) 
         sha256.Update(secretKey);
         sha256.Finish(hash);
 
-        aAddress.GetAddress().GetIid().SetBytes(hash.GetBytes());
+        aAddress.GetAddress().GetIid().InitFrom(hash.GetBytes());
 
         // If the IID is reserved, try again with a new dadCounter
         if (aAddress.GetAddress().GetIid().IsReserved())

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -786,7 +786,7 @@ template <> void AddressResolver::HandleTmf<kUriAddressError>(Coap::Msg &aMsg)
 
             if (child.RemoveIp6Address(target) == kErrorNone)
             {
-                destination.SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), child.GetRloc16());
+                destination.InitAsRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), child.GetRloc16());
 
                 SendAddressError(target, meshLocalIid, destination);
                 ExitNow();

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -498,7 +498,8 @@ void DuaManager::PerformNextRegistration(void)
     }
     else
     {
-        destAddr.SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), Get<BackboneRouter::Leader>().GetServer16());
+        destAddr.InitAsRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(),
+                                      Get<BackboneRouter::Leader>().GetServer16());
     }
 
     SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, destAddr, HandleDuaResponse, this));

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -46,7 +46,7 @@ void Context::InitForMeshLocalPrefix(Instance &aInstance)
     mIsValid      = true;
     mCompressFlag = true;
     mContextId    = Mle::kMeshLocalPrefixContextId;
-    mPrefix.Set(aInstance.Get<Mle::Mle>().GetMeshLocalPrefix());
+    mPrefix.InitFrom(aInstance.Get<Mle::Mle>().GetMeshLocalPrefix());
 }
 
 void Context::InitFrom(const NetworkData::PrefixTlv &aPrefixTlv, const NetworkData::ContextTlv &aContextTlv)
@@ -87,11 +87,11 @@ Error Lowpan::ComputeIid(const Mac::Address &aMacAddr, const Context &aContext, 
     switch (aMacAddr.GetType())
     {
     case Mac::Address::kTypeShort:
-        aIid.SetToLocator(aMacAddr.GetShort());
+        aIid.InitAsLocator(aMacAddr.GetShort());
         break;
 
     case Mac::Address::kTypeExtended:
-        aIid.SetFromExtAddress(aMacAddr.GetExtended());
+        aIid.InitFromExtAddress(aMacAddr.GetExtended());
         break;
 
     default:

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -558,7 +558,7 @@ void MeshForwarder::SendDestinationUnreachable(uint16_t aMeshSource, const Ip6::
 {
     Ip6::MessageInfo messageInfo;
 
-    messageInfo.GetPeerAddr().SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aMeshSource);
+    messageInfo.GetPeerAddr().InitAsRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aMeshSource);
 
     IgnoreError(Get<Ip6::Icmp>().SendError(Ip6::Icmp::Header::kTypeDstUnreach,
                                            Ip6::Icmp::Header::kCodeDstUnreachNoRoute, messageInfo, aIp6Headers));

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -112,13 +112,13 @@ Mle::Mle(Instance &aInstance)
     ResetCounters();
 
     mLinkLocalAddress.InitAsThreadOrigin();
-    mLinkLocalAddress.GetAddress().SetToLinkLocalAddress(Get<Mac::Mac>().GetExtAddress());
+    mLinkLocalAddress.GetAddress().InitAsLinkLocalAddress(Get<Mac::Mac>().GetExtAddress());
 
     mMeshLocalEid.InitAsThreadOriginMeshLocal();
     mMeshLocalEid.GetAddress().GetIid().GenerateRandom();
 
     mMeshLocalRloc.InitAsThreadOriginMeshLocal();
-    mMeshLocalRloc.GetAddress().GetIid().SetToLocator(0);
+    mMeshLocalRloc.GetAddress().GetIid().InitAsLocator(0);
     mMeshLocalRloc.mRloc = true;
 
     mLinkLocalAllThreadNodes.InitAsThreadOrigin();
@@ -771,7 +771,7 @@ exit:
 void Mle::UpdateLinkLocalAddress(void)
 {
     Get<ThreadNetif>().RemoveUnicastAddress(mLinkLocalAddress);
-    mLinkLocalAddress.GetAddress().GetIid().SetFromExtAddress(Get<Mac::Mac>().GetExtAddress());
+    mLinkLocalAddress.GetAddress().GetIid().InitFromExtAddress(Get<Mac::Mac>().GetExtAddress());
     Get<ThreadNetif>().AddUnicastAddress(mLinkLocalAddress);
 
     Get<Notifier>().Signal(kEventThreadLinkLocalAddrChanged);
@@ -896,22 +896,22 @@ void Mle::SetLeaderData(uint32_t aPartitionId, uint8_t aWeighting, uint8_t aLead
 
 void Mle::GetLeaderRloc(Ip6::Address &aAddress) const
 {
-    aAddress.SetToRoutingLocator(mMeshLocalPrefix, GetLeaderRloc16());
+    aAddress.InitAsRoutingLocator(mMeshLocalPrefix, GetLeaderRloc16());
 }
 
 void Mle::GetLeaderAloc(Ip6::Address &aAddress) const
 {
-    aAddress.SetToAnycastLocator(mMeshLocalPrefix, Aloc16::ForLeader());
+    aAddress.InitAsAnycastLocator(mMeshLocalPrefix, Aloc16::ForLeader());
 }
 
 void Mle::GetCommissionerAloc(uint16_t aSessionId, Ip6::Address &aAddress) const
 {
-    aAddress.SetToAnycastLocator(mMeshLocalPrefix, Aloc16::FromCommissionerSessionId(aSessionId));
+    aAddress.InitAsAnycastLocator(mMeshLocalPrefix, Aloc16::FromCommissionerSessionId(aSessionId));
 }
 
 void Mle::GetServiceAloc(uint8_t aServiceId, Ip6::Address &aAddress) const
 {
-    aAddress.SetToAnycastLocator(mMeshLocalPrefix, Aloc16::FromServiceId(aServiceId));
+    aAddress.InitAsAnycastLocator(mMeshLocalPrefix, Aloc16::FromServiceId(aServiceId));
 }
 
 const LeaderData &Mle::GetLeaderData(void)
@@ -1128,7 +1128,7 @@ Error Mle::SendDataRequestToParent(void)
 {
     Ip6::Address destination;
 
-    destination.SetToLinkLocalAddress(mParent.GetExtAddress());
+    destination.InitAsLinkLocalAddress(mParent.GetExtAddress());
 
     return SendDataRequest(destination);
 }
@@ -1285,7 +1285,7 @@ Error Mle::SendChildUpdateRequestToParent(ChildUpdateRequestMode aMode)
         SuccessOrExit(error = message->AppendAddressRegistrationTlv(addrRegMode));
     }
 
-    destination.SetToLinkLocalAddress(mParent.GetExtAddress());
+    destination.InitAsLinkLocalAddress(mParent.GetExtAddress());
     SuccessOrExit(error = message->SendTo(destination));
 
     Log(kMessageSend, kTypeChildUpdateRequestAsChild, destination);
@@ -2683,7 +2683,7 @@ void Mle::InformPreviousParent(void)
     SuccessOrExit(error = message->SetLength(0));
 
     messageInfo.SetSockAddr(GetMeshLocalEid());
-    messageInfo.GetPeerAddr().SetToRoutingLocator(mMeshLocalPrefix, mPreviousParentRloc);
+    messageInfo.GetPeerAddr().InitAsRoutingLocator(mMeshLocalPrefix, mPreviousParentRloc);
 
     SuccessOrExit(error = Get<Ip6::Ip6>().SendDatagram(*message, messageInfo, Ip6::kProtoNone));
 
@@ -3194,7 +3194,7 @@ void Mle::DelayedSender::ScheduleChildUpdateRequestToParent(uint32_t aDelay)
 {
     Ip6::Address destination;
 
-    destination.SetToLinkLocalAddress(Get<Mle>().mParent.GetExtAddress());
+    destination.InitAsLinkLocalAddress(Get<Mle>().mParent.GetExtAddress());
     VerifyOrExit(!HasMatchingSchedule(kTypeChildUpdateRequestAsChild, destination));
     AddSchedule(kTypeChildUpdateRequestAsChild, destination, aDelay, nullptr, 0);
 
@@ -3206,7 +3206,7 @@ void Mle::DelayedSender::RemoveScheduledChildUpdateRequestToParent(void)
 {
     Ip6::Address destination;
 
-    destination.SetToLinkLocalAddress(Get<Mle>().mParent.GetExtAddress());
+    destination.InitAsLinkLocalAddress(Get<Mle>().mParent.GetExtAddress());
     RemoveMatchingSchedules(kTypeChildUpdateRequestAsChild, destination);
 }
 
@@ -3216,7 +3216,7 @@ void Mle::DelayedSender::ScheduleParentResponse(const ParentResponseInfo &aInfo,
 {
     Ip6::Address destination;
 
-    destination.SetToLinkLocalAddress(aInfo.mChildExtAddress);
+    destination.InitAsLinkLocalAddress(aInfo.mChildExtAddress);
 
     RemoveMatchingSchedules(kTypeParentResponse, destination);
     AddSchedule(kTypeParentResponse, destination, aDelay, &aInfo, sizeof(aInfo));
@@ -3253,7 +3253,7 @@ void Mle::DelayedSender::ScheduleLinkRequest(const Router &aRouter, uint32_t aDe
     Ip6::Address destination;
     uint16_t     routerRloc16;
 
-    destination.SetToLinkLocalAddress(aRouter.GetExtAddress());
+    destination.InitAsLinkLocalAddress(aRouter.GetExtAddress());
 
     VerifyOrExit(!HasMatchingSchedule(kTypeLinkRequest, destination));
     routerRloc16 = aRouter.GetRloc16();
@@ -3267,7 +3267,7 @@ void Mle::DelayedSender::RemoveScheduledLinkRequest(const Router &aRouter)
 {
     Ip6::Address destination;
 
-    destination.SetToLinkLocalAddress(aRouter.GetExtAddress());
+    destination.InitAsLinkLocalAddress(aRouter.GetExtAddress());
     RemoveMatchingSchedules(kTypeLinkRequest, destination);
 }
 
@@ -3275,7 +3275,7 @@ bool Mle::DelayedSender::HasAnyScheduledLinkRequest(const Router &aRouter) const
 {
     Ip6::Address destination;
 
-    destination.SetToLinkLocalAddress(aRouter.GetExtAddress());
+    destination.InitAsLinkLocalAddress(aRouter.GetExtAddress());
 
     return HasMatchingSchedule(kTypeLinkRequest, destination);
 }
@@ -3284,7 +3284,7 @@ void Mle::DelayedSender::ScheduleLinkAccept(const LinkAcceptInfo &aInfo, uint32_
 {
     Ip6::Address destination;
 
-    destination.SetToLinkLocalAddress(aInfo.mExtAddress);
+    destination.InitAsLinkLocalAddress(aInfo.mExtAddress);
 
     RemoveMatchingSchedules(kTypeLinkAccept, destination);
     AddSchedule(kTypeLinkAccept, destination, aDelay, &aInfo, sizeof(aInfo));
@@ -5047,7 +5047,7 @@ void Mle::Attacher::SendParentRequest(ParentRequestType aType)
         messageToCurParent = static_cast<TxMessage *>(Get<Mle>().mSocket.CloneMessage(*message));
         VerifyOrExit(messageToCurParent != nullptr, error = kErrorNoBufs);
 
-        destination.SetToLinkLocalAddress(Get<Mle>().mParent.GetExtAddress());
+        destination.InitAsLinkLocalAddress(Get<Mle>().mParent.GetExtAddress());
         error = messageToCurParent->SendTo(destination);
 
         if (error != kErrorNone)
@@ -5058,7 +5058,7 @@ void Mle::Attacher::SendParentRequest(ParentRequestType aType)
 
         Log(kMessageSend, kTypeParentRequestToRouters, destination);
 
-        destination.SetToLinkLocalAddress(Get<Mle>().mParentSearch.GetSelectedParent().GetExtAddress());
+        destination.InitAsLinkLocalAddress(Get<Mle>().mParentSearch.GetSelectedParent().GetExtAddress());
     }
     else
 #endif
@@ -5168,7 +5168,7 @@ Error Mle::Attacher::SendChildIdRequest(void)
 
     message->RegisterTxCallback(HandleChildIdRequestTxDone, this);
 
-    destination.SetToLinkLocalAddress(mParentCandidate.GetExtAddress());
+    destination.InitAsLinkLocalAddress(mParentCandidate.GetExtAddress());
     SuccessOrExit(error = message->SendTo(destination));
 
     Log(kMessageSend,

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -552,7 +552,7 @@ void Mle::ScheduleUnicastAdvertisementTo(const Router &aRouter)
 {
     Ip6::Address destination;
 
-    destination.SetToLinkLocalAddress(aRouter.GetExtAddress());
+    destination.InitAsLinkLocalAddress(aRouter.GetExtAddress());
     mDelayedSender.ScheduleAdvertisement(destination, GenerateRandomDelay(kMaxUnicastAdvertisementDelay));
 }
 
@@ -671,7 +671,7 @@ void Mle::SendLinkRequest(Router *aRouter)
             SuccessOrExit(error = message->AppendChallengeTlv(challenge));
         }
 
-        destination.SetToLinkLocalAddress(aRouter->GetExtAddress());
+        destination.InitAsLinkLocalAddress(aRouter->GetExtAddress());
         aRouter->RestartLinkAcceptTimeout();
     }
 
@@ -870,7 +870,7 @@ Error Mle::SendLinkAccept(const LinkAcceptInfo &aInfo)
     }
 #endif
 
-    destination.SetToLinkLocalAddress(aInfo.mExtAddress);
+    destination.InitAsLinkLocalAddress(aInfo.mExtAddress);
 
     SuccessOrExit(error = message->SendTo(destination));
 
@@ -1809,7 +1809,7 @@ void Mle::SendParentResponse(const ParentResponseInfo &aInfo)
     SuccessOrExit(error = message->AppendConnectivityTlv());
     SuccessOrExit(error = message->AppendVersionTlv());
 
-    destination.SetToLinkLocalAddress(aInfo.mChildExtAddress);
+    destination.InitAsLinkLocalAddress(aInfo.mChildExtAddress);
 
     SuccessOrExit(error = message->SendTo(destination));
 
@@ -2919,7 +2919,7 @@ Error Mle::SendChildIdResponse(Child &aChild)
     }
 #endif
 
-    destination.SetToLinkLocalAddress(aChild.GetExtAddress());
+    destination.InitAsLinkLocalAddress(aChild.GetExtAddress());
     SuccessOrExit(error = message->SendTo(destination));
 
     SetChildStateToValid(aChild);
@@ -2983,7 +2983,7 @@ Error Mle::SendChildUpdateRequestToChild(Child &aChild)
         SuccessOrExit(error = message->AppendChallengeTlv(aChild.GetChallenge()));
     }
 
-    destination.SetToLinkLocalAddress(aChild.GetExtAddress());
+    destination.InitAsLinkLocalAddress(aChild.GetExtAddress());
     SuccessOrExit(error = message->SendTo(destination));
 
     if (aChild.IsRxOnWhenIdle())

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -525,7 +525,8 @@ Error Manager::SendMessage(const Ip6::Address         *aAddresses,
     }
     else
     {
-        destAddr.SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), Get<BackboneRouter::Leader>().GetServer16());
+        destAddr.InitAsRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(),
+                                      Get<BackboneRouter::Leader>().GetServer16());
     }
 
     error = Get<Tmf::Agent>().SendMessageTo(*message, destAddr, aResponseHandler, this);

--- a/src/core/thread/net_diag.cpp
+++ b/src/core/thread/net_diag.cpp
@@ -254,7 +254,7 @@ Error Server::AppendBrPrefixTlv(uint8_t aTlvType, Message &aMessage)
         ExitNow();
     }
 
-    IgnoreError(netPrefix.SetFrom(prefix));
+    IgnoreError(netPrefix.InitFrom(prefix));
 
 exit:
     return Tlv::AppendTlv(aMessage, aTlvType, &netPrefix, sizeof(netPrefix));

--- a/src/core/thread/network_data_service.cpp
+++ b/src/core/thread/network_data_service.cpp
@@ -158,8 +158,8 @@ Error Iterator::GetNextDnsSrpUnicastInfo(DnsSrpUnicastType aType, DnsSrpUnicastI
                 // contains a port number and use the RLOC as the
                 // IPv6 address.
 
-                aInfo.mSockAddr.GetAddress().SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(),
-                                                                 mServerSubTlv->GetServer16());
+                aInfo.mSockAddr.GetAddress().InitAsRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(),
+                                                                  mServerSubTlv->GetServer16());
                 aInfo.mSockAddr.SetPort(BigEndian::ReadUint16(mServerSubTlv->GetServerData()));
                 aInfo.mVersion = 0;
                 ExitNow();
@@ -552,7 +552,7 @@ exit:
 Manager::ServiceAloc::ServiceAloc(void)
 {
     InitAsThreadOriginMeshLocal();
-    GetAddress().GetIid().SetToLocator(kNotInUse);
+    GetAddress().GetIid().InitAsLocator(kNotInUse);
 }
 
 #endif

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -656,7 +656,7 @@ public:
      *
      * @param[out] aPrefix  An `Ip6::Prefix` to copy the Prefix from TLV into.
      */
-    void CopyPrefixTo(Ip6::Prefix &aPrefix) const { aPrefix.Set(GetPrefix(), GetPrefixLength()); }
+    void CopyPrefixTo(Ip6::Prefix &aPrefix) const { aPrefix.InitFrom(GetPrefix(), GetPrefixLength()); }
 
     /**
      * Indicates whether the Prefix from TLV is equal to a given `Ip6::Prefix`.

--- a/src/core/thread/peer.hpp
+++ b/src/core/thread/peer.hpp
@@ -81,7 +81,10 @@ public:
      *
      * @returns The link local IPv6 address of the peer.
      */
-    void GetLinkLocalIp6Address(Ip6::Address &aIp6Address) const { aIp6Address.SetToLinkLocalAddress(GetExtAddress()); }
+    void GetLinkLocalIp6Address(Ip6::Address &aIp6Address) const
+    {
+        aIp6Address.InitAsLinkLocalAddress(GetExtAddress());
+    }
 
     /**
      * Generates a new challenge value to use during a child attach.

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -251,7 +251,7 @@ Error Agent::SendMessageToRloc(Message &aMessage, uint16_t aRloc16, ResponseHand
 {
     Ip6::MessageInfo messageInfo;
 
-    messageInfo.GetPeerAddr().SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aRloc16);
+    messageInfo.GetPeerAddr().InitAsRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aRloc16);
     PrepareMessageInfo(messageInfo);
 
     return SendMessage(aMessage, messageInfo, aHandler, aContext);

--- a/src/core/utils/link_metrics_manager.cpp
+++ b/src/core/utils/link_metrics_manager.cpp
@@ -286,7 +286,7 @@ Error LinkMetricsManager::Subject::ConfigureEap(Instance &aInstance)
     LinkMetrics::Metrics     metricsFlags;
 
     VerifyOrExit(neighbor != nullptr, error = kErrorUnknownNeighbor);
-    destination.SetToLinkLocalAddress(neighbor->GetExtAddress());
+    destination.InitAsLinkLocalAddress(neighbor->GetExtAddress());
 
     metricsFlags.Clear();
     metricsFlags.mLinkMargin = 1;
@@ -311,7 +311,7 @@ Error LinkMetricsManager::Subject::UnregisterEap(Instance &aInstance)
     LinkMetrics::EnhAckFlags enhAckFlags = LinkMetrics::kEnhAckClear;
 
     VerifyOrExit(neighbor != nullptr, error = kErrorUnknownNeighbor);
-    destination.SetToLinkLocalAddress(neighbor->GetExtAddress());
+    destination.InitAsLinkLocalAddress(neighbor->GetExtAddress());
 
     error = aInstance.Get<LinkMetrics::Initiator>().SendMgmtRequestEnhAckProbing(destination, enhAckFlags, nullptr);
 exit:

--- a/src/core/utils/mesh_diag.cpp
+++ b/src/core/utils/mesh_diag.cpp
@@ -99,7 +99,7 @@ Error MeshDiag::DiscoverTopology(const DiscoverConfig &aConfig, DiscoverCallback
             continue;
         }
 
-        destination.SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), Mle::Rloc16FromRouterId(routerId));
+        destination.InitAsRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), Mle::Rloc16FromRouterId(routerId));
 
         SuccessOrExit(error = Get<Client>().SendCommand(kUriDiagnosticGetRequest, Message::kPriorityLow, destination,
                                                         tlvs, tlvsLength, HandleDiagGetResponse, this));
@@ -165,7 +165,7 @@ Error MeshDiag::SendQuery(uint16_t aRloc16, const uint8_t *aTlvs, uint8_t aTlvsL
     VerifyOrExit(Mle::IsRouterRloc16(aRloc16), error = kErrorInvalidArgs);
     VerifyOrExit(Get<RouterTable>().IsAllocated(Mle::RouterIdFromRloc16(aRloc16)), error = kErrorNotFound);
 
-    destination.SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aRloc16);
+    destination.InitAsRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aRloc16);
 
     SuccessOrExit(error = Get<Client>().SendCommand(kUriDiagnosticGetQuery, Message::kPriorityNormal, destination,
                                                     aTlvs, aTlvsLength));

--- a/src/posix/platform/multicast_routing.cpp
+++ b/src/posix/platform/multicast_routing.cpp
@@ -279,8 +279,8 @@ void MulticastRoutingManager::ProcessMulticastRouterMessages(void)
     VerifyOrExit(mrt6msg->im6_mbz == 0);
     VerifyOrExit(mrt6msg->im6_msgtype == MRT6MSG_NOCACHE);
 
-    src.SetBytes(mrt6msg->im6_src.s6_addr);
-    dst.SetBytes(mrt6msg->im6_dst.s6_addr);
+    src.InitFrom(mrt6msg->im6_src.s6_addr);
+    dst.InitFrom(mrt6msg->im6_dst.s6_addr);
 
     error = AddMulticastForwardingCache(src, dst, static_cast<MifIndex>(mrt6msg->im6_mif));
 

--- a/tests/nexus/platform/nexus_core.cpp
+++ b/tests/nexus/platform/nexus_core.cpp
@@ -275,7 +275,8 @@ void Core::SaveTestInfo(const char *aFilename, Node *aLeaderNode)
     if (leaderNode != nullptr)
     {
         Ip6::Prefix prefix;
-        prefix.Set(leaderNode->Get<Mle::Mle>().GetMeshLocalPrefix());
+
+        prefix.InitFrom(leaderNode->Get<Mle::Mle>().GetMeshLocalPrefix());
         fprintf(file, "    \"mesh_local_prefix\": \"%s\"%s\n", prefix.ToString().AsCString(),
                 mTestVars.IsEmpty() ? "" : ",");
     }

--- a/tests/nexus/platform/nexus_infra_if.cpp
+++ b/tests/nexus/platform/nexus_infra_if.cpp
@@ -57,7 +57,7 @@ void InfraIf::AfterInit(void)
     GetLinkLayerAddress(mac);
     SuccessOrQuit(mac.ConvertToIid(iid));
 
-    address.SetToLinkLocalAddress(iid);
+    address.InitAsLinkLocalAddress(iid);
 
     AddAddress(address);
 }

--- a/tests/nexus/test_1_1_9_2_13.cpp
+++ b/tests/nexus/test_1_1_9_2_13.cpp
@@ -171,7 +171,7 @@ void Test9_2_13(void)
     Ip6::NetworkPrefix networkPrefix;
 
     SuccessOrQuit(prefix.FromString("fd00:7d1:a11:1::/64"));
-    SuccessOrQuit(networkPrefix.SetFrom(prefix));
+    SuccessOrQuit(networkPrefix.InitFrom(prefix));
 
     /** Network 1 on Primary Channel. */
     {

--- a/tests/nexus/test_1_1_9_2_16.cpp
+++ b/tests/nexus/test_1_1_9_2_16.cpp
@@ -272,7 +272,7 @@ void Test9_2_16(void)
             Ip6::NetworkPrefix networkPrefix;
 
             SuccessOrQuit(prefix.FromString(kMeshLocalPrefixStep3));
-            SuccessOrQuit(networkPrefix.SetFrom(prefix));
+            SuccessOrQuit(networkPrefix.InitFrom(prefix));
             SuccessOrQuit(Tlv::Append<MeshCoP::MeshLocalPrefixTlv>(*message, networkPrefix));
         }
         SuccessOrQuit(Tlv::Append<MeshCoP::DelayTimerTlv>(*message, kDelayTimerStep3));
@@ -425,7 +425,7 @@ void Test9_2_16(void)
             Ip6::NetworkPrefix networkPrefix;
 
             SuccessOrQuit(prefix.FromString(kMeshLocalPrefixStep11));
-            SuccessOrQuit(networkPrefix.SetFrom(prefix));
+            SuccessOrQuit(networkPrefix.InitFrom(prefix));
             SuccessOrQuit(Tlv::Append<MeshCoP::MeshLocalPrefixTlv>(*message, networkPrefix));
         }
         SuccessOrQuit(Tlv::Append<MeshCoP::NetworkNameTlv>(*message, kNetworkNameStep13));

--- a/tests/nexus/test_1_3_DIAG_TC_1.cpp
+++ b/tests/nexus/test_1_3_DIAG_TC_1.cpp
@@ -162,7 +162,7 @@ void TestDiagTc1(const char *aJsonFileName)
      *   - N/A
      */
     Ip6::Address dutRloc;
-    dutRloc.SetToRoutingLocator(leader.Get<Mle::Mle>().GetMeshLocalPrefix(), router1.Get<Mle::Mle>().GetRloc16());
+    dutRloc.InitAsRoutingLocator(leader.Get<Mle::Mle>().GetMeshLocalPrefix(), router1.Get<Mle::Mle>().GetRloc16());
 
     uint8_t tlvTypesStep2[] = {
         NetDiag::Tlv::kMaxChildTimeout,    NetDiag::Tlv::kEui64,       NetDiag::Tlv::kVersion,

--- a/tests/nexus/test_1_3_DIAG_TC_2.cpp
+++ b/tests/nexus/test_1_3_DIAG_TC_2.cpp
@@ -150,7 +150,7 @@ void TestDiagTc2(const char *aJsonFile)
      *   - N/A
      */
     Ip6::Address td1Rloc;
-    td1Rloc.SetToRoutingLocator(leader1.Get<Mle::Mle>().GetMeshLocalPrefix(), td1.Get<Mle::Mle>().GetRloc16());
+    td1Rloc.InitAsRoutingLocator(leader1.Get<Mle::Mle>().GetMeshLocalPrefix(), td1.Get<Mle::Mle>().GetRloc16());
 
     uint8_t tlvTypesStep2[] = {
         NetDiag::Tlv::kMaxChildTimeout,    NetDiag::Tlv::kEui64,       NetDiag::Tlv::kVersion,

--- a/tests/nexus/test_1_3_DPR_TC_2.cpp
+++ b/tests/nexus/test_1_3_DPR_TC_2.cpp
@@ -130,7 +130,7 @@ void Test_1_3_DPR_TC_2(void)
         Ip6::NetworkPrefix networkPrefix;
 
         SuccessOrQuit(prefix.FromString("fd00:db8::/64"));
-        SuccessOrQuit(networkPrefix.SetFrom(prefix));
+        SuccessOrQuit(networkPrefix.InitFrom(prefix));
         br1.Get<Mle::Mle>().SetMeshLocalPrefix(networkPrefix);
         br2.Get<Mle::Mle>().SetMeshLocalPrefix(networkPrefix);
     }

--- a/tests/nexus/test_1_3_GEN_TC_1.cpp
+++ b/tests/nexus/test_1_3_GEN_TC_1.cpp
@@ -280,7 +280,7 @@ void Test_1_3_GEN_TC_1(Topology aTopology, const char *aJsonFileName)
      *     - N/A
      */
     Ip6::Address br1Rloc;
-    br1Rloc.SetToRoutingLocator(router1.Get<Mle::Mle>().GetMeshLocalPrefix(), br1.Get<Mle::Mle>().GetRloc16());
+    br1Rloc.InitAsRoutingLocator(router1.Get<Mle::Mle>().GetMeshLocalPrefix(), br1.Get<Mle::Mle>().GetRloc16());
     uint8_t tlvTypes[] = {NetDiag::Tlv::kVersion};
     SuccessOrQuit(
         router1.Get<NetDiag::Client>().SendDiagnosticGet(br1Rloc, tlvTypes, sizeof(tlvTypes), nullptr, nullptr));
@@ -312,7 +312,7 @@ void Test_1_3_GEN_TC_1(Topology aTopology, const char *aJsonFileName)
      *     - N/A
      */
     Ip6::Address router1Rloc;
-    router1Rloc.SetToRoutingLocator(br1.Get<Mle::Mle>().GetMeshLocalPrefix(), router1.Get<Mle::Mle>().GetRloc16());
+    router1Rloc.InitAsRoutingLocator(br1.Get<Mle::Mle>().GetMeshLocalPrefix(), router1.Get<Mle::Mle>().GetRloc16());
     SuccessOrQuit(
         br1.Get<NetDiag::Client>().SendDiagnosticGet(router1Rloc, tlvTypes, sizeof(tlvTypes), nullptr, nullptr));
 
@@ -343,7 +343,7 @@ void Test_1_3_GEN_TC_1(Topology aTopology, const char *aJsonFileName)
      *     - N/A
      */
     Ip6::Address ed1Rloc;
-    ed1Rloc.SetToRoutingLocator(router1.Get<Mle::Mle>().GetMeshLocalPrefix(), ed1.Get<Mle::Mle>().GetRloc16());
+    ed1Rloc.InitAsRoutingLocator(router1.Get<Mle::Mle>().GetMeshLocalPrefix(), ed1.Get<Mle::Mle>().GetRloc16());
     SuccessOrQuit(
         router1.Get<NetDiag::Client>().SendDiagnosticGet(ed1Rloc, tlvTypes, sizeof(tlvTypes), nullptr, nullptr));
 

--- a/tests/nexus/test_1_4_DNS_TC_5.cpp
+++ b/tests/nexus/test_1_4_DNS_TC_5.cpp
@@ -344,7 +344,7 @@ void Test_1_4_DNS_TC_5(const char *aJsonFileName)
         SuccessOrQuit(eth1.Get<Dns::Multicast::Core>().SetEnabled(true, 1));
 
         SuccessOrQuit(ip4Addr.FromString("192.168.217.100"));
-        eth1Ip4Addr.SetToIp4Mapped(ip4Addr);
+        eth1Ip4Addr.InitAsIp4Mapped(ip4Addr);
         eth1.mInfraIf.AddAddress(eth1Ip4Addr);
         eth1.mMdns.SignalIfAddresses(eth1.GetInstance());
 

--- a/tests/nexus/test_border_admitter.cpp
+++ b/tests/nexus/test_border_admitter.cpp
@@ -1859,7 +1859,7 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
                                                   /* aCallback */ nullptr,
                                                   /* aContext */ nullptr));
 
-    joinerIids[0].SetFromExtAddress(joiners[0]->Get<Joiner>().GetId());
+    joinerIids[0].InitFromExtAddress(joiners[0]->Get<Joiner>().GetId());
 
     nexus.AdvanceTime(8 * Time::kOneSecondInMsec);
 
@@ -2008,7 +2008,7 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
                                                   /* aCallback */ nullptr,
                                                   /* aContext */ nullptr));
 
-    joinerIids[1].SetFromExtAddress(joiners[1]->Get<Joiner>().GetId());
+    joinerIids[1].InitFromExtAddress(joiners[1]->Get<Joiner>().GetId());
 
     nexus.AdvanceTime(8 * Time::kOneSecondInMsec);
 
@@ -2154,7 +2154,7 @@ void TestBorderAdmitterJoinerEnrollerInteraction(void)
                                                   /* aCallback */ nullptr,
                                                   /* aContext */ nullptr));
 
-    joinerIids[1].SetFromExtAddress(joiners[1]->Get<Joiner>().GetId());
+    joinerIids[1].InitFromExtAddress(joiners[1]->Get<Joiner>().GetId());
 
     nexus.AdvanceTime(8 * Time::kOneSecondInMsec);
 

--- a/tests/nexus/test_pbbr_aloc.cpp
+++ b/tests/nexus/test_pbbr_aloc.cpp
@@ -92,7 +92,7 @@ void TestPbbrAloc(void)
 
     // 2. PBBR ALOC
     aloc.SetPrefix(leader.Get<Mle::Mle>().GetMeshLocalPrefix());
-    aloc.GetIid().SetToLocator(Mle::Aloc16::ForPrimaryBackboneRouter());
+    aloc.GetIid().InitAsLocator(Mle::Aloc16::ForPrimaryBackboneRouter());
     Log("Pinging PBBR ALOC %s from ROUTER", aloc.ToString().AsCString());
     nexus.SendAndVerifyEchoRequest(router, aloc);
 

--- a/tests/nexus/test_service.cpp
+++ b/tests/nexus/test_service.cpp
@@ -110,8 +110,8 @@ void TestService(void)
     Ip6::Address aloc0;
     Ip6::Address aloc1;
 
-    aloc0.SetToAnycastLocator(leader.Get<Mle::Mle>().GetMeshLocalPrefix(), Mle::Aloc16::FromServiceId(0));
-    aloc1.SetToAnycastLocator(leader.Get<Mle::Mle>().GetMeshLocalPrefix(), Mle::Aloc16::FromServiceId(1));
+    aloc0.InitAsAnycastLocator(leader.Get<Mle::Mle>().GetMeshLocalPrefix(), Mle::Aloc16::FromServiceId(0));
+    aloc1.InitAsAnycastLocator(leader.Get<Mle::Mle>().GetMeshLocalPrefix(), Mle::Aloc16::FromServiceId(1));
 
     // Initial check: no ALOCs
     for (Node &node : nexus.GetNodes())

--- a/tests/unit/test_child.cpp
+++ b/tests/unit/test_child.cpp
@@ -109,7 +109,7 @@ void TestChildIp6Address(void)
     const uint8_t            meshLocalIidArray[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
     Ip6::InterfaceIdentifier meshLocalIid;
 
-    meshLocalIid.SetBytes(meshLocalIidArray);
+    meshLocalIid.InitFrom(meshLocalIidArray);
 
     sInstance = testInitInstance();
     VerifyOrQuit(sInstance != nullptr);

--- a/tests/unit/test_ip_address.cpp
+++ b/tests/unit/test_ip_address.cpp
@@ -406,7 +406,7 @@ void TestIp6AddressSetPrefix(void)
         for (size_t prefixLength = 0; prefixLength <= sizeof(Ip6::Address) * kBitsPerByte; prefixLength++)
         {
             ip6Prefix.Clear();
-            ip6Prefix.Set(prefix, prefixLength);
+            ip6Prefix.InitFrom(prefix, prefixLength);
 
             address = allZeroAddress;
             address.SetPrefix(ip6Prefix);
@@ -442,7 +442,7 @@ Ip6::Prefix PrefixFrom(const char *aAddressString, uint8_t aPrefixLength)
     Ip6::Address address;
 
     SuccessOrQuit(address.FromString(aAddressString));
-    prefix.Set(address.GetBytes(), aPrefixLength);
+    prefix.InitFrom(address.GetBytes(), aPrefixLength);
 
     return prefix;
 }
@@ -466,7 +466,7 @@ void TestIp6Prefix(void)
 
         for (uint8_t prefixLength = 1; prefixLength <= Ip6::Prefix::kMaxLength; prefixLength++)
         {
-            prefix.Set(prefixBytes, prefixLength);
+            prefix.InitFrom(prefixBytes, prefixLength);
 
             printf("Prefix %s\n", prefix.ToString().AsCString());
 
@@ -484,7 +484,7 @@ void TestIp6Prefix(void)
             {
                 Ip6::Prefix subPrefix;
 
-                subPrefix.Set(prefixBytes, subPrefixLength);
+                subPrefix.InitFrom(prefixBytes, subPrefixLength);
 
                 VerifyOrQuit(prefix.ContainsPrefix(subPrefix));
 
@@ -740,7 +740,7 @@ void TestIp6PrefixTidy(void)
             Ip6::Prefix prefix, answer;
 
             SuccessOrQuit(answer.FromString(test.prefixStringAfterTidy[i]));
-            prefix.Set(test.originalPrefix, i);
+            prefix.InitFrom(test.originalPrefix, i);
             prefix.Tidy();
 
             {
@@ -774,10 +774,10 @@ void TestIp4MappedIp6Address(void)
 
     printf("\nTestIp4MappedIp6Address()\n");
 
-    expectedIp4Address.SetBytes(kIp4Address);
+    expectedIp4Address.InitFrom(kIp4Address);
 
     SuccessOrQuit(expectedIp6Address.FromString("::ffff:192.0.2.33"));
-    ip6Address.SetToIp4Mapped(expectedIp4Address);
+    ip6Address.InitAsIp4Mapped(expectedIp4Address);
 
     printf("IPv4-mapped IPv6 address: %s\n", ip6Address.ToString().AsCString());
 
@@ -823,7 +823,7 @@ void TestIp4Ip6Translation(void)
 
     printf("\nTestIp4Ip6Translation()\n");
 
-    ip4Address.SetBytes(kIp4Address);
+    ip4Address.InitFrom(kIp4Address);
 
     for (const TestCase &testCase : kTestCases)
     {
@@ -832,7 +832,7 @@ void TestIp4Ip6Translation(void)
         Ip6::Address expectedAddress;
 
         SuccessOrQuit(address.FromString(testCase.mPrefix));
-        prefix.Set(address.GetBytes(), testCase.mLength);
+        prefix.InitFrom(address.GetBytes(), testCase.mLength);
 
         SuccessOrQuit(expectedAddress.FromString(testCase.mIp6Address));
 

--- a/tests/unit/test_link_metrics_manager.cpp
+++ b/tests/unit/test_link_metrics_manager.cpp
@@ -161,7 +161,7 @@ void UnitTester::TestLinkMetricsManager(void)
     }
 
     // subject1 received a response with a success status code
-    linkLocalAddr.SetToLinkLocalAddress(AsCoreType(&mTestChildList[0].mExtAddress));
+    linkLocalAddr.InitAsLinkLocalAddress(AsCoreType(&mTestChildList[0].mExtAddress));
     linkMetricsMgr->HandleMgmtResponse(&linkLocalAddr, MapEnum(LinkMetrics::Status::kStatusSuccess));
     VerifyOrQuit(subject1->mState == LinkMetricsManager::SubjectState::kActive);
 

--- a/tests/unit/test_mdns.cpp
+++ b/tests/unit/test_mdns.cpp
@@ -2271,7 +2271,7 @@ void TestLocalHost(void)
 
     SuccessOrQuit(ip4Address.FromString("200.1.5.6"));
     SuccessOrQuit(localHost.mIp4Addrs.PushBack(ip4Address));
-    ip6Address.SetToIp4Mapped(ip4Address);
+    ip6Address.InitAsIp4Mapped(ip4Address);
     otPlatMdnsHandleHostAddressEvent(sInstance, &ip6Address, /* aAdded */ true, kInfraIfIndex);
 
     AdvanceTime(4);
@@ -2436,17 +2436,17 @@ void TestLocalHost(void)
 
     SuccessOrQuit(ip4Address.FromString("200.1.5.7"));
     SuccessOrQuit(localHost.mIp4Addrs.PushBack(ip4Address));
-    ip6Address.SetToIp4Mapped(ip4Address);
+    ip6Address.InitAsIp4Mapped(ip4Address);
     otPlatMdnsHandleHostAddressEvent(sInstance, &ip6Address, /* aAdded */ true, kInfraIfIndex);
 
     SuccessOrQuit(ip4Address.FromString("200.1.2.100"));
     SuccessOrQuit(localHost.mIp4Addrs.PushBack(ip4Address));
-    ip6Address.SetToIp4Mapped(ip4Address);
+    ip6Address.InitAsIp4Mapped(ip4Address);
     otPlatMdnsHandleHostAddressEvent(sInstance, &ip6Address, /* aAdded */ true, kInfraIfIndex);
 
     SuccessOrQuit(ip4Address.FromString("200.1.4.0"));
     SuccessOrQuit(localHost.mIp4Addrs.PushBack(ip4Address));
-    ip6Address.SetToIp4Mapped(ip4Address);
+    ip6Address.InitAsIp4Mapped(ip4Address);
     otPlatMdnsHandleHostAddressEvent(sInstance, &ip6Address, /* aAdded */ true, kInfraIfIndex);
 
     Log("Validate the announcements");
@@ -2481,7 +2481,7 @@ void TestLocalHost(void)
 
     for (Ip4::Address &ip4Addr : localHost.mIp4Addrs)
     {
-        ip6Address.SetToIp4Mapped(ip4Addr);
+        ip6Address.InitAsIp4Mapped(ip4Addr);
         otPlatMdnsHandleHostAddressEvent(sInstance, &ip6Address, /* aAdded */ true, kInfraIfIndex);
     }
 
@@ -2510,7 +2510,7 @@ void TestLocalHost(void)
 
     for (Ip4::Address &ip4Addr : localHost.mIp4Addrs)
     {
-        ip6Address.SetToIp4Mapped(ip4Addr);
+        ip6Address.InitAsIp4Mapped(ip4Addr);
         otPlatMdnsHandleHostAddressEvent(sInstance, &ip6Address, /* aAdded */ true, kInfraIfIndex);
     }
 
@@ -2562,7 +2562,7 @@ void TestLocalHost(void)
 
     for (Ip4::Address &ip4Addr : localHost.mIp4Addrs)
     {
-        ip6Address.SetToIp4Mapped(ip4Addr);
+        ip6Address.InitAsIp4Mapped(ip4Addr);
         otPlatMdnsHandleHostAddressEvent(sInstance, &ip6Address, /* aAdded */ true, kInfraIfIndex);
     }
 
@@ -2589,7 +2589,7 @@ void TestLocalHost(void)
 
     for (const Ip4::Address &ip4Addr : localHost.mIp4Addrs)
     {
-        ip6Address.SetToIp4Mapped(ip4Addr);
+        ip6Address.InitAsIp4Mapped(ip4Addr);
         otPlatMdnsHandleHostAddressEvent(sInstance, &ip6Address, /* aAdded */ false, kInfraIfIndex);
     }
 

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -4997,7 +4997,7 @@ void TestDhcp6Pd(void)
 
     prefix = PrefixFromString("2001:db8:cafe:0::", 64);
 
-    shortPrefix.Set(prefix.GetBytes(), 48);
+    shortPrefix.InitFrom(prefix.GetBytes(), 48);
     ReportPdPrefixesAsRa({Pio(shortPrefix, kValidLitime, kPreferredLifetime)});
 
     sExpectedRios.Add(prefix);


### PR DESCRIPTION
This commit renames several methods in `Ip6::Address`, `Ip6::InterfaceIdentifier`, `Ip6::Prefix`, and `Ip4::Address` that fully initialize the object from `Set...()` to `Init...()`.

This creates a clear semantic distinction in the API:
- `Init...()`: Fully (re-)initializing the object.
- `Set...()`: Modifies a specific property or a sub-component of the object (e.g., `SetPrefix()`,  `SetLocator()`, `SetSubnetId()`).

Some examples of renames include:
- `SetFromExtAddress()` -> `InitFromExtAddress()`
- `SetToLocator()` -> `InitAsLocator()`
- `SetToLinkLocalAddress()` -> `InitAsLinkLocalAddress()`
- `SetToRoutingLocator()` -> `InitAsRoutingLocator()`
- `SetToAnycastLocator()` -> `InitAsAnycastLocator()`
- `SetToIp4Mapped()` -> `InitAsIp4Mapped()`

All calls to these methods across the codebase have been updated to reflect the new names.