### PR TITLE
[key-manager] avoid persistent temporary key members in KeyManager

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -848,6 +848,7 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame)
         if (aFrame.GetRadioType() == Radio::kTypeTrel)
 #endif
         {
+            KeyMaterial        temporaryMacKey;
             const KeyMaterial *macKey;
 
             // If the frame header is marked as updated, `MeshForwarder` which
@@ -862,7 +863,7 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame)
                 aFrame.SetKeyIndex(DetermineKeyIndexFor(keyManager.GetCurrentKeySequence()));
             }
 
-            macKey = DetermineMode1Key(aFrame);
+            macKey = DetermineMode1Key(aFrame, temporaryMacKey);
             VerifyOrExit(macKey != nullptr);
             aFrame.SetAesKey(*macKey);
             extAddress = &GetExtAddress();
@@ -1574,14 +1575,14 @@ void Mac::HandleTimer(void)
     }
 }
 
-const KeyMaterial *Mac::DetermineMode1Key(const Frame &aFrame) const
+const KeyMaterial *Mac::DetermineMode1Key(const Frame &aFrame, KeyMaterial &aKey) const
 {
     uint32_t keySequence;
 
-    return DetermineMode1KeyAndSequence(aFrame, keySequence);
+    return DetermineMode1KeyAndSequence(aFrame, keySequence, aKey);
 }
 
-const KeyMaterial *Mac::DetermineMode1KeyAndSequence(const Frame &aFrame, uint32_t &aKeySequence) const
+const KeyMaterial *Mac::DetermineMode1KeyAndSequence(const Frame &aFrame, uint32_t &aKeySequence, KeyMaterial &aKey) const
 {
     // Determines the MAC key and key sequence for given `aFrame`.
     // The caller MUST already ensure that the frame's Key ID Mode
@@ -1634,13 +1635,16 @@ const KeyMaterial *Mac::DetermineMode1KeyAndSequence(const Frame &aFrame, uint32
             break;
         case KeyTrio::kNext:
         case KeyTrio::kPrev:
-            key = &Get<KeyManager>().GetTemporaryTrelMacKey(aKeySequence);
+            Get<KeyManager>().GetTemporaryTrelMacKey(aKeySequence, aKey);
+            key = &aKey;
             break;
         }
 
         ExitNow();
     }
 #endif
+
+    OT_UNUSED_VARIABLE(aKey);
 
 exit:
     return key;
@@ -1653,6 +1657,7 @@ Error Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Neig
     Frame::KeyIdMode   keyIdMode;
     uint32_t           frameCounter;
     uint32_t           keySequence = 0;
+    KeyMaterial        temporaryMacKey;
     const KeyMaterial *macKey;
     const ExtAddress  *extAddress;
 
@@ -1676,7 +1681,7 @@ Error Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Neig
     case Frame::kKeyIdMode1:
         VerifyOrExit(aNeighbor != nullptr);
 
-        macKey = DetermineMode1KeyAndSequence(aFrame, keySequence);
+        macKey = DetermineMode1KeyAndSequence(aFrame, keySequence, temporaryMacKey);
         VerifyOrExit(macKey != nullptr);
 
         // If the frame is from a neighbor not in valid state (e.g., it is from a child being
@@ -1724,7 +1729,8 @@ Error Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Neig
             sequence = BigEndian::ReadUint32(keySource.GetBytes());
             VerifyOrExit(DetermineKeyIndexFor(sequence) == keyIndex, error = kErrorSecurity);
 
-            macKey     = &keyManager.GetTemporaryMacKey(sequence);
+            keyManager.GetTemporaryMacKey(sequence, temporaryMacKey);
+            macKey     = &temporaryMacKey;
             extAddress = &aSrcAddr.GetExtended();
         }
         else
@@ -1790,6 +1796,7 @@ Error Mac::ProcessEnhAckSecurity(TxFrame &aTxFrame, RxFrame &aAckFrame)
     Address            srcAddr;
     Address            dstAddr;
     Neighbor          *neighbor = nullptr;
+    KeyMaterial        temporaryMacKey;
     const KeyMaterial *macKey;
 
     if (!aAckFrame.GetSecurityEnabled())
@@ -1844,7 +1851,7 @@ Error Mac::ProcessEnhAckSecurity(TxFrame &aTxFrame, RxFrame &aAckFrame)
 
     VerifyOrExit(srcAddr.IsExtended() && neighbor != nullptr);
 
-    macKey = DetermineMode1Key(aAckFrame);
+    macKey = DetermineMode1Key(aAckFrame, temporaryMacKey);
     VerifyOrExit(macKey != nullptr);
 
     if (neighbor->IsStateValid())

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -772,8 +772,8 @@ private:
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
     Error ProcessEnhAckSecurity(TxFrame &aTxFrame, RxFrame &aAckFrame);
 #endif
-    const KeyMaterial *DetermineMode1Key(const Frame &aFrame) const;
-    const KeyMaterial *DetermineMode1KeyAndSequence(const Frame &aFrame, uint32_t &aKeySequence) const;
+    const KeyMaterial *DetermineMode1Key(const Frame &aFrame, KeyMaterial &aKey) const;
+    const KeyMaterial *DetermineMode1KeyAndSequence(const Frame &aFrame, uint32_t &aKeySequence, KeyMaterial &aKey) const;
 
     void     UpdateIdleMode(void);
     bool     IsPending(Operation aOperation) const { return mPendingOperations & (1U << aOperation); }

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -414,37 +414,31 @@ exit:
     return;
 }
 
-const Mle::KeyMaterial &KeyManager::GetTemporaryMleKey(uint32_t aKeySequence)
+void KeyManager::GetTemporaryMleKey(uint32_t aKeySequence, Mle::KeyMaterial &aKey) const
 {
     HashKeys hashKeys;
 
     ComputeKeys(aKeySequence, hashKeys);
-    mTemporaryMleKey.SetFrom(hashKeys.GetMleKey());
-
-    return mTemporaryMleKey;
+    aKey.SetFrom(hashKeys.GetMleKey());
 }
 
 #if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-const Mle::KeyMaterial &KeyManager::GetTemporaryMacKey(uint32_t aKeySequence)
+void KeyManager::GetTemporaryMacKey(uint32_t aKeySequence, Mac::KeyMaterial &aKey) const
 {
     HashKeys hashKeys;
 
     ComputeKeys(aKeySequence, hashKeys);
-    mTemporaryMacKey.SetFrom(hashKeys.GetMacKey());
-
-    return mTemporaryMacKey;
+    aKey.SetFrom(hashKeys.GetMacKey());
 }
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-const Mac::KeyMaterial &KeyManager::GetTemporaryTrelMacKey(uint32_t aKeySequence)
+void KeyManager::GetTemporaryTrelMacKey(uint32_t aKeySequence, Mac::KeyMaterial &aKey) const
 {
     Mac::Key key;
 
     ComputeTrelKey(aKeySequence, key);
-    mTemporaryTrelKey.SetFrom(key);
-
-    return mTemporaryTrelKey;
+    aKey.SetFrom(key);
 }
 #endif
 

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -342,13 +342,12 @@ public:
     const Mac::KeyMaterial &GetCurrentTrelMacKey(void) const { return mTrelKey; }
 
     /**
-     * Returns a temporary MAC key for TREL radio link computed from the given key sequence.
+     * Computes the temporary MAC key for TREL radio link from the given key sequence.
      *
      * @param[in]  aKeySequence  The key sequence value.
-     *
-     * @returns The temporary TREL MAC key.
+     * @param[out] aKey          A reference to a `Mac::KeyMaterial` to output the temporary TREL MAC key.
      */
-    const Mac::KeyMaterial &GetTemporaryTrelMacKey(uint32_t aKeySequence);
+    void GetTemporaryTrelMacKey(uint32_t aKeySequence, Mac::KeyMaterial &aKey) const;
 #endif
 
     /**
@@ -359,22 +358,22 @@ public:
     const Mle::KeyMaterial &GetCurrentMleKey(void) const { return mMleKey; }
 
     /**
-     * Returns a temporary MLE key Material computed from the given key sequence.
+     * Computes a temporary MLE key Material from the given key sequence.
      *
      * @param[in]  aKeySequence  The key sequence value.
-     *
-     * @returns The temporary MLE key.
+     * @param[out] aKey          A reference to a `Mle::KeyMaterial` to output the temporary MLE key.
      */
-    const Mle::KeyMaterial &GetTemporaryMleKey(uint32_t aKeySequence);
+    void GetTemporaryMleKey(uint32_t aKeySequence, Mle::KeyMaterial &aKey) const;
 
+#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
     /**
-     * Returns a temporary MAC key Material computed from the given key sequence.
+     * Computes a temporary MAC key Material from the given key sequence.
      *
      * @param[in]  aKeySequence  The key sequence value.
-     *
-     * @returns The temporary MAC key.
+     * @param[out] aKey          A reference to a `Mac::KeyMaterial` to output the temporary MAC key.
      */
-    const Mle::KeyMaterial &GetTemporaryMacKey(uint32_t aKeySequence);
+    void GetTemporaryMacKey(uint32_t aKeySequence, Mac::KeyMaterial &aKey) const;
+#endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
     /**
@@ -626,15 +625,9 @@ private:
 
     uint32_t         mKeySequence;
     Mle::KeyMaterial mMleKey;
-    Mle::KeyMaterial mTemporaryMleKey;
-
-#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-    Mle::KeyMaterial mTemporaryMacKey;
-#endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
     Mac::KeyMaterial mTrelKey;
-    Mac::KeyMaterial mTemporaryTrelKey;
 #endif
 
     Mac::LinkFrameCounters mMacFrameCounters;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1535,9 +1535,17 @@ Error Mle::ProcessMessageSecurity(Crypto::AesCcm::Operation aOperation,
 
     keySequence = aAuthData.mSecurityHeader.GetKeyId();
 
-    aesCcm.SetKey(keySequence == Get<KeyManager>().GetCurrentKeySequence()
-                      ? Get<KeyManager>().GetCurrentMleKey()
-                      : Get<KeyManager>().GetTemporaryMleKey(keySequence));
+    if (keySequence == Get<KeyManager>().GetCurrentKeySequence())
+    {
+        aesCcm.SetKey(Get<KeyManager>().GetCurrentMleKey());
+    }
+    else
+    {
+        KeyMaterial key;
+
+        Get<KeyManager>().GetTemporaryMleKey(keySequence, key);
+        aesCcm.SetKey(key);
+    }
 
     aesCcm.SetNonce(nonce);
     aesCcm.SetAuthData(&aAuthData, sizeof(AesCcmAuthData));


### PR DESCRIPTION
This commit drops the `mTemporaryMleKey`, `mTemporaryMacKey`, and `mTemporaryTrelKey` member variables from `KeyManager`. Instead of storing temporary keys in `KeyManager` instance members to return references, callers now supply a local `KeyMaterial` variable on the stack via an output reference parameter.

Rationale:
1. Reduces persistent memory footprint by eliminating 3 `KeyMaterial` member variables from `KeyManager` that are only used occasionally (e.g., during key rotation or wake-up frames).
2. Improves PSA ITS key lifecycle management: with PSA Crypto enabled (`OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE`), `KeyMaterial` allocates volatile keys in the PSA ITS keystore. Using stack-allocated local variables ensures these temporary keys are freed as soon as the calling frame finishes rather than occupying keystore slots indefinitely.
3. Eliminates shared mutable state in `KeyManager` and avoids side-effect mutations during key getter operations.