### PR TITLE
[spinel] fix out-of-bounds read in GetNextSavedFrame when RCP recover

### DIFF
--- a/src/lib/spinel/multi_frame_buffer.hpp
+++ b/src/lib/spinel/multi_frame_buffer.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/error.h>
 
+#include "common/code_utils.hpp"
 #include "lib/utils/endian.hpp"
 
 namespace ot {
@@ -179,6 +180,7 @@ public:
      */
     MultiFrameBuffer(void)
         : FrameWritePointer()
+        , mBufferCleared(true)
     {
         Clear();
     }
@@ -193,6 +195,7 @@ public:
         mWriteFrameStart = mBuffer;
         mWritePointer    = mBuffer + kHeaderSize;
         mRemainingLength = kSize - kHeaderSize;
+        mBufferCleared   = true;
 
         IgnoreError(SetSkipLength(0));
     }
@@ -348,6 +351,17 @@ public:
 
         assert(aFrame == nullptr || (mBuffer <= aFrame && aFrame < GetArrayEnd(mBuffer)));
 
+        if (aFrame == nullptr)
+        {
+            mBufferCleared = false;
+        }
+        else if (mBufferCleared)
+        {
+            aLength = 0;
+            aFrame  = nullptr;
+            ExitNow(error = OT_ERROR_NOT_FOUND);
+        }
+
         aFrame = (aFrame == nullptr) ? mBuffer : aFrame + aLength;
 
         if (HasSavedFrame() && (aFrame != mWriteFrameStart))
@@ -365,6 +379,7 @@ public:
             error   = OT_ERROR_NOT_FOUND;
         }
 
+    exit:
         return error;
     }
 
@@ -385,6 +400,7 @@ public:
             mWritePointer -= len;
             mWriteFrameStart -= len;
             mRemainingLength += len;
+            mBufferCleared = true;
         }
     }
 
@@ -443,6 +459,7 @@ private:
 
     uint8_t  mBuffer[kSize];
     uint8_t *mWriteFrameStart; // Pointer to start of current frame being written.
+    bool     mBufferCleared;   // Tracks if buffer was cleared during an active iteration.
 };
 
 } // namespace Spinel


### PR DESCRIPTION
This PR fixed the out-of-bounds read in GetNextSavedFrame when RCP recover.

## Root Cause
  
The crash occurs when ProcessFrameQueue() (spinel_driver.cpp:504) iterates through saved frames via a while loop while an RCP recovery event resets the receive buffer mid-iteration.

ProcessFrameQueue() drives the iteration as follows:
```
// spinel_driver.cpp:511-516
while (mRxFrameBuffer.GetNextSavedFrame(frame, length) == OT_ERROR_NONE)
{
mSavedFrameHandler(frame, length, mFrameHandlerContext);
}
mRxFrameBuffer.ClearSavedFrames();
```
Inside mSavedFrameHandler, the call chain HandleSavedFrame → HandleNotification → HandleValueIs (radio_spinel.cpp:498) can trigger RCP recovery in the following path:
```
- HandleValueIs(SPINEL_PROP_STREAM_RAW) → RadioReceive() → mCallbacks.mReceiveDone() → OT MAC → otPlatRadioTransmit() → Transmit() → WaitResponse() → HandleTransmitDone()
```
If HandleTransmitDone() encounters a parse error (radio_spinel.cpp:1594), it calls RecoverFromRcpFailure() directly:
```
// radio_spinel.cpp:1596-1598
mTxError = kErrorAbort;
HandleRcpTimeout();
RecoverFromRcpFailure();
```
RecoverFromRcpFailure() (radio_spinel.cpp:2051) calls ClearRxBuffer() which resets mWriteFrameStart to mBuffer, then issues Set(SPINEL_PROP_PHY_ENABLED) and RestoreProperties(), both of which call WaitResponse() internally. During these waits, new frames (e.g. SPINEL_PROP_STREAM_RAW notifications) arrive and are saved via SaveFrame(), advancing mWriteFrameStart to a new position P.

When RecoverFromRcpFailure() returns and the while loop resumes, the stale aFrame pointer is at an old position A > P. The original termination check in GetNextSavedFrame():
```
if (HasSavedFrame() && (aFrame != mWriteFrameStart))
```
evaluates to true — HasSavedFrame() is true because new frames were saved, and aFrame != mWriteFrameStart is true because the stale A does not equal the new P. The code then reads a frame header at A, which is now outside the valid region, causing an out-of-bounds read and crash.

## Fix

Add a mBufferCleared flag to MultiFrameBuffer to detect that the buffer was reset during an active iteration:

- Clear() and ClearSavedFrames(): set mBufferCleared = true
- GetNextSavedFrame(): 
- On a fresh iteration (aFrame == nullptr): reset mBufferCleared = false
- On a mid-iteration call (aFrame != nullptr) with mBufferCleared set: abort immediately via ExitNow(error = OT_ERROR_NOT_FOUND)

This ensures that once the buffer is reset, any in-progress iteration is safely terminated, regardless of where mWriteFrameStart ends up after recovery. Subsequent iterations starting from nullptr will operate on the new buffer state correctly.

