### PR TITLE
[ip6] adhere to style guide for var declarations in `HandleDatagram()`

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1267,14 +1267,14 @@ exit:
 
 Error Ip6::HandleDatagram(OwnedPtr<Message> aMessagePtr, bool aIsReassembled, uint8_t aRecursionDepth)
 {
-    Error  error;
-    Header header;
-
-    VerifyOrExit(aRecursionDepth <= kMaxRecursionDepth, error = kErrorDrop);
+    Error   error;
+    Header  header;
     bool    receive;
     bool    forwardThread;
     bool    forwardHost;
     uint8_t nextHeader;
+
+    VerifyOrExit(aRecursionDepth <= kMaxRecursionDepth, error = kErrorDrop);
 
     SuccessOrExit(error = header.ParseFrom(*aMessagePtr));
 


### PR DESCRIPTION
This is a small style guide fix in `Ip6::HandleDatagram()`, ensuring all scoped stack variable declarations are placed together at the top of the enclosing scope in which they are used.