### PR TITLE
[netdata] restrict server data removal to entries related to the sender

### DIFF
--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -254,8 +254,7 @@ template <> void Leader::HandleTmf<kUriServerData>(Coap::Msg &aMsg)
         }
         else
         {
-            LogWarn("Ignoring server data removal for un-owned rloc16 0x%04x (sender 0x%04x)", rloc16,
-                    senderRloc16);
+            LogWarn("Ignoring server data removal for un-owned rloc16 0x%04x (sender 0x%04x)", rloc16, senderRloc16);
         }
 
         break;

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -245,10 +245,11 @@ template <> void Leader::HandleTmf<kUriServerData>(Coap::Msg &aMsg)
         // flows are not delayed.
 
         uint16_t senderRloc16 = aMsg.mMessageInfo.GetPeerAddr().GetIid().GetLocator();
+        uint8_t  routerId     = Mle::RouterIdFromRloc16(rloc16);
 
         if ((rloc16 == senderRloc16) ||
             (Mle::IsRouterRloc16(senderRloc16) && Mle::RouterIdMatch(senderRloc16, rloc16)) ||
-            !Get<RouterTable>().IsAllocated(Mle::RouterIdFromRloc16(rloc16)))
+            !Mle::IsRouterIdValid(routerId) || !Get<RouterTable>().IsAllocated(routerId))
         {
             RemoveBorderRouter(rloc16, kMatchModeRloc16);
         }

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -233,8 +233,33 @@ template <> void Leader::HandleTmf<kUriServerData>(Coap::Msg &aMsg)
     switch (Tlv::Find<ThreadRloc16Tlv>(aMsg.mMessage, rloc16))
     {
     case kErrorNone:
-        RemoveBorderRouter(rloc16, kMatchModeRloc16);
+    {
+        // Ownership check: the RLOC16 being removed must relate to the
+        // sender; otherwise any on-mesh device could strip another
+        // device's Network Data entries. Permitted: the sender's own
+        // RLOC16; a child of the sending router (stale-child cleanup);
+        // or an RLOC16 under a router ID that is no longer allocated
+        // (stale partition remnants). On failure only the REMOVAL is
+        // skipped: the rest of the message (registration) is still
+        // processed and acknowledged, so legitimate re-registration
+        // flows are not delayed.
+
+        uint16_t senderRloc16 = aMsg.mMessageInfo.GetPeerAddr().GetIid().GetLocator();
+
+        if ((rloc16 == senderRloc16) ||
+            (Mle::IsRouterRloc16(senderRloc16) && Mle::RouterIdMatch(senderRloc16, rloc16)) ||
+            !Get<RouterTable>().IsAllocated(Mle::RouterIdFromRloc16(rloc16)))
+        {
+            RemoveBorderRouter(rloc16, kMatchModeRloc16);
+        }
+        else
+        {
+            LogWarn("Ignoring server data removal for un-owned rloc16 0x%04x (sender 0x%04x)", rloc16,
+                    senderRloc16);
+        }
+
         break;
+    }
     case kErrorNotFound:
         break;
     default:


### PR DESCRIPTION
In `Leader::HandleTmf<kUriServerData>`, a message carrying a Thread RLOC16 TLV caused the referenced border router entries to be removed without relating the RLOC16 to the sending device, so any on-mesh device could remove Network Data entries registered by another device.

This change permits the removal only when the RLOC16 is the sender's own, belongs to a child of the sending router (stale-child cleanup), or is under a router ID that is no longer allocated (stale partition remnants). When the check fails, only the removal is skipped; the remainder of the message (registration) is still processed and acknowledged, so legitimate re-registration flows are unaffected.
