### PR TITLE
[spi-hdlc-adapter] define explicit worst-case HDLC frame size macro

### DIFF
--- a/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
+++ b/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
@@ -92,6 +92,7 @@
 
 #define MAX_FRAME_SIZE 2048
 #define HEADER_LEN 5
+#define HDLC_MAX_FRAME_SIZE ((MAX_FRAME_SIZE - HEADER_LEN) * 2 + 5)
 #define SPI_HEADER_RESET_FLAG 0x80
 #define SPI_HEADER_CRC_FLAG 0x40
 #define SPI_HEADER_PATTERN_VALUE 0x02
@@ -803,7 +804,7 @@ static int push_hdlc(void)
 {
     int             ret              = 0;
     const uint8_t  *spiRxFrameBuffer = get_real_rx_frame_start();
-    static uint8_t  escaped_frame_buffer[MAX_FRAME_SIZE * 2];
+    static uint8_t  escaped_frame_buffer[HDLC_MAX_FRAME_SIZE];
     static uint16_t unescaped_frame_len;
     static uint16_t escaped_frame_len;
     static uint16_t escaped_frame_sent;


### PR DESCRIPTION
This commit replaces the implicit sizing of `escaped_frame_buffer` with an explicit macro `HDLC_MAX_FRAME_SIZE` in the standalone `spi-hdlc-adapter` tool.

Previously, `escaped_frame_buffer` was sized statically to `MAX_FRAME_SIZE * 2` (4096 bytes). While this size is mathematically sufficient to hold a worst-case escaped payload (4091 bytes for a 2043-byte max payload, 4 escaped CRC bytes, and 1 flag byte), it was not self-documenting and relied on implicit math.

This commit defines `HDLC_MAX_FRAME_SIZE` explicitly as: `((MAX_FRAME_SIZE - HEADER_LEN) * 2 + 5)`
making the worst-case framing overhead bounds clear and robust to any future changes to the constants.