### PR TITLE
[mac] rename `KeyId` to `KeyIndex` (in `Mac::Frame`)

### DIFF
--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -1126,7 +1126,7 @@ uint8_t otPlatRadioGetCslAccuracy(otInstance *aInstance)
 
 void otPlatRadioSetMacKey(otInstance             *aInstance,
                           uint8_t                 aKeyIdMode,
-                          uint8_t                 aKeyId,
+                          uint8_t                 aKeyIndex,
                           const otMacKeyMaterial *aPrevKey,
                           const otMacKeyMaterial *aCurrKey,
                           const otMacKeyMaterial *aNextKey,
@@ -1137,7 +1137,7 @@ void otPlatRadioSetMacKey(otInstance             *aInstance,
 
     otEXPECT(aPrevKey != NULL && aCurrKey != NULL && aNextKey != NULL);
 
-    sRadioContext.mKeyId               = aKeyId;
+    sRadioContext.mKeyId               = aKeyIndex;
     sRadioContext.mKeyType             = aKeyType;
     sRadioContext.mPrevMacFrameCounter = sRadioContext.mMacFrameCounter;
     sRadioContext.mMacFrameCounter     = 0;

--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -236,14 +236,17 @@ bool otMacFrameIsKeyIdMode2(otRadioFrame *aFrame)
 
 uint8_t otMacFrameGetKeyId(otRadioFrame *aFrame)
 {
-    uint8_t keyId = 0;
+    uint8_t keyIndex = 0;
 
-    IgnoreError(static_cast<const Mac::Frame *>(aFrame)->GetKeyId(keyId));
+    IgnoreError(static_cast<const Mac::Frame *>(aFrame)->GetKeyIndex(keyIndex));
 
-    return keyId;
+    return keyIndex;
 }
 
-void otMacFrameSetKeyId(otRadioFrame *aFrame, uint8_t aKeyId) { static_cast<Mac::Frame *>(aFrame)->SetKeyId(aKeyId); }
+void otMacFrameSetKeyId(otRadioFrame *aFrame, uint8_t aKeyId)
+{
+    static_cast<Mac::Frame *>(aFrame)->SetKeyIndex(aKeyId);
+}
 
 uint32_t otMacFrameGetFrameCounter(otRadioFrame *aFrame)
 {

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (611)
+#define OPENTHREAD_API_VERSION (612)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/link_raw.h
+++ b/include/openthread/link_raw.h
@@ -339,7 +339,7 @@ otError otLinkRawSrcMatchClearExtEntries(otInstance *aInstance);
  *
  * @param[in]   aInstance    A pointer to an OpenThread instance.
  * @param[in]   aKeyIdMode   The key ID mode.
- * @param[in]   aKeyId       The key index.
+ * @param[in]   aKeyIndex    The key index.
  * @param[in]   aPrevKey     The previous MAC key.
  * @param[in]   aCurrKey     The current MAC key.
  * @param[in]   aNextKey     The next MAC key.
@@ -349,7 +349,7 @@ otError otLinkRawSrcMatchClearExtEntries(otInstance *aInstance);
  */
 otError otLinkRawSetMacKey(otInstance     *aInstance,
                            uint8_t         aKeyIdMode,
-                           uint8_t         aKeyId,
+                           uint8_t         aKeyIndex,
                            const otMacKey *aPrevKey,
                            const otMacKey *aCurrKey,
                            const otMacKey *aNextKey);

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -729,7 +729,7 @@ void otPlatRadioSetRxOnWhenIdle(otInstance *aInstance, bool aEnable);
  *
  * @param[in]   aInstance    A pointer to an OpenThread instance.
  * @param[in]   aKeyIdMode   The key ID mode.
- * @param[in]   aKeyId       Current MAC key index.
+ * @param[in]   aKeyIndex       Current MAC key index.
  * @param[in]   aPrevKey     A pointer to the previous MAC key.
  * @param[in]   aCurrKey     A pointer to the current MAC key.
  * @param[in]   aNextKey     A pointer to the next MAC key.
@@ -737,7 +737,7 @@ void otPlatRadioSetRxOnWhenIdle(otInstance *aInstance, bool aEnable);
  */
 void otPlatRadioSetMacKey(otInstance             *aInstance,
                           uint8_t                 aKeyIdMode,
-                          uint8_t                 aKeyId,
+                          uint8_t                 aKeyIndex,
                           const otMacKeyMaterial *aPrevKey,
                           const otMacKeyMaterial *aCurrKey,
                           const otMacKeyMaterial *aNextKey,

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -204,12 +204,12 @@ exit:
 
 otError otLinkRawSetMacKey(otInstance     *aInstance,
                            uint8_t         aKeyIdMode,
-                           uint8_t         aKeyId,
+                           uint8_t         aKeyIndex,
                            const otMacKey *aPrevKey,
                            const otMacKey *aCurrKey,
                            const otMacKey *aNextKey)
 {
-    return AsCoreType(aInstance).Get<Mac::LinkRaw>().SetMacKey(aKeyIdMode, aKeyId, AsCoreType(aPrevKey),
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().SetMacKey(aKeyIdMode, aKeyIndex, AsCoreType(aPrevKey),
                                                                AsCoreType(aCurrKey), AsCoreType(aNextKey));
 }
 

--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -163,7 +163,7 @@ Mac::TxFrame *DataPollHandler::HandleFrameRequest(Mac::TxFrames &aTxFrames)
         if (frame->GetSecurityEnabled())
         {
             frame->SetFrameCounter(mIndirectTxChild->GetIndirectFrameCounter());
-            frame->SetKeyId(mIndirectTxChild->GetIndirectKeyId());
+            frame->SetKeyIndex(mIndirectTxChild->GetIndirectKeyIndex());
         }
     }
     else
@@ -237,13 +237,13 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, 
             if (aFrame.GetSecurityEnabled() && aFrame.IsHeaderUpdated())
             {
                 uint32_t frameCounter;
-                uint8_t  keyId;
+                uint8_t  keyIndex;
 
                 SuccessOrAssert(aFrame.GetFrameCounter(frameCounter));
                 aChild.SetIndirectFrameCounter(frameCounter);
 
-                SuccessOrAssert(aFrame.GetKeyId(keyId));
-                aChild.SetIndirectKeyId(keyId);
+                SuccessOrAssert(aFrame.GetKeyIndex(keyIndex));
+                aChild.SetIndirectKeyIndex(keyIndex);
             }
 
             ExitNow();

--- a/src/core/mac/data_poll_handler.hpp
+++ b/src/core/mac/data_poll_handler.hpp
@@ -99,8 +99,8 @@ public:
         uint32_t GetIndirectFrameCounter(void) const { return mIndirectFrameCounter; }
         void     SetIndirectFrameCounter(uint32_t aFrameCounter) { mIndirectFrameCounter = aFrameCounter; }
 
-        uint8_t GetIndirectKeyId(void) const { return mIndirectKeyId; }
-        void    SetIndirectKeyId(uint8_t aKeyId) { mIndirectKeyId = aKeyId; }
+        uint8_t GetIndirectKeyIndex(void) const { return mIndirectKeyIndex; }
+        void    SetIndirectKeyIndex(uint8_t aKeyIndex) { mIndirectKeyIndex = aKeyIndex; }
 
         uint8_t GetIndirectTxAttempts(void) const { return mIndirectTxAttempts; }
         void    ResetIndirectTxAttempts(void) { mIndirectTxAttempts = 0; }
@@ -121,7 +121,7 @@ public:
 #endif
 
         uint32_t mIndirectFrameCounter;    // Frame counter for current indirect frame (used for retx).
-        uint8_t  mIndirectKeyId;           // Key Id for current indirect frame (used for retx).
+        uint8_t  mIndirectKeyIndex;        // Key Index for current indirect frame (used for retx).
         uint8_t  mIndirectDsn;             // MAC level Data Sequence Number (DSN) for retx attempts.
         uint8_t  mIndirectTxAttempts : 5;  // Number of data poll triggered tx attempts.
         bool     mDataPollPending : 1;     // Indicates whether or not a Data Poll was received.

--- a/src/core/mac/link_raw.cpp
+++ b/src/core/mac/link_raw.cpp
@@ -241,7 +241,7 @@ void LinkRaw::InvokeEnergyScanDone(int8_t aEnergyScanMaxRssi)
 }
 
 Error LinkRaw::SetMacKey(uint8_t    aKeyIdMode,
-                         uint8_t    aKeyId,
+                         uint8_t    aKeyIndex,
                          const Key &aPrevKey,
                          const Key &aCurrKey,
                          const Key &aNextKey)
@@ -257,7 +257,7 @@ Error LinkRaw::SetMacKey(uint8_t    aKeyIdMode,
     currKey.SetFrom(aCurrKey, kDefaultMacKeysExportable);
     nextKey.SetFrom(aNextKey, kDefaultMacKeysExportable);
 
-    mSubMac.SetMacKey(aKeyIdMode, aKeyId, prevKey, currKey, nextKey);
+    mSubMac.SetMacKey(aKeyIdMode, aKeyIndex, prevKey, currKey, nextKey);
 
 exit:
     return error;

--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -245,7 +245,7 @@ public:
      * Updates MAC keys and key index.
      *
      * @param[in]   aKeyIdMode        The key ID mode.
-     * @param[in]   aKeyId            The key index.
+     * @param[in]   aKeyIndex            The key index.
      * @param[in]   aPrevKey          The previous MAC key.
      * @param[in]   aCurrKey          The current MAC key.
      * @param[in]   aNextKey          The next MAC key.
@@ -254,7 +254,11 @@ public:
      * @retval kErrorFailed          Platform failed to import key.
      * @retval kErrorInvalidState    If the raw link-layer isn't enabled.
      */
-    Error SetMacKey(uint8_t aKeyIdMode, uint8_t aKeyId, const Key &aPrevKey, const Key &aCurrKey, const Key &aNextKey);
+    Error SetMacKey(uint8_t    aKeyIdMode,
+                    uint8_t    aKeyIndex,
+                    const Key &aPrevKey,
+                    const Key &aCurrKey,
+                    const Key &aNextKey);
 
     /**
      * Sets the current MAC frame counter value.

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -845,7 +845,7 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame)
         if (!aFrame.IsHeaderUpdated())
         {
             mLinks.SetMacFrameCounter(aFrame);
-            aFrame.SetKeyId((keyManager.GetCurrentKeySequence() & 0x7f) + 1);
+            aFrame.SetKeyIndex((keyManager.GetCurrentKeySequence() & 0x7f) + 1);
         }
 #endif
         break;
@@ -868,7 +868,7 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame)
         mKeyIdMode2FrameCounter++;
         aFrame.SetFrameCounter(mKeyIdMode2FrameCounter);
         aFrame.SetKeySource(keySource);
-        aFrame.SetKeyId(0xff);
+        aFrame.SetKeyIndex(0xff);
         extAddress = &AsCoreType(&sMode2ExtAddress);
         break;
     }
@@ -1552,7 +1552,7 @@ Error Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Neig
     uint8_t            securityLevel;
     uint8_t            keyIdMode;
     uint32_t           frameCounter;
-    uint8_t            keyid;
+    uint8_t            keyIndex;
     uint32_t           keySequence = 0;
     const KeyMaterial *macKey;
     const ExtAddress  *extAddress;
@@ -1578,20 +1578,20 @@ Error Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Neig
     case Frame::kKeyIdMode1:
         VerifyOrExit(aNeighbor != nullptr);
 
-        IgnoreError(aFrame.GetKeyId(keyid));
-        keyid--;
+        IgnoreError(aFrame.GetKeyIndex(keyIndex));
+        keyIndex--;
 
-        if (keyid == (keyManager.GetCurrentKeySequence() & 0x7f))
+        if (keyIndex == (keyManager.GetCurrentKeySequence() & 0x7f))
         {
             keySequence = keyManager.GetCurrentKeySequence();
             macKey      = mLinks.GetCurrentMacKey(aFrame);
         }
-        else if (keyid == ((keyManager.GetCurrentKeySequence() - 1) & 0x7f))
+        else if (keyIndex == ((keyManager.GetCurrentKeySequence() - 1) & 0x7f))
         {
             keySequence = keyManager.GetCurrentKeySequence() - 1;
             macKey      = mLinks.GetTemporaryMacKey(aFrame, keySequence);
         }
-        else if (keyid == ((keyManager.GetCurrentKeySequence() + 1) & 0x7f))
+        else if (keyIndex == ((keyManager.GetCurrentKeySequence() + 1) & 0x7f))
         {
             keySequence = keyManager.GetCurrentKeySequence() + 1;
             macKey      = mLinks.GetTemporaryMacKey(aFrame, keySequence);
@@ -1639,9 +1639,9 @@ Error Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Neig
 
             // TODO: Avoid generating a new key if a wake-up frame was recently received already
 
-            IgnoreError(aFrame.GetKeyId(keyid));
+            IgnoreError(aFrame.GetKeyIndex(keyIndex));
             sequence = BigEndian::ReadUint32(aFrame.GetKeySource());
-            VerifyOrExit(((sequence & 0x7f) + 1) == keyid, error = kErrorSecurity);
+            VerifyOrExit(((sequence & 0x7f) + 1) == keyIndex, error = kErrorSecurity);
 
             macKey     = (sequence == keyManager.GetCurrentKeySequence()) ? mLinks.GetCurrentMacKey(aFrame)
                                                                           : &keyManager.GetTemporaryMacKey(sequence);
@@ -1705,8 +1705,8 @@ Error Mac::ProcessEnhAckSecurity(TxFrame &aTxFrame, RxFrame &aAckFrame)
 {
     Error              error = kErrorSecurity;
     uint8_t            securityLevel;
-    uint8_t            txKeyId;
-    uint8_t            ackKeyId;
+    uint8_t            txKeyIndex;
+    uint8_t            ackKeyIndex;
     uint8_t            keyIdMode;
     uint32_t           frameCounter;
     Address            srcAddr;
@@ -1726,10 +1726,10 @@ Error Mac::ProcessEnhAckSecurity(TxFrame &aTxFrame, RxFrame &aAckFrame)
     IgnoreError(aAckFrame.GetKeyIdMode(keyIdMode));
     VerifyOrExit(keyIdMode == Frame::kKeyIdMode1);
 
-    IgnoreError(aTxFrame.GetKeyId(txKeyId));
-    IgnoreError(aAckFrame.GetKeyId(ackKeyId));
+    IgnoreError(aTxFrame.GetKeyIndex(txKeyIndex));
+    IgnoreError(aAckFrame.GetKeyIndex(ackKeyIndex));
 
-    VerifyOrExit(txKeyId == ackKeyId);
+    VerifyOrExit(txKeyIndex == ackKeyIndex);
 
     IgnoreError(aAckFrame.GetFrameCounter(frameCounter));
     LogDebg("Rx security - Ack frame counter %lu", ToUlong(frameCounter));
@@ -1758,17 +1758,17 @@ Error Mac::ProcessEnhAckSecurity(TxFrame &aTxFrame, RxFrame &aAckFrame)
 
     VerifyOrExit(srcAddr.IsExtended() && neighbor != nullptr);
 
-    ackKeyId--;
+    ackKeyIndex--;
 
-    if (ackKeyId == (keyManager.GetCurrentKeySequence() & 0x7f))
+    if (ackKeyIndex == (keyManager.GetCurrentKeySequence() & 0x7f))
     {
         macKey = &mLinks.GetSubMac().GetCurrentMacKey();
     }
-    else if (ackKeyId == ((keyManager.GetCurrentKeySequence() - 1) & 0x7f))
+    else if (ackKeyIndex == ((keyManager.GetCurrentKeySequence() - 1) & 0x7f))
     {
         macKey = &mLinks.GetSubMac().GetPreviousMacKey();
     }
-    else if (ackKeyId == ((keyManager.GetCurrentKeySequence() + 1) & 0x7f))
+    else if (ackKeyIndex == ((keyManager.GetCurrentKeySequence() + 1) & 0x7f))
     {
         macKey = &mLinks.GetSubMac().GetNextMacKey();
     }

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -708,7 +708,7 @@ void Frame::SetKeySource(const uint8_t *aKeySource)
     memcpy(&mPsdu[index + kSecurityControlSize + kFrameCounterSize], aKeySource, keySourceSize);
 }
 
-Error Frame::GetKeyId(uint8_t &aKeyId) const
+Error Frame::GetKeyIndex(uint8_t &aKeyIndex) const
 {
     Error   error = kErrorNone;
     uint8_t keySourceSize;
@@ -718,13 +718,13 @@ Error Frame::GetKeyId(uint8_t &aKeyId) const
 
     keySourceSize = CalculateKeySourceSize(mPsdu[index]);
 
-    aKeyId = mPsdu[index + kSecurityControlSize + kFrameCounterSize + keySourceSize];
+    aKeyIndex = mPsdu[index + kSecurityControlSize + kFrameCounterSize + keySourceSize];
 
 exit:
     return error;
 }
 
-void Frame::SetKeyId(uint8_t aKeyId)
+void Frame::SetKeyIndex(uint8_t aKeyIndex)
 {
     uint8_t keySourceSize;
     uint8_t index = FindSecurityHeaderIndex();
@@ -733,7 +733,7 @@ void Frame::SetKeyId(uint8_t aKeyId)
 
     keySourceSize = CalculateKeySourceSize(mPsdu[index]);
 
-    mPsdu[index + kSecurityControlSize + kFrameCounterSize + keySourceSize] = aKeyId;
+    mPsdu[index + kSecurityControlSize + kFrameCounterSize + keySourceSize] = aKeyIndex;
 }
 
 Error Frame::GetCommandId(uint8_t &aCommandId) const
@@ -1348,10 +1348,10 @@ Error TxFrame::GenerateEnhAck(const RxFrame &aRxFrame, bool aIsFramePending, con
 
     if (aRxFrame.GetSecurityEnabled())
     {
-        uint8_t keyId;
+        uint8_t keyIndex;
 
-        SuccessOrExit(error = aRxFrame.GetKeyId(keyId));
-        SetKeyId(keyId);
+        SuccessOrExit(error = aRxFrame.GetKeyIndex(keyIndex));
+        SetKeyIndex(keyIndex);
     }
 
     if (aIeLength > 0)

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -421,20 +421,21 @@ public:
     void SetKeySource(const uint8_t *aKeySource);
 
     /**
-     * Gets the Key Identifier.
+     * Gets the Key Index (sub-field of Key ID).
      *
-     * @param[out]  aKeyId  The Key Identifier.
+     * @param[out]  aKeyIndex  The Key Index
      *
-     * @retval kErrorNone  Successfully retrieved the Key Identifier.
+     * @retval kErrorNone   Successfully retrieved the Key Index.
+     * @retval kErrorParse  Failed to parse MAC or security header.
      */
-    Error GetKeyId(uint8_t &aKeyId) const;
+    Error GetKeyIndex(uint8_t &aKeyIndex) const;
 
     /**
-     * Sets the Key Identifier.
+     * Sets the Key Index (sub-field of Key ID).
      *
-     * @param[in]  aKeyId  The Key Identifier.
+     * @param[in]  aKeyIndex  The Key Index.
      */
-    void SetKeyId(uint8_t aKeyId);
+    void SetKeyIndex(uint8_t aKeyIndex);
 
     /**
      * Gets the Command ID.

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -94,7 +94,7 @@ void SubMac::Init(void)
     mNextKey.Clear();
 
     mFrameCounter = 0;
-    mKeyId        = 0;
+    mKeyIndex     = 0;
     mTimer.Stop();
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
@@ -383,7 +383,7 @@ void SubMac::ProcessTransmitSecurity(void)
 
     if (!mTransmitFrame.IsHeaderUpdated())
     {
-        mTransmitFrame.SetKeyId(mKeyId);
+        mTransmitFrame.SetKeyIndex(mKeyIndex);
     }
 
     VerifyOrExit(ShouldHandleTransmitSecurity());
@@ -406,7 +406,7 @@ void SubMac::ProcessTransmitSecurity(void)
         uint32_t frameCounter = GetFrameCounter();
 
         mTransmitFrame.SetFrameCounter(frameCounter);
-        SignalFrameCounterUsed(frameCounter, mKeyId);
+        SignalFrameCounterUsed(frameCounter, mKeyIndex);
     }
 
     extAddress = &GetExtAddress();
@@ -651,7 +651,7 @@ exit:
 void SubMac::SignalFrameCounterUsedOnTxDone(const TxFrame &aFrame)
 {
     uint8_t  keyIdMode;
-    uint8_t  keyId;
+    uint8_t  keyIndex;
     uint32_t frameCounter;
     bool     allowError = false;
 
@@ -676,9 +676,9 @@ void SubMac::SignalFrameCounterUsedOnTxDone(const TxFrame &aFrame)
     VerifyOrExit(keyIdMode == Frame::kKeyIdMode1);
 
     VerifyOrExit(aFrame.GetFrameCounter(frameCounter) == kErrorNone, OT_ASSERT(allowError));
-    VerifyOrExit(aFrame.GetKeyId(keyId) == kErrorNone, OT_ASSERT(allowError));
+    VerifyOrExit(aFrame.GetKeyIndex(keyIndex) == kErrorNone, OT_ASSERT(allowError));
 
-    SignalFrameCounterUsed(frameCounter, keyId);
+    SignalFrameCounterUsed(frameCounter, keyIndex);
 
 exit:
     return;
@@ -941,7 +941,7 @@ void SubMac::SetState(State aState)
 }
 
 void SubMac::SetMacKey(uint8_t            aKeyIdMode,
-                       uint8_t            aKeyId,
+                       uint8_t            aKeyIndex,
                        const KeyMaterial &aPrevKey,
                        const KeyMaterial &aCurrKey,
                        const KeyMaterial &aNextKey)
@@ -952,10 +952,10 @@ void SubMac::SetMacKey(uint8_t            aKeyIdMode,
     case Frame::kKeyIdMode2:
         break;
     case Frame::kKeyIdMode1:
-        mKeyId   = aKeyId;
-        mPrevKey = aPrevKey;
-        mCurrKey = aCurrKey;
-        mNextKey = aNextKey;
+        mKeyIndex = aKeyIndex;
+        mPrevKey  = aPrevKey;
+        mCurrKey  = aCurrKey;
+        mNextKey  = aNextKey;
         break;
 
     default:
@@ -965,15 +965,15 @@ void SubMac::SetMacKey(uint8_t            aKeyIdMode,
 
     VerifyOrExit(!ShouldHandleTransmitSecurity());
 
-    Get<Radio::Radio>().SetMacKey(aKeyIdMode, aKeyId, aPrevKey, aCurrKey, aNextKey);
+    Get<Radio::Radio>().SetMacKey(aKeyIdMode, aKeyIndex, aPrevKey, aCurrKey, aNextKey);
 
 exit:
     return;
 }
 
-void SubMac::SignalFrameCounterUsed(uint32_t aFrameCounter, uint8_t aKeyId)
+void SubMac::SignalFrameCounterUsed(uint32_t aFrameCounter, uint8_t aKeyIndex)
 {
-    VerifyOrExit(aKeyId == mKeyId);
+    VerifyOrExit(aKeyIndex == mKeyIndex);
 
     mCallbacks.FrameCounterUsed(aFrameCounter);
 

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -407,13 +407,13 @@ public:
      * Sets MAC keys and key index.
      *
      * @param[in] aKeyIdMode  MAC key ID mode.
-     * @param[in] aKeyId      The key ID.
+     * @param[in] aKeyIndex   The key Index
      * @param[in] aPrevKey    The previous MAC key.
      * @param[in] aCurrKey    The current MAC key.
      * @param[in] aNextKey    The next MAC key.
      */
     void SetMacKey(uint8_t            aKeyIdMode,
-                   uint8_t            aKeyId,
+                   uint8_t            aKeyIndex,
                    const KeyMaterial &aPrevKey,
                    const KeyMaterial &aCurrKey,
                    const KeyMaterial &aNextKey);
@@ -586,7 +586,7 @@ private:
     bool ShouldHandleTransitionToSleep(void) const;
 
     void ProcessTransmitSecurity(void);
-    void SignalFrameCounterUsed(uint32_t aFrameCounter, uint8_t aKeyId);
+    void SignalFrameCounterUsed(uint32_t aFrameCounter, uint8_t aKeyIndex);
     void StartCsmaBackoff(void);
     void StartTimerForBackoff(uint8_t aBackoffExponent);
     void BeginTransmit(void);
@@ -666,7 +666,7 @@ private:
     KeyMaterial                  mCurrKey;
     KeyMaterial                  mNextKey;
     uint32_t                     mFrameCounter;
-    uint8_t                      mKeyId;
+    uint8_t                      mKeyIndex;
 #if OPENTHREAD_CONFIG_MAC_ADD_DELAY_ON_NO_ACK_ERROR_BEFORE_RETRY
     uint8_t mRetxDelayBackOffExponent;
 #endif

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -396,7 +396,7 @@ public:
     void SetShortAddress(Mac::ShortAddress aShortAddress);
 
     /**
-     * Set the altrnate short address.
+     * Set the alternate short address.
      *
      * @param[in] aShortAddress  The alternate short address.
      */
@@ -406,13 +406,13 @@ public:
      * Sets MAC key and key ID.
      *
      * @param[in] aKeyIdMode  MAC key ID mode.
-     * @param[in] aKeyId      Current MAC key index.
+     * @param[in] aKeyIndex   Current MAC key index.
      * @param[in] aPrevKey    The previous MAC key.
      * @param[in] aCurrKey    The current MAC key.
      * @param[in] aNextKey    The next MAC key.
      */
     void SetMacKey(uint8_t                 aKeyIdMode,
-                   uint8_t                 aKeyId,
+                   uint8_t                 aKeyIndex,
                    const Mac::KeyMaterial &aPrevKey,
                    const Mac::KeyMaterial &aCurrKey,
                    const Mac::KeyMaterial &aNextKey);
@@ -891,7 +891,7 @@ inline void Radio::SetAlternateShortAddress(Mac::ShortAddress aShortAddress)
 }
 
 inline void Radio::SetMacKey(uint8_t                 aKeyIdMode,
-                             uint8_t                 aKeyId,
+                             uint8_t                 aKeyIndex,
                              const Mac::KeyMaterial &aPrevKey,
                              const Mac::KeyMaterial &aCurrKey,
                              const Mac::KeyMaterial &aNextKey)
@@ -904,7 +904,7 @@ inline void Radio::SetMacKey(uint8_t                 aKeyIdMode,
     keyType = OT_KEY_TYPE_LITERAL_KEY;
 #endif
 
-    otPlatRadioSetMacKey(GetInstancePtr(), aKeyIdMode, aKeyId, &aPrevKey, &aCurrKey, &aNextKey, keyType);
+    otPlatRadioSetMacKey(GetInstancePtr(), aKeyIdMode, aKeyIndex, &aPrevKey, &aCurrKey, &aNextKey, keyType);
 }
 
 inline Error Radio::GetTransmitPower(int8_t &aPower) { return otPlatRadioGetTransmitPower(GetInstancePtr(), &aPower); }

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -236,7 +236,7 @@ extern "C" OT_TOOL_WEAK otRadioState otPlatRadioGetState(otInstance *aInstance)
 
 extern "C" OT_TOOL_WEAK void otPlatRadioSetMacKey(otInstance             *aInstance,
                                                   uint8_t                 aKeyIdMode,
-                                                  uint8_t                 aKeyId,
+                                                  uint8_t                 aKeyIndex,
                                                   const otMacKeyMaterial *aPrevKey,
                                                   const otMacKeyMaterial *aCurrKey,
                                                   const otMacKeyMaterial *aNextKey,
@@ -244,7 +244,7 @@ extern "C" OT_TOOL_WEAK void otPlatRadioSetMacKey(otInstance             *aInsta
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aKeyIdMode);
-    OT_UNUSED_VARIABLE(aKeyId);
+    OT_UNUSED_VARIABLE(aKeyIndex);
     OT_UNUSED_VARIABLE(aPrevKey);
     OT_UNUSED_VARIABLE(aCurrKey);
     OT_UNUSED_VARIABLE(aNextKey);

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -187,7 +187,7 @@ Mac::TxFrame *CslTxScheduler::HandleFrameRequest(Mac::TxFrames &aTxFrames)
         if (frame->GetSecurityEnabled())
         {
             frame->SetFrameCounter(mCslTxNeighbor->GetIndirectFrameCounter());
-            frame->SetKeyId(mCslTxNeighbor->GetIndirectKeyId());
+            frame->SetKeyIndex(mCslTxNeighbor->GetIndirectKeyIndex());
         }
     }
     else
@@ -291,13 +291,13 @@ void CslTxScheduler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, C
             if (aFrame.GetSecurityEnabled() && aFrame.IsHeaderUpdated())
             {
                 uint32_t frameCounter;
-                uint8_t  keyId;
+                uint8_t  keyIndex;
 
                 IgnoreError(aFrame.GetFrameCounter(frameCounter));
                 aCslNeighbor.SetIndirectFrameCounter(frameCounter);
 
-                IgnoreError(aFrame.GetKeyId(keyId));
-                aCslNeighbor.SetIndirectKeyId(keyId);
+                IgnoreError(aFrame.GetKeyIndex(keyIndex));
+                aCslNeighbor.SetIndirectKeyIndex(keyIndex);
             }
         }
 

--- a/src/lib/spinel/logger.cpp
+++ b/src/lib/spinel/logger.cpp
@@ -563,7 +563,7 @@ void Logger::LogSpinelFrame(const uint8_t *aFrame, uint16_t aLength, bool aTx)
     case SPINEL_PROP_RCP_MAC_KEY:
     {
         uint8_t      keyIdMode;
-        uint8_t      keyId;
+        uint8_t      keyIndex;
         otMacKey     prevKey;
         unsigned int prevKeyLen = sizeof(otMacKey);
         otMacKey     currKey;
@@ -575,10 +575,10 @@ void Logger::LogSpinelFrame(const uint8_t *aFrame, uint16_t aLength, bool aTx)
             data, len,
             SPINEL_DATATYPE_UINT8_S SPINEL_DATATYPE_UINT8_S SPINEL_DATATYPE_DATA_WLEN_S SPINEL_DATATYPE_DATA_WLEN_S
                 SPINEL_DATATYPE_DATA_WLEN_S,
-            &keyIdMode, &keyId, prevKey.m8, &prevKeyLen, currKey.m8, &currKeyLen, nextKey.m8, &nextKeyLen);
+            &keyIdMode, &keyIndex, prevKey.m8, &prevKeyLen, currKey.m8, &currKeyLen, nextKey.m8, &nextKeyLen);
         VerifyOrExit(unpacked > 0, error = OT_ERROR_PARSE);
         start += Snprintf(start, static_cast<uint32_t>(end - start),
-                          ", keyIdMode:%u, keyId:%u, prevKey:***, currKey:***, nextKey:***", keyIdMode, keyId);
+                          ", keyIdMode:%u, keyIndex:%u, prevKey:***, currKey:***, nextKey:***", keyIdMode, keyIndex);
     }
     break;
 

--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -854,7 +854,7 @@ exit:
 }
 
 otError RadioSpinel::SetMacKey(uint8_t                 aKeyIdMode,
-                               uint8_t                 aKeyId,
+                               uint8_t                 aKeyIndex,
                                const otMacKeyMaterial *aPrevKey,
                                const otMacKeyMaterial *aCurrKey,
                                const otMacKeyMaterial *aNextKey)
@@ -867,7 +867,7 @@ otError RadioSpinel::SetMacKey(uint8_t                 aKeyIdMode,
     SuccessOrExit(error = ReadMacKey(*aPrevKey, prevKey));
     SuccessOrExit(error = ReadMacKey(*aCurrKey, currKey));
     SuccessOrExit(error = ReadMacKey(*aNextKey, nextKey));
-    error = SetMacKey(aKeyIdMode, aKeyId, prevKey, currKey, nextKey);
+    error = SetMacKey(aKeyIdMode, aKeyIndex, prevKey, currKey, nextKey);
 
 exit:
     return error;
@@ -876,19 +876,19 @@ exit:
 #else
 
 otError RadioSpinel::SetMacKey(uint8_t                 aKeyIdMode,
-                               uint8_t                 aKeyId,
+                               uint8_t                 aKeyIndex,
                                const otMacKeyMaterial *aPrevKey,
                                const otMacKeyMaterial *aCurrKey,
                                const otMacKeyMaterial *aNextKey)
 {
-    return SetMacKey(aKeyIdMode, aKeyId, aPrevKey->mKeyMaterial.mKey, aCurrKey->mKeyMaterial.mKey,
+    return SetMacKey(aKeyIdMode, aKeyIndex, aPrevKey->mKeyMaterial.mKey, aCurrKey->mKeyMaterial.mKey,
                      aNextKey->mKeyMaterial.mKey);
 }
 
 #endif // OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
 
 otError RadioSpinel::SetMacKey(uint8_t         aKeyIdMode,
-                               uint8_t         aKeyId,
+                               uint8_t         aKeyIndex,
                                const otMacKey &aPrevKey,
                                const otMacKey &aCurrKey,
                                const otMacKey &aNextKey)
@@ -898,12 +898,12 @@ otError RadioSpinel::SetMacKey(uint8_t         aKeyIdMode,
     SuccessOrExit(error = Set(SPINEL_PROP_RCP_MAC_KEY,
                               SPINEL_DATATYPE_UINT8_S SPINEL_DATATYPE_UINT8_S SPINEL_DATATYPE_DATA_WLEN_S
                                   SPINEL_DATATYPE_DATA_WLEN_S SPINEL_DATATYPE_DATA_WLEN_S,
-                              aKeyIdMode, aKeyId, aPrevKey.m8, sizeof(aPrevKey), aCurrKey.m8, sizeof(aCurrKey),
+                              aKeyIdMode, aKeyIndex, aPrevKey.m8, sizeof(aPrevKey), aCurrKey.m8, sizeof(aCurrKey),
                               aNextKey.m8, sizeof(aNextKey)));
 
 #if OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
     mKeyIdMode = aKeyIdMode;
-    mKeyId     = aKeyId;
+    mKeyIndex  = aKeyIndex;
 
     mPrevKey = aPrevKey;
     mCurrKey = aCurrKey;
@@ -1582,14 +1582,14 @@ void RadioSpinel::HandleTransmitDone(uint32_t          aCommand,
     if ((sRadioCaps & OT_RADIO_CAPS_TRANSMIT_SEC) && (!mTransmitFrame->mInfo.mTxInfo.mIsHeaderUpdated) &&
         headerUpdated && static_cast<Mac::TxFrame *>(mTransmitFrame)->GetSecurityEnabled())
     {
-        uint8_t  keyId;
+        uint8_t  keyIndex;
         uint32_t frameCounter;
 
         // Replace transmit frame security key index and frame counter with the one filled by RCP
-        unpacked = spinel_datatype_unpack(aBuffer, aLength, SPINEL_DATATYPE_UINT8_S SPINEL_DATATYPE_UINT32_S, &keyId,
+        unpacked = spinel_datatype_unpack(aBuffer, aLength, SPINEL_DATATYPE_UINT8_S SPINEL_DATATYPE_UINT32_S, &keyIndex,
                                           &frameCounter);
         VerifyOrExit(unpacked > 0, error = OT_ERROR_PARSE);
-        static_cast<Mac::TxFrame *>(mTransmitFrame)->SetKeyId(keyId);
+        static_cast<Mac::TxFrame *>(mTransmitFrame)->SetKeyIndex(keyIndex);
         static_cast<Mac::TxFrame *>(mTransmitFrame)->SetFrameCounter(frameCounter);
 
 #if OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT > 0
@@ -2192,8 +2192,8 @@ void RadioSpinel::RestoreProperties(void)
         SuccessOrDie(Set(SPINEL_PROP_RCP_MAC_KEY,
                          SPINEL_DATATYPE_UINT8_S SPINEL_DATATYPE_UINT8_S SPINEL_DATATYPE_DATA_WLEN_S
                              SPINEL_DATATYPE_DATA_WLEN_S SPINEL_DATATYPE_DATA_WLEN_S,
-                         mKeyIdMode, mKeyId, mPrevKey.m8, sizeof(otMacKey), mCurrKey.m8, sizeof(otMacKey), mNextKey.m8,
-                         sizeof(otMacKey)));
+                         mKeyIdMode, mKeyIndex, mPrevKey.m8, sizeof(otMacKey), mCurrKey.m8, sizeof(otMacKey),
+                         mNextKey.m8, sizeof(otMacKey)));
     }
 
     if (mMacFrameCounterSet)

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -713,7 +713,7 @@ public:
      * Sets MAC key and key index to RCP.
      *
      * @param[in] aKeyIdMode  The key ID mode.
-     * @param[in] aKeyId      The key index.
+     * @param[in] aKeyIndex   The key index.
      * @param[in] aPrevKey    Pointer to previous MAC key.
      * @param[in] aCurrKey    Pointer to current MAC key.
      * @param[in] aNextKey    Pointer to next MAC key.
@@ -724,7 +724,7 @@ public:
      * @retval  OT_ERROR_RESPONSE_TIMEOUT   Failed due to no response received from the transceiver.
      */
     otError SetMacKey(uint8_t                 aKeyIdMode,
-                      uint8_t                 aKeyId,
+                      uint8_t                 aKeyIndex,
                       const otMacKeyMaterial *aPrevKey,
                       const otMacKeyMaterial *aCurrKey,
                       const otMacKeyMaterial *aNextKey);
@@ -1199,7 +1199,7 @@ private:
     }
 
     otError SetMacKey(uint8_t         aKeyIdMode,
-                      uint8_t         aKeyId,
+                      uint8_t         aKeyIndex,
                       const otMacKey &aPrevKey,
                       const otMacKey &aCurrKey,
                       const otMacKey &NextKey);
@@ -1308,7 +1308,7 @@ private:
 
     // Properties set by core.
     uint8_t  mKeyIdMode;
-    uint8_t  mKeyId;
+    uint8_t  mKeyIndex;
     otMacKey mPrevKey;
     otMacKey mCurrKey;
     otMacKey mNextKey;

--- a/src/ncp/ncp_base_radio.cpp
+++ b/src/ncp/ncp_base_radio.cpp
@@ -192,14 +192,14 @@ void NcpBase::LinkRawTransmitDone(uint8_t aIid, otRadioFrame *aFrame, otRadioFra
 
         if (static_cast<Mac::TxFrame *>(aFrame)->GetSecurityEnabled() && headerUpdated)
         {
-            uint8_t  keyId;
+            uint8_t  keyIndex;
             uint32_t frameCounter;
 
             // Transmit frame auxiliary key index and frame counter
-            SuccessOrExit(static_cast<Mac::TxFrame *>(aFrame)->GetKeyId(keyId));
+            SuccessOrExit(static_cast<Mac::TxFrame *>(aFrame)->GetKeyIndex(keyIndex));
             SuccessOrExit(static_cast<Mac::TxFrame *>(aFrame)->GetFrameCounter(frameCounter));
 
-            SuccessOrExit(mEncoder.WriteUint8(keyId));
+            SuccessOrExit(mEncoder.WriteUint8(keyIndex));
             SuccessOrExit(mEncoder.WriteUint32(frameCounter));
         }
 
@@ -541,7 +541,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_RCP_MAC_KEY>(void)
 {
     otError        error = OT_ERROR_NONE;
     uint8_t        keyIdMode;
-    uint8_t        keyId;
+    uint8_t        keyIndex;
     uint16_t       keySize;
     const uint8_t *prevKey;
     const uint8_t *currKey;
@@ -550,7 +550,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_RCP_MAC_KEY>(void)
     SuccessOrExit(error = mDecoder.ReadUint8(keyIdMode));
     VerifyOrExit(keyIdMode == Mac::Frame::kKeyIdMode1, error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = mDecoder.ReadUint8(keyId));
+    SuccessOrExit(error = mDecoder.ReadUint8(keyIndex));
 
     SuccessOrExit(error = mDecoder.ReadDataWithLen(prevKey, keySize));
     VerifyOrExit(keySize == sizeof(otMacKey), error = OT_ERROR_INVALID_ARGS);
@@ -562,7 +562,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_RCP_MAC_KEY>(void)
     VerifyOrExit(keySize == sizeof(otMacKey), error = OT_ERROR_INVALID_ARGS);
 
     error =
-        otLinkRawSetMacKey(mInstance, keyIdMode, keyId, reinterpret_cast<const otMacKey *>(prevKey),
+        otLinkRawSetMacKey(mInstance, keyIdMode, keyIndex, reinterpret_cast<const otMacKey *>(prevKey),
                            reinterpret_cast<const otMacKey *>(currKey), reinterpret_cast<const otMacKey *>(nextKey));
 
 exit:

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -955,13 +955,13 @@ otRadioState otPlatRadioGetState(otInstance *aInstance)
 
 void otPlatRadioSetMacKey(otInstance             *aInstance,
                           uint8_t                 aKeyIdMode,
-                          uint8_t                 aKeyId,
+                          uint8_t                 aKeyIndex,
                           const otMacKeyMaterial *aPrevKey,
                           const otMacKeyMaterial *aCurrKey,
                           const otMacKeyMaterial *aNextKey,
                           otRadioKeyType          aKeyType)
 {
-    SuccessOrDie(GetRadioSpinel().SetMacKey(aKeyIdMode, aKeyId, aPrevKey, aCurrKey, aNextKey));
+    SuccessOrDie(GetRadioSpinel().SetMacKey(aKeyIdMode, aKeyIndex, aPrevKey, aCurrKey, aNextKey));
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aKeyType);
 }

--- a/src/posix/platform/rcp_caps_diag.cpp
+++ b/src/posix/platform/rcp_caps_diag.cpp
@@ -248,7 +248,7 @@ template <> otError RcpCapsDiag::HandleSpinelCommand<SPINEL_CMD_PROP_VALUE_SET, 
 template <> otError RcpCapsDiag::HandleSpinelCommand<SPINEL_CMD_PROP_VALUE_SET, SPINEL_PROP_RCP_MAC_KEY>(void)
 {
     static constexpr uint8_t keyIdMode1 = 1 << 3;
-    static constexpr uint8_t keyId      = 100;
+    static constexpr uint8_t keyIndex   = 100;
     otMacKeyMaterial         prevKey;
     otMacKeyMaterial         curKey;
     otMacKeyMaterial         nextKey;
@@ -256,7 +256,7 @@ template <> otError RcpCapsDiag::HandleSpinelCommand<SPINEL_CMD_PROP_VALUE_SET, 
     memset(prevKey.mKeyMaterial.mKey.m8, 0x11, OT_MAC_KEY_SIZE);
     memset(curKey.mKeyMaterial.mKey.m8, 0x22, OT_MAC_KEY_SIZE);
     memset(nextKey.mKeyMaterial.mKey.m8, 0x33, OT_MAC_KEY_SIZE);
-    return mRadioSpinel.SetMacKey(keyIdMode1, keyId, &prevKey, &curKey, &nextKey);
+    return mRadioSpinel.SetMacKey(keyIdMode1, keyIndex, &prevKey, &curKey, &nextKey);
 }
 
 template <> otError RcpCapsDiag::HandleSpinelCommand<SPINEL_CMD_PROP_VALUE_GET, SPINEL_PROP_RCP_CSL_ACCURACY>(void)

--- a/tests/nexus/platform/nexus_radio.cpp
+++ b/tests/nexus/platform/nexus_radio.cpp
@@ -243,7 +243,7 @@ void otPlatRadioClearSrcMatchExtEntries(otInstance *aInstance) { AsNode(aInstanc
 
 void otPlatRadioSetMacKey(otInstance             *aInstance,
                           uint8_t                 aKeyIdMode,
-                          uint8_t                 aKeyId,
+                          uint8_t                 aKeyIndex,
                           const otMacKeyMaterial *aPrevKey,
                           const otMacKeyMaterial *aCurrKey,
                           const otMacKeyMaterial *aNextKey,
@@ -253,7 +253,7 @@ void otPlatRadioSetMacKey(otInstance             *aInstance,
 
     OT_UNUSED_VARIABLE(aKeyIdMode);
 
-    radio.mRadioContext.mKeyId   = aKeyId;
+    radio.mRadioContext.mKeyId   = aKeyIndex;
     radio.mRadioContext.mKeyType = aKeyType;
 
     if (!radio.mMacFrameCounterReset)


### PR DESCRIPTION
In the IEEE 802.15.4 Auxiliary Security Header, the Key Identifier (Key ID) field structurally comprises two subfields:
- An optional Key Source subfield (0, 4, or 8 octets depending on the Key ID Mode), and
- A 1-octet Key Index subfield.

When `KeyIdMode == 1` (0x01) — which is what standard MAC Data and ACK frames in OpenThread use — the Key Source subfield is omitted, and the Key Identifier field contains only the 1-octet Key Index subfield.

This commit renames internal `Mac::Frame` and `SubMac` methods and parameters (`GetKeyId()`, `SetKeyId()`, `mKeyId`, etc.) along with associated input variables to use `KeyIndex` instead of `KeyId`. This change makes the terminology structurally accurate and avoids confusion between the overall Key Identifier field and its Key Index subfield.

For backward compatibility (`otPlat`) definitions (like `mAckKeyId` inside `otRadioFrame`), or `otMacFrame*()` helper functions are remained unchanged.