### PR TITLE
[dependabot] remove invalid if property from github-actions update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,6 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    if: github.repository == "openthread/openthread"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Dependabot configuration files (.github/dependabot.yml) do not support conditional execution or workflow expression syntax such as the `if:` property. Including `if:` causes a schema validation error when Dependabot parses the file:
"The property '#/updates/0/' contains additional properties ["if"] outside of the schema when none are allowed".

This commit removes `if: github.repository == "openthread/openthread"` from the github-actions package ecosystem update configuration to conform to Dependabot's v2 specification.

Because GitHub automatically disables Dependabot version updates and automated pull requests on repository forks by default (unless explicitly enabled by the fork owner in repository settings), removing this condition resolves the schema validation error without generating unwanted pull requests on standard forks.