### PR TITLE
[github-actions] skip coverage uploads for fork pull requests

### DIFF
--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -157,14 +157,12 @@ jobs:
         pattern: cov-*
         merge-multiple: true
     - name: Combine Coverage
-      continue-on-error: true
       run: |
         script/test combine_coverage
     - name: Upload Coverage
-      continue-on-error: true
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: final.info
-        fail_ci_if_error: true
+        fail_ci_if_error: ${{ github.repository == 'openthread/openthread' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/otns.yml
+++ b/.github/workflows/otns.yml
@@ -230,5 +230,6 @@ jobs:
           pattern: cov-*
           merge-multiple: true
       - name: Upload Coverage
+        continue-on-error: ${{ !(github.repository == 'openthread/openthread' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) }}
         run: |
           script/test upload_codecov

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -319,4 +319,4 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: final.info
-        fail_ci_if_error: true
+        fail_ci_if_error: ${{ github.repository == 'openthread/openthread' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -255,4 +255,4 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: final.info
-        fail_ci_if_error: true
+        fail_ci_if_error: ${{ github.repository == 'openthread/openthread' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -236,4 +236,4 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: final.info
-        fail_ci_if_error: true
+        fail_ci_if_error: ${{ github.repository == 'openthread/openthread' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -133,4 +133,4 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: final.info
-        fail_ci_if_error: true
+        fail_ci_if_error: ${{ github.repository == 'openthread/openthread' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}


### PR DESCRIPTION
## Problem

Coverage workflows fail on forks at the Codecov upload step because `CODECOV_TOKEN` isn't available there. Tests pass, but the job goes red with `Token required - not valid tokenless upload`.

My first attempt skipped the whole `upload-coverage` job for fork PRs. That backfired: since this PR came from a fork, the job was skipped in its own run and no coverage report was produced (thanks @jwhui for catching it).

## Solution

Let the job always run and only tolerate the missing-token failure when there's no token. Nothing is skipped, so the jobs still execute everywhere.

## Behavior

| Context | Token | Job runs | Report | CI |
|---|---|---|---|---|
| Push / internal PR (upstream) | yes | yes | yes | fails only on real upload error |
| Fork PR (runs on upstream) | no | yes | no | green |
| Push to a fork | no | yes | no | green |