### PR TITLE
[radio][ncp] Fix aStart treated as relative offset instead of absolute time (#13269)

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1710,12 +1710,12 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_MAC_RX_AT>(void)
 
     {
         otRadioTime64 now = otPlatRadioGetNow(mInstance);
-        uint32_t      start;
 
-        VerifyOrExit(when > now && (when - now) < UINT32_MAX, error = OT_ERROR_INVALID_ARGS);
+        VerifyOrExit(when > now && (when - now) <= INT32_MAX, error = OT_ERROR_INVALID_ARGS);
 
-        start = when - now;
-        error = otPlatRadioReceiveAt(mInstance, channel, start, duration);
+        // `otPlatRadioReceiveAt()`'s `aStart` is an absolute radio time (truncated to 32 bits), not a duration
+        // relative to `now` - see its documentation in `openthread/platform/radio.h`.
+        error = otPlatRadioReceiveAt(mInstance, channel, ConvertRadioTime64To32(when), duration);
     }
 
 exit:

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1715,7 +1715,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_MAC_RX_AT>(void)
 
         // `otPlatRadioReceiveAt()`'s `aStart` is an absolute radio time (truncated to 32 bits), not a duration
         // relative to `now` - see its documentation in `openthread/platform/radio.h`.
-        error = otPlatRadioReceiveAt(mInstance, channel, Radio::ConvertTime64To32(when), duration);
+        error = otPlatRadioReceiveAt(mInstance, channel, static_cast<otRadioTime32>(when), duration);
     }
 
 exit:

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1715,7 +1715,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_MAC_RX_AT>(void)
 
         // `otPlatRadioReceiveAt()`'s `aStart` is an absolute radio time (truncated to 32 bits), not a duration
         // relative to `now` - see its documentation in `openthread/platform/radio.h`.
-        error = otPlatRadioReceiveAt(mInstance, channel, ConvertRadioTime64To32(when), duration);
+        error = otPlatRadioReceiveAt(mInstance, channel, Radio::ConvertTime64To32(when), duration);
     }
 
 exit:

--- a/tests/gtest/fake_platform.hpp
+++ b/tests/gtest/fake_platform.hpp
@@ -84,8 +84,14 @@ public:
     virtual otError       Transmit(otRadioFrame *aFrame);
     virtual otError       ReceiveAt(uint8_t aChannel, uint32_t aStart, uint32_t aDuration)
     {
+        // `aStart` is an absolute radio time truncated to 32 bits (see `otPlatRadioReceiveAt()`'s
+        // documentation), not a duration relative to `mNow`. Reconstruct the intended 64-bit time by
+        // taking the signed difference between `aStart` and the low 32 bits of `mNow`, which correctly
+        // handles 32-bit rollover as long as the intended time is within `INT32_MAX` us of `mNow`.
+        int32_t diff = static_cast<int32_t>(aStart - static_cast<uint32_t>(mNow));
+
         mReceiveAtChannel = aChannel;
-        mReceiveAtStart   = mNow + aStart;
+        mReceiveAtStart   = static_cast<uint64_t>(static_cast<int64_t>(mNow) + diff);
         mReceiveAtEnd     = mReceiveAtStart + aDuration;
 
         return OT_ERROR_NONE;

--- a/tests/gtest/fake_platform.hpp
+++ b/tests/gtest/fake_platform.hpp
@@ -84,14 +84,16 @@ public:
     virtual otError       Transmit(otRadioFrame *aFrame);
     virtual otError       ReceiveAt(uint8_t aChannel, uint32_t aStart, uint32_t aDuration)
     {
+        static constexpr uint32_t kMaxForwardDelta = (1U << 31) - 1;
+
         // `aStart` is an absolute radio time truncated to 32 bits (see `otPlatRadioReceiveAt()`'s
-        // documentation), not a duration relative to `mNow`. Reconstruct the intended 64-bit time by
-        // taking the signed difference between `aStart` and the low 32 bits of `mNow`, which correctly
-        // handles 32-bit rollover as long as the intended time is within `INT32_MAX` us of `mNow`.
-        int32_t diff = static_cast<int32_t>(aStart - static_cast<uint32_t>(mNow));
+        // documentation), not a duration relative to `mNow`. Reconstruct the intended 64-bit time from
+        // the low 32 bits of `mNow` using pure unsigned arithmetic so rollover handling does not depend
+        // on casting an out-of-range unsigned value to a signed type.
+        uint32_t delta = aStart - static_cast<uint32_t>(mNow);
 
         mReceiveAtChannel = aChannel;
-        mReceiveAtStart   = static_cast<uint64_t>(static_cast<int64_t>(mNow) + diff);
+        mReceiveAtStart   = (delta <= kMaxForwardDelta) ? (mNow + delta) : (mNow - (0U - delta));
         mReceiveAtEnd     = mReceiveAtStart + aDuration;
 
         return OT_ERROR_NONE;

--- a/tests/gtest/radio_spinel_rcp_test.cpp
+++ b/tests/gtest/radio_spinel_rcp_test.cpp
@@ -315,6 +315,45 @@ TEST(RadioSpinelReceiveAt, shouldReceiveAtGiveRadioTime)
     EXPECT_EQ(platform.GetReceiveChannel(), 0);
 }
 
+TEST(RadioSpinelReceiveAt, shouldAcceptMaximumFutureRadioTime)
+{
+    FakeCoprocessorPlatform platform;
+
+    ASSERT_EQ(platform.mRadioSpinel.Enable(FakePlatform::CurrentInstance()), kErrorNone);
+    ASSERT_EQ(platform.mRadioSpinel.SetRxOnWhenIdle(false), kErrorNone);
+    ASSERT_EQ(platform.mRadioSpinel.ReceiveAt(INT32_MAX, 1, 11), kErrorNone);
+    platform.GoInUs(INT32_MAX);
+    EXPECT_EQ(platform.GetReceiveChannel(), 0);
+    platform.GoInUs(1);
+    EXPECT_EQ(platform.GetReceiveChannel(), 11);
+}
+
+TEST(RadioSpinelReceiveAt, shouldRejectRadioTimeBeyondSignedDifferenceRange)
+{
+    FakeCoprocessorPlatform platform;
+
+    ASSERT_EQ(platform.mRadioSpinel.Enable(FakePlatform::CurrentInstance()), kErrorNone);
+    ASSERT_EQ(platform.mRadioSpinel.SetRxOnWhenIdle(false), kErrorNone);
+    EXPECT_EQ(platform.mRadioSpinel.ReceiveAt(static_cast<uint64_t>(INT32_MAX) + 1, 1, 11), kErrorInvalidArgs);
+}
+
+TEST(RadioSpinelReceiveAt, shouldReconstructRadioTimeAcross32BitRollover)
+{
+    FakeCoprocessorPlatform platform;
+
+    constexpr uint64_t kNow   = static_cast<uint64_t>(UINT32_MAX) - 5;
+    constexpr uint64_t kStart = static_cast<uint64_t>(UINT32_MAX) + 5;
+
+    platform.GoInUs(kNow);
+    ASSERT_EQ(platform.mRadioSpinel.Enable(FakePlatform::CurrentInstance()), kErrorNone);
+    ASSERT_EQ(platform.mRadioSpinel.SetRxOnWhenIdle(false), kErrorNone);
+    ASSERT_EQ(platform.mRadioSpinel.ReceiveAt(kStart, 1, 11), kErrorNone);
+    platform.GoInUs(kStart - kNow);
+    EXPECT_EQ(platform.GetReceiveChannel(), 0);
+    platform.GoInUs(1);
+    EXPECT_EQ(platform.GetReceiveChannel(), 11);
+}
+
 TEST(RadioSpinelTransmit, shouldSkipCsmaBackoffWhenCsmaCaIsEnabledAndMaxBackoffsIsZero)
 {
     class MockPlatform : public FakeCoprocessorPlatform


### PR DESCRIPTION
Fixes #13269.

## Problem

As diagnosed by @abtink in the issue discussion (originally surfaced during review of #13268), there's an inconsistency in how `otPlatRadioReceiveAt()`'s `aStart` parameter is interpreted:

- Its documentation (`include/openthread/platform/radio.h`) and the core `SubMac` caller (`SubMac::HandleCslReceiveAt`, which computes `winStart = mCslSampleTime.GetAsRadio32() - aTimeAhead`) both treat `aStart` as an **absolute** radio time (truncated to 32 bits, same clock domain as `otPlatRadioGetNow()`).
- `NcpBase::HandlePropertySet<SPINEL_PROP_MAC_RX_AT>` (`src/ncp/ncp_base.cpp`) incorrectly computed `start = when - now`, i.e. a duration **relative** to `now`, before passing it to `otPlatRadioReceiveAt()`.
- The gtest `FakePlatform::ReceiveAt()` (`tests/gtest/fake_platform.hpp`) likewise treated its `aStart` argument as relative, computing `mReceiveAtStart = mNow + aStart`. Since the real `SubMac`/CSL code path passes an absolute value into this same mock, the reconstructed `mReceiveAtStart` used by the fake platform's internal scheduler is wrong today - this is latent because no existing test happens to assert its exact value.

## Fix

- `ncp_base.cpp`: pass the low 32 bits of the already-decoded absolute `when` (via `ConvertRadioTime64To32()`, matching the style introduced in #13268) instead of the relative `when - now`.
- `fake_platform.hpp`: reconstruct the intended 64-bit absolute time from the 32-bit truncated absolute `aStart` by taking the signed difference against the low 32 bits of `mNow`, correctly accounting for 32-bit radio-time rollover (same modulo-serial-arithmetic idea as `IsRadioTimeStrictlyBefore()`), instead of adding `aStart` as if it were a relative duration.

## Verification

I don't have the GTest/mbedTLS submodules or a local GTest install set up in this environment to run the full test suite (I attempted `cmake -DOT_BUILD_GTEST=ON` on `tests/gtest`, but it requires initializing several additional submodules first). Instead I verified the arithmetic with two standalone host-side C++ reproductions mirroring the exact logic:

**`ncp_base.cpp` fix** - with `now = 1,000,000us` and an intended absolute receive time `when = 1,050,000us`:
- Before: passes `aStart = 50,000` (`when - now`, a relative offset) to `otPlatRadioReceiveAt`.
- After: correctly passes `aStart = 1,050,000` (`when` truncated to 32 bits, absolute).

**`fake_platform.hpp` fix** - feeding an absolute 32-bit `aStart` into the mock `ReceiveAt()`:
- No rollover: `mNow = 1,000,000`, intended absolute start `1,050,000`. Before: reconstructed as `2,050,000` (off by `mNow`). After: correctly `1,050,000`.
- Crossing a 32-bit rollover boundary: `mNow`'s low 32 bits near `0xFFFFFFFF`, intended absolute start 100us later (wraps to a small 32-bit value). Before: reconstructed incorrectly. After: exactly matches the intended 64-bit absolute time.
