### PR TITLE
[TCAT] advertisement TLVs for oui24 and oui36 consolidated into one single TLV and application protocol TLV added

### DIFF
--- a/include/openthread/ble_secure.h
+++ b/include/openthread/ble_secure.h
@@ -50,7 +50,6 @@
 
 #include <openthread/error.h>
 #include <openthread/instance.h>
-#include <openthread/message.h>
 #include <openthread/tcat.h>
 
 #ifdef __cplusplus
@@ -418,22 +417,6 @@ bool otBleSecureIsTcatAgentStarted(otInstance *aInstance);
  * @retval FALSE  The command class is not authorized.
  */
 bool otBleSecureIsCommandClassAuthorized(otInstance *aInstance, otTcatCommandClass aCommandClass);
-
-/**
- * Sends a secure BLE message.
- *
- * @param[in]  aInstance     A pointer to an OpenThread instance.
- * @param[in]  aMessage      A pointer to the message to send.
- *
- * If the return value is OT_ERROR_NONE, OpenThread takes ownership of @p aMessage, and the caller should no longer
- * reference @p aMessage. If the return value is not OT_ERROR_NONE, the caller retains ownership of @p aMessage,
- * including freeing @p aMessage if the message buffer is no longer needed.
- *
- * @retval OT_ERROR_NONE           Successfully sent message.
- * @retval OT_ERROR_NO_BUFS        Failed to allocate buffer memory.
- * @retval OT_ERROR_INVALID_STATE  TLS connection was not initialized.
- */
-otError otBleSecureSendMessage(otInstance *aInstance, otMessage *aMessage);
 
 /**
  * Sends a secure BLE data packet.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (611)
+#define OPENTHREAD_API_VERSION (612)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/tcat.h
+++ b/include/openthread/tcat.h
@@ -181,12 +181,12 @@ typedef enum otTcatCommandClass
  */
 typedef enum otTcatAdvertisedDeviceIdType
 {
-    OT_TCAT_DEVICE_ID_EMPTY         = 0, ///< Advertised device ID type not set
-    OT_TCAT_DEVICE_ID_OUI24         = 1, ///< Advertised device ID type IEEE OUI-24
-    OT_TCAT_DEVICE_ID_OUI36         = 2, ///< Advertised device ID type IEEE OUI-36
-    OT_TCAT_DEVICE_ID_DISCRIMINATOR = 3, ///< Advertised device ID type Device Discriminator
-    OT_TCAT_DEVICE_ID_IANAPEN       = 4, ///< Advertised device ID type IANA PEN
-    OT_TCAT_DEVICE_ID_MAX           = 5, ///< Advertised device ID max number of types
+    OT_TCAT_DEVICE_ID_EMPTY                = 0, ///< Advertised device ID type not set
+    OT_TCAT_DEVICE_ID_OUI                  = 1, ///< Advertised device ID type IEEE OUI
+    OT_TCAT_DEVICE_ID_DISCRIMINATOR        = 2, ///< Advertised device ID type Device Discriminator
+    OT_TCAT_DEVICE_ID_IANAPEN              = 3, ///< Advertised device ID type IANA PEN
+    OT_TCAT_DEVICE_ID_APPLICATION_PROTOCOL = 4, ///< Advertised device ID type Application Protocol
+    OT_TCAT_DEVICE_ID_MAX                  = 5, ///< Advertised device ID max number of types
 } otTcatAdvertisedDeviceIdType;
 
 typedef struct otTcatAdvertisedDeviceId

--- a/src/cli/README_TCAT.md
+++ b/src/cli/README_TCAT.md
@@ -34,7 +34,7 @@ Displays currently set TCAT advertised IDs.
 
 ```bash
 tcat advid
-type oui24, value: f378aa
+type oui, value: f378aa
 Done
 ```
 
@@ -47,21 +47,12 @@ tcat advid ianapen f378aabb
 Done
 ```
 
-### advid oui24 \<id\>
+### advid oui \<id\>
 
-Sets TCAT advertised IEEE OUI-24 ID. See the [IEEE OUI registry](https://standards.ieee.org/products-programs/regauth/oui/).
-
-```bash
-tcat advid oui24 f378aa
-Done
-```
-
-### advid oui36 \<id\>
-
-Sets TCAT advertised IEEE OUI-36 ID. See the [IEEE OUI registry](https://standards.ieee.org/products-programs/regauth/oui/).
+Sets TCAT advertised IEEE OUI-24, OUI-28 or OUI-36 ID. See the [IEEE OUI registry](https://standards.ieee.org/products-programs/regauth/oui/).
 
 ```bash
-tcat advid oui36 f378aabbcc
+tcat advid oui f378aa
 Done
 ```
 
@@ -71,6 +62,15 @@ Sets TCAT advertised device discriminator ID.
 
 ```bash
 tcat advid discriminator f378aabbdd
+Done
+```
+
+### advid applicationprotocol \<id\>
+
+Sets TCAT advertised application protocol ID to a 2-byte network byte order protocol identifier and optionally up to 3-bytes application data.
+
+```bash
+tcat advid applicationprotocol c000aabbcc
 Done
 ```
 

--- a/src/cli/cli_tcat.cpp
+++ b/src/cli/cli_tcat.cpp
@@ -32,6 +32,7 @@
 #include "cli/cli_utils.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
+#include "common/encoding.hpp"
 #include "common/string.hpp"
 
 #include <openthread/ble_secure.h>
@@ -171,19 +172,19 @@ static void HandleBleSecureReceive(otInstance               *aInstance,
  * @cparam tcat advid [@ca{id_type}] [@ca{value}]
  * * The `id_type` has five possible values:
  *   * `clear` - removes all previously set advertised IDs.
- *   * `oui24` - sets OUI24 ID type.
- *   * `oui36` - sets OUI36 ID type.
+ *   * `oui` - sets OUI ID type.
  *   * `discriminator` - sets discriminator ID type.
  *   * `ianapen` - sets IANA PEN ID type.
+ *   * `applicationprotocol` - sets application protocol ID type.
  * * The `value` hexstring value of the ID.
  * @par
  * Sets/clears advertised ID type and value.
  */
 template <> otError Tcat::Process<Cmd("advid")>(Arg aArgs[])
 {
-    otError                  error = OT_ERROR_NONE;
-    otTcatAdvertisedDeviceId devId;
-    static const char *const kVendorIdTypes[] = {"clear", "oui24", "oui36", "discriminator", "ianapen"};
+    otError                  error            = OT_ERROR_NONE;
+    otTcatAdvertisedDeviceId devId            = {};
+    static const char *const kVendorIdTypes[] = {"clear", "oui", "discriminator", "ianapen", "applicationprotocol"};
 
     mVendorInfo.mAdvertisedDeviceIds = sAdvertisedDeviceIds;
 
@@ -202,13 +203,9 @@ template <> otError Tcat::Process<Cmd("advid")>(Arg aArgs[])
         ExitNow();
     }
 
-    if (aArgs[0] == kVendorIdTypes[OT_TCAT_DEVICE_ID_OUI24])
+    if (aArgs[0] == kVendorIdTypes[OT_TCAT_DEVICE_ID_OUI])
     {
-        devId.mDeviceIdType = OT_TCAT_DEVICE_ID_OUI24;
-    }
-    else if (aArgs[0] == kVendorIdTypes[OT_TCAT_DEVICE_ID_OUI36])
-    {
-        devId.mDeviceIdType = OT_TCAT_DEVICE_ID_OUI36;
+        devId.mDeviceIdType = OT_TCAT_DEVICE_ID_OUI;
     }
     else if (aArgs[0] == kVendorIdTypes[OT_TCAT_DEVICE_ID_DISCRIMINATOR])
     {
@@ -217,6 +214,10 @@ template <> otError Tcat::Process<Cmd("advid")>(Arg aArgs[])
     else if (aArgs[0] == kVendorIdTypes[OT_TCAT_DEVICE_ID_IANAPEN])
     {
         devId.mDeviceIdType = OT_TCAT_DEVICE_ID_IANAPEN;
+    }
+    else if (aArgs[0] == kVendorIdTypes[OT_TCAT_DEVICE_ID_APPLICATION_PROTOCOL])
+    {
+        devId.mDeviceIdType = OT_TCAT_DEVICE_ID_APPLICATION_PROTOCOL;
     }
     else if (aArgs[0] == kVendorIdTypes[OT_TCAT_DEVICE_ID_EMPTY])
     {
@@ -244,6 +245,12 @@ template <> otError Tcat::Process<Cmd("advid")>(Arg aArgs[])
                 vendorDeviceId = devId;
                 break;
             }
+        }
+
+        // Update the vendor info with the new advertised device IDs if the TCAT agent is already started
+        if (otBleSecureIsTcatAgentStarted(GetInstancePtr()))
+        {
+            SuccessOrExit(error = otBleSecureSetTcatVendorInfo(GetInstancePtr(), &mVendorInfo));
         }
     }
     else

--- a/src/core/api/ble_secure_api.cpp
+++ b/src/core/api/ble_secure_api.cpp
@@ -190,11 +190,6 @@ bool otBleSecureIsCommandClassAuthorized(otInstance *aInstance, otTcatCommandCla
         static_cast<Ble::BleSecure::CommandClass>(aCommandClass));
 }
 
-otError otBleSecureSendMessage(otInstance *aInstance, otMessage *aMessage)
-{
-    return AsCoreType(aInstance).Get<Ble::BleSecure>().SendMessage(AsCoreType(aMessage));
-}
-
 otError otBleSecureSend(otInstance *aInstance, uint8_t *aBuf, uint16_t aLength)
 {
     return AsCoreType(aInstance).Get<Ble::BleSecure>().Send(aBuf, aLength);

--- a/src/core/meshcop/tcat_agent.cpp
+++ b/src/core/meshcop/tcat_agent.cpp
@@ -1201,13 +1201,8 @@ Error TcatAgent::GetAdvertisementData(uint16_t &aLen, uint8_t *aAdvertisementDat
         {
             switch (MapEnum(mVendorInfo->mAdvertisedDeviceIds[i].mDeviceIdType))
             {
-            case kTcatDeviceIdOui24:
-                SerializeTcatAdvertisementTlv(aAdvertisementData, aLen, kTlvVendorOui24,
-                                              mVendorInfo->mAdvertisedDeviceIds[i].mDeviceIdLen,
-                                              mVendorInfo->mAdvertisedDeviceIds[i].mDeviceId);
-                break;
-            case kTcatDeviceIdOui36:
-                SerializeTcatAdvertisementTlv(aAdvertisementData, aLen, kTlvVendorOui36,
+            case kTcatDeviceIdOui:
+                SerializeTcatAdvertisementTlv(aAdvertisementData, aLen, kTlvVendorOui,
                                               mVendorInfo->mAdvertisedDeviceIds[i].mDeviceIdLen,
                                               mVendorInfo->mAdvertisedDeviceIds[i].mDeviceId);
                 break;
@@ -1218,6 +1213,11 @@ Error TcatAgent::GetAdvertisementData(uint16_t &aLen, uint8_t *aAdvertisementDat
                 break;
             case kTcatDeviceIdIanaPen:
                 SerializeTcatAdvertisementTlv(aAdvertisementData, aLen, kTlvVendorIanaPen,
+                                              mVendorInfo->mAdvertisedDeviceIds[i].mDeviceIdLen,
+                                              mVendorInfo->mAdvertisedDeviceIds[i].mDeviceId);
+                break;
+            case kTcatDeviceIdApplicationProtocol:
+                SerializeTcatAdvertisementTlv(aAdvertisementData, aLen, kTlvApplicationProtocolId,
                                               mVendorInfo->mAdvertisedDeviceIds[i].mDeviceIdLen,
                                               mVendorInfo->mAdvertisedDeviceIds[i].mDeviceId);
                 break;

--- a/src/core/meshcop/tcat_agent.hpp
+++ b/src/core/meshcop/tcat_agent.hpp
@@ -550,7 +550,7 @@ static constexpr uint8_t kTlvDeviceTypeAndStatusLength = 1;
 
 enum TcatAdvertisementTlvType : uint8_t
 {
-    kTlvVendorOui             = 1, ///< TCAT vendor OUI 24
+    kTlvVendorOui             = 1, ///< TCAT vendor OUI (OUI-24, OUI-28, or OUI-36)
     kTlvDeviceDiscriminator   = 3, ///< TCAT random vendor discriminator
     kTlvDeviceTypeAndStatus   = 4, ///< TCAT Thread device type and status
     kTlvBleLinkCapabilities   = 5, ///< TCAT BLE link capabilities of device

--- a/src/core/meshcop/tcat_agent.hpp
+++ b/src/core/meshcop/tcat_agent.hpp
@@ -275,11 +275,11 @@ public:
      */
     enum TcatDeviceIdType : uint8_t
     {
-        kTcatDeviceIdEmpty         = OT_TCAT_DEVICE_ID_EMPTY,
-        kTcatDeviceIdOui24         = OT_TCAT_DEVICE_ID_OUI24,
-        kTcatDeviceIdOui36         = OT_TCAT_DEVICE_ID_OUI36,
-        kTcatDeviceIdDiscriminator = OT_TCAT_DEVICE_ID_DISCRIMINATOR,
-        kTcatDeviceIdIanaPen       = OT_TCAT_DEVICE_ID_IANAPEN,
+        kTcatDeviceIdEmpty               = OT_TCAT_DEVICE_ID_EMPTY,
+        kTcatDeviceIdOui                 = OT_TCAT_DEVICE_ID_OUI,
+        kTcatDeviceIdDiscriminator       = OT_TCAT_DEVICE_ID_DISCRIMINATOR,
+        kTcatDeviceIdIanaPen             = OT_TCAT_DEVICE_ID_IANAPEN,
+        kTcatDeviceIdApplicationProtocol = OT_TCAT_DEVICE_ID_APPLICATION_PROTOCOL,
     };
 
     /**
@@ -545,21 +545,17 @@ struct DeviceTypeAndStatus
     bool    mDeviceType : 1;
 };
 
-static constexpr uint8_t kTlvVendorOui24Length         = 3;
-static constexpr uint8_t kTlvVendorOui36Length         = 5;
-static constexpr uint8_t kTlvDeviceDiscriminatorLength = 5;
 static constexpr uint8_t kTlvBleLinkCapabilitiesLength = 1;
 static constexpr uint8_t kTlvDeviceTypeAndStatusLength = 1;
-static constexpr uint8_t kTlvVendorIanaPenLength       = 4;
 
 enum TcatAdvertisementTlvType : uint8_t
 {
-    kTlvVendorOui24         = 1, ///< TCAT vendor OUI 24
-    kTlvVendorOui36         = 2, ///< TCAT vendor OUI 36
-    kTlvDeviceDiscriminator = 3, ///< TCAT random vendor discriminator
-    kTlvDeviceTypeAndStatus = 4, ///< TCAT Thread device type and status
-    kTlvBleLinkCapabilities = 5, ///< TCAT BLE link capabilities of device
-    kTlvVendorIanaPen       = 6, ///< TCAT Vendor IANA PEN
+    kTlvVendorOui             = 1, ///< TCAT vendor OUI 24
+    kTlvDeviceDiscriminator   = 3, ///< TCAT random vendor discriminator
+    kTlvDeviceTypeAndStatus   = 4, ///< TCAT Thread device type and status
+    kTlvBleLinkCapabilities   = 5, ///< TCAT BLE link capabilities of device
+    kTlvVendorIanaPen         = 6, ///< TCAT Vendor IANA PEN
+    kTlvApplicationProtocolId = 7, ///< TCAT Application Protocol ID
 };
 
 } // namespace MeshCoP

--- a/src/core/radio/ble_secure.cpp
+++ b/src/core/radio/ble_secure.cpp
@@ -111,6 +111,19 @@ exit:
     return error;
 }
 
+Error BleSecure::SetTcatVendorInfo(const MeshCoP::TcatAgent::VendorInfo &aVendorInfo)
+{
+    Error error;
+
+    error = Get<MeshCoP::TcatAgent>().SetTcatVendorInfo(aVendorInfo);
+    VerifyOrExit(error == kErrorNone);
+
+    IgnoreError(NotifyAdvertisementChanged());
+
+exit:
+    return error;
+}
+
 void BleSecure::Stop(void)
 {
     VerifyOrExit(mBleState != kStopped);
@@ -266,24 +279,6 @@ void BleSecure::SetPsk(const MeshCoP::JoinerPskd &aPskd)
                   "The maximum length of TLS PSK is smaller than joiner PSKd");
 
     SuccessOrAssert(mTls.SetPsk(reinterpret_cast<const uint8_t *>(aPskd.GetAsCString()), aPskd.GetLength()));
-}
-
-Error BleSecure::SendMessage(ot::Message &aMessage)
-{
-    Error error = kErrorNone;
-
-    VerifyOrExit(IsConnected(), error = kErrorInvalidState);
-    if (mSendMessage == nullptr)
-    {
-        mSendMessage = Get<MessagePool>().Allocate(Message::kTypeBle);
-        VerifyOrExit(mSendMessage != nullptr, error = kErrorNoBufs);
-    }
-    SuccessOrExit(error = mSendMessage->AppendBytesFromMessage(aMessage, 0, aMessage.GetLength()));
-    SuccessOrExit(error = Flush());
-
-    aMessage.Free();
-exit:
-    return error;
 }
 
 Error BleSecure::Send(uint8_t *aBuf, uint16_t aLength)

--- a/src/core/radio/ble_secure.hpp
+++ b/src/core/radio/ble_secure.hpp
@@ -114,10 +114,7 @@ public:
      * @retval kErrorNone         Successfully set vendor info.
      * @retval kErrorInvalidArgs  Vendor info could not be set.
      */
-    Error SetTcatVendorInfo(const MeshCoP::TcatAgent::VendorInfo &aVendorInfo)
-    {
-        return Get<MeshCoP::TcatAgent>().SetTcatVendorInfo(aVendorInfo);
-    }
+    Error SetTcatVendorInfo(const MeshCoP::TcatAgent::VendorInfo &aVendorInfo);
 
     /**
      * Enables the TCAT protocol over BLE Secure.
@@ -226,21 +223,6 @@ public:
      * @param[in]  aPskd  A Joiner PSKd.
      */
     void SetPsk(const MeshCoP::JoinerPskd &aPskd);
-
-    /**
-     * Sends a secure BLE message.
-     *
-     * @param[in]  aMessage        A pointer to the message to send.
-     *
-     * If the return value is kErrorNone, OpenThread takes ownership of @p aMessage, and the caller should no longer
-     * reference @p aMessage. If the return value is not kErrorNone, the caller retains ownership of @p aMessage,
-     * including freeing @p aMessage if the message buffer is no longer needed.
-     *
-     * @retval kErrorNone          Successfully sent message.
-     * @retval kErrorNoBufs        Failed to allocate buffer memory.
-     * @retval kErrorInvalidState  TLS connection was not initialized.
-     */
-    Error SendMessage(Message &aMessage);
 
     /**
      * Sends a secure BLE data packet.

--- a/tests/scripts/expect/cli-tcat-advertisement.exp
+++ b/tests/scripts/expect/cli-tcat-advertisement.exp
@@ -45,18 +45,18 @@ send "tcat advid\n"
 expect_line "type ianapen, value: f378aabb"
 expect_line "Done"
 
-send "tcat advid oui24 f378aa\n"
+send "tcat advid oui f378aa\n"
 expect_line "Done"
 
 send "tcat advid\n"
-expect_line "type oui24, value: f378aa"
+expect_line "type oui, value: f378aa"
 expect_line "Done"
 
-send "tcat advid oui36 f378aabbcc\n"
+send "tcat advid applicationprotocol c000aabb\n"
 expect_line "Done"
 
 send "tcat advid\n"
-expect_line "type oui36, value: f378aabbcc"
+expect_line "type applicationprotocol, value: c000aabb"
 expect_line "Done"
 
 send "tcat advid discriminator f378aabbdd\n"


### PR DESCRIPTION
Recent updates in the Thread specification require consolidation of the advertisement TLVs for oui24 and oui36 into one single TLV and adding a new advertisement TLV for the application protocol ID and optional payload.
This PR implements the necessary changes. 

The PR also fixes an inconsistency in the BleSecure API. The function otBleSecureSendMessage(...) has been removed because it was never possible for to create a Message of the correct type using the public API. The function otBleSecureSend(..) must be used.