### PR TITLE
[history] parse TLV headers safely in client answer processing

### DIFF
--- a/src/core/utils/history_tracker_client.cpp
+++ b/src/core/utils/history_tracker_client.cpp
@@ -163,23 +163,27 @@ void Client::ProcessNetInfoAnswer(const Coap::Message &aMessage)
 {
     Error          error = kErrorNone;
     OffsetRange    offsetRange;
-    Tlv            tlv;
+    Tlv::Info      tlvInfo;
     NetworkInfoTlv netInfoTlv;
     NetworkInfo    netInfo;
 
     offsetRange.InitFromMessageOffsetToEnd(aMessage);
 
-    for (; !offsetRange.IsEmpty(); offsetRange.AdvanceOffset(tlv.GetSize()))
+    for (; !offsetRange.IsEmpty(); offsetRange.AdvanceOffset(tlvInfo.GetSize()))
     {
-        SuccessOrExit(error = aMessage.Read(offsetRange, tlv));
-        VerifyOrExit(offsetRange.Contains(tlv.GetSize()), error = kErrorParse);
+        SuccessOrExit(error = tlvInfo.ParseFrom(aMessage, offsetRange));
 
-        if (tlv.GetType() != Tlv::kNetworkInfo)
+        if (tlvInfo.IsExtended())
         {
             continue;
         }
 
-        if (tlv.GetLength() == 0)
+        if (tlvInfo.GetType() != Tlv::kNetworkInfo)
+        {
+            continue;
+        }
+
+        if (tlvInfo.GetLength() == 0)
         {
             Finalize(kErrorNone);
             ExitNow();


### PR DESCRIPTION
`HistoryTracker::Client::ProcessNetInfoAnswer()` read a plain 2-byte `Tlv` header from the message and then called `GetSize()`. For a TLV whose length byte is 0xFF (`kExtendedLength`), `GetSize()` interprets the object as an `ExtendedTlv` and reads a 16-bit extended-length field that was never read from the message; the codebase norm at other TMF parse sites is to read the full TLV header from the message first.

This change switches the loop to `Tlv::Info::ParseFrom()`, which reads any extended-length field from the message and validates that the full TLV is contained within the remaining offset range, and skips extended TLVs (all answer TLVs the client consumes are non-extended).
