### PR TITLE
[radio] introduce C++ types for radio capabilities

### DIFF
--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -94,7 +94,7 @@ public:
      *
      * @returns The radio capability bit vector.
      */
-    otRadioCaps GetCaps(void) const { return mSubMac.GetCaps(); }
+    Radio::Capabilities GetCaps(void) const { return mSubMac.GetCaps(); }
 
     /**
      * Starts a (recurring) Receive on the link-layer.

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -65,7 +65,7 @@ SubMac::SubMac(Instance &aInstance)
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT && !OPENTHREAD_CONFIG_MAC_SOFTWARE_RETX_SECURITY_ENABLE
     // Assuming the platform must deal with the retransmission security correctly.
-    OT_ASSERT(mRadioCaps & OT_RADIO_CAPS_TRANSMIT_RETRIES);
+    OT_ASSERT(RadioSupports(kCapTransmitRetries));
 #endif
     Init();
 }
@@ -105,53 +105,52 @@ void SubMac::Init(void)
 #endif
 }
 
-otRadioCaps SubMac::GetCaps(void) const
+SubMac::Capabilities SubMac::GetCaps(void) const
 {
-    otRadioCaps caps;
+    Capabilities caps;
 
 #if OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
     caps = mRadioCaps;
 
 #if OPENTHREAD_CONFIG_MAC_SOFTWARE_ACK_TIMEOUT_ENABLE
-    caps |= OT_RADIO_CAPS_ACK_TIMEOUT;
+    caps |= kCapAckTimeout;
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_SOFTWARE_CSMA_BACKOFF_ENABLE
-    caps |= OT_RADIO_CAPS_CSMA_BACKOFF;
+    caps |= kCapCsmaBackoff;
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_SOFTWARE_RETRANSMIT_ENABLE
-    caps |= OT_RADIO_CAPS_TRANSMIT_RETRIES;
+    caps |= kCapTransmitRetries;
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_SOFTWARE_ENERGY_SCAN_ENABLE
-    caps |= OT_RADIO_CAPS_ENERGY_SCAN;
+    caps |= kCapEnergyScan;
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_SOFTWARE_TX_SECURITY_ENABLE && (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-    caps |= OT_RADIO_CAPS_TRANSMIT_SEC;
+    caps |= kCapTransmitSec;
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_SOFTWARE_TX_TIMING_ENABLE && (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-    caps |= OT_RADIO_CAPS_TRANSMIT_TIMING;
+    caps |= kCapTransmitTiming;
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE && (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-    caps |= OT_RADIO_CAPS_RECEIVE_TIMING;
+    caps |= kCapReceiveTiming;
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_ON_WHEN_IDLE_ENABLE
-    caps |= OT_RADIO_CAPS_RX_ON_WHEN_IDLE;
+    caps |= kCapRxOnWhenIdle;
 #endif
 
 #if OPENTHREAD_RADIO
-    caps |= OT_RADIO_CAPS_SLEEP_TO_TX;
+    caps |= kCapSleepToTx;
 #endif
 
 #else
-    caps = OT_RADIO_CAPS_ACK_TIMEOUT | OT_RADIO_CAPS_CSMA_BACKOFF | OT_RADIO_CAPS_TRANSMIT_RETRIES |
-           OT_RADIO_CAPS_ENERGY_SCAN | OT_RADIO_CAPS_TRANSMIT_SEC | OT_RADIO_CAPS_TRANSMIT_TIMING |
-           OT_RADIO_CAPS_RECEIVE_TIMING | OT_RADIO_CAPS_RX_ON_WHEN_IDLE;
+    caps = kCapAckTimeout | kCapCsmaBackoff | kCapTransmitRetries | kCapEnergyScan | kCapTransmitSec |
+           kCapTransmitTiming | kCapReceiveTiming | kCapRxOnWhenIdle;
 #endif
 
     return caps;
@@ -194,7 +193,7 @@ void SubMac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 {
     mRxOnWhenIdle = aRxOnWhenIdle;
 
-    if (RadioSupportsRxOnWhenIdle())
+    if (RadioSupports(kCapRxOnWhenIdle))
     {
 #if !OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
         Get<Radio::Radio>().SetRxOnWhenIdle(mRxOnWhenIdle);
@@ -503,7 +502,7 @@ void SubMac::BeginTransmit(void)
     VerifyOrExit(mState == kStateCsmaBackoff);
 #endif
 
-    if ((mRadioCaps & OT_RADIO_CAPS_SLEEP_TO_TX) == 0)
+    if (!RadioSupports(kCapSleepToTx))
     {
         SuccessOrAssert(Get<Radio::Radio>().Receive(mTransmitFrame.GetChannel()));
     }
@@ -734,7 +733,7 @@ Error SubMac::EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration)
     VerifyOrExit(!mRadioFilterEnabled, HandleEnergyScanDone(Radio::kInvalidRssi));
 #endif
 
-    if (RadioSupportsEnergyScan())
+    if (RadioSupports(kCapEnergyScan))
     {
         IgnoreError(Get<Radio::Radio>().EnergyScan(aScanChannel, aScanDuration));
         SetState(kStateEnergyScan);
@@ -759,7 +758,7 @@ exit:
 
 void SubMac::SampleRssi(void)
 {
-    OT_ASSERT(!RadioSupportsEnergyScan());
+    OT_ASSERT(!RadioSupports(kCapEnergyScan));
 
     int8_t rssi = GetRssi();
 
@@ -825,7 +824,7 @@ bool SubMac::ShouldHandleTransmitSecurity(void) const
 {
     bool swTxSecurity = true;
 
-    VerifyOrExit(!RadioSupportsTransmitSecurity(), swTxSecurity = false);
+    VerifyOrExit(!RadioSupports(kCapTransmitSec), swTxSecurity = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
     VerifyOrExit(Get<LinkRaw>().IsEnabled());
@@ -843,7 +842,8 @@ bool SubMac::ShouldHandleCsmaBackOff(void) const
 {
     bool swCsma = true;
 
-    VerifyOrExit(mTransmitFrame.IsCsmaCaEnabled() && !RadioSupportsCsmaBackoff(), swCsma = false);
+    VerifyOrExit(mTransmitFrame.IsCsmaCaEnabled(), swCsma = false);
+    VerifyOrExit(!RadioSupportsAny(kCapCsmaBackoff | kCapTransmitRetries), swCsma = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
     VerifyOrExit(Get<LinkRaw>().IsEnabled());
@@ -861,7 +861,7 @@ bool SubMac::ShouldHandleAckTimeout(void) const
 {
     bool swAckTimeout = true;
 
-    VerifyOrExit(!RadioSupportsAckTimeout(), swAckTimeout = false);
+    VerifyOrExit(!RadioSupports(kCapAckTimeout), swAckTimeout = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
     VerifyOrExit(Get<LinkRaw>().IsEnabled());
@@ -879,7 +879,7 @@ bool SubMac::ShouldHandleRetries(void) const
 {
     bool swRetries = true;
 
-    VerifyOrExit(!RadioSupportsRetries(), swRetries = false);
+    VerifyOrExit(!RadioSupports(kCapTransmitRetries), swRetries = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
     VerifyOrExit(Get<LinkRaw>().IsEnabled());
@@ -897,7 +897,7 @@ bool SubMac::ShouldHandleEnergyScan(void) const
 {
     bool swEnergyScan = true;
 
-    VerifyOrExit(!RadioSupportsEnergyScan(), swEnergyScan = false);
+    VerifyOrExit(!RadioSupports(kCapEnergyScan), swEnergyScan = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
     VerifyOrExit(Get<LinkRaw>().IsEnabled());
@@ -915,7 +915,7 @@ bool SubMac::ShouldHandleTransmitTargetTime(void) const
 {
     bool swTxDelay = true;
 
-    VerifyOrExit(!RadioSupportsTransmitTiming(), swTxDelay = false);
+    VerifyOrExit(!RadioSupports(kCapTransmitTiming), swTxDelay = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
     VerifyOrExit(Get<LinkRaw>().IsEnabled());
@@ -929,7 +929,7 @@ exit:
     return swTxDelay;
 }
 
-bool SubMac::ShouldHandleTransitionToSleep(void) const { return (mRxOnWhenIdle || !RadioSupportsRxOnWhenIdle()); }
+bool SubMac::ShouldHandleTransitionToSleep(void) const { return (mRxOnWhenIdle || !RadioSupports(kCapRxOnWhenIdle)); }
 
 void SubMac::SetState(State aState)
 {
@@ -1041,7 +1041,7 @@ void SubMac::RadioSample(void)
 
     SetState(kStateRadioSample);
 
-    if (!RadioSupportsReceiveTiming())
+    if (!RadioSupports(kCapReceiveTiming))
     {
         UpdateRadioSampleState();
     }

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -107,6 +107,9 @@ class SubMac : public InstanceLocator, private NonCopyable
     friend class LinkRaw;
 
 public:
+    using Capability   = Radio::Capability;   ///< A radio capability.
+    using Capabilities = Radio::Capabilities; ///< A bit-vector of radio capabilities.
+
     /**
      * Defines the callbacks notifying `SubMac` user of changes and events.
      */
@@ -200,16 +203,16 @@ public:
     /**
      * Gets the capabilities provided by platform radio.
      *
-     * @returns The capability bit vector (see `OT_RADIO_CAP_*` definitions).
+     * @returns The capability bit vector (see `Radio::Capability` definitions).
      */
-    otRadioCaps GetRadioCaps(void) const { return mRadioCaps; }
+    Capabilities GetRadioCaps(void) const { return mRadioCaps; }
 
     /**
      * Gets the capabilities provided by `SubMac` layer.
      *
-     * @returns The capability bit vector (see `OT_RADIO_CAP_*` definitions).
+     * @returns The capability bit vector (see `Radio::Capability` definitions).
      */
-    otRadioCaps GetCaps(void) const;
+    Capabilities GetCaps(void) const;
 
     /**
      * Sets the PAN ID.
@@ -512,6 +515,18 @@ private:
     static constexpr uint32_t kEnergyScanRssiSampleInterval = 1000; // RSSI sample interval for energy scan, in usec
 #endif
 
+    static constexpr Capability kCapAckTimeout         = Radio::kCapAckTimeout;
+    static constexpr Capability kCapEnergyScan         = Radio::kCapEnergyScan;
+    static constexpr Capability kCapTransmitRetries    = Radio::kCapTransmitRetries;
+    static constexpr Capability kCapCsmaBackoff        = Radio::kCapCsmaBackoff;
+    static constexpr Capability kCapSleepToTx          = Radio::kCapSleepToTx;
+    static constexpr Capability kCapTransmitSec        = Radio::kCapTransmitSec;
+    static constexpr Capability kCapTransmitTiming     = Radio::kCapTransmitTiming;
+    static constexpr Capability kCapReceiveTiming      = Radio::kCapReceiveTiming;
+    static constexpr Capability kCapRxOnWhenIdle       = Radio::kCapRxOnWhenIdle;
+    static constexpr Capability kCapTransmitFramePower = Radio::kCapTransmitFramePower;
+    static constexpr Capability kCapAltShortAddr       = Radio::kCapAltShortAddr;
+
     enum State : uint8_t
     {
         kStateDisabled,    // Radio is disabled.
@@ -551,27 +566,14 @@ private:
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
     // CSL transmitter would schedule delayed transmission `kCslTransmitTimeAhead` earlier
     // than expected delayed transmit time. The value is in usec.
-    // Only for radios not supporting OT_RADIO_CAPS_TRANSMIT_TIMING.
+    // Only for radios not supporting kCapTransmitTiming.
     static constexpr uint32_t kCslTransmitTimeAhead = OPENTHREAD_CONFIG_CSL_TRANSMIT_TIME_AHEAD;
 #endif
 
-    /**
-     * Initializes the states of the sub-MAC layer.
-     */
     void Init(void);
 
-    bool RadioSupportsCsmaBackoff(void) const
-    {
-        return ((mRadioCaps & (OT_RADIO_CAPS_CSMA_BACKOFF | OT_RADIO_CAPS_TRANSMIT_RETRIES)) != 0);
-    }
-
-    bool RadioSupportsTransmitSecurity(void) const { return ((mRadioCaps & OT_RADIO_CAPS_TRANSMIT_SEC) != 0); }
-    bool RadioSupportsRetries(void) const { return ((mRadioCaps & OT_RADIO_CAPS_TRANSMIT_RETRIES) != 0); }
-    bool RadioSupportsAckTimeout(void) const { return ((mRadioCaps & OT_RADIO_CAPS_ACK_TIMEOUT) != 0); }
-    bool RadioSupportsEnergyScan(void) const { return ((mRadioCaps & OT_RADIO_CAPS_ENERGY_SCAN) != 0); }
-    bool RadioSupportsTransmitTiming(void) const { return ((mRadioCaps & OT_RADIO_CAPS_TRANSMIT_TIMING) != 0); }
-    bool RadioSupportsReceiveTiming(void) const { return ((mRadioCaps & OT_RADIO_CAPS_RECEIVE_TIMING) != 0); }
-    bool RadioSupportsRxOnWhenIdle(void) const { return ((mRadioCaps & OT_RADIO_CAPS_RX_ON_WHEN_IDLE) != 0); }
+    bool RadioSupports(Capability aCapability) const { return (mRadioCaps & aCapability) != 0; }
+    bool RadioSupportsAny(Capabilities aCapabilities) const { return (mRadioCaps & aCapabilities) != 0; }
 
     bool ShouldHandleTransmitSecurity(void) const;
     bool ShouldHandleCsmaBackOff(void) const;
@@ -639,7 +641,7 @@ private:
     using SubMacTimer = TimerMilliIn<SubMac, &SubMac::HandleTimer>;
 #endif
 
-    otRadioCaps  mRadioCaps;
+    Capabilities mRadioCaps;
     State        mState;
     uint8_t      mCsmaBackoffs;
     uint8_t      mTransmitRetries;

--- a/src/core/mac/sub_mac_csl_receiver.cpp
+++ b/src/core/mac/sub_mac_csl_receiver.cpp
@@ -56,7 +56,7 @@ void SubMac::CslInit(void)
 void SubMac::RestartCslTimerAfterSyncUpdate(void)
 {
     // Only applies for the case where radio supports receive timing.
-    if (RadioSupportsReceiveTiming() && mCslTimer.IsRunning())
+    if (RadioSupports(kCapReceiveTiming) && mCslTimer.IsRunning())
     {
         uint32_t periodUs = mCslPeriod * Radio::kUsPerTenSymbols;
 
@@ -135,7 +135,7 @@ void SubMac::SetCslParams(uint16_t aPeriod, uint8_t aChannel, ShortAddress aShor
 
         HandleCslTimer();
     }
-    else if (!RadioSupportsReceiveTiming())
+    else if (!RadioSupports(kCapReceiveTiming))
     {
         UpdateRadioSampleState();
     }
@@ -151,7 +151,7 @@ void SubMac::HandleCslTimer(void)
     GetCslWindowEdges(timeAhead, timeAfter);
 
     // The handler works in different ways when the radio supports receive-timing and doesn't.
-    if (RadioSupportsReceiveTiming())
+    if (RadioSupports(kCapReceiveTiming))
     {
         HandleCslReceiveAt(timeAhead, timeAfter);
     }

--- a/src/core/mac/sub_mac_wed.cpp
+++ b/src/core/mac/sub_mac_wed.cpp
@@ -68,7 +68,7 @@ void SubMac::UpdateWakeupListening(bool aEnable, uint32_t aInterval, uint32_t aD
 
         HandleWedTimer();
     }
-    else if (!RadioSupportsReceiveTiming())
+    else if (!RadioSupports(kCapReceiveTiming))
     {
         UpdateRadioSampleState();
     }
@@ -76,7 +76,7 @@ void SubMac::UpdateWakeupListening(bool aEnable, uint32_t aInterval, uint32_t aD
 
 void SubMac::HandleWedTimer(void)
 {
-    if (RadioSupportsReceiveTiming())
+    if (RadioSupports(kCapReceiveTiming))
     {
         HandleWedReceiveAt();
     }

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -131,6 +131,29 @@ static_assert((OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT || OPENTHREAD_CONFIG
               "must be set to 1 to specify the radio mode");
 
 /**
+ * Represents a radio capability.
+ */
+enum Capability : uint16_t
+{
+    kCapAckTimeout         = OT_RADIO_CAPS_ACK_TIMEOUT,          ///< Supports ack timeout event.
+    kCapEnergyScan         = OT_RADIO_CAPS_ENERGY_SCAN,          ///< Supports energy scan.
+    kCapTransmitRetries    = OT_RADIO_CAPS_TRANSMIT_RETRIES,     ///< Supports tx retry logic (and CSMA).
+    kCapCsmaBackoff        = OT_RADIO_CAPS_CSMA_BACKOFF,         ///< Supports CSMA backoff for frame tx (but no retry).
+    kCapSleepToTx          = OT_RADIO_CAPS_SLEEP_TO_TX,          ///< Supports transition from sleep to TX.
+    kCapTransmitSec        = OT_RADIO_CAPS_TRANSMIT_SEC,         ///< Supports tx security.
+    kCapTransmitTiming     = OT_RADIO_CAPS_TRANSMIT_TIMING,      ///< Supports tx at specific time.
+    kCapReceiveTiming      = OT_RADIO_CAPS_RECEIVE_TIMING,       ///< Supports rx at specific time.
+    kCapRxOnWhenIdle       = OT_RADIO_CAPS_RX_ON_WHEN_IDLE,      ///< Supports RxOnWhenIdle handling.
+    kCapTransmitFramePower = OT_RADIO_CAPS_TRANSMIT_FRAME_POWER, ///< Supports setting per-frame transmit power.
+    kCapAltShortAddr       = OT_RADIO_CAPS_ALT_SHORT_ADDR,       ///< Supports setting alternate short address.
+};
+
+/**
+ * Represents a bit vector of radio capabilities (`Capability`).
+ */
+typedef otRadioCaps Capabilities;
+
+/**
  * Indicates whether a given channel page is supported based on the current configurations.
  *
  * @param[in] aChannelPage The channel page to check.
@@ -210,8 +233,7 @@ public:
     /**
      * This callback method handles "Energy Scan Done" event from radio platform.
      *
-     * Is used when radio provides OT_RADIO_CAPS_ENERGY_SCAN capability. It is called from
-     * `otPlatRadioEnergyScanDone()`.
+     * Is used when radio provides the `kCapEnergyScan` capability. It is called from `otPlatRadioEnergyScanDone()`.
      *
      * @param[in]  aMaxRssi  The maximum RSSI encountered on the scanned channel.
      */
@@ -356,9 +378,9 @@ public:
     /**
      * Gets the radio capabilities.
      *
-     * @returns The radio capability bit vector (see `OT_RADIO_CAP_*` definitions).
+     * @returns The radio capability bit vector (see `Capability` definitions).
      */
-    otRadioCaps GetCaps(void);
+    Capabilities GetCaps(void);
 
     /**
      * Gets the radio receive sensitivity value.
@@ -665,7 +687,7 @@ public:
     /**
      * Begins the energy scan sequence on the radio.
      *
-     * Is used when radio provides OT_RADIO_CAPS_ENERGY_SCAN capability.
+     * Is used when radio provides the `kCapEnergyScan` capability.
      *
      * @param[in] aScanChannel   The channel to perform the energy scan on.
      * @param[in] aScanDuration  The duration, in milliseconds, for the channel to be scanned.
@@ -879,7 +901,7 @@ inline uint32_t Radio::GetPreferredChannelMask(void) { return otPlatRadioGetPref
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 
-inline otRadioCaps Radio::GetCaps(void) { return otPlatRadioGetCaps(GetInstancePtr()); }
+inline Capabilities Radio::GetCaps(void) { return otPlatRadioGetCaps(GetInstancePtr()); }
 
 inline int8_t Radio::GetReceiveSensitivity(void) const { return otPlatRadioGetReceiveSensitivity(GetInstancePtr()); }
 
@@ -1037,10 +1059,7 @@ inline bool Radio::GetDiagMode(void) { return otPlatDiagModeGet(); }
 #endif
 #else //----------------------------------------------------------------------------------------------------------------
 
-inline otRadioCaps Radio::GetCaps(void)
-{
-    return OT_RADIO_CAPS_ACK_TIMEOUT | OT_RADIO_CAPS_CSMA_BACKOFF | OT_RADIO_CAPS_TRANSMIT_RETRIES;
-}
+inline Capabilities Radio::GetCaps(void) { return kCapAckTimeout | kCapCsmaBackoff | kCapTransmitRetries; }
 
 inline int8_t Radio::GetReceiveSensitivity(void) const { return kDefaultReceiveSensitivity; }
 


### PR DESCRIPTION
This commit adds the `Capability` enumeration and `Capabilities` bit-vector type inside `namespace Radio` (`radio.hpp`) to encapsulate the C API `OT_RADIO_CAPS_*` definitions within C++ types.

This commit also updates `SubMac` and `LinkRaw` to use these new types along with the `RadioSupports()` and `RadioSupportsAny()` helper methods, replacing and simplifying the previous individual capability check methods.