### PR TITLE
[mac] add and use `DetermineKeyIndexFor()` helper

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -845,7 +845,7 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame)
         if (!aFrame.IsHeaderUpdated())
         {
             mLinks.SetMacFrameCounter(aFrame);
-            aFrame.SetKeyIndex((keyManager.GetCurrentKeySequence() & 0x7f) + 1);
+            aFrame.SetKeyIndex(DetermineKeyIndexFor(keyManager.GetCurrentKeySequence()));
         }
 #endif
         break;
@@ -1580,26 +1580,28 @@ Error Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Neig
         VerifyOrExit(aNeighbor != nullptr);
 
         IgnoreError(aFrame.GetKeyIndex(keyIndex));
-        keyIndex--;
+        keySequence = keyManager.GetCurrentKeySequence();
 
-        if (keyIndex == (keyManager.GetCurrentKeySequence() & 0x7f))
+        if (keyIndex == DetermineKeyIndexFor(keySequence))
         {
-            keySequence = keyManager.GetCurrentKeySequence();
-            macKey      = mLinks.GetCurrentMacKey(aFrame);
-        }
-        else if (keyIndex == ((keyManager.GetCurrentKeySequence() - 1) & 0x7f))
-        {
-            keySequence = keyManager.GetCurrentKeySequence() - 1;
-            macKey      = mLinks.GetTemporaryMacKey(aFrame, keySequence);
-        }
-        else if (keyIndex == ((keyManager.GetCurrentKeySequence() + 1) & 0x7f))
-        {
-            keySequence = keyManager.GetCurrentKeySequence() + 1;
-            macKey      = mLinks.GetTemporaryMacKey(aFrame, keySequence);
+            macKey = mLinks.GetCurrentMacKey(aFrame);
         }
         else
         {
-            ExitNow();
+            if (keyIndex == DetermineKeyIndexFor(keySequence - 1))
+            {
+                keySequence--;
+            }
+            else if (keyIndex == DetermineKeyIndexFor(keySequence + 1))
+            {
+                keySequence++;
+            }
+            else
+            {
+                ExitNow();
+            }
+
+            macKey = mLinks.GetTemporaryMacKey(aFrame, keySequence);
         }
 
         // If the frame is from a neighbor not in valid state (e.g., it is from a child being
@@ -1642,7 +1644,7 @@ Error Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Neig
 
             IgnoreError(aFrame.GetKeyIndex(keyIndex));
             sequence = BigEndian::ReadUint32(aFrame.GetKeySource());
-            VerifyOrExit(((sequence & 0x7f) + 1) == keyIndex, error = kErrorSecurity);
+            VerifyOrExit(DetermineKeyIndexFor(sequence) == keyIndex, error = kErrorSecurity);
 
             macKey     = (sequence == keyManager.GetCurrentKeySequence()) ? mLinks.GetCurrentMacKey(aFrame)
                                                                           : &keyManager.GetTemporaryMacKey(sequence);
@@ -1709,11 +1711,11 @@ Error Mac::ProcessEnhAckSecurity(TxFrame &aTxFrame, RxFrame &aAckFrame)
     uint8_t            txKeyIndex;
     uint8_t            ackKeyIndex;
     uint8_t            keyIdMode;
+    uint32_t           keySequence;
     uint32_t           frameCounter;
     Address            srcAddr;
     Address            dstAddr;
-    Neighbor          *neighbor   = nullptr;
-    KeyManager        &keyManager = Get<KeyManager>();
+    Neighbor          *neighbor = nullptr;
     const KeyMaterial *macKey;
 
     VerifyOrExit(aAckFrame.GetSecurityEnabled(), error = kErrorNone);
@@ -1758,18 +1760,17 @@ Error Mac::ProcessEnhAckSecurity(TxFrame &aTxFrame, RxFrame &aAckFrame)
     }
 
     VerifyOrExit(srcAddr.IsExtended() && neighbor != nullptr);
+    keySequence = Get<KeyManager>().GetCurrentKeySequence();
 
-    ackKeyIndex--;
-
-    if (ackKeyIndex == (keyManager.GetCurrentKeySequence() & 0x7f))
+    if (ackKeyIndex == DetermineKeyIndexFor(keySequence))
     {
         macKey = &mLinks.GetSubMac().GetCurrentMacKey();
     }
-    else if (ackKeyIndex == ((keyManager.GetCurrentKeySequence() - 1) & 0x7f))
+    else if (ackKeyIndex == DetermineKeyIndexFor(keySequence - 1))
     {
         macKey = &mLinks.GetSubMac().GetPreviousMacKey();
     }
-    else if (ackKeyIndex == ((keyManager.GetCurrentKeySequence() + 1) & 0x7f))
+    else if (ackKeyIndex == DetermineKeyIndexFor(keySequence + 1))
     {
         macKey = &mLinks.GetSubMac().GetNextMacKey();
     }

--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -356,6 +356,8 @@ bool KeyMaterial::operator==(const KeyMaterial &aOther) const
 #endif
 }
 
+uint8_t DetermineKeyIndexFor(uint32_t aKeySequence) { return static_cast<uint8_t>((aKeySequence & 0x7f) + 1); }
+
 #if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
 uint8_t GetWakeupIdLength(WakeupId aWakeupId)
 {

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -650,6 +650,15 @@ private:
 };
 
 /**
+ * Determines the MAC Key Index for a given Key Sequence.
+ *
+ * @param[in] aKeySequence  The Key Sequence value.
+ *
+ * @returns The MAC Key Index corresponding to @p aKeySequence.
+ */
+uint8_t DetermineKeyIndexFor(uint32_t aKeySequence);
+
+/**
  * Represents Link Frame Counters for all supported radio links.
  */
 class LinkFrameCounters

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -352,7 +352,8 @@ void KeyManager::UpdateKeyMaterial(void)
         ComputeKeys(mKeySequence + 1, hashKeys);
         nextKey.SetFrom(hashKeys.GetMacKey(), Mac::kDefaultMacKeysExportable);
 
-        Get<Mac::SubMac>().SetMacKey(Mac::Frame::kKeyIdMode1, (mKeySequence & 0x7f) + 1, prevKey, curKey, nextKey);
+        Get<Mac::SubMac>().SetMacKey(Mac::Frame::kKeyIdMode1, Mac::DetermineKeyIndexFor(mKeySequence), prevKey, curKey,
+                                     nextKey);
     }
 #endif
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1839,7 +1839,7 @@ private:
         void     SetKeyId(uint32_t aKeySequence)
         {
             mKeySource = BigEndian::HostSwap32(aKeySequence);
-            mKeyIndex  = (aKeySequence & 0x7f) + 1;
+            mKeyIndex  = Mac::DetermineKeyIndexFor(aKeySequence);
         }
 
     private:


### PR DESCRIPTION
This commit introduces `DetermineKeyIndexFor(uint32_t aKeySequence)` in `mac_types.hpp` to centralize the `(aKeySequence & 0x7f) + 1` MAC Key Index calculation, and updates `Mac`, `KeyManager`, and `Mle` to use the new helper function.