### PR TITLE
[spinel] vendor spinel frame max size

### DIFF
--- a/script/check-simulation-build-cmake
+++ b/script/check-simulation-build-cmake
@@ -182,6 +182,12 @@ build_all_features()
         -DOT_THREAD_VERSION=1.1 \
         -DOT_VENDOR_EXTENSION=../../src/core/instance/extension_example.cpp
 
+    # Build with Spinel Radio vendor hook
+    reset_source
+    "$(dirname "$0")"/cmake-build simulation \
+        -DOT_SPINEL_VENDOR_HOOK_SOURCE=example_vendor_hook.cpp \
+        -DOT_SPINEL_VENDOR_HOOK_HEADER=example_vendor_hook.hpp
+
     # Build Thread 1.4 with no additional features
     reset_source
     "$(dirname "$0")"/cmake-build simulation -DOT_THREAD_VERSION=1.4

--- a/src/lib/spinel/example_vendor_hook.cpp
+++ b/src/lib/spinel/example_vendor_hook.cpp
@@ -39,18 +39,21 @@
 namespace ot {
 namespace Spinel {
 
-otError RadioSpinel::VendorHandleValueIs(spinel_prop_key_t aPropKey)
+otError RadioSpinel::VendorHandleValueIs(spinel_prop_key_t aPropKey, const uint8_t *aBuffer, uint16_t aLength);
 {
     otError error = OT_ERROR_NONE;
 
+    OT_UNUSED_VARIABLE(aBuffer);
+    OT_UNUSED_VARIABLE(aLength);
+
     switch (aPropKey)
     {
-        // TODO: Implement your property get handlers here.
+        // TODO: Implement your vendor property VALUE_IS handlers here.
         //
-        // Get handler should retrieve the property value and then encode and write the
-        // value into the NCP buffer. If the "get" operation itself fails, handler should
-        // write a `LAST_STATUS` with the error status into the NCP buffer. `OT_ERROR_NO_BUFS`
-        // should be returned if NCP buffer is full and response cannot be written.
+        // This hook is invoked when RadioSpinel receives a `SPINEL_CMD_PROP_VALUE_IS` for
+        // a vendor property. Decode the value from `aBuffer`/`aLength` and process it.
+        // Return `OT_ERROR_NOT_FOUND` if the property key is not supported. Return
+        // another error (e.g., `OT_ERROR_PARSE`) if decoding or handling of the value fails.
     default:
         error = OT_ERROR_NOT_FOUND;
         break;

--- a/src/lib/spinel/example_vendor_hook.cpp
+++ b/src/lib/spinel/example_vendor_hook.cpp
@@ -32,14 +32,14 @@
 
 #if OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_ENABLE
 
-#include OPENTRHEAD_SPINEL_CONFIG_VENDOR_HOOK_HEADER
+#include OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_HEADER
 #include "common/log.hpp"
 #include "lib/platform/exit_code.h"
 
 namespace ot {
 namespace Spinel {
 
-otError RadioSpinel::VendorHandleValueIs(spinel_prop_key_t aPropKey, const uint8_t *aBuffer, uint16_t aLength);
+otError RadioSpinel::VendorHandleValueIs(spinel_prop_key_t aPropKey, const uint8_t *aBuffer, uint16_t aLength)
 {
     otError error = OT_ERROR_NONE;
 
@@ -50,15 +50,14 @@ otError RadioSpinel::VendorHandleValueIs(spinel_prop_key_t aPropKey, const uint8
     {
         // TODO: Implement your vendor property VALUE_IS handlers here.
         //
-        // This hook is invoked when RadioSpinel receives a `SPINEL_CMD_PROP_VALUE_IS` for
-        // a vendor property. Decode the value from `aBuffer`/`aLength` and process it.
+        // This hook is invoked when RadioSpinel receives a `SPINEL_CMD_PROP_VALUE_IS` command
+        // for a vendor property. Decode the value from `aBuffer`/`aLength` and process it.
         // Return `OT_ERROR_NOT_FOUND` if the property key is not supported. Return
         // another error (e.g., `OT_ERROR_PARSE`) if decoding or handling of the value fails.
     default:
         error = OT_ERROR_NOT_FOUND;
         break;
     }
-exit:
     return error;
 }
 

--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -618,7 +618,7 @@ void RadioSpinel::HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, 
 #if OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_ENABLE
     else if (aKey >= SPINEL_PROP_VENDOR__BEGIN && aKey < SPINEL_PROP_VENDOR__END)
     {
-        error = VendorHandleValueIs(aKey);
+        error = VendorHandleValueIs(aKey, aBuffer, aLength);
     }
 #endif
 

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -1019,11 +1019,13 @@ public:
      * the `VendorGetPropertyHandler()` for the same property key to prepare the response.
      *
      * @param[in] aPropKey  The spinel property key.
+     * @param[in] aBuffer   A pointer to the buffer containing the property value.
+     * @param[in] aLength   The length of the @p aBuffer.
      *
      * @returns OT_ERROR_NOT_FOUND if it does not support the given property key, otherwise the error in either parsing
      *          of the input or the "set" operation.
      */
-    otError VendorHandleValueIs(spinel_prop_key_t aPropKey);
+    otError VendorHandleValueIs(spinel_prop_key_t aPropKey, const uint8_t *aBuffer, uint16_t aLength);
 
     /**
      *  A callback type for restoring vendor properties.

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -1019,7 +1019,7 @@ public:
      * @param[in] aBuffer   A pointer to the buffer containing the property value.
      * @param[in] aLength   The length of the @p aBuffer.
      *
-     * @returns OT_ERROR_NOT_FOUND if it does not support the given property key, otherwise the error in either decoding
+     * @returns OT_ERROR_NOT_FOUND if it does not support the given property key, or the error status if decoding
      *          or handling of the value fails.
      */
     otError VendorHandleValueIs(spinel_prop_key_t aPropKey, const uint8_t *aBuffer, uint16_t aLength);

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -1008,22 +1008,19 @@ public:
 #endif
 #if OPENTHREAD_SPINEL_CONFIG_VENDOR_HOOK_ENABLE
     /**
-     * Defines a vendor "set property handler" hook to process vendor spinel properties.
+     * Defines a vendor "value is" hook to process vendor spinel properties.
      *
-     * The vendor handler should return `OT_ERROR_NOT_FOUND` status if it does not support "set" operation for the
-     * given property key. Otherwise, the vendor handler should behave like other property set handlers, i.e., it
-     * should first decode the value from the input spinel frame and then perform the corresponding set operation. The
-     * handler should not prepare the spinel response and therefore should not write anything to the NCP buffer. The
-     * `otError` returned from handler (other than `OT_ERROR_NOT_FOUND`) indicates the error in either parsing of the
-     * input or the error of the set operation. In case of a successful "set", `NcpBase` set command handler will call
-     * the `VendorGetPropertyHandler()` for the same property key to prepare the response.
+     * This hook is invoked when RadioSpinel receives a `SPINEL_CMD_PROP_VALUE_IS` command
+     * for a vendor property. Decode the value from `aBuffer`/`aLength` and process it.
+     * Return `OT_ERROR_NOT_FOUND` if the property key is not supported. Return
+     * another error (e.g., `OT_ERROR_PARSE`) if decoding or handling of the value fails.
      *
      * @param[in] aPropKey  The spinel property key.
      * @param[in] aBuffer   A pointer to the buffer containing the property value.
      * @param[in] aLength   The length of the @p aBuffer.
      *
-     * @returns OT_ERROR_NOT_FOUND if it does not support the given property key, otherwise the error in either parsing
-     *          of the input or the "set" operation.
+     * @returns OT_ERROR_NOT_FOUND if it does not support the given property key, otherwise the error in either decoding
+     *          or handling of the value fails.
      */
     otError VendorHandleValueIs(spinel_prop_key_t aPropKey, const uint8_t *aBuffer, uint16_t aLength);
 

--- a/src/lib/spinel/spinel.h
+++ b/src/lib/spinel/spinel.h
@@ -437,7 +437,9 @@
  *
  *  The maximum size of SPINEL frame.
  */
+#ifndef SPINEL_FRAME_MAX_SIZE
 #define SPINEL_FRAME_MAX_SIZE 1300
+#endif
 
 /**
  * @def SPINEL_FRAME_MAX_COMMAND_HEADER_SIZE


### PR DESCRIPTION
Make `SPINEL_FRAME_MAX_SIZE` configurable by wrapping its definition with `#ifndef`, and add buffer and length parameters to `VendorHandleValueIs()` to support large vendor property values.