### PR TITLE
[ci] remove arm-gcc-4 build check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,9 +239,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - gcc_ver: 4
-            gcc_download_url: https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-linux.tar.bz2
-            gcc_extract_dir: gcc-arm-none-eabi-4_9-2015q3
           - gcc_ver: 5
             gcc_download_url: https://developer.arm.com/-/media/Files/downloads/gnu-rm/5_4-2016q3/gcc-arm-none-eabi-5_4-2016q3-20160926-linux.tar.bz2
             gcc_extract_dir: gcc-arm-none-eabi-5_4-2016q3


### PR DESCRIPTION
Remove arm-gcc-4 from the arm-gcc build matrix in GitHub Actions.

GCC 4.9 toolchain (arm-gcc-4) fails frequently due to outdated toolchain host dependencies and download sources. Supported GCC matrix now begins at GCC 5.