### PR TITLE
[radio] define `OT_CONFIG_RADIO_TIME_ENABLE` derived configuration

### DIFF
--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -560,8 +560,7 @@ public:
     Error ResetCsl(void);
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE || \
-    OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+#if OT_CONFIG_RADIO_TIME_ENABLE
     /**
      * Get the current radio time in microseconds referenced to a continuous monotonic local radio clock (64 bits
      * width).
@@ -592,7 +591,7 @@ public:
      * @returns The CSL Uncertainty in units of 10 us.
      */
     uint8_t GetCslUncertainty(void);
-#endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+#endif // OT_CONFIG_RADIO_TIME_ENABLE
 
     /**
      * Gets the radio transmit frame buffer.
@@ -1019,8 +1018,7 @@ inline Error Radio::EnableCsl(uint32_t aCslPeriod, Mac::ShortAddress aShortAddr,
 inline Error Radio::ResetCsl(void) { return otPlatRadioResetCsl(GetInstancePtr()); }
 #endif
 
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE || \
-    OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+#if OT_CONFIG_RADIO_TIME_ENABLE
 inline RadioTime64 Radio::GetNow(void) { return otPlatRadioGetNow(GetInstancePtr()); }
 
 inline uint8_t Radio::GetCslAccuracy(void) { return otPlatRadioGetCslAccuracy(GetInstancePtr()); }
@@ -1127,8 +1125,7 @@ inline Error Radio::EnableCsl(uint32_t, Mac::ShortAddress, const Mac::ExtAddress
 inline Error Radio::ResetCsl(void) { return kErrorNotImplemented; }
 #endif
 
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE || \
-    OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+#if OT_CONFIG_RADIO_TIME_ENABLE
 inline RadioTime64 Radio::GetNow(void) { return NumericLimits<uint64_t>::kMax; }
 
 inline uint8_t Radio::GetCslAccuracy(void) { return NumericLimits<uint8_t>::kMax; }

--- a/src/core/radio/radio_types.hpp
+++ b/src/core/radio/radio_types.hpp
@@ -40,6 +40,15 @@
 
 namespace ot {
 
+#ifdef OT_CONFIG_RADIO_TIME_ENABLE
+#error "OT_CONFIG_RADIO_TIME_ENABLE MUST NOT be defined directly. It is derived from other configs"
+#endif
+
+#define OT_CONFIG_RADIO_TIME_ENABLE                                                               \
+    (OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE || \
+     OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE || OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE || \
+     OPENTHREAD_CONFIG_TIME_SYNC_ENABLE)
+
 /**
  * Represents a 64-bit radio time in microseconds referenced to a continuous monotonic local radio clock.
  */


### PR DESCRIPTION
This commit defines `OT_CONFIG_RADIO_TIME_ENABLE` as a derived internal configuration macro in `radio.hpp`. It consolidates conditional checks for features that depend on radio clock time (CSL receiver/transmitter, wakeup, and time synchronization).

----

~This PR currently contains the commit from https://github.com/openthread/openthread/pull/13268. Please read and review the last commit on this PR. Thanks.~ 