### PR TITLE
[mac-frame] unconditionally include crypto/aes_ccm.hpp

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -40,11 +40,8 @@
 #include "common/frame_builder.hpp"
 #include "common/log.hpp"
 #include "common/num_utils.hpp"
-#include "radio/trel_link.hpp"
-#if OPENTHREAD_FTD || OPENTHREAD_MTD || OPENTHREAD_CONFIG_MAC_SOFTWARE_TX_SECURITY_ENABLE || \
-    (OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT && OPENTHREAD_CONFIG_MAC_SOFTWARE_RETX_SECURITY_ENABLE)
 #include "crypto/aes_ccm.hpp"
-#endif
+#include "radio/trel_link.hpp"
 
 namespace ot {
 namespace Mac {


### PR DESCRIPTION
Previously, `#include "crypto/aes_ccm.hpp"` in `mac_frame.cpp` was guarded under preprocessor conditionals (`OPENTHREAD_FTD || OPENTHREAD_MTD || ...`) because the crypto headers directly pulled in third-party crypto library headers (such as `mbedtls`), which caused build issues on RCP targets.

Now that `aes_ccm.hpp` only includes platform crypto definitions and OpenThread internal headers, it is safe to include across all build configurations. This commit removes the preprocessor guard to simplify the include list in `mac_frame.cpp`.