### PR TITLE
[common] add Clang lifetime safety annotations to smart pointers

### DIFF
--- a/src/core/common/owned_ptr.hpp
+++ b/src/core/common/owned_ptr.hpp
@@ -50,7 +50,7 @@ namespace ot {
  *
  * @tparam Type  The pointer type.
  */
-template <class Type> class OwnedPtr : public Ptr<Type>
+template <class Type> class OT_GSL_OWNER OwnedPtr : public Ptr<Type>
 {
     using Ptr<Type>::mPointer;
 
@@ -141,7 +141,7 @@ public:
      *
      * @returns An rvalue reference of the pointer to move from.
      */
-    OwnedPtr &&PassOwnership(void) { return static_cast<OwnedPtr &&>(*this); }
+    OwnedPtr &&PassOwnership(void) OT_LIFETIME_BOUND { return static_cast<OwnedPtr &&>(*this); }
 
     /**
      * Overload the assignment operator `=` to replace the object owned by the `OwnedPtr` with another one

--- a/src/core/common/ptr_wrapper.hpp
+++ b/src/core/common/ptr_wrapper.hpp
@@ -48,7 +48,7 @@ namespace ot {
  *
  * @tparam Type  The pointer type.
  */
-template <class Type> class Ptr
+template <class Type> class OT_GSL_POINTER Ptr
 {
 public:
     /**
@@ -82,28 +82,28 @@ public:
      *
      * @returns The wrapped pointer.
      */
-    Type *Get(void) { return mPointer; }
+    Type *Get(void) OT_LIFETIME_BOUND { return mPointer; }
 
     /**
      * Gets the wrapped pointer.
      *
      * @returns The wrapped pointer.
      */
-    const Type *Get(void) const { return mPointer; }
+    const Type *Get(void) const OT_LIFETIME_BOUND { return mPointer; }
 
     /**
      * Overloads the `->` dereference operator and returns the pointer.
      *
      * @returns The wrapped pointer.
      */
-    Type *operator->(void) { return mPointer; }
+    Type *operator->(void) OT_LIFETIME_BOUND { return mPointer; }
 
     /**
      * Overloads the `->` dereference operator and returns the pointer.
      *
      * @returns The wrapped pointer.
      */
-    const Type *operator->(void) const { return mPointer; }
+    const Type *operator->(void) const OT_LIFETIME_BOUND { return mPointer; }
 
     /**
      * Overloads the `*` dereference operator and returns a reference to the pointed object.
@@ -112,7 +112,7 @@ public:
      *
      * @returns A reference to the pointed object.
      */
-    Type &operator*(void) { return *mPointer; }
+    Type &operator*(void) OT_LIFETIME_BOUND { return *mPointer; }
 
     /**
      * Overloads the `*` dereference operator and returns a reference to the pointed object.
@@ -121,7 +121,7 @@ public:
      *
      * @returns A reference to the pointed object.
      */
-    const Type &operator*(void) const { return *mPointer; }
+    const Type &operator*(void) const OT_LIFETIME_BOUND { return *mPointer; }
 
     /**
      * Overloads the operator `==` to compare the `Ptr` with a given pointer.

--- a/src/core/common/retain_ptr.hpp
+++ b/src/core/common/retain_ptr.hpp
@@ -54,7 +54,7 @@ namespace ot {
  *
  * @tparam Type  The pointer type.
  */
-template <class Type> class RetainPtr : public Ptr<Type>
+template <class Type> class OT_GSL_OWNER RetainPtr : public Ptr<Type>
 {
     using Ptr<Type>::mPointer;
 


### PR DESCRIPTION
This commit applies Clang Lifetime Safety Analysis annotations to the smart pointer and pointer wrapper classes in `src/core/common/`:

- Annotates `Ptr<Type>` (`ptr_wrapper.hpp`) with `OT_GSL_POINTER` as a non-owning pointer wrapper base class.
- Annotates `OwnedPtr<Type>` (`owned_ptr.hpp`) and `RetainPtr<Type>` (`retain_ptr.hpp`) with `OT_GSL_OWNER` to designate them as resource owners that manage object lifespans.
- Annotates accessors returning raw pointers or references (`Get()`, `operator->()`, `operator*()`, `Release()`, and `PassOwnership()`) with `OT_LIFETIME_BOUND` so the compiler verifies that derived references and pointers do not outlive their managing smart pointer.