### PR TITLE
[radio] move `CalculateBusTransferTime()` to `Radio` class

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2742,20 +2742,5 @@ exit:
 }
 #endif // OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
 
-uint32_t Mac::CalculateRadioBusTransferTime(uint16_t aFrameSize) const
-{
-    uint32_t busSpeed     = Get<Radio::Radio>().GetBusSpeed();
-    uint32_t trasnferTime = 0;
-
-    if (busSpeed != 0)
-    {
-        trasnferTime = DivideAndRoundUp<uint32_t>(aFrameSize * kBitsPerByte * Time::kOneSecondInUsec, busSpeed);
-    }
-
-    trasnferTime += Get<Radio::Radio>().GetBusLatency();
-
-    return trasnferTime;
-}
-
 } // namespace Mac
 } // namespace ot

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -745,16 +745,6 @@ public:
     bool IsWakeupListenEnabled(void) const { return mWakeupListenEnabled; }
 #endif // OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
 
-    /**
-     * Calculates the radio bus transfer time (in microseconds) for a given frame size based on `Radio::GetBusSpeed()`
-     * and `Radio::GetBusLatency()`.
-     *
-     * @param[in] aFrameSize   The frame size to calculate for, in bytes.
-     *
-     * @returns The calculated radio bus transfer time in microseconds.
-     */
-    uint32_t CalculateRadioBusTransferTime(uint16_t aFrameSize) const;
-
 private:
     static constexpr uint16_t kMaxCcaSampleCount = OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW;
 

--- a/src/core/mac/wakeup_tx_scheduler.cpp
+++ b/src/core/mac/wakeup_tx_scheduler.cpp
@@ -162,7 +162,7 @@ void WakeupTxScheduler::HandleRadioBusLatencyChanged(void)
     // This is used to make sure that a wake-up frame is received by the radio early enough to be transmitted on time.
     constexpr uint32_t kWakeupFrameSize = 100;
 
-    mTxRequestAheadTimeUs = Mac::kCslRequestAhead + Get<Mac::Mac>().CalculateRadioBusTransferTime(kWakeupFrameSize);
+    mTxRequestAheadTimeUs = Mac::kCslRequestAhead + Get<Radio::Radio>().CalculateBusTransferTime(kWakeupFrameSize);
 }
 
 } // namespace ot

--- a/src/core/radio/radio.cpp
+++ b/src/core/radio/radio.cpp
@@ -163,7 +163,23 @@ Error Radio::Transmit(Mac::TxFrame &aFrame)
 
     return otPlatRadioTransmit(GetInstancePtr(), &aFrame);
 }
+
 #endif // OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
+
+uint32_t Radio::CalculateBusTransferTime(uint16_t aFrameSize) const
+{
+    uint32_t busSpeed     = GetBusSpeed();
+    uint32_t transferTime = 0;
+
+    if (busSpeed != 0)
+    {
+        transferTime = DivideAndRoundUp<uint32_t>(aFrameSize * kBitsPerByte * Time::kOneSecondInUsec, busSpeed);
+    }
+
+    transferTime += GetBusLatency();
+
+    return transferTime;
+}
 
 //---------------------------------------------------------------------------------------------------------------------
 

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -844,17 +844,25 @@ public:
      * @returns The bus speed in bits/second between the host and the radio chip.
      *          Return 0 when the MAC and above layer and Radio layer resides on the same chip.
      */
-    uint32_t GetBusSpeed(void);
+    uint32_t GetBusSpeed(void) const;
 
     /**
      * Get the bus latency in microseconds between the host and the radio chip.
      *
-     * @param[in]   aInstance    A pointer to an OpenThread instance.
-     *
      * @returns The bus latency in microseconds between the host and the radio chip.
      *          Return 0 when the MAC and above layer and Radio layer resides on the same chip.
      */
-    uint32_t GetBusLatency(void);
+    uint32_t GetBusLatency(void) const;
+
+    /**
+     * Calculates the radio bus transfer time (in microseconds) for a given frame size based on `GetBusSpeed()` and
+     * `GetBusLatency()`.
+     *
+     * @param[in] aFrameSize   The frame size to calculate for, in bytes.
+     *
+     * @returns The calculated radio bus transfer time in microseconds.
+     */
+    uint32_t CalculateBusTransferTime(uint16_t aFrameSize) const;
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
     /**
@@ -1046,9 +1054,9 @@ inline void Radio::ClearSrcMatchShortEntries(void) { otPlatRadioClearSrcMatchSho
 
 inline void Radio::ClearSrcMatchExtEntries(void) { otPlatRadioClearSrcMatchExtEntries(GetInstancePtr()); }
 
-inline uint32_t Radio::GetBusSpeed(void) { return otPlatRadioGetBusSpeed(GetInstancePtr()); }
+inline uint32_t Radio::GetBusSpeed(void) const { return otPlatRadioGetBusSpeed(GetInstancePtr()); }
 
-inline uint32_t Radio::GetBusLatency(void) { return otPlatRadioGetBusLatency(GetInstancePtr()); }
+inline uint32_t Radio::GetBusLatency(void) const { return otPlatRadioGetBusLatency(GetInstancePtr()); }
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
 inline void Radio::SetDiagMode(bool aMode) { otPlatDiagModeSet(aMode); }
@@ -1141,9 +1149,9 @@ inline void Radio::ClearSrcMatchShortEntries(void) {}
 
 inline void Radio::ClearSrcMatchExtEntries(void) {}
 
-inline uint32_t Radio::GetBusSpeed(void) { return 0; }
+inline uint32_t Radio::GetBusSpeed(void) const { return 0; }
 
-inline uint32_t Radio::GetBusLatency(void) { return 0; }
+inline uint32_t Radio::GetBusLatency(void) const { return 0; }
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
 inline void Radio::SetDiagMode(bool) {}

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -51,7 +51,7 @@ void CslTxScheduler::HandleRadioBusLatencyChanged(void)
     // 150 bytes for bus Tx time estimation
     static constexpr uint16_t kMaxFrameSize = 150;
 
-    mCslFrameRequestAheadUs = Mac::kCslRequestAhead + Get<Mac::Mac>().CalculateRadioBusTransferTime(kMaxFrameSize);
+    mCslFrameRequestAheadUs = Mac::kCslRequestAhead + Get<Radio::Radio>().CalculateBusTransferTime(kMaxFrameSize);
 
     LogInfo("Set frame request ahead: %lu usec", ToUlong(mCslFrameRequestAheadUs));
 }


### PR DESCRIPTION
This commit moves the bus transfer time calculation method from `Mac` to the `Radio` class (renaming it from `CalculateRadioBusTransferTime ()` to `Radio::CalculateBusTransferTime()`).

This makes the bus transfer time calculation accessible to lower-level radio components (such as `SubMac` and RCP) without requiring a dependency on the `Mac` layer.