### PR TITLE
[thread-direct] LTV codec and Thread Header IE LTV layer

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -122,6 +122,7 @@ set(COMMON_SOURCES
     common/frame_builder.cpp
     common/frame_data.cpp
     common/heap.cpp
+    common/ltvs.cpp
     common/heap_data.cpp
     common/heap_string.cpp
     common/log.cpp
@@ -157,6 +158,7 @@ set(COMMON_SOURCES
     mac/mac_filter.cpp
     mac/mac_frame.cpp
     mac/mac_header_ie.cpp
+    mac/mac_header_ltv.cpp
     mac/mac_links.cpp
     mac/mac_types.cpp
     mac/scan_result.cpp
@@ -316,6 +318,7 @@ set(RADIO_COMMON_SOURCES
     common/error.cpp
     common/frame_builder.cpp
     common/log.cpp
+    common/ltvs.cpp
     common/random.cpp
     common/string.cpp
     common/tasklet.cpp
@@ -331,6 +334,7 @@ set(RADIO_COMMON_SOURCES
     mac/link_raw.cpp
     mac/mac_frame.cpp
     mac/mac_header_ie.cpp
+    mac/mac_header_ltv.cpp
     mac/mac_types.cpp
     mac/sub_mac.cpp
     mac/sub_mac_callbacks.cpp

--- a/src/core/common/ltvs.cpp
+++ b/src/core/common/ltvs.cpp
@@ -1,0 +1,329 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements LTV (Length-Type-Value) generation and parsing.
+ */
+
+#include "ltvs.hpp"
+
+#include <string.h>
+
+#include "common/code_utils.hpp"
+
+namespace ot {
+
+// Minimum number of bits needed to represent [0, aL-1]: smallest n with 2^n >= aL.
+static uint8_t BitsFor(uint8_t aL)
+{
+    uint8_t n = 0;
+
+    while ((1u << n) < aL)
+    {
+        n++;
+    }
+
+    return n;
+}
+
+Error Ltv::AppendTo(FrameBuilder &aFrameBuilder) const { return aFrameBuilder.AppendBytes(this, GetTotalSize()); }
+
+Error Ltv::Append(FrameBuilder &aFrameBuilder, uint8_t aType, const void *aValue, uint8_t aLength)
+{
+    Error error;
+    Ltv   ltv;
+
+    ltv.SetLength(aLength);
+    ltv.SetType(aType);
+    SuccessOrExit(error = aFrameBuilder.AppendBytes(&ltv, kHeaderSize));
+
+    if (aLength > 0)
+    {
+        SuccessOrExit(error = aFrameBuilder.AppendBytes(aValue, aLength));
+    }
+
+exit:
+    return error;
+}
+
+const Ltv *Ltv::FindLtv(const void *aBuffer, uint16_t aLength, uint8_t aType)
+{
+    Iterator   iter;
+    const Ltv *result = nullptr;
+
+    iter.Init(static_cast<const uint8_t *>(aBuffer), aLength);
+
+    while (!iter.IsDone())
+    {
+        const Ltv &ltv = iter.GetLtv();
+
+        // Advance first: validates the declared length fits in the buffer.
+        VerifyOrExit(iter.Advance() == kErrorNone);
+
+        if (ltv.GetType() == aType)
+        {
+            result = &ltv;
+            ExitNow();
+        }
+    }
+
+exit:
+    return result;
+}
+
+void Ltv::Iterator::Init(const uint8_t *aBuffer, uint16_t aLength) { mData.Init(aBuffer, aLength); }
+
+Error Ltv::Iterator::Advance(void)
+{
+    Error    error = kErrorNone;
+    uint16_t size;
+
+    VerifyOrExit(!IsDone());
+
+    size = GetLtv().GetTotalSize();
+    VerifyOrExit(mData.CanRead(size), error = kErrorParse);
+    mData.SkipOver(size);
+
+exit:
+    return error;
+}
+
+uint8_t PackedLtvStream::Encode(const uint8_t *aPlain, uint8_t aPlainLen, uint8_t *aPacked, uint8_t aPackedMax)
+{
+    // Packed entries are encoded back-to-front because the header bit-split for each entry
+    // depends on L = (own encoded size) + (all subsequent entries' encoded size).  Collecting
+    // entries first and then iterating in reverse lets us track `scratchLen` as we go.
+
+    static constexpr uint8_t kMaxEntries = 8;
+
+    struct Entry
+    {
+        uint8_t        mType;
+        uint8_t        mLen;
+        const uint8_t *mValue;
+    };
+
+    Entry   entries[kMaxEntries];
+    uint8_t count = 0;
+
+    for (const uint8_t *p = aPlain, *end = aPlain + aPlainLen; p + 2 <= end && count < kMaxEntries; p += 2 + p[0])
+    {
+        entries[count].mLen   = p[0];
+        entries[count].mType  = p[1];
+        entries[count].mValue = p + 2;
+        count++;
+    }
+
+    uint8_t scratch[128]; // packed output never exceeds plain input; 128 covers max IE payload (127 bytes).
+    uint8_t scratchLen = 0;
+
+    for (int i = static_cast<int>(count) - 1; i >= 0; i--)
+    {
+        const Entry &e = entries[i];
+        uint8_t      header[2];
+        uint8_t      hdrBytes = 0;
+
+        for (uint8_t hdr = 1; hdr <= 2; hdr++)
+        {
+            uint8_t L     = static_cast<uint8_t>(hdr + e.mLen + scratchLen);
+            uint8_t n     = BitsFor(L);
+            uint8_t shift = static_cast<uint8_t>(8u - n);
+
+            if (n == 0)
+            {
+                // L == 1: the sole byte is a bare type with implicit zero length.
+                if (hdr == 1 && e.mLen == 0)
+                {
+                    header[0] = e.mType;
+                    hdrBytes  = 1;
+                    break;
+                }
+
+                continue;
+            }
+
+            if (e.mLen >= (1u << n))
+            {
+                continue;
+            }
+
+            uint8_t allOnes = static_cast<uint8_t>((1u << shift) - 1u);
+
+            if (hdr == 1 && e.mType < allOnes)
+            {
+                header[0] = static_cast<uint8_t>((e.mLen << shift) | e.mType);
+                hdrBytes  = 1;
+                break;
+            }
+
+            if (hdr == 2)
+            {
+                // All-ones in the type field is the escape code; type follows in the next byte.
+                header[0] = static_cast<uint8_t>((e.mLen << shift) | allOnes);
+                header[1] = e.mType;
+                hdrBytes  = 2;
+                break;
+            }
+        }
+
+        if (hdrBytes == 0)
+        {
+            continue;
+        }
+
+        uint8_t entryLen = static_cast<uint8_t>(hdrBytes + e.mLen);
+
+        memmove(scratch + entryLen, scratch, scratchLen);
+        memcpy(scratch, header, hdrBytes);
+
+        if (e.mLen > 0)
+        {
+            memcpy(scratch + hdrBytes, e.mValue, e.mLen);
+        }
+
+        scratchLen += entryLen;
+    }
+
+    uint8_t written = (scratchLen <= aPackedMax) ? scratchLen : aPackedMax;
+
+    memcpy(aPacked, scratch, written);
+
+    return written;
+}
+
+Error PackedLtvStream::Decode(const uint8_t *aPacked,
+                              uint8_t        aPackedLen,
+                              uint8_t       *aPlain,
+                              uint8_t        aPlainMax,
+                              uint8_t       &aPlainLen)
+{
+    Error    error  = kErrorNone;
+    uint8_t  outLen = 0;
+    Iterator iter;
+
+    for (iter.Init(aPacked, aPackedLen); !iter.IsDone();)
+    {
+        uint8_t len = iter.GetLength();
+
+        VerifyOrExit(outLen + Ltv::kHeaderSize + len <= aPlainMax, error = kErrorNoBufs);
+        aPlain[outLen++] = len;
+        aPlain[outLen++] = iter.GetType();
+
+        if (len > 0)
+        {
+            memcpy(aPlain + outLen, iter.GetValue(), len);
+            outLen += len;
+        }
+
+        VerifyOrExit(iter.Advance() == kErrorNone, error = kErrorParse);
+    }
+
+    aPlainLen = outLen;
+
+exit:
+    return error;
+}
+
+void PackedLtvStream::Iterator::Init(const uint8_t *aPacked, uint8_t aPackedLen)
+{
+    mBuffer   = aPacked;
+    mTotalLen = aPackedLen;
+    mOffset   = 0;
+    mDone     = false;
+    mType     = 0;
+    mLen      = 0;
+    mValue    = nullptr;
+    mHdrSize  = 0;
+    IgnoreError(DecodeEntry());
+}
+
+Error PackedLtvStream::Iterator::Advance(void)
+{
+    Error error = kErrorNone;
+
+    VerifyOrExit(!mDone);
+    mOffset = static_cast<uint8_t>(mOffset + mHdrSize + mLen);
+    error   = DecodeEntry();
+
+exit:
+    return error;
+}
+
+Error PackedLtvStream::Iterator::DecodeEntry(void)
+{
+    Error   error = kErrorNone;
+    uint8_t L;
+    uint8_t n;
+    uint8_t first;
+
+    if (mOffset >= mTotalLen)
+    {
+        mDone = true;
+        ExitNow();
+    }
+
+    L     = static_cast<uint8_t>(mTotalLen - mOffset);
+    n     = BitsFor(L);
+    first = mBuffer[mOffset];
+
+    if (n == 0)
+    {
+        mType    = first;
+        mLen     = 0;
+        mHdrSize = 1;
+    }
+    else
+    {
+        uint8_t shift    = static_cast<uint8_t>(8u - n);
+        uint8_t lenbits  = static_cast<uint8_t>(first >> shift);
+        uint8_t typebits = static_cast<uint8_t>(first & ((1u << shift) - 1u));
+
+        if (typebits == static_cast<uint8_t>((1u << shift) - 1u))
+        {
+            VerifyOrExit(mOffset + 1u < mTotalLen, error = kErrorParse; mDone = true);
+            mType    = mBuffer[mOffset + 1u];
+            mLen     = lenbits;
+            mHdrSize = 2;
+        }
+        else
+        {
+            mType    = typebits;
+            mLen     = lenbits;
+            mHdrSize = 1;
+        }
+    }
+
+    VerifyOrExit(mOffset + mHdrSize + mLen <= mTotalLen, error = kErrorParse; mDone = true);
+    mValue = mBuffer + mOffset + mHdrSize;
+
+exit:
+    return error;
+}
+
+} // namespace ot

--- a/src/core/common/ltvs.hpp
+++ b/src/core/common/ltvs.hpp
@@ -1,0 +1,264 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for generating and parsing LTV (Length-Type-Value) encoded data.
+ */
+
+#ifndef OT_CORE_COMMON_LTVS_HPP_
+#define OT_CORE_COMMON_LTVS_HPP_
+
+#include "openthread-core-config.h"
+
+#include <stdint.h>
+
+#include <openthread/platform/toolchain.h>
+
+#include "common/error.hpp"
+#include "common/frame_builder.hpp"
+#include "common/frame_data.hpp"
+#include "common/type_traits.hpp"
+
+namespace ot {
+
+/**
+ * Implements LTV generation and parsing.
+ *
+ * The wire format is `[Length][Type][Value...]` where Length is the byte count of the
+ * Value field only (not including Type).
+ */
+OT_TOOL_PACKED_BEGIN
+class Ltv
+{
+public:
+    static constexpr uint8_t kHeaderSize = 2; ///< Wire size of the LTV header (Length + Type bytes).
+
+    uint8_t GetLength(void) const { return mLength; }
+    void    SetLength(uint8_t aLength) { mLength = aLength; }
+
+    uint8_t GetType(void) const { return mType; }
+    void    SetType(uint8_t aType) { mType = aType; }
+
+    uint16_t GetTotalSize(void) const { return kHeaderSize + mLength; }
+
+    uint8_t       *GetValue(void) { return reinterpret_cast<uint8_t *>(this) + kHeaderSize; }
+    const uint8_t *GetValue(void) const { return reinterpret_cast<const uint8_t *>(this) + kHeaderSize; }
+
+    /**
+     * Returns the Value reinterpreted as @p T.
+     *
+     * The caller MUST verify `sizeof(T) <= GetLength()` before calling.
+     */
+    template <typename T> const T &GetValueAs(void) const { return *reinterpret_cast<const T *>(GetValue()); }
+
+    const Ltv *GetNext(void) const
+    {
+        return reinterpret_cast<const Ltv *>(reinterpret_cast<const uint8_t *>(this) + GetTotalSize());
+    }
+
+    /**
+     * Appends this LTV to @p aFrameBuilder.
+     *
+     * @retval kErrorNone    Successfully appended.
+     * @retval kErrorNoBufs  Insufficient buffer space.
+     */
+    Error AppendTo(FrameBuilder &aFrameBuilder) const;
+
+    /**
+     * Appends an LTV with @p aType and @p aLength value bytes to @p aFrameBuilder.
+     *
+     * @param[in] aValue  Pointer to the value bytes; may be `nullptr` when @p aLength is zero.
+     *
+     * @retval kErrorNone    Successfully appended.
+     * @retval kErrorNoBufs  Insufficient buffer space.
+     */
+    static Error Append(FrameBuilder &aFrameBuilder, uint8_t aType, const void *aValue, uint8_t aLength);
+
+    /**
+     * Appends a fixed-size LTV described by @p SimpleLtvType to @p aFrameBuilder.
+     *
+     * @tparam SimpleLtvType  A `SimpleLtvInfo<kType, ValueType>` specialization.
+     *
+     * @retval kErrorNone    Successfully appended.
+     * @retval kErrorNoBufs  Insufficient buffer space.
+     */
+    template <typename SimpleLtvType>
+    static Error Append(FrameBuilder &aFrameBuilder, const typename SimpleLtvType::ValueType &aValue)
+    {
+        static_assert(!TypeTraits::IsPointer<typename SimpleLtvType::ValueType>::kValue,
+                      "SimpleLtvType::ValueType must not be a pointer");
+
+        return Append(aFrameBuilder, SimpleLtvType::kType, &aValue, sizeof(typename SimpleLtvType::ValueType));
+    }
+
+    /**
+     * Searches @p aBuffer for the first LTV with @p aType.
+     *
+     * Returns `nullptr` on a truncated or missing entry.
+     */
+    static const Ltv *FindLtv(const void *aBuffer, uint16_t aLength, uint8_t aType);
+
+    /**
+     * Iterates forward through a plain LTV sequence.
+     */
+    class Iterator
+    {
+    public:
+        void Init(const uint8_t *aBuffer, uint16_t aLength);
+
+        bool IsDone(void) const { return mData.GetLength() < kHeaderSize; }
+
+        const Ltv &GetLtv(void) const { return *reinterpret_cast<const Ltv *>(mData.GetBytes()); }
+
+        /**
+         * Advances to the next LTV.
+         *
+         * @retval kErrorNone   Advanced (or already done).
+         * @retval kErrorParse  Buffer is truncated.
+         */
+        Error Advance(void);
+
+    private:
+        FrameData mData;
+    };
+
+private:
+    uint8_t mLength;
+    uint8_t mType;
+} OT_TOOL_PACKED_END;
+
+/**
+ * Provides the compile-time type code for an LTV type.
+ *
+ * @tparam kLtvTypeValue  The LTV Type byte value.
+ */
+template <uint8_t kLtvTypeValue> class LtvInfo
+{
+public:
+    static constexpr uint8_t kType = kLtvTypeValue;
+};
+
+/**
+ * Pairs a compile-time type code with a fixed-size value struct for use with `Ltv::Append<>`.
+ *
+ * @tparam kLtvTypeValue  The LTV Type byte value.
+ * @tparam TValueType     The C++ type of the Value field.
+ */
+template <uint8_t kLtvTypeValue, typename TValueType> class SimpleLtvInfo : public LtvInfo<kLtvTypeValue>
+{
+public:
+    typedef TValueType ValueType;
+};
+
+/**
+ * Encodes and decodes a context-sensitive packed LTV stream.
+ *
+ * In the plain `Ltv` format every entry has a fixed 2-byte `[L][T]` header.  The packed format
+ * shrinks that overhead by using `BitsFor(L)` bits for the length field and the remaining bits
+ * of the first byte for the type, where L is the total remaining byte count from the current
+ * entry to the end.  When the type value would collide with the all-ones escape code, a second
+ * type byte follows.  The encoded output is never larger than the plain input.
+ */
+class PackedLtvStream
+{
+public:
+    /**
+     * Encodes a plain `[L][T][V...]` buffer into the packed format.
+     *
+     * @param[in]  aPlain      Plain LTV bytes.
+     * @param[in]  aPlainLen   Byte count of @p aPlain.
+     * @param[out] aPacked     Output buffer; capacity must be at least @p aPlainLen bytes.
+     * @param[in]  aPackedMax  Capacity of @p aPacked.
+     *
+     * @returns Number of bytes written to @p aPacked.
+     */
+    static uint8_t Encode(const uint8_t *aPlain, uint8_t aPlainLen, uint8_t *aPacked, uint8_t aPackedMax);
+
+    /**
+     * Decodes a packed stream back to plain `[L][T][V...]` format.
+     *
+     * @param[in]  aPacked     Packed bytes.
+     * @param[in]  aPackedLen  Byte count of @p aPacked.
+     * @param[out] aPlain      Output buffer for plain LTV bytes.
+     * @param[in]  aPlainMax   Capacity of @p aPlain.
+     * @param[out] aPlainLen   Number of plain bytes written on success.
+     *
+     * @retval kErrorNone   Decoded successfully.
+     * @retval kErrorParse  Stream is malformed.
+     * @retval kErrorNoBufs @p aPlain is too small.
+     */
+    static Error Decode(const uint8_t *aPacked,
+                        uint8_t        aPackedLen,
+                        uint8_t       *aPlain,
+                        uint8_t        aPlainMax,
+                        uint8_t       &aPlainLen);
+
+    /**
+     * Iterates forward over a packed LTV stream without allocating a plain buffer.
+     */
+    class Iterator
+    {
+    public:
+        void Init(const uint8_t *aPacked, uint8_t aPackedLen);
+
+        bool IsDone(void) const { return mDone; }
+
+        uint8_t GetType(void) const { return mType; }
+        uint8_t GetLength(void) const { return mLen; }
+
+        const uint8_t *GetValue(void) const { return mValue; }
+
+        /** Returns the byte offset of the current entry's value within the stream buffer. */
+        uint8_t GetValueOffset(void) const { return static_cast<uint8_t>(mOffset + mHdrSize); }
+
+        /**
+         * Advances to the next LTV.
+         *
+         * @retval kErrorNone   Advanced (or already at end).
+         * @retval kErrorParse  Stream is malformed.
+         */
+        Error Advance(void);
+
+    private:
+        Error DecodeEntry(void);
+
+        const uint8_t *mBuffer;
+        uint8_t        mTotalLen;
+        uint8_t        mOffset;
+        uint8_t        mType;
+        uint8_t        mLen;
+        const uint8_t *mValue;
+        uint8_t        mHdrSize;
+        bool           mDone;
+    };
+};
+
+} // namespace ot
+
+#endif // OT_CORE_COMMON_LTVS_HPP_

--- a/src/core/mac/mac_header_ie.hpp
+++ b/src/core/mac/mac_header_ie.hpp
@@ -524,6 +524,21 @@ private:
 } OT_TOOL_PACKED_END;
 #endif // OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
 
+#if OPENTHREAD_CONFIG_THREAD_DIRECT_WAKE_INITIATOR_ENABLE || OPENTHREAD_CONFIG_THREAD_DIRECT_WAKE_LISTENER_ENABLE
+/**
+ * Defines the Thread Header IE Element ID and LTV type codes.
+ *
+ * Element ID 0x2d; payload is a packed LTV sequence (see `PackedLtvStream`).
+ */
+struct ThreadHeaderIe
+{
+    static constexpr uint8_t kElementId     = 0x2d;
+    static constexpr uint8_t kTypeTargetId  = 0x01;
+    static constexpr uint8_t kTypeSca       = 0x02;
+    static constexpr uint8_t kTypeChallenge = 0x03;
+};
+#endif // OPENTHREAD_CONFIG_THREAD_DIRECT_WAKE_INITIATOR_ENABLE || OPENTHREAD_CONFIG_THREAD_DIRECT_WAKE_LISTENER_ENABLE
+
 /**
  * @}
  */

--- a/src/core/mac/mac_header_ltv.cpp
+++ b/src/core/mac/mac_header_ltv.cpp
@@ -1,0 +1,215 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   Implements Thread Direct LTV encoding and parsing for the Thread Header IE.
+ */
+
+#include "mac_header_ltv.hpp"
+
+#include <string.h>
+
+#include "common/code_utils.hpp"
+#include "common/encoding.hpp"
+
+namespace ot {
+namespace Mac {
+
+#if (OPENTHREAD_CONFIG_THREAD_DIRECT_WAKE_INITIATOR_ENABLE || OPENTHREAD_CONFIG_THREAD_DIRECT_WAKE_LISTENER_ENABLE) && \
+    (OPENTHREAD_FTD || OPENTHREAD_MTD)
+
+// SCA LTV fixed-header word (2-byte LE) bit positions and masks.
+enum : uint16_t
+{
+    kScaSlotDurationShift = 0,
+    kScaSlotDurationMask  = 0x0003u,
+    kScaRamOffsetShift    = 2,
+    kScaRamOffsetMask     = 0x07FFu,
+    kScaRamOffsetMsb      = 0x0400u, ///< Sign bit of the 11-bit offset field.
+    kScaRamOffsetSignExt  = 0xF800u, ///< Upper bits set when sign-extending to int16_t.
+    kScaRamAvailableShift = 13,
+};
+
+Error AppendThreadHeaderIe(FrameBuilder &aFrameBuilder, const uint8_t *aLtvPayload, uint8_t aLtvLen)
+{
+    Error    error;
+    HeaderIe ie;
+
+    ie.Init(ThreadHeaderIe::kElementId, aLtvLen);
+    SuccessOrExit(error = aFrameBuilder.AppendBytes(&ie, sizeof(ie)));
+
+    if (aLtvLen > 0)
+    {
+        SuccessOrExit(error = aFrameBuilder.AppendBytes(aLtvPayload, aLtvLen));
+    }
+
+exit:
+    return error;
+}
+
+Error AppendScaLtv(FrameBuilder &aFrameBuilder, const ScaParams &aParams)
+{
+    uint16_t fixedHdr =
+        static_cast<uint16_t>((aParams.mSlotDuration & kScaSlotDurationMask) << kScaSlotDurationShift) |
+        static_cast<uint16_t>((static_cast<uint16_t>(aParams.mRamOffsetUs) & kScaRamOffsetMask) << kScaRamOffsetShift) |
+        (aParams.mRamAvailable ? static_cast<uint16_t>(1u << kScaRamAvailableShift) : 0u);
+
+    uint8_t ramBitsLen = (aParams.mRamAvailable && aParams.mRamDuration > 0)
+                             ? static_cast<uint8_t>((aParams.mRamDuration + 7u) / 8u)
+                             : 0u;
+
+    uint8_t valueLen =
+        static_cast<uint8_t>(2u + (aParams.mRamAvailable ? (1u + ramBitsLen) : 0u) + (aParams.mHasSlw ? 4u : 0u));
+
+    uint8_t value[39]; // 2 (fixed hdr) + 1 (RAM Duration) + 32 (RAM Bits) + 4 (SLW Period + Phase)
+    uint8_t pos = 0;
+
+    LittleEndian::WriteUint16(fixedHdr, value + pos);
+    pos += 2;
+
+    if (aParams.mRamAvailable)
+    {
+        value[pos++] = aParams.mRamDuration;
+
+        for (uint8_t i = 0; i < ramBitsLen; i++)
+        {
+            value[pos++] = aParams.mRamBits[i];
+        }
+    }
+
+    if (aParams.mHasSlw)
+    {
+        LittleEndian::WriteUint16(aParams.mSlwPeriodSlots, value + pos);
+        pos += 2;
+        LittleEndian::WriteUint16(aParams.mSlwPhaseSlots, value + pos);
+        pos += 2;
+    }
+
+    return Ltv::Append(aFrameBuilder, ThreadHeaderIe::kTypeSca, value, valueLen);
+}
+
+Error AppendScaLtvTeardown(FrameBuilder &aFrameBuilder)
+{
+    return Ltv::Append(aFrameBuilder, ThreadHeaderIe::kTypeSca, nullptr, 0);
+}
+
+Error AppendChallengeLtv(FrameBuilder &aFrameBuilder, const ChallengeLtv &aChallenge)
+{
+    return Ltv::Append<ChallengeLtvInfo>(aFrameBuilder, aChallenge);
+}
+
+Error AppendTargetIdLtv(FrameBuilder &aFrameBuilder, const uint8_t *aTargetId, uint8_t aLen)
+{
+    return Ltv::Append(aFrameBuilder, ThreadHeaderIe::kTypeTargetId, aTargetId, aLen);
+}
+
+Error ParseThreadHeaderIe(const uint8_t *aBuffer,
+                          uint8_t        aLength,
+                          ScaParams     *aScaParams,
+                          ChallengeLtv  *aChallenge,
+                          bool          *aTeardown,
+                          bool          *aChallengePresent)
+{
+    Error                     error = kErrorNone;
+    PackedLtvStream::Iterator iter;
+
+    iter.Init(aBuffer, aLength);
+
+    while (!iter.IsDone())
+    {
+        uint8_t        ltvType  = iter.GetType();
+        uint8_t        ltvLen   = iter.GetLength();
+        const uint8_t *ltvValue = iter.GetValue();
+
+        VerifyOrExit(iter.Advance() == kErrorNone, error = kErrorParse);
+
+        if (ltvType == ThreadHeaderIe::kTypeSca)
+        {
+            if (ltvLen == 0)
+            {
+                if (aTeardown != nullptr)
+                {
+                    *aTeardown = true;
+                }
+            }
+            else if (ltvLen >= 2 && aScaParams != nullptr)
+            {
+                uint16_t fixedHdr = LittleEndian::ReadUint16(ltvValue);
+                uint16_t rawOff   = (fixedHdr >> kScaRamOffsetShift) & kScaRamOffsetMask;
+                uint8_t  consumed = 2;
+
+                memset(aScaParams, 0, sizeof(ScaParams));
+                aScaParams->mSlotDuration =
+                    static_cast<uint8_t>((fixedHdr >> kScaSlotDurationShift) & kScaSlotDurationMask);
+                aScaParams->mRamOffsetUs  = (rawOff & kScaRamOffsetMsb)
+                                                ? static_cast<int16_t>(rawOff | kScaRamOffsetSignExt)
+                                                : static_cast<int16_t>(rawOff);
+                aScaParams->mRamAvailable = ((fixedHdr >> kScaRamAvailableShift) & 0x01u) != 0;
+
+                if (aScaParams->mRamAvailable && consumed < ltvLen)
+                {
+                    uint8_t ramDur           = ltvValue[consumed++];
+                    aScaParams->mRamDuration = ramDur;
+                    uint8_t ramBitsLen       = (ramDur > 0) ? static_cast<uint8_t>((ramDur + 7u) / 8u) : 0u;
+
+                    for (uint8_t i = 0; i < ramBitsLen && consumed < ltvLen && i < ScaParams::kRamBitsMaxBytes;
+                         i++, consumed++)
+                    {
+                        aScaParams->mRamBits[i] = ltvValue[consumed];
+                    }
+                }
+
+                if (static_cast<uint8_t>(ltvLen - consumed) >= 4)
+                {
+                    aScaParams->mSlwPeriodSlots = LittleEndian::ReadUint16(ltvValue + consumed);
+                    aScaParams->mSlwPhaseSlots  = LittleEndian::ReadUint16(ltvValue + consumed + 2u);
+                    aScaParams->mHasSlw         = true;
+                }
+            }
+        }
+        else if (ltvType == ChallengeLtvInfo::kType && aChallenge != nullptr && ltvLen == sizeof(ChallengeLtv))
+        {
+            *aChallenge = *reinterpret_cast<const ChallengeLtv *>(ltvValue);
+
+            if (aChallengePresent != nullptr)
+            {
+                *aChallengePresent = true;
+            }
+        }
+    }
+
+exit:
+    return error;
+}
+
+#endif // (OPENTHREAD_CONFIG_THREAD_DIRECT_WAKE_INITIATOR_ENABLE ||
+       // OPENTHREAD_CONFIG_THREAD_DIRECT_WAKE_LISTENER_ENABLE) && (OPENTHREAD_FTD || OPENTHREAD_MTD)
+
+} // namespace Mac
+} // namespace ot

--- a/src/core/mac/mac_header_ltv.hpp
+++ b/src/core/mac/mac_header_ltv.hpp
@@ -1,0 +1,166 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for Thread Direct LTV types and Thread Header IE helpers.
+ */
+
+#ifndef OT_CORE_MAC_MAC_HEADER_LTV_HPP_
+#define OT_CORE_MAC_MAC_HEADER_LTV_HPP_
+
+#include "openthread-core-config.h"
+
+#include "common/frame_builder.hpp"
+#include "common/ltvs.hpp"
+#include "mac/mac_header_ie.hpp"
+
+namespace ot {
+namespace Mac {
+
+#if OPENTHREAD_CONFIG_THREAD_DIRECT_WAKE_INITIATOR_ENABLE || OPENTHREAD_CONFIG_THREAD_DIRECT_WAKE_LISTENER_ENABLE
+
+/**
+ * In-memory representation of SCA LTV parameters.
+ */
+struct ScaParams
+{
+    static constexpr uint8_t kRamBitsMaxBytes = 32; ///< Maximum RAM bitmap size (256 bits).
+    static constexpr int16_t kRamOffsetUsMin  = -1024;
+    static constexpr int16_t kRamOffsetUsMax  = 1023;
+
+    uint16_t mSlwPeriodSlots; ///< SLW period in slot-duration units (0 = rx-on-when-idle); valid when mHasSlw.
+    uint16_t mSlwPhaseSlots;  ///< SLW phase in slot-duration units; valid when mHasSlw.
+    int16_t  mRamOffsetUs;    ///< RAM Offset in us, signed [-1024, 1023].
+    uint8_t  mRamDuration;    ///< Number of bits in mRamBits (0 = no change); valid when mRamAvailable.
+    uint8_t  mSlotDuration;   ///< Slot duration code: 0=625us, 1=1.25ms, 2=625ms, 3=1.25s.
+    bool     mRamAvailable;   ///< True if RAM Duration and RAM Bits are present in the SCA LTV.
+    bool     mHasSlw;         ///< True if SLW Period and Phase are present in the SCA LTV.
+    uint8_t  mRamBits[kRamBitsMaxBytes]; ///< RAM bitmap; ceil(mRamDuration/8) bytes valid when mRamAvailable.
+};
+
+/**
+ * Holds the 16-byte challenge value carried in a Thread Direct Challenge LTV.
+ */
+struct ChallengeLtv
+{
+    static constexpr uint8_t kLength = 16; ///< Challenge value length in bytes (truncated HMAC-SHA256).
+    uint8_t                  mChallenge[kLength];
+};
+
+/// Type alias for the Thread Direct Challenge LTV; used with `Ltv::Append<ChallengeLtvInfo>()`.
+using ChallengeLtvInfo = SimpleLtvInfo<ThreadHeaderIe::kTypeChallenge, ChallengeLtv>;
+
+/**
+ * Appends a Thread Header IE (Element ID 0x2d) containing the given LTV payload to a FrameBuilder.
+ *
+ * @param[in,out] aFrameBuilder  The FrameBuilder to append to.
+ * @param[in]     aLtvPayload    Pointer to the serialised LTV bytes to place inside the IE.
+ * @param[in]     aLtvLen        Length of aLtvPayload in bytes (must fit in 7-bit IE length field).
+ *
+ * @retval kErrorNone   Successfully appended.
+ * @retval kErrorNoBufs Insufficient space in the FrameBuilder.
+ */
+Error AppendThreadHeaderIe(FrameBuilder &aFrameBuilder, const uint8_t *aLtvPayload, uint8_t aLtvLen);
+
+/**
+ * Appends an SCA LTV to a FrameBuilder.
+ *
+ * @param[in,out] aFrameBuilder  The FrameBuilder to append to.
+ * @param[in]     aParams        SCA parameters to encode.
+ *
+ * @retval kErrorNone   Successfully appended.
+ * @retval kErrorNoBufs Insufficient space in the FrameBuilder.
+ */
+Error AppendScaLtv(FrameBuilder &aFrameBuilder, const ScaParams &aParams);
+
+/**
+ * Appends a zero-length (teardown) SCA LTV to a FrameBuilder.
+ *
+ * A zero-length SCA LTV signals TD link teardown to the receiver.
+ *
+ * @param[in,out] aFrameBuilder  The FrameBuilder to append to.
+ *
+ * @retval kErrorNone   Successfully appended.
+ * @retval kErrorNoBufs Insufficient space in the FrameBuilder.
+ */
+Error AppendScaLtvTeardown(FrameBuilder &aFrameBuilder);
+
+/**
+ * Appends a Challenge LTV to a FrameBuilder.
+ *
+ * @param[in,out] aFrameBuilder  The FrameBuilder to append to.
+ * @param[in]     aChallenge     The 16-byte challenge value to encode.
+ *
+ * @retval kErrorNone   Successfully appended.
+ * @retval kErrorNoBufs Insufficient space in the FrameBuilder.
+ */
+Error AppendChallengeLtv(FrameBuilder &aFrameBuilder, const ChallengeLtv &aChallenge);
+
+/**
+ * Appends a Target ID LTV to a FrameBuilder.
+ *
+ * @param[in,out] aFrameBuilder  The FrameBuilder to append to.
+ * @param[in]     aTargetId      Pointer to the Target ID bytes.
+ * @param[in]     aLen           Length of aTargetId in bytes.
+ *
+ * @retval kErrorNone   Successfully appended.
+ * @retval kErrorNoBufs Insufficient space in the FrameBuilder.
+ */
+Error AppendTargetIdLtv(FrameBuilder &aFrameBuilder, const uint8_t *aTargetId, uint8_t aLen);
+
+/**
+ * Parses the LTV payload of a Thread Header IE.
+ *
+ * Scans the packed LTV sequence; for each LTV whose type matches a known Thread Direct type the
+ * corresponding output parameter is populated when non-null.  Unknown types are skipped silently.
+ * A zero-length SCA LTV (teardown signal) sets @p aTeardown when non-null.
+ *
+ * @param[in]  aBuffer           Pointer to the IE payload (bytes after the 2-byte HeaderIe header).
+ * @param[in]  aLength           Length of @p aBuffer in bytes.
+ * @param[out] aScaParams        If non-null, populated when a non-empty SCA LTV is found.
+ * @param[out] aChallenge        If non-null, populated when a Challenge LTV is found.
+ * @param[out] aTeardown         If non-null, set to true when a zero-length (teardown) SCA LTV is found.
+ * @param[out] aChallengePresent If non-null, set to true when a Challenge LTV is found.
+ *
+ * @retval kErrorNone   Parsing succeeded.
+ * @retval kErrorParse  Buffer is truncated or malformed.
+ */
+Error ParseThreadHeaderIe(const uint8_t *aBuffer,
+                          uint8_t        aLength,
+                          ScaParams     *aScaParams,
+                          ChallengeLtv  *aChallenge,
+                          bool          *aTeardown         = nullptr,
+                          bool          *aChallengePresent = nullptr);
+
+#endif // OPENTHREAD_CONFIG_THREAD_DIRECT_WAKE_INITIATOR_ENABLE || OPENTHREAD_CONFIG_THREAD_DIRECT_WAKE_LISTENER_ENABLE
+
+} // namespace Mac
+} // namespace ot
+
+#endif // OT_CORE_MAC_MAC_HEADER_LTV_HPP_

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -233,6 +233,7 @@ ot_unit_test(link_metrics_manager)
 ot_unit_test(link_quality)
 ot_unit_test(linked_list)
 ot_unit_test(lowpan)
+ot_unit_test(ltv)
 ot_unit_test(mac_frame)
 ot_unit_test(macros)
 ot_unit_test(mdns)
@@ -272,6 +273,30 @@ ot_unit_test(toolchain test_toolchain_c.c)
 ot_unit_test(trickle_timer)
 ot_unit_test(url)
 ot_unit_test(vendor_oui)
+
+# Thread Direct LTV test — requires both WI and WL configs enabled.
+add_executable(ot-test-td-ltv
+    test_td_ltv.cpp
+)
+
+target_include_directories(ot-test-td-ltv
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_link_libraries(ot-test-td-ltv
+    PRIVATE
+        ${COMMON_LIBS}
+)
+
+target_compile_options(ot-test-td-ltv
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+        "-DOPENTHREAD_CONFIG_THREAD_DIRECT_WAKE_INITIATOR_ENABLE=1"
+        "-DOPENTHREAD_CONFIG_THREAD_DIRECT_WAKE_LISTENER_ENABLE=1"
+)
+
+add_test(NAME ot-test-td-ltv COMMAND ot-test-td-ltv)
 
 ot_unit_ncp_test(cli)
 ot_unit_ncp_test(dnssd)

--- a/tests/unit/test_ltv.cpp
+++ b/tests/unit/test_ltv.cpp
@@ -1,0 +1,471 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test_platform.h"
+
+#include <string.h>
+
+#include "common/frame_builder.hpp"
+#include "common/frame_data.hpp"
+#include "common/ltvs.hpp"
+
+#include "test_util.h"
+#include "test_util.hpp"
+
+namespace ot {
+
+// LTV type constants used throughout the tests.
+static constexpr uint8_t kTypeA = 0x01;
+static constexpr uint8_t kTypeB = 0x02;
+static constexpr uint8_t kTypeC = 0x03;
+
+// A fixed-size value type for SimpleLtvInfo tests.
+struct SimpleValue
+{
+    uint8_t  mField1;
+    uint16_t mField2;
+    uint8_t  mField3;
+};
+
+using SimpleValueLtv = SimpleLtvInfo<kTypeC, SimpleValue>;
+
+// ---------------------------------------------------------------------------
+// TestLtvAppendAndFind
+//
+// Appends a single LTV with a known value, then locates it by type and verifies
+// the Length, Type, and Value bytes are correct.
+// ---------------------------------------------------------------------------
+void TestLtvAppendAndFind(void)
+{
+    static constexpr uint8_t kValue[]    = {0xAA, 0xBB, 0xCC};
+    static constexpr uint8_t kBufSize    = Ltv::kHeaderSize + sizeof(kValue) + 4;
+    static constexpr uint8_t kAbsentType = 0xFF;
+
+    uint8_t      buffer[kBufSize];
+    FrameBuilder fb;
+    const Ltv   *ltv;
+
+    fb.Init(buffer, sizeof(buffer));
+    SuccessOrQuit(Ltv::Append(fb, kTypeA, kValue, sizeof(kValue)));
+
+    VerifyOrQuit(fb.GetLength() == Ltv::kHeaderSize + sizeof(kValue));
+
+    // Verify raw wire bytes: [Length][Type][Value...]
+    VerifyOrQuit(buffer[0] == sizeof(kValue));
+    VerifyOrQuit(buffer[1] == kTypeA);
+    VerifyOrQuit(memcmp(buffer + Ltv::kHeaderSize, kValue, sizeof(kValue)) == 0);
+
+    // FindLtv by matching type.
+    ltv = Ltv::FindLtv(buffer, fb.GetLength(), kTypeA);
+    VerifyOrQuit(ltv != nullptr);
+    VerifyOrQuit(ltv->GetType() == kTypeA);
+    VerifyOrQuit(ltv->GetLength() == sizeof(kValue));
+    VerifyOrQuit(memcmp(ltv->GetValue(), kValue, sizeof(kValue)) == 0);
+
+    // FindLtv returns nullptr for a type not present.
+    VerifyOrQuit(Ltv::FindLtv(buffer, fb.GetLength(), kAbsentType) == nullptr);
+
+    // FindLtv on an empty buffer returns nullptr.
+    VerifyOrQuit(Ltv::FindLtv(buffer, 0, kTypeA) == nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// TestLtvEmptyValue
+//
+// An LTV with Length=0 carries no value bytes; this is the teardown pattern
+// (e.g. SCA LTV with L=0 signals link teardown).
+// ---------------------------------------------------------------------------
+void TestLtvEmptyValue(void)
+{
+    static constexpr uint8_t kBufSize = Ltv::kHeaderSize + 4;
+
+    uint8_t      buffer[kBufSize];
+    FrameBuilder fb;
+    const Ltv   *ltv;
+
+    fb.Init(buffer, sizeof(buffer));
+    SuccessOrQuit(Ltv::Append(fb, kTypeB, nullptr, 0));
+
+    VerifyOrQuit(fb.GetLength() == Ltv::kHeaderSize);
+    VerifyOrQuit(buffer[0] == 0);      // Length = 0
+    VerifyOrQuit(buffer[1] == kTypeB); // Type
+
+    ltv = Ltv::FindLtv(buffer, fb.GetLength(), kTypeB);
+    VerifyOrQuit(ltv != nullptr);
+    VerifyOrQuit(ltv->GetLength() == 0);
+    VerifyOrQuit(ltv->GetTotalSize() == Ltv::kHeaderSize);
+}
+
+// ---------------------------------------------------------------------------
+// TestLtvIterator
+//
+// Appends three LTVs of different types, then uses Ltv::Iterator to walk the
+// sequence and verify each entry is visited exactly once in order.
+// ---------------------------------------------------------------------------
+void TestLtvIterator(void)
+{
+    static constexpr uint8_t kValA[]  = {0x01};
+    static constexpr uint8_t kValB[]  = {0x02, 0x03};
+    static constexpr uint8_t kValC[]  = {0x04, 0x05, 0x06};
+    static constexpr uint8_t kBufSize = 3 * Ltv::kHeaderSize + sizeof(kValA) + sizeof(kValB) + sizeof(kValC);
+
+    uint8_t       buffer[kBufSize];
+    FrameBuilder  fb;
+    Ltv::Iterator iter;
+    uint8_t       count = 0;
+
+    fb.Init(buffer, sizeof(buffer));
+    SuccessOrQuit(Ltv::Append(fb, kTypeA, kValA, sizeof(kValA)));
+    SuccessOrQuit(Ltv::Append(fb, kTypeB, kValB, sizeof(kValB)));
+    SuccessOrQuit(Ltv::Append(fb, kTypeC, kValC, sizeof(kValC)));
+
+    iter.Init(buffer, fb.GetLength());
+
+    // First LTV: type A, 1-byte value.
+    VerifyOrQuit(!iter.IsDone());
+    VerifyOrQuit(iter.GetLtv().GetType() == kTypeA);
+    VerifyOrQuit(iter.GetLtv().GetLength() == sizeof(kValA));
+    VerifyOrQuit(memcmp(iter.GetLtv().GetValue(), kValA, sizeof(kValA)) == 0);
+    SuccessOrQuit(iter.Advance());
+    count++;
+
+    // Second LTV: type B, 2-byte value.
+    VerifyOrQuit(!iter.IsDone());
+    VerifyOrQuit(iter.GetLtv().GetType() == kTypeB);
+    VerifyOrQuit(iter.GetLtv().GetLength() == sizeof(kValB));
+    VerifyOrQuit(memcmp(iter.GetLtv().GetValue(), kValB, sizeof(kValB)) == 0);
+    SuccessOrQuit(iter.Advance());
+    count++;
+
+    // Third LTV: type C, 3-byte value.
+    VerifyOrQuit(!iter.IsDone());
+    VerifyOrQuit(iter.GetLtv().GetType() == kTypeC);
+    VerifyOrQuit(iter.GetLtv().GetLength() == sizeof(kValC));
+    VerifyOrQuit(memcmp(iter.GetLtv().GetValue(), kValC, sizeof(kValC)) == 0);
+    SuccessOrQuit(iter.Advance());
+    count++;
+
+    // Iterator is exhausted.
+    VerifyOrQuit(iter.IsDone());
+    VerifyOrQuit(count == 3);
+
+    // Advance on an exhausted iterator is a no-op.
+    SuccessOrQuit(iter.Advance());
+    VerifyOrQuit(iter.IsDone());
+}
+
+// ---------------------------------------------------------------------------
+// TestLtvBufferBoundary
+//
+// Verifies that Append returns kErrorNoBufs when the buffer cannot accommodate
+// another full LTV.
+// ---------------------------------------------------------------------------
+void TestLtvBufferBoundary(void)
+{
+    static constexpr uint8_t kValue[] = {0x10, 0x20, 0x30};
+
+    // Buffer exactly fits one LTV.
+    static constexpr uint8_t kExactSize = Ltv::kHeaderSize + sizeof(kValue);
+
+    uint8_t      buffer[kExactSize];
+    FrameBuilder fb;
+
+    fb.Init(buffer, sizeof(buffer));
+    SuccessOrQuit(Ltv::Append(fb, kTypeA, kValue, sizeof(kValue)));
+    VerifyOrQuit(fb.GetLength() == kExactSize);
+
+    // One more byte would overflow.
+    VerifyOrQuit(Ltv::Append(fb, kTypeB, kValue, 1) == kErrorNoBufs);
+}
+
+// ---------------------------------------------------------------------------
+// TestLtvTruncated
+//
+// An iterator over a truncated buffer — where the declared LTV value does not
+// fit — returns kErrorParse from Advance().
+// ---------------------------------------------------------------------------
+void TestLtvTruncated(void)
+{
+    // Craft a buffer whose LTV header declares a 10-byte value but only 3 bytes follow.
+    static constexpr uint8_t kDeclaredLen = 10;
+    static constexpr uint8_t kActualBytes = 3;
+
+    uint8_t buffer[Ltv::kHeaderSize + kActualBytes];
+    buffer[0] = kDeclaredLen; // Length field claims 10 bytes.
+    buffer[1] = kTypeA;
+    buffer[2] = buffer[3] = buffer[4] = 0xFF; // Only 3 value bytes present.
+
+    Ltv::Iterator iter;
+    iter.Init(buffer, sizeof(buffer));
+
+    VerifyOrQuit(!iter.IsDone());
+    VerifyOrQuit(iter.Advance() == kErrorParse);
+
+    // FindLtv on a truncated buffer returns nullptr.
+    VerifyOrQuit(Ltv::FindLtv(buffer, sizeof(buffer), kTypeA) == nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// TestLtvOneByteBoundary
+//
+// A buffer with only one byte remaining (incomplete LTV header) is treated as
+// done by IsDone() without triggering a parse error.
+// ---------------------------------------------------------------------------
+void TestLtvOneByteBoundary(void)
+{
+    uint8_t       oneByte = 0x00;
+    Ltv::Iterator iter;
+
+    iter.Init(&oneByte, 1);
+    VerifyOrQuit(iter.IsDone());
+
+    // Advance on a "done" iterator is a no-op.
+    SuccessOrQuit(iter.Advance());
+    VerifyOrQuit(iter.IsDone());
+}
+
+// ---------------------------------------------------------------------------
+// TestLtvSimpleLtvInfo
+//
+// Exercises the SimpleLtvInfo<kType, ValueType> typed-append path, then reads
+// the value back using FindLtv and casts the value pointer.
+// ---------------------------------------------------------------------------
+void TestLtvSimpleLtvInfo(void)
+{
+    static constexpr uint8_t kBufSize = Ltv::kHeaderSize + sizeof(SimpleValue) + 4;
+
+    uint8_t      buffer[kBufSize];
+    FrameBuilder fb;
+    SimpleValue  original;
+    const Ltv   *ltv;
+
+    original.mField1 = 0xAB;
+    original.mField2 = 0xCDEF;
+    original.mField3 = 0x12;
+
+    fb.Init(buffer, sizeof(buffer));
+    SuccessOrQuit((Ltv::Append<SimpleValueLtv>(fb, original)));
+
+    VerifyOrQuit(fb.GetLength() == Ltv::kHeaderSize + sizeof(SimpleValue));
+
+    ltv = Ltv::FindLtv(buffer, fb.GetLength(), SimpleValueLtv::kType);
+    VerifyOrQuit(ltv != nullptr);
+    VerifyOrQuit(ltv->GetType() == kTypeC);
+    VerifyOrQuit(ltv->GetLength() == sizeof(SimpleValue));
+
+    // Verify value bytes round-trip correctly.
+    SimpleValue readBack;
+    memcpy(&readBack, ltv->GetValue(), sizeof(SimpleValue));
+    VerifyOrQuit(readBack.mField1 == original.mField1);
+    VerifyOrQuit(readBack.mField2 == original.mField2);
+    VerifyOrQuit(readBack.mField3 == original.mField3);
+}
+
+// ---------------------------------------------------------------------------
+// TestLtvFindSecond
+//
+// When two LTVs with different types are present, FindLtv returns the correct one.
+// ---------------------------------------------------------------------------
+void TestLtvFindSecond(void)
+{
+    static constexpr uint8_t kValA[]  = {0x11, 0x22};
+    static constexpr uint8_t kValB[]  = {0x33, 0x44, 0x55};
+    static constexpr uint8_t kBufSize = 2 * Ltv::kHeaderSize + sizeof(kValA) + sizeof(kValB);
+
+    uint8_t      buffer[kBufSize];
+    FrameBuilder fb;
+    const Ltv   *ltv;
+
+    fb.Init(buffer, sizeof(buffer));
+    SuccessOrQuit(Ltv::Append(fb, kTypeA, kValA, sizeof(kValA)));
+    SuccessOrQuit(Ltv::Append(fb, kTypeB, kValB, sizeof(kValB)));
+
+    ltv = Ltv::FindLtv(buffer, fb.GetLength(), kTypeB);
+    VerifyOrQuit(ltv != nullptr);
+    VerifyOrQuit(ltv->GetType() == kTypeB);
+    VerifyOrQuit(ltv->GetLength() == sizeof(kValB));
+    VerifyOrQuit(memcmp(ltv->GetValue(), kValB, sizeof(kValB)) == 0);
+
+    // kTypeA is still found too.
+    ltv = Ltv::FindLtv(buffer, fb.GetLength(), kTypeA);
+    VerifyOrQuit(ltv != nullptr);
+    VerifyOrQuit(ltv->GetLength() == sizeof(kValA));
+}
+
+// ---------------------------------------------------------------------------
+// TestPackedEncodeDecode
+//
+// Verifies that PackedLtvStream::Encode produces output no larger than the
+// plain input and that Decode recovers the original bytes exactly.
+// ---------------------------------------------------------------------------
+void TestPackedEncodeDecode(void)
+{
+    // Three entries: [L=1,T=0x01,V={0xAA}], [L=2,T=0x02,V={0xBB,0xCC}], [L=0,T=0x03]
+    static constexpr uint8_t kPlain[] = {0x01, 0x01, 0xAA, 0x02, 0x02, 0xBB, 0xCC, 0x00, 0x03};
+
+    uint8_t packed[sizeof(kPlain)];
+    uint8_t plain2[sizeof(kPlain)];
+    uint8_t packedLen;
+    uint8_t plain2Len;
+
+    packedLen = PackedLtvStream::Encode(kPlain, sizeof(kPlain), packed, sizeof(packed));
+    VerifyOrQuit(packedLen > 0);
+    VerifyOrQuit(packedLen <= sizeof(kPlain));
+
+    VerifyOrQuit(PackedLtvStream::Decode(packed, packedLen, plain2, sizeof(plain2), plain2Len) == kErrorNone);
+    VerifyOrQuit(plain2Len == sizeof(kPlain));
+    VerifyOrQuit(memcmp(plain2, kPlain, sizeof(kPlain)) == 0);
+}
+
+// ---------------------------------------------------------------------------
+// TestPackedIterator
+//
+// Walks a packed stream with PackedLtvStream::Iterator; verifies type, length,
+// value, and GetValueOffset() for each entry.
+// ---------------------------------------------------------------------------
+void TestPackedIterator(void)
+{
+    static constexpr uint8_t kValA[] = {0xDE, 0xAD};
+    static constexpr uint8_t kValB[] = {0xBE, 0xEF, 0xCA};
+
+    uint8_t      plain[16];
+    FrameBuilder fb;
+
+    fb.Init(plain, sizeof(plain));
+    SuccessOrQuit(Ltv::Append(fb, 0x01, kValA, sizeof(kValA)));
+    SuccessOrQuit(Ltv::Append(fb, 0x02, kValB, sizeof(kValB)));
+
+    uint8_t packed[sizeof(plain)];
+    uint8_t packedLen = PackedLtvStream::Encode(plain, static_cast<uint8_t>(fb.GetLength()), packed, sizeof(packed));
+
+    PackedLtvStream::Iterator iter;
+    iter.Init(packed, packedLen);
+
+    VerifyOrQuit(!iter.IsDone());
+    VerifyOrQuit(iter.GetType() == 0x01);
+    VerifyOrQuit(iter.GetLength() == sizeof(kValA));
+    VerifyOrQuit(memcmp(iter.GetValue(), kValA, sizeof(kValA)) == 0);
+
+    uint8_t off0 = iter.GetValueOffset();
+    VerifyOrQuit(memcmp(packed + off0, kValA, sizeof(kValA)) == 0);
+
+    SuccessOrQuit(iter.Advance());
+
+    VerifyOrQuit(!iter.IsDone());
+    VerifyOrQuit(iter.GetType() == 0x02);
+    VerifyOrQuit(iter.GetLength() == sizeof(kValB));
+    VerifyOrQuit(memcmp(iter.GetValue(), kValB, sizeof(kValB)) == 0);
+
+    uint8_t off1 = iter.GetValueOffset();
+    VerifyOrQuit(off0 + sizeof(kValA) <= off1);
+    VerifyOrQuit(off1 + sizeof(kValB) <= packedLen);
+    VerifyOrQuit(memcmp(packed + off1, kValB, sizeof(kValB)) == 0);
+
+    SuccessOrQuit(iter.Advance());
+    VerifyOrQuit(iter.IsDone());
+}
+
+// ---------------------------------------------------------------------------
+// TestPackedNL0
+//
+// When L=1 the stream is a single zero-length LTV encoded as a bare type byte
+// (N_L=0 case from the spec).
+// ---------------------------------------------------------------------------
+void TestPackedNL0(void)
+{
+    // Plain: [L=0, T=0xAA]
+    static constexpr uint8_t kPlain[] = {0x00, 0xAA};
+
+    uint8_t packed[4];
+    uint8_t packedLen = PackedLtvStream::Encode(kPlain, sizeof(kPlain), packed, sizeof(packed));
+
+    VerifyOrQuit(packedLen == 1);
+    VerifyOrQuit(packed[0] == 0xAA);
+
+    uint8_t plain2[4];
+    uint8_t plain2Len;
+    VerifyOrQuit(PackedLtvStream::Decode(packed, packedLen, plain2, sizeof(plain2), plain2Len) == kErrorNone);
+    VerifyOrQuit(plain2Len == sizeof(kPlain));
+    VerifyOrQuit(memcmp(plain2, kPlain, sizeof(kPlain)) == 0);
+}
+
+// ---------------------------------------------------------------------------
+// TestPackedEscapeCode
+//
+// A type value equal to all-ones in the available bits triggers the base
+// (escape) format: a second header byte carries the type.
+//
+// Entry A: len=0, type=0x01.  Entry B (last): len=1, type=0x7F, value={0xCC}.
+//
+// For entry B: L=2, N_L=1, shift=7, allOnes=127=0x7F.  type==allOnes, so
+// compact fails.  Base format: L=3, N_L=2, shift=6, header={0x7F,0x7F}.
+// For entry A: scratchLen=3, L=4, N_L=2, shift=6, allOnes=63.  type=1<63,
+// compact: header={0x01}.
+// Packed: {0x01, 0x7F, 0x7F, 0xCC}.
+// ---------------------------------------------------------------------------
+void TestPackedEscapeCode(void)
+{
+    // Plain: [L=0,T=0x01][L=1,T=0x7F,V={0xCC}]
+    static constexpr uint8_t kPlain[] = {0x00, 0x01, 0x01, 0x7F, 0xCC};
+
+    uint8_t packed[sizeof(kPlain)];
+    uint8_t packedLen = PackedLtvStream::Encode(kPlain, sizeof(kPlain), packed, sizeof(packed));
+
+    VerifyOrQuit(packedLen == 4);
+    VerifyOrQuit(packed[0] == 0x01); // Entry A compact
+    VerifyOrQuit(packed[1] == 0x7F); // Entry B: escape sentinel
+    VerifyOrQuit(packed[2] == 0x7F); // Entry B: type byte
+    VerifyOrQuit(packed[3] == 0xCC); // Entry B: value
+
+    uint8_t plain2[sizeof(kPlain)];
+    uint8_t plain2Len;
+    VerifyOrQuit(PackedLtvStream::Decode(packed, packedLen, plain2, sizeof(plain2), plain2Len) == kErrorNone);
+    VerifyOrQuit(plain2Len == sizeof(kPlain));
+    VerifyOrQuit(memcmp(plain2, kPlain, sizeof(kPlain)) == 0);
+}
+
+} // namespace ot
+
+int main(void)
+{
+    ot::TestLtvAppendAndFind();
+    ot::TestLtvEmptyValue();
+    ot::TestLtvIterator();
+    ot::TestLtvBufferBoundary();
+    ot::TestLtvTruncated();
+    ot::TestLtvOneByteBoundary();
+    ot::TestLtvSimpleLtvInfo();
+    ot::TestLtvFindSecond();
+    ot::TestPackedEncodeDecode();
+    ot::TestPackedIterator();
+    ot::TestPackedNL0();
+    ot::TestPackedEscapeCode();
+
+    printf("All tests passed\n");
+    return 0;
+}

--- a/tests/unit/test_td_ltv.cpp
+++ b/tests/unit/test_td_ltv.cpp
@@ -1,0 +1,556 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test_platform.h"
+
+#include <string.h>
+
+#include "common/encoding.hpp"
+#include "common/frame_builder.hpp"
+#include "common/frame_data.hpp"
+#include "common/ltvs.hpp"
+#include "mac/mac_frame.hpp"
+#include "mac/mac_header_ltv.hpp"
+
+#include "test_util.h"
+#include "test_util.hpp"
+
+namespace ot {
+namespace Mac {
+
+// ---------------------------------------------------------------------------
+// PackAndParse — helper for roundtrip tests
+//
+// AppendScaLtv / AppendChallengeLtv write plain L-T-V bytes (the intermediate
+// build format).  The wire format is adaptively packed.  This helper packs the
+// plain buffer and then calls ParseThreadHeaderIe, mirroring the actual
+// encode/decode pipeline used by GenerateThreadDirectLinkCommand.
+// ---------------------------------------------------------------------------
+static Error PackAndParse(const uint8_t *aPlain, uint8_t aPlainLen, ScaParams *aSca, ChallengeLtv *aChal)
+{
+    uint8_t packed[128];
+    uint8_t packedLen = PackedLtvStream::Encode(aPlain, aPlainLen, packed, sizeof(packed));
+    return ParseThreadHeaderIe(packed, packedLen, aSca, aChal);
+}
+
+// ---------------------------------------------------------------------------
+// TestScaLtvRoundTrip
+//
+// Verifies SCA LTV encode/decode for each distinct RAM Duration variant and
+// for the teardown (zero-length) form.
+// ---------------------------------------------------------------------------
+void TestScaLtvRoundTrip(void)
+{
+    printf("TestScaLtvRoundTrip\n");
+
+    // --- Case 1: No CoEx constraints (mRamAvailable=false), no SLW ---
+    // Fixed header LE: SlotDur=0, RamOffset=0, RamAvailable=0 => 0x0000
+    // Plain LTV: [L=2][T=0x02][0x00][0x00] = 4 bytes
+    {
+        ScaParams params;
+        memset(&params, 0, sizeof(params));
+        params.mRamAvailable = false;
+        params.mHasSlw       = false;
+
+        uint8_t      buf[32];
+        FrameBuilder fb;
+        fb.Init(buf, sizeof(buf));
+
+        VerifyOrQuit(AppendScaLtv(fb, params) == kErrorNone);
+
+        VerifyOrQuit(fb.GetLength() == 4); // [L=2][T=0x02][0x00][0x00]
+        VerifyOrQuit(buf[0] == 2 && buf[1] == ThreadHeaderIe::kTypeSca);
+        VerifyOrQuit(buf[2] == 0x00 && buf[3] == 0x00); // fixed header = 0x0000
+
+        ScaParams out;
+        memset(&out, 0xFF, sizeof(out));
+        VerifyOrQuit(PackAndParse(buf, fb.GetLength(), &out, nullptr) == kErrorNone);
+        VerifyOrQuit(!out.mRamAvailable);
+        VerifyOrQuit(!out.mHasSlw);
+        VerifyOrQuit(out.mRamOffsetUs == 0);
+        VerifyOrQuit(out.mSlotDuration == 0);
+    }
+
+    // --- Case 2: No CoEx constraints, SLW Period=100, Phase=50 (mHasSlw=true) ---
+    // Fixed header: 0x0000; SLW Period LE = {0x64,0x00}; Phase LE = {0x32,0x00}
+    // Plain LTV: [L=6][T=0x02][0x00][0x00][0x64][0x00][0x32][0x00] = 8 bytes
+    {
+        ScaParams params;
+        memset(&params, 0, sizeof(params));
+        params.mRamAvailable   = false;
+        params.mHasSlw         = true;
+        params.mSlwPeriodSlots = 100;
+        params.mSlwPhaseSlots  = 50;
+
+        uint8_t      buf[32];
+        FrameBuilder fb;
+        fb.Init(buf, sizeof(buf));
+
+        VerifyOrQuit(AppendScaLtv(fb, params) == kErrorNone);
+
+        VerifyOrQuit(fb.GetLength() == 8); // [L=6][T=0x02][fixed 2B][period 2B][phase 2B]
+
+        ScaParams out;
+        memset(&out, 0, sizeof(out));
+        VerifyOrQuit(PackAndParse(buf, fb.GetLength(), &out, nullptr) == kErrorNone);
+        VerifyOrQuit(!out.mRamAvailable);
+        VerifyOrQuit(out.mHasSlw);
+        VerifyOrQuit(out.mRamOffsetUs == 0);
+        VerifyOrQuit(out.mSlwPeriodSlots == 100);
+        VerifyOrQuit(out.mSlwPhaseSlots == 50);
+    }
+
+    // --- Case 3: No CoEx, negative RAM Offset=-512, SLW Period=4095, Phase=4095 ---
+    // RamOffset=-512: rawOffset11 = uint16(-512)&0x07FF = 0x0600
+    // Fixed header: (0x0600<<2)=0x1800 => LE {0x00, 0x18}
+    // SLW Period=4095 LE: {0xFF,0x0F}; Phase=4095 LE: {0xFF,0x0F}
+    {
+        ScaParams params;
+        memset(&params, 0, sizeof(params));
+        params.mRamAvailable   = false;
+        params.mHasSlw         = true;
+        params.mRamOffsetUs    = -512;
+        params.mSlwPeriodSlots = 4095;
+        params.mSlwPhaseSlots  = 4095;
+
+        uint8_t      buf[32];
+        FrameBuilder fb;
+        fb.Init(buf, sizeof(buf));
+
+        VerifyOrQuit(AppendScaLtv(fb, params) == kErrorNone);
+
+        VerifyOrQuit(fb.GetLength() == 8);
+        VerifyOrQuit(buf[2] == 0x00 && buf[3] == 0x18); // fixed header LE = 0x1800
+
+        ScaParams out;
+        memset(&out, 0, sizeof(out));
+        VerifyOrQuit(PackAndParse(buf, fb.GetLength(), &out, nullptr) == kErrorNone);
+        VerifyOrQuit(!out.mRamAvailable);
+        VerifyOrQuit(out.mRamOffsetUs == -512);
+        VerifyOrQuit(out.mSlwPeriodSlots == 4095);
+        VerifyOrQuit(out.mSlwPhaseSlots == 4095);
+    }
+
+    // --- Case 4: Teardown (AppendScaLtvTeardown emits zero-length SCA LTV) ---
+    // Wire: [L=0][T=0x02] = 2 bytes; ParseThreadHeaderIe sets aTeardown=true, leaves aScaParams unchanged.
+    {
+        uint8_t      buf[32];
+        FrameBuilder fb;
+        fb.Init(buf, sizeof(buf));
+
+        VerifyOrQuit(AppendScaLtvTeardown(fb) == kErrorNone);
+
+        VerifyOrQuit(fb.GetLength() == 2);
+        VerifyOrQuit(buf[0] == 0 && buf[1] == ThreadHeaderIe::kTypeSca);
+
+        ScaParams out;
+        bool      teardown = false;
+        memset(&out, 0xAB, sizeof(out));
+        VerifyOrQuit(PackAndParse(buf, fb.GetLength(), &out, nullptr) == kErrorNone);
+
+        // PackAndParse doesn't take aTeardown; call ParseThreadHeaderIe directly to verify.
+        uint8_t packed[8];
+        uint8_t packedLen = PackedLtvStream::Encode(buf, fb.GetLength(), packed, sizeof(packed));
+        memset(&out, 0xAB, sizeof(out));
+        VerifyOrQuit(ParseThreadHeaderIe(packed, packedLen, &out, nullptr, &teardown) == kErrorNone);
+        VerifyOrQuit(teardown);
+        VerifyOrQuit(reinterpret_cast<uint8_t *>(&out)[0] == 0xAB); // aScaParams untouched
+    }
+
+    // --- Case 5: mRamAvailable=true, mRamDuration=8 (one RAM byte), RamOffset=10, no SLW ---
+    // RamOffset=10: rawOffset11=10=0x000A; fixed header=(0x000A<<2)|(1<<13)=0x0028|0x2000=0x2028 LE {0x28,0x20}
+    // Value: [fixed 2B][RamDur 0x08][RamBits 0xA5] = 4 bytes
+    {
+        ScaParams params;
+        memset(&params, 0, sizeof(params));
+        params.mRamAvailable = true;
+        params.mRamDuration  = 8;
+        params.mRamOffsetUs  = 10;
+        params.mHasSlw       = false;
+        params.mRamBits[0]   = 0xA5;
+
+        uint8_t      buf[32];
+        FrameBuilder fb;
+        fb.Init(buf, sizeof(buf));
+
+        VerifyOrQuit(AppendScaLtv(fb, params) == kErrorNone);
+
+        VerifyOrQuit(fb.GetLength() == 6);              // [L=4][T=0x02][fixed 2B][RamDur][RamBits]
+        VerifyOrQuit(buf[2] == 0x28 && buf[3] == 0x20); // fixed header LE = 0x2028
+        VerifyOrQuit(buf[4] == 0x08);                   // RAM Duration
+        VerifyOrQuit(buf[5] == 0xA5);                   // RAM Bits byte
+
+        ScaParams out;
+        memset(&out, 0, sizeof(out));
+        VerifyOrQuit(PackAndParse(buf, fb.GetLength(), &out, nullptr) == kErrorNone);
+        VerifyOrQuit(out.mRamAvailable);
+        VerifyOrQuit(out.mRamDuration == 8);
+        VerifyOrQuit(out.mRamOffsetUs == 10);
+        VerifyOrQuit(out.mRamBits[0] == 0xA5);
+        VerifyOrQuit(!out.mHasSlw);
+    }
+
+    // --- Case 6: mRamAvailable=true, mRamDuration=32 (four RAM bytes), RamOffset=1023, SLW Period=200, Phase=75 ---
+    // RamOffset=1023: rawOffset11=0x03FF; fixed header=(0x03FF<<2)|(1<<13)=0x0FFC|0x2000=0x2FFC LE {0xFC,0x2F}
+    // Value: [fixed 2B][RamDur 0x20][4 RamBits bytes][Period LE 2B][Phase LE 2B] = 11 bytes
+    {
+        ScaParams params;
+        memset(&params, 0, sizeof(params));
+        params.mRamAvailable   = true;
+        params.mRamDuration    = 32;
+        params.mRamOffsetUs    = 1023;
+        params.mHasSlw         = true;
+        params.mSlwPeriodSlots = 200;
+        params.mSlwPhaseSlots  = 75;
+        params.mRamBits[0]     = 0x11;
+        params.mRamBits[1]     = 0x22;
+        params.mRamBits[2]     = 0x33;
+        params.mRamBits[3]     = 0x44;
+
+        uint8_t      buf[64];
+        FrameBuilder fb;
+        fb.Init(buf, sizeof(buf));
+
+        VerifyOrQuit(AppendScaLtv(fb, params) == kErrorNone);
+
+        VerifyOrQuit(fb.GetLength() == 13);             // [L=11][T=0x02] + 11 value bytes
+        VerifyOrQuit(buf[2] == 0xFC && buf[3] == 0x2F); // fixed header LE = 0x2FFC
+        VerifyOrQuit(buf[4] == 0x20);                   // RAM Duration = 32
+        VerifyOrQuit(buf[5] == 0x11 && buf[6] == 0x22 && buf[7] == 0x33 && buf[8] == 0x44);
+        VerifyOrQuit(buf[9] == 0xC8 && buf[10] == 0x00);  // SLW Period=200 LE
+        VerifyOrQuit(buf[11] == 0x4B && buf[12] == 0x00); // SLW Phase=75 LE
+
+        ScaParams out;
+        memset(&out, 0, sizeof(out));
+        VerifyOrQuit(PackAndParse(buf, fb.GetLength(), &out, nullptr) == kErrorNone);
+        VerifyOrQuit(out.mRamAvailable);
+        VerifyOrQuit(out.mRamDuration == 32);
+        VerifyOrQuit(out.mRamOffsetUs == 1023);
+        VerifyOrQuit(out.mRamBits[0] == 0x11);
+        VerifyOrQuit(out.mRamBits[1] == 0x22);
+        VerifyOrQuit(out.mRamBits[2] == 0x33);
+        VerifyOrQuit(out.mRamBits[3] == 0x44);
+        VerifyOrQuit(out.mHasSlw);
+        VerifyOrQuit(out.mSlwPeriodSlots == 200);
+        VerifyOrQuit(out.mSlwPhaseSlots == 75);
+    }
+
+    printf("PASSED\n");
+}
+
+// ---------------------------------------------------------------------------
+// TestChallengeLtvRoundTrip
+//
+// Appends a Challenge LTV with a known 16-byte value and parses it back.
+// ---------------------------------------------------------------------------
+void TestChallengeLtvRoundTrip(void)
+{
+    printf("TestChallengeLtvRoundTrip\n");
+
+    const uint8_t kKnownChallenge[ChallengeLtv::kLength] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                                                            0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10};
+    ChallengeLtv  challenge;
+    memcpy(challenge.mChallenge, kKnownChallenge, ChallengeLtv::kLength);
+
+    uint8_t      buf[32];
+    FrameBuilder fb;
+    fb.Init(buf, sizeof(buf));
+
+    VerifyOrQuit(AppendChallengeLtv(fb, challenge) == kErrorNone);
+
+    // Wire: [L=16][T=0x03][16 bytes] = 18 bytes
+    VerifyOrQuit(fb.GetLength() == 18);
+    VerifyOrQuit(buf[0] == 16 && buf[1] == ThreadHeaderIe::kTypeChallenge);
+    VerifyOrQuit(memcmp(&buf[2], kKnownChallenge, ChallengeLtv::kLength) == 0);
+
+    ChallengeLtv out;
+    memset(&out, 0, sizeof(out));
+    VerifyOrQuit(PackAndParse(buf, fb.GetLength(), nullptr, &out) == kErrorNone);
+    VerifyOrQuit(memcmp(out.mChallenge, kKnownChallenge, ChallengeLtv::kLength) == 0);
+
+    printf("PASSED\n");
+}
+
+// ---------------------------------------------------------------------------
+// TestTargetIdLtv
+//
+// Appends a Target ID LTV with an 8-byte extended address payload and verifies
+// the raw wire bytes.
+// ---------------------------------------------------------------------------
+void TestTargetIdLtv(void)
+{
+    printf("TestTargetIdLtv\n");
+
+    const uint8_t kTargetId[] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22};
+
+    uint8_t      buf[32];
+    FrameBuilder fb;
+    fb.Init(buf, sizeof(buf));
+
+    VerifyOrQuit(AppendTargetIdLtv(fb, kTargetId, sizeof(kTargetId)) == kErrorNone);
+
+    // Wire: [L=8][T=0x01][8 bytes] = 10 bytes
+    VerifyOrQuit(fb.GetLength() == 10);
+    VerifyOrQuit(buf[0] == 8 && buf[1] == ThreadHeaderIe::kTypeTargetId);
+    VerifyOrQuit(memcmp(&buf[2], kTargetId, sizeof(kTargetId)) == 0);
+
+    printf("PASSED\n");
+}
+
+// ---------------------------------------------------------------------------
+// TestThreadHeaderIeWrap
+//
+// Verifies that AppendThreadHeaderIe writes the 2-byte HeaderIe header with
+// the correct Element ID and length before the LTV payload.
+// ---------------------------------------------------------------------------
+void TestThreadHeaderIeWrap(void)
+{
+    printf("TestThreadHeaderIeWrap\n");
+
+    const uint8_t kPayload[] = {0x02, ThreadHeaderIe::kTypeSca, 0x01, 0x00};
+
+    uint8_t      buf[32];
+    FrameBuilder fb;
+    fb.Init(buf, sizeof(buf));
+
+    VerifyOrQuit(AppendThreadHeaderIe(fb, kPayload, sizeof(kPayload)) == kErrorNone);
+
+    // 2-byte HeaderIe: bits[14:7]=ElementId=0x2d, bits[6:0]=Length=4
+    // LE uint16: length in bits[6:0], id in bits[14:7], type=0 in bit[15]
+    // byte[0] = 0x04 (length=4, bits[6:0])
+    // byte[1] = 0x16 (id=0x2d >> 1 = 0x16, since id occupies bits[14:7] = byte[1] bits[7:0])
+    // HeaderIe byte layout: byte0 bits[6:0]=length, byte1 bits[7:0]=id>>1 (since id is at bits[14:7])
+    // Actually: kIdOffset=7, kIdMask=0x00ff<<7 = 0x7f80
+    // id=0x2d => stored in bits[14:7] of the 16-bit LE field
+    // LE uint16 = 0x2d << 7 | 4 = 0x1680 | 0x04 = 0x1684
+    // byte[0]=0x84, byte[1]=0x16
+    uint16_t ieWord = static_cast<uint16_t>((ThreadHeaderIe::kElementId << 7) | sizeof(kPayload));
+    VerifyOrQuit(buf[0] == static_cast<uint8_t>(ieWord & 0xFF));
+    VerifyOrQuit(buf[1] == static_cast<uint8_t>(ieWord >> 8));
+    VerifyOrQuit(memcmp(&buf[2], kPayload, sizeof(kPayload)) == 0);
+    VerifyOrQuit(fb.GetLength() == 2 + sizeof(kPayload));
+
+    printf("PASSED\n");
+}
+
+// ---------------------------------------------------------------------------
+// TestMultiLtvParse
+//
+// Encodes an SCA LTV followed by a Challenge LTV and verifies that
+// ParseThreadHeaderIe correctly populates both output parameters.
+// ---------------------------------------------------------------------------
+void TestMultiLtvParse(void)
+{
+    printf("TestMultiLtvParse\n");
+
+    ScaParams scaIn;
+    memset(&scaIn, 0, sizeof(scaIn));
+    scaIn.mRamAvailable   = false;
+    scaIn.mHasSlw         = true;
+    scaIn.mSlwPeriodSlots = 48;
+    scaIn.mSlwPhaseSlots  = 12;
+
+    const uint8_t kChallengeBytes[ChallengeLtv::kLength] = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
+                                                            0xFE, 0xED, 0xFA, 0xCE, 0xD0, 0xC0, 0xFF, 0xEE};
+    ChallengeLtv  chalIn;
+    memcpy(chalIn.mChallenge, kChallengeBytes, ChallengeLtv::kLength);
+
+    uint8_t      buf[64];
+    FrameBuilder fb;
+    fb.Init(buf, sizeof(buf));
+
+    VerifyOrQuit(AppendScaLtv(fb, scaIn) == kErrorNone);
+    VerifyOrQuit(AppendChallengeLtv(fb, chalIn) == kErrorNone);
+
+    ScaParams    scaOut;
+    ChallengeLtv chalOut;
+    memset(&scaOut, 0, sizeof(scaOut));
+    memset(&chalOut, 0, sizeof(chalOut));
+
+    VerifyOrQuit(PackAndParse(buf, fb.GetLength(), &scaOut, &chalOut) == kErrorNone);
+
+    VerifyOrQuit(!scaOut.mRamAvailable);
+    VerifyOrQuit(scaOut.mHasSlw);
+    VerifyOrQuit(scaOut.mSlwPeriodSlots == 48);
+    VerifyOrQuit(scaOut.mSlwPhaseSlots == 12);
+    VerifyOrQuit(memcmp(chalOut.mChallenge, kChallengeBytes, ChallengeLtv::kLength) == 0);
+
+    printf("PASSED\n");
+}
+
+// ---------------------------------------------------------------------------
+// TestParseTruncated
+//
+// A truncated LTV buffer (declared length exceeds bytes remaining) must cause
+// ParseThreadHeaderIe to return kErrorParse.
+// ---------------------------------------------------------------------------
+void TestParseTruncated(void)
+{
+    printf("TestParseTruncated\n");
+
+    // Build a valid SCA LTV then truncate by one byte.
+    ScaParams params;
+    memset(&params, 0, sizeof(params));
+    params.mRamAvailable   = false;
+    params.mHasSlw         = true;
+    params.mSlwPeriodSlots = 100;
+    params.mSlwPhaseSlots  = 25;
+
+    uint8_t      buf[32];
+    FrameBuilder fb;
+    fb.Init(buf, sizeof(buf));
+
+    VerifyOrQuit(AppendScaLtv(fb, params) == kErrorNone);
+
+    // Pack the plain LTVs to get the wire representation, then truncate by one byte.
+    // Passing an incomplete packed buffer to ParseThreadHeaderIe must return kErrorParse.
+    uint8_t packed[32];
+    uint8_t packedLen = PackedLtvStream::Encode(buf, static_cast<uint8_t>(fb.GetLength()), packed, sizeof(packed));
+    VerifyOrQuit(ParseThreadHeaderIe(packed, static_cast<uint8_t>(packedLen - 1), nullptr, nullptr) == kErrorParse);
+
+    printf("PASSED\n");
+}
+
+// ---------------------------------------------------------------------------
+// TestParseUnknownType
+//
+// LTVs with unknown types must be silently skipped; the function must return
+// kErrorNone and leave the valid LTVs parseable.
+// ---------------------------------------------------------------------------
+void TestParseUnknownType(void)
+{
+    printf("TestParseUnknownType\n");
+
+    // Manually build: [unknown LTV][Challenge LTV]
+    // Unknown: [L=4][T=0xAA][four bytes]
+    const uint8_t kUnknownValue[]                   = {0x11, 0x22, 0x33, 0x44};
+    const uint8_t kChalBytes[ChallengeLtv::kLength] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                                                       0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10};
+
+    uint8_t      buf[64];
+    FrameBuilder fb;
+    fb.Init(buf, sizeof(buf));
+
+    VerifyOrQuit(Ltv::Append(fb, 0xAA, kUnknownValue, sizeof(kUnknownValue)) == kErrorNone);
+    ChallengeLtv chal;
+    memcpy(chal.mChallenge, kChalBytes, ChallengeLtv::kLength);
+    VerifyOrQuit(AppendChallengeLtv(fb, chal) == kErrorNone);
+
+    ChallengeLtv out;
+    memset(&out, 0, sizeof(out));
+    VerifyOrQuit(PackAndParse(buf, fb.GetLength(), nullptr, &out) == kErrorNone);
+    VerifyOrQuit(memcmp(out.mChallenge, kChalBytes, ChallengeLtv::kLength) == 0);
+
+    printf("PASSED\n");
+}
+
+// ---------------------------------------------------------------------------
+// TestMaxCoExRoundTrip
+//
+// Exercises Encode/Decode with a maximum-size SCA LTV (255-bit RAM bitmap,
+// SLW present) plus Challenge and TargetID LTVs.  The combined plain buffer
+// exceeds 64 bytes, which would have overflowed the previous scratch[64]
+// buffer in PackedLtvStream::Encode.
+// ---------------------------------------------------------------------------
+void TestMaxCoExRoundTrip(void)
+{
+    printf("TestMaxCoExRoundTrip\n");
+
+    ScaParams scaIn;
+    memset(&scaIn, 0, sizeof(scaIn));
+    scaIn.mRamAvailable   = true;
+    scaIn.mRamDuration    = 255;
+    scaIn.mRamOffsetUs    = -100;
+    scaIn.mHasSlw         = true;
+    scaIn.mSlwPeriodSlots = 500;
+    scaIn.mSlwPhaseSlots  = 100;
+
+    for (uint8_t i = 0; i < ScaParams::kRamBitsMaxBytes; i++)
+    {
+        scaIn.mRamBits[i] = static_cast<uint8_t>(i + 1);
+    }
+
+    const uint8_t kChalBytes[ChallengeLtv::kLength] = {0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80,
+                                                       0x90, 0xA0, 0xB0, 0xC0, 0xD0, 0xE0, 0xF0, 0x01};
+    ChallengeLtv chalIn;
+    memcpy(chalIn.mChallenge, kChalBytes, sizeof(kChalBytes));
+
+    const uint8_t kTargetId[] = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE};
+
+    uint8_t      buf[128];
+    FrameBuilder fb;
+    fb.Init(buf, sizeof(buf));
+
+    VerifyOrQuit(AppendScaLtv(fb, scaIn) == kErrorNone);
+    VerifyOrQuit(AppendChallengeLtv(fb, chalIn) == kErrorNone);
+    VerifyOrQuit(AppendTargetIdLtv(fb, kTargetId, sizeof(kTargetId)) == kErrorNone);
+
+    // Plain must exceed 64 to confirm the scratch buffer fix is exercised.
+    VerifyOrQuit(fb.GetLength() > 64);
+
+    ScaParams    scaOut;
+    ChallengeLtv chalOut;
+    memset(&scaOut, 0, sizeof(scaOut));
+    memset(&chalOut, 0, sizeof(chalOut));
+
+    VerifyOrQuit(PackAndParse(buf, static_cast<uint8_t>(fb.GetLength()), &scaOut, &chalOut) == kErrorNone);
+
+    VerifyOrQuit(scaOut.mRamAvailable);
+    VerifyOrQuit(scaOut.mRamDuration == 255);
+    VerifyOrQuit(scaOut.mRamOffsetUs == -100);
+    VerifyOrQuit(scaOut.mHasSlw);
+    VerifyOrQuit(scaOut.mSlwPeriodSlots == 500);
+    VerifyOrQuit(scaOut.mSlwPhaseSlots == 100);
+
+    for (uint8_t i = 0; i < ScaParams::kRamBitsMaxBytes; i++)
+    {
+        VerifyOrQuit(scaOut.mRamBits[i] == static_cast<uint8_t>(i + 1));
+    }
+
+    VerifyOrQuit(memcmp(chalOut.mChallenge, kChalBytes, ChallengeLtv::kLength) == 0);
+
+    printf("PASSED\n");
+}
+
+} // namespace Mac
+} // namespace ot
+
+int main(void)
+{
+    ot::Mac::TestScaLtvRoundTrip();
+    ot::Mac::TestChallengeLtvRoundTrip();
+    ot::Mac::TestTargetIdLtv();
+    ot::Mac::TestThreadHeaderIeWrap();
+    ot::Mac::TestMultiLtvParse();
+    ot::Mac::TestParseTruncated();
+    ot::Mac::TestParseUnknownType();
+    ot::Mac::TestMaxCoExRoundTrip();
+
+    printf("All tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
Thread Direct frames carry typed fields (SCA schedule, challenge nonce, target ID) inside a Thread Header IE. Standard TLV encoding places Type first, then Length, with 2 bytes of fixed overhead per entry. For the small payloads in Thread Direct, that cost is disproportionate. Instead, Thread Direct uses LTV (Length-Type-Value): length information leads each entry, and the two header fields share a single byte by splitting it adaptively.

This split is determined by the remaining byte count at that position (L). As L shrinks, fewer bits are needed to represent it, freeing more bits for the type field. A decoder reading a stream position knows L and can recover both length and type from one byte. The all-ones pattern in the lower bits serves as an escape; a second header byte follows when needed.

This commit introduces two layers:

`ltvs.hpp/cpp` — generic LTV framework

- `Ltv`: in-memory accessor and FrameBuilder append helpers.
- `SimpleLtvInfo<kType, T>`: compile-time type-code/struct pairing so call sites write Ltv::Append<ChallengeLtvInfo>(builder, val) without repeating the type constant.
- `PackedLtvStream`: Encode, Decode, and a forward Iterator with GetValueOffset() for ISR-safe in-place field updates (eg. stamping the current SLW phase into a pre-built frame without repacking).

`mac_header_ltv.hpp/cpp` — Thread Header IE LTV layer

- `ThreadHeaderIe` (new in `mac_header_ie.hpp`): Element ID 0x2d and the three LTV type codes (`TargetId`, `SCA`, `Challenge`).
- `ScaParams`: in-memory representation of the Scheduled Channel Access LTV (SLW period/phase, RAM offset/duration/bitmap, slot duration code).
- `ChallengeLtv`/`ChallengeLtvInfo`: 16-byte HMAC-SHA256 challenge nonce.
- FrameBuilder-based encoders and single-pass decoder over a packed stream.