### PR TITLE
[tmf] introduce `SendResponseWithStateTlv()` helper

### DIFF
--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -202,20 +202,11 @@ exit:
 
 void DatasetManager::SendSetOrReplaceResponse(const Coap::Msg &aMsg, StateTlv::State aState)
 {
-    Error          error = kErrorNone;
-    Coap::Message *message;
-
-    message = Get<Tmf::Agent>().AllocateAndInitPriorityResponseFor(aMsg.mMessage);
-    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
-
-    SuccessOrExit(error = Tlv::Append<StateTlv>(*message, aState));
-
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, aMsg.mMessageInfo));
-
+    SuccessOrExit(Get<Tmf::Agent>().SendResponseWithStateTlv(aMsg, aState));
     LogInfo("sent dataset set/replace response");
 
 exit:
-    FreeMessageOnError(message, error);
+    return;
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -158,20 +158,12 @@ exit:
 
 void Leader::SendKeepAliveResponse(const Coap::Msg &aMsg, StateTlv::State aState)
 {
-    Error          error = kErrorNone;
-    Coap::Message *message;
+    Error error;
 
-    message = Get<Tmf::Agent>().AllocateAndInitPriorityResponseFor(aMsg.mMessage);
-    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
-
-    SuccessOrExit(error = Tlv::Append<StateTlv>(*message, aState));
-
-    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*message, aMsg.mMessageInfo));
-
+    SuccessOrExit(error = Get<Tmf::Agent>().SendResponseWithStateTlv(aMsg, aState));
     LogInfo("Sent %s response", UriToString<kUriLeaderKeepAlive>());
 
 exit:
-    FreeMessageOnError(message, error);
     LogWarnOnError(error, "send keep alive response");
 }
 

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -324,18 +324,11 @@ exit:
 
 void Leader::SendCommissioningSetResponse(const Coap::Msg &aMsg, MeshCoP::StateTlv::State aState)
 {
-    Coap::Message *message = Get<Tmf::Agent>().AllocateAndInitPriorityResponseFor(aMsg.mMessage);
-
-    VerifyOrExit(message != nullptr);
-    SuccessOrExit(Tlv::Append<MeshCoP::StateTlv>(*message, aState));
-
-    SuccessOrExit(Get<Tmf::Agent>().SendMessage(*message, aMsg.mMessageInfo));
-    message = nullptr; // `SendMessage` takes ownership on success
-
+    SuccessOrExit(Get<Tmf::Agent>().SendResponseWithStateTlv(aMsg, aState));
     LogInfo("Sent %s response", UriToString<kUriCommissionerSet>());
 
 exit:
-    FreeMessage(message);
+    return;
 }
 
 bool Leader::RlocMatch(uint16_t aFirstRloc16, uint16_t aSecondRloc16, MatchMode aMatchMode)

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -275,6 +275,22 @@ void Agent::PrepareMessageInfo(Ip6::MessageInfo &aMessageInfo) const
                                  : Get<Mle::Mle>().GetMeshLocalRloc());
 }
 
+Error Agent::SendResponseWithStateTlv(const Msg &aRequest, uint8_t aState)
+{
+    Error    error = kErrorNone;
+    Message *message;
+
+    message = AllocateAndInitPriorityResponseFor(aRequest.mMessage);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    SuccessOrExit(error = Tlv::Append<MeshCoP::StateTlv>(*message, aState));
+    SuccessOrExit(error = SendMessage(*message, aRequest.mMessageInfo));
+
+exit:
+    FreeMessageOnError(message, error);
+    return error;
+}
+
 uint8_t Agent::PriorityToDscp(Message::Priority aPriority)
 {
     uint8_t dscp = Ip6::kDscpTmfNormalPriority;

--- a/src/core/thread/tmf.hpp
+++ b/src/core/thread/tmf.hpp
@@ -224,6 +224,17 @@ public:
     Error SendMessageToLeaderAloc(Message &aMessage, ResponseHandler aHandler, void *aContext);
 
     /**
+     * Sends a TMF response containing a State TLV.
+     *
+     * @param[in] aRequest  The incoming TMF request message.
+     * @param[in] aState    The state value to append in the State TLV.
+     *
+     * @retval kErrorNone     Successfully sent the response.
+     * @retval kErrorNoBufs   Insufficient available buffers to allocate the response.
+     */
+    Error SendResponseWithStateTlv(const Msg &aRequest, uint8_t aState);
+
+    /**
      * Converts a TMF message priority to IPv6 header DSCP value.
      *
      * @param[in] aPriority  The message priority to convert.


### PR DESCRIPTION
This commit adds `SendResponseWithStateTlv()` to `Tmf::Agent` to streamline sending TMF responses that consist solely of a `StateTlv`.

By encapsulating message allocation, TLV appending, and message transmission into a single method, this reduces duplicate boilerplate code across `DatasetManager`, `Leader`, and `NetworkData::Leader`.