### PR TITLE
[radio] add `Radio::ConvertUncertaintyToUsec()` helper

### DIFF
--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -903,27 +903,18 @@ public:
     /**
      * Returns the CSL uncertainty.
      *
-     * @returns The uncertainty in units 10 microseconds.
+     * @returns The uncertainty in units of 10 microseconds (`Radio::kUncertaintyUnit`).
      */
     uint8_t GetUncertainty(void) const { return mUncertainty; }
 
     /**
-     * Gets the CLS uncertainty in microseconds.
-     *
-     * @returns the CLS uncertainty in microseconds.
-     */
-    uint16_t GetUncertaintyInMicrosec(void) const { return static_cast<uint16_t>(mUncertainty) * kUsPerUncertUnit; }
-
-    /**
      * Sets the CSL uncertainty.
      *
-     * @param[in]  aUncertainty  The CSL uncertainty in units 10 microseconds.
+     * @param[in]  aUncertainty  The CSL uncertainty in units of 10 microseconds.
      */
     void SetUncertainty(uint8_t aUncertainty) { mUncertainty = aUncertainty; }
 
 private:
-    static constexpr uint8_t kUsPerUncertUnit = 10;
-
     uint8_t mClockAccuracy;
     uint8_t mUncertainty;
 };

--- a/src/core/mac/sub_mac_csl_receiver.cpp
+++ b/src/core/mac/sub_mac_csl_receiver.cpp
@@ -261,7 +261,8 @@ void SubMac::GetCslWindowEdges(uint32_t &aAhead, uint32_t &aAfter)
     elapsed = curTime - mCslLastSync.GetValue();
 
     semiWindow = DetermineClockDrift(elapsed);
-    semiWindow += mCslParentAccuracy.GetUncertaintyInMicrosec() + Get<Radio::Radio>().GetCslUncertainty() * 10;
+    semiWindow +=
+        Radio::ConvertUncertaintyToUsec(mCslParentAccuracy.GetUncertainty() + Get<Radio::Radio>().GetCslUncertainty());
 
     aAhead = Min(semiPeriod, semiWindow + kMinReceiveOnAhead + kCslReceiveTimeAhead);
     aAfter = Min(semiPeriod, semiWindow + kMinReceiveOnAfter);

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -649,7 +649,7 @@ public:
     /**
      * Get the fixed uncertainty of the Device for scheduling CSL operations in units of 10 microseconds.
      *
-     * @returns The CSL Uncertainty in units of 10 us.
+     * @returns The CSL Uncertainty in units of 10 microseconds (`kUncertaintyUnit`).
      */
     uint8_t GetCslUncertainty(void);
 #endif // OT_CONFIG_RADIO_TIME_ENABLE

--- a/src/core/radio/radio_types.hpp
+++ b/src/core/radio/radio_types.hpp
@@ -56,6 +56,8 @@ namespace Radio {
 
 class Radio;
 
+constexpr uint32_t kUncertaintyUnit = 10; ///< Clock uncertainty unit in microseconds.
+
 /**
  * Represents a 64-bit radio time in microseconds referenced to a continuous monotonic local radio clock.
  */
@@ -98,6 +100,15 @@ bool IsTimeStrictlyBefore(Time32 aFirstTime, Time32 aSecondTime);
  * @returns The calculated clock drift in microseconds (rounded up).
  */
 uint32_t DetermineClockDrift(uint16_t aClockAccuracy, uint32_t aIntervalUs);
+
+/**
+ * Converts CSL uncertainty value to microseconds.
+ *
+ * @param[in] aUncertainty  The uncertainty in units of 10 microseconds (`kUncertaintyUnit`).
+ *
+ * @returns The uncertainty duration in microseconds.
+ */
+inline uint32_t ConvertUncertaintyToUsec(uint16_t aUncertainty) { return aUncertainty * kUncertaintyUnit; }
 
 #if OT_CONFIG_RADIO_TIME_ENABLE && OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3041,7 +3041,7 @@ uint64_t Mle::CalcParentCslMetric(const Mac::CslAccuracy &aCslAccuracy) const
     uint64_t k            = cslTimeoutUs / cslPeriodUs;
 
     return k * (k + 1) * cslPeriodUs / usInSecond * aCslAccuracy.GetClockAccuracy() +
-           aCslAccuracy.GetUncertaintyInMicrosec() * k;
+           Radio::ConvertUncertaintyToUsec(aCslAccuracy.GetUncertainty()) * k;
 }
 #endif
 


### PR DESCRIPTION
This commit introduces `Radio::kUncertaintyUnit` constant and `Radio::ConvertUncertaintyToUsec()` helper function to convert CSL uncertainty (in units of 10 microseconds) to microseconds.

It updates `SubMac`, `Mle`, and `CslAccuracy` to use the helper, eliminating manual `* 10` calculations and redundant internal constants.