### PR TITLE
[mac] reject unsecured Enh-Ack carrying IEs in response to a secured transmission

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1795,7 +1795,18 @@ Error Mac::ProcessEnhAckSecurity(TxFrame &aTxFrame, RxFrame &aAckFrame)
     Neighbor          *neighbor = nullptr;
     const KeyMaterial *macKey;
 
-    VerifyOrExit(aAckFrame.GetSecurityEnabled(), error = kErrorNone);
+    if (!aAckFrame.GetSecurityEnabled())
+    {
+        // Reject an unsecured ACK carrying IEs in response to a secured 2015 frame.
+
+        if (aTxFrame.GetSecurityEnabled() && aTxFrame.IsVersion2015() && aAckFrame.IsIePresent())
+        {
+            ExitNow(error = kErrorSecurity);
+        }
+
+        ExitNow(error = kErrorNone);
+    }
+
     VerifyOrExit(aAckFrame.IsVersion2015());
 
     SuccessOrExit(aAckFrame.ValidatePsdu());


### PR DESCRIPTION
Per the Thread specification, in response to a transmitted MAC-secured Frame Version 0b10 frame a device MUST accept either an Enh-Ack frame that is MAC-secured, or an Enh-Ack frame that is not MAC-secured and does not carry any IEs (thanks @abtink for the precise reference).

`Mac::ProcessEnhAckSecurity()` currently accepts ANY unsecured ack for a secured version-2015 transmission via the early `kErrorNone` return, including an unsecured Enh-Ack carrying IEs, which falls outside both acceptable categories. Such an ack then reaches `ProcessEnhAckProbing()`, which parses its Link Metrics probing IE with no security gate (unlike `ProcessCsl()`, which requires key ID mode 1 security).

This change rejects an unsecured Enh-Ack that carries IEs in response to a secured version-2015 transmission, and continues to accept all other unsecured acks: unsecured transmissions, IE-less unsecured Enh-Acks (as the specification requires), and Imm-Acks (which cannot carry IEs).
