### PR TITLE
[ci] improve PR number resolution for size-report workflow

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -63,7 +63,6 @@ jobs:
       run: |
         ./script/check-size
         cat /tmp/ot-size-report/report_pr >> $GITHUB_STEP_SUMMARY
-        echo "${{ github.event.pull_request.number }}" > /tmp/ot-size-report/pr_number
     - name: Upload report
       if: ${{ github.event_name == 'pull_request' }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -60,8 +60,26 @@ jobs:
         script: |
           const fs = require('fs')
 
-          const report = fs.readFileSync('/tmp/ot-size-report/report_pr', 'utf8');
-          const pr_number = parseInt(fs.readFileSync('/tmp/ot-size-report/pr_number', 'utf8').trim());
+          const report = fs.readFileSync('/tmp/ot-size-report/report_pr', 'utf8')
+
+          let pr_number = context.payload.workflow_run.pull_requests?.[0]?.number
+
+          if (!pr_number) {
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.payload.workflow_run.head_sha,
+            })
+            const open_pr = prs?.find(pr => pr.state === 'open') || prs?.[0]
+            if (open_pr) {
+              pr_number = open_pr.number
+            }
+          }
+
+          if (!pr_number) {
+            core.setFailed('Could not determine PR number for workflow run')
+            return
+          }
 
           const params = {
               issue_number: pr_number,
@@ -74,7 +92,7 @@ jobs:
             issue_number: pr_number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-          });
+          })
 
           const kMagicHeader = '<!-- Size Report of **OpenThread** -->'
           const comment = response.data.find(comment => comment.body.startsWith(kMagicHeader))


### PR DESCRIPTION
This commit updates the size-report GitHub workflow to dynamically resolve the pull request number instead of relying on a temporary file created during the size-check step.

- Remove writing pr_number to a temporary file in size-check.yml.
- Dynamically retrieve pr_number in size-report.yml using payload context (workflow_run.pull_requests[0]?.number).
- Fall back to github.rest.repos.listPullRequestsAssociatedWithCommit using the head SHA if pull_requests is empty (e.g. for PRs from fork repositories).
- Add explicit error check failing the step if the PR number cannot be determined.