### PR TITLE
api: validate TLVs before typed reads in otDatasetAffectsConnectivity

### DIFF
--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -237,6 +237,7 @@ bool otDatasetAffectsConnectivity(otInstance *aInstance, const otOperationalData
     AssertPointerIsNotNull(aDatasetTlvs);
 
     SuccessOrExit(dataset.SetFrom(*aDatasetTlvs));
+    SuccessOrExit(dataset.ValidateTlvs());
     affects = dataset.AffectsConnectivity(AsCoreType(aInstance));
 
 exit:

--- a/tests/unit/test_dataset.cpp
+++ b/tests/unit/test_dataset.cpp
@@ -28,6 +28,10 @@
 
 #include <openthread/config.h>
 
+#include <string.h>
+
+#include <openthread/dataset.h>
+
 #include "test_platform.h"
 #include "test_util.hpp"
 
@@ -320,12 +324,58 @@ void TestDataset(void)
     }
 }
 
+// `otDatasetAffectsConnectivity()` builds its working `Dataset` from raw caller
+// bytes via `SetFrom()`, which only checks the overall buffer length, not that each
+// TLV's declared length matches what its type requires. Without a `ValidateTlvs()`
+// call, a `NetworkKeyTlv` (type 5, needs 16 bytes) declared with length 0 lets
+// `Read<NetworkKeyTlv>()` read 16 bytes past the TLV header regardless -- past the
+// `mTlvs` array and the `Dataset` object itself. This checks the malformed case is
+// now safely rejected, and that a validly-formed dataset containing a real 16-byte
+// `NetworkKeyTlv` is still accepted (no regression for legitimate callers).
+void TestDatasetAffectsConnectivityRejectsMalformedTlvs(void)
+{
+    otInstance *instance = testInitInstance();
+
+    {
+        // Malformed: type 222 filler TLV (length 250) fills bytes [0..251], then a
+        // NetworkKeyTlv (type 5) with declared length 0 sits at [252..253]. The
+        // 254-byte buffer is internally consistent (every TLV's own header+declared
+        // length fits), but the NetworkKeyTlv's declared length is short of the 16
+        // bytes `NetworkKeyTlv::ValueType` requires.
+        otOperationalDatasetTlvs tlvs;
+
+        tlvs.mLength = 254;
+        memset(tlvs.mTlvs, 0x41, sizeof(tlvs.mTlvs));
+        tlvs.mTlvs[0]   = 222;
+        tlvs.mTlvs[1]   = 250;
+        tlvs.mTlvs[252] = OT_MESHCOP_TLV_NETWORKKEY;
+        tlvs.mTlvs[253] = 0;
+
+        VerifyOrQuit(!otDatasetAffectsConnectivity(instance, &tlvs));
+    }
+
+    {
+        // Well-formed: a single, correctly-sized `NetworkKeyTlv` (type 5, length 16).
+        otOperationalDatasetTlvs tlvs;
+
+        tlvs.mTlvs[0] = OT_MESHCOP_TLV_NETWORKKEY;
+        tlvs.mTlvs[1] = sizeof(otNetworkKey);
+        memset(&tlvs.mTlvs[2], 0x11, sizeof(otNetworkKey));
+        tlvs.mLength = 2 + sizeof(otNetworkKey);
+
+        // Must not crash; the returned value only depends on whether this key
+        // differs from the instance's own, which this test does not assert.
+        otDatasetAffectsConnectivity(instance, &tlvs);
+    }
+}
+
 } // namespace MeshCoP
 } // namespace ot
 
 int main(void)
 {
     ot::MeshCoP::TestDataset();
+    ot::MeshCoP::TestDatasetAffectsConnectivityRejectsMalformedTlvs();
 
     printf("All tests passed\n");
     return 0;


### PR DESCRIPTION
## Summary

`otDatasetAffectsConnectivity()` builds its working `Dataset` from raw caller-supplied
bytes via `SetFrom()`, which only checks the overall buffer length (`<= 254`) -- it
does not validate that each individual TLV's declared length is consistent with the
minimum size its type requires. `AffectsConnectivity()`/`AffectsNetworkKey()` then
perform several `Read<T>()` calls without any further validation. `Read<T>()` finds a
TLV by type and unconditionally reads `sizeof(T::ValueType)` bytes starting right
after the TLV header, regardless of what length that TLV actually declared.

A `NetworkKeyTlv` (type 5, requires 16 bytes) with a declared length of 0, placed at
the end of a full 254-byte buffer, passes the generic TLV-extent check (its own
header + declared length fits the buffer) but then causes a 16-byte read past both
the `mTlvs` array and the `Dataset` object's own trailing fields.

Every other `Dataset` entry point that accepts raw bytes already calls
`ValidateTlvs()` immediately after `SetFrom()` before touching any TLV value:
`mle.cpp`, `dataset_manager_ftd.cpp`, `tcat_agent.cpp`, and the `otDatasetIsValid`/
`otDatasetParseTlvs`/`otDatasetTlvsCompare` API functions. `otDatasetAffectsConnectivity`
was the one function found missing this call.

## Fix

Add the same `ValidateTlvs()` call used everywhere else in this codebase, right after
`SetFrom()` and before any TLV is read. On invalid input the function now safely
returns `false` instead of performing an out-of-bounds read.

## Testing

Added `TestDatasetAffectsConnectivityRejectsMalformedTlvs` to `tests/unit/test_dataset.cpp`,
covering:
- The malformed case (0-length `NetworkKeyTlv`) is now safely rejected.
- A well-formed dataset with a correctly-sized `NetworkKeyTlv` still works, confirming
  no regression for legitimate callers.

Verified locally with an ASan+UBSan build (`OT_PLATFORM=simulation`,
`-fsanitize=address,undefined`) of the `ot-test-dataset` unit test target: before this
change, the malformed-TLV case reliably reproduced an AddressSanitizer
stack-buffer-overflow (`READ of size 16`) inside `Dataset::Read<NetworkKeyTlv>`; after
the change, the same test input is safely rejected and the full test binary passes
cleanly under the sanitizer build.