### PR TITLE
[sub-mac] fix CSL timer restart to avoid scheduling a stale receive window

### DIFF
--- a/src/core/mac/sub_mac_csl_receiver.cpp
+++ b/src/core/mac/sub_mac_csl_receiver.cpp
@@ -78,9 +78,8 @@ void SubMac::UpdateCslLastSyncTimestamp(TxFrame &aFrame, RxFrame *aAckFrame)
     if (aAckFrame != nullptr && aFrame.Has<CslIe>())
     {
         mCslLastSync = TimeMicro(GetLocalTime());
+        RestartCslTimerAfterSyncUpdate();
     }
-
-    RestartCslTimerAfterSyncUpdate();
 }
 
 void SubMac::UpdateCslLastSyncTimestamp(RxFrame *aFrame, Error aError)
@@ -99,9 +98,8 @@ void SubMac::UpdateCslLastSyncTimestamp(RxFrame *aFrame, Error aError)
 #else
         mCslLastSync = TimeMicro(Radio::ConvertTime64To32(aFrame->GetTimestamp()));
 #endif
+        RestartCslTimerAfterSyncUpdate();
     }
-
-    RestartCslTimerAfterSyncUpdate();
 
 exit:
     return;
@@ -192,7 +190,8 @@ void SubMac::HandleCslReceiveAt(uint32_t aTimeAhead, uint32_t aTimeAfter)
 
     // Schedule reception window for any state except RX - so that CSL RX Window has lower priority
     // than scanning or RX after the data poll.
-    if ((mState != kStateDisabled) && (mState != kStateReceive))
+    if ((mState != kStateDisabled) && (mState != kStateReceive) &&
+        Radio::IsTimeStrictlyBefore(Get<Radio::Radio>().GetNowAsTime32(), winStart + winDuration))
     {
         IgnoreError(Get<Radio::Radio>().ReceiveAt(mCslChannel, winStart, winDuration));
     }


### PR DESCRIPTION
## Background 

PR #11601 introduced `RestartCslTimerAfterSyncUpdate()`. When the CSL last-sync
timestamp changes, the CSL sample schedule needs to be re-evaluated so that the
receive window tracks the newly synchronized time base.
`RestartCslTimerAfterSyncUpdate()` does this by rewinding `mCslSampleTime` by one
CSL period and re-running `HandleCslTimer()` (which calls `HandleCslReceiveAt()`
on radios that support receive-timing).

This PR contains two related fixes.

### Change 1: Only restart the CSL timer when the sync timestamp is actually updated 

Both `UpdateCslLastSyncTimestamp()` overloads used to call
`RestartCslTimerAfterSyncUpdate()` unconditionally, even when `mCslLastSync` was
NOT updated (e.g. no Enh-ACK was received, the frame carried no CSL IE, or the
received frame was not acked with a secured Enh-ACK).

`mCslLastSync` is the reference point for the whole CSL schedule, so the timer
only needs to be re-evaluated when that reference is actually re-recorded.
Restarting the timer without a sync update is unnecessary work and, worse, feeds
the schedule re-evaluation with a stale reference.

The `RestartCslTimerAfterSyncUpdate()` call is now moved inside the `if` block
that performs the `mCslLastSync` update in both overloads, so it runs only when
the sync timestamp actually changes.

    void SubMac::UpdateCslLastSyncTimestamp(TxFrame &aFrame, RxFrame *aAckFrame)
    {
        if (aAckFrame != nullptr && aFrame.Has<CslIe>())
        {
            mCslLastSync = TimeMicro(GetLocalTime());
            RestartCslTimerAfterSyncUpdate();
        }
    }

### Change 2: Do not schedule a CSL receive window whose start time is already in the past 

When Change 1 triggers `RestartCslTimerAfterSyncUpdate()` -- for example after we
proactively transmit a frame carrying a CSL IE (the TX path) -- the call chain
re-enters `HandleCslReceiveAt()`. There, the next window is recomputed from the
PREVIOUS CSL sample time:

    winStart    = mCslSampleTime.GetAsTime32() - aTimeAhead;
    winDuration = aTimeAhead + aTimeAfter;

    mCslSampleTime += periodUs;

    Get<Radio::Radio>().UpdateCslSampleTime(mCslSampleTime.GetAsTime32());

    // Schedule reception window for any state except RX - so that CSL RX Window has lower priority
    // than scanning or RX after the data poll.
    if ((mState != kStateDisabled) && (mState != kStateReceive) && Radio::IsTimeStrictlyBefore(Get<Radio::Radio>().GetNowAsTime32(), winStart + winDuration))
    {
        IgnoreError(Get<Radio::Radio>().ReceiveAt(mCslChannel, winStart, winDuration));
    }

If winStart is already in the past but we are still within the window (winStart ≤ now < winStart + winDuration), we still call `ReceiveAt()`, so the platform can keep receiving for the remainder of that window.

Once `RestartCslTimerAfterSyncUpdate()` runs, it rewinds mCslSampleTime by one CSL period and re-enters `HandleCslReceiveAt()` to recalculate the schedule. That recomputed window is based on the previous sample time, so by the time we get there the whole window can already be in the past — i.e. we end up with a `ReceiveAt()` where `winStart + winDuration` < `current_time`. Filtering that case out avoids handing the platform a fully stale window request.
