### PR TITLE
[mac] Fix uint16_t underflow in Frame::GetPayloadLength()

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -916,7 +916,11 @@ uint8_t Frame::CalculateMicSize(uint8_t aSecurityControl)
 
 uint16_t Frame::GetMaxPayloadLength(void) const { return GetMtu() - (GetHeaderLength() + GetFooterLength()); }
 
-uint16_t Frame::GetPayloadLength(void) const { return mLength - (GetHeaderLength() + GetFooterLength()); }
+uint16_t Frame::GetPayloadLength(void) const
+{
+    uint16_t overhead = static_cast<uint16_t>(GetHeaderLength()) + GetFooterLength();
+    return (mLength >= overhead) ? (mLength - overhead) : 0;
+}
 
 void Frame::SetPayloadLength(uint16_t aLength) { mLength = GetHeaderLength() + GetFooterLength() + aLength; }
 


### PR DESCRIPTION
### Summary

`Frame::GetPayloadLength()` in `src/core/mac/mac_frame.cpp` computes:

```cpp
return mLength - (GetHeaderLength() + GetFooterLength());
```

All three operands are unsigned (`uint16_t` / `uint8_t`). When a received frame is shorter than its combined header and footer — which is possible for SecurityEnabled=0 frames where `GetFooterLength()` returns only the 2-byte FCS — the subtraction wraps to a large `uint16_t` (e.g. 65534). This value is immediately used as a buffer length in `MeshForwarder::HandleReceivedFrame()`, causing an out-of-bounds heap read.

### Root cause

No lower-bound check on `mLength` before the subtraction. A minimal 7-byte SecurityEnabled=0 IEEE 802.15.4 frame produces `GetPayloadLength() = 7 - (7+2) = 65534`.

### Fix

Guard the subtraction; return 0 for malformed frames:

```cpp
uint16_t Frame::GetPayloadLength(void) const
{
    uint16_t overhead = static_cast<uint16_t>(GetHeaderLength()) + GetFooterLength();
    return (mLength >= overhead) ? (mLength - overhead) : 0;
}
```

### Impact

- **CWE-191**: Integer Underflow (Wrap or Wraparound)
- **CWE-125**: Out-of-Bounds Read
- Reachable from adjacent network by an unauthenticated attacker sending a crafted 802.15.4 frame with SecurityEnabled=0

