### PR TITLE
[ci] only upload size report file

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -68,4 +68,5 @@ jobs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: report_pr
-        path: /tmp/ot-size-report
+        path: |
+          /tmp/ot-size-report/report_pr

--- a/script/check-size
+++ b/script/check-size
@@ -42,7 +42,7 @@ OT_REPORT_FILE_TABLE="${OT_TMP_DIR}/report_table"
 readonly OT_REPORT_FILE_TABLE
 
 OT_REPORT_FILE_PR="${OT_TMP_DIR}/report_pr"
-readonly OT_REPORT_FILE_TABLE
+readonly OT_REPORT_FILE_PR
 
 PR_NUMBER="${PR_NUMBER:-}"
 


### PR DESCRIPTION
Currently, the `size-check` job uploads all intermediates used for generating the report. This commit changes the `size-check` to upload the final size report file only, so that it won't bloat the artifacts.