### PR TITLE
[sub-mac] sync RadioSpinel mState when Get<Radio>().Sleep() is skipped

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (603)
+#define OPENTHREAD_API_VERSION (604)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -854,6 +854,16 @@ bool otPlatRadioIsEnabled(otInstance *aInstance);
 otError otPlatRadioSleep(otInstance *aInstance);
 
 /**
+ * Updates the host-side sleep state without changing the radio hardware.
+ *
+ * Used when @ref otPlatRadioSetRxOnWhenIdle() is supported and idle sleep is handled on the radio side instead of
+ * calling @ref otPlatRadioSleep().
+ *
+ * @param[in] aInstance  The OpenThread instance structure.
+ */
+void otPlatRadioSyncSleepState(otInstance *aInstance);
+
+/**
  * Transition the radio from Sleep to Receive (turn on the radio).
  *
  * @param[in]  aInstance  The OpenThread instance structure.

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -267,6 +267,7 @@ Error SubMac::RadioSleep(void)
         SuccessOrExit(error = Get<Radio>().Sleep());
     }
 
+    Get<Radio>().SyncSleepState();
     SetState(kStateSleep);
 
 exit:

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -503,6 +503,12 @@ public:
     Error Sleep(void);
 
     /**
+     * Updates the host-side sleep state when the radio platform handles idle sleep
+     * via otPlatRadioSetRxOnWhenIdle() instead of otPlatRadioSleep().
+     */
+    void SyncSleepState(void);
+
+    /**
      * Transitions the radio from Sleep to Receive (turn on the radio).
      *
      * @param[in]  aChannel   The channel to use for receiving.
@@ -975,6 +981,8 @@ inline Error Radio::Sleep(void)
     return otPlatRadioSleep(GetInstancePtr());
 }
 
+inline void Radio::SyncSleepState(void) { otPlatRadioSyncSleepState(GetInstancePtr()); }
+
 inline Error Radio::Receive(uint8_t aChannel)
 {
 #if OPENTHREAD_CONFIG_RADIO_STATS_ENABLE && (OPENTHREAD_FTD || OPENTHREAD_MTD)
@@ -1104,6 +1112,8 @@ inline Error Radio::Disable(void) { return kErrorInvalidState; }
 inline bool Radio::IsEnabled(void) { return true; }
 
 inline Error Radio::Sleep(void) { return kErrorNone; }
+
+inline void Radio::SyncSleepState(void) {}
 
 inline Error Radio::Receive(uint8_t) { return kErrorNone; }
 

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -385,4 +385,6 @@ extern "C" OT_TOOL_WEAK void otPlatRadioSetRxOnWhenIdle(otInstance *aInstance, b
     OT_UNUSED_VARIABLE(aEnable);
 }
 
+extern "C" OT_TOOL_WEAK void otPlatRadioSyncSleepState(otInstance *aInstance) { OT_UNUSED_VARIABLE(aInstance); }
+
 OT_TOOL_WEAK otError otPlatRadioSetChannelTargetPower(otInstance *, uint8_t, int16_t) { return kErrorNotImplemented; }

--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -1754,6 +1754,14 @@ exit:
     return error;
 }
 
+void RadioSpinel::SyncSleepState(void)
+{
+    if (mState == kStateReceive)
+    {
+        mState = kStateSleep;
+    }
+}
+
 otError RadioSpinel::Enable(otInstance *aInstance)
 {
     otError error = OT_ERROR_NONE;

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -589,6 +589,14 @@ public:
     otError Sleep(void);
 
     /**
+     * Updates the host-side sleep state without changing the radio hardware.
+     *
+     * Used when @ref otPlatRadioSetRxOnWhenIdle() is supported and idle sleep is handled
+     * on the radio side instead of calling @ref Sleep().
+     */
+    void SyncSleepState(void);
+
+    /**
      * Enable the radio.
      *
      * @param[in]   aInstance   A pointer to the OpenThread instance.

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -335,6 +335,12 @@ otError otPlatRadioSleep(otInstance *aInstance)
     return GetRadioSpinel().Sleep();
 }
 
+void otPlatRadioSyncSleepState(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    GetRadioSpinel().SyncSleepState();
+}
+
 otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 {
     OT_UNUSED_VARIABLE(aInstance);


### PR DESCRIPTION
When SubMac idle sleep does not call `Get<Radio>().Sleep()` (sleepy device with `OT_RADIO_CAPS_RX_ON_WHEN_IDLE`), RadioSpinel mState can remain Receive after TX.
Add `SyncSleepState()` to align host-side mState so a later Receive() sends `MAC_RAW_STREAM_ENABLED` from Sleep.