### PR TITLE
[sub-mac] select transmit key material by key index from `KeyTrio`

### DIFF
--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -37,6 +37,7 @@
 
 #include "common/bit_utils.hpp"
 #include "common/code_utils.hpp"
+#include "common/num_utils.hpp"
 #include "common/random.hpp"
 #include "common/string.hpp"
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
@@ -374,7 +375,59 @@ void KeyTrio::Set(uint8_t aKeyIndex, const Key &aPrevKey, const Key &aCurKey, co
     mKeys[kNext].SetFrom(aNextKey, kIsExportable);
 }
 
+const KeyMaterial &KeyTrio::SelectKey(uint8_t aKeyIndex) const
+{
+    const KeyMaterial *key = &GetKey(kCur);
+
+    if (aKeyIndex == mKeyIndex)
+    {
+        ExitNow();
+    }
+
+    VerifyOrExit(IsValueInRange(mKeyIndex, kMinKeyIndex, kMaxKeyIndex));
+
+    if (aKeyIndex == DeterminePrevKeyIndex(mKeyIndex))
+    {
+        key = &GetKey(kPrev);
+    }
+    else if (aKeyIndex == DetermineNextKeyIndex(mKeyIndex))
+    {
+        key = &GetKey(kNext);
+    }
+
+exit:
+    return *key;
+}
+
 uint8_t DetermineKeyIndexFor(uint32_t aKeySequence) { return static_cast<uint8_t>((aKeySequence & 0x7f) + 1); }
+
+uint8_t DetermineNextKeyIndex(uint8_t aKeyIndex)
+{
+    uint8_t nextIndex = aKeyIndex;
+
+    nextIndex++;
+
+    if (nextIndex > kMaxKeyIndex)
+    {
+        nextIndex = kMinKeyIndex;
+    }
+
+    return nextIndex;
+}
+
+uint8_t DeterminePrevKeyIndex(uint8_t aKeyIndex)
+{
+    uint8_t prevIndex = aKeyIndex;
+
+    prevIndex--;
+
+    if (prevIndex < kMinKeyIndex)
+    {
+        prevIndex = kMaxKeyIndex;
+    }
+
+    return prevIndex;
+}
 
 #if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
 uint8_t GetWakeupIdLength(WakeupId aWakeupId)

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -689,6 +689,20 @@ public:
      */
     uint8_t GetKeyIndex(void) const { return mKeyIndex; }
 
+    /**
+     * Selects the MAC key from the trio for a given key index.
+     *
+     * This method always returns a valid key. If the given key index matches the current, previous, or next key index
+     * in the trio, the corresponding key material is returned. If the given key index does not match any of these,
+     * the current key material is returned by default. This is a safety precaution to ensure that any frame with
+     * security enabled is encrypted using a valid key.
+     *
+     * @param[in] aKeyIndex  The key index to select.
+     *
+     * @returns A reference to the selected MAC key.
+     */
+    const KeyMaterial &SelectKey(uint8_t aKeyIndex) const;
+
 private:
     static constexpr bool    kIsExportable = OPENTHREAD_CONFIG_PLATFORM_MAC_KEYS_EXPORTABLE_ENABLE;
     static constexpr uint8_t kNumTypes     = 3;
@@ -699,6 +713,9 @@ private:
     uint8_t     mKeyIndex;
 };
 
+constexpr uint8_t kMinKeyIndex = 1;    ///< Minimum Key Index value.
+constexpr uint8_t kMaxKeyIndex = 0x80; ///< Maximum Key Index value.
+
 /**
  * Determines the MAC Key Index for a given Key Sequence.
  *
@@ -707,6 +724,30 @@ private:
  * @returns The MAC Key Index corresponding to @p aKeySequence.
  */
 uint8_t DetermineKeyIndexFor(uint32_t aKeySequence);
+
+/**
+ * Determines the next MAC Key Index (handling 1-128 wrap-around).
+ *
+ * The caller MUST ensure @p aKeyIndex is valid and within range (`kMinKeyIndex` to `kMaxKeyIndex`), otherwise the
+ * behavior is undefined.
+ *
+ * @param[in] aKeyIndex  The current Key Index value.
+ *
+ * @returns The next MAC Key Index value.
+ */
+uint8_t DetermineNextKeyIndex(uint8_t aKeyIndex);
+
+/**
+ * Determines the previous MAC Key Index (handling 1-128 wrap-around).
+ *
+ * The caller MUST ensure @p aKeyIndex is valid and within range (`kMinKeyIndex` to `kMaxKeyIndex`), otherwise the
+ * behavior is undefined.
+ *
+ * @param[in] aKeyIndex  The current Key Index value.
+ *
+ * @returns The previous MAC Key Index value.
+ */
+uint8_t DeterminePrevKeyIndex(uint8_t aKeyIndex);
 
 /**
  * Represents Link Frame Counters for all supported radio links.

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -342,6 +342,7 @@ void SubMac::ProcessTransmitSecurity(void)
 {
     const ExtAddress *extAddress = nullptr;
     uint8_t           keyIdMode;
+    uint8_t           keyIndex;
 
     VerifyOrExit(mTransmitFrame.GetSecurityEnabled());
     VerifyOrExit(!mTransmitFrame.IsSecurityProcessed());
@@ -350,7 +351,12 @@ void SubMac::ProcessTransmitSecurity(void)
 
     if (!mTransmitFrame.IsHeaderUpdated())
     {
-        mTransmitFrame.SetKeyIndex(mKeyTrio.GetKeyIndex());
+        keyIndex = mKeyTrio.GetKeyIndex();
+        mTransmitFrame.SetKeyIndex(keyIndex);
+    }
+    else
+    {
+        SuccessOrExit(mTransmitFrame.GetKeyIndex(keyIndex));
     }
 
     VerifyOrExit(ShouldHandleTransmitSecurity());
@@ -366,14 +372,14 @@ void SubMac::ProcessTransmitSecurity(void)
         VerifyOrExit(keyIdMode == Frame::kKeyIdMode1);
     }
 
-    mTransmitFrame.SetAesKey(GetMacKey(KeyTrio::kCur));
+    mTransmitFrame.SetAesKey(mKeyTrio.SelectKey(keyIndex));
 
     if (!mTransmitFrame.IsHeaderUpdated())
     {
         uint32_t frameCounter = GetFrameCounter();
 
         mTransmitFrame.SetFrameCounter(frameCounter);
-        SignalFrameCounterUsed(frameCounter, mKeyTrio.GetKeyIndex());
+        SignalFrameCounterUsed(frameCounter, keyIndex);
     }
 
     extAddress = &GetExtAddress();


### PR DESCRIPTION
This commit fixes an issue in `SubMac::ProcessTransmitSecurity()` where it always used the current active MAC key.

While using the current key works in most scenarios, it fails during retransmissions (such as indirect frame retransmissions) if the original attempt occurred right before a key rotation. In these cases, the frame key index actually points to the previous MAC key, but the code incorrectly forced the new current key.

This commit resolves the issue by reading the key index directly from the frame's header and using newly introduced `KeyTrio::SelectKey` to lookup and apply the correct key material (previous, current, or next) matching that index.

----

~This PR contains the commit from https://github.com/openthread/openthread/pull/13359. Please read and review the top commit in this PR. Thanks.~ 


Should help address #13343