### PR TITLE
[meshcop] apply default delay when generating pending from active set

### DIFF
--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -375,7 +375,7 @@ void PendingDatasetManager::ApplyActiveDataset(Dataset &aDataset)
 
     SuccessOrExit(aDataset.Read<ActiveTimestampTlv>(activeTimestamp));
     SuccessOrExit(aDataset.Write<PendingTimestampTlv>(activeTimestamp));
-    SuccessOrExit(aDataset.Write<DelayTimerTlv>(GetDelayTimerMinimal()));
+    SuccessOrExit(aDataset.Write<DelayTimerTlv>(DelayTimerTlv::kDefaultDelay));
 
     IgnoreError(DatasetManager::Save(aDataset));
     StartDelayTimer(aDataset);

--- a/tests/scripts/expect/cli-dataset-mgmt-delay-floor.exp
+++ b/tests/scripts/expect/cli-dataset-mgmt-delay-floor.exp
@@ -1,0 +1,76 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+# Verifies that a MGMT_ACTIVE_SET request which changes the Network Key is
+# applied through the Pending Dataset with the default delay
+# (OPENTHREAD_CONFIG_TMF_PENDING_DATASET_DEFAULT_DELAY, 300s), so a key
+# change cannot take effect faster than the default delay. An unexpected
+# Delay Timer TLV in the Active Dataset is ignored, so the outcome is the
+# same whether the request omits the TLV or carries one.
+
+source "tests/scripts/expect/_common.exp"
+
+spawn_node 1
+setup_leader
+
+# Case A: key-changing MGMT_ACTIVE_SET without a Delay Timer TLV.
+
+send "dataset mgmtsetcommand active activetimestamp 99999998 networkkey 00112233445566778899aabbccddee0a\n"
+expect_line "Done"
+
+sleep 2
+
+send "dataset pending\n"
+expect -re {Delay: (\d+)}
+set delay $expect_out(1,string)
+expect -re {Network Key: 00112233445566778899aabbccddee0a}
+expect_line "Done"
+
+if {$delay < 250000} {
+    fail "Pending delay for key change (no Delay Timer TLV) is $delay ms, expected the 300s default delay"
+}
+
+# Case B: key-changing MGMT_ACTIVE_SET with a short explicit Delay Timer TLV.
+
+send "dataset mgmtsetcommand active activetimestamp 99999999 networkkey 00112233445566778899aabbccddee0b delaytimer 5000\n"
+expect_line "Done"
+
+sleep 2
+
+send "dataset pending\n"
+expect -re {Delay: (\d+)}
+set delay $expect_out(1,string)
+expect -re {Network Key: 00112233445566778899aabbccddee0b}
+expect_line "Done"
+
+if {$delay < 250000} {
+    fail "Pending delay for key change (explicit 5s Delay Timer TLV) is $delay ms, expected the 300s default delay"
+}
+
+dispose_all


### PR DESCRIPTION
`PendingDatasetManager::ApplyActiveDataset()` wrote `GetDelayTimerMinimal()` into the Pending Dataset it generates from an MGMT_ACTIVE_SET request that has to be applied via the Pending Dataset, so a Network Key change requested this way took effect after only the minimal delay. With this change it writes `DelayTimerTlv::kDefaultDelay` instead, so such changes cannot take effect faster than the default delay. Any Delay Timer TLV carried in the Active Dataset itself is overwritten, so the outcome is the same whether the request omits the TLV or carries a short one.

An expect-based CLI regression test is included covering both the omitted and the short explicit Delay Timer TLV cases.
