### PR TITLE
[radio] move PHY header constants to Radio namespace

### DIFF
--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -136,14 +136,6 @@ public:
 
     static constexpr uint16_t kInfoStringSize = 128; ///< Max chars for `InfoString` (ToInfoString()).
 
-    static constexpr uint8_t kPreambleSize  = 4;
-    static constexpr uint8_t kSfdSize       = 1;
-    static constexpr uint8_t kPhrSize       = 1;
-    static constexpr uint8_t kPhyHeaderSize = kPreambleSize + kSfdSize + kPhrSize;
-    static constexpr uint8_t kFcfSize       = sizeof(uint16_t);
-    static constexpr uint8_t kDsnSize       = sizeof(uint8_t);
-    static constexpr uint8_t kImmAckLength  = kFcfSize + kDsnSize + k154FcsSize;
-
     /**
      * Defines the fixed-length `String` object returned from `ToInfoString()` method.
      */
@@ -607,7 +599,18 @@ public:
      */
     uint16_t GetFrameControlField(void) const { return LittleEndian::ReadUint16(mPsdu); }
 
+    /**
+     * Returns the Immediate Acknowledgment (Imm-Ack) frame length in bytes.
+     *
+     * @returns The Imm-Ack frame length in bytes.
+     */
+    static constexpr uint8_t GetImmAckLength(void) { return kImmAckLength; }
+
 protected:
+    static constexpr uint8_t kFcfSize      = sizeof(uint16_t);
+    static constexpr uint8_t kDsnSize      = sizeof(uint8_t);
+    static constexpr uint8_t kImmAckLength = kFcfSize + kDsnSize + k154FcsSize;
+
     static constexpr uint8_t kSecurityControlSize = sizeof(uint8_t);
     static constexpr uint8_t kFrameCounterSize    = sizeof(uint32_t);
     static constexpr uint8_t kCommandIdSize       = sizeof(uint8_t);

--- a/src/core/radio/radio.cpp
+++ b/src/core/radio/radio.cpp
@@ -195,8 +195,8 @@ void Statistics::RecordTxDone(Error aError, uint16_t aPsduLength)
 {
     if (aError == kErrorNone || aError == kErrorNoAck)
     {
-        uint32_t txTimeUs    = (aPsduLength + Mac::Frame::kPhyHeaderSize) * kSymbolsPerOctet * kSymbolTime;
-        uint32_t rxAckTimeUs = (Mac::Frame::kImmAckLength + Mac::Frame::kPhyHeaderSize) * kPhyUsPerByte;
+        uint32_t txTimeUs    = (aPsduLength + kPhyHeaderSize) * kSymbolsPerOctet * kSymbolTime;
+        uint32_t rxAckTimeUs = (Mac::Frame::GetImmAckLength() + kPhyHeaderSize) * kPhyUsPerByte;
 
         UpdateTime();
         mTimeStats.mTxTime += txTimeUs;
@@ -225,7 +225,7 @@ void Statistics::RecordRxDone(Error aError)
 
     UpdateTime();
     // Currently we cannot know the actual length of ACK. So assume the ACK is an immediate ACK.
-    ackTimeUs = (Mac::Frame::kImmAckLength + Mac::Frame::kPhyHeaderSize) * kPhyUsPerByte;
+    ackTimeUs = (Mac::Frame::GetImmAckLength() + kPhyHeaderSize) * kPhyUsPerByte;
     mTimeStats.mTxTime += ackTimeUs;
     if (mStatus == kReceive)
     {

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -62,6 +62,11 @@ namespace Radio {
  * @{
  */
 
+constexpr uint8_t kPreambleSize  = 4;                                   ///< Preamble size in bytes.
+constexpr uint8_t kSfdSize       = 1;                                   ///< SFD size in bytes.
+constexpr uint8_t kPhrSize       = 1;                                   ///< PHY Header (PHR) size in bytes.
+constexpr uint8_t kPhyHeaderSize = kPreambleSize + kSfdSize + kPhrSize; ///< Total PHY header size in bytes.
+
 constexpr uint32_t kUsPerTenSymbols   = OT_US_PER_TEN_SYMBOLS; ///< Time for 10 symbols in units of microseconds
 constexpr uint32_t kHeaderShrDuration = 160;                   ///< Duration of SHR in us
 constexpr uint32_t kHeaderPhrDuration = 32;                    ///< Duration of PHR in us

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -745,8 +745,6 @@ void TestMacFrameApi(void)
 
 void TestMacFrameAckGeneration(void)
 {
-    constexpr uint8_t kImmAckLength = 5;
-
     Mac::RxFrame receivedFrame;
     Mac::TxFrame ackFrame;
     uint8_t      ackFrameBuffer[100];
@@ -782,7 +780,7 @@ void TestMacFrameAckGeneration(void)
     receivedFrame.mLength = sizeof(data_psdu1);
 
     ackFrame.GenerateImmAck(receivedFrame, false);
-    VerifyOrQuit(ackFrame.mLength == kImmAckLength);
+    VerifyOrQuit(ackFrame.mLength == Mac::Frame::GetImmAckLength());
     VerifyOrQuit(ackFrame.GetType() == Mac::Frame::kTypeAck);
     VerifyOrQuit(!ackFrame.GetSecurityEnabled());
     VerifyOrQuit(!ackFrame.GetFramePending());


### PR DESCRIPTION
This commit moves the PHY header size constants (`kPreambleSize`, `kSfdSize`, `kPhrSize`, and `kPhyHeaderSize`) from `Mac::Frame` to the `Radio` namespace.

This commit also introduces a static `Mac::Frame::GetImmAckLength()` method to access the Imm-Ack frame length and updates `Radio::Statistics` to use it.