### PR TITLE
[pktverify] fix IPv6 address parsing for IPv4-mapped addresses

### DIFF
--- a/tests/scripts/thread-cert/pktverify/addrs.py
+++ b/tests/scripts/thread-cert/pktverify/addrs.py
@@ -73,16 +73,15 @@ class Ipv6Addr(Bytes):
 
     def __init__(self, addr: Union[str, bytearray, 'Bytes']):
         if isinstance(addr, str):
-            # try to parse compacted ipv6 address
             try:
-                addr = Ipv6Addr._expand(addr)
+                addr = ipaddress.IPv6Address(addr).packed
             except ipaddress.AddressValueError:
                 pass
 
         super().__init__(addr)
         if len(self) != 16:
             raise ValueError(addr)
-        self._addr = ipaddress.IPv6Address(self)
+        self._addr = ipaddress.IPv6Address(bytes(self))
 
     def __repr__(self):
         return '%s(%r)' % (self.__class__.__name__, self.format_hextets())


### PR DESCRIPTION
This commit fixes a parsing error in pktverify (Ipv6Addr) when handling IPv4-mapped IPv6 addresses (e.g., 0:0:0:0:0:ffff:c0a8:d964).

Previously, Ipv6Addr.__init__ called Ipv6Addr._expand(addr) (ipaddress.IPv6Address(addr).exploded), which returned IPv4-mapped addresses formatted with dotted-quad IPv4 strings (e.g., 0000:0000:0000:0000:0000:ffff:192.168.217.100). Bytes parsing methods subsequently failed on the dotted-quad portion, causing tests such as 1_4_DNS_TC_5 to fail during packet verification.

This update uses ipaddress.IPv6Address(addr).packed to convert valid IPv6 string representations directly into raw 16-byte arrays.