### PR TITLE
[docs] fix double 'the' typos across the codebase

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (600)
+#define OPENTHREAD_API_VERSION (601)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/message.h
+++ b/include/openthread/message.h
@@ -234,7 +234,7 @@ void otMessageSetLoopbackToHostAllowed(otMessage *aMessage, bool aAllowLoopbackT
  * Indicates whether the given message may be looped back in a case of a multicast destination address.
  *
  * If @p aMessage is used along with an `otMessageInfo`, the `mMulticastLoop` field from `otMessageInfo` structure
- * takes precedence and will be used instead of the the value set on @p aMessage.
+ * takes precedence and will be used instead of the value set on @p aMessage.
  *
  * This API is mainly intended for use along with `otIp6Send()` which expects an already prepared IPv6 message.
  *

--- a/include/openthread/platform/dso_transport.h
+++ b/include/openthread/platform/dso_transport.h
@@ -53,8 +53,7 @@ extern "C" {
 typedef struct otPlatDsoConnection otPlatDsoConnection;
 
 /**
- * Can be used by DSO platform implementation to get the the OpenThread instance associated with a
- * connection instance.
+ * Can be used by DSO platform implementation to get the OpenThread instance associated with a connection instance.
  *
  * @param[in] aConnection   A pointer to the DSO connection.
  *
@@ -124,7 +123,7 @@ extern void otPlatDsoHandleConnected(otPlatDsoConnection *aConnection);
  * Passes the ownership of the @p aMessage to the DSO platform layer, and the platform implementation is
  * expected to free the message once it is no longer needed.
  *
- * The @p aMessage contains the DNS message (starting with DNS header). Note that it does not contain the the length
+ * The @p aMessage contains the DNS message (starting with DNS header). Note that it does not contain the length
  * field that is needed when sending over TLS/TCP transport. The platform layer MUST therefore include the length
  * field when passing the message to TLS/TCP layer.
  *

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -359,7 +359,7 @@ typedef struct otRadioFrame
              * If `mIsHeaderUpdated` is not set, then the frame counter and key CSL IE not set in the frame by
              * OpenThread core and it is the responsibility of the radio platform to assign them. The platform
              * must update the frame header (assign counter and CSL IE values) before sending the frame over the air,
-             * however if the the transmission gets aborted and the frame is never sent over the air (e.g., channel
+             * however if the transmission gets aborted and the frame is never sent over the air (e.g., channel
              * access error) the platform may choose to not update the header. If the platform updates the header,
              * it must also set this flag before passing the frame back from the `otPlatRadioTxDone()` callback.
              */

--- a/script/check-size
+++ b/script/check-size
@@ -125,7 +125,7 @@ build_nrf52840()
     git archive "${sha}" | tar x -C "${OT_TMP_DIR}/${folder}/openthread"
 
     if [ ! -e "${OT_TMP_DIR}/${folder}/openthread/examples/config/${config_name}" ]; then
-        # Check if the the config headers are not present, copy from
+        # Check if the config headers are not present, copy from
         # the main sha.
         case "$1" in
             br)

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -2556,7 +2556,7 @@ Locate the closest destination of an anycast address (i.e., find the destination
 
 `OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_ENABLE` is required.
 
-The closest destination is determined based on the the current routing table and path costs within the Thread mesh.
+The closest destination is determined based on the current routing table and path costs within the Thread mesh.
 
 Locate the leader using its anycast address:
 

--- a/src/core/common/log.hpp
+++ b/src/core/common/log.hpp
@@ -112,7 +112,7 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
 /**
  * Emits an error log message at critical log level if there is an error.
  *
- * The emitted log will use the the following format "Failed to {aFormattedText} - {ErrorToString(aError)}", and will
+ * The emitted log will use the following format "Failed to {aFormattedText} - {ErrorToString(aError)}", and will
  * be emitted only if there is an error, i.e., @p aError is not `kErrorNone`.
  *
  * @param[in] aError       The error to check and log.
@@ -135,7 +135,7 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
 /**
  * Emits an error log message at warning log level if there is an error.
  *
- * The emitted log will use the the following format "Failed to {aFormattedText} - {ErrorToString(aError)}", and will
+ * The emitted log will use the following format "Failed to {aFormattedText} - {ErrorToString(aError)}", and will
  * be emitted only if there is an error, i.e., @p aError is not `kErrorNone`.
  *
  * @param[in] aError       The error to check and log.
@@ -159,7 +159,7 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
 /**
  * Emits an error log message at note log level if there is an error.
  *
- * The emitted log will use the the following format "Failed to {aFormattedText} - {ErrorToString(aError)}", and will
+ * The emitted log will use the following format "Failed to {aFormattedText} - {ErrorToString(aError)}", and will
  * be emitted only if there is an error, i.e., @p aError is not `kErrorNone`.
  *
  * @param[in] aError       The error to check and log.
@@ -183,7 +183,7 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
 /**
  * Emits an error log message at info log level if there is an error.
  *
- * The emitted log will use the the following format "Failed to {aFormattedText} - {ErrorToString(aError)}", and will
+ * The emitted log will use the following format "Failed to {aFormattedText} - {ErrorToString(aError)}", and will
  * be emitted only if there is an error, i.e., @p aError is not `kErrorNone`.
  *
  * @param[in] aError       The error to check and log.
@@ -207,7 +207,7 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
 /**
  * Emits an error log message at debug log level if there is an error.
  *
- * The emitted log will use the the following format "Failed to {aFormattedText} - {ErrorToString(aError)}", and will
+ * The emitted log will use the following format "Failed to {aFormattedText} - {ErrorToString(aError)}", and will
  * be emitted only if there is an error, i.e., @p aError is not `kErrorNone`.
  *
  * @param[in] aError       The error to check and log.

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -578,7 +578,7 @@ public:
         uint32_t GetLifetime(void) const { return mLifetime; }
 
         /**
-         * Sets the the prefix lifetime.
+         * Sets the prefix lifetime.
          *
          * @param[in] aLifetime  The prefix lifetime in seconds.
          */

--- a/src/core/crypto/ecdsa.hpp
+++ b/src/core/crypto/ecdsa.hpp
@@ -164,7 +164,7 @@ public:
          *
          * Gives non-const pointer to the buffer and is intended for populating the buffer and setting
          * the key-pair (e.g., reading the key-pair from non-volatile settings). The buffer contains `kMaxDerSize`
-         * bytes. After populating the buffer, `SetDerLength()` can be used to set the the number of bytes written.
+         * bytes. After populating the buffer, `SetDerLength()` can be used to set the number of bytes written.
          *
          * @returns The pointer to the start of key-pair buffer in DER format.
          */

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -461,7 +461,7 @@ public:
 #endif
 
     /**
-     * Retrieves the the Message Buffer information.
+     * Retrieves the Message Buffer information.
      *
      * @param[out]  aInfo  A `BufferInfo` where information is written.
      */

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -397,7 +397,7 @@ public:
          * MUST only be used from `AddressCallback`.
          *
          * The response may include multiple IPv6 address records. @p aIndex can be used to iterate through the list of
-         * addresses. Index zero gets the the first address and so on. When we reach end of the list, this method
+         * addresses. Index zero gets the first address and so on. When we reach end of the list, this method
          * returns `kErrorNotFound`.
          *
          * @param[in]  aIndex        The address record index to retrieve.
@@ -455,7 +455,7 @@ public:
          * MUST only be used from `BrowseCallback`.
          *
          * A response may include multiple service instance records. @p aIndex can be used to iterate through the list.
-         * Index zero gives the the first record. When we reach end of the list, `kErrorNotFound` is returned.
+         * Index zero gives the first record. When we reach end of the list, `kErrorNotFound` is returned.
          *
          * Note that this method gets the service instance label and not the full service instance name which is of the
          * form `<Instance>.<Service>.<Domain>`.

--- a/src/core/net/dns_types.cpp
+++ b/src/core/net/dns_types.cpp
@@ -1046,7 +1046,7 @@ Error ResourceRecord::ReadName(const Message &aMessage,
     // `ResourceRecord`. `aSkipRecord` indicates whether to skip over
     // the entire resource record or just the read name. On exit, when
     // successfully read, `aOffset` is updated to either point after the
-    // end of record or after the the name field.
+    // end of record or after the name field.
     //
     // When read successfully, this method returns `kErrorNone`. On a
     // parse error (invalid format) returns `kErrorParse`. If the

--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -619,7 +619,7 @@ public:
      *
      * If the name is empty (not specified), then root "." is appended to @p aMessage. If the name is from a C string
      * then the string is checked and appended (similar to static `AppendName(const char *aName, Message &)` method).
-     * If the the name is from a message, then it is read from the message and appended to @p aMessage. Note that in
+     * If the name is from a message, then it is read from the message and appended to @p aMessage. Note that in
      * this case independent of whether the name is compressed or not in its original message, the name is appended
      * as full (uncompressed) in @p aMessage.
      *
@@ -814,7 +814,7 @@ public:
      * Can be used to compare labels one by one. It checks whether the label read from @p aMessage matches
      * @p aLabel string (case-insensitive comparison).
      *
-     * Unlike `CompareName()` which requires the labels in the the name string to contain no dot '.' character, this
+     * Unlike `CompareName()` which requires the labels in the name string to contain no dot '.' character, this
      * method allows @p aLabel to include any character.
      *
      * @param[in]     aMessage        The message to read the label from to compare. `aMessage.GetOffset()` MUST point

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -723,7 +723,7 @@ public:
      * @param[in]  aLinkMetrics  This parameter specifies what metrics to query. Per spec 4.11.3.4.4.6, at most 2
      *                           metrics can be specified. The probing would be disabled if @p `aLinkMetrics` is
      *                           bitwise 0.
-     * @param[in]  aShortAddress The short address of the the probing Initiator.
+     * @param[in]  aShortAddress The short address of the probing Initiator.
      * @param[in]  aExtAddress   The extended source address of the probing Initiator.
      *
      * @retval kErrorNone            Successfully enable/disable or update Enhanced-ACK Based Probing for a specific

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -122,7 +122,7 @@ public:
      * @param[out]    aInfo      An `EntryInfo` where the EID cache entry information is placed.
      * @param[in,out] aIterator  An iterator. It will be updated to point to the next entry on success.
      *                           To get the first entry, initialize the iterator by setting all its fields to zero.
-     *                           e.g., `memset` the the iterator structure to zero.
+     *                           e.g., `memset` the iterator structure to zero.
      *
      * @retval kErrorNone      Successfully populated @p aInfo with the info for the next EID cache entry.
      * @retval kErrorNotFound  No more entries in the address cache table.

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -416,7 +416,7 @@ public:
     Error ParseFrom(const Message &aMessage, uint16_t &aHeaderLength);
 
     /**
-     * Returns the the Mesh Header length when written to a frame.
+     * Returns the Mesh Header length when written to a frame.
      *
      * @note The returned value from this method gives the header length (number of bytes) when the header is written
      * to a frame or message. This should not be used to determine the parsed length (number of bytes read) when the

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1091,7 +1091,7 @@ void MeshForwarder::HandleFragment(RxInfo &aRxInfo)
         }
 
         // Duplication suppression for a "next fragment" is handled
-        // by the code below where the the datagram offset is
+        // by the code below where the datagram offset is
         // checked against the offset of the corresponding message
         // (same datagram tag and size) in Reassembly List. Note
         // that if there is no matching message in the Reassembly

--- a/src/lib/spinel/spi_frame.hpp
+++ b/src/lib/spinel/spi_frame.hpp
@@ -100,7 +100,7 @@ namespace Spinel {
  *   This protocol can be used either unidirectionally or bidirectionally,
  *   determined by the behavior of the master and the slave.
  *
- *   If the the master notices "PATTERN" is not set correctly, the master
+ *   If the master notices "PATTERN" is not set correctly, the master
  *   should consider the transaction to have failed and try again after 10
  *   milliseconds, retrying up to 200 times.  After unsuccessfully trying
  *   200 times in a row, the master MAY take appropriate remedial action

--- a/src/posix/platform/ip6_utils.hpp
+++ b/src/posix/platform/ip6_utils.hpp
@@ -87,7 +87,7 @@ inline void CopyIp6AddressTo(const otIp6Address &aAddress, void *aBuffer)
 }
 
 /**
- * Reads and set the the IPv6 address bytes from a given buffer.
+ * Reads and set the IPv6 address bytes from a given buffer.
  *
  * @param[in] aBuffer    A pointer to buffer to read from.
  * @param[out] aAddress  A reference to populate with the read IPv6 address.

--- a/tests/nexus/test_1_1_5_6_9.cpp
+++ b/tests/nexus/test_1_1_5_6_9.cpp
@@ -321,7 +321,7 @@ void Test5_6_9(void)
     Log("---------------------------------------------------------------------------------------");
     /**
      * Step 10: Router_1 (DUT)
-     * - Description: Depending on the the DUT’s implementation, automatically sends new stable network data to SED_1
+     * - Description: Depending on the DUT’s implementation, automatically sends new stable network data to SED_1
      *   via a unicast MLE Child Update Request or MLE Data Response.
      * - Pass Criteria: The DUT MUST send EITHER a unicast MLE Child Update Request OR a unicast MLE Data Response to
      *   SED_1, which includes the following TLVs:

--- a/tests/nexus/verify_1_1_5_6_9.py
+++ b/tests/nexus/verify_1_1_5_6_9.py
@@ -199,7 +199,7 @@ def verify(pv):
         must_next()
 
     # Step 10: Router_1 (DUT)
-    # - Description: Depending on the the DUT’s implementation, automatically sends new stable network data to SED_1
+    # - Description: Depending on the DUT’s implementation, automatically sends new stable network data to SED_1
     #   via a unicast MLE Child Update Request or MLE Data Response.
     # - Pass Criteria: The DUT MUST send EITHER a unicast MLE Child Update Request OR a unicast MLE Data Response to
     #   SED_1, which includes the following TLVs:

--- a/tests/scripts/thread-cert/border_router/MATN/MATN_09_DefaultBRMulticastForwarding.py
+++ b/tests/scripts/thread-cert/border_router/MATN/MATN_09_DefaultBRMulticastForwarding.py
@@ -111,7 +111,7 @@ class MATN_09_FailureOfPrimaryBBROutboundMulticast(thread_cert.TestCase):
         br1.interface_down()
         self.simulator.go(180)
 
-        # 4b. BR_2 detects the missing Primary BBR and becomes the the Leader of
+        # 4b. BR_2 detects the missing Primary BBR and becomes the Leader of
         # the Thread Network.
         self.assertEqual('disabled', br1.get_state())
         self.assertEqual('leader', br2.get_state())

--- a/tools/otci/otci/otci.py
+++ b/tools/otci/otci/otci.py
@@ -3292,7 +3292,7 @@ class OTCI(object):
         self.execute_command('diag rawpowersetting disable')
 
     def is_command_supported(self, command: str) -> bool:
-        """Check whether the the given command is supported by the device."""
+        """Check whether the given command is supported by the device."""
         output = self.__otcmd.execute_command(command, timeout=10)
 
         if re.match(r"Error \d+: \w*", output[-1]):


### PR DESCRIPTION
This commit fixes instances of "the the" typos found in various files across the codebase, including documentation, headers, source files, and test scripts.