### PR TITLE
[mesh monitor] Add Mesh Monitor Server Implementation

### DIFF
--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -114,6 +114,7 @@ typedef enum otCoapCode
     OT_COAP_CODE_PRECONDITION_FAILED = OT_COAP_CODE(4, 12), ///< Precondition Failed
     OT_COAP_CODE_REQUEST_TOO_LARGE   = OT_COAP_CODE(4, 13), ///< Request Entity Too Large
     OT_COAP_CODE_UNSUPPORTED_FORMAT  = OT_COAP_CODE(4, 15), ///< Unsupported Content-Format
+    OT_COAP_CODE_TOO_MANY_REQUESTS   = OT_COAP_CODE(4, 29), ///< RFC8516 Too Many Requests
 
     OT_COAP_CODE_INTERNAL_ERROR      = OT_COAP_CODE(5, 0), ///< Internal Server Error
     OT_COAP_CODE_NOT_IMPLEMENTED     = OT_COAP_CODE(5, 1), ///< Not Implemented

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -737,6 +737,7 @@ const char *Message::CodeToString(void) const
         {kCodePreconditionFailed, "PreconditionFailed"},
         {kCodeRequestTooLarge, "RequestTooLarge"},
         {kCodeUnsupportedFormat, "UnsupportedFormat"},
+        {kCodeTooManyRequests, "TooManyRequests"},
         {kCodeInternalError, "InternalError"},
         {kCodeNotImplemented, "NotImplemented"},
         {kCodeBadGateway, "BadGateway"},

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -121,6 +121,7 @@ enum Code : uint8_t
     kCodePreconditionFailed = OT_COAP_CODE_PRECONDITION_FAILED, ///< Precondition Failed
     kCodeRequestTooLarge    = OT_COAP_CODE_REQUEST_TOO_LARGE,   ///< Request Entity Too Large
     kCodeUnsupportedFormat  = OT_COAP_CODE_UNSUPPORTED_FORMAT,  ///< Unsupported Content-Format
+    kCodeTooManyRequests    = OT_COAP_CODE_TOO_MANY_REQUESTS,   ///< RFC8516 Too Many Requests
 
     // Server Error Codes:
 

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -159,7 +159,23 @@ void MessagePool::FreeBuffers(Buffer *aBuffer)
 
 Error MessagePool::ReclaimBuffers(Message::Priority aPriority)
 {
-    return Get<MeshForwarder>().EvictMessage(aPriority, MeshForwarder::kEvictReasonNoMessageBuffer);
+    Error error = kErrorNotFound;
+
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    error = Get<MeshMonitor::Server>().EvictCache(true);
+
+    if (error != kErrorNone)
+    {
+        error = Get<MeshMonitor::Server>().EvictCache(false);
+    }
+#endif
+
+    if (error != kErrorNone)
+    {
+        error = Get<MeshForwarder>().EvictMessage(aPriority, MeshForwarder::kEvictReasonNoMessageBuffer);
+    }
+
+    return error;
 }
 
 uint16_t MessagePool::GetFreeBufferCount(void) const

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -110,6 +110,9 @@ void Notifier::EmitEvents(void)
 #if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
     Get<Dhcp6::Server>().HandleNotifierEvents(events);
 #endif
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    Get<MeshMonitor::Server>().HandleNotifierEvents(events);
+#endif
 #if OPENTHREAD_CONFIG_NEIGHBOR_DISCOVERY_AGENT_ENABLE
     Get<NeighborDiscovery::Agent>().HandleNotifierEvents(events);
 #endif

--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -173,6 +173,9 @@ Instance::Instance(void)
 #endif
     , mNetworkDataServiceManager(*this)
     , mVendorInfo(*this)
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    , mMeshMonitorServer(*this)
+#endif
     , mNetDiagServer(*this)
 #if OPENTHREAD_CONFIG_TMF_NETDIAG_CLIENT_ENABLE
     , mNetDiagClient(*this)

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -134,6 +134,7 @@
 #include "thread/link_metrics.hpp"
 #include "thread/link_quality.hpp"
 #include "thread/mesh_forwarder.hpp"
+#include "thread/mesh_monitor.hpp"
 #include "thread/message_framer.hpp"
 #include "thread/mle.hpp"
 #include "thread/mlr_manager.hpp"
@@ -715,6 +716,10 @@ private:
 
     VendorInfo mVendorInfo;
 
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    MeshMonitor::Server mMeshMonitorServer;
+#endif
+
     NetDiag::Server mNetDiagServer;
 #if OPENTHREAD_CONFIG_TMF_NETDIAG_CLIENT_ENABLE
     NetDiag::Client mNetDiagClient;
@@ -1128,6 +1133,10 @@ template <> inline Dns::Dso &Instance::Get(void) { return mDnsDso; }
 
 #if OPENTHREAD_CONFIG_MULTICAST_DNS_ENABLE
 template <> inline Dns::Multicast::Core &Instance::Get(void) { return mMdnsCore; }
+#endif
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+template <> inline MeshMonitor::Server &Instance::Get(void) { return mMeshMonitorServer; }
 #endif
 
 template <> inline VendorInfo &Instance::Get(void) { return mVendorInfo; }

--- a/src/core/thread/child.hpp
+++ b/src/core/thread/child.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include "common/bit_set.hpp"
+#include "thread/mesh_monitor.hpp"
 #include "thread/neighbor.hpp"
 
 namespace ot {
@@ -51,6 +52,10 @@ namespace ot {
  * Represents a Thread Child.
  */
 class Child : public CslNeighbor
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    ,
+              public MeshMonitor::Server::ChildInfo
+#endif
 {
 public:
     static constexpr uint8_t kMaxRequestTlvs = 6;

--- a/src/core/thread/mesh_monitor.cpp
+++ b/src/core/thread/mesh_monitor.cpp
@@ -1,0 +1,2514 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mesh_monitor.hpp"
+
+#include "instance/instance.hpp"
+
+namespace ot {
+
+RegisterLogModule("MeshMon");
+
+namespace MeshMonitor {
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+
+const TlvSet Server::kExtDelayTlvMask = [] {
+    TlvSet set;
+    set.Set(Tlv::kLastHeard);
+    set.Set(Tlv::kConnectionTime);
+    set.Set(Tlv::kLinkMarginIn);
+    set.Set(Tlv::kMacLinkErrorRatesTx);
+    set.Set(Tlv::kMacCounters);
+    set.Set(Tlv::kMacLinkErrorRatesRx);
+    set.Set(Tlv::kMleCounters);
+    set.Set(Tlv::kLinkMarginOut);
+    return set;
+}();
+
+const TlvSet Server::kStaticNeighborTlvMask = [] {
+    TlvSet set;
+    set.Set(Tlv::kExtAddress);
+    set.Set(Tlv::kConnectionTime);
+    set.Set(Tlv::kThreadSpecVersion);
+    return set;
+}();
+
+const TlvSet Server::kChildAttachSkipTlvMask = [] {
+    TlvSet set;
+    set.Set(Tlv::kThreadStackVersion);
+    set.Set(Tlv::kVendorName);
+    set.Set(Tlv::kVendorModel);
+    set.Set(Tlv::kVendorSwVersion);
+    set.Set(Tlv::kVendorAppUrl);
+    set.Set(Tlv::kEui64);
+    set.Set(Tlv::kMacCounters);
+    set.Set(Tlv::kMleCounters);
+    return set;
+}();
+
+#if OPENTHREAD_FTD
+void Server::ChildInfo::MarkHostProvidedTlvsChanged(TlvSet aTlvs)
+{
+    if (mIsFtd)
+    {
+        mDirtySet.SetAll(aTlvs.GetNonFtdChildProvided());
+    }
+    else
+    {
+        mDirtySet.SetAll(aTlvs.GetNonMtdChildProvided());
+    }
+}
+
+void Server::ChildInfo::CommitCacheUpdate(void)
+{
+    OT_ASSERT(mDiagCacheLocked);
+    mDiagCacheLocked = false;
+
+    mAttachStateDirty = false;
+
+    mDirtySet.Clear();
+    mCache.Free();
+    mCacheBuffers = 0;
+}
+
+void Server::ChildInfo::AbortCacheUpdate(void)
+{
+    OT_ASSERT(mDiagCacheLocked);
+    mDiagCacheLocked = false;
+
+    if (mCache == nullptr)
+    {
+        EvictCache();
+    }
+}
+
+TlvSet Server::ChildInfo::GetDirtyHostProvided(TlvSet aFilter) const
+{
+    TlvSet set = mDirtySet.Intersect(aFilter);
+
+    if (mIsFtd)
+    {
+        set = set.GetNonFtdChildProvided();
+    }
+    else
+    {
+        set = set.GetNonMtdChildProvided();
+    }
+
+    return set;
+}
+
+void Server::ChildInfo::EvictCache(void)
+{
+    TlvSet lost;
+
+    OT_ASSERT(!mDiagCacheLocked);
+
+    if (mIsFtd)
+    {
+        lost = mDirtySet.GetFtdChildProvided();
+    }
+    else
+    {
+        lost = mDirtySet.GetMtdChildProvided();
+    }
+
+    mDirtySet.ClearAll(lost);
+    mLostSet.SetAll(lost);
+
+    mCache.Free();
+    mCacheBuffers = 0;
+}
+
+void Server::ChildInfo::ClearCache(void)
+{
+    OT_ASSERT(!mDiagCacheLocked);
+
+    mDirtySet.Clear();
+    mLostSet.Clear();
+
+    mCache.Free();
+    mCacheBuffers = 0;
+}
+
+Error Server::ChildInfo::RemoveCachedTlv(uint8_t aType)
+{
+    Error    error  = kErrorNone;
+    uint16_t offset = 0;
+
+    VerifyOrExit(mCache != nullptr);
+
+    while (offset < mCache->GetLength())
+    {
+        uint32_t tlvSize;
+        union
+        {
+            Tlv         tlv;
+            ExtendedTlv extTlv;
+        };
+
+        SuccessOrExit(error = mCache->Read(offset, tlv));
+
+        if (tlv.IsExtended())
+        {
+            SuccessOrExit(error = mCache->Read(offset, extTlv));
+            tlvSize = sizeof(ExtendedTlv) + extTlv.GetLength();
+        }
+        else
+        {
+            tlvSize = sizeof(Tlv) + tlv.GetLength();
+        }
+
+        VerifyOrExit(static_cast<uint32_t>(offset) + tlvSize <= mCache->GetLength(), error = kErrorParse);
+
+        if (tlv.GetType() == aType)
+        {
+            mCache->RemoveHeader(offset, static_cast<uint16_t>(tlvSize));
+            break;
+        }
+
+        offset += static_cast<uint16_t>(tlvSize);
+    }
+
+exit:
+    return error;
+}
+
+Error Server::ChildInfo::UpdateCache(const Message &aMessage, TlvSet aFilter)
+{
+    Error    error     = kErrorNone;
+    uint16_t srcOffset = aMessage.GetOffset();
+
+    TlvSet      set;
+    OffsetRange srcRange;
+    union
+    {
+        Tlv         tlv;
+        ExtendedTlv extTlv;
+    };
+
+    // Prevent freeing the cache we are currently building
+    // If we run out of memory, the error handler of this function will free it
+    OT_ASSERT(!mDiagCacheLocked);
+    mDiagCacheLocked = true;
+
+    while (srcOffset < aMessage.GetLength())
+    {
+        uint32_t tlvSize;
+
+        SuccessOrExit(error = aMessage.Read(srcOffset, tlv));
+
+        if (tlv.IsExtended())
+        {
+            SuccessOrExit(error = aMessage.Read(srcOffset, extTlv));
+            tlvSize = sizeof(ExtendedTlv) + extTlv.GetLength();
+        }
+        else
+        {
+            tlvSize = sizeof(Tlv) + tlv.GetLength();
+        }
+
+        VerifyOrExit(static_cast<uint32_t>(srcOffset) + tlvSize <= aMessage.GetLength(), error = kErrorParse);
+
+        srcRange.Init(srcOffset, static_cast<uint16_t>(tlvSize));
+        srcOffset = srcRange.GetEndOffset();
+
+        set.Clear();
+        set.SetValue(tlv.GetType());
+        set = set.Intersect(aFilter);
+
+        if (mIsFtd)
+        {
+            set = set.GetFtdChildProvided();
+        }
+        else
+        {
+            set = set.GetMtdChildProvided();
+        }
+
+        if (set.IsEmpty())
+        {
+            continue;
+        }
+
+        if (mCache == nullptr)
+        {
+            mCache.Reset(aMessage.Get<MessagePool>().Allocate(Message::kTypeOther));
+            VerifyOrExit(mCache != nullptr, error = kErrorNoBufs);
+        }
+
+        // We already made sure the TLV is child provided. To keep exactly one
+        // copy of each TLV in the cache, remove any previously cached copy of
+        // this type before appending the newest value.
+        if (mDirtySet.ContainsAll(set))
+        {
+            SuccessOrExit(error = RemoveCachedTlv(tlv.GetType()));
+        }
+
+        SuccessOrExit(error = mCache->AppendBytesFromMessage(aMessage, srcRange.GetOffset(), srcRange.GetLength()));
+
+        mDirtySet.SetAll(set);
+    }
+
+    mLostSet.ClearAll(mDirtySet);
+
+exit:
+    mDiagCacheLocked = false;
+    if (error != kErrorNone)
+    {
+        // An error here could render the cache invalid, so we just clear it and query
+        // the tlvs again using the lost set
+        LogCrit("Diag cache error %s", ErrorToString(error));
+        EvictCache();
+    }
+
+    if (mCache != nullptr)
+    {
+        mCacheBuffers = mCache->GetBufferCount();
+    }
+
+    return error;
+}
+
+Error Server::ChildInfo::AppendCachedTlvs(Message &aMessage)
+{
+    Error error = kErrorNone;
+
+    VerifyOrExit(mCache != nullptr);
+    OT_ASSERT(mDiagCacheLocked);
+
+    SuccessOrExit(error = aMessage.AppendBytesFromMessage(*mCache, 0, mCache->GetLength()));
+
+exit:
+    return error;
+}
+#endif // OPENTHREAD_FTD
+
+Server::Server(Instance &aInstance)
+    : InstanceLocator(aInstance)
+    , mActive(false)
+    , mUpdateSent(false)
+#if OPENTHREAD_FTD
+    , mSendFullUpdate(false)
+    , mSendChildBaseline(false)
+    , mSendNeighborBaseline(false)
+    , mUpdatePending(false)
+    , mChildResumeIndex(0)
+    , mNeighborResumeIndex(0)
+    , mClientRloc(Mle::kInvalidRloc16)
+    , mUpdateRetryCount(0)
+    , mCacheSyncEvictions(0)
+    , mCachePollEvictions(0)
+    , mCacheErrors(0)
+    , mRouterStateMask(0)
+#endif // OPENTHREAD_FTD
+    , mUpdateTimer(aInstance)
+#if OPENTHREAD_FTD
+    , mChildTimer(aInstance)
+    , mRegistrationTimer(aInstance)
+#endif // OPENTHREAD_FTD
+{
+    mSelfEnabled.Clear();
+    mSelfPendingUpdate.Clear();
+    mSelfDirty.Clear();
+
+#if OPENTHREAD_FTD
+    mChildEnabled.Clear();
+
+    mNeighborEnabled.Clear();
+
+    mClientRegistered = false;
+#endif // OPENTHREAD_FTD
+}
+
+void Server::MarkDiagDirty(Tlv::Type aTlv)
+{
+    TlvSet set;
+    set.Clear();
+    set.Set(aTlv);
+    MarkDiagDirty(set);
+}
+
+void Server::MarkDiagDirty(TlvSet aTlvs)
+{
+    aTlvs.Filter(mSelfEnabled);
+
+    // If the server is inactive, the enabled set will always be 0 so this
+    // check will always fail.
+    if (!aTlvs.IsEmpty())
+    {
+        mSelfDirty.SetAll(aTlvs);
+        if (IsOnlyExtDelayTlvs(aTlvs))
+        {
+            ScheduleUpdateTimer(kUpdateExtDelay);
+        }
+        else
+        {
+            ScheduleUpdateTimer(kUpdateBaseDelay);
+        }
+    }
+}
+
+#if OPENTHREAD_FTD
+void Server::MarkChildDiagDirty(Child &aChild, Tlv::Type aTlv)
+{
+    TlvSet set;
+    set.Clear();
+    set.Set(aTlv);
+    MarkChildDiagDirty(aChild, set);
+}
+
+void Server::MarkChildDiagDirty(Child &aChild, TlvSet aTlvs)
+{
+    VerifyOrExit(aChild.IsStateValid());
+
+    aTlvs.Filter(mChildEnabled);
+    // Use mIsFtd to allow the compiler to optimize away the check in MarkHostProvidedTlvsChanged
+    if (aChild.mIsFtd)
+    {
+        aTlvs = aTlvs.GetNonFtdChildProvided();
+    }
+    else
+    {
+        aTlvs = aTlvs.GetNonMtdChildProvided();
+    }
+
+    // If the server is inactive, the enabled set will always be 0 so this
+    // check will always fail.
+    if (!aTlvs.IsEmpty())
+    {
+        aChild.MarkHostProvidedTlvsChanged(aTlvs);
+        if (IsOnlyExtDelayTlvs(aTlvs))
+        {
+            ScheduleUpdateTimer(kUpdateExtDelay);
+        }
+        else
+        {
+            ScheduleUpdateTimer(kUpdateBaseDelay);
+        }
+    }
+
+exit:
+    return;
+}
+
+void Server::HandleChildAdded(Child &aChild)
+{
+    aChild.ClearCache();
+    aChild.SetChildIsFtd(aChild.IsFullThreadDevice());
+    aChild.SetDiagServerState(Child::kDiagServerStopped);
+
+    VerifyOrExit(mActive);
+
+    aChild.SetAttachStateDirty();
+
+    if (!mChildEnabled.IsEmpty())
+    {
+        TlvSet set;
+
+        if (aChild.IsFullThreadDevice())
+        {
+            set = mChildEnabled.GetFtdChildProvided();
+        }
+        else
+        {
+            set = mChildEnabled.GetMtdChildProvided();
+        }
+
+        set.ClearAll(static_cast<const TlvSet &>(kChildAttachSkipTlvMask));
+
+        if (!set.IsEmpty())
+        {
+            IgnoreError(SendEndDeviceRequestStart(aChild, set, true));
+        }
+
+        ScheduleUpdateTimer(kUpdateBaseDelay);
+    }
+
+exit:
+    return;
+}
+
+void Server::HandleChildRemoved(Child &aChild)
+{
+    aChild.ClearCache();
+    aChild.SetDiagServerState(Child::kDiagServerStopped);
+
+    VerifyOrExit(mActive);
+
+    aChild.SetAttachStateDirty();
+
+    if (!mChildEnabled.IsEmpty())
+    {
+        ScheduleUpdateTimer(kUpdateBaseDelay);
+    }
+
+exit:
+    return;
+}
+
+void Server::HandleRouterAdded(Router &aRouter)
+{
+    VerifyOrExit(mActive);
+
+    mRouterStateMask |= (1ULL << aRouter.GetRouterId());
+
+    if (!mNeighborEnabled.IsEmpty())
+    {
+        ScheduleUpdateTimer(kUpdateBaseDelay);
+    }
+
+exit:
+    return;
+}
+
+void Server::HandleRouterRemoved(Router &aRouter)
+{
+    VerifyOrExit(mActive);
+
+    mRouterStateMask |= (1ULL << aRouter.GetRouterId());
+
+    if (!mNeighborEnabled.IsEmpty())
+    {
+        ScheduleUpdateTimer(kUpdateBaseDelay);
+    }
+
+exit:
+    return;
+}
+
+Error Server::EvictCache(bool aOnlyRxOn)
+{
+    Error error = kErrorNotFound;
+
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateAny))
+    {
+        if (!child.CanEvictCache())
+        {
+            continue;
+        }
+
+        if (child.IsStateValid())
+        {
+            if (!child.IsRxOnWhenIdle())
+            {
+                if (aOnlyRxOn)
+                {
+                    continue;
+                }
+
+#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+                if (!child.IsCslSynchronized())
+                {
+                    // First avoid non csl children as their poll intervals may be
+                    // very large
+                    continue;
+                }
+#endif // OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+            }
+
+            child.EvictCache();
+            mCacheSyncEvictions++;
+        }
+        else
+        {
+            child.ClearCache();
+        }
+
+        ExitNow(error = kErrorNone);
+    }
+
+    // Try evicting from any child
+    VerifyOrExit(!aOnlyRxOn);
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
+    {
+        if (!child.CanEvictCache())
+        {
+            continue;
+        }
+
+        child.EvictCache();
+        mCachePollEvictions++;
+        ExitNow(error = kErrorNone);
+    }
+
+exit:
+    if (error == kErrorNone)
+    {
+        ScheduleChildTimer();
+    }
+    return error;
+}
+#endif // OPENTHREAD_FTD
+
+void Server::HandleNotifierEvents(Events aEvents)
+{
+    TlvSet tlvs;
+
+    VerifyOrExit(mActive);
+
+    if (aEvents.ContainsAny(kEventIp6AddressAdded | kEventIp6AddressRemoved | kEventIp6MulticastSubscribed |
+                            kEventIp6MulticastUnsubscribed))
+    {
+        tlvs.Set(Tlv::kIp6AddressList);
+        tlvs.Set(Tlv::kIp6LinkLocalAddressList);
+        tlvs.Set(Tlv::kAlocList);
+        MarkDiagDirty(tlvs);
+    }
+
+exit:
+    return;
+}
+
+template <> void Server::HandleTmf<kUriMeshMonEndDeviceRequest>(Coap::Msg &aMsg)
+{
+    Error          error    = kErrorNone;
+    Coap::Message *response = nullptr;
+
+    ChildRequestHeader header;
+    TlvSet             set;
+    uint16_t           offset;
+    bool               changed = false;
+
+    VerifyOrExit(aMsg.IsPostRequest(), error = kErrorInvalidArgs);
+
+    LogInfo("Received %s from %s", UriToString<kUriMeshMonEndDeviceRequest>(),
+            aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());
+
+    VerifyOrExit(Get<Mle::Mle>().IsChild(), error = kErrorInvalidState);
+
+    SuccessOrExit(error = aMsg.mMessage.Read(aMsg.mMessage.GetOffset(), header));
+
+    offset = aMsg.mMessage.GetOffset() + sizeof(ChildRequestHeader);
+    SuccessOrExit(error = set.ReadFrom(aMsg.mMessage, offset, header.GetRequestSetCount()));
+
+    response = Get<Tmf::Agent>().AllocateAndInitResponseFor(aMsg.mMessage);
+    VerifyOrExit(response != nullptr, error = kErrorNoBufs);
+
+    switch (header.GetCommand())
+    {
+    case ChildRequestHeader::kStart:
+        changed = ConfigureAsEndDevice(set);
+        break;
+
+    case ChildRequestHeader::kStop:
+        StopServer();
+        break;
+
+    default:
+        break;
+    }
+
+    if (header.GetQuery() || changed)
+    {
+        SuccessOrExit(error = AppendHostTlvs(*response, mSelfEnabled));
+    }
+
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*response, aMsg.mMessageInfo));
+
+exit:
+    FreeMessageOnError(response, error);
+}
+
+#if OPENTHREAD_FTD
+template <> void Server::HandleTmf<kUriMeshMonEndDeviceUpdate>(Coap::Msg &aMsg)
+{
+    Child *child = nullptr;
+    TlvSet set;
+
+    VerifyOrExit(aMsg.mMessageInfo.GetPeerAddr().GetIid().IsRoutingLocator());
+    child = Get<ChildTable>().FindChild(aMsg.mMessageInfo.GetPeerAddr().GetIid().GetLocator(), Child::kInStateValid);
+
+    VerifyOrExit(child != nullptr);
+    VerifyOrExit(aMsg.IsPostRequest());
+
+    LogInfo("Received %s from %s", UriToString<kUriMeshMonEndDeviceRequest>(),
+            aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());
+
+    IgnoreError(Get<Tmf::Agent>().SendAckResponse(aMsg));
+
+    // If the child should be disabled, this will update it
+    SyncChildDiagState(*child, false);
+
+    if (child->IsFullThreadDevice())
+    {
+        set = mChildEnabled.GetFtdChildProvided();
+    }
+    else
+    {
+        set = mChildEnabled.GetMtdChildProvided();
+    }
+
+    if (child->UpdateCache(aMsg.mMessage, set) != kErrorNone)
+    {
+        mCacheErrors++;
+    }
+
+    if (child->ShouldSendDiagUpdate())
+    {
+        ScheduleUpdateTimer(kUpdateBaseDelay);
+    }
+
+    UpdateIfCacheBufferLimit();
+
+exit:
+    return;
+}
+
+template <> void Server::HandleTmf<kUriMeshMonServerRequest>(Coap::Msg &aMsg)
+{
+    RequestHeader  header;
+    RequestContext context;
+    uint16_t       offset;
+    uint16_t       setOffset;
+    TlvSet         set;
+
+    TlvSet hostSet;
+    TlvSet childSet;
+    TlvSet neighborSet;
+
+    VerifyOrExit(aMsg.IsPostRequest());
+    SuccessOrExit(aMsg.mMessage.Read(aMsg.mMessage.GetOffset(), header));
+
+    LogInfo("Received %s from %s", UriToString<kUriMeshMonServerRequest>(),
+            aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());
+
+    VerifyOrExit(Get<Mle::Mle>().IsRouterOrLeader());
+    VerifyOrExit(aMsg.mMessageInfo.GetPeerAddr().GetIid().IsRoutingLocator());
+
+    if (header.GetRegistration() && (mClientRloc != Mle::kInvalidRloc16) &&
+        (aMsg.mMessageInfo.GetPeerAddr().GetIid().GetLocator() != mClientRloc))
+    {
+        LogInfo("Rejecting registration from %04x, client %04x already registered",
+                aMsg.mMessageInfo.GetPeerAddr().GetIid().GetLocator(), mClientRloc);
+        IgnoreError(Get<Tmf::Agent>().SendAckResponse(aMsg, Coap::kCodeTooManyRequests));
+        ExitNow();
+    }
+
+    hostSet.Clear();
+    childSet.Clear();
+    neighborSet.Clear();
+
+    offset = aMsg.mMessage.GetOffset() + sizeof(RequestHeader);
+    while (offset < aMsg.mMessage.GetLength())
+    {
+        SuccessOrExit(aMsg.mMessage.Read(offset, context));
+
+        setOffset = offset + sizeof(RequestContext);
+        SuccessOrExit(set.ReadFrom(aMsg.mMessage, setOffset, context.GetRequestSetCount()));
+
+        switch (context.GetType())
+        {
+        case kTypeHost:
+            hostSet.SetAll(set);
+            break;
+
+        case kTypeChild:
+            childSet.SetAll(set);
+            break;
+
+        case kTypeNeighbor:
+            neighborSet.SetAll(set);
+            break;
+
+        default:
+            break;
+        }
+
+        VerifyOrExit(context.GetLength() >= sizeof(RequestContext) &&
+                     static_cast<uint32_t>(offset) + context.GetLength() <= aMsg.mMessage.GetLength());
+        offset += context.GetLength();
+    }
+
+    if (header.GetRegistration())
+    {
+        mClientRloc = aMsg.mMessageInfo.GetPeerAddr().GetIid().GetLocator();
+    }
+
+    SuccessOrExit(ConfigureAsRouter(hostSet, childSet, neighborSet, header.GetQuery()));
+
+    if (header.GetQuery())
+    {
+        uint32_t jitter = Random::NonCrypto::GenerateFromMinUpToExcluding<uint32_t>(0, 500);
+
+        mSendFullUpdate = true;
+        ScheduleUpdateTimer(jitter);
+    }
+    else if (header.GetRegistration())
+    {
+        IgnoreError(SendEmptyServerUpdate(aMsg.mMessageInfo.GetPeerAddr()));
+    }
+
+exit:
+    return;
+}
+#endif // OPENTHREAD_FTD
+
+bool Server::ConfigureAsEndDevice(const TlvSet &aTypes)
+{
+    bool changed = false;
+
+    if (!mActive)
+    {
+        mActive     = true;
+        mUpdateSent = false;
+
+        mSelfEnabled.Clear();
+        mSelfPendingUpdate.Clear();
+        mSelfDirty.Clear();
+
+#if OPENTHREAD_FTD
+        mChildEnabled.Clear();
+
+        mNeighborEnabled.Clear();
+
+        mClientRegistered = false;
+#endif
+    }
+
+    changed = mSelfEnabled != aTypes;
+
+    // Filter incoming requested TLVs to child-valid and seed enabled set
+    mSelfEnabled = aTypes;
+    mSelfEnabled.FilterChildSupportedTlv();
+
+    // Seed dirty set with existing ExtDelay policy
+    mSelfDirty.SetAll(GetExtDelayTlvs(mSelfEnabled));
+
+    // Mark dirty any requested TLVs that are child-provided (MTD/FTD)
+    // so they are sent via EU when explicitly requested by the router/client
+#if OPENTHREAD_FTD
+    {
+        TlvSet childProvidedRequested;
+        if (Get<Mle::Mle>().IsFullThreadDevice())
+        {
+            childProvidedRequested = mSelfEnabled.GetFtdChildProvided();
+        }
+        else
+        {
+            childProvidedRequested = mSelfEnabled.GetMtdChildProvided();
+        }
+
+        // Union requested child-provided TLVs into dirty set
+        mSelfDirty.SetAll(mSelfDirty.Join(childProvidedRequested));
+    }
+#endif
+
+    if (!mSelfDirty.IsEmpty())
+    {
+        ScheduleUpdateTimer(Random::NonCrypto::AddJitter(kUpdateExtDelay, kUpdateJitter));
+    }
+
+    return changed;
+}
+
+void Server::StopServer(void)
+{
+    mSelfEnabled.Clear();
+    mSelfPendingUpdate.Clear();
+
+    mUpdateTimer.Stop();
+#if OPENTHREAD_FTD
+    mRegistrationTimer.Stop();
+    mUpdatePending = false;
+
+    mChildEnabled.Clear();
+    mNeighborEnabled.Clear();
+
+    mClientRegistered = false;
+    mClientRloc       = Mle::kInvalidRloc16;
+
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateAny))
+    {
+        child.ClearCache();
+    }
+
+    if (Get<Mle::Mle>().IsRouterOrLeader())
+    {
+        // Stop child servers
+        ScheduleChildTimer();
+    }
+#endif
+
+    mActive = false;
+}
+
+Error Server::SendEndDeviceUpdate(void)
+{
+    Error          error   = kErrorNone;
+    Coap::Message *message = nullptr;
+
+    VerifyOrExit(Get<Mle::Mle>().IsChild(), error = kErrorInvalidState);
+    VerifyOrExit(!mUpdateSent, error = kErrorAlready);
+
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriMeshMonEndDeviceUpdate);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    SuccessOrExit(error = AppendHostTlvs(*message, mSelfDirty));
+    mSelfPendingUpdate = mSelfDirty;
+    mSelfDirty.Clear();
+
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageToRloc(*message, Get<Mle::Mle>().GetParentRloc16(),
+                                                              HandleEndDeviceUpdateAck, this));
+    mUpdateSent = true;
+
+exit:
+    if (error != kErrorNone)
+    {
+        LogCrit("Failed to send child update: %s", ErrorToString(error));
+    }
+    FreeMessageOnError(message, error);
+    return error;
+}
+
+void Server::HandleEndDeviceUpdateAck(Coap::Msg *aMsg, Error aResult)
+{
+    OT_UNUSED_VARIABLE(aMsg);
+
+    VerifyOrExit(mActive);
+
+    mUpdateSent = false;
+
+    if (aResult != kErrorNone)
+    {
+        mSelfDirty = mSelfDirty.Join(mSelfPendingUpdate);
+    }
+
+exit:
+    return;
+}
+
+#if OPENTHREAD_FTD
+Error Server::SendFullServerUpdate(const Ip6::Address &aClientAddr)
+{
+    Error error = kErrorNone;
+
+    Coap::Message *message = nullptr;
+
+    UpdateHeader header;
+
+    // Don't send if we have a pending update awaiting ACK
+    VerifyOrExit(!mUpdatePending, error = kErrorBusy);
+
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriMeshMonServerUpdate);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    header.Init();
+    header.SetComplete(true);
+    header.SetRouterId(Mle::RouterIdFromRloc16(Get<Mle::Mle>().GetRloc16()));
+    header.SetFullSeqNumber(mSequenceNumber + 1);
+    SuccessOrExit(error = header.AppendTo(*message));
+
+    if (!mSelfEnabled.IsEmpty())
+    {
+        SuccessOrExit(error = AppendHostContext(*message, mSelfEnabled));
+    }
+
+    if (!mChildEnabled.IsEmpty())
+    {
+        mSendChildBaseline = true;
+        ScheduleUpdateTimer(0);
+    }
+
+    if (!mNeighborEnabled.IsEmpty())
+    {
+        mSendNeighborBaseline = true;
+        // Initialize router state mask to mark all valid routers for baseline
+        mRouterStateMask = 0;
+
+        for (uint8_t id = 0; id < Mle::kMaxRouterId; id++)
+        {
+            Router *router = Get<RouterTable>().FindRouterById(id);
+
+            if (router != nullptr && router->IsStateValid())
+            {
+                mRouterStateMask |= (1ULL << id);
+            }
+        }
+
+        ScheduleUpdateTimer(0);
+    }
+
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, aClientAddr, HandleServerUpdateAck, this));
+    mUpdatePending = true;
+
+exit:
+    if (error != kErrorNone)
+    {
+        LogCrit("Failed to send response: %s", ErrorToString(error));
+    }
+    FreeMessageOnError(message, error);
+    return error;
+}
+
+Error Server::SendEmptyServerUpdate(const Ip6::Address &aClientAddr)
+{
+    Error error = kErrorNone;
+
+    Coap::Message *message = nullptr;
+
+    UpdateHeader header;
+
+    // Don't send if we have a pending update awaiting ACK
+    VerifyOrExit(!mUpdatePending, error = kErrorBusy);
+
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriMeshMonServerUpdate);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    header.Init();
+    header.SetRouterId(Mle::RouterIdFromRloc16(Get<Mle::Mle>().GetRloc16()));
+    header.SetFullSeqNumber(mSequenceNumber + 1);
+    SuccessOrExit(error = header.AppendTo(*message));
+
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, aClientAddr, HandleServerUpdateAck, this));
+    mUpdatePending = true;
+
+exit:
+    if (error != kErrorNone)
+    {
+        LogCrit("Failed to send response: %s", ErrorToString(error));
+    }
+    FreeMessageOnError(message, error);
+    return error;
+}
+
+Error Server::SendServerUpdate(void)
+{
+    Error error = kErrorNone;
+
+    Coap::Message *message = nullptr;
+
+    UpdateHeader header;
+    TlvSet       hostSet;
+    Context      hostContext;
+    uint16_t     offset;
+    uint16_t     startIndex         = mChildResumeIndex;
+    uint8_t      neighborStartIndex = mNeighborResumeIndex;
+    bool         needsAnotherUpdate = false;
+    bool         neighborNeedsMore  = false;
+
+    // Don't send if we have a pending update awaiting ACK
+    VerifyOrExit(!mUpdatePending, error = kErrorBusy);
+
+    LockChildCaches();
+
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriMeshMonServerUpdate);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    header.Init();
+    header.SetRouterId(Mle::RouterIdFromRloc16(Get<Mle::Mle>().GetRloc16()));
+    header.SetShortSeqNumber(mSequenceNumber + 1);
+
+    SuccessOrExit(error = header.AppendTo(*message));
+
+    // Host TLVs only in first batch
+    if (startIndex == 0)
+    {
+        hostSet = mSelfDirty.Intersect(mSelfEnabled);
+        if (!hostSet.IsEmpty())
+        {
+            hostContext.Init();
+            hostContext.SetType(kTypeHost);
+
+            offset = message->GetLength();
+            SuccessOrExit(error = message->Append(hostContext));
+            SuccessOrExit(error = AppendHostTlvs(*message, hostSet));
+            hostContext.SetLength(message->GetLength() - offset);
+            message->Write(offset, hostContext);
+        }
+    }
+
+    // Child updates
+    if (!mChildEnabled.IsEmpty())
+    {
+        VerifyOrExit(AppendChildContextBatch(*message, needsAnotherUpdate), error = kErrorFailed);
+    }
+
+    // Neighbor updates only after children are done
+    if (!mNeighborEnabled.IsEmpty() && !needsAnotherUpdate && mChildResumeIndex == 0)
+    {
+        VerifyOrExit(AppendNeighborContextBatch(*message, neighborNeedsMore), error = kErrorFailed);
+    }
+
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageToRloc(*message, mClientRloc, HandleServerUpdateAck, this));
+
+    mUpdatePending = true;
+
+    if (startIndex == 0 && neighborStartIndex == 0)
+    {
+        mSelfDirty.Clear();
+    }
+
+exit:
+    if (error == kErrorNone)
+    {
+        CommitChildCacheUpdates();
+
+        if (!mUpdatePending && (needsAnotherUpdate || mSendChildBaseline || neighborNeedsMore || mSendNeighborBaseline))
+        {
+            ScheduleUpdateTimer(0);
+        }
+    }
+    else if (error == kErrorBusy)
+    {
+        // If busy due to pending ACK, don't treat as error
+    }
+    else
+    {
+        LogCrit("Failed to send router update %s", ErrorToString(error));
+        UnlockChildCaches();
+        FreeMessage(message);
+        mChildResumeIndex = 0;
+
+        ScheduleChildTimer();
+    }
+    return error;
+}
+
+Error Server::ConfigureAsRouter(const TlvSet &aSelf, const TlvSet &aChild, const TlvSet &aNeighbor, bool aQuery)
+{
+    Error  error = kErrorNone;
+    TlvSet oldFtd;
+    TlvSet oldMtd;
+
+    if (!mActive)
+    {
+        VerifyOrExit(!aSelf.IsEmpty() || !aChild.IsEmpty() || !aNeighbor.IsEmpty(), error = kErrorInvalidArgs);
+
+        mSequenceNumber = Random::NonCrypto::Generate<uint32_t>();
+        mSequenceNumber |= static_cast<uint64_t>(Random::NonCrypto::Generate<uint32_t>()) << 32;
+
+        mSelfEnabled.Clear();
+        mSelfPendingUpdate.Clear();
+        mSelfDirty.Clear();
+
+        mChildEnabled.Clear();
+        mChildResumeIndex = 0;
+        mUpdatePending    = false;
+
+        mNeighborEnabled.Clear();
+
+        mClientRegistered = false;
+
+        mActive = true;
+
+        mRouterStateMask = 0;
+
+        mRegistrationTimer.Start(kRegistrationInterval);
+    }
+
+    mSelfEnabled = aSelf;
+    mSelfEnabled.FilterHostSupportedTlv();
+
+    mSelfDirty.SetAll(GetExtDelayTlvs(mSelfEnabled));
+
+    oldFtd = mChildEnabled.GetFtdChildProvided();
+    oldMtd = mChildEnabled.GetMtdChildProvided();
+
+    mChildEnabled = aChild;
+    mChildEnabled.FilterChildSupportedTlv();
+
+    SyncAllChildDiagStates(oldFtd != mChildEnabled.GetFtdChildProvided(), oldMtd != mChildEnabled.GetMtdChildProvided(),
+                           aQuery);
+
+    mNeighborEnabled = aNeighbor;
+    mNeighborEnabled.FilterNeighborSupportedTlv();
+
+    // Mark client registered for this interval
+    mClientRegistered = true;
+
+    if (!mSelfDirty.IsEmpty())
+    {
+        ScheduleUpdateTimer(Random::NonCrypto::AddJitter(kUpdateExtDelay, kUpdateJitter));
+    }
+
+exit:
+    return error;
+}
+
+void Server::SyncAllChildDiagStates(bool aMtdChanged, bool aFtdChanged, bool aQuery)
+{
+    bool changed;
+
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
+    {
+        if (child.IsFullThreadDevice())
+        {
+            changed = aFtdChanged;
+        }
+        else
+        {
+            changed = aMtdChanged;
+        }
+
+        SyncChildDiagState(child, changed | aQuery);
+    }
+}
+
+void Server::SyncChildDiagState(Child &aChild, bool aQuery)
+{
+    TlvSet set;
+
+    if (aChild.IsFullThreadDevice())
+    {
+        set = mChildEnabled.GetFtdChildProvided();
+    }
+    else
+    {
+        set = mChildEnabled.GetMtdChildProvided();
+    }
+
+    if (set.IsEmpty())
+    {
+        aChild.ClearCache();
+
+        switch (aChild.GetDiagServerState())
+        {
+        case Child::kDiagServerActive:
+        case Child::kDiagServerActivePending:
+        case Child::kDiagServerUnknown:
+            IgnoreError(SendEndDeviceRequestStop(aChild));
+            break;
+
+        case Child::kDiagServerStopped:
+        case Child::kDiagServerStopPending:
+            break;
+        }
+    }
+    else
+    {
+        switch (aChild.GetDiagServerState())
+        {
+        case Child::kDiagServerActive:
+        case Child::kDiagServerActivePending:
+            if (!aQuery)
+            {
+                break;
+            }
+            // If SendEndDeviceRequestStart fails it will still stop the pending transaction
+            // and set state to unknown so the next update will retry even
+            // without aQuery being set.
+            OT_FALL_THROUGH;
+
+        case Child::kDiagServerUnknown:
+            // Make sure we always query after failed updates
+            aQuery = true;
+            OT_FALL_THROUGH;
+
+        case Child::kDiagServerStopped:
+        case Child::kDiagServerStopPending:
+            IgnoreError(SendEndDeviceRequestStart(aChild, set, aQuery));
+            break;
+        }
+    }
+}
+
+Error Server::SendEndDeviceRequestStop(Child &aChild)
+{
+    Error          error   = kErrorNone;
+    Coap::Message *message = nullptr;
+
+    ChildRequestHeader header;
+
+    if (aChild.IsDiagServerPending())
+    {
+        IgnoreError(Get<Tmf::Agent>().AbortTransaction(HandleEndDeviceRequestAck, &aChild));
+    }
+
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriMeshMonEndDeviceRequest);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    header.Clear();
+    header.SetCommand(ChildRequestHeader::kStop);
+
+    SuccessOrExit(error = message->Append(header));
+
+    SuccessOrExit(
+        error = Get<Tmf::Agent>().SendMessageToRloc(*message, aChild.GetRloc16(), HandleEndDeviceRequestAck, &aChild));
+    aChild.SetDiagServerState(Child::kDiagServerStopPending);
+
+    LogInfo("Sent DiagServer stop to child %04x", aChild.GetRloc16());
+
+exit:
+    FreeMessageOnError(message, error);
+    return error;
+}
+
+Error Server::SendEndDeviceRequestStart(Child &aChild, const TlvSet &aTypes, bool aQuery)
+{
+    Error          error   = kErrorNone;
+    Coap::Message *message = nullptr;
+
+    ChildRequestHeader header;
+    uint16_t           offset;
+    uint8_t            setCount = 0;
+
+    if (aChild.IsDiagServerPending())
+    {
+        IgnoreError(Get<Tmf::Agent>().AbortTransaction(HandleEndDeviceRequestAck, &aChild));
+    }
+
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriMeshMonEndDeviceRequest);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    offset = message->GetLength();
+
+    header.Clear();
+    header.SetCommand(ChildRequestHeader::kStart);
+    header.SetQuery(aQuery);
+
+    SuccessOrExit(error = message->Append(header));
+    SuccessOrExit(error = aTypes.AppendTo(*message, setCount));
+
+    header.SetRequestSetCount(setCount);
+    message->Write(offset, header);
+
+    SuccessOrExit(
+        error = Get<Tmf::Agent>().SendMessageToRloc(*message, aChild.GetRloc16(), HandleEndDeviceRequestAck, &aChild));
+    aChild.SetDiagServerState(Child::kDiagServerActivePending);
+
+    LogInfo("Sent DiagServer start to child %04x", aChild.GetRloc16());
+
+exit:
+    FreeMessageOnError(message, error);
+    return error;
+}
+
+Error Server::SendEndDeviceRecoveryQuery(Child &aChild, const TlvSet &aTypes)
+{
+    Error          error   = kErrorNone;
+    Coap::Message *message = nullptr;
+
+    ChildRequestHeader header;
+    uint16_t           offset;
+    uint8_t            setCount = 0;
+
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriMeshMonEndDeviceRequest);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    offset = message->GetLength();
+
+    header.Clear();
+    header.SetCommand(ChildRequestHeader::kStart);
+    header.SetQuery(true);
+
+    SuccessOrExit(error = message->Append(header));
+    SuccessOrExit(error = aTypes.AppendTo(*message, setCount));
+
+    header.SetRequestSetCount(setCount);
+    message->Write(offset, header);
+
+    SuccessOrExit(
+        error = Get<Tmf::Agent>().SendMessageToRloc(*message, aChild.GetRloc16(), HandleEndDeviceRecoveryAck, &aChild));
+    aChild.SetLostDiagQueryPending(true);
+
+    LogInfo("Sent DiagServer lost query to child %04x", aChild.GetRloc16());
+
+exit:
+    FreeMessageOnError(message, error);
+    return error;
+}
+
+void Server::HandleEndDeviceRequestAck(Child &aChild, Coap::Msg *aMsg, Error aResult)
+{
+    ChildInfo::DiagState state = aChild.GetDiagServerState();
+
+    if (aResult == kErrorNone)
+    {
+        if (state == Child::kDiagServerActivePending)
+        {
+            state = Child::kDiagServerActive;
+            LogInfo("Child %04x state changed to active", aChild.GetRloc16());
+        }
+        else if (state == Child::kDiagServerStopPending)
+        {
+            state = Child::kDiagServerStopped;
+            LogInfo("Child %04x state changed to stopped", aChild.GetRloc16());
+        }
+        else
+        {
+            LogWarn("Received response for child but state is not pending");
+            state = Child::kDiagServerUnknown;
+        }
+
+        aChild.SetDiagServerState(state);
+
+        VerifyOrExit(aMsg != nullptr);
+        if (aChild.UpdateCache(aMsg->mMessage, mChildEnabled) == kErrorNone)
+        {
+            ScheduleUpdateTimer(kUpdateBaseDelay);
+        }
+        else
+        {
+            mCacheErrors++;
+            // TODO: Cache allocation failure handling
+            //
+            // When UpdateCache() fails, typically kErrorNoBufs, we face a recovery dilemma:
+            // 1. The CoAP ACK was already sent -> child thinks we received the data
+            // 2. We are out of memory -> cannot allocate buffers to store the response
+            // 3. The child won't retry -> it believes transmission succeeded
+            //
+            // Current mitigation: mCacheErrors counter tracks failures, mLostSet marks
+            // missing TLVs for later re-query via SendEndDeviceRecoveryQuery().
+        }
+
+        UpdateIfCacheBufferLimit();
+    }
+    else
+    {
+        aChild.SetDiagServerState(Child::kDiagServerUnknown);
+    }
+
+exit:
+    // Verify child state
+    ScheduleChildTimer();
+}
+
+void Server::HandleEndDeviceRequestAck(void *aContext, Coap::Msg *aMsg, Error aResult)
+{
+    OT_ASSERT(aContext != nullptr);
+
+    Child *child = static_cast<Child *>(aContext);
+
+    child->GetInstance().Get<Server>().HandleEndDeviceRequestAck(*child, aMsg, aResult);
+}
+
+void Server::HandleEndDeviceRecoveryAck(Child &aChild, Coap::Msg *aMsg, Error aResult)
+{
+    aChild.SetLostDiagQueryPending(false);
+
+    if (aResult == kErrorNone)
+    {
+        OT_ASSERT(aMsg != nullptr);
+        if (aChild.UpdateCache(aMsg->mMessage, aChild.GetLostDiag()) != kErrorNone)
+        {
+            mCacheErrors++;
+        }
+
+        UpdateIfCacheBufferLimit();
+    }
+    else
+    {
+        // Retry later
+        ScheduleChildTimer();
+    }
+}
+
+void Server::HandleEndDeviceRecoveryAck(void *aContext, Coap::Msg *aMsg, Error aResult)
+{
+    OT_ASSERT(aContext != nullptr);
+
+    Child *child = static_cast<Child *>(aContext);
+
+    child->GetInstance().Get<Server>().HandleEndDeviceRecoveryAck(*child, aMsg, aResult);
+}
+
+void Server::HandleServerUpdateAck(Coap::Msg *aMsg, Error aResult)
+{
+    OT_UNUSED_VARIABLE(aMsg);
+
+    mUpdatePending = false;
+
+    if (aResult == kErrorNone)
+    {
+        mSequenceNumber++;
+        mUpdateRetryCount = 0; // Reset backoff counter on success
+
+        // If more batches pending, schedule next send
+        if (mSendChildBaseline || mChildResumeIndex != 0 || mSendNeighborBaseline || mNeighborResumeIndex != 0)
+        {
+            ScheduleUpdateTimer(0);
+        }
+    }
+    else
+    {
+        mUpdateRetryCount++;
+
+        if (mUpdateRetryCount >= kMaxUpdateRetries)
+        {
+            // Give up after 5 retry attempts. Increment sequence to maintain at-most-once semantics.
+            //
+            // Case 1: Client received the message but ACK was lost
+            //   -> Incrementing keeps our sequence in sync with client (both at N+1)
+            //   -> Without increment, we would send duplicate seq=(N+1) later
+            //
+            // Case 2: Client never received the message
+            //   -> Client detects sequence gap (expected N+1, gets N+2 later)
+            //   -> Client sends error query to request resync
+            //
+            // NOTE: We clear mChildResumeIndex and mSendChildBaseline to discard any pending
+            // child updates that haven't been sent yet. The client will detect missing data
+            // and request a full resync.
+
+            mSequenceNumber++;
+            mUpdateRetryCount = 0;
+            mSelfDirty.Clear();
+            mChildResumeIndex     = 0;
+            mSendChildBaseline    = false;
+            mNeighborResumeIndex  = 0;
+            mSendNeighborBaseline = false;
+        }
+        else
+        {
+            uint32_t backoffDelay = kUpdateBaseDelay << (mUpdateRetryCount - 1);
+            backoffDelay          = Min(backoffDelay, kMaxUpdateBackoff);
+
+            ScheduleUpdateTimer(backoffDelay);
+        }
+    }
+}
+#endif // OPENTHREAD_FTD
+
+Error Server::AppendHostTlvs(Message &aMessage, TlvSet aTlvs)
+{
+    Error error = kErrorNone;
+
+    for (Tlv::Type type : aTlvs)
+    {
+        switch (type)
+        {
+#if OPENTHREAD_FTD
+        case Tlv::kExtAddress:
+            SuccessOrExit(error = Tlv::Append<ExtAddressTlv>(aMessage, Get<Mac::Mac>().GetExtAddress()));
+            break;
+
+        case Tlv::kMode:
+            SuccessOrExit(error = Tlv::Append<ModeTlv>(aMessage, Get<Mle::Mle>().GetDeviceMode().Get()));
+            break;
+
+        case Tlv::kRoute64:
+            SuccessOrExit(error = Get<RouterTable>().AppendRouteTlv(aMessage, Tlv::kRoute64));
+            break;
+#endif
+
+        case Tlv::kMlEid:
+            SuccessOrExit(error = Tlv::Append<MlEidTlv>(aMessage, Get<Mle::Mle>().GetMeshLocalEid().GetIid()));
+            break;
+
+        case Tlv::kIp6AddressList:
+            SuccessOrExit(error = AppendHostIp6AddressList(aMessage));
+            break;
+
+        case Tlv::kAlocList:
+            SuccessOrExit(error = AppendHostAlocList(aMessage));
+            break;
+
+#if OPENTHREAD_FTD
+        case Tlv::kThreadSpecVersion:
+            SuccessOrExit(error = Tlv::Append<ThreadSpecVersionTlv>(aMessage, kThreadVersion));
+            break;
+#endif
+
+        case Tlv::kThreadStackVersion:
+            SuccessOrExit(error = Tlv::Append<ThreadStackVersionTlv>(aMessage, otGetVersionString()));
+            break;
+
+        case Tlv::kVendorName:
+            SuccessOrExit(error = Tlv::Append<VendorNameTlv>(aMessage, Get<VendorInfo>().GetName()));
+            break;
+
+        case Tlv::kVendorModel:
+            SuccessOrExit(error = Tlv::Append<VendorModelTlv>(aMessage, Get<VendorInfo>().GetModel()));
+            break;
+
+        case Tlv::kVendorSwVersion:
+            SuccessOrExit(error = Tlv::Append<VendorSwVersionTlv>(aMessage, Get<VendorInfo>().GetSwVersion()));
+            break;
+
+        case Tlv::kVendorAppUrl:
+            SuccessOrExit(error = Tlv::Append<VendorAppUrlTlv>(aMessage, Get<VendorInfo>().GetAppUrl()));
+            break;
+
+        case Tlv::kIp6LinkLocalAddressList:
+            SuccessOrExit(error = AppendHostLinkLocalAddressList(aMessage));
+            break;
+
+        case Tlv::kEui64:
+        {
+            Mac::ExtAddress eui64;
+
+            Get<Radio>().GetIeeeEui64(eui64);
+            SuccessOrExit(error = Tlv::Append<Eui64Tlv>(aMessage, eui64));
+            break;
+        }
+
+        case Tlv::kMacCounters:
+        {
+            NetDiag::MacCountersTlvValue tlvValue;
+            const Mac::Counters         &counters = Get<Mac::Mac>().GetCounters();
+
+            tlvValue.InitFrom(counters);
+            SuccessOrExit(error = Tlv::Append<MacCountersTlv>(aMessage, tlvValue));
+            break;
+        }
+
+        case Tlv::kMacLinkErrorRatesRx:
+        {
+            MacLinkErrorRatesRxTlv tlv;
+            Parent                &parent = Get<Mle::Mle>().GetParent();
+
+            VerifyOrExit(Get<Mle::Mle>().IsChild());
+
+            tlv.Init();
+            tlv.SetMessageErrorRates(parent.GetLinkInfo().GetMessageErrorRate());
+            tlv.SetFrameErrorRates(parent.GetLinkInfo().GetFrameErrorRate());
+
+            SuccessOrExit(error = aMessage.Append(tlv));
+            break;
+        }
+
+        case Tlv::kMleCounters:
+        {
+            NetDiag::MleCountersTlvValue tlvValue;
+
+            tlvValue.InitFrom(Get<Mle::Mle>().GetCounters());
+            SuccessOrExit(error = Tlv::Append<MleCountersTlv>(aMessage, tlvValue));
+            break;
+        }
+
+        case Tlv::kLinkMarginOut:
+        {
+            LinkMarginOutTlv tlv;
+            Parent          &parent = Get<Mle::Mle>().GetParent();
+
+            VerifyOrExit(Get<Mle::Mle>().IsChild());
+
+            tlv.Init();
+            tlv.SetLinkMargin(parent.GetLinkInfo().GetLinkMargin());
+            tlv.SetAverageRssi(parent.GetLinkInfo().GetAverageRss());
+            tlv.SetLastRssi(parent.GetLinkInfo().GetLastRss());
+
+            SuccessOrExit(error = aMessage.Append(tlv));
+            break;
+        }
+
+        default:
+            break;
+        }
+    }
+
+exit:
+    return error;
+}
+
+#if OPENTHREAD_FTD
+Error Server::AppendHostContext(Message &aMessage, TlvSet aTlvs)
+{
+    Error error = kErrorNone;
+
+    Context  context;
+    uint16_t offset = aMessage.GetLength();
+
+    context.Init();
+    context.SetType(kTypeHost);
+    SuccessOrExit(error = aMessage.Append(context));
+
+    SuccessOrExit(error = AppendHostTlvs(aMessage, aTlvs));
+
+    context.SetLength(aMessage.GetLength() - offset);
+    aMessage.Write(offset, context);
+
+exit:
+    return error;
+}
+
+Error Server::AppendChildContext(Message &aMessage, Child &aChild)
+{
+    Error error = kErrorNone;
+
+    ChildContext context;
+    uint16_t     offset  = aMessage.GetLength();
+    bool         allTlvs = false;
+
+    VerifyOrExit(aChild.ShouldSendDiagUpdate());
+
+    context.Init();
+    context.SetType(kTypeChild);
+    context.SetId(Mle::ChildIdFromRloc16(aChild.GetRloc16()));
+    SuccessOrExit(error = aMessage.Append(context));
+
+    context.SetUpdateMode(kModeUpdated);
+
+    if (aChild.IsAttachStateDirty())
+    {
+        if (aChild.IsStateValid())
+        {
+            context.SetUpdateMode(kModeAdded);
+            allTlvs = true;
+        }
+        else
+        {
+            context.SetUpdateMode(kModeRemoved);
+        }
+    }
+
+    if (aChild.IsStateValid())
+    {
+        TlvSet tlvs = aChild.GetDirtyHostProvided(mChildEnabled);
+        if (allTlvs)
+        {
+            if (aChild.mIsFtd)
+            {
+                tlvs = mChildEnabled.GetNonFtdChildProvided();
+            }
+            else
+            {
+                tlvs = mChildEnabled.GetNonMtdChildProvided();
+            }
+        }
+
+        SuccessOrExit(error = AppendChildTlvs(aMessage, tlvs, aChild));
+        SuccessOrExit(error = aChild.AppendCachedTlvs(aMessage));
+    }
+
+    context.SetLength(aMessage.GetLength() - offset);
+    aMessage.Write(offset, context);
+
+exit:
+    return error;
+}
+
+Error Server::AppendChildTlvs(Message &aMessage, TlvSet aTlvs, const Child &aChild)
+{
+    Error error = kErrorNone;
+
+    for (Tlv::Type type : aTlvs)
+    {
+        switch (type)
+        {
+        case Tlv::kExtAddress:
+            SuccessOrExit(error = Tlv::Append<ExtAddressTlv>(aMessage, aChild.GetExtAddress()));
+            break;
+
+        case Tlv::kMode:
+            SuccessOrExit(error = Tlv::Append<ModeTlv>(aMessage, aChild.GetDeviceMode().Get()));
+            break;
+
+        case Tlv::kTimeout:
+            SuccessOrExit(error = Tlv::Append<TimeoutTlv>(aMessage, aChild.GetTimeout()));
+            break;
+
+        case Tlv::kLastHeard:
+            SuccessOrExit(error = Tlv::Append<LastHeardTlv>(aMessage, TimerMilli::GetNow() - aChild.GetLastHeard()));
+            break;
+
+        case Tlv::kConnectionTime:
+            SuccessOrExit(error = Tlv::Append<ConnectionTimeTlv>(aMessage, aChild.GetConnectionTime()));
+            break;
+
+        case Tlv::kCsl:
+        {
+            CslTlv tlv;
+            tlv.Init();
+
+#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+            tlv.SetChannel(aChild.GetCslChannel());
+            tlv.SetTimeout(aChild.GetCslTimeout());
+
+            if (aChild.IsCslSynchronized())
+            {
+                tlv.SetPeriod(aChild.GetCslPeriod());
+            }
+#endif
+
+            SuccessOrExit(error = aMessage.Append(tlv));
+            break;
+        }
+
+        case Tlv::kLinkMarginIn:
+        {
+            LinkMarginInTlv tlv;
+            tlv.Init();
+
+            tlv.SetLinkMargin(aChild.GetLinkInfo().GetLinkMargin());
+            tlv.SetAverageRssi(aChild.GetLinkInfo().GetAverageRss());
+            tlv.SetLastRssi(aChild.GetLinkInfo().GetLastRss());
+
+            SuccessOrExit(error = aMessage.Append(tlv));
+            break;
+        }
+
+        case Tlv::kMacLinkErrorRatesTx:
+        {
+            MacLinkErrorRatesTxTlv tlv;
+            tlv.Init();
+
+            tlv.SetMessageErrorRates(aChild.GetLinkInfo().GetMessageErrorRate());
+            tlv.SetFrameErrorRates(aChild.GetLinkInfo().GetFrameErrorRate());
+
+            SuccessOrExit(error = aMessage.Append(tlv));
+            break;
+        }
+
+        case Tlv::kMlEid:
+            SuccessOrExit(error = Tlv::Append<MlEidTlv>(aMessage, aChild.GetMeshLocalIid()));
+            break;
+
+        case Tlv::kIp6AddressList:
+            SuccessOrExit(error = AppendChildIp6AddressList(aMessage, aChild));
+            break;
+
+        case Tlv::kAlocList:
+            SuccessOrExit(error = AppendChildAlocList(aMessage, aChild));
+            break;
+
+        case Tlv::kThreadSpecVersion:
+            SuccessOrExit(error = Tlv::Append<ThreadSpecVersionTlv>(aMessage, aChild.GetVersion()));
+            break;
+
+        default:
+            break;
+        }
+    }
+
+exit:
+    return error;
+}
+
+Error Server::AppendNeighborContextBaseline(Message &aMessage, const Router &aRouter)
+{
+    Error error = kErrorNone;
+
+    NeighborContext context;
+    uint16_t        offset = aMessage.GetLength();
+
+    context.Init();
+    context.SetType(kTypeNeighbor);
+    context.SetId(aRouter.GetRouterId());
+    context.SetUpdateMode(kModeAdded);
+    SuccessOrExit(error = aMessage.Append(context));
+    SuccessOrExit(error = AppendNeighborTlvs(aMessage, mNeighborEnabled, aRouter));
+
+    context.SetLength(aMessage.GetLength() - offset);
+    aMessage.Write(offset, context);
+
+exit:
+    return error;
+}
+
+Error Server::AppendNeighborContextUpdate(Message &aMessage, uint8_t aId)
+{
+    Error   error  = kErrorNone;
+    Router *router = Get<RouterTable>().FindRouterById(aId);
+    bool    valid  = (router != nullptr) && router->IsStateValid();
+    TlvSet  tlvs   = mNeighborEnabled;
+
+    NeighborContext context;
+    uint16_t        offset = aMessage.GetLength();
+
+    VerifyOrExit(valid || (mRouterStateMask & (1ULL << aId)) != 0);
+
+    context.Init();
+    context.SetType(kTypeNeighbor);
+    context.SetId(aId);
+    if (valid)
+    {
+        if (mRouterStateMask & (1ULL << aId))
+        {
+            context.SetUpdateMode(kModeAdded);
+        }
+        else
+        {
+            context.SetUpdateMode(kModeUpdated);
+
+            tlvs.ClearAll(static_cast<const TlvSet &>(kStaticNeighborTlvMask));
+            VerifyOrExit(!tlvs.IsEmpty());
+        }
+    }
+    else
+    {
+        context.SetUpdateMode(kModeRemoved);
+    }
+    SuccessOrExit(error = aMessage.Append(context));
+
+    if (valid)
+    {
+        SuccessOrExit(error = AppendNeighborTlvs(aMessage, tlvs, *router));
+    }
+
+    context.SetLength(aMessage.GetLength() - offset);
+    aMessage.Write(offset, context);
+
+exit:
+    return error;
+}
+
+Error Server::AppendNeighborTlvs(Message &aMessage, TlvSet aTlvs, const Router &aNeighbor)
+{
+    Error error = kErrorNone;
+
+    for (Tlv::Type type : aTlvs)
+    {
+        switch (type)
+        {
+        case Tlv::kExtAddress:
+            SuccessOrExit(error = Tlv::Append<ExtAddressTlv>(aMessage, aNeighbor.GetExtAddress()));
+            break;
+
+        case Tlv::kLastHeard:
+            SuccessOrExit(error = Tlv::Append<LastHeardTlv>(aMessage, TimerMilli::GetNow() - aNeighbor.GetLastHeard()));
+            break;
+
+        case Tlv::kConnectionTime:
+            SuccessOrExit(error = Tlv::Append<ConnectionTimeTlv>(aMessage, aNeighbor.GetConnectionTime()));
+            break;
+
+        case Tlv::kLinkMarginIn:
+        {
+            LinkMarginInTlv tlv;
+            tlv.Init();
+
+            tlv.SetLinkMargin(aNeighbor.GetLinkInfo().GetLinkMargin());
+            tlv.SetAverageRssi(aNeighbor.GetLinkInfo().GetAverageRss());
+            tlv.SetLastRssi(aNeighbor.GetLinkInfo().GetLastRss());
+
+            SuccessOrExit(error = aMessage.Append(tlv));
+            break;
+        }
+
+        case Tlv::kMacLinkErrorRatesTx:
+        {
+            MacLinkErrorRatesTxTlv tlv;
+            tlv.Init();
+
+            tlv.SetMessageErrorRates(aNeighbor.GetLinkInfo().GetMessageErrorRate());
+            tlv.SetFrameErrorRates(aNeighbor.GetLinkInfo().GetFrameErrorRate());
+
+            SuccessOrExit(error = aMessage.Append(tlv));
+            break;
+        }
+
+        case Tlv::kThreadSpecVersion:
+            SuccessOrExit(error = Tlv::Append<ThreadSpecVersionTlv>(aMessage, aNeighbor.GetVersion()));
+            break;
+
+        default:
+            break;
+        }
+    }
+
+exit:
+    return error;
+}
+
+bool Server::AppendChildContextBatch(Message &aMessage, bool &aNeedsMore)
+{
+    bool               success        = true;
+    uint16_t           childIndex     = 0;
+    uint16_t           startIndex     = mChildResumeIndex;
+    Child::StateFilter filter         = mSendChildBaseline ? Child::kInStateValid : Child::kInStateAny;
+    bool               abortRemaining = false;
+
+    aNeedsMore = false;
+
+    for (Child &child : Get<ChildTable>().Iterate(filter))
+    {
+        if (abortRemaining)
+        {
+            child.AbortCacheUpdate();
+            childIndex++;
+            continue;
+        }
+
+        if (childIndex < startIndex)
+        {
+            childIndex++;
+            continue;
+        }
+
+        if (mSendChildBaseline)
+        {
+            child.SetAttachStateDirty();
+        }
+        else if (!child.ShouldSendDiagUpdate())
+        {
+            childIndex++;
+            continue;
+        }
+
+        uint16_t beforeLen = aMessage.GetLength();
+        Error    error     = AppendChildContext(aMessage, child);
+
+        if (error == kErrorNoBufs || aMessage.GetLength() > kMaxUpdateMessageLength)
+        {
+            IgnoreError(aMessage.SetLength(beforeLen));
+            child.AbortCacheUpdate();
+            aNeedsMore        = true;
+            mChildResumeIndex = childIndex;
+            abortRemaining    = true;
+            childIndex++;
+            continue;
+        }
+
+        if (error != kErrorNone)
+        {
+            success        = false;
+            abortRemaining = true;
+            childIndex++;
+            continue;
+        }
+
+        childIndex++;
+    }
+
+    if (!aNeedsMore)
+    {
+        if (mSendChildBaseline)
+        {
+            mSendChildBaseline = false;
+        }
+        mChildResumeIndex = 0;
+    }
+
+    return success;
+}
+
+bool Server::AppendNeighborContextBatch(Message &aMessage, bool &aNeedsMore)
+{
+    bool    success    = true;
+    uint8_t startIndex = mNeighborResumeIndex;
+    aNeedsMore         = false;
+
+    for (uint8_t id = startIndex; id < Mle::kMaxRouterId; id++)
+    {
+        Router *router = Get<RouterTable>().FindRouterById(id);
+        bool    valid  = (router != nullptr) && router->IsStateValid();
+
+        // In baseline mode, only process valid routers that are in the state mask
+        // In update mode, process if there's a state change (added/removed)
+        if (mSendNeighborBaseline)
+        {
+            if (!valid || (mRouterStateMask & (1ULL << id)) == 0)
+            {
+                continue;
+            }
+        }
+        else
+        {
+            // Skip if no state change and router not valid (nothing to report)
+            if (!valid && (mRouterStateMask & (1ULL << id)) == 0)
+            {
+                continue;
+            }
+        }
+
+        uint16_t beforeLen = aMessage.GetLength();
+        Error    error;
+
+        if (mSendNeighborBaseline)
+        {
+            error = AppendNeighborContextBaseline(aMessage, *router);
+        }
+        else
+        {
+            error = AppendNeighborContextUpdate(aMessage, id);
+        }
+
+        if (error == kErrorNoBufs || aMessage.GetLength() > kMaxUpdateMessageLength)
+        {
+            IgnoreError(aMessage.SetLength(beforeLen));
+            aNeedsMore           = true;
+            mNeighborResumeIndex = id;
+            break;
+        }
+
+        if (error != kErrorNone)
+        {
+            // kErrorNotFound is expected when neighbor has no changes
+            if (error != kErrorNotFound)
+            {
+                success = false;
+                break;
+            }
+        }
+    }
+
+    if (!aNeedsMore)
+    {
+        if (mSendNeighborBaseline)
+        {
+            mSendNeighborBaseline = false;
+        }
+        mNeighborResumeIndex = 0;
+        mRouterStateMask     = 0;
+    }
+
+    return success;
+}
+
+void Server::LockChildCaches(void)
+{
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateAny))
+    {
+        child.LockCache();
+    }
+}
+
+void Server::CommitChildCacheUpdates(void)
+{
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateAny))
+    {
+        // Only commit if the cache is still locked (meaning it wasn't aborted)
+        if (child.IsDiagCacheLocked())
+        {
+            child.CommitCacheUpdate();
+        }
+    }
+}
+
+void Server::UnlockChildCaches(void)
+{
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateAny))
+    {
+        if (child.IsDiagCacheLocked())
+        {
+            child.AbortCacheUpdate();
+        }
+    }
+}
+#endif // OPENTHREAD_FTD
+
+bool Server::ShouldIncludeIp6Address(const Ip6::Address &aAddress)
+{
+    bool pass = false;
+
+    VerifyOrExit(!Get<Mle::Mle>().IsMeshLocalAddress(aAddress));
+    VerifyOrExit(!aAddress.IsLinkLocalUnicastOrMulticast());
+    VerifyOrExit(aAddress != Ip6::Address::GetRealmLocalAllNodesMulticast());
+    VerifyOrExit(aAddress != Ip6::Address::GetRealmLocalAllRoutersMulticast());
+    VerifyOrExit(aAddress != Ip6::Address::GetRealmLocalAllMplForwarders());
+    VerifyOrExit(aAddress.IsMulticast() || !aAddress.GetIid().IsAnycastLocator());
+
+    pass = true;
+
+exit:
+    return pass;
+}
+
+bool Server::ShouldIncludeAloc(const Ip6::Address &aAddress, uint8_t &aAloc)
+{
+    bool pass = false;
+
+    VerifyOrExit(aAddress.GetIid().IsAnycastLocator());
+    aAloc = static_cast<uint8_t>(aAddress.GetIid().GetLocator());
+
+    pass = true;
+
+exit:
+    return pass;
+}
+
+bool Server::ShouldIncludeLinkLocalAddress(const Ip6::Address &aAddress)
+{
+    bool pass = false;
+
+    VerifyOrExit(aAddress.IsLinkLocalUnicastOrMulticast());
+    VerifyOrExit(aAddress != Ip6::Address::GetLinkLocalAllNodesMulticast());
+    VerifyOrExit(aAddress != Ip6::Address::GetLinkLocalAllRoutersMulticast());
+
+    pass = true;
+
+exit:
+    return pass;
+}
+
+Error Server::AppendHostIp6AddressList(Message &aMessage)
+{
+    Error    error = kErrorNone;
+    uint16_t count = 0;
+
+    for (const Ip6::Netif::UnicastAddress &address : Get<ThreadNetif>().GetUnicastAddresses())
+    {
+        if (ShouldIncludeIp6Address(address.GetAddress()))
+        {
+            count++;
+        }
+    }
+    for (const Ip6::Netif::MulticastAddress &address : Get<ThreadNetif>().GetMulticastAddresses())
+    {
+        if (ShouldIncludeIp6Address(address.GetAddress()))
+        {
+            count++;
+        }
+    }
+
+    if (count * Ip6::Address::kSize <= Tlv::kBaseTlvMaxLength)
+    {
+        Tlv tlv;
+
+        tlv.SetType(Tlv::kIp6AddressList);
+        tlv.SetLength(static_cast<uint8_t>(count * Ip6::Address::kSize));
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+    else
+    {
+        ExtendedTlv tlv;
+
+        tlv.SetType(Tlv::kIp6AddressList);
+        tlv.SetLength(count * Ip6::Address::kSize);
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+
+    for (const Ip6::Netif::UnicastAddress &address : Get<ThreadNetif>().GetUnicastAddresses())
+    {
+        if (ShouldIncludeIp6Address(address.GetAddress()))
+        {
+            SuccessOrExit(error = aMessage.Append(address.GetAddress()));
+        }
+    }
+    for (const Ip6::Netif::MulticastAddress &address : Get<ThreadNetif>().GetMulticastAddresses())
+    {
+        if (ShouldIncludeIp6Address(address.GetAddress()))
+        {
+            SuccessOrExit(error = aMessage.Append(address.GetAddress()));
+        }
+    }
+
+exit:
+    return error;
+}
+
+Error Server::AppendHostAlocList(Message &aMessage)
+{
+    Error    error = kErrorNone;
+    uint16_t count = 0;
+    uint8_t  aloc;
+
+    for (const Ip6::Netif::UnicastAddress &address : Get<ThreadNetif>().GetUnicastAddresses())
+    {
+        if (ShouldIncludeAloc(address.GetAddress(), aloc))
+        {
+            count++;
+        }
+    }
+
+    if (count <= Tlv::kBaseTlvMaxLength)
+    {
+        Tlv tlv;
+
+        tlv.SetType(Tlv::kAlocList);
+        tlv.SetLength(static_cast<uint8_t>(count));
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+    else
+    {
+        ExtendedTlv tlv;
+
+        tlv.SetType(Tlv::kAlocList);
+        tlv.SetLength(count);
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+
+    for (const Ip6::Netif::UnicastAddress &address : Get<ThreadNetif>().GetUnicastAddresses())
+    {
+        if (ShouldIncludeAloc(address.GetAddress(), aloc))
+        {
+            SuccessOrExit(error = aMessage.Append(aloc));
+        }
+    }
+
+exit:
+    return error;
+}
+
+Error Server::AppendHostLinkLocalAddressList(Message &aMessage)
+{
+    Error    error = kErrorNone;
+    uint16_t count = 0;
+
+    for (const Ip6::Netif::UnicastAddress &address : Get<ThreadNetif>().GetUnicastAddresses())
+    {
+        if (ShouldIncludeLinkLocalAddress(address.GetAddress()))
+        {
+            count++;
+        }
+    }
+    for (const Ip6::Netif::MulticastAddress &address : Get<ThreadNetif>().GetMulticastAddresses())
+    {
+        if (ShouldIncludeLinkLocalAddress(address.GetAddress()))
+        {
+            count++;
+        }
+    }
+
+    if (count * Ip6::Address::kSize <= Tlv::kBaseTlvMaxLength)
+    {
+        Tlv tlv;
+
+        tlv.SetType(Tlv::kIp6LinkLocalAddressList);
+        tlv.SetLength(static_cast<uint8_t>(count * Ip6::Address::kSize));
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+    else
+    {
+        ExtendedTlv tlv;
+
+        tlv.SetType(Tlv::kIp6LinkLocalAddressList);
+        tlv.SetLength(count * Ip6::Address::kSize);
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+
+    for (const Ip6::Netif::UnicastAddress &address : Get<ThreadNetif>().GetUnicastAddresses())
+    {
+        if (ShouldIncludeLinkLocalAddress(address.GetAddress()))
+        {
+            SuccessOrExit(error = aMessage.Append(address.GetAddress()));
+        }
+    }
+    for (const Ip6::Netif::MulticastAddress &address : Get<ThreadNetif>().GetMulticastAddresses())
+    {
+        if (ShouldIncludeLinkLocalAddress(address.GetAddress()))
+        {
+            SuccessOrExit(error = aMessage.Append(address.GetAddress()));
+        }
+    }
+
+exit:
+    return error;
+}
+
+#if OPENTHREAD_FTD
+Error Server::AppendChildIp6AddressList(Message &aMessage, const Child &aChild)
+{
+    Error    error = kErrorNone;
+    uint16_t count = 0;
+
+    for (const Ip6::Address &address : aChild.GetIp6Addresses())
+    {
+        if (ShouldIncludeIp6Address(address))
+        {
+            count++;
+        }
+    }
+
+    if (count * Ip6::Address::kSize <= Tlv::kBaseTlvMaxLength)
+    {
+        Tlv tlv;
+
+        tlv.SetType(Tlv::kIp6AddressList);
+        tlv.SetLength(static_cast<uint8_t>(count * Ip6::Address::kSize));
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+    else
+    {
+        ExtendedTlv tlv;
+
+        tlv.SetType(Tlv::kIp6AddressList);
+        tlv.SetLength(count * Ip6::Address::kSize);
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+
+    for (const Ip6::Address &address : aChild.GetIp6Addresses())
+    {
+        if (ShouldIncludeIp6Address(address))
+        {
+            SuccessOrExit(error = aMessage.Append(address));
+        }
+    }
+
+exit:
+    return error;
+}
+
+Error Server::AppendChildAlocList(Message &aMessage, const Child &aChild)
+{
+    Error    error = kErrorNone;
+    uint16_t count = 0;
+    uint8_t  aloc;
+
+    for (const Ip6::Address &address : aChild.GetIp6Addresses())
+    {
+        if (ShouldIncludeAloc(address, aloc))
+        {
+            count++;
+        }
+    }
+
+    if (count <= Tlv::kBaseTlvMaxLength)
+    {
+        Tlv tlv;
+
+        tlv.SetType(Tlv::kAlocList);
+        tlv.SetLength(static_cast<uint8_t>(count));
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+    else
+    {
+        ExtendedTlv tlv;
+
+        tlv.SetType(Tlv::kAlocList);
+        tlv.SetLength(count);
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+
+    for (const Ip6::Address &address : aChild.GetIp6Addresses())
+    {
+        if (ShouldIncludeAloc(address, aloc))
+        {
+            SuccessOrExit(error = aMessage.Append(aloc));
+        }
+    }
+
+exit:
+    return error;
+}
+#endif // OPENTHREAD_FTD
+
+void Server::HandleUpdateTimer(void)
+{
+    Error error = kErrorNone;
+    VerifyOrExit(mActive);
+
+#if OPENTHREAD_FTD
+    if (Get<Mle::Mle>().IsRouterOrLeader())
+    {
+        if (mSendFullUpdate)
+        {
+            mSendFullUpdate = false;
+
+            Ip6::Address clientAddr;
+            clientAddr.InitAsRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), mClientRloc);
+            error = SendFullServerUpdate(clientAddr);
+        }
+        else
+        {
+            error = SendServerUpdate();
+        }
+    }
+    else
+#endif // OPENTHREAD_FTD
+    {
+        error = SendEndDeviceUpdate();
+    }
+
+    if (error != kErrorNone)
+    {
+        ScheduleUpdateTimer(kUpdateBaseDelay);
+    }
+    else
+    {
+        mSelfDirty = GetExtDelayTlvs(mSelfEnabled);
+
+#if OPENTHREAD_FTD
+        {
+            TlvSet childExtDelay = GetExtDelayTlvs(mChildEnabled);
+
+            if (!childExtDelay.IsEmpty())
+            {
+                for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
+                {
+                    child.MarkHostProvidedTlvsChanged(childExtDelay);
+                }
+            }
+        }
+#endif
+
+        if (!mSelfDirty.IsEmpty()
+#if OPENTHREAD_FTD
+            || HasExtDelayTlvs(mChildEnabled) || HasExtDelayTlvs(mNeighborEnabled)
+#endif
+        )
+        {
+            ScheduleUpdateTimer(Random::NonCrypto::AddJitter(kUpdateExtDelay, kUpdateJitter));
+        }
+    }
+
+exit:
+    return;
+}
+
+#if OPENTHREAD_FTD
+void Server::UpdateIfCacheBufferLimit(void)
+{
+    uint16_t total = 0;
+
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
+    {
+        total += child.GetUsedCacheBuffers();
+    }
+
+    if (total > kCacheBuffersLimit)
+    {
+        ScheduleUpdateTimer(0);
+    }
+}
+
+void Server::HandleChildTimer(void)
+{
+    VerifyOrExit(Get<Mle::Mle>().IsRouterOrLeader());
+
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
+    {
+        SyncChildDiagState(child, false);
+
+        // Potential future enhancement is to only try this when message
+        // buffers are available
+        if (child.ShouldSendLostDiagQuery())
+        {
+            IgnoreError(SendEndDeviceRecoveryQuery(child, child.GetLostDiag()));
+        }
+    }
+
+exit:
+    return;
+}
+
+void Server::HandleRegistrationTimer(void)
+{
+    VerifyOrExit(mActive && Get<Mle::Mle>().IsRouterOrLeader());
+
+    // If client didn't register this interval, stop server
+    if (!mClientRegistered)
+    {
+        StopServer();
+        ExitNow();
+    }
+
+    // Reset registration flag for next interval
+    mClientRegistered = false;
+
+    if (mSelfEnabled.IsEmpty() && mChildEnabled.IsEmpty() && mNeighborEnabled.IsEmpty())
+    {
+        StopServer();
+    }
+    else
+    {
+        mRegistrationTimer.Start(kRegistrationInterval);
+        SyncAllChildDiagStates(false, false, false);
+    }
+
+exit:
+    return;
+}
+#endif // OPENTHREAD_FTD
+#endif // OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+
+} // namespace MeshMonitor
+
+} // namespace ot

--- a/src/core/thread/mesh_monitor.cpp
+++ b/src/core/thread/mesh_monitor.cpp
@@ -1,0 +1,2518 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mesh_monitor.hpp"
+
+#include "instance/instance.hpp"
+
+namespace ot {
+
+RegisterLogModule("MeshMon");
+
+namespace MeshMonitor {
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+
+const TlvSet Server::kExtDelayTlvMask = [] {
+    TlvSet set;
+    set.Set(Tlv::kLastHeard);
+    set.Set(Tlv::kConnectionTime);
+    set.Set(Tlv::kLinkMarginIn);
+    set.Set(Tlv::kMacLinkErrorRatesTx);
+    set.Set(Tlv::kMacCounters);
+    set.Set(Tlv::kMacLinkErrorRatesRx);
+    set.Set(Tlv::kMleCounters);
+    set.Set(Tlv::kLinkMarginOut);
+    return set;
+}();
+
+const TlvSet Server::kStaticNeighborTlvMask = [] {
+    TlvSet set;
+    set.Set(Tlv::kExtAddress);
+    set.Set(Tlv::kConnectionTime);
+    set.Set(Tlv::kThreadVersion);
+    return set;
+}();
+
+const TlvSet Server::kChildAttachSkipTlvMask = [] {
+    TlvSet set;
+    set.Set(Tlv::kThreadStackVersion);
+    set.Set(Tlv::kVendorName);
+    set.Set(Tlv::kVendorModel);
+    set.Set(Tlv::kVendorSwVersion);
+    set.Set(Tlv::kVendorAppUrl);
+    set.Set(Tlv::kEui64);
+    set.Set(Tlv::kMacCounters);
+    set.Set(Tlv::kMleCounters);
+    return set;
+}();
+
+#if OPENTHREAD_FTD
+void Server::ChildInfo::MarkHostProvidedTlvsChanged(TlvSet aTlvs)
+{
+    if (mIsFtd)
+    {
+        mDirtySet.SetAll(aTlvs.GetNotProvidedByFtdChild());
+    }
+    else
+    {
+        mDirtySet.SetAll(aTlvs.GetNotProvidedByMtdChild());
+    }
+}
+
+void Server::ChildInfo::CommitCacheUpdate(void)
+{
+    OT_ASSERT(mDiagCacheLocked);
+    mDiagCacheLocked = false;
+
+    mAttachStateDirty = false;
+
+    mDirtySet.Clear();
+    mCache.Free();
+    mCacheBuffers = 0;
+}
+
+void Server::ChildInfo::AbortCacheUpdate(void)
+{
+    OT_ASSERT(mDiagCacheLocked);
+    mDiagCacheLocked = false;
+
+    if (mCache == nullptr)
+    {
+        EvictCache();
+    }
+}
+
+TlvSet Server::ChildInfo::GetDirtyHostProvided(TlvSet aFilter) const
+{
+    TlvSet set = mDirtySet.Intersect(aFilter);
+
+    if (mIsFtd)
+    {
+        set = set.GetNotProvidedByFtdChild();
+    }
+    else
+    {
+        set = set.GetNotProvidedByMtdChild();
+    }
+
+    return set;
+}
+
+void Server::ChildInfo::EvictCache(void)
+{
+    TlvSet lost;
+
+    OT_ASSERT(!mDiagCacheLocked);
+
+    if (mIsFtd)
+    {
+        lost = mDirtySet.GetProvidedByFtdChild();
+    }
+    else
+    {
+        lost = mDirtySet.GetProvidedByMtdChild();
+    }
+
+    mDirtySet.ClearAll(lost);
+    mLostSet.SetAll(lost);
+
+    mCache.Free();
+    mCacheBuffers = 0;
+}
+
+void Server::ChildInfo::ClearCache(void)
+{
+    OT_ASSERT(!mDiagCacheLocked);
+
+    mDirtySet.Clear();
+    mLostSet.Clear();
+
+    mCache.Free();
+    mCacheBuffers = 0;
+}
+
+Error Server::ChildInfo::RemoveCachedTlv(uint8_t aType)
+{
+    Error    error  = kErrorNone;
+    uint16_t offset = 0;
+
+    VerifyOrExit(mCache != nullptr);
+
+    while (offset < mCache->GetLength())
+    {
+        uint32_t tlvSize;
+        union
+        {
+            Tlv         tlv;
+            ExtendedTlv extTlv;
+        };
+
+        SuccessOrExit(error = mCache->Read(offset, tlv));
+
+        if (tlv.IsExtended())
+        {
+            SuccessOrExit(error = mCache->Read(offset, extTlv));
+            tlvSize = sizeof(ExtendedTlv) + extTlv.GetLength();
+        }
+        else
+        {
+            tlvSize = sizeof(Tlv) + tlv.GetLength();
+        }
+
+        VerifyOrExit(static_cast<uint32_t>(offset) + tlvSize <= mCache->GetLength(), error = kErrorParse);
+
+        if (tlv.GetType() == aType)
+        {
+            mCache->RemoveHeader(offset, static_cast<uint16_t>(tlvSize));
+            break;
+        }
+
+        offset += static_cast<uint16_t>(tlvSize);
+    }
+
+exit:
+    return error;
+}
+
+Error Server::ChildInfo::UpdateCache(const Message &aMessage, TlvSet aFilter)
+{
+    Error    error     = kErrorNone;
+    uint16_t srcOffset = aMessage.GetOffset();
+
+    TlvSet      set;
+    OffsetRange srcRange;
+    union
+    {
+        Tlv         tlv;
+        ExtendedTlv extTlv;
+    };
+
+    // Prevent freeing the cache we are currently building
+    // If we run out of memory, the error handler of this function will free it
+    OT_ASSERT(!mDiagCacheLocked);
+    mDiagCacheLocked = true;
+
+    while (srcOffset < aMessage.GetLength())
+    {
+        uint32_t tlvSize;
+
+        SuccessOrExit(error = aMessage.Read(srcOffset, tlv));
+
+        if (tlv.IsExtended())
+        {
+            SuccessOrExit(error = aMessage.Read(srcOffset, extTlv));
+            tlvSize = sizeof(ExtendedTlv) + extTlv.GetLength();
+        }
+        else
+        {
+            tlvSize = sizeof(Tlv) + tlv.GetLength();
+        }
+
+        VerifyOrExit(static_cast<uint32_t>(srcOffset) + tlvSize <= aMessage.GetLength(), error = kErrorParse);
+
+        srcRange.Init(srcOffset, static_cast<uint16_t>(tlvSize));
+        srcOffset = srcRange.GetEndOffset();
+
+        set.Clear();
+        set.SetValue(tlv.GetType());
+        set = set.Intersect(aFilter);
+
+        if (mIsFtd)
+        {
+            set = set.GetProvidedByFtdChild();
+        }
+        else
+        {
+            set = set.GetProvidedByMtdChild();
+        }
+
+        if (set.IsEmpty())
+        {
+            continue;
+        }
+
+        if (mCache == nullptr)
+        {
+            mCache.Reset(aMessage.Get<MessagePool>().Allocate(Message::kTypeOther));
+            VerifyOrExit(mCache != nullptr, error = kErrorNoBufs);
+        }
+
+        // We already made sure the TLV is child provided. To keep exactly one
+        // copy of each TLV in the cache, remove any previously cached copy of
+        // this type before appending the newest value.
+        if (mDirtySet.ContainsAll(set))
+        {
+            SuccessOrExit(error = RemoveCachedTlv(tlv.GetType()));
+        }
+
+        SuccessOrExit(error = mCache->AppendBytesFromMessage(aMessage, srcRange.GetOffset(), srcRange.GetLength()));
+
+        mDirtySet.SetAll(set);
+    }
+
+    mLostSet.ClearAll(mDirtySet);
+
+exit:
+    mDiagCacheLocked = false;
+    if (error != kErrorNone)
+    {
+        // An error here could render the cache invalid, so we just clear it and query
+        // the tlvs again using the lost set
+        LogCrit("Diag cache error %s", ErrorToString(error));
+        EvictCache();
+    }
+
+    if (mCache != nullptr)
+    {
+        mCacheBuffers = mCache->GetBufferCount();
+    }
+
+    return error;
+}
+
+Error Server::ChildInfo::AppendCachedTlvs(Message &aMessage)
+{
+    Error error = kErrorNone;
+
+    VerifyOrExit(mCache != nullptr);
+    OT_ASSERT(mDiagCacheLocked);
+
+    SuccessOrExit(error = aMessage.AppendBytesFromMessage(*mCache, 0, mCache->GetLength()));
+
+exit:
+    return error;
+}
+#endif // OPENTHREAD_FTD
+
+Server::Server(Instance &aInstance)
+    : InstanceLocator(aInstance)
+    , mActive(false)
+    , mUpdateSent(false)
+#if OPENTHREAD_FTD
+    , mSendFullUpdate(false)
+    , mSendChildBaseline(false)
+    , mSendNeighborBaseline(false)
+    , mUpdatePending(false)
+    , mChildResumeIndex(0)
+    , mNeighborResumeIndex(0)
+    , mClientRloc(Mle::kInvalidRloc16)
+    , mUpdateRetryCount(0)
+    , mCacheSyncEvictions(0)
+    , mCachePollEvictions(0)
+    , mCacheErrors(0)
+    , mRouterStateMask(0)
+#endif // OPENTHREAD_FTD
+    , mUpdateTimer(aInstance)
+#if OPENTHREAD_FTD
+    , mChildTimer(aInstance)
+    , mRegistrationTimer(aInstance)
+#endif // OPENTHREAD_FTD
+{
+    mSelfEnabled.Clear();
+    mSelfPendingUpdate.Clear();
+    mSelfDirty.Clear();
+
+#if OPENTHREAD_FTD
+    mChildEnabled.Clear();
+
+    mNeighborEnabled.Clear();
+
+    mClientRegistered = false;
+#endif // OPENTHREAD_FTD
+}
+
+void Server::MarkDiagDirty(Tlv::Type aTlv)
+{
+    TlvSet set;
+    set.Clear();
+    set.Set(aTlv);
+    MarkDiagDirty(set);
+}
+
+void Server::MarkDiagDirty(TlvSet aTlvs)
+{
+    aTlvs.Filter(mSelfEnabled);
+
+    // If the server is inactive, the enabled set will always be 0 so this
+    // check will always fail.
+    if (!aTlvs.IsEmpty())
+    {
+        mSelfDirty.SetAll(aTlvs);
+        if (IsOnlyExtDelayTlvs(aTlvs))
+        {
+            ScheduleUpdateTimer(kUpdateExtDelay);
+        }
+        else
+        {
+            ScheduleUpdateTimer(kUpdateBaseDelay);
+        }
+    }
+}
+
+#if OPENTHREAD_FTD
+void Server::MarkChildDiagDirty(Child &aChild, Tlv::Type aTlv)
+{
+    TlvSet set;
+    set.Clear();
+    set.Set(aTlv);
+    MarkChildDiagDirty(aChild, set);
+}
+
+void Server::MarkChildDiagDirty(Child &aChild, TlvSet aTlvs)
+{
+    VerifyOrExit(aChild.IsStateValid());
+
+    aTlvs.Filter(mChildEnabled);
+    // Use mIsFtd to allow the compiler to optimize away the check in MarkHostProvidedTlvsChanged
+    if (aChild.mIsFtd)
+    {
+        aTlvs = aTlvs.GetNotProvidedByFtdChild();
+    }
+    else
+    {
+        aTlvs = aTlvs.GetNotProvidedByMtdChild();
+    }
+
+    // If the server is inactive, the enabled set will always be 0 so this
+    // check will always fail.
+    if (!aTlvs.IsEmpty())
+    {
+        aChild.MarkHostProvidedTlvsChanged(aTlvs);
+        if (IsOnlyExtDelayTlvs(aTlvs))
+        {
+            ScheduleUpdateTimer(kUpdateExtDelay);
+        }
+        else
+        {
+            ScheduleUpdateTimer(kUpdateBaseDelay);
+        }
+    }
+
+exit:
+    return;
+}
+
+void Server::HandleChildAdded(Child &aChild)
+{
+    aChild.ClearCache();
+    aChild.SetChildIsFtd(aChild.IsFullThreadDevice());
+    aChild.SetDiagServerState(Child::kDiagServerStopped);
+
+    VerifyOrExit(mActive);
+
+    aChild.SetAttachStateDirty();
+
+    if (!mChildEnabled.IsEmpty())
+    {
+        TlvSet set;
+
+        if (aChild.IsFullThreadDevice())
+        {
+            set = mChildEnabled.GetProvidedByFtdChild();
+        }
+        else
+        {
+            set = mChildEnabled.GetProvidedByMtdChild();
+        }
+
+        set.ClearAll(static_cast<const TlvSet &>(kChildAttachSkipTlvMask));
+
+        if (!set.IsEmpty())
+        {
+            IgnoreError(SendEndDeviceRequestStart(aChild, set, true));
+        }
+
+        ScheduleUpdateTimer(kUpdateBaseDelay);
+    }
+
+exit:
+    return;
+}
+
+void Server::HandleChildRemoved(Child &aChild)
+{
+    aChild.ClearCache();
+    aChild.SetDiagServerState(Child::kDiagServerStopped);
+
+    VerifyOrExit(mActive);
+
+    aChild.SetAttachStateDirty();
+
+    if (!mChildEnabled.IsEmpty())
+    {
+        ScheduleUpdateTimer(kUpdateBaseDelay);
+    }
+
+exit:
+    return;
+}
+
+void Server::HandleRouterAdded(Router &aRouter)
+{
+    VerifyOrExit(mActive);
+
+    mRouterStateMask |= (1ULL << aRouter.GetRouterId());
+
+    if (!mNeighborEnabled.IsEmpty())
+    {
+        ScheduleUpdateTimer(kUpdateBaseDelay);
+    }
+
+exit:
+    return;
+}
+
+void Server::HandleRouterRemoved(Router &aRouter)
+{
+    VerifyOrExit(mActive);
+
+    mRouterStateMask |= (1ULL << aRouter.GetRouterId());
+
+    if (!mNeighborEnabled.IsEmpty())
+    {
+        ScheduleUpdateTimer(kUpdateBaseDelay);
+    }
+
+exit:
+    return;
+}
+
+Error Server::EvictCache(bool aOnlyRxOn)
+{
+    Error error = kErrorNotFound;
+
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateAny))
+    {
+        if (!child.CanEvictCache())
+        {
+            continue;
+        }
+
+        if (child.IsStateValid())
+        {
+            if (!child.IsRxOnWhenIdle())
+            {
+                if (aOnlyRxOn)
+                {
+                    continue;
+                }
+
+#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+                if (!child.IsCslSynchronized())
+                {
+                    // First avoid non csl children as their poll intervals may be
+                    // very large
+                    continue;
+                }
+#endif // OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+            }
+
+            child.EvictCache();
+            mCacheSyncEvictions++;
+        }
+        else
+        {
+            child.ClearCache();
+        }
+
+        ExitNow(error = kErrorNone);
+    }
+
+    // Try evicting from any child
+    VerifyOrExit(!aOnlyRxOn);
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
+    {
+        if (!child.CanEvictCache())
+        {
+            continue;
+        }
+
+        child.EvictCache();
+        mCachePollEvictions++;
+        ExitNow(error = kErrorNone);
+    }
+
+exit:
+    if (error == kErrorNone)
+    {
+        ScheduleChildTimer();
+    }
+    return error;
+}
+#endif // OPENTHREAD_FTD
+
+void Server::HandleNotifierEvents(Events aEvents)
+{
+    TlvSet tlvs;
+
+    VerifyOrExit(mActive);
+
+    if (aEvents.ContainsAny(kEventIp6AddressAdded | kEventIp6AddressRemoved | kEventIp6MulticastSubscribed |
+                            kEventIp6MulticastUnsubscribed))
+    {
+        tlvs.Set(Tlv::kIp6AddressList);
+        tlvs.Set(Tlv::kIp6LinkLocalAddressList);
+        tlvs.Set(Tlv::kAlocList);
+        MarkDiagDirty(tlvs);
+    }
+
+exit:
+    return;
+}
+
+template <> void Server::HandleTmf<kUriMeshMonEndDeviceRequest>(Coap::Msg &aMsg)
+{
+    Error          error    = kErrorNone;
+    Coap::Message *response = nullptr;
+
+    ChildRequestHeader header;
+    TlvSet             set;
+    uint16_t           offset;
+    bool               changed = false;
+
+    VerifyOrExit(aMsg.IsPostRequest(), error = kErrorInvalidArgs);
+
+    LogInfo("Received %s from %s", UriToString<kUriMeshMonEndDeviceRequest>(),
+            aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());
+
+    VerifyOrExit(Get<Mle::Mle>().IsChild(), error = kErrorInvalidState);
+
+    SuccessOrExit(error = aMsg.mMessage.Read(aMsg.mMessage.GetOffset(), header));
+
+    offset = aMsg.mMessage.GetOffset() + sizeof(ChildRequestHeader);
+    SuccessOrExit(error = set.ReadFrom(aMsg.mMessage, offset, header.GetRequestSetCount()));
+
+    response = Get<Tmf::Agent>().AllocateAndInitResponseFor(aMsg.mMessage);
+    VerifyOrExit(response != nullptr, error = kErrorNoBufs);
+
+    switch (header.GetCommand())
+    {
+    case ChildRequestHeader::kStart:
+        changed = ConfigureAsEndDevice(set);
+        break;
+
+    case ChildRequestHeader::kStop:
+        StopServer();
+        break;
+
+    default:
+        break;
+    }
+
+    if (header.GetQuery() || changed)
+    {
+        SuccessOrExit(error = AppendHostTlvs(*response, mSelfEnabled));
+    }
+
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessage(*response, aMsg.mMessageInfo));
+
+exit:
+    FreeMessageOnError(response, error);
+}
+
+#if OPENTHREAD_FTD
+template <> void Server::HandleTmf<kUriMeshMonEndDeviceUpdate>(Coap::Msg &aMsg)
+{
+    Child *child = nullptr;
+    TlvSet set;
+
+    VerifyOrExit(aMsg.mMessageInfo.GetPeerAddr().GetIid().IsRoutingLocator());
+    child = Get<ChildTable>().FindChild(aMsg.mMessageInfo.GetPeerAddr().GetIid().GetLocator(), Child::kInStateValid);
+
+    VerifyOrExit(child != nullptr);
+    VerifyOrExit(aMsg.IsPostRequest());
+
+    LogInfo("Received %s from %s", UriToString<kUriMeshMonEndDeviceRequest>(),
+            aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());
+
+    IgnoreError(Get<Tmf::Agent>().SendAckResponse(aMsg));
+
+    // If the child should be disabled, this will update it
+    SyncChildDiagState(*child, false);
+
+    if (child->IsFullThreadDevice())
+    {
+        set = mChildEnabled.GetProvidedByFtdChild();
+    }
+    else
+    {
+        set = mChildEnabled.GetProvidedByMtdChild();
+    }
+
+    if (child->UpdateCache(aMsg.mMessage, set) != kErrorNone)
+    {
+        mCacheErrors++;
+    }
+
+    if (child->ShouldSendDiagUpdate())
+    {
+        ScheduleUpdateTimer(kUpdateBaseDelay);
+    }
+
+    UpdateIfCacheBufferLimit();
+
+exit:
+    return;
+}
+
+template <> void Server::HandleTmf<kUriMeshMonServerRequest>(Coap::Msg &aMsg)
+{
+    RequestHeader  header;
+    RequestContext context;
+    uint16_t       offset;
+    uint16_t       setOffset;
+    TlvSet         set;
+
+    TlvSet hostSet;
+    TlvSet childSet;
+    TlvSet neighborSet;
+
+    VerifyOrExit(aMsg.IsPostRequest());
+    SuccessOrExit(aMsg.mMessage.Read(aMsg.mMessage.GetOffset(), header));
+
+    LogInfo("Received %s from %s", UriToString<kUriMeshMonServerRequest>(),
+            aMsg.mMessageInfo.GetPeerAddr().ToString().AsCString());
+
+    VerifyOrExit(Get<Mle::Mle>().IsRouterOrLeader());
+    VerifyOrExit(aMsg.mMessageInfo.GetPeerAddr().GetIid().IsRoutingLocator());
+
+    if (header.GetRegistration() && (mClientRloc != Mle::kInvalidRloc16) &&
+        (aMsg.mMessageInfo.GetPeerAddr().GetIid().GetLocator() != mClientRloc))
+    {
+        LogInfo("Rejecting registration from %04x, client %04x already registered",
+                aMsg.mMessageInfo.GetPeerAddr().GetIid().GetLocator(), mClientRloc);
+        IgnoreError(Get<Tmf::Agent>().SendAckResponse(aMsg, Coap::kCodeTooManyRequests));
+        ExitNow();
+    }
+
+    hostSet.Clear();
+    childSet.Clear();
+    neighborSet.Clear();
+
+    offset = aMsg.mMessage.GetOffset() + sizeof(RequestHeader);
+    while (offset < aMsg.mMessage.GetLength())
+    {
+        SuccessOrExit(aMsg.mMessage.Read(offset, context));
+
+        setOffset = offset + sizeof(RequestContext);
+        SuccessOrExit(set.ReadFrom(aMsg.mMessage, setOffset, context.GetRequestSetCount()));
+
+        switch (context.GetType())
+        {
+        case kTypeHost:
+            hostSet.SetAll(set);
+            break;
+
+        case kTypeChild:
+            childSet.SetAll(set);
+            break;
+
+        case kTypeNeighbor:
+            neighborSet.SetAll(set);
+            break;
+
+        default:
+            break;
+        }
+
+        VerifyOrExit(context.GetLength() >= sizeof(RequestContext) &&
+                     static_cast<uint32_t>(offset) + context.GetLength() <= aMsg.mMessage.GetLength());
+        offset += context.GetLength();
+    }
+
+    if (header.GetRegistration())
+    {
+        mClientRloc = aMsg.mMessageInfo.GetPeerAddr().GetIid().GetLocator();
+    }
+
+    SuccessOrExit(ConfigureAsRouter(hostSet, childSet, neighborSet, header.GetQuery()));
+
+    if (header.GetQuery())
+    {
+        uint32_t jitter = Random::NonCrypto::GenerateFromMinUpToExcluding<uint32_t>(0, 500);
+
+        mSendFullUpdate = true;
+        ScheduleUpdateTimer(jitter);
+    }
+    else if (header.GetRegistration())
+    {
+        IgnoreError(SendEmptyServerUpdate(aMsg.mMessageInfo.GetPeerAddr()));
+    }
+
+exit:
+    return;
+}
+#endif // OPENTHREAD_FTD
+
+bool Server::ConfigureAsEndDevice(const TlvSet &aTypes)
+{
+    bool changed = false;
+
+    if (!mActive)
+    {
+        mActive     = true;
+        mUpdateSent = false;
+
+        mSelfEnabled.Clear();
+        mSelfPendingUpdate.Clear();
+        mSelfDirty.Clear();
+
+#if OPENTHREAD_FTD
+        mChildEnabled.Clear();
+
+        mNeighborEnabled.Clear();
+
+        mClientRegistered = false;
+#endif
+    }
+
+    changed = mSelfEnabled != aTypes;
+
+    // Filter incoming requested TLVs to child-valid and seed enabled set
+    mSelfEnabled = aTypes;
+    mSelfEnabled.FilterChildSupportedTlv();
+
+    // Seed dirty set with existing ExtDelay policy
+    mSelfDirty.SetAll(GetExtDelayTlvs(mSelfEnabled));
+
+    // Mark dirty any requested TLVs that are child-provided (MTD/FTD)
+    // so they are sent via EU when explicitly requested by the router/client
+#if OPENTHREAD_FTD
+    {
+        TlvSet childProvidedRequested;
+        if (Get<Mle::Mle>().IsFullThreadDevice())
+        {
+            childProvidedRequested = mSelfEnabled.GetProvidedByFtdChild();
+        }
+        else
+        {
+            childProvidedRequested = mSelfEnabled.GetProvidedByMtdChild();
+        }
+
+        // Union requested child-provided TLVs into dirty set
+        mSelfDirty.SetAll(mSelfDirty.Join(childProvidedRequested));
+    }
+#endif
+
+    if (!mSelfDirty.IsEmpty())
+    {
+        ScheduleUpdateTimer(Random::NonCrypto::AddJitter(kUpdateExtDelay, kUpdateJitter));
+    }
+
+    return changed;
+}
+
+void Server::StopServer(void)
+{
+    mSelfEnabled.Clear();
+    mSelfPendingUpdate.Clear();
+
+    mUpdateTimer.Stop();
+#if OPENTHREAD_FTD
+    mRegistrationTimer.Stop();
+    mUpdatePending = false;
+
+    mChildEnabled.Clear();
+    mNeighborEnabled.Clear();
+
+    mClientRegistered = false;
+    mClientRloc       = Mle::kInvalidRloc16;
+
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateAny))
+    {
+        child.ClearCache();
+    }
+
+    if (Get<Mle::Mle>().IsRouterOrLeader())
+    {
+        // Stop child servers
+        ScheduleChildTimer();
+    }
+#endif
+
+    mActive = false;
+}
+
+Error Server::SendEndDeviceUpdate(void)
+{
+    Error          error   = kErrorNone;
+    Coap::Message *message = nullptr;
+
+    VerifyOrExit(Get<Mle::Mle>().IsChild(), error = kErrorInvalidState);
+    VerifyOrExit(!mUpdateSent, error = kErrorAlready);
+
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriMeshMonEndDeviceUpdate);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    SuccessOrExit(error = AppendHostTlvs(*message, mSelfDirty));
+    mSelfPendingUpdate = mSelfDirty;
+    mSelfDirty.Clear();
+
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageToRloc(*message, Get<Mle::Mle>().GetParentRloc16(),
+                                                              HandleEndDeviceUpdateAck, this));
+    mUpdateSent = true;
+
+exit:
+    if (error != kErrorNone)
+    {
+        LogCrit("Failed to send child update: %s", ErrorToString(error));
+    }
+    FreeMessageOnError(message, error);
+    return error;
+}
+
+void Server::HandleEndDeviceUpdateAck(Coap::Msg *aMsg, Error aResult)
+{
+    OT_UNUSED_VARIABLE(aMsg);
+
+    VerifyOrExit(mActive);
+
+    mUpdateSent = false;
+
+    if (aResult != kErrorNone)
+    {
+        mSelfDirty = mSelfDirty.Join(mSelfPendingUpdate);
+    }
+
+exit:
+    return;
+}
+
+#if OPENTHREAD_FTD
+Error Server::SendFullServerUpdate(const Ip6::Address &aClientAddr)
+{
+    Error error = kErrorNone;
+
+    Coap::Message *message = nullptr;
+
+    UpdateHeader header;
+
+    // Don't send if we have a pending update awaiting ACK
+    VerifyOrExit(!mUpdatePending, error = kErrorBusy);
+
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriMeshMonServerUpdate);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    header.Init();
+    header.SetComplete(true);
+    header.SetRouterId(Mle::RouterIdFromRloc16(Get<Mle::Mle>().GetRloc16()));
+    header.SetFullSeqNumber(mSequenceNumber + 1);
+    SuccessOrExit(error = header.AppendTo(*message));
+
+    if (!mSelfEnabled.IsEmpty())
+    {
+        SuccessOrExit(error = AppendHostContext(*message, mSelfEnabled));
+    }
+
+    if (!mChildEnabled.IsEmpty())
+    {
+        mSendChildBaseline = true;
+        ScheduleUpdateTimer(0);
+    }
+
+    if (!mNeighborEnabled.IsEmpty())
+    {
+        mSendNeighborBaseline = true;
+        // Initialize router state mask to mark all valid routers for baseline
+        mRouterStateMask = 0;
+
+        for (uint8_t id = 0; id < Mle::kMaxRouterId; id++)
+        {
+            Router *router = Get<RouterTable>().FindRouterById(id);
+
+            if (router != nullptr && router->IsStateValid())
+            {
+                mRouterStateMask |= (1ULL << id);
+            }
+        }
+
+        ScheduleUpdateTimer(0);
+    }
+
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, aClientAddr, HandleServerUpdateAck, this));
+    mUpdatePending = true;
+
+exit:
+    if (error != kErrorNone)
+    {
+        LogCrit("Failed to send response: %s", ErrorToString(error));
+    }
+    FreeMessageOnError(message, error);
+    return error;
+}
+
+Error Server::SendEmptyServerUpdate(const Ip6::Address &aClientAddr)
+{
+    Error error = kErrorNone;
+
+    Coap::Message *message = nullptr;
+
+    UpdateHeader header;
+
+    // Don't send if we have a pending update awaiting ACK
+    VerifyOrExit(!mUpdatePending, error = kErrorBusy);
+
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriMeshMonServerUpdate);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    header.Init();
+    header.SetRouterId(Mle::RouterIdFromRloc16(Get<Mle::Mle>().GetRloc16()));
+    header.SetFullSeqNumber(mSequenceNumber + 1);
+    SuccessOrExit(error = header.AppendTo(*message));
+
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageTo(*message, aClientAddr, HandleServerUpdateAck, this));
+    mUpdatePending = true;
+
+exit:
+    if (error != kErrorNone)
+    {
+        LogCrit("Failed to send response: %s", ErrorToString(error));
+    }
+    FreeMessageOnError(message, error);
+    return error;
+}
+
+Error Server::SendServerUpdate(void)
+{
+    Error error = kErrorNone;
+
+    Coap::Message *message = nullptr;
+
+    UpdateHeader header;
+    TlvSet       hostSet;
+    Context      hostContext;
+    uint16_t     offset;
+    uint16_t     startIndex         = mChildResumeIndex;
+    uint8_t      neighborStartIndex = mNeighborResumeIndex;
+    bool         needsAnotherUpdate = false;
+    bool         neighborNeedsMore  = false;
+
+    // Don't send if we have a pending update awaiting ACK
+    VerifyOrExit(!mUpdatePending, error = kErrorBusy);
+
+    LockChildCaches();
+
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriMeshMonServerUpdate);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    header.Init();
+    header.SetRouterId(Mle::RouterIdFromRloc16(Get<Mle::Mle>().GetRloc16()));
+    header.SetShortSeqNumber(mSequenceNumber + 1);
+
+    SuccessOrExit(error = header.AppendTo(*message));
+
+    // Host TLVs only in first batch
+    if (startIndex == 0)
+    {
+        hostSet = mSelfDirty.Intersect(mSelfEnabled);
+        if (!hostSet.IsEmpty())
+        {
+            hostContext.Init();
+            hostContext.SetType(kTypeHost);
+
+            offset = message->GetLength();
+            SuccessOrExit(error = message->Append(hostContext));
+            SuccessOrExit(error = AppendHostTlvs(*message, hostSet));
+            hostContext.SetLength(message->GetLength() - offset);
+            message->Write(offset, hostContext);
+        }
+    }
+
+    // Child updates
+    if (!mChildEnabled.IsEmpty())
+    {
+        VerifyOrExit(AppendChildContextBatch(*message, needsAnotherUpdate), error = kErrorFailed);
+    }
+
+    // Neighbor updates only after children are done
+    if (!mNeighborEnabled.IsEmpty() && !needsAnotherUpdate && mChildResumeIndex == 0)
+    {
+        VerifyOrExit(AppendNeighborContextBatch(*message, neighborNeedsMore), error = kErrorFailed);
+    }
+
+    SuccessOrExit(error = Get<Tmf::Agent>().SendMessageToRloc(*message, mClientRloc, HandleServerUpdateAck, this));
+
+    mUpdatePending = true;
+
+    if (startIndex == 0 && neighborStartIndex == 0)
+    {
+        mSelfDirty.Clear();
+    }
+
+exit:
+    if (error == kErrorNone)
+    {
+        CommitChildCacheUpdates();
+
+        if (!mUpdatePending && (needsAnotherUpdate || mSendChildBaseline || neighborNeedsMore || mSendNeighborBaseline))
+        {
+            ScheduleUpdateTimer(0);
+        }
+    }
+    else if (error == kErrorBusy)
+    {
+        // If busy due to pending ACK, don't treat as error
+    }
+    else
+    {
+        LogCrit("Failed to send router update %s", ErrorToString(error));
+        UnlockChildCaches();
+        FreeMessage(message);
+        mChildResumeIndex = 0;
+
+        ScheduleChildTimer();
+    }
+    return error;
+}
+
+Error Server::ConfigureAsRouter(const TlvSet &aSelf, const TlvSet &aChild, const TlvSet &aNeighbor, bool aQuery)
+{
+    Error  error = kErrorNone;
+    TlvSet oldFtd;
+    TlvSet oldMtd;
+
+    if (!mActive)
+    {
+        VerifyOrExit(!aSelf.IsEmpty() || !aChild.IsEmpty() || !aNeighbor.IsEmpty(), error = kErrorInvalidArgs);
+
+        mSequenceNumber = Random::NonCrypto::Generate<uint32_t>();
+
+        mSelfEnabled.Clear();
+        mSelfPendingUpdate.Clear();
+        mSelfDirty.Clear();
+
+        mChildEnabled.Clear();
+        mChildResumeIndex = 0;
+        mUpdatePending    = false;
+
+        mNeighborEnabled.Clear();
+
+        mClientRegistered = false;
+
+        mActive = true;
+
+        mRouterStateMask = 0;
+
+        mRegistrationTimer.Start(kRegistrationInterval);
+    }
+
+    mSelfEnabled = aSelf;
+    mSelfEnabled.FilterHostSupportedTlv();
+
+    mSelfDirty.SetAll(GetExtDelayTlvs(mSelfEnabled));
+
+    oldFtd = mChildEnabled.GetProvidedByFtdChild();
+    oldMtd = mChildEnabled.GetProvidedByMtdChild();
+
+    mChildEnabled = aChild;
+    mChildEnabled.FilterChildSupportedTlv();
+
+    SyncAllChildDiagStates(oldFtd != mChildEnabled.GetProvidedByFtdChild(),
+                           oldMtd != mChildEnabled.GetProvidedByMtdChild(), aQuery);
+
+    mNeighborEnabled = aNeighbor;
+    mNeighborEnabled.FilterNeighborSupportedTlv();
+
+    // Mark client registered for this interval
+    mClientRegistered = true;
+
+    if (!mSelfDirty.IsEmpty())
+    {
+        ScheduleUpdateTimer(Random::NonCrypto::AddJitter(kUpdateExtDelay, kUpdateJitter));
+    }
+
+exit:
+    return error;
+}
+
+void Server::SyncAllChildDiagStates(bool aMtdChanged, bool aFtdChanged, bool aQuery)
+{
+    bool changed;
+
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
+    {
+        if (child.IsFullThreadDevice())
+        {
+            changed = aFtdChanged;
+        }
+        else
+        {
+            changed = aMtdChanged;
+        }
+
+        SyncChildDiagState(child, changed | aQuery);
+    }
+}
+
+void Server::SyncChildDiagState(Child &aChild, bool aQuery)
+{
+    TlvSet set;
+
+    if (aChild.IsFullThreadDevice())
+    {
+        set = mChildEnabled.GetProvidedByFtdChild();
+    }
+    else
+    {
+        set = mChildEnabled.GetProvidedByMtdChild();
+    }
+
+    if (set.IsEmpty())
+    {
+        aChild.ClearCache();
+
+        switch (aChild.GetDiagServerState())
+        {
+        case Child::kDiagServerActive:
+        case Child::kDiagServerActivePending:
+        case Child::kDiagServerUnknown:
+            IgnoreError(SendEndDeviceRequestStop(aChild));
+            break;
+
+        case Child::kDiagServerStopped:
+        case Child::kDiagServerStopPending:
+            break;
+        }
+    }
+    else
+    {
+        switch (aChild.GetDiagServerState())
+        {
+        case Child::kDiagServerActive:
+        case Child::kDiagServerActivePending:
+            if (!aQuery)
+            {
+                break;
+            }
+            // If SendEndDeviceRequestStart fails it will still stop the pending transaction
+            // and set state to unknown so the next update will retry even
+            // without aQuery being set.
+            OT_FALL_THROUGH;
+
+        case Child::kDiagServerUnknown:
+            // Make sure we always query after failed updates
+            aQuery = true;
+            OT_FALL_THROUGH;
+
+        case Child::kDiagServerStopped:
+        case Child::kDiagServerStopPending:
+            IgnoreError(SendEndDeviceRequestStart(aChild, set, aQuery));
+            break;
+        }
+    }
+}
+
+Error Server::SendEndDeviceRequestStop(Child &aChild)
+{
+    Error          error   = kErrorNone;
+    Coap::Message *message = nullptr;
+
+    ChildRequestHeader header;
+
+    if (aChild.IsDiagServerPending())
+    {
+        IgnoreError(Get<Tmf::Agent>().AbortTransaction(HandleEndDeviceRequestAck, &aChild));
+    }
+
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriMeshMonEndDeviceRequest);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    header.Clear();
+    header.SetCommand(ChildRequestHeader::kStop);
+
+    SuccessOrExit(error = message->Append(header));
+
+    SuccessOrExit(
+        error = Get<Tmf::Agent>().SendMessageToRloc(*message, aChild.GetRloc16(), HandleEndDeviceRequestAck, &aChild));
+    aChild.SetDiagServerState(Child::kDiagServerStopPending);
+
+    LogInfo("Sent DiagServer stop to child %04x", aChild.GetRloc16());
+
+exit:
+    FreeMessageOnError(message, error);
+    return error;
+}
+
+Error Server::SendEndDeviceRequestStart(Child &aChild, const TlvSet &aTypes, bool aQuery)
+{
+    Error          error   = kErrorNone;
+    Coap::Message *message = nullptr;
+
+    ChildRequestHeader header;
+    uint16_t           offset;
+    uint8_t            setCount = 0;
+
+    if (aChild.IsDiagServerPending())
+    {
+        IgnoreError(Get<Tmf::Agent>().AbortTransaction(HandleEndDeviceRequestAck, &aChild));
+    }
+
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriMeshMonEndDeviceRequest);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    offset = message->GetLength();
+
+    header.Clear();
+    header.SetCommand(ChildRequestHeader::kStart);
+    header.SetQuery(aQuery);
+
+    SuccessOrExit(error = message->Append(header));
+    SuccessOrExit(error = aTypes.AppendTo(*message, setCount));
+
+    header.SetRequestSetCount(setCount);
+    message->Write(offset, header);
+
+    SuccessOrExit(
+        error = Get<Tmf::Agent>().SendMessageToRloc(*message, aChild.GetRloc16(), HandleEndDeviceRequestAck, &aChild));
+    aChild.SetDiagServerState(Child::kDiagServerActivePending);
+
+    LogInfo("Sent DiagServer start to child %04x", aChild.GetRloc16());
+
+exit:
+    FreeMessageOnError(message, error);
+    return error;
+}
+
+Error Server::SendEndDeviceRecoveryQuery(Child &aChild, const TlvSet &aTypes)
+{
+    Error          error   = kErrorNone;
+    Coap::Message *message = nullptr;
+
+    ChildRequestHeader header;
+    uint16_t           offset;
+    uint8_t            setCount = 0;
+
+    message = Get<Tmf::Agent>().AllocateAndInitConfirmablePostMessage(kUriMeshMonEndDeviceRequest);
+    VerifyOrExit(message != nullptr, error = kErrorNoBufs);
+
+    offset = message->GetLength();
+
+    header.Clear();
+    header.SetCommand(ChildRequestHeader::kStart);
+    header.SetQuery(true);
+
+    SuccessOrExit(error = message->Append(header));
+    SuccessOrExit(error = aTypes.AppendTo(*message, setCount));
+
+    header.SetRequestSetCount(setCount);
+    message->Write(offset, header);
+
+    SuccessOrExit(
+        error = Get<Tmf::Agent>().SendMessageToRloc(*message, aChild.GetRloc16(), HandleEndDeviceRecoveryAck, &aChild));
+    aChild.SetLostDiagQueryPending(true);
+
+    LogInfo("Sent DiagServer lost query to child %04x", aChild.GetRloc16());
+
+exit:
+    FreeMessageOnError(message, error);
+    return error;
+}
+
+void Server::HandleEndDeviceRequestAck(Child &aChild, Coap::Msg *aMsg, Error aResult)
+{
+    ChildInfo::DiagState state = aChild.GetDiagServerState();
+
+    if (aResult == kErrorNone)
+    {
+        if (state == Child::kDiagServerActivePending)
+        {
+            state = Child::kDiagServerActive;
+            LogInfo("Child %04x state changed to active", aChild.GetRloc16());
+        }
+        else if (state == Child::kDiagServerStopPending)
+        {
+            state = Child::kDiagServerStopped;
+            LogInfo("Child %04x state changed to stopped", aChild.GetRloc16());
+        }
+        else
+        {
+            LogWarn("Received response for child but state is not pending");
+            state = Child::kDiagServerUnknown;
+        }
+
+        aChild.SetDiagServerState(state);
+
+        VerifyOrExit(aMsg != nullptr);
+        if (aChild.UpdateCache(aMsg->mMessage, mChildEnabled) == kErrorNone)
+        {
+            ScheduleUpdateTimer(kUpdateBaseDelay);
+        }
+        else
+        {
+            mCacheErrors++;
+            // TODO: Cache allocation failure handling
+            //
+            // When UpdateCache() fails, typically kErrorNoBufs, we face a recovery dilemma:
+            // 1. The CoAP ACK was already sent -> child thinks we received the data
+            // 2. We are out of memory -> cannot allocate buffers to store the response
+            // 3. The child won't retry -> it believes transmission succeeded
+            //
+            // Current mitigation: mCacheErrors counter tracks failures, mLostSet marks
+            // missing TLVs for later re-query via SendEndDeviceRecoveryQuery().
+        }
+
+        UpdateIfCacheBufferLimit();
+    }
+    else
+    {
+        aChild.SetDiagServerState(Child::kDiagServerUnknown);
+    }
+
+exit:
+    // Verify child state
+    ScheduleChildTimer();
+}
+
+void Server::HandleEndDeviceRequestAck(void *aContext, Coap::Msg *aMsg, Error aResult)
+{
+    OT_ASSERT(aContext != nullptr);
+
+    Child *child = static_cast<Child *>(aContext);
+
+    child->GetInstance().Get<Server>().HandleEndDeviceRequestAck(*child, aMsg, aResult);
+}
+
+void Server::HandleEndDeviceRecoveryAck(Child &aChild, Coap::Msg *aMsg, Error aResult)
+{
+    aChild.SetLostDiagQueryPending(false);
+
+    if (aResult == kErrorNone)
+    {
+        OT_ASSERT(aMsg != nullptr);
+        if (aChild.UpdateCache(aMsg->mMessage, aChild.GetLostDiag()) != kErrorNone)
+        {
+            mCacheErrors++;
+        }
+
+        UpdateIfCacheBufferLimit();
+    }
+    else
+    {
+        // Retry later
+        ScheduleChildTimer();
+    }
+}
+
+void Server::HandleEndDeviceRecoveryAck(void *aContext, Coap::Msg *aMsg, Error aResult)
+{
+    OT_ASSERT(aContext != nullptr);
+
+    Child *child = static_cast<Child *>(aContext);
+
+    child->GetInstance().Get<Server>().HandleEndDeviceRecoveryAck(*child, aMsg, aResult);
+}
+
+void Server::HandleServerUpdateAck(Coap::Msg *aMsg, Error aResult)
+{
+    OT_UNUSED_VARIABLE(aMsg);
+
+    mUpdatePending = false;
+
+    if (aResult == kErrorNone)
+    {
+        mSequenceNumber++;
+        mUpdateRetryCount = 0; // Reset backoff counter on success
+
+        // If more batches pending, schedule next send
+        if (mSendChildBaseline || mChildResumeIndex != 0 || mSendNeighborBaseline || mNeighborResumeIndex != 0)
+        {
+            ScheduleUpdateTimer(0);
+        }
+    }
+    else
+    {
+        mUpdateRetryCount++;
+
+        if (mUpdateRetryCount >= kMaxUpdateRetries)
+        {
+            // Give up after 5 retry attempts. Increment sequence to maintain at-most-once semantics.
+            //
+            // Case 1: Client received the message but ACK was lost
+            //   -> Incrementing keeps our sequence in sync with client (both at N+1)
+            //   -> Without increment, we would send duplicate seq=(N+1) later
+            //
+            // Case 2: Client never received the message
+            //   -> Client detects sequence gap (expected N+1, gets N+2 later)
+            //   -> Client sends error query to request resync
+            //
+            // NOTE: We clear mChildResumeIndex and mSendChildBaseline to discard any pending
+            // child updates that haven't been sent yet. The client will detect missing data
+            // and request a full resync.
+
+            mSequenceNumber++;
+            mUpdateRetryCount = 0;
+            mSelfDirty.Clear();
+            mChildResumeIndex     = 0;
+            mSendChildBaseline    = false;
+            mNeighborResumeIndex  = 0;
+            mSendNeighborBaseline = false;
+        }
+        else
+        {
+            uint32_t backoffDelay = kUpdateBaseDelay << (mUpdateRetryCount - 1);
+            backoffDelay          = Min(backoffDelay, kMaxUpdateBackoff);
+
+            ScheduleUpdateTimer(backoffDelay);
+        }
+    }
+}
+#endif // OPENTHREAD_FTD
+
+static void SetLinkMarginTlvValue(LinkMarginTlvValue &aTlvValue, const LinkQualityInfo &aLinkInfo)
+{
+    int8_t averageRssi = aLinkInfo.GetAverageRss();
+
+    aTlvValue.SetLinkMargin((averageRssi == LinkMarginTlvValue::kUnknownRssi)
+                                ? LinkMarginTlvValue::kUnknownLinkMargin
+                                : Min(aLinkInfo.GetLinkMargin(), LinkMarginTlvValue::kMaxLinkMargin));
+    aTlvValue.SetAverageRssi(averageRssi);
+    aTlvValue.SetLastRssi(aLinkInfo.GetLastRss());
+}
+
+Error Server::AppendHostTlvs(Message &aMessage, TlvSet aTlvs)
+{
+    Error error = kErrorNone;
+
+    for (Tlv::Type type : aTlvs)
+    {
+        switch (type)
+        {
+#if OPENTHREAD_FTD
+        case Tlv::kExtAddress:
+            SuccessOrExit(error = Tlv::Append<ExtAddressTlv>(aMessage, Get<Mac::Mac>().GetExtAddress()));
+            break;
+
+        case Tlv::kMode:
+            SuccessOrExit(error = Tlv::Append<ModeTlv>(aMessage, Get<Mle::Mle>().GetDeviceMode().Get()));
+            break;
+
+        case Tlv::kRoute64:
+            SuccessOrExit(error = Get<RouterTable>().AppendRouteTlv(aMessage, Tlv::kRoute64));
+            break;
+#endif
+
+        case Tlv::kMlEid:
+            SuccessOrExit(error = Tlv::Append<MlEidTlv>(aMessage, Get<Mle::Mle>().GetMeshLocalEid().GetIid()));
+            break;
+
+        case Tlv::kIp6AddressList:
+            SuccessOrExit(error = AppendHostIp6AddressList(aMessage));
+            break;
+
+        case Tlv::kAlocList:
+            SuccessOrExit(error = AppendHostAlocList(aMessage));
+            break;
+
+#if OPENTHREAD_FTD
+        case Tlv::kThreadVersion:
+            SuccessOrExit(error = Tlv::Append<ThreadVersionTlv>(aMessage, kThreadVersion));
+            break;
+#endif
+
+        case Tlv::kThreadStackVersion:
+            SuccessOrExit(error = Tlv::Append<ThreadStackVersionTlv>(aMessage, otGetVersionString()));
+            break;
+
+        case Tlv::kVendorName:
+            SuccessOrExit(error = Tlv::Append<VendorNameTlv>(aMessage, Get<VendorInfo>().GetName()));
+            break;
+
+        case Tlv::kVendorModel:
+            SuccessOrExit(error = Tlv::Append<VendorModelTlv>(aMessage, Get<VendorInfo>().GetModel()));
+            break;
+
+        case Tlv::kVendorSwVersion:
+            SuccessOrExit(error = Tlv::Append<VendorSwVersionTlv>(aMessage, Get<VendorInfo>().GetSwVersion()));
+            break;
+
+        case Tlv::kVendorAppUrl:
+            SuccessOrExit(error = Tlv::Append<VendorAppUrlTlv>(aMessage, Get<VendorInfo>().GetAppUrl()));
+            break;
+
+        case Tlv::kIp6LinkLocalAddressList:
+            SuccessOrExit(error = AppendHostLinkLocalAddressList(aMessage));
+            break;
+
+        case Tlv::kEui64:
+        {
+            Mac::ExtAddress eui64;
+
+            Get<Radio>().GetIeeeEui64(eui64);
+            SuccessOrExit(error = Tlv::Append<Eui64Tlv>(aMessage, eui64));
+            break;
+        }
+
+        case Tlv::kMacCounters:
+        {
+            NetDiag::MacCountersTlvValue tlvValue;
+            const Mac::Counters         &counters = Get<Mac::Mac>().GetCounters();
+
+            tlvValue.InitFrom(counters);
+            SuccessOrExit(error = Tlv::Append<MacCountersTlv>(aMessage, tlvValue));
+            break;
+        }
+
+        case Tlv::kMacLinkErrorRatesRx:
+        {
+            MacLinkErrorRatesRxTlv tlv;
+            Parent                &parent = Get<Mle::Mle>().GetParent();
+
+            VerifyOrExit(Get<Mle::Mle>().IsChild());
+
+            tlv.Init();
+            tlv.SetMessageErrorRate(parent.GetLinkInfo().GetMessageErrorRate());
+            tlv.SetFrameErrorRate(parent.GetLinkInfo().GetFrameErrorRate());
+
+            SuccessOrExit(error = aMessage.Append(tlv));
+            break;
+        }
+
+        case Tlv::kMleCounters:
+        {
+            NetDiag::MleCountersTlvValue tlvValue;
+
+            tlvValue.InitFrom(Get<Mle::Mle>().GetCounters());
+            SuccessOrExit(error = Tlv::Append<MleCountersTlv>(aMessage, tlvValue));
+            break;
+        }
+
+        case Tlv::kLinkMarginOut:
+        {
+            LinkMarginOutTlv tlv;
+            Parent          &parent = Get<Mle::Mle>().GetParent();
+
+            VerifyOrExit(Get<Mle::Mle>().IsChild());
+
+            tlv.Init();
+            SetLinkMarginTlvValue(tlv, parent.GetLinkInfo());
+
+            SuccessOrExit(error = aMessage.Append(tlv));
+            break;
+        }
+
+        default:
+            break;
+        }
+    }
+
+exit:
+    return error;
+}
+
+#if OPENTHREAD_FTD
+Error Server::AppendHostContext(Message &aMessage, TlvSet aTlvs)
+{
+    Error error = kErrorNone;
+
+    Context  context;
+    uint16_t offset = aMessage.GetLength();
+
+    context.Init();
+    context.SetType(kTypeHost);
+    SuccessOrExit(error = aMessage.Append(context));
+
+    SuccessOrExit(error = AppendHostTlvs(aMessage, aTlvs));
+
+    context.SetLength(aMessage.GetLength() - offset);
+    aMessage.Write(offset, context);
+
+exit:
+    return error;
+}
+
+Error Server::AppendChildContext(Message &aMessage, Child &aChild)
+{
+    Error error = kErrorNone;
+
+    ChildContext context;
+    uint16_t     offset  = aMessage.GetLength();
+    bool         allTlvs = false;
+
+    VerifyOrExit(aChild.ShouldSendDiagUpdate());
+
+    context.Init();
+    context.SetType(kTypeChild);
+    context.SetId(Mle::ChildIdFromRloc16(aChild.GetRloc16()));
+    SuccessOrExit(error = aMessage.Append(context));
+
+    context.SetUpdateMode(kModeUpdated);
+
+    if (aChild.IsAttachStateDirty())
+    {
+        if (aChild.IsStateValid())
+        {
+            context.SetUpdateMode(kModeAdded);
+            allTlvs = true;
+        }
+        else
+        {
+            context.SetUpdateMode(kModeRemoved);
+        }
+    }
+
+    if (aChild.IsStateValid())
+    {
+        TlvSet tlvs = aChild.GetDirtyHostProvided(mChildEnabled);
+        if (allTlvs)
+        {
+            if (aChild.mIsFtd)
+            {
+                tlvs = mChildEnabled.GetNotProvidedByFtdChild();
+            }
+            else
+            {
+                tlvs = mChildEnabled.GetNotProvidedByMtdChild();
+            }
+        }
+
+        SuccessOrExit(error = AppendChildTlvs(aMessage, tlvs, aChild));
+        SuccessOrExit(error = aChild.AppendCachedTlvs(aMessage));
+    }
+
+    context.SetLength(aMessage.GetLength() - offset);
+    aMessage.Write(offset, context);
+
+exit:
+    return error;
+}
+
+Error Server::AppendChildTlvs(Message &aMessage, TlvSet aTlvs, const Child &aChild)
+{
+    Error error = kErrorNone;
+
+    for (Tlv::Type type : aTlvs)
+    {
+        switch (type)
+        {
+        case Tlv::kExtAddress:
+            SuccessOrExit(error = Tlv::Append<ExtAddressTlv>(aMessage, aChild.GetExtAddress()));
+            break;
+
+        case Tlv::kMode:
+            SuccessOrExit(error = Tlv::Append<ModeTlv>(aMessage, aChild.GetDeviceMode().Get()));
+            break;
+
+        case Tlv::kTimeout:
+            SuccessOrExit(error = Tlv::Append<TimeoutTlv>(aMessage, aChild.GetTimeout()));
+            break;
+
+        case Tlv::kLastHeard:
+            SuccessOrExit(error = Tlv::Append<LastHeardTlv>(aMessage, TimerMilli::GetNow() - aChild.GetLastHeard()));
+            break;
+
+        case Tlv::kConnectionTime:
+            SuccessOrExit(error = Tlv::Append<ConnectionTimeTlv>(aMessage, aChild.GetConnectionTime()));
+            break;
+
+        case Tlv::kCsl:
+        {
+            CslTlv tlv;
+            tlv.Init();
+
+#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+            tlv.SetChannel(aChild.GetCslChannel());
+            tlv.SetTimeout(aChild.GetCslTimeout());
+
+            if (aChild.IsCslSynchronized())
+            {
+                tlv.SetPeriod(aChild.GetCslPeriod());
+            }
+#endif
+
+            SuccessOrExit(error = aMessage.Append(tlv));
+            break;
+        }
+
+        case Tlv::kLinkMarginIn:
+        {
+            LinkMarginInTlv tlv;
+            tlv.Init();
+
+            SetLinkMarginTlvValue(tlv, aChild.GetLinkInfo());
+
+            SuccessOrExit(error = aMessage.Append(tlv));
+            break;
+        }
+
+        case Tlv::kMacLinkErrorRatesTx:
+        {
+            MacLinkErrorRatesTxTlv tlv;
+            tlv.Init();
+
+            tlv.SetMessageErrorRate(aChild.GetLinkInfo().GetMessageErrorRate());
+            tlv.SetFrameErrorRate(aChild.GetLinkInfo().GetFrameErrorRate());
+
+            SuccessOrExit(error = aMessage.Append(tlv));
+            break;
+        }
+
+        case Tlv::kMlEid:
+            SuccessOrExit(error = Tlv::Append<MlEidTlv>(aMessage, aChild.GetMeshLocalIid()));
+            break;
+
+        case Tlv::kIp6AddressList:
+            SuccessOrExit(error = AppendChildIp6AddressList(aMessage, aChild));
+            break;
+
+        case Tlv::kAlocList:
+            SuccessOrExit(error = AppendChildAlocList(aMessage, aChild));
+            break;
+
+        case Tlv::kThreadVersion:
+            SuccessOrExit(error = Tlv::Append<ThreadVersionTlv>(aMessage, aChild.GetVersion()));
+            break;
+
+        default:
+            break;
+        }
+    }
+
+exit:
+    return error;
+}
+
+Error Server::AppendNeighborContextBaseline(Message &aMessage, const Router &aRouter)
+{
+    Error error = kErrorNone;
+
+    NeighborContext context;
+    uint16_t        offset = aMessage.GetLength();
+
+    context.Init();
+    context.SetType(kTypeNeighbor);
+    context.SetId(aRouter.GetRouterId());
+    context.SetUpdateMode(kModeAdded);
+    SuccessOrExit(error = aMessage.Append(context));
+    SuccessOrExit(error = AppendNeighborTlvs(aMessage, mNeighborEnabled, aRouter));
+
+    context.SetLength(aMessage.GetLength() - offset);
+    aMessage.Write(offset, context);
+
+exit:
+    return error;
+}
+
+Error Server::AppendNeighborContextUpdate(Message &aMessage, uint8_t aId)
+{
+    Error   error  = kErrorNone;
+    Router *router = Get<RouterTable>().FindRouterById(aId);
+    bool    valid  = (router != nullptr) && router->IsStateValid();
+    TlvSet  tlvs   = mNeighborEnabled;
+
+    NeighborContext context;
+    uint16_t        offset = aMessage.GetLength();
+
+    VerifyOrExit(valid || (mRouterStateMask & (1ULL << aId)) != 0);
+
+    context.Init();
+    context.SetType(kTypeNeighbor);
+    context.SetId(aId);
+    if (valid)
+    {
+        if (mRouterStateMask & (1ULL << aId))
+        {
+            context.SetUpdateMode(kModeAdded);
+        }
+        else
+        {
+            context.SetUpdateMode(kModeUpdated);
+
+            tlvs.ClearAll(static_cast<const TlvSet &>(kStaticNeighborTlvMask));
+            VerifyOrExit(!tlvs.IsEmpty());
+        }
+    }
+    else
+    {
+        context.SetUpdateMode(kModeRemoved);
+    }
+    SuccessOrExit(error = aMessage.Append(context));
+
+    if (valid)
+    {
+        SuccessOrExit(error = AppendNeighborTlvs(aMessage, tlvs, *router));
+    }
+
+    context.SetLength(aMessage.GetLength() - offset);
+    aMessage.Write(offset, context);
+
+exit:
+    return error;
+}
+
+Error Server::AppendNeighborTlvs(Message &aMessage, TlvSet aTlvs, const Router &aNeighbor)
+{
+    Error error = kErrorNone;
+
+    for (Tlv::Type type : aTlvs)
+    {
+        switch (type)
+        {
+        case Tlv::kExtAddress:
+            SuccessOrExit(error = Tlv::Append<ExtAddressTlv>(aMessage, aNeighbor.GetExtAddress()));
+            break;
+
+        case Tlv::kLastHeard:
+            SuccessOrExit(error = Tlv::Append<LastHeardTlv>(aMessage, TimerMilli::GetNow() - aNeighbor.GetLastHeard()));
+            break;
+
+        case Tlv::kConnectionTime:
+            SuccessOrExit(error = Tlv::Append<ConnectionTimeTlv>(aMessage, aNeighbor.GetConnectionTime()));
+            break;
+
+        case Tlv::kLinkMarginIn:
+        {
+            LinkMarginInTlv tlv;
+            tlv.Init();
+
+            SetLinkMarginTlvValue(tlv, aNeighbor.GetLinkInfo());
+
+            SuccessOrExit(error = aMessage.Append(tlv));
+            break;
+        }
+
+        case Tlv::kMacLinkErrorRatesTx:
+        {
+            MacLinkErrorRatesTxTlv tlv;
+            tlv.Init();
+
+            tlv.SetMessageErrorRate(aNeighbor.GetLinkInfo().GetMessageErrorRate());
+            tlv.SetFrameErrorRate(aNeighbor.GetLinkInfo().GetFrameErrorRate());
+
+            SuccessOrExit(error = aMessage.Append(tlv));
+            break;
+        }
+
+        case Tlv::kThreadVersion:
+            SuccessOrExit(error = Tlv::Append<ThreadVersionTlv>(aMessage, aNeighbor.GetVersion()));
+            break;
+
+        default:
+            break;
+        }
+    }
+
+exit:
+    return error;
+}
+
+bool Server::AppendChildContextBatch(Message &aMessage, bool &aNeedsMore)
+{
+    bool               success        = true;
+    uint16_t           childIndex     = 0;
+    uint16_t           startIndex     = mChildResumeIndex;
+    Child::StateFilter filter         = mSendChildBaseline ? Child::kInStateValid : Child::kInStateAny;
+    bool               abortRemaining = false;
+
+    aNeedsMore = false;
+
+    for (Child &child : Get<ChildTable>().Iterate(filter))
+    {
+        if (abortRemaining)
+        {
+            child.AbortCacheUpdate();
+            childIndex++;
+            continue;
+        }
+
+        if (childIndex < startIndex)
+        {
+            childIndex++;
+            continue;
+        }
+
+        if (mSendChildBaseline)
+        {
+            child.SetAttachStateDirty();
+        }
+        else if (!child.ShouldSendDiagUpdate())
+        {
+            childIndex++;
+            continue;
+        }
+
+        uint16_t beforeLen = aMessage.GetLength();
+        Error    error     = AppendChildContext(aMessage, child);
+
+        if (error == kErrorNoBufs || aMessage.GetLength() > kMaxUpdateMessageLength)
+        {
+            IgnoreError(aMessage.SetLength(beforeLen));
+            child.AbortCacheUpdate();
+            aNeedsMore        = true;
+            mChildResumeIndex = childIndex;
+            abortRemaining    = true;
+            childIndex++;
+            continue;
+        }
+
+        if (error != kErrorNone)
+        {
+            success        = false;
+            abortRemaining = true;
+            childIndex++;
+            continue;
+        }
+
+        childIndex++;
+    }
+
+    if (!aNeedsMore)
+    {
+        if (mSendChildBaseline)
+        {
+            mSendChildBaseline = false;
+        }
+        mChildResumeIndex = 0;
+    }
+
+    return success;
+}
+
+bool Server::AppendNeighborContextBatch(Message &aMessage, bool &aNeedsMore)
+{
+    bool    success    = true;
+    uint8_t startIndex = mNeighborResumeIndex;
+    aNeedsMore         = false;
+
+    for (uint8_t id = startIndex; id < Mle::kMaxRouterId; id++)
+    {
+        Router *router = Get<RouterTable>().FindRouterById(id);
+        bool    valid  = (router != nullptr) && router->IsStateValid();
+
+        // In baseline mode, only process valid routers that are in the state mask
+        // In update mode, process if there's a state change (added/removed)
+        if (mSendNeighborBaseline)
+        {
+            if (!valid || (mRouterStateMask & (1ULL << id)) == 0)
+            {
+                continue;
+            }
+        }
+        else
+        {
+            // Skip if no state change and router not valid (nothing to report)
+            if (!valid && (mRouterStateMask & (1ULL << id)) == 0)
+            {
+                continue;
+            }
+        }
+
+        uint16_t beforeLen = aMessage.GetLength();
+        Error    error;
+
+        if (mSendNeighborBaseline)
+        {
+            error = AppendNeighborContextBaseline(aMessage, *router);
+        }
+        else
+        {
+            error = AppendNeighborContextUpdate(aMessage, id);
+        }
+
+        if (error == kErrorNoBufs || aMessage.GetLength() > kMaxUpdateMessageLength)
+        {
+            IgnoreError(aMessage.SetLength(beforeLen));
+            aNeedsMore           = true;
+            mNeighborResumeIndex = id;
+            break;
+        }
+
+        if (error != kErrorNone)
+        {
+            // kErrorNotFound is expected when neighbor has no changes
+            if (error != kErrorNotFound)
+            {
+                success = false;
+                break;
+            }
+        }
+    }
+
+    if (!aNeedsMore)
+    {
+        if (mSendNeighborBaseline)
+        {
+            mSendNeighborBaseline = false;
+        }
+        mNeighborResumeIndex = 0;
+        mRouterStateMask     = 0;
+    }
+
+    return success;
+}
+
+void Server::LockChildCaches(void)
+{
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateAny))
+    {
+        child.LockCache();
+    }
+}
+
+void Server::CommitChildCacheUpdates(void)
+{
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateAny))
+    {
+        // Only commit if the cache is still locked (meaning it wasn't aborted)
+        if (child.IsDiagCacheLocked())
+        {
+            child.CommitCacheUpdate();
+        }
+    }
+}
+
+void Server::UnlockChildCaches(void)
+{
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateAny))
+    {
+        if (child.IsDiagCacheLocked())
+        {
+            child.AbortCacheUpdate();
+        }
+    }
+}
+#endif // OPENTHREAD_FTD
+
+bool Server::ShouldIncludeIp6Address(const Ip6::Address &aAddress)
+{
+    bool pass = false;
+
+    VerifyOrExit(!Get<Mle::Mle>().IsMeshLocalAddress(aAddress));
+    VerifyOrExit(!aAddress.IsLinkLocalUnicastOrMulticast());
+    VerifyOrExit(aAddress != Ip6::Address::GetRealmLocalAllNodesMulticast());
+    VerifyOrExit(aAddress != Ip6::Address::GetRealmLocalAllRoutersMulticast());
+    VerifyOrExit(aAddress != Ip6::Address::GetRealmLocalAllMplForwarders());
+    VerifyOrExit(aAddress.IsMulticast() || !aAddress.GetIid().IsAnycastLocator());
+
+    pass = true;
+
+exit:
+    return pass;
+}
+
+bool Server::ShouldIncludeAloc(const Ip6::Address &aAddress, uint8_t &aAloc)
+{
+    bool pass = false;
+
+    VerifyOrExit(aAddress.GetIid().IsAnycastLocator());
+    aAloc = static_cast<uint8_t>(aAddress.GetIid().GetLocator());
+
+    pass = true;
+
+exit:
+    return pass;
+}
+
+bool Server::ShouldIncludeLinkLocalAddress(const Ip6::Address &aAddress)
+{
+    bool pass = false;
+
+    VerifyOrExit(aAddress.IsLinkLocalUnicastOrMulticast());
+    VerifyOrExit(aAddress != Ip6::Address::GetLinkLocalAllNodesMulticast());
+    VerifyOrExit(aAddress != Ip6::Address::GetLinkLocalAllRoutersMulticast());
+
+    pass = true;
+
+exit:
+    return pass;
+}
+
+Error Server::AppendHostIp6AddressList(Message &aMessage)
+{
+    Error    error = kErrorNone;
+    uint16_t count = 0;
+
+    for (const Ip6::Netif::UnicastAddress &address : Get<ThreadNetif>().GetUnicastAddresses())
+    {
+        if (ShouldIncludeIp6Address(address.GetAddress()))
+        {
+            count++;
+        }
+    }
+    for (const Ip6::Netif::MulticastAddress &address : Get<ThreadNetif>().GetMulticastAddresses())
+    {
+        if (ShouldIncludeIp6Address(address.GetAddress()))
+        {
+            count++;
+        }
+    }
+
+    if (count * Ip6::Address::kSize <= Tlv::kBaseTlvMaxLength)
+    {
+        Tlv tlv;
+
+        tlv.SetType(Tlv::kIp6AddressList);
+        tlv.SetLength(static_cast<uint8_t>(count * Ip6::Address::kSize));
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+    else
+    {
+        ExtendedTlv tlv;
+
+        tlv.SetType(Tlv::kIp6AddressList);
+        tlv.SetLength(count * Ip6::Address::kSize);
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+
+    for (const Ip6::Netif::UnicastAddress &address : Get<ThreadNetif>().GetUnicastAddresses())
+    {
+        if (ShouldIncludeIp6Address(address.GetAddress()))
+        {
+            SuccessOrExit(error = aMessage.Append(address.GetAddress()));
+        }
+    }
+    for (const Ip6::Netif::MulticastAddress &address : Get<ThreadNetif>().GetMulticastAddresses())
+    {
+        if (ShouldIncludeIp6Address(address.GetAddress()))
+        {
+            SuccessOrExit(error = aMessage.Append(address.GetAddress()));
+        }
+    }
+
+exit:
+    return error;
+}
+
+Error Server::AppendHostAlocList(Message &aMessage)
+{
+    Error    error = kErrorNone;
+    uint16_t count = 0;
+    uint8_t  aloc;
+
+    for (const Ip6::Netif::UnicastAddress &address : Get<ThreadNetif>().GetUnicastAddresses())
+    {
+        if (ShouldIncludeAloc(address.GetAddress(), aloc))
+        {
+            count++;
+        }
+    }
+
+    if (count <= Tlv::kBaseTlvMaxLength)
+    {
+        Tlv tlv;
+
+        tlv.SetType(Tlv::kAlocList);
+        tlv.SetLength(static_cast<uint8_t>(count));
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+    else
+    {
+        ExtendedTlv tlv;
+
+        tlv.SetType(Tlv::kAlocList);
+        tlv.SetLength(count);
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+
+    for (const Ip6::Netif::UnicastAddress &address : Get<ThreadNetif>().GetUnicastAddresses())
+    {
+        if (ShouldIncludeAloc(address.GetAddress(), aloc))
+        {
+            SuccessOrExit(error = aMessage.Append(aloc));
+        }
+    }
+
+exit:
+    return error;
+}
+
+Error Server::AppendHostLinkLocalAddressList(Message &aMessage)
+{
+    Error    error = kErrorNone;
+    uint16_t count = 0;
+
+    for (const Ip6::Netif::UnicastAddress &address : Get<ThreadNetif>().GetUnicastAddresses())
+    {
+        if (ShouldIncludeLinkLocalAddress(address.GetAddress()))
+        {
+            count++;
+        }
+    }
+    for (const Ip6::Netif::MulticastAddress &address : Get<ThreadNetif>().GetMulticastAddresses())
+    {
+        if (ShouldIncludeLinkLocalAddress(address.GetAddress()))
+        {
+            count++;
+        }
+    }
+
+    if (count * Ip6::Address::kSize <= Tlv::kBaseTlvMaxLength)
+    {
+        Tlv tlv;
+
+        tlv.SetType(Tlv::kIp6LinkLocalAddressList);
+        tlv.SetLength(static_cast<uint8_t>(count * Ip6::Address::kSize));
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+    else
+    {
+        ExtendedTlv tlv;
+
+        tlv.SetType(Tlv::kIp6LinkLocalAddressList);
+        tlv.SetLength(count * Ip6::Address::kSize);
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+
+    for (const Ip6::Netif::UnicastAddress &address : Get<ThreadNetif>().GetUnicastAddresses())
+    {
+        if (ShouldIncludeLinkLocalAddress(address.GetAddress()))
+        {
+            SuccessOrExit(error = aMessage.Append(address.GetAddress()));
+        }
+    }
+    for (const Ip6::Netif::MulticastAddress &address : Get<ThreadNetif>().GetMulticastAddresses())
+    {
+        if (ShouldIncludeLinkLocalAddress(address.GetAddress()))
+        {
+            SuccessOrExit(error = aMessage.Append(address.GetAddress()));
+        }
+    }
+
+exit:
+    return error;
+}
+
+#if OPENTHREAD_FTD
+Error Server::AppendChildIp6AddressList(Message &aMessage, const Child &aChild)
+{
+    Error    error = kErrorNone;
+    uint16_t count = 0;
+
+    for (const Ip6::Address &address : aChild.GetIp6Addresses())
+    {
+        if (ShouldIncludeIp6Address(address))
+        {
+            count++;
+        }
+    }
+
+    if (count * Ip6::Address::kSize <= Tlv::kBaseTlvMaxLength)
+    {
+        Tlv tlv;
+
+        tlv.SetType(Tlv::kIp6AddressList);
+        tlv.SetLength(static_cast<uint8_t>(count * Ip6::Address::kSize));
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+    else
+    {
+        ExtendedTlv tlv;
+
+        tlv.SetType(Tlv::kIp6AddressList);
+        tlv.SetLength(count * Ip6::Address::kSize);
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+
+    for (const Ip6::Address &address : aChild.GetIp6Addresses())
+    {
+        if (ShouldIncludeIp6Address(address))
+        {
+            SuccessOrExit(error = aMessage.Append(address));
+        }
+    }
+
+exit:
+    return error;
+}
+
+Error Server::AppendChildAlocList(Message &aMessage, const Child &aChild)
+{
+    Error    error = kErrorNone;
+    uint16_t count = 0;
+    uint8_t  aloc;
+
+    for (const Ip6::Address &address : aChild.GetIp6Addresses())
+    {
+        if (ShouldIncludeAloc(address, aloc))
+        {
+            count++;
+        }
+    }
+
+    if (count <= Tlv::kBaseTlvMaxLength)
+    {
+        Tlv tlv;
+
+        tlv.SetType(Tlv::kAlocList);
+        tlv.SetLength(static_cast<uint8_t>(count));
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+    else
+    {
+        ExtendedTlv tlv;
+
+        tlv.SetType(Tlv::kAlocList);
+        tlv.SetLength(count);
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+
+    for (const Ip6::Address &address : aChild.GetIp6Addresses())
+    {
+        if (ShouldIncludeAloc(address, aloc))
+        {
+            SuccessOrExit(error = aMessage.Append(aloc));
+        }
+    }
+
+exit:
+    return error;
+}
+#endif // OPENTHREAD_FTD
+
+void Server::HandleUpdateTimer(void)
+{
+    Error error = kErrorNone;
+    VerifyOrExit(mActive);
+
+#if OPENTHREAD_FTD
+    if (Get<Mle::Mle>().IsRouterOrLeader())
+    {
+        if (mSendFullUpdate)
+        {
+            mSendFullUpdate = false;
+
+            Ip6::Address clientAddr;
+            clientAddr.InitAsRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(), mClientRloc);
+            error = SendFullServerUpdate(clientAddr);
+        }
+        else
+        {
+            error = SendServerUpdate();
+        }
+    }
+    else
+#endif // OPENTHREAD_FTD
+    {
+        error = SendEndDeviceUpdate();
+    }
+
+    if (error != kErrorNone)
+    {
+        ScheduleUpdateTimer(kUpdateBaseDelay);
+    }
+    else
+    {
+        mSelfDirty = GetExtDelayTlvs(mSelfEnabled);
+
+#if OPENTHREAD_FTD
+        {
+            TlvSet childExtDelay = GetExtDelayTlvs(mChildEnabled);
+
+            if (!childExtDelay.IsEmpty())
+            {
+                for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
+                {
+                    child.MarkHostProvidedTlvsChanged(childExtDelay);
+                }
+            }
+        }
+#endif
+
+        if (!mSelfDirty.IsEmpty()
+#if OPENTHREAD_FTD
+            || HasExtDelayTlvs(mChildEnabled) || HasExtDelayTlvs(mNeighborEnabled)
+#endif
+        )
+        {
+            ScheduleUpdateTimer(Random::NonCrypto::AddJitter(kUpdateExtDelay, kUpdateJitter));
+        }
+    }
+
+exit:
+    return;
+}
+
+#if OPENTHREAD_FTD
+void Server::UpdateIfCacheBufferLimit(void)
+{
+    uint16_t total = 0;
+
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
+    {
+        total += child.GetUsedCacheBuffers();
+    }
+
+    if (total > kCacheBuffersLimit)
+    {
+        ScheduleUpdateTimer(0);
+    }
+}
+
+void Server::HandleChildTimer(void)
+{
+    VerifyOrExit(Get<Mle::Mle>().IsRouterOrLeader());
+
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
+    {
+        SyncChildDiagState(child, false);
+
+        // Potential future enhancement is to only try this when message
+        // buffers are available
+        if (child.ShouldSendLostDiagQuery())
+        {
+            IgnoreError(SendEndDeviceRecoveryQuery(child, child.GetLostDiag()));
+        }
+    }
+
+exit:
+    return;
+}
+
+void Server::HandleRegistrationTimer(void)
+{
+    VerifyOrExit(mActive && Get<Mle::Mle>().IsRouterOrLeader());
+
+    // If client didn't register this interval, stop server
+    if (!mClientRegistered)
+    {
+        StopServer();
+        ExitNow();
+    }
+
+    // Reset registration flag for next interval
+    mClientRegistered = false;
+
+    if (mSelfEnabled.IsEmpty() && mChildEnabled.IsEmpty() && mNeighborEnabled.IsEmpty())
+    {
+        StopServer();
+    }
+    else
+    {
+        mRegistrationTimer.Start(kRegistrationInterval);
+        SyncAllChildDiagStates(false, false, false);
+    }
+
+exit:
+    return;
+}
+#endif // OPENTHREAD_FTD
+#endif // OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+
+} // namespace MeshMonitor
+
+} // namespace ot

--- a/src/core/thread/mesh_monitor.hpp
+++ b/src/core/thread/mesh_monitor.hpp
@@ -1,0 +1,479 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OT_CORE_THREAD_MESH_MONITOR_HPP_
+#define OT_CORE_THREAD_MESH_MONITOR_HPP_
+
+#include "common/locator.hpp"
+#include "common/non_copyable.hpp"
+#include "common/notifier.hpp"
+#include "common/owned_ptr.hpp"
+#include "config/mesh_monitor.h"
+#include "net/ip6_address.hpp"
+#include "thread/mesh_monitor_types.hpp"
+#include "thread/tmf.hpp"
+#include "thread/uri_paths.hpp"
+
+namespace ot {
+
+#if OPENTHREAD_FTD
+class Child;
+class Router;
+#endif
+
+namespace MeshMonitor {
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+/**
+ * Implements the Mesh Monitor server functionality for both routers and end devices.
+ */
+class Server : public InstanceLocator, private NonCopyable
+{
+private:
+    friend class ot::TimeTicker;
+    friend class Tmf::Agent;
+
+    static constexpr uint16_t kCacheBuffersLimit    = OPENTHREAD_CONFIG_MESH_MONITOR_CACHE_BUFFERS_LIMIT;
+    static constexpr uint32_t kRegistrationInterval = OPENTHREAD_CONFIG_MESH_MONITOR_REGISTRATION_INTERVAL;
+    static constexpr uint32_t kUpdateBaseDelay      = OPENTHREAD_CONFIG_MESH_MONITOR_UPDATE_BASE_DELAY;
+    static constexpr uint32_t kUpdateExtDelay       = OPENTHREAD_CONFIG_MESH_MONITOR_UPDATE_EXT_DELAY;
+    static constexpr uint32_t kUpdateJitter         = OPENTHREAD_CONFIG_MESH_MONITOR_UPDATE_JITTER;
+
+    /**
+     * Hard limit for SU message length to avoid oversized updates when many children exist.
+     * IPv6 minimum MTU is 1280 bytes, subtracting UDP(8) + IPv6(40) headers leaves 1232 bytes for the CoAP message.
+     */
+    static constexpr uint16_t kMaxUpdateMessageLength = 1232;
+
+    /**
+     * Maximum number of consecutive SU (Server Update) retry attempts when ACKs fail.
+     * Used for exponential backoff in HandleServerUpdateAck().
+     */
+    static constexpr uint8_t kMaxUpdateRetries = 5;
+
+    /**
+     * Maximum backoff delay for SU retries (in milliseconds).
+     * Caps the exponential backoff at 320 seconds (5.3 minutes).
+     */
+    static constexpr uint32_t kMaxUpdateBackoff = 320000;
+
+    /**
+     * Delay between attempts to update child server state.
+     *
+     * In milliseconds.
+     */
+    static constexpr uint32_t kChildUpdateDelay = Time::kOneSecondInMsec;
+
+    /**
+     * Bitmask of TLVs for which the extended delay duration should be applied.
+     */
+    static const TlvSet kExtDelayTlvMask;
+
+    /**
+     * Bitmask of TLVs which are static in neighbors and therefore do not need
+     * to be sent in updates.
+     */
+    static const TlvSet kStaticNeighborTlvMask;
+
+    /**
+     * Bitmask of child-provided TLVs to skip when a child attaches/re-attaches.
+     *
+     * When a child changes parent, we avoid re-querying these TLVs immediately
+     * to reduce traffic. They will still be sent:
+     * - On initial client registration (baseline query)
+     * - Periodically via normal update cycles
+     *
+     */
+    static const TlvSet kChildAttachSkipTlvMask;
+
+    /**
+     * Determines whether the given TLV set has any TLVs that require extended delay.
+     *
+     * @param[in]  aTlvs  The TLV set to check.
+     * @returns TRUE if any TLVs in `aTlvs` require extended delay, FALSE otherwise.
+     */
+    bool HasExtDelayTlvs(const TlvSet &aTlvs)
+    {
+        return !aTlvs.Intersect(static_cast<const TlvSet &>(kExtDelayTlvMask)).IsEmpty();
+    }
+
+    /**
+     * Determines whether the given TLV set contains only TLVs that require extended delay.
+     *
+     * @param[in]  aTlvs  The TLV set to check.
+     * @returns TRUE if all TLVs in `aTlvs` require extended delay, FALSE otherwise.
+     */
+    bool IsOnlyExtDelayTlvs(const TlvSet &aTlvs)
+    {
+        return aTlvs.Cut(static_cast<const TlvSet &>(kExtDelayTlvMask)).IsEmpty();
+    }
+
+    /**
+     * Gets the intersection of the given TLV set with the extended delay TLVs.
+     *
+     * @param[in]  aTlvs  The TLV set to intersect.
+     * @returns A TLV set containing only the TLVs from `aTlvs` that require extended delay.
+     */
+    TlvSet GetExtDelayTlvs(const TlvSet &aTlvs)
+    {
+        return aTlvs.Intersect(static_cast<const TlvSet &>(kExtDelayTlvMask));
+    }
+
+public:
+#if OPENTHREAD_FTD
+    /**
+     * Provides per child state for the diagnostic server on routers.
+     */
+    class ChildInfo
+    {
+        friend class Server;
+
+    private:
+        enum DiagState : uint8_t
+        {
+            kDiagServerStopped = 0,   ///< The diagnostic server is stopped
+            kDiagServerActive,        ///< The diagnostic server is active
+            kDiagServerStopPending,   ///< A stop command to the child is pending a response
+            kDiagServerActivePending, ///< An active command to the child is pending a response
+            kDiagServerUnknown,       ///< The last command to the child was not acked
+        };
+
+        void MarkHostProvidedTlvsChanged(TlvSet aTlvs);
+
+        void SetChildIsFtd(bool aFtd) { mIsFtd = aFtd; }
+
+        DiagState GetDiagServerState(void) const { return static_cast<DiagState>(mState); }
+
+        bool IsDiagServerPending(void) const
+        {
+            return (mState == kDiagServerActivePending) || (mState == kDiagServerStopPending);
+        }
+
+        void SetDiagServerState(DiagState aState) { mState = aState; }
+
+        bool IsAttachStateDirty(void) const { return mAttachStateDirty; }
+        void SetAttachStateDirty(void) { mAttachStateDirty = true; }
+
+        uint16_t GetUsedCacheBuffers(void) const { return mCacheBuffers; }
+
+        void LockCache(void)
+        {
+            OT_ASSERT(!mDiagCacheLocked);
+            mDiagCacheLocked = true;
+        }
+        void CommitCacheUpdate(void);
+        void AbortCacheUpdate(void);
+
+        bool IsDiagCacheLocked(void) const { return mDiagCacheLocked; }
+
+        bool ShouldSendDiagUpdate(void) const { return !mDirtySet.IsEmpty() || mAttachStateDirty; }
+
+        TlvSet GetDirtyHostProvided(TlvSet aFilter) const;
+
+        bool CanEvictCache(void) const { return (mCache != nullptr) && !mDiagCacheLocked; }
+
+        void EvictCache(void);
+        void ClearCache(void);
+
+        Error UpdateCache(const Message &aMessage, TlvSet aFilter);
+
+        Error RemoveCachedTlv(uint8_t aType);
+
+        Error AppendCachedTlvs(Message &aMessage);
+
+        TlvSet GetLostDiag(void) const { return mLostSet; }
+
+        bool ShouldSendLostDiagQuery(void) const { return !mLostSet.IsEmpty() && !mLostQueryPending; }
+        void SetLostDiagQueryPending(bool aPending) { mLostQueryPending = aPending; }
+
+    private:
+        uint8_t mState : 4;
+        bool    mIsFtd : 1;         ///< When in state valid must be true if the child is a FTD
+        bool mLostQueryPending : 1; ///< True if a query for lost diagnostic data is pending a response from the child
+        bool mAttachStateDirty : 1; ///< True if the child state has changed since the last diagnostic update
+        bool mDiagCacheLocked : 1;  ///< If true the diagnostic cache must not be evicted
+
+        uint8_t mCacheBuffers; ///< The number of buffers used for the diag cache
+
+        TlvSet            mDirtySet; ///< Includes both host dirty as well as cached diag
+        TlvSet            mLostSet;  ///< Diag that was evicted from the cache
+        OwnedPtr<Message> mCache;
+    };
+#endif
+
+    explicit Server(Instance &aInstance);
+
+    /**
+     * Called when this thread device detaches. Including for router upgrades.
+     */
+    void HandleDetach(void) { StopServer(); }
+
+    /**
+     * Signals that some diagnostic type of this thread device has changed.
+     *
+     * @param[in]  aTlv  The diagnostic type that has changed state.
+     */
+    void MarkDiagDirty(Tlv::Type aTlv);
+
+    /**
+     * Signals that some collection of diagnostic types of this thread device
+     * have changed.
+     *
+     * @param[in]  aTlvs  The set of diagnostic types that have changed state.
+     */
+    void MarkDiagDirty(TlvSet aTlvs);
+
+#if OPENTHREAD_FTD
+    void MarkChildDiagDirty(Child &aChild, Tlv::Type aTlv);
+
+    void MarkChildDiagDirty(Child &aChild, TlvSet aTlvs);
+
+    /**
+     * Called when a new child has been added.
+     *
+     * @param[in]  aChild  The child that has been added.
+     */
+    void HandleChildAdded(Child &aChild);
+
+    /**
+     * Called when a child has been removed.
+     *
+     * @param[in]  aChild  The child that has been removed.
+     */
+    void HandleChildRemoved(Child &aChild);
+
+    /**
+     * Called when a router link has been added.
+     *
+     * @param[in]  aRouter  The router that has been added.
+     */
+    void HandleRouterAdded(Router &aRouter);
+
+    /**
+     * Called when a router link has been removed.
+     *
+     * @param[in]  aRouter  The router that has been removed.
+     */
+    void HandleRouterRemoved(Router &aRouter);
+
+    /**
+     * Attempts to evict diagnostic cache buffers to free up memory for messages.
+     *
+     * @param[in]  aOnlyRxOn  If true only caches from rx on when idle devices are considered.
+     *
+     * @retval kErrorNone      Successfully evicted at least one message buffer.
+     * @retval kErrorNotFound  If no caches could be evicted.
+     */
+    Error EvictCache(bool aOnlyRxOn);
+
+    /**
+     * Returns the total number of cache evictions from devices that are either
+     * rx on when idle or csl synchronized.
+     */
+    uint32_t GetCacheSyncEvictions(void) const { return mCacheSyncEvictions; }
+
+    /**
+     * Returns the total number of cache evictions from devices that are rx off
+     * when idle and not csl synchronized.
+     */
+    uint32_t GetCachePollEvictions(void) const { return mCachePollEvictions; }
+
+    /**
+     * Returns the total number of cases where a child update message failed to
+     * be added to the diagnostic cache.
+     */
+    uint32_t GetCacheErrors(void) const { return mCacheErrors; }
+#endif
+
+    void HandleNotifierEvents(Events aEvents);
+
+private:
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
+
+    bool ConfigureAsEndDevice(const TlvSet &aTypes);
+
+    void StopServer(void);
+
+    Error SendEndDeviceUpdate(void);
+
+    DeclareTmfResponseHandlerIn(Server, HandleEndDeviceUpdateAck);
+
+#if OPENTHREAD_FTD
+    Error SendFullServerUpdate(const Ip6::Address &aClientAddr);
+
+    Error SendEmptyServerUpdate(const Ip6::Address &aClientAddr);
+
+    Error SendServerUpdate(void);
+
+    Error ConfigureAsRouter(const TlvSet &aSelf, const TlvSet &aChild, const TlvSet &aNeighbor, bool aQuery);
+
+    void SyncAllChildDiagStates(bool aMtdChanged, bool aFtdChanged, bool aQuery);
+
+    void SyncChildDiagState(Child &aChild, bool aQuery);
+
+    Error SendEndDeviceRequestStop(Child &aChild);
+
+    Error SendEndDeviceRequestStart(Child &aChild, const TlvSet &aTypes, bool aQuery);
+
+    Error SendEndDeviceRecoveryQuery(Child &aChild, const TlvSet &aTypes);
+
+    void        HandleEndDeviceRequestAck(Child &aChild, Coap::Msg *aMsg, Error aResult);
+    static void HandleEndDeviceRequestAck(void *aContext, Coap::Msg *aMsg, Error aResult);
+
+    void        HandleEndDeviceRecoveryAck(Child &aChild, Coap::Msg *aMsg, Error aResult);
+    static void HandleEndDeviceRecoveryAck(void *aContext, Coap::Msg *aMsg, Error aResult);
+
+    DeclareTmfResponseHandlerIn(Server, HandleServerUpdateAck);
+#endif
+
+    Error AppendHostTlvs(Message &aMessage, TlvSet aTlvs);
+#if OPENTHREAD_FTD
+    Error AppendHostContext(Message &aMessage, TlvSet aTlvs);
+
+    Error AppendChildContext(Message &aMessage, Child &aChild);
+
+    Error AppendChildTlvs(Message &aMessage, TlvSet aTlvs, const Child &aChild);
+
+    Error AppendNeighborContextBaseline(Message &aMessage, const Router &aRouter);
+
+    Error AppendNeighborContextUpdate(Message &aMessage, uint8_t aId);
+
+    Error AppendNeighborTlvs(Message &aMessage, TlvSet aTlvs, const Router &aNeighbor);
+
+    bool AppendChildContextBatch(Message &aMessage, bool &aNeedsMore);
+    bool AppendNeighborContextBatch(Message &aMessage, bool &aNeedsMore);
+
+    void LockChildCaches(void);
+
+    void CommitChildCacheUpdates(void);
+
+    void UnlockChildCaches(void);
+#endif
+
+    bool ShouldIncludeIp6Address(const Ip6::Address &aAddress);
+
+    bool ShouldIncludeAloc(const Ip6::Address &aAddress, uint8_t &aAloc);
+
+    bool ShouldIncludeLinkLocalAddress(const Ip6::Address &aAddress);
+
+    Error AppendHostIp6AddressList(Message &aMessage);
+
+    Error AppendHostAlocList(Message &aMessage);
+
+    Error AppendHostLinkLocalAddressList(Message &aMessage);
+
+#if OPENTHREAD_FTD
+    Error AppendChildIp6AddressList(Message &aMessage, const Child &aChild);
+
+    Error AppendChildAlocList(Message &aMessage, const Child &aChild);
+#endif
+
+    void ScheduleUpdateTimer(uint32_t aDelay) { mUpdateTimer.FireAtIfEarlier(TimerMilli::GetNow() + aDelay); }
+
+    void HandleUpdateTimer(void);
+
+#if OPENTHREAD_FTD
+    void UpdateIfCacheBufferLimit(void);
+
+    void ScheduleChildTimer(void) { mChildTimer.FireAtIfEarlier(TimerMilli::GetNow() + kChildUpdateDelay); }
+
+    void HandleChildTimer(void);
+
+    void HandleRegistrationTimer(void);
+#endif
+
+    using UpdateTimer = TimerMilliIn<Server, &Server::HandleUpdateTimer>;
+#if OPENTHREAD_FTD
+    using ChildTimer        = TimerMilliIn<Server, &Server::HandleChildTimer>;
+    using RegistrationTimer = TimerMilliIn<Server, &Server::HandleRegistrationTimer>;
+#endif
+
+    bool mActive : 1;
+    bool mUpdateSent : 1; ///< On children set to true when a update message has been sent to the parent and not yet
+                          ///< been acked
+#if OPENTHREAD_FTD
+    bool     mSendFullUpdate : 1;
+    bool     mSendChildBaseline : 1;    ///< When set, next SU will include baseline host-provided child TLVs
+    bool     mSendNeighborBaseline : 1; ///< When set, next SU will include baseline neighbor TLVs
+    bool     mUpdatePending : 1;
+    uint16_t mChildResumeIndex;    ///< Index to resume child iteration from after size-limited SU
+    uint8_t  mNeighborResumeIndex; ///< Router ID to resume neighbor iteration from after size-limited SU
+
+    uint16_t mClientRloc; ///< Rloc16 of the client that last sent a registration request
+
+    uint8_t mUpdateRetryCount; ///< Number of consecutive ACK failures (for exponential backoff)
+
+    uint32_t mCacheSyncEvictions;
+    uint32_t mCachePollEvictions;
+    uint32_t mCacheErrors;
+
+    uint64_t mRouterStateMask; ///< Bitmask of router ids which have changed link state.
+#endif
+
+    TlvSet mSelfEnabled;       ///< The TLVs which are requested by clients for this device
+    TlvSet mSelfPendingUpdate; ///< On children: TLVs sent in last EU, pending ACK (for retry on failure)
+
+#if OPENTHREAD_FTD
+    TlvSet mChildEnabled;    ///< The TLVs which are requested by clients for children
+    TlvSet mNeighborEnabled; ///< The TLVs which are requested by clients for router neighbors
+
+    bool mClientRegistered; ///< True if client sent registration this interval
+
+    uint64_t mSequenceNumber; ///< The current sequence number used by the server
+#endif
+
+    TlvSet mSelfDirty; ///< The TLVs of this device which have changed since the last update
+
+    UpdateTimer mUpdateTimer;
+#if OPENTHREAD_FTD
+    ChildTimer        mChildTimer;
+    RegistrationTimer mRegistrationTimer;
+#endif
+};
+
+DeclareTmfHandler(Server, kUriMeshMonEndDeviceRequest);
+
+#if OPENTHREAD_FTD
+DeclareTmfHandler(Server, kUriMeshMonEndDeviceUpdate);
+DeclareTmfHandler(Server, kUriMeshMonServerRequest);
+#endif // OPENTHREAD_FTD
+
+#endif // OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_CLIENT_ENABLE
+/**
+ * Implements Mesh Monitor client functionality.
+ */
+class Client;
+#endif // OPENTHREAD_CONFIG_MESH_MONITOR_CLIENT_ENABLE
+
+} // namespace MeshMonitor
+
+} // namespace ot
+
+#endif // OT_CORE_THREAD_MESH_MONITOR_HPP_

--- a/src/core/thread/mesh_monitor.hpp
+++ b/src/core/thread/mesh_monitor.hpp
@@ -1,0 +1,479 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OT_CORE_THREAD_MESH_MONITOR_HPP_
+#define OT_CORE_THREAD_MESH_MONITOR_HPP_
+
+#include "common/locator.hpp"
+#include "common/non_copyable.hpp"
+#include "common/notifier.hpp"
+#include "common/owned_ptr.hpp"
+#include "config/mesh_monitor.h"
+#include "net/ip6_address.hpp"
+#include "thread/mesh_monitor_types.hpp"
+#include "thread/tmf.hpp"
+#include "thread/uri_paths.hpp"
+
+namespace ot {
+
+#if OPENTHREAD_FTD
+class Child;
+class Router;
+#endif
+
+namespace MeshMonitor {
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+/**
+ * Implements the Mesh Monitor server functionality for both routers and end devices.
+ */
+class Server : public InstanceLocator, private NonCopyable
+{
+private:
+    friend class ot::TimeTicker;
+    friend class Tmf::Agent;
+
+    static constexpr uint16_t kCacheBuffersLimit    = OPENTHREAD_CONFIG_MESH_MONITOR_CACHE_BUFFERS_LIMIT;
+    static constexpr uint32_t kRegistrationInterval = OPENTHREAD_CONFIG_MESH_MONITOR_REGISTRATION_INTERVAL_MAX;
+    static constexpr uint32_t kUpdateBaseDelay      = OPENTHREAD_CONFIG_MESH_MONITOR_UPDATE_BASE_DELAY;
+    static constexpr uint32_t kUpdateExtDelay       = OPENTHREAD_CONFIG_MESH_MONITOR_UPDATE_EXT_DELAY;
+    static constexpr uint32_t kUpdateJitter         = OPENTHREAD_CONFIG_MESH_MONITOR_UPDATE_JITTER;
+
+    /**
+     * Hard limit for SU message length to avoid oversized updates when many children exist.
+     * IPv6 minimum MTU is 1280 bytes, subtracting UDP(8) + IPv6(40) headers leaves 1232 bytes for the CoAP message.
+     */
+    static constexpr uint16_t kMaxUpdateMessageLength = 1232;
+
+    /**
+     * Maximum number of consecutive SU (Server Update) retry attempts when ACKs fail.
+     * Used for exponential backoff in HandleServerUpdateAck().
+     */
+    static constexpr uint8_t kMaxUpdateRetries = 5;
+
+    /**
+     * Maximum backoff delay for SU retries (in milliseconds).
+     * Caps the exponential backoff at 320 seconds (5.3 minutes).
+     */
+    static constexpr uint32_t kMaxUpdateBackoff = 320000;
+
+    /**
+     * Delay between attempts to update child server state.
+     *
+     * In milliseconds.
+     */
+    static constexpr uint32_t kChildUpdateDelay = Time::kOneSecondInMsec;
+
+    /**
+     * Bitmask of TLVs for which the extended delay duration should be applied.
+     */
+    static const TlvSet kExtDelayTlvMask;
+
+    /**
+     * Bitmask of TLVs which are static in neighbors and therefore do not need
+     * to be sent in updates.
+     */
+    static const TlvSet kStaticNeighborTlvMask;
+
+    /**
+     * Bitmask of child-provided TLVs to skip when a child attaches/re-attaches.
+     *
+     * When a child changes parent, we avoid re-querying these TLVs immediately
+     * to reduce traffic. They will still be sent:
+     * - On initial client registration (baseline query)
+     * - Periodically via normal update cycles
+     *
+     */
+    static const TlvSet kChildAttachSkipTlvMask;
+
+    /**
+     * Determines whether the given TLV set has any TLVs that require extended delay.
+     *
+     * @param[in]  aTlvs  The TLV set to check.
+     * @returns TRUE if any TLVs in `aTlvs` require extended delay, FALSE otherwise.
+     */
+    bool HasExtDelayTlvs(const TlvSet &aTlvs)
+    {
+        return !aTlvs.Intersect(static_cast<const TlvSet &>(kExtDelayTlvMask)).IsEmpty();
+    }
+
+    /**
+     * Determines whether the given TLV set contains only TLVs that require extended delay.
+     *
+     * @param[in]  aTlvs  The TLV set to check.
+     * @returns TRUE if all TLVs in `aTlvs` require extended delay, FALSE otherwise.
+     */
+    bool IsOnlyExtDelayTlvs(const TlvSet &aTlvs)
+    {
+        return aTlvs.Cut(static_cast<const TlvSet &>(kExtDelayTlvMask)).IsEmpty();
+    }
+
+    /**
+     * Gets the intersection of the given TLV set with the extended delay TLVs.
+     *
+     * @param[in]  aTlvs  The TLV set to intersect.
+     * @returns A TLV set containing only the TLVs from `aTlvs` that require extended delay.
+     */
+    TlvSet GetExtDelayTlvs(const TlvSet &aTlvs)
+    {
+        return aTlvs.Intersect(static_cast<const TlvSet &>(kExtDelayTlvMask));
+    }
+
+public:
+#if OPENTHREAD_FTD
+    /**
+     * Provides per child state for the diagnostic server on routers.
+     */
+    class ChildInfo
+    {
+        friend class Server;
+
+    private:
+        enum DiagState : uint8_t
+        {
+            kDiagServerStopped = 0,   ///< The diagnostic server is stopped
+            kDiagServerActive,        ///< The diagnostic server is active
+            kDiagServerStopPending,   ///< A stop command to the child is pending a response
+            kDiagServerActivePending, ///< An active command to the child is pending a response
+            kDiagServerUnknown,       ///< The last command to the child was not acked
+        };
+
+        void MarkHostProvidedTlvsChanged(TlvSet aTlvs);
+
+        void SetChildIsFtd(bool aFtd) { mIsFtd = aFtd; }
+
+        DiagState GetDiagServerState(void) const { return static_cast<DiagState>(mState); }
+
+        bool IsDiagServerPending(void) const
+        {
+            return (mState == kDiagServerActivePending) || (mState == kDiagServerStopPending);
+        }
+
+        void SetDiagServerState(DiagState aState) { mState = aState; }
+
+        bool IsAttachStateDirty(void) const { return mAttachStateDirty; }
+        void SetAttachStateDirty(void) { mAttachStateDirty = true; }
+
+        uint16_t GetUsedCacheBuffers(void) const { return mCacheBuffers; }
+
+        void LockCache(void)
+        {
+            OT_ASSERT(!mDiagCacheLocked);
+            mDiagCacheLocked = true;
+        }
+        void CommitCacheUpdate(void);
+        void AbortCacheUpdate(void);
+
+        bool IsDiagCacheLocked(void) const { return mDiagCacheLocked; }
+
+        bool ShouldSendDiagUpdate(void) const { return !mDirtySet.IsEmpty() || mAttachStateDirty; }
+
+        TlvSet GetDirtyHostProvided(TlvSet aFilter) const;
+
+        bool CanEvictCache(void) const { return (mCache != nullptr) && !mDiagCacheLocked; }
+
+        void EvictCache(void);
+        void ClearCache(void);
+
+        Error UpdateCache(const Message &aMessage, TlvSet aFilter);
+
+        Error RemoveCachedTlv(uint8_t aType);
+
+        Error AppendCachedTlvs(Message &aMessage);
+
+        TlvSet GetLostDiag(void) const { return mLostSet; }
+
+        bool ShouldSendLostDiagQuery(void) const { return !mLostSet.IsEmpty() && !mLostQueryPending; }
+        void SetLostDiagQueryPending(bool aPending) { mLostQueryPending = aPending; }
+
+    private:
+        uint8_t mState : 4;
+        bool    mIsFtd : 1;         ///< When in state valid must be true if the child is a FTD
+        bool mLostQueryPending : 1; ///< True if a query for lost diagnostic data is pending a response from the child
+        bool mAttachStateDirty : 1; ///< True if the child state has changed since the last diagnostic update
+        bool mDiagCacheLocked : 1;  ///< If true the diagnostic cache must not be evicted
+
+        uint8_t mCacheBuffers; ///< The number of buffers used for the diag cache
+
+        TlvSet            mDirtySet; ///< Includes both host dirty as well as cached diag
+        TlvSet            mLostSet;  ///< Diag that was evicted from the cache
+        OwnedPtr<Message> mCache;
+    };
+#endif
+
+    explicit Server(Instance &aInstance);
+
+    /**
+     * Called when this thread device detaches. Including for router upgrades.
+     */
+    void HandleDetach(void) { StopServer(); }
+
+    /**
+     * Signals that some diagnostic type of this thread device has changed.
+     *
+     * @param[in]  aTlv  The diagnostic type that has changed state.
+     */
+    void MarkDiagDirty(Tlv::Type aTlv);
+
+    /**
+     * Signals that some collection of diagnostic types of this thread device
+     * have changed.
+     *
+     * @param[in]  aTlvs  The set of diagnostic types that have changed state.
+     */
+    void MarkDiagDirty(TlvSet aTlvs);
+
+#if OPENTHREAD_FTD
+    void MarkChildDiagDirty(Child &aChild, Tlv::Type aTlv);
+
+    void MarkChildDiagDirty(Child &aChild, TlvSet aTlvs);
+
+    /**
+     * Called when a new child has been added.
+     *
+     * @param[in]  aChild  The child that has been added.
+     */
+    void HandleChildAdded(Child &aChild);
+
+    /**
+     * Called when a child has been removed.
+     *
+     * @param[in]  aChild  The child that has been removed.
+     */
+    void HandleChildRemoved(Child &aChild);
+
+    /**
+     * Called when a router link has been added.
+     *
+     * @param[in]  aRouter  The router that has been added.
+     */
+    void HandleRouterAdded(Router &aRouter);
+
+    /**
+     * Called when a router link has been removed.
+     *
+     * @param[in]  aRouter  The router that has been removed.
+     */
+    void HandleRouterRemoved(Router &aRouter);
+
+    /**
+     * Attempts to evict diagnostic cache buffers to free up memory for messages.
+     *
+     * @param[in]  aOnlyRxOn  If true only caches from rx on when idle devices are considered.
+     *
+     * @retval kErrorNone      Successfully evicted at least one message buffer.
+     * @retval kErrorNotFound  If no caches could be evicted.
+     */
+    Error EvictCache(bool aOnlyRxOn);
+
+    /**
+     * Returns the total number of cache evictions from devices that are either
+     * rx on when idle or csl synchronized.
+     */
+    uint32_t GetCacheSyncEvictions(void) const { return mCacheSyncEvictions; }
+
+    /**
+     * Returns the total number of cache evictions from devices that are rx off
+     * when idle and not csl synchronized.
+     */
+    uint32_t GetCachePollEvictions(void) const { return mCachePollEvictions; }
+
+    /**
+     * Returns the total number of cases where a child update message failed to
+     * be added to the diagnostic cache.
+     */
+    uint32_t GetCacheErrors(void) const { return mCacheErrors; }
+#endif
+
+    void HandleNotifierEvents(Events aEvents);
+
+private:
+    template <Uri kUri> void HandleTmf(Coap::Msg &aMsg);
+
+    bool ConfigureAsEndDevice(const TlvSet &aTypes);
+
+    void StopServer(void);
+
+    Error SendEndDeviceUpdate(void);
+
+    DeclareTmfResponseHandlerIn(Server, HandleEndDeviceUpdateAck);
+
+#if OPENTHREAD_FTD
+    Error SendFullServerUpdate(const Ip6::Address &aClientAddr);
+
+    Error SendEmptyServerUpdate(const Ip6::Address &aClientAddr);
+
+    Error SendServerUpdate(void);
+
+    Error ConfigureAsRouter(const TlvSet &aSelf, const TlvSet &aChild, const TlvSet &aNeighbor, bool aQuery);
+
+    void SyncAllChildDiagStates(bool aMtdChanged, bool aFtdChanged, bool aQuery);
+
+    void SyncChildDiagState(Child &aChild, bool aQuery);
+
+    Error SendEndDeviceRequestStop(Child &aChild);
+
+    Error SendEndDeviceRequestStart(Child &aChild, const TlvSet &aTypes, bool aQuery);
+
+    Error SendEndDeviceRecoveryQuery(Child &aChild, const TlvSet &aTypes);
+
+    void        HandleEndDeviceRequestAck(Child &aChild, Coap::Msg *aMsg, Error aResult);
+    static void HandleEndDeviceRequestAck(void *aContext, Coap::Msg *aMsg, Error aResult);
+
+    void        HandleEndDeviceRecoveryAck(Child &aChild, Coap::Msg *aMsg, Error aResult);
+    static void HandleEndDeviceRecoveryAck(void *aContext, Coap::Msg *aMsg, Error aResult);
+
+    DeclareTmfResponseHandlerIn(Server, HandleServerUpdateAck);
+#endif
+
+    Error AppendHostTlvs(Message &aMessage, TlvSet aTlvs);
+#if OPENTHREAD_FTD
+    Error AppendHostContext(Message &aMessage, TlvSet aTlvs);
+
+    Error AppendChildContext(Message &aMessage, Child &aChild);
+
+    Error AppendChildTlvs(Message &aMessage, TlvSet aTlvs, const Child &aChild);
+
+    Error AppendNeighborContextBaseline(Message &aMessage, const Router &aRouter);
+
+    Error AppendNeighborContextUpdate(Message &aMessage, uint8_t aId);
+
+    Error AppendNeighborTlvs(Message &aMessage, TlvSet aTlvs, const Router &aNeighbor);
+
+    bool AppendChildContextBatch(Message &aMessage, bool &aNeedsMore);
+    bool AppendNeighborContextBatch(Message &aMessage, bool &aNeedsMore);
+
+    void LockChildCaches(void);
+
+    void CommitChildCacheUpdates(void);
+
+    void UnlockChildCaches(void);
+#endif
+
+    bool ShouldIncludeIp6Address(const Ip6::Address &aAddress);
+
+    bool ShouldIncludeAloc(const Ip6::Address &aAddress, uint8_t &aAloc);
+
+    bool ShouldIncludeLinkLocalAddress(const Ip6::Address &aAddress);
+
+    Error AppendHostIp6AddressList(Message &aMessage);
+
+    Error AppendHostAlocList(Message &aMessage);
+
+    Error AppendHostLinkLocalAddressList(Message &aMessage);
+
+#if OPENTHREAD_FTD
+    Error AppendChildIp6AddressList(Message &aMessage, const Child &aChild);
+
+    Error AppendChildAlocList(Message &aMessage, const Child &aChild);
+#endif
+
+    void ScheduleUpdateTimer(uint32_t aDelay) { mUpdateTimer.FireAtIfEarlier(TimerMilli::GetNow() + aDelay); }
+
+    void HandleUpdateTimer(void);
+
+#if OPENTHREAD_FTD
+    void UpdateIfCacheBufferLimit(void);
+
+    void ScheduleChildTimer(void) { mChildTimer.FireAtIfEarlier(TimerMilli::GetNow() + kChildUpdateDelay); }
+
+    void HandleChildTimer(void);
+
+    void HandleRegistrationTimer(void);
+#endif
+
+    using UpdateTimer = TimerMilliIn<Server, &Server::HandleUpdateTimer>;
+#if OPENTHREAD_FTD
+    using ChildTimer        = TimerMilliIn<Server, &Server::HandleChildTimer>;
+    using RegistrationTimer = TimerMilliIn<Server, &Server::HandleRegistrationTimer>;
+#endif
+
+    bool mActive : 1;
+    bool mUpdateSent : 1; ///< On children set to true when a update message has been sent to the parent and not yet
+                          ///< been acked
+#if OPENTHREAD_FTD
+    bool     mSendFullUpdate : 1;
+    bool     mSendChildBaseline : 1;    ///< When set, next SU will include baseline host-provided child TLVs
+    bool     mSendNeighborBaseline : 1; ///< When set, next SU will include baseline neighbor TLVs
+    bool     mUpdatePending : 1;
+    uint16_t mChildResumeIndex;    ///< Index to resume child iteration from after size-limited SU
+    uint8_t  mNeighborResumeIndex; ///< Router ID to resume neighbor iteration from after size-limited SU
+
+    uint16_t mClientRloc; ///< Rloc16 of the client that last sent a registration request
+
+    uint8_t mUpdateRetryCount; ///< Number of consecutive ACK failures (for exponential backoff)
+
+    uint32_t mCacheSyncEvictions;
+    uint32_t mCachePollEvictions;
+    uint32_t mCacheErrors;
+
+    uint64_t mRouterStateMask; ///< Bitmask of router ids which have changed link state.
+#endif
+
+    TlvSet mSelfEnabled;       ///< The TLVs which are requested by clients for this device
+    TlvSet mSelfPendingUpdate; ///< On children: TLVs sent in last EU, pending ACK (for retry on failure)
+
+#if OPENTHREAD_FTD
+    TlvSet mChildEnabled;    ///< The TLVs which are requested by clients for children
+    TlvSet mNeighborEnabled; ///< The TLVs which are requested by clients for router neighbors
+
+    bool mClientRegistered; ///< True if client sent registration this interval
+
+    uint32_t mSequenceNumber; ///< The current sequence number used by the server
+#endif
+
+    TlvSet mSelfDirty; ///< The TLVs of this device which have changed since the last update
+
+    UpdateTimer mUpdateTimer;
+#if OPENTHREAD_FTD
+    ChildTimer        mChildTimer;
+    RegistrationTimer mRegistrationTimer;
+#endif
+};
+
+DeclareTmfHandler(Server, kUriMeshMonEndDeviceRequest);
+
+#if OPENTHREAD_FTD
+DeclareTmfHandler(Server, kUriMeshMonEndDeviceUpdate);
+DeclareTmfHandler(Server, kUriMeshMonServerRequest);
+#endif // OPENTHREAD_FTD
+
+#endif // OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_CLIENT_ENABLE
+/**
+ * Implements Mesh Monitor client functionality.
+ */
+class Client;
+#endif // OPENTHREAD_CONFIG_MESH_MONITOR_CLIENT_ENABLE
+
+} // namespace MeshMonitor
+
+} // namespace ot
+
+#endif // OT_CORE_THREAD_MESH_MONITOR_HPP_

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -510,6 +510,10 @@ Error Mle::BecomeDetached(void)
 
     VerifyOrExit(!IsDisabled(), error = kErrorInvalidState);
 
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    Get<MeshMonitor::Server>().HandleDetach();
+#endif
+
     if (IsDetached() && mAttacher.WillStartAttachSoon())
     {
         // Already detached and waiting to start an attach attempt, so
@@ -5487,7 +5491,7 @@ void Mle::Attacher::HandleChildIdResponse(RxInfo &aRxInfo)
         IgnoreError(Get<Mle>().BecomeDetached());
         ExitNow();
     }
-
+    
     Get<Mle>().SetStateChild(shortAddress);
 
     if (!Get<Mle>().IsRxOnWhenIdle())

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -517,6 +517,10 @@ Error Mle::BecomeDetached(void)
 
     VerifyOrExit(!IsDisabled(), error = kErrorInvalidState);
 
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    Get<MeshMonitor::Server>().HandleDetach();
+#endif
+
     if (IsDetached() && mAttacher.WillStartAttachSoon())
     {
         // Already detached and waiting to start an attach attempt, so
@@ -5545,7 +5549,7 @@ void Mle::Attacher::HandleChildIdResponse(RxInfo &aRxInfo)
         IgnoreError(Get<Mle>().BecomeDetached());
         ExitNow();
     }
-
+    
     Get<Mle>().SetStateChild(shortAddress);
 
     if (!Get<Mle>().IsRxOnWhenIdle())

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -1047,13 +1047,13 @@ void Mle::HandleLinkAcceptVariant(RxInfo &aRxInfo, MessageType aMessageType)
 
     if (neighborState != Neighbor::kStateValid)
     {
-        InitNeighbor(*router, aRxInfo);
-        router->SetRloc16(sourceAddress);
-        router->GetLinkFrameCounters().SetAll(linkFrameCounter);
-        router->SetLinkAckFrameCounter(linkFrameCounter);
-        router->SetMleFrameCounter(mleFrameCounter);
-        router->SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
-                                         DeviceMode::kModeFullNetworkData));
+    InitNeighbor(*router, aRxInfo);
+    router->SetRloc16(sourceAddress);
+    router->GetLinkFrameCounters().SetAll(linkFrameCounter);
+    router->SetLinkAckFrameCounter(linkFrameCounter);
+    router->SetMleFrameCounter(mleFrameCounter);
+    router->SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
+                                     DeviceMode::kModeFullNetworkData));
         router->SetKeySequence(aRxInfo.mKeySequence);
         router->SetState(Neighbor::kStateValid);
     }
@@ -1071,6 +1071,10 @@ void Mle::HandleLinkAcceptVariant(RxInfo &aRxInfo, MessageType aMessageType)
     {
         mNeighborTable.Signal(NeighborTable::kRouterAdded, *router);
     }
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    Get<MeshMonitor::Server>().HandleRouterAdded(*router);
+#endif
 
     mDelayedSender.RemoveScheduledLinkRequest(*router);
 
@@ -2139,6 +2143,11 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
     TlvList                 requestedTlvList;
     ChildUpdateResponseInfo info;
     bool                    childDidChange = false;
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    MeshMonitor::TlvSet diagTlvs;
+
+    diagTlvs.Set(MeshMonitor::Tlv::kLastHeard);
+#endif
 
     Log(kMessageReceive, kTypeChildUpdateRequestOfChild, aRxInfo.mMessageInfo.GetPeerAddr());
 
@@ -2204,6 +2213,10 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
     {
     case kErrorNone:
         info.mTlvList.Add(Tlv::kAddressRegistration);
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+        diagTlvs.Set(MeshMonitor::Tlv::kIp6AddressList);
+        diagTlvs.Set(MeshMonitor::Tlv::kAlocList);
+#endif
         break;
     case kErrorNotFound:
         break;
@@ -2229,6 +2242,10 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
         {
             child->SetTimeout(timeout);
             childDidChange = true;
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+            diagTlvs.Set(MeshMonitor::Tlv::kTimeout);
+#endif
         }
 
         info.mTlvList.Add(Tlv::kTimeout);
@@ -2281,6 +2298,9 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
             child->SetCslTimeout(cslTimeout);
             // MUST include CSL accuracy TLV when request includes CSL timeout
             info.mTlvList.Add(Tlv::kCslClockAccuracy);
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+            diagTlvs.Set(MeshMonitor::Tlv::kCsl);
+#endif
             break;
         case kErrorNotFound:
             break;
@@ -2293,6 +2313,9 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
             // Special value of zero is used to indicate that
             // CSL channel is not specified.
             child->SetCslChannel(static_cast<uint8_t>(cslChannelTlvValue.GetChannel()));
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+            diagTlvs.Set(MeshMonitor::Tlv::kCsl);
+#endif
         }
     }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
@@ -2320,6 +2343,10 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
         // are added to the child.
 
         Get<IndirectSender>().HandleChildModeChange(*child, oldMode);
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+        diagTlvs.Set(MeshMonitor::Tlv::kMode);
+#endif
     }
 
     if (childDidChange)
@@ -2339,6 +2366,10 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
 #endif
 
     SendChildUpdateResponseToChild(child, info);
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    Get<MeshMonitor::Server>().MarkChildDiagDirty(*child, diagTlvs);
+#endif
 
     aRxInfo.mClass = RxInfo::kPeerMessage;
 
@@ -3127,6 +3158,9 @@ void Mle::RemoveNeighbor(Neighbor &aNeighbor)
         if (aNeighbor.IsStateValidOrRestoring())
         {
             mNeighborTable.Signal(NeighborTable::kChildRemoved, aNeighbor);
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+            Get<MeshMonitor::Server>().HandleChildRemoved(static_cast<Child &>(aNeighbor));
+#endif
         }
 
         Get<IndirectSender>().ClearAllMessagesForSleepyChild(static_cast<Child &>(aNeighbor));
@@ -3276,6 +3310,10 @@ void Mle::HandleAddressSolicitResponse(Coap::Msg *aMsg, Error aResult)
     SuccessOrExit(Tlv::Find<ThreadRouterMaskTlv>(aMsg->mMessage, routerIdMask));
     VerifyOrExit(routerIdMask.IsValid());
     VerifyOrExit(routerIdMask.IsAllocated(GetLeaderId()));
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    Get<MeshMonitor::Server>().HandleDetach();
+#endif
 
     SetAlternateRloc16(GetRloc16());
 
@@ -3775,6 +3813,10 @@ void Mle::SetChildStateToValid(Child &aChild)
 #endif
 
     mNeighborTable.Signal(NeighborTable::kChildAdded, aChild);
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    Get<MeshMonitor::Server>().HandleChildAdded(aChild);
+#endif
 
 exit:
     return;

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -1096,13 +1096,13 @@ void Mle::HandleLinkAcceptVariant(RxInfo &aRxInfo, MessageType aMessageType)
 
     if (neighborState != Neighbor::kStateValid)
     {
-        InitNeighbor(*router, aRxInfo);
-        router->SetRloc16(sourceAddress);
-        router->GetLinkFrameCounters().SetAll(linkFrameCounter);
-        router->SetLinkAckFrameCounter(linkFrameCounter);
-        router->SetMleFrameCounter(mleFrameCounter);
-        router->SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
-                                         DeviceMode::kModeFullNetworkData));
+    InitNeighbor(*router, aRxInfo);
+    router->SetRloc16(sourceAddress);
+    router->GetLinkFrameCounters().SetAll(linkFrameCounter);
+    router->SetLinkAckFrameCounter(linkFrameCounter);
+    router->SetMleFrameCounter(mleFrameCounter);
+    router->SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
+                                     DeviceMode::kModeFullNetworkData));
         router->SetKeySequence(aRxInfo.mKeySequence);
         router->SetState(Neighbor::kStateValid);
     }
@@ -1120,6 +1120,10 @@ void Mle::HandleLinkAcceptVariant(RxInfo &aRxInfo, MessageType aMessageType)
     {
         mNeighborTable.Signal(NeighborTable::kRouterAdded, *router);
     }
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    Get<MeshMonitor::Server>().HandleRouterAdded(*router);
+#endif
 
     mDelayedSender.RemoveScheduledLinkRequest(*router);
 
@@ -2203,6 +2207,11 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
     TlvList                 requestedTlvList;
     ChildUpdateResponseInfo info;
     bool                    childDidChange = false;
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    MeshMonitor::TlvSet diagTlvs;
+
+    diagTlvs.Set(MeshMonitor::Tlv::kLastHeard);
+#endif
 
     Log(kMessageReceive, kTypeChildUpdateRequestOfChild, aRxInfo.mMessageInfo.GetPeerAddr());
 
@@ -2274,6 +2283,10 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
     {
     case kErrorNone:
         info.mTlvList.Add(Tlv::kAddressRegistration);
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+        diagTlvs.Set(MeshMonitor::Tlv::kIp6AddressList);
+        diagTlvs.Set(MeshMonitor::Tlv::kAlocList);
+#endif
         break;
     case kErrorNotFound:
         break;
@@ -2299,6 +2312,10 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
         {
             child->SetTimeout(timeout);
             childDidChange = true;
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+            diagTlvs.Set(MeshMonitor::Tlv::kTimeout);
+#endif
         }
 
         info.mTlvList.Add(Tlv::kTimeout);
@@ -2351,6 +2368,9 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
             child->SetCslTimeout(cslTimeout);
             // MUST include CSL accuracy TLV when request includes CSL timeout
             info.mTlvList.Add(Tlv::kCslClockAccuracy);
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+            diagTlvs.Set(MeshMonitor::Tlv::kCsl);
+#endif
             break;
         case kErrorNotFound:
             break;
@@ -2363,6 +2383,9 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
             // Special value of zero is used to indicate that
             // CSL channel is not specified.
             child->SetCslChannel(static_cast<uint8_t>(cslChannelTlvValue.GetChannel()));
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+            diagTlvs.Set(MeshMonitor::Tlv::kCsl);
+#endif
         }
     }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
@@ -2390,6 +2413,10 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
         // are added to the child.
 
         Get<IndirectSender>().HandleChildModeChange(*child, oldMode);
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+        diagTlvs.Set(MeshMonitor::Tlv::kMode);
+#endif
     }
 
     if (childDidChange)
@@ -2409,6 +2436,10 @@ void Mle::HandleChildUpdateRequestOnParent(RxInfo &aRxInfo)
 #endif
 
     SendChildUpdateResponseToChild(child, info);
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    Get<MeshMonitor::Server>().MarkChildDiagDirty(*child, diagTlvs);
+#endif
 
     aRxInfo.mClass = RxInfo::kPeerMessage;
 
@@ -3202,6 +3233,9 @@ void Mle::RemoveNeighbor(Neighbor &aNeighbor)
         if (aNeighbor.IsStateValidOrRestoring())
         {
             mNeighborTable.Signal(NeighborTable::kChildRemoved, aNeighbor);
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+            Get<MeshMonitor::Server>().HandleChildRemoved(static_cast<Child &>(aNeighbor));
+#endif
         }
 
         Get<IndirectSender>().ClearAllMessagesForSleepyChild(child);
@@ -3351,6 +3385,10 @@ void Mle::HandleAddressSolicitResponse(Coap::Msg *aMsg, Error aResult)
     SuccessOrExit(Tlv::Find<ThreadRouterMaskTlv>(aMsg->mMessage, routerIdMask));
     VerifyOrExit(routerIdMask.IsValid());
     VerifyOrExit(routerIdMask.IsAllocated(GetLeaderId()));
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    Get<MeshMonitor::Server>().HandleDetach();
+#endif
 
     SetAlternateRloc16(GetRloc16());
 
@@ -3857,6 +3895,10 @@ void Mle::SetChildStateToValid(Child &aChild)
     mDelayedSender.RemoveScheduledChildUpdateRequestToChild(aChild);
 
     mNeighborTable.Signal(NeighborTable::kChildAdded, aChild);
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+    Get<MeshMonitor::Server>().HandleChildAdded(aChild);
+#endif
 
 exit:
     return;

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -112,6 +112,10 @@ void RouterTable::RemoveRouter(Router &aRouter)
     if (aRouter.IsStateValid())
     {
         Get<NeighborTable>().Signal(NeighborTable::kRouterRemoved, aRouter);
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+        Get<MeshMonitor::Server>().HandleRouterRemoved(aRouter);
+#endif
     }
 
     mRouterIdMap.Release(aRouter.GetRouterId());
@@ -248,6 +252,10 @@ void RouterTable::RemoveRouterLink(Router &aRouter)
         aRouter.SetLinkQualityOut(kLinkQuality0);
         aRouter.SetLastHeard(TimerMilli::GetNow());
         SignalTableChanged(kEventLinkQualityOutChanged);
+
+#if OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+        Get<MeshMonitor::Server>().HandleRouterRemoved(aRouter);
+#endif
     }
 
     for (Router &router : mRouters)

--- a/src/core/thread/tmf.cpp
+++ b/src/core/thread/tmf.cpp
@@ -151,6 +151,14 @@ bool Agent::HandleResource(const char *aUriPath, Msg &aMsg)
         Case(kUriTcatEnable, MeshCoP::TcatAgent);
 #endif
 
+#if (OPENTHREAD_FTD || OPENTHREAD_MTD) && OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+        Case(kUriMeshMonEndDeviceRequest, MeshMonitor::Server);
+#endif
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MESH_MONITOR_SERVER_ENABLE
+        Case(kUriMeshMonEndDeviceUpdate, MeshMonitor::Server);
+        Case(kUriMeshMonServerRequest, MeshMonitor::Server);
+#endif
+
     default:
         didHandle = false;
         break;


### PR DESCRIPTION
# Mesh Monitor - Server Implementation

This is the **second PR** splitting #12304.
Each PR is independently reviewable. The full feature will land once all are merged.

> [!IMPORTANT]
> **This PR will not build on its own.** It depends on the infrastructure layer (configs, public API types, `Tlv`/`TlvSet`, message types, stub class shells, URI constants, CMake wiring) introduced in the first PR (#13045). The two PRs were deliberately kept separate to avoid duplicating those files across branches and the constant re-syncing that would require.
>
> **This PR builds if and only if the first PR is merged** (or the two branches are combined). It is published now so the **server logic and the infrastructure files can be reviewed in parallel**, rather than serializing the review.

## Background
PR #12304 implements the Mesh Monitor Protocol for Thread networks: a client-driven, incremental diagnostic system that allows a single client to subscribe to diagnostic updates from all routers in the network. Routers aggregate data from themselves, their children, and neighbors, then push updates to the client.

Because the original PR was large (~12k LoC), it has been split into multiple focused PRs to reduce reviewer load and unblock CI approvals.

## What This PR Includes
This PR fills in the **Server** side of the protocol. The complete `Server` class implementation that turns the first PR's stubs into working runtime behavior:

- **TMF handlers** for the Mesh Monitor request/update messages (ER/EU/SR).
- **Diagnostic aggregation** across host, child, and neighbor contexts, including per-context TLV collection.
- **MTU-aware batching** that splits updates across multiple messages when they exceed the available payload.
- **Incremental updates** with dirty-TLV tracking, full vs. partial update handling, and sequence numbering.
- **Exponential backoff** and **timer management** for scheduling and retrying updates.
- **Registration handling** for client subscriptions (query vs. registration requests).

## What This PR Does NOT Include
- Any `Client` class implementation
- Any public API function implementations
- CLI commands
- Tests

These are delivered in the follow-up PR described below.

## Relationship to Other PRs
- **PR 1 – Stubs, Configs, Types & TlvSets** (#<first-pr-number>): Infrastructure layer this PR builds on. **Must be merged first.**
- **PR 2 – Server (this PR):** Complete `Server` class implementation.
- **PR 3 – Client + Tests:** Adds the complete `Client` class, all public API functions, CLI commands, and the full Nexus integration test suite and associated scripts.

## Summary
This PR adds the full server-side runtime for the Mesh Monitor feature on top of the scaffolding from PR 1. It is intentionally not self-building so that server review can proceed concurrently with review of the infrastructure files, speeding up the overall review of the split.

(Reference: original large PR split – #12304)