### PR TITLE
[tests] fix flakiness in publish meshcop service test

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
+++ b/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
@@ -172,7 +172,7 @@ class PublishMeshCopService(thread_cert.TestCase):
         self.simulator.go(5)
         self.assertEqual(len(host.browse_mdns_services('_meshcop._udp')), 1)
         br1.start_otbr_service()
-        self.simulator.go(10)
+        self.simulator.go(config.BORDER_ROUTER_STARTUP_DELAY)
         br1.enable_border_agent()
         self.simulator.go(5)
         self.assertEqual(len(host.browse_mdns_services('_meshcop._udp')), 2)


### PR DESCRIPTION
Increase wait delay after starting the OTBR service in the test_publish_meshcop_service.py script.

Starting otbr-agent requires the node to re-attach to the simulated Thread network and transition to the leader role. In virtualized CI environments, this role transition can take up to 14.5 seconds. Using a hardcoded 10-second delay results in a race condition where the service is published very late, causing the subsequent browse query to miss the service and fail with AssertionError.

Substituting the delay with BORDER_ROUTER_STARTUP_DELAY (20s) ensures the node has sufficient time to attach, become leader, start the border agent, and fully register the mDNS service before browsing.