### PR TITLE
[bit-utils] un-inline `CountBitsInMask` helper method

### DIFF
--- a/src/core/common/bit_utils.cpp
+++ b/src/core/common/bit_utils.cpp
@@ -38,6 +38,19 @@
 
 namespace ot {
 
+uint8_t CountBitsInMask(uint32_t aMask)
+{
+    uint8_t count = 0;
+
+    while (aMask != 0)
+    {
+        aMask &= aMask - 1;
+        count++;
+    }
+
+    return count;
+}
+
 uint16_t CountMatchingBits(const uint8_t *aFirst, const uint8_t *aSecond, uint16_t aMaxBitLength)
 {
     uint16_t remainingLen = aMaxBitLength;

--- a/src/core/common/bit_utils.hpp
+++ b/src/core/common/bit_utils.hpp
@@ -61,28 +61,13 @@ static constexpr uint8_t kBitsPerByte = 8; ///< Number of bits in a byte.
 #define BytesForBitSize(aBitSize) static_cast<uint8_t>(((aBitSize) + (kBitsPerByte - 1)) / kBitsPerByte)
 
 /**
- * Counts the number of `1` bits in the binary representation of a given unsigned int bit-mask value.
- *
- * @tparam UintType   The unsigned int type (MUST be `uint8_t`, `uint16_t`, `uint32_t`, or `uint64_t`).
+ * Counts the number of `1` bits in the binary representation of a given `uint32_t` bit-mask value.
  *
  * @param[in] aMask   A bit mask.
  *
  * @returns The number of `1` bits in @p aMask.
  */
-template <typename UintType> uint8_t CountBitsInMask(UintType aMask)
-{
-    static_assert(TypeTraits::IsUint<UintType>::kValue, "UintType must be an unsigned int (8, 16, 32, or 64 bit len)");
-
-    uint8_t count = 0;
-
-    while (aMask != 0)
-    {
-        aMask &= aMask - 1;
-        count++;
-    }
-
-    return count;
-}
+uint8_t CountBitsInMask(uint32_t aMask);
 
 /**
  * Counts the number of consecutive matching bits between two byte arrays.

--- a/tests/unit/test_bit_utils.cpp
+++ b/tests/unit/test_bit_utils.cpp
@@ -37,23 +37,28 @@ namespace ot {
 
 void TestCountBitsInMask(void)
 {
-    VerifyOrQuit(CountBitsInMask<uint8_t>(0) == 0);
-    VerifyOrQuit(CountBitsInMask<uint8_t>(1) == 1);
-    VerifyOrQuit(CountBitsInMask<uint8_t>(2) == 1);
-    VerifyOrQuit(CountBitsInMask<uint8_t>(3) == 2);
-    VerifyOrQuit(CountBitsInMask<uint8_t>(4) == 1);
-    VerifyOrQuit(CountBitsInMask<uint8_t>(7) == 3);
-    VerifyOrQuit(CountBitsInMask<uint8_t>(11) == 3);
-    VerifyOrQuit(CountBitsInMask<uint8_t>(15) == 4);
-    VerifyOrQuit(CountBitsInMask<uint8_t>(0x11) == 2);
-    VerifyOrQuit(CountBitsInMask<uint8_t>(0xef) == 7);
-    VerifyOrQuit(CountBitsInMask<uint8_t>(0xff) == 8);
+    VerifyOrQuit(CountBitsInMask(0) == 0);
+    VerifyOrQuit(CountBitsInMask(1) == 1);
+    VerifyOrQuit(CountBitsInMask(2) == 1);
+    VerifyOrQuit(CountBitsInMask(3) == 2);
+    VerifyOrQuit(CountBitsInMask(4) == 1);
+    VerifyOrQuit(CountBitsInMask(7) == 3);
+    VerifyOrQuit(CountBitsInMask(11) == 3);
+    VerifyOrQuit(CountBitsInMask(15) == 4);
+    VerifyOrQuit(CountBitsInMask(0x11) == 2);
+    VerifyOrQuit(CountBitsInMask(0xef) == 7);
+    VerifyOrQuit(CountBitsInMask(0xff) == 8);
 
-    VerifyOrQuit(CountBitsInMask<uint16_t>(0) == 0);
-    VerifyOrQuit(CountBitsInMask<uint16_t>(0xff00) == 8);
-    VerifyOrQuit(CountBitsInMask<uint16_t>(0xff) == 8);
-    VerifyOrQuit(CountBitsInMask<uint16_t>(0xaa55) == 8);
-    VerifyOrQuit(CountBitsInMask<uint16_t>(0xffff) == 16);
+    VerifyOrQuit(CountBitsInMask(0xff00) == 8);
+    VerifyOrQuit(CountBitsInMask(0xaa55) == 8);
+    VerifyOrQuit(CountBitsInMask(0xffff) == 16);
+
+    VerifyOrQuit(CountBitsInMask(0x10000) == 1);
+    VerifyOrQuit(CountBitsInMask(0xff0055) == 12);
+    VerifyOrQuit(CountBitsInMask(0xaa0055) == 8);
+    VerifyOrQuit(CountBitsInMask(0xaa007700) == 10);
+    VerifyOrQuit(CountBitsInMask(0xffff0000) == 16);
+    VerifyOrQuit(CountBitsInMask(0xffffffff) == 32);
 
     printf("TestCountBitsInMask() passed\n");
 }


### PR DESCRIPTION
This commit replaces the template function `CountBitsInMask<UintType>` with a non-template function `CountBitsInMask(uint32_t)` in `bit_utils.hpp` and moves its implementation to `bit_utils.cpp`.

Un-inlining this helper function avoids template instantiation overhead and reduces binary size across translation units. Small integer arguments (`uint8_t`, `uint16_t`) automatically promote to `uint32_t`, preserving existing functionality.