### PR TITLE
[sub-mac] simplify CSL debug check handling

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -163,14 +163,18 @@ void SubMac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 {
     mRxOnWhenIdle = aRxOnWhenIdle;
 
-    if (RadioSupports(kCapRxOnWhenIdle))
-    {
-#if !OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
-        Get<Radio::Radio>().SetRxOnWhenIdle(mRxOnWhenIdle);
-#endif
-    }
+    LogDebg("RxOnWhenIdle: %u", mRxOnWhenIdle);
 
-    LogDebg("RxOnWhenIdle: %d", mRxOnWhenIdle);
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE && OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
+    // Keep radio rx-on-when-idle enabled for debugging when `MAC_CSL_DEBUG_ENABLE`.
+    ExitNow();
+#endif
+
+    VerifyOrExit(RadioSupports(kCapRxOnWhenIdle));
+    Get<Radio::Radio>().SetRxOnWhenIdle(mRxOnWhenIdle);
+
+exit:
+    return;
 }
 
 Error SubMac::Enable(void)
@@ -981,12 +985,15 @@ void SubMac::RadioSample(void)
         ExitNow();
     }
 
-#if !OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE && OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
+    // Don't sleep for debugging when `MAC_CSL_DEBUG_ENABLE`.
+    ExitNow();
+#endif
+
     if (!RadioSupports(kCapRxOnWhenIdle))
     {
         IgnoreError(Get<Radio::Radio>().Sleep());
     }
-#endif
 
 exit:
     return;
@@ -1056,9 +1063,12 @@ void SubMac::UpdateRadioSampleState(void)
     }
 #endif
 
-#if !OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
-    IgnoreError(Get<Radio::Radio>().Sleep()); // Don't actually sleep for debugging
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE && OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
+    // Don't sleep for debugging when `MAC_CSL_DEBUG_ENABLE`.
+    ExitNow();
 #endif
+
+    IgnoreError(Get<Radio::Radio>().Sleep());
 
 exit:
     return;

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -91,10 +91,6 @@ namespace Mac {
 
 #endif
 
-#if OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE && !OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-#error "OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE is required for OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE."
-#endif
-
 //----------------------------------------------------------------------------------------------------------------------
 
 #if OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE

--- a/src/core/mac/sub_mac_csl_receiver.cpp
+++ b/src/core/mac/sub_mac_csl_receiver.cpp
@@ -360,7 +360,7 @@ void SubMac::LogReceived(RxFrame *aFrame)
 exit:
     return;
 }
-#endif
+#endif // OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
 
 } // namespace Mac
 } // namespace ot


### PR DESCRIPTION
This commit simplifies and improves the readability of CSL debug checks in `SubMac`.

1. Improved Readability: Avoids placing primary operational code under negative preprocessor (`#if !OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE`). Instead, uses an early exit (`ExitNow()`) when the debug condition is enabled, keeping normal execution flow uncluttered.

2. Evaluates `MAC_CSL_DEBUG_ENABLE` only when CSL Receiver is enabled (`OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE`). If CSL Receiver support is disabled, `MAC_CSL_DEBUG_ENABLE` automatically becomes a safe no-op.