### PR TITLE
[logging] allow platforms to supply their own logging macros

### DIFF
--- a/include/openthread/logging.h
+++ b/include/openthread/logging.h
@@ -43,6 +43,10 @@
 #include <openthread/platform/logging.h>
 #include <openthread/platform/toolchain.h>
 
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#include OPENTHREAD_CONFIG_LOG_OFFLOADING_HEADER_FILE
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -129,10 +133,17 @@ otError otLoggingSetLevel(otLogLevel aLogLevel);
  * Is intended for use by platform. If `OPENTHREAD_CONFIG_LOG_PLATFORM` is not set or the current log
  * level is below critical, this function does not emit any log message.
  *
+ * @note If `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is set, this expands directly to the platform-provided
+ * `OT_LOG_PLATFORM_CRIT()` macro (using `"Platform"` as the module name) instead of calling a real function.
+ *
  * @param[in]  aFormat  The format string.
  * @param[in]  ...      Arguments for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define otLogCritPlat(...) OT_LOG_PLATFORM_CRIT("Platform", __VA_ARGS__)
+#else
 void otLogCritPlat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
+#endif
 
 /**
  * Emits a log message at warning log level.
@@ -140,10 +151,17 @@ void otLogCritPlat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHE
  * Is intended for use by platform. If `OPENTHREAD_CONFIG_LOG_PLATFORM` is not set or the current log
  * level is below warning, this function does not emit any log message.
  *
+ * @note If `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is set, this expands directly to the platform-provided
+ * `OT_LOG_PLATFORM_WARN()` macro (using `"Platform"` as the module name) instead of calling a real function.
+ *
  * @param[in]  aFormat  The format string.
  * @param[in]  ...      Arguments for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define otLogWarnPlat(...) OT_LOG_PLATFORM_WARN("Platform", __VA_ARGS__)
+#else
 void otLogWarnPlat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
+#endif
 
 /**
  * Emits a log message at note log level.
@@ -151,10 +169,17 @@ void otLogWarnPlat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHE
  * Is intended for use by platform. If `OPENTHREAD_CONFIG_LOG_PLATFORM` is not set or the current log
  * level is below note, this function does not emit any log message.
  *
+ * @note If `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is set, this expands directly to the platform-provided
+ * `OT_LOG_PLATFORM_NOTE()` macro (using `"Platform"` as the module name) instead of calling a real function.
+ *
  * @param[in]  aFormat  The format string.
  * @param[in]  ...      Arguments for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define otLogNotePlat(...) OT_LOG_PLATFORM_NOTE("Platform", __VA_ARGS__)
+#else
 void otLogNotePlat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
+#endif
 
 /**
  * Emits a log message at info log level.
@@ -162,10 +187,17 @@ void otLogNotePlat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHE
  * Is intended for use by platform. If `OPENTHREAD_CONFIG_LOG_PLATFORM` is not set or the current log
  * level is below info, this function does not emit any log message.
  *
+ * @note If `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is set, this expands directly to the platform-provided
+ * `OT_LOG_PLATFORM_INFO()` macro (using `"Platform"` as the module name) instead of calling a real function.
+ *
  * @param[in]  aFormat  The format string.
  * @param[in]  ...      Arguments for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define otLogInfoPlat(...) OT_LOG_PLATFORM_INFO("Platform", __VA_ARGS__)
+#else
 void otLogInfoPlat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
+#endif
 
 /**
  * Emits a log message at debug log level.
@@ -173,10 +205,17 @@ void otLogInfoPlat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHE
  * Is intended for use by platform. If `OPENTHREAD_CONFIG_LOG_PLATFORM` is not set or the current log
  * level is below debug, this function does not emit any log message.
  *
+ * @note If `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is set, this expands directly to the platform-provided
+ * `OT_LOG_PLATFORM_DEBG()` macro (using `"Platform"` as the module name) instead of calling a real function.
+ *
  * @param[in]  aFormat  The format string.
  * @param[in]  ...      Arguments for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define otLogDebgPlat(...) OT_LOG_PLATFORM_DEBG("Platform", __VA_ARGS__)
+#else
 void otLogDebgPlat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
+#endif
 
 /**
  * Generates a memory dump at critical log level.
@@ -184,11 +223,18 @@ void otLogDebgPlat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHE
  * If `OPENTHREAD_CONFIG_LOG_PLATFORM` or `OPENTHREAD_CONFIG_LOG_PKT_DUMP` is not set or the current log level is below
  * critical this function does not emit any log message.
  *
+ * @note If `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is set, this expands directly to the platform-provided
+ * `OT_LOG_PLATFORM_DUMP_CRIT()` macro (using `"Platform"` as the module name) instead of calling a real function.
+ *
  * @param[in]  aText         A string that is printed before the bytes.
  * @param[in]  aData         A pointer to the data buffer.
  * @param[in]  aDataLength   Number of bytes in @p aData.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define otDumpCritPlat(aText, aData, aDataLength) OT_LOG_PLATFORM_DUMP_CRIT("Platform", aText, aData, aDataLength)
+#else
 void otDumpCritPlat(const char *aText, const void *aData, uint16_t aDataLength);
+#endif
 
 /**
  * Generates a memory dump at warning log level.
@@ -196,11 +242,18 @@ void otDumpCritPlat(const char *aText, const void *aData, uint16_t aDataLength);
  * If `OPENTHREAD_CONFIG_LOG_PLATFORM` or `OPENTHREAD_CONFIG_LOG_PKT_DUMP` is not set or the current log level is below
  * warning this function does not emit any log message.
  *
+ * @note If `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is set, this expands directly to the platform-provided
+ * `OT_LOG_PLATFORM_DUMP_WARN()` macro (using `"Platform"` as the module name) instead of calling a real function.
+ *
  * @param[in]  aText         A string that is printed before the bytes.
  * @param[in]  aData         A pointer to the data buffer.
  * @param[in]  aDataLength   Number of bytes in @p aData.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define otDumpWarnPlat(aText, aData, aDataLength) OT_LOG_PLATFORM_DUMP_WARN("Platform", aText, aData, aDataLength)
+#else
 void otDumpWarnPlat(const char *aText, const void *aData, uint16_t aDataLength);
+#endif
 
 /**
  * Generates a memory dump at note log level.
@@ -208,11 +261,18 @@ void otDumpWarnPlat(const char *aText, const void *aData, uint16_t aDataLength);
  * If `OPENTHREAD_CONFIG_LOG_PLATFORM` or `OPENTHREAD_CONFIG_LOG_PKT_DUMP` is not set or the current log level is below
  * note this function does not emit any log message.
  *
+ * @note If `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is set, this expands directly to the platform-provided
+ * `OT_LOG_PLATFORM_DUMP_NOTE()` macro (using `"Platform"` as the module name) instead of calling a real function.
+ *
  * @param[in]  aText         A string that is printed before the bytes.
  * @param[in]  aData         A pointer to the data buffer.
  * @param[in]  aDataLength   Number of bytes in @p aData.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define otDumpNotePlat(aText, aData, aDataLength) OT_LOG_PLATFORM_DUMP_NOTE("Platform", aText, aData, aDataLength)
+#else
 void otDumpNotePlat(const char *aText, const void *aData, uint16_t aDataLength);
+#endif
 
 /**
  * Generates a memory dump at info log level.
@@ -220,11 +280,18 @@ void otDumpNotePlat(const char *aText, const void *aData, uint16_t aDataLength);
  * If `OPENTHREAD_CONFIG_LOG_PLATFORM` or `OPENTHREAD_CONFIG_LOG_PKT_DUMP` is not set or the current log level is below
  * info this function does not emit any log message.
  *
+ * @note If `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is set, this expands directly to the platform-provided
+ * `OT_LOG_PLATFORM_DUMP_INFO()` macro (using `"Platform"` as the module name) instead of calling a real function.
+ *
  * @param[in]  aText         A string that is printed before the bytes.
  * @param[in]  aData         A pointer to the data buffer.
  * @param[in]  aDataLength   Number of bytes in @p aData.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define otDumpInfoPlat(aText, aData, aDataLength) OT_LOG_PLATFORM_DUMP_INFO("Platform", aText, aData, aDataLength)
+#else
 void otDumpInfoPlat(const char *aText, const void *aData, uint16_t aDataLength);
+#endif
 
 /**
  * Generates a memory dump at debug log level.
@@ -232,11 +299,18 @@ void otDumpInfoPlat(const char *aText, const void *aData, uint16_t aDataLength);
  * If `OPENTHREAD_CONFIG_LOG_PLATFORM` or `OPENTHREAD_CONFIG_LOG_PKT_DUMP` is not set or the current log level is below
  * debug this function does not emit any log message.
  *
+ * @note If `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is set, this expands directly to the platform-provided
+ * `OT_LOG_PLATFORM_DUMP_DEBG()` macro (using `"Platform"` as the module name) instead of calling a real function.
+ *
  * @param[in]  aText         A string that is printed before the bytes.
  * @param[in]  aData         A pointer to the data buffer.
  * @param[in]  aDataLength   Number of bytes in @p aData.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define otDumpDebgPlat(aText, aData, aDataLength) OT_LOG_PLATFORM_DUMP_DEBG("Platform", aText, aData, aDataLength)
+#else
 void otDumpDebgPlat(const char *aText, const void *aData, uint16_t aDataLength);
+#endif
 
 /**
  * Emits a log message at given log level using a platform module name.

--- a/src/core/api/logging_api.cpp
+++ b/src/core/api/logging_api.cpp
@@ -75,6 +75,12 @@ otError otLoggingSetLevel(otLogLevel aLogLevel)
 
 #endif // OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE
 
+// When `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is set, `otLog{Level}Plat()`/`otDump{Level}Plat()` are defined
+// as macros in `<openthread/logging.h>` instead, expanding directly to the platform-provided `OT_LOG_PLATFORM_*`
+// macros at every call site. In that case, no caller anywhere ever calls through these symbols, so the
+// `Logger`-based implementations below are neither needed nor (being macros elsewhere) definable here.
+#if !OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+
 static const char kPlatformModuleName[] = "Platform";
 
 void otLogCritPlat(const char *aFormat, ...)
@@ -197,6 +203,8 @@ void otDumpDebgPlat(const char *aText, const void *aData, uint16_t aDataLength)
     OT_UNUSED_VARIABLE(aDataLength);
 #endif
 }
+
+#endif // !OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
 
 void otLogPlat(otLogLevel aLogLevel, const char *aPlatModuleName, const char *aFormat, ...)
 {

--- a/src/core/common/log.cpp
+++ b/src/core/common/log.cpp
@@ -60,6 +60,11 @@ namespace ot {
 
 #if OT_SHOULD_LOG
 
+// `LogAtLevel()` and `LogOnError()` back the `Log{Crit,Warn,Note,Info,Debg}()`/`Log{Level}OnError()` macros only
+// when `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is not set (see the corresponding note in `log.hpp`), so they are
+// excluded here to avoid dead code when it is set.
+#if !OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+
 template <LogLevel kLogLevel> void Logger::LogAtLevel(const char *aModuleName, const char *aFormat, ...)
 {
     va_list args;
@@ -98,6 +103,8 @@ template void Logger::LogOnError<kLogLevelWarn>(const char *aModuleName, Error a
 template void Logger::LogOnError<kLogLevelNote>(const char *aModuleName, Error aError, const char *aFormat, ...);
 template void Logger::LogOnError<kLogLevelInfo>(const char *aModuleName, Error aError, const char *aFormat, ...);
 template void Logger::LogOnError<kLogLevelDebg>(const char *aModuleName, Error aError, const char *aFormat, ...);
+
+#endif // !OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
 
 void Logger::LogInModule(const char *aModuleName, LogLevel aLogLevel, const char *aFormat, ...)
 {
@@ -233,6 +240,11 @@ exit:
 
 #if OPENTHREAD_CONFIG_LOG_PKT_DUMP
 
+// `DumpAtLevel()` backs the `Dump{Crit,Warn,Note,Info,Debg}()` macros only when
+// `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is not set (see the corresponding note in `log.hpp`), so it is excluded
+// here to avoid dead code when it is set.
+#if !OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+
 template <LogLevel kLogLevel>
 void Logger::DumpAtLevel(const char *aModuleName, const char *aText, const void *aData, uint16_t aDataLength)
 {
@@ -264,6 +276,8 @@ template void Logger::DumpAtLevel<kLogLevelDebg>(const char *aModuleName,
                                                  const char *aText,
                                                  const void *aData,
                                                  uint16_t    aDataLength);
+
+#endif // !OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
 
 void Logger::DumpInModule(const char *aModuleName,
                           LogLevel    aLogLevel,

--- a/src/core/common/log.hpp
+++ b/src/core/common/log.hpp
@@ -43,6 +43,10 @@
 #include "common/as_core_type.hpp"
 #include "common/error.hpp"
 
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#include OPENTHREAD_CONFIG_LOG_OFFLOADING_HEADER_FILE
+#endif
+
 namespace ot {
 
 /**
@@ -87,6 +91,18 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  *
  * @param[in] aName  The log module name string (MUST be shorter than `kMaxLogModuleNameLength`).
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define RegisterLogModule(aName)                                     \
+    constexpr char kLogModuleName[] = aName;                         \
+    namespace {                                                      \
+    /* Defining this type to silence "unused constant" warning/error \
+     * for `kLogModuleName` under any log level config.              \
+     */                                                              \
+    using DummyType = char[sizeof(kLogModuleName)];                  \
+    }                                                                \
+    OT_LOG_PLATFORM_MODULE_REGISTER(kLogModuleName);                 \
+    static_assert(sizeof(kLogModuleName) <= kMaxLogModuleNameLength + 1, "Log module name is too long")
+#else
 #define RegisterLogModule(aName)                                     \
     constexpr char kLogModuleName[] = aName;                         \
     namespace {                                                      \
@@ -96,6 +112,7 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
     using DummyType = char[sizeof(kLogModuleName)];                  \
     }                                                                \
     static_assert(sizeof(kLogModuleName) <= kMaxLogModuleNameLength + 1, "Log module name is too long")
+#endif
 
 #else
 #define RegisterLogModule(aName) static_assert(true, "Consume the required semi-colon at the end of macro")
@@ -107,7 +124,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  *
  * @param[in]  ...   Arguments for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define LogCrit(...) OT_LOG_PLATFORM_CRIT(kLogModuleName, __VA_ARGS__)
+#else
 #define LogCrit(...) Logger::LogAtLevel<kLogLevelCrit>(kLogModuleName, __VA_ARGS__)
+#endif
 
 /**
  * Emits an error log message at critical log level if there is an error.
@@ -118,7 +139,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in] aError       The error to check and log.
  * @param[in] ...          Arguments for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define LogCritOnError(aError, ...) OT_LOG_PLATFORM_CRIT_ON_ERROR(kLogModuleName, aError, __VA_ARGS__)
+#else
 #define LogCritOnError(aError, ...) Logger::LogOnError<kLogLevelCrit>(kLogModuleName, aError, __VA_ARGS__)
+#endif
 #else
 #define LogCrit(...)
 #define LogCritOnError(aError, ...) OT_UNUSED_VARIABLE(aError)
@@ -130,7 +155,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  *
  * @param[in]  ...   Arguments for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define LogWarn(...) OT_LOG_PLATFORM_WARN(kLogModuleName, __VA_ARGS__)
+#else
 #define LogWarn(...) Logger::LogAtLevel<kLogLevelWarn>(kLogModuleName, __VA_ARGS__)
+#endif
 
 /**
  * Emits an error log message at warning log level if there is an error.
@@ -141,8 +170,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in] aError       The error to check and log.
  * @param[in] ...          Arguments for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define LogWarnOnError(aError, ...) OT_LOG_PLATFORM_WARN_ON_ERROR(kLogModuleName, aError, __VA_ARGS__)
+#else
 #define LogWarnOnError(aError, ...) Logger::LogOnError<kLogLevelWarn>(kLogModuleName, aError, __VA_ARGS__)
-
+#endif
 #else
 #define LogWarn(...)
 #define LogWarnOnError(aError, ...) OT_UNUSED_VARIABLE(aError)
@@ -154,7 +186,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  *
  * @param[in]  ...   Arguments for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define LogNote(...) OT_LOG_PLATFORM_NOTE(kLogModuleName, __VA_ARGS__)
+#else
 #define LogNote(...) Logger::LogAtLevel<kLogLevelNote>(kLogModuleName, __VA_ARGS__)
+#endif
 
 /**
  * Emits an error log message at note log level if there is an error.
@@ -165,8 +201,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in] aError       The error to check and log.
  * @param[in] ...          Arguments for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define LogNoteOnError(aError, ...) OT_LOG_PLATFORM_NOTE_ON_ERROR(kLogModuleName, aError, __VA_ARGS__)
+#else
 #define LogNoteOnError(aError, ...) Logger::LogOnError<kLogLevelNote>(kLogModuleName, aError, __VA_ARGS__)
-
+#endif
 #else
 #define LogNote(...)
 #define LogNoteOnError(aError, ...) OT_UNUSED_VARIABLE(aError)
@@ -178,7 +217,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  *
  * @param[in]  ...   Arguments for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define LogInfo(...) OT_LOG_PLATFORM_INFO(kLogModuleName, __VA_ARGS__)
+#else
 #define LogInfo(...) Logger::LogAtLevel<kLogLevelInfo>(kLogModuleName, __VA_ARGS__)
+#endif
 
 /**
  * Emits an error log message at info log level if there is an error.
@@ -189,8 +232,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in] aError       The error to check and log.
  * @param[in] ...          Arguments for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define LogInfoOnError(aError, ...) OT_LOG_PLATFORM_INFO_ON_ERROR(kLogModuleName, aError, __VA_ARGS__)
+#else
 #define LogInfoOnError(aError, ...) Logger::LogOnError<kLogLevelInfo>(kLogModuleName, aError, __VA_ARGS__)
-
+#endif
 #else
 #define LogInfo(...)
 #define LogInfoOnError(aError, ...) OT_UNUSED_VARIABLE(aError)
@@ -202,7 +248,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  *
  * @param[in]  ...   Arguments for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define LogDebg(...) OT_LOG_PLATFORM_DEBG(kLogModuleName, __VA_ARGS__)
+#else
 #define LogDebg(...) Logger::LogAtLevel<kLogLevelDebg>(kLogModuleName, __VA_ARGS__)
+#endif
 
 /**
  * Emits an error log message at debug log level if there is an error.
@@ -213,8 +263,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in] aError       The error to check and log.
  * @param[in] ...          Arguments for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define LogDebgOnError(aError, ...) OT_LOG_PLATFORM_DEBG_ON_ERROR(kLogModuleName, aError, __VA_ARGS__)
+#else
 #define LogDebgOnError(aError, ...) Logger::LogOnError<kLogLevelDebg>(kLogModuleName, aError, __VA_ARGS__)
-
+#endif
 #else
 #define LogDebg(...)
 #define LogDebgOnError(aError, ...) OT_UNUSED_VARIABLE(aError)
@@ -227,7 +280,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in] aLogLevel  The log level to use.
  * @param[in] ...        Argument for the format specification.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define LogAt(aLogLevel, ...) OT_LOG_PLATFORM_LOG_AT(kLogModuleName, aLogLevel, __VA_ARGS__)
+#else
 #define LogAt(aLogLevel, ...) Logger::LogInModule(kLogModuleName, aLogLevel, __VA_ARGS__)
+#endif
 #else
 #define LogAt(aLogLevel, ...)
 #endif
@@ -262,7 +319,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in]  aData         A pointer to the data buffer.
  * @param[in]  aDataLength   Number of bytes in @p aData.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define DumpCrit(aText, aData, aDataLength) OT_LOG_PLATFORM_DUMP_CRIT(kLogModuleName, aText, aData, aDataLength)
+#else
 #define DumpCrit(aText, aData, aDataLength) Logger::Dump<kLogLevelCrit, kLogModuleName>(aText, aData, aDataLength)
+#endif
 #else
 #define DumpCrit(aText, aData, aDataLength)
 #endif
@@ -275,7 +336,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in]  aData         A pointer to the data buffer.
  * @param[in]  aDataLength   Number of bytes in @p aData.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define DumpWarn(aText, aData, aDataLength) OT_LOG_PLATFORM_DUMP_WARN(kLogModuleName, aText, aData, aDataLength)
+#else
 #define DumpWarn(aText, aData, aDataLength) Logger::Dump<kLogLevelWarn, kLogModuleName>(aText, aData, aDataLength)
+#endif
 #else
 #define DumpWarn(aText, aData, aDataLength)
 #endif
@@ -288,7 +353,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in]  aData         A pointer to the data buffer.
  * @param[in]  aDataLength   Number of bytes in @p aData.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define DumpNote(aText, aData, aDataLength) OT_LOG_PLATFORM_DUMP_NOTE(kLogModuleName, aText, aData, aDataLength)
+#else
 #define DumpNote(aText, aData, aDataLength) Logger::Dump<kLogLevelNote, kLogModuleName>(aText, aData, aDataLength)
+#endif
 #else
 #define DumpNote(aText, aData, aDataLength)
 #endif
@@ -301,7 +370,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in]  aData         A pointer to the data buffer.
  * @param[in]  aDataLength   Number of bytes in @p aData.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define DumpInfo(aText, aData, aDataLength) OT_LOG_PLATFORM_DUMP_INFO(kLogModuleName, aText, aData, aDataLength)
+#else
 #define DumpInfo(aText, aData, aDataLength) Logger::Dump<kLogLevelInfo, kLogModuleName>(aText, aData, aDataLength)
+#endif
 #else
 #define DumpInfo(aText, aData, aDataLength)
 #endif
@@ -314,7 +387,11 @@ constexpr uint16_t kMaxLogStringSize = OPENTHREAD_CONFIG_LOG_MAX_SIZE; ///< Max 
  * @param[in]  aData         A pointer to the data buffer.
  * @param[in]  aDataLength   Number of bytes in @p aData.
  */
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define DumpDebg(aText, aData, aDataLength) OT_LOG_PLATFORM_DUMP_DEBG(kLogModuleName, aText, aData, aDataLength)
+#else
 #define DumpDebg(aText, aData, aDataLength) Logger::Dump<kLogLevelDebg, kLogModuleName>(aText, aData, aDataLength)
+#endif
 #else
 #define DumpDebg(aText, aData, aDataLength)
 #endif
@@ -358,6 +435,10 @@ public:
     static void LogInModule(const char *aModuleName, LogLevel aLogLevel, const char *aFormat, ...)
         OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(3, 4);
 
+    // `LogAtLevel()` and `LogOnError()` back the `Log{Crit,Warn,Note,Info,Debg}()`/`Log{Level}OnError()` macros only
+    // when `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is not set. When it is set, those macros expand directly to
+    // platform-provided macros instead and never call these methods, so they are excluded to avoid dead code.
+#if !OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
     template <LogLevel kLogLevel>
     static void LogAtLevel(const char *aModuleName, const char *aFormat, ...)
         OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 3);
@@ -365,6 +446,7 @@ public:
     template <LogLevel kLogLevel>
     static void LogOnError(const char *aModuleName, Error aError, const char *aFormat, ...)
         OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(3, 4);
+#endif
 
     static void LogVarArgs(const char *aModuleName, LogLevel aLogLevel, const char *aFormat, va_list aArgs)
         OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(3, 0);
@@ -373,11 +455,15 @@ public:
     static constexpr uint8_t kStringLineLength = 80;
     static constexpr uint8_t kDumpBytesPerLine = 16;
 
+    // `Dump()` and `DumpAtLevel()` back the `Dump{Crit,Warn,Note,Info,Debg}()` macros only when
+    // `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is not set (see the note on `LogAtLevel()` above).
+#if !OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
     template <LogLevel kLogLevel, const char *kModuleName>
     static void Dump(const char *aText, const void *aData, uint16_t aDataLength)
     {
         DumpAtLevel<kLogLevel>(kModuleName, aText, aData, aDataLength);
     }
+#endif
 
     static void DumpInModule(const char *aModuleName,
                              LogLevel    aLogLevel,
@@ -385,8 +471,10 @@ public:
                              const void *aData,
                              uint16_t    aDataLength);
 
+#if !OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
     template <LogLevel kLogLevel>
     static void DumpAtLevel(const char *aModuleName, const char *aText, const void *aData, uint16_t aDataLength);
+#endif
 #endif
 
 private:
@@ -394,6 +482,7 @@ private:
         OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(4, 0);
 };
 
+#if !OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
 extern template void Logger::LogAtLevel<kLogLevelNone>(const char *aModuleName, const char *aFormat, ...);
 extern template void Logger::LogAtLevel<kLogLevelCrit>(const char *aModuleName, const char *aFormat, ...);
 extern template void Logger::LogAtLevel<kLogLevelWarn>(const char *aModuleName, const char *aFormat, ...);
@@ -407,8 +496,9 @@ extern template void Logger::LogOnError<kLogLevelWarn>(const char *aModuleName, 
 extern template void Logger::LogOnError<kLogLevelNote>(const char *aModuleName, Error aError, const char *aFormat, ...);
 extern template void Logger::LogOnError<kLogLevelInfo>(const char *aModuleName, Error aError, const char *aFormat, ...);
 extern template void Logger::LogOnError<kLogLevelDebg>(const char *aModuleName, Error aError, const char *aFormat, ...);
+#endif // !OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
 
-#if OPENTHREAD_CONFIG_LOG_PKT_DUMP
+#if OPENTHREAD_CONFIG_LOG_PKT_DUMP && !OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
 extern template void Logger::DumpAtLevel<kLogLevelNone>(const char *aModuleName,
                                                         const char *aText,
                                                         const void *aData,
@@ -433,7 +523,7 @@ extern template void Logger::DumpAtLevel<kLogLevelDebg>(const char *aModuleName,
                                                         const char *aText,
                                                         const void *aData,
                                                         uint16_t    aDataLength);
-#endif // OPENTHREAD_CONFIG_LOG_PKT_DUMP
+#endif // OPENTHREAD_CONFIG_LOG_PKT_DUMP && !OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
 #endif // OT_SHOULD_LOG
 
 typedef otLogHexDumpInfo HexDumpInfo; ///< Represents the hex dump info.

--- a/src/core/config/logging.h
+++ b/src/core/config/logging.h
@@ -198,6 +198,54 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+ *
+ * Define to 1 to have the `LogCrit()`/`LogWarn()`/`LogNote()`/`LogInfo()`/`LogDebg()`/`LogAt()` logging macros
+ * (and the `Log{Level}OnError()` family) expand directly to platform-provided logging macros, instead of going
+ * through `Logger::LogAtLevel()` / `Logger::LogInModule()` / `Logger::LogOnError()`.
+ *
+ * This allows the platform to package a log message (format string and arguments, including the module name)
+ * directly at the original call site, e.g. to avoid an extra text-rendering step and to let read-only/rodata
+ * string arguments be handled as pointers instead of being copied.
+ *
+ * This also applies to the `DumpCrit()`/`DumpWarn()`/`DumpNote()`/`DumpInfo()`/`DumpDebg()` macros, which are
+ * likewise expanded to platform-provided macros instead of going through `Logger::Dump()`.
+ *
+ * `RegisterLogModule()` is also affected: in addition to defining `kLogModuleName`, it invokes
+ * `OT_LOG_PLATFORM_MODULE_REGISTER(aName)`, so the platform can register its own equivalent of a "log
+ * module" for the calling file (e.g. to get native, per-module log filtering).
+ *
+ * The public `otLog{Level}Plat()` / `otDump{Level}Plat()` API (declared in `<openthread/logging.h>` and used by
+ * platform code, e.g. `otLogCritPlat()`, to route its own logs through OpenThread's formatting) is likewise
+ * affected: it expands to the same `OT_LOG_PLATFORM_{LEVEL}()` / `OT_LOG_PLATFORM_DUMP_{LEVEL}()` macros, using
+ * `"Platform"` as the module name, instead of calling into `Logger`. `otLogPlat()`/`otLogPlatArgs()`/`otLogCli()`
+ * are NOT affected and always go through `Logger`, since they carry a runtime module name/log level that isn't a
+ * fixed part of the macro name.
+ *
+ * When enabled, the platform MUST provide the header file named by
+ * `OPENTHREAD_CONFIG_LOG_OFFLOADING_HEADER_FILE` (including quotes or angle brackets, since no default is
+ * provided by OpenThread core), defining the following macros for each log level (`CRIT`, `WARN`, `NOTE`,
+ * `INFO`, `DEBG`):
+ *
+ *   - `OT_LOG_PLATFORM_MODULE_REGISTER(aName)`
+ *   - `OT_LOG_PLATFORM_{LEVEL}(aModuleName, aFormat, ...)`
+ *   - `OT_LOG_PLATFORM_{LEVEL}_ON_ERROR(aModuleName, aError, aFormat, ...)`
+ *   - `OT_LOG_PLATFORM_LOG_AT(aModuleName, aLogLevel, aFormat, ...)`
+ *   - `OT_LOG_PLATFORM_DUMP_{LEVEL}(aModuleName, aText, aData, aDataLength)`
+ *
+ * `LogAt()` uses `OT_LOG_PLATFORM_LOG_AT()`, which is passed the (only known at run time) `ot::LogLevel`
+ * value as an argument rather than having a level baked into its name, since the platform then has to
+ * dispatch to the right underlying macro itself (e.g. via a runtime `switch`).
+ *
+ * @note `LogAlways()`, `LogCert()`, and `DumpAlways()`/`DumpCert()` are unaffected and continue to go
+ * through `Logger`, since they are not tied to any of the levels above (they always log, regardless of
+ * the configured log level).
+ */
+#ifndef OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
+#define OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE 0
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_LOG_LEVEL_OVERRIDE_ENABLE
  *
  * Define to 1 to enable the log level override feature and its associated APIs.
@@ -209,6 +257,26 @@
  */
 #ifndef OPENTHREAD_CONFIG_LOG_LEVEL_OVERRIDE_ENABLE
 #define OPENTHREAD_CONFIG_LOG_LEVEL_OVERRIDE_ENABLE 0
+#endif
+
+#if OPENTHREAD_CONFIG_LOG_LEVEL_OVERRIDE_ENABLE && !OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE
+#error "OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE is required for OPENTHREAD_CONFIG_LOG_LEVEL_OVERRIDE_ENABLE"
+#endif
+
+#if OPENTHREAD_CONFIG_LOG_LEVEL_INIT > OPENTHREAD_CONFIG_LOG_LEVEL
+#error "OPENTHREAD_CONFIG_LOG_LEVEL_INIT must not be more verbose than OPENTHREAD_CONFIG_LOG_LEVEL"
+#endif
+
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE && !defined(OPENTHREAD_CONFIG_LOG_OFFLOADING_HEADER_FILE)
+#error \
+    "OPENTHREAD_CONFIG_LOG_OFFLOADING_HEADER_FILE must be defined when OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE is set"
+#endif
+
+#if OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE && OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE
+#error "OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE has no effect on the `Log{Level}()`/`LogAt()`/`Dump{Level}()` " \
+       "macros (i.e. on the vast majority of OpenThread's internal log statements) when " \
+       "OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE is set, since those macros then bypass `Logger` (and its runtime " \
+       "log-level check) entirely and expand directly to platform-provided macros. Disable one of the two options."
 #endif
 
 /**

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -232,6 +232,7 @@ ot_unit_test(ip_address)
 ot_unit_test(link_metrics_manager)
 ot_unit_test(link_quality)
 ot_unit_test(linked_list)
+ot_unit_test(log_platform_macro)
 ot_unit_test(lowpan)
 ot_unit_test(ltv)
 ot_unit_test(mac_frame)
@@ -279,6 +280,41 @@ ot_unit_ncp_test(dnssd)
 ot_unit_ncp_test(infra_if)
 ot_unit_ncp_test(srp_server)
 ot_unit_ncp_test(ephemeral_key)
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# `ot-test-log_platform_macro` is compiled with `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE=1` and a
+# test-only platform header (`test_log_platform_macro_stub.h`) to verify that the `Log{Crit,Warn,Note,Info,Debg}()`,
+# `LogAt()`, `LogWarnOnError()`, and `Dump*()` macros correctly expand to platform-provided `OT_LOG_PLATFORM_*`
+# macros (instead of `ot::Logger`) when a platform opts into that mode. `OPENTHREAD_CONFIG_LOG_LEVEL` is raised
+# to `DEBG` so every log level macro is actually compiled in and exercised. `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE`
+# is enabled so `LogCert()`/`DumpCert()` (which must always go through `ot::Logger`, never the platform macros) are
+# also compiled in and can be tested.
+target_compile_definitions(ot-test-log_platform_macro
+    PRIVATE
+        "OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE=1"
+        "OPENTHREAD_CONFIG_LOG_OFFLOADING_HEADER_FILE=\"test_log_platform_macro_stub.h\""
+        "OPENTHREAD_CONFIG_LOG_LEVEL=OT_LOG_LEVEL_DEBG"
+        "OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE=1"
+)
+
+# `ot-config`'s Debug-build default of `OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE=1` is incompatible with
+# `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE=1` (see `openthread-core-config-check.h`) and is irrelevant to what this
+# test verifies, so it is undefined and redefined to 0 here. This must be done via `target_compile_options()`
+# (mapped to ninja's `$FLAGS`, which come after `$DEFINES` on the compile command line), since `ot-config`'s
+# `INTERFACE` compile definition is otherwise appended after (and so would win over) a same-named
+# `target_compile_definitions()` override on this target.
+target_compile_options(ot-test-log_platform_macro
+    PRIVATE
+        "-UOPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE"
+        "-DOPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE=0"
+)
+
+# `common/log.hpp` (in src/core) does `#include OPENTHREAD_CONFIG_LOG_OFFLOADING_HEADER_FILE`, so
+# `tests/unit/` (where the stub header lives) must be on the include path.
+target_include_directories(ot-test-log_platform_macro
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/tests/unit/test_log_platform_macro.cpp
+++ b/tests/unit/test_log_platform_macro.cpp
@@ -1,0 +1,316 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This test verifies `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE`: when enabled, `RegisterLogModule()` and
+ *   every `Log{Crit,Warn,Note,Info,Debg}()` / `Log{Level}OnError()` / `LogAt()` / `Dump{Level}()` macro must
+ *   expand to the platform-provided `OT_LOG_PLATFORM_*` macros instead of going through `ot::Logger`. The same
+ *   applies to the public `otLog{Level}Plat()`/`otDump{Level}Plat()` API declared in `<openthread/logging.h>`.
+ *   It also verifies that `LogAlways()`/`LogCert()`/`DumpAlways()`/`DumpCert()`/`otLogPlat()`/`otLogCli()` remain
+ *   unaffected and never reach the platform macros, since they aren't tied to a specific log level.
+ *
+ *   This translation unit is compiled (see `tests/unit/CMakeLists.txt`) with
+ *   `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE=1` and `OPENTHREAD_CONFIG_LOG_OFFLOADING_HEADER_FILE`
+ *   pointing at `test_log_platform_macro_stub.h`, which records every platform-macro invocation into
+ *   `gTestLogPlatformCapture` so we can assert on the captured level/module-name/message here.
+ */
+
+#include "test_platform.h"
+
+#include "test_util.h"
+
+#include "common/log.hpp"
+
+TestLogPlatformCapture gTestLogPlatformCapture;
+
+namespace ot {
+
+RegisterLogModule("TestLogPlat");
+
+void TestLogPlatformMacroModuleRegister(void)
+{
+    // `RegisterLogModule()` must invoke `OT_LOG_PLATFORM_MODULE_REGISTER()` with the module name, in addition to
+    // defining `kLogModuleName`. The stub records it into `kTestLogPlatformRegisteredModule` (file-scope, defined
+    // right above by the `RegisterLogModule("TestLogPlat")` call at the top of this file).
+    VerifyOrQuit(strcmp(kTestLogPlatformRegisteredModule, "TestLogPlat") == 0);
+    VerifyOrQuit(strcmp(kLogModuleName, "TestLogPlat") == 0);
+}
+
+void TestLogPlatformMacroBasicLevels(void)
+{
+    TestLogPlatformCaptureReset();
+    LogCrit("crit %d", 1);
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "CRIT") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "TestLogPlat") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mMessage, "crit 1") == 0);
+
+    TestLogPlatformCaptureReset();
+    LogWarn("warn %d", 2);
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "WARN") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "TestLogPlat") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mMessage, "warn 2") == 0);
+
+    TestLogPlatformCaptureReset();
+    LogNote("note %d", 3);
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "NOTE") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mMessage, "note 3") == 0);
+
+    TestLogPlatformCaptureReset();
+    LogInfo("info %d", 4);
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "INFO") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mMessage, "info 4") == 0);
+
+    TestLogPlatformCaptureReset();
+    LogDebg("debg %d", 5);
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "DEBG") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mMessage, "debg 5") == 0);
+}
+
+void TestLogPlatformMacroOnError(void)
+{
+    // No error (`kErrorNone`): none of the `Log{Level}OnError()` macros should log anything.
+
+    TestLogPlatformCaptureReset();
+    LogCritOnError(kErrorNone, "should not log");
+    LogWarnOnError(kErrorNone, "should not log");
+    LogNoteOnError(kErrorNone, "should not log");
+    LogInfoOnError(kErrorNone, "should not log");
+    LogDebgOnError(kErrorNone, "should not log");
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 0, "Log{Level}OnError() must not log when there is no error");
+
+    // With an error, each `Log{Level}OnError()` must log once, at its own level.
+
+    TestLogPlatformCaptureReset();
+    LogCritOnError(kErrorFailed, "the operation");
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1, "LogCritOnError() must log when there is an error");
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "CRIT") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "TestLogPlat") == 0);
+
+    TestLogPlatformCaptureReset();
+    LogWarnOnError(kErrorFailed, "the operation");
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1, "LogWarnOnError() must log when there is an error");
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "WARN") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "TestLogPlat") == 0);
+
+    TestLogPlatformCaptureReset();
+    LogNoteOnError(kErrorFailed, "the operation");
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1, "LogNoteOnError() must log when there is an error");
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "NOTE") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "TestLogPlat") == 0);
+
+    TestLogPlatformCaptureReset();
+    LogInfoOnError(kErrorFailed, "the operation");
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1, "LogInfoOnError() must log when there is an error");
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "INFO") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "TestLogPlat") == 0);
+
+    TestLogPlatformCaptureReset();
+    LogDebgOnError(kErrorFailed, "the operation");
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1, "LogDebgOnError() must log when there is an error");
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "DEBG") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "TestLogPlat") == 0);
+}
+
+void TestLogPlatformMacroLogAt(void)
+{
+    TestLogPlatformCaptureReset();
+    LogAt(kLogLevelInfo, "logat %d", 6);
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "INFO") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "TestLogPlat") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mMessage, "logat 6") == 0);
+
+    TestLogPlatformCaptureReset();
+    LogAt(kLogLevelCrit, "logat crit");
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "CRIT") == 0);
+}
+
+void TestLogPlatformMacroDump(void)
+{
+    static const uint8_t kData[] = {0x01, 0x02, 0x03};
+
+    TestLogPlatformCaptureReset();
+    DumpCrit("dump text", kData, sizeof(kData));
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "CRIT-DUMP") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "TestLogPlat") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mMessage, "dump text") == 0);
+
+    TestLogPlatformCaptureReset();
+    DumpWarn("dump text", kData, sizeof(kData));
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "WARN-DUMP") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "TestLogPlat") == 0);
+
+    TestLogPlatformCaptureReset();
+    DumpNote("dump text", kData, sizeof(kData));
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "NOTE-DUMP") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "TestLogPlat") == 0);
+
+    TestLogPlatformCaptureReset();
+    DumpInfo("dump text", kData, sizeof(kData));
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "INFO-DUMP") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "TestLogPlat") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mMessage, "dump text") == 0);
+
+    TestLogPlatformCaptureReset();
+    DumpDebg("dump text", kData, sizeof(kData));
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "DEBG-DUMP") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "TestLogPlat") == 0);
+}
+
+void TestLogPlatformMacroPublicPlatApi(void)
+{
+    // The public `otLog{Level}Plat()`/`otDump{Level}Plat()` API (declared in `<openthread/logging.h>`, used by
+    // platform code to route its own logs through OpenThread) must also expand to the platform-provided macros
+    // when this feature is enabled, using `"Platform"` as the fixed module name.
+    static const uint8_t kData[] = {0x01, 0x02, 0x03};
+
+    TestLogPlatformCaptureReset();
+    otLogCritPlat("plat crit %d", 1);
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "CRIT") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "Platform") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mMessage, "plat crit 1") == 0);
+
+    TestLogPlatformCaptureReset();
+    otLogWarnPlat("plat warn %d", 2);
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "WARN") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "Platform") == 0);
+
+    TestLogPlatformCaptureReset();
+    otLogNotePlat("plat note %d", 3);
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "NOTE") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "Platform") == 0);
+
+    TestLogPlatformCaptureReset();
+    otLogInfoPlat("plat info %d", 4);
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "INFO") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "Platform") == 0);
+
+    TestLogPlatformCaptureReset();
+    otLogDebgPlat("plat debg %d", 5);
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "DEBG") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "Platform") == 0);
+
+    TestLogPlatformCaptureReset();
+    otDumpCritPlat("plat dump text", kData, sizeof(kData));
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "CRIT-DUMP") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "Platform") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mMessage, "plat dump text") == 0);
+
+    TestLogPlatformCaptureReset();
+    otDumpWarnPlat("plat dump text", kData, sizeof(kData));
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "WARN-DUMP") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "Platform") == 0);
+
+    TestLogPlatformCaptureReset();
+    otDumpNotePlat("plat dump text", kData, sizeof(kData));
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "NOTE-DUMP") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "Platform") == 0);
+
+    TestLogPlatformCaptureReset();
+    otDumpInfoPlat("plat dump text", kData, sizeof(kData));
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "INFO-DUMP") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "Platform") == 0);
+
+    TestLogPlatformCaptureReset();
+    otDumpDebgPlat("plat dump text", kData, sizeof(kData));
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 1);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mLevel, "DEBG-DUMP") == 0);
+    VerifyOrQuit(strcmp(gTestLogPlatformCapture.mModuleName, "Platform") == 0);
+}
+
+void TestLogPlatformMacroUnaffectedMacros(void)
+{
+    // `LogAlways()`, `LogCert()`, `DumpAlways()`, and `DumpCert()` are documented to always go through `ot::Logger`
+    // and are *not* affected by `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE`, since they aren't tied to a specific
+    // log level. Verify none of them ever reach the platform-macro stub (i.e. `gTestLogPlatformCapture` stays
+    // untouched), even though this translation unit is compiled with the feature enabled.
+    static const uint8_t kData[] = {0x01, 0x02, 0x03};
+
+    TestLogPlatformCaptureReset();
+    LogAlways("always %d", 1);
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 0, "LogAlways() must not go through the platform macros");
+
+    TestLogPlatformCaptureReset();
+    LogCert("cert %d", 2);
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 0, "LogCert() must not go through the platform macros");
+
+    TestLogPlatformCaptureReset();
+    DumpAlways("dump text", kData, sizeof(kData));
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 0, "DumpAlways() must not go through the platform macros");
+
+    TestLogPlatformCaptureReset();
+    DumpCert("dump text", kData, sizeof(kData));
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 0, "DumpCert() must not go through the platform macros");
+
+    // Likewise, `otLogPlat()` and `otLogCli()` carry a runtime module name/log level and are not tied to a fixed
+    // per-level macro name, so they must always go through `Logger` too.
+
+    TestLogPlatformCaptureReset();
+    otLogPlat(OT_LOG_LEVEL_INFO, "SubModule", "plat %d", 3);
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 0, "otLogPlat() must not go through the platform macros");
+
+    TestLogPlatformCaptureReset();
+    otLogCli(OT_LOG_LEVEL_INFO, "cli %d", 4);
+    VerifyOrQuit(gTestLogPlatformCapture.mCallCount == 0, "otLogCli() must not go through the platform macros");
+}
+
+} // namespace ot
+
+int main(void)
+{
+    ot::TestLogPlatformMacroModuleRegister();
+    ot::TestLogPlatformMacroBasicLevels();
+    ot::TestLogPlatformMacroOnError();
+    ot::TestLogPlatformMacroLogAt();
+    ot::TestLogPlatformMacroDump();
+    ot::TestLogPlatformMacroPublicPlatApi();
+    ot::TestLogPlatformMacroUnaffectedMacros();
+    printf("All tests passed\n");
+    return 0;
+}

--- a/tests/unit/test_log_platform_macro_stub.h
+++ b/tests/unit/test_log_platform_macro_stub.h
@@ -1,0 +1,144 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This is a fake "platform" logging header used by `test_log_platform_macro.cpp` to verify that
+ *   `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` correctly routes `LogCrit()`/`LogWarn()`/... (and
+ *   `DumpCrit()`/... ) to platform-provided macros instead of going through `ot::Logger`.
+ *
+ *   Every macro records its invocation (level, module name, formatted text) into `gTestLogPlatformCapture`
+ *   so the test can assert on it with `VerifyOrQuit()`.
+ */
+
+#ifndef TEST_LOG_PLATFORM_MACRO_STUB_H_
+#define TEST_LOG_PLATFORM_MACRO_STUB_H_
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <openthread/platform/toolchain.h>
+
+struct TestLogPlatformCapture
+{
+    int  mCallCount;
+    char mLevel[16];
+    char mModuleName[32];
+    char mMessage[256];
+};
+
+extern TestLogPlatformCapture gTestLogPlatformCapture;
+
+inline void TestLogPlatformCaptureReset(void)
+{
+    gTestLogPlatformCapture.mCallCount     = 0;
+    gTestLogPlatformCapture.mLevel[0]      = '\0';
+    gTestLogPlatformCapture.mModuleName[0] = '\0';
+    gTestLogPlatformCapture.mMessage[0]    = '\0';
+}
+
+inline void TestLogPlatformRecordV(const char *aLevel, const char *aModuleName, const char *aFormat, va_list aArgs)
+{
+    gTestLogPlatformCapture.mCallCount++;
+    snprintf(gTestLogPlatformCapture.mLevel, sizeof(gTestLogPlatformCapture.mLevel), "%s", aLevel);
+    snprintf(gTestLogPlatformCapture.mModuleName, sizeof(gTestLogPlatformCapture.mModuleName), "%s", aModuleName);
+    vsnprintf(gTestLogPlatformCapture.mMessage, sizeof(gTestLogPlatformCapture.mMessage), aFormat, aArgs);
+}
+
+inline void TestLogPlatformRecord(const char *aLevel, const char *aModuleName, const char *aFormat, ...)
+    OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(3, 4);
+
+inline void TestLogPlatformRecord(const char *aLevel, const char *aModuleName, const char *aFormat, ...)
+{
+    va_list args;
+
+    va_start(args, aFormat);
+    TestLogPlatformRecordV(aLevel, aModuleName, aFormat, args);
+    va_end(args);
+}
+
+inline void TestLogPlatformRecordDump(const char *aLevel, const char *aModuleName, const char *aText)
+{
+    gTestLogPlatformCapture.mCallCount++;
+    snprintf(gTestLogPlatformCapture.mLevel, sizeof(gTestLogPlatformCapture.mLevel), "%s-DUMP", aLevel);
+    snprintf(gTestLogPlatformCapture.mModuleName, sizeof(gTestLogPlatformCapture.mModuleName), "%s", aModuleName);
+    snprintf(gTestLogPlatformCapture.mMessage, sizeof(gTestLogPlatformCapture.mMessage), "%s", aText);
+}
+
+inline const char *TestLogLevelToString(int aLogLevel)
+{
+    // Mirrors `ot::LogLevel` (0=None, 1=Crit, 2=Warn, 3=Note, 4=Info, 5=Debg).
+    static const char *const kLevelStrings[] = {"NONE", "CRIT", "WARN", "NOTE", "INFO", "DEBG"};
+
+    return (aLogLevel >= 0 && aLogLevel <= 5) ? kLevelStrings[aLogLevel] : "UNKNOWN";
+}
+
+#define OT_LOG_PLATFORM_MODULE_REGISTER(aName) static const char *const kTestLogPlatformRegisteredModule = (aName)
+
+#define OT_LOG_PLATFORM_CRIT(aModuleName, ...) TestLogPlatformRecord("CRIT", aModuleName, __VA_ARGS__)
+#define OT_LOG_PLATFORM_WARN(aModuleName, ...) TestLogPlatformRecord("WARN", aModuleName, __VA_ARGS__)
+#define OT_LOG_PLATFORM_NOTE(aModuleName, ...) TestLogPlatformRecord("NOTE", aModuleName, __VA_ARGS__)
+#define OT_LOG_PLATFORM_INFO(aModuleName, ...) TestLogPlatformRecord("INFO", aModuleName, __VA_ARGS__)
+#define OT_LOG_PLATFORM_DEBG(aModuleName, ...) TestLogPlatformRecord("DEBG", aModuleName, __VA_ARGS__)
+
+#define TEST_LOG_PLATFORM_ON_ERROR_(aLevel, aModuleName, aError, ...) \
+    do                                                                \
+    {                                                                 \
+        if ((aError) != 0)                                            \
+        {                                                             \
+            TestLogPlatformRecord(aLevel, aModuleName, __VA_ARGS__);  \
+        }                                                             \
+    } while (false)
+
+#define OT_LOG_PLATFORM_CRIT_ON_ERROR(aModuleName, aError, ...) \
+    TEST_LOG_PLATFORM_ON_ERROR_("CRIT", aModuleName, aError, __VA_ARGS__)
+#define OT_LOG_PLATFORM_WARN_ON_ERROR(aModuleName, aError, ...) \
+    TEST_LOG_PLATFORM_ON_ERROR_("WARN", aModuleName, aError, __VA_ARGS__)
+#define OT_LOG_PLATFORM_NOTE_ON_ERROR(aModuleName, aError, ...) \
+    TEST_LOG_PLATFORM_ON_ERROR_("NOTE", aModuleName, aError, __VA_ARGS__)
+#define OT_LOG_PLATFORM_INFO_ON_ERROR(aModuleName, aError, ...) \
+    TEST_LOG_PLATFORM_ON_ERROR_("INFO", aModuleName, aError, __VA_ARGS__)
+#define OT_LOG_PLATFORM_DEBG_ON_ERROR(aModuleName, aError, ...) \
+    TEST_LOG_PLATFORM_ON_ERROR_("DEBG", aModuleName, aError, __VA_ARGS__)
+
+#define OT_LOG_PLATFORM_LOG_AT(aModuleName, aLogLevel, ...) \
+    TestLogPlatformRecord(TestLogLevelToString(static_cast<int>(aLogLevel)), aModuleName, __VA_ARGS__)
+
+#define OT_LOG_PLATFORM_DUMP_CRIT(aModuleName, aText, aData, aDataLength) \
+    TestLogPlatformRecordDump("CRIT", aModuleName, aText)
+#define OT_LOG_PLATFORM_DUMP_WARN(aModuleName, aText, aData, aDataLength) \
+    TestLogPlatformRecordDump("WARN", aModuleName, aText)
+#define OT_LOG_PLATFORM_DUMP_NOTE(aModuleName, aText, aData, aDataLength) \
+    TestLogPlatformRecordDump("NOTE", aModuleName, aText)
+#define OT_LOG_PLATFORM_DUMP_INFO(aModuleName, aText, aData, aDataLength) \
+    TestLogPlatformRecordDump("INFO", aModuleName, aText)
+#define OT_LOG_PLATFORM_DUMP_DEBG(aModuleName, aText, aData, aDataLength) \
+    TestLogPlatformRecordDump("DEBG", aModuleName, aText)
+
+#endif // TEST_LOG_PLATFORM_MACRO_STUB_H_

--- a/tools/ot-fct/logging.cpp
+++ b/tools/ot-fct/logging.cpp
@@ -31,6 +31,10 @@
 
 #include <openthread/logging.h>
 
+// When `OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE` is set, `otLogCritPlat()` is defined as a macro in
+// `<openthread/logging.h>` instead, expanding directly to a platform-provided `OT_LOG_PLATFORM_CRIT()` macro. In
+// that case, this tool's own definition below is neither needed nor (being a macro) definable here.
+#if !OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE
 void otLogCritPlat(const char *aFormat, ...)
 {
     va_list args;
@@ -39,3 +43,4 @@ void otLogCritPlat(const char *aFormat, ...)
     vprintf(aFormat, args);
     va_end(args);
 }
+#endif // !OPENTHREAD_CONFIG_LOG_OFFLOADING_ENABLE


### PR DESCRIPTION
Introduces an opt-in mode where a platform can handle log messages directly instead of going through OpenThread's built-in logger, letting the platform format and filter logs however it wants. It is important if OpenThread is built as a submodule of a bigger system which can also control OT's log levels, filters, etc (e.g. in Zephyr RTOS). 