### PR TITLE
[mesh-forwarder] Validate 6LoWPAN fragment datagramSize >= IPv6 header size

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1106,6 +1106,8 @@ void MeshForwarder::HandleFragment(RxInfo &aRxInfo)
     {
         uint16_t datagramSize = fragmentHeader.GetDatagramSize();
 
+        VerifyOrExit(datagramSize >= sizeof(Ip6::Header), error = kErrorParse);
+
 #if OPENTHREAD_FTD
         UpdateEidRlocCacheAndStaleChild(aRxInfo);
 #endif


### PR DESCRIPTION
### Summary

In `MeshForwarder::HandleFragment()`, the datagram size from a received 6LoWPAN FRAG1 header is not lower-bounded before being passed to `Lowpan::Decompress()`. Inside `Decompress()`:

```cpp
ip6PayloadLength = BigEndian::HostSwap16(
    aDatagramLength - currentOffset - sizeof(Ip6::Header));
```

When `aDatagramLength < sizeof(Ip6::Header)` (40 bytes), this `uint16_t` subtraction wraps (~65496), writing a bogus payload-length field into the reconstructed IPv6 packet and causing an overread during subsequent processing.

### Root cause

The 11-bit datagramSize field in a FRAG1 header is attacker-controlled (range 0–2047). No check existed that it satisfies the minimum RFC 2460 requirement of at least 40 bytes for a valid IPv6 datagram.

### Fix

Reject fragments whose declared datagram size is smaller than a minimal IPv6 header immediately after parsing the fragment header:

```cpp
uint16_t datagramSize = fragmentHeader.GetDatagramSize();
VerifyOrExit(datagramSize >= sizeof(Ip6::Header), error = kErrorParse);
```

### Impact

- **CWE-191**: Integer Underflow (Wrap or Wraparound)
- **CWE-125**: Out-of-Bounds Read
- Reachable from an adjacent network by a node that has been accepted as a Thread neighbor

