### PR TITLE
[radio] introduce secured Enh-ACK properties to `RxFrameProperties`

### DIFF
--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -329,7 +329,7 @@ void DataPollSender::ProcessTxDone(const Mac::TxFrame &aFrame, const Mac::RxFram
     VerifyOrExit(aFrame.GetSecurityEnabled());
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    if (aFrame.mInfo.mTxInfo.mIsARetx && aFrame.Has<Mac::CslIe>())
+    if (aFrame.IsARetransmission() && aFrame.Has<Mac::CslIe>())
     {
         // For retransmission frame, use a data poll to resync its parent with correct CSL phase
         sendDataPoll = true;

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -304,9 +304,9 @@ void SubMac::HandleReceiveDone(RxFrame *aFrame, Error aError)
         mPcapCallback.Invoke(aFrame, false);
     }
 
-    if (!ShouldHandleTransmitSecurity() && aFrame != nullptr && aFrame->mInfo.mRxInfo.mAckedWithSecEnhAck)
+    if (!ShouldHandleTransmitSecurity() && aFrame != nullptr && aFrame->IsAckedWithSecEnhAck())
     {
-        SignalFrameCounterUsed(aFrame->mInfo.mRxInfo.mAckFrameCounter, aFrame->mInfo.mRxInfo.mAckKeyId);
+        SignalFrameCounterUsed(aFrame->GetAckFrameCounter(), aFrame->GetAckKeyIndex());
     }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
@@ -438,7 +438,7 @@ void SubMac::StartCsmaBackoff(void)
             Radio::Time32 radioNow    = Get<Radio::Radio>().GetNowAsTime32();
             Radio::Time32 txStartTime = mTransmitFrame.GetTxDelayBaseTime();
 
-            txStartTime += (mTransmitFrame.mInfo.mTxInfo.mTxDelay - kAheadTime);
+            txStartTime += (mTransmitFrame.GetTxDelay() - kAheadTime);
 
             if (Radio::IsTimeStrictlyBefore(radioNow, txStartTime))
             {
@@ -511,11 +511,11 @@ void SubMac::BeginTransmit(void)
 
     error = Get<Radio::Radio>().Transmit(mTransmitFrame);
 
-    if (error == kErrorInvalidState && mTransmitFrame.mInfo.mTxInfo.mTxDelay > 0)
+    if (error == kErrorInvalidState && mTransmitFrame.GetTxDelay() > 0)
     {
         // Platform `transmit_at` fails and we send the frame directly.
-        mTransmitFrame.mInfo.mTxInfo.mTxDelay         = 0;
-        mTransmitFrame.mInfo.mTxInfo.mTxDelayBaseTime = 0;
+        mTransmitFrame.SetTxDelay(0);
+        mTransmitFrame.SetTxDelayBaseTime(0);
 
         error = Get<Radio::Radio>().Transmit(mTransmitFrame);
     }

--- a/src/core/mac/sub_mac_csl_receiver.cpp
+++ b/src/core/mac/sub_mac_csl_receiver.cpp
@@ -92,7 +92,7 @@ void SubMac::UpdateCslLastSyncTimestamp(RxFrame *aFrame, Error aError)
 #endif
 
     // Assuming the risk of the parent missing the Enh-ACK in favor of smaller CSL receive window
-    if ((mCslPeriod > 0) && aFrame->mInfo.mRxInfo.mAckedWithSecEnhAck)
+    if ((mCslPeriod > 0) && aFrame->IsAckedWithSecEnhAck())
     {
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_LOCAL_TIME_SYNC
         mCslLastSync = TimerMicro::GetNow();

--- a/src/core/radio/radio_frame.hpp
+++ b/src/core/radio/radio_frame.hpp
@@ -194,6 +194,32 @@ public:
     bool IsAckedWithFramePending(void) const { return AsFrame().mInfo.mRxInfo.mAckedWithFramePending; }
 
     /**
+     * Indicates whether or not the frame was acknowledged with a secured Enh-ACK.
+     *
+     * @retval TRUE   The frame was acknowledged with a secured Enh-ACK.
+     * @retval FALSE  The frame was not acknowledged with a secured Enh-ACK.
+     */
+    bool IsAckedWithSecEnhAck(void) const { return AsFrame().mInfo.mRxInfo.mAckedWithSecEnhAck; }
+
+    /**
+     * Returns the frame counter from the received secured Enh-ACK.
+     *
+     * Only applicable when `IsAckedWithSecEnhAck()` is true.
+     *
+     * @returns The secured Enh-ACK frame counter.
+     */
+    uint32_t GetAckFrameCounter(void) const { return AsFrame().mInfo.mRxInfo.mAckFrameCounter; }
+
+    /**
+     * Returns the key index from the received secured Enh-ACK.
+     *
+     * Only applicable when `IsAckedWithSecEnhAck()` is true.
+     *
+     * @returns The secured Enh-ACK key index.
+     */
+    uint8_t GetAckKeyIndex(void) const { return AsFrame().mInfo.mRxInfo.mAckKeyId; }
+
+    /**
      * Returns the timestamp when the frame was received.
      *
      * The value SHALL be the time of the local radio clock in
@@ -422,7 +448,6 @@ public:
     void SetTimeSyncSeq(uint8_t aTimeSyncSeq) { AsFrame().mInfo.mTxInfo.mIeInfo->mTimeSyncSeq = aTimeSyncSeq; }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
-#if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
     /**
      * Gets the TX delay field for the frame.
      *
@@ -450,7 +475,6 @@ public:
      * @param[in]    aTxDelayBaseTime    The delay base time for the TX frame.
      */
     void SetTxDelayBaseTime(Time32 aTxDelayBaseTime) { AsFrame().mInfo.mTxInfo.mTxDelayBaseTime = aTxDelayBaseTime; }
-#endif
 
 private:
     Frame       &AsFrame(void) { return *static_cast<TxFrameType *>(this); }

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -110,7 +110,7 @@ extern "C" void otPlatRadioTxDone(otInstance *aInstance, otRadioFrame *aFrame, o
     if (instance.Get<Radio::Radio>().GetDiagMode())
     {
 #if OPENTHREAD_RADIO
-        uint8_t channel = txFrame.mInfo.mTxInfo.mRxChannelAfterTxDone;
+        uint8_t channel = txFrame.GetRxChannelAfterTxDone();
 
         if (channel != aFrame->mChannel)
         {
@@ -171,7 +171,7 @@ extern "C" void otPlatDiagRadioTransmitDone(otInstance *aInstance, otRadioFrame 
 {
     Mac::TxFrame &txFrame = *static_cast<Mac::TxFrame *>(aFrame);
 #if OPENTHREAD_RADIO
-    uint8_t channel = txFrame.mInfo.mTxInfo.mRxChannelAfterTxDone;
+    uint8_t channel = txFrame.GetRxChannelAfterTxDone();
 
     if (channel != aFrame->mChannel)
     {


### PR DESCRIPTION
This commit introduces `IsAckedWithSecEnhAck()`, `GetAckFrameCounter()`, and `GetAckKeyIndex()` helper methods in `RxFrameProperties` class to encapsulate raw received Enh-ACK security information.

This commit also updates the remaining direct struct member accesses of `mInfo.mTxInfo` across `data_poll_sender.cpp`, `sub_mac.cpp`, and `radio_platform.cpp` to use the matching `TxFrameProperties` helper methods.