### PR TITLE
[ip6] bound prefix length in `Prefix::Tidy()` and `ToString()`

### DIFF
--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -97,8 +97,9 @@ bool Prefix::ContainsPrefix(const NetworkPrefix &aSubPrefix) const
 
 void Prefix::Tidy(void)
 {
-    uint8_t byteLength      = GetBytesSize();
-    uint8_t lastByteBitMask = static_cast<uint8_t>(~(static_cast<uint8_t>(1 << (byteLength * 8 - mLength)) - 1));
+    uint8_t length          = Min(mLength, kMaxLength);
+    uint8_t byteLength      = SizeForLength(length);
+    uint8_t lastByteBitMask = static_cast<uint8_t>(~(static_cast<uint8_t>(1 << (byteLength * 8 - length)) - 1));
 
     if (byteLength != 0)
     {
@@ -186,13 +187,14 @@ void Prefix::ToString(char *aBuffer, uint16_t aSize) const
 
 void Prefix::ToString(StringWriter &aWriter) const
 {
-    uint8_t sizeInUint16 = DivideAndRoundUp<uint8_t>(GetBytesSize(), sizeof(uint16_t));
+    uint8_t byteSize     = Min(GetBytesSize(), kMaxSize);
+    uint8_t sizeInUint16 = DivideAndRoundUp<uint8_t>(byteSize, sizeof(uint16_t));
     Prefix  tidyPrefix   = *this;
 
     tidyPrefix.Tidy();
     AsCoreType(&tidyPrefix.mPrefix).AppendHexWords(aWriter, sizeInUint16);
 
-    if (GetBytesSize() < Address::kSize - 1)
+    if (byteSize < Address::kSize - 1)
     {
         aWriter.Append("::");
     }

--- a/tests/unit/test_ip_address.cpp
+++ b/tests/unit/test_ip_address.cpp
@@ -756,6 +756,23 @@ void TestIp6PrefixTidy(void)
             }
         }
     }
+
+    printf("Tidy Prefixes with length longer than max:\n");
+
+    for (uint16_t length = Ip6::Prefix::kMaxLength + 1; length <= NumericLimits<uint8_t>::kMax; length++)
+    {
+        Ip6::Prefix prefix;
+
+        prefix.InitFrom(kPrefixes[0].originalPrefix, Ip6::Prefix::kMaxLength);
+        prefix.SetLength(static_cast<uint8_t>(length));
+        prefix.Tidy();
+
+        printf("Prefix length: %-5u TidyResult: %-42s\n", length, prefix.ToString().AsCString());
+
+        VerifyOrQuit(
+            memcmp(prefix.mPrefix.mFields.m8, kPrefixes[0].originalPrefix, sizeof(prefix.mPrefix.mFields.m8)) == 0);
+        VerifyOrQuit(prefix.GetLength() == length);
+    }
 }
 
 void TestIp4MappedIp6Address(void)


### PR DESCRIPTION
`Ip6::Prefix` turns `mLength` into a byte count in two places without capping it to the 16-byte address, so any prefix length above 128 runs off the end of `mPrefix`:

- `Tidy()` masks `m8[byteLength - 1]`; at lengths 129-136 that index is `mLength` itself, which gets rewritten (129 becomes 128), and from 137 up the write leaves the packed object
- `ToString()` hands the same uncapped `GetBytesSize()` to `AppendHexWords()`, so it reads past the address and prints the bytes that follow it
- Lengths arrive unvalidated over spinel via `SPINEL_PROP_BORDER_ROUTER_DHCP6_PD_PREFIX`, and `PdPrefixManager::EvaluateCandidatePrefix()` calls `ToString()` on the branch that rejects the prefix for being out of range

Clamped both to the address size, the same way `Dhcp6::IaPrefixOption::GetPrefix()` already does for this field. The new case in `TestIp6PrefixTidy` covers lengths 129-255; it fails on the current tree and is ASan-clean with the change.
