### PR TITLE
[posix] fix ot-ctl crash on unrecognized long options

### DIFF
--- a/src/posix/client.cpp
+++ b/src/posix/client.cpp
@@ -210,7 +210,8 @@ constexpr char kOptHelp          = 'h';
 
 const struct option kOptions[] = {
     {"interface-name", required_argument, NULL, kOptInterfaceName},
-    {"help", required_argument, NULL, kOptHelp},
+    {"help", no_argument, NULL, kOptHelp},
+    {nullptr, 0, nullptr, 0},
 };
 
 void PrintUsage(const char *aProgramName, FILE *aStream, int aExitCode)


### PR DESCRIPTION
`ot-ctl` segfaults on any long option it does not recognize:

```
$ ot-ctl --version
Segmentation fault
```

The `kOptions` array passed to `getopt_long()` is missing its required terminating
entry, so glibc walks past the end of the array while trying to match a long option
and dereferences whatever follows it:

```
#0  __strncmp_evex ()
#1  process_long_option (..., longopts=kOptions, ...) at getopt.c:212
#2  _getopt_internal_r (...) at getopt.c:650
#5  ParseArg (...) at src/posix/client.cpp:239
#6  main (argc=2, ...) at src/posix/client.cpp:273
```

`getopt_long()` stops scanning only on an *exact* match, so `--help` and
`--interface-name` spelled out in full return before running off the end.
Everything else walks past it — not just unrecognized options like `--version`,
but also unambiguous abbreviations of the recognized ones, so
`ot-ctl --interface wpan0 state` segfaults too. Short options are unaffected, as
they never walk the long option array.

`src/posix/client.cpp` is the only `struct option` array in the tree missing its
terminator — `src/posix/main.c`, the simulation platform and `spi-hdlc-adapter`
all have theirs — so no other binary is affected.

This is reachable from packaging: OpenWrt's package test harness probes each
installed binary with `--version`, which crashes there.

The same change also declares `--help` as `no_argument`. It takes no argument, and
the short form already has none in the option string (`"+I:h"`), so `ot-ctl --help`
failed with `option '--help' requires an argument` and exited non-zero instead of
printing the usage.

Verified on a POSIX daemon build (`-DOT_PLATFORM=posix -DOT_DAEMON=ON`), before → after:

| invocation | before | after |
|---|---|---|
| `ot-ctl --version` | SIGSEGV | exit 1 + usage |
| `ot-ctl --bogus` | SIGSEGV | exit 1 + usage |
| `ot-ctl --help` | exit 1, "requires an argument" | exit 0 + usage |
| `ot-ctl -h` | exit 0 + usage | unchanged |
| `ot-ctl --interface wpan0 state` | SIGSEGV | connect error |
| `ot-ctl -I wpan0 state` | connect error | unchanged |



---

Follow-up in #13424, which adds `--version` to the POSIX binaries.
