### PR TITLE
[ip6] add `MatchesExtAddress()` to `InterfaceIdentifier`

### DIFF
--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -140,6 +140,7 @@ public:
      * @param[in] aIid   The IPv6 Interface Identifier to convert to Extended Address.
      */
     void SetFromIid(const Ip6::InterfaceIdentifier &aIid);
+
 #endif
 
     /**

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -238,6 +238,14 @@ void InterfaceIdentifier::InitFromExtAddress(const Mac::ExtAddress &aExtAddress)
     addr.CopyTo(mFields.m8);
 }
 
+bool InterfaceIdentifier::MatchesExtAddress(const Mac::ExtAddress &aExtAddress) const
+{
+    InterfaceIdentifier iid;
+
+    iid.InitFromExtAddress(aExtAddress);
+    return *this == iid;
+}
+
 void InterfaceIdentifier::InitAsLocator(uint16_t aLocator)
 {
     // Locator IID pattern `0000:00ff:fe00:xxxx`

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -409,6 +409,16 @@ public:
     void InitFromExtAddress(const Mac::ExtAddress &aExtAddress);
 
     /**
+     * Indicates whether the Interface Identifier matches a given IEEE 802.15.4 Extended Address.
+     *
+     * @param[in] aExtAddress  The Extended Address to match against.
+     *
+     * @retval TRUE   The Interface Identifier matches the @p aExtAddress.
+     * @retval FALSE  The Interface Identifier does not match the @p aExtAddress.
+     */
+    bool MatchesExtAddress(const Mac::ExtAddress &aExtAddress) const;
+
+    /**
      * Initializes the Interface Identifier to Routing/Anycast Locator pattern `0000:00ff:fe00:xxxx` with a given
      * locator (RLOC16 or ALOC16) value.
      *

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -731,10 +731,6 @@ template <> void AddressResolver::HandleTmf<kUriAddressError>(Coap::Msg &aMsg)
     Error                    error = kErrorNone;
     Ip6::Address             target;
     Ip6::InterfaceIdentifier meshLocalIid;
-#if OPENTHREAD_FTD
-    Mac::ExtAddress extAddr;
-    Ip6::Address    destination;
-#endif
 
     LogInfo("Received %s", UriToString<kUriAddressError>());
 
@@ -760,8 +756,6 @@ template <> void AddressResolver::HandleTmf<kUriAddressError>(Coap::Msg &aMsg)
     }
 
 #if OPENTHREAD_FTD
-    extAddr.SetFromIid(meshLocalIid);
-
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {
         if (child.IsFullThreadDevice())
@@ -769,13 +763,15 @@ template <> void AddressResolver::HandleTmf<kUriAddressError>(Coap::Msg &aMsg)
             continue;
         }
 
-        if (child.GetExtAddress() != extAddr)
+        if (!meshLocalIid.MatchesExtAddress(child.GetExtAddress()))
         {
             // Mesh Local EID differs, so check whether Target EID
             // matches a child address and if so remove it.
 
             if (child.RemoveIp6Address(target) == kErrorNone)
             {
+                Ip6::Address destination;
+
                 Get<Mle::Mle>().ComposeRloc(child.GetRloc16(), destination);
 
                 SendAddressError(target, meshLocalIid, destination);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -5252,7 +5252,6 @@ void Mle::Attacher::HandleParentResponse(RxInfo &aRxInfo)
     Connectivity     connectivity;
     uint32_t         linkFrameCounter;
     uint32_t         mleFrameCounter;
-    Mac::ExtAddress  extAddress;
     Mac::CslAccuracy cslAccuracy;
 
     SuccessOrExit(error = Tlv::Find<SourceAddressTlv>(aRxInfo.mMessage, sourceAddress));
@@ -5265,9 +5264,8 @@ void Mle::Attacher::HandleParentResponse(RxInfo &aRxInfo)
 
     SuccessOrExit(error = aRxInfo.mMessage.ReadAndMatchResponseTlvWith(mParentRequestChallenge));
 
-    extAddress.SetFromIid(aRxInfo.mMessageInfo.GetPeerAddr().GetIid());
-
-    if (Get<Mle>().IsChild() && Get<Mle>().mParent.GetExtAddress() == extAddress)
+    if (Get<Mle>().IsChild() &&
+        aRxInfo.mMessageInfo.GetPeerAddr().GetIid().MatchesExtAddress(Get<Mle>().mParent.GetExtAddress()))
     {
         mReceivedResponseFromParent = true;
     }
@@ -5299,7 +5297,7 @@ void Mle::Attacher::HandleParentResponse(RxInfo &aRxInfo)
     {
         otThreadParentResponseInfo parentinfo;
 
-        parentinfo.mExtAddr      = extAddress;
+        AsCoreType(&parentinfo.mExtAddr).SetFromIid(aRxInfo.mMessageInfo.GetPeerAddr().GetIid());
         parentinfo.mRloc16       = sourceAddress;
         parentinfo.mRssi         = rss;
         parentinfo.mPriority     = connectivity.GetParentPriority();
@@ -5353,7 +5351,8 @@ void Mle::Attacher::HandleParentResponse(RxInfo &aRxInfo)
     // Continue to process the "ParentResponse" if it is from current
     // parent candidate to update the challenge and frame counters.
 
-    if (mParentCandidate.IsStateParentResponse() && (mParentCandidate.GetExtAddress() != extAddress))
+    if (mParentCandidate.IsStateParentResponse() &&
+        !aRxInfo.mMessageInfo.GetPeerAddr().GetIid().MatchesExtAddress(mParentCandidate.GetExtAddress()))
     {
         // If already have a candidate parent, only seek a better parent
 

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -903,7 +903,6 @@ void Mle::HandleLinkAcceptVariant(RxInfo &aRxInfo, MessageType aMessageType)
     LeaderData      leaderData;
     uint8_t         linkMargin;
     bool            shouldUpdateRoutes = false;
-    Mac::ExtAddress extAddress;
 
     SuccessOrExit(error = Tlv::Find<SourceAddressTlv>(aRxInfo.mMessage, sourceAddress));
 
@@ -929,8 +928,8 @@ void Mle::HandleLinkAcceptVariant(RxInfo &aRxInfo, MessageType aMessageType)
         break;
 
     case Neighbor::kStateValid:
-        extAddress.SetFromIid(aRxInfo.mMessageInfo.GetPeerAddr().GetIid());
-        VerifyOrExit(router->GetExtAddress() == extAddress, error = kErrorSecurity);
+        VerifyOrExit(aRxInfo.mMessageInfo.GetPeerAddr().GetIid().MatchesExtAddress(router->GetExtAddress()),
+                     error = kErrorSecurity);
         break;
 
     default:


### PR DESCRIPTION
This commit adds a new `MatchesExtAddress()` helper method to the `Ip6::InterfaceIdentifier` class to easily check if the IID matches a given IEEE 802.15.4 Extended Address.

This simplifies various checks throughout the codebase (in `Mle`, `AddressResolver`, etc.) where an IID needed to be temporarily converted to a `Mac::ExtAddress` (via `SetFromIid`) just to perform a comparison. These call sites have been updated to use the new inline matcher method, reducing boilerplate variables and lines of code.