### PR TITLE
[radio] remove RadioContext.mCslPresent

### DIFF
--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -645,7 +645,6 @@ void radioSendMessage(otInstance *aInstance)
     {
         uint64_t sfdTxTime = otPlatTimeGet();
 
-        sRadioContext.mCslPresent = sTransmitFrame.mInfo.mTxInfo.mCslPresent;
         otEXPECT(otMacFrameProcessTxSfd(&sTransmitFrame, sfdTxTime, &sRadioContext) == OT_ERROR_NONE);
     }
 
@@ -1061,10 +1060,7 @@ static uint8_t generateAckIeData(uint8_t                   *aLinkMetricsIeData,
     uint8_t offset = 0;
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    sRadioContext.mCslPresent =
-        (sRadioContext.mCslPeriod > 0) && otMacFrameSrcAddrMatchCslReceiverPeer(aReceivedFrame, &sRadioContext);
-
-    if (sRadioContext.mCslPresent)
+    if ((sRadioContext.mCslPeriod > 0) && otMacFrameSrcAddrMatchCslReceiverPeer(aReceivedFrame, &sRadioContext))
     {
         offset += otMacFrameGenerateCslIeTemplate(sAckIeData);
     }

--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -411,7 +411,7 @@ otError otMacFrameProcessTxSfd(otRadioFrame *aFrame, uint64_t aRadioTime, otRadi
     VerifyOrExit(!otMacFrameIsSecurityEnabled(aFrame) || !aFrame->mInfo.mTxInfo.mIsSecurityProcessed);
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    if (aRadioContext->mCslPresent) // CSL IE should be filled for every transmit attempt
+    if (static_cast<Mac::Frame *>(aFrame)->HasCslIe()) // CSL IE should be filled for every transmit attempt
     {
         otMacFrameSetCslIe(aFrame, aRadioContext->mCslPeriod, ComputeCslPhase(aRadioTime, aRadioContext));
     }

--- a/examples/platforms/utils/mac_frame.h
+++ b/examples/platforms/utils/mac_frame.h
@@ -349,7 +349,6 @@ typedef struct otRadioContext
     uint16_t         mCslPeriod;       ///< In unit of 10 symbols.
     otShortAddress   mCslShortAddress; ///< The short address of the CSL receiver's peer.
     otExtAddress     mCslExtAddress;   ///< The extended address of the CSL receiver's peer.
-    bool             mCslPresent : 1;  ///< Indicates whether the CSL header IE is present.
     otShortAddress   mShortAddress;
     otShortAddress   mAlternateShortAddress;
     otRadioKeyType   mKeyType;

--- a/tests/nexus/platform/nexus_core.cpp
+++ b/tests/nexus/platform/nexus_core.cpp
@@ -740,8 +740,7 @@ void Core::ProcessRadio(Node &aNode)
         dstPanId = Mac::kPanIdBroadcast;
     }
 
-    ackRequested                           = aNode.mRadio.mTxFrame.GetAckRequest();
-    aNode.mRadio.mRadioContext.mCslPresent = aNode.mRadio.mTxFrame.mInfo.mTxInfo.mCslPresent;
+    ackRequested = aNode.mRadio.mTxFrame.GetAckRequest();
 
     SuccessOrQuit(otMacFrameProcessTxSfd(&aNode.mRadio.mTxFrame, mNow, &aNode.mRadio.mRadioContext));
     static_cast<Radio::Frame &>(aNode.mRadio.mTxFrame).UpdateFcs();
@@ -856,11 +855,8 @@ void Core::ProcessRadio(Node &aNode)
             uint8_t ackIeDataLength = 0;
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-            ackNode->mRadio.mRadioContext.mCslPresent =
-                (ackNode->mRadio.mRadioContext.mCslPeriod > 0) &&
-                otMacFrameSrcAddrMatchCslReceiverPeer(&aNode.mRadio.mTxFrame, &ackNode->mRadio.mRadioContext);
-
-            if (ackNode->mRadio.mRadioContext.mCslPresent)
+            if ((ackNode->mRadio.mRadioContext.mCslPeriod > 0) &&
+                otMacFrameSrcAddrMatchCslReceiverPeer(&aNode.mRadio.mTxFrame, &ackNode->mRadio.mRadioContext))
             {
                 ackIeDataLength = otMacFrameGenerateCslIeTemplate(ackIeData);
             }


### PR DESCRIPTION
This commit removes RadioContext.mCslPresent. Instead we directly check whether the CSL is in the frame data, so there is not risk of mismatch.