### PR TITLE
[mac] reorder private methods in `SubMac`

### DIFF
--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -499,32 +499,6 @@ public:
 #endif
 
 private:
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    void        CslInit(void);
-    void        RestartCslTimerAfterSyncUpdate(void);
-    void        UpdateCslLastSyncTimestamp(TxFrame &aFrame, RxFrame *aAckFrame);
-    void        UpdateCslLastSyncTimestamp(RxFrame *aFrame, Error aError);
-    static void HandleCslTimer(Timer &aTimer);
-    void        HandleCslTimer(void);
-    void        GetCslWindowEdges(uint32_t &aAhead, uint32_t &aAfter);
-    uint32_t    GetNextCycleDrift(void);
-    uint32_t    GetLocalTime(void);
-    bool        IsCslEnabled(void) const { return mCslPeriod > 0; }
-#if OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
-    void LogReceived(RxFrame *aFrame);
-#endif
-    void HandleCslReceiveAt(uint32_t aTimeAhead, uint32_t aTimeAfter);
-    void HandleCslReceiveOrSleep(uint32_t aTimeAhead, uint32_t aTimeAfter);
-    void LogCslWindow(uint32_t aWinStart, uint32_t aWinDuration);
-#endif
-#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-    void        WedInit(void);
-    static void HandleWedTimer(Timer &aTimer);
-    void        HandleWedTimer(void);
-    void        HandleWedReceiveAt(void);
-    void        HandleWedReceiveOrSleep(void);
-#endif
-
     static constexpr uint8_t  kCsmaMinBe         = 3;                  // macMinBE (IEEE 802.15.4-2006).
     static constexpr uint8_t  kCsmaMaxBe         = 5;                  // macMaxBE (IEEE 802.15.4-2006).
     static constexpr uint32_t kUnitBackoffPeriod = 20;                 // Number of symbols (IEEE 802.15.4-2006).
@@ -636,6 +610,33 @@ private:
     bool IsRadioSampleEnabled(void) const;
     void UpdateRadioSampleState(void);
     void RadioSample(void);
+#endif
+
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+    void        CslInit(void);
+    void        RestartCslTimerAfterSyncUpdate(void);
+    void        UpdateCslLastSyncTimestamp(TxFrame &aFrame, RxFrame *aAckFrame);
+    void        UpdateCslLastSyncTimestamp(RxFrame *aFrame, Error aError);
+    static void HandleCslTimer(Timer &aTimer);
+    void        HandleCslTimer(void);
+    void        GetCslWindowEdges(uint32_t &aAhead, uint32_t &aAfter);
+    uint32_t    GetNextCycleDrift(void);
+    uint32_t    GetLocalTime(void);
+    bool        IsCslEnabled(void) const { return mCslPeriod > 0; }
+#if OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
+    void LogReceived(RxFrame *aFrame);
+#endif
+    void HandleCslReceiveAt(uint32_t aTimeAhead, uint32_t aTimeAfter);
+    void HandleCslReceiveOrSleep(uint32_t aTimeAhead, uint32_t aTimeAfter);
+    void LogCslWindow(uint32_t aWinStart, uint32_t aWinDuration);
+#endif
+
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
+    void        WedInit(void);
+    static void HandleWedTimer(Timer &aTimer);
+    void        HandleWedTimer(void);
+    void        HandleWedReceiveAt(void);
+    void        HandleWedReceiveOrSleep(void);
 #endif
 
     using SubMacTimer =


### PR DESCRIPTION
Reorder the private methods in `SubMac` so that all method declarations are grouped together, following the general class layout order of constants, types, methods, and member variables.