### PR TITLE
[csl] put radio to sleep in RadioSample()

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -978,9 +978,15 @@ void SubMac::RadioSample(void)
     if (!RadioSupports(kCapReceiveTiming))
     {
         UpdateRadioSampleState();
+        ExitNow();
     }
 
-    ExitNow();
+#if !OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
+    if (!RadioSupports(kCapRxOnWhenIdle))
+    {
+        IgnoreError(Get<Radio::Radio>().Sleep());
+    }
+#endif
 
 exit:
     return;


### PR DESCRIPTION
Re-adding the sleep call which got missed during the CSL rework (PR#11301/#11318). Earlier Mac/sub-mac state machine putting the radio to sleep from cslSample() if radio is not sampling. After the rework, it would do only if the radio is not supporting receive timing.

This commit makes the behavior same as before the re-work.

Re-worked PRs:
PR#11301: https://github.com/openthread/openthread/pull/11301
PR#11318: https://github.com/openthread/openthread/pull/11318