### PR TITLE
[csl] rename and hide bus latency update methods

### DIFF
--- a/src/core/mac/wakeup_tx_scheduler.cpp
+++ b/src/core/mac/wakeup_tx_scheduler.cpp
@@ -48,7 +48,7 @@ WakeupTxScheduler::WakeupTxScheduler(Instance &aInstance)
     , mTimer(aInstance)
     , mIsRunning(false)
 {
-    UpdateFrameRequestAhead();
+    HandleRadioBusLatencyChanged();
 }
 
 Error WakeupTxScheduler::WakeUp(const Mac::WakeupRequest &aWakeupRequest, uint16_t aIntervalUs, uint16_t aDurationMs)
@@ -156,7 +156,7 @@ void WakeupTxScheduler::Stop(void)
     mTimer.Stop();
 }
 
-void WakeupTxScheduler::UpdateFrameRequestAhead(void)
+void WakeupTxScheduler::HandleRadioBusLatencyChanged(void)
 {
     // A rough estimate of the size of data that has to be exchanged with the radio to schedule a wake-up frame TX.
     // This is used to make sure that a wake-up frame is received by the radio early enough to be transmitted on time.

--- a/src/core/mac/wakeup_tx_scheduler.hpp
+++ b/src/core/mac/wakeup_tx_scheduler.hpp
@@ -37,6 +37,7 @@
 #include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "mac/mac.hpp"
+#include "radio/radio.hpp"
 
 namespace ot {
 
@@ -48,6 +49,7 @@ class Child;
 class WakeupTxScheduler : public InstanceLocator, private NonCopyable
 {
     friend class Mac::Mac;
+    friend class Radio::Callbacks;
 
 public:
     /**
@@ -95,11 +97,6 @@ public:
     void Stop(void);
 
     /**
-     * Updates the value of `mTxRequestAheadTimeUs`, based on bus speed, bus latency and `Mac::kCslRequestAhead`.
-     */
-    void UpdateFrameRequestAhead(void);
-
-    /**
      * Returns the wake-up request.
      */
     const Mac::WakeupRequest &GetWakeupRequest(void) const { return mWakeupRequest; }
@@ -113,6 +110,9 @@ private:
 
     // Called by the MAC layer when a wake-up frame transmission is about to be started.
     Mac::TxFrame *PrepareWakeupFrame(Mac::TxFrames &aTxFrames);
+
+    // Callback from `Radio`
+    void HandleRadioBusLatencyChanged(void);
 
     // Called at the beginning of a wake-up sequence and right after a wake-up frame has been prepared for transmission.
     void ScheduleTimer(void);

--- a/src/core/radio/radio_callbacks.cpp
+++ b/src/core/radio/radio_callbacks.cpp
@@ -61,10 +61,10 @@ void Callbacks::HandleEnergyScanDone(int8_t aMaxRssi) { Get<Mac::SubMac>().Handl
 void Callbacks::HandleBusLatencyChanged(void)
 {
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-    Get<CslTxScheduler>().UpdateFrameRequestAhead();
+    Get<CslTxScheduler>().HandleRadioBusLatencyChanged();
 #endif
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
-    Get<WakeupTxScheduler>().UpdateFrameRequestAhead();
+    Get<WakeupTxScheduler>().HandleRadioBusLatencyChanged();
 #endif
 }
 

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -42,10 +42,10 @@ CslTxScheduler::CslTxScheduler(Instance &aInstance)
     , mCslTxMessage(nullptr)
     , mFrameContext()
 {
-    UpdateFrameRequestAhead();
+    HandleRadioBusLatencyChanged();
 }
 
-void CslTxScheduler::UpdateFrameRequestAhead(void)
+void CslTxScheduler::HandleRadioBusLatencyChanged(void)
 {
     // Longest frame on bus is 127 bytes with some metadata, we use
     // 150 bytes for bus Tx time estimation

--- a/src/core/thread/csl_tx_scheduler.hpp
+++ b/src/core/thread/csl_tx_scheduler.hpp
@@ -39,6 +39,7 @@
 #include "common/time.hpp"
 #include "mac/mac.hpp"
 #include "mac/mac_frame.hpp"
+#include "radio/radio.hpp"
 #include "thread/indirect_sender_frame_context.hpp"
 
 namespace ot {
@@ -60,6 +61,7 @@ class CslNeighbor;
 class CslTxScheduler : public InstanceLocator, private NonCopyable
 {
     friend class Mac::Mac;
+    friend class Radio::Callbacks;
     friend class IndirectSender;
 
 public:
@@ -177,11 +179,6 @@ public:
      */
     void Clear(void);
 
-    /**
-     * Updates the value of `mCslFrameRequestAheadUs`, based on bus speed, bus latency and `Mac::kCslRequestAhead`.
-     */
-    void UpdateFrameRequestAhead(void);
-
 private:
     // Guard time in usec to add when checking delay while preparing the CSL frame for tx.
     static constexpr uint32_t kFramePreparationGuardInterval = 1500;
@@ -197,6 +194,9 @@ private:
     // Callbacks from `Mac`
     Mac::TxFrame *HandleFrameRequest(Mac::TxFrames &aTxFrames);
     void          HandleSentFrame(const Mac::TxFrame &aFrame, Error aError);
+
+    // Callback from `Radio`
+    void HandleRadioBusLatencyChanged(void);
 
     void HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, CslNeighbor &aaCslNeighbor);
 


### PR DESCRIPTION
This commit renames `UpdateFrameRequestAhead()` to `HandleRadioBusLatencyChanged()` in `CslTxScheduler` and `WakeupTxScheduler`.

This commit also moves `HandleRadioBusLatencyChanged()` from the public interface to `private` in both schedulers, restricting access to `Radio::Callbacks` via `friend` class declarations. This clarifies that the method is an event handler triggered by radio bus latency changes and improves encapsulation.