### PR TITLE
[otci] drain pending lines in OtCliCommandRunner before timing out

### DIFF
--- a/tools/otci/otci/command_handlers.py
+++ b/tools/otci/otci/command_handlers.py
@@ -214,6 +214,24 @@ class OtCliCommandRunner(OTCommandHandler):
                         break
 
             if not done:
+                deadline = time.monotonic() + 0.1
+                while True:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+
+                    try:
+                        line = self.__pending_lines.get(timeout=remaining)
+                    except queue.Empty:
+                        break
+
+                    output.append(line)
+
+                    if match_line(line, expect_line):
+                        done = True
+                        break
+
+            if not done:
                 raise ExpectLineTimeoutError(expect_line)
 
         return output


### PR DESCRIPTION
In `OtCliCommandRunner.__expect_line()`, asynchronous commands loop for `timeout` iterations, calling `self.wait(1)` in each step. Under virtual-time simulation (`VIRTUAL_TIME=1`), `VirtualTime.go()` advances simulation time without delay when no timer events or radio traffic are scheduled on the node.

In each iteration, `self.wait(1)` calls `__pending_lines.get_nowait()`. Because the background reader thread (`__otcli_reader`) transfers output asynchronously from the subprocess stdout pipe to the queue, a fast-forwarding simulation can exhaust all timeout iterations in sub-millisecond wall-clock time before the reader thread has pushed the buffered lines (such as `Done`) into `__pending_lines`. This results in an intermittent and spurious `ExpectLineTimeoutError`.

This commit updates `__expect_line()` to drain `__pending_lines` with a short timeout (0.1s) after the timeout loop concludes, giving the reader thread sufficient time to process any remaining stdout lines before raising `ExpectLineTimeoutError`.