### PR TITLE
[sub-mac] do not claim `kCapRxOnWhenIdle` in `SubMac::GetCaps()`

### DIFF
--- a/src/core/config/mac.h
+++ b/src/core/config/mac.h
@@ -374,15 +374,6 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_ON_WHEN_IDLE_ENABLE
- *
- * Define to 1 to enable software rx off when idle switching.
- */
-#ifndef OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_ON_WHEN_IDLE_ENABLE
-#define OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_ON_WHEN_IDLE_ENABLE 0
-#endif
-
-/**
  * @def OPENTHREAD_CONFIG_MAC_SOFTWARE_RETX_SECURITY_ENABLE
  *
  * Define to 1 to enable software retransmission security logic.

--- a/src/core/config/openthread-core-config-check.h
+++ b/src/core/config/openthread-core-config-check.h
@@ -707,4 +707,9 @@
        "It was originally implemented as a provisional solution for the wake mechanism."
 #endif
 
+#ifdef OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_ON_WHEN_IDLE_ENABLE
+#error "OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_ON_WHEN_IDLE_ENABLE was removed. " \
+       "Software support for RxOnWhenIdle in SubMac was never implemented."
+#endif
+
 #endif // OT_CORE_CONFIG_OPENTHREAD_CORE_CONFIG_CHECK_H_

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -116,7 +116,7 @@ SubMac::Capabilities SubMac::GetCaps(void) const
 #endif
     {
         caps |= (kCapAckTimeout | kCapCsmaBackoff | kCapTransmitRetries | kCapEnergyScan | kCapTransmitSec |
-                 kCapTransmitTiming | kCapReceiveTiming | kCapRxOnWhenIdle);
+                 kCapTransmitTiming | kCapReceiveTiming);
     }
 
     return caps;

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -521,7 +521,6 @@ private:
         ConditionalCap(kCapTransmitSec, OPENTHREAD_CONFIG_MAC_SOFTWARE_TX_SECURITY_ENABLE) |
         ConditionalCap(kCapTransmitTiming, OPENTHREAD_CONFIG_MAC_SOFTWARE_TX_TIMING_ENABLE) |
         ConditionalCap(kCapReceiveTiming, OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE) |
-        ConditionalCap(kCapRxOnWhenIdle, OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_ON_WHEN_IDLE_ENABLE) |
         ConditionalCap(kCapSleepToTx, OPENTHREAD_RADIO);
 
 #undef ConditionalCap


### PR DESCRIPTION
This commit updates `SubMac::GetCaps()` to no longer include `kCapRxOnWhenIdle` in the set of capabilities that `SubMac` claims to provide.

The `kCapRxOnWhenIdle` capability was originally introduced in #9554. In that same PR, `SubMac::GetCaps()` was updated to claim that `SubMac` provides this capability. However, supporting `kCapRxOnWhenIdle` requires implementing all radio behaviors documented in `otPlatRadioSetRxOnWhenIdle()` (such as handling rx-on-when-idle state transitions, sleep after frame reception or tx done, etc), which `SubMac` does not actually implement.

Due to this incorrect claim, in RCP/Host architecture, an RCP running `SubMac` would falsely report to the Host that `kCapRxOnWhenIdle` was supported. The Host would then assume the RCP radio platform managed `RxOnWhenIdle` state handling internally, leading to radio state desynchronization and unexpected issues.

With this commit, `SubMac` only reports `kCapRxOnWhenIdle` if the underlying platform radio natively supports it (via `otPlatRadioGetCaps()`).

It also removes the `OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_ON_WHEN_IDLE_ENABLE` configuration which was never actually implemented in `SubMac and adds a compile-time check against its use in `openthread-core-config-check.h`.