### PR TITLE
[radio] introduce `SyncedRadioLocalTime` helper class

### DIFF
--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -672,28 +672,26 @@ private:
     SubMacTimer mTimer;
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    uint16_t mCslPeriod;             // The CSL sample period, in units of 10 symbols (160 microseconds).
-    uint8_t  mCslChannel : 7;        // The CSL sample channel.
-    bool     mIsCslSampling : 1;     // Indicates that the current time is in CSL sample window
-                                     // for platforms not supporting `Radio::ReceiveAt()`.
-    uint16_t    mCslPeerShort;       // The CSL peer short address.
-    RadioTime32 mCslSampleTimeRadio; // The CSL sample time of the current period based on radio time (lower 32-bit).
-    TimeMicro   mCslSampleTimeLocal; // The CSL sample time of the current period based on local time.
-    TimeMicro   mCslLastSync;        // The timestamp of the last successful CSL synchronization.
-    CslAccuracy mCslParentAccuracy;  // The parent's CSL accuracy (clock accuracy and uncertainty).
-    TimerMicro  mCslTimer;
+    uint16_t mCslPeriod;                     // The CSL sample period, in units of 10 symbols (160 microseconds).
+    uint8_t  mCslChannel : 7;                // The CSL sample channel.
+    bool     mIsCslSampling : 1;             // Indicates that the current time is in CSL sample window
+                                             // for platforms not supporting `Radio::ReceiveAt()`.
+    uint16_t             mCslPeerShort;      // The CSL peer short address.
+    SyncedRadioLocalTime mCslSampleTime;     // The CSL sample time for current period.
+    TimeMicro            mCslLastSync;       // The timestamp of the last successful CSL synchronization.
+    CslAccuracy          mCslParentAccuracy; // The parent's CSL accuracy (clock accuracy and uncertainty).
+    TimerMicro           mCslTimer;
 #endif
 
 #if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-    bool mIsWedSampling : 1;           // Indicates that the current time is in WED's sample window
-                                       // for platforms not supporting `Radio::ReceiveAt()`.
-    bool        mIsWedEnabled : 1;     // Indicates if the WED is enabled.
-    uint32_t    mWakeupListenInterval; // The wake-up listen interval, in microseconds.
-    uint32_t    mWakeupListenDuration; // The wake-up listen duration, in microseconds.
-    uint8_t     mWakeupChannel;        // The wake-up sample channel.
-    TimeMicro   mWedSampleTime;        // The WED sample time of the current interval in local time.
-    RadioTime64 mWedSampleTimeRadio;   // The WED sample time of the current interval in radio time.
-    TimerMicro  mWedTimer;
+    bool mIsWedSampling : 1;                    // Indicates that the current time is in WED's sample window
+                                                // for platforms not supporting `Radio::ReceiveAt()`.
+    bool                 mIsWedEnabled : 1;     // Indicates if the WED is enabled.
+    uint32_t             mWakeupListenInterval; // The wake-up listen interval, in microseconds.
+    uint32_t             mWakeupListenDuration; // The wake-up listen duration, in microseconds.
+    uint8_t              mWakeupChannel;        // The wake-up sample channel.
+    SyncedRadioLocalTime mWedSampleTime;        // The WED sample time of the current interval.
+    TimerMicro           mWedTimer;
 #endif
 };
 

--- a/src/core/mac/sub_mac_csl_receiver.cpp
+++ b/src/core/mac/sub_mac_csl_receiver.cpp
@@ -44,12 +44,11 @@ RegisterLogModule("SubMac");
 
 void SubMac::CslInit(void)
 {
-    mCslPeriod          = 0;
-    mCslChannel         = 0;
-    mCslPeerShort       = 0;
-    mIsCslSampling      = false;
-    mCslSampleTimeRadio = 0;
-    mCslSampleTimeLocal.SetValue(0);
+    mCslPeriod     = 0;
+    mCslChannel    = 0;
+    mCslPeerShort  = 0;
+    mIsCslSampling = false;
+    mCslSampleTime.Clear();
     mCslLastSync.SetValue(0);
     mCslTimer.Stop();
 }
@@ -66,8 +65,7 @@ void SubMac::RestartCslTimerAfterSyncUpdate(void)
         // Rewind sample times by one period. HandleCslTimer() will add this
         // period back, effectively re-evaluating the current CSL period's
         // schedule using the updated mCslLastSync.
-        mCslSampleTimeRadio -= periodUs;
-        mCslSampleTimeLocal -= periodUs;
+        mCslSampleTime -= periodUs;
 
         HandleCslTimer();
     }
@@ -127,12 +125,13 @@ void SubMac::SetCslParams(uint16_t aPeriod, uint8_t aChannel, ShortAddress aShor
     mCslPeriod     = aPeriod;
 
     mCslTimer.Stop();
+
     if (mCslPeriod > 0)
     {
-        mCslSampleTimeRadio = Get<Radio>().GetNowAsRadioTime32();
-        mCslSampleTimeLocal = TimerMicro::GetNow();
+        mCslSampleTime.SetToNow(Get<Radio>());
+
         // Update CSL sync time whenever CSL parameters are re-initialized.
-        mCslLastSync = mCslSampleTimeLocal;
+        mCslLastSync = mCslSampleTime.GetAsTimeMicro();
 
         HandleCslTimer();
     }
@@ -184,15 +183,14 @@ void SubMac::HandleCslReceiveAt(uint32_t aTimeAhead, uint32_t aTimeAfter)
     RadioTime32 winStart;
     uint32_t    winDuration;
 
-    mCslTimer.FireAt(mCslSampleTimeLocal + periodUs - aTimeAhead - GetNextCycleDrift());
+    mCslTimer.FireAt(mCslSampleTime.GetAsTimeMicro() + periodUs - aTimeAhead - GetNextCycleDrift());
     aTimeAhead -= kCslReceiveTimeAhead;
-    winStart    = mCslSampleTimeRadio - aTimeAhead;
+    winStart    = mCslSampleTime.GetAsRadio32() - aTimeAhead;
     winDuration = aTimeAhead + aTimeAfter;
 
-    mCslSampleTimeRadio += periodUs;
-    mCslSampleTimeLocal += periodUs;
+    mCslSampleTime += periodUs;
 
-    Get<Radio>().UpdateCslSampleTime(mCslSampleTimeRadio);
+    Get<Radio>().UpdateCslSampleTime(mCslSampleTime.GetAsRadio32());
 
     // Schedule reception window for any state except RX - so that CSL RX Window has lower priority
     // than scanning or RX after the data poll.
@@ -221,7 +219,7 @@ void SubMac::HandleCslReceiveOrSleep(uint32_t aTimeAhead, uint32_t aTimeAfter)
     if (mIsCslSampling)
     {
         mIsCslSampling = false;
-        mCslTimer.FireAt(mCslSampleTimeLocal - aTimeAhead - GetNextCycleDrift());
+        mCslTimer.FireAt(mCslSampleTime.GetAsTimeMicro() - aTimeAhead - GetNextCycleDrift());
         if (mState == kStateRadioSample)
         {
             LogDebg("CSL sleep %lu", ToUlong(mCslTimer.GetNow().GetValue()));
@@ -233,15 +231,14 @@ void SubMac::HandleCslReceiveOrSleep(uint32_t aTimeAhead, uint32_t aTimeAfter)
         uint32_t winStart;
         uint32_t winDuration;
 
-        mCslTimer.FireAt(mCslSampleTimeLocal + aTimeAfter);
+        mCslTimer.FireAt(mCslSampleTime.GetAsTimeMicro() + aTimeAfter);
         mIsCslSampling = true;
         winStart       = TimerMicro::GetNow().GetValue();
         winDuration    = aTimeAhead + aTimeAfter;
 
-        mCslSampleTimeRadio += periodUs;
-        mCslSampleTimeLocal += periodUs;
+        mCslSampleTime += periodUs;
 
-        Get<Radio>().UpdateCslSampleTime(mCslSampleTimeRadio);
+        Get<Radio>().UpdateCslSampleTime(mCslSampleTime.GetAsRadio32());
 
         LogCslWindow(winStart, winDuration);
     }
@@ -328,7 +325,7 @@ void SubMac::LogReceived(RxFrame *aFrame)
     GetCslWindowEdges(ahead, after);
     ahead -= kMinReceiveOnAhead + kCslReceiveTimeAhead;
 
-    sampleTime = mCslSampleTimeRadio - mCslPeriod * kUsPerTenSymbols;
+    sampleTime = mCslSampleTime.GetAsRadio32() - mCslPeriod * kUsPerTenSymbols;
     deviation  = ConvertRadioTime64To32(aFrame->GetTimestamp()) + kRadioHeaderPhrDuration - sampleTime;
 
     // This logs three values (all in microseconds):

--- a/src/core/mac/sub_mac_wed.cpp
+++ b/src/core/mac/sub_mac_wed.cpp
@@ -62,8 +62,9 @@ void SubMac::UpdateWakeupListening(bool aEnable, uint32_t aInterval, uint32_t aD
 
     if (aEnable)
     {
-        mWedSampleTime      = TimerMicro::GetNow() + kCslReceiveTimeAhead - mWakeupListenInterval;
-        mWedSampleTimeRadio = Get<Radio>().GetNow() + kCslReceiveTimeAhead - mWakeupListenInterval;
+        mWedSampleTime.SetToNow(Get<Radio>());
+        mWedSampleTime += kCslReceiveTimeAhead;
+        mWedSampleTime -= mWakeupListenInterval;
 
         HandleWedTimer();
     }
@@ -90,13 +91,12 @@ void SubMac::HandleWedTimer(void)
 void SubMac::HandleWedReceiveAt(void)
 {
     mWedSampleTime += mWakeupListenInterval;
-    mWedSampleTimeRadio += mWakeupListenInterval;
-    mWedTimer.FireAt(mWedSampleTime + mWakeupListenDuration + kWedReceiveTimeAfter);
+
+    mWedTimer.FireAt(mWedSampleTime.GetAsTimeMicro() + mWakeupListenDuration + kWedReceiveTimeAfter);
 
     if (mState != kStateDisabled)
     {
-        IgnoreError(
-            Get<Radio>().ReceiveAt(mWakeupChannel, ConvertRadioTime64To32(mWedSampleTimeRadio), mWakeupListenDuration));
+        IgnoreError(Get<Radio>().ReceiveAt(mWakeupChannel, mWedSampleTime.GetAsRadio32(), mWakeupListenDuration));
     }
 }
 
@@ -108,12 +108,12 @@ void SubMac::HandleWedReceiveOrSleep(void)
 
     if (mIsWedSampling)
     {
-        fireTime = mWedSampleTime + mWakeupListenDuration + kMinReceiveOnAfter;
+        fireTime = mWedSampleTime.GetAsTimeMicro() + mWakeupListenDuration + kMinReceiveOnAfter;
     }
     else
     {
         mWedSampleTime += mWakeupListenInterval;
-        fireTime = mWedSampleTime - kMinReceiveOnAhead;
+        fireTime = mWedSampleTime.GetAsTimeMicro() - kMinReceiveOnAhead;
     }
 
     mWedTimer.FireAt(fireTime);

--- a/src/core/radio/radio_types.cpp
+++ b/src/core/radio/radio_types.cpp
@@ -33,7 +33,7 @@
 
 #include "radio_types.hpp"
 
-#include "common/time.hpp"
+#include "instance/instance.hpp"
 
 namespace ot {
 
@@ -44,5 +44,18 @@ bool IsRadioTimeStrictlyBefore(RadioTime32 aFirstTime, RadioTime32 aSecondTime)
 
     return (firstTime < secondTime);
 }
+
+//---------------------------------------------------------------------------------------------------------------------
+// SyncedRadioLocalTime
+
+#if OT_CONFIG_RADIO_TIME_ENABLE && OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
+
+void SyncedRadioLocalTime::SetToNow(Radio &aRadio)
+{
+    mRadioTime = aRadio.GetNow();
+    mLocalTime = TimerMicro::GetNow();
+}
+
+#endif
 
 } // namespace ot

--- a/src/core/radio/radio_types.hpp
+++ b/src/core/radio/radio_types.hpp
@@ -38,6 +38,9 @@
 
 #include <openthread/platform/radio.h>
 
+#include "common/clearable.hpp"
+#include "common/time.hpp"
+
 namespace ot {
 
 #ifdef OT_CONFIG_RADIO_TIME_ENABLE
@@ -48,6 +51,8 @@ namespace ot {
     (OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE || \
      OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE || OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE || \
      OPENTHREAD_CONFIG_TIME_SYNC_ENABLE)
+
+class Radio;
 
 /**
  * Represents a 64-bit radio time in microseconds referenced to a continuous monotonic local radio clock.
@@ -80,6 +85,71 @@ inline RadioTime32 ConvertRadioTime64To32(RadioTime64 aRadioTime64) { return sta
  * @retval FALSE  @p aFirstTime is not strictly before @p aSecondTime.
  */
 bool IsRadioTimeStrictlyBefore(RadioTime32 aFirstTime, RadioTime32 aSecondTime);
+
+#if OT_CONFIG_RADIO_TIME_ENABLE && OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
+
+/**
+ * Represents synchronized radio time and local `TimeMicro`.
+ */
+class SyncedRadioLocalTime : public Clearable<SyncedRadioLocalTime>
+{
+public:
+    /**
+     * Sets the synchronized radio and local time values to the current time.
+     *
+     * @param[in] aRadio  The `Radio` to use for radio time.
+     */
+    void SetToNow(Radio &aRadio);
+
+    /**
+     * Gets the local time as `TimeMicro`
+     *
+     * @returns The local microsecond time.
+     */
+    TimeMicro GetAsTimeMicro(void) const { return mLocalTime; }
+
+    /**
+     * Gets the 64-bit radio time.
+     *
+     * @returns The 64-bit radio time.
+     */
+    RadioTime64 GetAsRadio64(void) const { return mRadioTime; }
+
+    /**
+     * Gets the 32-bit radio time.
+     *
+     * @returns The 32-bit radio time.
+     */
+    RadioTime32 GetAsRadio32(void) const { return ConvertRadioTime64To32(mRadioTime); }
+
+    /**
+     * Advances the synchronized radio and local time values by a given duration.
+     *
+     * @param[in] aDuration  The duration in microseconds to add.
+     */
+    void operator+=(uint32_t aDuration)
+    {
+        mRadioTime += aDuration;
+        mLocalTime += aDuration;
+    }
+
+    /**
+     * Rewinds the synchronized radio and local time values by a given duration.
+     *
+     * @param[in] aDuration  The duration in microseconds to subtract.
+     */
+    void operator-=(uint32_t aDuration)
+    {
+        mRadioTime -= aDuration;
+        mLocalTime -= aDuration;
+    }
+
+private:
+    RadioTime64 mRadioTime;
+    TimeMicro   mLocalTime;
+};
+
+#endif // OT_CONFIG_RADIO_TIME_ENABLE && OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 
 } // namespace ot
 


### PR DESCRIPTION
This commit introduces `SyncedRadioLocalTime` to encapsulate paired radio time and local `TimeMicro` values, and refactors `SubMac` to use it for tracking CSL and WED sample timing.
