### PR TITLE
[tcp] preserve forward progress callback during endpoint deinit

### DIFF
--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -478,11 +478,14 @@ bool Tcp::Endpoint::FirePendingCallbacks(void)
 
     if ((mPendingCallbacks & kForwardProgressCallbackFlag) != 0 && mForwardProgressCallback != nullptr)
     {
-        mForwardProgressCallback(this, GetSendBufferBytes(), GetBacklogBytes());
+        otTcpForwardProgress callback        = mForwardProgressCallback;
+        size_t               sendBufferBytes = GetSendBufferBytes();
+        size_t               backlogBytes    = GetBacklogBytes();
+
+        mPendingCallbacks &= ~kForwardProgressCallbackFlag;
+        callback(this, sendBufferBytes, backlogBytes);
         calledUserCallback = true;
     }
-
-    mPendingCallbacks = 0;
 
     return calledUserCallback;
 }
@@ -734,11 +737,27 @@ void Tcp::ProcessSignals(Endpoint             &aEndpoint,
     if (aEndpoint.mForwardProgressCallback != nullptr)
     {
         size_t backlogBytes = aEndpoint.GetBacklogBytes();
+        bool   hasReceiveCallback =
+            (aSignals.recvbuf_added || aSignals.rcvd_fin) && aEndpoint.mReceiveAvailableCallback != nullptr;
+        bool hasDisconnectedCallback =
+            aEndpoint.GetTcb().t_state == TCP6S_TIME_WAIT && aEndpoint.mDisconnectedCallback != nullptr;
 
         if (aSignals.bytes_acked > 0 || backlogBytes < aPriorBacklog)
         {
-            aEndpoint.mForwardProgressCallback(&aEndpoint, aEndpoint.GetSendBufferBytes(), backlogBytes);
-            aEndpoint.mPendingCallbacks &= ~kForwardProgressCallbackFlag;
+            if (hasReceiveCallback || hasDisconnectedCallback)
+            {
+                aEndpoint.mPendingCallbacks |= kForwardProgressCallbackFlag;
+                aEndpoint.Get<Tcp>().mTasklet.Post();
+            }
+            else
+            {
+                otTcpForwardProgress callback        = aEndpoint.mForwardProgressCallback;
+                size_t               sendBufferBytes = aEndpoint.GetSendBufferBytes();
+
+                aEndpoint.mPendingCallbacks &= ~kForwardProgressCallbackFlag;
+                callback(&aEndpoint, sendBufferBytes, backlogBytes);
+                ExitNow();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

This PR fixes a use-after-free in OpenThread's TCP forward progress callback lifetime.

## Analysis

When a TCP forward progress callback fires, both `FirePendingCallbacks()` and `ProcessSignals()` invoke the application callback and then write to `mPendingCallbacks`. If the application deinitializes the endpoint inside that callback (`otTcpEndpointDeinitialize`), the subsequent `mPendingCallbacks` write accesses freed memory.

The vulnerable code was introduced with the `otTcpForwardProgress` callback support [tcp] add support for otTcpForwardProgress callback (d79468bb, v2026.06.0+).

## The Fix

Snapshot the callback pointer and arguments before invocation, clear the pending flag before the callback runs, and remove the unconditional `mPendingCallbacks = 0` store after it.

In `ProcessSignals`, defer forward progress callbacks when receive or disconnected callbacks are also pending (they will be dispatched via the tasklet path). When no other callbacks are active, invoke directly with `ExitNow()` to prevent any post-callback access to the endpoint.

## Testing

- Custom non-ASAN regression test allocates a replacement object at the freed endpoint's address and verifies no stale write occurs
- Test fails RED on unpatched code (`mPendingCallbacks` byte corrupted from `0xFF` to `0xFB`)
- Test passes GREEN on patched code
- Full nexus regression suite: 248/248 tests pass 
- Test kept locally; not committed -- no similar tests exist in the tree (unless mistaken), available on demand