### PR TITLE
fix: validate pr_number in size-report workflow to prevent comment injection

### DIFF
--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -62,6 +62,17 @@ jobs:
           const report = fs.readFileSync('/tmp/ot-size-report/report_pr', 'utf8');
           const pr_number = parseInt(fs.readFileSync('/tmp/ot-size-report/pr_number', 'utf8').trim());
 
+          // Validate pr_number against the workflow_run's actual PR associations.
+          // Without this check, an attacker with RCE in the size-check job can
+          // overwrite pr_number to post comments on arbitrary PRs using this
+          // workflow's pull-requests:write token.
+          const run = context.payload.workflow_run;
+          const associatedPRs = (run.pull_requests || []).map(pr => pr.number);
+          if (!associatedPRs.includes(pr_number)) {
+            core.setFailed(`pr_number ${pr_number} does not match any PR associated with workflow run ${run.id} (expected one of: ${associatedPRs.join(', ')})`);
+            return;
+          }
+
           const params = {
               issue_number: pr_number,
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

Validate the `pr_number` read from the untrusted size-check artifact against the `workflow_run`'s actual PR associations before posting comments.

## Vulnerability (#12981)

The size-report workflow downloads an untrusted artifact from size-check and posts its contents as a PR comment with `pull-requests:write` permissions. Both `report_pr` (the comment body) and `pr_number` (the target PR) are read from the artifact without validation.

An attacker with code execution in the size-check job (via malicious `CMakeLists.txt` as described in #12981) can:

1. Overwrite `pr_number` to target **any** PR in the repository
2. Overwrite `report_pr` with arbitrary markdown/links
3. The privileged size-report job posts it as an official comment

## Fix

Validate `pr_number` against `context.payload.workflow_run.pull_requests`. If the number doesn't match any associated PR, the workflow fails with an error.

Partially addresses #12981