### PR TITLE
[clang-tidy] exclude third_party headers from fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,3 +21,4 @@ Checks: >
   readability-static-accessed-through-instance
 WarningsAsErrors: '*'
 HeaderFilterRegex: '(examples|include|src).*(?<!third_party.*repo)'
+ExcludeHeaderFilterRegex: '(^|/)third_party/'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,5 +20,5 @@ Checks: >
   readability-simplify-boolean-expr,
   readability-static-accessed-through-instance
 WarningsAsErrors: '*'
-HeaderFilterRegex: '(examples|include|src).*(?<!third_party.*repo)'
+HeaderFilterRegex: '(examples|include|src)'
 ExcludeHeaderFilterRegex: '(^|/)third_party/'


### PR DESCRIPTION
## Summary

Explicitly exclude vendored `third_party` headers from clang-tidy diagnostics and fixes.

## Motivation

`script/make-pretty clang-tidy` operates on OpenThread source directories, but headers included by those translation units can still be considered by clang-tidy.

The current `HeaderFilterRegex` can match paths such as an `include` directory nested under `third_party`, allowing clang-tidy fixes to affect vendored sources.

LLVM 19.1 provides `ExcludeHeaderFilterRegex` specifically for excluding headers even when they otherwise match the normal header filter. OpenThread already requires clang-tidy 19.1.7.

## Change

Add:

`ExcludeHeaderFilterRegex: '(^|/)third_party/'`

to `.clang-tidy`.

Fixes #8920