### PR TITLE
[mle] rename `Get{Addr}()` to `Compose{Addr}()`

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -73,7 +73,7 @@ otError otThreadGetLeaderRloc(otInstance *aInstance, otIp6Address *aLeaderRloc)
     Error error = kErrorNone;
 
     VerifyOrExit(!AsCoreType(aInstance).Get<Mle::Mle>().HasRloc16(Mle::kInvalidRloc16), error = kErrorDetached);
-    AsCoreType(aInstance).Get<Mle::Mle>().GetLeaderRloc(AsCoreType(aLeaderRloc));
+    AsCoreType(aInstance).Get<Mle::Mle>().ComposeLeaderRloc(AsCoreType(aLeaderRloc));
 
 exit:
     return error;
@@ -189,7 +189,7 @@ otError otThreadGetServiceAloc(otInstance *aInstance, uint8_t aServiceId, otIp6A
     Error error = kErrorNone;
 
     VerifyOrExit(!AsCoreType(aInstance).Get<Mle::Mle>().HasRloc16(Mle::kInvalidRloc16), error = kErrorDetached);
-    AsCoreType(aInstance).Get<Mle::Mle>().GetServiceAloc(aServiceId, AsCoreType(aServiceAloc));
+    AsCoreType(aInstance).Get<Mle::Mle>().ComposeServiceAloc(aServiceId, AsCoreType(aServiceAloc));
 
 exit:
     return error;

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -331,7 +331,7 @@ void Manager::HandleCommissionerPetitionAccepted(CoapDtlsSession &aSession, uint
 
     mCommissionerSession = &aSession;
 
-    Get<Mle::Mle>().GetCommissionerAloc(aSessionId, mCommissionerAloc.GetAddress());
+    Get<Mle::Mle>().ComposeCommissionerAloc(aSessionId, mCommissionerAloc.GetAddress());
     Get<ThreadNetif>().AddUnicastAddress(mCommissionerAloc);
 
     IgnoreError(Get<Ip6::Udp>().AddReceiver(mCommissionerUdpReceiver));

--- a/src/core/meshcop/border_agent_admitter.cpp
+++ b/src/core/meshcop/border_agent_admitter.cpp
@@ -678,7 +678,7 @@ void Admitter::CommissionerPetitioner::AddAlocAndUdpReceiver(void)
 {
     Ip6::Address alocAddr;
 
-    Get<Mle::Mle>().GetCommissionerAloc(mSessionId, alocAddr);
+    Get<Mle::Mle>().ComposeCommissionerAloc(mSessionId, alocAddr);
 
     if (Get<ThreadNetif>().HasUnicastAddress(mAloc))
     {

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -735,7 +735,7 @@ void Commissioner::HandleLeaderPetitionResponse(Coap::Msg *aMsg, Error aResult)
         ExitNow();
     }
 
-    Get<Mle::Mle>().GetCommissionerAloc(mSessionId, mCommissionerAloc.GetAddress());
+    Get<Mle::Mle>().ComposeCommissionerAloc(mSessionId, mCommissionerAloc.GetAddress());
     Get<ThreadNetif>().AddUnicastAddress(mCommissionerAloc);
 
     SetState(kStateActive);

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -190,7 +190,7 @@ Error DatasetManager::HandleSetOrReplace(MgmtCommand aCommand, const Coap::Msg &
         Ip6::Address destination;
 
         SuccessOrExit(Get<NetworkData::Leader>().FindCommissioningSessionId(localSessionId));
-        Get<Mle::Mle>().GetCommissionerAloc(localSessionId, destination);
+        Get<Mle::Mle>().ComposeCommissionerAloc(localSessionId, destination);
         Get<Leader>().SendDatasetChanged(destination);
     }
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -887,22 +887,22 @@ void Mle::SetLeaderData(uint32_t aPartitionId, uint8_t aWeighting, uint8_t aLead
     mLeaderData.SetLeaderRouterId(aLeaderRouterId);
 }
 
-void Mle::GetLeaderRloc(Ip6::Address &aAddress) const
+void Mle::ComposeLeaderRloc(Ip6::Address &aAddress) const
 {
     aAddress.InitAsRoutingLocator(mMeshLocalPrefix, GetLeaderRloc16());
 }
 
-void Mle::GetLeaderAloc(Ip6::Address &aAddress) const
+void Mle::ComposeLeaderAloc(Ip6::Address &aAddress) const
 {
     aAddress.InitAsAnycastLocator(mMeshLocalPrefix, Aloc16::ForLeader());
 }
 
-void Mle::GetCommissionerAloc(uint16_t aSessionId, Ip6::Address &aAddress) const
+void Mle::ComposeCommissionerAloc(uint16_t aSessionId, Ip6::Address &aAddress) const
 {
     aAddress.InitAsAnycastLocator(mMeshLocalPrefix, Aloc16::FromCommissionerSessionId(aSessionId));
 }
 
-void Mle::GetServiceAloc(uint8_t aServiceId, Ip6::Address &aAddress) const
+void Mle::ComposeServiceAloc(uint8_t aServiceId, Ip6::Address &aAddress) const
 {
     aAddress.InitAsAnycastLocator(mMeshLocalPrefix, Aloc16::FromServiceId(aServiceId));
 }

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -566,34 +566,34 @@ public:
     uint16_t GetLeaderRloc16(void) const { return Rloc16FromRouterId(GetLeaderId()); }
 
     /**
-     * Retrieves the Leader's RLOC.
+     * Composes the Leader's RLOC.
      *
      * @param[out]  aAddress  A reference to an address to return the Leader's RLOC.
      */
-    void GetLeaderRloc(Ip6::Address &aAddress) const;
+    void ComposeLeaderRloc(Ip6::Address &aAddress) const;
 
     /**
-     * Retrieves the Leader's ALOC.
+     * Composes the Leader's ALOC.
      *
      * @param[out]  aAddress  A reference to an address to return the Leader's ALOC.
      */
-    void GetLeaderAloc(Ip6::Address &aAddress) const;
+    void ComposeLeaderAloc(Ip6::Address &aAddress) const;
 
     /**
-     * Retrieves the Commissioner's ALOC for a given session ID.
+     * Composes the Commissioner's ALOC for a given session ID.
      *
-     * @param[in]   aSessionId      Commissioner session id.
+     * @param[in]   aSessionId      Commissioner session ID.
      * @param[out]  aAddress        A reference to an address to return the Commissioner's ALOC.
      */
-    void GetCommissionerAloc(uint16_t aSessionId, Ip6::Address &aAddress) const;
+    void ComposeCommissionerAloc(uint16_t aSessionId, Ip6::Address &aAddress) const;
 
     /**
-     * Retrieves the Service ALOC for given Service ID.
+     * Composes the Service ALOC for a given Service ID.
      *
-     * @param[in]   aServiceId Service ID to get ALOC for.
-     * @param[out]  aAddress   A reference to an address to return the Service ALOC.
+     * @param[in]   aServiceId   Service ID to compose ALOC for.
+     * @param[out]  aAddress     A reference to an address to return the Service ALOC.
      */
-    void GetServiceAloc(uint8_t aServiceId, Ip6::Address &aAddress) const;
+    void ComposeServiceAloc(uint8_t aServiceId, Ip6::Address &aAddress) const;
 
     /**
      * Returns the most recently received Leader Data.

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -456,7 +456,7 @@ void Mle::SetStateRouterOrLeader(DeviceRole aRole, uint16_t aRloc16, LeaderStart
 
     if (aRole == kRoleLeader)
     {
-        GetLeaderAloc(mLeaderAloc.GetAddress());
+        ComposeLeaderAloc(mLeaderAloc.GetAddress());
         Get<ThreadNetif>().AddUnicastAddress(mLeaderAloc);
         Get<NetworkData::Leader>().Start(aStartMode);
         Get<MeshCoP::ActiveDatasetManager>().StartLeader();
@@ -3185,7 +3185,7 @@ Error Mle::SendAddressSolicit(RouterUpgradeReason aReason)
     SuccessOrExit(error = Tlv::Append<XtalAccuracyTlv>(*message, otPlatTimeGetXtalAccuracy()));
 #endif
 
-    GetLeaderRloc(leaderRloc);
+    ComposeLeaderRloc(leaderRloc);
 
     SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, leaderRloc, HandleAddressSolicitResponse, this));
     mAddressSolicitPending = true;
@@ -3209,7 +3209,7 @@ void Mle::SendAddressRelease(void)
     SuccessOrExit(error = Tlv::Append<ThreadRloc16Tlv>(*message, Rloc16FromRouterId(mRouterId)));
     SuccessOrExit(error = Tlv::Append<ThreadExtMacAddressTlv>(*message, Get<Mac::Mac>().GetExtAddress()));
 
-    GetLeaderRloc(leaderRloc);
+    ComposeLeaderRloc(leaderRloc);
 
     SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, leaderRloc));
 

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -528,7 +528,7 @@ Error Manager::SendMessage(const Ip6::Address         *aAddresses,
         uint8_t pbbrServiceId;
 
         SuccessOrExit(error = Get<BackboneRouter::Leader>().GetServiceId(pbbrServiceId));
-        Get<Mle::Mle>().GetServiceAloc(pbbrServiceId, destAddr);
+        Get<Mle::Mle>().ComposeServiceAloc(pbbrServiceId, destAddr);
     }
     else
     {

--- a/src/core/thread/network_data_service.cpp
+++ b/src/core/thread/network_data_service.cpp
@@ -83,7 +83,7 @@ Error Iterator::GetNextDnsSrpAnycastInfo(DnsSrpAnycastInfo &aInfo)
                 const Manager::DnsSrpAnycastServiceData *anycastData =
                     reinterpret_cast<const Manager::DnsSrpAnycastServiceData *>(mServiceTlv->GetServiceData());
 
-                Get<Mle::Mle>().GetServiceAloc(mServiceTlv->GetServiceId(), aInfo.mAnycastAddress);
+                Get<Mle::Mle>().ComposeServiceAloc(mServiceTlv->GetServiceId(), aInfo.mAnycastAddress);
                 aInfo.mSequenceNumber = anycastData->GetSequenceNumber();
                 aInfo.mRloc16         = mServerSubTlv->GetServer16();
                 aInfo.mVersion =

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -259,7 +259,7 @@ Error Agent::SendMessageToLeaderAloc(Message &aMessage, ResponseHandler aHandler
 {
     Ip6::MessageInfo messageInfo;
 
-    Get<Mle::Mle>().GetLeaderAloc(messageInfo.GetPeerAddr());
+    Get<Mle::Mle>().ComposeLeaderAloc(messageInfo.GetPeerAddr());
     PrepareMessageInfo(messageInfo);
 
     return SendMessage(aMessage, messageInfo, aHandler, aContext);

--- a/tests/nexus/platform/nexus_core.cpp
+++ b/tests/nexus/platform/nexus_core.cpp
@@ -172,7 +172,7 @@ void Core::SaveTestInfo(const char *aFilename, Node *aLeaderNode)
         if (leaderNode->Get<Mle::Mle>().IsLeader())
         {
             Ip6::Address aloc;
-            leaderNode->Get<Mle::Mle>().GetLeaderAloc(aloc);
+            leaderNode->Get<Mle::Mle>().ComposeLeaderAloc(aloc);
             fprintf(file, "  \"leader_aloc\": \"%s\",\n", aloc.ToString().AsCString());
         }
     }

--- a/tests/nexus/test_1_1_9_2_3.cpp
+++ b/tests/nexus/test_1_1_9_2_3.cpp
@@ -151,7 +151,7 @@ void RunTest9_2_3(Topology aTopology, const char *aJsonFile)
         MeshCoP::Dataset::Components components;
         Ip6::Address                 leaderAloc;
 
-        leader.Get<Mle::Mle>().GetLeaderAloc(leaderAloc);
+        leader.Get<Mle::Mle>().ComposeLeaderAloc(leaderAloc);
         components.Clear();
         SuccessOrQuit(
             commissioner.Get<MeshCoP::ActiveDatasetManager>().SendGetRequest(components, nullptr, 0, &leaderAloc));
@@ -198,7 +198,7 @@ void RunTest9_2_3(Topology aTopology, const char *aJsonFile)
         Ip6::Address                 leaderAloc;
         uint8_t tlvs[] = {MeshCoP::Tlv::kChannelMask, MeshCoP::Tlv::kMeshLocalPrefix, MeshCoP::Tlv::kNetworkName};
 
-        leader.Get<Mle::Mle>().GetLeaderAloc(leaderAloc);
+        leader.Get<Mle::Mle>().ComposeLeaderAloc(leaderAloc);
         components.Clear();
         SuccessOrQuit(commissioner.Get<MeshCoP::ActiveDatasetManager>().SendGetRequest(components, tlvs, sizeof(tlvs),
                                                                                        &leaderAloc));
@@ -246,7 +246,7 @@ void RunTest9_2_3(Topology aTopology, const char *aJsonFile)
         uint8_t tlvs[] = {MeshCoP::Tlv::kChannel, MeshCoP::Tlv::kMeshLocalPrefix, MeshCoP::Tlv::kNetworkName,
                           MeshCoP::Tlv::kScanDuration, MeshCoP::Tlv::kEnergyList};
 
-        leader.Get<Mle::Mle>().GetLeaderAloc(leaderAloc);
+        leader.Get<Mle::Mle>().ComposeLeaderAloc(leaderAloc);
         components.Clear();
         SuccessOrQuit(commissioner.Get<MeshCoP::ActiveDatasetManager>().SendGetRequest(components, tlvs, sizeof(tlvs),
                                                                                        &leaderAloc));

--- a/tests/nexus/test_anycast_locator.cpp
+++ b/tests/nexus/test_anycast_locator.cpp
@@ -136,7 +136,7 @@ void TestAnycastLocator(void)
     Log("1. Locate leader ALOC from all nodes");
 
     Ip6::Address leaderAloc;
-    leader.Get<Mle::Mle>().GetLeaderAloc(leaderAloc);
+    leader.Get<Mle::Mle>().ComposeLeaderAloc(leaderAloc);
 
     LocateResult result;
 

--- a/tests/nexus/test_ipv6_source_selection.cpp
+++ b/tests/nexus/test_ipv6_source_selection.cpp
@@ -70,7 +70,7 @@ void TestIPv6SourceSelection(void)
     Ip6::Address leaderMleid     = leader.Get<Mle::Mle>().GetMeshLocalEid();
     Ip6::Address leaderLinkLocal = leader.Get<Mle::Mle>().GetLinkLocalAddress();
     Ip6::Address leaderAloc;
-    leader.Get<Mle::Mle>().GetLeaderAloc(leaderAloc);
+    leader.Get<Mle::Mle>().ComposeLeaderAloc(leaderAloc);
 
     Ip6::Address routerRloc      = router.Get<Mle::Mle>().GetMeshLocalRloc();
     Ip6::Address routerMleid     = router.Get<Mle::Mle>().GetMeshLocalEid();

--- a/tests/nexus/test_pbbr_aloc.cpp
+++ b/tests/nexus/test_pbbr_aloc.cpp
@@ -86,7 +86,7 @@ void TestPbbrAloc(void)
     Ip6::Address aloc;
 
     // 1. Leader ALOC
-    leader.Get<Mle::Mle>().GetLeaderAloc(aloc);
+    leader.Get<Mle::Mle>().ComposeLeaderAloc(aloc);
     Log("Pinging Leader ALOC %s from ROUTER", aloc.ToString().AsCString());
     nexus.SendAndVerifyEchoRequest(router, aloc);
 


### PR DESCRIPTION
This commit renames several methods in the `Mle` class that construct an IPv6 address from the mesh-local prefix and an RLOC16/ALOC16 from `Get...()` to `Compose...()` to better reflect their behavior.

The affected methods are:
- `GetLeaderRloc()` -> `ComposeLeaderRloc()`
- `GetLeaderAloc()` -> `ComposeLeaderAloc()`
- `GetCommissionerAloc()` -> `ComposeCommissionerAloc()`
- `GetServiceAloc()` -> `ComposeServiceAloc()`