### PR TITLE
[tests] fix flake in trickle timer unit test

### DIFF
--- a/tests/unit/test_trickle_timer.cpp
+++ b/tests/unit/test_trickle_timer.cpp
@@ -240,6 +240,7 @@ void TestTrickleTimerMinMaxIntervalChange(void)
     TimeMilli          fireTime;
     uint32_t           interval;
     uint32_t           t;
+    uint32_t           newIntervalMax;
 
     sInstance = instance;
     TrickleTimerTester::RemoveAll(*instance);
@@ -457,9 +458,11 @@ void TestTrickleTimerMinMaxIntervalChange(void)
     AdvanceTime(1999);
     timer.VerifyTimerDidFire();
 
-    timer.SetIntervalMax(t + 1);
+    newIntervalMax = Min(t + 1, interval - 1);
 
-    VerifyOrQuit(timer.GetInterval() == t + 1);
+    timer.SetIntervalMax(newIntervalMax);
+
+    VerifyOrQuit(timer.GetInterval() == newIntervalMax);
     fireTime = timer.GetFireTime();
 
     // Check that new interval is started immediately.
@@ -487,9 +490,11 @@ void TestTrickleTimerMinMaxIntervalChange(void)
     AdvanceTime(t);
     timer.VerifyTimerDidFire();
 
-    timer.SetIntervalMax(t + 1);
+    newIntervalMax = Min(t + 1, interval - 1);
 
-    VerifyOrQuit(timer.GetInterval() == t + 1);
+    timer.SetIntervalMax(newIntervalMax);
+
+    VerifyOrQuit(timer.GetInterval() == newIntervalMax);
     fireTime = timer.GetFireTime();
 
     AdvanceTime(1);


### PR DESCRIPTION
This commit fixes a frequent unit test flake in ot-test-trickle_timer under the TestTrickleTimerMinMaxIntervalChange test case.

The test case starts the trickle timer with Imin = 2000 and Imax = 2000. The random time t (mTimeInInterval) is chosen in [1000, 2000), so t can range up to 1999.

When t randomly evaluates to 1999, t + 1 becomes 2000. Calling timer.SetIntervalMax(2000) triggers an early-exit optimization in TrickleTimer::SetIntervalMax because mIntervalMax is already 2000, leaving the scheduled timer's fire time unchanged. The test then crashes on the assertion expecting the fire time to have changed.

This is resolved by setting the new interval max to Min(t + 1, interval - 1). This ensures that the requested value is strictly less than 2000 even when t = 1999, successfully triggering the interval shortening and rescheduling logic tested by this case.