### PR TITLE
[ip6-prefix] rename `ContainsPrefix()` to `IsCoveredBy()`

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -641,7 +641,7 @@ bool RoutingManager::NetworkDataContainsUlaRoute(void) const
 {
     // Determine whether leader Network Data contains a route
     // prefix which is either the ULA prefix `fc00::/7` or
-    // a sub-prefix of it (e.g., default route).
+    // a broader prefix covering it (e.g., default route).
 
     NetworkData::Iterator            iterator = NetworkData::kIteratorInit;
     NetworkData::ExternalRouteConfig routeConfig;
@@ -649,7 +649,7 @@ bool RoutingManager::NetworkDataContainsUlaRoute(void) const
 
     while (Get<NetworkData::Leader>().GetNext(iterator, routeConfig) == kErrorNone)
     {
-        if (routeConfig.mStable && RoutePublisher::GetUlaPrefix().ContainsPrefix(routeConfig.GetPrefix()))
+        if (routeConfig.mStable && RoutePublisher::GetUlaPrefix().IsCoveredBy(routeConfig.GetPrefix()))
         {
             contains = true;
             break;
@@ -1488,12 +1488,12 @@ void RoutingManager::OnLinkPrefixManager::PublishAndAdvertise(void)
     SetState(kPublishing);
     ResetExpireTime(TimerMilli::GetNow());
 
-    // We wait for the ULA `fc00::/7` route or a sub-prefix of it (e.g.,
-    // default route) to be added in Network Data before
-    // starting to advertise the local on-link prefix in RAs.
-    // However, if it is already present in Network Data (e.g.,
-    // added by another BR on the same Thread mesh), we can
-    // immediately start advertising it.
+    // We wait for the ULA `fc00::/7` route or a broader prefix
+    // covering it (e.g., default route) to be added in Network Data
+    // before starting to advertise the local on-link prefix in RAs.
+    // However, if it is already present in Network Data (e.g., added
+    // by another BR on the same Thread mesh), we can immediately
+    // start advertising it.
 
     if (Get<RoutingManager>().NetworkDataContainsUlaRoute())
     {

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -83,16 +83,16 @@ bool Prefix::IsEqual(const uint8_t *aPrefixBytes, uint8_t aPrefixLength) const
     return (mLength == aPrefixLength) && (CountMatchingBits(GetBytes(), aPrefixBytes, mLength) >= mLength);
 }
 
-bool Prefix::ContainsPrefix(const Prefix &aSubPrefix) const
+bool Prefix::IsCoveredBy(const Prefix &aPrefix) const
 {
-    return (mLength >= aSubPrefix.mLength) &&
-           (CountMatchingBits(GetBytes(), aSubPrefix.GetBytes(), aSubPrefix.GetLength()) >= aSubPrefix.GetLength());
+    return (mLength >= aPrefix.mLength) &&
+           (CountMatchingBits(GetBytes(), aPrefix.GetBytes(), aPrefix.GetLength()) >= aPrefix.GetLength());
 }
 
-bool Prefix::ContainsPrefix(const NetworkPrefix &aSubPrefix) const
+bool Prefix::IsCoveredBy(const NetworkPrefix &aNetworkPrefix) const
 {
     return (mLength >= NetworkPrefix::kLength) &&
-           (CountMatchingBits(GetBytes(), aSubPrefix.m8, NetworkPrefix::kLength) >= NetworkPrefix::kLength);
+           (CountMatchingBits(GetBytes(), aNetworkPrefix.m8, NetworkPrefix::kLength) >= NetworkPrefix::kLength);
 }
 
 void Prefix::Tidy(void)

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -217,24 +217,31 @@ public:
     bool IsEqual(const uint8_t *aPrefixBytes, uint8_t aPrefixLength) const;
 
     /**
-     * Indicates whether the prefix contains a sub-prefix.
+     * Indicates whether the prefix is covered by a given prefix.
      *
-     * @param[in] aSubPrefix  A sub-prefix.
+     * The prefix is considered covered by @p aPrefix if its length is greater than or equal to @p aPrefix's length and
+     * its leading bits match @p aPrefix. For example, `2001:db8:1:2::/64` is covered by `2001:db8:1::/48`, and any
+     * prefix is covered by `::/0`.
      *
-     * @retval TRUE   The prefix contains the @p aSubPrefix
-     * @retval FALSE  The prefix does not contains the @p aSubPrefix.
+     * @param[in] aPrefix  A prefix.
+     *
+     * @retval TRUE   The prefix is covered by @p aPrefix.
+     * @retval FALSE  The prefix is not covered by @p aPrefix.
      */
-    bool ContainsPrefix(const Prefix &aSubPrefix) const;
+    bool IsCoveredBy(const Prefix &aPrefix) const;
 
     /**
-     * Indicates whether the prefix contains a sub-prefix (given as a `NetworkPrefix`).
+     * Indicates whether the prefix is covered by a given `NetworkPrefix`.
      *
-     * @param[in] aSubPrefix  A sub-prefix (as a `NetworkPrefix`).
+     * The prefix is considered covered by @p aNetworkPrefix if its length is greater than or equal to
+     * `NetworkPrefix::kLength` (64 bits) and its leading 64 bits match @p aNetworkPrefix.
      *
-     * @retval TRUE   The prefix contains the @p aSubPrefix
-     * @retval FALSE  The prefix does not contains the @p aSubPrefix.
+     * @param[in] aNetworkPrefix  A `NetworkPrefix`.
+     *
+     * @retval TRUE   The prefix is covered by @p aNetworkPrefix.
+     * @retval FALSE  The prefix is not covered by @p aNetworkPrefix.
      */
-    bool ContainsPrefix(const NetworkPrefix &aSubPrefix) const;
+    bool IsCoveredBy(const NetworkPrefix &aNetworkPrefix) const;
 
     /**
      * Overloads operator `==` to evaluate whether or not two prefixes are equal.

--- a/src/core/thread/network_data_types.cpp
+++ b/src/core/thread/network_data_types.cpp
@@ -45,7 +45,7 @@ static bool IsPrefixValid(Instance &aInstance, const Ip6::Prefix &aPrefix)
     // Check that prefix length is within the valid range and the prefix
     // does not overlap with the mesh-local prefix.
 
-    return aPrefix.IsValid() && !aPrefix.ContainsPrefix(aInstance.Get<Mle::Mle>().GetMeshLocalPrefix());
+    return aPrefix.IsValid() && !aPrefix.IsCoveredBy(aInstance.Get<Mle::Mle>().GetMeshLocalPrefix());
 }
 
 bool OnMeshPrefixConfig::IsValid(Instance &aInstance) const

--- a/tests/unit/test_ip_address.cpp
+++ b/tests/unit/test_ip_address.cpp
@@ -480,25 +480,42 @@ void TestIp6Prefix(void)
             VerifyOrQuit(prefix == prefix);
             VerifyOrQuit(!(prefix < prefix));
 
-            for (uint8_t subPrefixLength = 1; subPrefixLength <= prefixLength; subPrefixLength++)
+            for (uint8_t shorterPrefixLength = 0; shorterPrefixLength <= prefixLength; shorterPrefixLength++)
             {
-                Ip6::Prefix subPrefix;
+                Ip6::Prefix shorterPrefix;
 
-                subPrefix.InitFrom(prefixBytes, subPrefixLength);
+                shorterPrefix.InitFrom(prefixBytes, shorterPrefixLength);
 
-                VerifyOrQuit(prefix.ContainsPrefix(subPrefix));
+                VerifyOrQuit(prefix.IsCoveredBy(shorterPrefix));
 
-                if (prefixLength == subPrefixLength)
+                if (prefixLength == shorterPrefixLength)
                 {
-                    VerifyOrQuit(prefix == subPrefix);
-                    VerifyOrQuit(prefix.IsEqual(subPrefix.GetBytes(), subPrefix.GetLength()));
-                    VerifyOrQuit(!(subPrefix < prefix));
+                    VerifyOrQuit(prefix == shorterPrefix);
+                    VerifyOrQuit(prefix.IsEqual(shorterPrefix.GetBytes(), shorterPrefix.GetLength()));
+                    VerifyOrQuit(!(shorterPrefix < prefix));
                 }
                 else
                 {
-                    VerifyOrQuit(prefix != subPrefix);
-                    VerifyOrQuit(!prefix.IsEqual(subPrefix.GetBytes(), subPrefix.GetLength()));
-                    VerifyOrQuit(subPrefix < prefix);
+                    VerifyOrQuit(prefix != shorterPrefix);
+                    VerifyOrQuit(!prefix.IsEqual(shorterPrefix.GetBytes(), shorterPrefix.GetLength()));
+                    VerifyOrQuit(shorterPrefix < prefix);
+                }
+
+                for (uint8_t bitNumber = 0; bitNumber < shorterPrefixLength; bitNumber++)
+                {
+                    Ip6::Prefix alteredShorterPrefix;
+                    uint8_t     mask  = static_cast<uint8_t>(1U << (7 - (bitNumber & 7)));
+                    uint8_t     index = (bitNumber / 8);
+
+                    alteredShorterPrefix = shorterPrefix;
+                    VerifyOrQuit(alteredShorterPrefix == shorterPrefix);
+
+                    // Flip the `bitNumber` bit.
+
+                    alteredShorterPrefix.mPrefix.mFields.m8[index] ^= mask;
+                    VerifyOrQuit(alteredShorterPrefix != shorterPrefix);
+
+                    VerifyOrQuit(!prefix.IsCoveredBy(alteredShorterPrefix));
                 }
             }
 


### PR DESCRIPTION
This commit renames `Ip6::Prefix::ContainsPrefix()` to `IsCoveredBy()` to make the method self-documenting, clear, and intuitive.

A prefix is considered covered by another prefix if its length is greater than or equal to the other prefix's length and its leading bits match (e.g., `2001:db8:1:2::/64` is covered by `2001:db8:1::/48`).

This commit updates the method name, parameter names, Doxygen documentation with concrete examples, all call sites, and unit tests.