### PR TITLE
[tests] add startup delay to prevent expect desync

### DIFF
--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -118,6 +118,7 @@ proc spawn_node {id {type ""} {args ""}} {
             # avoid the error: "bind(sTxFd): Address already in use"
             sleep 0.2
             spawn /usr/bin/env GCOV_PREFIX=$gcov_prefix $ot_posix_apps/ot-cli $radio_url
+            sleep 0.1
             send "factoryreset\n"
             wait_for "state" "disabled"
             expect_line "Done"
@@ -127,6 +128,7 @@ proc spawn_node {id {type ""} {args ""}} {
         cli {
             spawn /usr/bin/env GCOV_PREFIX=$gcov_prefix $ot_simulation_apps/cli/ot-cli-ftd \
                 -L$ot_simulation_local_host $id
+            sleep 0.1
             send "factoryreset\n"
             wait_for "state" "disabled"
             expect_line "Done"
@@ -136,6 +138,7 @@ proc spawn_node {id {type ""} {args ""}} {
         mtd {
             spawn /usr/bin/env GCOV_PREFIX=$gcov_prefix $ot_simulation_apps/cli/ot-cli-mtd \
                 -L$ot_simulation_local_host $id
+            sleep 0.1
             send "factoryreset\n"
             wait_for "state" "disabled"
             expect_line "Done"


### PR DESCRIPTION
This commit adds a brief 0.1-second sleep delay immediately after spawning node processes (rcp, cli, and mtd types) in the expect test harness.

Under high CPU load on GitHub Actions runner VMs, the PTY file descriptors can take a fraction of a second to fully initialize. If commands are sent immediately after spawn without delay, the initial expect match can fail with an instant timeout. This triggers duplicate retransmissions in wait_for, leaving extra "Done" strings in expect's PTY read buffer. The leftover "Done" strings desynchronize subsequent assertions, causing tests to match cached output instead of waiting for actual command execution (e.g., sending "diag stats" during an active "diag send" command, which fails).

Adding a 100ms delay gives the PTY and child process enough time to fully initialize and stabilize, avoiding instant timeouts and subsequent test harness desynchronization.