### PR TITLE
[mac] introduce and use `PcapCallback` type alias

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -437,16 +437,12 @@ public:
     bool IsInTransmitState(void) const;
 
     /**
-     * Registers a callback to provide received raw IEEE 802.15.4 frames.
+     * Registers a callback to provide received packet capture for IEEE 802.15.4 frames.
      *
-     * @param[in]  aPcapCallback     A pointer to a function that is called when receiving an IEEE 802.15.4 link frame
-     *                               or `nullptr` to disable the callback.
-     * @param[in]  aCallbackContext  A pointer to application-specific context.
+     * @param[in]  aCallback   The packet capture callback, or `nullptr` to disable packet capture.
+     * @param[in]  aContext    A pointer to application-specific context.
      */
-    void SetPcapCallback(otLinkPcapCallback aPcapCallback, void *aCallbackContext)
-    {
-        mLinks.SetPcapCallback(aPcapCallback, aCallbackContext);
-    }
+    void SetPcapCallback(PcapCallback aCallback, void *aContext) { mLinks.SetPcapCallback(aCallback, aContext); }
 
     /**
      * Indicates whether or not promiscuous mode is enabled at the link layer.

--- a/src/core/mac/mac_links.hpp
+++ b/src/core/mac/mac_links.hpp
@@ -395,17 +395,16 @@ public:
     /**
      * Registers a callback to provide received packet capture for IEEE 802.15.4 frames.
      *
-     * @param[in]  aPcapCallback     A pointer to a function that is called when receiving an IEEE 802.15.4 link frame
-     *                               or nullptr to disable the callback.
-     * @param[in]  aCallbackContext  A pointer to application-specific context.
+     * @param[in]  aCallback   The packet capture callback, or `nullptr` to disable packet capture.
+     * @param[in]  aContext    A pointer to application-specific context.
      */
-    void SetPcapCallback(otLinkPcapCallback aPcapCallback, void *aCallbackContext)
+    void SetPcapCallback(PcapCallback aCallback, void *aContext)
     {
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-        mSubMac.SetPcapCallback(aPcapCallback, aCallbackContext);
+        mSubMac.SetPcapCallback(aCallback, aContext);
 #endif
-        OT_UNUSED_VARIABLE(aPcapCallback);
-        OT_UNUSED_VARIABLE(aCallbackContext);
+        OT_UNUSED_VARIABLE(aCallback);
+        OT_UNUSED_VARIABLE(aContext);
     }
 
     /**

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -85,6 +85,11 @@ constexpr bool         kDefaultMacKeysExportable =
     OPENTHREAD_CONFIG_PLATFORM_MAC_KEYS_EXPORTABLE_ENABLE; ///< Default exportability policy for MAC key refs.
 
 /**
+ * Represents the packet capture callback function pointer.
+ */
+typedef otLinkPcapCallback PcapCallback;
+
+/**
  * Represents the wake-up identifier.
  */
 typedef otWakeupId WakeupId;

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -263,14 +263,10 @@ public:
     /**
      * Registers a callback to provide received packet capture for IEEE 802.15.4 frames.
      *
-     * @param[in]  aPcapCallback     A pointer to a function that is called when receiving an IEEE 802.15.4 link frame
-     *                               or `nullptr` to disable the callback.
-     * @param[in]  aCallbackContext  A pointer to application-specific context.
+     * @param[in]  aCallback   The packet capture callback, or `nullptr` to disable packet capture.
+     * @param[in]  aContext    A pointer to application-specific context.
      */
-    void SetPcapCallback(otLinkPcapCallback aPcapCallback, void *aCallbackContext)
-    {
-        mPcapCallback.Set(aPcapCallback, aCallbackContext);
-    }
+    void SetPcapCallback(PcapCallback aCallback, void *aContext) { mPcapCallback.Set(aCallback, aContext); }
 
     /**
      * Indicates whether radio should stay in Receive or Sleep during idle periods.
@@ -654,16 +650,16 @@ private:
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
     bool mRadioFilterEnabled : 1;
 #endif
-    int8_t                       mEnergyScanMaxRssi;
-    TimeMilli                    mEnergyScanEndTime;
-    TxFrame                     &mTransmitFrame;
-    Callbacks                    mCallbacks;
-    Callback<otLinkPcapCallback> mPcapCallback;
-    KeyMaterial                  mPrevKey;
-    KeyMaterial                  mCurrKey;
-    KeyMaterial                  mNextKey;
-    uint32_t                     mFrameCounter;
-    uint8_t                      mKeyIndex;
+    int8_t                 mEnergyScanMaxRssi;
+    TimeMilli              mEnergyScanEndTime;
+    TxFrame               &mTransmitFrame;
+    Callbacks              mCallbacks;
+    Callback<PcapCallback> mPcapCallback;
+    KeyMaterial            mPrevKey;
+    KeyMaterial            mCurrKey;
+    KeyMaterial            mNextKey;
+    uint32_t               mFrameCounter;
+    uint8_t                mKeyIndex;
 #if OPENTHREAD_CONFIG_MAC_ADD_DELAY_ON_NO_ACK_ERROR_BEFORE_RETRY
     uint8_t mRetxDelayBackOffExponent;
 #endif


### PR DESCRIPTION
This commit introduces the `PcapCallback` type alias in `mac_types.hpp` for `otLinkPcapCallback`.

It updates `Mac`, `Links`, and `SubMac` (`SetPcapCallback()`) to use this new type alias and simplifies the callback parameter names.