### PR TITLE
[sub-mac] fix transmit and receive timing capability reporting

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -115,8 +115,10 @@ SubMac::Capabilities SubMac::GetCaps(void) const
     else
 #endif
     {
-        caps |= (kCapAckTimeout | kCapCsmaBackoff | kCapTransmitRetries | kCapEnergyScan | kCapTransmitSec |
-                 kCapTransmitTiming | kCapReceiveTiming);
+        caps |= (kCapAckTimeout | kCapCsmaBackoff | kCapTransmitRetries | kCapEnergyScan | kCapTransmitSec);
+#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+        caps |= kCapTransmitTiming;
+#endif
     }
 
     return caps;

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -519,8 +519,8 @@ private:
         ConditionalCap(kCapTransmitRetries, OPENTHREAD_CONFIG_MAC_SOFTWARE_RETRANSMIT_ENABLE) |
         ConditionalCap(kCapCsmaBackoff, OPENTHREAD_CONFIG_MAC_SOFTWARE_CSMA_BACKOFF_ENABLE) |
         ConditionalCap(kCapTransmitSec, OPENTHREAD_CONFIG_MAC_SOFTWARE_TX_SECURITY_ENABLE) |
-        ConditionalCap(kCapTransmitTiming, OPENTHREAD_CONFIG_MAC_SOFTWARE_TX_TIMING_ENABLE) |
-        ConditionalCap(kCapReceiveTiming, OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE) |
+        ConditionalCap(kCapTransmitTiming,
+                       OPENTHREAD_CONFIG_MAC_SOFTWARE_TX_TIMING_ENABLE &&OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE) |
         ConditionalCap(kCapSleepToTx, OPENTHREAD_RADIO);
 
 #undef ConditionalCap


### PR DESCRIPTION
This commit updates `SubMac::GetCaps()` to accurately report transmit and receive timing capabilities:

- `kCapTransmitTiming` is now only claimed when CSL transmitter support is enabled (`OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE`), as delayed transmissions are handled by `SubMac` only when this feature is active.

- `kCapReceiveTiming` is removed from `SubMac::GetCaps()`. This capability requires the `ReceiveAt()` API, which is not supported by `SubMac` (or `LinkRaw`). Claiming software support for receive timing in `SubMac` was therefore invalid.