### PR TITLE
[common] prevent Heap::Array capacity wrap

### DIFF
--- a/src/core/common/heap_array.hpp
+++ b/src/core/common/heap_array.hpp
@@ -45,7 +45,6 @@
 #include "common/heap.hpp"
 #include "common/new.hpp"
 #include "common/num_utils.hpp"
-#include "common/numeric_limits.hpp"
 
 namespace ot {
 namespace Heap {
@@ -60,6 +59,8 @@ namespace Heap {
  * The `Type` class MUST provide a move constructor `Type(Type &&aOther)` (or a copy constructor if no move constructor
  * is provided). This constructor is used to move existing elements when array buffer is grown (new buffer is
  * allocated) to make room for new elements.
+ *
+ * The array length and capacity are represented by `uint16_t` and cannot exceed `UINT16_MAX` (2^16 - 1).
  *
  * @tparam  Type                  The array element type.
  * @tparam  kCapacityIncrements   Number of elements to allocate at a time when updating the array buffer.
@@ -506,19 +507,12 @@ public:
 private:
     Error Grow(void)
     {
+        Error error = kErrorNone;
+
         static_assert(kCapacityIncrements > 0, "kCapacityIncrements must be greater than zero");
 
-        Error     error       = kErrorNone;
-        IndexType newCapacity = NumericLimits<IndexType>::kMax;
-
-        VerifyOrExit(mCapacity < newCapacity, error = kErrorNoBufs);
-
-        if (kCapacityIncrements <= newCapacity - mCapacity)
-        {
-            newCapacity = static_cast<IndexType>(mCapacity + kCapacityIncrements);
-        }
-
-        error = Allocate(newCapacity);
+        VerifyOrExit(CanAddSafely<IndexType>(mCapacity, kCapacityIncrements), error = kErrorNoBufs);
+        error = Allocate(static_cast<IndexType>(mCapacity + kCapacityIncrements));
 
     exit:
         return error;
@@ -526,13 +520,11 @@ private:
 
     Error Allocate(IndexType aCapacity)
     {
-        Error  error = kErrorNone;
-        Type  *newArray;
-        size_t allocationSize;
+        Error error = kErrorNone;
+        Type *newArray;
 
         VerifyOrExit((aCapacity != mCapacity) && (aCapacity >= mLength));
-        VerifyOrExit(SafeMultiply<size_t>(aCapacity, sizeof(Type), allocationSize) == kErrorNone, error = kErrorNoBufs);
-        newArray = static_cast<Type *>(Heap::CAlloc(1, allocationSize));
+        newArray = static_cast<Type *>(Heap::CAlloc(aCapacity, sizeof(Type)));
         VerifyOrExit(newArray != nullptr, error = kErrorNoBufs);
 
         for (IndexType index = 0; index < mLength; index++)

--- a/src/core/common/heap_array.hpp
+++ b/src/core/common/heap_array.hpp
@@ -44,6 +44,8 @@
 #include "common/error.hpp"
 #include "common/heap.hpp"
 #include "common/new.hpp"
+#include "common/num_utils.hpp"
+#include "common/numeric_limits.hpp"
 
 namespace ot {
 namespace Heap {
@@ -283,7 +285,7 @@ public:
 
         if (mLength == mCapacity)
         {
-            SuccessOrExit(error = Allocate(mCapacity + kCapacityIncrements));
+            SuccessOrExit(error = Grow());
         }
 
         new (&mArray[mLength++]) Type(aEntry);
@@ -309,7 +311,7 @@ public:
 
         if (mLength == mCapacity)
         {
-            SuccessOrExit(error = Allocate(mCapacity + kCapacityIncrements));
+            SuccessOrExit(error = Grow());
         }
 
         new (&mArray[mLength++]) Type(static_cast<Type &&>(aEntry));
@@ -335,7 +337,7 @@ public:
 
         if (mLength == mCapacity)
         {
-            SuccessOrExit(Allocate(mCapacity + kCapacityIncrements));
+            SuccessOrExit(Grow());
         }
 
         newEntry = new (&mArray[mLength++]) Type();
@@ -502,13 +504,33 @@ public:
     Array &operator=(const Array &) = delete;
 
 private:
+    Error Grow(void)
+    {
+        Error     error       = kErrorNone;
+        IndexType newCapacity = NumericLimits<IndexType>::kMax;
+
+        VerifyOrExit((kCapacityIncrements > 0) && (mCapacity < newCapacity), error = kErrorNoBufs);
+
+        if (kCapacityIncrements <= newCapacity - mCapacity)
+        {
+            newCapacity = static_cast<IndexType>(mCapacity + kCapacityIncrements);
+        }
+
+        error = Allocate(newCapacity);
+
+    exit:
+        return error;
+    }
+
     Error Allocate(IndexType aCapacity)
     {
-        Error error = kErrorNone;
-        Type *newArray;
+        Error  error = kErrorNone;
+        Type  *newArray;
+        size_t allocationSize;
 
         VerifyOrExit((aCapacity != mCapacity) && (aCapacity >= mLength));
-        newArray = static_cast<Type *>(Heap::CAlloc(aCapacity, sizeof(Type)));
+        VerifyOrExit(SafeMultiply<size_t>(aCapacity, sizeof(Type), allocationSize) == kErrorNone, error = kErrorNoBufs);
+        newArray = static_cast<Type *>(Heap::CAlloc(1, allocationSize));
         VerifyOrExit(newArray != nullptr, error = kErrorNoBufs);
 
         for (IndexType index = 0; index < mLength; index++)

--- a/src/core/common/heap_array.hpp
+++ b/src/core/common/heap_array.hpp
@@ -506,10 +506,12 @@ public:
 private:
     Error Grow(void)
     {
+        static_assert(kCapacityIncrements > 0, "kCapacityIncrements must be greater than zero");
+
         Error     error       = kErrorNone;
         IndexType newCapacity = NumericLimits<IndexType>::kMax;
 
-        VerifyOrExit((kCapacityIncrements > 0) && (mCapacity < newCapacity), error = kErrorNoBufs);
+        VerifyOrExit(mCapacity < newCapacity, error = kErrorNoBufs);
 
         if (kCapacityIncrements <= newCapacity - mCapacity)
         {

--- a/tests/unit/test_heap_array.cpp
+++ b/tests/unit/test_heap_array.cpp
@@ -39,17 +39,10 @@
 #include "common/type_traits.hpp"
 
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-static bool   sFailHeapAllocation;
-static size_t sHeapAllocationCount;
-static size_t sLastHeapAllocationCount;
-static size_t sLastHeapAllocationSize;
+static bool sFailHeapAllocation;
 
 extern "C" void *otPlatCAlloc(size_t aNum, size_t aSize)
 {
-    sHeapAllocationCount++;
-    sLastHeapAllocationCount = aNum;
-    sLastHeapAllocationSize  = aSize;
-
     return sFailHeapAllocation ? nullptr : calloc(aNum, aSize);
 }
 
@@ -100,11 +93,6 @@ public:
 private:
     uint16_t mValue;
     bool     mInitialized;
-};
-
-struct LargeEntry
-{
-    uint8_t mBytes[65538];
 };
 
 template <typename EntryType>
@@ -538,7 +526,6 @@ void TestHeapArrayCapacityLimit(void)
     Heap::Array<uint8_t, 2> array;
     const uint8_t           value = 0xa5;
     uint8_t                *arrayBuffer;
-    size_t                  allocationCount;
 
     printf("\n\n====================================================================================\n");
     printf("TestHeapArrayCapacityLimit\n\n");
@@ -566,9 +553,8 @@ void TestHeapArrayCapacityLimit(void)
     VerifyOrQuit(array.GetCapacity() == kMaxCapacity);
     arrayBuffer = const_cast<uint8_t *>(array.AsCArray());
 
-    // Two source entries beyond the representable limit must both be rejected
+    // All PushBack overloads must reject growth beyond the representable limit
     // without changing the buffer, length, capacity, or existing contents.
-    VerifyOrQuit(array.PushBack(value) == kErrorNoBufs);
     VerifyOrQuit(array.PushBack(value) == kErrorNoBufs);
     VerifyOrQuit(array.PushBack(uint8_t{value}) == kErrorNoBufs);
     VerifyOrQuit(array.PushBack() == nullptr);
@@ -577,20 +563,13 @@ void TestHeapArrayCapacityLimit(void)
     VerifyOrQuit(array.AsCArray() == arrayBuffer);
     VerifyOrQuit(array.Back() != nullptr && *array.Back() == 0xfe);
 
-    // Removing an entry restores room in the existing buffer and all PushBack
-    // overloads remain usable without another allocation.
+    // Removing an entry restores room in the existing buffer.
     array.PopBack();
     SuccessOrQuit(array.PushBack(value));
     VerifyOrQuit(array.Back() != nullptr && *array.Back() == value);
-    array.PopBack();
-    SuccessOrQuit(array.PushBack(uint8_t{0x5a}));
-    VerifyOrQuit(array.Back() != nullptr && *array.Back() == 0x5a);
-    array.PopBack();
-    VerifyOrQuit(array.PushBack() != nullptr);
-    VerifyOrQuit(array.GetLength() == kMaxCapacity);
 
-    // Allocation failure during ordinary growth must be reported without
-    // mutating the existing allocation, and a later valid growth must work.
+    // Allocation failure during ordinary growth must not mutate the existing
+    // allocation, and a later valid growth must still work.
     array.Free();
     SuccessOrQuit(array.PushBack(value));
     SuccessOrQuit(array.PushBack(value));
@@ -604,28 +583,6 @@ void TestHeapArrayCapacityLimit(void)
     SuccessOrQuit(array.PushBack(value));
     VerifyOrQuit(array.GetLength() == 3);
     VerifyOrQuit(array.GetCapacity() == 4);
-
-    // Allocate() must check the full byte-size multiplication before handing
-    // it to the platform allocator. On 32-bit size_t the request overflows and
-    // never reaches the allocator; on wider hosts the exact size is retained.
-    Heap::Array<LargeEntry, 2> largeArray;
-    allocationCount     = sHeapAllocationCount;
-    sFailHeapAllocation = true;
-    VerifyOrQuit(largeArray.ReserveCapacity(kMaxCapacity) == kErrorNoBufs);
-    sFailHeapAllocation = false;
-    VerifyOrQuit(largeArray.GetLength() == 0);
-    VerifyOrQuit(largeArray.GetCapacity() == 0);
-
-    if (sizeof(size_t) == sizeof(uint32_t))
-    {
-        VerifyOrQuit(sHeapAllocationCount == allocationCount);
-    }
-    else
-    {
-        VerifyOrQuit(sHeapAllocationCount == allocationCount + 1);
-        VerifyOrQuit(sLastHeapAllocationCount == 1);
-        VerifyOrQuit(sLastHeapAllocationSize == static_cast<size_t>(kMaxCapacity) * sizeof(LargeEntry));
-    }
 
     printf("\n -- PASS\n");
 }

--- a/tests/unit/test_heap_array.cpp
+++ b/tests/unit/test_heap_array.cpp
@@ -28,6 +28,7 @@
 
 #include "test_platform.h"
 
+#include <stdlib.h>
 #include <string.h>
 
 #include <openthread/config.h>
@@ -36,6 +37,24 @@
 
 #include "common/heap_array.hpp"
 #include "common/type_traits.hpp"
+
+#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+static bool   sFailHeapAllocation;
+static size_t sHeapAllocationCount;
+static size_t sLastHeapAllocationCount;
+static size_t sLastHeapAllocationSize;
+
+extern "C" void *otPlatCAlloc(size_t aNum, size_t aSize)
+{
+    sHeapAllocationCount++;
+    sLastHeapAllocationCount = aNum;
+    sLastHeapAllocationSize  = aSize;
+
+    return sFailHeapAllocation ? nullptr : calloc(aNum, aSize);
+}
+
+extern "C" void otPlatFree(void *aPtr) { free(aPtr); }
+#endif
 
 namespace ot {
 
@@ -81,6 +100,11 @@ public:
 private:
     uint16_t mValue;
     bool     mInitialized;
+};
+
+struct LargeEntry
+{
+    uint8_t mBytes[65538];
 };
 
 template <typename EntryType>
@@ -507,12 +531,115 @@ void TestHeapArray(void)
     printf("\n -- PASS\n");
 }
 
+#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+void TestHeapArrayCapacityLimit(void)
+{
+    constexpr uint16_t      kMaxCapacity = NumericLimits<uint16_t>::kMax;
+    Heap::Array<uint8_t, 2> array;
+    const uint8_t           value = 0xa5;
+    uint8_t                *arrayBuffer;
+    size_t                  allocationCount;
+
+    printf("\n\n====================================================================================\n");
+    printf("TestHeapArrayCapacityLimit\n\n");
+
+    // Verify growth across the signed 16-bit boundary remains supported.
+    SuccessOrQuit(array.ReserveCapacity(32767));
+
+    for (uint32_t index = 0; index < 32769; index++)
+    {
+        SuccessOrQuit(array.PushBack(static_cast<uint8_t>(index)));
+    }
+
+    VerifyOrQuit(array.GetLength() == 32769);
+    VerifyOrQuit(array.GetCapacity() == 32769);
+
+    array.Free();
+    SuccessOrQuit(array.ReserveCapacity(kMaxCapacity));
+
+    for (uint32_t index = 0; index < kMaxCapacity; index++)
+    {
+        SuccessOrQuit(array.PushBack(static_cast<uint8_t>(index)));
+    }
+
+    VerifyOrQuit(array.GetLength() == kMaxCapacity);
+    VerifyOrQuit(array.GetCapacity() == kMaxCapacity);
+    arrayBuffer = const_cast<uint8_t *>(array.AsCArray());
+
+    // Two source entries beyond the representable limit must both be rejected
+    // without changing the buffer, length, capacity, or existing contents.
+    VerifyOrQuit(array.PushBack(value) == kErrorNoBufs);
+    VerifyOrQuit(array.PushBack(value) == kErrorNoBufs);
+    VerifyOrQuit(array.PushBack(uint8_t{value}) == kErrorNoBufs);
+    VerifyOrQuit(array.PushBack() == nullptr);
+    VerifyOrQuit(array.GetLength() == kMaxCapacity);
+    VerifyOrQuit(array.GetCapacity() == kMaxCapacity);
+    VerifyOrQuit(array.AsCArray() == arrayBuffer);
+    VerifyOrQuit(array.Back() != nullptr && *array.Back() == 0xfe);
+
+    // Removing an entry restores room in the existing buffer and all PushBack
+    // overloads remain usable without another allocation.
+    array.PopBack();
+    SuccessOrQuit(array.PushBack(value));
+    VerifyOrQuit(array.Back() != nullptr && *array.Back() == value);
+    array.PopBack();
+    SuccessOrQuit(array.PushBack(uint8_t{0x5a}));
+    VerifyOrQuit(array.Back() != nullptr && *array.Back() == 0x5a);
+    array.PopBack();
+    VerifyOrQuit(array.PushBack() != nullptr);
+    VerifyOrQuit(array.GetLength() == kMaxCapacity);
+
+    // Allocation failure during ordinary growth must be reported without
+    // mutating the existing allocation, and a later valid growth must work.
+    array.Free();
+    SuccessOrQuit(array.PushBack(value));
+    SuccessOrQuit(array.PushBack(value));
+    arrayBuffer         = const_cast<uint8_t *>(array.AsCArray());
+    sFailHeapAllocation = true;
+    VerifyOrQuit(array.PushBack(value) == kErrorNoBufs);
+    sFailHeapAllocation = false;
+    VerifyOrQuit(array.GetLength() == 2);
+    VerifyOrQuit(array.GetCapacity() == 2);
+    VerifyOrQuit(array.AsCArray() == arrayBuffer);
+    SuccessOrQuit(array.PushBack(value));
+    VerifyOrQuit(array.GetLength() == 3);
+    VerifyOrQuit(array.GetCapacity() == 4);
+
+    // Allocate() must check the full byte-size multiplication before handing
+    // it to the platform allocator. On 32-bit size_t the request overflows and
+    // never reaches the allocator; on wider hosts the exact size is retained.
+    Heap::Array<LargeEntry, 2> largeArray;
+    allocationCount     = sHeapAllocationCount;
+    sFailHeapAllocation = true;
+    VerifyOrQuit(largeArray.ReserveCapacity(kMaxCapacity) == kErrorNoBufs);
+    sFailHeapAllocation = false;
+    VerifyOrQuit(largeArray.GetLength() == 0);
+    VerifyOrQuit(largeArray.GetCapacity() == 0);
+
+    if (sizeof(size_t) == sizeof(uint32_t))
+    {
+        VerifyOrQuit(sHeapAllocationCount == allocationCount);
+    }
+    else
+    {
+        VerifyOrQuit(sHeapAllocationCount == allocationCount + 1);
+        VerifyOrQuit(sLastHeapAllocationCount == 1);
+        VerifyOrQuit(sLastHeapAllocationSize == static_cast<size_t>(kMaxCapacity) * sizeof(LargeEntry));
+    }
+
+    printf("\n -- PASS\n");
+}
+#endif
+
 } // namespace ot
 
 int main(void)
 {
     ot::TestHeapArrayOfUint16();
     ot::TestHeapArray();
+#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+    ot::TestHeapArrayCapacityLimit();
+#endif
     printf("\nAll tests passed.\n");
     return 0;
 }


### PR DESCRIPTION
 ## Summary

  This PR fixes an out-of-bounds heap write when `Heap::Array` reaches the limit of its 16-bit capacity type.

  ## Analysis

  `Heap::Array` stores its length and capacity as `uint16_t`. When a full array grows, `mCapacity + kCapacityIncrements` can wrap before it reaches `Allocate()`.

  The existing `Allocate()` guard treats a wrapped capacity below the current length as a no-op and returns `kErrorNone`. `PushBack()` therefore continues and placement-constructs the next element beyond the allocated buffer.

  A native mDNS address-result construction with 65,537 retained entries reproduced this as a 20-byte ASAN heap-buffer-overflow.

  ## The Fix

  Centralize capacity growth in `Grow()`. It computes the next capacity without wrapping, saturates at the maximum value representable by `IndexType`, and returns `kErrorNoBufs` when the array is full.

  Also validate the complete allocation size with checked `size_t` multiplication before calling the allocator. All three `PushBack()` paths now use the checked growth path.

  ## Testing

  - Committed regression test covers growth past 32,767, the 65,535 capacity ceiling, and insertion attempts beyond that ceiling through every `PushBack()` overload
  - Verifies rejected insertions do not change the allocation, length, capacity, or existing contents
  - Verifies recovery after removing an entry and after a temporary allocation failure
  - Verifies checked allocation-size multiplication using a large element type
  - Vulnerable focused runs reproduced the 20-byte ASAN heap-buffer-overflow at 65,537 entries
  - Patched focused runs reject the overflowing insertion with `kErrorNoBufs`, without mutation or an ASAN diagnostic
  - Full functional unit suite under Clang ASAN: 81/81 tests passed

