### PR TITLE
[mac] unify and optimize MAC operation logging

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -570,7 +570,7 @@ void Mac::StartOperation(Operation aOperation)
     {
         SetPending(aOperation);
 
-        LogDebg("Request to start operation \"%s\"", OperationToString(aOperation));
+        LogOperation(kRequest, aOperation);
 
 #if OPENTHREAD_CONFIG_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS
         if (mDelayingSleep)
@@ -647,7 +647,7 @@ void Mac::PerformNextOperation(void)
     if (mOperation != kOperationIdle)
     {
         ClearPending(mOperation);
-        LogDebg("Starting operation \"%s\"", OperationToString(mOperation));
+        LogOperation(kStarting, mOperation);
         mTimer.Stop(); // Stop the timer before any non-idle operation, have the operation itself be responsible to
                        // start the timer (if it wants to).
     }
@@ -693,7 +693,7 @@ exit:
 
 void Mac::FinishOperation(void)
 {
-    LogDebg("Finishing operation \"%s\"", OperationToString(mOperation));
+    LogOperation(kFinishing, mOperation);
     mOperation = kOperationIdle;
 }
 
@@ -2309,7 +2309,7 @@ uint8_t Mac::ComputeLinkMargin(int8_t aRss) const { return ot::ComputeLinkMargin
 
 // LCOV_EXCL_START
 
-#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)
 
 const char *Mac::OperationToString(Operation aOperation)
 {
@@ -2345,6 +2345,31 @@ const char *Mac::OperationToString(Operation aOperation)
 
     return kStrings[aOperation];
 }
+
+const char *Mac::OperationActionToString(OperationAction aAction)
+{
+#define OperationActionMapList(_)   \
+    _(kRequest, "Request to start") \
+    _(kStarting, "Starting")        \
+    _(kFinishing, "Finishing")
+
+    DefineEnumStringArray(OperationActionMapList);
+
+    return kStrings[aAction];
+}
+
+void Mac::LogOperation(OperationAction aAction, Operation aOperation) const
+{
+    LogDebg("%s operation \"%s\"", OperationActionToString(aAction), OperationToString(aOperation));
+}
+
+#else // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)
+
+void Mac::LogOperation(OperationAction, Operation) const {}
+
+#endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)
+
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 void Mac::LogFrameRxFailure(const RxFrame *aFrame, Error aError) const
 {

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -753,6 +753,13 @@ private:
     };
 #endif
 
+    enum OperationAction : uint8_t // Used in `LogOperation`
+    {
+        kRequest,
+        kStarting,
+        kFinishing,
+    };
+
     // Callbacks from `SubMac` or `Trel::Link`
     void HandleReceivedFrame(RxFrame *aFrame, Error aError);
     void RecordCcaStatus(bool aCcaSuccess, uint8_t aChannel);
@@ -803,6 +810,10 @@ private:
     void LogFrameRxFailure(const RxFrame *aFrame, Error aError) const;
     void LogFrameTxFailure(const TxFrame &aFrame, Error aError, uint8_t aRetryCount, bool aWillRetx) const;
     void LogBeacon(const char *aActionText) const;
+    void LogOperation(OperationAction aAction, Operation aOperation) const;
+
+    static const char *OperationToString(Operation aOperation);
+    static const char *OperationActionToString(OperationAction aAction);
 
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
     void ProcessCsl(const RxFrame &aFrame, const Address &aSrcAddr);
@@ -818,7 +829,6 @@ private:
     Error HandleWakeupFrame(const RxFrame &aFrame);
     void  UpdateWakeupListening(void);
 #endif
-    static const char *OperationToString(Operation aOperation);
 
     using OperationTask = TaskletIn<Mac, &Mac::PerformNextOperation>;
     using MacTimer      = TimerMilliIn<Mac, &Mac::HandleTimer>;


### PR DESCRIPTION
This commit consolidates the debug logging for MAC operation state transitions into a helper method `Mac::LogOperation()`.