### PR TITLE
[aes-ccm] only allow nonces in the length range [7, 13] in AesCcm

### DIFF
--- a/src/core/crypto/aes_ccm.cpp
+++ b/src/core/crypto/aes_ccm.cpp
@@ -190,10 +190,8 @@ bool AesCcm::Config::IsValid(void) const
 {
     bool isValid = false;
 
-    if (mNonceLength > 0)
-    {
-        VerifyOrExit(mNonce != nullptr);
-    }
+    VerifyOrExit(IsValueInRange(mNonceLength, kMinNonceLength, kMaxNonceLength));
+    VerifyOrExit(mNonce != nullptr);
 
     VerifyOrExit((mTagLength % 2) == 0);
     VerifyOrExit(IsValueInRange(mTagLength, kMinTagLength, kMaxTagLength));

--- a/src/core/crypto/aes_ccm.hpp
+++ b/src/core/crypto/aes_ccm.hpp
@@ -61,8 +61,10 @@ namespace Crypto {
 class AesCcm
 {
 public:
-    static constexpr uint8_t kMinTagLength = 4;                  ///< Minimum tag length (in bytes).
-    static constexpr uint8_t kMaxTagLength = AesEcb::kBlockSize; ///< Maximum tag length (in bytes).
+    static constexpr uint8_t kMinTagLength   = 4;                  ///< Minimum tag length (in bytes).
+    static constexpr uint8_t kMaxTagLength   = AesEcb::kBlockSize; ///< Maximum tag length (in bytes).
+    static constexpr uint8_t kMinNonceLength = 7;                  ///< Minimum nonce length (in bytes).
+    static constexpr uint8_t kMaxNonceLength = 13;                 ///< Maximum nonce length (in bytes).
 
     /**
      * Initializes the AES-CCM object.


### PR DESCRIPTION
AesCcm does not allow zero length nonces. This commit rejects a config with zero length nonce set.