### PR TITLE
[radio] move multi-radio link types to `namespace Radio`

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -886,7 +886,7 @@ void Message::UpdateLinkInfoFrom(const ThreadLinkInfo &aLinkInfo)
 #endif
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    SetRadioType(static_cast<Mac::RadioType>(aLinkInfo.mRadioType));
+    SetRadioType(static_cast<Radio::Type>(aLinkInfo.mRadioType));
 #endif
 }
 

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -227,7 +227,7 @@ protected:
         uint8_t mOrigin : 2;   // The origin of the message.
 #if OPENTHREAD_CONFIG_MULTI_RADIO
         uint8_t mRadioType : 2; // The radio link type the message was received on, or should be sent on.
-        static_assert(Mac::kNumRadioTypes <= (1 << 2), "mRadioType bitfield cannot store all radio type values");
+        static_assert(Radio::kNumTypes <= (1 << 2), "mRadioType bitfield cannot store all radio type values");
 #endif
         uint8_t mType : 3;    // The message type.
         uint8_t mSubType : 4; // The message sub type.
@@ -1573,14 +1573,14 @@ public:
      *
      * @returns The radio link type of the message.
      */
-    Mac::RadioType GetRadioType(void) const { return static_cast<Mac::RadioType>(GetMetadata().mRadioType); }
+    Radio::Type GetRadioType(void) const { return static_cast<Radio::Type>(GetMetadata().mRadioType); }
 
     /**
      * Sets the radio link type the message was received on, or should be sent on.
      *
      * @param[in] aRadioType   A radio link type of the message.
      */
-    void SetRadioType(Mac::RadioType aRadioType)
+    void SetRadioType(Radio::Type aRadioType)
     {
         GetMetadata().mIsRadioTypeSet = true;
         GetMetadata().mRadioType      = aRadioType;

--- a/src/core/mac/data_poll_handler.hpp
+++ b/src/core/mac/data_poll_handler.hpp
@@ -116,8 +116,8 @@ public:
         void SetFrameReplacePending(bool aReplacePending) { mFrameReplacePending = aReplacePending; }
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-        Mac::RadioType GetLastPollRadioType(void) const { return mLastPollRadioType; }
-        void           SetLastPollRadioType(Mac::RadioType aRadioType) { mLastPollRadioType = aRadioType; }
+        Radio::Type GetLastPollRadioType(void) const { return mLastPollRadioType; }
+        void        SetLastPollRadioType(Radio::Type aRadioType) { mLastPollRadioType = aRadioType; }
 #endif
 
         uint32_t mIndirectFrameCounter;    // Frame counter for current indirect frame (used for retx).
@@ -128,7 +128,7 @@ public:
         bool     mFramePurgePending : 1;   // Indicates a pending purge request for the current indirect frame.
         bool     mFrameReplacePending : 1; // Indicates a pending replace request for the current indirect frame.
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-        Mac::RadioType mLastPollRadioType; // The radio link last data poll frame was received on.
+        Radio::Type mLastPollRadioType; // The radio link last data poll frame was received on.
 #endif
 
         static_assert(kMaxPollTriggeredTxAttempts < (1 << 5), "mIndirectTxAttempts cannot fit max!");

--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -124,7 +124,7 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-Error DataPollSender::GetPollDestinationAddress(Mac::Address &aDest, Mac::RadioType &aRadioType) const
+Error DataPollSender::GetPollDestinationAddress(Mac::Address &aDest, Radio::Type &aRadioType) const
 #else
 Error DataPollSender::GetPollDestinationAddress(Mac::Address &aDest) const
 #endif
@@ -543,7 +543,7 @@ Mac::TxFrame *DataPollSender::PrepareDataRequest(Mac::TxFrames &aTxFrames)
     Mac::TxFrame::BuildInfo buildInfo;
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    Mac::RadioType radio;
+    Radio::Type radio;
 
     SuccessOrExit(GetPollDestinationAddress(buildInfo.mAddrs.mDestination, radio));
     frame = &aTxFrames.GetTxFrame(radio);

--- a/src/core/mac/data_poll_sender.hpp
+++ b/src/core/mac/data_poll_sender.hpp
@@ -259,7 +259,7 @@ private:
     const Neighbor &GetParent(void) const;
     void            HandlePollTimer(void) { IgnoreError(SendDataPoll()); }
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    Error GetPollDestinationAddress(Mac::Address &aDest, Mac::RadioType &aRadioType) const;
+    Error GetPollDestinationAddress(Mac::Address &aDest, Radio::Type &aRadioType) const;
 #else
     Error GetPollDestinationAddress(Mac::Address &aDest) const;
 #endif

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -828,7 +828,7 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame)
 #if !OPENTHREAD_CONFIG_MULTI_RADIO
         ExitNow();
 #else
-        VerifyOrExit(aFrame.GetRadioType() != kRadioTypeIeee802154);
+        VerifyOrExit(aFrame.GetRadioType() != Radio::kTypeIeee802154);
 #endif
 #endif
 
@@ -1020,7 +1020,7 @@ void Mac::BeginTransmit(void)
         // copy the frame into correct `TxFrame` for each radio type
         // (if it is not already prepared).
 
-        for (RadioType radio : RadioTypes::kAllRadioTypes)
+        for (Radio::Type radio : Radio::Types::kAllTypes)
         {
             if (txFrames.GetSelectedRadioTypes().Contains(radio))
             {
@@ -1037,7 +1037,7 @@ void Mac::BeginTransmit(void)
         // process security for each radio type separately. This
         // allows radio links to handle security differently, e.g.,
         // with different keys or link frame counters.
-        for (RadioType radio : RadioTypes::kAllRadioTypes)
+        for (Radio::Type radio : Radio::Types::kAllTypes)
         {
             if (txFrames.GetSelectedRadioTypes().Contains(radio))
             {
@@ -1240,7 +1240,7 @@ Error Mac::ProcessTxDone(TxFrame &aFrame, RxFrame *aAckFrame, Error &aError)
     VerifyOrExit(!aFrame.IsEmpty());
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    VerifyOrExit(aFrame.GetRadioType() == kRadioTypeIeee802154);
+    VerifyOrExit(aFrame.GetRadioType() == Radio::kTypeIeee802154);
 #endif
     IgnoreError(aFrame.GetDstAddr(dstAddr));
 
@@ -1254,8 +1254,9 @@ Error Mac::ProcessTxDone(TxFrame &aFrame, RxFrame *aAckFrame, Error &aError)
         {
 #if OPENTHREAD_CONFIG_MULTI_RADIO
             {
-                RadioTypes radioTypes;
-                radioTypes.Add(kRadioTypeIeee802154);
+                Radio::Types radioTypes;
+
+                radioTypes.Add(Radio::kTypeIeee802154);
                 mLinks.Send(aFrame, radioTypes);
             }
 #else
@@ -1329,9 +1330,9 @@ Error Mac::ProcessMultiRadioTxDone(TxFrame &aFrame, Error &aError)
     // completed and updates `aError` with the overall transmission
     // result (`mTxError`).
 
-    Error      error = kErrorNone;
-    RadioType  radio;
-    RadioTypes requiredRadios;
+    Error        error = kErrorNone;
+    Radio::Type  radio;
+    Radio::Types requiredRadios;
 
     VerifyOrExit(!aFrame.IsEmpty());
 
@@ -1363,7 +1364,7 @@ Error Mac::ProcessMultiRadioTxDone(TxFrame &aFrame, Error &aError)
 
         if (requiredRadios.Contains(radio) && (aError != kErrorNone))
         {
-            LogDebgOnError(aError, "tx frame on required radio link %s", RadioTypeToString(radio));
+            LogDebgOnError(aError, "tx frame on required radio link %s", Radio::TypeToString(radio));
             mTxError = aError;
         }
     }
@@ -1678,7 +1679,7 @@ Error Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Neig
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2) && OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-        if (aFrame.GetRadioType() == kRadioTypeIeee802154)
+        if (aFrame.GetRadioType() == Radio::kTypeIeee802154)
 #endif
         {
             if ((frameCounter + 1) > aNeighbor->GetLinkAckFrameCounter())
@@ -2127,7 +2128,7 @@ exit:
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    if (aFrame->GetRadioType() == kRadioTypeTrel)
+    if (aFrame->GetRadioType() == Radio::kTypeTrel)
 #endif
     {
         if (error == kErrorNone)
@@ -2329,7 +2330,7 @@ void Mac::LogFrameTxFailure(const TxFrame &aFrame, Error aError, uint8_t aRetryC
 {
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    if (aFrame.GetRadioType() == kRadioTypeIeee802154)
+    if (aFrame.GetRadioType() == Radio::kTypeIeee802154)
 #endif
     {
         uint8_t maxAttempts = aFrame.GetMaxFrameRetries() + 1;
@@ -2345,7 +2346,7 @@ void Mac::LogFrameTxFailure(const TxFrame &aFrame, Error aError, uint8_t aRetryC
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    if (aFrame.GetRadioType() == kRadioTypeTrel)
+    if (aFrame.GetRadioType() == Radio::kTypeTrel)
 #endif
     {
         if (Get<Trel::Interface>().IsEnabled())

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -54,6 +54,7 @@
 #include "mac/mac_types.hpp"
 #include "mac/scan_result.hpp"
 #include "mac/sub_mac.hpp"
+#include "radio/radio_types.hpp"
 #include "radio/trel_link.hpp"
 #include "thread/key_manager.hpp"
 #include "thread/link_quality.hpp"
@@ -941,9 +942,9 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    RadioTypes mTxPendingRadioLinks;
-    RadioTypes mTxBeaconRadioLinks;
-    Error      mTxError;
+    Radio::Types mTxPendingRadioLinks;
+    Radio::Types mTxBeaconRadioLinks;
+    Error        mTxError;
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1121,13 +1121,13 @@ uint16_t Frame::GetMtu(void) const
     switch (GetRadioType())
     {
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    case kRadioTypeIeee802154:
+    case Radio::kTypeIeee802154:
         mtu = OT_RADIO_FRAME_MAX_SIZE;
         break;
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    case kRadioTypeTrel:
+    case Radio::kTypeTrel:
         mtu = Trel::Link::kMtuSize;
         break;
 #endif
@@ -1143,13 +1143,13 @@ uint8_t Frame::GetFcsSize(void) const
     switch (GetRadioType())
     {
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    case kRadioTypeIeee802154:
+    case Radio::kTypeIeee802154:
         fcsSize = k154FcsSize;
         break;
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    case kRadioTypeTrel:
+    case Radio::kTypeTrel:
         fcsSize = Trel::Link::kFcsSize;
         break;
 #endif
@@ -1518,7 +1518,7 @@ Frame::InfoString Frame::ToInfoString(void) const
     }
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    string.Append(", radio:%s", RadioTypeToString(GetRadioType()));
+    string.Append(", radio:%s", Radio::TypeToString(GetRadioType()));
 #endif
 
     return string;

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -642,14 +642,14 @@ public:
      *
      * @returns Frame's radio link type.
      */
-    RadioType GetRadioType(void) const { return static_cast<RadioType>(mRadioType); }
+    Radio::Type GetRadioType(void) const { return static_cast<Radio::Type>(mRadioType); }
 
     /**
      * Sets the radio link type of the frame.
      *
      * @param[in] aRadioType  A radio link type.
      */
-    void SetRadioType(RadioType aRadioType) { mRadioType = static_cast<uint8_t>(aRadioType); }
+    void SetRadioType(Radio::Type aRadioType) { mRadioType = static_cast<uint8_t>(aRadioType); }
 #endif
 
     /**

--- a/src/core/mac/mac_links.cpp
+++ b/src/core/mac/mac_links.cpp
@@ -54,19 +54,19 @@ TxFrames::TxFrames(Instance &aInstance)
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
 
-TxFrame &TxFrames::GetTxFrame(RadioType aRadioType)
+TxFrame &TxFrames::GetTxFrame(Radio::Type aRadioType)
 {
     TxFrame *frame = nullptr;
 
     switch (aRadioType)
     {
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    case kRadioTypeIeee802154:
+    case Radio::kTypeIeee802154:
         frame = &mTxFrame802154;
         break;
 #endif
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    case kRadioTypeTrel:
+    case Radio::kTypeTrel:
         frame = &mTxFrameTrel;
         break;
 #endif
@@ -77,7 +77,7 @@ TxFrame &TxFrames::GetTxFrame(RadioType aRadioType)
     return *frame;
 }
 
-TxFrame &TxFrames::GetTxFrame(RadioTypes aRadioTypes)
+TxFrame &TxFrames::GetTxFrame(Radio::Types aRadioTypes)
 {
     // Return the TxFrame among all set of `aRadioTypes` with the smallest MTU.
     // Note that this is `TxFrame` to be sent out in parallel over multiple radio
@@ -87,14 +87,14 @@ TxFrame &TxFrames::GetTxFrame(RadioTypes aRadioTypes)
     TxFrame *frame = nullptr;
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    if (aRadioTypes.Contains(kRadioTypeIeee802154))
+    if (aRadioTypes.Contains(Radio::kTypeIeee802154))
     {
         frame = &mTxFrame802154;
     }
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    if (aRadioTypes.Contains(kRadioTypeTrel) && ((frame == nullptr) || (frame->GetMtu() > mTxFrameTrel.GetMtu())))
+    if (aRadioTypes.Contains(Radio::kTypeTrel) && ((frame == nullptr) || (frame->GetMtu() > mTxFrameTrel.GetMtu())))
     {
         frame = &mTxFrameTrel;
     }
@@ -107,7 +107,7 @@ TxFrame &TxFrames::GetTxFrame(RadioTypes aRadioTypes)
 
 TxFrame &TxFrames::GetBroadcastTxFrame(void)
 {
-    RadioTypes allRadios;
+    Radio::Types allRadios;
 
     allRadios.AddAll();
     return GetTxFrame(allRadios);
@@ -137,29 +137,29 @@ Links::Links(Instance &aInstance)
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
 
-void Links::Send(TxFrame &aFrame, RadioTypes aRadioTypes)
+void Links::Send(TxFrame &aFrame, Radio::Types aRadioTypes)
 {
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    if (aRadioTypes.Contains(kRadioTypeIeee802154) && mTxFrames.mTxFrame802154.IsEmpty())
+    if (aRadioTypes.Contains(Radio::kTypeIeee802154) && mTxFrames.mTxFrame802154.IsEmpty())
     {
         mTxFrames.mTxFrame802154.CopyFrom(aFrame);
     }
 #endif
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    if (aRadioTypes.Contains(kRadioTypeTrel) && mTxFrames.mTxFrameTrel.IsEmpty())
+    if (aRadioTypes.Contains(Radio::kTypeTrel) && mTxFrames.mTxFrameTrel.IsEmpty())
     {
         mTxFrames.mTxFrameTrel.CopyFrom(aFrame);
     }
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    if (aRadioTypes.Contains(kRadioTypeIeee802154))
+    if (aRadioTypes.Contains(Radio::kTypeIeee802154))
     {
         SuccessOrAssert(mSubMac.Send());
     }
 #endif
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    if (aRadioTypes.Contains(kRadioTypeTrel))
+    if (aRadioTypes.Contains(Radio::kTypeTrel))
     {
         mTrel.Send();
     }
@@ -174,12 +174,12 @@ const KeyMaterial *Links::GetCurrentMacKey(const Frame &aFrame) const
 
     const KeyMaterial *key = nullptr;
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    RadioType radioType = aFrame.GetRadioType();
+    Radio::Type radioType = aFrame.GetRadioType();
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    if (radioType == kRadioTypeIeee802154)
+    if (radioType == Radio::kTypeIeee802154)
 #endif
     {
         ExitNow(key = &Get<SubMac>().GetCurrentMacKey());
@@ -188,7 +188,7 @@ const KeyMaterial *Links::GetCurrentMacKey(const Frame &aFrame) const
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    if (radioType == kRadioTypeTrel)
+    if (radioType == Radio::kTypeTrel)
 #endif
     {
         ExitNow(key = &Get<KeyManager>().GetCurrentTrelMacKey());
@@ -208,12 +208,12 @@ const KeyMaterial *Links::GetTemporaryMacKey(const Frame &aFrame, uint32_t aKeyS
 
     const KeyMaterial *key = nullptr;
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    RadioType radioType = aFrame.GetRadioType();
+    Radio::Type radioType = aFrame.GetRadioType();
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    if (radioType == kRadioTypeIeee802154)
+    if (radioType == Radio::kTypeIeee802154)
 #endif
     {
         if (aKeySequence == Get<KeyManager>().GetCurrentKeySequence() - 1)
@@ -233,7 +233,7 @@ const KeyMaterial *Links::GetTemporaryMacKey(const Frame &aFrame, uint32_t aKeyS
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    if (radioType == kRadioTypeTrel)
+    if (radioType == Radio::kTypeTrel)
 #endif
     {
         ExitNow(key = &Get<KeyManager>().GetTemporaryTrelMacKey(aKeySequence));
@@ -250,12 +250,12 @@ exit:
 void Links::SetMacFrameCounter(TxFrame &aFrame)
 {
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    RadioType radioType = aFrame.GetRadioType();
+    Radio::Type radioType = aFrame.GetRadioType();
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    if (radioType == kRadioTypeTrel)
+    if (radioType == Radio::kTypeTrel)
 #endif
     {
         aFrame.SetFrameCounter(Get<KeyManager>().GetTrelMacFrameCounter());

--- a/src/core/mac/mac_links.hpp
+++ b/src/core/mac/mac_links.hpp
@@ -42,6 +42,7 @@
 #include "mac/mac_types.hpp"
 #include "mac/sub_mac.hpp"
 #include "radio/radio.hpp"
+#include "radio/radio_types.hpp"
 #include "radio/trel_link.hpp"
 
 namespace ot {
@@ -74,7 +75,7 @@ public:
      *
      * @returns A reference to the `TxFrame` for the given radio link type.
      */
-    TxFrame &GetTxFrame(RadioType aRadioType);
+    TxFrame &GetTxFrame(Radio::Type aRadioType);
 
     /**
      * Gets the `TxFrame` with the smallest MTU size among a given set of radio types.
@@ -86,7 +87,7 @@ public:
      *
      * @returns A reference to the `TxFrame` with the smallest MTU size among the set of @p aRadioTypes.
      */
-    TxFrame &GetTxFrame(RadioTypes aRadioTypes);
+    TxFrame &GetTxFrame(Radio::Types aRadioTypes);
 
     /**
      * Gets the `TxFrame` for sending a broadcast frame.
@@ -109,7 +110,7 @@ public:
      *
      * @returns The selected radio types.
      */
-    RadioTypes GetSelectedRadioTypes(void) const { return mSelectedRadioTypes; }
+    Radio::Types GetSelectedRadioTypes(void) const { return mSelectedRadioTypes; }
 
     /**
      * Gets the required radio types.
@@ -122,7 +123,7 @@ public:
      *
      * @returns The required radio types.
      */
-    RadioTypes GetRequiredRadioTypes(void) const { return mRequiredRadioTypes; }
+    Radio::Types GetRequiredRadioTypes(void) const { return mRequiredRadioTypes; }
 
     /**
      * Sets the required types.
@@ -131,7 +132,7 @@ public:
      *
      * @param[in] aRadioTypes   A set of radio link types.
      */
-    void SetRequiredRadioTypes(RadioTypes aRadioTypes) { mRequiredRadioTypes = aRadioTypes; }
+    void SetRequiredRadioTypes(Radio::Types aRadioTypes) { mRequiredRadioTypes = aRadioTypes; }
 
 #else // #if OPENTHREAD_CONFIG_MULTI_RADIO
 
@@ -266,8 +267,8 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    RadioTypes mSelectedRadioTypes;
-    RadioTypes mRequiredRadioTypes;
+    Radio::Types mSelectedRadioTypes;
+    Radio::Types mRequiredRadioTypes;
 #endif
 };
 
@@ -554,7 +555,7 @@ public:
      * @param[in] aFrame       A reference to a prepared frame.
      * @param[in] aRadioTypes  A set of radio types to send on.
      */
-    void Send(TxFrame &aFrame, RadioTypes aRadioTypes);
+    void Send(TxFrame &aFrame, Radio::Types aRadioTypes);
 
     /**
      * Gets the required radio types (`GetRequiredRadioTypes()`) from `TxFrames`.
@@ -565,7 +566,7 @@ public:
      *
      * @returns The required radio types.
      */
-    RadioTypes GetTxFramesRequiredRadioTypes(void) const { return mTxFrames.GetRequiredRadioTypes(); }
+    Radio::Types GetTxFramesRequiredRadioTypes(void) const { return mTxFrames.GetRequiredRadioTypes(); }
 
 #endif // !OPENTHREAD_CONFIG_MULTI_RADIO
 

--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -202,90 +202,20 @@ void PanIds::SetBothSourceDestination(PanId aPanId)
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
 
-const RadioType RadioTypes::kAllRadioTypes[kNumRadioTypes] = {
-#if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    kRadioTypeIeee802154,
-#endif
-#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    kRadioTypeTrel,
-#endif
-};
-
-void RadioTypes::AddAll(void)
-{
-#if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    Add(kRadioTypeIeee802154);
-#endif
-#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    Add(kRadioTypeTrel);
-#endif
-}
-
-RadioTypes::InfoString RadioTypes::ToString(void) const
-{
-    InfoString string;
-    bool       addComma = false;
-
-    string.Append("{");
-#if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    if (Contains(kRadioTypeIeee802154))
-    {
-        string.Append("%s%s", addComma ? ", " : " ", RadioTypeToString(kRadioTypeIeee802154));
-        addComma = true;
-    }
-#endif
-
-#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    if (Contains(kRadioTypeTrel))
-    {
-        string.Append("%s%s", addComma ? ", " : " ", RadioTypeToString(kRadioTypeTrel));
-        addComma = true;
-    }
-#endif
-
-    OT_UNUSED_VARIABLE(addComma);
-
-    string.Append(" }");
-
-    return string;
-}
-
-const char *RadioTypeToString(RadioType aRadioType)
-{
-    const char *str = "unknown";
-
-    switch (aRadioType)
-    {
-#if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    case kRadioTypeIeee802154:
-        str = "15.4";
-        break;
-#endif
-
-#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    case kRadioTypeTrel:
-        str = "trel";
-        break;
-#endif
-    }
-
-    return str;
-}
-
-uint32_t LinkFrameCounters::Get(RadioType aRadioType) const
+uint32_t LinkFrameCounters::Get(Radio::Type aRadioType) const
 {
     uint32_t counter = 0;
 
     switch (aRadioType)
     {
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    case kRadioTypeIeee802154:
+    case Radio::kTypeIeee802154:
         counter = m154Counter;
         break;
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    case kRadioTypeTrel:
+    case Radio::kTypeTrel:
         counter = mTrelCounter;
         break;
 #endif
@@ -294,18 +224,18 @@ uint32_t LinkFrameCounters::Get(RadioType aRadioType) const
     return counter;
 }
 
-void LinkFrameCounters::Set(RadioType aRadioType, uint32_t aCounter)
+void LinkFrameCounters::Set(Radio::Type aRadioType, uint32_t aCounter)
 {
     switch (aRadioType)
     {
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    case kRadioTypeIeee802154:
+    case Radio::kTypeIeee802154:
         m154Counter = aCounter;
         break;
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    case kRadioTypeTrel:
+    case Radio::kTypeTrel:
         mTrelCounter = aCounter;
         break;
 #endif

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -49,6 +49,7 @@
 #include "common/equatable.hpp"
 #include "common/string.hpp"
 #include "crypto/storage.hpp"
+#include "radio/radio_types.hpp"
 
 namespace ot {
 
@@ -643,160 +644,6 @@ private:
     void SetKey(const Key &aKey) { mKeyMaterial.mKey = aKey; }
 };
 
-#if OPENTHREAD_CONFIG_MULTI_RADIO
-
-/**
- * Defines the radio link types.
- */
-enum RadioType : uint8_t
-{
-#if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    kRadioTypeIeee802154, ///< IEEE 802.15.4 (2.4GHz) link type.
-#endif
-#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    kRadioTypeTrel, ///< Thread Radio Encapsulation link type.
-#endif
-};
-
-/**
- * This constant specifies the number of supported radio link types.
- */
-constexpr uint8_t kNumRadioTypes = (((OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE) ? 1 : 0) +
-                                    ((OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE) ? 1 : 0));
-
-/**
- * Represents a set of radio links.
- */
-class RadioTypes
-{
-public:
-    static constexpr uint16_t kInfoStringSize = 32; ///< Max chars for the info string (`ToString()`).
-
-    /**
-     * Defines the fixed-length `String` object returned from `ToString()`.
-     */
-    typedef String<kInfoStringSize> InfoString;
-
-    /**
-     * This static class variable defines an array containing all supported radio link types.
-     */
-    static const RadioType kAllRadioTypes[kNumRadioTypes];
-
-    /**
-     * Initializes a `RadioTypes` object as empty set
-     */
-    RadioTypes(void)
-        : mBitMask(0)
-    {
-    }
-
-    /**
-     * Initializes a `RadioTypes` object with a given bit-mask.
-     *
-     * @param[in] aMask   A bit-mask representing the radio types (the first bit corresponds to radio type 0, and so on)
-     */
-    explicit RadioTypes(uint8_t aMask)
-        : mBitMask(aMask)
-    {
-    }
-
-    /**
-     * Clears the set.
-     */
-    void Clear(void) { mBitMask = 0; }
-
-    /**
-     * Indicates whether the set is empty or not
-     *
-     * @returns TRUE if the set is empty, FALSE otherwise.
-     */
-    bool IsEmpty(void) const { return (mBitMask == 0); }
-
-    /**
-     *  This method indicates whether the set contains only a single radio type.
-     *
-     * @returns TRUE if the set contains a single radio type, FALSE otherwise.
-     */
-    bool ContainsSingleRadio(void) const { return !IsEmpty() && ((mBitMask & (mBitMask - 1)) == 0); }
-
-    /**
-     * Indicates whether or not the set contains a given radio type.
-     *
-     * @param[in] aType  A radio link type.
-     *
-     * @returns TRUE if the set contains @p aType, FALSE otherwise.
-     */
-    bool Contains(RadioType aType) const { return ((mBitMask & BitFlag(aType)) != 0); }
-
-    /**
-     * Adds a radio type to the set.
-     *
-     * @param[in] aType  A radio link type.
-     */
-    void Add(RadioType aType) { mBitMask |= BitFlag(aType); }
-
-    /**
-     * Adds another radio types set to the current one.
-     *
-     * @param[in] aTypes   A radio link type set to add.
-     */
-    void Add(RadioTypes aTypes) { mBitMask |= aTypes.mBitMask; }
-
-    /**
-     * Adds all radio types supported by device to the set.
-     */
-    void AddAll(void);
-
-    /**
-     * Removes a given radio type from the set.
-     *
-     * @param[in] aType  A radio link type.
-     */
-    void Remove(RadioType aType) { mBitMask &= ~BitFlag(aType); }
-
-    /**
-     * Gets the radio type set as a bitmask.
-     *
-     * The first bit in the mask corresponds to first radio type (radio type with value zero), and so on.
-     *
-     * @returns A bitmask representing the set of radio types.
-     */
-    uint8_t GetAsBitMask(void) const { return mBitMask; }
-
-    /**
-     * Overloads operator `-` to return a new set which is the set difference between current set and
-     * a given set.
-     *
-     * @param[in] aOther  Another radio type set.
-     *
-     * @returns A new set which is set difference between current one and @p aOther.
-     */
-    RadioTypes operator-(const RadioTypes &aOther) const { return RadioTypes(mBitMask & ~aOther.mBitMask); }
-
-    /**
-     * Converts the radio set to human-readable string.
-     *
-     * @return A string representation of the set of radio types.
-     */
-    InfoString ToString(void) const;
-
-private:
-    static uint8_t BitFlag(RadioType aType) { return static_cast<uint8_t>(1U << static_cast<uint8_t>(aType)); }
-
-    uint8_t mBitMask;
-};
-
-/**
- * Converts a link type to a string
- *
- * @param[in] aRadioType  A link type value.
- *
- * @returns A string representation of the link type.
- */
-const char *RadioTypeToString(RadioType aRadioType);
-
-#endif // OPENTHREAD_CONFIG_MULTI_RADIO
-
 /**
  * Represents Link Frame Counters for all supported radio links.
  */
@@ -817,7 +664,7 @@ public:
      *
      * @returns The Link Frame Counter for radio link @p aRadioType.
      */
-    uint32_t Get(RadioType aRadioType) const;
+    uint32_t Get(Radio::Type aRadioType) const;
 
     /**
      * Sets the Link Frame Counter for a given radio link.
@@ -825,7 +672,7 @@ public:
      * @param[in] aRadioType  A radio link type.
      * @param[in] aCounter    The new counter value.
      */
-    void Set(RadioType aRadioType, uint32_t aCounter);
+    void Set(Radio::Type aRadioType, uint32_t aCounter);
 
 #else
 

--- a/src/core/mac/wakeup_tx_scheduler.cpp
+++ b/src/core/mac/wakeup_tx_scheduler.cpp
@@ -93,7 +93,7 @@ Mac::TxFrame *WakeupTxScheduler::PrepareWakeupFrame(Mac::TxFrames &aTxFrames)
     radioTxDelay = mTxTimeUs - nowUs;
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    frame = &aTxFrames.GetTxFrame(Mac::kRadioTypeIeee802154);
+    frame = &aTxFrames.GetTxFrame(Radio::kTypeIeee802154);
 #else
     frame = &aTxFrames.GetTxFrame();
 #endif

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -53,7 +53,7 @@ extern "C" void otPlatRadioReceiveDone(otInstance *aInstance, otRadioFrame *aFra
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     if (rxFrame != nullptr)
     {
-        rxFrame->SetRadioType(Mac::kRadioTypeIeee802154);
+        rxFrame->SetRadioType(Radio::kTypeIeee802154);
     }
 #endif
 
@@ -80,7 +80,7 @@ extern "C" void otPlatRadioTxStarted(otInstance *aInstance, otRadioFrame *aFrame
     VerifyOrExit(instance.IsInitialized());
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    txFrame.SetRadioType(Mac::kRadioTypeIeee802154);
+    txFrame.SetRadioType(Radio::kTypeIeee802154);
 #endif
 
     instance.Get<Radio::Callbacks>().HandleTransmitStarted(txFrame);
@@ -100,10 +100,10 @@ extern "C" void otPlatRadioTxDone(otInstance *aInstance, otRadioFrame *aFrame, o
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     if (ackFrame != nullptr)
     {
-        ackFrame->SetRadioType(Mac::kRadioTypeIeee802154);
+        ackFrame->SetRadioType(Radio::kTypeIeee802154);
     }
 
-    txFrame.SetRadioType(Mac::kRadioTypeIeee802154);
+    txFrame.SetRadioType(Radio::kTypeIeee802154);
 #endif
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
@@ -160,7 +160,7 @@ extern "C" void otPlatDiagRadioReceiveDone(otInstance *aInstance, otRadioFrame *
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     if (rxFrame != nullptr)
     {
-        rxFrame->SetRadioType(Mac::kRadioTypeIeee802154);
+        rxFrame->SetRadioType(Radio::kTypeIeee802154);
     }
 #endif
 
@@ -180,7 +180,7 @@ extern "C" void otPlatDiagRadioTransmitDone(otInstance *aInstance, otRadioFrame 
     }
 #endif
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    txFrame.SetRadioType(Mac::kRadioTypeIeee802154);
+    txFrame.SetRadioType(Radio::kTypeIeee802154);
 #endif
 
     AsCoreType(aInstance).Get<Radio::Callbacks>().HandleDiagsTransmitDone(txFrame, aError);

--- a/src/core/radio/radio_types.cpp
+++ b/src/core/radio/radio_types.cpp
@@ -59,5 +59,84 @@ void SyncedTime::SetToNow(Radio &aRadio)
 
 #endif
 
+#if OPENTHREAD_CONFIG_MULTI_RADIO
+
+//---------------------------------------------------------------------------------------------------------------------
+// Types
+
+const Type Types::kAllTypes[kNumTypes] = {
+#if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
+    kTypeIeee802154,
+#endif
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+    kTypeTrel,
+#endif
+};
+
+void Types::AddAll(void)
+{
+#if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
+    Add(kTypeIeee802154);
+#endif
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+    Add(kTypeTrel);
+#endif
+}
+
+Types::InfoString Types::ToString(void) const
+{
+    InfoString string;
+    bool       addComma = false;
+
+    string.Append("{");
+#if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
+    if (Contains(kTypeIeee802154))
+    {
+        string.Append("%s%s", addComma ? ", " : " ", TypeToString(kTypeIeee802154));
+        addComma = true;
+    }
+#endif
+
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+    if (Contains(kTypeTrel))
+    {
+        string.Append("%s%s", addComma ? ", " : " ", TypeToString(kTypeTrel));
+        addComma = true;
+    }
+#endif
+
+    OT_UNUSED_VARIABLE(addComma);
+
+    string.Append(" }");
+
+    return string;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
+const char *TypeToString(Type aType)
+{
+    const char *str = "unknown";
+
+    switch (aType)
+    {
+#if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
+    case kTypeIeee802154:
+        str = "15.4";
+        break;
+#endif
+
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+    case kTypeTrel:
+        str = "trel";
+        break;
+#endif
+    }
+
+    return str;
+}
+
+#endif // OPENTHREAD_CONFIG_MULTI_RADIO
+
 } // namespace Radio
 } // namespace ot

--- a/src/core/radio/radio_types.hpp
+++ b/src/core/radio/radio_types.hpp
@@ -39,6 +39,7 @@
 #include <openthread/platform/radio.h>
 
 #include "common/clearable.hpp"
+#include "common/string.hpp"
 #include "common/time.hpp"
 
 namespace ot {
@@ -151,6 +152,160 @@ private:
 };
 
 #endif // OT_CONFIG_RADIO_TIME_ENABLE && OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
+
+#if OPENTHREAD_CONFIG_MULTI_RADIO
+
+/**
+ * Defines the radio link types.
+ */
+enum Type : uint8_t
+{
+#if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
+    kTypeIeee802154, ///< IEEE 802.15.4 (2.4GHz) link type.
+#endif
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+    kTypeTrel, ///< Thread Radio Encapsulation link type.
+#endif
+};
+
+/**
+ * This constant specifies the number of supported radio link types.
+ */
+constexpr uint8_t kNumTypes = (((OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE) ? 1 : 0) +
+                               ((OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE) ? 1 : 0));
+
+/**
+ * Represents a set of radio links.
+ */
+class Types
+{
+public:
+    static constexpr uint16_t kInfoStringSize = 32; ///< Max chars for the info string (`ToString()`).
+
+    /**
+     * Defines the fixed-length `String` object returned from `ToString()`.
+     */
+    typedef String<kInfoStringSize> InfoString;
+
+    /**
+     * This static class variable defines an array containing all supported radio link types.
+     */
+    static const Type kAllTypes[kNumTypes];
+
+    /**
+     * Initializes a `Types` object as empty set
+     */
+    Types(void)
+        : mBitMask(0)
+    {
+    }
+
+    /**
+     * Initializes a `Types` object with a given bit-mask.
+     *
+     * @param[in] aMask   A bit-mask representing the radio types (the first bit corresponds to radio type 0, and so on)
+     */
+    explicit Types(uint8_t aMask)
+        : mBitMask(aMask)
+    {
+    }
+
+    /**
+     * Clears the set.
+     */
+    void Clear(void) { mBitMask = 0; }
+
+    /**
+     * Indicates whether the set is empty or not
+     *
+     * @returns TRUE if the set is empty, FALSE otherwise.
+     */
+    bool IsEmpty(void) const { return (mBitMask == 0); }
+
+    /**
+     *  This method indicates whether the set contains only a single radio type.
+     *
+     * @returns TRUE if the set contains a single radio type, FALSE otherwise.
+     */
+    bool ContainsSingleRadio(void) const { return !IsEmpty() && ((mBitMask & (mBitMask - 1)) == 0); }
+
+    /**
+     * Indicates whether or not the set contains a given radio type.
+     *
+     * @param[in] aType  A radio link type.
+     *
+     * @returns TRUE if the set contains @p aType, FALSE otherwise.
+     */
+    bool Contains(Type aType) const { return ((mBitMask & BitFlag(aType)) != 0); }
+
+    /**
+     * Adds a radio type to the set.
+     *
+     * @param[in] aType  A radio link type.
+     */
+    void Add(Type aType) { mBitMask |= BitFlag(aType); }
+
+    /**
+     * Adds another radio types set to the current one.
+     *
+     * @param[in] aTypes   A radio link type set to add.
+     */
+    void Add(Types aTypes) { mBitMask |= aTypes.mBitMask; }
+
+    /**
+     * Adds all radio types supported by device to the set.
+     */
+    void AddAll(void);
+
+    /**
+     * Removes a given radio type from the set.
+     *
+     * @param[in] aType  A radio link type.
+     */
+    void Remove(Type aType) { mBitMask &= ~BitFlag(aType); }
+
+    /**
+     * Gets the radio type set as a bitmask.
+     *
+     * The first bit in the mask corresponds to first radio type (radio type with value zero), and so on.
+     *
+     * @returns A bitmask representing the set of radio types.
+     */
+    uint8_t GetAsBitMask(void) const { return mBitMask; }
+
+    /**
+     * Overloads operator `-` to return a new set which is the set difference between current set and
+     * a given set.
+     *
+     * @param[in] aOther  Another radio type set.
+     *
+     * @returns A new set which is set difference between current one and @p aOther.
+     */
+    Types operator-(const Types &aOther) const { return Types(mBitMask & ~aOther.mBitMask); }
+
+    /**
+     * Converts the radio set to human-readable string.
+     *
+     * @return A string representation of the set of radio types.
+     */
+    InfoString ToString(void) const;
+
+private:
+    static uint8_t BitFlag(Type aType) { return static_cast<uint8_t>(1U << static_cast<uint8_t>(aType)); }
+
+    uint8_t mBitMask;
+};
+
+/**
+ * Converts a link type to a string
+ *
+ * @param[in] aType  A link type value.
+ *
+ * @returns A string representation of the link type.
+ */
+const char *TypeToString(Type aType);
+
+#endif // OPENTHREAD_CONFIG_MULTI_RADIO
 
 } // namespace Radio
 } // namespace ot

--- a/src/core/radio/trel_link.cpp
+++ b/src/core/radio/trel_link.cpp
@@ -61,8 +61,8 @@ Link::Link(Instance &aInstance)
     mTxFrame.SetLength(0);
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    mTxFrame.SetRadioType(Mac::kRadioTypeTrel);
-    mRxFrame.SetRadioType(Mac::kRadioTypeTrel);
+    mTxFrame.SetRadioType(Radio::kTypeTrel);
+    mRxFrame.SetRadioType(Radio::kTypeTrel);
 #endif
 
     mTimer.Start(kAckWaitWindow);
@@ -229,7 +229,7 @@ void Link::BeginTransmit(void)
         mRxFrame.mLength  = k154AckFrameSize;
         mRxFrame.mChannel = mTxFrame.GetChannel();
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-        mRxFrame.mRadioType = Mac::kRadioTypeTrel;
+        mRxFrame.mRadioType = Radio::kTypeTrel;
 #endif
         mRxFrame.mInfo.mRxInfo.mTimestamp             = 0;
         mRxFrame.mInfo.mRxInfo.mRssi                  = Radio::kInvalidRssi;
@@ -380,7 +380,7 @@ void Link::ProcessReceivedPacket(Packet &aPacket, const Ip6::SockAddr &aSockAddr
     mRxFrame.mLength  = aPacket.GetPayloadLength();
     mRxFrame.mChannel = aPacket.GetHeader().GetChannel();
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    mRxFrame.mRadioType = Mac::kRadioTypeTrel;
+    mRxFrame.mRadioType = Radio::kTypeTrel;
 #endif
     mRxFrame.mInfo.mRxInfo.mTimestamp             = 0;
     mRxFrame.mInfo.mRxInfo.mRssi                  = kRxRssi;

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -165,7 +165,7 @@ Mac::TxFrame *CslTxScheduler::HandleFrameRequest(Mac::TxFrames &aTxFrames)
     VerifyOrExit(mCslTxNeighbor->IsCslSynchronized());
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    frame = &aTxFrames.GetTxFrame(Mac::kRadioTypeIeee802154);
+    frame = &aTxFrames.GetTxFrame(Radio::kTypeIeee802154);
 #else
     frame = &aTxFrames.GetTxFrame();
 #endif

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -758,7 +758,7 @@ Neighbor *MeshForwarder::UpdateNeighborOnSentFrame(Mac::TxFrame       &aFrame,
     // `SendDone` event from `Mac` layer with success status and
     // wait for deferred ack callback instead.
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    if (aFrame.GetRadioType() == Mac::kRadioTypeTrel)
+    if (aFrame.GetRadioType() == Radio::kTypeTrel)
 #endif
     {
         VerifyOrExit(aError != kErrorNone);
@@ -1523,7 +1523,7 @@ void MeshForwarder::AppendSecErrorPrioRssRadioLabelsToLogString(StringWriter  &a
     }
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    aString.Append(", radio:%s", aMessage.IsRadioTypeSet() ? RadioTypeToString(aMessage.GetRadioType()) : "all");
+    aString.Append(", radio:%s", aMessage.IsRadioTypeSet() ? Radio::TypeToString(aMessage.GetRadioType()) : "all");
 #endif
 }
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1923,7 +1923,7 @@ void Mle::CheckTrelPeerAddrOnSecureMleRx(const Message &aMessage)
     OT_UNUSED_VARIABLE(aMessage);
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    if (aMessage.IsRadioTypeSet() && aMessage.GetRadioType() == Mac::kRadioTypeTrel)
+    if (aMessage.IsRadioTypeSet() && aMessage.GetRadioType() == Radio::kTypeTrel)
 #endif
     {
         Get<Trel::Link>().CheckPeerAddrOnRxSuccess(Trel::Link::kAllowPeerSockAddrUpdate);

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1741,7 +1741,7 @@ private:
     {
         Mac::PanId mPanId;
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-        Mac::RadioType mRadioType;
+        Radio::Type mRadioType;
 #endif
     };
 

--- a/src/core/thread/radio_selector.cpp
+++ b/src/core/thread/radio_selector.cpp
@@ -43,12 +43,12 @@ RegisterLogModule("RadioSelector");
 
 // This array defines the order in which different radio link types are
 // selected for message tx (direct message).
-const Mac::RadioType RadioSelector::sRadioSelectionOrder[Mac::kNumRadioTypes] = {
+const Radio::Type RadioSelector::sRadioSelectionOrder[Radio::kNumTypes] = {
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    Mac::kRadioTypeTrel,
+    Radio::kTypeTrel,
 #endif
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    Mac::kRadioTypeIeee802154,
+    Radio::kTypeIeee802154,
 #endif
 };
 
@@ -62,23 +62,23 @@ void RadioSelector::NeighborInfo::PopulateMultiRadioInfo(MultiRadioInfo &aInfo)
     ClearAllBytes(aInfo);
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    if (GetSupportedRadioTypes().Contains(Mac::kRadioTypeIeee802154))
+    if (GetSupportedRadioTypes().Contains(Radio::kTypeIeee802154))
     {
         aInfo.mSupportsIeee802154         = true;
-        aInfo.mIeee802154Info.mPreference = GetRadioPreference(Mac::kRadioTypeIeee802154);
+        aInfo.mIeee802154Info.mPreference = GetRadioPreference(Radio::kTypeIeee802154);
     }
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    if (GetSupportedRadioTypes().Contains(Mac::kRadioTypeTrel))
+    if (GetSupportedRadioTypes().Contains(Radio::kTypeTrel))
     {
         aInfo.mSupportsTrelUdp6         = true;
-        aInfo.mTrelUdp6Info.mPreference = GetRadioPreference(Mac::kRadioTypeTrel);
+        aInfo.mTrelUdp6Info.mPreference = GetRadioPreference(Radio::kTypeTrel);
     }
 #endif
 }
 
-LogLevel RadioSelector::UpdatePreference(Neighbor &aNeighbor, Mac::RadioType aRadioType, int16_t aDifference)
+LogLevel RadioSelector::UpdatePreference(Neighbor &aNeighbor, Radio::Type aRadioType, int16_t aDifference)
 {
     uint8_t old        = aNeighbor.GetRadioPreference(aRadioType);
     int16_t preference = static_cast<int16_t>(old);
@@ -105,7 +105,7 @@ LogLevel RadioSelector::UpdatePreference(Neighbor &aNeighbor, Mac::RadioType aRa
     return ((old >= kHighPreference) != (preference >= kHighPreference)) ? kLogLevelInfo : kLogLevelDebg;
 }
 
-void RadioSelector::UpdateOnReceive(Neighbor &aNeighbor, Mac::RadioType aRadioType, bool aIsDuplicate)
+void RadioSelector::UpdateOnReceive(Neighbor &aNeighbor, Radio::Type aRadioType, bool aIsDuplicate)
 {
     LogLevel logLevel = kLogLevelInfo;
 
@@ -127,13 +127,13 @@ void RadioSelector::UpdateOnReceive(Neighbor &aNeighbor, Mac::RadioType aRadioTy
 
 void RadioSelector::UpdateOnSendDone(Mac::TxFrame &aFrame, Error aTxError)
 {
-    LogLevel       logLevel  = kLogLevelInfo;
-    Mac::RadioType radioType = aFrame.GetRadioType();
-    Mac::Address   macDest;
-    Neighbor      *neighbor;
+    LogLevel     logLevel  = kLogLevelInfo;
+    Radio::Type  radioType = aFrame.GetRadioType();
+    Mac::Address macDest;
+    Neighbor    *neighbor;
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    if (radioType == Mac::kRadioTypeTrel)
+    if (radioType == Radio::kTypeTrel)
     {
         // TREL radio link uses deferred ack model. We ignore
         // `SendDone` event from `Mac` layer with success status and
@@ -175,13 +175,13 @@ void RadioSelector::UpdateOnDeferredAck(Neighbor &aNeighbor, Error aTxError, boo
 
     aAllowNeighborRemove = true;
 
-    if (aNeighbor.GetSupportedRadioTypes().Contains(Mac::kRadioTypeTrel))
+    if (aNeighbor.GetSupportedRadioTypes().Contains(Radio::kTypeTrel))
     {
-        logLevel = UpdatePreference(aNeighbor, Mac::kRadioTypeTrel,
+        logLevel = UpdatePreference(aNeighbor, Radio::kTypeTrel,
                                     (aTxError == kErrorNone) ? kPreferenceChangeOnDeferredAckSuccess
                                                              : kPreferenceChangeOnDeferredAckTimeout);
 
-        Log(logLevel, (aTxError == kErrorNone) ? "UpdateOnDefAckSucc" : "UpdateOnDefAckFail", Mac::kRadioTypeTrel,
+        Log(logLevel, (aTxError == kErrorNone) ? "UpdateOnDefAckSucc" : "UpdateOnDefAckFail", Radio::kTypeTrel,
             aNeighbor);
 
         // In case of deferred ack timeout, we check if the neighbor
@@ -191,9 +191,9 @@ void RadioSelector::UpdateOnDeferredAck(Neighbor &aNeighbor, Error aTxError, boo
 
         VerifyOrExit(aTxError != kErrorNone);
 
-        for (Mac::RadioType radio : sRadioSelectionOrder)
+        for (Radio::Type radio : sRadioSelectionOrder)
         {
-            if ((radio != Mac::kRadioTypeTrel) && aNeighbor.GetSupportedRadioTypes().Contains(radio) &&
+            if ((radio != Radio::kTypeTrel) && aNeighbor.GetSupportedRadioTypes().Contains(radio) &&
                 aNeighbor.GetRadioPreference(radio) >= kHighPreference)
             {
                 aAllowNeighborRemove = false;
@@ -204,10 +204,10 @@ void RadioSelector::UpdateOnDeferredAck(Neighbor &aNeighbor, Error aTxError, boo
     else
     {
         VerifyOrExit(aTxError == kErrorNone);
-        aNeighbor.AddSupportedRadioType(Mac::kRadioTypeTrel);
-        aNeighbor.SetRadioPreference(Mac::kRadioTypeTrel, kInitPreference);
+        aNeighbor.AddSupportedRadioType(Radio::kTypeTrel);
+        aNeighbor.SetRadioPreference(Radio::kTypeTrel, kInitPreference);
 
-        Log(logLevel, "NewRadio(OnDefAckSucc)", Mac::kRadioTypeTrel, aNeighbor);
+        Log(logLevel, "NewRadio(OnDefAckSucc)", Radio::kTypeTrel, aNeighbor);
     }
 
 exit:
@@ -215,11 +215,11 @@ exit:
 }
 #endif // OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 
-Mac::RadioType RadioSelector::Select(Mac::RadioTypes aRadioOptions, const Neighbor &aNeighbor)
+Radio::Type RadioSelector::Select(Radio::Types aRadioOptions, const Neighbor &aNeighbor)
 {
-    Mac::RadioType selectedRadio      = sRadioSelectionOrder[0];
-    uint8_t        selectedPreference = 0;
-    bool           found              = false;
+    Radio::Type selectedRadio      = sRadioSelectionOrder[0];
+    uint8_t     selectedPreference = 0;
+    bool        found              = false;
 
     // Select the first radio links with preference higher than
     // threshold `kHighPreference`. The radio links are checked in the
@@ -227,7 +227,7 @@ Mac::RadioType RadioSelector::Select(Mac::RadioTypes aRadioOptions, const Neighb
     // link has preference higher then threshold, select the one with
     // highest preference.
 
-    for (Mac::RadioType radio : sRadioSelectionOrder)
+    for (Radio::Type radio : sRadioSelectionOrder)
     {
         if (aRadioOptions.Contains(radio))
         {
@@ -253,9 +253,9 @@ Mac::RadioType RadioSelector::Select(Mac::RadioTypes aRadioOptions, const Neighb
 
 Mac::TxFrame &RadioSelector::SelectRadio(Message &aMessage, const Mac::Address &aMacDest, Mac::TxFrames &aTxFrames)
 {
-    Neighbor       *neighbor;
-    Mac::RadioType  selectedRadio;
-    Mac::RadioTypes selections;
+    Neighbor    *neighbor;
+    Radio::Type  selectedRadio;
+    Radio::Types selections;
 
     if (aMacDest.IsBroadcast() || aMacDest.IsNone())
     {
@@ -308,13 +308,13 @@ Mac::TxFrame &RadioSelector::SelectRadio(Message &aMessage, const Mac::Address &
     // faster.
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    if (!selections.Contains(Mac::kRadioTypeTrel) && neighbor->GetSupportedRadioTypes().Contains(Mac::kRadioTypeTrel) &&
+    if (!selections.Contains(Radio::kTypeTrel) && neighbor->GetSupportedRadioTypes().Contains(Radio::kTypeTrel) &&
         (Random::NonCrypto::GenerateUpToExcluding<uint8_t>(100) < kTrelProbeProbability))
     {
         aTxFrames.SetRequiredRadioTypes(selections);
-        selections.Add(Mac::kRadioTypeTrel);
+        selections.Add(Radio::kTypeTrel);
 
-        Log(kLogLevelDebg, "Probe", Mac::kRadioTypeTrel, *neighbor);
+        Log(kLogLevelDebg, "Probe", Radio::kTypeTrel, *neighbor);
     }
 #endif
 
@@ -322,22 +322,22 @@ exit:
     return aTxFrames.GetTxFrame(selections);
 }
 
-Mac::RadioType RadioSelector::SelectPollFrameRadio(const Neighbor &aParent)
+Radio::Type RadioSelector::SelectPollFrameRadio(const Neighbor &aParent)
 {
     // This array defines the order in which different radio link types
     // are selected for data poll frame tx.
-    static const Mac::RadioType selectionOrder[Mac::kNumRadioTypes] = {
+    static const Radio::Type selectionOrder[Radio::kNumTypes] = {
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-        Mac::kRadioTypeIeee802154,
+        Radio::kTypeIeee802154,
 #endif
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-        Mac::kRadioTypeTrel,
+        Radio::kTypeTrel,
 #endif
     };
 
-    Mac::RadioType selection = selectionOrder[0];
+    Radio::Type selection = selectionOrder[0];
 
-    for (Mac::RadioType radio : selectionOrder)
+    for (Radio::Type radio : selectionOrder)
     {
         if (aParent.GetSupportedRadioTypes().Contains(radio))
         {
@@ -353,28 +353,25 @@ Mac::RadioType RadioSelector::SelectPollFrameRadio(const Neighbor &aParent)
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
-void RadioSelector::Log(LogLevel        aLogLevel,
-                        const char     *aActionText,
-                        Mac::RadioType  aRadioType,
-                        const Neighbor &aNeighbor)
+void RadioSelector::Log(LogLevel aLogLevel, const char *aActionText, Radio::Type aRadioType, const Neighbor &aNeighbor)
 {
     String<kRadioPreferenceStringSize> preferenceString;
     bool                               isFirstEntry = true;
 
     VerifyOrExit(GetInstance().GetLogLevel() >= aLogLevel);
 
-    for (Mac::RadioType radio : sRadioSelectionOrder)
+    for (Radio::Type radio : sRadioSelectionOrder)
     {
         if (aNeighbor.GetSupportedRadioTypes().Contains(radio))
         {
-            preferenceString.Append("%s%s:%d", isFirstEntry ? "" : " ", RadioTypeToString(radio),
+            preferenceString.Append("%s%s:%d", isFirstEntry ? "" : " ", Radio::TypeToString(radio),
                                     aNeighbor.GetRadioPreference(radio));
             isFirstEntry = false;
         }
     }
 
     LogAt(aLogLevel, "RadioSelector: %s %s - neighbor:[%s rloc16:0x%04x radio-pref:{%s} state:%s]", aActionText,
-          RadioTypeToString(aRadioType), aNeighbor.GetExtAddress().ToString().AsCString(), aNeighbor.GetRloc16(),
+          Radio::TypeToString(aRadioType), aNeighbor.GetExtAddress().ToString().AsCString(), aNeighbor.GetRloc16(),
           preferenceString.AsCString(), Neighbor::StateToString(aNeighbor.GetState()));
 
 exit:
@@ -383,7 +380,7 @@ exit:
 
 #else // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
-void RadioSelector::Log(LogLevel, const char *, Mac::RadioType, const Neighbor &) {}
+void RadioSelector::Log(LogLevel, const char *, Radio::Type, const Neighbor &) {}
 
 #endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 

--- a/src/core/thread/radio_selector.hpp
+++ b/src/core/thread/radio_selector.hpp
@@ -46,6 +46,7 @@
 #include "mac/mac_frame.hpp"
 #include "mac/mac_links.hpp"
 #include "mac/mac_types.hpp"
+#include "radio/radio_types.hpp"
 
 namespace ot {
 
@@ -83,7 +84,7 @@ public:
          *
          * @returns The supported radio types set.
          */
-        Mac::RadioTypes GetSupportedRadioTypes(void) const { return mSupportedRadioTypes; }
+        Radio::Types GetSupportedRadioTypes(void) const { return mSupportedRadioTypes; }
 
         /**
          * Retrieves the multi radio information `otMultiRadioNeighborInfo` associated with the neighbor.
@@ -93,15 +94,15 @@ public:
         void PopulateMultiRadioInfo(MultiRadioInfo &aInfo);
 
     private:
-        void AddSupportedRadioType(Mac::RadioType aType) { mSupportedRadioTypes.Add(aType); }
-        void RemoveSupportedRadioType(Mac::RadioType aType) { mSupportedRadioTypes.Remove(aType); }
+        void AddSupportedRadioType(Radio::Type aType) { mSupportedRadioTypes.Add(aType); }
+        void RemoveSupportedRadioType(Radio::Type aType) { mSupportedRadioTypes.Remove(aType); }
         void ClearSupportedRadioType(void) { mSupportedRadioTypes.Clear(); }
 
-        uint8_t GetRadioPreference(Mac::RadioType aType) const { return mRadioPreference[aType]; }
-        void    SetRadioPreference(Mac::RadioType aType, uint8_t aValue) { mRadioPreference[aType] = aValue; }
+        uint8_t GetRadioPreference(Radio::Type aType) const { return mRadioPreference[aType]; }
+        void    SetRadioPreference(Radio::Type aType, uint8_t aValue) { mRadioPreference[aType] = aValue; }
 
-        Mac::RadioTypes mSupportedRadioTypes;
-        uint8_t         mRadioPreference[Mac::kNumRadioTypes];
+        Radio::Types mSupportedRadioTypes;
+        uint8_t      mRadioPreference[Radio::kNumTypes];
     };
 
     /**
@@ -122,7 +123,7 @@ public:
      * @param[in] aRadioType    The radio link type on which the frame/message was received.
      * @param[in] aIsDuplicate  Indicates whether the received frame/message is a duplicate or not.
      */
-    void UpdateOnReceive(Neighbor &aNeighbor, Mac::RadioType aRadioType, bool aIsDuplicate);
+    void UpdateOnReceive(Neighbor &aNeighbor, Radio::Type aRadioType, bool aIsDuplicate);
 
     /**
      * Updates the neighbor info (for multi radio support) on a send done event.
@@ -155,7 +156,7 @@ public:
      *
      * @returns The radio type on which the data poll frame should be sent.
      */
-    Mac::RadioType SelectPollFrameRadio(const Neighbor &aParent);
+    Radio::Type SelectPollFrameRadio(const Neighbor &aParent);
 
     /**
      * Selects the radio link for sending a given message to a specified MAC destination.
@@ -188,11 +189,11 @@ private:
 
     static constexpr uint16_t kRadioPreferenceStringSize = 75;
 
-    LogLevel       UpdatePreference(Neighbor &aNeighbor, Mac::RadioType aRadioType, int16_t aDifference);
-    Mac::RadioType Select(Mac::RadioTypes aRadioOptions, const Neighbor &aNeighbor);
-    void           Log(LogLevel aLogLevel, const char *aActionText, Mac::RadioType aType, const Neighbor &aNeighbor);
+    LogLevel    UpdatePreference(Neighbor &aNeighbor, Radio::Type aRadioType, int16_t aDifference);
+    Radio::Type Select(Radio::Types aRadioOptions, const Neighbor &aNeighbor);
+    void        Log(LogLevel aLogLevel, const char *aActionText, Radio::Type aType, const Neighbor &aNeighbor);
 
-    static const Mac::RadioType sRadioSelectionOrder[Mac::kNumRadioTypes];
+    static const Radio::Type sRadioSelectionOrder[Radio::kNumTypes];
 };
 
 /**

--- a/src/core/utils/history_tracker.cpp
+++ b/src/core/utils/history_tracker.cpp
@@ -149,12 +149,12 @@ void Local::RecordMessage(const Message      &aMessage,
         switch (aMessage.GetRadioType())
         {
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-        case Mac::kRadioTypeIeee802154:
+        case Radio::kTypeIeee802154:
             entry->mRadioIeee802154 = true;
             break;
 #endif
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-        case Mac::kRadioTypeTrel:
+        case Radio::kTypeTrel:
             entry->mRadioTrelUdp6 = true;
             break;
 #endif

--- a/tests/nexus/test_1_4_TREL_TC_1.cpp
+++ b/tests/nexus/test_1_4_TREL_TC_1.cpp
@@ -133,8 +133,8 @@ void Test1_4_Trel_Tc_1(void)
         const Neighbor *neighbor = router1.Get<NeighborTable>().FindNeighbor(br.Get<Mac::Mac>().GetExtAddress());
 
         VerifyOrQuit(neighbor != nullptr);
-        VerifyOrQuit(neighbor->GetSupportedRadioTypes().Contains(Mac::kRadioTypeIeee802154));
-        VerifyOrQuit(neighbor->GetSupportedRadioTypes().Contains(Mac::kRadioTypeTrel));
+        VerifyOrQuit(neighbor->GetSupportedRadioTypes().Contains(ot::Radio::kTypeIeee802154));
+        VerifyOrQuit(neighbor->GetSupportedRadioTypes().Contains(ot::Radio::kTypeTrel));
     }
 
     /**

--- a/tests/nexus/test_1_4_TREL_TC_2.cpp
+++ b/tests/nexus/test_1_4_TREL_TC_2.cpp
@@ -151,12 +151,12 @@ void Test_1_4_TREL_TC_2(void)
     {
         const Neighbor *neighbor = leader.Get<NeighborTable>().FindNeighbor(router1.Get<Mac::Mac>().GetExtAddress());
         VerifyOrQuit(neighbor != nullptr);
-        VerifyOrQuit(neighbor->GetSupportedRadioTypes().Contains(Mac::kRadioTypeTrel));
+        VerifyOrQuit(neighbor->GetSupportedRadioTypes().Contains(ot::Radio::kTypeTrel));
     }
     {
         const Neighbor *neighbor = router1.Get<NeighborTable>().FindNeighbor(router4.Get<Mac::Mac>().GetExtAddress());
         VerifyOrQuit(neighbor != nullptr);
-        VerifyOrQuit(neighbor->GetSupportedRadioTypes().Contains(Mac::kRadioTypeTrel));
+        VerifyOrQuit(neighbor->GetSupportedRadioTypes().Contains(ot::Radio::kTypeTrel));
     }
     VerifyOrQuit(leader.Get<NeighborTable>().FindNeighbor(router2.Get<Mac::Mac>().GetExtAddress()) != nullptr);
     VerifyOrQuit(router2.Get<NeighborTable>().FindNeighbor(leader.Get<Mac::Mac>().GetExtAddress()) != nullptr);


### PR DESCRIPTION
This commit moves multi-radio link type definitions under `OPENTHREAD_CONFIG_MULTI_RADIO` from `Mac` to `namespace Radio` in `radio_types.hpp`:

- `Mac::RadioType` -> `Radio::Type` (`kTypeIeee802154`, `kTypeTrel`)
- `Mac::kNumRadioTypes` -> `Radio::kNumTypes`
- `Mac::RadioTypes` -> `Radio::Types`

Moving these types to `namespace Radio` improves module encapsulation and layering. Call sites across `src/core/` (`Mac`, `RadioSelector`, `Message`) and Nexus tests are updated accordingly.

----

~This PR contains the commit from https://github.com/openthread/openthread/pull/13333. Please read and review the top commit in this PR. Thanks.~ 
