### PR TITLE
[cli] allow a default argument "def" for `dns config` settings

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1711,7 +1711,7 @@ TransportProtocol: tcp
 Done
 ```
 
-We can leave some of the fields as unspecified (or use value zero). The unspecified fields are replaced by the corresponding OT config option definitions `OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_{}` to form the default query config.
+We can leave some of the fields as unspecified (or use value zero). The unspecified fields are replaced by the corresponding OT config option definitions `OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_{}` to form the default query config. Note that specifying a zero value for a boolean argument will mean _disabled_ and cannot be used to imply default behavior.
 
 ```bash
 > dns config fd00::2

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1711,7 +1711,7 @@ TransportProtocol: tcp
 Done
 ```
 
-We can leave some of the fields as unspecified (or use value zero). The unspecified fields are replaced by the corresponding OT config option definitions `OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_{}` to form the default query config. Note that specifying a zero value for a boolean argument will mean _disabled_ and cannot be used to imply default behavior.
+We can leave some of the fields as unspecified (or use value zero or "def"). The unspecified fields are replaced by the corresponding OT config option definitions `OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_{}` to form the default query config. Note that specifying a zero value for a boolean argument will mean _disabled_ and cannot be used to imply default behavior. For a boolean value "def" is the only option to specify the default value.
 
 ```bash
 > dns config fd00::2
@@ -1727,10 +1727,10 @@ TransportProtocol: udp
 Done
 ```
 
-This final example shows how only 'recursion desired' and the service mode are set, and all other parameters are set to their defaults:
+This final example shows how only the 'service mode' is set, and all other parameters are set to their defaults. Especially note, that the boolean value 'recursion required' is set to its default by using the `def` value.
 
 ```bash
-> dns config :: 0 0 0 1 srv_txt_sep
+> dns config :: 0 0 0 def srv_txt_sep
 Done
 
 > dns config

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1727,7 +1727,7 @@ TransportProtocol: udp
 Done
 ```
 
-This final example shows how only the 'service mode' is set, and all other parameters are set to their defaults. Especially note, that the boolean value 'recursion required' is set to its default by using the `def` value.
+This final example shows how only the 'service mode' is set, and all other parameters are set to their defaults. Especially note, that the boolean value 'recursion desired' is set to its default by using the `def` value.
 
 ```bash
 > dns config :: 0 0 0 def srv_txt_sep

--- a/src/cli/cli_dns.cpp
+++ b/src/cli/cli_dns.cpp
@@ -164,7 +164,7 @@ template <> otError Dns::Process<Cmd("config")>(Arg aArgs[])
      * -->                [@ca{recursion-desired-boolean}] [@ca{service-mode}] <!--
      * -->                [@ca{protocol}]
      * @par
-     * We can leave some of the fields as unspecified (or use value zero). The
+     * We can leave some of the fields as unspecified (or use value zero or "def"). The
      * unspecified fields are replaced by the corresponding OT config option
      * definitions `OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT` to form the default
      * query config.
@@ -444,9 +444,10 @@ otError Dns::GetDnsConfig(Arg aArgs[], otDnsQueryConfig *&aConfig)
     // [max tx attempt] [recursion desired] [service mode]
     // [transport]`
 
-    otError error = OT_ERROR_NONE;
-    bool    recursionDesired;
-    bool    nat64Synth;
+    otError    error = OT_ERROR_NONE;
+    bool       recursionDesired;
+    bool       nat64Synth;
+    const char kDefaultValue[] = "def";
 
     ClearAllBytes(*aConfig);
 
@@ -461,23 +462,37 @@ otError Dns::GetDnsConfig(Arg aArgs[], otDnsQueryConfig *&aConfig)
     }
 
     VerifyOrExit(!aArgs[1].IsEmpty());
-    SuccessOrExit(error = aArgs[1].ParseAsUint16(aConfig->mServerSockAddr.mPort));
+    if (aArgs[1] != kDefaultValue)
+    {
+        SuccessOrExit(error = aArgs[1].ParseAsUint16(aConfig->mServerSockAddr.mPort));
+    }
 
     VerifyOrExit(!aArgs[2].IsEmpty());
-    SuccessOrExit(error = aArgs[2].ParseAsUint32(aConfig->mResponseTimeout));
+    if (aArgs[2] != kDefaultValue)
+    {
+        SuccessOrExit(error = aArgs[2].ParseAsUint32(aConfig->mResponseTimeout));
+    }
 
     VerifyOrExit(!aArgs[3].IsEmpty());
-    SuccessOrExit(error = aArgs[3].ParseAsUint8(aConfig->mMaxTxAttempts));
+    if (aArgs[3] != kDefaultValue)
+    {
+        SuccessOrExit(error = aArgs[3].ParseAsUint8(aConfig->mMaxTxAttempts));
+    }
 
     VerifyOrExit(!aArgs[4].IsEmpty());
-    SuccessOrExit(error = aArgs[4].ParseAsBool(recursionDesired));
-    aConfig->mRecursionFlag = recursionDesired ? OT_DNS_FLAG_RECURSION_DESIRED : OT_DNS_FLAG_NO_RECURSION;
+    if (aArgs[4] != kDefaultValue)
+    {
+        SuccessOrExit(error = aArgs[4].ParseAsBool(recursionDesired));
+        aConfig->mRecursionFlag = recursionDesired ? OT_DNS_FLAG_RECURSION_DESIRED : OT_DNS_FLAG_NO_RECURSION;
+    }
 
     VerifyOrExit(!aArgs[5].IsEmpty());
-    SuccessOrExit(error = ParseDnsServiceMode(aArgs[5], aConfig->mServiceMode));
+    if (aArgs[5] != kDefaultValue)
+    {
+        SuccessOrExit(error = ParseDnsServiceMode(aArgs[5], aConfig->mServiceMode));
+    }
 
     VerifyOrExit(!aArgs[6].IsEmpty());
-
     if (aArgs[6] == "tcp")
     {
         aConfig->mTransportProto = OT_DNS_TRANSPORT_TCP;
@@ -486,7 +501,7 @@ otError Dns::GetDnsConfig(Arg aArgs[], otDnsQueryConfig *&aConfig)
     {
         aConfig->mTransportProto = OT_DNS_TRANSPORT_UDP;
     }
-    else
+    else if (aArgs[6] != kDefaultValue)
     {
         error = OT_ERROR_INVALID_ARGS;
     }
@@ -743,7 +758,7 @@ const char *Dns::RecordSectionToString(otDnsRecordSection aSection)
 
     static_assert(0 == OT_DNS_SECTION_ANSWER, "OT_DNS_SECTION_ANSWER value is incorrect");
     static_assert(1 == OT_DNS_SECTION_AUTHORITY, "OT_DNS_SECTION_AUTHORITY value is incorrect");
-    static_assert(2 == OT_DNS_SECTION_ADDITIONAL, "OT_DNS_SECTION_ADDITIONALATA value is incorrect");
+    static_assert(2 == OT_DNS_SECTION_ADDITIONAL, "OT_DNS_SECTION_ADDITIONAL value is incorrect");
 
     return Stringify(aSection, kSectionString);
 }

--- a/tests/scripts/thread-cert/border_router/test_mdns_restart.py
+++ b/tests/scripts/thread-cert/border_router/test_mdns_restart.py
@@ -151,7 +151,19 @@ class MdnsRestart(thread_cert.TestCase):
         self.assertEqual(len(host.browse_mdns_services('_ed1._tcp')), 1)
         self.assertEqual(len(host.browse_mdns_services('_ed2._tcp')), 1)
 
-        ed1.dns_set_config(br1.get_ip6_address(config.ADDRESS_TYPE.ML_EID))
+        # Explicitly set every field, using "def" to request the default
+        # value for the port, response timeout, max tx attempts, and
+        # recursion desired fields, while still setting the service
+        # mode and transport protocol explicitly (previously "def" did
+        # not exist, so leaving a field unspecified also forced every
+        # field after it to remain unspecified).
+        ed1.dns_set_config(f'{br1.get_ip6_address(config.ADDRESS_TYPE.ML_EID)} def def def def srv_txt_sep udp')
+        dns_config = ed1.dns_get_config()
+        self.assertEqual(dns_config['ResponseTimeout'], '7000 ms')
+        self.assertEqual(dns_config['MaxTxAttempts'], '3')
+        self.assertEqual(dns_config['RecursionDesired'], 'yes')
+        self.assertEqual(dns_config['ServiceMode'], 'srv_txt_sep')
+        self.assertEqual(dns_config['TransportProtocol'], 'udp')
 
         # Since there is only one match, server should include
         # service info in additional section of its response.


### PR DESCRIPTION
When setting the dns config, a zero value can be used to imply default behavior. For a boolean value this is not true. This commit allows a value "def" to be used as a default argument for all dns config settings, targeting especially boolean values that didn't have this feature.

Resolves https://github.com/openthread/openthread/issues/13202