### PR TITLE
[thread-netif] disable MAC when bringing interface down

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -514,6 +514,7 @@ void Mac::UpdateIdleMode(void)
 {
     bool shouldSleep = !mRxOnWhenIdle && !mPromiscuous;
 
+    VerifyOrExit(IsEnabled());
     VerifyOrExit(mOperation == kOperationIdle);
 
     if (!mRxOnWhenIdle)

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -99,6 +99,7 @@ void ThreadNetif::Down(void)
 #if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE && OPENTHREAD_CONFIG_CHANNEL_MONITOR_AUTO_START_ENABLE
     IgnoreError(Get<Utils::ChannelMonitor>().Stop());
 #endif
+    Get<Mac::Mac>().SetEnabled(false);
     Get<Notifier>().Signal(kEventThreadNetifStateChanged);
 
 exit:


### PR DESCRIPTION
This commit fixes an asymmetry between `ifconfig up` and `ifconfig down`. `ifconfig up` enables the MAC layer, but `ifconfig down` did not disable it, leaving the MAC layer enabled even when the interface was down.

Now, `ThreadNetif::Down()` explicitly disables the MAC layer by calling `Get<Mac::Mac>().SetEnabled(false)`.