### PR TITLE
[net] use `TcpHeader` and `UdpHeader` directly

### DIFF
--- a/src/core/net/checksum.cpp
+++ b/src/core/net/checksum.cpp
@@ -176,11 +176,11 @@ void Checksum::UpdateMessageChecksum(Message            &aMessage,
     switch (aIpProto)
     {
     case Ip6::kProtoTcp:
-        headerOffset = Ip6::Tcp::Header::kChecksumFieldOffset;
+        headerOffset = Ip6::TcpHeader::kChecksumFieldOffset;
         break;
 
     case Ip6::kProtoUdp:
-        headerOffset = Ip6::Udp::Header::kChecksumFieldOffset;
+        headerOffset = Ip6::UdpHeader::kChecksumFieldOffset;
         break;
 
     case Ip6::kProtoIcmp6:
@@ -211,11 +211,11 @@ void Checksum::UpdateMessageChecksum(Message            &aMessage,
     switch (aIpProto)
     {
     case Ip4::kProtoTcp:
-        headerOffset = Ip4::Tcp::Header::kChecksumFieldOffset;
+        headerOffset = Ip4::TcpHeader::kChecksumFieldOffset;
         break;
 
     case Ip4::kProtoUdp:
-        headerOffset = Ip4::Udp::Header::kChecksumFieldOffset;
+        headerOffset = Ip4::UdpHeader::kChecksumFieldOffset;
         break;
 
     case Ip4::kProtoIcmp:

--- a/src/core/net/ip4_types.hpp
+++ b/src/core/net/ip4_types.hpp
@@ -687,8 +687,8 @@ static constexpr uint8_t kProtoTcp  = Ip6::kProtoTcp; ///< Transmission Control 
 static constexpr uint8_t kProtoUdp  = Ip6::kProtoUdp; ///< User Datagram
 static constexpr uint8_t kProtoIcmp = 1;              ///< ICMP for IPv4
 
-using Tcp = Ip6::Tcp; // TCP in IPv4 is the same as TCP in IPv6
-using Udp = Ip6::Udp; // UDP in IPv4 is the same as UDP in IPv6
+using TcpHeader = Ip6::TcpHeader; ///< TCP header (the same as in IPv6)
+using UdpHeader = Ip6::UdpHeader; ///< UDP header (the same as in IPv6)
 
 /**
  * Represents parsed IPv4 header along with UDP/TCP/ICMP4 headers from a received message/frame.
@@ -781,7 +781,7 @@ public:
      *
      * @returns The UDP header.
      */
-    const Udp::Header &GetUdpHeader(void) const { return mHeader.mUdp; }
+    const UdpHeader &GetUdpHeader(void) const { return mHeader.mUdp; }
 
     /**
      * Returns the TCP header.
@@ -790,7 +790,7 @@ public:
      *
      * @returns The TCP header.
      */
-    const Tcp::Header &GetTcpHeader(void) const { return mHeader.mTcp; }
+    const TcpHeader &GetTcpHeader(void) const { return mHeader.mTcp; }
 
     /**
      * Returns the ICMPv4 header.
@@ -833,8 +833,8 @@ private:
     Header mIp4Header;
     union
     {
-        Udp::Header  mUdp;
-        Tcp::Header  mTcp;
+        UdpHeader    mUdp;
+        TcpHeader    mTcp;
         Icmp::Header mIcmp;
     } mHeader;
 };

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1021,7 +1021,7 @@ Error Ip6::PassToHost(OwnedPtr<Message> &aMessagePtr,
 
         case kProtoUdp:
         {
-            Udp::Header udp;
+            UdpHeader udp;
 
             IgnoreError(aMessagePtr->Read(aMessagePtr->GetOffset(), udp));
             VerifyOrExit(!Get<Udp>().IsPortInUse(udp.GetDestinationPort()), error = kErrorNoRoute);
@@ -1358,7 +1358,7 @@ Error Ip6::HandleDatagram(OwnedPtr<Message> aMessagePtr, bool aIsReassembled, ui
         {
             if (aMessagePtr->IsOriginHostUntrusted() && (nextHeader == kProtoUdp))
             {
-                Udp::Header udpHeader;
+                UdpHeader udpHeader;
 
                 SuccessOrExit(error = aMessagePtr->Read(aMessagePtr->GetOffset(), udpHeader));
 

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -525,7 +525,7 @@ public:
      *
      * @returns The UDP header.
      */
-    const Udp::Header &GetUdpHeader(void) const { return mHeader.mUdp; }
+    const UdpHeader &GetUdpHeader(void) const { return mHeader.mUdp; }
 
     /**
      * Returns the TCP header.
@@ -534,7 +534,7 @@ public:
      *
      * @returns The TCP header.
      */
-    const Tcp::Header &GetTcpHeader(void) const { return mHeader.mTcp; }
+    const TcpHeader &GetTcpHeader(void) const { return mHeader.mTcp; }
 
     /**
      * Returns the ICMPv6 header.
@@ -577,8 +577,8 @@ private:
     Header mIp6Header;
     union
     {
-        Udp::Header  mUdp;
-        Tcp::Header  mTcp;
+        UdpHeader    mUdp;
+        TcpHeader    mTcp;
         Icmp::Header mIcmp;
     } mHeader;
 };

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -983,7 +983,7 @@ void Client::SendUpdate(void)
     info.mSingleServiceMode = false;
     SuccessOrExit(error = PrepareUpdateMessage(info));
 
-    length = info.mMessage->GetLength() + sizeof(Ip6::Udp::Header) + sizeof(Ip6::Header);
+    length = info.mMessage->GetLength() + sizeof(Ip6::UdpHeader) + sizeof(Ip6::Header);
 
     if (length >= Ip6::kMaxDatagramLength)
     {

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -766,7 +766,7 @@ private:
         OPENTHREAD_CONFIG_SRP_CLIENT_MAX_TIMEOUT_FAILURES_TO_SWITCH_SERVER;
 #endif
 
-    static constexpr uint16_t kUdpPayloadSize = Ip6::kMaxDatagramLength - sizeof(Ip6::Udp::Header);
+    static constexpr uint16_t kUdpPayloadSize = Ip6::kMaxDatagramLength - sizeof(Ip6::UdpHeader);
 
     // -------------------------------
     // Lease related constants

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -832,7 +832,7 @@ public:
 private:
     static constexpr uint8_t kSrpVersion = 0;
 
-    static constexpr uint16_t kUdpPayloadSize = Ip6::kMaxDatagramLength - sizeof(Ip6::Udp::Header);
+    static constexpr uint16_t kUdpPayloadSize = Ip6::kMaxDatagramLength - sizeof(Ip6::UdpHeader);
 
     static constexpr uint32_t kDefaultMinLease             = 30;          // 30 seconds.
     static constexpr uint32_t kDefaultMaxLease             = 27u * 3600;  // 27 hours (in seconds).

--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -640,7 +640,7 @@ Error Tcp::HandleMessage(ot::Ip6::Header &aIp6Header, Message &aMessage, Message
     int                  nextAction;
 
     VerifyOrExit(length == aMessage.DetermineLengthAfterOffset(), error = kErrorParse);
-    VerifyOrExit(length >= sizeof(Tcp::Header), error = kErrorParse);
+    VerifyOrExit(length >= sizeof(TcpHeader), error = kErrorParse);
     SuccessOrExit(error = aMessage.Read(aMessage.GetOffset() + offsetof(struct tcphdr, th_off_x2), headerSize));
     headerSize = static_cast<uint8_t>((headerSize >> TH_OFF_SHIFT) << 2);
     VerifyOrExit(headerSize >= sizeof(struct tcphdr) && headerSize <= sizeof(header) &&

--- a/src/core/net/tcp6.hpp
+++ b/src/core/net/tcp6.hpp
@@ -86,8 +86,6 @@ namespace Ip6 {
 class Tcp : public InstanceLocator, private NonCopyable
 {
 public:
-    typedef TcpHeader Header; ///< TCP Header.
-
     /**
      * Represents an endpoint of a TCP/IPv6 connection.
      */
@@ -561,6 +559,8 @@ private:
     static constexpr uint8_t kForwardProgressCallbackFlag  = (1 << 2);
     static constexpr uint8_t kReceiveAvailableCallbackFlag = (1 << 3);
     static constexpr uint8_t kDisconnectedCallbackFlag     = (1 << 4);
+
+    typedef TcpHeader Header;
 
     void ProcessSignals(Endpoint             &aEndpoint,
                         otLinkedBuffer       *aPriorHead,

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -83,7 +83,6 @@ enum NetifIdentifier : uint8_t
 class Udp : public InstanceLocator, public MessageAllocator<Udp, ReservedHeaderSize::kUdpMessage>, private NonCopyable
 {
 public:
-    typedef UdpHeader    Header;         ///< UDP header.
     typedef otUdpReceive ReceiveHandler; ///< Receive handler callback.
 
     /**
@@ -534,6 +533,8 @@ private:
     // Reserved range for use by SRP server
     static constexpr uint16_t kSrpServerPortMin = OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT_MIN;
     static constexpr uint16_t kSrpServerPortMax = OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT_MAX;
+
+    typedef UdpHeader Header;
 
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
     struct Plat

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -523,11 +523,11 @@ exit:
 
 Error Lowpan::CompressUdp(Message &aMessage, FrameBuilder &aFrameBuilder)
 {
-    Error            error       = kErrorNone;
-    uint16_t         startOffset = aMessage.GetOffset();
-    Ip6::Udp::Header udpHeader;
-    uint16_t         source;
-    uint16_t         destination;
+    Error          error       = kErrorNone;
+    uint16_t       startOffset = aMessage.GetOffset();
+    Ip6::UdpHeader udpHeader;
+    uint16_t       source;
+    uint16_t       destination;
 
     SuccessOrExit(error = aMessage.ReadAtAndAdvanceOffset(udpHeader));
 
@@ -554,7 +554,7 @@ Error Lowpan::CompressUdp(Message &aMessage, FrameBuilder &aFrameBuilder)
     else
     {
         SuccessOrExit(error = aFrameBuilder.AppendUint8(kUdpDispatch));
-        SuccessOrExit(error = aFrameBuilder.AppendBytes(&udpHeader, Ip6::Udp::Header::kLengthFieldOffset));
+        SuccessOrExit(error = aFrameBuilder.AppendBytes(&udpHeader, Ip6::UdpHeader::kLengthFieldOffset));
     }
 
     SuccessOrExit(error = aFrameBuilder.AppendBigEndianUint16(udpHeader.GetChecksum()));
@@ -895,7 +895,7 @@ exit:
     return error;
 }
 
-Error Lowpan::DecompressUdpHeader(Ip6::Udp::Header &aUdpHeader, FrameData &aFrameData)
+Error Lowpan::DecompressUdpHeader(Ip6::UdpHeader &aUdpHeader, FrameData &aFrameData)
 {
     Error    error = kErrorParse;
     uint8_t  udpCtl;
@@ -958,8 +958,8 @@ exit:
 
 Error Lowpan::DecompressUdpHeader(Message &aMessage, FrameData &aFrameData, uint16_t aDatagramLength)
 {
-    Error            error;
-    Ip6::Udp::Header udpHeader;
+    Error          error;
+    Ip6::UdpHeader udpHeader;
 
     SuccessOrExit(error = DecompressUdpHeader(udpHeader, aFrameData));
 

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -234,7 +234,7 @@ public:
      * @retval kErrorNone    The header was decompressed successfully. @p aUdpHeader and @p aFrameData are updated.
      * @retval kErrorParse   Failed to parse the lowpan header.
      */
-    Error DecompressUdpHeader(Ip6::Udp::Header &aUdpHeader, FrameData &aFrameData);
+    Error DecompressUdpHeader(Ip6::UdpHeader &aUdpHeader, FrameData &aFrameData);
 
     /**
      * Decompresses the IPv6 ECN field in a LOWPAN_IPHC header.

--- a/tests/nexus/platform/nexus_infra_if.cpp
+++ b/tests/nexus/platform/nexus_infra_if.cpp
@@ -382,12 +382,12 @@ void InfraIf::SendUdp(const Ip6::Address &aSrcAddress,
                       uint16_t            aDestPort,
                       Message            &aPayload)
 {
-    Ip6::Header      ip6Header;
-    Ip6::Udp::Header udpHeader;
+    Ip6::Header    ip6Header;
+    Ip6::UdpHeader udpHeader;
 
     ip6Header.Clear();
     ip6Header.InitVersionTrafficClassFlow();
-    ip6Header.SetPayloadLength(sizeof(Ip6::Udp::Header) + aPayload.GetLength());
+    ip6Header.SetPayloadLength(sizeof(Ip6::UdpHeader) + aPayload.GetLength());
     ip6Header.SetNextHeader(Ip6::kProtoUdp);
     ip6Header.SetHopLimit(64);
     ip6Header.SetSource(aSrcAddress);
@@ -395,7 +395,7 @@ void InfraIf::SendUdp(const Ip6::Address &aSrcAddress,
 
     udpHeader.SetSourcePort(aSourcePort);
     udpHeader.SetDestinationPort(aDestPort);
-    udpHeader.SetLength(sizeof(Ip6::Udp::Header) + aPayload.GetLength());
+    udpHeader.SetLength(sizeof(Ip6::UdpHeader) + aPayload.GetLength());
     udpHeader.SetChecksum(0);
 
     SuccessOrQuit(aPayload.Prepend(udpHeader));
@@ -435,7 +435,7 @@ void InfraIf::Receive(Message &aMessage)
         Message *payload = aMessage.Clone<kNoReservedHeader>();
 
         VerifyOrQuit(payload != nullptr);
-        payload->RemoveHeader(sizeof(Ip6::Header) + sizeof(Ip6::Udp::Header));
+        payload->RemoveHeader(sizeof(Ip6::Header) + sizeof(Ip6::UdpHeader));
         otPlatInfraIfDhcp6PdClientHandleReceived(&GetInstance(), payload, mIfIndex);
         ExitNow();
     }
@@ -483,7 +483,7 @@ void InfraIf::Receive(Message &aMessage)
             Message          *payload = aMessage.Clone<kNoReservedHeader>();
 
             VerifyOrQuit(payload != nullptr);
-            payload->RemoveHeader(sizeof(Ip6::Header) + sizeof(Ip6::Udp::Header));
+            payload->RemoveHeader(sizeof(Ip6::Header) + sizeof(Ip6::UdpHeader));
 
             senderAddress.mAddress      = headers.GetSourceAddress();
             senderAddress.mPort         = headers.GetSourcePort();
@@ -502,13 +502,13 @@ void InfraIf::Receive(Message &aMessage)
         {
             Ip6::SockAddr senderAddr;
             Heap::Data    payload;
-            uint16_t      offset = sizeof(Ip6::Header) + sizeof(Ip6::Udp::Header);
+            uint16_t      offset = sizeof(Ip6::Header) + sizeof(Ip6::UdpHeader);
 
             senderAddr.SetAddress(headers.GetSourceAddress());
             senderAddr.SetPort(headers.GetSourcePort());
 
             SuccessOrQuit(
-                payload.SetFrom(aMessage, offset, headers.GetUdpHeader().GetLength() - sizeof(Ip6::Udp::Header)));
+                payload.SetFrom(aMessage, offset, headers.GetUdpHeader().GetLength() - sizeof(Ip6::UdpHeader)));
             Get<Trel>().Receive(GetInstance(), payload, senderAddr);
         }
         ExitNow();
@@ -518,7 +518,7 @@ void InfraIf::Receive(Message &aMessage)
 #if OPENTHREAD_CONFIG_DNS_UPSTREAM_QUERY_ENABLE
     if (headers.IsUdp() && headers.GetDestinationPort() == UpstreamDns::kDnsPort)
     {
-        aMessage.SetOffset(sizeof(Ip6::Header) + sizeof(Ip6::Udp::Header));
+        aMessage.SetOffset(sizeof(Ip6::Header) + sizeof(Ip6::UdpHeader));
         if (Get<UpstreamDns>().HandleUpstreamDnsResponse(headers.GetSourceAddress(), aMessage))
         {
             ExitNow();
@@ -540,7 +540,7 @@ void InfraIf::Receive(Message &aMessage)
         messageInfo.SetSockAddr(headers.GetDestinationAddress());
         messageInfo.SetSockPort(headers.GetDestinationPort());
 
-        aMessage.SetOffset(sizeof(Ip6::Header) + sizeof(Ip6::Udp::Header));
+        aMessage.SetOffset(sizeof(Ip6::Header) + sizeof(Ip6::UdpHeader));
         if (mUdpHook(GetInstance(), aMessage, messageInfo))
         {
             ExitNow();

--- a/tests/nexus/platform/nexus_udp.cpp
+++ b/tests/nexus/platform/nexus_udp.cpp
@@ -226,7 +226,7 @@ bool Udp::HandleReceive(const Message &aMessage, const Ip6::Headers &aHeaders)
             Message *payload = aMessage.Clone<kNoReservedHeader>();
 
             VerifyOrExit(payload != nullptr);
-            payload->RemoveHeader(sizeof(Ip6::Header) + sizeof(Ip6::Udp::Header));
+            payload->RemoveHeader(sizeof(Ip6::Header) + sizeof(Ip6::UdpHeader));
 
             socket.mHandler(socket.mContext, payload, &messageInfo);
             payload->Free();

--- a/tests/nexus/test_nat64_translator.cpp
+++ b/tests/nexus/test_nat64_translator.cpp
@@ -294,10 +294,10 @@ Message *PrepareUdpMessage(Node               &aNode,
                            uint16_t            aDstPort    = 1235,
                            uint16_t            aPayloadLen = 10)
 {
-    Message         *message = nullptr;
-    Ip6::Prefix      nat64Prefix;
-    Ip6::Header      ip6Header;
-    Ip6::Udp::Header udpHeader;
+    Message       *message = nullptr;
+    Ip6::Prefix    nat64Prefix;
+    Ip6::Header    ip6Header;
+    Ip6::UdpHeader udpHeader;
 
     message = aNode.Get<MessagePool>().Allocate(Message::kTypeIp6);
     VerifyOrQuit(message != nullptr);
@@ -311,7 +311,7 @@ Message *PrepareUdpMessage(Node               &aNode,
     ip6Header.GetDestination().SynthesizeFromIp4Address(nat64Prefix, aDstIp4Address);
 
     ip6Header.SetNextHeader(Ip6::kProtoUdp);
-    ip6Header.SetPayloadLength(sizeof(Ip6::Udp::Header) + aPayloadLen);
+    ip6Header.SetPayloadLength(sizeof(Ip6::UdpHeader) + aPayloadLen);
 
     SuccessOrQuit(message->Append(ip6Header));
 
@@ -337,10 +337,10 @@ Message *PrepareTcpMessage(Node               &aNode,
                            uint16_t            aDstPort    = 1235,
                            uint16_t            aPayloadLen = 10)
 {
-    Message         *message = nullptr;
-    Ip6::Prefix      nat64Prefix;
-    Ip6::Header      ip6Header;
-    Ip6::Tcp::Header tcpHeader;
+    Message       *message = nullptr;
+    Ip6::Prefix    nat64Prefix;
+    Ip6::Header    ip6Header;
+    Ip6::TcpHeader tcpHeader;
 
     message = aNode.Get<MessagePool>().Allocate(Message::kTypeIp6);
     VerifyOrQuit(message != nullptr);
@@ -354,7 +354,7 @@ Message *PrepareTcpMessage(Node               &aNode,
     ip6Header.GetDestination().SynthesizeFromIp4Address(nat64Prefix, aDstIp4Address);
 
     ip6Header.SetNextHeader(Ip6::kProtoTcp);
-    ip6Header.SetPayloadLength(sizeof(Ip6::Tcp::Header) + aPayloadLen);
+    ip6Header.SetPayloadLength(sizeof(Ip6::TcpHeader) + aPayloadLen);
 
     SuccessOrQuit(message->Append(ip6Header));
 
@@ -1147,14 +1147,14 @@ void TestNat64IhlBypass(void)
         ip6Header.SetSource(ip6Addr);
         ip6Header.GetDestination().SynthesizeFromIp4Address(prefix, ip4Addr);
         ip6Header.SetNextHeader(Ip6::kProtoUdp);
-        ip6Header.SetPayloadLength(sizeof(Ip6::Udp::Header) + payloadLen);
+        ip6Header.SetPayloadLength(sizeof(Ip6::UdpHeader) + payloadLen);
         SuccessOrQuit(message->Append(ip6Header));
 
-        Ip6::Udp::Header udpHeader;
+        Ip6::UdpHeader udpHeader;
         udpHeader.Clear();
         udpHeader.SetSourcePort(srcPort);
         udpHeader.SetDestinationPort(dstPort);
-        udpHeader.SetLength(sizeof(Ip6::Udp::Header) + payloadLen);
+        udpHeader.SetLength(sizeof(Ip6::UdpHeader) + payloadLen);
         SuccessOrQuit(message->Append(udpHeader));
 
         for (uint16_t i = 0; i < payloadLen; i++)
@@ -1176,7 +1176,7 @@ void TestNat64IhlBypass(void)
         ip4Header.Clear();
         // IHL=6 means header length is 6*4 = 24 bytes.
         ip4Header.SetVersionIhl(0x46);
-        ip4Header.SetTotalLength(24 + sizeof(Ip4::Udp::Header) + payloadLen);
+        ip4Header.SetTotalLength(24 + sizeof(Ip4::UdpHeader) + payloadLen);
         ip4Header.SetProtocol(Ip4::kProtoUdp);
         ip4Header.SetTtl(64);
         ip4Header.SetSource(ip4Addr);
@@ -1194,11 +1194,11 @@ void TestNat64IhlBypass(void)
         uint8_t options[] = {0x01, 0x01, 0x01, 0x00};
         SuccessOrQuit(message->Append(options));
 
-        Ip4::Udp::Header udpHeader;
+        Ip4::UdpHeader udpHeader;
         udpHeader.Clear();
         udpHeader.SetSourcePort(srcPort);
         udpHeader.SetDestinationPort(dstPort);
-        udpHeader.SetLength(sizeof(Ip4::Udp::Header) + payloadLen);
+        udpHeader.SetLength(sizeof(Ip4::UdpHeader) + payloadLen);
         SuccessOrQuit(message->Append(udpHeader));
 
         for (uint16_t i = 0; i < payloadLen; i++)
@@ -1230,7 +1230,7 @@ void TestNat64IhlBypass(void)
         ip4Header.Clear();
         // IHL=7 means header length is 7*4 = 28 bytes.
         ip4Header.SetVersionIhl(0x47);
-        ip4Header.SetTotalLength(28 + sizeof(Ip4::Udp::Header) + payloadLen);
+        ip4Header.SetTotalLength(28 + sizeof(Ip4::UdpHeader) + payloadLen);
         ip4Header.SetProtocol(Ip4::kProtoUdp);
         ip4Header.SetTtl(64);
         ip4Header.SetSource(ip4Addr);
@@ -1248,11 +1248,11 @@ void TestNat64IhlBypass(void)
         uint8_t options[] = {0x83, 0x08, 0x04, 0x01, 0x01, 0x01, 0x01, 0x00};
         SuccessOrQuit(message->Append(options));
 
-        Ip4::Udp::Header udpHeader;
+        Ip4::UdpHeader udpHeader;
         udpHeader.Clear();
         udpHeader.SetSourcePort(srcPort);
         udpHeader.SetDestinationPort(dstPort);
-        udpHeader.SetLength(sizeof(Ip4::Udp::Header) + payloadLen);
+        udpHeader.SetLength(sizeof(Ip4::UdpHeader) + payloadLen);
         SuccessOrQuit(message->Append(udpHeader));
 
         for (uint16_t i = 0; i < payloadLen; i++)
@@ -1276,7 +1276,7 @@ void TestNat64IhlBypass(void)
         ip4Header.Clear();
         // IHL=7 means header length is 7*4 = 28 bytes.
         ip4Header.SetVersionIhl(0x47);
-        ip4Header.SetTotalLength(28 + sizeof(Ip4::Udp::Header) + payloadLen);
+        ip4Header.SetTotalLength(28 + sizeof(Ip4::UdpHeader) + payloadLen);
         ip4Header.SetProtocol(Ip4::kProtoUdp);
         ip4Header.SetTtl(64);
         ip4Header.SetSource(ip4Addr);
@@ -1294,11 +1294,11 @@ void TestNat64IhlBypass(void)
         uint8_t options[] = {0x89, 0x08, 0x04, 0x01, 0x01, 0x01, 0x01, 0x00};
         SuccessOrQuit(message->Append(options));
 
-        Ip4::Udp::Header udpHeader;
+        Ip4::UdpHeader udpHeader;
         udpHeader.Clear();
         udpHeader.SetSourcePort(srcPort);
         udpHeader.SetDestinationPort(dstPort);
-        udpHeader.SetLength(sizeof(Ip4::Udp::Header) + payloadLen);
+        udpHeader.SetLength(sizeof(Ip4::UdpHeader) + payloadLen);
         SuccessOrQuit(message->Append(udpHeader));
 
         for (uint16_t i = 0; i < payloadLen; i++)

--- a/tests/nexus/test_tmf_origin.cpp
+++ b/tests/nexus/test_tmf_origin.cpp
@@ -52,11 +52,11 @@ void TestTmfOrigin(void)
     VerifyOrQuit(message != nullptr);
 
     // 1. Inner UDP Header
-    Ip6::Udp::Header udpHeader;
+    Ip6::UdpHeader udpHeader;
     udpHeader.Clear();
     udpHeader.SetSourcePort(1234);
     udpHeader.SetDestinationPort(Tmf::kUdpPort);
-    udpHeader.SetLength(sizeof(Ip6::Udp::Header));
+    udpHeader.SetLength(sizeof(Ip6::UdpHeader));
 
     // 2. Inner IPv6 Header
     Ip6::Header innerHeader;
@@ -65,7 +65,7 @@ void TestTmfOrigin(void)
     innerHeader.SetSource(Ip6::Address::GetLinkLocalAllNodesMulticast()); // dummy LL source
     innerHeader.SetDestination(linkLocal);
     innerHeader.SetNextHeader(Ip6::kProtoUdp);
-    innerHeader.SetPayloadLength(sizeof(Ip6::Udp::Header));
+    innerHeader.SetPayloadLength(sizeof(Ip6::UdpHeader));
 
     // 3. Outer IPv6 Header (IP-in-IP)
     Ip6::Header outerHeader;
@@ -74,7 +74,7 @@ void TestTmfOrigin(void)
     outerHeader.SetSource(linkLocal);
     outerHeader.SetDestination(mlEid);
     outerHeader.SetNextHeader(Ip6::kProtoIp6);
-    outerHeader.SetPayloadLength(sizeof(Ip6::Header) + sizeof(Ip6::Udp::Header));
+    outerHeader.SetPayloadLength(sizeof(Ip6::Header) + sizeof(Ip6::UdpHeader));
 
     // Append all headers to the message
     SuccessOrQuit(message->Append(outerHeader));
@@ -113,11 +113,11 @@ void TestTmfOriginBypassed(void)
     VerifyOrQuit(message != nullptr);
 
     // 1. Inner UDP Header
-    Ip6::Udp::Header udpHeader;
+    Ip6::UdpHeader udpHeader;
     udpHeader.Clear();
     udpHeader.SetSourcePort(1234);
     udpHeader.SetDestinationPort(Tmf::kUdpPort);
-    udpHeader.SetLength(sizeof(Ip6::Udp::Header));
+    udpHeader.SetLength(sizeof(Ip6::UdpHeader));
 
     // 2. Inner IPv6 Header
     Ip6::Header innerHeader;
@@ -126,7 +126,7 @@ void TestTmfOriginBypassed(void)
     innerHeader.SetSource(Ip6::Address::GetLinkLocalAllNodesMulticast()); // dummy LL source
     innerHeader.SetDestination(linkLocal);
     innerHeader.SetNextHeader(Ip6::kProtoUdp);
-    innerHeader.SetPayloadLength(sizeof(Ip6::Udp::Header));
+    innerHeader.SetPayloadLength(sizeof(Ip6::UdpHeader));
 
     // 3. Destination Options Header (containing 6 bytes of padding to make it 8 bytes total)
     Ip6::ExtensionHeader dstHeader;
@@ -143,7 +143,7 @@ void TestTmfOriginBypassed(void)
     outerHeader.SetSource(linkLocal);
     outerHeader.SetDestination(mlEid);
     outerHeader.SetNextHeader(Ip6::kProtoDstOpts);
-    outerHeader.SetPayloadLength(dstHeader.GetSize() + sizeof(Ip6::Header) + sizeof(Ip6::Udp::Header));
+    outerHeader.SetPayloadLength(dstHeader.GetSize() + sizeof(Ip6::Header) + sizeof(Ip6::UdpHeader));
 
     // Append all headers to the message
     SuccessOrQuit(message->Append(outerHeader));

--- a/tests/unit/test_checksum.cpp
+++ b/tests/unit/test_checksum.cpp
@@ -172,7 +172,7 @@ void CorruptMessage(Message &aMessage)
 
 void TestUdpMessageChecksum(void)
 {
-    constexpr uint16_t kMinSize = sizeof(Ip6::Udp::Header);
+    constexpr uint16_t kMinSize = sizeof(Ip6::UdpHeader);
     constexpr uint16_t kMaxSize = Buffer::kSize * 3 + 24;
 
     const char *kSourceAddress = "fd00:1122:3344:5566:7788:99aa:bbcc:ddee";
@@ -185,7 +185,7 @@ void TestUdpMessageChecksum(void)
     for (uint16_t size = kMinSize; size <= kMaxSize; size++)
     {
         Message         *message = instance->Get<Ip6::Ip6>().NewMessage();
-        Ip6::Udp::Header udpHeader;
+        Ip6::UdpHeader   udpHeader;
         Ip6::MessageInfo messageInfo;
 
         VerifyOrQuit(message != nullptr, "Ip6::NewMesssage() failed");
@@ -309,7 +309,7 @@ void TestIcmp6MessageChecksum(void)
 
 void TestTcp4MessageChecksum(void)
 {
-    constexpr size_t kMinSize = sizeof(Ip4::Tcp::Header);
+    constexpr size_t kMinSize = sizeof(Ip4::TcpHeader);
     constexpr size_t kMaxSize = Buffer::kSize * 3 + 24;
 
     const char *kSourceAddress = "12.34.56.78";
@@ -327,8 +327,8 @@ void TestTcp4MessageChecksum(void)
 
     for (uint16_t size = kMinSize; size <= kMaxSize; size++)
     {
-        Message         *message = instance->Get<Ip6::Ip6>().NewMessage();
-        Ip4::Tcp::Header tcpHeader;
+        Message       *message = instance->Get<Ip6::Ip6>().NewMessage();
+        Ip4::TcpHeader tcpHeader;
 
         VerifyOrQuit(message != nullptr, "Ip6::NewMesssage() failed");
         SuccessOrQuit(message->SetLength(size));
@@ -364,7 +364,7 @@ void TestTcp4MessageChecksum(void)
 
 void TestUdp4MessageChecksum(void)
 {
-    constexpr uint16_t kMinSize = sizeof(Ip4::Udp::Header);
+    constexpr uint16_t kMinSize = sizeof(Ip4::UdpHeader);
     constexpr uint16_t kMaxSize = Buffer::kSize * 3 + 24;
 
     const char *kSourceAddress = "12.34.56.78";
@@ -382,8 +382,8 @@ void TestUdp4MessageChecksum(void)
 
     for (uint16_t size = kMinSize; size <= kMaxSize; size++)
     {
-        Message         *message = instance->Get<Ip6::Ip6>().NewMessage();
-        Ip4::Udp::Header udpHeader;
+        Message       *message = instance->Get<Ip6::Ip6>().NewMessage();
+        Ip4::UdpHeader udpHeader;
 
         VerifyOrQuit(message != nullptr, "Ip6::NewMesssage() failed");
         SuccessOrQuit(message->SetLength(size));

--- a/tests/unit/test_lowpan.hpp
+++ b/tests/unit/test_lowpan.hpp
@@ -237,11 +237,11 @@ public:
     /**
      * This fields represent uncompressed IPv6 packet.
      */
-    Mac::Addresses   mMacAddrs;
-    Ip6::Header      mIpHeader;
-    Payload          mExtHeader;
-    Ip6::Header      mIpTunneledHeader;
-    Ip6::Udp::Header mUdpHeader;
+    Mac::Addresses mMacAddrs;
+    Ip6::Header    mIpHeader;
+    Payload        mExtHeader;
+    Ip6::Header    mIpTunneledHeader;
+    Ip6::UdpHeader mUdpHeader;
 
     /**
      * This fields represent compressed IPv6 packet.


### PR DESCRIPTION
This commit updates the codebase to use `TcpHeader` and `UdpHeader` types directly, instead of the nested `Tcp::Header` and `Udp::Header` types. The `TcpHeader` and `UdpHeader` classes are already defined in `ip6_headers.hpp`. This change reduces dependencies on the `Tcp` and `Udp` class definitions, which is particularly useful when TCP is disabled in the build configuration, avoiding the need to include their respective class headers just for the header definitions.