### PR TITLE
[tcat] restrict TCAT Commissioner's dataset overwriting authorization

### DIFF
--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -226,7 +226,7 @@ void Settings::DeleteOperationalDataset(MeshCoP::Dataset::Type aType)
 }
 
 #if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
-void Settings::SaveTcatCommissionerCertificate(uint8_t *aCert, uint16_t aCertLen)
+void Settings::SaveTcatCommissionerCertificate(const uint8_t *aCert, uint16_t aCertLen)
 {
     Error error = Get<SettingsDriver>().Set(kKeyTcatCommrCert, aCert, aCertLen);
 

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -770,7 +770,7 @@ public:
      * @param[in]  aCert            The DER-encoded X509 end-entity certificate to store.
      * @param[in]  aCertLen         Certificate length.
      */
-    void SaveTcatCommissionerCertificate(uint8_t *aCert, uint16_t aCertLen);
+    void SaveTcatCommissionerCertificate(const uint8_t *aCert, uint16_t aCertLen);
 
     /**
      * Reads the Tcat Commissioner certificate.

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -1011,6 +1011,7 @@ Error TcatAgent::HandleStartThreadInterface(void)
     VerifyOrExit(IsCommandClassAuthorized(kCommissioning), error = kErrorRejected);
     VerifyOrExit(Get<ActiveDatasetManager>().Read(datasetInfo) == kErrorNone, error = kErrorInvalidState);
     VerifyOrExit(datasetInfo.IsPresent<Dataset::kNetworkKey>(), error = kErrorInvalidState);
+    VerifyOrExit(Get<Mle::Mle>().IsDisabled(), error = kErrorAlready);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
     VerifyOrExit(!Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
@@ -1020,8 +1021,16 @@ Error TcatAgent::HandleStartThreadInterface(void)
     SuccessOrExit(error = Get<Mle::Mle>().Start());
 
 exit:
-    // error values for callback MUST be limited to the allowed set, see #JoinCallback
-    mJoinCallback.InvokeIfSet(&GetInstance(), /* aIsJoin */ true, error);
+    if (error != kErrorAlready)
+    {
+        // error values for callback MUST be limited to the allowed set, see #JoinCallback
+        mJoinCallback.InvokeIfSet(&GetInstance(), /* aIsJoin */ true, error);
+    }
+    else
+    {
+        error = kErrorNone; // TCAT spec: success resp if already started. No callback in this case.
+    }
+
     return error;
 }
 
@@ -1030,6 +1039,7 @@ Error TcatAgent::HandleStopThreadInterface(void)
     Error error = kErrorNone;
 
     VerifyOrExit(IsCommandClassAuthorized(kCommissioning), error = kErrorRejected);
+    VerifyOrExit(!Get<Mle::Mle>().IsDisabled(), error = kErrorAlready);
 
     Get<Mle::Mle>().Stop();
 
@@ -1039,7 +1049,14 @@ Error TcatAgent::HandleStopThreadInterface(void)
     }
 
 exit:
-    mJoinCallback.InvokeIfSet(&GetInstance(), /* aIsJoin */ false, error);
+    if (error != kErrorAlready)
+    {
+        mJoinCallback.InvokeIfSet(&GetInstance(), /* aIsJoin */ false, error);
+    }
+    else
+    {
+        error = kErrorNone; // TCAT spec: success resp if already stopped. No callback in this case.
+    }
     return error;
 }
 

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -80,7 +80,7 @@ void TcatAgent::ClearCommissionerState(void)
     mPskdVerified                  = false;
     mPskcVerified                  = false;
     mInstallCodeVerified           = false;
-    mIsCommissioned                = false;
+    mCanOverwriteDataset           = false;
     mApplicationResponsePending    = false;
     mHasWrittenActiveDataset       = false;
 }
@@ -243,8 +243,8 @@ Error TcatAgent::Connected(MeshCoP::Tls::Extension &aTls)
     NotifyStateChange();
     LogInfo("Connected");
 
-    // This specifically stores the state IsCommissioned at _start_ of session:
-    mIsCommissioned = Get<ActiveDatasetManager>().IsCommissioned();
+    // If already commissioned at start of session, overwriting is never allowed.
+    mCanOverwriteDataset = !Get<ActiveDatasetManager>().IsCommissioned();
 
 exit:
     return error;
@@ -403,7 +403,7 @@ exit:
 
 bool TcatAgent::IsSetActiveDatasetAuthorized(const Dataset *aDataset) const
 {
-    return !mIsCommissioned &&
+    return mCanOverwriteDataset &&
            IsCommandClassAuthorizedWithFlags(mCommissionerAuthorizationField.mCommissioningFlags,
                                              mDeviceAuthorizationField.mCommissioningFlags, aDataset);
 }
@@ -585,7 +585,7 @@ Error TcatAgent::HandleSetActiveOperationalDataset(const Message &aIncomingMessa
     uint8_t buf[kCommissionerCertMaxLength];
     size_t  bufLen = sizeof(buf);
 
-    VerifyOrExit(!mIsCommissioned, error = kErrorAlready);
+    VerifyOrExit(mCanOverwriteDataset, error = kErrorAlready);
 
     SuccessOrExit(error = dataset.SetFrom(aIncomingMessage, aOffsetRange));
     SuccessOrExit(error = dataset.ValidateTlvs());
@@ -719,7 +719,7 @@ Error TcatAgent::HandleDecommission(void)
 #endif
 
     mJoinCallback.InvokeIfSet(&GetInstance(), /* aIsJoin */ false, error);
-    mIsCommissioned = false; // enable repeated commissioning/decommissioning in a session
+    mCanOverwriteDataset = true; // enable repeated commissioning/decommissioning cycles in a session
 
 exit:
     return error;
@@ -1121,7 +1121,7 @@ void TcatAgent::HandleNotifierEvents(Events aEvents)
     // This event revokes the Commissioner's existing authorization (if any) to rewrite datasets.
     if (!mHasWrittenActiveDataset && aEvents.ContainsAny(kEventNetworkKeyChanged | kEventThreadExtPanIdChanged))
     {
-        mIsCommissioned = true;
+        mCanOverwriteDataset = false;
     }
     mHasWrittenActiveDataset = false;
 

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -82,6 +82,7 @@ void TcatAgent::ClearCommissionerState(void)
     mInstallCodeVerified           = false;
     mIsCommissioned                = false;
     mApplicationResponsePending    = false;
+    mHasWrittenActiveDataset       = false;
 }
 
 Error TcatAgent::Start(AppDataReceiveCallback aAppDataReceiveCallback, JoinCallback aJoinHandler, void *aContext)
@@ -590,12 +591,18 @@ Error TcatAgent::HandleSetActiveOperationalDataset(const Message &aIncomingMessa
     SuccessOrExit(error = dataset.ValidateTlvs());
     VerifyOrExit(dataset.ContainsTlv(Tlv::kNetworkKey), error = kErrorInvalidArgs);
 
+    VerifyOrExit(Get<Mle::Mle>().IsDisabled(), error = kErrorInvalidState);
     VerifyOrExit(IsSetActiveDatasetAuthorized(&dataset), error = kErrorRejected);
 
     SuccessOrExit(error = Get<Ble::BleSecure>().GetPeerCertificateDer(buf, &bufLen, bufLen));
     Get<Settings>().SaveTcatCommissionerCertificate(buf, static_cast<uint16_t>(bufLen));
 
     Get<ActiveDatasetManager>().SaveLocal(dataset);
+
+    // Flag lets HandleNotifierEvents() know that the Agent is the source of the change. In theory, this could be
+    // coalesced with another module's dataset write at exactly the same time, but this is in practice impossible
+    // to exploit as an attack vector by the TCAT Commissioner.
+    mHasWrittenActiveDataset = true;
 
 exit:
     return error;
@@ -1083,15 +1090,27 @@ void TcatAgent::HandleNotifierEvents(Events aEvents)
     VerifyOrExit(IsStarted());
     VerifyOrExit(mVendorInfo != nullptr);
 
-    if (aEvents.ContainsAny(kEventThreadRoleChanged))
+    if (aEvents.Contains(kEventThreadRoleChanged))
     {
         if (!mVendorInfo->mKeepActiveAfterJoining && Get<Mle::Mle>().IsAttached() &&
             (mLastDeviceRole == Mle::kRoleDisabled || mLastDeviceRole == Mle::kRoleDetached))
         {
             IgnoreError(Standby());
         }
-
         mLastDeviceRole = Get<Mle::Mle>().GetRole();
+    }
+
+    // Change of network key or ExtPanId by another process: it wrote a dataset for *another* Thread Network.
+    // This event revokes the Commissioner's existing authorization (if any) to rewrite datasets.
+    if (!mHasWrittenActiveDataset && aEvents.ContainsAny(kEventNetworkKeyChanged | kEventThreadExtPanIdChanged))
+    {
+        mIsCommissioned = true;
+    }
+    mHasWrittenActiveDataset = false;
+
+    if (aEvents.Contains(kEventPskcChanged))
+    {
+        mPskcVerified = false; // if changed: require new proof-of-PSKc-possession by Commissioner
     }
 
 exit:

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -82,6 +82,7 @@ void TcatAgent::ClearCommissionerState(void)
     mInstallCodeVerified           = false;
     mIsCommissioned                = false;
     mApplicationResponsePending    = false;
+    mHasWrittenActiveDataset       = false;
 }
 
 Error TcatAgent::Start(AppDataReceiveCallback aAppDataReceiveCallback, JoinCallback aJoinHandler, void *aContext)
@@ -584,7 +585,8 @@ Error TcatAgent::HandleSetActiveOperationalDataset(const Message &aIncomingMessa
     uint8_t buf[kCommissionerCertMaxLength];
     size_t  bufLen = sizeof(buf);
 
-    VerifyOrExit(!mIsCommissioned, error = kErrorAlready);
+    VerifyOrExit(mCanOverwriteDataset, error = kErrorAlready);
+    VerifyOrExit(Get<Mle::Mle>().IsDisabled(), error = kErrorInvalidState);
 
     SuccessOrExit(error = dataset.SetFrom(aIncomingMessage, aOffsetRange));
     SuccessOrExit(error = dataset.ValidateTlvs());
@@ -596,6 +598,11 @@ Error TcatAgent::HandleSetActiveOperationalDataset(const Message &aIncomingMessa
     Get<Settings>().SaveTcatCommissionerCertificate(buf, static_cast<uint16_t>(bufLen));
 
     Get<ActiveDatasetManager>().SaveLocal(dataset);
+
+    // Flag lets HandleNotifierEvents() know that the Agent is the source of the change. In theory, this could be
+    // coalesced with another module's dataset write at exactly the same time, but this is in practice impossible
+    // to exploit as an attack vector by the TCAT Commissioner.
+    mHasWrittenActiveDataset = true;
 
 exit:
     return error;
@@ -1083,15 +1090,27 @@ void TcatAgent::HandleNotifierEvents(Events aEvents)
     VerifyOrExit(IsStarted());
     VerifyOrExit(mVendorInfo != nullptr);
 
-    if (aEvents.ContainsAny(kEventThreadRoleChanged))
+    if (aEvents.Contains(kEventThreadRoleChanged))
     {
         if (!mVendorInfo->mKeepActiveAfterJoining && Get<Mle::Mle>().IsAttached() &&
             (mLastDeviceRole == Mle::kRoleDisabled || mLastDeviceRole == Mle::kRoleDetached))
         {
             IgnoreError(Standby());
         }
-
         mLastDeviceRole = Get<Mle::Mle>().GetRole();
+    }
+
+    // Change of network key or ExtPanId by another process: it wrote a dataset for *another* Thread Network.
+    // This event revokes the Commissioner's existing authorization (if any) to rewrite datasets.
+    if (!mHasWrittenActiveDataset && aEvents.ContainsAny(kEventNetworkKeyChanged | kEventThreadExtPanIdChanged))
+    {
+        mIsCommissioned = true;
+    }
+    mHasWrittenActiveDataset = false;
+
+    if (aEvents.Contains(kEventPskcChanged))
+    {
+        mPskcVerified = false; // if changed: require new proof-of-PSKc-possession by Commissioner
     }
 
 exit:

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -82,7 +82,7 @@ void TcatAgent::ClearCommissionerState(void)
     mInstallCodeVerified           = false;
     mCanOverwriteDataset           = false;
     mApplicationResponsePending    = false;
-    mHasWrittenActiveDataset       = false;
+    mIsSourceOfDatasetChange       = false;
 }
 
 Error TcatAgent::Start(AppDataReceiveCallback aAppDataReceiveCallback, JoinCallback aJoinHandler, void *aContext)
@@ -602,7 +602,7 @@ Error TcatAgent::HandleSetActiveOperationalDataset(const Message &aIncomingMessa
     // Flag lets HandleNotifierEvents() know that the Agent is the source of the change. In theory, this could be
     // coalesced with another module's dataset write at exactly the same time, but this is in practice impossible
     // to exploit as an attack vector by the TCAT Commissioner.
-    mHasWrittenActiveDataset = true;
+    mIsSourceOfDatasetChange = true;
 
 exit:
     return error;
@@ -697,6 +697,15 @@ Error TcatAgent::HandleDecommission(void)
     VerifyOrExit(IsCommandClassAuthorized(kDecommissioning), error = kErrorRejected);
     SuccessOrExit(error = Get<Ble::BleSecure>().GetPeerCertificateDer(buf, &bufLen, bufLen));
 
+    Decommission(buf, static_cast<uint16_t>(bufLen));
+
+exit:
+    mJoinCallback.InvokeIfSet(&GetInstance(), /* aIsJoin */ false, error);
+    return error;
+}
+
+void TcatAgent::Decommission(const uint8_t *aCommissionerCert, uint16_t aCertLength)
+{
     Get<Mle::Mle>().Stop();
 
     if (!mVendorInfo->mDoNotActivateAfterLeaving)
@@ -708,7 +717,7 @@ Error TcatAgent::HandleDecommission(void)
     Get<PendingDatasetManager>().Clear();
 
     IgnoreReturnValue(Get<Instance>().ErasePersistentInfo());
-    Get<Settings>().SaveTcatCommissionerCertificate(buf, static_cast<uint16_t>(bufLen));
+    Get<Settings>().SaveTcatCommissionerCertificate(aCommissionerCert, aCertLength);
 
 #if !OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
     {
@@ -718,11 +727,8 @@ Error TcatAgent::HandleDecommission(void)
     }
 #endif
 
-    mJoinCallback.InvokeIfSet(&GetInstance(), /* aIsJoin */ false, error);
-    mCanOverwriteDataset = true; // enable repeated commissioning/decommissioning cycles in a session
-
-exit:
-    return error;
+    mCanOverwriteDataset     = true; // enable repeated commissioning/decommissioning cycles in a session
+    mIsSourceOfDatasetChange = true; // record that we made the dataset change (causing callback event later)
 }
 
 Error TcatAgent::HandlePing(const Message     &aIncomingMessage,
@@ -1119,11 +1125,11 @@ void TcatAgent::HandleNotifierEvents(Events aEvents)
 
     // Change of network key or ExtPanId by another process: it wrote a dataset for *another* Thread Network.
     // This event revokes the Commissioner's existing authorization (if any) to rewrite datasets.
-    if (!mHasWrittenActiveDataset && aEvents.ContainsAny(kEventNetworkKeyChanged | kEventThreadExtPanIdChanged))
+    if (!mIsSourceOfDatasetChange && aEvents.ContainsAny(kEventNetworkKeyChanged | kEventThreadExtPanIdChanged))
     {
         mCanOverwriteDataset = false;
     }
-    mHasWrittenActiveDataset = false;
+    mIsSourceOfDatasetChange = false;
 
     if (aEvents.Contains(kEventPskcChanged))
     {

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -80,7 +80,7 @@ void TcatAgent::ClearCommissionerState(void)
     mPskdVerified                  = false;
     mPskcVerified                  = false;
     mInstallCodeVerified           = false;
-    mIsCommissioned                = false;
+    mCanOverwriteDataset           = false;
     mApplicationResponsePending    = false;
     mHasWrittenActiveDataset       = false;
 }
@@ -243,8 +243,8 @@ Error TcatAgent::Connected(MeshCoP::Tls::Extension &aTls)
     NotifyStateChange();
     LogInfo("Connected");
 
-    // This specifically stores the state IsCommissioned at _start_ of session:
-    mIsCommissioned = Get<ActiveDatasetManager>().IsCommissioned();
+    // If already commissioned at start of session, overwriting is never allowed.
+    mCanOverwriteDataset = !Get<ActiveDatasetManager>().IsCommissioned();
 
 exit:
     return error;
@@ -403,7 +403,7 @@ exit:
 
 bool TcatAgent::IsSetActiveDatasetAuthorized(const Dataset *aDataset) const
 {
-    return !mIsCommissioned &&
+    return mCanOverwriteDataset &&
            IsCommandClassAuthorizedWithFlags(mCommissionerAuthorizationField.mCommissioningFlags,
                                              mDeviceAuthorizationField.mCommissioningFlags, aDataset);
 }
@@ -719,7 +719,7 @@ Error TcatAgent::HandleDecommission(void)
 #endif
 
     mJoinCallback.InvokeIfSet(&GetInstance(), /* aIsJoin */ false, error);
-    mIsCommissioned = false; // enable repeated commissioning/decommissioning in a session
+    mCanOverwriteDataset = true; // enable repeated commissioning/decommissioning cycles in a session
 
 exit:
     return error;
@@ -1121,7 +1121,7 @@ void TcatAgent::HandleNotifierEvents(Events aEvents)
     // This event revokes the Commissioner's existing authorization (if any) to rewrite datasets.
     if (!mHasWrittenActiveDataset && aEvents.ContainsAny(kEventNetworkKeyChanged | kEventThreadExtPanIdChanged))
     {
-        mIsCommissioned = true;
+        mCanOverwriteDataset = false;
     }
     mHasWrittenActiveDataset = false;
 

--- a/src/core/meshcop/tcat_agent.hpp
+++ b/src/core/meshcop/tcat_agent.hpp
@@ -520,7 +520,7 @@ private:
     bool                             mPskdVerified : 1;
     bool                             mPskcVerified : 1;
     bool                             mInstallCodeVerified : 1;
-    bool                             mIsCommissioned : 1;
+    bool                             mCanOverwriteDataset : 1;
     bool                             mApplicationResponsePending : 1;
     bool                             mHasWrittenActiveDataset : 1;
     using ExpireTimer = TimerMilliIn<TcatAgent, &TcatAgent::HandleTimer>;

--- a/src/core/meshcop/tcat_agent.hpp
+++ b/src/core/meshcop/tcat_agent.hpp
@@ -397,6 +397,11 @@ public:
      * Indicates if Set Active Dataset commands in the Commissioning command class are currently
      * authorized for use by the active TCAT Commissioner for setting the @p aDataset.
      *
+     * Authorization is granted when the TCAT Commissioner certificate's flags allow commissioning
+     * operations (for the given aDataset) and the TCAT Device is not already commissioned by or due
+     * to another process/source. If the TCAT Commissioner did set a dataset within the same session
+     * then that dataset can be overwritten.
+     *
      * @param aDataset  The specific Active Operational Dataset intended to be written.
      *
      * @retval TRUE     The command for writing @p aDataset is currently authorized.
@@ -517,6 +522,7 @@ private:
     bool                             mInstallCodeVerified : 1;
     bool                             mIsCommissioned : 1;
     bool                             mApplicationResponsePending : 1;
+    bool                             mHasWrittenActiveDataset : 1;
     using ExpireTimer = TimerMilliIn<TcatAgent, &TcatAgent::HandleTimer>;
     ExpireTimer     mActiveOrStandbyTimer;
     uint32_t        mTcatActiveDurationMs;

--- a/src/core/meshcop/tcat_agent.hpp
+++ b/src/core/meshcop/tcat_agent.hpp
@@ -523,7 +523,7 @@ private:
     bool                             mPskdVerified : 1;
     bool                             mPskcVerified : 1;
     bool                             mInstallCodeVerified : 1;
-    bool                             mIsCommissioned : 1;
+    bool                             mCanOverwriteDataset : 1;
     bool                             mApplicationResponsePending : 1;
     bool                             mHasWrittenActiveDataset : 1;
     using ExpireTimer = TimerMilliIn<TcatAgent, &TcatAgent::HandleTimer>;

--- a/src/core/meshcop/tcat_agent.hpp
+++ b/src/core/meshcop/tcat_agent.hpp
@@ -459,6 +459,7 @@ private:
                                   const OffsetRange &aOffsetRange,
                                   bool              &aResponse);
     Error HandleDecommission(void);
+    void  Decommission(const uint8_t *aCommissionerCert, uint16_t aCertLength);
     Error HandlePing(const Message     &aIncomingMessage,
                      Message           &aOutgoingMessage,
                      const OffsetRange &aOffsetRange,
@@ -525,7 +526,7 @@ private:
     bool                             mInstallCodeVerified : 1;
     bool                             mCanOverwriteDataset : 1;
     bool                             mApplicationResponsePending : 1;
-    bool                             mHasWrittenActiveDataset : 1;
+    bool                             mIsSourceOfDatasetChange : 1;
     using ExpireTimer = TimerMilliIn<TcatAgent, &TcatAgent::HandleTimer>;
     ExpireTimer     mActiveOrStandbyTimer;
     uint32_t        mTcatActiveDurationMs;

--- a/src/core/meshcop/tcat_agent.hpp
+++ b/src/core/meshcop/tcat_agent.hpp
@@ -397,6 +397,14 @@ public:
      * Indicates if Set Active Dataset commands in the Commissioning command class are currently
      * authorized for use by the active TCAT Commissioner for setting the @p aDataset.
      *
+     * Authorization is granted when the TCAT Commissioner certificate's flags allow commissioning
+     * operations (for the given aDataset) and the TCAT Device is not already commissioned by or due
+     * to another process/source. If the TCAT Commissioner did set a dataset within the same session
+     * then that dataset can be overwritten.
+     *
+     * @note Executing a Set Active Dataset operation (#HandleSetActiveOperationalDataset())
+     *       requires the Thread Interface to be stopped (Get<Mle::Mle>().IsDisabled() == true).
+     *
      * @param aDataset  The specific Active Operational Dataset intended to be written.
      *
      * @retval TRUE     The command for writing @p aDataset is currently authorized.
@@ -517,6 +525,7 @@ private:
     bool                             mInstallCodeVerified : 1;
     bool                             mIsCommissioned : 1;
     bool                             mApplicationResponsePending : 1;
+    bool                             mHasWrittenActiveDataset : 1;
     using ExpireTimer = TimerMilliIn<TcatAgent, &TcatAgent::HandleTimer>;
     ExpireTimer     mActiveOrStandbyTimer;
     uint32_t        mTcatActiveDurationMs;

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -319,7 +319,7 @@ OT_TOOL_WEAK otError otPlatSettingsGet(otInstance *, uint16_t aKey, int aIndex, 
         return OT_ERROR_NOT_FOUND;
     }
 
-    if (aIndex > setting->second.size())
+    if (aIndex < 0 || static_cast<size_t>(aIndex) >= setting->second.size())
     {
         return OT_ERROR_NOT_FOUND;
     }
@@ -373,7 +373,13 @@ OT_TOOL_WEAK otError otPlatSettingsDelete(otInstance *, uint16_t aKey, int aInde
         return OT_ERROR_NOT_FOUND;
     }
 
-    if (aIndex >= setting->second.size())
+    if (aIndex == -1) // per API contract, all values will be removed.
+    {
+        setting->second.clear();
+        return OT_ERROR_NONE;
+    }
+
+    if (aIndex < 0 || static_cast<size_t>(aIndex) >= setting->second.size())
     {
         return OT_ERROR_NOT_FOUND;
     }

--- a/tests/unit/test_tcat.cpp
+++ b/tests/unit/test_tcat.cpp
@@ -97,6 +97,16 @@ void otPlatAlarmMilliStartAt(otInstance *, uint32_t aT0, uint32_t aDt)
 
 uint32_t otPlatAlarmMilliGetNow(void) { return sNow; }
 
+// Override the weak test platform stub to prevent buffer NULL dereference during the tests.
+otRadioFrame *otPlatRadioGetTransmitBuffer(otInstance *)
+{
+    static otRadioFrame sTxFrame;
+    static uint8_t      sTxPsdu[OT_RADIO_FRAME_MAX_SIZE];
+
+    sTxFrame.mPsdu = sTxPsdu;
+    return &sTxFrame;
+}
+
 } // extern "C"
 
 namespace ot {
@@ -561,7 +571,7 @@ private:
         aAgent->ClearCommissionerState();
         aAgent->mCommissionerAuthorizationField = aCommAuth;
         aAgent->mDeviceAuthorizationField       = aDeviceAuth;
-        aAgent->mIsCommissioned                 = aIsCommissionedAtStart;
+        aAgent->mCanOverwriteDataset            = !aIsCommissionedAtStart;
 
         aAgent->mNextState =
             (aAgent->mState == TcatAgent::kStateActiveTemporary) ? TcatAgent::kStateStandby : TcatAgent::kStateActive;
@@ -621,11 +631,15 @@ private:
     // just like a real attach. Requires a complete Active Dataset to be present.
     static void MockDeviceAttachedToNetwork(Instance *aInstance)
     {
-        SuccessOrQuit(otIp6SetEnabled(aInstance, true));
-        SuccessOrQuit(otThreadSetEnabled(aInstance, true));
         SuccessOrQuit(otThreadBecomeLeader(aInstance));
         otTaskletsProcess(aInstance);
         VerifyOrQuit(otThreadGetDeviceRole(aInstance) == OT_DEVICE_ROLE_LEADER);
+    }
+
+    static void MockDeviceDetachedFromNetwork(Instance *aInstance)
+    {
+        otTaskletsProcess(aInstance);
+        VerifyOrQuit(otThreadGetDeviceRole(aInstance) == OT_DEVICE_ROLE_DISABLED);
     }
 
 public:
@@ -1066,7 +1080,7 @@ public:
         testFreeInstance(instance);
     }
 
-    static void TestTcatAttemptDatasetOverwrite(void)
+    static void TestTcatDatasetOverwrite(void)
     {
         Instance  *instance = TestInitInstanceTcat();
         TcatAgent *agent    = &instance->Get<TcatAgent>();
@@ -1122,7 +1136,7 @@ public:
         testFreeInstance(instance);
     }
 
-    static void TestTcatAttemptDatasetOverwriteAfterAttach(void)
+    static void TestTcatDatasetOverwriteAfterAttach(void)
     {
         Instance  *instance = TestInitInstanceTcat();
         TcatAgent *agent    = &instance->Get<TcatAgent>();
@@ -1136,15 +1150,29 @@ public:
         VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
         VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
-        // Once the device attaches to a Thread network, the TCAT Commissioner can no longer overwrite the
-        // Active Dataset (this prevents a dataset from propagating to other already-networked devices).
+        for (int i = 0; i < 3; i++)
+        {
+            // Once the device is attached to a Thread network, the TCAT Commissioner can no longer overwrite the
+            // Active Dataset (this prevents a dataset from propagating to other already-networked devices).
+            agent->HandleStartThreadInterface();
+            MockDeviceAttachedToNetwork(instance);
+            VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+            VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+
+            // When the device has detached from Thread, the TCAT Commissioner can overwrite the Active Dataset
+            // even without a Decommission command, because it's still in the same TCAT session.
+            agent->HandleStopThreadInterface();
+            MockDeviceDetachedFromNetwork(instance);
+            VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+            VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+        }
+
+        // Attach to Thread Network again to prepare for the next test.
+        agent->HandleStartThreadInterface();
         MockDeviceAttachedToNetwork(instance);
 
-        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
-        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
-
         // After the Active Dataset is cleared (decommissioned), the agent considers the device no longer
-        // commissioned and allows overwriting again.
+        // commissioned and allows overwriting.
         MockActiveDatasetCleared(instance);
         VerifyOrQuit(!instance->Get<ActiveDatasetManager>().IsCommissioned());
         VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
@@ -1210,7 +1238,7 @@ public:
         // A Commissioner connects to the (uncommissioned) device
         MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, /* aIsCommissionedAtStart */ false);
         VerifyOrQuit(agent->IsStarted());
-        VerifyOrQuit(!agent->mIsCommissioned);
+        VerifyOrQuit(agent->mCanOverwriteDataset);
 
         // Start observing state-changed notifications.
         SuccessOrQuit(otSetStateChangedCallback(instance, HandleNotifierStateChanged, &observer));
@@ -1239,7 +1267,7 @@ public:
 
             // Because the agent saw both events coalesced while mHasWrittenActiveDataset was set, it recognizes the
             // change as its own and retains the Commissioner's authorization to overwrite the dataset.
-            VerifyOrQuit(!agent->mIsCommissioned, "a self-made dataset change must not revoke authorization");
+            VerifyOrQuit(agent->mCanOverwriteDataset, "a self-made dataset change must not revoke authorization");
         }
 
         otRemoveStateChangeCallback(instance, HandleNotifierStateChanged, &observer);
@@ -1265,8 +1293,8 @@ int main(void)
     ot::MeshCoP::UnitTester::TestTcatCommissioner1AuthWithDeviceRequirements();
     ot::MeshCoP::UnitTester::TestTcatCommissioner2AuthWithDeviceRequirements();
     ot::MeshCoP::UnitTester::TestTcatCommissioner4AuthWithExistingPartialDataset();
-    ot::MeshCoP::UnitTester::TestTcatAttemptDatasetOverwrite();
-    ot::MeshCoP::UnitTester::TestTcatAttemptDatasetOverwriteAfterAttach();
+    ot::MeshCoP::UnitTester::TestTcatDatasetOverwrite();
+    ot::MeshCoP::UnitTester::TestTcatDatasetOverwriteAfterAttach();
     ot::MeshCoP::UnitTester::TestTcatRepeatedCommandActivation();
     ot::MeshCoP::UnitTester::TestTcatNotifierCoalescesEvents();
     printf("All tests passed\n");

--- a/tests/unit/test_tcat.cpp
+++ b/tests/unit/test_tcat.cpp
@@ -35,8 +35,7 @@
 
 #include <openthread/ble_secure.h>
 
-#include "cli/cli_dataset.hpp"
-#include "radio/ble_secure.hpp"
+#include "instance/instance.hpp"
 
 #define OT_TCAT_X509_CERT                                                \
     "-----BEGIN CERTIFICATE-----\n"                                      \
@@ -297,14 +296,15 @@ static bool CommandClassesAuthorized(const TcatAgent *aAgent, const uint16_t aCo
     return validationResult;
 }
 
-// test helper to validate if Set Active Dataset commands are authorized or not, given the dataset to write.
-static bool SetActiveDatasetAuthorized(const TcatAgent *aAgent, const Dataset::Info &aDatasetInfo)
+// test helper to validate if the Set Active Dataset command would be successful, given the dataset to write
+// and the current state of the device/agent.
+static bool IsSetActiveDatasetSuccessful(const TcatAgent *aAgent, const Dataset::Info &aDatasetInfo)
 {
     Dataset dataset;
 
     // Convert high-level Dataset::Info into TLVs representation required by IsSetActiveDatasetAuthorized()
     VerifyOrQuit(dataset.WriteTlvsFrom(aDatasetInfo) == kErrorNone);
-    return aAgent->IsSetActiveDatasetAuthorized(&dataset);
+    return aAgent->Get<Mle::Mle>().IsDisabled() && aAgent->IsSetActiveDatasetAuthorized(&dataset);
 }
 
 // Advances fake time by aDuration, firing any expired alarms and processing tasklets along the way.
@@ -530,6 +530,44 @@ private:
         aAgent->mCommissionerDomainName    = *aDomainName;
     }
 
+    // Mock operation: TCAT Commissioner writes `aDataset` as the new local Active Operational Dataset.
+    // It models the behavior of `HandleSetActiveOperationalDataset()`, without checking authorization.
+    static void MockWriteActiveDataset(Instance *aInstance, const Dataset::Info &aDataset)
+    {
+        aInstance->Get<Mle::Mle>().Disable();
+        aInstance->Get<ActiveDatasetManager>().SaveLocal(aDataset);
+        aInstance->Get<TcatAgent>().mHasWrittenActiveDataset = true;
+        otTaskletsProcess(aInstance);
+    }
+
+    // Mock operation: some entity other than a TCAT Commissioner / Agent caused a dataset change.
+    // The existing state of Thread (MLE) is not changed.
+    static void MockActiveDatasetChanged(Instance *aInstance, const Dataset::Info &aDataset)
+    {
+        aInstance->Get<ActiveDatasetManager>().SaveLocal(aDataset);
+        otTaskletsProcess(aInstance);
+    }
+
+    // Mock operation: an entity other than a TCAT Commissioner clears the active dataset.
+    static void MockActiveDatasetCleared(Instance *aInstance)
+    {
+        aInstance->Get<Mle::Mle>().Disable();
+        aInstance->Get<ActiveDatasetManager>().Clear();
+        otTaskletsProcess(aInstance);
+    }
+
+    // Mock operation: the device attaches to a Thread network. Implemented by directly becoming Leader,
+    // which is synchronous (no need to drive the attach state machine) and signals `kEventThreadRoleChanged`
+    // just like a real attach. Requires a complete Active Dataset to be present.
+    static void MockDeviceAttachedToNetwork(Instance *aInstance)
+    {
+        SuccessOrQuit(otIp6SetEnabled(aInstance, true));
+        SuccessOrQuit(otThreadSetEnabled(aInstance, true));
+        SuccessOrQuit(otThreadBecomeLeader(aInstance));
+        otTaskletsProcess(aInstance);
+        VerifyOrQuit(otThreadGetDeviceRole(aInstance) == OT_DEVICE_ROLE_LEADER);
+    }
+
 public:
     static void TestTcatCommissioner1Auth(void)
     {
@@ -547,34 +585,34 @@ public:
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassExtraction |
                                                          kClassDecommissioning | kClassApplication));
         VerifyOrQuit(!instance->Get<ActiveDatasetManager>().IsCommissioned());
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // Write a partial Active Dataset and verify that Commissioner can still overwrite this with another dataset
         // if needed.
-        instance->Get<ActiveDatasetManager>().SaveLocal(sPartialDataset);
+        MockWriteActiveDataset(instance, sPartialDataset);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassExtraction |
                                                          kClassDecommissioning | kClassApplication));
         VerifyOrQuit(!instance->Get<ActiveDatasetManager>().IsCommissioned());
         VerifyOrQuit(instance->Get<ActiveDatasetManager>().IsPartiallyComplete());
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // Write a full Active Dataset and verify that Commissioner can still overwrite this.
-        instance->Get<ActiveDatasetManager>().SaveLocal(sFullDataset);
+        MockWriteActiveDataset(instance, sFullDataset);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassExtraction |
                                                          kClassDecommissioning | kClassApplication));
         VerifyOrQuit(instance->Get<ActiveDatasetManager>().IsCommissioned());
         VerifyOrQuit(!instance->Get<ActiveDatasetManager>().IsPartiallyComplete());
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sPartialDataset));
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // And back to partial dataset.
-        instance->Get<ActiveDatasetManager>().SaveLocal(sPartialDataset);
+        MockWriteActiveDataset(instance, sPartialDataset);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassExtraction |
                                                          kClassDecommissioning | kClassApplication));
         VerifyOrQuit(!instance->Get<ActiveDatasetManager>().IsCommissioned());
         VerifyOrQuit(instance->Get<ActiveDatasetManager>().IsPartiallyComplete());
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sPartialDataset));
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // provide PSKc proof-of-possession - verify access is same as before
         agent->mPskcVerified = true;
@@ -582,8 +620,8 @@ public:
                                                          kClassDecommissioning | kClassApplication));
         VerifyOrQuit(!instance->Get<ActiveDatasetManager>().IsCommissioned());
         VerifyOrQuit(instance->Get<ActiveDatasetManager>().IsPartiallyComplete());
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sPartialDataset));
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         testFreeInstance(instance);
     }
@@ -605,41 +643,41 @@ public:
 
         // Verify that Set Active Dataset can't be used yet, despite a matching XPAN ID and Network Name for the
         // dataset that the Commissioner wants to write.
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // provide PSKd proof-of-possession - this is required for all 4 command classes, but not sufficient yet.
         // So verify there's no change.
         agent->mPskdVerified = true;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // Commissioner cert now has a matching Domain Name - does not unlock any new classes, because
         // Network Name and XPAN ID can't match, due to Device being uncommissioned. Writing Active Dataset works now.
         MockDomainName(agent, true, &sCommDomainName);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // Writing a partial dataset does not work: misses the required Network Name and XPAN ID
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // Commissioner now has no XPAN ID anymore in cert - verify this prevents Set Active Dataset.
         // It's a misconfig in the Commissioner's cert.
         MockExtPanId(agent, false, &sCommExtPanId);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // Commissioner now has correct XPAN ID in cert, but not matching the dataset it wants to write.
         MockExtPanId(agent, true, &sCommExtPanId);
         sFullDataset.mExtendedPanId.m8[2]++; // modify bits in dataset to be written.
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // Commissioner now attempts to write a dataset with XPAN ID matching to that in cert.
         sFullDataset.mExtendedPanId = sCommExtPanId;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // New situation: Active Dataset is now configured (device is commissioned), but XPAN ID in Dataset
         // doesn't match the XPAN ID in the Commissioner's cert; and PSKc proof is not given yet,
@@ -648,8 +686,8 @@ public:
         instance->Get<ActiveDatasetManager>().SaveLocal(sFullDataset);
         VerifyOrQuit(instance->Get<ActiveDatasetManager>().IsCommissioned());
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // XPAN ID now matches again; class Commissioning authorization (0x1F) is restored. It doesn't require
         // PSKc proof.
@@ -657,35 +695,35 @@ public:
         instance->Get<ActiveDatasetManager>().SaveLocal(sFullDataset);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning));
         // Active Dataset can be overwritten because Device was uncommissioned at session start.
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // Now PSKc proof is given, unlocking more command classes
         agent->mPskcVerified = true;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassExtraction |
                                                          kClassDecommissioning | kClassApplication));
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // Commissioner connects again - this time, the Device is already commissioned at the start of the session.
         MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, true);
         MockNetworkName(agent, true, &sCommNetworkName);
         MockExtPanId(agent, true, &sCommExtPanId);
         MockDomainName(agent, true, &sCommDomainName);
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // PSKd proof does not authorize Set Active Dataset - because device is already commissioned.
         agent->mPskdVerified = true;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         agent->mPskcVerified = true;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassExtraction |
                                                          kClassDecommissioning | kClassApplication));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         testFreeInstance(instance);
     }
@@ -702,62 +740,62 @@ public:
         memcpy(&sCommAuth, &kCommCert4AuthField, sizeof(sCommAuth));
         MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, true);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // PSKc proof - satisfies 0x21. Set Active Dataset is not allowed: Device already commissioned.
         agent->mPskcVerified = true;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // Matching network name now in Commissioner cert - satisfies 0x05
         MockNetworkName(agent, true, &sCommNetworkName);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassExtraction));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // New situation: matching XPAN ID present in Comm cert - satisfies 0x09
         MockExtPanId(agent, true, &sCommExtPanId);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassExtraction |
                                                          kClassDecommissioning));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // New situation: Thread Domain name in cert matches - Application class added.
         MockDomainName(agent, true, &sCommDomainName);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassExtraction |
                                                          kClassDecommissioning | kClassApplication));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // New situation: PSKc proof not given - Commissioning class is revoked
         agent->mPskcVerified = false;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassExtraction | kClassDecommissioning |
                                                          kClassApplication));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // New situation: network name present, but mismatch - Extraction revoked
         NetworkName wrongNetworkName;
         SuccessOrQuit(wrongNetworkName.Set("WrongName"));
         MockNetworkName(agent, true, &wrongNetworkName);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassDecommissioning | kClassApplication));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // New situation: XPAN ID present, but mismatch - Decommissioning revoked
         sFullDataset.mExtendedPanId.m8[4]++; // change bits to force a mismatch
         instance->Get<ActiveDatasetManager>().SaveLocal(sFullDataset);
         MockExtPanId(agent, true, &sCommExtPanId);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassApplication));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // New situation: XPAN ID not present in dataset - same as before
         sFullDataset.mExtendedPanId                      = sCommExtPanId; // restore changes bits of above
         sFullDataset.mComponents.mIsExtendedPanIdPresent = false;
         instance->Get<ActiveDatasetManager>().SaveLocal(sFullDataset);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassApplication));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // New situation: Network Name not present in dataset - same as before
         sFullDataset.mComponents.mIsNetworkNamePresent = false;
         instance->Get<ActiveDatasetManager>().SaveLocal(sFullDataset);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassApplication));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // New situation: Device is decommissioned (by some other Commissioner). Then, this Commissioner
         // connects again and does PSKc proof. Set Active Dataset access should now be allowed.
@@ -765,8 +803,8 @@ public:
         MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, false);
         agent->mPskcVerified = true;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning));
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         testFreeInstance(instance);
     }
@@ -781,7 +819,7 @@ public:
         memcpy(&sCommAuth, &kCommCert5AuthField, sizeof(sCommAuth));
         MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, true);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // PSKd proof is given: it won't enable Extraction, because Extraction access flag bit 0 = 0.
         // Also it won't enable Decommissioning, because this class has an unknown flag bit 7 set i.e. the Commissioner
@@ -789,8 +827,8 @@ public:
         // enabled, since it requires a check with unknown flag bit 6. Device will enable Commissioning class.
         agent->mPskdVerified = true;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // Connect again and test the situation that Device was uncommissioned at connection start.
         // Commissioning is now enabled with PSKd proof.
@@ -798,8 +836,8 @@ public:
         MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, false);
         agent->mPskdVerified = true;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning));
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         testFreeInstance(instance);
     }
@@ -817,13 +855,13 @@ public:
         memcpy(&sCommAuth, &kCommCert1AuthField, sizeof(sCommAuth));
         MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, false);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassExtraction));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // PSKd proof
         agent->mPskdVerified = true;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassExtraction));
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // New situation: Device is commissioned and Commissioner has matching Network Name; and connects.
         instance->Get<ActiveDatasetManager>().SaveLocal(sFullDataset);
@@ -831,31 +869,31 @@ public:
         MockNetworkName(agent, true, &sCommNetworkName);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassExtraction | kClassDecommissioning |
                                                          kClassApplication));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // PSKc proof
         agent->mPskcVerified = true;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassExtraction | kClassDecommissioning |
                                                          kClassApplication));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // If Network Name does not match
         NetworkName wrongNetworkName;
         SuccessOrQuit(wrongNetworkName.Set(kWrongName));
         MockNetworkName(agent, true, &wrongNetworkName);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassExtraction | kClassApplication));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         agent->mPskdVerified = true;
         agent->mPskcVerified = false;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassExtraction));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         agent->mPskcVerified = true;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassExtraction |
                                                          kClassApplication));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         testFreeInstance(instance);
     }
@@ -873,46 +911,46 @@ public:
         memcpy(&sCommAuth, &kCommCert2AuthField, sizeof(sCommAuth));
         MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, false);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // PSKd proof
         agent->mPskdVerified = true;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // Network Name match
         MockNetworkName(agent, true, &sCommNetworkName);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // XPAN ID match
         MockExtPanId(agent, true, &sCommExtPanId);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // Domain Name match - but Commissioning in general is still not authorized, due to missing Active Dataset.
         // Hence the Network Name and XPAN ID checks cannot succeed in general. They will succeed now for the
         // specific 'Set Active Dataset' command.
         MockDomainName(agent, true, &sCommDomainName);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // the partial dataset cannot be written, because it lacks the required Network Name and XPAN ID combo.
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // PSKc proof
         agent->mPskcVerified = true;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
-        VerifyOrQuit(SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         // Try write a full dataset with differing XPAN ID - this fails
         sFullDataset.mExtendedPanId.m8[2]++;
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // Test an equivalent case to above where the device does have a full dataset stored already, and the
         // Commissioner connects. Now it has full access to all classes due to matching Network Name / XPAN ID combo.
@@ -927,8 +965,8 @@ public:
 
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassDecommissioning |
                                                          kClassExtraction | kClassApplication));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sPartialDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
         testFreeInstance(instance);
     }
@@ -951,22 +989,110 @@ public:
         // It wants access to Extraction class (0x05) based on matching Network Name, but it's denied.
         // Decommissioning (0x09) based on matching XPAN ID is also denied.
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // PSKc proof - satisfies 0x21. Set Active Dataset is not allowed: Device already commissioned.
         agent->mPskcVerified = true;
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         // As a sanity check, redo the test assuming that a (matching) full dataset was initially in the Device.
         // Now, Extraction and Commissioning classes do work because of matching elements in the Commcert.
         instance->Get<ActiveDatasetManager>().SaveLocal(sFullDataset);
         VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassExtraction |
                                                          kClassDecommissioning));
-        VerifyOrQuit(!SetActiveDatasetAuthorized(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
 
         testFreeInstance(instance);
     }
+
+    static void TestTcatAttemptDatasetOverwrite(void)
+    {
+        Instance  *instance = TestInitInstanceTcat();
+        TcatAgent *agent    = &instance->Get<TcatAgent>();
+
+        VerifyOrQuit(!instance->Get<ActiveDatasetManager>().IsCommissioned());
+
+        // A fresh session on an uncommissioned device: writing the Active Dataset is allowed.
+        MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, /* aIsCommissionedAtStart */ false);
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+
+        // TCAT agent itself writes a dataset. Overwriting this is allowed.
+        MockWriteActiveDataset(instance, sFullDataset);
+        VerifyOrQuit(instance->Get<ActiveDatasetManager>().IsCommissioned());
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+
+        // A bumped Active Timestamp (e.g. applied by the network) is a change not made by this Agent,
+        // however the network key and ExtPanId remain the same, so dataset-overwriting is still allowed -
+        // considering it still as 'same network'.
+        {
+            Dataset::Info bumpedInfo = sFullDataset;
+
+            bumpedInfo.mActiveTimestamp.mSeconds = 272899;
+            MockActiveDatasetChanged(instance, bumpedInfo);
+            VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+            VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+        }
+
+        // Another module/process changes the Active Dataset content significantly (here: a different Network Key).
+        // The agent now refuses to overwrite the dataset.
+        {
+            Dataset::Info externalInfo = sFullDataset;
+
+            externalInfo.mNetworkKey.m8[0] ^= 0xff;
+            MockActiveDatasetChanged(instance, externalInfo);
+            VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+            VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+        }
+
+        // After the Active Dataset is cleared (decommissioned), by an entity other than the TCAT agent,
+        // the agent still consider the TCAT session as no longer authorized to overwrite datasets.
+        // The TCAT Commissioner would need a fresh reconnection to authorize dataset-(over)writing again.
+        MockActiveDatasetCleared(instance);
+        VerifyOrQuit(!instance->Get<ActiveDatasetManager>().IsCommissioned());
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+
+        // TCAT Commissioner reconnects and can write a dataset again.
+        MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, /* aIsCommissionedAtStart */ false);
+        VerifyOrQuit(!instance->Get<ActiveDatasetManager>().IsCommissioned());
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+
+        testFreeInstance(instance);
+    }
+
+    static void TestTcatAttemptDatasetOverwriteAfterAttach(void)
+    {
+        Instance  *instance = TestInitInstanceTcat();
+        TcatAgent *agent    = &instance->Get<TcatAgent>();
+
+        // TCAT Commissioner connects and writes dataset.
+        MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, /* aIsCommissionedAtStart */ false);
+        MockWriteActiveDataset(instance, sFullDataset);
+        VerifyOrQuit(instance->Get<ActiveDatasetManager>().IsCommissioned());
+
+        // Before attaching, the agent still permits overwriting its own freshly-written dataset.
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+
+        // Once the device attaches to a Thread network, the TCAT Commissioner can no longer overwrite the
+        // Active Dataset (this prevents a dataset from propagating to other already-networked devices).
+        MockDeviceAttachedToNetwork(instance);
+
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+
+        // After the Active Dataset is cleared (decommissioned), the agent considers the device no longer
+        // commissioned and allows overwriting again.
+        MockActiveDatasetCleared(instance);
+        VerifyOrQuit(!instance->Get<ActiveDatasetManager>().IsCommissioned());
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+
+        testFreeInstance(instance);
+    }
+
 }; // class UnitTester
 
 } // namespace MeshCoP
@@ -978,6 +1104,7 @@ int main(void)
 {
 #if OPENTHREAD_CONFIG_BLE_TCAT_ENABLE
     ot::MeshCoP::TestTcatConnectionAndCertAttributes();
+    ot::MeshCoP::TestTcatAdvertisementUpdates();
     ot::MeshCoP::UnitTester::TestTcatCommissioner1Auth();
     ot::MeshCoP::UnitTester::TestTcatCommissioner2Auth();
     ot::MeshCoP::UnitTester::TestTcatCommissioner4Auth();
@@ -985,7 +1112,8 @@ int main(void)
     ot::MeshCoP::UnitTester::TestTcatCommissioner1AuthWithDeviceRequirements();
     ot::MeshCoP::UnitTester::TestTcatCommissioner2AuthWithDeviceRequirements();
     ot::MeshCoP::UnitTester::TestTcatCommissioner4AuthWithExistingPartialDataset();
-    ot::MeshCoP::TestTcatAdvertisementUpdates();
+    ot::MeshCoP::UnitTester::TestTcatAttemptDatasetOverwrite();
+    ot::MeshCoP::UnitTester::TestTcatAttemptDatasetOverwriteAfterAttach();
     printf("All tests passed\n");
 #else
     printf("TCAT feature is not enabled\n");

--- a/tests/unit/test_tcat.cpp
+++ b/tests/unit/test_tcat.cpp
@@ -324,6 +324,31 @@ static void AdvanceTime(Instance *aInstance, uint32_t aDuration)
     otTaskletsProcess(aInstance);
 }
 
+// Observer for the TCAT join callback (`otHandleTcatJoin`), counting join (Start) vs. leave (Stop) invocations.
+struct TcatJoinCounters
+{
+    uint32_t mJoinCount;  // invocations reporting aIsJoin == true  (StartThreadInterface)
+    uint32_t mLeaveCount; // invocations reporting aIsJoin == false (StopThreadInterface / Decommission)
+    Error    mLastError;
+};
+
+static void HandleTcatJoin(otInstance *aInstance, bool aIsJoin, otError aError, void *aContext)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    TcatJoinCounters &counters = *static_cast<TcatJoinCounters *>(aContext);
+
+    if (aIsJoin)
+    {
+        counters.mJoinCount++;
+    }
+    else
+    {
+        counters.mLeaveCount++;
+    }
+    counters.mLastError = static_cast<Error>(aError);
+}
+
 static Instance *TestInitInstanceTcat(void)
 {
     Instance *instance = testInitInstance();
@@ -1093,6 +1118,47 @@ public:
         testFreeInstance(instance);
     }
 
+    static void TestTcatRepeatedCommandActivation(void)
+    {
+        Instance        *instance = TestInitInstanceTcat();
+        TcatAgent       *agent    = &instance->Get<TcatAgent>();
+        TcatJoinCounters counters = {};
+
+        // Set up a commissioned device: Commissioning class authorized, a full Active Dataset present, and the
+        // Thread interface initially down. Observe the TCAT join callback throughout.
+        MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, /* aIsCommissionedAtStart */ false);
+        MockWriteActiveDataset(instance, sFullDataset);
+        agent->mJoinCallback.Set(HandleTcatJoin, &counters);
+        VerifyOrQuit(instance->Get<ActiveDatasetManager>().IsCommissioned());
+        VerifyOrQuit(instance->Get<Mle::Mle>().IsDisabled());
+
+        // First StartThreadInterface brings the interface up and reports a successful join.
+        SuccessOrQuit(agent->HandleStartThreadInterface());
+        VerifyOrQuit(!instance->Get<Mle::Mle>().IsDisabled());
+        VerifyOrQuit(counters.mJoinCount == 1 && counters.mLastError == kErrorNone);
+
+        // Repeated StartThreadInterface while already started is an idempotent success (TCAT spec): the interface
+        // stays up and the successful-join response is repeated on each invocation.
+        SuccessOrQuit(agent->HandleStartThreadInterface());
+        SuccessOrQuit(agent->HandleStartThreadInterface());
+        VerifyOrQuit(!instance->Get<Mle::Mle>().IsDisabled());
+        VerifyOrQuit(counters.mJoinCount == 1 && counters.mLeaveCount == 0 && counters.mLastError == kErrorNone);
+
+        // First StopThreadInterface brings the interface back down and reports a successful leave.
+        SuccessOrQuit(agent->HandleStopThreadInterface());
+        VerifyOrQuit(instance->Get<Mle::Mle>().IsDisabled());
+        VerifyOrQuit(counters.mLeaveCount == 1 && counters.mLastError == kErrorNone && counters.mJoinCount == 1);
+
+        // Repeated StopThreadInterface while already stopped is an idempotent success (TCAT spec), but the
+        // 'already stopped' case does NOT re-invoke the join callback.
+        SuccessOrQuit(agent->HandleStopThreadInterface());
+        SuccessOrQuit(agent->HandleStopThreadInterface());
+        VerifyOrQuit(instance->Get<Mle::Mle>().IsDisabled());
+        VerifyOrQuit(counters.mLeaveCount == 1 && counters.mLastError == kErrorNone && counters.mJoinCount == 1);
+
+        testFreeInstance(instance);
+    }
+
 }; // class UnitTester
 
 } // namespace MeshCoP
@@ -1114,6 +1180,7 @@ int main(void)
     ot::MeshCoP::UnitTester::TestTcatCommissioner4AuthWithExistingPartialDataset();
     ot::MeshCoP::UnitTester::TestTcatAttemptDatasetOverwrite();
     ot::MeshCoP::UnitTester::TestTcatAttemptDatasetOverwriteAfterAttach();
+    ot::MeshCoP::UnitTester::TestTcatRepeatedCommandActivation();
     printf("All tests passed\n");
 #else
     printf("TCAT feature is not enabled\n");

--- a/tests/unit/test_tcat.cpp
+++ b/tests/unit/test_tcat.cpp
@@ -349,6 +349,41 @@ static void HandleTcatJoin(otInstance *aInstance, bool aIsJoin, otError aError, 
     counters.mLastError = static_cast<Error>(aError);
 }
 
+// Observer for the public OpenThread state-changed callback (`otStateChangedCallback`). Used to verify
+// that the Notifier coalesces multiple changes into a single notification rather than delivering them
+// across several callbacks.
+struct StateChangeObserver
+{
+    uint32_t mTotalCount;      // total number of state-changed callbacks received
+    uint32_t mNetworkKeyCount; // callbacks that reported OT_CHANGED_NETWORK_KEY
+    uint32_t mExtPanIdCount;   // callbacks that reported OT_CHANGED_THREAD_EXT_PANID
+    uint32_t mBothInOneCount;  // callbacks that reported BOTH of the above together (i.e. coalesced)
+};
+
+static void HandleNotifierStateChanged(otChangedFlags aFlags, void *aContext)
+{
+    static constexpr otChangedFlags kBothFlags = OT_CHANGED_NETWORK_KEY | OT_CHANGED_THREAD_EXT_PANID;
+
+    StateChangeObserver &observer = *static_cast<StateChangeObserver *>(aContext);
+
+    observer.mTotalCount++;
+
+    if (aFlags & OT_CHANGED_NETWORK_KEY)
+    {
+        observer.mNetworkKeyCount++;
+    }
+
+    if (aFlags & OT_CHANGED_THREAD_EXT_PANID)
+    {
+        observer.mExtPanIdCount++;
+    }
+
+    if ((aFlags & kBothFlags) == kBothFlags)
+    {
+        observer.mBothInOneCount++;
+    }
+}
+
 static Instance *TestInitInstanceTcat(void)
 {
     Instance *instance = testInitInstance();
@@ -1159,6 +1194,58 @@ public:
         testFreeInstance(instance);
     }
 
+    // Verifies the OpenThread Notifier assumption that TcatAgent::HandleNotifierEvents() relies on:
+    // multiple state changes that occur back-to-back are coalesced into a single notification carrying all of
+    // the corresponding event flags.
+    static void TestTcatNotifierCoalescesEvents(void)
+    {
+        Instance           *instance = TestInitInstanceTcat();
+        TcatAgent          *agent    = &instance->Get<TcatAgent>();
+        StateChangeObserver observer = {};
+
+        // Commit a baseline Active Dataset and drain all resulting notifications.
+        instance->Get<ActiveDatasetManager>().SaveLocal(sFullDataset);
+        otTaskletsProcess(instance);
+
+        // A Commissioner connects to the (uncommissioned) device
+        MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, /* aIsCommissionedAtStart */ false);
+        VerifyOrQuit(agent->IsStarted());
+        VerifyOrQuit(!agent->mIsCommissioned);
+
+        // Start observing state-changed notifications.
+        SuccessOrQuit(otSetStateChangedCallback(instance, HandleNotifierStateChanged, &observer));
+
+        // The agent writes a new Active Dataset that differs in exactly 2 items - signalled as two distinct
+        // Notifier events.
+        {
+            Dataset::Info changed = sFullDataset;
+
+            changed.mNetworkKey.m8[0] ^= 0xff;
+            changed.mExtendedPanId.m8[0] ^= 0xff;
+            instance->Get<ActiveDatasetManager>().SaveLocal(changed);
+            agent->mHasWrittenActiveDataset = true; // model that this Agent is the source of the change
+        }
+
+        // repeat the tasklets processing to ensure subsequent notifer calls are not made.
+        for (int i = 0; i < 3; i++)
+        {
+            // Process pending tasklets: this drives the Notifier to emit the accumulated events.
+            otTaskletsProcess(instance);
+
+            VerifyOrQuit(observer.mTotalCount == 1, "two changes must produce exactly one notification, not two");
+            VerifyOrQuit(observer.mNetworkKeyCount == 1, "Network Key change must be reported exactly once");
+            VerifyOrQuit(observer.mExtPanIdCount == 1, "Extended PAN ID change must be reported exactly once");
+            VerifyOrQuit(observer.mBothInOneCount == 1, "both changes must be coalesced into the same notification");
+
+            // Because the agent saw both events coalesced while mHasWrittenActiveDataset was set, it recognizes the
+            // change as its own and retains the Commissioner's authorization to overwrite the dataset.
+            VerifyOrQuit(!agent->mIsCommissioned, "a self-made dataset change must not revoke authorization");
+        }
+
+        otRemoveStateChangeCallback(instance, HandleNotifierStateChanged, &observer);
+        testFreeInstance(instance);
+    }
+
 }; // class UnitTester
 
 } // namespace MeshCoP
@@ -1181,6 +1268,7 @@ int main(void)
     ot::MeshCoP::UnitTester::TestTcatAttemptDatasetOverwrite();
     ot::MeshCoP::UnitTester::TestTcatAttemptDatasetOverwriteAfterAttach();
     ot::MeshCoP::UnitTester::TestTcatRepeatedCommandActivation();
+    ot::MeshCoP::UnitTester::TestTcatNotifierCoalescesEvents();
     printf("All tests passed\n");
 #else
     printf("TCAT feature is not enabled\n");

--- a/tests/unit/test_tcat.cpp
+++ b/tests/unit/test_tcat.cpp
@@ -606,7 +606,7 @@ private:
     {
         aInstance->Get<Mle::Mle>().Disable();
         aInstance->Get<ActiveDatasetManager>().SaveLocal(aDataset);
-        aInstance->Get<TcatAgent>().mHasWrittenActiveDataset = true;
+        aInstance->Get<TcatAgent>().mIsSourceOfDatasetChange = true;
         otTaskletsProcess(aInstance);
     }
 
@@ -623,6 +623,22 @@ private:
     {
         aInstance->Get<Mle::Mle>().Disable();
         aInstance->Get<ActiveDatasetManager>().Clear();
+        otTaskletsProcess(aInstance);
+    }
+
+    // Mock operation: TCAT Commissioner sends the Decommission command. `HandleDecommission()` itself can't be
+    // called here because it reads the peer certificate from a real (mbedtls) TLS session, which these unit
+    // tests don't set up. So its authorization check is mimicked and the rest of it - `Decommission()` - is
+    // invoked with a stand-in commissioner certificate.
+    static void MockDecommission(Instance *aInstance)
+    {
+        static uint8_t sCommissionerCert[] = {0x30, 0x82, 0x01, 0x00};
+
+        TcatAgent &agent = aInstance->Get<TcatAgent>();
+
+        VerifyOrQuit(agent.IsCommandClassAuthorized(TcatAgent::kDecommissioning));
+        agent.Decommission(sCommissionerCert, sizeof(sCommissionerCert));
+        agent.mJoinCallback.InvokeIfSet(aInstance, /* aIsJoin */ false, kErrorNone);
         otTaskletsProcess(aInstance);
     }
 
@@ -1250,6 +1266,59 @@ public:
         testFreeInstance(instance);
     }
 
+    // Verifies that a Decommission command restores the Commissioner's authorization to (over)write the Active
+    // Dataset within the same TCAT session, so that commissioning/decommissioning cycles can be repeated.
+    static void TestTcatDecommissionRestoresDatasetWrite(void)
+    {
+        Instance        *instance = TestInitInstanceTcat();
+        TcatAgent       *agent    = &instance->Get<TcatAgent>();
+        TcatJoinCounters counters = {};
+
+        // A device that was commissioned by some other entity (not this TCAT Agent) before the session started.
+        MockActiveDatasetChanged(instance, sFullDataset);
+        VerifyOrQuit(instance->Get<ActiveDatasetManager>().IsCommissioned());
+
+        // The Commissioner connects: it is not authorized to overwrite the existing Active Dataset, but it is
+        // authorized to decommission the device.
+        MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, /* aIsCommissionedAtStart */ true);
+        agent->mJoinCallback.Set(HandleTcatJoin, &counters);
+        VerifyOrQuit(CommandClassesAuthorized(agent, kClassGeneral | kClassCommissioning | kClassExtraction |
+                                                         kClassDecommissioning | kClassApplication));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+
+        for (int i = 0; i < 3; i++)
+        {
+            // Decommission erases the Active Dataset and reports a successful 'leave'.
+            MockDecommission(instance);
+            VerifyOrQuit(!instance->Get<ActiveDatasetManager>().IsCommissioned());
+            VerifyOrQuit(instance->Get<Mle::Mle>().IsDisabled());
+            VerifyOrQuit(counters.mLeaveCount == static_cast<uint32_t>(i + 1) && counters.mJoinCount == 0 &&
+                         counters.mLastError == kErrorNone);
+
+            // Regression test: decommissioning clears the Network Key, which signals a Notifier event that would
+            // otherwise be mistaken for an external dataset change and immediately revoke the authorization again.
+            VerifyOrQuit(agent->mCanOverwriteDataset, "Decommission must restore dataset-write authorization");
+            VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+            VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+
+            // The Commissioner recommissions the device in the same session, and may still overwrite afterwards.
+            MockWriteActiveDataset(instance, sFullDataset);
+            VerifyOrQuit(instance->Get<ActiveDatasetManager>().IsCommissioned());
+            VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+            VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+        }
+
+        // A dataset change by another module still revokes the authorization after a Decommission.
+        MockDecommission(instance);
+        VerifyOrQuit(agent->mCanOverwriteDataset);
+        MockActiveDatasetChanged(instance, sFullDataset);
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+
+        testFreeInstance(instance);
+    }
+
     // Verifies the OpenThread Notifier assumption that TcatAgent::HandleNotifierEvents() relies on:
     // multiple state changes that occur back-to-back are coalesced into a single notification carrying all of
     // the corresponding event flags.
@@ -1279,7 +1348,7 @@ public:
             changed.mNetworkKey.m8[0] ^= 0xff;
             changed.mExtendedPanId.m8[0] ^= 0xff;
             instance->Get<ActiveDatasetManager>().SaveLocal(changed);
-            agent->mHasWrittenActiveDataset = true; // model that this Agent is the source of the change
+            agent->mIsSourceOfDatasetChange = true; // model that this Agent is the source of the change
         }
 
         // repeat the tasklets processing to ensure subsequent notifer calls are not made.
@@ -1293,7 +1362,7 @@ public:
             VerifyOrQuit(observer.mExtPanIdCount == 1, "Extended PAN ID change must be reported exactly once");
             VerifyOrQuit(observer.mBothInOneCount == 1, "both changes must be coalesced into the same notification");
 
-            // Because the agent saw both events coalesced while mHasWrittenActiveDataset was set, it recognizes the
+            // Because the agent saw both events coalesced while mIsSourceOfDatasetChange was set, it recognizes the
             // change as its own and retains the Commissioner's authorization to overwrite the dataset.
             VerifyOrQuit(agent->mCanOverwriteDataset, "a self-made dataset change must not revoke authorization");
         }
@@ -1324,6 +1393,7 @@ int main(void)
     ot::MeshCoP::UnitTester::TestTcatDatasetOverwrite();
     ot::MeshCoP::UnitTester::TestTcatDatasetOverwriteAfterAttach();
     ot::MeshCoP::UnitTester::TestTcatRepeatedCommandActivation();
+    ot::MeshCoP::UnitTester::TestTcatDecommissionRestoresDatasetWrite();
     ot::MeshCoP::UnitTester::TestTcatNotifierCoalescesEvents();
     printf("All tests passed\n");
 #else

--- a/tests/unit/test_tcat.cpp
+++ b/tests/unit/test_tcat.cpp
@@ -97,6 +97,16 @@ void otPlatAlarmMilliStartAt(otInstance *, uint32_t aT0, uint32_t aDt)
 
 uint32_t otPlatAlarmMilliGetNow(void) { return sNow; }
 
+// Override the weak test platform stub to prevent buffer NULL dereference during the tests.
+otRadioFrame *otPlatRadioGetTransmitBuffer(otInstance *)
+{
+    static otRadioFrame sTxFrame;
+    static uint8_t      sTxPsdu[OT_RADIO_FRAME_MAX_SIZE];
+
+    sTxFrame.mPsdu = sTxPsdu;
+    return &sTxFrame;
+}
+
 } // extern "C"
 
 namespace ot {
@@ -561,7 +571,7 @@ private:
         aAgent->ClearCommissionerState();
         aAgent->mCommissionerAuthorizationField = aCommAuth;
         aAgent->mDeviceAuthorizationField       = aDeviceAuth;
-        aAgent->mIsCommissioned                 = aIsCommissionedAtStart;
+        aAgent->mCanOverwriteDataset            = !aIsCommissionedAtStart;
 
         aAgent->mNextState =
             (aAgent->mState == TcatAgent::kStateActiveTemporary) ? TcatAgent::kStateStandby : TcatAgent::kStateActive;
@@ -621,11 +631,15 @@ private:
     // just like a real attach. Requires a complete Active Dataset to be present.
     static void MockDeviceAttachedToNetwork(Instance *aInstance)
     {
-        SuccessOrQuit(otIp6SetEnabled(aInstance, true));
-        SuccessOrQuit(otThreadSetEnabled(aInstance, true));
         SuccessOrQuit(otThreadBecomeLeader(aInstance));
         otTaskletsProcess(aInstance);
         VerifyOrQuit(otThreadGetDeviceRole(aInstance) == OT_DEVICE_ROLE_LEADER);
+    }
+
+    static void MockDeviceDetachedFromNetwork(Instance *aInstance)
+    {
+        otTaskletsProcess(aInstance);
+        VerifyOrQuit(otThreadGetDeviceRole(aInstance) == OT_DEVICE_ROLE_DISABLED);
     }
 
 public:
@@ -1066,7 +1080,7 @@ public:
         testFreeInstance(instance);
     }
 
-    static void TestTcatAttemptDatasetOverwrite(void)
+    static void TestTcatDatasetOverwrite(void)
     {
         Instance  *instance = TestInitInstanceTcat();
         TcatAgent *agent    = &instance->Get<TcatAgent>();
@@ -1122,7 +1136,7 @@ public:
         testFreeInstance(instance);
     }
 
-    static void TestTcatAttemptDatasetOverwriteAfterAttach(void)
+    static void TestTcatDatasetOverwriteAfterAttach(void)
     {
         Instance  *instance = TestInitInstanceTcat();
         TcatAgent *agent    = &instance->Get<TcatAgent>();
@@ -1136,16 +1150,58 @@ public:
         VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
         VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
-        // Once the device attaches to a Thread network, the TCAT Commissioner can no longer overwrite the
-        // Active Dataset (this prevents a dataset from propagating to other already-networked devices).
+        for (int i = 0; i < 3; i++)
+        {
+            // Once the device is attached to a Thread network, the TCAT Commissioner can no longer overwrite the
+            // Active Dataset (this prevents a dataset from propagating to other already-networked devices).
+            agent->HandleStartThreadInterface();
+            MockDeviceAttachedToNetwork(instance);
+            VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+            VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+
+            // When the device has detached from Thread, the TCAT Commissioner can overwrite the Active Dataset
+            // even without a Decommission command, because it's still in the same TCAT session.
+            agent->HandleStopThreadInterface();
+            MockDeviceDetachedFromNetwork(instance);
+            VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
+            VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+        }
+
+        // Attach to Thread Network again to prepare for the next test.
+        agent->HandleStartThreadInterface();
         MockDeviceAttachedToNetwork(instance);
 
+        // Another module/process changes the Active Dataset content significantly (here: a different Network Key).
+        {
+            Dataset::Info externalInfo = sFullDataset;
+
+            externalInfo.mNetworkKey.m8[0] ^= 0xff;
+            MockActiveDatasetChanged(instance, externalInfo);
+            VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+            VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+        }
+
+        // Thread is stopped
+        agent->HandleStopThreadInterface();
+        MockDeviceDetachedFromNetwork(instance);
         VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
         VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
 
-        // After the Active Dataset is cleared (decommissioned), the agent considers the device no longer
-        // commissioned and allows overwriting again.
+        // Attach to Thread Network again
+        agent->HandleStartThreadInterface();
+        MockDeviceAttachedToNetwork(instance);
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+
+        // After the Active Dataset is cleared (decommissioned) by an external source, the agent
+        // still cannot set the active dataset.
         MockActiveDatasetCleared(instance);
+        VerifyOrQuit(!instance->Get<ActiveDatasetManager>().IsCommissioned());
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sFullDataset));
+        VerifyOrQuit(!IsSetActiveDatasetSuccessful(agent, sPartialDataset));
+
+        // TCAT Commissioner reconnects and then can write a dataset again.
+        MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, /* aIsCommissionedAtStart */ false);
         VerifyOrQuit(!instance->Get<ActiveDatasetManager>().IsCommissioned());
         VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sFullDataset));
         VerifyOrQuit(IsSetActiveDatasetSuccessful(agent, sPartialDataset));
@@ -1210,7 +1266,7 @@ public:
         // A Commissioner connects to the (uncommissioned) device
         MockCommissionerConnected(agent, sCommAuth, sDeviceAuth, /* aIsCommissionedAtStart */ false);
         VerifyOrQuit(agent->IsStarted());
-        VerifyOrQuit(!agent->mIsCommissioned);
+        VerifyOrQuit(agent->mCanOverwriteDataset);
 
         // Start observing state-changed notifications.
         SuccessOrQuit(otSetStateChangedCallback(instance, HandleNotifierStateChanged, &observer));
@@ -1239,7 +1295,7 @@ public:
 
             // Because the agent saw both events coalesced while mHasWrittenActiveDataset was set, it recognizes the
             // change as its own and retains the Commissioner's authorization to overwrite the dataset.
-            VerifyOrQuit(!agent->mIsCommissioned, "a self-made dataset change must not revoke authorization");
+            VerifyOrQuit(agent->mCanOverwriteDataset, "a self-made dataset change must not revoke authorization");
         }
 
         otRemoveStateChangeCallback(instance, HandleNotifierStateChanged, &observer);
@@ -1265,8 +1321,8 @@ int main(void)
     ot::MeshCoP::UnitTester::TestTcatCommissioner1AuthWithDeviceRequirements();
     ot::MeshCoP::UnitTester::TestTcatCommissioner2AuthWithDeviceRequirements();
     ot::MeshCoP::UnitTester::TestTcatCommissioner4AuthWithExistingPartialDataset();
-    ot::MeshCoP::UnitTester::TestTcatAttemptDatasetOverwrite();
-    ot::MeshCoP::UnitTester::TestTcatAttemptDatasetOverwriteAfterAttach();
+    ot::MeshCoP::UnitTester::TestTcatDatasetOverwrite();
+    ot::MeshCoP::UnitTester::TestTcatDatasetOverwriteAfterAttach();
     ot::MeshCoP::UnitTester::TestTcatRepeatedCommandActivation();
     ot::MeshCoP::UnitTester::TestTcatNotifierCoalescesEvents();
     printf("All tests passed\n");


### PR DESCRIPTION
By design, the TCAT Agent allows a TCAT Commissioner to overwrite a previously written dataset while in the same session. This is to correct mistakes. It uses the same 'commission' authorization as the first dataset write.

An issue was found that when multiple concurrent commissioning methods are active, a TCAT Commissioner might exploit this design by overwriting a dataset that was configured by another method in the meantime, by keeping a long TCAT session open for example. This PR fixes the issue by restricting the dataset overwrite ability:
 - if another process/module wrote a full or partial dataset (source not TCAT), device is considered 'commissioned' from then on - flag mIsCommissioned is set.
 - if the device attached to a network or became a (sole) Leader based on the written dataset, the device is considered 'commissioned' from then on. Since it did use the written dataset for Thread Network connectivity, any further writes by TCAT Commissioner must be disallowed.

Unit test is improved and extended to test the above scenarios.