### PR TITLE
[thread-cert] handle BrokenPipeError on resetting node in simulator

### DIFF
--- a/tests/scripts/thread-cert/simulator.py
+++ b/tests/scripts/thread-cert/simulator.py
@@ -511,7 +511,12 @@ class VirtualTime(BaseSimulator):
         else:
             sock = self.devices[port].get('sock', None)
             if sock:
-                sent = sock.send(message)
+                try:
+                    sent = sock.send(message)
+                except (BrokenPipeError, ConnectionResetError):
+                    assert port in self._maybeoff_ports, f'The node {port} is unexpectedly off'
+                    dbg_print('skip sending message to off node', port)
+                    return
             else:
                 assert port in self._maybeoff_ports, f'The node {port} is unexpectedly off'
                 dbg_print('skip sending message to off node', port)


### PR DESCRIPTION
When a simulated node restarts (e.g. during `factoryreset`), the child process re-executes itself via `execvp`, disconnecting its UNIX domain socket connection to the virtual-time simulator.

If `VirtualTime._send_message()` attempts to send an event before the socket disconnection event has been processed by `selectors`, `sock.send()` raises `BrokenPipeError` or `ConnectionResetError`, even though the node is marked as temporarily offline in `_maybeoff_ports` (via `maybeoff=True`).

This commit catches `BrokenPipeError` and `ConnectionResetError` in `VirtualTime._send_message()`, verifying that the destination port is present in `_maybeoff_ports` and skipping delivery cleanly.