### PR TITLE
[infra-if] free dropped DHCPv6 message in `HandleDhcp6Received()`

### DIFF
--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -136,11 +136,12 @@ void otIp6SetReceiveFilterEnabled(otInstance *aInstance, bool aEnabled)
 
 otError otIp6Send(otInstance *aInstance, otMessage *aMessage)
 {
-    otError error;
+    otError           error;
+    OwnedPtr<Message> messagePtr(AsCoreTypePtr(aMessage));
 
-    VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
+    VerifyOrExit(!messagePtr->IsOriginThreadNetif(), error = kErrorInvalidArgs);
 
-    error = AsCoreType(aInstance).Get<Ip6::Ip6>().SendRaw(OwnedPtr<Message>(AsCoreTypePtr(aMessage)));
+    error = AsCoreType(aInstance).Get<Ip6::Ip6>().SendRaw(messagePtr.PassOwnership());
 
 exit:
     return error;

--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -223,6 +223,11 @@ void InfraIf::HandleDhcp6Received(Message &aMessage, uint32_t aInfraIfIndex)
     Get<Dhcp6PdClient>().HandleReceived(aMessage);
 
 exit:
+    if (error != kErrorNone)
+    {
+        aMessage.Free();
+    }
+
     LogDebgOnError(error, "process DHCPv6 msg");
 }
 

--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -223,6 +223,7 @@ void InfraIf::HandleDhcp6Received(Message &aMessage, uint32_t aInfraIfIndex)
     Get<Dhcp6PdClient>().HandleReceived(aMessage);
 
 exit:
+    FreeMessageOnError(&aMessage, error);
     LogDebgOnError(error, "process DHCPv6 msg");
 }
 

--- a/tests/unit/test_dhcp6_pd_client.cpp
+++ b/tests/unit/test_dhcp6_pd_client.cpp
@@ -721,7 +721,7 @@ struct Dhcp6TxMsg : public Dhcp6Msg
     void PrepareAdvertise(const Dhcp6RxMsg &aClientMsg, const Mac::ExtAddress &aServerMacAddr);
     void PrepareReply(const Dhcp6RxMsg &aClientMsg, const Mac::ExtAddress &aServerMacAddr);
     void AddIaPrefix(const PrefixInfo &aInfo);
-    void Send(void);
+    void Send(uint32_t aInfraIfIndex = kInfraIfIndex);
 };
 
 void Dhcp6TxMsg::PrepareAdvertise(const Dhcp6RxMsg &aClientMsg, const Mac::ExtAddress &aServerMacAddr)
@@ -779,7 +779,7 @@ void Dhcp6TxMsg::AddIaPrefix(const PrefixInfo &aInfo)
     iaPrefix->mValidLifetime     = aInfo.mValidLifetime;
 }
 
-void Dhcp6TxMsg::Send(void)
+void Dhcp6TxMsg::Send(uint32_t aInfraIfIndex)
 {
     Message *message;
 
@@ -789,7 +789,7 @@ void Dhcp6TxMsg::Send(void)
 
     LogMsg("Sending");
 
-    otPlatInfraIfDhcp6PdClientHandleReceived(sInstance, message, kInfraIfIndex);
+    otPlatInfraIfDhcp6PdClientHandleReceived(sInstance, message, aInfraIfIndex);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -2591,6 +2591,78 @@ void TestDhcp6PdServerReplyWithNoBindingToRelease(void)
     FinalizeTest();
 }
 
+void TestDhcp6PdMsgFreedWhenInfraIfIsNotRunning(void)
+{
+    uint16_t               heapAllocations;
+    uint16_t               freeBufferCount;
+    Dhcp6TxMsg             txMsg;
+    Dhcp6TxMsg::PrefixInfo prefixInfo;
+    Mac::ExtAddress        serverMacAddr;
+
+    Log("--------------------------------------------------------------------------------------------");
+    Log("TestDhcp6PdMsgFreedWhenInfraIfIsNotRunning");
+
+    InitTest();
+
+    heapAllocations = sHeapAllocatedPtrs.GetLength();
+
+    serverMacAddr.GenerateRandom();
+
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
+    Log("Start the client and wait for the first Solicit message");
+
+    sInstance->Get<BorderRouter::Dhcp6PdClient>().Start();
+    VerifyOrQuit(sDhcp6ListeningEnabled);
+
+    AdvanceTime(1000);
+
+    VerifyOrQuit(sDhcp6RxMsgs.GetLength() == 1);
+    sDhcp6RxMsgs[0].ValidateAsSolicit();
+
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
+    Log("Signal that the infra interface is no longer running while the platform is still listening");
+
+    SuccessOrQuit(otPlatInfraIfStateChanged(sInstance, kInfraIfIndex, /* aIsRunning */ false));
+    VerifyOrQuit(sDhcp6ListeningEnabled);
+
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
+    Log("Send an Advertise and validate that the dropped message is freed");
+
+    freeBufferCount = sInstance->Get<MessagePool>().GetFreeBufferCount();
+
+    txMsg.PrepareAdvertise(sDhcp6RxMsgs[0], serverMacAddr);
+
+    prefixInfo.mIaid              = sDhcp6RxMsgs[0].mIaPds[0].mIaid;
+    prefixInfo.mT1                = 2000;
+    prefixInfo.mT2                = 3200;
+    prefixInfo.mPreferredLifetime = 3600;
+    prefixInfo.mValidLifetime     = 4000;
+    prefixInfo.mPrefix            = PrefixFromString("2001:2222::", 64);
+    txMsg.AddIaPrefix(prefixInfo);
+
+    txMsg.Send();
+
+    VerifyOrQuit(sInstance->Get<MessagePool>().GetFreeBufferCount() == freeBufferCount);
+
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
+    Log("Validate that a message received on a different interface index is also freed");
+
+    txMsg.Send(kInfraIfIndex + 1);
+
+    VerifyOrQuit(sInstance->Get<MessagePool>().GetFreeBufferCount() == freeBufferCount);
+
+    Log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
+
+    sInstance->Get<BorderRouter::Dhcp6PdClient>().Stop();
+    AdvanceTime(10 * 1000);
+
+    VerifyOrQuit(heapAllocations == sHeapAllocatedPtrs.GetLength());
+
+    Log("End of TestDhcp6PdMsgFreedWhenInfraIfIsNotRunning");
+
+    FinalizeTest();
+}
+
 #endif // OT_CONFIG_DHCP6_PD_CLIENT_ENABLE
 
 } // namespace ot
@@ -2611,6 +2683,7 @@ int main(void)
     ot::TestDhcp6PdServerNotExtendingLeaseDuringRenew();
     ot::TestDhcp6PdServerReplacingPrefix();
     ot::TestDhcp6PdServerReplyWithNoBindingToRelease();
+    ot::TestDhcp6PdMsgFreedWhenInfraIfIsNotRunning();
 
     printf("All tests passed\n");
 #else


### PR DESCRIPTION
`InfraIf::HandleDhcp6Received()` takes ownership of the message from `otPlatInfraIfDhcp6PdClientHandleReceived()` but returns early when the infra interface is not running or the index does not match, and neither guard frees it.

That window is reachable from the infra link: `EnterState()` only calls `SetDhcp6ListeningEnabled(false)` for `kStateStopped`, so once the interface is signalled down while a lease is held the socket keeps delivering into the rejecting callee, and each dropped packet costs a `Message` from the shared pool for good.

The fix frees the message at the exit label when an error is set, matching how `Dhcp6PdClient::HandleReceived()` frees at its exit. The new case in `test_dhcp6_pd_client` covers both drop paths and fails on the current tree.

(The `otIp6Send()` half of the original PR is split out per review feedback.)