### PR TITLE
[mac-frame] ignore IE present bit on legacy frame versions

### DIFF
--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -192,7 +192,7 @@ public:
      *
      * @returns The IEEE 802.15.4 Frame Version.
      */
-    uint16_t GetVersion(void) const { return GetFrameControlField() & kFcfFrameVersionMask; }
+    uint16_t GetVersion(void) const { return GetVersion(GetFrameControlField()); }
 
     /**
      * Returns if this IEEE 802.15.4 frame's version is 2015.
@@ -682,9 +682,10 @@ protected:
     static bool     IsSrcAddrPresent(uint16_t aFcf) { return (aFcf & kFcfSrcAddrMask) != 0; }
     static bool     IsSecurityEnabled(uint16_t aFcf) { return (aFcf & kFcfSecurityEnabled) != 0; }
     static bool     IsFramePending(uint16_t aFcf) { return (aFcf & kFcfFramePending) != 0; }
-    static bool     IsIePresent(uint16_t aFcf) { return (aFcf & kFcfIePresent) != 0; }
+    static bool     IsIePresent(uint16_t aFcf) { return IsVersion2015(aFcf) && ((aFcf & kFcfIePresent) != 0); }
     static bool     IsAckRequest(uint16_t aFcf) { return (aFcf & kFcfAckRequest) != 0; }
-    static bool     IsVersion2015(uint16_t aFcf) { return (aFcf & kFcfFrameVersionMask) == kVersion2015; }
+    static uint16_t GetVersion(uint16_t aFcf) { return (aFcf & kFcfFrameVersionMask); }
+    static bool     IsVersion2015(uint16_t aFcf) { return GetVersion(aFcf) == kVersion2015; }
     static bool     IsDstPanIdPresent(uint16_t aFcf);
     static bool     IsSrcPanIdPresent(uint16_t aFcf);
     static uint16_t DetermineFcfAddrType(const Address &aAddress, uint16_t aBitShift);

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -423,7 +423,15 @@ void TestMacHeader(void)
         {
             VerifyOrQuit(!frame.IsSequencePresent());
         }
+
         DumpBuffer(string, frame.GetPsdu(), frame.GetLength());
+
+        // Verify that the IE Present bit in FCF is only recognized for
+        // IEEE 802.15.4-2015 frame version, and is ignored for older
+        // versions (2003/2006).
+
+        frame.SetIePresent(true);
+        VerifyOrQuit(frame.IsIePresent() == (testCase.mVersion == Mac::Frame::kVersion2015));
     }
 }
 
@@ -722,6 +730,9 @@ void TestMacFrameApi(void)
     VerifyOrQuit(frame.GetType() == Mac::Frame::kTypeMacCmd);
     SuccessOrQuit(frame.GetCommandId(commandId));
     VerifyOrQuit(commandId == Mac::Frame::kMacCmdDataRequest);
+    VerifyOrQuit(!frame.IsIePresent());
+    frame.SetIePresent(true);
+    VerifyOrQuit(!frame.IsIePresent());
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
     // IEEE 802.15.4-2015 Mac Command


### PR DESCRIPTION
In legacy IEEE 802.15.4 frame formats (2003 and 2006), bits 7-9 of the Frame Control field (FCF) are defined as reserved. The standard mandates that for legacy versions, all reserved bits must be ignored upon receipt. Information Elements (IEs) and the IE Present bit (bit 9) were only introduced in IEEE 802.15.4-2015.

This commit updates `Frame::IsIePresent()` to verify that the frame version is IEEE 802.15.4-2015 or later before checking the IE Present bit in the FCF, preventing legacy frames with bit 9 set from being misinterpreted as containing IEs.