### PR TITLE
[ip6] move origin check into `SendRaw()` and free message on failure

### DIFF
--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -136,14 +136,7 @@ void otIp6SetReceiveFilterEnabled(otInstance *aInstance, bool aEnabled)
 
 otError otIp6Send(otInstance *aInstance, otMessage *aMessage)
 {
-    otError error;
-
-    VerifyOrExit(!AsCoreType(aMessage).IsOriginThreadNetif(), error = kErrorInvalidArgs);
-
-    error = AsCoreType(aInstance).Get<Ip6::Ip6>().SendRaw(OwnedPtr<Message>(AsCoreTypePtr(aMessage)));
-
-exit:
-    return error;
+    return AsCoreType(aInstance).Get<Ip6::Ip6>().SendRaw(OwnedPtr<Message>(AsCoreTypePtr(aMessage)));
 }
 
 otMessage *otIp6NewMessage(otInstance *aInstance, const otMessageSettings *aSettings)

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1121,6 +1121,8 @@ Error Ip6::SendRaw(OwnedPtr<Message> aMessagePtr)
     Error  error = kErrorNone;
     Header header;
 
+    VerifyOrExit(!aMessagePtr->IsOriginThreadNetif(), error = kErrorInvalidArgs);
+
     SuccessOrExit(error = header.ParseFrom(*aMessagePtr));
     VerifyOrExit(!header.GetSource().IsMulticast(), error = kErrorInvalidSourceAddress);
 

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -163,11 +163,12 @@ public:
      *
      * @param[in]  aMessage   An owned pointer to a message (ownership is transferred to the method).
      *
-     * @retval kErrorNone     Successfully processed the message.
-     * @retval kErrorDrop     Message was well-formed but not fully processed due to packet processing rules.
-     * @retval kErrorNoBufs   Could not allocate necessary message buffers when processing the datagram.
-     * @retval kErrorNoRoute  No route to host.
-     * @retval kErrorParse    Encountered a malformed header when processing the message.
+     * @retval kErrorNone         Successfully processed the message.
+     * @retval kErrorDrop         Message was well-formed but not fully processed due to packet processing rules.
+     * @retval kErrorInvalidArgs  The message origin is the Thread network interface.
+     * @retval kErrorNoBufs       Could not allocate necessary message buffers when processing the datagram.
+     * @retval kErrorNoRoute      No route to host.
+     * @retval kErrorParse        Encountered a malformed header when processing the message.
      */
     Error SendRaw(OwnedPtr<Message> aMessage);
 


### PR DESCRIPTION
Split out of #13477 per review feedback.

`otIp6Send()` bails out on the `IsOriginThreadNetif()` check before the `OwnedPtr` is built, so a rejected message is never freed, though `ip6.h` promises the free "including when a value other than `OT_ERROR_NONE` is returned".

Per the suggestion in #13477, the check moves into `Ip6::SendRaw()` in the C++ core, and `otIp6Send()` becomes a thin pass-through that hands the message to the `OwnedPtr` up front, so every path owns and frees it. The other `SendRaw()` caller (`Nat64::Translator`) only sends host-originated messages, so the new check does not change its behavior.