### PR TITLE
[mac] validate mLength before reading frame fields

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1224,10 +1224,10 @@ Error TxFrame::GenerateEnhAck(const RxFrame &aRxFrame, bool aIsFramePending, con
 
     // Validate the received frame.
 
+    SuccessOrExit(error = aRxFrame.ValidatePsdu());
     VerifyOrExit(aRxFrame.IsVersion2015(), error = kErrorParse);
     VerifyOrExit(aRxFrame.GetAckRequest(), error = kErrorParse);
     VerifyOrExit(aRxFrame.IsSequencePresent(), error = kErrorParse);
-    SuccessOrExit(error = aRxFrame.ValidatePsdu());
 
     // Check `aRxFrame` has a valid destination address. The ack frame
     // will not use this as its source though and will always use no

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1226,6 +1226,8 @@ Error TxFrame::GenerateEnhAck(const RxFrame &aRxFrame, bool aIsFramePending, con
 
     VerifyOrExit(aRxFrame.IsVersion2015(), error = kErrorParse);
     VerifyOrExit(aRxFrame.GetAckRequest(), error = kErrorParse);
+    VerifyOrExit(aRxFrame.IsSequencePresent(), error = kErrorParse);
+    SuccessOrExit(error = aRxFrame.ValidatePsdu());
 
     // Check `aRxFrame` has a valid destination address. The ack frame
     // will not use this as its source though and will always use no


### PR DESCRIPTION
Add missing length validation in Frame accessor functions before reading destination/source addresses, frame counter, or key index.

The offset helpers (FindDstAddrIndex(), FindSrcAddrIndex(), and FindSecurityHeaderIndex()) derive field offsets from the FCF without verifying that the PSDU is long enough, and they never return kInvalidIndex. As a result, the existing VerifyOrExit(index != kInvalidIndex) checks in the accessors are ineffective.

Validate mLength before accessing the buffer so truncated frames cannot trigger out-of-bounds reads.

Bug: 540333980