### PR TITLE
[mac-frame] simplify FCF flag changes using `UpdateFcfFlag`

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -288,52 +288,17 @@ bool Frame::IsWakeupFrame(void) const
 }
 #endif
 
-void Frame::SetAckRequest(bool aAckRequest)
+void Frame::UpdateFcfFlag(bool aSet, uint16_t aBitFlag)
 {
-    uint16_t fcf  = GetFrameControlField();
-    uint16_t mask = kFcfAckRequest;
+    uint16_t fcf = GetFrameControlField();
 
-    if (aAckRequest)
+    if (aSet)
     {
-        fcf |= mask;
+        fcf |= aBitFlag;
     }
     else
     {
-        fcf &= ~mask;
-    }
-
-    SetFrameControlField(fcf);
-}
-
-void Frame::SetFramePending(bool aFramePending)
-{
-    uint16_t fcf  = GetFrameControlField();
-    uint16_t mask = kFcfFramePending;
-
-    if (aFramePending)
-    {
-        fcf |= mask;
-    }
-    else
-    {
-        fcf &= ~mask;
-    }
-
-    SetFrameControlField(fcf);
-}
-
-void Frame::SetIePresent(bool aIePresent)
-{
-    uint16_t fcf  = GetFrameControlField();
-    uint16_t mask = kFcfIePresent;
-
-    if (aIePresent)
-    {
-        fcf |= mask;
-    }
-    else
-    {
-        fcf &= ~mask;
+        fcf &= ~aBitFlag;
     }
 
     SetFrameControlField(fcf);

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -233,7 +233,7 @@ public:
      *
      * @param[in]  aFramePending  The Frame Pending bit.
      */
-    void SetFramePending(bool aFramePending);
+    void SetFramePending(bool aFramePending) { UpdateFcfFlag(aFramePending, kFcfFramePending); }
 
     /**
      * Indicates whether or not the Ack Request bit is set.
@@ -248,7 +248,7 @@ public:
      *
      * @param[in]  aAckRequest  The Ack Request bit.
      */
-    void SetAckRequest(bool aAckRequest);
+    void SetAckRequest(bool aAckRequest) { UpdateFcfFlag(aAckRequest, kFcfAckRequest); }
 
     /**
      * Indicates whether or not the PanId Compression bit is set.
@@ -271,7 +271,7 @@ public:
      *
      * @param[in]  aIePresent   The IE Present bit.
      */
-    void SetIePresent(bool aIePresent);
+    void SetIePresent(bool aIePresent) { UpdateFcfFlag(aIePresent, kFcfIePresent); }
 
     /**
      * Returns the Sequence Number value.
@@ -744,6 +744,7 @@ protected:
     static constexpr uint8_t kMaxPsduSize  = kInvalidSize - 1;
 
     void    SetFrameControlField(uint16_t aFcf) { LittleEndian::WriteUint16(aFcf, mPsdu); }
+    void    UpdateFcfFlag(bool aSet, uint16_t aBitFlag);
     uint8_t SkipSequenceIndex(void) const;
     uint8_t FindDstPanIdIndex(void) const;
     uint8_t FindDstAddrIndex(void) const;


### PR DESCRIPTION
This commit introduces a private helper method `UpdateFcfFlag()` in `Mac::Frame` to consolidate repetitive Frame Control Field (FCF) flag modification logic across MAC frame setters.

----

~This PR contains the commit from https://github.com/openthread/openthread/pull/13281. Please read and review the last commit in this PR. Thanks.~ 
