### PR TITLE
[mac-frame] remove empty `RxFrame::ProcessReceiveAesCcm()` under RCP

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1404,9 +1404,10 @@ exit:
     return isSecure;
 }
 
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
+
 Error RxFrame::ProcessReceiveAesCcm(const ExtAddress &aExtAddress, const KeyMaterial &aMacKey)
 {
-#if OPENTHREAD_FTD || OPENTHREAD_MTD
     Error                 error        = kErrorSecurity;
     uint32_t              frameCounter = 0;
     uint8_t               securityLevel;
@@ -1434,13 +1435,9 @@ Error RxFrame::ProcessReceiveAesCcm(const ExtAddress &aExtAddress, const KeyMate
 
 exit:
     return error;
-#else
-    OT_UNUSED_VARIABLE(aExtAddress);
-    OT_UNUSED_VARIABLE(aMacKey);
-
-    return kErrorNone;
-#endif // OPENTHREAD_FTD || OPENTHREAD_MTD
 }
+
+#endif // OPENTHREAD_FTD || OPENTHREAD_MTD
 
 // LCOV_EXCL_START
 

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -870,6 +870,7 @@ public:
      */
     const RadioTime64 &GetTimestamp(void) const { return mInfo.mRxInfo.mTimestamp; }
 
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
     /**
      * Performs AES CCM on the frame which is received.
      *
@@ -881,6 +882,7 @@ public:
      * @retval kErrorSecurity  Received frame MIC check failed.
      */
     Error ProcessReceiveAesCcm(const ExtAddress &aExtAddress, const KeyMaterial &aMacKey);
+#endif
 };
 
 /**


### PR DESCRIPTION
`RxFrame::ProcessReceiveAesCcm()` is only called from `Mac` methods in `mac.cpp` (`ProcessReceiveSecurity()` and `ProcessAckSecurity()`), which are compiled exclusively for `OPENTHREAD_FTD` or `OPENTHREAD_MTD` configurations.

This commit guards the `RxFrame::ProcessReceiveAesCcm()` declaration and definition under `#if OPENTHREAD_FTD || OPENTHREAD_MTD`, removing unused dummy code from `OPENTHREAD_RADIO` (RCP) builds.