### PR TITLE
[crypto] align LinkRaw MAC key exportability with KeyManager

### DIFF
--- a/src/core/mac/link_raw.cpp
+++ b/src/core/mac/link_raw.cpp
@@ -253,9 +253,9 @@ Error LinkRaw::SetMacKey(uint8_t    aKeyIdMode,
 
     VerifyOrExit(IsEnabled(), error = kErrorInvalidState);
 
-    prevKey.SetFrom(aPrevKey);
-    currKey.SetFrom(aCurrKey);
-    nextKey.SetFrom(aNextKey);
+    prevKey.SetFrom(aPrevKey, kDefaultMacKeysExportable);
+    currKey.SetFrom(aCurrKey, kDefaultMacKeysExportable);
+    nextKey.SetFrom(aNextKey, kDefaultMacKeysExportable);
 
     mSubMac.SetMacKey(aKeyIdMode, aKeyId, prevKey, currKey, nextKey);
 

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -80,6 +80,8 @@ typedef otShortAddress ShortAddress;
 
 constexpr ShortAddress kShortAddrBroadcast = OT_RADIO_BROADCAST_SHORT_ADDR; ///< Broadcast Short Address.
 constexpr ShortAddress kShortAddrInvalid   = OT_RADIO_INVALID_SHORT_ADDR;   ///< Invalid Short Address.
+constexpr bool         kDefaultMacKeysExportable =
+    OPENTHREAD_CONFIG_PLATFORM_MAC_KEYS_EXPORTABLE_ENABLE; ///< Default exportability policy for MAC key refs.
 
 /**
  * Represents the wake-up identifier.

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -344,13 +344,13 @@ void KeyManager::UpdateKeyMaterial(void)
         Mac::KeyMaterial prevKey;
         Mac::KeyMaterial nextKey;
 
-        curKey.SetFrom(hashKeys.GetMacKey(), kExportableMacKeys);
+        curKey.SetFrom(hashKeys.GetMacKey(), Mac::kDefaultMacKeysExportable);
 
         ComputeKeys(mKeySequence - 1, hashKeys);
-        prevKey.SetFrom(hashKeys.GetMacKey(), kExportableMacKeys);
+        prevKey.SetFrom(hashKeys.GetMacKey(), Mac::kDefaultMacKeysExportable);
 
         ComputeKeys(mKeySequence + 1, hashKeys);
-        nextKey.SetFrom(hashKeys.GetMacKey(), kExportableMacKeys);
+        nextKey.SetFrom(hashKeys.GetMacKey(), Mac::kDefaultMacKeysExportable);
 
         Get<Mac::SubMac>().SetMacKey(Mac::Frame::kKeyIdMode1, (mKeySequence & 0x7f) + 1, prevKey, curKey, nextKey);
     }

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -571,7 +571,6 @@ public:
 private:
     static constexpr uint16_t kDefaultKeySwitchGuardTime    = 624; // ~ 93% of 672 (default key rotation time)
     static constexpr uint32_t kKeySwitchGuardTimePercentage = 93;  // Percentage of key rotation time.
-    static constexpr bool     kExportableMacKeys            = OPENTHREAD_CONFIG_PLATFORM_MAC_KEYS_EXPORTABLE_ENABLE;
 
     static_assert(kDefaultKeySwitchGuardTime ==
                       SecurityPolicy::kDefaultKeyRotationTime * kKeySwitchGuardTimePercentage / 100,


### PR DESCRIPTION
This change completes a previously unfinished part of the "MAC keys must be exportable" fix. `KeyManager` already applies an explicit exportable policy (`kExportableMacKeys`) when updating MAC keys, but `LinkRaw::SetMacKey()` still relied on `SetFrom(..., aIsExportable=false)` by default, which made key import permissions inconsistent across code paths.

On RCP paths with `OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE`, MAC key bytes from host spinel are re-imported on RCP as key references before being passed to the platform radio. If those key references are not created with export permission as required by `OPENTHREAD_CONFIG_PLATFORM_MAC_KEYS_EXPORTABLE_ENABLE`, the platform can fail to retrieve key material when setting MAC keys, which can break subsequent 802.15.4 security processing.

This patch introduces a shared `Mac::kDefaultMacKeysExportable` policy (derived from `OPENTHREAD_CONFIG_PLATFORM_MAC_KEYS_EXPORTABLE_ENABLE`) and uses it in both `KeyManager` and `LinkRaw`, so MAC key import behavior stays consistent whenever `OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE` is enabled.