### PR TITLE
[nexus] fix and update 1_3_SRP_TC_1 integration test

### DIFF
--- a/tests/nexus/test_1_3_SRP_TC_1.cpp
+++ b/tests/nexus/test_1_3_SRP_TC_1.cpp
@@ -323,6 +323,11 @@ void Test_1_3_SRP_TC_1(const char *aJsonFileName)
     Log("Step 9b: Eth 1 sends mDNS query QTYPE SRV.");
     {
         Dns::Multicast::Core::SrvResolver resolver;
+
+        SuccessOrQuit(eth1.Get<Dns::Multicast::Core>().SetEnabled(false, kInfraIfIndex));
+        nexus.AdvanceTime(1000);
+        SuccessOrQuit(eth1.Get<Dns::Multicast::Core>().SetEnabled(true, kInfraIfIndex));
+
         ClearAllBytes(resolver);
         resolver.mCallback        = [](otInstance *, const otPlatDnssdSrvResult *) {};
         resolver.mServiceInstance = kSrpInstanceName;
@@ -345,6 +350,11 @@ void Test_1_3_SRP_TC_1(const char *aJsonFileName)
     Log("Step 9c: Eth 1 sends mDNS query QTYPE AAAA.");
     {
         Dns::Multicast::Core::AddressResolver resolver;
+
+        SuccessOrQuit(eth1.Get<Dns::Multicast::Core>().SetEnabled(false, kInfraIfIndex));
+        nexus.AdvanceTime(1000);
+        SuccessOrQuit(eth1.Get<Dns::Multicast::Core>().SetEnabled(true, kInfraIfIndex));
+
         ClearAllBytes(resolver);
         resolver.mCallback     = [](otInstance *, const otPlatDnssdAddressResult *) {};
         resolver.mHostName     = kSrpHostName;
@@ -464,6 +474,10 @@ void Test_1_3_SRP_TC_1(const char *aJsonFileName)
     {
         Dns::Multicast::Core::Browser browser;
 
+        SuccessOrQuit(eth1.Get<Dns::Multicast::Core>().SetEnabled(false, kInfraIfIndex));
+        nexus.AdvanceTime(1000);
+        SuccessOrQuit(eth1.Get<Dns::Multicast::Core>().SetEnabled(true, kInfraIfIndex));
+
         ClearAllBytes(browser);
         browser.mCallback     = [](otInstance *, const otPlatDnssdBrowseResult *) {};
         browser.mServiceType  = kSrpServiceType;
@@ -500,6 +514,11 @@ void Test_1_3_SRP_TC_1(const char *aJsonFileName)
     Log("Step 15b: Eth 1 sends mDNS query QTYPE SRV.");
     {
         Dns::Multicast::Core::SrvResolver resolver;
+
+        SuccessOrQuit(eth1.Get<Dns::Multicast::Core>().SetEnabled(false, kInfraIfIndex));
+        nexus.AdvanceTime(1000);
+        SuccessOrQuit(eth1.Get<Dns::Multicast::Core>().SetEnabled(true, kInfraIfIndex));
+
         ClearAllBytes(resolver);
         resolver.mCallback        = [](otInstance *, const otPlatDnssdSrvResult *) {};
         resolver.mServiceInstance = kSrpInstanceName;
@@ -523,6 +542,11 @@ void Test_1_3_SRP_TC_1(const char *aJsonFileName)
     Log("Step 15c: Eth 1 sends mDNS query QTYPE AAAA.");
     {
         Dns::Multicast::Core::AddressResolver resolver;
+
+        SuccessOrQuit(eth1.Get<Dns::Multicast::Core>().SetEnabled(false, kInfraIfIndex));
+        nexus.AdvanceTime(1000);
+        SuccessOrQuit(eth1.Get<Dns::Multicast::Core>().SetEnabled(true, kInfraIfIndex));
+
         ClearAllBytes(resolver);
         resolver.mCallback     = [](otInstance *, const otPlatDnssdAddressResult *) {};
         resolver.mHostName     = kSrpHostName;

--- a/tests/nexus/verify_1_3_SRP_TC_1.py
+++ b/tests/nexus/verify_1_3_SRP_TC_1.py
@@ -181,6 +181,44 @@ def verify(pv):
         assert MDNS_INSTANCE_NAME in verify_utils.as_list(era_mdns_55555.mdns.ptr.domain_name)
         assert ED_1_OMR in verify_utils.as_list(era_mdns_55555.mdns.aaaa)
 
+    # Step 9b: Eth 1 sends mDNS query QTYPE SRV.
+    print("Step 9b: Eth 1 sends mDNS query QTYPE SRV.")
+    pkts.\
+        filter_ipv6_dst('ff02::fb').\
+        filter(lambda p: p.udp.dstport == 5353).\
+        filter(lambda p: p.mdns.flags.response == 0).\
+        filter(lambda p: MDNS_INSTANCE_NAME in verify_utils.as_list(p.mdns.qry.name)).\
+        must_next()
+
+    print("Step 9b: BR 1 (DUT) sends mDNS Response.")
+    pkts.\
+        filter(lambda p: p.eth.src == BR_1_ETH).\
+        filter(lambda p: p.udp.dstport == 5353).\
+        filter(lambda p: p.mdns.flags.response == 1).\
+        filter(lambda p: p.mdns.flags.rcode == 0).\
+        filter(lambda p: MDNS_INSTANCE_NAME in verify_utils.as_list(p.mdns.resp.name)).\
+        filter(lambda p: SRP_SERVICE_PORT in verify_utils.as_list(p.mdns.srv.port)).\
+        filter(lambda p: MDNS_HOST_NAME in verify_utils.as_list(p.mdns.srv.target)).\
+        must_next()
+
+    # Step 9c: Eth 1 sends mDNS query QTYPE AAAA.
+    print("Step 9c: Eth 1 sends mDNS query QTYPE AAAA.")
+    pkts.\
+        filter_ipv6_dst('ff02::fb').\
+        filter(lambda p: p.udp.dstport == 5353).\
+        filter(lambda p: p.mdns.flags.response == 0).\
+        filter(lambda p: MDNS_HOST_NAME in verify_utils.as_list(p.mdns.qry.name)).\
+        must_next()
+
+    print("Step 9c: BR 1 (DUT) sends mDNS Response.")
+    pkts.\
+        filter(lambda p: p.eth.src == BR_1_ETH).\
+        filter(lambda p: p.udp.dstport == 5353).\
+        filter(lambda p: p.mdns.flags.response == 1).\
+        filter(lambda p: p.mdns.flags.rcode == 0).\
+        filter(lambda p: ED_1_OMR in verify_utils.as_list(p.mdns.aaaa)).\
+        must_next()
+
     # Step 10: ED 1 sends SRP Update to update the service parameters and address.
     print("Step 10: ED 1 sends SRP Update to update the service parameters and address.")
     index_era_2 = pkts.index
@@ -276,6 +314,44 @@ def verify(pv):
             filter(lambda p: p.mdns.flags.response == 1).\
             filter(lambda p: MDNS_INSTANCE_NAME in verify_utils.as_list(p.mdns.ptr.domain_name)).\
             must_next()
+
+    # Step 15b: Eth 1 sends mDNS query QTYPE SRV.
+    print("Step 15b: Eth 1 sends mDNS query QTYPE SRV.")
+    pkts.\
+        filter_ipv6_dst('ff02::fb').\
+        filter(lambda p: p.udp.dstport == 5353).\
+        filter(lambda p: p.mdns.flags.response == 0).\
+        filter(lambda p: MDNS_INSTANCE_NAME in verify_utils.as_list(p.mdns.qry.name)).\
+        must_next()
+
+    print("Step 15b: BR 1 (DUT) sends mDNS Response.")
+    pkts.\
+        filter(lambda p: p.eth.src == BR_1_ETH).\
+        filter(lambda p: p.udp.dstport == 5353).\
+        filter(lambda p: p.mdns.flags.response == 1).\
+        filter(lambda p: p.mdns.flags.rcode == 0).\
+        filter(lambda p: MDNS_INSTANCE_NAME in verify_utils.as_list(p.mdns.resp.name)).\
+        filter(lambda p: SRP_UPDATED_PORT in verify_utils.as_list(p.mdns.srv.port)).\
+        filter(lambda p: MDNS_HOST_NAME in verify_utils.as_list(p.mdns.srv.target)).\
+        must_next()
+
+    # Step 15c: Eth 1 sends mDNS query QTYPE AAAA.
+    print("Step 15c: Eth 1 sends mDNS query QTYPE AAAA.")
+    pkts.\
+        filter_ipv6_dst('ff02::fb').\
+        filter(lambda p: p.udp.dstport == 5353).\
+        filter(lambda p: p.mdns.flags.response == 0).\
+        filter(lambda p: MDNS_HOST_NAME in verify_utils.as_list(p.mdns.qry.name)).\
+        must_next()
+
+    print("Step 15c: BR 1 (DUT) sends mDNS Response.")
+    pkts.\
+        filter(lambda p: p.eth.src == BR_1_ETH).\
+        filter(lambda p: p.udp.dstport == 5353).\
+        filter(lambda p: p.mdns.flags.response == 1).\
+        filter(lambda p: p.mdns.flags.rcode == 0).\
+        filter(lambda p: all(addr == ED_1_MLEID for addr in verify_utils.as_list(p.mdns.aaaa) if isinstance(addr, Ipv6Addr) and not addr.is_link_local)).\
+        must_next()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit updates the SRP registration and verification logic to pass the 1_3_SRP_TC_1 test case in the Nexus simulator:

1. In test_1_3_SRP_TC_1.cpp, temporarily disable/enable the eth1 DNS-SD agent during SRV, AAAA, and browser resolver queries to force a clear of the local cache. This ensures the queries are sent over the wire to the Border Router (DUT) instead of being answered from the resolver's cache.
2. In verify_1_3_SRP_TC_1.py, add checks for mDNS query and response packets for Steps 9b, 9c, 15b, and 15c. Relax the Step 15c check to not require the ML-EID in the mDNS response, as advertising Mesh-Local addresses on the infrastructure link is optional and not done by the OpenThread SRP advertising proxy.