### PR TITLE
[trel] limit direct peer sockaddr updates to mode 0/1 secured frames

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2202,13 +2202,19 @@ exit:
             // saved in the corresponding TREL peer, and signal this to
             // the platform layer.
             //
-            // If the frame used link security and was successfully
+            // If the frame was secured with the network key (key ID
+            // mode 1) or the KEK (key ID mode 0) and was successfully
             // processed, we allow the `Peer` entry socket information
-            // to be updated directly.
+            // to be updated directly. Key ID mode 2 uses the
+            // well-known key and therefore does not identify a
+            // specific sender, so it is not accepted for a direct
+            // update (matching the policy in
+            // `ThreadLinkInfo::SetFrom()`).
 
-            Get<Trel::Link>().CheckPeerAddrOnRxSuccess(aFrame->GetSecurityEnabled()
-                                                           ? Trel::Link::kAllowPeerSockAddrUpdate
-                                                           : Trel::Link::kDisallowPeerSockAddrUpdate);
+            Get<Trel::Link>().CheckPeerAddrOnRxSuccess(
+                aFrame->IsSecuredWith(RxFrame::kAllowKeyIdMode0 | RxFrame::kAllowKeyIdMode1)
+                    ? Trel::Link::kAllowPeerSockAddrUpdate
+                    : Trel::Link::kDisallowPeerSockAddrUpdate);
         }
     }
 #endif // OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE


### PR DESCRIPTION
This PR makes a single change: the rx-based fallback that directly updates a TREL peer's socket address is restricted to frames secured with the network key (key ID mode 1) or the KEK (key ID mode 0), by replacing `aFrame->GetSecurityEnabled()` with `aFrame->IsSecuredWith(RxFrame::kAllowKeyIdMode0 | RxFrame::kAllowKeyIdMode1)` at the peer update site in `Mac::HandleReceivedFrame()`.

Key ID mode 2 uses the well-known key and does not identify a specific sender, so mode 2 frames, like unsecured frames, now only trigger the discrepancy signal to the platform layer, matching the policy in `ThreadLinkInfo::SetFrom()`.
