### PR TITLE
[mac-frame] simplify address field processing in `Mac::Frame`

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -53,8 +53,8 @@ void TxFrame::BuildInfo::PrepareHeadersIn(TxFrame &aTxFrame) const
 
     fcf = static_cast<uint16_t>(mType) | static_cast<uint16_t>(mVersion);
 
-    fcf |= DetermineFcfAddrType(mAddrs.mSource, kFcfSrcAddrShift);
-    fcf |= DetermineFcfAddrType(mAddrs.mDestination, kFcfDstAddrShift);
+    fcf |= static_cast<uint16_t>(DetermineAddrMode(mAddrs.mSource) << kFcfSrcAddrShift);
+    fcf |= static_cast<uint16_t>(DetermineAddrMode(mAddrs.mDestination) << kFcfDstAddrShift);
 
     if (!mAddrs.mDestination.IsNone() && !mAddrs.mDestination.IsBroadcast() && (mType != kTypeAck))
     {
@@ -407,30 +407,38 @@ void Frame::SetSequence(uint8_t aSequence)
 
 uint8_t Frame::FindDstAddrIndex(void) const { return SkipSequenceIndex() + (IsDstPanIdPresent() ? sizeof(PanId) : 0); }
 
-Error Frame::GetDstAddr(Address &aAddress) const
+Error Frame::ReadAddressAt(uint8_t aIndex, AddrMode aAddrMode, Address &aAddress) const
 {
-    Error   error = kErrorNone;
-    uint8_t index = FindDstAddrIndex();
+    Error error = kErrorNone;
 
-    VerifyOrExit(index != kInvalidIndex, error = kErrorParse);
+    VerifyOrExit(aIndex != kInvalidIndex, error = kErrorParse);
 
-    switch (GetFcfDstAddr(GetFrameControlField()))
+    switch (aAddrMode)
     {
-    case kFcfAddrShort:
-        aAddress.SetShort(LittleEndian::ReadUint16(&mPsdu[index]));
-        break;
-
-    case kFcfAddrExt:
-        aAddress.SetExtended(&mPsdu[index], ExtAddress::kReverseByteOrder);
-        break;
-
-    default:
+    case kAddrModeNone:
         aAddress.SetNone();
+        break;
+
+    case kAddrModeReserved:
+        error = kErrorParse;
+        break;
+
+    case kAddrModeShort:
+        aAddress.SetShort(LittleEndian::ReadUint16(&mPsdu[aIndex]));
+        break;
+
+    case kAddrModeExt:
+        aAddress.SetExtended(&mPsdu[aIndex], ExtAddress::kReverseByteOrder);
         break;
     }
 
 exit:
     return error;
+}
+
+Error Frame::GetDstAddr(Address &aAddress) const
+{
+    return ReadAddressAt(FindDstAddrIndex(), ReadDstAddrMode(GetFrameControlField()), aAddress);
 }
 
 uint8_t Frame::FindSrcPanIdIndex(void) const
@@ -447,16 +455,7 @@ uint8_t Frame::FindSrcPanIdIndex(void) const
         index += sizeof(PanId);
     }
 
-    switch (GetFcfDstAddr(fcf))
-    {
-    case kFcfAddrShort:
-        index += sizeof(ShortAddress);
-        break;
-
-    case kFcfAddrExt:
-        index += sizeof(ExtAddress);
-        break;
-    }
+    SuccessOrExit(AddAddrSizeTo(index, ReadDstAddrMode(fcf)));
 
 exit:
     return index;
@@ -528,55 +527,20 @@ uint8_t Frame::FindSrcAddrIndex(void) const
         index += sizeof(PanId);
     }
 
-    switch (GetFcfDstAddr(fcf))
-    {
-    case kFcfAddrShort:
-        index += sizeof(ShortAddress);
-        break;
-
-    case kFcfAddrExt:
-        index += sizeof(ExtAddress);
-        break;
-    }
+    SuccessOrExit(AddAddrSizeTo(index, ReadDstAddrMode(fcf)));
 
     if (IsSrcPanIdPresent(fcf))
     {
         index += sizeof(PanId);
     }
 
+exit:
     return index;
 }
 
 Error Frame::GetSrcAddr(Address &aAddress) const
 {
-    Error    error = kErrorNone;
-    uint8_t  index = FindSrcAddrIndex();
-    uint16_t fcf   = GetFrameControlField();
-
-    VerifyOrExit(index != kInvalidIndex, error = kErrorParse);
-
-    switch (GetFcfSrcAddr(fcf))
-    {
-    case kFcfAddrShort:
-        aAddress.SetShort(LittleEndian::ReadUint16(&mPsdu[index]));
-        break;
-
-    case kFcfAddrExt:
-        aAddress.SetExtended(&mPsdu[index], ExtAddress::kReverseByteOrder);
-        break;
-
-    case kFcfAddrNone:
-        aAddress.SetNone();
-        break;
-
-    default:
-        // reserved value
-        error = kErrorParse;
-        break;
-    }
-
-exit:
-    return error;
+    return ReadAddressAt(FindSrcAddrIndex(), ReadSrcAddrMode(GetFrameControlField()), aAddress);
 }
 
 Error Frame::GetSecurityControlField(uint8_t &aSecurityControlField) const
@@ -843,31 +807,23 @@ exit:
     return index;
 }
 
-uint16_t Frame::DetermineFcfAddrType(const Address &aAddress, uint16_t aBitShift)
+Frame::AddrMode Frame::DetermineAddrMode(const Address &aAddress)
 {
-    // Determines the FCF address type for a given `aAddress`. The
-    // result will be bit-shifted using `aBitShift` value which
-    // correspond to whether address is the source or destination
-    // and whether the frame uses the general format or is a
-    // multipurpose frame
-
-    uint16_t fcfAddrType = kFcfAddrNone;
+    AddrMode addrMode = kAddrModeNone;
 
     switch (aAddress.GetType())
     {
     case Address::kTypeNone:
         break;
     case Address::kTypeShort:
-        fcfAddrType = kFcfAddrShort;
+        addrMode = kAddrModeShort;
         break;
     case Address::kTypeExtended:
-        fcfAddrType = kFcfAddrExt;
+        addrMode = kAddrModeExt;
         break;
     }
 
-    fcfAddrType <<= aBitShift;
-
-    return fcfAddrType;
+    return addrMode;
 }
 
 uint8_t Frame::CalculateSecurityHeaderSize(uint8_t aSecurityControl)
@@ -887,28 +843,44 @@ exit:
     return size;
 }
 
+Error Frame::AddAddrSizeTo(uint8_t &aIndex, AddrMode aAddrMode)
+{
+    static constexpr uint8_t kSizeForAddrMode[] = {
+        /* [0] kAddrModeNone     */ 0,
+        /* [1] kAddrModeReserved */ kInvalidSize,
+        /* [2] kAddrModeShort    */ sizeof(ShortAddress),
+        /* [3] kAddrModeExt      */ sizeof(ExtAddress),
+    };
+
+    static_assert(kSizeForAddrMode[kAddrModeNone] == 0, "kSizeForAddrMode[] array is incorrect");
+    static_assert(kSizeForAddrMode[kAddrModeReserved] == kInvalidSize, "kSizeForAddrMode[] array is incorrect");
+    static_assert(kSizeForAddrMode[kAddrModeShort] == sizeof(ShortAddress), "kSizeForAddrMode[] array is incorrect");
+    static_assert(kSizeForAddrMode[kAddrModeExt] == sizeof(ExtAddress), "kSizeForAddrMode[] array is incorrect");
+
+    Error error = kErrorNone;
+
+    if (aAddrMode == kAddrModeReserved)
+    {
+        aIndex = kInvalidIndex;
+        error  = kErrorParse;
+        ExitNow();
+    }
+
+    aIndex += kSizeForAddrMode[aAddrMode];
+
+exit:
+    return error;
+}
+
 uint8_t Frame::SkipAddrFieldIndex(void) const
 {
     // Returns the index after the MAC address header fields (Frame Control,
     // Sequence Number, Destination/Source PAN ID, and Destination/Source
     // Addresses). If the header is invalid, returns `kInvalidIndex`.
 
-    static constexpr uint8_t kSizeForAddrMode[] = {
-        /* [0] kFcfAddrNone     */ 0,
-        /* [1] kFcfAddrReserved */ kInvalidSize,
-        /* [2] kFcfAddrShort    */ sizeof(ShortAddress),
-        /* [3] kFcfAddrExt      */ sizeof(ExtAddress),
-    };
-
-    static_assert(kSizeForAddrMode[kFcfAddrNone] == 0, "kSizeForAddrMode[] array is incorrect");
-    static_assert(kSizeForAddrMode[kFcfAddrReserved] == kInvalidSize, "kSizeForAddrMode[] array is incorrect");
-    static_assert(kSizeForAddrMode[kFcfAddrShort] == sizeof(ShortAddress), "kSizeForAddrMode[] array is incorrect");
-    static_assert(kSizeForAddrMode[kFcfAddrExt] == sizeof(ExtAddress), "kSizeForAddrMode[] array is incorrect");
-
     uint8_t  index = kInvalidIndex;
     uint8_t  size;
     uint16_t fcf;
-    uint16_t addrMode;
 
     VerifyOrExit(kFcfSize + GetFcsSize() <= GetLength());
 
@@ -929,18 +901,14 @@ uint8_t Frame::SkipAddrFieldIndex(void) const
         size += sizeof(PanId);
     }
 
-    addrMode = GetFcfDstAddr(fcf);
-    VerifyOrExit(addrMode != kFcfAddrReserved);
-    size += kSizeForAddrMode[addrMode];
+    SuccessOrExit(AddAddrSizeTo(size, ReadDstAddrMode(fcf)));
 
     if (IsSrcPanIdPresent(fcf))
     {
         size += sizeof(PanId);
     }
 
-    addrMode = GetFcfSrcAddr(fcf);
-    VerifyOrExit(addrMode != kFcfAddrReserved);
-    size += kSizeForAddrMode[addrMode];
+    SuccessOrExit(AddAddrSizeTo(size, ReadSrcAddrMode(fcf)));
 
     index = size;
 

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -623,11 +623,15 @@ protected:
 
     static constexpr uint16_t kFcfFrameTypeMask = 7 << 0;
 
-    static constexpr uint16_t kFcfAddrNone     = 0;
-    static constexpr uint16_t kFcfAddrReserved = 1;
-    static constexpr uint16_t kFcfAddrShort    = 2;
-    static constexpr uint16_t kFcfAddrExt      = 3;
-    static constexpr uint16_t kFcfAddrMask     = 3;
+    enum AddrMode : uint8_t
+    {
+        kAddrModeNone     = 0,
+        kAddrModeReserved = 1,
+        kAddrModeShort    = 2,
+        kAddrModeExt      = 3,
+    };
+
+    static constexpr uint16_t kFcfAddrMask = 3;
 
     // Frame Control field format for general MAC frame
     static constexpr uint16_t kFcfSecurityEnabled  = 1 << 3;
@@ -637,15 +641,15 @@ protected:
     static constexpr uint16_t kFcfSeqSuppression   = 1 << 8;
     static constexpr uint16_t kFcfIePresent        = 1 << 9;
     static constexpr uint16_t kFcfDstAddrShift     = 10;
-    static constexpr uint16_t kFcfDstAddrNone      = kFcfAddrNone << kFcfDstAddrShift;
-    static constexpr uint16_t kFcfDstAddrShort     = kFcfAddrShort << kFcfDstAddrShift;
-    static constexpr uint16_t kFcfDstAddrExt       = kFcfAddrExt << kFcfDstAddrShift;
+    static constexpr uint16_t kFcfDstAddrNone      = kAddrModeNone << kFcfDstAddrShift;
+    static constexpr uint16_t kFcfDstAddrShort     = kAddrModeShort << kFcfDstAddrShift;
+    static constexpr uint16_t kFcfDstAddrExt       = kAddrModeExt << kFcfDstAddrShift;
     static constexpr uint16_t kFcfDstAddrMask      = kFcfAddrMask << kFcfDstAddrShift;
     static constexpr uint16_t kFcfFrameVersionMask = 3 << 12;
     static constexpr uint16_t kFcfSrcAddrShift     = 14;
-    static constexpr uint16_t kFcfSrcAddrNone      = kFcfAddrNone << kFcfSrcAddrShift;
-    static constexpr uint16_t kFcfSrcAddrShort     = kFcfAddrShort << kFcfSrcAddrShift;
-    static constexpr uint16_t kFcfSrcAddrExt       = kFcfAddrExt << kFcfSrcAddrShift;
+    static constexpr uint16_t kFcfSrcAddrNone      = kAddrModeNone << kFcfSrcAddrShift;
+    static constexpr uint16_t kFcfSrcAddrShort     = kAddrModeShort << kFcfSrcAddrShift;
+    static constexpr uint16_t kFcfSrcAddrExt       = kAddrModeExt << kFcfSrcAddrShift;
     static constexpr uint16_t kFcfSrcAddrMask      = kFcfAddrMask << kFcfSrcAddrShift;
 
     static constexpr uint8_t kSecLevelMask  = 7 << 0;
@@ -676,12 +680,12 @@ protected:
     uint8_t FindHeaderIeIndex(void) const;
 #endif
 
-    static uint16_t GetFcfDstAddr(uint16_t aFcf) { return ReadBits<uint16_t, kFcfDstAddrMask>(aFcf); }
-    static uint16_t GetFcfSrcAddr(uint16_t aFcf) { return ReadBits<uint16_t, kFcfSrcAddrMask>(aFcf); }
+    static AddrMode ReadDstAddrMode(uint16_t aFcf) { return As<AddrMode>(ReadBits<uint16_t, kFcfDstAddrMask>(aFcf)); }
+    static AddrMode ReadSrcAddrMode(uint16_t aFcf) { return As<AddrMode>(ReadBits<uint16_t, kFcfSrcAddrMask>(aFcf)); }
     static bool     IsSeqSuppressed(uint16_t aFcf) { return IsVersion2015(aFcf) && ((aFcf & kFcfSeqSuppression) != 0); }
     static bool     IsSeqPresent(uint16_t aFcf) { return !IsSeqSuppressed(aFcf); }
-    static bool     IsDstAddrPresent(uint16_t aFcf) { return (aFcf & kFcfDstAddrMask) != 0; }
-    static bool     IsSrcAddrPresent(uint16_t aFcf) { return (aFcf & kFcfSrcAddrMask) != 0; }
+    static bool     IsDstAddrPresent(uint16_t aFcf) { return ReadDstAddrMode(aFcf) != kAddrModeNone; }
+    static bool     IsSrcAddrPresent(uint16_t aFcf) { return ReadSrcAddrMode(aFcf) != kAddrModeNone; }
     static bool     IsSecurityEnabled(uint16_t aFcf) { return (aFcf & kFcfSecurityEnabled) != 0; }
     static bool     IsFramePending(uint16_t aFcf) { return (aFcf & kFcfFramePending) != 0; }
     static bool     IsIePresent(uint16_t aFcf) { return IsVersion2015(aFcf) && ((aFcf & kFcfIePresent) != 0); }
@@ -690,18 +694,22 @@ protected:
     static bool     IsVersion2015(uint16_t aFcf) { return GetVersion(aFcf) == kVersion2015; }
     static bool     IsDstPanIdPresent(uint16_t aFcf);
     static bool     IsSrcPanIdPresent(uint16_t aFcf);
-    static uint16_t DetermineFcfAddrType(const Address &aAddress, uint16_t aBitShift);
+    static AddrMode DetermineAddrMode(const Address &aAddress);
+    static Error    AddAddrSizeTo(uint8_t &aIndex, AddrMode aAddrMode);
     static uint8_t  CalculateSecurityHeaderSize(uint8_t aSecurityControl);
     static uint8_t  CalculateKeySourceSize(uint8_t aSecurityControl);
     static uint8_t  CalculateMicSize(uint8_t aSecurityControl);
 
 private:
+    template <typename EnumType> static EnumType As(uint16_t aValue) { return static_cast<EnumType>(aValue); }
+
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
     typedef bool (&HeaderIeMatcher)(const HeaderIe &aHeaderIe);
 
     const HeaderIe *FindHeaderIe(HeaderIeMatcher aMatcher) const;
     HeaderIe       *FindHeaderIe(HeaderIeMatcher aMatcher) { return AsNonConst(AsConst(this)->FindHeaderIe(aMatcher)); }
 #endif
+    Error ReadAddressAt(uint8_t aIndex, AddrMode aAddrMode, Address &aAddress) const;
 };
 
 /**


### PR DESCRIPTION
This commit simplifies MAC address field handling and parsing in `Mac::Frame`.

Specifically:
- Introduces `enum AddrMode : uint8_t` (`kAddrModeNone`, `kAddrModeReserved`, `kAddrModeShort`, `kAddrModeExt`) to represent unshifted address modes.
- Adds `ReadDstAddrMode()` and `ReadSrcAddrMode()` static helper methods.
- Refactors `DetermineFcfAddrType()` to `DetermineAddrMode()`, returning raw `AddrMode`.
- Introduces `ReadAddressAt()` helper to consolidate `GetDstAddr()` and `GetSrcAddr()` implementations.
- Introduces `AddAddrSizeTo()` helper methods for navigating MAC address header fields.