### PR TITLE
[mle] reserve vendor specific tlv types

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (605)
+#define OPENTHREAD_API_VERSION (606)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/netdiag.h
+++ b/include/openthread/netdiag.h
@@ -94,6 +94,8 @@ extern "C" {
 #define OT_NETWORK_DIAGNOSTIC_TLV_BR_DHCP6_PD_OMR_PREFIX 41 ///< Border Router DHCPv6-PD OMR Prefix TLV
 #define OT_NETWORK_DIAGNOSTIC_TLV_BR_LOCAL_OL_PREFIX 42     ///< Border Router Local On-link Prefix TLV
 #define OT_NETWORK_DIAGNOSTIC_TLV_BR_FAVORED_OL_PREFIX 43   ///< Border Router Favored On-link Prefix TLV
+#define OT_NETWORK_DIAGNOSTIC_TLV_VENDOR_DIAG 44            ///< Vendor Diagnostics TLV
+#define OT_NETWORK_DIAGNOSTIC_TLV_VENDOR_OUI 45             ///< Vendor OUI TLV
 
 #define OT_NETWORK_DIAGNOSTIC_MAX_VENDOR_NAME_TLV_LENGTH 32          ///< Max length of Vendor Name TLV.
 #define OT_NETWORK_DIAGNOSTIC_MAX_VENDOR_MODEL_TLV_LENGTH 32         ///< Max length of Vendor Model TLV.

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -106,6 +106,7 @@ public:
         kLinkMetricsManagement = 88, ///< Link Metrics Management TLV
         kLinkMetricsReport     = 89, ///< Link Metrics Report TLV
         kLinkProbe             = 90, ///< Link Probe TLV
+        kVendorSpecificData    = 92, ///< Vendor Specific Data TLV
 
         /**
          * Applicable/Required only when time synchronization service

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -166,6 +166,7 @@ enum Command : uint8_t
     kCommandLinkMetricsManagementRequest  = 18,  ///< Link Metrics Management Request command
     kCommandLinkMetricsManagementResponse = 19,  ///< Link Metrics Management Response command
     kCommandLinkProbe                     = 20,  ///< Link Probe command
+    kCommandVendorSpecific                = 24,  ///< Vendor Specific MLE Message command
     kCommandTimeSync                      = 99,  ///< Time Sync command
     kCommandP2pLinkRequest                = 100, ///< P2P Link Request command
     kCommandP2pLinkAccept                 = 101, ///< P2P Link Accept command

--- a/src/core/thread/net_diag_tlvs.hpp
+++ b/src/core/thread/net_diag_tlvs.hpp
@@ -105,6 +105,8 @@ public:
         kBrDhcp6PdOmrPrefix    = OT_NETWORK_DIAGNOSTIC_TLV_BR_DHCP6_PD_OMR_PREFIX,
         kBrLocalOnlinkPrefix   = OT_NETWORK_DIAGNOSTIC_TLV_BR_LOCAL_OL_PREFIX,
         kBrFavoredOnLinkPrefix = OT_NETWORK_DIAGNOSTIC_TLV_BR_FAVORED_OL_PREFIX,
+        kVendorDiag            = OT_NETWORK_DIAGNOSTIC_TLV_VENDOR_DIAG,
+        kVendorOui             = OT_NETWORK_DIAGNOSTIC_TLV_VENDOR_OUI,
     };
 
     /**


### PR DESCRIPTION
This is one part of multi-part PR. It reserves vendor specific TLV as per [SPEC-1439](https://threadgroup.atlassian.net/browse/SPEC-1439)