### PR TITLE
[mle] bound router id in RouterIdMask and RouterIdMap IsAllocated

### DIFF
--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -666,7 +666,10 @@ public:
      * @retval TRUE   If the Router ID bit is set in the mask.
      * @retval FALSE  If the Router ID bit is not set in the mask.
      */
-    bool IsAllocated(uint8_t aRouterId) const { return (mMask[aRouterId / 8] & MaskFor(aRouterId)) != 0; }
+    bool IsAllocated(uint8_t aRouterId) const
+    {
+        return (aRouterId <= kMaxRouterId) && ((mMask[aRouterId / 8] & MaskFor(aRouterId)) != 0);
+    }
 
     /**
      * Sets a given Router ID in the mask.

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -465,7 +465,10 @@ private:
         // remaining reuse delay time (in seconds).
 
         RouterIdMap(void) { Clear(); }
-        bool    IsAllocated(uint8_t aRouterId) const { return (mIndexes[aRouterId] & kAllocatedFlag); }
+        bool IsAllocated(uint8_t aRouterId) const
+        {
+            return (aRouterId <= Mle::kMaxRouterId) && ((mIndexes[aRouterId] & kAllocatedFlag) != 0);
+        }
         uint8_t GetIndex(uint8_t aRouterId) const { return (mIndexes[aRouterId] & kIndexMask); }
         void    SetIndex(uint8_t aRouterId, uint8_t aIndex) { mIndexes[aRouterId] = kAllocatedFlag | aIndex; }
         bool    CanAllocate(uint8_t aRouterId) const { return (mIndexes[aRouterId] == 0); }

--- a/tests/unit/test_mle.cpp
+++ b/tests/unit/test_mle.cpp
@@ -609,12 +609,54 @@ void TestLeaderWeightCalculation(void)
 
 #endif // #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MLE_DEVICE_PROPERTY_LEADER_WEIGHT_ENABLE
 
+void TestRouterIdRangeChecks(void)
+{
+    Mle::RouterIdMask mask;
+
+    // `RouterIdMask` (carried in `RouteTlv`/`ThreadRouterMaskTlv`) indexes
+    // its bitmask by Router ID. A Router ID taken from a received message
+    // (e.g., the Leader Router ID from a Leader Data TLV) can exceed
+    // `kMaxRouterId`, so the lookup must reject out-of-range IDs instead of
+    // reading past the mask.
+
+    mask.Clear();
+    mask.Add(0);
+    mask.Add(Mle::kMaxRouterId);
+
+    VerifyOrQuit(mask.IsAllocated(0));
+    VerifyOrQuit(mask.IsAllocated(Mle::kMaxRouterId));
+    VerifyOrQuit(!mask.IsAllocated(1));
+
+    VerifyOrQuit(!mask.IsAllocated(Mle::kInvalidRouterId));
+    VerifyOrQuit(!mask.IsAllocated(64));
+    VerifyOrQuit(!mask.IsAllocated(NumericLimits<uint8_t>::kMax));
+
+#if OPENTHREAD_FTD
+    {
+        Instance *instance = static_cast<Instance *>(testInitInstance());
+
+        VerifyOrQuit(instance != nullptr);
+
+        // `RouterTable` maps Router IDs to entries and must reject
+        // out-of-range IDs the same way `FindRouterById()` already does.
+
+        VerifyOrQuit(!instance->Get<RouterTable>().IsAllocated(Mle::kInvalidRouterId));
+        VerifyOrQuit(!instance->Get<RouterTable>().IsAllocated(NumericLimits<uint8_t>::kMax));
+
+        testFreeInstance(instance);
+    }
+#endif
+
+    printf("TestRouterIdRangeChecks passed\n");
+}
+
 } // namespace ot
 
 int main(void)
 {
     ot::TestDeviceMode();
     ot::UnitTester::TestChildIdResponseNetworkDataHandling();
+    ot::TestRouterIdRangeChecks();
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MLE_DEVICE_PROPERTY_LEADER_WEIGHT_ENABLE
     ot::TestDefaultDeviceProperties();


### PR DESCRIPTION
Two router-id lookups index their backing array by a Router ID from a received message before checking it against `kMaxRouterId`:
- `RouterIdMask::IsAllocated` reads `mMask[aRouterId / 8]` (8-byte mask). `HandleAddressSolicitResponse` passes `GetLeaderId()`, the Leader Router ID copied verbatim from a Leader Data TLV, so ids 64-255 read up to 24 bytes past the mask.
- `RouterTable::RouterIdMap::IsAllocated` reads `mIndexes[aRouterId]` (63-byte map), reachable from an Advertisement whose Source Address decodes to router id 63.

`FindRouterById()` already guards the same map with `aRouterId <= kMaxRouterId`; both lookups now do too and return not-allocated for an out-of-range id. Regression test added in `test_mle.cpp`.