### PR TITLE
[rcp] remove redundant `keyIdMode` check for `SPINEL_PROP_RCP_MAC_KEY`

### DIFF
--- a/src/ncp/ncp_base_radio.cpp
+++ b/src/ncp/ncp_base_radio.cpp
@@ -548,7 +548,6 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_RCP_MAC_KEY>(void)
     const uint8_t *nextKey;
 
     SuccessOrExit(error = mDecoder.ReadUint8(keyIdMode));
-    VerifyOrExit(keyIdMode == Mac::Frame::kKeyIdMode1, error = OT_ERROR_INVALID_ARGS);
 
     SuccessOrExit(error = mDecoder.ReadUint8(keyIndex));
 


### PR DESCRIPTION
This commit removes the redundant `keyIdMode` validation check in `NcpBase::HandlePropertySet<SPINEL_PROP_RCP_MAC_KEY>()`.

Background & Issue:

The `otPlatRadioSetMacKey()` / `otLinkRawSetMacKey()` API previously contained ambiguity around `aKeyIdMode` parameter, which was recently clarified. Historically, OpenThread passed the bit-shifted enum value `Mac::Frame::kKeyIdMode1` (`1 << 3` / `0x08`) as `aKeyIdMode` instead of the literal mode number `1`.

`NcpBase` contained an explicit validation check enforcing that the decoded `keyIdMode` equaled `Mac::Frame::kKeyIdMode1`. This was problematic:

1. `NcpBase` must act as a Spinel transport/serialization layer and should not perform payload parameter validation or depend on internal core MAC definitions.
2. `keyIdMode` is expected to be ignored by the radio platform layer.
3. Backward Compatibility: When updated Host software sends literal `1` for `keyIdMode`, older RCP builds performing this unnecessary check reject the property set with `OT_ERROR_INVALID_ARGS`.

This commit removes the extra check from `NcpBase`. The decoded `keyIdMode` is passed directly to `otLinkRawSetMacKey()`, allowing its value to be ignored by the platform layer as intended.


---

Relates to https://github.com/openthread/openthread/issues/13471 & https://github.com/openthread/ot-br-posix/issues/3501