### PR TITLE
[instance] guard key-ref offset setup for MTD/FTD

### DIFF
--- a/src/core/instance/instance.cpp
+++ b/src/core/instance/instance.cpp
@@ -332,7 +332,8 @@ Instance::Instance(void)
     , mIsInitialized(false)
     , mId(Random::NonCrypto::Generate<uint32_t>())
 {
-#if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE && OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
+#if (OPENTHREAD_MTD || OPENTHREAD_FTD) && OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE && \
+    OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
 #if OPENTHREAD_CONFIG_MULTIPLE_STATIC_INSTANCE_ENABLE
     mCryptoStorageKeyRefManager.SetKeyRefExtraOffset(Crypto::Storage::KeyRefManager::kKeyRefExtraOffset * GetIdx(this));
 #else


### PR DESCRIPTION
Fix a macro guard mismatch in Instance constructor: the key-ref extra offset setup now requires `(OPENTHREAD_MTD || OPENTHREAD_FTD)` in addition to `MULTIPLE_INSTANCE` and `PLATFORM_KEY_REFERENCES`. This matches where `KeyRefManager` is defined and avoids RADIO build issues.