### PR TITLE
[dns] fix `otDnsEncodeTxtData()` parameter type mismatch

### DIFF
--- a/src/core/api/dns_api.cpp
+++ b/src/core/api/dns_api.cpp
@@ -49,7 +49,7 @@ otError otDnsGetNextTxtEntry(otDnsTxtEntryIterator *aIterator, otDnsTxtEntry *aE
 }
 
 otError otDnsEncodeTxtData(const otDnsTxtEntry *aTxtEntries,
-                           uint8_t              aNumTxtEntries,
+                           uint16_t             aNumTxtEntries,
                            uint8_t             *aTxtData,
                            uint16_t            *aTxtDataLength)
 {


### PR DESCRIPTION
This commit fixes a parameter type mismatch between declaration and implementation of function `otDnsEncodeTxtData()`.

`include/openthread/dns.h` provides an API `otDnsEncodeTxtData()` for encoding TXT record entries list into TXT data, which is implemented in `src/core/api/dns_api.cpp`. The problem is, `otDnsEncodeTxtData()` is declared with `uint16_t aNumTxtEntries` in the public header, but defined with `uint8_t aNumTxtEntries` in the implementation. This mismatch can lead to symbol/ABI inconsistency for C callers and causes link failure in downstream integrations.

This PR changes the type of parameter `aNumTxtEntries` in cpp implementation from `uint8_t` to `uint16_t`, to follow up type definitions in the declaration and later called `Dns::TxtEntry::AppendEntries()`. So that downstream integrations will not run into link failure when using `otDnsEncodeTxtData()`.