### PR TITLE
[sub-mac] fix `mCslLastSync` type and timestamp tracking

### DIFF
--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -612,11 +612,11 @@ private:
     void     RestartCslTimerAfterSyncUpdate(void);
     void     UpdateCslLastSyncTimestamp(TxFrame &aFrame, RxFrame *aAckFrame);
     void     UpdateCslLastSyncTimestamp(RxFrame *aFrame, Error aError);
+    void     SetCslLastSyncToNow(void);
     void     HandleCslTimer(void);
     void     GetCslWindowEdges(uint32_t &aAhead, uint32_t &aAfter);
     uint32_t DetermineClockDrift(uint32_t aIntervalUs) const;
     uint32_t GetNextCycleDrift(void) const;
-    uint32_t GetLocalTime(void);
     bool     IsCslEnabled(void) const { return mCslPeriod > 0; }
 #if OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
     void LogReceived(RxFrame *aFrame);
@@ -671,9 +671,13 @@ private:
                                           // for platforms not supporting `Radio::ReceiveAt()`.
     uint16_t          mCslPeerShort;      // The CSL peer short address.
     Radio::SyncedTime mCslSampleTime;     // The CSL sample time for current period.
-    TimeMicro         mCslLastSync;       // The timestamp of the last successful CSL synchronization.
     CslAccuracy       mCslParentAccuracy; // The parent's CSL accuracy (clock accuracy and uncertainty).
     CslTimer          mCslTimer;
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_LOCAL_TIME_SYNC
+    TimeMicro mCslLastSync; // The timestamp of the last successful CSL synchronization.
+#else
+    Radio::Time64 mCslLastSync;
+#endif
 #endif
 
 #if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE

--- a/src/core/mac/sub_mac_csl_receiver.cpp
+++ b/src/core/mac/sub_mac_csl_receiver.cpp
@@ -49,8 +49,12 @@ void SubMac::CslInit(void)
     mCslPeerShort  = 0;
     mIsCslSampling = false;
     mCslSampleTime.Clear();
-    mCslLastSync.SetValue(0);
     mCslTimer.Stop();
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_LOCAL_TIME_SYNC
+    mCslLastSync.SetValue(0);
+#else
+    mCslLastSync = 0;
+#endif
 }
 
 void SubMac::RestartCslTimerAfterSyncUpdate(void)
@@ -77,7 +81,7 @@ void SubMac::UpdateCslLastSyncTimestamp(TxFrame &aFrame, RxFrame *aAckFrame)
     // Assuming the error here since it is bounded and has very small effect on the final window duration.
     if (aAckFrame != nullptr && aFrame.Has<CslIe>())
     {
-        mCslLastSync = TimeMicro(GetLocalTime());
+        SetCslLastSyncToNow();
         RestartCslTimerAfterSyncUpdate();
     }
 }
@@ -94,9 +98,9 @@ void SubMac::UpdateCslLastSyncTimestamp(RxFrame *aFrame, Error aError)
     if ((mCslPeriod > 0) && aFrame->IsAckedWithSecEnhAck())
     {
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_LOCAL_TIME_SYNC
-        mCslLastSync = TimerMicro::GetNow();
+        SetCslLastSyncToNow();
 #else
-        mCslLastSync = TimeMicro(Radio::ConvertTime64To32(aFrame->GetTimestamp()));
+        mCslLastSync = aFrame->GetTimestamp();
 #endif
         RestartCslTimerAfterSyncUpdate();
     }
@@ -128,9 +132,11 @@ void SubMac::SetCslParams(uint16_t aPeriod, uint8_t aChannel, ShortAddress aShor
     {
         mCslSampleTime.SetToNow(Get<Radio::Radio>());
 
-        // Update CSL sync time whenever CSL parameters are re-initialized.
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_LOCAL_TIME_SYNC
         mCslLastSync = mCslSampleTime.GetAsLocalTimeMicro();
-
+#else
+        mCslLastSync = mCslSampleTime.GetAsTime64();
+#endif
         HandleCslTimer();
     }
     else if (!RadioSupports(kCapReceiveTiming))
@@ -255,10 +261,14 @@ void SubMac::GetCslWindowEdges(uint32_t &aAhead, uint32_t &aAfter)
      * -timeAhead                           CslPhase                             +timeAfter             -timeAhead
      */
     uint32_t semiPeriod = mCslPeriod * Radio::kUsPerTenSymbols / 2;
-    uint32_t curTime, elapsed, semiWindow;
+    uint32_t elapsed;
+    uint32_t semiWindow;
 
-    curTime = GetLocalTime();
-    elapsed = curTime - mCslLastSync.GetValue();
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_LOCAL_TIME_SYNC
+    elapsed = TimerMicro::GetNow() - mCslLastSync;
+#else
+    elapsed = ClampToUint32(Get<Radio::Radio>().GetNow() - mCslLastSync);
+#endif
 
     semiWindow = DetermineClockDrift(elapsed);
     semiWindow += mCslParentAccuracy.GetUncertaintyInMicrosec() + Get<Radio::Radio>().GetCslUncertainty() * 10;
@@ -279,17 +289,13 @@ uint32_t SubMac::GetNextCycleDrift(void) const
     return DetermineClockDrift(static_cast<uint32_t>(mCslPeriod) * Radio::kUsPerTenSymbols);
 }
 
-uint32_t SubMac::GetLocalTime(void)
+void SubMac::SetCslLastSyncToNow(void)
 {
-    uint32_t now;
-
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_LOCAL_TIME_SYNC
-    now = TimerMicro::GetNow().GetValue();
+    mCslLastSync = TimerMicro::GetNow();
 #else
-    now = Get<Radio::Radio>().GetNowAsTime32();
+    mCslLastSync = Get<Radio::Radio>().GetNow();
 #endif
-
-    return now;
 }
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)


### PR DESCRIPTION
This commit fixes `SubMac::mCslLastSync` tracking and typing when using radio clock time versus local clock time.

`mCslLastSync` was previously declared as `TimeMicro`, which is intended for local system clock time (`TimerMicro::GetNow()`). However, when `OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_LOCAL_TIME_SYNC` is disabled (the default configuration), `mCslLastSync` is used to store radio clock time, making `TimeMicro` a misleading type choice. Additionally, `SetCslParams()` was directly assigning local clock time to `mCslLastSync` regardless of the `OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_LOCAL_TIME_SYNC` setting.

This commit updates `SubMac` to:
- Declare `mCslLastSync` as `Radio::Time64` when local time sync is disabled (the default) and as `TimeMicro` when local time sync is enabled.
- Ensure `SetCslParams()`, `UpdateCslLastSyncTimestamp()`, and `GetCslWindowEdges()` consistently use 64-bit radio clock timestamps without truncation when local time sync is disabled.
- Introduce `SetCslLastSyncToNow()` helper to unify setting `mCslLastSync` to the current timestamp based on the active clock source.

---

Should help address 
- #13456