### PR TITLE
[csl-tx-scheduler] manage CSL tx delay timer in scheduler

### DIFF
--- a/src/core/common/time.hpp
+++ b/src/core/common/time.hpp
@@ -258,6 +258,15 @@ public:
      */
     static uint32_t constexpr MsecToSec(uint32_t aMilliseconds) { return aMilliseconds / 1000u; }
 
+    /**
+     * Converts a given number of microseconds to milliseconds.
+     *
+     * @param[in] aMicroseconds  The microseconds value to convert to milliseconds.
+     *
+     * @returns The number of milliseconds.
+     */
+    static uint32_t constexpr UsecToMsec(uint32_t aMicroseconds) { return aMicroseconds / 1000u; }
+
 private:
     static constexpr uint32_t kDistantInterval = (1UL << 31) - 1;
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -83,9 +83,6 @@ Mac::Mac(Instance &aInstance)
     , mMaxFrameRetriesDirect(kDefaultMaxFrameRetriesDirect)
 #if OPENTHREAD_FTD
     , mMaxFrameRetriesIndirect(kDefaultMaxFrameRetriesIndirect)
-#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-    , mCslTxFireTime(TimeMilli::kMaxDuration)
-#endif
 #endif
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     , mIsCslEnabled(false)
@@ -469,11 +466,10 @@ exit:
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-void Mac::RequestCslFrameTransmission(uint32_t aDelay)
+void Mac::RequestCslFrameTransmission(void)
 {
     VerifyOrExit(mEnabled);
-
-    mCslTxFireTime = TimerMilli::GetNow() + aDelay;
+    VerifyOrExit(!IsActiveOrPending(kOperationTransmitDataCsl));
 
     StartOperation(kOperationTransmitDataCsl);
 
@@ -535,12 +531,6 @@ void Mac::UpdateIdleMode(void)
         }
 #endif
     }
-#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-    else if (IsPending(kOperationTransmitDataCsl))
-    {
-        mTimer.FireAt(mCslTxFireTime);
-    }
-#endif
 
     if (shouldSleep)
     {
@@ -613,7 +603,7 @@ void Mac::PerformNextOperation(void)
     }
 #endif
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-    else if (IsPending(kOperationTransmitDataCsl) && TimerMilli::GetNow() >= mCslTxFireTime)
+    else if (IsPending(kOperationTransmitDataCsl))
     {
         mOperation = kOperationTransmitDataCsl;
     }

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -200,11 +200,9 @@ public:
 
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
     /**
-     * Requests `Mac` to start a CSL tx operation after a delay of @p aDelay time.
-     *
-     * @param[in]  aDelay  Delay time for `Mac` to start a CSL tx, in units of milliseconds.
+     * Requests `Mac` to start a CSL TX operation.
      */
-    void RequestCslFrameTransmission(uint32_t aDelay);
+    void RequestCslFrameTransmission(void);
 #endif
 
 #if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
@@ -908,9 +906,6 @@ private:
     uint8_t     mMaxFrameRetriesDirect;
 #if OPENTHREAD_FTD
     uint8_t mMaxFrameRetriesIndirect;
-#endif
-#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-    TimeMilli mCslTxFireTime;
 #endif
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     bool mIsCslEnabled : 1;

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -41,6 +41,7 @@ CslTxScheduler::CslTxScheduler(Instance &aInstance)
     , mCslTxNeighbor(nullptr)
     , mCslTxMessage(nullptr)
     , mFrameContext()
+    , mTimer(aInstance)
 {
     HandleRadioBusLatencyChanged();
 }
@@ -90,6 +91,7 @@ void CslTxScheduler::Clear(void)
     mFrameContext.mMessageNextOffset = 0;
     mCslTxNeighbor                   = nullptr;
     mCslTxMessage                    = nullptr;
+    mTimer.Stop();
 }
 
 /**
@@ -125,10 +127,24 @@ void CslTxScheduler::RescheduleCslTx(void)
 
     if (bestNeighbor != nullptr)
     {
-        Get<Mac::Mac>().RequestCslFrameTransmission(minDelayTime / 1000UL);
+        mTimer.Start(Time::UsecToMsec(minDelayTime));
+    }
+    else
+    {
+        mTimer.Stop();
     }
 
     mCslTxNeighbor = bestNeighbor;
+}
+
+void CslTxScheduler::HandleTimer(void)
+{
+    VerifyOrExit(mCslTxNeighbor != nullptr);
+
+    Get<Mac::Mac>().RequestCslFrameTransmission();
+
+exit:
+    return;
 }
 
 uint32_t CslTxScheduler::GetNextCslTransmissionDelay(const CslNeighbor &aCslNeighbor,

--- a/src/core/thread/csl_tx_scheduler.hpp
+++ b/src/core/thread/csl_tx_scheduler.hpp
@@ -37,6 +37,7 @@
 #include "common/message.hpp"
 #include "common/non_copyable.hpp"
 #include "common/time.hpp"
+#include "common/timer.hpp"
 #include "mac/mac.hpp"
 #include "mac/mac_frame.hpp"
 #include "radio/radio.hpp"
@@ -186,6 +187,7 @@ private:
     typedef IndirectSenderBase::FrameContext FrameContext;
 
     void RescheduleCslTx(void);
+    void HandleTimer(void);
 
     uint32_t GetNextCslTransmissionDelay(const CslNeighbor &aCslNeighbor,
                                          uint32_t          &aDelayFromLastRx,
@@ -200,10 +202,13 @@ private:
 
     void HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, CslNeighbor &aaCslNeighbor);
 
+    using CslTxTimer = TimerMilliIn<CslTxScheduler, &CslTxScheduler::HandleTimer>;
+
     uint32_t     mCslFrameRequestAheadUs;
     CslNeighbor *mCslTxNeighbor;
     Message     *mCslTxMessage;
     FrameContext mFrameContext;
+    CslTxTimer   mTimer;
 };
 
 /**


### PR DESCRIPTION
Previously, `CslTxScheduler` calculated the CSL transmission delay and passed it to `Mac::RequestCslFrameTransmission(aDelay)`. The `Mac` layer was responsible for storing `mCslTxFireTime`, arming its idle timer, and checking `TimerMilli::GetNow() >= mCslTxFireTime` before executing the operation. This coupled CSL-specific timing details into the MAC layer's state machine.

This commit refactors CSL TX scheduling so that `CslTxScheduler` manages its own millisecond timer. When the timer fires, `CslTxScheduler` requests `Mac` to start the CSL transmission immediately via `Mac::RequestCslFrameTransmission(void)`.

This change decouples CSL delay timing from `Mac`, simplifies the MAC operation state machine, and aligns `CslTxScheduler` with the design pattern used in other modules. A `Time::UsecToMsec()` helper is also added to `time.hpp`.