### PR TITLE
[github-actions] add gcc-15 to arm-gcc build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,6 +238,9 @@ jobs:
           - gcc_ver: 14
             gcc_download_url: https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz
             gcc_extract_dir: arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi
+          - gcc_ver: 15
+            gcc_download_url: https://developer.arm.com/-/media/Files/downloads/gnu/15.2.rel1/binrel/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi.tar.xz
+            gcc_extract_dir: arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2


### PR DESCRIPTION
This commit adds GCC 15 (version 15.2.rel1) to the `arm-gcc` job matrix in the OpenThread build (`build.yml`) workflow.

Including GCC 15 in the builds helps ensure that OpenThread compiles successfully and is free from warnings or errors with the latest GCC 15.2.rel1 release.