### PR TITLE
[cli] add `CLI_LINK_METRICS_ENH_ACK_VERBOSE_ENABLE` config guard (#13435)

### DIFF
--- a/src/cli/cli_config.h
+++ b/src/cli/cli_config.h
@@ -76,6 +76,22 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_CLI_LINK_METRICS_ENH_ACK_VERBOSE_ENABLE
+ *
+ * Define to 1 to enable unsolicited CLI output of Link Metrics data
+ * received in Enhanced-ACK frames. When disabled (default), no Enhanced-ACK
+ * IE callback is registered with otLinkMetricsConfigEnhAckProbing(), so the
+ * callback and its CLI output are compiled out entirely.
+ *
+ * Enabling this option adds OutputFormat() calls inside the time-critical
+ * Mac::HandleTransmitDone() path. On platforms with synchronous/blocking
+ * CLI transport, this may break SED fast-poll timing.
+ */
+#ifndef OPENTHREAD_CONFIG_CLI_LINK_METRICS_ENH_ACK_VERBOSE_ENABLE
+#define OPENTHREAD_CONFIG_CLI_LINK_METRICS_ENH_ACK_VERBOSE_ENABLE 0
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_CLI_BLE_SECURE_ENABLE
  *
  * Indicates whether TCAT should be enabled in the CLI tool.

--- a/src/cli/cli_link_metrics.cpp
+++ b/src/cli/cli_link_metrics.cpp
@@ -325,10 +325,14 @@ template <> otError LinkMetrics::Process<Cmd("config")>(Arg aArgs[])
             ExitNow(error = OT_ERROR_INVALID_ARGS);
         }
 
-        SuccessOrExit(
-            error = otLinkMetricsConfigEnhAckProbing(GetInstancePtr(), &address, enhAckFlags, pLinkMetrics,
-                                                     &LinkMetrics::HandleLinkMetricsConfigEnhAckProbingMgmtResponse,
-                                                     this, &LinkMetrics::HandleLinkMetricsEnhAckProbingIe, this));
+        error = otLinkMetricsConfigEnhAckProbing(GetInstancePtr(), &address, enhAckFlags, pLinkMetrics,
+                                                 &LinkMetrics::HandleLinkMetricsConfigEnhAckProbingMgmtResponse, this,
+#if OPENTHREAD_CONFIG_CLI_LINK_METRICS_ENH_ACK_VERBOSE_ENABLE
+                                                 &LinkMetrics::HandleLinkMetricsEnhAckProbingIe, this);
+#else
+                                                 nullptr, nullptr);
+#endif
+        SuccessOrExit(error);
 
         if (sync)
         {
@@ -542,6 +546,7 @@ void LinkMetrics::HandleLinkMetricsMgmtResponse(const otIp6Address *aAddress, ot
     OutputLine("Status: %s", LinkMetricsStatusToStr(aStatus));
 }
 
+#if OPENTHREAD_CONFIG_CLI_LINK_METRICS_ENH_ACK_VERBOSE_ENABLE
 void LinkMetrics::HandleLinkMetricsEnhAckProbingIe(otShortAddress             aShortAddress,
                                                    const otExtAddress        *aExtAddress,
                                                    const otLinkMetricsValues *aMetricsValues,
@@ -563,6 +568,7 @@ void LinkMetrics::HandleLinkMetricsEnhAckProbingIe(otShortAddress             aS
         PrintLinkMetricsValue(aMetricsValues);
     }
 }
+#endif
 
 const char *LinkMetrics::LinkMetricsStatusToStr(otLinkMetricsStatus aStatus)
 {

--- a/src/cli/cli_link_metrics.cpp
+++ b/src/cli/cli_link_metrics.cpp
@@ -325,10 +325,18 @@ template <> otError LinkMetrics::Process<Cmd("config")>(Arg aArgs[])
             ExitNow(error = OT_ERROR_INVALID_ARGS);
         }
 
+#if OPENTHREAD_CONFIG_CLI_LINK_METRICS_ENH_ACK_VERBOSE_ENABLE
+        otLinkMetricsEnhAckProbingIeReportCallback enhAckCallback = &LinkMetrics::HandleLinkMetricsEnhAckProbingIe;
+        void                                      *enhAckContext  = this;
+#else
+        otLinkMetricsEnhAckProbingIeReportCallback enhAckCallback = nullptr;
+        void                                      *enhAckContext  = nullptr;
+#endif
+
         SuccessOrExit(
             error = otLinkMetricsConfigEnhAckProbing(GetInstancePtr(), &address, enhAckFlags, pLinkMetrics,
                                                      &LinkMetrics::HandleLinkMetricsConfigEnhAckProbingMgmtResponse,
-                                                     this, &LinkMetrics::HandleLinkMetricsEnhAckProbingIe, this));
+                                                     this, enhAckCallback, enhAckContext));
 
         if (sync)
         {
@@ -542,6 +550,7 @@ void LinkMetrics::HandleLinkMetricsMgmtResponse(const otIp6Address *aAddress, ot
     OutputLine("Status: %s", LinkMetricsStatusToStr(aStatus));
 }
 
+#if OPENTHREAD_CONFIG_CLI_LINK_METRICS_ENH_ACK_VERBOSE_ENABLE
 void LinkMetrics::HandleLinkMetricsEnhAckProbingIe(otShortAddress             aShortAddress,
                                                    const otExtAddress        *aExtAddress,
                                                    const otLinkMetricsValues *aMetricsValues,
@@ -563,6 +572,7 @@ void LinkMetrics::HandleLinkMetricsEnhAckProbingIe(otShortAddress             aS
         PrintLinkMetricsValue(aMetricsValues);
     }
 }
+#endif
 
 const char *LinkMetrics::LinkMetricsStatusToStr(otLinkMetricsStatus aStatus)
 {

--- a/src/cli/cli_link_metrics.hpp
+++ b/src/cli/cli_link_metrics.hpp
@@ -104,6 +104,7 @@ private:
     void HandleLinkMetricsConfigEnhAckProbingMgmtResponse(const otIp6Address *aAddress, otLinkMetricsStatus aStatus);
     void HandleLinkMetricsMgmtResponse(const otIp6Address *aAddress, otLinkMetricsStatus aStatus);
 
+#if OPENTHREAD_CONFIG_CLI_LINK_METRICS_ENH_ACK_VERBOSE_ENABLE
     static void HandleLinkMetricsEnhAckProbingIe(otShortAddress             aShortAddress,
                                                  const otExtAddress        *aExtAddress,
                                                  const otLinkMetricsValues *aMetricsValues,
@@ -112,6 +113,7 @@ private:
     void HandleLinkMetricsEnhAckProbingIe(otShortAddress             aShortAddress,
                                           const otExtAddress        *aExtAddress,
                                           const otLinkMetricsValues *aMetricsValues);
+#endif
 
     const char *LinkMetricsStatusToStr(otLinkMetricsStatus aStatus);
 


### PR DESCRIPTION
HandleLinkMetricsEnhAckProbingIe() emits unsolicited CLI output from the time-critical MAC transmit-done path on every Enhanced-ACK Link Metrics reception, which can break SED fast-poll timing on platforms with a synchronous/blocking CLI transport.

Guard this output behind the new OPENTHREAD_CONFIG_CLI_LINK_METRICS_ENH_ACK_VERBOSE_ENABLE option (disabled by default). Link Metrics data is still processed internally and queryable via linkmetrics show.

Fixes #13435