### PR TITLE
[script] simplify check-posix-pty using socat link= and exec:

### DIFF
--- a/script/check-posix-pty
+++ b/script/check-posix-pty
@@ -50,18 +50,6 @@ at_exit()
     exit $EXIT_CODE
 }
 
-wait_for_socat()
-{
-    if [[ "$(head -n2 "$SOCAT_OUTPUT" | wc -l | tr -d ' ')" == 2 ]]; then
-        RADIO_PTY=$(head -n1 "$SOCAT_OUTPUT" | grep -o '/dev/.\+')
-        CORE_PTY=$(head -n2 "$SOCAT_OUTPUT" | tail -n1 | grep -o '/dev/.\+')
-        return 0
-    else
-        echo 'Still waiting for socat'
-    fi
-    return 1
-}
-
 wait_for_leader()
 {
     if grep -q leader "$OT_OUTPUT"; then
@@ -98,24 +86,21 @@ do_check()
     trap at_exit INT TERM EXIT
 
     sudo rm -rf tmp
+    mkdir tmp
 
-    SOCAT_OUTPUT=/tmp/ot-socat
-    OT_OUTPUT=/tmp/ot-output
-    socat -d -d pty,raw,echo=0 pty,raw,echo=0 >/dev/null 2>$SOCAT_OUTPUT &
-    timeout_run 10 wait_for_socat
-    echo 'RADIO_PTY' "$RADIO_PTY"
-    echo 'CORE_PTY' "$CORE_PTY"
-
+    SOCAT_PTY="$PWD/tmp/ot-rcp-pty"
+    OT_OUTPUT="$PWD/tmp/ot-output"
     RADIO_NCP_PATH="$PWD/build/simulation/examples/apps/ncp/ot-rcp"
 
-    # shellcheck disable=SC2094
-    $RADIO_NCP_PATH 1 >"$RADIO_PTY" <"$RADIO_PTY" &
+    socat pty,raw,echo=0,link="${SOCAT_PTY}" exec:"${RADIO_NCP_PATH} 1" &
+    timeout_run 10 test -c "${SOCAT_PTY}"
+    echo 'SOCAT_PTY' "${SOCAT_PTY}"
 
     # Cover setting a valid network interface name.
     VALID_NETIF_NAME="wan$(date +%H%M%S)"
     readonly VALID_NETIF_NAME
 
-    RADIO_URL="spinel+hdlc+uart://${CORE_PTY}?region=US&max-power-table=11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26"
+    RADIO_URL="spinel+hdlc+uart://${SOCAT_PTY}?region=US&max-power-table=11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26"
 
     if [[ ${OT_DAEMON} == 'on' ]]; then
         sudo -E "$PWD/build/posix/src/posix/ot-daemon" -d7 -v -I "${VALID_NETIF_NAME}" "${RADIO_URL}" 2>&1 | tee "${OT_OUTPUT}" &
@@ -217,12 +202,12 @@ EOF
     # wait coap service start
     sleep 5
 
-    netstat -an | grep -q 5683 || die 'Application CoAP port is not available!'
+    sudo lsof -iUDP:5683 -nP || die 'Application CoAP port is not available!'
 
-    extaddr=$(grep -ao -A +1 'extaddr' $OT_OUTPUT | tail -n1 | tr -d '\r\n\0')
+    extaddr=$(grep -ao -A +1 'extaddr' "$OT_OUTPUT" | tail -n1 | tr -d '\r\n\0')
     echo "Extended address is: ${extaddr}"
 
-    prefix=$(grep -ao 'Mesh Local Prefix: [0-9a-f:]\+' $OT_OUTPUT | cut -d: -f2- | tr -d ' \r\n')
+    prefix=$(grep -ao 'Mesh Local Prefix: [0-9a-f:]\+' "$OT_OUTPUT" | cut -d: -f2- | tr -d ' \r\n')
     LEADER_ALOC="${prefix}ff:fe00:fc00"
 
     # skip testing CoAP for https://github.com/openthread/openthread/issues/6363


### PR DESCRIPTION
- Remove wait_for_socat() log polling function
- Use a single deterministic PTY endpoint linked to `tmp/ot-rcp-pty`
- Use socat exec: process management to spawn ot-rcp directly without two-PTY bridging or shell input/output redirections
- Use lsof to check ports