### PR TITLE
[parse-cmdline] make ParseAsHexString() inline

### DIFF
--- a/src/core/utils/parse_cmdline.hpp
+++ b/src/core/utils/parse_cmdline.hpp
@@ -237,7 +237,7 @@ otError ParseAsHexString(const char *aString, uint8_t *aBuffer, uint16_t aSize);
  * @retval kErrorNone         The string was parsed successfully.
  * @retval kErrorInvalidArgs  The string does not contain valid hex bytes and/or not @p aSize bytes.
  */
-template <uint16_t kBufferSize> static otError ParseAsHexString(const char *aString, uint8_t (&aBuffer)[kBufferSize])
+template <uint16_t kBufferSize> inline otError ParseAsHexString(const char *aString, uint8_t (&aBuffer)[kBufferSize])
 {
     return ParseAsHexString(aString, aBuffer, kBufferSize);
 }


### PR DESCRIPTION
This commit updates the `ParseAsHexString()` function template in `parse_cmdline.hpp` to be `inline` instead of `static`.

When declared `static` in a header file, each translation unit including `parse_cmdline.hpp` creates its own internal linkage copy of the template definition. If a translation unit (such as `parse_cmdline.cpp`) includes `parse_cmdline.hpp` without instantiating `ParseAsHexString()`, newer LLVM/Clang versions (including recent Emscripten SDK builds used in `nexus-wasm-tests`) emit a `-Wunused-template` compiler warning.

Because OpenThread builds with `-Werror`, this warning caused build failures when compiling `parse_cmdline.cpp.o` across the repository. Changing `static` to `inline` matches other function templates in `parse_cmdline.hpp` (e.g. `ParseCmd()`) and resolves the unused template warning.

Fixes: https://github.com/openthread/openthread/actions/runs/29287395338/job/86954015599?pr=13332