### PR TITLE
[simulation] increase socket receive buffer size to 2MB

### DIFF
--- a/examples/platforms/simulation/simul_utils.c
+++ b/examples/platforms/simulation/simul_utils.c
@@ -91,6 +91,7 @@ static void InitRxSocket(utilsSocket           *aSocket,
     int fd;
     int one = 1;
     int rval;
+    int rcvBufSize = 2 * 1024 * 1024;
 
     fd = socket(aIp4Address ? AF_INET : AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
     ExpectOrExitWithErrorMsg(fd != -1, "socket(RxFd)");
@@ -100,6 +101,9 @@ static void InitRxSocket(utilsSocket           *aSocket,
 
     rval = setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one));
     ExpectOrExitWithErrorMsg(rval != -1, "setsockopt(RxFd, SO_REUSEPORT)");
+
+    rval = setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvBufSize, sizeof(rcvBufSize));
+    ExpectOrExitWithErrorMsg(rval != -1, "setsockopt(RxFd, SO_RCVBUF)");
 
     if (aIp4Address)
     {


### PR DESCRIPTION
This commit sets the SO_RCVBUF socket option to 2MB on the multicast receiving sockets in the simulation platform.

Under heavy simulation load (such as expect tests with 15 nodes all sending MLE advertisements and discovery packets), the default OS UDP receive socket buffer can overflow, leading to silent packet drops. This occasionally caused expect tests like cli-big-table.exp to fail with "Join failed [NotFound]" because Node 4's discovery requests or response beacons were dropped.

Increasing the receive buffer size to 2MB prevents packet loss during dense simulation runs, resolving intermittent CI test failures.