### PR TITLE
[posix] use nullptr instead of NULL in client

### DIFF
--- a/src/posix/client.cpp
+++ b/src/posix/client.cpp
@@ -209,8 +209,8 @@ constexpr char kOptInterfaceName = 'I';
 constexpr char kOptHelp          = 'h';
 
 const struct option kOptions[] = {
-    {"interface-name", required_argument, NULL, kOptInterfaceName},
-    {"help", no_argument, NULL, kOptHelp},
+    {"interface-name", required_argument, nullptr, kOptInterfaceName},
+    {"help", no_argument, nullptr, kOptHelp},
     {nullptr, 0, nullptr, 0},
 };
 


### PR DESCRIPTION
This commit updates src/posix/client.cpp to replace instances of NULL with nullptr in option array structure definitions.