### PR TITLE
[script] install expect in apt bootstrap dependencies

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -63,7 +63,7 @@ install_packages_apt()
 
     # apt-get update and install dependencies
     sudo apt-get update
-    sudo apt-get --no-install-recommends install -y g++ lsb-release cmake ninja-build shellcheck libgtest-dev libgmock-dev
+    sudo apt-get --no-install-recommends install -y g++ lsb-release cmake ninja-build shellcheck expect libgtest-dev libgmock-dev
 
     echo 'Installing GNU Arm Embedded Toolchain...'
 


### PR DESCRIPTION
## Summary

Install the `expect` package as part of the Ubuntu/Debian bootstrap dependencies.

## Motivation

`./script test expect` requires the `expect` executable, but Ubuntu 24.04 does not install it by default and the OpenThread bootstrap script currently does not install it.

This causes the expect-based test suite to fail on a clean environment with `expect: command not found`.

## Change

Add `expect` to the packages installed by `install_packages_apt()`.

Fixes #12412