### PR TITLE
[mac] introduce and use `KeyTrio` class

### DIFF
--- a/src/core/mac/link_raw.cpp
+++ b/src/core/mac/link_raw.cpp
@@ -243,21 +243,14 @@ void LinkRaw::InvokeEnergyScanDone(int8_t aEnergyScanMaxRssi)
 Error LinkRaw::SetMacKey(uint8_t    aKeyIdMode,
                          uint8_t    aKeyIndex,
                          const Key &aPrevKey,
-                         const Key &aCurrKey,
+                         const Key &aCurKey,
                          const Key &aNextKey)
 {
-    Error       error = kErrorNone;
-    KeyMaterial prevKey;
-    KeyMaterial currKey;
-    KeyMaterial nextKey;
+    Error error = kErrorNone;
 
     VerifyOrExit(IsEnabled(), error = kErrorInvalidState);
 
-    prevKey.SetFrom(aPrevKey, kDefaultMacKeysExportable);
-    currKey.SetFrom(aCurrKey, kDefaultMacKeysExportable);
-    nextKey.SetFrom(aNextKey, kDefaultMacKeysExportable);
-
-    mSubMac.SetMacKey(aKeyIdMode, aKeyIndex, prevKey, currKey, nextKey);
+    mSubMac.SetMacKey(aKeyIdMode, aKeyIndex, aPrevKey, aCurKey, aNextKey);
 
 exit:
     return error;

--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -245,19 +245,18 @@ public:
      * Updates MAC keys and key index.
      *
      * @param[in]   aKeyIdMode        The key ID mode.
-     * @param[in]   aKeyIndex            The key index.
+     * @param[in]   aKeyIndex         The key index.
      * @param[in]   aPrevKey          The previous MAC key.
-     * @param[in]   aCurrKey          The current MAC key.
+     * @param[in]   aCurKey           The current MAC key.
      * @param[in]   aNextKey          The next MAC key.
      *
      * @retval kErrorNone            If successful.
-     * @retval kErrorFailed          Platform failed to import key.
      * @retval kErrorInvalidState    If the raw link-layer isn't enabled.
      */
     Error SetMacKey(uint8_t    aKeyIdMode,
                     uint8_t    aKeyIndex,
                     const Key &aPrevKey,
-                    const Key &aCurrKey,
+                    const Key &aCurKey,
                     const Key &aNextKey);
 
     /**

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1764,15 +1764,15 @@ Error Mac::ProcessEnhAckSecurity(TxFrame &aTxFrame, RxFrame &aAckFrame)
 
     if (ackKeyIndex == DetermineKeyIndexFor(keySequence))
     {
-        macKey = &mLinks.GetSubMac().GetCurrentMacKey();
+        macKey = &mLinks.GetSubMac().GetMacKey(KeyTrio::kCur);
     }
     else if (ackKeyIndex == DetermineKeyIndexFor(keySequence - 1))
     {
-        macKey = &mLinks.GetSubMac().GetPreviousMacKey();
+        macKey = &mLinks.GetSubMac().GetMacKey(KeyTrio::kPrev);
     }
     else if (ackKeyIndex == DetermineKeyIndexFor(keySequence + 1))
     {
-        macKey = &mLinks.GetSubMac().GetNextMacKey();
+        macKey = &mLinks.GetSubMac().GetMacKey(KeyTrio::kNext);
     }
     else
     {

--- a/src/core/mac/mac_links.cpp
+++ b/src/core/mac/mac_links.cpp
@@ -182,7 +182,7 @@ const KeyMaterial *Links::GetCurrentMacKey(const Frame &aFrame) const
     if (radioType == Radio::kTypeIeee802154)
 #endif
     {
-        ExitNow(key = &Get<SubMac>().GetCurrentMacKey());
+        ExitNow(key = &Get<SubMac>().GetMacKey(KeyTrio::kCur));
     }
 #endif
 
@@ -218,11 +218,11 @@ const KeyMaterial *Links::GetTemporaryMacKey(const Frame &aFrame, uint32_t aKeyS
     {
         if (aKeySequence == Get<KeyManager>().GetCurrentKeySequence() - 1)
         {
-            ExitNow(key = &Get<SubMac>().GetPreviousMacKey());
+            ExitNow(key = &Get<SubMac>().GetMacKey(KeyTrio::kPrev));
         }
         else if (aKeySequence == Get<KeyManager>().GetCurrentKeySequence() + 1)
         {
-            ExitNow(key = &Get<SubMac>().GetNextMacKey());
+            ExitNow(key = &Get<SubMac>().GetMacKey(KeyTrio::kNext));
         }
         else
         {

--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -356,6 +356,24 @@ bool KeyMaterial::operator==(const KeyMaterial &aOther) const
 #endif
 }
 
+void KeyTrio::Clear(void)
+{
+    mKeyIndex = 0;
+
+    for (KeyMaterial &key : mKeys)
+    {
+        key.Clear();
+    }
+}
+
+void KeyTrio::Set(uint8_t aKeyIndex, const Key &aPrevKey, const Key &aCurKey, const Key &aNextKey)
+{
+    mKeyIndex = aKeyIndex;
+    mKeys[kPrev].SetFrom(aPrevKey, kIsExportable);
+    mKeys[kCur].SetFrom(aCurKey, kIsExportable);
+    mKeys[kNext].SetFrom(aNextKey, kIsExportable);
+}
+
 uint8_t DetermineKeyIndexFor(uint32_t aKeySequence) { return static_cast<uint8_t>((aKeySequence & 0x7f) + 1); }
 
 #if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -47,6 +47,7 @@
 #include "common/clearable.hpp"
 #include "common/data.hpp"
 #include "common/equatable.hpp"
+#include "common/non_copyable.hpp"
 #include "common/string.hpp"
 #include "crypto/storage.hpp"
 #include "radio/radio_types.hpp"
@@ -81,8 +82,6 @@ typedef otShortAddress ShortAddress;
 
 constexpr ShortAddress kShortAddrBroadcast = OT_RADIO_BROADCAST_SHORT_ADDR; ///< Broadcast Short Address.
 constexpr ShortAddress kShortAddrInvalid   = OT_RADIO_INVALID_SHORT_ADDR;   ///< Invalid Short Address.
-constexpr bool         kDefaultMacKeysExportable =
-    OPENTHREAD_CONFIG_PLATFORM_MAC_KEYS_EXPORTABLE_ENABLE; ///< Default exportability policy for MAC key refs.
 
 /**
  * Represents the packet capture callback function pointer.
@@ -647,6 +646,57 @@ private:
 #endif
     Key &GetKey(void) { return static_cast<Key &>(mKeyMaterial.mKey); }
     void SetKey(const Key &aKey) { mKeyMaterial.mKey = aKey; }
+};
+
+class SubMac;
+
+/**
+ * Represents a trio of MAC keys (previous, current, and next) and their associated key index.
+ */
+class KeyTrio : private NonCopyable
+{
+    friend class SubMac;
+
+public:
+    /**
+     * Represents the key type (previous, current, or next).
+     */
+    enum Type : uint8_t
+    {
+        kPrev, ///< Previous MAC key.
+        kCur,  ///< Current MAC key.
+        kNext, ///< Next MAC key.
+    };
+
+    /**
+     * Clears the stored keys and key index.
+     */
+    void Clear(void);
+
+    /**
+     * Gets a MAC key of a given type from the trio.
+     *
+     * @param[in] aType  The key type (`kPrev`, `kCur`, or `kNext`).
+     *
+     * @returns A reference to the requested MAC key.
+     */
+    const KeyMaterial &GetKey(Type aType) const { return mKeys[aType]; }
+
+    /**
+     * Gets the MAC key index.
+     *
+     * @returns The MAC key index.
+     */
+    uint8_t GetKeyIndex(void) const { return mKeyIndex; }
+
+private:
+    static constexpr bool    kIsExportable = OPENTHREAD_CONFIG_PLATFORM_MAC_KEYS_EXPORTABLE_ENABLE;
+    static constexpr uint8_t kNumTypes     = 3;
+
+    void Set(uint8_t aKeyIndex, const Key &aPrevKey, const Key &aCurKey, const Key &aNextKey);
+
+    KeyMaterial mKeys[kNumTypes];
+    uint8_t     mKeyIndex;
 };
 
 /**

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -89,12 +89,8 @@ void SubMac::Init(void)
     mRadioFilterEnabled = false;
 #endif
 
-    mPrevKey.Clear();
-    mCurrKey.Clear();
-    mNextKey.Clear();
-
+    mKeyTrio.Clear();
     mFrameCounter = 0;
-    mKeyIndex     = 0;
     mTimer.Stop();
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
@@ -382,7 +378,7 @@ void SubMac::ProcessTransmitSecurity(void)
 
     if (!mTransmitFrame.IsHeaderUpdated())
     {
-        mTransmitFrame.SetKeyIndex(mKeyIndex);
+        mTransmitFrame.SetKeyIndex(mKeyTrio.GetKeyIndex());
     }
 
     VerifyOrExit(ShouldHandleTransmitSecurity());
@@ -398,14 +394,14 @@ void SubMac::ProcessTransmitSecurity(void)
         VerifyOrExit(keyIdMode == Frame::kKeyIdMode1);
     }
 
-    mTransmitFrame.SetAesKey(GetCurrentMacKey());
+    mTransmitFrame.SetAesKey(GetMacKey(KeyTrio::kCur));
 
     if (!mTransmitFrame.IsHeaderUpdated())
     {
         uint32_t frameCounter = GetFrameCounter();
 
         mTransmitFrame.SetFrameCounter(frameCounter);
-        SignalFrameCounterUsed(frameCounter, mKeyIndex);
+        SignalFrameCounterUsed(frameCounter, mKeyTrio.GetKeyIndex());
     }
 
     extAddress = &GetExtAddress();
@@ -940,22 +936,32 @@ void SubMac::SetState(State aState)
     }
 }
 
-void SubMac::SetMacKey(uint8_t            aKeyIdMode,
-                       uint8_t            aKeyIndex,
-                       const KeyMaterial &aPrevKey,
-                       const KeyMaterial &aCurrKey,
-                       const KeyMaterial &aNextKey)
+void SubMac::SetMacKey(uint8_t    aKeyIdMode,
+                       uint8_t    aKeyIndex,
+                       const Key &aPrevKey,
+                       const Key &aCurKey,
+                       const Key &aNextKey)
 {
+    const KeyTrio *radioKeys = nullptr;
+    KeyTrio        tempKeyTrio;
+
+    if (aKeyIdMode == Frame::kKeyIdMode1)
+    {
+        mKeyTrio.Set(aKeyIndex, aPrevKey, aCurKey, aNextKey);
+    }
+
+    VerifyOrExit(!ShouldHandleTransmitSecurity());
+
     switch (aKeyIdMode)
     {
     case Frame::kKeyIdMode0:
     case Frame::kKeyIdMode2:
+        tempKeyTrio.Set(aKeyIndex, aPrevKey, aCurKey, aNextKey);
+        radioKeys = &tempKeyTrio;
         break;
+
     case Frame::kKeyIdMode1:
-        mKeyIndex = aKeyIndex;
-        mPrevKey  = aPrevKey;
-        mCurrKey  = aCurrKey;
-        mNextKey  = aNextKey;
+        radioKeys = &mKeyTrio;
         break;
 
     default:
@@ -963,9 +969,8 @@ void SubMac::SetMacKey(uint8_t            aKeyIdMode,
         break;
     }
 
-    VerifyOrExit(!ShouldHandleTransmitSecurity());
-
-    Get<Radio::Radio>().SetMacKey(aKeyIdMode, aKeyIndex, aPrevKey, aCurrKey, aNextKey);
+    VerifyOrExit(radioKeys != nullptr);
+    Get<Radio::Radio>().SetMacKey(aKeyIdMode, *radioKeys);
 
 exit:
     return;
@@ -973,7 +978,7 @@ exit:
 
 void SubMac::SignalFrameCounterUsed(uint32_t aFrameCounter, uint8_t aKeyIndex)
 {
-    VerifyOrExit(aKeyIndex == mKeyIndex);
+    VerifyOrExit(aKeyIndex == mKeyTrio.GetKeyIndex());
 
     mCallbacks.FrameCounterUsed(aFrameCounter);
 

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -403,50 +403,29 @@ public:
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
     /**
+     * Gets a MAC key of a given type from `SubMac`.
+     *
+     * @param[in] aType  The key type (`KeyTrio::kPrev`, `KeyTrio::kCur`, or `KeyTrio::kNext`).
+     *
+     * @returns A reference to the requested MAC key.
+     */
+    const KeyMaterial &GetMacKey(KeyTrio::Type aType) const { return mKeyTrio.GetKey(aType); }
+
+    /**
      * Sets MAC keys and key index.
      *
      * @param[in] aKeyIdMode  MAC key ID mode.
-     * @param[in] aKeyIndex   The key Index
+     * @param[in] aKeyIndex   The key index.
      * @param[in] aPrevKey    The previous MAC key.
-     * @param[in] aCurrKey    The current MAC key.
+     * @param[in] aCurKey     The current MAC key.
      * @param[in] aNextKey    The next MAC key.
      */
-    void SetMacKey(uint8_t            aKeyIdMode,
-                   uint8_t            aKeyIndex,
-                   const KeyMaterial &aPrevKey,
-                   const KeyMaterial &aCurrKey,
-                   const KeyMaterial &aNextKey);
-
-    /**
-     * Returns a reference to the current MAC key.
-     *
-     * @returns A reference to the current MAC key.
-     */
-    const KeyMaterial &GetCurrentMacKey(void) const { return mCurrKey; }
-
-    /**
-     * Returns a reference to the previous MAC key.
-     *
-     * @returns A reference to the previous MAC key.
-     */
-    const KeyMaterial &GetPreviousMacKey(void) const { return mPrevKey; }
-
-    /**
-     * Returns a reference to the next MAC key.
-     *
-     * @returns A reference to the next MAC key.
-     */
-    const KeyMaterial &GetNextMacKey(void) const { return mNextKey; }
+    void SetMacKey(uint8_t aKeyIdMode, uint8_t aKeyIndex, const Key &aPrevKey, const Key &aCurKey, const Key &aNextKey);
 
     /**
      * Clears the stored MAC keys.
      */
-    void ClearMacKeys(void)
-    {
-        mPrevKey.Clear();
-        mCurrKey.Clear();
-        mNextKey.Clear();
-    }
+    void ClearMacKeys(void) { mKeyTrio.Clear(); }
 
     /**
      * Returns the current MAC frame counter value.
@@ -657,11 +636,8 @@ private:
     TxFrame               &mTransmitFrame;
     Callbacks              mCallbacks;
     Callback<PcapCallback> mPcapCallback;
-    KeyMaterial            mPrevKey;
-    KeyMaterial            mCurrKey;
-    KeyMaterial            mNextKey;
+    KeyTrio                mKeyTrio;
     uint32_t               mFrameCounter;
-    uint8_t                mKeyIndex;
 #if OPENTHREAD_CONFIG_MAC_ADD_DELAY_ON_NO_ACK_ERROR_BEFORE_RETRY
     uint8_t mRetxDelayBackOffExponent;
 #endif

--- a/src/core/radio/radio.cpp
+++ b/src/core/radio/radio.cpp
@@ -84,8 +84,8 @@ bool IsCslChannelValid(uint8_t aCslChannel)
 void Radio::Init(void)
 {
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    Mac::ExtAddress  allZeroExtAddress;
-    Mac::KeyMaterial emptyKeyMaterial;
+    Mac::ExtAddress allZeroExtAddress;
+    Mac::KeyTrio    emptyKeyTrio;
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     SuccessOrAssert(ResetCsl());
@@ -105,8 +105,9 @@ void Radio::Init(void)
     allZeroExtAddress.Clear();
     SetExtendedAddress(allZeroExtAddress);
     SetShortAddress(Mac::kShortAddrInvalid);
-    emptyKeyMaterial.Clear();
-    SetMacKey(0, 0, emptyKeyMaterial, emptyKeyMaterial, emptyKeyMaterial);
+
+    emptyKeyTrio.Clear();
+    SetMacKey(Mac::Frame::kKeyIdMode1, emptyKeyTrio);
     SetMacFrameCounter(0);
 
     SetPromiscuous(false);

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -46,6 +46,7 @@
 #include "common/numeric_limits.hpp"
 #include "common/time.hpp"
 #include "mac/mac_frame.hpp"
+#include "mac/mac_types.hpp"
 #include "radio/radio_frame.hpp"
 #include "radio/radio_types.hpp"
 
@@ -426,19 +427,12 @@ public:
     void SetAlternateShortAddress(Mac::ShortAddress aShortAddress);
 
     /**
-     * Sets MAC key and key ID.
+     * Sets MAC keys and key index.
      *
      * @param[in] aKeyIdMode  MAC key ID mode.
-     * @param[in] aKeyIndex   Current MAC key index.
-     * @param[in] aPrevKey    The previous MAC key.
-     * @param[in] aCurrKey    The current MAC key.
-     * @param[in] aNextKey    The next MAC key.
+     * @param[in] aKeyTrio    The `KeyTrio` set (prev, cur, next) along with the key index.
      */
-    void SetMacKey(uint8_t                 aKeyIdMode,
-                   uint8_t                 aKeyIndex,
-                   const Mac::KeyMaterial &aPrevKey,
-                   const Mac::KeyMaterial &aCurrKey,
-                   const Mac::KeyMaterial &aNextKey);
+    void SetMacKey(uint8_t aKeyIdMode, const Mac::KeyTrio &aKeyTrio);
 
     /**
      * Sets the current MAC Frame Counter value.
@@ -913,11 +907,7 @@ inline void Radio::SetAlternateShortAddress(Mac::ShortAddress aShortAddress)
     otPlatRadioSetAlternateShortAddress(GetInstancePtr(), aShortAddress);
 }
 
-inline void Radio::SetMacKey(uint8_t                 aKeyIdMode,
-                             uint8_t                 aKeyIndex,
-                             const Mac::KeyMaterial &aPrevKey,
-                             const Mac::KeyMaterial &aCurrKey,
-                             const Mac::KeyMaterial &aNextKey)
+inline void Radio::SetMacKey(uint8_t aKeyIdMode, const Mac::KeyTrio &aKeyTrio)
 {
     otRadioKeyType keyType;
 
@@ -927,7 +917,8 @@ inline void Radio::SetMacKey(uint8_t                 aKeyIdMode,
     keyType = OT_KEY_TYPE_LITERAL_KEY;
 #endif
 
-    otPlatRadioSetMacKey(GetInstancePtr(), aKeyIdMode, aKeyIndex, &aPrevKey, &aCurrKey, &aNextKey, keyType);
+    otPlatRadioSetMacKey(GetInstancePtr(), aKeyIdMode, aKeyTrio.GetKeyIndex(), &aKeyTrio.GetKey(Mac::KeyTrio::kPrev),
+                         &aKeyTrio.GetKey(Mac::KeyTrio::kCur), &aKeyTrio.GetKey(Mac::KeyTrio::kNext), keyType);
 }
 
 inline Error Radio::GetTransmitPower(int8_t &aPower) { return otPlatRadioGetTransmitPower(GetInstancePtr(), &aPower); }
@@ -1072,13 +1063,7 @@ inline void Radio::SetShortAddress(Mac::ShortAddress) {}
 
 inline void Radio::SetAlternateShortAddress(Mac::ShortAddress) {}
 
-inline void Radio::SetMacKey(uint8_t,
-                             uint8_t,
-                             const Mac::KeyMaterial &,
-                             const Mac::KeyMaterial &,
-                             const Mac::KeyMaterial &)
-{
-}
+inline void Radio::SetMacKey(uint8_t, const Mac::KeyTrio &) {}
 
 inline Error Radio::GetTransmitPower(int8_t &) { return kErrorNotImplemented; }
 

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -340,20 +340,14 @@ void KeyManager::UpdateKeyMaterial(void)
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
     {
-        Mac::KeyMaterial curKey;
-        Mac::KeyMaterial prevKey;
-        Mac::KeyMaterial nextKey;
+        HashKeys prevHashKeys;
+        HashKeys nextHashKeys;
 
-        curKey.SetFrom(hashKeys.GetMacKey(), Mac::kDefaultMacKeysExportable);
+        ComputeKeys(mKeySequence - 1, prevHashKeys);
+        ComputeKeys(mKeySequence + 1, nextHashKeys);
 
-        ComputeKeys(mKeySequence - 1, hashKeys);
-        prevKey.SetFrom(hashKeys.GetMacKey(), Mac::kDefaultMacKeysExportable);
-
-        ComputeKeys(mKeySequence + 1, hashKeys);
-        nextKey.SetFrom(hashKeys.GetMacKey(), Mac::kDefaultMacKeysExportable);
-
-        Get<Mac::SubMac>().SetMacKey(Mac::Frame::kKeyIdMode1, Mac::DetermineKeyIndexFor(mKeySequence), prevKey, curKey,
-                                     nextKey);
+        Get<Mac::SubMac>().SetMacKey(Mac::Frame::kKeyIdMode1, Mac::DetermineKeyIndexFor(mKeySequence),
+                                     prevHashKeys.GetMacKey(), hashKeys.GetMacKey(), nextHashKeys.GetMacKey());
     }
 #endif
 


### PR DESCRIPTION
This commit introduces `KeyTrio` in `mac_types.hpp` to bundle the previous, current, and next MAC keys along with their associated key index into a single class.

This commit also updates `SubMac`, `Radio`, `LinkRaw`, and `KeyManager` to  use `KeyTrio`, simplifying method parameter lists and removing intermediate key buffer copies when updating MAC security material.