### PR TITLE
[core] add Query ID filter to netdiag GET

### DIFF
--- a/src/core/thread/net_diag.cpp
+++ b/src/core/thread/net_diag.cpp
@@ -985,7 +985,13 @@ exit:
 
 template <> void Client::HandleTmf<kUriDiagnosticGetAnswer>(Coap::Msg &aMsg)
 {
+    uint16_t queryId = 0;
     VerifyOrExit(aMsg.IsConfirmable());
+    if (Tlv::Find<QueryIdTlv>(aMsg.mMessage, queryId) == kErrorNone && queryId != mQueryId)
+    {
+        IgnoreError(Get<Tmf::Agent>().SendAckResponse(aMsg));
+        ExitNow();
+    }
 
     LogInfo("Received %s from %s", ot::UriToString<kUriDiagnosticGetAnswer>(),
             aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());


### PR DESCRIPTION
When a Query ID is present in the answer, verify that it matches the expected query ID sent by the client.

This pattern mirrors behavior in MeshDiag and HistoryTracker for filtering out messages that do not match the current query.