### PR TITLE
[mle] remove unused router threshold variables

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -2597,8 +2597,6 @@ private:
     uint8_t  mRouterId;
     uint8_t  mPreviousRouterId;
     uint8_t  mNetworkIdTimeout;
-    uint8_t  mRouterUpgradeThreshold;
-    uint8_t  mRouterDowngradeThreshold;
     uint8_t  mLeaderWeight;
     uint8_t  mPreviousPartitionRouterIdSequence;
     uint8_t  mPreviousPartitionIdTimeout;


### PR DESCRIPTION
This commit removes `mRouterUpgradeThreshold` and
`mRouterDowngradeThreshold` from the `Mle` class. These variables were previously moved into the `RoleTransitioner` class, but their declarations in `Mle` were left behind. Removing them cleans up the class definition and eliminates unused state.