### PR TITLE
[posix] validate UDP message length against payload buffer

### DIFF
--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -448,6 +448,7 @@ otError otPlatUdpSend(otUdpSocket *aUdpSocket, otMessage *aMessage, const otMess
     fd = FdFromHandle(aUdpSocket->mHandle);
 
     len = otMessageGetLength(aMessage);
+    VerifyOrExit(len <= sizeof(payload), error = OT_ERROR_NO_BUFS);
     VerifyOrExit(len == otMessageRead(aMessage, 0, payload, len), error = OT_ERROR_INVALID_ARGS);
 
     if (aMessageInfo->mMulticastLoop)


### PR DESCRIPTION
Previously, otPlatUdpSend passed the message length directly to otMessageRead without verifying that it fit within the fixed-size payload buffer, potentially causing an out-of-bounds write.

Reject oversized messages with OT_ERROR_NO_BUFS before reading their contents.