### PR TITLE
[border-router] handle DHCPv6-PD socket setup failure gracefully

### DIFF
--- a/examples/platforms/simulation/infra_if.c
+++ b/examples/platforms/simulation/infra_if.c
@@ -221,11 +221,13 @@ otError otPlatInfraIfDiscoverNat64Prefix(otInstance *aInstance, uint32_t aInfraI
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_ENABLE
 
-void otPlatInfraIfDhcp6PdClientSetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex)
+otError otPlatInfraIfDhcp6PdClientSetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aEnable);
     OT_UNUSED_VARIABLE(aInfraIfIndex);
+
+    return OT_ERROR_NONE;
 }
 
 void otPlatInfraIfDhcp6PdClientSend(otInstance   *aInstance,

--- a/include/openthread/border_routing.h
+++ b/include/openthread/border_routing.h
@@ -221,6 +221,7 @@ typedef enum
     OT_BORDER_ROUTING_DHCP6_PD_STATE_STOPPED,  ///< DHCPv6 PD in enabled but won't try to request and publish a prefix.
     OT_BORDER_ROUTING_DHCP6_PD_STATE_RUNNING,  ///< DHCPv6 PD is enabled and will try to request and publish a prefix.
     OT_BORDER_ROUTING_DHCP6_PD_STATE_IDLE,     ///< DHCPv6 PD is idle; Higher-prf prefix published by other BRs.
+    OT_BORDER_ROUTING_DHCP6_PD_STATE_ERROR,    ///< DHCPv6 PD encountered a platform/socket error.
 } otBorderRoutingDhcp6PdState;
 
 /**

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (613)
+#define OPENTHREAD_API_VERSION (614)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/infra_if.h
+++ b/include/openthread/platform/infra_if.h
@@ -211,8 +211,11 @@ otError otPlatGetInfraIfLinkLayerAddress(otInstance                    *aInstanc
  * @param[in] aInstance      The OpenThread instance.
  * @param[in] aEnable        A boolean to enable (`true`) or disable (`false`) listening.
  * @param[in] aInfraIfIndex  The index of the infrastructure interface to operate on.
+ *
+ * @retval OT_ERROR_NONE    Successfully enabled or disabled listening.
+ * @retval OT_ERROR_FAILED  Failed to open/bind socket or enable listening.
  */
-void otPlatInfraIfDhcp6PdClientSetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex);
+otError otPlatInfraIfDhcp6PdClientSetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex);
 
 /**
  * Sends a DHCPv6 message to a unicast or multicast destination address.

--- a/src/cli/cli_br.cpp
+++ b/src/cli/cli_br.cpp
@@ -877,12 +877,14 @@ const char *Br::Dhcp6PdStateToString(otBorderRoutingDhcp6PdState aState)
         "stopped",  // (1) OT_BORDER_ROUTING_DHCP6_PD_STATE_STOPPED
         "running",  // (2) OT_BORDER_ROUTING_DHCP6_PD_STATE_RUNNING
         "idle",     // (3) OT_BORDER_ROUTING_DHCP6_PD_STATE_IDLE
+        "error",    // (4) OT_BORDER_ROUTING_DHCP6_PD_STATE_ERROR
     };
 
     static_assert(0 == OT_BORDER_ROUTING_DHCP6_PD_STATE_DISABLED, "DHCP6_PD_STATE_DISABLED value is incorrect");
     static_assert(1 == OT_BORDER_ROUTING_DHCP6_PD_STATE_STOPPED, "DHCP6_PD_STATE_STOPPED value is incorrect");
     static_assert(2 == OT_BORDER_ROUTING_DHCP6_PD_STATE_RUNNING, "DHCP6_PD_STATE_RUNNING value is incorrect");
     static_assert(3 == OT_BORDER_ROUTING_DHCP6_PD_STATE_IDLE, "DHCP6_PD_STATE_IDLE value is incorrect");
+    static_assert(4 == OT_BORDER_ROUTING_DHCP6_PD_STATE_ERROR, "DHCP6_PD_STATE_ERROR value is incorrect");
 
     return Stringify(aState, kDhcpv6PdStateStrings);
 }

--- a/src/core/border_router/dhcp6_pd_client.cpp
+++ b/src/core/border_router/dhcp6_pd_client.cpp
@@ -49,6 +49,7 @@ Dhcp6PdClient::Dhcp6PdClient(Instance &aInstance)
     , mState(kStateStopped)
     , mPdPrefixCommited(false)
     , mMaxSolicitTimeout(kMaxSolicitTimeout)
+    , mSocketErrorRetryInterval(kMinSocketErrorRetryInterval)
     , mTimer(aInstance)
 {
 }
@@ -60,7 +61,14 @@ void Dhcp6PdClient::Start(void)
     switch (mState)
     {
     case kStateStopped:
-        Get<InfraIf>().SetDhcp6ListeningEnabled(true);
+    case kStateError:
+        if (Get<InfraIf>().SetDhcp6ListeningEnabled(true) != kErrorNone)
+        {
+            LogWarn("Failed to enable DHCPv6 listening socket; entering error state");
+            EnterState(kStateError);
+            ExitNow();
+        }
+        mSocketErrorRetryInterval = kMinSocketErrorRetryInterval;
         OT_FALL_THROUGH;
 
     case kStateReleasing:
@@ -89,6 +97,7 @@ void Dhcp6PdClient::Stop(void)
     case kStateStopped:
     case kStateReleasing:
         break;
+    case kStateError:
     case kStateToSolicit:
     case kStateSoliciting:
     case kStateRequesting:
@@ -104,16 +113,33 @@ void Dhcp6PdClient::Stop(void)
 
 void Dhcp6PdClient::EnterState(State aState)
 {
+    State oldState = mState;
+
+    VerifyOrExit(aState != mState || aState == kStateError);
+
     LogInfo("State: %s -> %s", StateToString(mState), StateToString(aState));
 
     mState = aState;
+
+    if (oldState == kStateError || mState == kStateError)
+    {
+        Get<RoutingManager>().HandleDhcp6PdClientStateChanged();
+    }
 
     switch (mState)
     {
     case kStateStopped:
         ClearServerDuid();
         ClearPdPrefix();
-        Get<InfraIf>().SetDhcp6ListeningEnabled(false);
+        mTimer.Stop();
+        IgnoreError(Get<InfraIf>().SetDhcp6ListeningEnabled(false));
+        break;
+
+    case kStateError:
+        ClearServerDuid();
+        ClearPdPrefix();
+        mTimer.Start(Random::NonCrypto::AddJitter(mSocketErrorRetryInterval, kJitterDivisor));
+        mSocketErrorRetryInterval = Min(mSocketErrorRetryInterval * 2, kMaxSocketErrorRetryInterval);
         break;
 
     case kStateToSolicit:
@@ -157,7 +183,13 @@ void Dhcp6PdClient::EnterState(State aState)
         break;
     }
 
-    SendMessage();
+    if (mState != kStateError)
+    {
+        SendMessage();
+    }
+
+exit:
+    return;
 }
 
 void Dhcp6PdClient::HandleTimer(void)
@@ -165,6 +197,10 @@ void Dhcp6PdClient::HandleTimer(void)
     switch (mState)
     {
     case kStateStopped:
+        break;
+
+    case kStateError:
+        Start();
         break;
 
     case kStateToSolicit:
@@ -220,6 +256,7 @@ void Dhcp6PdClient::SendMessage(void)
         msgType = kMsgTypeRelease;
         break;
     case kStateStopped:
+    case kStateError:
     case kStateToSolicit:
     case kStateToRenew:
         ExitNow();
@@ -295,6 +332,7 @@ void Dhcp6PdClient::UpdateStateAfterRetxExhausted(void)
     switch (mState)
     {
     case kStateStopped:
+    case kStateError:
     case kStateToSolicit:
     case kStateSoliciting:
     case kStateToRenew:
@@ -389,6 +427,7 @@ void Dhcp6PdClient::HandleReceived(Message &aMessage)
         break;
 
     case kStateStopped:
+    case kStateError:
     case kStateToSolicit:
     case kStateToRenew:
         ExitNow();
@@ -727,6 +766,7 @@ void Dhcp6PdClient::ReportPdPrefixToRoutingManager(void)
         break;
 
     case kStateStopped:
+    case kStateError:
     case kStateReleasing:
         ExitNow();
     }
@@ -961,6 +1001,7 @@ const char *Dhcp6PdClient::StateToString(State aState)
 {
 #define StateMapList(_)               \
     _(kStateStopped, "Stopped")       \
+    _(kStateError, "Error")           \
     _(kStateToSolicit, "ToSolicit")   \
     _(kStateSoliciting, "Soliciting") \
     _(kStateRequesting, "Requesting") \

--- a/src/core/border_router/dhcp6_pd_client.hpp
+++ b/src/core/border_router/dhcp6_pd_client.hpp
@@ -116,22 +116,31 @@ public:
      */
     const DelegatedPrefix *GetDelegatedPrefix(void) const { return mPdPrefixCommited ? &mPdPrefix : nullptr; }
 
+    /**
+     * Indicates whether the client is in error state (e.g. socket bind failed).
+     *
+     * @retval TRUE   The client is in error state.
+     * @retval FALSE  The client is not in error state.
+     */
+    bool IsErrorState(void) const { return mState == kStateError; }
+
 private:
-    // All intervals are in milli-seconds (from RFC 8415 section 7.6)
-    static constexpr uint32_t kMaxDelayFirstSolicit  = Time::kOneSecondInMsec;        // SOL_MAX_DELAY
-    static constexpr uint32_t kInitialSolicitTimeout = Time::kOneSecondInMsec;        // SOL_TIMEOUT
-    static constexpr uint32_t kMaxSolicitTimeout     = 3600 * Time::kOneSecondInMsec; // SOL_MAX_RT
-    static constexpr uint32_t kInitialRequestTimeout = Time::kOneSecondInMsec;        // REQ_TIMEOUT
-    static constexpr uint32_t kMaxRequestTimeout     = 30 * Time::kOneSecondInMsec;   // REQ_MAX_RT
-    static constexpr uint16_t kMaxRequestRetxCount   = 10;                            // REQ_MAX_RC
-    static constexpr uint32_t kInitialRenewTimeout   = 10 * Time::kOneSecondInMsec;   // REN_TIMEOUT
-    static constexpr uint32_t kMaxRenewTimeout       = 600 * Time::kOneSecondInMsec;  // REN_MAX_RT
-    static constexpr uint32_t kInitialRebindTimeout  = 10 * Time::kOneSecondInMsec;   // REB_TIMEOUT
-    static constexpr uint32_t kMaxRebindTimeout      = 600 * Time::kOneSecondInMsec;  // REB_MAX_RT
-    static constexpr uint32_t kInitialReleaseTimeout = 1 * Time::kOneSecondInMsec;    // REL_TIMEOUT
-    static constexpr uint16_t kMaxReleaseRetxCount   = 4;                             // REL_MAX_RC
-    static constexpr uint32_t kInfiniteTimeout       = 0;
-    static constexpr uint16_t kInfiniteRetxCount     = 0;
+    static constexpr uint32_t kMinSocketErrorRetryInterval = 5 * Time::kOneSecondInMsec;    // 5 sec
+    static constexpr uint32_t kMaxSocketErrorRetryInterval = 60 * Time::kOneSecondInMsec;   // 60 sec
+    static constexpr uint32_t kMaxDelayFirstSolicit        = Time::kOneSecondInMsec;        // SOL_MAX_DELAY
+    static constexpr uint32_t kInitialSolicitTimeout       = Time::kOneSecondInMsec;        // SOL_TIMEOUT
+    static constexpr uint32_t kMaxSolicitTimeout           = 3600 * Time::kOneSecondInMsec; // SOL_MAX_RT
+    static constexpr uint32_t kInitialRequestTimeout       = Time::kOneSecondInMsec;        // REQ_TIMEOUT
+    static constexpr uint32_t kMaxRequestTimeout           = 30 * Time::kOneSecondInMsec;   // REQ_MAX_RT
+    static constexpr uint16_t kMaxRequestRetxCount         = 10;                            // REQ_MAX_RC
+    static constexpr uint32_t kInitialRenewTimeout         = 10 * Time::kOneSecondInMsec;   // REN_TIMEOUT
+    static constexpr uint32_t kMaxRenewTimeout             = 600 * Time::kOneSecondInMsec;  // REN_MAX_RT
+    static constexpr uint32_t kInitialRebindTimeout        = 10 * Time::kOneSecondInMsec;   // REB_TIMEOUT
+    static constexpr uint32_t kMaxRebindTimeout            = 600 * Time::kOneSecondInMsec;  // REB_MAX_RT
+    static constexpr uint32_t kInitialReleaseTimeout       = 1 * Time::kOneSecondInMsec;    // REL_TIMEOUT
+    static constexpr uint16_t kMaxReleaseRetxCount         = 4;                             // REL_MAX_RC
+    static constexpr uint32_t kInfiniteTimeout             = 0;
+    static constexpr uint16_t kInfiniteRetxCount           = 0;
 
     static constexpr uint32_t kRetxDelayOnFailedTx = 330; // in msec
 
@@ -160,6 +169,7 @@ private:
     enum State : uint8_t
     {
         kStateStopped,
+        kStateError,
         kStateToSolicit,
         kStateSoliciting,
         kStateRequesting,
@@ -262,6 +272,7 @@ private:
     bool        mPdPrefixCommited;
     RetxTracker mRetxTracker;
     uint32_t    mMaxSolicitTimeout;
+    uint32_t    mSocketErrorRetryInterval;
     PdPrefix    mPdPrefix;
     ServerDuid  mServerDuid;
     DelayTimer  mTimer;

--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -203,9 +203,9 @@ exit:
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_ENABLE
 
-void InfraIf::SetDhcp6ListeningEnabled(bool aEnable)
+Error InfraIf::SetDhcp6ListeningEnabled(bool aEnable)
 {
-    otPlatInfraIfDhcp6PdClientSetListeningEnabled(&GetInstance(), aEnable, mIfIndex);
+    return otPlatInfraIfDhcp6PdClientSetListeningEnabled(&GetInstance(), aEnable, mIfIndex);
 }
 
 void InfraIf::SendDhcp6(Message &aMessage, Ip6::Address &aDestAddress)

--- a/src/core/border_router/infra_if.hpp
+++ b/src/core/border_router/infra_if.hpp
@@ -248,7 +248,7 @@ public:
      *
      * @param[in] aEnable        A boolean to enable (`true`) or disable (`false`) listening.
      */
-    void SetDhcp6ListeningEnabled(bool aEnable);
+    Error SetDhcp6ListeningEnabled(bool aEnable);
 
     /**
      * Sends a DHCPv6 message to a unicast or multicast destination address.

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -2679,6 +2679,15 @@ void RoutingManager::PdPrefixManager::UpdateState(void)
     }
 }
 
+RoutingManager::PdPrefixManager::State RoutingManager::PdPrefixManager::GetState(void) const
+{
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_ENABLE
+    return (mState == kDhcp6PdStateRunning && Get<Dhcp6PdClient>().IsErrorState()) ? kDhcp6PdStateError : mState;
+#else
+    return mState;
+#endif
+}
+
 void RoutingManager::PdPrefixManager::SetState(State aState)
 {
     VerifyOrExit(aState != mState);
@@ -2697,6 +2706,7 @@ void RoutingManager::PdPrefixManager::SetState(State aState)
     case kDhcp6PdStateDisabled:
     case kDhcp6PdStateStopped:
     case kDhcp6PdStateIdle:
+    case kDhcp6PdStateError:
         WithdrawPrefix();
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_ENABLE
         Get<Dhcp6PdClient>().Stop();
@@ -2989,13 +2999,13 @@ void RoutingManager::PdPrefixManager::HandleEventTask(void)
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
     if (events & (kEventStateChanged | kEventPdPrefixChanged))
     {
-        Get<HistoryTracker::Local>().RecordDhcp6Pd(mState, mPrefix.GetPrefix());
+        Get<HistoryTracker::Local>().RecordDhcp6Pd(GetState(), mPrefix.GetPrefix());
     }
 #endif
 
     if (events & kEventStateChanged)
     {
-        mStateCallback.InvokeIfSet(MapEnum(mState));
+        mStateCallback.InvokeIfSet(MapEnum(GetState()));
     }
 }
 
@@ -3040,7 +3050,8 @@ const char *RoutingManager::PdPrefixManager::StateToString(State aState)
     _(kDhcp6PdStateDisabled, "Disabled") \
     _(kDhcp6PdStateStopped, "Stopped")   \
     _(kDhcp6PdStateRunning, "Running")   \
-    _(kDhcp6PdStateIdle, "Idle")
+    _(kDhcp6PdStateIdle, "Idle")         \
+    _(kDhcp6PdStateError, "Error")
 
     DefineEnumStringArray(PdPrefixManagerStateMapList);
 

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -141,6 +141,7 @@ public:
         kDhcp6PdStateStopped  = OT_BORDER_ROUTING_DHCP6_PD_STATE_STOPPED,  ///< Enabled, but currently stopped.
         kDhcp6PdStateRunning  = OT_BORDER_ROUTING_DHCP6_PD_STATE_RUNNING,  ///< Enabled, and running.
         kDhcp6PdStateIdle     = OT_BORDER_ROUTING_DHCP6_PD_STATE_IDLE,     ///< Enabled, but is not requesting prefix.
+        kDhcp6PdStateError    = OT_BORDER_ROUTING_DHCP6_PD_STATE_ERROR,    ///< Enabled, but in error state.
     };
 
     /**
@@ -505,6 +506,8 @@ public:
     {
         mPdPrefixManager.ProcessPrefixesFromRa(aRaPacket);
     }
+
+    void HandleDhcp6PdClientStateChanged(void) { mPdPrefixManager.HandleDhcp6PdClientStateChanged(); }
 
     /**
      * Returns the DHCPv6-PD based off-mesh-routable (OMR) prefix.
@@ -1010,14 +1013,15 @@ private:
         bool               HasPrefix(void) const { return !mPrefix.IsEmpty(); }
         bool               HasConflict(void) const { return mOnLinkPrefixConflict || mRoutePrefixConflict; }
         const Ip6::Prefix &GetPrefix(void) const { return mPrefix.GetPrefix(); }
-        State              GetState(void) const { return mState; }
-        void               CheckConflict(ConflictCheckEvent aEvent);
+        State              GetState(void) const;
+        void CheckConflict(ConflictCheckEvent aEvent);
 
         void  ProcessPrefixesFromRa(const InfraIf::Icmp6Packet &aRaPacket);
         void  ProcessPrefix(const Dhcp6PdPrefix &aPrefix);
         Error GetPrefix(Dhcp6PdPrefix &aPrefix) const;
         Error GetCounters(Dhcp6PdCounters &aCounters) const;
         void  HandleTimer(void) { WithdrawPrefix(); }
+        void  HandleDhcp6PdClientStateChanged(void) { SignalEvent(kEventStateChanged); }
         void  SetStateCallback(Dhcp6PdCallback aCallback, void *aContext) { mStateCallback.Set(aCallback, aContext); }
         void  Evaluate(void);
         void  HandleEventTask(void);

--- a/src/posix/platform/dhcp6_pd_socket.cpp
+++ b/src/posix/platform/dhcp6_pd_socket.cpp
@@ -48,11 +48,11 @@
 #include "platform-posix.h"
 #include "common/code_utils.hpp"
 
-extern "C" void otPlatInfraIfDhcp6PdClientSetListeningEnabled(otInstance *aInstance,
-                                                              bool        aEnable,
-                                                              uint32_t    aInfraIfIndex)
+extern "C" otError otPlatInfraIfDhcp6PdClientSetListeningEnabled(otInstance *aInstance,
+                                                                 bool        aEnable,
+                                                                 uint32_t    aInfraIfIndex)
 {
-    ot::Posix::InfraNetif::GetDhcp6PdSocket().SetListeningEnabled(aInstance, aEnable, aInfraIfIndex);
+    return ot::Posix::InfraNetif::GetDhcp6PdSocket().SetListeningEnabled(aInstance, aEnable, aInfraIfIndex);
 }
 
 extern "C" void otPlatInfraIfDhcp6PdClientSend(otInstance   *aInstance,
@@ -139,14 +139,16 @@ exit:
     return;
 }
 
-void Dhcp6PdSocket::SetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex)
+otError Dhcp6PdSocket::SetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex)
 {
+    otError error = OT_ERROR_NONE;
+
     VerifyOrExit(aEnable != mEnabled);
     mInstance = aInstance;
 
     if (aEnable)
     {
-        Enable(aInfraIfIndex);
+        error = Enable(aInfraIfIndex);
     }
     else
     {
@@ -154,18 +156,28 @@ void Dhcp6PdSocket::SetListeningEnabled(otInstance *aInstance, bool aEnable, uin
     }
 
 exit:
-    return;
+    return error;
 }
 
-void Dhcp6PdSocket::Enable(uint32_t aInfraIfIndex)
+otError Dhcp6PdSocket::Enable(uint32_t aInfraIfIndex)
 {
-    SuccessOrDie(OpenSocket(aInfraIfIndex));
-    SuccessOrDie(JoinOrLeaveMulticastGroup(/* aJoin */ true, aInfraIfIndex));
+    otError error;
+
+    SuccessOrExit(error = OpenSocket(aInfraIfIndex));
+    SuccessOrExit(error = JoinOrLeaveMulticastGroup(/* aJoin */ true, aInfraIfIndex));
 
     mEnabled      = true;
     mInfraIfIndex = aInfraIfIndex;
 
     LogInfo("Enabled");
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        CloseSocket();
+        LogWarn("Failed to enable DHCPv6 socket on infra ifindex %u: %s", aInfraIfIndex, otThreadErrorToString(error));
+    }
+    return error;
 }
 
 void Dhcp6PdSocket::Disable(uint32_t aInfraIfIndex)

--- a/src/posix/platform/dhcp6_pd_socket.hpp
+++ b/src/posix/platform/dhcp6_pd_socket.hpp
@@ -103,8 +103,8 @@ public:
     void Process(const otSysMainloopContext &aContext);
 
     // otPlatInfraIfDhcp6PdClient APIs
-    void SetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex);
-    void Send(otMessage *aMessage, const otIp6Address *aDstAddress, uint32_t aInfraIfIndex);
+    otError SetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex);
+    void    Send(otMessage *aMessage, const otIp6Address *aDstAddress, uint32_t aInfraIfIndex);
 
 private:
     static constexpr uint16_t kMaxMessageLength = 2000;
@@ -125,11 +125,11 @@ private:
     otIp6Address   mMulticastAddress;
     otInstance    *mInstance;
 
-    void Enable(uint32_t aInfraIfIndex);
-    void Disable(uint32_t aInfraIfIndex);
-    void ClearTxQueue(void);
-    void SendQueuedMessages(void);
-    void ReceiveMessage(void);
+    otError Enable(uint32_t aInfraIfIndex);
+    void    Disable(uint32_t aInfraIfIndex);
+    void    ClearTxQueue(void);
+    void    SendQueuedMessages(void);
+    void    ReceiveMessage(void);
 
     otError OpenSocket(uint32_t aInfraIfIndex);
     otError JoinOrLeaveMulticastGroup(bool aJoin, uint32_t aInfraIfIndex);

--- a/tests/nexus/platform/nexus_infra_if.cpp
+++ b/tests/nexus/platform/nexus_infra_if.cpp
@@ -680,10 +680,11 @@ otError otPlatGetInfraIfLinkLayerAddress(otInstance                    *aInstanc
     return OT_ERROR_NONE;
 }
 
-void otPlatInfraIfDhcp6PdClientSetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex)
+otError otPlatInfraIfDhcp6PdClientSetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex)
 {
     OT_UNUSED_VARIABLE(aInfraIfIndex);
     AsNode(aInstance).mInfraIf.SetDhcp6ListeningEnabled(aEnable);
+    return OT_ERROR_NONE;
 }
 
 void otPlatInfraIfDhcp6PdClientSend(otInstance *aInstance, otMessage *aMessage, otIp6Address *aDest, uint32_t aIfIndex)

--- a/tests/unit/test_dhcp6_pd_client.cpp
+++ b/tests/unit/test_dhcp6_pd_client.cpp
@@ -797,18 +797,31 @@ void Dhcp6TxMsg::Send(void)
 
 typedef BorderRouter::Dhcp6PdClient::DelegatedPrefix DelegatedPrefix;
 
-static bool                               sDhcp6ListeningEnabled = false;
+static bool                               sDhcp6ListeningEnabled         = false;
+static otError                            sDhcp6SetListeningEnabledError = OT_ERROR_NONE;
 static Array<Dhcp6RxMsg, kMaxDhcp6RxMsgs> sDhcp6RxMsgs;
 
 extern "C" {
 
-void otPlatInfraIfDhcp6PdClientSetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex)
+otError otPlatInfraIfDhcp6PdClientSetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex)
 {
+    otError error = OT_ERROR_NONE;
+
     Log("otPlatInfraIfDhcp6PdClientSetListeningEnabled(aEnable:%u)", aEnable);
 
     VerifyOrQuit(aInstance == sInstance);
     VerifyOrQuit(aInfraIfIndex == kInfraIfIndex);
+
+    if (aEnable && sDhcp6SetListeningEnabledError != OT_ERROR_NONE)
+    {
+        error = sDhcp6SetListeningEnabledError;
+        ExitNow();
+    }
+
     sDhcp6ListeningEnabled = aEnable;
+
+exit:
+    return error;
 }
 
 void otPlatInfraIfDhcp6PdClientSend(otInstance   *aInstance,
@@ -882,10 +895,12 @@ void InitTest(void)
     sAlarmOn  = false;
     sInstance = static_cast<Instance *>(testInitInstance());
 
-    sDhcp6ListeningEnabled = false;
+    sDhcp6ListeningEnabled         = false;
+    sDhcp6SetListeningEnabledError = OT_ERROR_NONE;
     sDhcp6RxMsgs.Clear();
 
     SuccessOrQuit(otBorderRoutingInit(sInstance, kInfraIfIndex, /* aInfraIfIsRunning */ true));
+    SuccessOrQuit(otBorderRoutingSetEnabled(sInstance, true));
     AdvanceTime(100);
 }
 
@@ -2591,6 +2606,94 @@ void TestDhcp6PdServerReplyWithNoBindingToRelease(void)
     FinalizeTest();
 }
 
+void TestDhcp6PdSocketBindFailureAndRecovery(void)
+{
+    uint32_t heapAllocations;
+
+    Log("---------------------------------------------------------------------------------------------");
+    Log("TestDhcp6PdSocketBindFailureAndRecovery()");
+
+    InitTest();
+    heapAllocations = sHeapAllocatedPtrs.GetLength();
+
+    otBorderRoutingDhcp6PdSetEnabled(sInstance, false);
+    sDhcp6SetListeningEnabledError = OT_ERROR_FAILED;
+
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
+    Log("Start client when socket listening fails");
+
+    otBorderRoutingDhcp6PdSetEnabled(sInstance, true);
+
+    Log("clientState:%u, pdState:%u", sInstance->Get<BorderRouter::Dhcp6PdClient>().IsErrorState(),
+        otBorderRoutingDhcp6PdGetState(sInstance));
+
+    VerifyOrQuit(sInstance->Get<BorderRouter::Dhcp6PdClient>().IsErrorState() == true);
+    VerifyOrQuit(otBorderRoutingDhcp6PdGetState(sInstance) == OT_BORDER_ROUTING_DHCP6_PD_STATE_ERROR);
+
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
+    Log("Advance time past 1st retry interval (5s + jitter) with socket still failing");
+
+    AdvanceTime(6 * 1000);
+    VerifyOrQuit(sInstance->Get<BorderRouter::Dhcp6PdClient>().IsErrorState() == true);
+    VerifyOrQuit(otBorderRoutingDhcp6PdGetState(sInstance) == OT_BORDER_ROUTING_DHCP6_PD_STATE_ERROR);
+
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
+    Log("Fix socket failure and advance time past 2nd retry interval (10s + jitter)");
+
+    sDhcp6SetListeningEnabledError = OT_ERROR_NONE;
+
+    AdvanceTime(12 * 1000);
+
+    VerifyOrQuit(sInstance->Get<BorderRouter::Dhcp6PdClient>().IsErrorState() == false);
+    VerifyOrQuit(otBorderRoutingDhcp6PdGetState(sInstance) == OT_BORDER_ROUTING_DHCP6_PD_STATE_RUNNING);
+
+    otBorderRoutingDhcp6PdSetEnabled(sInstance, false);
+    sDhcp6RxMsgs.Clear();
+
+    VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
+
+    Log("End of TestDhcp6PdSocketBindFailureAndRecovery()");
+
+    FinalizeTest();
+}
+
+void TestDhcp6PdSocketBindFailureStop(void)
+{
+    uint32_t heapAllocations;
+
+    Log("---------------------------------------------------------------------------------------------");
+    Log("TestDhcp6PdSocketBindFailureStop()");
+
+    InitTest();
+    heapAllocations = sHeapAllocatedPtrs.GetLength();
+
+    otBorderRoutingDhcp6PdSetEnabled(sInstance, false);
+    sDhcp6SetListeningEnabledError = OT_ERROR_FAILED;
+
+    Log("Start client when socket listening fails");
+    otBorderRoutingDhcp6PdSetEnabled(sInstance, true);
+
+    VerifyOrQuit(sInstance->Get<BorderRouter::Dhcp6PdClient>().IsErrorState() == true);
+    VerifyOrQuit(otBorderRoutingDhcp6PdGetState(sInstance) == OT_BORDER_ROUTING_DHCP6_PD_STATE_ERROR);
+
+    Log("Stop client while in error state");
+    otBorderRoutingDhcp6PdSetEnabled(sInstance, false);
+
+    VerifyOrQuit(sInstance->Get<BorderRouter::Dhcp6PdClient>().IsErrorState() == false);
+    VerifyOrQuit(otBorderRoutingDhcp6PdGetState(sInstance) == OT_BORDER_ROUTING_DHCP6_PD_STATE_DISABLED);
+
+    sDhcp6SetListeningEnabledError = OT_ERROR_NONE;
+
+    AdvanceTime(60 * 1000);
+    VerifyOrQuit(sDhcp6RxMsgs.IsEmpty());
+
+    VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
+
+    Log("End of TestDhcp6PdSocketBindFailureStop()");
+
+    FinalizeTest();
+}
+
 #endif // OT_CONFIG_DHCP6_PD_CLIENT_ENABLE
 
 } // namespace ot
@@ -2611,6 +2714,8 @@ int main(void)
     ot::TestDhcp6PdServerNotExtendingLeaseDuringRenew();
     ot::TestDhcp6PdServerReplacingPrefix();
     ot::TestDhcp6PdServerReplyWithNoBindingToRelease();
+    ot::TestDhcp6PdSocketBindFailureAndRecovery();
+    ot::TestDhcp6PdSocketBindFailureStop();
 
     printf("All tests passed\n");
 #else

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -513,13 +513,15 @@ OT_TOOL_WEAK otError otPlatInfraIfDiscoverNat64Prefix(otInstance *, uint32_t) { 
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_ENABLE
 
-OT_TOOL_WEAK void otPlatInfraIfDhcp6PdClientSetListeningEnabled(otInstance *aInstance,
-                                                                bool        aEnable,
-                                                                uint32_t    aInfraIfIndex)
+OT_TOOL_WEAK otError otPlatInfraIfDhcp6PdClientSetListeningEnabled(otInstance *aInstance,
+                                                                   bool        aEnable,
+                                                                   uint32_t    aInfraIfIndex)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aEnable);
     OT_UNUSED_VARIABLE(aInfraIfIndex);
+
+    return OT_ERROR_NONE;
 }
 
 OT_TOOL_WEAK void otPlatInfraIfDhcp6PdClientSend(otInstance   *aInstance,


### PR DESCRIPTION
This commit enhances DHCPv6-PD error handling to prevent otbr-agent crashes when the platform fails to open or bind UDP port 546 (e.g., when another host DHCPv6 daemon is running).

Key changes:
- Updated otPlatInfraIfDhcp6PdClientSetListeningEnabled platform API return type from void to otError to surface socket initialization failures to OpenThread core.
- Added OT_BORDER_ROUTING_DHCP6_PD_STATE_ERROR (value 4) to public enum otBorderRoutingDhcp6PdState and mapped string "error" in CLI.
- Updated Dhcp6PdClient to enter kStateError on socket setup failure, scheduling retries with exponential backoff (5s to 60s + jitter) and notifying RoutingManager of state changes.
- Updated RoutingManager::PdPrefixManager to return and record kDhcp6PdStateError when Dhcp6PdClient is in error state, firing state change callbacks for DBus and external subscribers.
- Replaced SuccessOrDie() in POSIX Dhcp6PdSocket::Enable() with graceful error propagation and LogWarn logging.
- Added unit tests in test_dhcp6_pd_client.cpp verifying error state transitions, backoff recovery, and stop handling.

Depends-On: https://github.com/openthread/ot-br-posix/pull/3475