### PR TITLE
[tcat] Validate device ID lengths in VendorInfo::IsValid()

### DIFF
--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -49,7 +49,27 @@ RegisterLogModule("TcatAgent");
 bool TcatAgent::VendorInfo::IsValid(void) const
 {
     // Note: mProvisioningUrl can be nullptr, if not present
-    return mPskdString != nullptr && Tlv::ValidateStringValue<ProvisioningUrlTlv>(mProvisioningUrl) == kErrorNone;
+    bool valid = (mPskdString != nullptr) &&
+                 (Tlv::ValidateStringValue<ProvisioningUrlTlv>(mProvisioningUrl) == kErrorNone);
+
+    VerifyOrExit(valid);
+
+    if (mGeneralDeviceId != nullptr)
+    {
+        VerifyOrExit(mGeneralDeviceId->mDeviceIdLen <= OT_TCAT_MAX_DEVICEID_SIZE, valid = false);
+    }
+
+    if (mAdvertisedDeviceIds != nullptr)
+    {
+        for (uint8_t i = 0; mAdvertisedDeviceIds[i].mDeviceIdType != OT_TCAT_DEVICE_ID_EMPTY; i++)
+        {
+            VerifyOrExit(mAdvertisedDeviceIds[i].mDeviceIdLen <= OT_TCAT_MAX_ADVERTISED_DEVICEID_SIZE,
+                         valid = false);
+        }
+    }
+
+exit:
+    return valid;
 }
 
 TcatAgent::TcatAgent(Instance &aInstance)


### PR DESCRIPTION
### Summary

`TcatAgent::VendorInfo::IsValid()` only checked `mPskdString` and `mProvisioningUrl`. An application could supply:

- `mAdvertisedDeviceIds[i].mDeviceIdLen > OT_TCAT_MAX_ADVERTISED_DEVICEID_SIZE` (5)
- `mGeneralDeviceId->mDeviceIdLen > OT_TCAT_MAX_DEVICEID_SIZE` (64)

Both fields back fixed-size arrays declared in the public API structs (`otTcatAdvertisedDeviceId.mDeviceId[5]`, `otTcatGeneralDeviceId.mDeviceId[64]`). An oversized length causes `GetAdvertisementData()` to `memcpy` past the end of `mDeviceId[]`, giving an out-of-bounds read that can expose stack or heap contents over the BLE advertisement.

### Root cause

`IsValid()` did not validate device ID lengths, so `SetTcatVendorInfo()` accepted structs with lengths exceeding the corresponding array sizes.

### Fix

Add length bounds checks for both device ID fields in `IsValid()`:

```cpp
if (mGeneralDeviceId != nullptr)
    VerifyOrExit(mGeneralDeviceId->mDeviceIdLen <= OT_TCAT_MAX_DEVICEID_SIZE, valid = false);

if (mAdvertisedDeviceIds != nullptr)
    for each entry:
        VerifyOrExit(entry.mDeviceIdLen <= OT_TCAT_MAX_ADVERTISED_DEVICEID_SIZE, valid = false);
```

`SetTcatVendorInfo()` now returns `kErrorInvalidArgs` for malformed input.

### Impact

- **CWE-125**: Out-of-Bounds Read
- Requires local API access (`otBleSecureSetTcatVendorInfo()`) to trigger; information disclosed over BLE advertisement channel

