### PR TITLE
[mac-frame] enforce supported frame versions

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -894,73 +894,63 @@ exit:
 
 uint8_t Frame::SkipAddrFieldIndex(void) const
 {
-    uint8_t index;
+    // Returns the index after the MAC address header fields (Frame Control,
+    // Sequence Number, Destination/Source PAN ID, and Destination/Source
+    // Addresses). If the header is invalid, returns `kInvalidIndex`.
 
-    VerifyOrExit(kFcfSize + GetFcsSize() <= mLength, index = kInvalidIndex);
+    static constexpr uint8_t kSizeForAddrMode[] = {
+        /* [0] kFcfAddrNone     */ 0,
+        /* [1] kFcfAddrReserved */ kInvalidSize,
+        /* [2] kFcfAddrShort    */ sizeof(ShortAddress),
+        /* [3] kFcfAddrExt      */ sizeof(ExtAddress),
+    };
 
-    index = CalculateAddrFieldSize(GetFrameControlField());
+    static_assert(kSizeForAddrMode[kFcfAddrNone] == 0, "kSizeForAddrMode[] array is incorrect");
+    static_assert(kSizeForAddrMode[kFcfAddrReserved] == kInvalidSize, "kSizeForAddrMode[] array is incorrect");
+    static_assert(kSizeForAddrMode[kFcfAddrShort] == sizeof(ShortAddress), "kSizeForAddrMode[] array is incorrect");
+    static_assert(kSizeForAddrMode[kFcfAddrExt] == sizeof(ExtAddress), "kSizeForAddrMode[] array is incorrect");
+
+    uint8_t  index = kInvalidIndex;
+    uint8_t  size;
+    uint16_t fcf;
+    uint16_t addrMode;
+
+    VerifyOrExit(kFcfSize + GetFcsSize() <= GetLength());
+
+    // Only accept standard frame types (Beacon, Data, Ack, MAC Command).
+    // Other types (e.g., Multipurpose) use a different FCF/header layout.
+    VerifyOrExit(GetType() <= kTypeMacCmd);
+
+    fcf = GetFrameControlField();
+
+    // Only accept supported frame versions (2003, 2006, 2015).
+    // Future frame versions can alter the MAC header layout.
+    VerifyOrExit(GetVersion(fcf) <= kVersion2015);
+
+    size = kFcfSize + (IsSequenceSuppressed(fcf) ? 0 : kDsnSize);
+
+    if (IsDstPanIdPresent(fcf))
+    {
+        size += sizeof(PanId);
+    }
+
+    addrMode = GetFcfDstAddr(fcf);
+    VerifyOrExit(addrMode != kFcfAddrReserved);
+    size += kSizeForAddrMode[addrMode];
+
+    if (IsSrcPanIdPresent(fcf))
+    {
+        size += sizeof(PanId);
+    }
+
+    addrMode = GetFcfSrcAddr(fcf);
+    VerifyOrExit(addrMode != kFcfAddrReserved);
+    size += kSizeForAddrMode[addrMode];
+
+    index = size;
 
 exit:
     return index;
-}
-
-uint8_t Frame::CalculateAddrFieldSize(uint16_t aFcf)
-{
-    uint8_t size = kFcfSize + (IsSequenceSuppressed(aFcf) ? 0 : kDsnSize);
-
-    // This static method calculates the size (number of bytes) of
-    // Address header field for a given Frame Control `aFcf` value.
-    // The size includes the Frame Control and Sequence Number fields
-    // along with Destination and Source PAN ID and Short/Extended
-    // Addresses. If the `aFcf` is not valid, this method returns
-    // `kInvalidSize`.
-
-    if (IsDstPanIdPresent(aFcf))
-    {
-        size += sizeof(PanId);
-    }
-
-    switch (GetFcfDstAddr(aFcf))
-    {
-    case kFcfAddrNone:
-        break;
-
-    case kFcfAddrShort:
-        size += sizeof(ShortAddress);
-        break;
-
-    case kFcfAddrExt:
-        size += sizeof(ExtAddress);
-        break;
-
-    default:
-        ExitNow(size = kInvalidSize);
-    }
-
-    if (IsSrcPanIdPresent(aFcf))
-    {
-        size += sizeof(PanId);
-    }
-
-    switch (GetFcfSrcAddr(aFcf))
-    {
-    case kFcfAddrNone:
-        break;
-
-    case kFcfAddrShort:
-        size += sizeof(ShortAddress);
-        break;
-
-    case kFcfAddrExt:
-        size += sizeof(ExtAddress);
-        break;
-
-    default:
-        ExitNow(size = kInvalidSize);
-    }
-
-exit:
-    return size;
 }
 
 uint8_t Frame::FindPayloadIndex(void) const

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -623,10 +623,11 @@ protected:
 
     static constexpr uint16_t kFcfFrameTypeMask = 7 << 0;
 
-    static constexpr uint16_t kFcfAddrNone  = 0;
-    static constexpr uint16_t kFcfAddrShort = 2;
-    static constexpr uint16_t kFcfAddrExt   = 3;
-    static constexpr uint16_t kFcfAddrMask  = 3;
+    static constexpr uint16_t kFcfAddrNone     = 0;
+    static constexpr uint16_t kFcfAddrReserved = 1;
+    static constexpr uint16_t kFcfAddrShort    = 2;
+    static constexpr uint16_t kFcfAddrExt      = 3;
+    static constexpr uint16_t kFcfAddrMask     = 3;
 
     // Frame Control field format for general MAC frame
     static constexpr uint16_t kFcfSecurityEnabled     = 1 << 3;
@@ -692,7 +693,6 @@ protected:
     static bool     IsDstPanIdPresent(uint16_t aFcf);
     static bool     IsSrcPanIdPresent(uint16_t aFcf);
     static uint16_t DetermineFcfAddrType(const Address &aAddress, uint16_t aBitShift);
-    static uint8_t  CalculateAddrFieldSize(uint16_t aFcf);
     static uint8_t  CalculateSecurityHeaderSize(uint8_t aSecurityControl);
     static uint8_t  CalculateKeySourceSize(uint8_t aSecurityControl);
     static uint8_t  CalculateMicSize(uint8_t aSecurityControl);

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -903,6 +903,38 @@ void TestMacFrameAckGeneration(void)
 #endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 }
 
+void TestMacFrameValidation(void)
+{
+    // Simple IEEE 802.15.4-2003 Data Frame (FCF: 0x0001, DSN: 0x01, FCS: 2 bytes)
+    uint8_t    psdu[] = {0x01, 0x00, 0x01, 0x00, 0x00};
+    Mac::Frame frame;
+
+    frame.mPsdu   = psdu;
+    frame.mLength = sizeof(psdu);
+
+    // Verify valid 2003 Data frame passes validation
+    SuccessOrQuit(frame.ValidatePsdu());
+
+    // Verify unsupported frame types fail validation (Multipurpose = 5, Reserved = 4)
+    psdu[0] = (psdu[0] & ~0x07) | 5;
+    VerifyOrQuit(frame.ValidatePsdu() == kErrorParse);
+
+    psdu[0] = (psdu[0] & ~0x07) | 4;
+    VerifyOrQuit(frame.ValidatePsdu() == kErrorParse);
+
+    // Restore valid frame type (Data = 1)
+    psdu[0] = (psdu[0] & ~0x07) | 1;
+    SuccessOrQuit(frame.ValidatePsdu());
+
+    // Verify unsupported frame version fails validation (Version 3 = 3 << 4 in high byte of FCF)
+    psdu[1] = (psdu[1] & ~0x30) | (3 << 4);
+    VerifyOrQuit(frame.ValidatePsdu() == kErrorParse);
+
+    // Restore valid frame version (2003 = 0)
+    psdu[1] = (psdu[1] & ~0x30) | (0 << 4);
+    SuccessOrQuit(frame.ValidatePsdu());
+}
+
 } // namespace ot
 
 int main(void)
@@ -913,6 +945,7 @@ int main(void)
     ot::TestMacChannelMask();
     ot::TestMacFrameApi();
     ot::TestMacFrameAckGeneration();
+    ot::TestMacFrameValidation();
     printf("All tests passed\n");
     return 0;
 }


### PR DESCRIPTION
This commit updates `Frame::SkipAddrFieldIndex()` to validate that the frame type and version in the Frame Control Field (FCF) are supported before parsing header fields.

Specifically:
- Validates that the frame type is one of the standard IEEE 802.15.4 types (Beacon, Data, Ack, or MAC Command) and rejects non-standard or unsupported types (e.g. Multipurpose frame type, which uses a completely different FCF and header format).
- Validates that the frame version is one of the supported IEEE 802.15.4 versions (2003, 2006, or 2015).
- Inlines `CalculateAddrFieldSize()` into `SkipAddrFieldIndex()` and uses a  table-driven lookup (`kSizeForAddrMode[]`) to simplify address field length calculations and early-reject reserved address modes.

Frames with unsupported frame types or versions are rejected, causing `ValidatePsdu()` to return `kErrorParse`.

Unit tests are added in `test_mac_frame` to cover frame validation with unsupported frame types and versions.