### PR TITLE
[sub-mac] simplify `SubMac::Sleep()` implementation

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -215,21 +215,17 @@ Error SubMac::Sleep(void)
     if (IsRadioSampleEnabled())
     {
         RadioSample();
+        ExitNow();
     }
-    else
 #endif
-    {
-        error = RadioSleep();
-    }
 
-    return error;
-}
+    // Even if the radio platform supports `kCapRxOnWhenIdle`, when
+    // `SubMac::Sleep()` is explicitly called while `mRxOnWhenIdle`
+    // is true, we still call `Radio::Sleep()`. This supports radio
+    // validation and test scenarios where the radio is being forced
+    // to sleep.
 
-Error SubMac::RadioSleep(void)
-{
-    Error error = kErrorNone;
-
-    if (ShouldHandleTransitionToSleep())
+    if (!RadioSupports(kCapRxOnWhenIdle) || mRxOnWhenIdle)
     {
         SuccessOrExit(error = Get<Radio::Radio>().Sleep());
     }
@@ -237,7 +233,7 @@ Error SubMac::RadioSleep(void)
     SetState(kStateSleep);
 
 exit:
-    LogWarnOnError(error, "RadioSleep()");
+    LogWarnOnError(error, "Sleep()");
     return error;
 }
 
@@ -883,8 +879,6 @@ bool SubMac::ShouldHandleCsmaBackOff(void) const
 exit:
     return shouldHandle;
 }
-
-bool SubMac::ShouldHandleTransitionToSleep(void) const { return (mRxOnWhenIdle || !RadioSupports(kCapRxOnWhenIdle)); }
 
 void SubMac::SetState(State aState)
 {

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -581,7 +581,6 @@ private:
     bool ShouldHandleEnergyScan(void) const { return ShouldHandle(kCapEnergyScan); }
     bool ShouldHandleTransmitTargetTime(void) const { return ShouldHandle(kCapTransmitTiming); }
     bool ShouldHandleCsmaBackOff(void) const;
-    bool ShouldHandleTransitionToSleep(void) const;
 
     void ProcessTransmitSecurity(void);
     void ReprocessSecurityForRetx(TxFrame &aFrame);
@@ -599,8 +598,6 @@ private:
     void SignalFrameCounterUsedOnTxDone(const TxFrame &aFrame);
     void HandleEnergyScanDone(int8_t aMaxRssi);
     void HandleTimer(void);
-
-    Error RadioSleep(void);
 
     void               SetState(State aState);
     static const char *StateToString(State aState);


### PR DESCRIPTION
This commit simplifies `SubMac::Sleep()` by inlining the logic previously in `RadioSleep()` and `ShouldHandleTransitionToSleep()`, allowing the removal of those private helper methods.

It also clarifies via comment why `Radio::Sleep()` is invoked when `mRxOnWhenIdle` is true even if `kCapRxOnWhenIdle` is supported (to support radio validation and test scenarios where the radio is forced to sleep).