### PR TITLE
[mle] introduce `TxChallengeTable` for routers

### DIFF
--- a/src/core/common/msg_backed_array.hpp
+++ b/src/core/common/msg_backed_array.hpp
@@ -141,6 +141,29 @@ public:
     bool IsFull(void) const { return GetLength() == kMaxSize; }
 
     /**
+     * Adjusts (reduces) the array length to a given length.
+     *
+     * This method can only be used to reduce the length of the array. If @p aLength is greater than `GetLength()`,
+     * the array length remains unchanged.
+     *
+     * @param[in] aLength  The new length (number of elements).
+     */
+    void AdjustLength(uint16_t aLength)
+    {
+        if (aLength < GetLength())
+        {
+            if (aLength == 0)
+            {
+                Clear();
+            }
+            else
+            {
+                IgnoreError(mMessage->SetLength(aLength * sizeof(Type)));
+            }
+        }
+    }
+
+    /**
      * Reads an element from the array at a given index.
      *
      * @param[in]  aIndex  The index to read from.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -100,6 +100,7 @@ Mle::Mle(Instance &aInstance)
     , mChildTable(aInstance)
     , mRouterTable(aInstance)
     , mRoleTransitioner(aInstance)
+    , mTxChallengeTable(aInstance)
 #endif // OPENTHREAD_FTD
 #if OPENTHREAD_CONFIG_P2P_ENABLE
     , mP2p(aInstance)
@@ -709,6 +710,7 @@ Error Mle::SetDeviceMode(DeviceMode aDeviceMode)
     if (!aDeviceMode.IsFullThreadDevice())
     {
         ClearAlternateRloc16();
+        mTxChallengeTable.Clear();
     }
 
     mRoleTransitioner.UpdateRouterRoleAllowed(RoleTransitioner::kReasonDeviceModeChanged);

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -45,6 +45,7 @@
 #include "common/encoding.hpp"
 #include "common/locator.hpp"
 #include "common/log.hpp"
+#include "common/msg_backed_array.hpp"
 #include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/time_ticker.hpp"
@@ -1927,7 +1928,6 @@ private:
         Error Start(void);
         void  Stop(void);
         bool  IsRestoringChildRole(void) const { return mState == kRestoringChildRole; }
-        bool  IsRestoringRouterOrLeaderRole(void) const { return mState == kRestoringRouterOrLeaderRole; }
         void  HandleTimer(void);
         void  HandleChildUpdateRequest(RxInfo &aRxInfo) { CheckIfMessageIsFromParent(aRxInfo); }
 
@@ -2328,6 +2328,43 @@ private:
         uint8_t mDowngradeThreshold;
     };
 
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    class TxChallengeTable : public InstanceLocator
+    {
+        // Track challenges used in Link Request tx to routers
+
+    public:
+        static constexpr uint8_t kTimeout = kLinkAcceptTimeout + 1; // + 1 for extra margin before removing entry
+
+        explicit TxChallengeTable(Instance &aInstance);
+
+        void  Clear(void);
+        Error GenerateFor(uint8_t aRouterId, TxChallenge &aChallenge);
+        Error GenerateForMulticast(TxChallenge &aChallenge) { return GenerateFor(kAnyRouterId, aChallenge); }
+        bool  ContainsMatching(const RxChallenge &aRxChallenge, uint8_t aRouterId) const;
+        void  HandleTimeTick(void);
+
+    private:
+        static constexpr uint8_t  kAnyRouterId = kInvalidRouterId;
+        static constexpr uint16_t kMaxEntries  = kMaxRouters + 1; // + 1 for multicast (kAnyRouterId)
+
+        struct Entry
+        {
+            bool Matches(uint8_t aRouterId) const { return (mRouterId == aRouterId); }
+            bool Matches(const RxChallenge &aRxChallenge, uint8_t aRouterId) const;
+
+            TxChallenge mChallenge;
+            uint8_t     mRouterId;
+            uint8_t     mTimeout;
+        };
+
+        using EntryArray   = MessageBackedArray<Entry, kMaxEntries>;
+        using IndexedEntry = EntryArray::IndexedEntry;
+
+        EntryArray mEntries;
+    };
+
 #endif // OPENTHREAD_FTD
 
     //------------------------------------------------------------------------------------------------------------------
@@ -2656,6 +2693,7 @@ private:
     ChildTable                 mChildTable;
     RouterTable                mRouterTable;
     RoleTransitioner           mRoleTransitioner;
+    TxChallengeTable           mTxChallengeTable;
     Ip6::Netif::UnicastAddress mLeaderAloc;
 #if OPENTHREAD_CONFIG_MLE_DEVICE_PROPERTY_LEADER_WEIGHT_ENABLE
     DeviceProperties mDeviceProperties;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -45,6 +45,7 @@
 #include "common/encoding.hpp"
 #include "common/locator.hpp"
 #include "common/log.hpp"
+#include "common/msg_backed_array.hpp"
 #include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/time_ticker.hpp"
@@ -2328,6 +2329,43 @@ private:
         uint8_t mDowngradeThreshold;
     };
 
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    class TxChallengeTable : public InstanceLocator
+    {
+        // Track challenges used in Link Request tx to routers
+
+    public:
+        static constexpr uint8_t kTimeout = kLinkAcceptTimeout + 1; // + 1 for extra margin before removing entry
+
+        explicit TxChallengeTable(Instance &aInstance);
+
+        void  Clear(void);
+        Error GenerateFor(uint8_t aRouterId, TxChallenge &aChallenge);
+        Error GenerateForMulticast(TxChallenge &aChallenge) { return GenerateFor(kAnyRouterId, aChallenge); }
+        bool  ContainsMatching(const RxChallenge &aRxChallenge, uint8_t aRouterId) const;
+        void  HandleTimeTick(void);
+
+    private:
+        static constexpr uint8_t  kAnyRouterId = kInvalidRouterId;
+        static constexpr uint16_t kMaxEntries  = kMaxRouters + 1; // + 1 for multicast (kAnyRouterId)
+
+        struct Entry
+        {
+            bool Matches(uint8_t aRouterId) const { return (mRouterId == aRouterId); }
+            bool Matches(const RxChallenge &aRxChallenge, uint8_t aRouterId) const;
+
+            TxChallenge mChallenge;
+            uint8_t     mRouterId;
+            uint8_t     mTimeout;
+        };
+
+        using EntryArray   = MessageBackedArray<Entry, kMaxEntries>;
+        using IndexedEntry = EntryArray::IndexedEntry;
+
+        EntryArray mEntries;
+    };
+
 #endif // OPENTHREAD_FTD
 
     //------------------------------------------------------------------------------------------------------------------
@@ -2656,6 +2694,7 @@ private:
     ChildTable                 mChildTable;
     RouterTable                mRouterTable;
     RoleTransitioner           mRoleTransitioner;
+    TxChallengeTable           mTxChallengeTable;
     Ip6::Netif::UnicastAddress mLeaderAloc;
 #if OPENTHREAD_CONFIG_MLE_DEVICE_PROPERTY_LEADER_WEIGHT_ENABLE
     DeviceProperties mDeviceProperties;

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -333,6 +333,7 @@ void Mle::StopLeader(void)
 void Mle::HandleDetachStart(void)
 {
     mRouterTable.ClearNeighbors();
+    mTxChallengeTable.Clear();
     StopLeader();
     Get<TimeTicker>().UnregisterReceiver(TimeTicker::kMle);
 }
@@ -449,6 +450,7 @@ void Mle::SetStateRouterOrLeader(DeviceRole aRole, uint16_t aRloc16, LeaderStart
     Get<ThreadNetif>().SubscribeAllRoutersMulticast();
     mPreviousPartitionIdRouter = mLeaderData.GetPartitionId();
     Get<Mac::Mac>().SetBeaconEnabled(true);
+    mTxChallengeTable.Clear();
     Get<TimeTicker>().RegisterReceiver(TimeTicker::kMle);
 
     // Avoid informing an old parent when attaching next as a child after becoming an active router
@@ -672,6 +674,7 @@ void Mle::SendLinkRequest(Router *aRouter)
     Error        error   = kErrorNone;
     TxMessage   *message = nullptr;
     Ip6::Address destination;
+    TxChallenge  challenge;
 
     destination.Clear();
 
@@ -712,28 +715,17 @@ void Mle::SendLinkRequest(Router *aRouter)
 
     if (aRouter == nullptr)
     {
-        mPrevRoleRestorer.GenerateRandomChallenge();
-        SuccessOrExit(error = message->AppendChallengeTlv(mPrevRoleRestorer.GetChallenge()));
+        SuccessOrExit(error = mTxChallengeTable.GenerateForMulticast(challenge));
         destination = Ip6::Address::GetLinkLocalAllRoutersMulticast();
     }
     else
     {
-        if (!aRouter->IsStateValid())
-        {
-            aRouter->GenerateChallenge();
-            SuccessOrExit(error = message->AppendChallengeTlv(aRouter->GetChallenge()));
-        }
-        else
-        {
-            TxChallenge challenge;
-
-            challenge.GenerateRandom();
-            SuccessOrExit(error = message->AppendChallengeTlv(challenge));
-        }
-
+        SuccessOrExit(error = mTxChallengeTable.GenerateFor(aRouter->GetRouterId(), challenge));
         destination.InitAsLinkLocalAddress(aRouter->GetExtAddress());
         aRouter->RestartLinkAcceptTimeout();
     }
+
+    SuccessOrExit(error = message->AppendChallengeTlv(challenge));
 
     SuccessOrExit(error = message->SendTo(destination));
 
@@ -917,9 +909,10 @@ Error Mle::SendLinkAccept(const LinkAcceptInfo &aInfo)
 
     if (command == kCommandLinkAcceptAndRequest)
     {
-        router->GenerateChallenge();
+        TxChallenge challenge;
 
-        SuccessOrExit(error = message->AppendChallengeTlv(router->GetChallenge()));
+        SuccessOrExit(error = mTxChallengeTable.GenerateFor(router->GetRouterId(), challenge));
+        SuccessOrExit(error = message->AppendChallengeTlv(challenge));
         SuccessOrExit(error = message->AppendTlvRequestTlv(kRouterTlvs));
     }
 
@@ -976,16 +969,12 @@ void Mle::HandleLinkAcceptVariant(RxInfo &aRxInfo, MessageType aMessageType)
     neighborState = (router != nullptr) ? router->GetState() : Neighbor::kStateInvalid;
 
     SuccessOrExit(error = aRxInfo.mMessage.ReadResponseTlv(response));
+    VerifyOrExit(mTxChallengeTable.ContainsMatching(response, routerId), error = kErrorSecurity);
 
     switch (neighborState)
     {
     case Neighbor::kStateLinkRequest:
-        VerifyOrExit(response == router->GetChallenge(), error = kErrorSecurity);
-        break;
-
     case Neighbor::kStateInvalid:
-        VerifyOrExit(mPrevRoleRestorer.IsRestoringRouterOrLeaderRole(), error = kErrorSecurity);
-        VerifyOrExit(response == mPrevRoleRestorer.GetChallenge(), error = kErrorSecurity);
         break;
 
     case Neighbor::kStateValid:
@@ -1756,7 +1745,9 @@ void Mle::HandleTimeTick(void)
     }
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    // Update `RouterTable`
+    // Update `TxChallegeTable` and `RouterTable`
+
+    mTxChallengeTable.HandleTimeTick();
 
     for (Router &router : Get<RouterTable>())
     {
@@ -4067,6 +4058,72 @@ void Mle::RoleTransitioner::HandleTimeTick(void)
 
 exit:
     return;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// TxChallengeTable
+
+Mle::TxChallengeTable::TxChallengeTable(Instance &aInstance)
+    : InstanceLocator(aInstance)
+    , mEntries(aInstance)
+{
+}
+
+void Mle::TxChallengeTable::Clear(void) { mEntries.Clear(); }
+
+Error Mle::TxChallengeTable::GenerateFor(uint8_t aRouterId, TxChallenge &aChallenge)
+{
+    IndexedEntry entry;
+    bool         shouldPushAsNew;
+
+    shouldPushAsNew = (mEntries.FindMatching(entry, aRouterId) != kErrorNone);
+
+    aChallenge.GenerateRandom();
+
+    entry.mChallenge = aChallenge;
+    entry.mRouterId  = aRouterId;
+    entry.mTimeout   = kTimeout;
+
+    return shouldPushAsNew ? mEntries.Push(entry) : mEntries.Write(entry);
+}
+
+bool Mle::TxChallengeTable::ContainsMatching(const RxChallenge &aRxChallenge, uint8_t aRouterId) const
+{
+    IndexedEntry entry;
+
+    return (mEntries.FindMatching(entry, aRxChallenge, aRouterId) == kErrorNone);
+}
+
+bool Mle::TxChallengeTable::Entry::Matches(const RxChallenge &aRxChallenge, uint8_t aRouterId) const
+{
+    bool matches = false;
+
+    VerifyOrExit((mRouterId == aRouterId) || (mRouterId == kAnyRouterId));
+    matches = (aRxChallenge == mChallenge);
+
+exit:
+    return matches;
+}
+
+void Mle::TxChallengeTable::HandleTimeTick(void)
+{
+    uint8_t      writeIndex = 0;
+    IndexedEntry entry;
+
+    entry.InitForIteration();
+
+    while (mEntries.ReadNext(entry) == kErrorNone)
+    {
+        entry.mTimeout--;
+
+        if (entry.mTimeout > 0)
+        {
+            IgnoreError(mEntries.WriteAt(writeIndex, entry));
+            writeIndex++;
+        }
+    }
+
+    mEntries.AdjustLength(writeIndex);
 }
 
 } // namespace Mle

--- a/src/core/thread/mle_ftd.cpp
+++ b/src/core/thread/mle_ftd.cpp
@@ -333,6 +333,7 @@ void Mle::StopLeader(void)
 void Mle::HandleDetachStart(void)
 {
     mRouterTable.ClearNeighbors();
+    mTxChallengeTable.Clear();
     StopLeader();
     Get<TimeTicker>().UnregisterReceiver(TimeTicker::kMle);
 }
@@ -449,6 +450,7 @@ void Mle::SetStateRouterOrLeader(DeviceRole aRole, uint16_t aRloc16, LeaderStart
     Get<ThreadNetif>().SubscribeAllRoutersMulticast();
     mPreviousPartitionIdRouter = mLeaderData.GetPartitionId();
     Get<Mac::Mac>().SetBeaconEnabled(true);
+    mTxChallengeTable.Clear();
     Get<TimeTicker>().RegisterReceiver(TimeTicker::kMle);
 
     // Avoid informing an old parent when attaching next as a child after becoming an active router
@@ -672,6 +674,7 @@ void Mle::SendLinkRequest(Router *aRouter)
     Error        error   = kErrorNone;
     TxMessage   *message = nullptr;
     Ip6::Address destination;
+    TxChallenge  challenge;
 
     destination.Clear();
 
@@ -712,28 +715,17 @@ void Mle::SendLinkRequest(Router *aRouter)
 
     if (aRouter == nullptr)
     {
-        mPrevRoleRestorer.GenerateRandomChallenge();
-        SuccessOrExit(error = message->AppendChallengeTlv(mPrevRoleRestorer.GetChallenge()));
+        SuccessOrExit(error = mTxChallengeTable.GenerateForMulticast(challenge));
         destination = Ip6::Address::GetLinkLocalAllRoutersMulticast();
     }
     else
     {
-        if (!aRouter->IsStateValid())
-        {
-            aRouter->GenerateChallenge();
-            SuccessOrExit(error = message->AppendChallengeTlv(aRouter->GetChallenge()));
-        }
-        else
-        {
-            TxChallenge challenge;
-
-            challenge.GenerateRandom();
-            SuccessOrExit(error = message->AppendChallengeTlv(challenge));
-        }
-
+        SuccessOrExit(error = mTxChallengeTable.GenerateFor(aRouter->GetRouterId(), challenge));
         destination.InitAsLinkLocalAddress(aRouter->GetExtAddress());
         aRouter->RestartLinkAcceptTimeout();
     }
+
+    SuccessOrExit(error = message->AppendChallengeTlv(challenge));
 
     SuccessOrExit(error = message->SendTo(destination));
 
@@ -917,9 +909,10 @@ Error Mle::SendLinkAccept(const LinkAcceptInfo &aInfo)
 
     if (command == kCommandLinkAcceptAndRequest)
     {
-        router->GenerateChallenge();
+        TxChallenge challenge;
 
-        SuccessOrExit(error = message->AppendChallengeTlv(router->GetChallenge()));
+        SuccessOrExit(error = mTxChallengeTable.GenerateFor(router->GetRouterId(), challenge));
+        SuccessOrExit(error = message->AppendChallengeTlv(challenge));
         SuccessOrExit(error = message->AppendTlvRequestTlv(kRouterTlvs));
     }
 
@@ -976,16 +969,12 @@ void Mle::HandleLinkAcceptVariant(RxInfo &aRxInfo, MessageType aMessageType)
     neighborState = (router != nullptr) ? router->GetState() : Neighbor::kStateInvalid;
 
     SuccessOrExit(error = aRxInfo.mMessage.ReadResponseTlv(response));
+    VerifyOrExit(mTxChallengeTable.ContainsMatching(response, routerId), error = kErrorSecurity);
 
     switch (neighborState)
     {
     case Neighbor::kStateLinkRequest:
-        VerifyOrExit(response == router->GetChallenge(), error = kErrorSecurity);
-        break;
-
     case Neighbor::kStateInvalid:
-        VerifyOrExit(mPrevRoleRestorer.IsRestoringRouterOrLeaderRole(), error = kErrorSecurity);
-        VerifyOrExit(response == mPrevRoleRestorer.GetChallenge(), error = kErrorSecurity);
         break;
 
     case Neighbor::kStateValid:
@@ -1756,7 +1745,9 @@ void Mle::HandleTimeTick(void)
     }
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    // Update `RouterTable`
+    // Update `mTxChallengeTable` and `RouterTable`
+
+    mTxChallengeTable.HandleTimeTick();
 
     for (Router &router : Get<RouterTable>())
     {
@@ -4067,6 +4058,72 @@ void Mle::RoleTransitioner::HandleTimeTick(void)
 
 exit:
     return;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// TxChallengeTable
+
+Mle::TxChallengeTable::TxChallengeTable(Instance &aInstance)
+    : InstanceLocator(aInstance)
+    , mEntries(aInstance)
+{
+}
+
+void Mle::TxChallengeTable::Clear(void) { mEntries.Clear(); }
+
+Error Mle::TxChallengeTable::GenerateFor(uint8_t aRouterId, TxChallenge &aChallenge)
+{
+    IndexedEntry entry;
+    bool         shouldPushAsNew;
+
+    shouldPushAsNew = (mEntries.FindMatching(entry, aRouterId) != kErrorNone);
+
+    aChallenge.GenerateRandom();
+
+    entry.mChallenge = aChallenge;
+    entry.mRouterId  = aRouterId;
+    entry.mTimeout   = kTimeout;
+
+    return shouldPushAsNew ? mEntries.Push(entry) : mEntries.Write(entry);
+}
+
+bool Mle::TxChallengeTable::ContainsMatching(const RxChallenge &aRxChallenge, uint8_t aRouterId) const
+{
+    IndexedEntry entry;
+
+    return (mEntries.FindMatching(entry, aRxChallenge, aRouterId) == kErrorNone);
+}
+
+bool Mle::TxChallengeTable::Entry::Matches(const RxChallenge &aRxChallenge, uint8_t aRouterId) const
+{
+    bool matches = false;
+
+    VerifyOrExit((mRouterId == aRouterId) || (mRouterId == kAnyRouterId));
+    matches = (aRxChallenge == mChallenge);
+
+exit:
+    return matches;
+}
+
+void Mle::TxChallengeTable::HandleTimeTick(void)
+{
+    uint16_t     writeIndex = 0;
+    IndexedEntry entry;
+
+    entry.InitForIteration();
+
+    while (mEntries.ReadNext(entry) == kErrorNone)
+    {
+        entry.mTimeout--;
+
+        if (entry.mTimeout > 0)
+        {
+            IgnoreError(mEntries.WriteAt(writeIndex, entry));
+            writeIndex++;
+        }
+    }
+
+    mEntries.AdjustLength(writeIndex);
 }
 
 } // namespace Mle

--- a/src/core/thread/mle_types.cpp
+++ b/src/core/thread/mle_types.cpp
@@ -192,6 +192,12 @@ exit:
     return error;
 }
 
+void RxChallenge::InitFrom(const TxChallenge &aTxChallenge)
+{
+    memcpy(mArray.GetArrayBuffer(), aTxChallenge.m8, sizeof(aTxChallenge.m8));
+    mArray.SetLength(sizeof(aTxChallenge.m8));
+}
+
 bool RxChallenge::operator==(const TxChallenge &aTxChallenge) const
 {
     return (mArray.GetLength() == kMaxSize) && (memcmp(mArray.GetArrayBuffer(), aTxChallenge.m8, kMaxSize) == 0);

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -769,6 +769,13 @@ public:
     Error ReadFrom(const Message &aMessage, const OffsetRange &aOffsetRange);
 
     /**
+     * Initializes the `RxChallenge` from a given `TxChallenge`.
+     *
+     * @param[in] aTxChallenge  The `TxChallenge` to initialize from.
+     */
+    void InitFrom(const TxChallenge &aTxChallenge);
+
+    /**
      * Compares the `RxChallenge` with a given `TxChallenge`.
      *
      * @param[in] aTxChallenge  The `TxChallenge` to compare with.

--- a/src/core/thread/neighbor.hpp
+++ b/src/core/thread/neighbor.hpp
@@ -389,14 +389,14 @@ public:
      *
      * @returns A reference to `Mac::LinkFrameCounters` containing link frame counter for all supported radio links.
      */
-    Mac::LinkFrameCounters &GetLinkFrameCounters(void) { return mValidPending.mValid.mLinkFrameCounters; }
+    Mac::LinkFrameCounters &GetLinkFrameCounters(void) { return mLinkFrameCounters; }
 
     /**
      * Gets the link frame counters.
      *
      * @returns A reference to `Mac::LinkFrameCounters` containing link frame counter for all supported radio links.
      */
-    const Mac::LinkFrameCounters &GetLinkFrameCounters(void) const { return mValidPending.mValid.mLinkFrameCounters; }
+    const Mac::LinkFrameCounters &GetLinkFrameCounters(void) const { return mLinkFrameCounters; }
 
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
     /**
@@ -404,7 +404,7 @@ public:
      *
      * @returns The link ACK frame counter value.
      */
-    uint32_t GetLinkAckFrameCounter(void) const { return mValidPending.mValid.mLinkAckFrameCounter; }
+    uint32_t GetLinkAckFrameCounter(void) const { return mLinkAckFrameCounter; }
 #endif
 
     /**
@@ -415,7 +415,7 @@ public:
     void SetLinkAckFrameCounter(uint32_t aAckFrameCounter)
     {
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
-        mValidPending.mValid.mLinkAckFrameCounter = aAckFrameCounter;
+        mLinkAckFrameCounter = aAckFrameCounter;
 #else
         OT_UNUSED_VARIABLE(aAckFrameCounter);
 #endif
@@ -426,14 +426,14 @@ public:
      *
      * @returns The MLE frame counter value.
      */
-    uint32_t GetMleFrameCounter(void) const { return mValidPending.mValid.mMleFrameCounter; }
+    uint32_t GetMleFrameCounter(void) const { return mMleFrameCounter; }
 
     /**
      * Sets the MLE frame counter value.
      *
      * @param[in]  aFrameCounter  The MLE frame counter value.
      */
-    void SetMleFrameCounter(uint32_t aFrameCounter) { mValidPending.mValid.mMleFrameCounter = aFrameCounter; }
+    void SetMleFrameCounter(uint32_t aFrameCounter) { mMleFrameCounter = aFrameCounter; }
 
     /**
      * Gets the RLOC16 value.
@@ -587,18 +587,6 @@ public:
     LinkQuality GetLinkQualityIn(void) const { return GetLinkInfo().GetLinkQualityIn(); }
 
     /**
-     * Generates a new challenge value for MLE Link Request/Response exchanges.
-     */
-    void GenerateChallenge(void) { mValidPending.mPending.mChallenge.GenerateRandom(); }
-
-    /**
-     * Returns the current challenge value for MLE Link Request/Response exchanges.
-     *
-     * @returns The current challenge value.
-     */
-    const Mle::TxChallenge &GetChallenge(void) const { return mValidPending.mPending.mChallenge; }
-
-    /**
      * Returns the connection time (in seconds) of the neighbor (seconds since entering `kStateValid`).
      *
      * @returns The connection time (in seconds), zero if device is not currently in `kStateValid`.
@@ -715,23 +703,13 @@ protected:
 private:
     static constexpr uint32_t kLastRxFragmentTagTimeout = OPENTHREAD_CONFIG_MULTI_RADIO_FRAG_TAG_TIMEOUT; // in msec
 
-    Mac::ExtAddress mMacAddr;
-    TimeMilli       mLastHeard;
-    union
-    {
-        struct
-        {
-            Mac::LinkFrameCounters mLinkFrameCounters;
-            uint32_t               mMleFrameCounter;
+    Mac::ExtAddress        mMacAddr;
+    TimeMilli              mLastHeard;
+    Mac::LinkFrameCounters mLinkFrameCounters;
+    uint32_t               mMleFrameCounter;
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
-            uint32_t mLinkAckFrameCounter;
+    uint32_t mLinkAckFrameCounter;
 #endif
-        } mValid;
-        struct
-        {
-            Mle::TxChallenge mChallenge;
-        } mPending;
-    } mValidPending;
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     uint16_t  mLastRxFragmentTag;

--- a/tests/unit/test_mle.cpp
+++ b/tests/unit/test_mle.cpp
@@ -265,6 +265,246 @@ public:
         printf("TestChildIdResponseNetworkDataHandling passed\n");
     }
 
+#if OPENTHREAD_FTD
+    class TxChallenge : public Mle::TxChallenge
+    {
+    public:
+        Mle::RxChallenge AsRx(void) const
+        {
+            Mle::RxChallenge rxChallenge;
+
+            rxChallenge.InitFrom(*this);
+            return rxChallenge;
+        }
+    };
+
+    static void TestTxChallengeTable(void)
+    {
+        Instance                   *instance = static_cast<Instance *>(testInitInstance());
+        Mle::Mle::TxChallengeTable *table;
+
+        printf("TestTxChallengeTable\n");
+
+        VerifyOrQuit(instance != nullptr);
+
+        table = &instance->Get<Mle::Mle>().mTxChallengeTable;
+
+        // Generate one challenge for router ID 1 and check matching & aging
+        {
+            static constexpr uint8_t kRouterId      = 1;
+            static constexpr uint8_t kWrongRouterId = 2;
+
+            TxChallenge challenge;
+            TxChallenge badChallenge;
+
+            table->Clear();
+
+            SuccessOrQuit(table->GenerateFor(kRouterId, challenge));
+
+            badChallenge.GenerateRandom();
+
+            // Positive match
+            VerifyOrQuit(table->ContainsMatching(challenge.AsRx(), kRouterId));
+
+            // Negative matches
+            VerifyOrQuit(!table->ContainsMatching(challenge.AsRx(), kWrongRouterId)); // Wrong router ID
+            VerifyOrQuit(!table->ContainsMatching(badChallenge.AsRx(), kRouterId));   // Wrong challenge
+            VerifyOrQuit(!table->ContainsMatching(badChallenge.AsRx(), kWrongRouterId));
+
+            // Aging
+
+            for (uint8_t i = 0; i < Mle::Mle::TxChallengeTable::kTimeout - 1; i++)
+            {
+                table->HandleTimeTick();
+                VerifyOrQuit(table->ContainsMatching(challenge.AsRx(), kRouterId));
+            }
+
+            table->HandleTimeTick();
+            VerifyOrQuit(!table->ContainsMatching(challenge.AsRx(), kRouterId));
+        }
+
+        // Multicast challenge
+        {
+            static constexpr uint8_t kRouterId = 5;
+
+            TxChallenge challenge;
+            TxChallenge multiChallenge;
+
+            table->Clear();
+
+            SuccessOrQuit(table->GenerateFor(kRouterId, challenge));
+
+            SuccessOrQuit(table->GenerateForMulticast(multiChallenge));
+
+            // Multicast challenge matches any router ID
+
+            for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
+            {
+                VerifyOrQuit(table->ContainsMatching(multiChallenge.AsRx(), routerId));
+
+                if (routerId != kRouterId)
+                {
+                    VerifyOrQuit(!table->ContainsMatching(challenge.AsRx(), routerId));
+                }
+                else
+                {
+                    VerifyOrQuit(table->ContainsMatching(challenge.AsRx(), routerId));
+                }
+            }
+        }
+
+        // Overwriting & Timeout Reset
+        {
+            static constexpr uint8_t kRouterIdR1 = 3;
+            static constexpr uint8_t kRouterIdR2 = 12;
+
+            TxChallenge challengeR1;
+            TxChallenge challengeR2;
+            TxChallenge challengeMulti;
+            TxChallenge newChallengeR2;
+            TxChallenge newChallengeMulti;
+
+            table->Clear();
+
+            SuccessOrQuit(table->GenerateFor(kRouterIdR1, challengeR1));
+            SuccessOrQuit(table->GenerateFor(kRouterIdR2, challengeR2));
+            SuccessOrQuit(table->GenerateForMulticast(challengeMulti));
+
+            // Tick 2 times
+            table->HandleTimeTick();
+            table->HandleTimeTick();
+
+            VerifyOrQuit(table->ContainsMatching(challengeR1.AsRx(), kRouterIdR1));
+            VerifyOrQuit(table->ContainsMatching(challengeR2.AsRx(), kRouterIdR2));
+
+            for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
+            {
+                VerifyOrQuit(table->ContainsMatching(challengeMulti.AsRx(), routerId));
+            }
+
+            // Regenerate challenge for Router ID 2 (overwrites old entry and resets timeout)
+
+            SuccessOrQuit(table->GenerateFor(kRouterIdR2, newChallengeR2));
+
+            // Check that old challenge for R2 no longer matches, but new challenge for R2 matches
+            VerifyOrQuit(!table->ContainsMatching(challengeR2.AsRx(), kRouterIdR2));
+            VerifyOrQuit(table->ContainsMatching(newChallengeR2.AsRx(), kRouterIdR2));
+
+            // Tick 1 time
+            table->HandleTimeTick();
+
+            VerifyOrQuit(table->ContainsMatching(challengeR1.AsRx(), kRouterIdR1));
+            VerifyOrQuit(table->ContainsMatching(newChallengeR2.AsRx(), kRouterIdR2));
+
+            for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
+            {
+                VerifyOrQuit(table->ContainsMatching(challengeMulti.AsRx(), routerId));
+            }
+
+            // Regenerate multicast challenge
+            SuccessOrQuit(table->GenerateForMulticast(newChallengeMulti));
+
+            VerifyOrQuit(table->ContainsMatching(challengeR1.AsRx(), kRouterIdR1));
+            VerifyOrQuit(table->ContainsMatching(newChallengeR2.AsRx(), kRouterIdR2));
+
+            for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
+            {
+                VerifyOrQuit(!table->ContainsMatching(challengeMulti.AsRx(), routerId));
+                VerifyOrQuit(table->ContainsMatching(newChallengeMulti.AsRx(), routerId));
+            }
+
+            table->HandleTimeTick();
+
+            // R1 entry should have aged
+            VerifyOrQuit(!table->ContainsMatching(challengeR1.AsRx(), kRouterIdR1));
+
+            VerifyOrQuit(table->ContainsMatching(newChallengeR2.AsRx(), kRouterIdR2));
+            VerifyOrQuit(table->ContainsMatching(newChallengeMulti.AsRx(), 0));
+
+            // Wait two ticks - Now new R2 entry must have aged
+            table->HandleTimeTick();
+            table->HandleTimeTick();
+            VerifyOrQuit(!table->ContainsMatching(newChallengeR2.AsRx(), kRouterIdR2));
+            VerifyOrQuit(table->ContainsMatching(newChallengeMulti.AsRx(), 1));
+
+            table->HandleTimeTick();
+            VerifyOrQuit(!table->ContainsMatching(newChallengeMulti.AsRx(), 1));
+        }
+
+        // Fill Capacity & Clear
+        {
+            static constexpr uint8_t kChosenRouterId = 10;
+
+            TxChallenge challenges[Mle::kMaxRouters];
+            TxChallenge multicastChallenge;
+            TxChallenge updatedChallenge;
+
+            table->Clear();
+
+            // Fill all router IDs (0 to kMaxRouters-1) and 1 multicast entry
+            for (uint8_t routerId = 0; routerId < Mle::kMaxRouters; routerId++)
+            {
+                SuccessOrQuit(table->GenerateFor(routerId, challenges[routerId]));
+                VerifyOrQuit(table->ContainsMatching(challenges[routerId].AsRx(), routerId));
+            }
+
+            SuccessOrQuit(table->GenerateForMulticast(multicastChallenge));
+
+            table->HandleTimeTick();
+
+            // Verify all entries match correctly
+            for (uint8_t routerId = 0; routerId < Mle::kMaxRouters; routerId++)
+            {
+                VerifyOrQuit(table->ContainsMatching(challenges[routerId].AsRx(), routerId));
+                VerifyOrQuit(table->ContainsMatching(multicastChallenge.AsRx(), routerId));
+            }
+
+            // Overwrite an existing router ID when full (should succeed)
+            SuccessOrQuit(table->GenerateFor(kChosenRouterId, updatedChallenge));
+
+            VerifyOrQuit(table->ContainsMatching(updatedChallenge.AsRx(), kChosenRouterId));
+            VerifyOrQuit(!table->ContainsMatching(challenges[kChosenRouterId].AsRx(), kChosenRouterId));
+
+            for (uint8_t i = 0; i < Mle::Mle::TxChallengeTable::kTimeout - 1; i++)
+            {
+                table->HandleTimeTick();
+            }
+
+            for (uint8_t routerId = 0; routerId < Mle::kMaxRouters; routerId++)
+            {
+                if (routerId == kChosenRouterId)
+                {
+                    VerifyOrQuit(table->ContainsMatching(updatedChallenge.AsRx(), routerId));
+                }
+                else
+                {
+                    VerifyOrQuit(!table->ContainsMatching(challenges[routerId].AsRx(), routerId));
+                }
+
+                VerifyOrQuit(!table->ContainsMatching(multicastChallenge.AsRx(), routerId));
+            }
+
+            // Fill table again
+            for (uint8_t routerId = 0; routerId < Mle::kMaxRouters; routerId++)
+            {
+                SuccessOrQuit(table->GenerateFor(routerId, challenges[routerId]));
+                VerifyOrQuit(table->ContainsMatching(challenges[routerId].AsRx(), routerId));
+            }
+
+            // Clear table and verify no matches
+            table->Clear();
+
+            for (uint8_t routerId = 0; routerId < Mle::kMaxRouters; routerId++)
+            {
+                VerifyOrQuit(!table->ContainsMatching(challenges[routerId].AsRx(), routerId));
+            }
+        }
+
+        testFreeInstance(instance);
+        printf("TestTxChallengeTable passed\n");
+    }
+#endif // OPENTHREAD_FTD
+
 private:
     static void SetNetworkData(Instance      &aInstance,
                                uint8_t        aDataVersion,
@@ -615,6 +855,10 @@ int main(void)
 {
     ot::TestDeviceMode();
     ot::UnitTester::TestChildIdResponseNetworkDataHandling();
+
+#if OPENTHREAD_FTD
+    ot::UnitTester::TestTxChallengeTable();
+#endif
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MLE_DEVICE_PROPERTY_LEADER_WEIGHT_ENABLE
     ot::TestDefaultDeviceProperties();

--- a/tests/unit/test_mle.cpp
+++ b/tests/unit/test_mle.cpp
@@ -265,6 +265,246 @@ public:
         printf("TestChildIdResponseNetworkDataHandling passed\n");
     }
 
+#if OPENTHREAD_FTD
+    class TxChallenge : public Mle::TxChallenge
+    {
+    public:
+        Mle::RxChallenge AsRx(void) const
+        {
+            Mle::RxChallenge rxChallenge;
+
+            rxChallenge.InitFrom(*this);
+            return rxChallenge;
+        }
+    };
+
+    static void TestTxChallengeTable(void)
+    {
+        Instance                   *instance = static_cast<Instance *>(testInitInstance());
+        Mle::Mle                   &mle      = instance->Get<Mle::Mle>();
+        Mle::Mle::TxChallengeTable &table    = mle.mTxChallengeTable;
+
+        printf("TestTxChallengeTable\n");
+
+        VerifyOrQuit(instance != nullptr);
+
+        // Generate one challenge for router ID 1 and check matching & aging
+        {
+            static constexpr uint8_t kRouterId      = 1;
+            static constexpr uint8_t kWrongRouterId = 2;
+
+            TxChallenge challenge;
+            TxChallenge badChallenge;
+
+            table.Clear();
+
+            SuccessOrQuit(table.GenerateFor(kRouterId, challenge));
+
+            badChallenge.GenerateRandom();
+
+            // Positive match
+            VerifyOrQuit(table.ContainsMatching(challenge.AsRx(), kRouterId));
+
+            // Negative matches
+            VerifyOrQuit(!table.ContainsMatching(challenge.AsRx(), kWrongRouterId)); // Wrong router ID
+            VerifyOrQuit(!table.ContainsMatching(badChallenge.AsRx(), kRouterId));   // Wrong challenge
+            VerifyOrQuit(!table.ContainsMatching(badChallenge.AsRx(), kWrongRouterId));
+
+            // Aging
+
+            for (uint8_t i = 0; i < Mle::Mle::TxChallengeTable::kTimeout - 1; i++)
+            {
+                table.HandleTimeTick();
+                VerifyOrQuit(table.ContainsMatching(challenge.AsRx(), kRouterId));
+            }
+
+            table.HandleTimeTick();
+            VerifyOrQuit(!table.ContainsMatching(challenge.AsRx(), kRouterId));
+        }
+
+        // Multicast challenge
+        {
+            static constexpr uint8_t kRouterId = 5;
+
+            TxChallenge challenge;
+            TxChallenge multiChallenge;
+            TxChallenge badChallenge;
+
+            table.Clear();
+
+            SuccessOrQuit(table.GenerateFor(kRouterId, challenge));
+
+            SuccessOrQuit(table.GenerateForMulticast(multiChallenge));
+
+            // Multicast challenge matches any router ID
+
+            for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
+            {
+                VerifyOrQuit(table.ContainsMatching(multiChallenge.AsRx(), routerId));
+
+                if (routerId != kRouterId)
+                {
+                    VerifyOrQuit(!table.ContainsMatching(challenge.AsRx(), routerId));
+                }
+                else
+                {
+                    VerifyOrQuit(table.ContainsMatching(challenge.AsRx(), routerId));
+                }
+            }
+        }
+
+        // Overwriting & Timeout Reset
+        {
+            static constexpr uint8_t kRouterIdR1 = 3;
+            static constexpr uint8_t kRouterIdR2 = 12;
+
+            TxChallenge challengeR1;
+            TxChallenge challengeR2;
+            TxChallenge challengeMulti;
+            TxChallenge newChallengeR2;
+            TxChallenge newChallengeMulti;
+
+            table.Clear();
+
+            SuccessOrQuit(table.GenerateFor(kRouterIdR1, challengeR1));
+            SuccessOrQuit(table.GenerateFor(kRouterIdR2, challengeR2));
+            SuccessOrQuit(table.GenerateForMulticast(challengeMulti));
+
+            // Tick 2 times
+            table.HandleTimeTick();
+            table.HandleTimeTick();
+
+            VerifyOrQuit(table.ContainsMatching(challengeR1.AsRx(), kRouterIdR1));
+            VerifyOrQuit(table.ContainsMatching(challengeR2.AsRx(), kRouterIdR2));
+
+            for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
+            {
+                VerifyOrQuit(table.ContainsMatching(challengeMulti.AsRx(), routerId));
+            }
+
+            // Regenerate challenge for Router ID 2 (overwrites old entry and resets timeout)
+
+            SuccessOrQuit(table.GenerateFor(kRouterIdR2, newChallengeR2));
+
+            // Check that old challenge for R2 no longer matches, but new challenge for R2 matches
+            VerifyOrQuit(!table.ContainsMatching(challengeR2.AsRx(), kRouterIdR2));
+            VerifyOrQuit(table.ContainsMatching(newChallengeR2.AsRx(), kRouterIdR2));
+
+            // Tick 1 time
+            table.HandleTimeTick();
+
+            VerifyOrQuit(table.ContainsMatching(challengeR1.AsRx(), kRouterIdR1));
+            VerifyOrQuit(table.ContainsMatching(newChallengeR2.AsRx(), kRouterIdR2));
+
+            for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
+            {
+                VerifyOrQuit(table.ContainsMatching(challengeMulti.AsRx(), routerId));
+            }
+
+            // Regenerate multicast challenge
+            SuccessOrQuit(table.GenerateForMulticast(newChallengeMulti));
+
+            VerifyOrQuit(table.ContainsMatching(challengeR1.AsRx(), kRouterIdR1));
+            VerifyOrQuit(table.ContainsMatching(newChallengeR2.AsRx(), kRouterIdR2));
+
+            for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
+            {
+                VerifyOrQuit(!table.ContainsMatching(challengeMulti.AsRx(), routerId));
+                VerifyOrQuit(table.ContainsMatching(newChallengeMulti.AsRx(), routerId));
+            }
+
+            table.HandleTimeTick();
+
+            // R1 entry should have aged
+            VerifyOrQuit(!table.ContainsMatching(challengeR1.AsRx(), kRouterIdR1));
+
+            VerifyOrQuit(table.ContainsMatching(newChallengeR2.AsRx(), kRouterIdR2));
+            VerifyOrQuit(table.ContainsMatching(newChallengeMulti.AsRx(), 0));
+
+            // Wait two ticks - Now new R2 entry must have aged
+            table.HandleTimeTick();
+            table.HandleTimeTick();
+            VerifyOrQuit(!table.ContainsMatching(newChallengeR2.AsRx(), kRouterIdR2));
+            VerifyOrQuit(table.ContainsMatching(newChallengeMulti.AsRx(), 1));
+
+            table.HandleTimeTick();
+            VerifyOrQuit(!table.ContainsMatching(newChallengeMulti.AsRx(), 1));
+        }
+
+        // Fill Capacity & Clear
+        {
+            static constexpr uint8_t kChosenRouterId = 10;
+
+            TxChallenge challenges[Mle::kMaxRouters];
+            TxChallenge multicastChallenge;
+            TxChallenge updatedChallenge;
+
+            table.Clear();
+
+            // Fill all router IDs (0 to kMaxRouters-1) and 1 multicast entry
+            for (uint8_t routerId = 0; routerId < Mle::kMaxRouters; routerId++)
+            {
+                SuccessOrQuit(table.GenerateFor(routerId, challenges[routerId]));
+                VerifyOrQuit(table.ContainsMatching(challenges[routerId].AsRx(), routerId));
+            }
+
+            SuccessOrQuit(table.GenerateForMulticast(multicastChallenge));
+
+            table.HandleTimeTick();
+
+            // Verify all entries match correctly
+            for (uint8_t routerId = 0; routerId < Mle::kMaxRouters; routerId++)
+            {
+                VerifyOrQuit(table.ContainsMatching(challenges[routerId].AsRx(), routerId));
+                VerifyOrQuit(table.ContainsMatching(multicastChallenge.AsRx(), routerId));
+            }
+
+            // Overwrite an existing router ID when full (should succeed)
+            SuccessOrQuit(table.GenerateFor(kChosenRouterId, updatedChallenge));
+
+            VerifyOrQuit(table.ContainsMatching(updatedChallenge.AsRx(), kChosenRouterId));
+            VerifyOrQuit(!table.ContainsMatching(challenges[kChosenRouterId].AsRx(), kChosenRouterId));
+
+            for (uint8_t i = 0; i < Mle::Mle::TxChallengeTable::kTimeout - 1; i++)
+            {
+                table.HandleTimeTick();
+            }
+
+            for (uint8_t routerId = 0; routerId < Mle::kMaxRouters; routerId++)
+            {
+                if (routerId == kChosenRouterId)
+                {
+                    VerifyOrQuit(table.ContainsMatching(updatedChallenge.AsRx(), routerId));
+                }
+                else
+                {
+                    VerifyOrQuit(!table.ContainsMatching(challenges[routerId].AsRx(), routerId));
+                }
+
+                VerifyOrQuit(!table.ContainsMatching(multicastChallenge.AsRx(), routerId));
+            }
+
+            // Fill table again
+            for (uint8_t routerId = 0; routerId < Mle::kMaxRouters; routerId++)
+            {
+                SuccessOrQuit(table.GenerateFor(routerId, challenges[routerId]));
+                VerifyOrQuit(table.ContainsMatching(challenges[routerId].AsRx(), routerId));
+            }
+
+            // Clear table and verify no matches
+            table.Clear();
+
+            for (uint8_t routerId = 0; routerId < Mle::kMaxRouters; routerId++)
+            {
+                VerifyOrQuit(!table.ContainsMatching(challenges[routerId].AsRx(), routerId));
+            }
+        }
+
+        testFreeInstance(instance);
+        printf("TestTxChallengeTable passed\n");
+    }
+#endif // OPENTHREAD_FTD
+
 private:
     static void SetNetworkData(Instance      &aInstance,
                                uint8_t        aDataVersion,
@@ -615,6 +855,10 @@ int main(void)
 {
     ot::TestDeviceMode();
     ot::UnitTester::TestChildIdResponseNetworkDataHandling();
+
+#if OPENTHREAD_FTD
+    ot::UnitTester::TestTxChallengeTable();
+#endif
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MLE_DEVICE_PROPERTY_LEADER_WEIGHT_ENABLE
     ot::TestDefaultDeviceProperties();


### PR DESCRIPTION
This commit introduces `Mle::TxChallengeTable` to manage active challenges issued in MLE Link Requests to routers.

Background & Motivation:

Previously, MLE challenge storage for link handshakes was embedded inside `Neighbor` using a union (`mValidPending`) that shared memory between the in-flight `mChallenge` and valid frame counters (`mLinkFrameCounters`, `mMleFrameCounter`). Consequently, challenges could only be stored when a neighbor entry was in a pending/linking state.

Key Improvements & Design:

1. `Mle::TxChallengeTable`: Tracks active in-flight challenges issued to routers in any state.
2. Short-Lived Tracking: Uses a `MessageBackedArray` where challenges  age out after a short duration.
3. Zero Static RAM Overhead: Dynamically allocates message pool buffers only when challenges are actively in-flight, avoiding permanent RAM additions to `Router` or `Neighbor` structs.
4. Clean `Neighbor` Struct: Removes the `mValidPending` union from `Neighbor`, making frame counter variables direct, type-safe member fields.

This commit also adds a detailed unit test in `test_mle.cpp` validating the behavior of `TxChallengeTable` (multicast, challenge overwriting, timeout reset, capacity limits, and table clearing).
