### PR TITLE
[csl-tx-scheduler] update CSL scheduling on MAC enable status change

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -56,7 +56,7 @@ const otMacKey Mac::kMode2Key = {
 
 Mac::Mac(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mEnabled(false)
+    , mEnabled(true)
     , mShouldTxPollBeforeData(false)
     , mRxOnWhenIdle(false)
     , mPromiscuous(false)
@@ -112,7 +112,13 @@ Mac::Mac(Instance &aInstance)
     mCcaSuccessRateTracker.Clear();
     ResetCounters();
 
-    SetEnabled(true);
+    // MAC starts in the enabled state (`mEnabled` is set to `true`).
+    // Enable `mLinks` directly instead of calling `SetEnabled()` to
+    // avoid invoking callbacks on other modules (e.g., `CslTxScheduler`)
+    // before they are fully initialized during `Instance` initialization
+    // and constructor calls.
+
+    mLinks.Enable();
 
     SetPanId(mPanId);
     SetExtAddress(randomExtAddress);
@@ -128,6 +134,8 @@ void Mac::Init(void) { Get<KeyManager>().UpdateKeyMaterial(); }
 
 void Mac::SetEnabled(bool aEnable)
 {
+    VerifyOrExit(mEnabled != aEnable);
+
     mEnabled = aEnable;
 
     if (aEnable)
@@ -138,6 +146,13 @@ void Mac::SetEnabled(bool aEnable)
     {
         mLinks.Disable();
     }
+
+#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+    Get<CslTxScheduler>().HandleMacEnableStatusChanged();
+#endif
+
+exit:
+    return;
 }
 
 Error Mac::CanScan(void) const

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -57,8 +57,22 @@ void CslTxScheduler::HandleRadioBusLatencyChanged(void)
     LogInfo("Set frame request ahead: %lu usec", ToUlong(mCslFrameRequestAheadUs));
 }
 
+void CslTxScheduler::HandleMacEnableStatusChanged(void)
+{
+    if (Get<Mac::Mac>().IsEnabled())
+    {
+        Update();
+    }
+    else
+    {
+        mTimer.Stop();
+    }
+}
+
 void CslTxScheduler::Update(void)
 {
+    VerifyOrExit(Get<Mac::Mac>().IsEnabled());
+
     if (mCslTxMessage == nullptr)
     {
         RescheduleCslTx();
@@ -371,7 +385,7 @@ void CslTxScheduler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError)
 exit:
     mCslTxMessage  = nullptr;
     mCslTxNeighbor = nullptr;
-    RescheduleCslTx();
+    Update();
 }
 
 } // namespace ot

--- a/src/core/thread/csl_tx_scheduler.hpp
+++ b/src/core/thread/csl_tx_scheduler.hpp
@@ -247,6 +247,7 @@ private:
     // Callbacks from `Mac`
     Mac::TxFrame *HandleFrameRequest(Mac::TxFrames &aTxFrames);
     void          HandleSentFrame(const Mac::TxFrame &aFrame, Error aError);
+    void          HandleMacEnableStatusChanged(void);
 
     // Callback from `Radio`
     void HandleRadioBusLatencyChanged(void);


### PR DESCRIPTION
This commit updates `CslTxScheduler` to track MAC enable status changes.

Specifically:
- `Mac` starts in the enabled state (`mEnabled` initialized to `true`). In the `Mac` constructor, `mLinks.Enable()` is called directly instead of `SetEnabled(true)` to avoid invoking callbacks on downstream modules (like `CslTxScheduler`) before they are constructed during `Instance` initialization.
- `Mac::SetEnabled()` is updated to exit early if the enable status is unchanged, and to notify `CslTxScheduler` via `HandleMacEnableStatusChanged()` whenever the status changes.
- `CslTxScheduler::Update()` is updated to verify that the MAC layer is enabled before rescheduling CSL transmissions, ensuring CSL scheduling  does not run when MAC is disabled and automatically resumes when MAC is re-enabled.