### PR TITLE
[mac] call sleep() after scan, before setting rx_on_when_idle

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -245,6 +245,11 @@ void Mac::PerformActiveScan(void)
     }
     else
     {
+        if (!mRxOnWhenIdle && !mPromiscuous)
+        {
+            mLinks.Sleep();
+        }
+
         mLinks.SetRxOnWhenIdle(mRxOnWhenIdle);
         mLinks.SetPanId(mPanId);
         FinishOperation();


### PR DESCRIPTION
When `PerformActiveScan` has no remaining channels to scan (i.e., the scan is complete), first attempt to call sleep, and then call `mLinks.SetRxOnWhenIdle(mRxOnWhenIdle)` to set the `SubMac::mRxOnWhenIdle` flag. Otherwise, in the Spinel case, a state inconsistency may occur: before `SubMac::Sleep` is reached via `PerformNextOperation`, `SubMac::mRxOnWhenIdle` has already been set to false, which may cause `ShouldHandleTransitionToSleep()` to no longer be satisfied, preventing `Get<Radio>().Sleep()` from being actually called.

In the Spinel case, this will result in `RadioSpinel::mState` not being correctly set back to sleep after the scan ends. This state inconsistency can further lead to other issues. For example, when the network is actually enabled and `RadioSpinel::Receive` is called, `SPINEL_PROP_MAC_RAW_STREAM_ENABLED` may not be properly configured on the radio device. This will not be elaborated further here.