### PR TITLE
(UNDER WORK) [neighbor] store MLE challenge as separate member in Neighbor

### DIFF
--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -718,18 +718,8 @@ void Mle::SendLinkRequest(Router *aRouter)
     }
     else
     {
-        if (!aRouter->IsStateValid())
-        {
-            aRouter->GenerateChallenge();
-            SuccessOrExit(error = message->AppendChallengeTlv(aRouter->GetChallenge()));
-        }
-        else
-        {
-            TxChallenge challenge;
-
-            challenge.GenerateRandom();
-            SuccessOrExit(error = message->AppendChallengeTlv(challenge));
-        }
+        aRouter->GenerateChallenge();
+        SuccessOrExit(error = message->AppendChallengeTlv(aRouter->GetChallenge()));
 
         destination.InitAsLinkLocalAddress(aRouter->GetExtAddress());
         aRouter->RestartLinkAcceptTimeout();
@@ -979,10 +969,6 @@ void Mle::HandleLinkAcceptVariant(RxInfo &aRxInfo, MessageType aMessageType)
 
     switch (neighborState)
     {
-    case Neighbor::kStateLinkRequest:
-        VerifyOrExit(response == router->GetChallenge(), error = kErrorSecurity);
-        break;
-
     case Neighbor::kStateInvalid:
         VerifyOrExit(mPrevRoleRestorer.IsRestoringRouterOrLeaderRole(), error = kErrorSecurity);
         VerifyOrExit(response == mPrevRoleRestorer.GetChallenge(), error = kErrorSecurity);
@@ -991,6 +977,13 @@ void Mle::HandleLinkAcceptVariant(RxInfo &aRxInfo, MessageType aMessageType)
     case Neighbor::kStateValid:
         extAddress.SetFromIid(aRxInfo.mMessageInfo.GetPeerAddr().GetIid());
         VerifyOrExit(router->GetExtAddress() == extAddress, error = kErrorSecurity);
+
+        OT_FALL_THROUGH;
+
+    case Neighbor::kStateLinkRequest:
+        VerifyOrExit(response == router->GetChallenge(), error = kErrorSecurity);
+        break;
+
         break;
 
     default:

--- a/src/core/thread/neighbor.hpp
+++ b/src/core/thread/neighbor.hpp
@@ -389,14 +389,14 @@ public:
      *
      * @returns A reference to `Mac::LinkFrameCounters` containing link frame counter for all supported radio links.
      */
-    Mac::LinkFrameCounters &GetLinkFrameCounters(void) { return mValidPending.mValid.mLinkFrameCounters; }
+    Mac::LinkFrameCounters &GetLinkFrameCounters(void) { return mLinkFrameCounters; }
 
     /**
      * Gets the link frame counters.
      *
      * @returns A reference to `Mac::LinkFrameCounters` containing link frame counter for all supported radio links.
      */
-    const Mac::LinkFrameCounters &GetLinkFrameCounters(void) const { return mValidPending.mValid.mLinkFrameCounters; }
+    const Mac::LinkFrameCounters &GetLinkFrameCounters(void) const { return mLinkFrameCounters; }
 
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
     /**
@@ -404,7 +404,7 @@ public:
      *
      * @returns The link ACK frame counter value.
      */
-    uint32_t GetLinkAckFrameCounter(void) const { return mValidPending.mValid.mLinkAckFrameCounter; }
+    uint32_t GetLinkAckFrameCounter(void) const { return mLinkAckFrameCounter; }
 #endif
 
     /**
@@ -415,7 +415,7 @@ public:
     void SetLinkAckFrameCounter(uint32_t aAckFrameCounter)
     {
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
-        mValidPending.mValid.mLinkAckFrameCounter = aAckFrameCounter;
+        mLinkAckFrameCounter = aAckFrameCounter;
 #else
         OT_UNUSED_VARIABLE(aAckFrameCounter);
 #endif
@@ -426,14 +426,14 @@ public:
      *
      * @returns The MLE frame counter value.
      */
-    uint32_t GetMleFrameCounter(void) const { return mValidPending.mValid.mMleFrameCounter; }
+    uint32_t GetMleFrameCounter(void) const { return mMleFrameCounter; }
 
     /**
      * Sets the MLE frame counter value.
      *
      * @param[in]  aFrameCounter  The MLE frame counter value.
      */
-    void SetMleFrameCounter(uint32_t aFrameCounter) { mValidPending.mValid.mMleFrameCounter = aFrameCounter; }
+    void SetMleFrameCounter(uint32_t aFrameCounter) { mMleFrameCounter = aFrameCounter; }
 
     /**
      * Gets the RLOC16 value.
@@ -587,18 +587,6 @@ public:
     LinkQuality GetLinkQualityIn(void) const { return GetLinkInfo().GetLinkQualityIn(); }
 
     /**
-     * Generates a new challenge value for MLE Link Request/Response exchanges.
-     */
-    void GenerateChallenge(void) { mValidPending.mPending.mChallenge.GenerateRandom(); }
-
-    /**
-     * Returns the current challenge value for MLE Link Request/Response exchanges.
-     *
-     * @returns The current challenge value.
-     */
-    const Mle::TxChallenge &GetChallenge(void) const { return mValidPending.mPending.mChallenge; }
-
-    /**
      * Returns the connection time (in seconds) of the neighbor (seconds since entering `kStateValid`).
      *
      * @returns The connection time (in seconds), zero if device is not currently in `kStateValid`.
@@ -715,41 +703,32 @@ protected:
 private:
     static constexpr uint32_t kLastRxFragmentTagTimeout = OPENTHREAD_CONFIG_MULTI_RADIO_FRAG_TAG_TIMEOUT; // in msec
 
-    Mac::ExtAddress mMacAddr;
-    TimeMilli       mLastHeard;
-    union
-    {
-        struct
-        {
-            Mac::LinkFrameCounters mLinkFrameCounters;
-            uint32_t               mMleFrameCounter;
-#if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
-            uint32_t mLinkAckFrameCounter;
-#endif
-        } mValid;
-        struct
-        {
-            Mle::TxChallenge mChallenge;
-        } mPending;
-    } mValidPending;
-
-#if OPENTHREAD_CONFIG_MULTI_RADIO
-    uint16_t  mLastRxFragmentTag;
-    TimeMilli mLastRxFragmentTagTime;
-#endif
-
-    uint32_t mKeySequence;
-    uint16_t mRloc16;
-    uint8_t  mState : 4;
-    uint8_t  mMode : 4;
+    uint8_t mState : 4;
+    uint8_t mMode : 4;
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     uint8_t mLinkFailures : 7;
     bool    mTimeSyncEnabled : 1;
 #else
     uint8_t mLinkFailures;
 #endif
-    uint16_t        mVersion;
-    LinkQualityInfo mLinkInfo;
+    uint16_t mRloc16;
+    uint16_t mVersion;
+#if OPENTHREAD_CONFIG_MULTI_RADIO
+    uint16_t mLastRxFragmentTag;
+#endif
+    TimeMilli mLastHeard;
+    UptimeSec mConnectionStart;
+#if OPENTHREAD_CONFIG_MULTI_RADIO
+    TimeMilli mLastRxFragmentTagTime;
+#endif
+    uint32_t mKeySequence;
+    uint32_t mMleFrameCounter;
+#if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
+    uint32_t mLinkAckFrameCounter;
+#endif
+    Mac::LinkFrameCounters mLinkFrameCounters;
+    Mac::ExtAddress        mMacAddr;
+    LinkQualityInfo        mLinkInfo;
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
     // A list of Link Metrics Forward Tracking Series that is being
     // tracked for this neighbor. Note that this device is the
@@ -761,7 +740,6 @@ private:
     // and this neighbor is the Subject.
     LinkMetrics::Metrics mEnhAckProbingMetrics;
 #endif
-    UptimeSec mConnectionStart;
 };
 
 DefineCoreType(otNeighborInfo, Neighbor::Info);

--- a/src/core/thread/router.hpp
+++ b/src/core/thread/router.hpp
@@ -87,6 +87,18 @@ public:
     void SetFrom(const Parent &aParent);
 
     /**
+     * Generates a new challenge value for MLE Link Request/Response exchanges.
+     */
+    void GenerateChallenge(void) { mChallenge.GenerateRandom(); }
+
+    /**
+     * Returns the current challenge value for MLE Link Request/Response exchanges.
+     *
+     * @returns The current challenge value.
+     */
+    const Mle::TxChallenge &GetChallenge(void) const { return mChallenge; }
+
+    /**
      * Restarts the Link Accept timeout (setting it to max value).
      *
      * This method is used after sending a Link Request to the router to restart the timeout and start waiting to
@@ -235,10 +247,10 @@ private:
     static_assert(Mle::kParentReselectTimeout <= (1U << 15) - 1,
                   "kParentReselectTimeout won't fit in mParentReselectTimeout (15-bit filed)");
 #endif
-
-    uint8_t mNextHop;                 // The next hop towards this router
-    uint8_t mLinkRequestAttempts : 2; // Number of Link Request attempts
-    uint8_t mLinkAcceptTimeout : 2;   // Timeout (in seconds) after sending Link Request waiting for Link Accept
+    Mle::TxChallenge mChallenge;
+    uint8_t          mNextHop;                 // The next hop towards this router
+    uint8_t          mLinkRequestAttempts : 2; // Number of Link Request attempts
+    uint8_t          mLinkAcceptTimeout : 2;   // Timeout (in sec) after sending Link Request waiting for Link Accept
 #if !OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
     uint8_t mCost : 4; // The cost to this router via neighbor router
 #else


### PR DESCRIPTION
This commit refactors `Neighbor` and `Child` struct layouts by making `mChallenge` a dedicated member variable of `Neighbor` instead of union-aliased with frame counters.

Specifically:
- Removes `mValidPending` union from `Neighbor`, separating `mLinkFrameCounters`, `mMleFrameCounter`, `mLinkAckFrameCounter`, and `mChallenge` into standalone member variables.
- Removes `Child`'s internal union (`mRequestTlvs` vs `mAttachChallenge`) and shadowed challenge methods, inheriting challenge handling directly from `Neighbor`.
- Simplifies `Mle::SendLinkRequest()` to use `aRouter->GenerateChallenge()` and `aRouter->GetChallenge()` unconditionally, eliminating temporary local `TxChallenge` variables.
- Unifies challenge response verification in `Mle::HandleLinkAcceptVariant()` for valid and pending routers.