### PR TITLE
[dataset] clarify validity requirement for `otDatasetAffectsConnectivity`

### DIFF
--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -636,6 +636,9 @@ otError otDatasetUpdateTlvs(const otOperationalDataset *aDataset, otOperationalD
 /**
  * Indicates whether or not a given Operational Dataset (in TLVs format) affects connectivity.
  *
+ * The caller MUST ensure that the given @p aDatasetTlvs is valid (e.g., using `otDatasetIsValid()`). Otherwise, the
+ * behavior of this function is undefined.
+ *
  * A Dataset affects connectivity if it contains a different Channel, PAN ID, Mesh Local Prefix, Network Key, or
  * Security Policy than the current values in use.
  *

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (616)
+#define OPENTHREAD_API_VERSION (617)
 
 /**
  * @addtogroup api-instance


### PR DESCRIPTION
This commit updates the documentation for `otDatasetAffectsConnectivity()` to clarify that the caller must ensure the provided Dataset TLVs are valid (e.g., using `otDatasetIsValid()`), otherwise the behavior of the function is undefined.