### PR TITLE
[mac-frame] clean up `KeyMaterial` usage in `TxFrame`

### DIFF
--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -1051,19 +1051,16 @@ public:
     /**
      * Returns the key used for frame encryption and authentication (AES CCM).
      *
-     * @returns The pointer to the key.
+     * @returns The key.
      */
-    const Mac::KeyMaterial &GetAesKey(void) const
-    {
-        return *static_cast<const Mac::KeyMaterial *>(mInfo.mTxInfo.mAesKey);
-    }
+    const KeyMaterial &GetAesKey(void) const { return AsCoreType(mInfo.mTxInfo.mAesKey); }
 
     /**
      * Sets the key used for frame encryption and authentication (AES CCM).
      *
-     * @param[in]  aAesKey  The pointer to the key.
+     * @param[in]  aAesKey  The key.
      */
-    void SetAesKey(const Mac::KeyMaterial &aAesKey) { mInfo.mTxInfo.mAesKey = &aAesKey; }
+    void SetAesKey(const KeyMaterial &aAesKey) { mInfo.mTxInfo.mAesKey = &aAesKey; }
 
     /**
      * Copies the PSDU and all attributes (except for frame link type) from another frame.

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -1109,6 +1109,7 @@ struct WakeupInfo
 
 DefineCoreType(otExtAddress, Mac::ExtAddress);
 DefineCoreType(otMacKey, Mac::Key);
+DefineCoreType(otMacKeyMaterial, Mac::KeyMaterial);
 #if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
 DefineCoreType(otWakeupRequest, Mac::WakeupRequest);
 DefineMapEnum(otWakeupType, Mac::WakeupRequest::Type);


### PR DESCRIPTION
Define `CoreType` mapping for `otMacKeyMaterial` -> `Mac::KeyMaterial` and use `AsCoreType()` in `TxFrame::GetAesKey()`. Also remove redundant `Mac::` namespace qualification when referencing `KeyMaterial` in `TxFrame`.