### PR TITLE
[mac] fix missing beacon header in transmitted beacon frames

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -727,9 +727,9 @@ TxFrame *Mac::PrepareBeacon(TxFrames &aTxFrames)
 {
     TxFrame           *frame;
     TxFrame::BuildInfo buildInfo;
-    Beacon            *beacon = nullptr;
+    Beacon            *beacon;
+    uint8_t            beaconLength;
 #if OPENTHREAD_CONFIG_MAC_OUTGOING_BEACON_PAYLOAD_ENABLE
-    uint8_t        beaconLength;
     BeaconPayload *beaconPayload = nullptr;
 #endif
 
@@ -752,10 +752,9 @@ TxFrame *Mac::PrepareBeacon(TxFrames &aTxFrames)
 
     beacon = reinterpret_cast<Beacon *>(frame->GetPayload());
     beacon->Init();
-
-#if OPENTHREAD_CONFIG_MAC_OUTGOING_BEACON_PAYLOAD_ENABLE
     beaconLength = sizeof(*beacon);
 
+#if OPENTHREAD_CONFIG_MAC_OUTGOING_BEACON_PAYLOAD_ENABLE
     beaconPayload = reinterpret_cast<BeaconPayload *>(beacon->GetPayload());
 
     beaconPayload->Init();
@@ -773,9 +772,9 @@ TxFrame *Mac::PrepareBeacon(TxFrames &aTxFrames)
     beaconPayload->SetExtendedPanId(Get<MeshCoP::NetworkIdentity>().GetExtPanId());
 
     beaconLength += sizeof(*beaconPayload);
+#endif
 
     frame->SetPayloadLength(beaconLength);
-#endif
 
     LogBeacon("Sending");
 


### PR DESCRIPTION
This commit fixes an issue introduced in PR #7472, which deprecated outgoing Thread beacon payloads but unintentionally omitted setting the MAC frame payload length for the base IEEE 802.15.4 beacon header.

While `PrepareBeacon()` initialized the beacon header fields (Superframe Spec, GTS Spec, Pending Address Spec), it did not update the MAC frame payload length when outgoing beacon payloads were disabled. As a result, the beacon header bytes were effectively not included in transmitted beacon frames.

On the receiver side, OpenThread does not check or enforce the presence of the beacon header bytes, which allowed active scan behavior to continue functioning normally. This receiver behavior is kept as-is to ensure compatibility.

This commit resolves the issue by ensuring the MAC frame payload length is always set properly to include the beacon header.