### PR TITLE
[icmp6] use `Icmp6Header` instead of `Icmp::Header`

### DIFF
--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -107,25 +107,25 @@ Error InfraIf::Send(const Icmp6Packet &aPacket, const Ip6::Address &aDestination
 
 void InfraIf::HandledReceived(uint32_t aIfIndex, const Ip6::Address &aSource, const Icmp6Packet &aPacket)
 {
-    Error                    error = kErrorNone;
-    const Ip6::Icmp::Header *icmp6Header;
+    Error                   error = kErrorNone;
+    const Ip6::Icmp6Header *icmp6Header;
 
     VerifyOrExit(mInitialized && mIsRunning, error = kErrorInvalidState);
     VerifyOrExit(aIfIndex == mIfIndex, error = kErrorDrop);
     VerifyOrExit(aPacket.GetBytes() != nullptr, error = kErrorInvalidArgs);
-    VerifyOrExit(aPacket.GetLength() >= sizeof(Ip6::Icmp::Header), error = kErrorParse);
+    VerifyOrExit(aPacket.GetLength() >= sizeof(Ip6::Icmp6Header), error = kErrorParse);
 
-    icmp6Header = reinterpret_cast<const Ip6::Icmp::Header *>(aPacket.GetBytes());
+    icmp6Header = reinterpret_cast<const Ip6::Icmp6Header *>(aPacket.GetBytes());
 
     switch (icmp6Header->GetType())
     {
-    case Ip6::Icmp::Header::kTypeRouterAdvert:
+    case Ip6::Icmp6Header::kTypeRouterAdvert:
         Get<RxRaTracker>().HandleRouterAdvertisement(aPacket, aSource);
         break;
-    case Ip6::Icmp::Header::kTypeNeighborAdvert:
+    case Ip6::Icmp6Header::kTypeNeighborAdvert:
         Get<RxRaTracker>().HandleNeighborAdvertisement(aPacket);
         break;
-    case Ip6::Icmp::Header::kTypeRouterSolicit:
+    case Ip6::Icmp6Header::kTypeRouterSolicit:
         Get<RoutingManager>().HandleRouterSolicit(aPacket, aSource);
         break;
     default:

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -706,8 +706,8 @@ void RoutingManager::CheckReachabilityToSendIcmpError(const Message &aMessage, c
     messageInfo.Clear();
     messageInfo.SetPeerAddr(aIp6Header.GetSource());
 
-    IgnoreError(Get<Ip6::Icmp>().SendError(Ip6::Icmp::Header::kTypeDstUnreach,
-                                           Ip6::Icmp::Header::kCodeDstUnreachProhibited, messageInfo, aMessage));
+    IgnoreError(Get<Ip6::Icmp>().SendError(Ip6::Icmp6Header::kTypeDstUnreach,
+                                           Ip6::Icmp6Header::kCodeDstUnreachProhibited, messageInfo, aMessage));
 
 exit:
     return;

--- a/src/core/net/checksum.cpp
+++ b/src/core/net/checksum.cpp
@@ -184,7 +184,7 @@ void Checksum::UpdateMessageChecksum(Message            &aMessage,
         break;
 
     case Ip6::kProtoIcmp6:
-        headerOffset = Ip6::Icmp::Header::kChecksumFieldOffset;
+        headerOffset = Ip6::Icmp6Header::kChecksumFieldOffset;
         break;
 
     default:

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -74,7 +74,10 @@ exit:
     return error;
 }
 
-Error Icmp::SendError(Header::Type aType, Header::Code aCode, const MessageInfo &aMessageInfo, const Message &aMessage)
+Error Icmp::SendError(Icmp6Header::Type  aType,
+                      Icmp6Header::Code  aCode,
+                      const MessageInfo &aMessageInfo,
+                      const Message     &aMessage)
 {
     Error   error;
     Headers headers;
@@ -86,7 +89,10 @@ exit:
     return error;
 }
 
-Error Icmp::SendError(Header::Type aType, Header::Code aCode, const MessageInfo &aMessageInfo, const Headers &aHeaders)
+Error Icmp::SendError(Icmp6Header::Type  aType,
+                      Icmp6Header::Code  aCode,
+                      const MessageInfo &aMessageInfo,
+                      const Headers     &aHeaders)
 {
     Error             error = kErrorNone;
     MessageInfo       messageInfoLocal;

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -69,8 +69,6 @@ class Icmp : public InstanceLocator,
              private NonCopyable
 {
 public:
-    typedef Icmp6Header Header; ///< ICMPv6 header
-
     /**
      * Implements ICMPv6 message handlers.
      */
@@ -93,7 +91,7 @@ public:
         }
 
     private:
-        void HandleReceiveMessage(Message &aMessage, const MessageInfo &aMessageInfo, const Header &aIcmp6Header)
+        void HandleReceiveMessage(Message &aMessage, const MessageInfo &aMessageInfo, const Icmp6Header &aIcmp6Header)
         {
             mReceiveCallback(mContext, &aMessage, &aMessageInfo, &aIcmp6Header);
         }
@@ -150,7 +148,10 @@ public:
      * @retval kErrorNone     Successfully enqueued the ICMPv6 error message.
      * @retval kErrorNoBufs   Insufficient buffers available.
      */
-    Error SendError(Header::Type aType, Header::Code aCode, const MessageInfo &aMessageInfo, const Message &aMessage);
+    Error SendError(Icmp6Header::Type  aType,
+                    Icmp6Header::Code  aCode,
+                    const MessageInfo &aMessageInfo,
+                    const Message     &aMessage);
 
     /**
      * Sends an ICMPv6 error message.
@@ -163,7 +164,10 @@ public:
      * @retval kErrorNone     Successfully enqueued the ICMPv6 error message.
      * @retval kErrorNoBufs   Insufficient buffers available.
      */
-    Error SendError(Header::Type aType, Header::Code aCode, const MessageInfo &aMessageInfo, const Headers &aHeaders);
+    Error SendError(Icmp6Header::Type  aType,
+                    Icmp6Header::Code  aCode,
+                    const MessageInfo &aMessageInfo,
+                    const Headers     &aHeaders);
 
     /**
      * Handles an ICMPv6 message.
@@ -210,6 +214,8 @@ public:
     uint16_t GetEchoSequence(void) const { return mEchoSequence; }
 
 private:
+    typedef Icmp6Header Header;
+
     Error HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMessageInfo);
 
     LinkedList<Handler> mHandlers;

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -41,8 +41,8 @@ namespace Ip6 {
 RegisterLogModule("Ip6");
 
 const uint8_t Ip6::kForwardIcmpTypes[] = {
-    Icmp::Header::kTypeDstUnreach,       Icmp::Header::kTypePacketToBig, Icmp::Header::kTypeTimeExceeded,
-    Icmp::Header::kTypeParameterProblem, Icmp::Header::kTypeEchoRequest, Icmp::Header::kTypeEchoReply,
+    Icmp6Header::kTypeDstUnreach,       Icmp6Header::kTypePacketToBig, Icmp6Header::kTypeTimeExceeded,
+    Icmp6Header::kTypeParameterProblem, Icmp6Header::kTypeEchoRequest, Icmp6Header::kTypeEchoReply,
 };
 
 Ip6::Ip6(Instance &aInstance)
@@ -756,14 +756,14 @@ void Ip6::UpdateReassemblyList(void)
         if (now - message.GetTimestamp() >= TimeMilli::SecToMsec(kReassemblyTimeout))
         {
             LogInfo("Reassembly timeout.");
-            SendIcmpError(message, Icmp::Header::kTypeTimeExceeded, Icmp::Header::kCodeFragmReasTimeEx);
+            SendIcmpError(message, Icmp6Header::kTypeTimeExceeded, Icmp6Header::kCodeFragmReasTimeEx);
 
             mReassemblyList.DequeueAndFree(message);
         }
     }
 }
 
-void Ip6::SendIcmpError(Message &aMessage, Icmp::Header::Type aIcmpType, Icmp::Header::Code aIcmpCode)
+void Ip6::SendIcmpError(Message &aMessage, Icmp6Header::Type aIcmpType, Icmp6Header::Code aIcmpCode)
 {
     Error       error = kErrorNone;
     Header      header;
@@ -1011,10 +1011,10 @@ Error Ip6::PassToHost(OwnedPtr<Message> &aMessagePtr,
         case kProtoIcmp6:
             if (mIcmp.ShouldHandleEchoRequest(aHeader.GetDestination()))
             {
-                Icmp::Header icmp;
+                Icmp6Header icmp;
 
                 IgnoreError(aMessagePtr->Read(aMessagePtr->GetOffset(), icmp));
-                VerifyOrExit(icmp.GetType() != Icmp::Header::kTypeEchoRequest, error = kErrorDrop);
+                VerifyOrExit(icmp.GetType() != Icmp6Header::kTypeEchoRequest, error = kErrorDrop);
             }
 
             break;

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -360,7 +360,7 @@ private:
     void CleanupFragmentationBuffer(void);
     void HandleTimeTick(void);
     void UpdateReassemblyList(void);
-    void SendIcmpError(Message &aMessage, Icmp::Header::Type aIcmpType, Icmp::Header::Code aIcmpCode);
+    void SendIcmpError(Message &aMessage, Icmp6Header::Type aIcmpType, Icmp6Header::Code aIcmpCode);
 #endif
     Error ReadHopByHopHeader(const Message &aMessage, OffsetRange &aOffsetRange, HopByHopHeader &aHbhHeader) const;
     Error AddMplOption(Message &aMessage, Header &aHeader);
@@ -546,7 +546,7 @@ public:
      *
      * @returns The ICMPv6 header.
      */
-    const Icmp::Header &GetIcmpHeader(void) const { return mHeader.mIcmp; }
+    const Icmp6Header &GetIcmpHeader(void) const { return mHeader.mIcmp; }
 
     /**
      * Returns the source port number if header is UDP or TCP, or zero otherwise
@@ -580,9 +580,9 @@ private:
     Header mIp6Header;
     union
     {
-        UdpHeader    mUdp;
-        TcpHeader    mTcp;
-        Icmp::Header mIcmp;
+        UdpHeader   mUdp;
+        TcpHeader   mTcp;
+        Icmp6Header mIcmp;
     } mHeader;
 };
 

--- a/src/core/net/nat64_translator.cpp
+++ b/src/core/net/nat64_translator.cpp
@@ -622,9 +622,9 @@ exit:
 
 Error Translator::TranslateIcmp4(Message &aMessage, uint16_t aOriginalId)
 {
-    Error             error = kErrorNone;
-    Ip4::Icmp4Header  icmp4Header;
-    Ip6::Icmp::Header icmp6Header;
+    Error            error = kErrorNone;
+    Ip4::Icmp4Header icmp4Header;
+    Ip6::Icmp6Header icmp6Header;
 
     // TODO: Implement the translation of other ICMP messages.
 
@@ -639,7 +639,7 @@ Error Translator::TranslateIcmp4(Message &aMessage, uint16_t aOriginalId)
         // the message type field, so we can reinterpret it as ICMP6
         // header and set the message type.
         SuccessOrExit(error = aMessage.Read(0, icmp6Header));
-        icmp6Header.SetType(Ip6::Icmp::Header::kTypeEchoReply);
+        icmp6Header.SetType(Ip6::Icmp6Header::kTypeEchoReply);
         icmp6Header.SetId(aOriginalId);
         aMessage.Write(0, icmp6Header);
         break;
@@ -655,9 +655,9 @@ exit:
 
 Error Translator::TranslateIcmp6(Message &aMessage, uint16_t aTranslatedId)
 {
-    Error             error = kErrorNone;
-    Ip4::Icmp4Header  icmp4Header;
-    Ip6::Icmp::Header icmp6Header;
+    Error            error = kErrorNone;
+    Ip4::Icmp4Header icmp4Header;
+    Ip6::Icmp6Header icmp6Header;
 
     // TODO: Implement the translation of other ICMP messages.
 
@@ -667,7 +667,7 @@ Error Translator::TranslateIcmp6(Message &aMessage, uint16_t aTranslatedId)
 
     switch (icmp6Header.GetType())
     {
-    case Ip6::Icmp::Header::kTypeEchoRequest:
+    case Ip6::Icmp6Header::kTypeEchoRequest:
         // The only difference between ICMPv6 echo and ICMP4 echo is
         // the message type field, so we can reinterpret it as ICMP4
         // header and set the message type.

--- a/src/core/net/nd6.cpp
+++ b/src/core/net/nd6.cpp
@@ -275,7 +275,7 @@ void RouterAdvert::Header::SetToDefault(void)
     OT_UNUSED_VARIABLE(mRetransTimer);
 
     Clear();
-    mType = Icmp::Header::kTypeRouterAdvert;
+    mType = Icmp6Header::kTypeRouterAdvert;
 }
 
 RoutePreference RouterAdvert::Header::GetDefaultRouterPreference(void) const
@@ -443,7 +443,7 @@ exit:
 RouterSolicitHeader::RouterSolicitHeader(void)
 {
     mHeader.Clear();
-    mHeader.SetType(Icmp::Header::kTypeRouterSolicit);
+    mHeader.SetType(Icmp6Header::kTypeRouterSolicit);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -455,7 +455,7 @@ NeighborSolicitHeader::NeighborSolicitHeader(void)
     OT_UNUSED_VARIABLE(mReserved);
 
     Clear();
-    mType = Icmp::Header::kTypeNeighborSolicit;
+    mType = Icmp6Header::kTypeNeighborSolicit;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -467,7 +467,7 @@ NeighborAdvertMessage::NeighborAdvertMessage(void)
     OT_UNUSED_VARIABLE(mReserved);
 
     Clear();
-    mType = Icmp::Header::kTypeNeighborAdvert;
+    mType = Icmp6Header::kTypeNeighborAdvert;
 }
 
 } // namespace Nd

--- a/src/core/net/nd6.hpp
+++ b/src/core/net/nd6.hpp
@@ -832,7 +832,7 @@ public:
          * @retval TRUE  The header is valid.
          * @retval FALSE The header is not valid.
          */
-        bool IsValid(void) const { return GetType() == Icmp::Header::kTypeRouterAdvert; }
+        bool IsValid(void) const { return GetType() == Icmp6Header::kTypeRouterAdvert; }
 
         /**
          * Sets the RA message to default values.
@@ -920,7 +920,7 @@ public:
          *
          * @returns The ICMPv6 message type.
          */
-        Icmp::Header::Type GetType(void) const { return static_cast<Icmp::Header::Type>(mType); }
+        Icmp6Header::Type GetType(void) const { return static_cast<Icmp6Header::Type>(mType); }
 
     private:
         // Router Advertisement Message
@@ -989,7 +989,7 @@ public:
         bool IsValid(void) const
         {
             return (mData.GetBytes() != nullptr) && (mData.GetLength() >= sizeof(Header)) &&
-                   (GetHeader().GetType() == Icmp::Header::kTypeRouterAdvert);
+                   (GetHeader().GetType() == Icmp6Header::kTypeRouterAdvert);
         }
 
         /**
@@ -1125,7 +1125,7 @@ public:
     RouterSolicitHeader(void);
 
 private:
-    Icmp::Header mHeader; // The common ICMPv6 header.
+    Icmp6Header mHeader; // The common ICMPv6 header.
 } OT_TOOL_PACKED_END;
 
 static_assert(sizeof(RouterSolicitHeader) == 8, "invalid RouterSolicitHeader structure");
@@ -1147,7 +1147,7 @@ public:
      * @retval TRUE  If the message header is valid.
      * @retval FALSE If the message header is not valid.
      */
-    bool IsValid(void) const { return (mType == Icmp::Header::kTypeNeighborSolicit) && (mCode == 0); }
+    bool IsValid(void) const { return (mType == Icmp6Header::kTypeNeighborSolicit) && (mCode == 0); }
 
     /**
      * Gets the Target Address field.
@@ -1208,7 +1208,7 @@ public:
      * @retval TRUE  If the message is valid.
      * @retval FALSE If the message is not valid.
      */
-    bool IsValid(void) const { return (mType == Icmp::Header::kTypeNeighborAdvert) && (mCode == 0); }
+    bool IsValid(void) const { return (mType == Icmp6Header::kTypeNeighborAdvert) && (mCode == 0); }
 
     /**
      * Indicates whether or not the Router Flag is set in the NA message.

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -985,16 +985,16 @@ void AddressResolver::HandleIcmpReceive(void                *aContext,
                                                                 AsCoreType(aIcmpHeader));
 }
 
-void AddressResolver::HandleIcmpReceive(Message                 &aMessage,
-                                        const Ip6::MessageInfo  &aMessageInfo,
-                                        const Ip6::Icmp::Header &aIcmpHeader)
+void AddressResolver::HandleIcmpReceive(Message                &aMessage,
+                                        const Ip6::MessageInfo &aMessageInfo,
+                                        const Ip6::Icmp6Header &aIcmpHeader)
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
     Ip6::Header ip6Header;
 
-    VerifyOrExit(aIcmpHeader.GetType() == Ip6::Icmp::Header::kTypeDstUnreach);
-    VerifyOrExit(aIcmpHeader.GetCode() == Ip6::Icmp::Header::kCodeDstUnreachNoRoute);
+    VerifyOrExit(aIcmpHeader.GetType() == Ip6::Icmp6Header::kTypeDstUnreach);
+    VerifyOrExit(aIcmpHeader.GetCode() == Ip6::Icmp6Header::kCodeDstUnreachNoRoute);
     SuccessOrExit(aMessage.Read(aMessage.GetOffset(), ip6Header));
 
     Remove(ip6Header.GetDestination(), kReasonReceivedIcmpDstUnreachNoRoute);

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -366,9 +366,9 @@ private:
                                   otMessage           *aMessage,
                                   const otMessageInfo *aMessageInfo,
                                   const otIcmp6Header *aIcmpHeader);
-    void        HandleIcmpReceive(Message                 &aMessage,
-                                  const Ip6::MessageInfo  &aMessageInfo,
-                                  const Ip6::Icmp::Header &aIcmpHeader);
+    void        HandleIcmpReceive(Message                &aMessage,
+                                  const Ip6::MessageInfo &aMessageInfo,
+                                  const Ip6::Icmp6Header &aIcmpHeader);
 
     void        HandleTimeTick(void);
     void        LogCacheEntryChange(EntryChange       aChange,

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -560,8 +560,8 @@ void MeshForwarder::SendDestinationUnreachable(uint16_t aMeshSource, const Ip6::
 
     messageInfo.GetPeerAddr().InitAsRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), aMeshSource);
 
-    IgnoreError(Get<Ip6::Icmp>().SendError(Ip6::Icmp::Header::kTypeDstUnreach,
-                                           Ip6::Icmp::Header::kCodeDstUnreachNoRoute, messageInfo, aIp6Headers));
+    IgnoreError(Get<Ip6::Icmp>().SendError(Ip6::Icmp6Header::kTypeDstUnreach, Ip6::Icmp6Header::kCodeDstUnreachNoRoute,
+                                           messageInfo, aIp6Headers));
 }
 
 void MeshForwarder::HandleMesh(RxInfo &aRxInfo)

--- a/src/core/utils/ping_sender.cpp
+++ b/src/core/utils/ping_sender.cpp
@@ -185,15 +185,15 @@ void PingSender::HandleIcmpReceive(void                *aContext,
                                                                 AsCoreType(aIcmpHeader));
 }
 
-void PingSender::HandleIcmpReceive(const Message           &aMessage,
-                                   const Ip6::MessageInfo  &aMessageInfo,
-                                   const Ip6::Icmp::Header &aIcmpHeader)
+void PingSender::HandleIcmpReceive(const Message          &aMessage,
+                                   const Ip6::MessageInfo &aMessageInfo,
+                                   const Ip6::Icmp6Header &aIcmpHeader)
 {
     Reply    reply;
     uint32_t timestamp;
 
     VerifyOrExit(mTimer.IsRunning());
-    VerifyOrExit(aIcmpHeader.GetType() == Ip6::Icmp::Header::kTypeEchoReply);
+    VerifyOrExit(aIcmpHeader.GetType() == Ip6::Icmp6Header::kTypeEchoReply);
     VerifyOrExit(aIcmpHeader.GetId() == mIdentifier);
 
     SuccessOrExit(aMessage.Read(aMessage.GetOffset(), timestamp));

--- a/src/core/utils/ping_sender.hpp
+++ b/src/core/utils/ping_sender.hpp
@@ -160,9 +160,9 @@ private:
                                   otMessage           *aMessage,
                                   const otMessageInfo *aMessageInfo,
                                   const otIcmp6Header *aIcmpHeader);
-    void        HandleIcmpReceive(const Message           &aMessage,
-                                  const Ip6::MessageInfo  &aMessageInfo,
-                                  const Ip6::Icmp::Header &aIcmpHeader);
+    void        HandleIcmpReceive(const Message          &aMessage,
+                                  const Ip6::MessageInfo &aMessageInfo,
+                                  const Ip6::Icmp6Header &aIcmpHeader);
 
     using PingTimer = TimerMilliIn<PingSender, &PingSender::HandleTimer>;
 

--- a/tests/nexus/platform/nexus_core.cpp
+++ b/tests/nexus/platform/nexus_core.cpp
@@ -1044,14 +1044,14 @@ void Core::HandleIcmpResponse(void                *aContext,
     OT_UNUSED_VARIABLE(aMessage);
 
     IcmpEchoResponseContext *context     = static_cast<IcmpEchoResponseContext *>(aContext);
-    const Ip6::Icmp::Header *header      = AsCoreTypePtr(aIcmpHeader);
+    const Ip6::Icmp6Header  *header      = AsCoreTypePtr(aIcmpHeader);
     const Ip6::MessageInfo  *messageInfo = AsCoreTypePtr(aMessageInfo);
 
     VerifyOrQuit(context != nullptr);
     VerifyOrQuit(header != nullptr);
     VerifyOrQuit(messageInfo != nullptr);
 
-    if ((header->GetType() == Ip6::Icmp::Header::kTypeEchoReply) && (header->GetId() == context->mIdentifier))
+    if ((header->GetType() == Ip6::Icmp6Header::kTypeEchoReply) && (header->GetId() == context->mIdentifier))
     {
         context->mResponseReceived = true;
 

--- a/tests/nexus/platform/nexus_infra_if.cpp
+++ b/tests/nexus/platform/nexus_infra_if.cpp
@@ -247,11 +247,11 @@ void InfraIf::ProcessIcmp6Nd(const Ip6::Address &aSrcAddress, const uint8_t *aBu
 
     packet.Init(aBuffer, aBufferLength);
 
-    VerifyOrExit(packet.GetLength() >= sizeof(Ip6::Icmp::Header));
+    VerifyOrExit(packet.GetLength() >= sizeof(Ip6::Icmp6Header));
 
-    switch (reinterpret_cast<const Ip6::Icmp::Header *>(packet.GetBytes())->GetType())
+    switch (reinterpret_cast<const Ip6::Icmp6Header *>(packet.GetBytes())->GetType())
     {
-    case Ip6::Icmp::Header::kTypeRouterAdvert:
+    case Ip6::Icmp6Header::kTypeRouterAdvert:
     {
         Ip6::Nd::RouterAdvert::RxMessage raMessage(packet);
 
@@ -267,12 +267,12 @@ void InfraIf::ProcessIcmp6Nd(const Ip6::Address &aSrcAddress, const uint8_t *aBu
         break;
     }
 
-    case Ip6::Icmp::Header::kTypeRouterSolicit:
+    case Ip6::Icmp6Header::kTypeRouterSolicit:
         HandleRouterSolicitation(aSrcAddress);
         break;
 
-    case Ip6::Icmp::Header::kTypeNeighborAdvert:
-    case Ip6::Icmp::Header::kTypeNeighborSolicit:
+    case Ip6::Icmp6Header::kTypeNeighborAdvert:
+    case Ip6::Icmp6Header::kTypeNeighborSolicit:
         // TODO: Handle other ND messages as needed for the simulation.
         break;
 
@@ -345,24 +345,24 @@ void InfraIf::SendEchoRequest(const Ip6::Address &aSrcAddress,
                               uint16_t            aPayloadSize,
                               uint8_t             aHopLimit)
 {
-    Message          *message;
-    Ip6::Header       ip6Header;
-    Ip6::Icmp::Header icmpHeader;
+    Message         *message;
+    Ip6::Header      ip6Header;
+    Ip6::Icmp6Header icmpHeader;
 
     message = Get<Ip6::Ip6>().NewMessage();
     VerifyOrQuit(message != nullptr);
 
     ip6Header.Clear();
     ip6Header.InitVersionTrafficClassFlow();
-    ip6Header.SetPayloadLength(sizeof(Ip6::Icmp::Header) + aPayloadSize);
+    ip6Header.SetPayloadLength(sizeof(Ip6::Icmp6Header) + aPayloadSize);
     ip6Header.SetNextHeader(Ip6::kProtoIcmp6);
     ip6Header.SetHopLimit(aHopLimit);
     ip6Header.SetSource(aSrcAddress);
     ip6Header.SetDestination(aDestAddress);
 
     icmpHeader.Clear();
-    icmpHeader.SetType(Ip6::Icmp::Header::kTypeEchoRequest);
-    icmpHeader.SetCode(static_cast<Ip6::Icmp::Header::Code>(0));
+    icmpHeader.SetType(Ip6::Icmp6Header::kTypeEchoRequest);
+    icmpHeader.SetCode(static_cast<Ip6::Icmp6Header::Code>(0));
     icmpHeader.SetId(aIdentifier);
     icmpHeader.SetSequence(0);
 
@@ -446,10 +446,10 @@ void InfraIf::Receive(Message &aMessage)
     {
         switch (headers.GetIcmpHeader().GetType())
         {
-        case Ip6::Icmp::Header::kTypeRouterAdvert:
-        case Ip6::Icmp::Header::kTypeRouterSolicit:
-        case Ip6::Icmp::Header::kTypeNeighborAdvert:
-        case Ip6::Icmp::Header::kTypeNeighborSolicit:
+        case Ip6::Icmp6Header::kTypeRouterAdvert:
+        case Ip6::Icmp6Header::kTypeRouterSolicit:
+        case Ip6::Icmp6Header::kTypeNeighborAdvert:
+        case Ip6::Icmp6Header::kTypeNeighborSolicit:
         {
             Heap::Data payload;
             uint16_t   offset = sizeof(Ip6::Header);
@@ -462,11 +462,11 @@ void InfraIf::Receive(Message &aMessage)
             ExitNow();
         }
 
-        case Ip6::Icmp::Header::kTypeEchoRequest:
+        case Ip6::Icmp6Header::kTypeEchoRequest:
             HandleEchoRequest(headers.GetIp6Header(), aMessage);
             ExitNow();
 
-        case Ip6::Icmp::Header::kTypeEchoReply:
+        case Ip6::Icmp6Header::kTypeEchoReply:
             HandleEchoReply(headers.GetIp6Header(), aMessage);
             ExitNow();
 
@@ -584,10 +584,10 @@ exit:
 
 void InfraIf::HandleEchoRequest(const Ip6::Header &aHeader, Message &aMessage)
 {
-    Message          *replyMessage;
-    Ip6::Header       replyHeader;
-    Ip6::Icmp::Header replyIcmp;
-    uint16_t          payloadLen = aMessage.GetLength() - sizeof(Ip6::Header);
+    Message         *replyMessage;
+    Ip6::Header      replyHeader;
+    Ip6::Icmp6Header replyIcmp;
+    uint16_t         payloadLen = aMessage.GetLength() - sizeof(Ip6::Header);
 
     replyMessage = Get<MessagePool>().Allocate(Message::kTypeIp6);
     VerifyOrQuit(replyMessage != nullptr);
@@ -604,7 +604,7 @@ void InfraIf::HandleEchoRequest(const Ip6::Header &aHeader, Message &aMessage)
     replyHeader.SetSource(aHeader.GetDestination());
     replyHeader.SetDestination(aHeader.GetSource());
 
-    replyIcmp.SetType(Ip6::Icmp::Header::kTypeEchoReply);
+    replyIcmp.SetType(Ip6::Icmp6Header::kTypeEchoReply);
     replyMessage->Write(0, replyIcmp);
 
     // Recalculate ICMPv6 checksum
@@ -619,7 +619,7 @@ void InfraIf::HandleEchoRequest(const Ip6::Header &aHeader, Message &aMessage)
 
 void InfraIf::HandleEchoReply(const Ip6::Header &aHeader, Message &aMessage)
 {
-    Ip6::Icmp::Header icmpHeader;
+    Ip6::Icmp6Header icmpHeader;
 
     SuccessOrQuit(aMessage.Read(sizeof(Ip6::Header), icmpHeader));
     mEchoReplyCallback.InvokeIfSet(aHeader.GetSource(), icmpHeader.GetId(), icmpHeader.GetSequence());

--- a/tests/nexus/test_history_tracker.cpp
+++ b/tests/nexus/test_history_tracker.cpp
@@ -175,7 +175,7 @@ void TestHistoryTracker(void)
             VerifyOrQuit(txRequestsFound < 3);
             uint16_t expectedSize = kPingSizes[2 - txRequestsFound];
             VerifyOrQuit(msgInfo->mIpProto == OT_IP6_PROTO_ICMP6);
-            VerifyOrQuit(msgInfo->mPayloadLength == expectedSize + sizeof(Ip6::Icmp::Header));
+            VerifyOrQuit(msgInfo->mPayloadLength == expectedSize + sizeof(Ip6::Icmp6Header));
             VerifyOrQuit(AsCoreType(&msgInfo->mSource.mAddress) == leader.Get<Mle::Mle>().GetMeshLocalEid());
             VerifyOrQuit(AsCoreType(&msgInfo->mDestination.mAddress) == child.Get<Mle::Mle>().GetMeshLocalEid());
             VerifyOrQuit(msgInfo->mLinkSecurity);
@@ -199,7 +199,7 @@ void TestHistoryTracker(void)
             VerifyOrQuit(rxRequestsFound < 3);
             uint16_t expectedSize = kPingSizes[2 - rxRequestsFound];
             VerifyOrQuit(msgInfo->mIpProto == OT_IP6_PROTO_ICMP6);
-            VerifyOrQuit(msgInfo->mPayloadLength == expectedSize + sizeof(Ip6::Icmp::Header));
+            VerifyOrQuit(msgInfo->mPayloadLength == expectedSize + sizeof(Ip6::Icmp6Header));
             VerifyOrQuit(AsCoreType(&msgInfo->mSource.mAddress) == leader.Get<Mle::Mle>().GetMeshLocalEid());
             VerifyOrQuit(AsCoreType(&msgInfo->mDestination.mAddress) == child.Get<Mle::Mle>().GetMeshLocalEid());
             VerifyOrQuit(msgInfo->mLinkSecurity);

--- a/tests/nexus/test_nat64_translator.cpp
+++ b/tests/nexus/test_nat64_translator.cpp
@@ -377,10 +377,10 @@ Message *PrepareIcmp6Message(Node               &aNode,
                              const Ip4::Address &aDstIp4Address,
                              uint16_t            aPayloadLen = 10)
 {
-    Message          *message = nullptr;
-    Ip6::Prefix       nat64Prefix;
-    Ip6::Header       ip6Header;
-    Ip6::Icmp::Header icmpHeader;
+    Message         *message = nullptr;
+    Ip6::Prefix      nat64Prefix;
+    Ip6::Header      ip6Header;
+    Ip6::Icmp6Header icmpHeader;
 
     message = aNode.Get<MessagePool>().Allocate(Message::kTypeIp6);
     VerifyOrQuit(message != nullptr);
@@ -394,12 +394,12 @@ Message *PrepareIcmp6Message(Node               &aNode,
     ip6Header.GetDestination().SynthesizeFromIp4Address(nat64Prefix, aDstIp4Address);
 
     ip6Header.SetNextHeader(Ip6::kProtoIcmp6);
-    ip6Header.SetPayloadLength(sizeof(Ip6::Icmp::Header) + aPayloadLen);
+    ip6Header.SetPayloadLength(sizeof(Ip6::Icmp6Header) + aPayloadLen);
 
     SuccessOrQuit(message->Append(ip6Header));
 
     icmpHeader.Clear();
-    icmpHeader.SetType(Ip6::Icmp::Header::kTypeEchoRequest);
+    icmpHeader.SetType(Ip6::Icmp6Header::kTypeEchoRequest);
 
     SuccessOrQuit(message->Append(icmpHeader));
 

--- a/tests/nexus/test_service.cpp
+++ b/tests/nexus/test_service.cpp
@@ -45,10 +45,10 @@ struct NoEchoReplyContext
 
 void HandleIcmpNoEchoReply(void *aContext, otMessage *, const otMessageInfo *, const otIcmp6Header *aIcmpHeader)
 {
-    NoEchoReplyContext      *ctx    = static_cast<NoEchoReplyContext *>(aContext);
-    const Ip6::Icmp::Header *header = AsCoreTypePtr(aIcmpHeader);
+    NoEchoReplyContext     *ctx    = static_cast<NoEchoReplyContext *>(aContext);
+    const Ip6::Icmp6Header *header = AsCoreTypePtr(aIcmpHeader);
 
-    if (header->GetType() == Ip6::Icmp::Header::kTypeEchoReply && header->GetId() == ctx->mId)
+    if (header->GetType() == Ip6::Icmp6Header::kTypeEchoReply && header->GetId() == ctx->mId)
     {
         ctx->mReceived = true;
     }

--- a/tests/nexus/test_zero_len_external_route.cpp
+++ b/tests/nexus/test_zero_len_external_route.cpp
@@ -157,10 +157,10 @@ struct IcmpResponseContext
 
 static void HandleIcmpResponse(void *aContext, otMessage *, const otMessageInfo *, const otIcmp6Header *aIcmpHeader)
 {
-    IcmpResponseContext     *context = static_cast<IcmpResponseContext *>(aContext);
-    const Ip6::Icmp::Header *header  = AsCoreTypePtr(aIcmpHeader);
+    IcmpResponseContext    *context = static_cast<IcmpResponseContext *>(aContext);
+    const Ip6::Icmp6Header *header  = AsCoreTypePtr(aIcmpHeader);
 
-    if ((header->GetType() == Ip6::Icmp::Header::kTypeEchoReply) && (header->GetId() == context->mIdentifier))
+    if ((header->GetType() == Ip6::Icmp6Header::kTypeEchoReply) && (header->GetId() == context->mIdentifier))
     {
         context->mResponseReceived = true;
     }

--- a/tests/unit/test_checksum.cpp
+++ b/tests/unit/test_checksum.cpp
@@ -240,7 +240,7 @@ void TestUdpMessageChecksum(void)
 
 void TestIcmp6MessageChecksum(void)
 {
-    constexpr uint16_t kMinSize = sizeof(Ip6::Icmp::Header);
+    constexpr uint16_t kMinSize = sizeof(Ip6::Icmp6Header);
     constexpr uint16_t kMaxSize = Buffer::kSize * 3 + 24;
 
     const char *kSourceAddress = "fd00:feef:dccd:baab:9889:7667:5444:3223";
@@ -252,9 +252,9 @@ void TestIcmp6MessageChecksum(void)
 
     for (uint16_t size = kMinSize; size <= kMaxSize; size++)
     {
-        Message          *message = instance->Get<Ip6::Ip6>().NewMessage();
-        Ip6::Icmp::Header icmp6Header;
-        Ip6::MessageInfo  messageInfo;
+        Message         *message = instance->Get<Ip6::Ip6>().NewMessage();
+        Ip6::Icmp6Header icmp6Header;
+        Ip6::MessageInfo messageInfo;
 
         VerifyOrQuit(message != nullptr, "Ip6::NewMesssage() failed");
         SuccessOrQuit(message->SetLength(size));

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -302,8 +302,8 @@ otError otPlatInfraIfSendIcmp6Nd(otInstance         *aInstance,
                                  const uint8_t      *aBuffer,
                                  uint16_t            aBufferLength)
 {
-    Icmp6Packet        packet;
-    Ip6::Icmp::Header *header;
+    Icmp6Packet       packet;
+    Ip6::Icmp6Header *header;
 
     Log("otPlatInfraIfSendIcmp6Nd(aDestAddr: %s, aBufferLength:%u)", AsCoreType(aDestAddress).ToString().AsCString(),
         aBufferLength);
@@ -313,19 +313,19 @@ otError otPlatInfraIfSendIcmp6Nd(otInstance         *aInstance,
 
     packet.Init(aBuffer, aBufferLength);
 
-    VerifyOrQuit(aBufferLength >= sizeof(Ip6::Icmp::Header));
+    VerifyOrQuit(aBufferLength >= sizeof(Ip6::Icmp6Header));
 
-    header = reinterpret_cast<Ip6::Icmp::Header *>(const_cast<uint8_t *>(aBuffer));
+    header = reinterpret_cast<Ip6::Icmp6Header *>(const_cast<uint8_t *>(aBuffer));
 
     switch (header->GetType())
     {
-    case Ip6::Icmp::Header::kTypeRouterSolicit:
+    case Ip6::Icmp6Header::kTypeRouterSolicit:
         Log("  Router Solicit message");
         sRsEmitted = true;
         otPlatInfraIfRecvIcmp6Nd(sInstance, kInfraIfIndex, &sInfraIfAddress, aBuffer, aBufferLength);
         break;
 
-    case Ip6::Icmp::Header::kTypeRouterAdvert:
+    case Ip6::Icmp6Header::kTypeRouterAdvert:
         Log("  Router Advertisement message");
         LogRouterAdvert(packet);
         ValidateRouterAdvert(packet);
@@ -335,7 +335,7 @@ otError otPlatInfraIfSendIcmp6Nd(otInstance         *aInstance,
         otPlatInfraIfRecvIcmp6Nd(sInstance, kInfraIfIndex, &sInfraIfAddress, aBuffer, aBufferLength);
         break;
 
-    case Ip6::Icmp::Header::kTypeNeighborSolicit:
+    case Ip6::Icmp6Header::kTypeNeighborSolicit:
     {
         const Ip6::Nd::NeighborSolicitHeader *nsMsg =
             reinterpret_cast<const Ip6::Nd::NeighborSolicitHeader *>(packet.GetBytes());


### PR DESCRIPTION
This commit updates the codebase to use the `Icmp6Header` type directly, replacing the nested `Ip6::Icmp::Header` definition. This change aligns the ICMPv6 header type definition with the conventions used for other network protocol headers and simplifies type references across the network, border router, and utility modules.