### PR TITLE
[mesh-forwarder] reject oversized mesh frames

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -712,7 +712,9 @@ Mac::TxFrame *MeshForwarder::HandleFrameRequest(Mac::TxFrames &aTxFrames)
 #if OPENTHREAD_FTD
 
     case Message::kType6lowpan:
-        mMessageNextOffset = Get<MessageFramer>().PrepareMeshFrame(*frame, *mSendMessage, mMacAddrs);
+        mMessageNextOffset = mSendMessage->GetLength();
+        VerifyOrExit(Get<MessageFramer>().PrepareMeshFrame(*frame, *mSendMessage, mMacAddrs) == kErrorNone,
+                     frame = nullptr);
         break;
 
     case Message::kTypeSupervision:

--- a/src/core/thread/message_framer.cpp
+++ b/src/core/thread/message_framer.cpp
@@ -356,8 +356,9 @@ start:
 
 #if OPENTHREAD_FTD
 
-uint16_t MessageFramer::PrepareMeshFrame(Mac::TxFrame &aFrame, Message &aMessage, const Mac::Addresses &aMacAddrs)
+Error MessageFramer::PrepareMeshFrame(Mac::TxFrame &aFrame, Message &aMessage, const Mac::Addresses &aMacAddrs)
 {
+    Error                        error = kErrorNone;
     Mac::TxFrame::BuildInfo      buildInfo;
     Mac::TxFrame::PayloadBuilder frameBuilder;
 
@@ -369,10 +370,11 @@ uint16_t MessageFramer::PrepareMeshFrame(Mac::TxFrame &aFrame, Message &aMessage
 
     PrepareMacHeaders(aFrame, buildInfo, frameBuilder, &aMessage);
 
-    SuccessOrAssert(frameBuilder.AppendBytesFromMessage(aMessage, 0, aMessage.GetLength()));
+    SuccessOrExit(error = frameBuilder.AppendBytesFromMessage(aMessage, 0, aMessage.GetLength()));
     aFrame.FinishPayload(frameBuilder);
 
-    return aMessage.GetLength();
+exit:
+    return error;
 }
 
 #endif // OPENTHREAD_FTD

--- a/src/core/thread/message_framer.hpp
+++ b/src/core/thread/message_framer.hpp
@@ -115,9 +115,10 @@ public:
      * @param[in]  aMessage          The 6LoWPAN Mesh message.
      * @param[in]  aMacAddrs         The MAC source and destination addresses.
      *
-     * @returns The next offset into @p aMessage after the prepared frame.
+     * @retval kErrorNone    Successfully prepared the frame.
+     * @retval kErrorNoBufs  The message does not fit in the frame.
      */
-    uint16_t PrepareMeshFrame(Mac::TxFrame &aFrame, Message &aMessage, const Mac::Addresses &aMacAddrs);
+    Error PrepareMeshFrame(Mac::TxFrame &aFrame, Message &aMessage, const Mac::Addresses &aMacAddrs);
 
 #endif // OPENTHREAD_FTD
 

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -31,11 +31,69 @@
 #include "common/message.hpp"
 #include "common/random.hpp"
 #include "instance/instance.hpp"
+#include "mac/mac_frame.hpp"
+#include "thread/message_framer.hpp"
 
 #include "test_platform.h"
 #include "test_util.hpp"
 
 namespace ot {
+
+void TestMeshFrameMessageSize(void)
+{
+    static constexpr uint16_t kOversizeLength = 240;
+
+    Instance      *instance = static_cast<Instance *>(testInitInstance());
+    Message       *message;
+    Mac::Addresses addresses;
+    Mac::TxFrame   frame{};
+    uint8_t        psdu[OT_RADIO_FRAME_MAX_SIZE];
+    uint16_t       maxPayloadLength;
+    uint16_t       lengths[3];
+
+    VerifyOrQuit(instance != nullptr);
+
+    frame.mPsdu = psdu;
+    frame.SetRadioType(Radio::kTypeIeee802154);
+    addresses.mSource.SetShort(0x1111);
+    addresses.mDestination.SetShort(0x2222);
+
+    VerifyOrQuit((message = instance->Get<MessagePool>().Allocate(Message::kType6lowpan)) != nullptr);
+    SuccessOrQuit(message->SetLength(kOversizeLength));
+
+    // An oversized forwarded mesh message must be rejected before its payload is copied.
+    VerifyOrQuit(instance->Get<MessageFramer>().PrepareMeshFrame(frame, *message, addresses) == kErrorNoBufs);
+    message->Free();
+
+    // Prepare an empty frame to determine the payload capacity for these MAC headers.
+    VerifyOrQuit((message = instance->Get<MessagePool>().Allocate(Message::kType6lowpan)) != nullptr);
+    SuccessOrQuit(instance->Get<MessageFramer>().PrepareMeshFrame(frame, *message, addresses));
+    maxPayloadLength = frame.GetMtu() - frame.GetLength();
+    message->Free();
+
+    lengths[0] = maxPayloadLength - 1;
+    lengths[1] = maxPayloadLength;
+    lengths[2] = maxPayloadLength + 1;
+
+    for (uint16_t length : lengths)
+    {
+        VerifyOrQuit((message = instance->Get<MessagePool>().Allocate(Message::kType6lowpan)) != nullptr);
+        SuccessOrQuit(message->SetLength(length));
+
+        VerifyOrQuit(instance->Get<MessageFramer>().PrepareMeshFrame(frame, *message, addresses) ==
+                     ((length <= maxPayloadLength) ? kErrorNone : kErrorNoBufs));
+        message->Free();
+    }
+
+    // Rejection must not prevent a subsequent valid frame from being prepared.
+    VerifyOrQuit((message = instance->Get<MessagePool>().Allocate(Message::kType6lowpan)) != nullptr);
+    SuccessOrQuit(message->SetLength(maxPayloadLength));
+    SuccessOrQuit(instance->Get<MessageFramer>().PrepareMeshFrame(frame, *message, addresses));
+    VerifyOrQuit(frame.GetLength() == frame.GetMtu());
+    message->Free();
+
+    testFreeInstance(instance);
+}
 
 void TestMessage(uint16_t aReservedLength)
 {
@@ -542,6 +600,8 @@ void TestAppender(void)
 int main(void)
 {
     static const uint16_t kReserveLengths[] = {0, 33, 400};
+
+    ot::TestMeshFrameMessageSize();
 
     for (uint16_t reservedLength : kReserveLengths)
     {

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -31,8 +31,6 @@
 #include "common/message.hpp"
 #include "common/random.hpp"
 #include "instance/instance.hpp"
-#include "mac/mac_frame.hpp"
-#include "thread/message_framer.hpp"
 
 #include "test_platform.h"
 #include "test_util.hpp"


### PR DESCRIPTION
## Summary

  This PR rejects a forwarded 6LoWPAN mesh message when it does not fit in the selected MAC frame.

   ## Analysis

  A conforming OpenThread sender already limits Mesh Header frames to the IEEE 802.15.4 MTU. This condition therefore requires malformed or nonconforming traffic.

  `PayloadBuilder::AppendBytesFromMessage()` correctly returns `kErrorNoBufs` when the message does not fit. However, `PrepareMeshFrame()` handles that result with `SuccessOrAssert()`. When assertions are disabled, the error is ignored,  the incomplete frame is finalized, and `MeshForwarder` considers the complete message consumed.


  ## The Fix

  Change `PrepareMeshFrame()` to return `Error` and propagate the `PayloadBuilder` result.

  Update `MeshForwarder::HandleFrameRequest()` so a preparation error enters the existing abort/drop path instead of returning an incomplete frame. The message offset is advanced to its end so the rejected message cannot be retried
  indefinitely.

  ## Testing

  - Committed regression test verifies rejection of a 240-byte oversized mesh message
  - Covers the dynamically derived `max-1`, `max`, and `max+1` payload boundaries
  - Verifies exact-capacity frame preparation succeeds
  - Verifies a valid exact-capacity frame can still be prepared after an oversized message is rejected
  - Full functional unit suite under Clang ASAN: 81/81 tests passed

