### PR TITLE
[lowpan] check datagramSize in Decompress and DecompressUdpHeader

### DIFF
--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -970,6 +970,7 @@ Error Lowpan::DecompressUdpHeader(Message &aMessage, FrameData &aFrameData, uint
     }
     else
     {
+        VerifyOrExit(aDatagramLength >= aMessage.GetOffset() + sizeof(Ip6::UdpHeader), error = kErrorParse);
         udpHeader.SetLength(aDatagramLength - aMessage.GetOffset());
     }
 
@@ -1035,6 +1036,7 @@ Error Lowpan::Decompress(Message              &aMessage,
 
     if (aDatagramLength)
     {
+        VerifyOrExit(aDatagramLength >= currentOffset + sizeof(Ip6::Header), error = kErrorParse);
         ip6PayloadLength = BigEndian::HostSwap16(aDatagramLength - currentOffset - sizeof(Ip6::Header));
     }
     else


### PR DESCRIPTION
This commit adds robust bounds validation checks inside the lowpan decompression routines to prevent potential integer underflows.

Specifically:
- In Lowpan::Decompress, we ensure that the declared datagramSize is large enough to contain the IPv6 header being decompressed at the current offset. This prevents underflow during recursive calls (e.g., for tunneled packets) when the datagram size is smaller than the combined headers.
- In Lowpan::DecompressUdpHeader, we verify that the remaining datagram length is sufficient to fit a UDP header, preventing underflow when calculating the UDP length from the offset.