### PR TITLE
[github-action] fix `markdown-lint-check` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,8 +78,11 @@ jobs:
         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
     - name: Run linkspector
       uses: umbrelladocs/action-linkspector@963b6264d7de32c904942a70b488d3407453049e # v1.5.1
+      env:
+        PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         reporter: github-pr-review


### PR DESCRIPTION
This commit updates the `markdown-lint-check` job to explicitly set the `PUPPETEER_EXECUTABLE_PATH` environment variable to use the system-installed Google Chrome (`/usr/bin/google-chrome`) for the `linkspector` action. This resolves issues where the action fails to find a browser environment to execute properly.
