### PR TITLE
[mac-frame] rename `kFcfSeqSuppression` & fix `IsSequencePresent` return type

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -168,7 +168,7 @@ void TxFrame::BuildInfo::PrepareHeadersIn(TxFrame &aTxFrame) const
 
     if (mSuppressSequence)
     {
-        fcf |= kFcfSequenceSuppression;
+        fcf |= kFcfSeqSuppression;
     }
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
@@ -183,7 +183,7 @@ void TxFrame::BuildInfo::PrepareHeadersIn(TxFrame &aTxFrame) const
     builder.Init(aTxFrame.mPsdu, aTxFrame.GetMtu());
     IgnoreError(builder.AppendUint<kLittleEndian>(fcf));
 
-    if (!IsSequenceSuppressed(fcf))
+    if (IsSeqPresent(fcf))
     {
         builder.Append<uint8_t>(); // Place holder for seq number
     }
@@ -305,7 +305,7 @@ uint8_t Frame::SkipSequenceIndex(void) const
     uint16_t fcf   = GetFrameControlField();
     uint8_t  index = kFcfSize;
 
-    if (!IsSequenceSuppressed(fcf))
+    if (IsSeqPresent(fcf))
     {
         index += kDsnSize;
     }
@@ -922,7 +922,7 @@ uint8_t Frame::SkipAddrFieldIndex(void) const
     // Future frame versions can alter the MAC header layout.
     VerifyOrExit(GetVersion(fcf) <= kVersion2015);
 
-    size = kFcfSize + (IsSequenceSuppressed(fcf) ? 0 : kDsnSize);
+    size = kFcfSize + (IsSeqPresent(fcf) ? kDsnSize : 0);
 
     if (IsDstPanIdPresent(fcf))
     {

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -281,7 +281,7 @@ public:
      *
      * @returns TRUE if the Sequence Number is present, FALSE otherwise.
      */
-    uint8_t IsSequencePresent(void) const { return !IsSequenceSuppressed(GetFrameControlField()); }
+    bool IsSequencePresent(void) const { return IsSeqPresent(GetFrameControlField()); }
 
     /**
      * Indicates whether or not the Destination PAN ID is present.
@@ -630,23 +630,23 @@ protected:
     static constexpr uint16_t kFcfAddrMask     = 3;
 
     // Frame Control field format for general MAC frame
-    static constexpr uint16_t kFcfSecurityEnabled     = 1 << 3;
-    static constexpr uint16_t kFcfFramePending        = 1 << 4;
-    static constexpr uint16_t kFcfAckRequest          = 1 << 5;
-    static constexpr uint16_t kFcfPanidCompression    = 1 << 6;
-    static constexpr uint16_t kFcfSequenceSuppression = 1 << 8;
-    static constexpr uint16_t kFcfIePresent           = 1 << 9;
-    static constexpr uint16_t kFcfDstAddrShift        = 10;
-    static constexpr uint16_t kFcfDstAddrNone         = kFcfAddrNone << kFcfDstAddrShift;
-    static constexpr uint16_t kFcfDstAddrShort        = kFcfAddrShort << kFcfDstAddrShift;
-    static constexpr uint16_t kFcfDstAddrExt          = kFcfAddrExt << kFcfDstAddrShift;
-    static constexpr uint16_t kFcfDstAddrMask         = kFcfAddrMask << kFcfDstAddrShift;
-    static constexpr uint16_t kFcfFrameVersionMask    = 3 << 12;
-    static constexpr uint16_t kFcfSrcAddrShift        = 14;
-    static constexpr uint16_t kFcfSrcAddrNone         = kFcfAddrNone << kFcfSrcAddrShift;
-    static constexpr uint16_t kFcfSrcAddrShort        = kFcfAddrShort << kFcfSrcAddrShift;
-    static constexpr uint16_t kFcfSrcAddrExt          = kFcfAddrExt << kFcfSrcAddrShift;
-    static constexpr uint16_t kFcfSrcAddrMask         = kFcfAddrMask << kFcfSrcAddrShift;
+    static constexpr uint16_t kFcfSecurityEnabled  = 1 << 3;
+    static constexpr uint16_t kFcfFramePending     = 1 << 4;
+    static constexpr uint16_t kFcfAckRequest       = 1 << 5;
+    static constexpr uint16_t kFcfPanidCompression = 1 << 6;
+    static constexpr uint16_t kFcfSeqSuppression   = 1 << 8;
+    static constexpr uint16_t kFcfIePresent        = 1 << 9;
+    static constexpr uint16_t kFcfDstAddrShift     = 10;
+    static constexpr uint16_t kFcfDstAddrNone      = kFcfAddrNone << kFcfDstAddrShift;
+    static constexpr uint16_t kFcfDstAddrShort     = kFcfAddrShort << kFcfDstAddrShift;
+    static constexpr uint16_t kFcfDstAddrExt       = kFcfAddrExt << kFcfDstAddrShift;
+    static constexpr uint16_t kFcfDstAddrMask      = kFcfAddrMask << kFcfDstAddrShift;
+    static constexpr uint16_t kFcfFrameVersionMask = 3 << 12;
+    static constexpr uint16_t kFcfSrcAddrShift     = 14;
+    static constexpr uint16_t kFcfSrcAddrNone      = kFcfAddrNone << kFcfSrcAddrShift;
+    static constexpr uint16_t kFcfSrcAddrShort     = kFcfAddrShort << kFcfSrcAddrShift;
+    static constexpr uint16_t kFcfSrcAddrExt       = kFcfAddrExt << kFcfSrcAddrShift;
+    static constexpr uint16_t kFcfSrcAddrMask      = kFcfAddrMask << kFcfSrcAddrShift;
 
     static constexpr uint8_t kSecLevelMask  = 7 << 0;
     static constexpr uint8_t kKeyIdModeMask = 3 << 3;
@@ -678,10 +678,8 @@ protected:
 
     static uint16_t GetFcfDstAddr(uint16_t aFcf) { return ReadBits<uint16_t, kFcfDstAddrMask>(aFcf); }
     static uint16_t GetFcfSrcAddr(uint16_t aFcf) { return ReadBits<uint16_t, kFcfSrcAddrMask>(aFcf); }
-    static bool     IsSequenceSuppressed(uint16_t aFcf)
-    {
-        return IsVersion2015(aFcf) && ((aFcf & kFcfSequenceSuppression) != 0);
-    }
+    static bool     IsSeqSuppressed(uint16_t aFcf) { return IsVersion2015(aFcf) && ((aFcf & kFcfSeqSuppression) != 0); }
+    static bool     IsSeqPresent(uint16_t aFcf) { return !IsSeqSuppressed(aFcf); }
     static bool     IsDstAddrPresent(uint16_t aFcf) { return (aFcf & kFcfDstAddrMask) != 0; }
     static bool     IsSrcAddrPresent(uint16_t aFcf) { return (aFcf & kFcfSrcAddrMask) != 0; }
     static bool     IsSecurityEnabled(uint16_t aFcf) { return (aFcf & kFcfSecurityEnabled) != 0; }


### PR DESCRIPTION
This commit updates `Mac::Frame` helper methods and constants related to sequence number suppression:

- Renames `kFcfSequenceSuppression` to `kFcfSeqSuppression` and `IsSequenceSuppressed()` to `IsSeqSuppressed()`. The shorter name allows `IsSeqSuppressed()` to fit on a single line in `mac_frame.hpp`, matching  the inline formatting style used by neighboring FCF helper methods.
- Adds `IsSeqPresent(aFcf)` static helper method and uses it in place of `!IsSeqSuppressed(aFcf)` across `mac_frame.cpp`.
- Fixes the return type of `IsSequencePresent()` from `uint8_t` to `bool`.