### PR TITLE
[spi-hdlc-adapter] size frame buffers to fit the full transfer

### DIFF
--- a/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
+++ b/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
@@ -531,8 +531,9 @@ static int push_pull_spi(void)
     spi_header_set_accept_len(sSpiTxFrameBuffer, 0);
     spi_header_set_data_len(sSpiTxFrameBuffer, 0);
 
-    // Sanity check.
-    if (slave_data_len > MAX_FRAME_SIZE)
+    // Sanity check. The header `data_len` carries the payload length only
+    // (it excludes HEADER_LEN), so the largest valid value is the MTU.
+    if (slave_data_len > MAX_FRAME_SIZE - HEADER_LEN)
     {
         slave_data_len = 0;
     }
@@ -630,8 +631,8 @@ static int push_pull_spi(void)
     slave_max_rx   = spi_header_get_accept_len(spiRxFrameBuffer);
     slave_data_len = spi_header_get_data_len(spiRxFrameBuffer);
 
-    if (((slave_header & SPI_HEADER_PATTERN_MASK) != SPI_HEADER_PATTERN_VALUE) || (slave_max_rx > MAX_FRAME_SIZE) ||
-        (slave_data_len > MAX_FRAME_SIZE))
+    if (((slave_header & SPI_HEADER_PATTERN_MASK) != SPI_HEADER_PATTERN_VALUE) ||
+        (slave_max_rx > MAX_FRAME_SIZE - HEADER_LEN) || (slave_data_len > MAX_FRAME_SIZE - HEADER_LEN))
     {
         sSpiGarbageFrameCount++;
         sSpiTxRefusedCount++;


### PR DESCRIPTION
### What

The standalone `spi-hdlc-adapter` tool sizes three static frame buffers smaller than the maximum data they can hold:

- `push_hdlc()` escapes a frame into `escaped_frame_buffer[MAX_FRAME_SIZE * 2]`. HDLC escaping can double the payload, and the function then appends a 2-byte CRC (each byte itself escapable) and a trailing flag, so the escaped output of a maximum-size frame can reach `MAX_FRAME_SIZE * 2 + 5` bytes.
- `do_spi_xfer(len)` performs an SPI transfer of `len + HEADER_LEN + sSpiRxAlignAllowance` bytes into `sSpiRxFrameBuffer` / `sSpiTxFrameBuffer`, but those buffers reserve only `MAX_FRAME_SIZE + SPI_RX_ALIGN_ALLOWANCE_MAX` and omit the `HEADER_LEN` bytes that are always part of the transfer (reachable when `--spi-align-allowance` is non-zero).

In both cases an RCP that advertises `data_len = MAX_FRAME_SIZE` can drive a write past the end of the buffer.

### Fix

Size the three buffers for their actual worst case. The production posix SPI driver already bounds the same transfer in `src/posix/platform/spi_interface.cpp` (`VerifyOrExit(mRxFrameBuffer->GetFrameMaxLength() >= spiTransferBytes + mSpiAlignAllowance)`); this brings the standalone tool in line.
