### PR TITLE
[radio-spinel] add workaround for legacy RCP keyIdMode check

### DIFF
--- a/src/lib/spinel/openthread-spinel-config.h
+++ b/src/lib/spinel/openthread-spinel-config.h
@@ -89,6 +89,19 @@
 #endif
 
 /**
+ * @def OPENTHREAD_SPINEL_CONFIG_RCP_KEY_ID_MODE_CHECK_COMPATIBILITY_WORKAROUND_ENABLE
+ *
+ * Define to 1 to enable backward compatibility workaround for Key ID Mode check in RCP.
+ *
+ * Older RCP builds enforce a validation check in `NcpBase` expecting the legacy bit-shifted value `(1 << 3)` for
+ * Key ID Mode 1. When enabled, `RadioSpinel` maps `aKeyIdMode` to the legacy bit-shifted value `(1 << 3)` when
+ * setting `SPINEL_PROP_RCP_MAC_KEY` to maintain compatibility with older RCP builds.
+ */
+#ifndef OPENTHREAD_SPINEL_CONFIG_RCP_KEY_ID_MODE_CHECK_COMPATIBILITY_WORKAROUND_ENABLE
+#define OPENTHREAD_SPINEL_CONFIG_RCP_KEY_ID_MODE_CHECK_COMPATIBILITY_WORKAROUND_ENABLE 1
+#endif
+
+/**
  * @def OPENTHREAD_SPINEL_CONFIG_MAX_SRC_MATCH_ENTRIES
  *
  * Defines size of the local source match table used by RadioSpinel

--- a/src/lib/spinel/radio_spinel.cpp
+++ b/src/lib/spinel/radio_spinel.cpp
@@ -895,6 +895,22 @@ otError RadioSpinel::SetMacKey(uint8_t         aKeyIdMode,
 {
     otError error;
 
+#if OPENTHREAD_SPINEL_CONFIG_RCP_KEY_ID_MODE_CHECK_COMPATIBILITY_WORKAROUND_ENABLE
+    static constexpr uint8_t kLegacyKeyIdMode1 = (1 << 3);
+
+    // Older RCP builds enforce a validation check in `NcpBase`
+    // (`HandlePropertySet<SPINEL_PROP_RCP_MAC_KEY>()`) expecting the
+    // legacy bit-shifted value `(1 << 3)` for Key ID Mode 1. This
+    // check is removed so future RCP builds ignore `aKeyIdMode`
+    // as documented/expected for the `otPlatRadioSetMacKey()` API.
+    //
+    // To maintain backward compatibility with older RCP firmware
+    // builds, we map `aKeyIdMode` to the legacy bit-shifted value
+    // `kLegacyKeyIdMode1` when setting `SPINEL_PROP_RCP_MAC_KEY`.
+
+    aKeyIdMode = kLegacyKeyIdMode1;
+#endif
+
     SuccessOrExit(error = Set(SPINEL_PROP_RCP_MAC_KEY,
                               SPINEL_DATATYPE_UINT8_S SPINEL_DATATYPE_UINT8_S SPINEL_DATATYPE_DATA_WLEN_S
                                   SPINEL_DATATYPE_DATA_WLEN_S SPINEL_DATATYPE_DATA_WLEN_S,


### PR DESCRIPTION
This commit adds a Host-side compatibility workaround in POSIX `RadioSpinel` when setting `SPINEL_PROP_RCP_MAC_KEY`.

The `otPlatRadioSetMacKey()` / `otLinkRawSetMacKey()` API previously contained ambiguity around `aKeyIdMode`, which was recently clarified. Historically, OpenThread passed the bit-shifted enum value `Mac::Frame::kKeyIdMode1`(`1 << 3` / `0x08`) as `aKeyIdMode` instead of the literal mode number `1`.

Older RCP firmware builds contained an explicit validation check in `NcpBase`(`HandlePropertySet<SPINEL_PROP_RCP_MAC_KEY>()`) enforcing that `keyIdMode` equaled `(1 << 3)`. When updated Host software sends literal `1` for `keyIdMode`, older RCP builds reject the property set with `OT_ERROR_INVALID_ARGS`.

This commit introduces a new configuration option (enabled by default) `..._RCP_KEY_ID_MODE_CHECK_COMPATIBILITY_WORKAROUND_ENABLE`.

When enabled, `RadioSpinel::SetMacKey()` maps `aKeyIdMode` to the legacy bit-shifted value `(1 << 3)` when serializing `SPINEL_PROP_RCP_MAC_KEY`, ensuring updated Host builds remain fully backward-compatible when communicating with older RCP firmware builds.

-----

Relates to https://github.com/openthread/openthread/issues/13471 & https://github.com/openthread/ot-br-posix/issues/3501

~This PR currently contains the commit from https://github.com/openthread/openthread/pull/13473. Please read and review the top commit. Thanks.~ 