### PR TITLE
[mac] rename `TxFrame::Info` to `TxFrame::BuildInfo`

### DIFF
--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -539,36 +539,36 @@ uint32_t DataPollSender::GetDefaultPollPeriod(void) const
 
 Mac::TxFrame *DataPollSender::PrepareDataRequest(Mac::TxFrames &aTxFrames)
 {
-    Mac::TxFrame      *frame = nullptr;
-    Mac::TxFrame::Info frameInfo;
+    Mac::TxFrame           *frame = nullptr;
+    Mac::TxFrame::BuildInfo buildInfo;
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     Mac::RadioType radio;
 
-    SuccessOrExit(GetPollDestinationAddress(frameInfo.mAddrs.mDestination, radio));
+    SuccessOrExit(GetPollDestinationAddress(buildInfo.mAddrs.mDestination, radio));
     frame = &aTxFrames.GetTxFrame(radio);
 #else
-    SuccessOrExit(GetPollDestinationAddress(frameInfo.mAddrs.mDestination));
+    SuccessOrExit(GetPollDestinationAddress(buildInfo.mAddrs.mDestination));
     frame = &aTxFrames.GetTxFrame();
 #endif
 
-    if (frameInfo.mAddrs.mDestination.IsExtended())
+    if (buildInfo.mAddrs.mDestination.IsExtended())
     {
-        frameInfo.mAddrs.mSource.SetExtended(Get<Mac::Mac>().GetExtAddress());
+        buildInfo.mAddrs.mSource.SetExtended(Get<Mac::Mac>().GetExtAddress());
     }
     else
     {
-        frameInfo.mAddrs.mSource.SetShort(Get<Mac::Mac>().GetShortAddress());
+        buildInfo.mAddrs.mSource.SetShort(Get<Mac::Mac>().GetShortAddress());
     }
 
-    frameInfo.mPanIds.SetBothSourceDestination(Get<Mac::Mac>().GetPanId());
+    buildInfo.mPanIds.SetBothSourceDestination(Get<Mac::Mac>().GetPanId());
 
-    frameInfo.mType          = Mac::Frame::kTypeMacCmd;
-    frameInfo.mCommandId     = Mac::Frame::kMacCmdDataRequest;
-    frameInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
-    frameInfo.mKeyIdMode     = Mac::Frame::kKeyIdMode1;
+    buildInfo.mType          = Mac::Frame::kTypeMacCmd;
+    buildInfo.mCommandId     = Mac::Frame::kMacCmdDataRequest;
+    buildInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
+    buildInfo.mKeyIdMode     = Mac::Frame::kKeyIdMode1;
 
-    Get<MessageFramer>().PrepareMacHeaders(*frame, frameInfo, nullptr);
+    Get<MessageFramer>().PrepareMacHeaders(*frame, buildInfo, nullptr);
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT && OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     if (frame->Has<Mac::CslIe>())

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -705,18 +705,18 @@ void Mac::FinishOperation(void)
 
 TxFrame *Mac::PrepareBeaconRequest(TxFrames &aTxFrames)
 {
-    TxFrame      &frame = aTxFrames.GetBroadcastTxFrame();
-    TxFrame::Info frameInfo;
+    TxFrame           &frame = aTxFrames.GetBroadcastTxFrame();
+    TxFrame::BuildInfo buildInfo;
 
-    frameInfo.mAddrs.mSource.SetNone();
-    frameInfo.mAddrs.mDestination.SetShort(kShortAddrBroadcast);
-    frameInfo.mPanIds.SetDestination(kShortAddrBroadcast);
+    buildInfo.mAddrs.mSource.SetNone();
+    buildInfo.mAddrs.mDestination.SetShort(kShortAddrBroadcast);
+    buildInfo.mPanIds.SetDestination(kShortAddrBroadcast);
 
-    frameInfo.mType      = Frame::kTypeMacCmd;
-    frameInfo.mCommandId = Frame::kMacCmdBeaconRequest;
-    frameInfo.mVersion   = Frame::kVersion2003;
+    buildInfo.mType      = Frame::kTypeMacCmd;
+    buildInfo.mCommandId = Frame::kMacCmdBeaconRequest;
+    buildInfo.mVersion   = Frame::kVersion2003;
 
-    frameInfo.PrepareHeadersIn(frame);
+    buildInfo.PrepareHeadersIn(frame);
 
     LogInfo("Sending Beacon Request");
 
@@ -725,9 +725,9 @@ TxFrame *Mac::PrepareBeaconRequest(TxFrames &aTxFrames)
 
 TxFrame *Mac::PrepareBeacon(TxFrames &aTxFrames)
 {
-    TxFrame      *frame;
-    TxFrame::Info frameInfo;
-    Beacon       *beacon = nullptr;
+    TxFrame           *frame;
+    TxFrame::BuildInfo buildInfo;
+    Beacon            *beacon = nullptr;
 #if OPENTHREAD_CONFIG_MAC_OUTGOING_BEACON_PAYLOAD_ENABLE
     uint8_t        beaconLength;
     BeaconPayload *beaconPayload = nullptr;
@@ -741,14 +741,14 @@ TxFrame *Mac::PrepareBeacon(TxFrames &aTxFrames)
     frame = &aTxFrames.GetBroadcastTxFrame();
 #endif
 
-    frameInfo.mAddrs.mSource.SetExtended(GetExtAddress());
-    frameInfo.mPanIds.SetSource(mPanId);
-    frameInfo.mAddrs.mDestination.SetNone();
+    buildInfo.mAddrs.mSource.SetExtended(GetExtAddress());
+    buildInfo.mPanIds.SetSource(mPanId);
+    buildInfo.mAddrs.mDestination.SetNone();
 
-    frameInfo.mType    = Frame::kTypeBeacon;
-    frameInfo.mVersion = Frame::kVersion2003;
+    buildInfo.mType    = Frame::kTypeBeacon;
+    buildInfo.mVersion = Frame::kVersion2003;
 
-    frameInfo.PrepareHeadersIn(*frame);
+    buildInfo.PrepareHeadersIn(*frame);
 
     beacon = reinterpret_cast<Beacon *>(frame->GetPayload());
     beacon->Init();

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -49,7 +49,7 @@
 namespace ot {
 namespace Mac {
 
-void TxFrame::Info::PrepareHeadersIn(TxFrame &aTxFrame) const
+void TxFrame::BuildInfo::PrepareHeadersIn(TxFrame &aTxFrame) const
 {
     uint16_t     fcf;
     FrameBuilder builder;
@@ -1384,12 +1384,12 @@ void TxFrame::GenerateImmAck(const RxFrame &aFrame, bool aIsFramePending)
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
 Error TxFrame::GenerateEnhAck(const RxFrame &aRxFrame, bool aIsFramePending, const uint8_t *aIeData, uint8_t aIeLength)
 {
-    Error   error = kErrorNone;
-    Info    frameInfo;
-    Address address;
-    PanId   panId;
-    uint8_t securityLevel = kSecurityNone;
-    uint8_t keyIdMode     = kKeyIdMode0;
+    Error     error = kErrorNone;
+    BuildInfo buildInfo;
+    Address   address;
+    PanId     panId;
+    uint8_t   securityLevel = kSecurityNone;
+    uint8_t   keyIdMode     = kKeyIdMode0;
 
     // Validate the received frame.
 
@@ -1406,8 +1406,8 @@ Error TxFrame::GenerateEnhAck(const RxFrame &aRxFrame, bool aIsFramePending, con
     // Check `aRxFrame` has a valid source, which is then used as
     // ack frames destination.
 
-    SuccessOrExit(error = aRxFrame.GetSrcAddr(frameInfo.mAddrs.mDestination));
-    VerifyOrExit(!frameInfo.mAddrs.mDestination.IsNone(), error = kErrorParse);
+    SuccessOrExit(error = aRxFrame.GetSrcAddr(buildInfo.mAddrs.mDestination));
+    VerifyOrExit(!buildInfo.mAddrs.mDestination.IsNone(), error = kErrorParse);
 
     if (aRxFrame.GetSecurityEnabled())
     {
@@ -1420,12 +1420,12 @@ Error TxFrame::GenerateEnhAck(const RxFrame &aRxFrame, bool aIsFramePending, con
     if (aRxFrame.IsSrcPanIdPresent())
     {
         SuccessOrExit(error = aRxFrame.GetSrcPanId(panId));
-        frameInfo.mPanIds.SetDestination(panId);
+        buildInfo.mPanIds.SetDestination(panId);
     }
     else if (aRxFrame.IsDstPanIdPresent())
     {
         SuccessOrExit(error = aRxFrame.GetDstPanId(panId));
-        frameInfo.mPanIds.SetDestination(panId);
+        buildInfo.mPanIds.SetDestination(panId);
     }
 
     // Prepare the ack frame
@@ -1433,12 +1433,12 @@ Error TxFrame::GenerateEnhAck(const RxFrame &aRxFrame, bool aIsFramePending, con
     mChannel = aRxFrame.mChannel;
     ClearAllBytes(mInfo.mTxInfo);
 
-    frameInfo.mType          = kTypeAck;
-    frameInfo.mVersion       = kVersion2015;
-    frameInfo.mSecurityLevel = static_cast<SecurityLevel>(securityLevel);
-    frameInfo.mKeyIdMode     = static_cast<KeyIdMode>(keyIdMode);
+    buildInfo.mType          = kTypeAck;
+    buildInfo.mVersion       = kVersion2015;
+    buildInfo.mSecurityLevel = static_cast<SecurityLevel>(securityLevel);
+    buildInfo.mKeyIdMode     = static_cast<KeyIdMode>(keyIdMode);
 
-    frameInfo.PrepareHeadersIn(*this);
+    buildInfo.PrepareHeadersIn(*this);
 
     SetFramePending(aIsFramePending);
     SetIePresent(aIeLength != 0);

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -967,22 +967,22 @@ class TxFrame : public Frame
 {
 public:
     /**
-     * Represents header information.
+     * Represents the information to use to build the frame.
      */
-    struct Info : public Clearable<Info>
+    struct BuildInfo : public Clearable<BuildInfo>
     {
         /**
-         * Initializes the `Info` by clearing all its fields (setting all bytes to zero).
+         * Initializes the `BuildInfo` by clearing all its fields (setting all bytes to zero).
          */
-        Info(void) { Clear(); }
+        BuildInfo(void) { Clear(); }
 
         /**
-         * Prepares MAC headers based on `Info` fields in a given `TxFrame`.
+         * Prepares MAC headers based on `BuildInfo` fields in a given `TxFrame`.
          *
-         * This method uses the `Info` structure to construct the MAC address and security headers in @p aTxFrame.
+         * This method uses the `BuildInfo` structure to construct the MAC address and security headers in @p aTxFrame.
          * It determines the Frame Control Field (FCF), including setting the appropriate frame type, security level,
          * and addressing mode flags. It populates the source and destination addresses and PAN IDs within the MAC
-         * header based on the information provided in the `Info` structure.
+         * header based on the information provided in the `BuildInfo` structure.
          *
          * It sets the Ack Request bit in the FCF if the following criteria are met:
          *   - A destination address is present

--- a/src/core/thread/message_framer.cpp
+++ b/src/core/thread/message_framer.cpp
@@ -53,11 +53,13 @@ void MessageFramer::DetermineMacSourceAddress(const Ip6::Address &aIp6Addr, Mac:
     }
 }
 
-void MessageFramer::PrepareMacHeaders(Mac::TxFrame &aTxFrame, Mac::TxFrame::Info &aTxFrameInfo, const Message *aMessage)
+void MessageFramer::PrepareMacHeaders(Mac::TxFrame            &aTxFrame,
+                                      Mac::TxFrame::BuildInfo &aBuildInfo,
+                                      const Message           *aMessage)
 {
     const Neighbor *neighbor;
 
-    aTxFrameInfo.mVersion = Mac::Frame::kVersion2006;
+    aBuildInfo.mVersion = Mac::Frame::kVersion2006;
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
 
@@ -67,7 +69,7 @@ void MessageFramer::PrepareMacHeaders(Mac::TxFrame &aTxFrame, Mac::TxFrame::Info
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Determine frame version and Header IE entries
 
-    neighbor = Get<NeighborTable>().FindNeighbor(aTxFrameInfo.mAddrs.mDestination);
+    neighbor = Get<NeighborTable>().FindNeighbor(aBuildInfo.mAddrs.mDestination);
 
     if (neighbor == nullptr)
     {
@@ -75,20 +77,20 @@ void MessageFramer::PrepareMacHeaders(Mac::TxFrame &aTxFrame, Mac::TxFrame::Info
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     else if (Get<Mac::Mac>().IsCslEnabled())
     {
-        aTxFrameInfo.mAppendCslIe = true;
-        aTxFrameInfo.mVersion     = Mac::Frame::kVersion2015;
+        aBuildInfo.mAppendCslIe = true;
+        aBuildInfo.mVersion     = Mac::Frame::kVersion2015;
     }
 #endif
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
     else if ((Get<ChildTable>().Contains(*neighbor) && static_cast<const Child *>(neighbor)->IsCslSynchronized()))
     {
-        aTxFrameInfo.mVersion = Mac::Frame::kVersion2015;
+        aBuildInfo.mVersion = Mac::Frame::kVersion2015;
     }
 #endif
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
     else if (neighbor->IsEnhAckProbingActive())
     {
-        aTxFrameInfo.mVersion = Mac::Frame::kVersion2015;
+        aBuildInfo.mVersion = Mac::Frame::kVersion2015;
     }
 #endif
 
@@ -98,19 +100,19 @@ void MessageFramer::PrepareMacHeaders(Mac::TxFrame &aTxFrame, Mac::TxFrame::Info
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     if ((aMessage != nullptr) && aMessage->IsTimeSync())
     {
-        aTxFrameInfo.mAppendTimeIe = true;
-        aTxFrameInfo.mVersion      = Mac::Frame::kVersion2015;
+        aBuildInfo.mAppendTimeIe = true;
+        aBuildInfo.mVersion      = Mac::Frame::kVersion2015;
     }
 #endif
 
-    aTxFrameInfo.mEmptyPayload = (aMessage == nullptr) || (aMessage->GetLength() == 0);
+    aBuildInfo.mEmptyPayload = (aMessage == nullptr) || (aMessage->GetLength() == 0);
 
 #endif // OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Prepare MAC headers
 
-    aTxFrameInfo.PrepareHeadersIn(aTxFrame);
+    aBuildInfo.PrepareHeadersIn(aTxFrame);
 
     OT_UNUSED_VARIABLE(aMessage);
     OT_UNUSED_VARIABLE(neighbor);
@@ -118,23 +120,23 @@ void MessageFramer::PrepareMacHeaders(Mac::TxFrame &aTxFrame, Mac::TxFrame::Info
 
 void MessageFramer::PrepareEmptyFrame(Mac::TxFrame &aFrame, const Mac::Address &aMacDest, bool aAckRequest)
 {
-    Mac::TxFrame::Info frameInfo;
+    Mac::TxFrame::BuildInfo buildInfo;
 
-    frameInfo.mAddrs.mSource.SetShort(Get<Mac::Mac>().GetShortAddress());
+    buildInfo.mAddrs.mSource.SetShort(Get<Mac::Mac>().GetShortAddress());
 
-    if (frameInfo.mAddrs.mSource.IsShortAddrInvalid() || aMacDest.IsExtended())
+    if (buildInfo.mAddrs.mSource.IsShortAddrInvalid() || aMacDest.IsExtended())
     {
-        frameInfo.mAddrs.mSource.SetExtended(Get<Mac::Mac>().GetExtAddress());
+        buildInfo.mAddrs.mSource.SetExtended(Get<Mac::Mac>().GetExtAddress());
     }
 
-    frameInfo.mAddrs.mDestination = aMacDest;
-    frameInfo.mPanIds.SetBothSourceDestination(Get<Mac::Mac>().GetPanId());
+    buildInfo.mAddrs.mDestination = aMacDest;
+    buildInfo.mPanIds.SetBothSourceDestination(Get<Mac::Mac>().GetPanId());
 
-    frameInfo.mType          = Mac::Frame::kTypeData;
-    frameInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
-    frameInfo.mKeyIdMode     = Mac::Frame::kKeyIdMode1;
+    buildInfo.mType          = Mac::Frame::kTypeData;
+    buildInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
+    buildInfo.mKeyIdMode     = Mac::Frame::kKeyIdMode1;
 
-    PrepareMacHeaders(aFrame, frameInfo, nullptr);
+    PrepareMacHeaders(aFrame, buildInfo, nullptr);
 
     aFrame.SetAckRequest(aAckRequest);
     aFrame.SetPayloadLength(0);
@@ -148,34 +150,34 @@ uint16_t MessageFramer::PrepareFrame(Mac::TxFrame         &aFrame,
                                      uint16_t              aMeshDest,
                                      bool                  aAddFragHeader)
 {
-    Mac::TxFrame::Info frameInfo;
-    uint16_t           payloadLength;
-    uint16_t           origMsgOffset;
-    uint16_t           nextOffset;
-    FrameBuilder       frameBuilder;
+    Mac::TxFrame::BuildInfo buildInfo;
+    uint16_t                payloadLength;
+    uint16_t                origMsgOffset;
+    uint16_t                nextOffset;
+    FrameBuilder            frameBuilder;
 
 start:
-    frameInfo.Clear();
+    buildInfo.Clear();
 
     if (aMessage.IsLinkSecurityEnabled())
     {
-        frameInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
+        buildInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
 
         if (aMessage.GetSubType() == Message::kSubTypeJoinerEntrust)
         {
-            frameInfo.mKeyIdMode = Mac::Frame::kKeyIdMode0;
+            buildInfo.mKeyIdMode = Mac::Frame::kKeyIdMode0;
         }
         else if (aMessage.IsMleCommand(Mle::kCommandAnnounce))
         {
-            frameInfo.mKeyIdMode = Mac::Frame::kKeyIdMode2;
+            buildInfo.mKeyIdMode = Mac::Frame::kKeyIdMode2;
         }
         else
         {
-            frameInfo.mKeyIdMode = Mac::Frame::kKeyIdMode1;
+            buildInfo.mKeyIdMode = Mac::Frame::kKeyIdMode1;
         }
     }
 
-    frameInfo.mPanIds.SetBothSourceDestination(Get<Mac::Mac>().GetPanId());
+    buildInfo.mPanIds.SetBothSourceDestination(Get<Mac::Mac>().GetPanId());
 
     if (aMessage.IsSubTypeMle())
     {
@@ -184,12 +186,12 @@ start:
         case Mle::kCommandAnnounce:
             aFrame.SetChannel(aMessage.GetChannel());
             aFrame.SetRxChannelAfterTxDone(Get<Mac::Mac>().GetPanChannel());
-            frameInfo.mPanIds.SetDestination(Mac::kPanIdBroadcast);
+            buildInfo.mPanIds.SetDestination(Mac::kPanIdBroadcast);
             break;
 
         case Mle::kCommandDiscoveryRequest:
         case Mle::kCommandDiscoveryResponse:
-            frameInfo.mPanIds.SetDestination(aMessage.GetPanId());
+            buildInfo.mPanIds.SetDestination(aMessage.GetPanId());
             break;
 
         default:
@@ -197,10 +199,10 @@ start:
         }
     }
 
-    frameInfo.mType  = Mac::Frame::kTypeData;
-    frameInfo.mAddrs = aMacAddrs;
+    buildInfo.mType  = Mac::Frame::kTypeData;
+    buildInfo.mAddrs = aMacAddrs;
 
-    PrepareMacHeaders(aFrame, frameInfo, &aMessage);
+    PrepareMacHeaders(aFrame, buildInfo, &aMessage);
 
     frameBuilder.Init(aFrame.GetPayload(), aFrame.GetMaxPayloadLength());
 
@@ -350,15 +352,15 @@ start:
 
 uint16_t MessageFramer::PrepareMeshFrame(Mac::TxFrame &aFrame, Message &aMessage, const Mac::Addresses &aMacAddrs)
 {
-    Mac::TxFrame::Info frameInfo;
+    Mac::TxFrame::BuildInfo buildInfo;
 
-    frameInfo.mType          = Mac::Frame::kTypeData;
-    frameInfo.mAddrs         = aMacAddrs;
-    frameInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
-    frameInfo.mKeyIdMode     = Mac::Frame::kKeyIdMode1;
-    frameInfo.mPanIds.SetBothSourceDestination(Get<Mac::Mac>().GetPanId());
+    buildInfo.mType          = Mac::Frame::kTypeData;
+    buildInfo.mAddrs         = aMacAddrs;
+    buildInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
+    buildInfo.mKeyIdMode     = Mac::Frame::kKeyIdMode1;
+    buildInfo.mPanIds.SetBothSourceDestination(Get<Mac::Mac>().GetPanId());
 
-    PrepareMacHeaders(aFrame, frameInfo, &aMessage);
+    PrepareMacHeaders(aFrame, buildInfo, &aMessage);
 
     // write payload
     OT_ASSERT(aMessage.GetLength() <= aFrame.GetMaxPayloadLength());

--- a/src/core/thread/message_framer.hpp
+++ b/src/core/thread/message_framer.hpp
@@ -131,7 +131,7 @@ private:
     // (requiring one hop) and one as additional guard increment.
     static constexpr uint8_t kMeshHeaderHopsLeft = Mle::kMaxRouteCost + 3;
 
-    void PrepareMacHeaders(Mac::TxFrame &aTxFrame, Mac::TxFrame::Info &aTxFrameInfo, const Message *aMessage);
+    void PrepareMacHeaders(Mac::TxFrame &aTxFrame, Mac::TxFrame::BuildInfo &aBuildInfo, const Message *aMessage);
 
     uint16_t mFragTag;
 };

--- a/tests/gtest/radio_spinel_rcp_test.cpp
+++ b/tests/gtest/radio_spinel_rcp_test.cpp
@@ -66,17 +66,17 @@ TEST(RadioSpinelTransmit, shouldPassDesiredTxPowerToRadioPlatform)
     txFrame.mPsdu = frameBuffer;
 
     {
-        Mac::TxFrame::Info frameInfo;
+        Mac::TxFrame::BuildInfo buildInfo;
 
-        frameInfo.mType    = Mac::Frame::kTypeData;
-        frameInfo.mVersion = Mac::Frame::kVersion2006;
-        frameInfo.mAddrs.mSource.SetShort(kSrcAddr);
-        frameInfo.mAddrs.mDestination.SetExtended(kDstAddr);
-        frameInfo.mPanIds.SetSource(kSrcPanId);
-        frameInfo.mPanIds.SetDestination(kDstPanId);
-        frameInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
+        buildInfo.mType    = Mac::Frame::kTypeData;
+        buildInfo.mVersion = Mac::Frame::kVersion2006;
+        buildInfo.mAddrs.mSource.SetShort(kSrcAddr);
+        buildInfo.mAddrs.mDestination.SetExtended(kDstAddr);
+        buildInfo.mPanIds.SetSource(kSrcPanId);
+        buildInfo.mPanIds.SetDestination(kDstPanId);
+        buildInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
 
-        frameInfo.PrepareHeadersIn(txFrame);
+        buildInfo.PrepareHeadersIn(txFrame);
     }
 
     txFrame.mInfo.mTxInfo.mTxPower = kTxPower;
@@ -110,17 +110,17 @@ TEST(RadioSpinelTransmit, shouldCauseSwitchingToRxChannelAfterTxDone)
     txFrame.mPsdu = frameBuffer;
 
     {
-        Mac::TxFrame::Info frameInfo;
+        Mac::TxFrame::BuildInfo buildInfo;
 
-        frameInfo.mType    = Mac::Frame::kTypeData;
-        frameInfo.mVersion = Mac::Frame::kVersion2006;
-        frameInfo.mAddrs.mSource.SetShort(kSrcAddr);
-        frameInfo.mAddrs.mDestination.SetExtended(kDstAddr);
-        frameInfo.mPanIds.SetSource(kSrcPanId);
-        frameInfo.mPanIds.SetDestination(kDstPanId);
-        frameInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
+        buildInfo.mType    = Mac::Frame::kTypeData;
+        buildInfo.mVersion = Mac::Frame::kVersion2006;
+        buildInfo.mAddrs.mSource.SetShort(kSrcAddr);
+        buildInfo.mAddrs.mDestination.SetExtended(kDstAddr);
+        buildInfo.mPanIds.SetSource(kSrcPanId);
+        buildInfo.mPanIds.SetDestination(kDstPanId);
+        buildInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
 
-        frameInfo.PrepareHeadersIn(txFrame);
+        buildInfo.PrepareHeadersIn(txFrame);
     }
 
     txFrame.mInfo.mTxInfo.mTxPower              = kTxPower;
@@ -156,17 +156,17 @@ TEST(RadioSpinelTransmit, shouldSkipCsmaCaWhenDisabled)
     txFrame.mPsdu = frameBuffer;
 
     {
-        Mac::TxFrame::Info frameInfo;
+        Mac::TxFrame::BuildInfo buildInfo;
 
-        frameInfo.mType    = Mac::Frame::kTypeData;
-        frameInfo.mVersion = Mac::Frame::kVersion2006;
-        frameInfo.mAddrs.mSource.SetShort(kSrcAddr);
-        frameInfo.mAddrs.mDestination.SetExtended(kDstAddr);
-        frameInfo.mPanIds.SetSource(kSrcPanId);
-        frameInfo.mPanIds.SetDestination(kDstPanId);
-        frameInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
+        buildInfo.mType    = Mac::Frame::kTypeData;
+        buildInfo.mVersion = Mac::Frame::kVersion2006;
+        buildInfo.mAddrs.mSource.SetShort(kSrcAddr);
+        buildInfo.mAddrs.mDestination.SetExtended(kDstAddr);
+        buildInfo.mPanIds.SetSource(kSrcPanId);
+        buildInfo.mPanIds.SetDestination(kDstPanId);
+        buildInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
 
-        frameInfo.PrepareHeadersIn(txFrame);
+        buildInfo.PrepareHeadersIn(txFrame);
     }
 
     txFrame.mInfo.mTxInfo.mCsmaCaEnabled = false;
@@ -212,17 +212,17 @@ TEST(RadioSpinelTransmit, shouldPerformCsmaCaWhenEnabled)
     txFrame.mPsdu = frameBuffer;
 
     {
-        Mac::TxFrame::Info frameInfo;
+        Mac::TxFrame::BuildInfo buildInfo;
 
-        frameInfo.mType    = Mac::Frame::kTypeData;
-        frameInfo.mVersion = Mac::Frame::kVersion2006;
-        frameInfo.mAddrs.mSource.SetShort(kSrcAddr);
-        frameInfo.mAddrs.mDestination.SetExtended(kDstAddr);
-        frameInfo.mPanIds.SetSource(kSrcPanId);
-        frameInfo.mPanIds.SetDestination(kDstPanId);
-        frameInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
+        buildInfo.mType    = Mac::Frame::kTypeData;
+        buildInfo.mVersion = Mac::Frame::kVersion2006;
+        buildInfo.mAddrs.mSource.SetShort(kSrcAddr);
+        buildInfo.mAddrs.mDestination.SetExtended(kDstAddr);
+        buildInfo.mPanIds.SetSource(kSrcPanId);
+        buildInfo.mPanIds.SetDestination(kDstPanId);
+        buildInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
 
-        frameInfo.PrepareHeadersIn(txFrame);
+        buildInfo.PrepareHeadersIn(txFrame);
     }
 
     txFrame.mInfo.mTxInfo.mCsmaCaEnabled   = true;
@@ -262,17 +262,17 @@ TEST(RadioSpinelTransmit, shouldNotCauseSwitchingToRxAfterTxDoneIfNotRxOnWhenIdl
     txFrame.mPsdu = frameBuffer;
 
     {
-        Mac::TxFrame::Info frameInfo;
+        Mac::TxFrame::BuildInfo buildInfo;
 
-        frameInfo.mType    = Mac::Frame::kTypeData;
-        frameInfo.mVersion = Mac::Frame::kVersion2006;
-        frameInfo.mAddrs.mSource.SetShort(kSrcAddr);
-        frameInfo.mAddrs.mDestination.SetExtended(kDstAddr);
-        frameInfo.mPanIds.SetSource(kSrcPanId);
-        frameInfo.mPanIds.SetDestination(kDstPanId);
-        frameInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
+        buildInfo.mType    = Mac::Frame::kTypeData;
+        buildInfo.mVersion = Mac::Frame::kVersion2006;
+        buildInfo.mAddrs.mSource.SetShort(kSrcAddr);
+        buildInfo.mAddrs.mDestination.SetExtended(kDstAddr);
+        buildInfo.mPanIds.SetSource(kSrcPanId);
+        buildInfo.mPanIds.SetDestination(kDstPanId);
+        buildInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
 
-        frameInfo.PrepareHeadersIn(txFrame);
+        buildInfo.PrepareHeadersIn(txFrame);
     }
 
     txFrame.mInfo.mTxInfo.mTxPower              = kTxPower;
@@ -338,17 +338,17 @@ TEST(RadioSpinelTransmit, shouldSkipCsmaBackoffWhenCsmaCaIsEnabledAndMaxBackoffs
     txFrame.mPsdu = frameBuffer;
 
     {
-        Mac::TxFrame::Info frameInfo;
+        Mac::TxFrame::BuildInfo buildInfo;
 
-        frameInfo.mType    = Mac::Frame::kTypeData;
-        frameInfo.mVersion = Mac::Frame::kVersion2006;
-        frameInfo.mAddrs.mSource.SetShort(kSrcAddr);
-        frameInfo.mAddrs.mDestination.SetExtended(kDstAddr);
-        frameInfo.mPanIds.SetSource(kSrcPanId);
-        frameInfo.mPanIds.SetDestination(kDstPanId);
-        frameInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
+        buildInfo.mType    = Mac::Frame::kTypeData;
+        buildInfo.mVersion = Mac::Frame::kVersion2006;
+        buildInfo.mAddrs.mSource.SetShort(kSrcAddr);
+        buildInfo.mAddrs.mDestination.SetExtended(kDstAddr);
+        buildInfo.mPanIds.SetSource(kSrcPanId);
+        buildInfo.mPanIds.SetDestination(kDstPanId);
+        buildInfo.mSecurityLevel = Mac::Frame::kSecurityEncMic32;
 
-        frameInfo.PrepareHeadersIn(txFrame);
+        buildInfo.PrepareHeadersIn(txFrame);
     }
 
     txFrame.mInfo.mTxInfo.mCsmaCaEnabled   = true;

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -290,43 +290,43 @@ void TestMacHeader(void)
         uint8_t psdu[OT_RADIO_FRAME_MAX_SIZE];
         uint8_t offset;
 
-        Mac::TxFrame       frame;
-        Mac::TxFrame::Info frameInfo;
-        Mac::Address       address;
-        Mac::PanId         panId;
+        Mac::TxFrame            frame;
+        Mac::TxFrame::BuildInfo buildInfo;
+        Mac::Address            address;
+        Mac::PanId              panId;
 
         frame.mPsdu      = psdu;
         frame.mLength    = 0;
         frame.mRadioType = 0;
 
-        VerifyOrQuit(frameInfo.mAddrs.mSource.IsNone());
-        VerifyOrQuit(frameInfo.mAddrs.mDestination.IsNone());
-        VerifyOrQuit(!frameInfo.mPanIds.IsSourcePresent());
-        VerifyOrQuit(!frameInfo.mPanIds.IsDestinationPresent());
+        VerifyOrQuit(buildInfo.mAddrs.mSource.IsNone());
+        VerifyOrQuit(buildInfo.mAddrs.mDestination.IsNone());
+        VerifyOrQuit(!buildInfo.mPanIds.IsSourcePresent());
+        VerifyOrQuit(!buildInfo.mPanIds.IsDestinationPresent());
 
         switch (testCase.mSrcAddrType)
         {
         case kNoneAddr:
-            frameInfo.mAddrs.mSource.SetNone();
+            buildInfo.mAddrs.mSource.SetNone();
             break;
         case kShrtAddr:
-            frameInfo.mAddrs.mSource.SetShort(kShortAddr1);
+            buildInfo.mAddrs.mSource.SetShort(kShortAddr1);
             break;
         case kExtdAddr:
-            frameInfo.mAddrs.mSource.SetExtended(extAddr1);
+            buildInfo.mAddrs.mSource.SetExtended(extAddr1);
             break;
         }
 
         switch (testCase.mDstAddrType)
         {
         case kNoneAddr:
-            frameInfo.mAddrs.mDestination.SetNone();
+            buildInfo.mAddrs.mDestination.SetNone();
             break;
         case kShrtAddr:
-            frameInfo.mAddrs.mDestination.SetShort(kShortAddr2);
+            buildInfo.mAddrs.mDestination.SetShort(kShortAddr2);
             break;
         case kExtdAddr:
-            frameInfo.mAddrs.mDestination.SetExtended(extAddr2);
+            buildInfo.mAddrs.mDestination.SetExtended(extAddr2);
             break;
         }
 
@@ -335,10 +335,10 @@ void TestMacHeader(void)
         case kNoPanId:
             break;
         case kUsePanId1:
-            frameInfo.mPanIds.SetSource(kPanId1);
+            buildInfo.mPanIds.SetSource(kPanId1);
             break;
         case kUsePanId2:
-            frameInfo.mPanIds.SetSource(kPanId2);
+            buildInfo.mPanIds.SetSource(kPanId2);
             break;
         }
 
@@ -347,20 +347,20 @@ void TestMacHeader(void)
         case kNoPanId:
             break;
         case kUsePanId1:
-            frameInfo.mPanIds.SetDestination(kPanId1);
+            buildInfo.mPanIds.SetDestination(kPanId1);
             break;
         case kUsePanId2:
-            frameInfo.mPanIds.SetDestination(kPanId2);
+            buildInfo.mPanIds.SetDestination(kPanId2);
             break;
         }
 
-        frameInfo.mType             = Mac::Frame::kTypeData;
-        frameInfo.mVersion          = testCase.mVersion;
-        frameInfo.mSecurityLevel    = testCase.mSecurity;
-        frameInfo.mKeyIdMode        = testCase.mKeyIdMode;
-        frameInfo.mSuppressSequence = testCase.mSuppressSequence;
+        buildInfo.mType             = Mac::Frame::kTypeData;
+        buildInfo.mVersion          = testCase.mVersion;
+        buildInfo.mSecurityLevel    = testCase.mSecurity;
+        buildInfo.mKeyIdMode        = testCase.mKeyIdMode;
+        buildInfo.mSuppressSequence = testCase.mSuppressSequence;
 
-        frameInfo.PrepareHeadersIn(frame);
+        buildInfo.PrepareHeadersIn(frame);
 
         VerifyOrQuit(frame.GetHeaderLength() == testCase.mHeaderLength);
         VerifyOrQuit(frame.GetFooterLength() == testCase.mFooterLength);
@@ -376,25 +376,25 @@ void TestMacHeader(void)
 
         VerifyOrQuit(frame.IsSrcAddrPresent() == (testCase.mSrcAddrType != kNoneAddr));
         SuccessOrQuit(frame.GetSrcAddr(address));
-        VerifyOrQuit(CompareAddresses(address, frameInfo.mAddrs.mSource));
+        VerifyOrQuit(CompareAddresses(address, buildInfo.mAddrs.mSource));
         VerifyOrQuit(frame.IsDstAddrPresent() == (testCase.mDstAddrType != kNoneAddr));
         SuccessOrQuit(frame.GetDstAddr(address));
-        VerifyOrQuit(CompareAddresses(address, frameInfo.mAddrs.mDestination));
+        VerifyOrQuit(CompareAddresses(address, buildInfo.mAddrs.mDestination));
 
         VerifyOrQuit(frame.IsDstPanIdPresent() == (testCase.mDstPanIdMode != kNoPanId));
 
         if (frame.IsDstPanIdPresent())
         {
             SuccessOrQuit(frame.GetDstPanId(panId));
-            VerifyOrQuit(panId == frameInfo.mPanIds.GetDestination());
-            VerifyOrQuit(frameInfo.mPanIds.IsDestinationPresent());
+            VerifyOrQuit(panId == buildInfo.mPanIds.GetDestination());
+            VerifyOrQuit(buildInfo.mPanIds.IsDestinationPresent());
         }
 
         if (frame.IsSrcPanIdPresent())
         {
             SuccessOrQuit(frame.GetSrcPanId(panId));
-            VerifyOrQuit(panId == frameInfo.mPanIds.GetSource());
-            VerifyOrQuit(frameInfo.mPanIds.IsSourcePresent());
+            VerifyOrQuit(panId == buildInfo.mPanIds.GetSource());
+            VerifyOrQuit(buildInfo.mPanIds.IsSourcePresent());
         }
 
         if (frame.GetSecurityEnabled())


### PR DESCRIPTION
This commit renames `TxFrame::Info` to `TxFrame::BuildInfo` across the MAC module, message framer, and related tests.

Renaming this structure to `BuildInfo` explicitly conveys its purpose as the specification used to construct/build headers for transmission, distinguishing it from parsed frame header metadata.