### PR TITLE
[dns] reject empty labels in general DNS name parser

### DIFF
--- a/src/core/net/dns_types.cpp
+++ b/src/core/net/dns_types.cpp
@@ -639,6 +639,9 @@ Error Name::LabelIterator::ReadLabel(char *aLabelBuffer, uint8_t &aLabelLength, 
     aLabelBuffer[mLabelLength] = kNullChar;
     aLabelLength               = mLabelLength;
 
+    // Ensure the label is not empty (represented as a null-terminated string).
+    VerifyOrExit(aLabelBuffer[0] != kNullChar, error = kErrorParse);
+
     if (!aAllowDotCharInLabel)
     {
         VerifyOrExit(StringFind(aLabelBuffer, kLabelSeparatorChar) == nullptr, error = kErrorParse);
@@ -1591,10 +1594,6 @@ Error PtrRecord::ReadPtrName(const Message &aMessage,
 
     aOffset = startOffset + sizeof(PtrRecord);
     SuccessOrExit(error = Name::ReadLabel(aMessage, aOffset, aLabelBuffer, aLabelBufferSize));
-
-    // The first label of a PTR target (the service-instance or host label)
-    // must be non-empty.
-    VerifyOrExit(aLabelBuffer[0] != kNullChar, error = kErrorParse);
 
     if (aNameBuffer != nullptr)
     {


### PR DESCRIPTION
This commit implements a defense-in-depth enhancement by centralizing empty text label validation directly in the general DNS name parser.

Specifically, `Name::LabelIterator::ReadLabel()` now verifies that the first character of a successfully read label is not `kNullChar`. Since labels in messages are read as null-terminated C-strings, this ensures any empty/NUL-start text labels are immediately rejected with `kErrorParse`.

This general check protects all downstream DNS name parsers, clients, and servers against processing or caching malformed labels. As a result, the redundant empty label validation previously added in `PtrRecord::ReadPtrName` is removed.