### PR TITLE
[radio] introduce `namespace Radio` for radio types and constants

### DIFF
--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -198,5 +198,5 @@ const char *otGetVersionString(void)
 
 const char *otGetRadioVersionString(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<Radio>().GetVersionString();
+    return AsCoreType(aInstance).Get<Radio::Radio>().GetVersionString();
 }

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -142,7 +142,7 @@ exit:
 
 void otLinkGetFactoryAssignedIeeeEui64(otInstance *aInstance, otExtAddress *aEui64)
 {
-    AsCoreType(aInstance).Get<Radio>().GetIeeeEui64(AsCoreType(aEui64));
+    AsCoreType(aInstance).Get<Radio::Radio>().GetIeeeEui64(AsCoreType(aEui64));
 }
 
 otPanId otLinkGetPanId(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mac::Mac>().GetPanId(); }
@@ -453,9 +453,9 @@ otError otLinkSetCslPeriod(otInstance *aInstance, uint32_t aPeriod)
     }
     else
     {
-        VerifyOrExit((aPeriod % kUsPerTenSymbols) == 0, error = kErrorInvalidArgs);
-        periodInTenSymbolsUnit = ClampToUint16(aPeriod / kUsPerTenSymbols);
-        VerifyOrExit(periodInTenSymbolsUnit >= kMinCslPeriod, error = kErrorInvalidArgs);
+        VerifyOrExit((aPeriod % Radio::kUsPerTenSymbols) == 0, error = kErrorInvalidArgs);
+        periodInTenSymbolsUnit = ClampToUint16(aPeriod / Radio::kUsPerTenSymbols);
+        VerifyOrExit(periodInTenSymbolsUnit >= Radio::kMinCslPeriod, error = kErrorInvalidArgs);
     }
 
     AsCoreType(aInstance).Get<Mac::Mac>().SetCslPeriod(periodInTenSymbolsUnit);
@@ -470,7 +470,7 @@ otError otLinkSetCslTimeout(otInstance *aInstance, uint32_t aTimeout)
 {
     Error error = kErrorNone;
 
-    VerifyOrExit(kMaxCslTimeout >= aTimeout, error = kErrorInvalidArgs);
+    VerifyOrExit(Radio::kMaxCslTimeout >= aTimeout, error = kErrorInvalidArgs);
     AsCoreType(aInstance).Get<Mle::Mle>().SetCslTimeout(aTimeout);
 
 exit:

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -58,7 +58,10 @@ otError otLinkRawSetAlternateShortAddress(otInstance *aInstance, otShortAddress 
     return AsCoreType(aInstance).Get<Mac::LinkRaw>().SetAlternateShortAddress(aShortAddress);
 }
 
-bool otLinkRawGetPromiscuous(otInstance *aInstance) { return AsCoreType(aInstance).Get<Radio>().GetPromiscuous(); }
+bool otLinkRawGetPromiscuous(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).Get<Radio::Radio>().GetPromiscuous();
+}
 
 otError otLinkRawSetPromiscuous(otInstance *aInstance, bool aEnable)
 {
@@ -66,7 +69,7 @@ otError otLinkRawSetPromiscuous(otInstance *aInstance, bool aEnable)
     Instance &instance = AsCoreType(aInstance);
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
-    instance.Get<Radio>().SetPromiscuous(aEnable);
+    instance.Get<Radio::Radio>().SetPromiscuous(aEnable);
 
 exit:
     return error;
@@ -79,7 +82,7 @@ otError otLinkRawSleep(otInstance *aInstance)
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
 
-    error = instance.Get<Radio>().Sleep();
+    error = instance.Get<Radio::Radio>().Sleep();
 
 exit:
     return error;
@@ -97,7 +100,7 @@ otError otLinkRawTransmit(otInstance *aInstance, otLinkRawTransmitDone aCallback
     return AsCoreType(aInstance).Get<Mac::LinkRaw>().Transmit(aCallback);
 }
 
-int8_t otLinkRawGetRssi(otInstance *aInstance) { return AsCoreType(aInstance).Get<Radio>().GetRssi(); }
+int8_t otLinkRawGetRssi(otInstance *aInstance) { return AsCoreType(aInstance).Get<Radio::Radio>().GetRssi(); }
 
 otRadioCaps otLinkRawGetCaps(otInstance *aInstance) { return AsCoreType(aInstance).Get<Mac::LinkRaw>().GetCaps(); }
 
@@ -116,7 +119,7 @@ otError otLinkRawSrcMatchEnable(otInstance *aInstance, bool aEnable)
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
 
-    instance.Get<Radio>().EnableSrcMatch(aEnable);
+    instance.Get<Radio::Radio>().EnableSrcMatch(aEnable);
 
 exit:
     return error;
@@ -129,7 +132,7 @@ otError otLinkRawSrcMatchAddShortEntry(otInstance *aInstance, uint16_t aShortAdd
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
 
-    error = instance.Get<Radio>().AddSrcMatchShortEntry(aShortAddress);
+    error = instance.Get<Radio::Radio>().AddSrcMatchShortEntry(aShortAddress);
 
 exit:
     return error;
@@ -142,7 +145,7 @@ otError otLinkRawSrcMatchAddExtEntry(otInstance *aInstance, const otExtAddress *
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
 
-    error = instance.Get<Radio>().AddSrcMatchExtEntry(AsCoreType(aExtAddress));
+    error = instance.Get<Radio::Radio>().AddSrcMatchExtEntry(AsCoreType(aExtAddress));
 
 exit:
     return error;
@@ -154,7 +157,7 @@ otError otLinkRawSrcMatchClearShortEntry(otInstance *aInstance, uint16_t aShortA
     Instance &instance = AsCoreType(aInstance);
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
-    error = instance.Get<Radio>().ClearSrcMatchShortEntry(aShortAddress);
+    error = instance.Get<Radio::Radio>().ClearSrcMatchShortEntry(aShortAddress);
 
 exit:
     return error;
@@ -167,7 +170,7 @@ otError otLinkRawSrcMatchClearExtEntry(otInstance *aInstance, const otExtAddress
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
 
-    error = instance.Get<Radio>().ClearSrcMatchExtEntry(AsCoreType(aExtAddress));
+    error = instance.Get<Radio::Radio>().ClearSrcMatchExtEntry(AsCoreType(aExtAddress));
 
 exit:
     return error;
@@ -180,7 +183,7 @@ otError otLinkRawSrcMatchClearShortEntries(otInstance *aInstance)
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
 
-    instance.Get<Radio>().ClearSrcMatchShortEntries();
+    instance.Get<Radio::Radio>().ClearSrcMatchShortEntries();
 
 exit:
     return error;
@@ -193,7 +196,7 @@ otError otLinkRawSrcMatchClearExtEntries(otInstance *aInstance)
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
 
-    instance.Get<Radio>().ClearSrcMatchExtEntries();
+    instance.Get<Radio::Radio>().ClearSrcMatchExtEntries();
 
 exit:
     return error;

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -154,7 +154,7 @@ Error Diags::ProcessStart(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
-    Get<Radio>().SetDiagMode(true);
+    Get<Radio::Radio>().SetDiagMode(true);
 
     return kErrorNone;
 }
@@ -164,7 +164,7 @@ Error Diags::ProcessStop(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
-    Get<Radio>().SetDiagMode(false);
+    Get<Radio::Radio>().SetDiagMode(false);
 
     return kErrorNone;
 }
@@ -193,7 +193,7 @@ const struct Diags::Command Diags::sCommands[] = {
 
 Diags::Diags(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mTxPacket(&Get<Radio>().GetTransmitBuffer())
+    , mTxPacket(&Get<Radio::Radio>().GetTransmitBuffer())
     , mTxPeriod(0)
     , mTxPackets(0)
     , mChannel(20)
@@ -349,7 +349,7 @@ Error Diags::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
 
         if (!mIsSleepOn)
         {
-            IgnoreError(Get<Radio>().Receive(mChannel));
+            IgnoreError(Get<Radio::Radio>().Receive(mChannel));
         }
     }
 
@@ -372,7 +372,7 @@ Error Diags::ProcessPower(uint8_t aArgsLength, char *aArgs[])
         SuccessOrExit(error = Utils::CmdLineParser::ParseAsInt8(aArgs[0], txPower));
 
         mTxPower = txPower;
-        SuccessOrExit(error = Get<Radio>().SetTransmitPower(mTxPower));
+        SuccessOrExit(error = Get<Radio::Radio>().SetTransmitPower(mTxPower));
         otPlatDiagTxPowerSet(mTxPower);
     }
 
@@ -492,21 +492,21 @@ Error Diags::ProcessStart(uint8_t aArgsLength, char *aArgs[])
 #endif
 
     mStats.Clear();
-    IgnoreError(Get<Radio>().Enable());
-    Get<Radio>().SetDiagMode(true);
+    IgnoreError(Get<Radio::Radio>().Enable());
+    Get<Radio::Radio>().SetDiagMode(true);
     otPlatDiagChannelSet(mChannel);
     otPlatDiagTxPowerSet(mTxPower);
 
-    Get<Radio>().SetPromiscuous(true);
+    Get<Radio::Radio>().SetPromiscuous(true);
     Get<Mac::SubMac>().SetRxOnWhenIdle(true);
     otPlatAlarmMilliStop(&GetInstance());
-    SuccessOrExit(error = Get<Radio>().Receive(mChannel));
-    SuccessOrExit(error = Get<Radio>().SetTransmitPower(mTxPower));
+    SuccessOrExit(error = Get<Radio::Radio>().Receive(mChannel));
+    SuccessOrExit(error = Get<Radio::Radio>().SetTransmitPower(mTxPower));
 
 exit:
     if (error != kErrorNone)
     {
-        Get<Radio>().SetDiagMode(false);
+        Get<Radio::Radio>().SetDiagMode(false);
     }
 
     return error;
@@ -552,8 +552,8 @@ Error Diags::ProcessStop(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgs);
 
     otPlatAlarmMilliStop(&GetInstance());
-    Get<Radio>().SetDiagMode(false);
-    Get<Radio>().SetPromiscuous(false);
+    Get<Radio::Radio>().SetDiagMode(false);
+    Get<Radio::Radio>().SetPromiscuous(false);
     Get<Mac::SubMac>().SetRxOnWhenIdle(false);
 
     return kErrorNone;
@@ -623,7 +623,7 @@ Error Diags::TransmitPacket(void)
         }
     }
 
-    error = Get<Radio>().Transmit(*static_cast<Mac::TxFrame *>(mTxPacket));
+    error = Get<Radio::Radio>().Transmit(*static_cast<Mac::TxFrame *>(mTxPacket));
     if (error == kErrorNone)
     {
         mDiagSendOn = true;
@@ -671,8 +671,8 @@ Error Diags::RadioReceive(void)
 {
     Error error;
 
-    SuccessOrExit(error = Get<Radio>().Receive(mChannel));
-    SuccessOrExit(error = Get<Radio>().SetTransmitPower(mTxPower));
+    SuccessOrExit(error = Get<Radio::Radio>().Receive(mChannel));
+    SuccessOrExit(error = Get<Radio::Radio>().SetTransmitPower(mTxPower));
     otPlatDiagChannelSet(mChannel);
     otPlatDiagTxPowerSet(mTxPower);
     mIsSleepOn = false;
@@ -689,7 +689,7 @@ Error Diags::ProcessRadio(uint8_t aArgsLength, char *aArgs[])
 
     if (StringMatch(aArgs[0], "sleep"))
     {
-        SuccessOrExit(error = Get<Radio>().Sleep());
+        SuccessOrExit(error = Get<Radio::Radio>().Sleep());
         mIsSleepOn = true;
     }
     else if (StringMatch(aArgs[0], "receive"))
@@ -784,7 +784,7 @@ Error Diags::ProcessRadio(uint8_t aArgsLength, char *aArgs[])
     }
     else if (StringMatch(aArgs[0], "state"))
     {
-        otRadioState state = Get<Radio>().GetState();
+        otRadioState state = Get<Radio::Radio>().GetState();
 
         error = kErrorNone;
 
@@ -813,11 +813,11 @@ Error Diags::ProcessRadio(uint8_t aArgsLength, char *aArgs[])
     }
     else if (StringMatch(aArgs[0], "enable"))
     {
-        SuccessOrExit(error = Get<Radio>().Enable());
+        SuccessOrExit(error = Get<Radio::Radio>().Enable());
     }
     else if (StringMatch(aArgs[0], "disable"))
     {
-        SuccessOrExit(error = Get<Radio>().Disable());
+        SuccessOrExit(error = Get<Radio::Radio>().Disable());
     }
 
 exit:
@@ -920,7 +920,7 @@ void Diags::TransmitDone(Error aError)
 
     if (mIsSleepOn)
     {
-        IgnoreError(Get<Radio>().Sleep());
+        IgnoreError(Get<Radio::Radio>().Sleep());
     }
 
     UpdateTxStats(aError);
@@ -1319,7 +1319,7 @@ void Diags::Output(const char *aFormat, ...)
     va_end(args);
 }
 
-bool Diags::IsEnabled(void) { return Get<Radio>().GetDiagMode(); }
+bool Diags::IsEnabled(void) { return Get<Radio::Radio>().GetDiagMode(); }
 
 } // namespace FactoryDiags
 } // namespace ot

--- a/src/core/instance/instance.hpp
+++ b/src/core/instance/instance.hpp
@@ -595,7 +595,7 @@ private:
     // Radio is initialized before other member variables
     // (particularly, SubMac and Mac) to allow them to use its methods
     // from their constructor.
-    Radio mRadio;
+    Radio::Radio mRadio;
 
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
     UptimeTracker mUptimeTracker;
@@ -921,7 +921,7 @@ DefineCoreType(otBufferInfo, Instance::BufferInfo);
 
 template <> inline Instance &Instance::Get(void) { return *this; }
 
-template <> inline Radio &Instance::Get(void) { return mRadio; }
+template <> inline Radio::Radio &Instance::Get(void) { return mRadio; }
 
 template <> inline Radio::Callbacks &Instance::Get(void) { return mRadio.mCallbacks; }
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -73,7 +73,7 @@ Mac::Mac(Instance &aInstance)
     , mPanId(kPanIdBroadcast)
     , mPanChannel(OPENTHREAD_CONFIG_DEFAULT_CHANNEL)
     , mRadioChannel(OPENTHREAD_CONFIG_DEFAULT_CHANNEL)
-    , mSupportedChannelMask(Get<Radio>().GetSupportedChannelMask())
+    , mSupportedChannelMask(Get<Radio::Radio>().GetSupportedChannelMask())
     , mScanChannel(Radio::kChannelMin)
     , mScanDuration(0)
     , mMaxFrameRetriesDirect(kDefaultMaxFrameRetriesDirect)
@@ -2214,7 +2214,7 @@ bool Mac::HandleMacCommand(RxFrame &aFrame)
 void Mac::SetPromiscuous(bool aPromiscuous)
 {
     mPromiscuous = aPromiscuous;
-    Get<Radio>().SetPromiscuous(aPromiscuous);
+    Get<Radio::Radio>().SetPromiscuous(aPromiscuous);
 
 #if OPENTHREAD_CONFIG_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS
     mDelayingSleep    = false;
@@ -2230,15 +2230,15 @@ Error Mac::SetRegion(uint16_t aRegionCode)
     Error       error;
     ChannelMask oldMask = mSupportedChannelMask;
 
-    SuccessOrExit(error = Get<Radio>().SetRegion(aRegionCode));
-    mSupportedChannelMask.SetMask(Get<Radio>().GetSupportedChannelMask());
+    SuccessOrExit(error = Get<Radio::Radio>().SetRegion(aRegionCode));
+    mSupportedChannelMask.SetMask(Get<Radio::Radio>().GetSupportedChannelMask());
     IgnoreError(Get<Notifier>().Update(oldMask, mSupportedChannelMask, kEventSupportedChannelMaskChanged));
 
 exit:
     return error;
 }
 
-Error Mac::GetRegion(uint16_t &aRegionCode) const { return Get<Radio>().GetRegion(aRegionCode); }
+Error Mac::GetRegion(uint16_t &aRegionCode) const { return Get<Radio::Radio>().GetRegion(aRegionCode); }
 
 #if OPENTHREAD_CONFIG_MAC_RETRY_SUCCESS_HISTOGRAM_ENABLE
 const uint32_t *Mac::GetDirectRetrySuccessHistogram(uint16_t &aSize) const
@@ -2478,7 +2478,7 @@ uint32_t Mac::GetCslPeriodInMsec(void) const
 
 uint32_t Mac::CslPeriodToUsec(uint16_t aPeriodInTenSymbols)
 {
-    return static_cast<uint32_t>(aPeriodInTenSymbols) * kUsPerTenSymbols;
+    return static_cast<uint32_t>(aPeriodInTenSymbols) * Radio::kUsPerTenSymbols;
 }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
@@ -2511,7 +2511,7 @@ void Mac::ProcessCsl(const RxFrame &aFrame, const Address &aSrcAddr)
     neighbor->SetCslLastHeard(TimerMilli::GetNow());
     neighbor->SetLastRxTimestamp(aFrame.GetTimestamp());
     LogDebg("Timestamp=%lu Sequence=%u CslPeriod=%u CslPhase=%u TransmitPhase=%u",
-            ToUlong(ConvertRadioTime64To32(aFrame.GetTimestamp())), aFrame.GetSequence(), csl->GetPeriod(),
+            ToUlong(Radio::ConvertTime64To32(aFrame.GetTimestamp())), aFrame.GetSequence(), csl->GetPeriod(),
             csl->GetPhase(), neighbor->GetCslPhase());
 
 #if OPENTHREAD_FTD
@@ -2583,7 +2583,7 @@ Error Mac::SetWakeupListenParameters(uint32_t aInterval, uint32_t aDuration)
 {
     Error error = kErrorNone;
 
-    VerifyOrExit(aDuration >= kMinWakeupListenDuration, error = kErrorInvalidArgs);
+    VerifyOrExit(aDuration >= Radio::kMinWakeupListenDuration, error = kErrorInvalidArgs);
     VerifyOrExit(aInterval > aDuration, error = kErrorInvalidArgs);
 
     mWakeupListenInterval = aInterval;
@@ -2635,9 +2635,9 @@ Error Mac::HandleWakeupFrame(const RxFrame &aFrame)
     const ConnectionIe *connectionIe;
     Address             srcAddress;
     WakeupInfo          wakeupInfo;
-    RadioTime32         rvTimeUs;
-    RadioTime64         rvTimestampUs;
-    RadioTime64         radioNowUs;
+    Radio::Time32       rvTimeUs;
+    Radio::Time64       rvTimestampUs;
+    Radio::Time64       radioNowUs;
 
     VerifyOrExit(mWakeupListenEnabled && aFrame.IsWakeupFrame());
 
@@ -2650,13 +2650,14 @@ Error Mac::HandleWakeupFrame(const RxFrame &aFrame)
     wakeupInfo.mRetryCount    = connectionIe->GetRetryCount();
     VerifyOrExit(wakeupInfo.mRetryInterval > 0 && wakeupInfo.mRetryCount > 0, error = kErrorInvalidArgs);
 
-    radioNowUs    = Get<Radio>().GetNow();
-    rvTimeUs      = aFrame.Find<RendezvousTimeIe>()->GetRendezvousTime() * kUsPerTenSymbols;
-    rvTimestampUs = aFrame.GetTimestamp() + kRadioHeaderPhrDuration + aFrame.GetLength() * kOctetDuration + rvTimeUs;
+    radioNowUs = Get<Radio::Radio>().GetNow();
+    rvTimeUs   = aFrame.Find<RendezvousTimeIe>()->GetRendezvousTime() * Radio::kUsPerTenSymbols;
+    rvTimestampUs =
+        aFrame.GetTimestamp() + Radio::kHeaderPhrDuration + aFrame.GetLength() * Radio::kOctetDuration + rvTimeUs;
 
     if (rvTimestampUs > radioNowUs + kCslRequestAhead)
     {
-        wakeupInfo.mAttachDelayMs = ConvertRadioTime64To32(rvTimestampUs - radioNowUs - kCslRequestAhead);
+        wakeupInfo.mAttachDelayMs = Radio::ConvertTime64To32(rvTimestampUs - radioNowUs - kCslRequestAhead);
         wakeupInfo.mAttachDelayMs = wakeupInfo.mAttachDelayMs / Time::kOneMsecInUsec;
     }
     else
@@ -2686,7 +2687,7 @@ exit:
 
 uint32_t Mac::CalculateRadioBusTransferTime(uint16_t aFrameSize) const
 {
-    uint32_t busSpeed     = Get<Radio>().GetBusSpeed();
+    uint32_t busSpeed     = Get<Radio::Radio>().GetBusSpeed();
     uint32_t trasnferTime = 0;
 
     if (busSpeed != 0)
@@ -2694,7 +2695,7 @@ uint32_t Mac::CalculateRadioBusTransferTime(uint16_t aFrameSize) const
         trasnferTime = DivideAndRoundUp<uint32_t>(aFrameSize * kBitsPerByte * Time::kOneSecondInUsec, busSpeed);
     }
 
-    trasnferTime += Get<Radio>().GetBusLatency();
+    trasnferTime += Get<Radio::Radio>().GetBusLatency();
 
     return trasnferTime;
 }

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -737,7 +737,7 @@ public:
      * Sets the wake-up listen parameters.
      *
      * The listen interval must be greater than the listen duration.
-     * The listen duration must be greater or equal than `kMinWakeupListenDuration`.
+     * The listen duration must be greater or equal than `Radio::kMinWakeupListenDuration`.
      *
      * @param[in]  aInterval  The wake-up listen interval in microseconds.
      * @param[in]  aDuration  The wake-up listen duration in microseconds.

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -868,7 +868,7 @@ public:
      *
      * @returns The timestamp in microseconds.
      */
-    const RadioTime64 &GetTimestamp(void) const { return mInfo.mRxInfo.mTimestamp; }
+    const Radio::Time64 &GetTimestamp(void) const { return mInfo.mRxInfo.mTimestamp; }
 
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
     /**
@@ -1225,16 +1225,16 @@ public:
     /**
      * Gets the TX delay base time field for the frame.
      *
-     * @returns The delay base time for the TX frame as a `RadioTime32`.
+     * @returns The delay base time for the TX frame as a `Radio::Time32`.
      */
-    RadioTime32 GetTxDelayBaseTime(void) const { return mInfo.mTxInfo.mTxDelayBaseTime; }
+    Radio::Time32 GetTxDelayBaseTime(void) const { return mInfo.mTxInfo.mTxDelayBaseTime; }
 
     /**
      * Set TX delay base time field for the frame.
      *
      * @param[in]    aTxDelayBaseTime    The delay base time for the TX frame.
      */
-    void SetTxDelayBaseTime(RadioTime32 aTxDelayBaseTime) { mInfo.mTxInfo.mTxDelayBaseTime = aTxDelayBaseTime; }
+    void SetTxDelayBaseTime(Radio::Time32 aTxDelayBaseTime) { mInfo.mTxInfo.mTxDelayBaseTime = aTxDelayBaseTime; }
 #endif
 };
 

--- a/src/core/mac/mac_links.hpp
+++ b/src/core/mac/mac_links.hpp
@@ -174,7 +174,7 @@ public:
         mTxFrame802154.SetTxDelay(0);
         mTxFrame802154.SetTxDelayBaseTime(0);
 #endif
-        mTxFrame802154.SetTxPower(kRadioPowerInvalid);
+        mTxFrame802154.SetTxPower(Radio::kInvalidPower);
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
         mTxFrame802154.SetCslIePresent(false);
 #endif

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -48,8 +48,8 @@ RegisterLogModule("SubMac");
 
 SubMac::SubMac(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mRadioCaps(Get<Radio>().GetCaps())
-    , mTransmitFrame(Get<Radio>().GetTransmitBuffer())
+    , mRadioCaps(Get<Radio::Radio>().GetCaps())
+    , mTransmitFrame(Get<Radio::Radio>().GetTransmitBuffer())
     , mCallbacks(aInstance)
     , mTimer(aInstance)
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
@@ -159,14 +159,14 @@ otRadioCaps SubMac::GetCaps(void) const
 
 void SubMac::SetPanId(PanId aPanId)
 {
-    Get<Radio>().SetPanId(aPanId);
+    Get<Radio::Radio>().SetPanId(aPanId);
     LogDebg("RadioPanId: 0x%04x", aPanId);
 }
 
 void SubMac::SetShortAddress(ShortAddress aShortAddress)
 {
     mShortAddress = aShortAddress;
-    Get<Radio>().SetShortAddress(mShortAddress);
+    Get<Radio::Radio>().SetShortAddress(mShortAddress);
     LogDebg("RadioShortAddress: 0x%04x", mShortAddress);
 }
 
@@ -175,7 +175,7 @@ void SubMac::SetAlternateShortAddress(ShortAddress aShortAddress)
     VerifyOrExit(mAlternateShortAddress != aShortAddress);
 
     mAlternateShortAddress = aShortAddress;
-    Get<Radio>().SetAlternateShortAddress(mAlternateShortAddress);
+    Get<Radio::Radio>().SetAlternateShortAddress(mAlternateShortAddress);
     LogDebg("RadioAlternateShortAddress: 0x%04x", mAlternateShortAddress);
 
 exit:
@@ -185,7 +185,7 @@ exit:
 void SubMac::SetExtAddress(const ExtAddress &aExtAddress)
 {
     mExtAddress = aExtAddress;
-    Get<Radio>().SetExtendedAddress(aExtAddress);
+    Get<Radio::Radio>().SetExtendedAddress(aExtAddress);
 
     LogDebg("RadioExtAddress: %s", mExtAddress.ToString().AsCString());
 }
@@ -197,7 +197,7 @@ void SubMac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
     if (RadioSupportsRxOnWhenIdle())
     {
 #if !OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
-        Get<Radio>().SetRxOnWhenIdle(mRxOnWhenIdle);
+        Get<Radio::Radio>().SetRxOnWhenIdle(mRxOnWhenIdle);
 #endif
     }
 
@@ -210,8 +210,8 @@ Error SubMac::Enable(void)
 
     VerifyOrExit(mState == kStateDisabled);
 
-    SuccessOrExit(error = Get<Radio>().Enable());
-    SuccessOrExit(error = Get<Radio>().Sleep());
+    SuccessOrExit(error = Get<Radio::Radio>().Enable());
+    SuccessOrExit(error = Get<Radio::Radio>().Sleep());
 
     SetState(kStateSleep);
 
@@ -232,8 +232,8 @@ Error SubMac::Disable(void)
 #endif
 
     mTimer.Stop();
-    SuccessOrExit(error = Get<Radio>().Sleep());
-    SuccessOrExit(error = Get<Radio>().Disable());
+    SuccessOrExit(error = Get<Radio::Radio>().Sleep());
+    SuccessOrExit(error = Get<Radio::Radio>().Disable());
     SetState(kStateDisabled);
 
 exit:
@@ -264,7 +264,7 @@ Error SubMac::RadioSleep(void)
 
     if (ShouldHandleTransitionToSleep())
     {
-        SuccessOrExit(error = Get<Radio>().Sleep());
+        SuccessOrExit(error = Get<Radio::Radio>().Sleep());
     }
 
     SetState(kStateSleep);
@@ -281,12 +281,12 @@ Error SubMac::Receive(uint8_t aChannel)
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
     if (mRadioFilterEnabled)
     {
-        error = Get<Radio>().Sleep();
+        error = Get<Radio::Radio>().Sleep();
     }
     else
 #endif
     {
-        error = Get<Radio>().Receive(aChannel);
+        error = Get<Radio::Radio>().Receive(aChannel);
     }
 
     SuccessOrExit(error);
@@ -433,14 +433,15 @@ void SubMac::StartCsmaBackoff(void)
 
         if (ShouldHandleTransmitTargetTime())
         {
-            static constexpr uint32_t kAheadTime = kCcaSampleInterval + kCslTransmitTimeAhead + kRadioHeaderShrDuration;
+            static constexpr uint32_t kAheadTime =
+                kCcaSampleInterval + kCslTransmitTimeAhead + Radio::kHeaderShrDuration;
 
-            RadioTime32 radioNow    = Get<Radio>().GetNowAsRadioTime32();
-            RadioTime32 txStartTime = mTransmitFrame.GetTxDelayBaseTime();
+            Radio::Time32 radioNow    = Get<Radio::Radio>().GetNowAsTime32();
+            Radio::Time32 txStartTime = mTransmitFrame.GetTxDelayBaseTime();
 
             txStartTime += (mTransmitFrame.mInfo.mTxInfo.mTxDelay - kAheadTime);
 
-            if (IsRadioTimeStrictlyBefore(radioNow, txStartTime))
+            if (Radio::IsTimeStrictlyBefore(radioNow, txStartTime))
             {
                 StartTimer(txStartTime - radioNow);
                 ExitNow();
@@ -475,11 +476,11 @@ void SubMac::StartTimerForBackoff(uint8_t aBackoffExponent)
 
     if (mRxOnWhenIdle)
     {
-        IgnoreError(Get<Radio>().Receive(mTransmitFrame.GetChannel()));
+        IgnoreError(Get<Radio::Radio>().Receive(mTransmitFrame.GetChannel()));
     }
     else
     {
-        IgnoreError(Get<Radio>().Sleep());
+        IgnoreError(Get<Radio::Radio>().Sleep());
     }
 
     StartTimer(backoff);
@@ -504,12 +505,12 @@ void SubMac::BeginTransmit(void)
 
     if ((mRadioCaps & OT_RADIO_CAPS_SLEEP_TO_TX) == 0)
     {
-        SuccessOrAssert(Get<Radio>().Receive(mTransmitFrame.GetChannel()));
+        SuccessOrAssert(Get<Radio::Radio>().Receive(mTransmitFrame.GetChannel()));
     }
 
     SetState(kStateTransmit);
 
-    error = Get<Radio>().Transmit(mTransmitFrame);
+    error = Get<Radio::Radio>().Transmit(mTransmitFrame);
 
     if (error == kErrorInvalidState && mTransmitFrame.mInfo.mTxInfo.mTxDelay > 0)
     {
@@ -517,7 +518,7 @@ void SubMac::BeginTransmit(void)
         mTransmitFrame.mInfo.mTxInfo.mTxDelay         = 0;
         mTransmitFrame.mInfo.mTxInfo.mTxDelayBaseTime = 0;
 
-        error = Get<Radio>().Transmit(mTransmitFrame);
+        error = Get<Radio::Radio>().Transmit(mTransmitFrame);
     }
 
     SuccessOrAssert(error);
@@ -637,7 +638,7 @@ void SubMac::HandleTransmitDone(TxFrame &aFrame, RxFrame *aAckFrame, Error aErro
         // the same as the `Mac` will switch the channel from the
         // `mCallbacks.TransmitDone()`.
 
-        IgnoreError(Get<Radio>().Receive(aFrame.GetRxChannelAfterTxDone()));
+        IgnoreError(Get<Radio::Radio>().Receive(aFrame.GetRxChannelAfterTxDone()));
     }
 #endif
 
@@ -695,13 +696,13 @@ int8_t SubMac::GetRssi(void) const
     else
 #endif
     {
-        rssi = Get<Radio>().GetRssi();
+        rssi = Get<Radio::Radio>().GetRssi();
     }
 
     return rssi;
 }
 
-int8_t SubMac::GetNoiseFloor(void) const { return Get<Radio>().GetReceiveSensitivity(); }
+int8_t SubMac::GetNoiseFloor(void) const { return Get<Radio::Radio>().GetReceiveSensitivity(); }
 
 Error SubMac::EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration)
 {
@@ -735,12 +736,12 @@ Error SubMac::EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration)
 
     if (RadioSupportsEnergyScan())
     {
-        IgnoreError(Get<Radio>().EnergyScan(aScanChannel, aScanDuration));
+        IgnoreError(Get<Radio::Radio>().EnergyScan(aScanChannel, aScanDuration));
         SetState(kStateEnergyScan);
     }
     else if (ShouldHandleEnergyScan())
     {
-        SuccessOrAssert(Get<Radio>().Receive(aScanChannel));
+        SuccessOrAssert(Get<Radio::Radio>().Receive(aScanChannel));
 
         SetState(kStateEnergyScan);
         mEnergyScanMaxRssi = Radio::kInvalidRssi;
@@ -801,7 +802,7 @@ void SubMac::HandleTimer(void)
 
     case kStateTransmit:
         LogDebg("Ack timer timed out");
-        IgnoreError(Get<Radio>().Receive(mTransmitFrame.GetChannel()));
+        IgnoreError(Get<Radio::Radio>().Receive(mTransmitFrame.GetChannel()));
         HandleTransmitDone(mTransmitFrame, nullptr, kErrorNoAck);
         break;
 
@@ -964,7 +965,7 @@ void SubMac::SetMacKey(uint8_t            aKeyIdMode,
 
     VerifyOrExit(!ShouldHandleTransmitSecurity());
 
-    Get<Radio>().SetMacKey(aKeyIdMode, aKeyId, aPrevKey, aCurrKey, aNextKey);
+    Get<Radio::Radio>().SetMacKey(aKeyIdMode, aKeyId, aPrevKey, aCurrKey, aNextKey);
 
 exit:
     return;
@@ -1002,11 +1003,11 @@ void SubMac::SetFrameCounter(uint32_t aFrameCounter, bool aSetIfLarger)
 
     if (aSetIfLarger)
     {
-        Get<Radio>().SetMacFrameCounterIfLarger(aFrameCounter);
+        Get<Radio::Radio>().SetMacFrameCounterIfLarger(aFrameCounter);
     }
     else
     {
-        Get<Radio>().SetMacFrameCounter(aFrameCounter);
+        Get<Radio::Radio>().SetMacFrameCounter(aFrameCounter);
     }
 
 exit:
@@ -1035,7 +1036,7 @@ void SubMac::StartTimerAt(Time aStartTime, uint32_t aDelayUs)
 void SubMac::RadioSample(void)
 {
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
-    VerifyOrExit(!mRadioFilterEnabled, IgnoreError(Get<Radio>().Sleep()));
+    VerifyOrExit(!mRadioFilterEnabled, IgnoreError(Get<Radio::Radio>().Sleep()));
 #endif
 
     SetState(kStateRadioSample);
@@ -1102,7 +1103,7 @@ void SubMac::UpdateRadioSampleState(void)
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     if (mIsCslSampling)
     {
-        IgnoreError(Get<Radio>().Receive(mCslChannel));
+        IgnoreError(Get<Radio::Radio>().Receive(mCslChannel));
         ExitNow();
     }
 #endif
@@ -1110,13 +1111,13 @@ void SubMac::UpdateRadioSampleState(void)
 #if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
     if (mIsWedSampling)
     {
-        IgnoreError(Get<Radio>().Receive(mWakeupChannel));
+        IgnoreError(Get<Radio::Radio>().Receive(mWakeupChannel));
         ExitNow();
     }
 #endif
 
 #if !OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
-    IgnoreError(Get<Radio>().Sleep()); // Don't actually sleep for debugging
+    IgnoreError(Get<Radio::Radio>().Sleep()); // Don't actually sleep for debugging
 #endif
 
 exit:

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -672,26 +672,26 @@ private:
     SubMacTimer mTimer;
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    uint16_t mCslPeriod;                     // The CSL sample period, in units of 10 symbols (160 microseconds).
-    uint8_t  mCslChannel : 7;                // The CSL sample channel.
-    bool     mIsCslSampling : 1;             // Indicates that the current time is in CSL sample window
-                                             // for platforms not supporting `Radio::ReceiveAt()`.
-    uint16_t             mCslPeerShort;      // The CSL peer short address.
-    SyncedRadioLocalTime mCslSampleTime;     // The CSL sample time for current period.
-    TimeMicro            mCslLastSync;       // The timestamp of the last successful CSL synchronization.
-    CslAccuracy          mCslParentAccuracy; // The parent's CSL accuracy (clock accuracy and uncertainty).
-    TimerMicro           mCslTimer;
+    uint16_t mCslPeriod;                  // The CSL sample period, in units of 10 symbols (160 microseconds).
+    uint8_t  mCslChannel : 7;             // The CSL sample channel.
+    bool     mIsCslSampling : 1;          // Indicates that the current time is in CSL sample window
+                                          // for platforms not supporting `Radio::ReceiveAt()`.
+    uint16_t          mCslPeerShort;      // The CSL peer short address.
+    Radio::SyncedTime mCslSampleTime;     // The CSL sample time for current period.
+    TimeMicro         mCslLastSync;       // The timestamp of the last successful CSL synchronization.
+    CslAccuracy       mCslParentAccuracy; // The parent's CSL accuracy (clock accuracy and uncertainty).
+    TimerMicro        mCslTimer;
 #endif
 
 #if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-    bool mIsWedSampling : 1;                    // Indicates that the current time is in WED's sample window
-                                                // for platforms not supporting `Radio::ReceiveAt()`.
-    bool                 mIsWedEnabled : 1;     // Indicates if the WED is enabled.
-    uint32_t             mWakeupListenInterval; // The wake-up listen interval, in microseconds.
-    uint32_t             mWakeupListenDuration; // The wake-up listen duration, in microseconds.
-    uint8_t              mWakeupChannel;        // The wake-up sample channel.
-    SyncedRadioLocalTime mWedSampleTime;        // The WED sample time of the current interval.
-    TimerMicro           mWedTimer;
+    bool mIsWedSampling : 1;                 // Indicates that the current time is in WED's sample window
+                                             // for platforms not supporting `Radio::ReceiveAt()`.
+    bool              mIsWedEnabled : 1;     // Indicates if the WED is enabled.
+    uint32_t          mWakeupListenInterval; // The wake-up listen interval, in microseconds.
+    uint32_t          mWakeupListenDuration; // The wake-up listen duration, in microseconds.
+    uint8_t           mWakeupChannel;        // The wake-up sample channel.
+    Radio::SyncedTime mWedSampleTime;        // The WED sample time of the current interval.
+    TimerMicro        mWedTimer;
 #endif
 };
 

--- a/src/core/mac/sub_mac_csl_receiver.cpp
+++ b/src/core/mac/sub_mac_csl_receiver.cpp
@@ -58,7 +58,7 @@ void SubMac::RestartCslTimerAfterSyncUpdate(void)
     // Only applies for the case where radio supports receive timing.
     if (RadioSupportsReceiveTiming() && mCslTimer.IsRunning())
     {
-        uint32_t periodUs = mCslPeriod * kUsPerTenSymbols;
+        uint32_t periodUs = mCslPeriod * Radio::kUsPerTenSymbols;
 
         mCslTimer.Stop();
 
@@ -97,7 +97,7 @@ void SubMac::UpdateCslLastSyncTimestamp(RxFrame *aFrame, Error aError)
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_LOCAL_TIME_SYNC
         mCslLastSync = TimerMicro::GetNow();
 #else
-        mCslLastSync = TimeMicro(ConvertRadioTime64To32(aFrame->GetTimestamp()));
+        mCslLastSync = TimeMicro(Radio::ConvertTime64To32(aFrame->GetTimestamp()));
 #endif
     }
 
@@ -119,7 +119,7 @@ void SubMac::SetCslParams(uint16_t aPeriod, uint8_t aChannel, ShortAddress aShor
 
     VerifyOrExit(diffPeriod || diffPeer);
     mCslPeerShort = aShortAddr;
-    IgnoreError(Get<Radio>().EnableCsl(aPeriod, aShortAddr, aExtAddr));
+    IgnoreError(Get<Radio::Radio>().EnableCsl(aPeriod, aShortAddr, aExtAddr));
 
     mIsCslSampling = false;
     mCslPeriod     = aPeriod;
@@ -128,10 +128,10 @@ void SubMac::SetCslParams(uint16_t aPeriod, uint8_t aChannel, ShortAddress aShor
 
     if (mCslPeriod > 0)
     {
-        mCslSampleTime.SetToNow(Get<Radio>());
+        mCslSampleTime.SetToNow(Get<Radio::Radio>());
 
         // Update CSL sync time whenever CSL parameters are re-initialized.
-        mCslLastSync = mCslSampleTime.GetAsTimeMicro();
+        mCslLastSync = mCslSampleTime.GetAsLocalTimeMicro();
 
         HandleCslTimer();
     }
@@ -179,24 +179,24 @@ void SubMac::HandleCslReceiveAt(uint32_t aTimeAhead, uint32_t aTimeAfter)
      *       x-|------------|-------------------------------------x-|------------|---------------------------------------|
      *            sample                   sleep                        sample                    sleep
      */
-    uint32_t    periodUs = mCslPeriod * kUsPerTenSymbols;
-    RadioTime32 winStart;
-    uint32_t    winDuration;
+    uint32_t      periodUs = mCslPeriod * Radio::kUsPerTenSymbols;
+    Radio::Time32 winStart;
+    uint32_t      winDuration;
 
-    mCslTimer.FireAt(mCslSampleTime.GetAsTimeMicro() + periodUs - aTimeAhead - GetNextCycleDrift());
+    mCslTimer.FireAt(mCslSampleTime.GetAsLocalTimeMicro() + periodUs - aTimeAhead - GetNextCycleDrift());
     aTimeAhead -= kCslReceiveTimeAhead;
-    winStart    = mCslSampleTime.GetAsRadio32() - aTimeAhead;
+    winStart    = mCslSampleTime.GetAsTime32() - aTimeAhead;
     winDuration = aTimeAhead + aTimeAfter;
 
     mCslSampleTime += periodUs;
 
-    Get<Radio>().UpdateCslSampleTime(mCslSampleTime.GetAsRadio32());
+    Get<Radio::Radio>().UpdateCslSampleTime(mCslSampleTime.GetAsTime32());
 
     // Schedule reception window for any state except RX - so that CSL RX Window has lower priority
     // than scanning or RX after the data poll.
     if ((mState != kStateDisabled) && (mState != kStateReceive))
     {
-        IgnoreError(Get<Radio>().ReceiveAt(mCslChannel, winStart, winDuration));
+        IgnoreError(Get<Radio::Radio>().ReceiveAt(mCslChannel, winStart, winDuration));
     }
 
     LogCslWindow(winStart, winDuration);
@@ -219,7 +219,7 @@ void SubMac::HandleCslReceiveOrSleep(uint32_t aTimeAhead, uint32_t aTimeAfter)
     if (mIsCslSampling)
     {
         mIsCslSampling = false;
-        mCslTimer.FireAt(mCslSampleTime.GetAsTimeMicro() - aTimeAhead - GetNextCycleDrift());
+        mCslTimer.FireAt(mCslSampleTime.GetAsLocalTimeMicro() - aTimeAhead - GetNextCycleDrift());
         if (mState == kStateRadioSample)
         {
             LogDebg("CSL sleep %lu", ToUlong(mCslTimer.GetNow().GetValue()));
@@ -227,18 +227,18 @@ void SubMac::HandleCslReceiveOrSleep(uint32_t aTimeAhead, uint32_t aTimeAfter)
     }
     else
     {
-        uint32_t periodUs = mCslPeriod * kUsPerTenSymbols;
+        uint32_t periodUs = mCslPeriod * Radio::kUsPerTenSymbols;
         uint32_t winStart;
         uint32_t winDuration;
 
-        mCslTimer.FireAt(mCslSampleTime.GetAsTimeMicro() + aTimeAfter);
+        mCslTimer.FireAt(mCslSampleTime.GetAsLocalTimeMicro() + aTimeAfter);
         mIsCslSampling = true;
         winStart       = TimerMicro::GetNow().GetValue();
         winDuration    = aTimeAhead + aTimeAfter;
 
         mCslSampleTime += periodUs;
 
-        Get<Radio>().UpdateCslSampleTime(mCslSampleTime.GetAsRadio32());
+        Get<Radio::Radio>().UpdateCslSampleTime(mCslSampleTime.GetAsTime32());
 
         LogCslWindow(winStart, winDuration);
     }
@@ -257,16 +257,16 @@ void SubMac::GetCslWindowEdges(uint32_t &aAhead, uint32_t &aAfter)
      * ---|-----------|------------|-----------|-----------|------------|------------|----------//------------|---
      * -timeAhead                           CslPhase                             +timeAfter             -timeAhead
      */
-    uint32_t semiPeriod = mCslPeriod * kUsPerTenSymbols / 2;
+    uint32_t semiPeriod = mCslPeriod * Radio::kUsPerTenSymbols / 2;
     uint32_t curTime, elapsed, semiWindow;
 
     curTime = GetLocalTime();
     elapsed = curTime - mCslLastSync.GetValue();
 
     semiWindow = static_cast<uint32_t>(static_cast<uint64_t>(elapsed) *
-                                       (Get<Radio>().GetCslAccuracy() + mCslParentAccuracy.GetClockAccuracy()) /
+                                       (Get<Radio::Radio>().GetCslAccuracy() + mCslParentAccuracy.GetClockAccuracy()) /
                                        Time::kOneSecondInUsec);
-    semiWindow += mCslParentAccuracy.GetUncertaintyInMicrosec() + Get<Radio>().GetCslUncertainty() * 10;
+    semiWindow += mCslParentAccuracy.GetUncertaintyInMicrosec() + Get<Radio::Radio>().GetCslUncertainty() * 10;
 
     aAhead = Min(semiPeriod, semiWindow + kMinReceiveOnAhead + kCslReceiveTimeAhead);
     aAfter = Min(semiPeriod, semiWindow + kMinReceiveOnAfter);
@@ -274,9 +274,10 @@ void SubMac::GetCslWindowEdges(uint32_t &aAhead, uint32_t &aAfter)
 
 uint32_t SubMac::GetNextCycleDrift(void)
 {
-    uint64_t periodUs = mCslPeriod * kUsPerTenSymbols;
+    uint64_t periodUs = mCslPeriod * Radio::kUsPerTenSymbols;
 
-    return static_cast<uint32_t>(periodUs * (Get<Radio>().GetCslAccuracy() + mCslParentAccuracy.GetClockAccuracy()) /
+    return static_cast<uint32_t>(periodUs *
+                                 (Get<Radio::Radio>().GetCslAccuracy() + mCslParentAccuracy.GetClockAccuracy()) /
                                  Time::kOneSecondInUsec);
 }
 
@@ -287,7 +288,7 @@ uint32_t SubMac::GetLocalTime(void)
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_LOCAL_TIME_SYNC
     now = TimerMicro::GetNow().GetValue();
 #else
-    now = Get<Radio>().GetNowAsRadioTime32();
+    now = Get<Radio::Radio>().GetNowAsTime32();
 #endif
 
     return now;
@@ -318,15 +319,15 @@ void SubMac::LogReceived(RxFrame *aFrame)
                  (dst.GetType() == Address::kTypeExtended && dst.GetExtended() == GetExtAddress()));
 
     LogDebg("Received frame in state (SubMac %s, CSL %s), timestamp %lu", StateToString(mState),
-            mIsCslSampling ? "CslSample" : "CslSleep", ToUlong(ConvertRadioTime64To32(aFrame->GetTimestamp())));
+            mIsCslSampling ? "CslSample" : "CslSleep", ToUlong(Radio::ConvertTime64To32(aFrame->GetTimestamp())));
 
     VerifyOrExit(mState == kStateRadioSample);
 
     GetCslWindowEdges(ahead, after);
     ahead -= kMinReceiveOnAhead + kCslReceiveTimeAhead;
 
-    sampleTime = mCslSampleTime.GetAsRadio32() - mCslPeriod * kUsPerTenSymbols;
-    deviation  = ConvertRadioTime64To32(aFrame->GetTimestamp()) + kRadioHeaderPhrDuration - sampleTime;
+    sampleTime = mCslSampleTime.GetAsTime32() - mCslPeriod * Radio::kUsPerTenSymbols;
+    deviation  = Radio::ConvertTime64To32(aFrame->GetTimestamp()) + Radio::kHeaderPhrDuration - sampleTime;
 
     // This logs three values (all in microseconds):
     // - Absolute sample time in which the CSL receiver expected the MHR of the received frame.

--- a/src/core/mac/sub_mac_wed.cpp
+++ b/src/core/mac/sub_mac_wed.cpp
@@ -62,7 +62,7 @@ void SubMac::UpdateWakeupListening(bool aEnable, uint32_t aInterval, uint32_t aD
 
     if (aEnable)
     {
-        mWedSampleTime.SetToNow(Get<Radio>());
+        mWedSampleTime.SetToNow(Get<Radio::Radio>());
         mWedSampleTime += kCslReceiveTimeAhead;
         mWedSampleTime -= mWakeupListenInterval;
 
@@ -92,11 +92,11 @@ void SubMac::HandleWedReceiveAt(void)
 {
     mWedSampleTime += mWakeupListenInterval;
 
-    mWedTimer.FireAt(mWedSampleTime.GetAsTimeMicro() + mWakeupListenDuration + kWedReceiveTimeAfter);
+    mWedTimer.FireAt(mWedSampleTime.GetAsLocalTimeMicro() + mWakeupListenDuration + kWedReceiveTimeAfter);
 
     if (mState != kStateDisabled)
     {
-        IgnoreError(Get<Radio>().ReceiveAt(mWakeupChannel, mWedSampleTime.GetAsRadio32(), mWakeupListenDuration));
+        IgnoreError(Get<Radio::Radio>().ReceiveAt(mWakeupChannel, mWedSampleTime.GetAsTime32(), mWakeupListenDuration));
     }
 }
 
@@ -108,12 +108,12 @@ void SubMac::HandleWedReceiveOrSleep(void)
 
     if (mIsWedSampling)
     {
-        fireTime = mWedSampleTime.GetAsTimeMicro() + mWakeupListenDuration + kMinReceiveOnAfter;
+        fireTime = mWedSampleTime.GetAsLocalTimeMicro() + mWakeupListenDuration + kMinReceiveOnAfter;
     }
     else
     {
         mWedSampleTime += mWakeupListenInterval;
-        fireTime = mWedSampleTime.GetAsTimeMicro() - kMinReceiveOnAhead;
+        fireTime = mWedSampleTime.GetAsLocalTimeMicro() - kMinReceiveOnAhead;
     }
 
     mWedTimer.FireAt(fireTime);

--- a/src/core/mac/wakeup_tx_scheduler.cpp
+++ b/src/core/mac/wakeup_tx_scheduler.cpp
@@ -100,7 +100,7 @@ Mac::TxFrame *WakeupTxScheduler::PrepareWakeupFrame(Mac::TxFrames &aTxFrames)
 
     VerifyOrExit(frame->GenerateWakeupFrame(Get<Mac::Mac>().GetPanId(), mWakeupRequest, source) == kErrorNone,
                  frame = nullptr);
-    frame->SetTxDelayBaseTime(Get<Radio>().GetNowAsRadioTime32());
+    frame->SetTxDelayBaseTime(Get<Radio::Radio>().GetNowAsTime32());
     frame->SetTxDelay(radioTxDelay);
     frame->SetCsmaCaEnabled(kWakeupFrameTxCca);
     frame->SetMaxCsmaBackoffs(0);
@@ -110,9 +110,9 @@ Mac::TxFrame *WakeupTxScheduler::PrepareWakeupFrame(Mac::TxFrames &aTxFrames)
     // For the n-th wake-up frame, set the Rendezvous Time so that the expected reception of a Parent Request happens in
     // the "free space" between the "n+1"-th and "n+2"-th wake-up frame.
     rendezvousTimeUs = mIntervalUs;
-    rendezvousTimeUs += (mIntervalUs - (kWakeupFrameLength + kParentRequestLength) * kOctetDuration) / 2;
+    rendezvousTimeUs += (mIntervalUs - (kWakeupFrameLength + kParentRequestLength) * Radio::kOctetDuration) / 2;
 
-    frame->Find<Mac::RendezvousTimeIe>()->SetRendezvousTime(ClampToUint16(rendezvousTimeUs / kUsPerTenSymbols));
+    frame->Find<Mac::RendezvousTimeIe>()->SetRendezvousTime(ClampToUint16(rendezvousTimeUs / Radio::kUsPerTenSymbols));
 
     connectionIe = frame->Find<Mac::ConnectionIe>();
     connectionIe->SetRetryInterval(kConnectionRetryInterval);

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -44,7 +44,7 @@ Error Dataset::Info::GenerateRandom(Instance &aInstance)
 {
     Error            error;
     Mac::ChannelMask supportedChannels = aInstance.Get<Mac::Mac>().GetSupportedChannelMask();
-    Mac::ChannelMask preferredChannels(aInstance.Get<Radio>().GetPreferredChannelMask());
+    Mac::ChannelMask preferredChannels(aInstance.Get<Radio::Radio>().GetPreferredChannelMask());
     StringWriter     nameWriter(mNetworkName.m8, sizeof(mNetworkName));
 
     // If the preferred channel mask is not empty, select a random

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -56,7 +56,7 @@ void Joiner::SetIdFromIeeeEui64(void)
 {
     Mac::ExtAddress eui64;
 
-    Get<Radio>().GetIeeeEui64(eui64);
+    Get<Radio::Radio>().GetIeeeEui64(eui64);
     ComputeJoinerId(eui64, mId);
 }
 

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -764,7 +764,7 @@ Error TcatAgent::HandleGetDeviceId(Message &aOutgoingMessage, bool &aResponse)
 
     if (length == 0)
     {
-        Get<Radio>().GetIeeeEui64(eui64);
+        Get<Radio::Radio>().GetIeeeEui64(eui64);
 
         length   = sizeof(Mac::ExtAddress);
         deviceId = eui64.m8;

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -307,7 +307,7 @@ Error Client::AppendClientIdOption(Message &aMessage)
 {
     Mac::ExtAddress eui64;
 
-    Get<Radio>().GetIeeeEui64(eui64);
+    Get<Radio::Radio>().GetIeeeEui64(eui64);
 
     return ClientIdOption::AppendWithEui64Duid(aMessage, eui64);
 }
@@ -394,7 +394,7 @@ Error Client::ProcessClientIdOption(const Message &aMessage)
 {
     Mac::ExtAddress eui64;
 
-    Get<Radio>().GetIeeeEui64(eui64);
+    Get<Radio::Radio>().GetIeeeEui64(eui64);
 
     return ClientIdOption::MatchesEui64Duid(aMessage, eui64);
 }

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -323,7 +323,7 @@ Error Server::AppendServerIdOption(Message &aMessage)
 {
     Mac::ExtAddress eui64;
 
-    Get<Radio>().GetIeeeEui64(eui64);
+    Get<Radio::Radio>().GetIeeeEui64(eui64);
 
     return ServerIdOption::AppendWithEui64Duid(aMessage, eui64);
 }

--- a/src/core/radio/radio.cpp
+++ b/src/core/radio/radio.cpp
@@ -31,8 +31,9 @@
 #include "instance/instance.hpp"
 
 namespace ot {
+namespace Radio {
 
-const uint8_t Radio::kSupportedChannelPages[kNumChannelPages] = {
+const uint8_t kSupportedChannelPages[kNumChannelPages] = {
 #if OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT
     kChannelPage0,
 #endif
@@ -43,6 +44,41 @@ const uint8_t Radio::kSupportedChannelPages[kNumChannelPages] = {
     OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_PAGE,
 #endif
 };
+
+uint32_t ChannelMaskForPage(uint8_t aChannelPage)
+{
+    uint32_t mask = 0;
+
+#if OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT
+    if (aChannelPage == kChannelPage0)
+    {
+        mask = OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MASK;
+    }
+#endif
+
+#if OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT
+    if (aChannelPage == kChannelPage2)
+    {
+        mask = OT_RADIO_915MHZ_OQPSK_CHANNEL_MASK;
+    }
+#endif
+
+#if OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_SUPPORT
+    if (aChannelPage == OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_PAGE)
+    {
+        mask = OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_MASK;
+    }
+#endif
+    return mask;
+}
+
+bool IsCslChannelValid(uint8_t aCslChannel)
+{
+    return ((aCslChannel == 0) ||
+            ((kChannelMin == aCslChannel) || ((kChannelMin < aCslChannel) && (aCslChannel <= kChannelMax))));
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 
 #if OPENTHREAD_RADIO
 void Radio::Init(void)
@@ -133,19 +169,19 @@ Error Radio::Transmit(Mac::TxFrame &aFrame)
 #if OPENTHREAD_CONFIG_RADIO_STATS_ENABLE && (OPENTHREAD_FTD || OPENTHREAD_MTD)
 inline uint64_t UintSafeMinus(uint64_t aLhs, uint64_t aRhs) { return aLhs > aRhs ? (aLhs - aRhs) : 0; }
 
-Radio::Statistics::Statistics(void)
+Statistics::Statistics(void)
     : mStatus(kDisabled)
 {
     ResetTime();
 }
 
-void Radio::Statistics::RecordStateChange(Status aStatus)
+void Statistics::RecordStateChange(Status aStatus)
 {
     UpdateTime();
     mStatus = aStatus;
 }
 
-void Radio::Statistics::HandleReceiveAt(uint32_t aDurationUs)
+void Statistics::HandleReceiveAt(uint32_t aDurationUs)
 {
     // The actual rx time of ReceiveAt cannot be obtained from software level. This is a workaround.
     if (mStatus == kSleep)
@@ -154,12 +190,12 @@ void Radio::Statistics::HandleReceiveAt(uint32_t aDurationUs)
     }
 }
 
-void Radio::Statistics::RecordTxDone(otError aError, uint16_t aPsduLength)
+void Statistics::RecordTxDone(Error aError, uint16_t aPsduLength)
 {
     if (aError == kErrorNone || aError == kErrorNoAck)
     {
-        uint32_t txTimeUs = (aPsduLength + Mac::Frame::kPhyHeaderSize) * Radio::kSymbolsPerOctet * Radio::kSymbolTime;
-        uint32_t rxAckTimeUs = (Mac::Frame::kImmAckLength + Mac::Frame::kPhyHeaderSize) * Radio::kPhyUsPerByte;
+        uint32_t txTimeUs    = (aPsduLength + Mac::Frame::kPhyHeaderSize) * kSymbolsPerOctet * kSymbolTime;
+        uint32_t rxAckTimeUs = (Mac::Frame::kImmAckLength + Mac::Frame::kPhyHeaderSize) * kPhyUsPerByte;
 
         UpdateTime();
         mTimeStats.mTxTime += txTimeUs;
@@ -180,7 +216,7 @@ void Radio::Statistics::RecordTxDone(otError aError, uint16_t aPsduLength)
     }
 }
 
-void Radio::Statistics::RecordRxDone(otError aError)
+void Statistics::RecordRxDone(Error aError)
 {
     uint32_t ackTimeUs;
 
@@ -188,7 +224,7 @@ void Radio::Statistics::RecordRxDone(otError aError)
 
     UpdateTime();
     // Currently we cannot know the actual length of ACK. So assume the ACK is an immediate ACK.
-    ackTimeUs = (Mac::Frame::kImmAckLength + Mac::Frame::kPhyHeaderSize) * Radio::kPhyUsPerByte;
+    ackTimeUs = (Mac::Frame::kImmAckLength + Mac::Frame::kPhyHeaderSize) * kPhyUsPerByte;
     mTimeStats.mTxTime += ackTimeUs;
     if (mStatus == kReceive)
     {
@@ -199,20 +235,20 @@ exit:
     return;
 }
 
-const Radio::Statistics::TimeStats &Radio::Statistics::GetStats(void)
+const Statistics::TimeStats &Statistics::GetStats(void)
 {
     UpdateTime();
 
     return mTimeStats;
 }
 
-void Radio::Statistics::ResetTime(void)
+void Statistics::ResetTime(void)
 {
     ClearAllBytes(mTimeStats);
     mLastUpdateTime = TimerMicro::GetNow();
 }
 
-void Radio::Statistics::UpdateTime(void)
+void Statistics::UpdateTime(void)
 {
     TimeMicro nowTime     = TimerMicro::GetNow();
     uint32_t  timeElapsed = nowTime - mLastUpdateTime;
@@ -234,4 +270,5 @@ void Radio::Statistics::UpdateTime(void)
 
 #endif // OPENTHREAD_CONFIG_RADIO_STATS_ENABLE && (OPENTHREAD_FTD || OPENTHREAD_MTD)
 
+} // namespace Radio
 } // namespace ot

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -49,28 +49,7 @@
 #include "radio/radio_types.hpp"
 
 namespace ot {
-
-static constexpr uint32_t kUsPerTenSymbols = OT_US_PER_TEN_SYMBOLS; ///< Time for 10 symbols in units of microseconds
-static constexpr uint32_t kRadioHeaderShrDuration = 160;            ///< Duration of SHR in us
-static constexpr uint32_t kRadioHeaderPhrDuration = 32;             ///< Duration of PHR in us
-static constexpr uint32_t kOctetDuration          = 32;             ///< Duration of one octet in us
-
-static constexpr int8_t kRadioPowerInvalid = OT_RADIO_POWER_INVALID; ///< Invalid TX power value
-
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-/**
- * Minimum CSL period supported in units of 10 symbols.
- */
-static constexpr uint64_t kMinCslPeriod  = OPENTHREAD_CONFIG_MAC_CSL_MIN_PERIOD * 1000 / kUsPerTenSymbols;
-static constexpr uint64_t kMaxCslTimeout = OPENTHREAD_CONFIG_MAC_CSL_MAX_TIMEOUT;
-#endif
-
-#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-/**
- * Minimum wake-up listen duration supported in microseconds.
- */
-static constexpr uint32_t kMinWakeupListenDuration = 100;
-#endif
+namespace Radio {
 
 /**
  * @addtogroup core-radio
@@ -81,213 +60,274 @@ static constexpr uint32_t kMinWakeupListenDuration = 100;
  * @{
  */
 
+constexpr uint32_t kUsPerTenSymbols   = OT_US_PER_TEN_SYMBOLS; ///< Time for 10 symbols in units of microseconds
+constexpr uint32_t kHeaderShrDuration = 160;                   ///< Duration of SHR in us
+constexpr uint32_t kHeaderPhrDuration = 32;                    ///< Duration of PHR in us
+constexpr uint32_t kOctetDuration     = 32;                    ///< Duration of one octet in us
+
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+/**
+ * Minimum CSL period supported in units of 10 symbols.
+ */
+constexpr uint64_t kMinCslPeriod  = OPENTHREAD_CONFIG_MAC_CSL_MIN_PERIOD * 1000 / kUsPerTenSymbols;
+constexpr uint64_t kMaxCslTimeout = OPENTHREAD_CONFIG_MAC_CSL_MAX_TIMEOUT;
+#endif
+
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+/**
+ * Minimum wake-up listen duration supported in microseconds.
+ */
+constexpr uint32_t kMinWakeupListenDuration = 100;
+#endif
+
 #if OPENTHREAD_CONFIG_RADIO_STATS_ENABLE && (OPENTHREAD_FTD || OPENTHREAD_MTD) && \
     !OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 #error "OPENTHREAD_CONFIG_RADIO_STATS_ENABLE requires OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE".
 #endif
+
+constexpr uint32_t kSymbolTime      = OT_RADIO_SYMBOL_TIME;
+constexpr uint8_t  kSymbolsPerOctet = OT_RADIO_SYMBOLS_PER_OCTET;
+constexpr uint32_t kPhyUsPerByte    = kSymbolsPerOctet * kSymbolTime;
+constexpr uint8_t  kChannelPage0    = OT_RADIO_CHANNEL_PAGE_0;
+constexpr uint8_t  kChannelPage2    = OT_RADIO_CHANNEL_PAGE_2;
+#if (OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT && OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT)
+constexpr uint16_t kNumChannelPages   = 2;
+constexpr uint32_t kSupportedChannels = OT_RADIO_915MHZ_OQPSK_CHANNEL_MASK | OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MASK;
+constexpr uint8_t  kChannelMin        = OT_RADIO_915MHZ_OQPSK_CHANNEL_MIN;
+constexpr uint8_t  kChannelMax        = OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MAX;
+#elif OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT
+constexpr uint16_t kNumChannelPages   = 1;
+constexpr uint32_t kSupportedChannels = OT_RADIO_915MHZ_OQPSK_CHANNEL_MASK;
+constexpr uint8_t  kChannelMin        = OT_RADIO_915MHZ_OQPSK_CHANNEL_MIN;
+constexpr uint8_t  kChannelMax        = OT_RADIO_915MHZ_OQPSK_CHANNEL_MAX;
+#elif OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT
+constexpr uint16_t kNumChannelPages   = 1;
+constexpr uint32_t kSupportedChannels = OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MASK;
+constexpr uint8_t  kChannelMin        = OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MIN;
+constexpr uint8_t  kChannelMax        = OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MAX;
+#elif OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_SUPPORT
+constexpr uint16_t kNumChannelPages   = 1;
+constexpr uint32_t kSupportedChannels = OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_MASK;
+constexpr uint8_t  kChannelMin        = OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_MIN;
+constexpr uint8_t  kChannelMax        = OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_MAX;
+#endif
+
+constexpr uint8_t kFrameMinSize = OT_RADIO_FRAME_MIN_SIZE;
+constexpr uint8_t kFrameMaxSize = OT_RADIO_FRAME_MAX_SIZE;
+
+extern const uint8_t kSupportedChannelPages[kNumChannelPages];
+
+constexpr int8_t kInvalidRssi = OT_RADIO_RSSI_INVALID; ///< Invalid RSSI value.
+
+constexpr int8_t kDefaultReceiveSensitivity = -110; ///< Default receive sensitivity (in dBm).
+
+constexpr int8_t kInvalidPower = OT_RADIO_POWER_INVALID; ///< Invalid TX power value
+
+static_assert((OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT || OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT ||
+               OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_SUPPORT),
+              "OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT "
+              "or OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT "
+              "or OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_SUPPORT "
+              "must be set to 1 to specify the radio mode");
+
+/**
+ * Indicates whether a given channel page is supported based on the current configurations.
+ *
+ * @param[in] aChannelPage The channel page to check.
+ *
+ * @retval TRUE    The @p aChannelPage is supported by radio.
+ * @retval FALSE   The @p aChannelPage is not supported by radio.
+ */
+constexpr bool SupportsChannelPage(uint8_t aChannelPage)
+{
+#if OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT && OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT
+    return (aChannelPage == kChannelPage0) || (aChannelPage == kChannelPage2);
+#elif OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT
+    return (aChannelPage == kChannelPage0);
+#elif OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT
+    return (aChannelPage == kChannelPage2);
+#elif OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_SUPPORT
+    return (aChannelPage == OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_PAGE);
+#endif
+}
+
+/**
+ * Returns the channel mask for a given channel page if supported by the radio.
+ *
+ * @param[in] aChannelPage   The channel page.
+ *
+ * @returns The channel mask for @p aChannelPage if page is supported by the radio, otherwise zero.
+ */
+uint32_t ChannelMaskForPage(uint8_t aChannelPage);
+
+/**
+ * Checks if a given channel is valid as a CSL channel.
+ *
+ * @retval true   The channel is valid.
+ * @retval false  The channel is invalid.
+ */
+bool IsCslChannelValid(uint8_t aCslChannel);
+
+class Radio;
+
+/**
+ * Defines the Radio callbacks.
+ */
+class Callbacks : public InstanceLocator
+{
+    friend class Radio;
+
+public:
+    /**
+     * This callback method handles a "Receive Done" event from radio platform.
+     *
+     * @param[in]  aFrame    A pointer to the received frame or `nullptr` if the receive operation failed.
+     * @param[in]  aError    kErrorNone when successfully received a frame,
+     *                       kErrorAbort when reception was aborted and a frame was not received,
+     *                       kErrorNoBufs when a frame could not be received due to lack of rx buffer space.
+     */
+    void HandleReceiveDone(Mac::RxFrame *aFrame, Error aError);
+
+    /**
+     * This callback method handles a "Transmit Started" event from radio platform.
+     *
+     * @param[in]  aFrame     The frame that is being transmitted.
+     */
+    void HandleTransmitStarted(Mac::TxFrame &aFrame);
+
+    /**
+     * This callback method handles a "Transmit Done" event from radio platform.
+     *
+     * @param[in]  aFrame     The frame that was transmitted.
+     * @param[in]  aAckFrame  A pointer to the ACK frame, `nullptr` if no ACK was received.
+     * @param[in]  aError     kErrorNone when the frame was transmitted,
+     *                        kErrorNoAck when the frame was transmitted but no ACK was received,
+     *                        kErrorChannelAccessFailure tx could not take place due to activity on the
+     *                        channel, kErrorAbort when transmission was aborted for other reasons.
+     */
+    void HandleTransmitDone(Mac::TxFrame &aFrame, Mac::RxFrame *aAckFrame, Error aError);
+
+    /**
+     * This callback method handles "Energy Scan Done" event from radio platform.
+     *
+     * Is used when radio provides OT_RADIO_CAPS_ENERGY_SCAN capability. It is called from
+     * `otPlatRadioEnergyScanDone()`.
+     *
+     * @param[in]  aMaxRssi  The maximum RSSI encountered on the scanned channel.
+     */
+    void HandleEnergyScanDone(int8_t aMaxRssi);
+
+    /**
+     * This callback method handles "Bus Latency Changed" event from radio platform.
+     */
+    void HandleBusLatencyChanged(void);
+
+#if OPENTHREAD_CONFIG_DIAG_ENABLE
+    /**
+     * This callback method handles a "Receive Done" event from radio platform when diagnostics mode is enabled.
+     *
+     * @param[in]  aFrame    A pointer to the received frame or `nullptr` if the receive operation failed.
+     * @param[in]  aError    kErrorNone when successfully received a frame,
+     *                       kErrorAbort when reception was aborted and a frame was not received,
+     *                       kErrorNoBufs when a frame could not be received due to lack of rx buffer space.
+     */
+    void HandleDiagsReceiveDone(Mac::RxFrame *aFrame, Error aError);
+
+    /**
+     * This callback method handles a "Transmit Done" event from radio platform when diagnostics mode is enabled.
+     *
+     * @param[in]  aFrame     The frame that was transmitted.
+     * @param[in]  aError     kErrorNone when the frame was transmitted,
+     *                        kErrorNoAck when the frame was transmitted but no ACK was received,
+     *                        kErrorChannelAccessFailure tx could not take place due to activity on the
+     *                        channel, kErrorAbort when transmission was aborted for other reasons.
+     */
+    void HandleDiagsTransmitDone(Mac::TxFrame &aFrame, Error aError);
+#endif
+
+private:
+    explicit Callbacks(Instance &aInstance)
+        : InstanceLocator(aInstance)
+    {
+    }
+};
+
+#if OPENTHREAD_CONFIG_RADIO_STATS_ENABLE && (OPENTHREAD_FTD || OPENTHREAD_MTD)
+
+/**
+ * Implements the radio statistics logic.
+ *
+ * The radio statistics are the time when the radio in TX/RX/radio state.
+ * Since this class collects these statistics from pure software level
+ * and no platform API is involved, a simplified model is used to
+ * calculate the time of different radio states. The data may not be very
+ * accurate, but it's sufficient to provide a general understanding of
+ * the proportion of time a device is in different radio states.
+ *
+ * The simplified model is:
+ * - The radio statistics is only aware of 2 states: RX and sleep.
+ * - Each time `Radio::Receive` or `Radio::Sleep` is called, it will check
+ *   the current state and add the time since last time the methods were
+ *   called. For example, `Sleep` is first called and `Receive` is called
+ *   after 1 second, then 1 second will be added to SleepTime and the
+ *   current state switches to `Receive`.
+ * - The time of TX will be calculated from the callback of TransmitDone.
+ *   If TX returns kErrorNone or kErrorNoAck, the tx time will be added
+ *   according to the number of bytes sent. And the SleepTime or RxTime
+ *   will be reduced accordingly.
+ * - When `GetStats` is called, an operation will be executed to calculate
+ *   the time for the last state. And the result will be returned.
+ */
+class Statistics : private NonCopyable
+{
+    friend class Radio;
+    friend class Callbacks;
+
+public:
+    using TimeStats = otRadioTimeStats; ///< Radio statistics (time spend in each state).
+
+    /**
+     * Retrieves the current radio statistics.
+     *
+     * @return The current time statistics.
+     */
+    const TimeStats &GetStats(void);
+
+    /**
+     * Resets the radio statistics.
+     */
+    void ResetTime(void);
+
+private:
+    enum Status : uint8_t
+    {
+        kDisabled,
+        kSleep,
+        kReceive,
+    };
+
+    Statistics(void);
+    void RecordStateChange(Status aStatus);
+    void HandleReceiveAt(uint32_t aDurationUs);
+    void RecordTxDone(Error aError, uint16_t aPsduLength);
+    void RecordRxDone(Error aError);
+    void UpdateTime(void);
+
+    Status    mStatus;
+    TimeStats mTimeStats;
+    TimeMicro mLastUpdateTime;
+};
+
+#endif // OPENTHREAD_CONFIG_RADIO_STATS_ENABLE && (OPENTHREAD_FTD || OPENTHREAD_MTD)
 
 /**
  * Represents an OpenThread radio abstraction.
  */
 class Radio : public InstanceLocator, private NonCopyable
 {
-    friend class Instance;
+    friend class ot::Instance;
 
 public:
-    static constexpr uint32_t kSymbolTime      = OT_RADIO_SYMBOL_TIME;
-    static constexpr uint8_t  kSymbolsPerOctet = OT_RADIO_SYMBOLS_PER_OCTET;
-    static constexpr uint32_t kPhyUsPerByte    = kSymbolsPerOctet * kSymbolTime;
-    static constexpr uint8_t  kChannelPage0    = OT_RADIO_CHANNEL_PAGE_0;
-    static constexpr uint8_t  kChannelPage2    = OT_RADIO_CHANNEL_PAGE_2;
-#if (OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT && OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT)
-    static constexpr uint16_t kNumChannelPages = 2;
-    static constexpr uint32_t kSupportedChannels =
-        OT_RADIO_915MHZ_OQPSK_CHANNEL_MASK | OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MASK;
-    static constexpr uint8_t kChannelMin = OT_RADIO_915MHZ_OQPSK_CHANNEL_MIN;
-    static constexpr uint8_t kChannelMax = OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MAX;
-#elif OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT
-    static constexpr uint16_t kNumChannelPages   = 1;
-    static constexpr uint32_t kSupportedChannels = OT_RADIO_915MHZ_OQPSK_CHANNEL_MASK;
-    static constexpr uint8_t  kChannelMin        = OT_RADIO_915MHZ_OQPSK_CHANNEL_MIN;
-    static constexpr uint8_t  kChannelMax        = OT_RADIO_915MHZ_OQPSK_CHANNEL_MAX;
-#elif OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT
-    static constexpr uint16_t kNumChannelPages   = 1;
-    static constexpr uint32_t kSupportedChannels = OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MASK;
-    static constexpr uint8_t  kChannelMin        = OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MIN;
-    static constexpr uint8_t  kChannelMax        = OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MAX;
-#elif OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_SUPPORT
-    static constexpr uint16_t kNumChannelPages   = 1;
-    static constexpr uint32_t kSupportedChannels = OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_MASK;
-    static constexpr uint8_t  kChannelMin        = OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_MIN;
-    static constexpr uint8_t  kChannelMax        = OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_MAX;
-#endif
-
-    static constexpr uint8_t kFrameMinSize = OT_RADIO_FRAME_MIN_SIZE;
-    static constexpr uint8_t kFrameMaxSize = OT_RADIO_FRAME_MAX_SIZE;
-
-    static const uint8_t kSupportedChannelPages[kNumChannelPages];
-
-    static constexpr int8_t kInvalidRssi = OT_RADIO_RSSI_INVALID; ///< Invalid RSSI value.
-
-    static constexpr int8_t kDefaultReceiveSensitivity = -110; ///< Default receive sensitivity (in dBm).
-
-    static constexpr int8_t kInvalidPower = OT_RADIO_POWER_INVALID;
-
-    static_assert((OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT || OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT ||
-                   OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_SUPPORT),
-                  "OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT "
-                  "or OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT "
-                  "or OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_SUPPORT "
-                  "must be set to 1 to specify the radio mode");
-
-    /**
-     * Defines the callbacks from `Radio`.
-     */
-    class Callbacks : public InstanceLocator
-    {
-        friend class Radio;
-
-    public:
-        /**
-         * This callback method handles a "Receive Done" event from radio platform.
-         *
-         * @param[in]  aFrame    A pointer to the received frame or `nullptr` if the receive operation failed.
-         * @param[in]  aError    kErrorNone when successfully received a frame,
-         *                       kErrorAbort when reception was aborted and a frame was not received,
-         *                       kErrorNoBufs when a frame could not be received due to lack of rx buffer space.
-         */
-        void HandleReceiveDone(Mac::RxFrame *aFrame, Error aError);
-
-        /**
-         * This callback method handles a "Transmit Started" event from radio platform.
-         *
-         * @param[in]  aFrame     The frame that is being transmitted.
-         */
-        void HandleTransmitStarted(Mac::TxFrame &aFrame);
-
-        /**
-         * This callback method handles a "Transmit Done" event from radio platform.
-         *
-         * @param[in]  aFrame     The frame that was transmitted.
-         * @param[in]  aAckFrame  A pointer to the ACK frame, `nullptr` if no ACK was received.
-         * @param[in]  aError     kErrorNone when the frame was transmitted,
-         *                        kErrorNoAck when the frame was transmitted but no ACK was received,
-         *                        kErrorChannelAccessFailure tx could not take place due to activity on the
-         *                        channel, kErrorAbort when transmission was aborted for other reasons.
-         */
-        void HandleTransmitDone(Mac::TxFrame &aFrame, Mac::RxFrame *aAckFrame, Error aError);
-
-        /**
-         * This callback method handles "Energy Scan Done" event from radio platform.
-         *
-         * Is used when radio provides OT_RADIO_CAPS_ENERGY_SCAN capability. It is called from
-         * `otPlatRadioEnergyScanDone()`.
-         *
-         * @param[in]  aMaxRssi  The maximum RSSI encountered on the scanned channel.
-         */
-        void HandleEnergyScanDone(int8_t aMaxRssi);
-
-        /**
-         * This callback method handles "Bus Latency Changed" event from radio platform.
-         */
-        void HandleBusLatencyChanged(void);
-
-#if OPENTHREAD_CONFIG_DIAG_ENABLE
-        /**
-         * This callback method handles a "Receive Done" event from radio platform when diagnostics mode is enabled.
-         *
-         * @param[in]  aFrame    A pointer to the received frame or `nullptr` if the receive operation failed.
-         * @param[in]  aError    kErrorNone when successfully received a frame,
-         *                       kErrorAbort when reception was aborted and a frame was not received,
-         *                       kErrorNoBufs when a frame could not be received due to lack of rx buffer space.
-         */
-        void HandleDiagsReceiveDone(Mac::RxFrame *aFrame, Error aError);
-
-        /**
-         * This callback method handles a "Transmit Done" event from radio platform when diagnostics mode is enabled.
-         *
-         * @param[in]  aFrame     The frame that was transmitted.
-         * @param[in]  aError     kErrorNone when the frame was transmitted,
-         *                        kErrorNoAck when the frame was transmitted but no ACK was received,
-         *                        kErrorChannelAccessFailure tx could not take place due to activity on the
-         *                        channel, kErrorAbort when transmission was aborted for other reasons.
-         */
-        void HandleDiagsTransmitDone(Mac::TxFrame &aFrame, Error aError);
-#endif
-
-    private:
-        explicit Callbacks(Instance &aInstance)
-            : InstanceLocator(aInstance)
-        {
-        }
-    };
-
-#if OPENTHREAD_CONFIG_RADIO_STATS_ENABLE && (OPENTHREAD_FTD || OPENTHREAD_MTD)
-    /**
-     * Implements the radio statistics logic.
-     *
-     * The radio statistics are the time when the radio in TX/RX/radio state.
-     * Since this class collects these statistics from pure software level
-     * and no platform API is involved, a simplified model is used to
-     * calculate the time of different radio states. The data may not be very
-     * accurate, but it's sufficient to provide a general understanding of
-     * the proportion of time a device is in different radio states.
-     *
-     * The simplified model is:
-     * - The radio statistics is only aware of 2 states: RX and sleep.
-     * - Each time `Radio::Receive` or `Radio::Sleep` is called, it will check
-     *   the current state and add the time since last time the methods were
-     *   called. For example, `Sleep` is first called and `Receive` is called
-     *   after 1 second, then 1 second will be added to SleepTime and the
-     *   current state switches to `Receive`.
-     * - The time of TX will be calculated from the callback of TransmitDone.
-     *   If TX returns kErrorNone or kErrorNoAk, the tx time will be added
-     *   according to the number of bytes sent. And the SleepTime or RxTime
-     *   will be reduced accordingly.
-     * - When `GetStats` is called, an operation will be executed to calculate
-     *   the time for the last state. And the result will be returned.
-     */
-    class Statistics : private NonCopyable
-    {
-        friend class Radio;
-        friend class Callbacks;
-
-    public:
-        using TimeStats = otRadioTimeStats; ///< Radio statistics (time spend in each state).
-
-        /**
-         * Retrieves the current radio statistics.
-         *
-         * @return The current time statistics.
-         */
-        const TimeStats &GetStats(void);
-
-        /**
-         * Resets the radio statistics.
-         */
-        void ResetTime(void);
-
-    private:
-        enum Status : uint8_t
-        {
-            kDisabled,
-            kSleep,
-            kReceive,
-        };
-
-        Statistics(void);
-        void RecordStateChange(Status aStatus);
-        void HandleReceiveAt(uint32_t aDurationUs);
-        void RecordTxDone(otError aError, uint16_t aPsduLength);
-        void RecordRxDone(otError aError);
-        void UpdateTime(void);
-
-        Status    mStatus;
-        TimeStats mTimeStats;
-        TimeMicro mLastUpdateTime;
-    };
-#endif // OPENTHREAD_CONFIG_RADIO_STATS_ENABLE && (OPENTHREAD_FTD || OPENTHREAD_MTD)
-
     /**
      * Initializes the `Radio` object.
      *
@@ -524,7 +564,7 @@ public:
      * @retval kErrorNone    Successfully scheduled receive window.
      * @retval kErrorFailed  The receive window could not be scheduled.
      */
-    Error ReceiveAt(uint8_t aChannel, RadioTime32 aStart, uint32_t aDuration);
+    Error ReceiveAt(uint8_t aChannel, Time32 aStart, uint32_t aDuration);
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
@@ -533,7 +573,7 @@ public:
      *
      * @param[in]  aCslSampleTime  The CSL sample time.
      */
-    void UpdateCslSampleTime(RadioTime32 aCslSampleTime);
+    void UpdateCslSampleTime(Time32 aCslSampleTime);
 
     /**
      * Enables CSL sampling in radio.
@@ -567,14 +607,14 @@ public:
      *
      * @returns The current radio clock time.
      */
-    RadioTime64 GetNow(void);
+    Time64 GetNow(void);
 
     /**
      * Get the current radio time in microseconds as a 32-bit value (lower 32 bits of the full radio time).
      *
-     * @returns The current radio clock time as a `RadioTime32`.
+     * @returns The current radio clock time as a `Time32`.
      */
-    RadioTime32 GetNowAsRadioTime32(void) { return ConvertRadioTime64To32(GetNow()); }
+    Time32 GetNowAsTime32(void) { return ConvertTime64To32(GetNow()); }
 
     /**
      * Get the current accuracy, in units of ± ppm, of the clock used for scheduling CSL operations.
@@ -749,18 +789,6 @@ public:
 #endif // OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
 
     /**
-     * Checks if a given channel is valid as a CSL channel.
-     *
-     * @retval true   The channel is valid.
-     * @retval false  The channel is invalid.
-     */
-    static bool IsCslChannelValid(uint8_t aCslChannel)
-    {
-        return ((aCslChannel == 0) ||
-                ((kChannelMin == aCslChannel) || ((kChannelMin < aCslChannel) && (aCslChannel <= kChannelMax))));
-    }
-
-    /**
      * Sets the region code.
      *
      * The radio region format is the 2-bytes ascii representation of the ISO 3166 alpha-2 code.
@@ -787,61 +815,6 @@ public:
      * @retval  kErrorNotImplemented  The feature is not implemented.
      */
     Error GetRegion(uint16_t &aRegionCode) const { return otPlatRadioGetRegion(GetInstancePtr(), &aRegionCode); }
-
-    /**
-     * Indicates whether a given channel page is supported based on the current configurations.
-     *
-     * @param[in] aChannelPage The channel page to check.
-     *
-     * @retval TRUE    The @p aChannelPage is supported by radio.
-     * @retval FALASE  The @p aChannelPage is not supported by radio.
-     */
-    static constexpr bool SupportsChannelPage(uint8_t aChannelPage)
-    {
-#if OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT && OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT
-        return (aChannelPage == kChannelPage0) || (aChannelPage == kChannelPage2);
-#elif OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT
-        return (aChannelPage == kChannelPage0);
-#elif OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT
-        return (aChannelPage == kChannelPage2);
-#elif OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_SUPPORT
-        return (aChannelPage == OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_PAGE);
-#endif
-    }
-
-    /**
-     * Returns the channel mask for a given channel page if supported by the radio.
-     *
-     * @param[in] aChannelPage   The channel page.
-     *
-     * @returns The channel mask for @p aChannelPage if page is supported by the radio, otherwise zero.
-     */
-    static uint32_t ChannelMaskForPage(uint8_t aChannelPage)
-    {
-        uint32_t mask = 0;
-
-#if OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT
-        if (aChannelPage == kChannelPage0)
-        {
-            mask = OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MASK;
-        }
-#endif
-
-#if OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT
-        if (aChannelPage == kChannelPage2)
-        {
-            mask = OT_RADIO_915MHZ_OQPSK_CHANNEL_MASK;
-        }
-#endif
-
-#if OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_SUPPORT
-        if (aChannelPage == OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_PAGE)
-        {
-            mask = OPENTHREAD_CONFIG_PLATFORM_RADIO_PROPRIETARY_CHANNEL_MASK;
-        }
-#endif
-        return mask;
-    }
 
     /**
      * Get the bus speed in bits/second between the host and the radio chip.
@@ -991,7 +964,7 @@ inline Error Radio::Receive(uint8_t aChannel)
 }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-inline Error Radio::ReceiveAt(uint8_t aChannel, RadioTime32 aStart, uint32_t aDuration)
+inline Error Radio::ReceiveAt(uint8_t aChannel, Time32 aStart, uint32_t aDuration)
 {
     Error error = otPlatRadioReceiveAt(GetInstancePtr(), aChannel, aStart, aDuration);
 #if OPENTHREAD_CONFIG_RADIO_STATS_ENABLE && (OPENTHREAD_FTD || OPENTHREAD_MTD)
@@ -1005,7 +978,7 @@ inline Error Radio::ReceiveAt(uint8_t aChannel, RadioTime32 aStart, uint32_t aDu
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-inline void Radio::UpdateCslSampleTime(RadioTime32 aCslSampleTime)
+inline void Radio::UpdateCslSampleTime(Time32 aCslSampleTime)
 {
     otPlatRadioUpdateCslSampleTime(GetInstancePtr(), aCslSampleTime);
 }
@@ -1019,7 +992,7 @@ inline Error Radio::ResetCsl(void) { return otPlatRadioResetCsl(GetInstancePtr()
 #endif
 
 #if OT_CONFIG_RADIO_TIME_ENABLE
-inline RadioTime64 Radio::GetNow(void) { return otPlatRadioGetNow(GetInstancePtr()); }
+inline Time64 Radio::GetNow(void) { return otPlatRadioGetNow(GetInstancePtr()); }
 
 inline uint8_t Radio::GetCslAccuracy(void) { return otPlatRadioGetCslAccuracy(GetInstancePtr()); }
 
@@ -1118,7 +1091,7 @@ inline Error Radio::ReceiveAt(uint8_t, uint32_t, uint32_t) { return kErrorNone; 
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-inline void Radio::UpdateCslSampleTime(RadioTime32) {}
+inline void Radio::UpdateCslSampleTime(Time32) {}
 
 inline Error Radio::EnableCsl(uint32_t, Mac::ShortAddress, const Mac::ExtAddress &) { return kErrorNotImplemented; }
 
@@ -1126,7 +1099,7 @@ inline Error Radio::ResetCsl(void) { return kErrorNotImplemented; }
 #endif
 
 #if OT_CONFIG_RADIO_TIME_ENABLE
-inline RadioTime64 Radio::GetNow(void) { return NumericLimits<uint64_t>::kMax; }
+inline Time64 Radio::GetNow(void) { return NumericLimits<uint64_t>::kMax; }
 
 inline uint8_t Radio::GetCslAccuracy(void) { return NumericLimits<uint8_t>::kMax; }
 
@@ -1168,6 +1141,7 @@ inline bool Radio::GetDiagMode(void) { return false; }
 #endif
 #endif // #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 
+} // namespace Radio
 } // namespace ot
 
 #endif // OT_CORE_RADIO_RADIO_HPP_

--- a/src/core/radio/radio_callbacks.cpp
+++ b/src/core/radio/radio_callbacks.cpp
@@ -36,28 +36,29 @@
 #include "instance/instance.hpp"
 
 namespace ot {
+namespace Radio {
 
-void Radio::Callbacks::HandleReceiveDone(Mac::RxFrame *aFrame, Error aError)
+void Callbacks::HandleReceiveDone(Mac::RxFrame *aFrame, Error aError)
 {
 #if OPENTHREAD_CONFIG_RADIO_STATS_ENABLE && (OPENTHREAD_FTD || OPENTHREAD_MTD)
-    Get<Radio::Statistics>().RecordRxDone(aError);
+    Get<Statistics>().RecordRxDone(aError);
 #endif
     Get<Mac::SubMac>().HandleReceiveDone(aFrame, aError);
 }
 
-void Radio::Callbacks::HandleTransmitStarted(Mac::TxFrame &aFrame) { Get<Mac::SubMac>().HandleTransmitStarted(aFrame); }
+void Callbacks::HandleTransmitStarted(Mac::TxFrame &aFrame) { Get<Mac::SubMac>().HandleTransmitStarted(aFrame); }
 
-void Radio::Callbacks::HandleTransmitDone(Mac::TxFrame &aFrame, Mac::RxFrame *aAckFrame, Error aError)
+void Callbacks::HandleTransmitDone(Mac::TxFrame &aFrame, Mac::RxFrame *aAckFrame, Error aError)
 {
 #if OPENTHREAD_CONFIG_RADIO_STATS_ENABLE && (OPENTHREAD_FTD || OPENTHREAD_MTD)
-    Get<Radio::Statistics>().RecordTxDone(aError, aFrame.GetLength());
+    Get<Statistics>().RecordTxDone(aError, aFrame.GetLength());
 #endif
     Get<Mac::SubMac>().HandleTransmitDone(aFrame, aAckFrame, aError);
 }
 
-void Radio::Callbacks::HandleEnergyScanDone(int8_t aMaxRssi) { Get<Mac::SubMac>().HandleEnergyScanDone(aMaxRssi); }
+void Callbacks::HandleEnergyScanDone(int8_t aMaxRssi) { Get<Mac::SubMac>().HandleEnergyScanDone(aMaxRssi); }
 
-void Radio::Callbacks::HandleBusLatencyChanged(void)
+void Callbacks::HandleBusLatencyChanged(void)
 {
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
     Get<CslTxScheduler>().UpdateFrameRequestAhead();
@@ -68,7 +69,7 @@ void Radio::Callbacks::HandleBusLatencyChanged(void)
 }
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-void Radio::Callbacks::HandleDiagsReceiveDone(Mac::RxFrame *aFrame, Error aError)
+void Callbacks::HandleDiagsReceiveDone(Mac::RxFrame *aFrame, Error aError)
 {
 #if OPENTHREAD_RADIO && !OPENTHREAD_RADIO_CLI
     // Pass it to notify OpenThread `Diags` module on host side.
@@ -78,7 +79,7 @@ void Radio::Callbacks::HandleDiagsReceiveDone(Mac::RxFrame *aFrame, Error aError
 #endif
 }
 
-void Radio::Callbacks::HandleDiagsTransmitDone(Mac::TxFrame &aFrame, Error aError)
+void Callbacks::HandleDiagsTransmitDone(Mac::TxFrame &aFrame, Error aError)
 {
 #if OPENTHREAD_RADIO && !OPENTHREAD_RADIO_CLI
     // Pass it to notify OpenThread `Diags` module on host side.
@@ -90,4 +91,5 @@ void Radio::Callbacks::HandleDiagsTransmitDone(Mac::TxFrame &aFrame, Error aErro
 }
 #endif // OPENTHREAD_CONFIG_DIAG_ENABLE
 
+} // namespace Radio
 } // namespace ot

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -58,7 +58,7 @@ extern "C" void otPlatRadioReceiveDone(otInstance *aInstance, otRadioFrame *aFra
 #endif
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-    if (instance.Get<Radio>().GetDiagMode())
+    if (instance.Get<Radio::Radio>().GetDiagMode())
     {
         instance.Get<Radio::Callbacks>().HandleDiagsReceiveDone(rxFrame, aError);
     }
@@ -107,7 +107,7 @@ extern "C" void otPlatRadioTxDone(otInstance *aInstance, otRadioFrame *aFrame, o
 #endif
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-    if (instance.Get<Radio>().GetDiagMode())
+    if (instance.Get<Radio::Radio>().GetDiagMode())
     {
 #if OPENTHREAD_RADIO
         uint8_t channel = txFrame.mInfo.mTxInfo.mRxChannelAfterTxDone;

--- a/src/core/radio/radio_types.cpp
+++ b/src/core/radio/radio_types.cpp
@@ -36,8 +36,9 @@
 #include "instance/instance.hpp"
 
 namespace ot {
+namespace Radio {
 
-bool IsRadioTimeStrictlyBefore(RadioTime32 aFirstTime, RadioTime32 aSecondTime)
+bool IsTimeStrictlyBefore(Time32 aFirstTime, Time32 aSecondTime)
 {
     Time firstTime(aFirstTime);
     Time secondTime(aSecondTime);
@@ -46,11 +47,11 @@ bool IsRadioTimeStrictlyBefore(RadioTime32 aFirstTime, RadioTime32 aSecondTime)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-// SyncedRadioLocalTime
+// SyncedTime
 
 #if OT_CONFIG_RADIO_TIME_ENABLE && OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 
-void SyncedRadioLocalTime::SetToNow(Radio &aRadio)
+void SyncedTime::SetToNow(Radio &aRadio)
 {
     mRadioTime = aRadio.GetNow();
     mLocalTime = TimerMicro::GetNow();
@@ -58,4 +59,5 @@ void SyncedRadioLocalTime::SetToNow(Radio &aRadio)
 
 #endif
 
+} // namespace Radio
 } // namespace ot

--- a/src/core/radio/radio_types.hpp
+++ b/src/core/radio/radio_types.hpp
@@ -42,6 +42,7 @@
 #include "common/time.hpp"
 
 namespace ot {
+namespace Radio {
 
 #ifdef OT_CONFIG_RADIO_TIME_ENABLE
 #error "OT_CONFIG_RADIO_TIME_ENABLE MUST NOT be defined directly. It is derived from other configs"
@@ -57,21 +58,21 @@ class Radio;
 /**
  * Represents a 64-bit radio time in microseconds referenced to a continuous monotonic local radio clock.
  */
-typedef otRadioTime64 RadioTime64;
+typedef otRadioTime64 Time64;
 
 /**
- * Represents a 32-bit radio time in microseconds (holds the lower 32 bits of a `RadioTime64`).
+ * Represents a 32-bit radio time in microseconds (holds the lower 32 bits of a `Radio::Time64`).
  */
-typedef otRadioTime32 RadioTime32;
+typedef otRadioTime32 Time32;
 
 /**
  * Converts a 64-bit radio time to a 32-bit radio time.
  *
- * @param[in] aRadioTime64  The 64-bit radio time to convert.
+ * @param[in] aTime64  The 64-bit radio time to convert.
  *
- * @returns The converted 32-bit radio time (lower 32 bits of @p aRadioTime64).
+ * @returns The converted 32-bit radio time (lower 32 bits of @p aTime64).
  */
-inline RadioTime32 ConvertRadioTime64To32(RadioTime64 aRadioTime64) { return static_cast<RadioTime32>(aRadioTime64); }
+inline Time32 ConvertTime64To32(Time64 aTime64) { return static_cast<Time32>(aTime64); }
 
 /**
  * Indicates whether a given 32-bit radio time is strictly before another 32-bit radio time.
@@ -84,14 +85,14 @@ inline RadioTime32 ConvertRadioTime64To32(RadioTime64 aRadioTime64) { return sta
  * @retval TRUE   @p aFirstTime is strictly before @p aSecondTime.
  * @retval FALSE  @p aFirstTime is not strictly before @p aSecondTime.
  */
-bool IsRadioTimeStrictlyBefore(RadioTime32 aFirstTime, RadioTime32 aSecondTime);
+bool IsTimeStrictlyBefore(Time32 aFirstTime, Time32 aSecondTime);
 
 #if OT_CONFIG_RADIO_TIME_ENABLE && OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 
 /**
  * Represents synchronized radio time and local `TimeMicro`.
  */
-class SyncedRadioLocalTime : public Clearable<SyncedRadioLocalTime>
+class SyncedTime : public Clearable<SyncedTime>
 {
 public:
     /**
@@ -106,21 +107,21 @@ public:
      *
      * @returns The local microsecond time.
      */
-    TimeMicro GetAsTimeMicro(void) const { return mLocalTime; }
+    TimeMicro GetAsLocalTimeMicro(void) const { return mLocalTime; }
 
     /**
      * Gets the 64-bit radio time.
      *
      * @returns The 64-bit radio time.
      */
-    RadioTime64 GetAsRadio64(void) const { return mRadioTime; }
+    Time64 GetAsTime64(void) const { return mRadioTime; }
 
     /**
      * Gets the 32-bit radio time.
      *
      * @returns The 32-bit radio time.
      */
-    RadioTime32 GetAsRadio32(void) const { return ConvertRadioTime64To32(mRadioTime); }
+    Time32 GetAsTime32(void) const { return ConvertTime64To32(mRadioTime); }
 
     /**
      * Advances the synchronized radio and local time values by a given duration.
@@ -145,12 +146,13 @@ public:
     }
 
 private:
-    RadioTime64 mRadioTime;
-    TimeMicro   mLocalTime;
+    Time64    mRadioTime;
+    TimeMicro mLocalTime;
 };
 
 #endif // OT_CONFIG_RADIO_TIME_ENABLE && OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 
+} // namespace Radio
 } // namespace ot
 
 #endif // OT_CORE_RADIO_RADIO_TYPES_HPP_

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -137,10 +137,11 @@ uint32_t CslTxScheduler::GetNextCslTransmissionDelay(const CslNeighbor &aCslNeig
 {
     // See CslTxScheduler::NeighborInfo::mCslPhase
 
-    RadioTime64 radioNow      = Get<Radio>().GetNow();
-    uint32_t    periodInUs    = aCslNeighbor.GetCslPeriod() * kUsPerTenSymbols;
-    RadioTime64 firstTxWindow = aCslNeighbor.GetLastRxTimestamp() + aCslNeighbor.GetCslPhase() * kUsPerTenSymbols;
-    RadioTime64 nextTxWindow  = radioNow - (radioNow % periodInUs) + (firstTxWindow % periodInUs);
+    Radio::Time64 radioNow   = Get<Radio::Radio>().GetNow();
+    uint32_t      periodInUs = aCslNeighbor.GetCslPeriod() * Radio::kUsPerTenSymbols;
+    Radio::Time64 firstTxWindow =
+        aCslNeighbor.GetLastRxTimestamp() + aCslNeighbor.GetCslPhase() * Radio::kUsPerTenSymbols;
+    Radio::Time64 nextTxWindow = radioNow - (radioNow % periodInUs) + (firstTxWindow % periodInUs);
 
     while (nextTxWindow < radioNow + aAheadUs)
     {
@@ -222,7 +223,7 @@ Mac::TxFrame *CslTxScheduler::HandleFrameRequest(Mac::TxFrames &aTxFrames)
     VerifyOrExit(delay <= mCslFrameRequestAheadUs + kFramePreparationGuardInterval, frame = nullptr);
 
     frame->SetTxDelay(txDelay);
-    frame->SetTxDelayBaseTime(ConvertRadioTime64To32(mCslTxNeighbor->GetLastRxTimestamp()));
+    frame->SetTxDelayBaseTime(Radio::ConvertTime64To32(mCslTxNeighbor->GetLastRxTimestamp()));
     frame->SetCsmaCaEnabled(true);
 
 exit:

--- a/src/core/thread/csl_tx_scheduler.hpp
+++ b/src/core/thread/csl_tx_scheduler.hpp
@@ -95,8 +95,8 @@ public:
         TimeMilli GetCslLastHeard(void) const { return mCslLastHeard; }
         void      SetCslLastHeard(TimeMilli aCslLastHeard) { mCslLastHeard = aCslLastHeard; }
 
-        RadioTime64 GetLastRxTimestamp(void) const { return mLastRxTimestamp; }
-        void        SetLastRxTimestamp(RadioTime64 aLastRxTimestamp) { mLastRxTimestamp = aLastRxTimestamp; }
+        Radio::Time64 GetLastRxTimestamp(void) const { return mLastRxTimestamp; }
+        void          SetLastRxTimestamp(Radio::Time64 aLastRxTimestamp) { mLastRxTimestamp = aLastRxTimestamp; }
 
     private:
         uint8_t  mCslTxAttempts : 7;   ///< Number of CSL triggered tx attempts.

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -78,7 +78,7 @@ Error DiscoverScanner::Discover(const Mac::ChannelMask &aScanChannels,
         {
             Mac::ExtAddress extAddress;
 
-            Get<Radio>().GetIeeeEui64(extAddress);
+            Get<Radio::Radio>().GetIeeeEui64(extAddress);
             MeshCoP::ComputeJoinerId(extAddress, extAddress);
             MeshCoP::SteeringData::CalculateHashBitIndexes(extAddress, mFilterIndexes);
         }

--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -724,12 +724,12 @@ Status Subject::ConfigureEnhAckProbing(uint8_t aEnhAckFlags, const Metrics &aMet
         VerifyOrExit(aMetrics.mLqi || aMetrics.mLinkMargin || aMetrics.mRssi, status = kStatusOtherError);
         VerifyOrExit(!(aMetrics.mLqi && aMetrics.mLinkMargin && aMetrics.mRssi), status = kStatusOtherError);
 
-        error = Get<Radio>().ConfigureEnhAckProbing(aMetrics, aNeighbor.GetRloc16(), aNeighbor.GetExtAddress());
+        error = Get<Radio::Radio>().ConfigureEnhAckProbing(aMetrics, aNeighbor.GetRloc16(), aNeighbor.GetExtAddress());
     }
     else if (aEnhAckFlags == kEnhAckClear)
     {
         VerifyOrExit(!aMetrics.mLqi && !aMetrics.mLinkMargin && !aMetrics.mRssi, status = kStatusOtherError);
-        error = Get<Radio>().ConfigureEnhAckProbing(aMetrics, aNeighbor.GetRloc16(), aNeighbor.GetExtAddress());
+        error = Get<Radio::Radio>().ConfigureEnhAckProbing(aMetrics, aNeighbor.GetRloc16(), aNeighbor.GetExtAddress());
     }
     else
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -188,7 +188,7 @@ Error Mle::Start(StartMode aMode)
     Error error = kErrorNone;
 
     // cannot bring up the interface if IEEE 802.15.4 promiscuous mode is enabled
-    VerifyOrExit(!Get<Radio>().GetPromiscuous(), error = kErrorInvalidState);
+    VerifyOrExit(!Get<Radio::Radio>().GetPromiscuous(), error = kErrorInvalidState);
     VerifyOrExit(Get<ThreadNetif>().IsUp(), error = kErrorInvalidState);
 
     if (Get<Mac::Mac>().GetPanId() == Mac::kPanIdBroadcast)
@@ -3034,7 +3034,7 @@ uint64_t Mle::CalcParentCslMetric(const Mac::CslAccuracy &aCslAccuracy) const
 
     static constexpr uint64_t usInSecond = 1000000;
 
-    uint64_t cslPeriodUs  = kMinCslPeriod * kUsPerTenSymbols;
+    uint64_t cslPeriodUs  = Radio::kMinCslPeriod * Radio::kUsPerTenSymbols;
     uint64_t cslTimeoutUs = GetCslTimeout() * usInSecond;
     uint64_t k            = cslTimeoutUs / cslPeriodUs;
 
@@ -3809,7 +3809,7 @@ Error Mle::TxMessage::AppendCslTimeoutTlv(void)
 Error Mle::TxMessage::AppendCslClockAccuracyTlv(void)
 {
     return Tlv::Append<CslClockAccuracyTlv>(
-        *this, CslClockAccuracyTlvValue(Get<Radio>().GetCslAccuracy(), Get<Radio>().GetCslUncertainty()));
+        *this, CslClockAccuracyTlvValue(Get<Radio::Radio>().GetCslAccuracy(), Get<Radio::Radio>().GetCslUncertainty()));
 }
 #endif
 

--- a/src/core/thread/mle_p2p.cpp
+++ b/src/core/thread/mle_p2p.cpp
@@ -65,7 +65,7 @@ Error Mle::P2p::WakeupAndLink(const P2pRequest &aP2pRequest, P2pLinkDoneCallback
 {
     Error error = kErrorNone;
 
-    VerifyOrExit(!Get<Radio>().GetPromiscuous(), error = kErrorInvalidState);
+    VerifyOrExit(!Get<Radio::Radio>().GetPromiscuous(), error = kErrorInvalidState);
     VerifyOrExit(Get<ThreadNetif>().IsUp(), error = kErrorInvalidState);
     VerifyOrExit(!Get<Mle>().IsDisabled(), error = kErrorInvalidState);
     VerifyOrExit(mState == kStateIdle, error = kErrorBusy);

--- a/src/core/thread/net_diag.cpp
+++ b/src/core/thread/net_diag.cpp
@@ -345,7 +345,7 @@ Error Server::AppendDiagTlv(uint8_t aTlvType, Message &aMessage)
     {
         Mac::ExtAddress eui64;
 
-        Get<Radio>().GetIeeeEui64(eui64);
+        Get<Radio::Radio>().GetIeeeEui64(eui64);
         error = Tlv::Append<Eui64Tlv>(aMessage, eui64);
         break;
     }

--- a/src/core/thread/src_match_controller.cpp
+++ b/src/core/thread/src_match_controller.cpp
@@ -104,15 +104,15 @@ exit:
 
 void SourceMatchController::ClearTable(void)
 {
-    Get<Radio>().ClearSrcMatchShortEntries();
-    Get<Radio>().ClearSrcMatchExtEntries();
+    Get<Radio::Radio>().ClearSrcMatchShortEntries();
+    Get<Radio::Radio>().ClearSrcMatchExtEntries();
     LogDebg("Cleared all entries");
 }
 
 void SourceMatchController::Enable(bool aEnable)
 {
     mEnabled = aEnable;
-    Get<Radio>().EnableSrcMatch(mEnabled);
+    Get<Radio::Radio>().EnableSrcMatch(mEnabled);
     LogDebg("%sabling", mEnabled ? "En" : "Dis");
 }
 
@@ -141,13 +141,13 @@ Error SourceMatchController::AddAddress(const Child &aChild)
 
     if (aChild.IsIndirectSourceMatchShort())
     {
-        error = Get<Radio>().AddSrcMatchShortEntry(aChild.GetRloc16());
+        error = Get<Radio::Radio>().AddSrcMatchShortEntry(aChild.GetRloc16());
 
         LogDebg("Adding short addr: 0x%04x -- %s (%d)", aChild.GetRloc16(), ErrorToString(error), error);
     }
     else
     {
-        error = Get<Radio>().AddSrcMatchExtEntry(aChild.GetExtAddress());
+        error = Get<Radio::Radio>().AddSrcMatchExtEntry(aChild.GetExtAddress());
 
         LogDebg("Adding addr: %s -- %s (%d)", aChild.GetExtAddress().ToString().AsCString(), ErrorToString(error),
                 error);
@@ -169,13 +169,13 @@ void SourceMatchController::ClearEntry(Child &aChild)
 
     if (aChild.IsIndirectSourceMatchShort())
     {
-        error = Get<Radio>().ClearSrcMatchShortEntry(aChild.GetRloc16());
+        error = Get<Radio::Radio>().ClearSrcMatchShortEntry(aChild.GetRloc16());
 
         LogDebg("Clearing short addr: 0x%04x -- %s (%d)", aChild.GetRloc16(), ErrorToString(error), error);
     }
     else
     {
-        error = Get<Radio>().ClearSrcMatchExtEntry(aChild.GetExtAddress());
+        error = Get<Radio::Radio>().ClearSrcMatchExtEntry(aChild.GetExtAddress());
 
         LogDebg("Clearing addr: %s -- %s (%d)", aChild.GetExtAddress().ToString().AsCString(), ErrorToString(error),
                 error);

--- a/src/core/thread/time_sync_service.cpp
+++ b/src/core/thread/time_sync_service.cpp
@@ -64,7 +64,7 @@ TimeSync::TimeSync(Instance &aInstance)
 
 TimeSync::Status TimeSync::GetTime(uint64_t &aNetworkTime) const
 {
-    aNetworkTime = static_cast<uint64_t>(static_cast<int64_t>(Get<Radio>().GetNow()) + mNetworkTimeOffset);
+    aNetworkTime = static_cast<uint64_t>(static_cast<int64_t>(Get<Radio::Radio>().GetNow()) + mNetworkTimeOffset);
 
     return mCurrentStatus;
 }

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -160,7 +160,7 @@ void JamDetector::HandleTimer(void)
 
     VerifyOrExit(mEnabled);
 
-    rssi = Get<Radio>().GetRssi();
+    rssi = Get<Radio::Radio>().GetRssi();
 
     // If the RSSI is valid, check if it exceeds the threshold
     // and try to update the history bit map

--- a/tests/nexus/test_1_2_LP_5_3_2.cpp
+++ b/tests/nexus/test_1_2_LP_5_3_2.cpp
@@ -70,7 +70,7 @@ static constexpr uint32_t kCslPeriodMs = 500;
 /**
  * CSL period in units of 10 symbols.
  */
-static constexpr uint32_t kCslPeriodInTenSymbols = kCslPeriodMs * kUsPerMs / kUsPerTenSymbols;
+static constexpr uint32_t kCslPeriodInTenSymbols = kCslPeriodMs * kUsPerMs / ot::Radio::kUsPerTenSymbols;
 
 /**
  * CSL timeout in seconds.


### PR DESCRIPTION
This commit introduces `namespace Radio` (`ot::Radio`) and moves radio-specific types, constants, helpers, and supporting classes (`Callbacks`, `Statistics`, `Time64`, `Time32`, PHY/timing constants) into this namespace.

This reduces top-level namespace pollution in `ot`, aligns the radio module with other sub-namespaces (`Mac`, `MeshCoP`, `Tmf`), and provides a clean, dedicated scope for adding new `Radio`-specific types and constants in the future.

Call sites across `src/core/` and tests are updated accordingly.