### PR TITLE
[tests] simplify RLOC address creation using `GetMeshLocalRloc()`

### DIFF
--- a/tests/nexus/test_1_3_DIAG_TC_1.cpp
+++ b/tests/nexus/test_1_3_DIAG_TC_1.cpp
@@ -161,8 +161,7 @@ void TestDiagTc1(const char *aJsonFileName)
      * - Pass Criteria:
      *   - N/A
      */
-    Ip6::Address dutRloc;
-    dutRloc.InitAsRoutingLocator(leader.Get<Mle::Mle>().GetMeshLocalPrefix(), router1.Get<Mle::Mle>().GetRloc16());
+    Ip6::Address dutRloc = router1.Get<Mle::Mle>().GetMeshLocalRloc();
 
     uint8_t tlvTypesStep2[] = {
         NetDiag::Tlv::kMaxChildTimeout,    NetDiag::Tlv::kEui64,       NetDiag::Tlv::kVersion,

--- a/tests/nexus/test_1_3_DIAG_TC_2.cpp
+++ b/tests/nexus/test_1_3_DIAG_TC_2.cpp
@@ -149,8 +149,7 @@ void TestDiagTc2(const char *aJsonFile)
      * - Pass Criteria:
      *   - N/A
      */
-    Ip6::Address td1Rloc;
-    td1Rloc.InitAsRoutingLocator(leader1.Get<Mle::Mle>().GetMeshLocalPrefix(), td1.Get<Mle::Mle>().GetRloc16());
+    Ip6::Address td1Rloc = td1.Get<Mle::Mle>().GetMeshLocalRloc();
 
     uint8_t tlvTypesStep2[] = {
         NetDiag::Tlv::kMaxChildTimeout,    NetDiag::Tlv::kEui64,       NetDiag::Tlv::kVersion,

--- a/tests/nexus/test_1_3_GEN_TC_1.cpp
+++ b/tests/nexus/test_1_3_GEN_TC_1.cpp
@@ -279,9 +279,8 @@ void Test_1_3_GEN_TC_1(Topology aTopology, const char *aJsonFileName)
      *   - Pass Criteria (only applies if Device == DUT):
      *     - N/A
      */
-    Ip6::Address br1Rloc;
-    br1Rloc.InitAsRoutingLocator(router1.Get<Mle::Mle>().GetMeshLocalPrefix(), br1.Get<Mle::Mle>().GetRloc16());
-    uint8_t tlvTypes[] = {NetDiag::Tlv::kVersion};
+    Ip6::Address br1Rloc    = br1.Get<Mle::Mle>().GetMeshLocalRloc();
+    uint8_t      tlvTypes[] = {NetDiag::Tlv::kVersion};
     SuccessOrQuit(
         router1.Get<NetDiag::Client>().SendDiagnosticGet(br1Rloc, tlvTypes, sizeof(tlvTypes), nullptr, nullptr));
 
@@ -311,8 +310,7 @@ void Test_1_3_GEN_TC_1(Topology aTopology, const char *aJsonFileName)
      *   - Pass Criteria (only applies if Device == DUT):
      *     - N/A
      */
-    Ip6::Address router1Rloc;
-    router1Rloc.InitAsRoutingLocator(br1.Get<Mle::Mle>().GetMeshLocalPrefix(), router1.Get<Mle::Mle>().GetRloc16());
+    Ip6::Address router1Rloc = router1.Get<Mle::Mle>().GetMeshLocalRloc();
     SuccessOrQuit(
         br1.Get<NetDiag::Client>().SendDiagnosticGet(router1Rloc, tlvTypes, sizeof(tlvTypes), nullptr, nullptr));
 
@@ -342,8 +340,7 @@ void Test_1_3_GEN_TC_1(Topology aTopology, const char *aJsonFileName)
      *   - Pass Criteria (only applies if Device == DUT):
      *     - N/A
      */
-    Ip6::Address ed1Rloc;
-    ed1Rloc.InitAsRoutingLocator(router1.Get<Mle::Mle>().GetMeshLocalPrefix(), ed1.Get<Mle::Mle>().GetRloc16());
+    Ip6::Address ed1Rloc = ed1.Get<Mle::Mle>().GetMeshLocalRloc();
     SuccessOrQuit(
         router1.Get<NetDiag::Client>().SendDiagnosticGet(ed1Rloc, tlvTypes, sizeof(tlvTypes), nullptr, nullptr));
 


### PR DESCRIPTION
This commit refactors several Nexus diagnostic test cases to use the existing `Mle::GetMeshLocalRloc()` method instead of manually assembling the RLOC by combining the mesh-local prefix and the node's RLOC16. This improves code readability and adheres to the standard pattern for retrieving a node's Routing Locator.