### PR TITLE
[net_diag] only return Enhanced Route TLV when active Router

### DIFF
--- a/src/core/thread/net_diag.cpp
+++ b/src/core/thread/net_diag.cpp
@@ -436,6 +436,7 @@ Error Server::AppendDiagTlv(uint8_t aTlvType, Message &aMessage)
         break;
 
     case Tlv::kEnhancedRoute:
+        VerifyOrExit(Get<Mle::Mle>().IsRouterOrLeader());
         error = AppendEnhancedRoute(aMessage);
         break;
 


### PR DESCRIPTION
Adds a guard for Enhanced Route TLV, to conform to the Thread spec requirement in 10.11.4.17.