### PR TITLE
[sub-mac] secure retransmissions having header IEs with new frame counters

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1238,7 +1238,7 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT && OPENTHREAD_CONFIG_MAC_SOFTWARE_RETX_SECURITY_ENABLE
-void TxFrame::DecryptTransmitAesCcm(const ExtAddress &aExtAddress)
+void TxFrame::RestoreTransmitSecurity(const ExtAddress &aExtAddress)
 {
     uint32_t              frameCounter = 0;
     uint8_t               securityLevel;
@@ -1262,10 +1262,9 @@ void TxFrame::DecryptTransmitAesCcm(const ExtAddress &aExtAddress)
     IgnoreError(aesCcm.Process(Crypto::AesCcm::kDecrypt, GetPayload(), GetPayloadLength()));
 
     SetIsSecurityProcessed(false);
-    SetIsHeaderUpdated(false);
 
 exit:
-    return;
+    SetIsHeaderUpdated(false);
 }
 #endif // OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT && OPENTHREAD_CONFIG_MAC_SOFTWARE_RETX_SECURITY_ENABLE
 

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -1082,12 +1082,12 @@ public:
     void ProcessTransmitAesCcm(const ExtAddress &aExtAddress);
 
     /**
-     * Decrypts the frame which was previously encrypted.
+     * Restore the frame for transmit processing.
      *
      * @param[in]  aExtAddress  A reference to the extended address, which will be used to generate nonce
      *                          for AES CCM computation.
      */
-    void DecryptTransmitAesCcm(const ExtAddress &aExtAddress);
+    void RestoreTransmitSecurity(const ExtAddress &aExtAddress);
 
     /**
      * Indicates whether or not the frame has security processed.

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -603,9 +603,9 @@ void SubMac::HandleTransmitDone(TxFrame &aFrame, RxFrame *aAckFrame, Error aErro
         aFrame.SetIsARetransmission(true);
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT && OPENTHREAD_CONFIG_MAC_SOFTWARE_RETX_SECURITY_ENABLE
-        if (aFrame.GetSecurityEnabled() && aFrame.IsSecurityProcessed() && aFrame.HasAnyHeaderIe())
+        if (aFrame.GetSecurityEnabled() && aFrame.HasAnyHeaderIe())
         {
-            aFrame.DecryptTransmitAesCcm(GetExtAddress());
+            aFrame.RestoreTransmitSecurity(GetExtAddress());
         }
 
         ProcessTransmitSecurity();


### PR DESCRIPTION
Since the core is not sure whether the frame counter is used by the platform or not, this commit modifies the sub-mac to always use a new frame counter to secure retransmissions having header IEs.