### PR TITLE
[platform] evaluate aError only once in SuccessOrDie

### DIFF
--- a/src/lib/platform/exit_code.h
+++ b/src/lib/platform/exit_code.h
@@ -132,9 +132,13 @@ const char *otExitCodeToString(uint8_t aExitCode);
  *
  * @param[in]  aError  An error code to be evaluated against OT_ERROR_NONE.
  */
-#define SuccessOrDie(aError)             \
-    VerifyOrDie(aError == OT_ERROR_NONE, \
-                (aError == OT_ERROR_INVALID_ARGS ? OT_EXIT_INVALID_ARGUMENTS : OT_EXIT_FAILURE))
+#define SuccessOrDie(aError)                                                                                      \
+    do                                                                                                            \
+    {                                                                                                             \
+        otError _successOrDieError = (aError);                                                                    \
+        VerifyOrDie(_successOrDieError == OT_ERROR_NONE,                                                          \
+                    (_successOrDieError == OT_ERROR_INVALID_ARGS ? OT_EXIT_INVALID_ARGUMENTS : OT_EXIT_FAILURE)); \
+    } while (false)
 
 /**
  * Unconditionally both records exit status and terminates the program.


### PR DESCRIPTION
Previously, `SuccessOrDie(aError)` evaluated the `aError` argument twice inside `VerifyOrDie` (once to compare against `OT_ERROR_NONE` and once to compare against `OT_ERROR_INVALID_ARGS`). If `aError` was an expression with side effects or a function call, it would be executed multiple times.

This commit updates `SuccessOrDie` to assign `aError` to a temporary local variable within a `do { ... } while (false)` block, ensuring `aError` is evaluated exactly once.