### PR TITLE
[mle] introduce `ComposeMeshLocalAddress()` helper method

### DIFF
--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -858,8 +858,7 @@ template <> void Commissioner::HandleTmf<kUriRelayRx>(Coap::Msg &aMsg)
     aMsg.mMessage.SetOffset(offsetRange.GetOffset());
     SuccessOrExit(error = aMsg.mMessage.SetLength(offsetRange.GetEndOffset()));
 
-    joinerMessageInfo.SetPeerAddr(Get<Mle::Mle>().GetMeshLocalEid());
-    joinerMessageInfo.GetPeerAddr().SetIid(mJoinerIid);
+    Get<Mle::Mle>().ComposeMeshLocalAddress(mJoinerIid, joinerMessageInfo.GetPeerAddr());
     joinerMessageInfo.SetPeerPort(mJoinerPort);
 
     Get<Tmf::SecureAgent>().HandleReceive(aMsg.mMessage, joinerMessageInfo);

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -123,8 +123,7 @@ Error AddressResolver::GetNextCacheEntry(EntryInfo &aInfo, Iterator &aIterator) 
         VerifyOrExit(entry->IsLastTransactionTimeValid());
 
         aInfo.mLastTransTime = entry->GetLastTransactionTime();
-        AsCoreType(&aInfo.mMeshLocalEid).SetPrefix(Get<Mle::Mle>().GetMeshLocalPrefix());
-        AsCoreType(&aInfo.mMeshLocalEid).SetIid(entry->GetMeshLocalIid());
+        Get<Mle::Mle>().ComposeMeshLocalAddress(entry->GetMeshLocalIid(), AsCoreType(&aInfo.mMeshLocalEid));
 
         ExitNow();
     }

--- a/src/core/thread/child.cpp
+++ b/src/core/thread/child.cpp
@@ -110,8 +110,7 @@ Error Child::GetMeshLocalIp6Address(Ip6::Address &aAddress) const
 
     VerifyOrExit(!mMeshLocalIid.IsUnspecified(), error = kErrorNotFound);
 
-    aAddress.SetPrefix(Get<Mle::Mle>().GetMeshLocalPrefix());
-    aAddress.SetIid(mMeshLocalIid);
+    Get<Mle::Mle>().ComposeMeshLocalAddress(mMeshLocalIid, aAddress);
 
 exit:
     return error;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -906,6 +906,12 @@ void Mle::ComposeServiceAloc(uint8_t aServiceId, Ip6::Address &aAddress) const
     ComposeAloc(Aloc16::FromServiceId(aServiceId), aAddress);
 }
 
+void Mle::ComposeMeshLocalAddress(const Ip6::InterfaceIdentifier &aIid, Ip6::Address &aAddress) const
+{
+    aAddress.SetPrefix(mMeshLocalPrefix);
+    aAddress.SetIid(aIid);
+}
+
 const LeaderData &Mle::GetLeaderData(void)
 {
     mLeaderData.SetDataVersion(Get<NetworkData::Leader>().GetVersion(NetworkData::kFullSet));

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -612,6 +612,14 @@ public:
     void ComposeServiceAloc(uint8_t aServiceId, Ip6::Address &aAddress) const;
 
     /**
+     * Composes a Mesh-Local IPv6 Address from a given Interface Identifier.
+     *
+     * @param[in]   aIid       The Interface Identifier to use.
+     * @param[out]  aAddress   A reference to the IPv6 Address to populate.
+     */
+    void ComposeMeshLocalAddress(const Ip6::InterfaceIdentifier &aIid, Ip6::Address &aAddress) const;
+
+    /**
      * Returns the most recently received Leader Data.
      *
      * @returns  A reference to the most recently received Leader Data.

--- a/tests/unit/test_child.cpp
+++ b/tests/unit/test_child.cpp
@@ -123,9 +123,7 @@ void TestChildIp6Address(void)
     numAddresses = 0;
 
     // First addresses uses the mesh local prefix (mesh-local address).
-    addresses[numAddresses] = sInstance->Get<Mle::Mle>().GetMeshLocalEid();
-    addresses[numAddresses].SetIid(meshLocalIid);
-
+    sInstance->Get<Mle::Mle>().ComposeMeshLocalAddress(meshLocalIid, addresses[numAddresses]);
     numAddresses++;
 
     for (const char *ip6Address : ip6Addresses)


### PR DESCRIPTION
This commit introduces a new `ComposeMeshLocalAddress()` helper method in the `Mle` class. This method constructs a full IPv6 Address by combining the Mesh-Local Prefix with a provided Interface Identifier (IID).

By using this helper, we eliminate the repetitive two-step process of calling `SetPrefix()` followed by `SetIid()` previously scattered across `Commissioner`, `AddressResolver`, `Child`, and unit tests. This improves code readability and correctly encapsulates address composition logic within the `Mle` module.