### PR TITLE
[docs] add missing TCP and UDP Doxygen groups

### DIFF
--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -87,6 +87,9 @@ namespace Ip6 {
  * @defgroup core-ip6-mpl MPL
  * @defgroup core-ip6-netif Network Interfaces
  * @defgroup core-ip6-slaac SLAAC
+ * @defgroup core-tcp TCP
+ * @defgroup core-tcp-ext TCP Extension
+ * @defgroup core-udp UDP
  *
  * @}
  */


### PR DESCRIPTION
This commit adds the missing Doxygen groups for TCP (`core-tcp`), TCP Extensions (`core-tcp-ext`), and UDP (`core-udp`). These groups are used in the code but were not previously defined.