### PR TITLE
[fuzz] add targets for multi-frame, mesh-internal and discovery paths

### DIFF
--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -87,8 +87,11 @@ endmacro()
 #----------------------------------------------------------------------------------------------------------------------
 
 ot_nexus_test(cli)
+ot_nexus_test(discovery)
 ot_nexus_test(icmp6)
 ot_nexus_test(ip6)
+ot_nexus_test(ip6-recv)
 ot_nexus_test(mdns)
+ot_nexus_test(radio-multi)
 ot_nexus_test(radio-one-node)
 ot_nexus_test(trel)

--- a/tests/fuzz/fuzz_discovery.cpp
+++ b/tests/fuzz/fuzz_discovery.cpp
@@ -1,0 +1,217 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * MLE Discovery fuzzer.
+ *
+ * `Mle::HandleUdpReceive()` dispatches `kCommandDiscoveryRequest` and
+ * `kCommandDiscoveryResponse` under the `kNoSecurity` suite, so this is one of
+ * the few receive paths that parses bytes before any key material is involved.
+ * The response side then walks a chain of MeshCoP TLVs -- discovery response,
+ * extended PAN ID, network name, joiner UDP port, and the variable-length
+ * steering data -- which no existing target in this directory reaches.
+ *
+ * Unlike the other targets here, the node is built once in
+ * `LLVMFuzzerInitialize()` rather than per test case. Node construction and
+ * interface bring-up dominate runtime for this surface, and the only per-input
+ * work is assembling the datagram and handing it to the stack. The trade-off
+ * is that stack state persists across inputs; see the note on the PR for
+ * discussion.
+ *
+ * `DiscoverScanner::HandleDiscoveryResponse()` returns early unless a scan is
+ * in progress, so the scan is re-armed before every input. Without that the
+ * scan completes and every later input becomes a silent early exit that is
+ * indistinguishable from a clean negative.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "platform/nexus_core.hpp"
+#include "platform/nexus_node.hpp"
+
+namespace ot {
+namespace Nexus {
+
+static constexpr uint16_t kMaxMlePayload = 1024;
+
+static Core *sCore  = nullptr;
+static Node *sNode  = nullptr;
+static bool  sTrace = false;
+
+static void HandleDiscoverResult(otActiveScanResult *aResult, void *aContext)
+{
+    OT_UNUSED_VARIABLE(aResult);
+    OT_UNUSED_VARIABLE(aContext);
+}
+
+// Re-arm the discovery scan. Without this the scan ends and every subsequent
+// input becomes a silent early exit indistinguishable from a clean negative.
+static void EnsureScanning(void)
+{
+    if (!sNode->Get<Mle::DiscoverScanner>().IsInProgress())
+    {
+        Mac::ChannelMask mask(0);
+
+        mask.SetMask(::ot::Radio::kSupportedChannels);
+        IgnoreError(sNode->Get<Mle::DiscoverScanner>().Discover(
+            mask, Mac::kPanIdBroadcast, /* aJoiner */ false, /* aEnableFiltering */ false,
+            /* aFilterIndexes */ nullptr, HandleDiscoverResult, nullptr));
+    }
+}
+
+// Wrap an attacker-controlled MLE payload in the framing
+// `Mle::HandleUdpReceive` requires: link-local source, a destination this node
+// holds, the hop limit MLE requires, and the MLE port on both sides.
+static Message *BuildMleDatagram(const uint8_t *aPayload, uint16_t aLength, bool aMulticastDst)
+{
+    Instance      &instance = sNode->GetInstance();
+    Message       *message  = nullptr;
+    Ip6::Header    ip6;
+    Ip6::UdpHeader udp;
+    Ip6::Address   src;
+    Ip6::Address   dst;
+
+    src.Clear();
+    src.mFields.m8[0]  = 0xfe;
+    src.mFields.m8[1]  = 0x80;
+    src.mFields.m8[8]  = 0x02;
+    src.mFields.m8[15] = 0x77;
+
+    dst =
+        aMulticastDst ? Ip6::Address::GetLinkLocalAllNodesMulticast() : instance.Get<Mle::Mle>().GetLinkLocalAddress();
+
+    udp.SetSourcePort(Mle::kUdpPort);
+    udp.SetDestinationPort(Mle::kUdpPort);
+    udp.SetLength(static_cast<uint16_t>(sizeof(udp) + aLength));
+    udp.SetChecksum(0);
+
+    ip6.Clear();
+    ip6.InitVersionTrafficClassFlow();
+    ip6.SetPayloadLength(static_cast<uint16_t>(sizeof(udp) + aLength));
+    ip6.SetNextHeader(Ip6::kProtoUdp);
+    ip6.SetHopLimit(255); // Mle::Mle::kMleHopLimit, which is private
+    ip6.SetSource(src);
+    ip6.SetDestination(dst);
+
+    message = instance.Get<MessagePool>().Allocate(Message::kTypeIp6);
+    VerifyOrExit(message != nullptr);
+
+    if ((message->Append(ip6) != kErrorNone) || (message->Append(udp) != kErrorNone) ||
+        (message->AppendBytes(aPayload, aLength) != kErrorNone))
+    {
+        message->Free();
+        message = nullptr;
+        ExitNow();
+    }
+
+    // `UpdateMessageChecksum` computes from `Message::GetOffset()`, so the
+    // offset must point at the UDP header while it runs.
+    message->SetOffset(sizeof(Ip6::Header));
+    Checksum::UpdateMessageChecksum(*message, src, dst, Ip6::kProtoUdp);
+    message->SetOffset(0);
+
+    message->SetOrigin(Message::kOriginThreadNetif);
+    message->SetLinkSecurityEnabled(false);
+
+exit:
+    return message;
+}
+
+} // namespace Nexus
+} // namespace ot
+
+extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+    using namespace ot;
+    using namespace ot::Nexus;
+
+    OT_UNUSED_VARIABLE(argc);
+    OT_UNUSED_VARIABLE(argv);
+
+    srand(0x0764A17E);
+
+    sTrace = (getenv("OT_FUZZ_TRACE") != nullptr);
+
+    sCore = new Core();
+    sNode = &sCore->CreateNode();
+
+    sNode->GetInstance().SetLogLevel((getenv("OT_FUZZ_VERBOSE") != nullptr) ? kLogLevelInfo : kLogLevelCrit);
+
+    // Bring the interface up so the MLE socket is bound. No attach: Discovery
+    // dispatches before the IsDisabled() check.
+    sNode->Get<ThreadNetif>().Up();
+    IgnoreError(sNode->Get<Mle::Mle>().Start());
+    sCore->AdvanceTime(20);
+
+    EnsureScanning();
+
+    return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    using namespace ot;
+    using namespace ot::Nexus;
+
+    static uint64_t sInputs = 0;
+
+    Message *message;
+    bool     multicast;
+
+    if ((size < 2) || (size > kMaxMlePayload))
+    {
+        return 0;
+    }
+
+    sInputs++;
+
+    // First byte selects unicast vs link-local-multicast destination; the rest
+    // is the MLE payload, so entropy goes to the parser rather than to
+    // rediscovering the framing.
+    multicast = (data[0] & 0x01) != 0;
+
+    EnsureScanning();
+
+    message = BuildMleDatagram(data + 1, static_cast<uint16_t>(size - 1), multicast);
+
+    if (message != nullptr)
+    {
+        IgnoreError(sNode->GetInstance().Get<Ip6::Ip6>().HandleDatagram(OwnedPtr<Message>(message)));
+    }
+
+    if (sTrace && ((sInputs % 200000) == 0))
+    {
+        fprintf(stderr, "[trace] inputs=%llu scanning=%d\n", (unsigned long long)sInputs,
+                sNode->Get<Mle::DiscoverScanner>().IsInProgress());
+    }
+
+    return 0;
+}

--- a/tests/fuzz/fuzz_discovery.cpp
+++ b/tests/fuzz/fuzz_discovery.cpp
@@ -1,0 +1,230 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * MLE Discovery fuzzer -- THE unauthenticated MeshCoP TLV surface.
+ *
+ * This is the only entry point in OpenThread that parses attacker bytes with no
+ * key of any kind involved. `Mle::HandleUdpReceive` dispatches
+ * `kCommandDiscoveryRequest` (16) and `kCommandDiscoveryResponse` (17) on
+ * security suite `kNoSecurity` BEFORE `VerifyOrExit(!IsDisabled())` and before
+ * any MIC verification (mle.cpp:1587-1607). Attacker position: radio range. No
+ * Network Key, no PSKc, no credentials.
+ *
+ * Everything else that parses pre-key bytes is either compiled out or capped:
+ *   - Beacon payload parsing: OPENTHREAD_CONFIG_MAC_BEACON_PAYLOAD_PARSING_ENABLE
+ *     defaults to 0 (config/mac.h:528), and NetworkName::Set is bounded anyway.
+ *   - Header IE / CSL / link metrics: behind ProcessReceiveSecurity, so any
+ *     finding there is capped at the compromised-device premise.
+ *   - Mac::Frame field accessors: gated by ValidatePsdu (see F-002).
+ *
+ * Response-side parse chain (discover_scanner.cpp:315):
+ *     Tlv::FindTlvValueOffsetRange(msg, kDiscovery, range)
+ *     msg.SetOffset(range.GetOffset()); msg.SetLength(range.GetEndOffset())
+ *     Tlv::Find<DiscoveryResponseTlv>   version + flags
+ *     Tlv::Find<ExtendedPanIdTlv>       fixed 8 bytes
+ *     Tlv::Find<NetworkNameTlv>         wire length -> fixed char[] in a stack ScanResult
+ *     Tlv::Find<JoinerUdpPortTlv>       uint16
+ *     SteeringDataTlv::FindIn           variable-length bloom filter, then a bit walk
+ * Request side: Mle::HandleDiscoveryRequest (mle_ftd.cpp:2700).
+ *
+ * THROUGHPUT: node construction, interface bring-up and the initial scan run
+ * ONCE in LLVMFuzzerInitialize. The previous revision rebuilt a Nexus Core and
+ * a node per input and managed ~400 exec/s; only the message build and the
+ * datagram handoff belong on the per-input path.
+ *
+ * SCAN LIVENESS: `DiscoverScanner::HandleDiscoveryResponse` exits on its third
+ * line unless `mState == kStateScanning`. With a persistent node the scan can
+ * finish and silently turn every later input into an early exit -- a textbook
+ * clean-looking negative. The scan is therefore re-armed before every input,
+ * and OT_FUZZ_TRACE=1 periodically reports the scan state.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "platform/nexus_core.hpp"
+#include "platform/nexus_node.hpp"
+
+namespace ot {
+namespace Nexus {
+
+static constexpr uint16_t kMaxMlePayload = 1024;
+
+static Core *sCore = nullptr;
+static Node *sNode = nullptr;
+
+static void HandleDiscoverResult(otActiveScanResult *aResult, void *aContext)
+{
+    OT_UNUSED_VARIABLE(aResult);
+    OT_UNUSED_VARIABLE(aContext);
+}
+
+// Re-arm the discovery scan. Without this the scan ends and every subsequent
+// input becomes a silent early exit indistinguishable from a clean negative.
+static void EnsureScanning(void)
+{
+    if (!sNode->Get<Mle::DiscoverScanner>().IsInProgress())
+    {
+        Mac::ChannelMask mask(0);
+
+        mask.SetMask(::ot::Radio::kSupportedChannels);
+        IgnoreError(sNode->Get<Mle::DiscoverScanner>().Discover(
+            mask, Mac::kPanIdBroadcast, /* aJoiner */ false, /* aEnableFiltering */ false,
+            /* aFilterIndexes */ nullptr, HandleDiscoverResult, nullptr));
+    }
+}
+
+// Wrap an attacker-controlled MLE payload in the framing
+// `Mle::HandleUdpReceive` requires: link-local source, a destination this node
+// holds, hop limit exactly 255 (mle.cpp:1583), MLE port both ways.
+static Message *BuildMleDatagram(const uint8_t *aPayload, uint16_t aLength, bool aMulticastDst)
+{
+    Instance      &instance = sNode->GetInstance();
+    Message       *message  = nullptr;
+    Ip6::Header    ip6;
+    Ip6::UdpHeader udp;
+    Ip6::Address   src;
+    Ip6::Address   dst;
+
+    src.Clear();
+    src.mFields.m8[0]  = 0xfe;
+    src.mFields.m8[1]  = 0x80;
+    src.mFields.m8[8]  = 0x02;
+    src.mFields.m8[15] = 0x77;
+
+    dst =
+        aMulticastDst ? Ip6::Address::GetLinkLocalAllNodesMulticast() : instance.Get<Mle::Mle>().GetLinkLocalAddress();
+
+    udp.SetSourcePort(Mle::kUdpPort);
+    udp.SetDestinationPort(Mle::kUdpPort);
+    udp.SetLength(static_cast<uint16_t>(sizeof(udp) + aLength));
+    udp.SetChecksum(0);
+
+    ip6.Clear();
+    ip6.InitVersionTrafficClassFlow();
+    ip6.SetPayloadLength(static_cast<uint16_t>(sizeof(udp) + aLength));
+    ip6.SetNextHeader(Ip6::kProtoUdp);
+    ip6.SetHopLimit(255); // Mle::Mle::kMleHopLimit, which is private
+    ip6.SetSource(src);
+    ip6.SetDestination(dst);
+
+    message = instance.Get<MessagePool>().Allocate(Message::kTypeIp6);
+    VerifyOrExit(message != nullptr);
+
+    if ((message->Append(ip6) != kErrorNone) || (message->Append(udp) != kErrorNone) ||
+        (message->AppendBytes(aPayload, aLength) != kErrorNone))
+    {
+        message->Free();
+        message = nullptr;
+        ExitNow();
+    }
+
+    // `UpdateMessageChecksum` computes from `Message::GetOffset()`, so the
+    // offset must point at the UDP header while it runs.
+    message->SetOffset(sizeof(Ip6::Header));
+    Checksum::UpdateMessageChecksum(*message, src, dst, Ip6::kProtoUdp);
+    message->SetOffset(0);
+
+    message->SetOrigin(Message::kOriginThreadNetif);
+    message->SetLinkSecurityEnabled(false);
+
+exit:
+    return message;
+}
+
+} // namespace Nexus
+} // namespace ot
+
+extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+    using namespace ot;
+    using namespace ot::Nexus;
+
+    OT_UNUSED_VARIABLE(argc);
+    OT_UNUSED_VARIABLE(argv);
+
+    srand(0x0764A17E);
+
+    sCore = new Core();
+    sNode = &sCore->CreateNode();
+
+    sNode->GetInstance().SetLogLevel((getenv("OT_FUZZ_VERBOSE") != nullptr) ? kLogLevelInfo : kLogLevelCrit);
+
+    // Bring the interface up so the MLE socket is bound. No attach: Discovery
+    // dispatches before the IsDisabled() check.
+    sNode->Get<ThreadNetif>().Up();
+    IgnoreError(sNode->Get<Mle::Mle>().Start());
+    sCore->AdvanceTime(20);
+
+    EnsureScanning();
+
+    return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    using namespace ot;
+    using namespace ot::Nexus;
+
+    static uint64_t sInputs = 0;
+
+    Message *message;
+    bool     multicast;
+
+    if ((size < 2) || (size > kMaxMlePayload))
+    {
+        return 0;
+    }
+
+    sInputs++;
+
+    // First byte selects unicast vs link-local-multicast destination; the rest
+    // is the MLE payload, so entropy goes to the parser rather than to
+    // rediscovering the framing.
+    multicast = (data[0] & 0x01) != 0;
+
+    EnsureScanning();
+
+    message = BuildMleDatagram(data + 1, static_cast<uint16_t>(size - 1), multicast);
+
+    if (message != nullptr)
+    {
+        IgnoreError(sNode->GetInstance().Get<Ip6::Ip6>().HandleDatagram(OwnedPtr<Message>(message)));
+    }
+
+    if ((getenv("OT_FUZZ_TRACE") != nullptr) && ((sInputs % 200000) == 0))
+    {
+        fprintf(stderr, "[trace] inputs=%llu scanning=%d\n", (unsigned long long)sInputs,
+                sNode->Get<Mle::DiscoverScanner>().IsInProgress());
+    }
+
+    return 0;
+}

--- a/tests/fuzz/fuzz_ip6-recv.cpp
+++ b/tests/fuzz/fuzz_ip6-recv.cpp
@@ -1,0 +1,281 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN AY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Received-IPv6-datagram fuzzer.
+ *
+ * Attacker model: a device that holds the Thread Network Key -- any joined
+ * mesh member, for example a sensor or bulb -- sending IPv6 datagrams to the
+ * target. Frames from such a device pass MAC security, so everything above
+ * IPv6 parses attacker-controlled bytes.
+ *
+ * No existing fuzz target reaches this code:
+ *
+ *   - `ip6-fuzzer` calls `otIp6Send` -> `Ip6::SendRaw`, which is the HOST
+ *     injection path. `SendRaw` drops any datagram whose source is on-mesh or
+ *     whose destination is mesh-local unless the address belongs to this
+ *     device (ip6.cpp:1146-1150), which is exactly the addressing every TMF,
+ *     MeshCoP and SRP exchange uses. The whole mesh-internal service surface
+ *     is therefore unreachable through it.
+ *   - `radio-one-node-fuzzer` would have to produce a frame carrying a valid
+ *     MAC MIC under a key it does not have.
+ *
+ * Injecting at `Ip6::HandleDatagram` with `kOriginThreadNetif` and link
+ * security marked enabled models the post-decrypt state precisely, and reaches
+ * IPv6 extension headers, MPL, ICMPv6, UDP and TCP demultiplexing, and from
+ * there MLE, TMF/CoAP, MeshCoP, SRP server, DNS-SD server and DHCPv6.
+ *
+ * Several datagrams are delivered per test case so that state built by one
+ * message is visible to the next.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "platform/nexus_core.hpp"
+#include "platform/nexus_node.hpp"
+
+namespace ot {
+namespace Nexus {
+
+static constexpr uint32_t kMaxDatagrams   = 8;
+static constexpr uint16_t kMaxDatagramLen = 1280;
+
+class FuzzDataProvider
+{
+public:
+    FuzzDataProvider(const uint8_t *aData, size_t aSize)
+        : mData(aData)
+        , mSize(aSize)
+    {
+    }
+
+    bool ConsumeData(void *aBuf, size_t aLength)
+    {
+        if (aLength > mSize)
+        {
+            return false;
+        }
+
+        memcpy(aBuf, mData, aLength);
+        mData += aLength;
+        mSize -= aLength;
+
+        return true;
+    }
+
+    uint8_t ConsumeByte(void)
+    {
+        uint8_t result = 0;
+
+        if (mSize > 0)
+        {
+            result = *mData;
+            mData++;
+            mSize--;
+        }
+
+        return result;
+    }
+
+    const uint8_t *Peek(void) const { return mData; }
+
+    void Skip(size_t aLength)
+    {
+        aLength = (aLength > mSize) ? mSize : aLength;
+        mData += aLength;
+        mSize -= aLength;
+    }
+
+    size_t RemainingBytes(void) const { return mSize; }
+
+private:
+    const uint8_t *mData;
+    size_t         mSize;
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    FuzzDataProvider fdp(data, size);
+
+    // A stream of records:
+    //     u16 length  (little endian, clamped to kMaxDatagramLen)
+    //     u8  flags
+    //           bit0     deliver with link security marked enabled
+    //           bit1     advance simulated time after this datagram
+    //           bit2     rewrite the destination to one of the node's addresses
+    //           bit3     rewrite the source to a mesh-local locator
+    //           bits 4-7 index selecting which address those rewrites use
+    //     u8  datagram[length]
+
+    if (size < 3)
+    {
+        return 0;
+    }
+
+    if (size > kMaxDatagrams * (3 + kMaxDatagramLen))
+    {
+        return 0;
+    }
+
+    // Unlike the radio targets, the network is formed from a FIXED seed rather
+    // than one taken from the input. Node addresses -- mesh-local prefix, RLOC,
+    // ML-EID, extended address -- are derived from `rand()` in
+    // `Dataset::Info::GenerateRandom()`, so seeding from the input would give
+    // every test case a different 128-bit destination that the fuzzer cannot
+    // guess, and almost no datagram would reach a bound socket. A fixed seed
+    // also keeps reproducers deterministic.
+    srand(0x0764A17E);
+
+    Core nexus;
+
+    Node &node = nexus.CreateNode();
+
+    SuccessOrQuit(node.GetInstance().SetLogLevel(kLogLevelInfo));
+
+    node.GetInstance().Get<BorderRouter::InfraIf>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
+    SuccessOrQuit(node.GetInstance().Get<BorderRouter::RoutingManager>().SetEnabled(true));
+    node.GetInstance().Get<Srp::Server>().SetAutoEnableMode(true);
+    node.GetInstance().Get<BorderRouter::RoutingManager>().SetDhcp6PdEnabled(true);
+    node.GetInstance().Get<BorderRouter::RoutingManager>().SetNat64PrefixManagerEnabled(true);
+    node.GetInstance().Get<Nat64::Translator>().SetEnabled(true);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Form network");
+
+    node.Form();
+    nexus.AdvanceTime(60 * 1000);
+    VerifyOrQuit(node.Get<Mle::Mle>().IsLeader());
+    VerifyOrQuit(node.Get<Srp::Server>().GetState() == Srp::Server::kStateRunning);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Fuzz");
+
+    for (uint32_t num = 0; (num < kMaxDatagrams) && (fdp.RemainingBytes() >= 3); num++)
+    {
+        Message *message;
+        uint16_t length;
+        uint8_t  flags;
+
+        length = fdp.ConsumeByte();
+        length |= static_cast<uint16_t>(fdp.ConsumeByte()) << 8;
+        flags = fdp.ConsumeByte();
+
+        if (length > kMaxDatagramLen)
+        {
+            length = static_cast<uint16_t>(length % (kMaxDatagramLen + 1));
+        }
+
+        if (length > fdp.RemainingBytes())
+        {
+            length = static_cast<uint16_t>(fdp.RemainingBytes());
+        }
+
+        message = node.GetInstance().Get<MessagePool>().Allocate(Message::kTypeIp6);
+        VerifyOrExit(message != nullptr);
+
+        if (message->AppendBytes(fdp.Peek(), length) != kErrorNone)
+        {
+            message->Free();
+            break;
+        }
+
+        fdp.Skip(length);
+
+        // Optionally rewrite the destination address to one the node actually
+        // holds. Services such as TMF, the SRP server and the DNS-SD server
+        // bind to unicast mesh-local addresses; without this the fuzzer would
+        // have to guess a 128-bit address to reach any of them, so nearly
+        // every datagram would die in the address filter.
+        if (((flags & 0x04) != 0) && (length >= sizeof(Ip6::Header)))
+        {
+            // Offset of the destination address inside an IPv6 header:
+            // 4 (version/class/flow) + 2 (payload length) + 1 (next header)
+            // + 1 (hop limit) + 16 (source address).
+            static constexpr uint16_t kDstOffset = 24;
+            static_assert(sizeof(Ip6::Header) == kDstOffset + sizeof(Ip6::Address), "unexpected Ip6::Header layout");
+
+            uint8_t wanted = (flags >> 4) & 0x0F;
+            uint8_t seen   = 0;
+
+            for (const Ip6::Netif::UnicastAddress &addr : node.GetInstance().Get<ThreadNetif>().GetUnicastAddresses())
+            {
+                if (seen == wanted)
+                {
+                    message->WriteBytes(kDstOffset, &addr.GetAddress(), sizeof(Ip6::Address));
+                    break;
+                }
+
+                seen++;
+            }
+        }
+
+        // Optionally rewrite the source to a mesh-local address, i.e. make the
+        // datagram look like it came from another node on the mesh. TMF admits
+        // a message only when BOTH source and destination are mesh-local
+        // (tmf.cpp `Agent::IsTmfMessage`), so without this the entire TMF
+        // surface -- MeshCoP dataset management, network data registration,
+        // address resolution, diagnostics, commissioning -- is unreachable.
+        if (((flags & 0x08) != 0) && (length >= sizeof(Ip6::Header)))
+        {
+            static constexpr uint16_t kSrcOffset = 8;
+
+            Ip6::Address src;
+
+            src.InitAsLocator(node.GetInstance().Get<Mle::Mle>().GetMeshLocalPrefix(),
+                              static_cast<uint16_t>(0x2800 | ((flags >> 4) & 0x0F)));
+
+            message->WriteBytes(kSrcOffset, &src, sizeof(Ip6::Address));
+        }
+
+        // Model the message as one that arrived over the Thread radio. TMF and
+        // several other consumers gate on the origin, so a message injected
+        // with any other origin never reaches them.
+        message->SetOrigin(Message::kOriginThreadNetif);
+        message->SetLinkSecurityEnabled((flags & 0x01) != 0);
+
+        Log("--- datagram %u: len=%u sec=%u ---", num, length, (flags & 0x01) != 0);
+
+        IgnoreError(node.GetInstance().Get<Ip6::Ip6>().HandleDatagram(OwnedPtr<Message>(message)));
+
+        if ((flags & 0x02) != 0)
+        {
+            nexus.AdvanceTime(50);
+        }
+    }
+
+    nexus.AdvanceTime(10 * 1000);
+
+exit:
+    return 0;
+}
+
+} // namespace Nexus
+} // namespace ot

--- a/tests/fuzz/fuzz_ip6-recv.cpp
+++ b/tests/fuzz/fuzz_ip6-recv.cpp
@@ -1,0 +1,284 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN AY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Received-IPv6-datagram fuzzer.
+ *
+ * Attacker model: a device that holds the Thread Network Key -- any joined
+ * mesh member, for example a sensor or bulb -- sending IPv6 datagrams to the
+ * target. Frames from such a device pass MAC security, so everything above
+ * IPv6 parses attacker-controlled bytes.
+ *
+ * No existing fuzz target reaches this code:
+ *
+ *   - `ip6-fuzzer` calls `otIp6Send` -> `Ip6::SendRaw`, which is the HOST
+ *     injection path. `SendRaw` drops any datagram whose source is on-mesh or
+ *     whose destination is mesh-local unless the address belongs to this
+ *     device (ip6.cpp:1146-1150), which is exactly the addressing every TMF,
+ *     MeshCoP and SRP exchange uses. The whole mesh-internal service surface
+ *     is therefore unreachable through it.
+ *   - `radio-one-node-fuzzer` would have to produce a frame carrying a valid
+ *     MAC MIC under a key it does not have.
+ *
+ * Injecting at `Ip6::HandleDatagram` with `kOriginThreadNetif` and link
+ * security marked enabled models the post-decrypt state precisely, and reaches
+ * IPv6 extension headers, MPL, ICMPv6, UDP and TCP demultiplexing, and from
+ * there MLE, TMF/CoAP, MeshCoP, SRP server, DNS-SD server and DHCPv6.
+ *
+ * Several datagrams are delivered per test case so that state built by one
+ * message is visible to the next.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "platform/nexus_core.hpp"
+#include "platform/nexus_node.hpp"
+
+namespace ot {
+namespace Nexus {
+
+static constexpr uint32_t kMaxDatagrams   = 8;
+static constexpr uint16_t kMaxDatagramLen = 1280;
+
+class FuzzDataProvider
+{
+public:
+    FuzzDataProvider(const uint8_t *aData, size_t aSize)
+        : mData(aData)
+        , mSize(aSize)
+    {
+    }
+
+    bool ConsumeData(void *aBuf, size_t aLength)
+    {
+        if (aLength > mSize)
+        {
+            return false;
+        }
+
+        memcpy(aBuf, mData, aLength);
+        mData += aLength;
+        mSize -= aLength;
+
+        return true;
+    }
+
+    uint8_t ConsumeByte(void)
+    {
+        uint8_t result = 0;
+
+        if (mSize > 0)
+        {
+            result = *mData;
+            mData++;
+            mSize--;
+        }
+
+        return result;
+    }
+
+    const uint8_t *Peek(void) const { return mData; }
+
+    void Skip(size_t aLength)
+    {
+        aLength = (aLength > mSize) ? mSize : aLength;
+        mData += aLength;
+        mSize -= aLength;
+    }
+
+    size_t RemainingBytes(void) const { return mSize; }
+
+private:
+    const uint8_t *mData;
+    size_t         mSize;
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    FuzzDataProvider fdp(data, size);
+
+    unsigned int seed;
+
+    // Header: u32 seed. Then records:
+    //     u16 length  (little endian, clamped to kMaxDatagramLen)
+    //     u8  flags   (bit0 link security, bit1 advance time)
+    //     u8  datagram[length]
+
+    if (size < sizeof(seed) + 3)
+    {
+        return 0;
+    }
+
+    if (size > sizeof(seed) + kMaxDatagrams * (3 + kMaxDatagramLen))
+    {
+        return 0;
+    }
+
+    if (!fdp.ConsumeData(&seed, sizeof(seed)))
+    {
+        return 0;
+    }
+
+    // The network is formed from a FIXED seed rather than the input's. Node
+    // addresses (mesh-local prefix, RLOC, ML-EID, ExtAddress) are derived from
+    // `rand()` in `Dataset::Info::GenerateRandom()`, so seeding from the input
+    // would give every test case a different 128-bit destination address that
+    // the fuzzer cannot guess -- almost no datagram would ever reach a bound
+    // socket. Fixing it also makes any reproducer deterministic, which a
+    // submitted PoC requires.
+    OT_UNUSED_VARIABLE(seed);
+    srand(0x0764A17E);
+
+    Core nexus;
+
+    Node &node = nexus.CreateNode();
+
+    SuccessOrQuit(node.GetInstance().SetLogLevel(kLogLevelInfo));
+
+    node.GetInstance().Get<BorderRouter::InfraIf>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
+    SuccessOrQuit(node.GetInstance().Get<BorderRouter::RoutingManager>().SetEnabled(true));
+    node.GetInstance().Get<Srp::Server>().SetAutoEnableMode(true);
+    node.GetInstance().Get<BorderRouter::RoutingManager>().SetDhcp6PdEnabled(true);
+    node.GetInstance().Get<BorderRouter::RoutingManager>().SetNat64PrefixManagerEnabled(true);
+    node.GetInstance().Get<Nat64::Translator>().SetEnabled(true);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Form network");
+
+    node.Form();
+    nexus.AdvanceTime(60 * 1000);
+    VerifyOrQuit(node.Get<Mle::Mle>().IsLeader());
+    VerifyOrQuit(node.Get<Srp::Server>().GetState() == Srp::Server::kStateRunning);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Fuzz");
+
+    for (uint32_t num = 0; (num < kMaxDatagrams) && (fdp.RemainingBytes() >= 3); num++)
+    {
+        Message *message;
+        uint16_t length;
+        uint8_t  flags;
+
+        length = fdp.ConsumeByte();
+        length |= static_cast<uint16_t>(fdp.ConsumeByte()) << 8;
+        flags = fdp.ConsumeByte();
+
+        if (length > kMaxDatagramLen)
+        {
+            length = static_cast<uint16_t>(length % (kMaxDatagramLen + 1));
+        }
+
+        if (length > fdp.RemainingBytes())
+        {
+            length = static_cast<uint16_t>(fdp.RemainingBytes());
+        }
+
+        message = node.GetInstance().Get<MessagePool>().Allocate(Message::kTypeIp6);
+        VerifyOrExit(message != nullptr);
+
+        if (message->AppendBytes(fdp.Peek(), length) != kErrorNone)
+        {
+            message->Free();
+            break;
+        }
+
+        fdp.Skip(length);
+
+        // Optionally rewrite the destination address to one the node actually
+        // holds. Services such as TMF, the SRP server and the DNS-SD server
+        // bind to unicast mesh-local addresses; without this the fuzzer would
+        // have to guess a 128-bit address to reach any of them, so nearly
+        // every datagram would die in the address filter.
+        if (((flags & 0x04) != 0) && (length >= sizeof(Ip6::Header)))
+        {
+            // Offset of the destination address inside an IPv6 header:
+            // 4 (version/class/flow) + 2 (payload length) + 1 (next header)
+            // + 1 (hop limit) + 16 (source address).
+            static constexpr uint16_t kDstOffset = 24;
+            static_assert(sizeof(Ip6::Header) == kDstOffset + sizeof(Ip6::Address), "unexpected Ip6::Header layout");
+
+            uint8_t wanted = (flags >> 4) & 0x0F;
+            uint8_t seen   = 0;
+
+            for (const Ip6::Netif::UnicastAddress &addr : node.GetInstance().Get<ThreadNetif>().GetUnicastAddresses())
+            {
+                if (seen == wanted)
+                {
+                    message->WriteBytes(kDstOffset, &addr.GetAddress(), sizeof(Ip6::Address));
+                    break;
+                }
+
+                seen++;
+            }
+        }
+
+        // Optionally rewrite the source to a mesh-local address, i.e. make the
+        // datagram look like it came from another node on the mesh. TMF admits
+        // a message only when BOTH source and destination are mesh-local
+        // (tmf.cpp `Agent::IsTmfMessage`), so without this the entire TMF
+        // surface -- MeshCoP dataset management, network data registration,
+        // address resolution, diagnostics, commissioning -- is unreachable.
+        if (((flags & 0x08) != 0) && (length >= sizeof(Ip6::Header)))
+        {
+            static constexpr uint16_t kSrcOffset = 8;
+
+            Ip6::Address src;
+
+            src.InitAsLocator(node.GetInstance().Get<Mle::Mle>().GetMeshLocalPrefix(),
+                              static_cast<uint16_t>(0x2800 | ((flags >> 4) & 0x0F)));
+
+            message->WriteBytes(kSrcOffset, &src, sizeof(Ip6::Address));
+        }
+
+        // Model the message as one that arrived over the Thread radio. TMF and
+        // several other consumers gate on the origin, so a message injected
+        // with any other origin never reaches them.
+        message->SetOrigin(Message::kOriginThreadNetif);
+        message->SetLinkSecurityEnabled((flags & 0x01) != 0);
+
+        Log("--- datagram %u: len=%u sec=%u ---", num, length, (flags & 0x01) != 0);
+
+        IgnoreError(node.GetInstance().Get<Ip6::Ip6>().HandleDatagram(OwnedPtr<Message>(message)));
+
+        if ((flags & 0x02) != 0)
+        {
+            nexus.AdvanceTime(50);
+        }
+    }
+
+    nexus.AdvanceTime(10 * 1000);
+
+exit:
+    return 0;
+}
+
+} // namespace Nexus
+} // namespace ot

--- a/tests/fuzz/fuzz_radio-multi.cpp
+++ b/tests/fuzz/fuzz_radio-multi.cpp
@@ -1,0 +1,226 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Multi-frame radio fuzzer.
+ *
+ * The existing `radio-one-node` fuzzer delivers exactly ONE 802.15.4 frame per
+ * test case. Any parser whose state is built across several frames is therefore
+ * structurally unreachable by it, including:
+ *
+ *   - 6LoWPAN fragment reassembly (`MeshForwarder` / `Lowpan` reassembly list),
+ *     which by definition needs a FRAG1 frame followed by one or more FRAGN.
+ *   - CoAP block-wise transfer reassembly.
+ *   - Any MLE / TMF exchange whose second message is parsed only after the
+ *     first has installed state.
+ *
+ * This harness delivers a SEQUENCE of frames, with attacker-chosen inter-frame
+ * delays, to a single node that has formed a network and is the Leader.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "platform/nexus_core.hpp"
+#include "platform/nexus_node.hpp"
+
+namespace ot {
+namespace Nexus {
+
+// Upper bound on frames per test case; keeps a single execution bounded so the
+// fuzzer does not report timeouts for merely-long inputs.
+static constexpr uint32_t kMaxFrames = 24;
+
+class FuzzDataProvider
+{
+public:
+    FuzzDataProvider(const uint8_t *aData, size_t aSize)
+        : mData(aData)
+        , mSize(aSize)
+    {
+    }
+
+    bool ConsumeData(void *aBuf, size_t aLength)
+    {
+        if (aLength > mSize)
+        {
+            return false;
+        }
+
+        memcpy(aBuf, mData, aLength);
+        mData += aLength;
+        mSize -= aLength;
+
+        return true;
+    }
+
+    uint8_t ConsumeByte(void)
+    {
+        uint8_t result = 0;
+
+        if (mSize > 0)
+        {
+            result = *mData;
+            mData++;
+            mSize--;
+        }
+
+        return result;
+    }
+
+    const uint8_t *Peek(void) const { return mData; }
+
+    void Skip(size_t aLength)
+    {
+        aLength = (aLength > mSize) ? mSize : aLength;
+        mData += aLength;
+        mSize -= aLength;
+    }
+
+    size_t RemainingBytes(void) const { return mSize; }
+
+private:
+    const uint8_t *mData;
+    size_t         mSize;
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    FuzzDataProvider fdp(data, size);
+
+    unsigned int seed;
+
+    // Header: 4-byte seed. Then a stream of records:
+    //     u8 length   (0 .. OT_RADIO_FRAME_MAX_SIZE, values above are clamped)
+    //     u8 delayMs  (inter-frame delay, in units of 4 ms)
+    //     u8 psdu[length]
+
+    if (size < sizeof(seed) + 2)
+    {
+        return 0;
+    }
+
+    if (size > sizeof(seed) + kMaxFrames * (2 + OT_RADIO_FRAME_MAX_SIZE))
+    {
+        return 0;
+    }
+
+    if (!fdp.ConsumeData(&seed, sizeof(seed)))
+    {
+        return 0;
+    }
+
+    srand(seed);
+
+    Core nexus;
+
+    Node &node = nexus.CreateNode();
+
+    SuccessOrQuit(node.GetInstance().SetLogLevel(kLogLevelInfo));
+
+    node.GetInstance().Get<BorderRouter::InfraIf>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
+    SuccessOrQuit(node.GetInstance().Get<BorderRouter::RoutingManager>().SetEnabled(true));
+    node.GetInstance().Get<Srp::Server>().SetAutoEnableMode(true);
+    node.GetInstance().Get<BorderRouter::RoutingManager>().SetDhcp6PdEnabled(true);
+    node.GetInstance().Get<BorderRouter::RoutingManager>().SetNat64PrefixManagerEnabled(true);
+    node.GetInstance().Get<Nat64::Translator>().SetEnabled(true);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Form network");
+
+    node.Form();
+    nexus.AdvanceTime(60 * 1000);
+    VerifyOrQuit(node.Get<Mle::Mle>().IsLeader());
+    VerifyOrQuit(node.Get<Srp::Server>().GetState() == Srp::Server::kStateRunning);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Fuzz");
+
+    for (uint32_t frameNum = 0; (frameNum < kMaxFrames) && (fdp.RemainingBytes() >= 2); frameNum++)
+    {
+        otRadioFrame frame;
+        uint8_t      length;
+        uint8_t      delay;
+        uint8_t     *psdu = nullptr;
+
+        length = fdp.ConsumeByte();
+        delay  = fdp.ConsumeByte();
+
+        if (length > OT_RADIO_FRAME_MAX_SIZE)
+        {
+            length = static_cast<uint8_t>(length % (OT_RADIO_FRAME_MAX_SIZE + 1));
+        }
+
+        if (length > fdp.RemainingBytes())
+        {
+            length = static_cast<uint8_t>(fdp.RemainingBytes());
+        }
+
+        memset(&frame, 0, sizeof(frame));
+
+        if (length > 0)
+        {
+            psdu = static_cast<uint8_t *>(malloc(length));
+            VerifyOrQuit(psdu != nullptr);
+            memcpy(psdu, fdp.Peek(), length);
+            fdp.Skip(length);
+        }
+
+        frame.mPsdu                                = psdu;
+        frame.mLength                              = length;
+        frame.mChannel                             = 11;
+        frame.mInfo.mRxInfo.mRssi                  = -20;
+        frame.mInfo.mRxInfo.mLqi                   = OT_RADIO_LQI_NONE;
+        frame.mInfo.mRxInfo.mTimestamp             = nexus.GetNowMicro64();
+        frame.mInfo.mRxInfo.mAckedWithFramePending = false;
+
+        Log("--- frame %u: len=%u delay=%u ---", frameNum, length, delay);
+
+        otPlatRadioReceiveDone(&node.GetInstance(), &frame, OT_ERROR_NONE);
+
+        // Inter-frame delay. Bounded so a test case cannot advance simulated
+        // time far enough to be slow, but large enough to cross reassembly and
+        // retransmission timers.
+        nexus.AdvanceTime(static_cast<uint32_t>(delay) * 4);
+
+        if (psdu != nullptr)
+        {
+            free(psdu);
+        }
+    }
+
+    nexus.AdvanceTime(10 * 1000);
+
+exit:
+    return 0;
+}
+
+} // namespace Nexus
+} // namespace ot

--- a/tests/fuzz/fuzz_radio-multi.cpp
+++ b/tests/fuzz/fuzz_radio-multi.cpp
@@ -1,0 +1,221 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Multi-frame radio fuzzer.
+ *
+ * The existing `radio-one-node` fuzzer delivers exactly ONE 802.15.4 frame per
+ * test case. Any parser whose state is built across several frames is therefore
+ * structurally unreachable by it, including:
+ *
+ *   - 6LoWPAN fragment reassembly (`MeshForwarder` / `Lowpan` reassembly list),
+ *     which by definition needs a FRAG1 frame followed by one or more FRAGN.
+ *   - CoAP block-wise transfer reassembly.
+ *   - Any MLE / TMF exchange whose second message is parsed only after the
+ *     first has installed state.
+ *
+ * This harness delivers a SEQUENCE of frames, with attacker-chosen inter-frame
+ * delays, to a single node that has formed a network and is the Leader.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "platform/nexus_core.hpp"
+#include "platform/nexus_node.hpp"
+
+namespace ot {
+namespace Nexus {
+
+// Upper bound on frames per test case; keeps a single execution bounded so the
+// fuzzer does not report timeouts for merely-long inputs.
+static constexpr uint32_t kMaxFrames = 24;
+
+class FuzzDataProvider
+{
+public:
+    FuzzDataProvider(const uint8_t *aData, size_t aSize)
+        : mData(aData)
+        , mSize(aSize)
+    {
+    }
+
+    bool ConsumeData(void *aBuf, size_t aLength)
+    {
+        if (aLength > mSize)
+        {
+            return false;
+        }
+
+        memcpy(aBuf, mData, aLength);
+        mData += aLength;
+        mSize -= aLength;
+
+        return true;
+    }
+
+    uint8_t ConsumeByte(void)
+    {
+        uint8_t result = 0;
+
+        IgnoreError(ConsumeData(&result, sizeof(result)) ? kErrorNone : kErrorParse);
+
+        return result;
+    }
+
+    const uint8_t *Peek(void) const { return mData; }
+
+    void Skip(size_t aLength)
+    {
+        aLength = (aLength > mSize) ? mSize : aLength;
+        mData += aLength;
+        mSize -= aLength;
+    }
+
+    size_t RemainingBytes(void) const { return mSize; }
+
+private:
+    const uint8_t *mData;
+    size_t         mSize;
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    FuzzDataProvider fdp(data, size);
+
+    unsigned int seed;
+
+    // Header: 4-byte seed. Then a stream of records:
+    //     u8 length   (0 .. OT_RADIO_FRAME_MAX_SIZE, values above are clamped)
+    //     u8 delayMs  (inter-frame delay, in units of 4 ms)
+    //     u8 psdu[length]
+
+    if (size < sizeof(seed) + 2)
+    {
+        return 0;
+    }
+
+    if (size > sizeof(seed) + kMaxFrames * (2 + OT_RADIO_FRAME_MAX_SIZE))
+    {
+        return 0;
+    }
+
+    if (!fdp.ConsumeData(&seed, sizeof(seed)))
+    {
+        return 0;
+    }
+
+    srand(seed);
+
+    Core nexus;
+
+    Node &node = nexus.CreateNode();
+
+    SuccessOrQuit(node.GetInstance().SetLogLevel(kLogLevelInfo));
+
+    node.GetInstance().Get<BorderRouter::InfraIf>().Init(/* aInfraIfIndex */ 1, /* aInfraIfIsRunning */ true);
+    SuccessOrQuit(node.GetInstance().Get<BorderRouter::RoutingManager>().SetEnabled(true));
+    node.GetInstance().Get<Srp::Server>().SetAutoEnableMode(true);
+    node.GetInstance().Get<BorderRouter::RoutingManager>().SetDhcp6PdEnabled(true);
+    node.GetInstance().Get<BorderRouter::RoutingManager>().SetNat64PrefixManagerEnabled(true);
+    node.GetInstance().Get<Nat64::Translator>().SetEnabled(true);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Form network");
+
+    node.Form();
+    nexus.AdvanceTime(60 * 1000);
+    VerifyOrQuit(node.Get<Mle::Mle>().IsLeader());
+    VerifyOrQuit(node.Get<Srp::Server>().GetState() == Srp::Server::kStateRunning);
+
+    Log("---------------------------------------------------------------------------------------");
+    Log("Fuzz");
+
+    for (uint32_t frameNum = 0; (frameNum < kMaxFrames) && (fdp.RemainingBytes() >= 2); frameNum++)
+    {
+        otRadioFrame frame;
+        uint8_t      length;
+        uint8_t      delay;
+        uint8_t     *psdu = nullptr;
+
+        length = fdp.ConsumeByte();
+        delay  = fdp.ConsumeByte();
+
+        if (length > OT_RADIO_FRAME_MAX_SIZE)
+        {
+            length = static_cast<uint8_t>(length % (OT_RADIO_FRAME_MAX_SIZE + 1));
+        }
+
+        if (length > fdp.RemainingBytes())
+        {
+            length = static_cast<uint8_t>(fdp.RemainingBytes());
+        }
+
+        memset(&frame, 0, sizeof(frame));
+
+        if (length > 0)
+        {
+            psdu = static_cast<uint8_t *>(malloc(length));
+            VerifyOrQuit(psdu != nullptr);
+            memcpy(psdu, fdp.Peek(), length);
+            fdp.Skip(length);
+        }
+
+        frame.mPsdu                                = psdu;
+        frame.mLength                              = length;
+        frame.mChannel                             = 11;
+        frame.mInfo.mRxInfo.mRssi                  = -20;
+        frame.mInfo.mRxInfo.mLqi                   = OT_RADIO_LQI_NONE;
+        frame.mInfo.mRxInfo.mTimestamp             = nexus.GetNowMicro64();
+        frame.mInfo.mRxInfo.mAckedWithFramePending = false;
+
+        Log("--- frame %u: len=%u delay=%u ---", frameNum, length, delay);
+
+        otPlatRadioReceiveDone(&node.GetInstance(), &frame, OT_ERROR_NONE);
+
+        // Inter-frame delay. Bounded so a test case cannot advance simulated
+        // time far enough to be slow, but large enough to cross reassembly and
+        // retransmission timers.
+        nexus.AdvanceTime(static_cast<uint32_t>(delay) * 4);
+
+        if (psdu != nullptr)
+        {
+            free(psdu);
+        }
+    }
+
+    nexus.AdvanceTime(10 * 1000);
+
+exit:
+    return 0;
+}
+
+} // namespace Nexus
+} // namespace ot

--- a/tests/fuzz/pcap_to_corpus.py
+++ b/tests/fuzz/pcap_to_corpus.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Convert a Nexus pcapng capture into a radio-multi fuzzer seed corpus.
+
+Nexus writes DLT_IEEE802_15_4_TAP (283) frames when OT_NEXUS_PCAP_FILE is set.
+Real frames make far better seeds than hand-built ones: they already carry valid
+IPHC compression, MLE/CoAP payloads and MAC framing that the fuzzer would
+otherwise have to rediscover byte by byte.
+
+Usage:  pcap_to_corpus.py <in.pcapng> [<in.pcapng> ...] <outdir>
+"""
+
+import os
+import struct
+import sys
+
+EPB = 0x00000006
+IDB = 0x00000001
+SHB = 0x0A0D0D0A
+
+
+def parse_pcapng(path):
+    """Yield raw packet payloads from every Enhanced Packet Block."""
+    with open(path, "rb") as f:
+        data = f.read()
+    off = 0
+    endian = "<"
+    while off + 12 <= len(data):
+        (btype,) = struct.unpack_from(endian + "I", data, off)
+        if btype == SHB:
+            (magic,) = struct.unpack_from("<I", data, off + 8)
+            endian = "<" if magic == 0x1A2B3C4D else ">"
+        (blen,) = struct.unpack_from(endian + "I", data, off + 4)
+        if blen < 12 or off + blen > len(data):
+            break
+        if btype == EPB:
+            caplen = struct.unpack_from(endian + "I", data, off + 20)[0]
+            yield data[off + 28 : off + 28 + caplen]
+        off += blen
+
+
+def strip_tap(pkt):
+    """Remove the IEEE 802.15.4 TAP pseudo-header, returning the raw PSDU."""
+    if len(pkt) < 4:
+        return None
+    _ver, _res, hdrlen = struct.unpack_from("<BBH", pkt, 0)
+    if hdrlen < 4 or hdrlen > len(pkt):
+        return None
+    return pkt[hdrlen:]
+
+
+def broadcast_dst_pan(psdu):
+    """Rewrite the destination PAN ID to 0xFFFF.
+
+    Captured frames carry the PAN ID of the network that produced them. The
+    fuzz node generates a *random* dataset per run, so a captured PAN never
+    matches and every frame is silently dropped by the destination-address
+    filter (mac.cpp:1951) before reaching any parser. Broadcast PAN is
+    accepted unconditionally, which is also what a real off-network attacker
+    would send.
+    """
+    if len(psdu) < 5:
+        return psdu
+    fcf = struct.unpack_from("<H", psdu, 0)[0]
+    dst_mode = (fcf >> 10) & 0x3
+    if dst_mode == 0:  # no destination addressing -> no dst PAN present
+        return psdu
+    return psdu[:3] + b"\xff\xff" + psdu[5:]
+
+
+def record(psdu, delay=1):
+    psdu = broadcast_dst_pan(psdu)[:127]
+    return bytes([len(psdu), delay]) + psdu
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__)
+        return 1
+
+    *inputs, outdir = sys.argv[1:]
+    os.makedirs(outdir, exist_ok=True)
+
+    frames = []
+    for path in inputs:
+        for pkt in parse_pcapng(path):
+            psdu = strip_tap(pkt)
+            if psdu and 0 < len(psdu) <= 127:
+                frames.append(psdu)
+
+    if not frames:
+        print("NO FRAMES EXTRACTED -- check the capture", file=sys.stderr)
+        return 2
+
+    written = 0
+
+    # One seed per individual frame, so the fuzzer has every distinct real
+    # frame shape available as a mutation base.
+    for i, f in enumerate(frames):
+        blob = struct.pack("<I", i) + record(f)
+        with open(os.path.join(outdir, f"real_single_{i:04d}"), "wb") as out:
+            out.write(blob)
+        written += 1
+
+    # Sliding windows of consecutive frames, which is what actually exercises
+    # multi-frame state (reassembly, block transfer, MLE exchanges).
+    for width in (2, 3, 5, 8):
+        for i in range(0, max(0, len(frames) - width + 1), max(1, width // 2)):
+            window = frames[i : i + width]
+            blob = struct.pack("<I", 0x1000 + i) + b"".join(record(f) for f in window)
+            if len(blob) > 4 + 24 * (2 + 127):
+                continue
+            with open(os.path.join(outdir, f"real_seq{width}_{i:04d}"), "wb") as out:
+                out.write(blob)
+            written += 1
+
+    sizes = sorted(set(len(f) for f in frames))
+    print(f"extracted {len(frames)} frames, wrote {written} seeds to {outdir}/")
+    print(f"frame lengths seen: min={sizes[0]} max={sizes[-1]} distinct={len(sizes)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fuzz/pcap_to_corpus.py
+++ b/tests/fuzz/pcap_to_corpus.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Convert a Nexus pcapng capture into a radio-multi fuzzer seed corpus.
+
+Nexus writes DLT_IEEE802_15_4_TAP (283) frames when OT_NEXUS_PCAP_FILE is set.
+Real frames make far better seeds than hand-built ones: they already carry valid
+IPHC compression, MLE/CoAP payloads and MAC framing that the fuzzer would
+otherwise have to rediscover byte by byte.
+
+Usage:  pcap_to_corpus.py <in.pcapng> [<in.pcapng> ...] <outdir>
+"""
+
+import os
+import struct
+import sys
+
+EPB = 0x00000006
+IDB = 0x00000001
+SHB = 0x0A0D0D0A
+
+
+def parse_pcapng(path):
+    """Yield raw packet payloads from every Enhanced Packet Block."""
+    data = open(path, "rb").read()
+    off = 0
+    endian = "<"
+    while off + 12 <= len(data):
+        (btype,) = struct.unpack_from(endian + "I", data, off)
+        if btype == SHB:
+            (magic,) = struct.unpack_from("<I", data, off + 8)
+            endian = "<" if magic == 0x1A2B3C4D else ">"
+        (blen,) = struct.unpack_from(endian + "I", data, off + 4)
+        if blen < 12 or off + blen > len(data):
+            break
+        if btype == EPB:
+            caplen = struct.unpack_from(endian + "I", data, off + 20)[0]
+            yield data[off + 28 : off + 28 + caplen]
+        off += blen
+
+
+def strip_tap(pkt):
+    """Remove the IEEE 802.15.4 TAP pseudo-header, returning the raw PSDU."""
+    if len(pkt) < 4:
+        return None
+    _ver, _res, hdrlen = struct.unpack_from("<BBH", pkt, 0)
+    if hdrlen < 4 or hdrlen > len(pkt):
+        return None
+    return pkt[hdrlen:]
+
+
+def broadcast_dst_pan(psdu):
+    """Rewrite the destination PAN ID to 0xFFFF.
+
+    Captured frames carry the PAN ID of the network that produced them. The
+    fuzz node generates a *random* dataset per run, so a captured PAN never
+    matches and every frame is silently dropped by the destination-address
+    filter (mac.cpp:1951) before reaching any parser. Broadcast PAN is
+    accepted unconditionally, which is also what a real off-network attacker
+    would send.
+    """
+    if len(psdu) < 5:
+        return psdu
+    fcf = struct.unpack_from("<H", psdu, 0)[0]
+    dst_mode = (fcf >> 10) & 0x3
+    if dst_mode == 0:  # no destination addressing -> no dst PAN present
+        return psdu
+    return psdu[:3] + b"\xff\xff" + psdu[5:]
+
+
+def record(psdu, delay=1):
+    psdu = broadcast_dst_pan(psdu)[:127]
+    return bytes([len(psdu), delay]) + psdu
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__)
+        return 1
+
+    *inputs, outdir = sys.argv[1:]
+    os.makedirs(outdir, exist_ok=True)
+
+    frames = []
+    for path in inputs:
+        for pkt in parse_pcapng(path):
+            psdu = strip_tap(pkt)
+            if psdu and 0 < len(psdu) <= 127:
+                frames.append(psdu)
+
+    if not frames:
+        print("NO FRAMES EXTRACTED -- check the capture", file=sys.stderr)
+        return 2
+
+    written = 0
+
+    # One seed per individual frame, so the fuzzer has every distinct real
+    # frame shape available as a mutation base.
+    for i, f in enumerate(frames):
+        blob = struct.pack("<I", i) + record(f)
+        open(os.path.join(outdir, f"real_single_{i:04d}"), "wb").write(blob)
+        written += 1
+
+    # Sliding windows of consecutive frames, which is what actually exercises
+    # multi-frame state (reassembly, block transfer, MLE exchanges).
+    for width in (2, 3, 5, 8):
+        for i in range(0, max(0, len(frames) - width + 1), max(1, width // 2)):
+            window = frames[i : i + width]
+            blob = struct.pack("<I", 0x1000 + i) + b"".join(record(f) for f in window)
+            if len(blob) > 4 + 24 * (2 + 127):
+                continue
+            open(os.path.join(outdir, f"real_seq{width}_{i:04d}"), "wb").write(blob)
+            written += 1
+
+    sizes = sorted(set(len(f) for f in frames))
+    print(f"extracted {len(frames)} frames, wrote {written} seeds to {outdir}/")
+    print(f"frame lengths seen: min={sizes[0]} max={sizes[-1]} distinct={len(sizes)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### What this changes

Adds three fuzz targets to `tests/fuzz/`, plus a script for building seed corpora from Nexus captures.

### Why

While reading the existing targets I found two structural limits that leave reachable code unreachable by fuzzing. Neither is a bug in the targets — both follow from where they inject.

**1. One input per test case.** Every existing target delivers a single input and returns, so none can build state that spans frames. 6LoWPAN reassembly is driven entirely by a FRAG1/FRAGN *sequence*, so it cannot be reached at all today.

**2. `ip6-fuzzer` cannot reach mesh-internal services.** It injects at `otIp6Send`, which reaches `Ip6::SendRaw()`. When a datagram's destination is mesh-local, that function requires the source to be a unicast address assigned to this device and drops it otherwise:

```c
// When the packet is forwarded from host to Thread, if its source is on-mesh or its destination is
// mesh-local, we'll drop the packet unless the packet originates from this device.
if (Get<NetworkData::Leader>().IsOnMesh(header.GetSource()) ||
    Get<Mle::Mle>().IsMeshLocalAddress(header.GetDestination()))
{
    VerifyOrExit(Get<ThreadNetif>().HasUnicastAddress(header.GetSource()), error = kErrorDrop);
}
```

Fuzz input supplies an arbitrary source, so anything addressed to a mesh-local destination is dropped. `Tmf::Agent` requires *both* endpoints to be mesh-local, so TMF, MeshCoP and SRP are never entered.

### The targets

| target | reaches |
|---|---|
| `radio-multi` | up to 24 802.15.4 frames with per-frame delays from one test case — multi-frame 6LoWPAN reassembly state |
| `ip6-recv` | injects at `Ip6::HandleDatagram()` with `kOriginThreadNetif` (the path a *received* datagram takes) and can substitute the node's own mesh-local source/destination, so TMF messages are accepted |
| `discovery` | the MLE Discovery Request/Response exchange, processed with `kNoSecurity` and so reachable without the network key |

`pcap_to_corpus.py` turns `OT_NEXUS_PCAP_FILE` captures into seed corpora. One note that cost me a while: captured frames must have their destination PAN rewritten to broadcast, otherwise every frame is dropped by the address filter before reaching any parser.

`radio-multi` and `ip6-recv` construct a node per test case, following `radio-one-node`. `discovery` instead builds its node once in `LLVMFuzzerInitialize()`, because node construction dominates runtime on that surface; it re-arms the discovery scan before each input, since `DiscoverScanner` otherwise finishes scanning and turns every later input into a silent early exit. That makes `discovery` the only target here that carries state across inputs — see my note below, I'd like your view on it.

### Testing

- Builds with the exact `oss-fuzz-build` configuration (`OT_PLATFORM=nexus`, `OT_THREAD_VERSION=1.4`, nexus project config) with `OT_COMPILE_WARNING_AS_ERROR=ON`, alongside the existing six targets.
- `script/make-pretty check` clean (clang-format 19.1.7).
- Each target run against seeded corpora:

```
discovery-fuzzer    cov: 430    ft: 456
ip6-recv-fuzzer     cov: 10551  ft: 13120
radio-multi-fuzzer  cov: 10568  ft: 13138
```

No changes are needed to `tests/fuzz/oss-fuzz-build` — it discovers targets with `find . -name '*-fuzzer'`, so these are picked up automatically.

### Note

I have further unit-level targets for the MAC frame, MeshCoP TLV, DNS name/record and 6LoWPAN IPHC parsers, which run 8–13k exec/s against a byte buffer with no node construction. Kept out of this PR to keep the review small — happy to open a follow-up if useful.

