### PR TITLE
[ci] use head repo looking up pr_number

### DIFF
--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -75,6 +75,10 @@ jobs:
             const pr = prs?.find(pr => pr.base.repo.full_name === base_full_name && pr.state === 'open') ||
                        prs?.find(pr => pr.base.repo.full_name === base_full_name);
             if (pr) {
+              if (!pr_number) {
+                core.setFailed('No associated pull request found for this workflow run.');
+                return;
+              }
               pr_number = pr.number
             }
           }

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -70,7 +70,7 @@ jobs:
               core.setFailed('Head repository not found in workflow run context payload.');
               return;
             }
-            const [owner, repo] = context.payload.workflow_run.head_repository.full_name.split('/')
+            const [owner, repo] = head_repo.split('/')
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner,
               repo,
@@ -80,10 +80,6 @@ jobs:
             const pr = prs?.find(pr => pr.base.repo.full_name === base_full_name && pr.state === 'open') ||
                        prs?.find(pr => pr.base.repo.full_name === base_full_name);
             if (pr) {
-              if (!pr_number) {
-                core.setFailed('No associated pull request found for this workflow run.');
-                return;
-              }
               pr_number = pr.number
             }
           }

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -72,7 +72,8 @@ jobs:
               commit_sha: context.payload.workflow_run.head_sha,
             })
             const base_full_name = `${context.repo.owner}/${context.repo.repo}`
-            const pr = prs.find(pr => pr.base.repo.full_name === base_full_name)
+            const pr = prs?.find(pr => pr.base.repo.full_name === base_full_name && pr.state === 'open') ||
+                       prs?.find(pr => pr.base.repo.full_name === base_full_name);
             if (pr) {
               pr_number = pr.number
             }

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -65,6 +65,11 @@ jobs:
           let pr_number = context.payload.workflow_run.pull_requests?.[0]?.number
 
           if (!pr_number) {
+            const head_repo = context.payload.workflow_run.head_repository?.full_name;
+            if (!head_repo) {
+              core.setFailed('Head repository not found in workflow run context payload.');
+              return;
+            }
             const [owner, repo] = context.payload.workflow_run.head_repository.full_name.split('/')
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner,

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -65,14 +65,16 @@ jobs:
           let pr_number = context.payload.workflow_run.pull_requests?.[0]?.number
 
           if (!pr_number) {
+            const [owner, repo] = context.payload.workflow_run.head_repository.full_name.split('/')
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner,
+              repo,
               commit_sha: context.payload.workflow_run.head_sha,
             })
-            const open_pr = prs?.find(pr => pr.state === 'open') || prs?.[0]
-            if (open_pr) {
-              pr_number = open_pr.number
+            const base_full_name = `${context.repo.owner}/${context.repo.repo}`
+            const pr = prs.find(pr => pr.base.repo.full_name === base_full_name)
+            if (pr) {
+              pr_number = pr.number
             }
           }
 


### PR DESCRIPTION
The API `github.rest.repos.listPullRequestsAssociatedWithCommit()` can only query commits from the repo owning those commits. Although a fork PR is pushed to the base repo, the base repo doesn't have the commit yet. This commit changes the workflow to query pull request from head repo.