### PR TITLE
[msg-backed-array] add `Remove` methods to `MsgBackedArray`

### DIFF
--- a/src/core/common/msg_backed_array.hpp
+++ b/src/core/common/msg_backed_array.hpp
@@ -284,6 +284,90 @@ public:
         return Read(aIndexedEntry);
     }
 
+    /**
+     * Removes an element from the array at a given index.
+     *
+     * To remove the element, it is replaced by the last element in the array. So the order of items in the array
+     * can change after a call to this method.
+     *
+     * @param[in] aIndex  The index of the element to remove.
+     *
+     * @retval kErrorNone         Successfully removed the element.
+     * @retval kErrorInvalidArgs  The @p aIndex is out of bounds (beyond current array length).
+     */
+    Error RemoveAt(uint16_t aIndex)
+    {
+        Error    error  = kErrorNone;
+        uint16_t length = GetLength();
+
+        VerifyOrExit(aIndex < length, error = kErrorInvalidArgs);
+
+        if (aIndex < length - 1)
+        {
+            mMessage->WriteBytesFromMessage(/* aWriteOffset */ aIndex * sizeof(Type), *mMessage,
+                                            /* aReadOffset */ (length - 1) * sizeof(Type), /* aLength */ sizeof(Type));
+        }
+
+        if (length == 1)
+        {
+            Clear();
+        }
+        else
+        {
+            mMessage->RemoveFooter(sizeof(Type));
+        }
+
+    exit:
+        return error;
+    }
+
+    /**
+     * Removes an element from the array.
+     *
+     * To remove the element, it is replaced by the last element in the array. So the order of items in the array
+     * can change after a call to this method.
+     *
+     * @param[in,out] aIndexedEntry  A reference to an `IndexedEntry` specifying the element to remove. On success, its
+     *                               index is set to invalid.
+     *
+     * @retval kErrorNone         Successfully removed the element.
+     * @retval kErrorInvalidArgs  The `GetIndex()` in @p aIndexedEntry is out of bounds.
+     */
+    Error Remove(IndexedEntry &aIndexedEntry)
+    {
+        Error error = RemoveAt(aIndexedEntry.GetIndex());
+
+        if (error == kErrorNone)
+        {
+            aIndexedEntry.SetIndexToInvalid();
+        }
+
+        return error;
+    }
+
+    /**
+     * Removes the first entry in the array matching a set of conditions.
+     *
+     * Behaves similar to `RemoveAt()`, i.e., the matched entry (if found) is replaced with the last entry in the
+     * array. So the order of items in the array can change after a call to this method.
+     *
+     * @param[in]  aArgs  The args to pass to `Matches()` to find the matching entry.
+     *
+     * @retval kErrorNone      A matching entry was found and removed.
+     * @retval kErrorNotFound  Could not find a matching entry in the array.
+     */
+    template <typename... Args> Error RemoveMatching(Args &&...aArgs)
+    {
+        Error        error;
+        IndexedEntry entry;
+
+        SuccessOrExit(error = FindMatching(entry, aArgs...));
+        error = Remove(entry);
+
+    exit:
+        return error;
+    }
+
 private:
     Message *mMessage;
 };

--- a/tests/unit/test_msg_backed_array.cpp
+++ b/tests/unit/test_msg_backed_array.cpp
@@ -198,8 +198,49 @@ void TestMsgBackedArray(void)
 
     VerifyOrQuit(array.Push(entry4) == kErrorNoBufs);
 
-    // Clearing array
+    // Test RemoveAt
+    // Array: [entry0, entry4, entry2, entry1]
+    SuccessOrQuit(array.RemoveAt(1)); // Removes entry4, replaced by entry1
+    VerifyOrQuit(array.GetLength() == 3);
+    SuccessOrQuit(array.ReadAt(0, entry));
+    VerifyOrQuit(entry == entry0);
+    SuccessOrQuit(array.ReadAt(1, entry));
+    VerifyOrQuit(entry == entry1);
+    SuccessOrQuit(array.ReadAt(2, entry));
+    VerifyOrQuit(entry == entry2);
+    VerifyOrQuit(array.ReadAt(3, entry) == kErrorNotFound);
 
+    // Test Remove with IndexedEntry
+    // Array: [entry0, entry1, entry2]
+    SuccessOrQuit(array.FindMatching(entry, true)); // Finds entry2 at index 2
+    VerifyOrQuit(entry.GetIndex() == 2);
+    SuccessOrQuit(array.Remove(entry)); // Removes entry2 (last element, no replacement)
+    VerifyOrQuit(entry.IsIndexInvalid());
+    VerifyOrQuit(array.GetLength() == 2);
+    SuccessOrQuit(array.ReadAt(0, entry));
+    VerifyOrQuit(entry == entry0);
+    SuccessOrQuit(array.ReadAt(1, entry));
+    VerifyOrQuit(entry == entry1);
+    VerifyOrQuit(array.ReadAt(2, entry) == kErrorNotFound);
+
+    // Test RemoveMatching
+    // Array: [entry0, entry1]
+    SuccessOrQuit(array.Push(entry2));
+    SuccessOrQuit(array.Push(entry3));
+    // Array: [entry0, entry1, entry2, entry3]
+    VerifyOrQuit(array.GetLength() == 4);
+
+    SuccessOrQuit(array.RemoveMatching("Second Entry")); // Removes entry1, replaced by entry3
+    VerifyOrQuit(array.GetLength() == 3);
+    SuccessOrQuit(array.ReadAt(0, entry));
+    VerifyOrQuit(entry == entry0);
+    SuccessOrQuit(array.ReadAt(1, entry));
+    VerifyOrQuit(entry == entry3);
+    SuccessOrQuit(array.ReadAt(2, entry));
+    VerifyOrQuit(entry == entry2);
+    VerifyOrQuit(array.ReadAt(3, entry) == kErrorNotFound);
+
+    // Clearing array
     array.Clear();
 
     VerifyOrQuit(array.GetLength() == 0);


### PR DESCRIPTION
This commit enhances the `MsgBackedArray` template class by adding methods to remove elements from the array.

The following methods were added:
- `RemoveAt(uint16_t aIndex)`: Removes the element at the specified index.
- `Remove(IndexedEntry &aIndexedEntry)`: Removes the element specified by the `IndexedEntry` and updates its index to invalid.
- `RemoveMatching(Args &&...aArgs)`: Finds and removes the first element that matches the given arguments.

To efficiently remove elements without shifting the entire array, the element to be removed is replaced by the last element in the array, and the underlying message is shrunk. This operation can alter the order of the elements.

Unit tests in `test_msg_backed_array.cpp` have been updated to cover all three new removal methods.