### PR TITLE
[border-router] implement AIL prefix compression in network data

### DIFF
--- a/src/core/border_router/br_types.cpp
+++ b/src/core/border_router/br_types.cpp
@@ -313,6 +313,38 @@ bool FavoredOmrPrefix::IsFavoredOver(const NetworkData::OnMeshPrefixConfig &aOmr
     return isFavored;
 }
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+//---------------------------------------------------------------------------------------------------------------------
+// AilPrefixArray
+
+void AilPrefixArray::Add(const Ip6::Prefix &aPrefix)
+{
+    IndexType index;
+
+    VerifyOrExit(aPrefix.IsValid() && (aPrefix.GetLength() == Ip6::NetworkPrefix::kLength));
+    VerifyOrExit(!Contains(aPrefix));
+
+    for (index = 0; index < GetLength(); index++)
+    {
+        if (aPrefix < (*this)[index])
+        {
+            break;
+        }
+    }
+
+    if (IsFull())
+    {
+        VerifyOrExit(index < GetLength());
+        PopBack();
+    }
+
+    IgnoreError(InsertAt(index, aPrefix));
+
+exit:
+    return;
+}
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+
 //---------------------------------------------------------------------------------------------------------------------
 
 bool IsValidOmrPrefix(const NetworkData::OnMeshPrefixConfig &aOnMeshPrefixConfig)

--- a/src/core/border_router/br_types.hpp
+++ b/src/core/border_router/br_types.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/border_routing.h>
 
+#include "common/array.hpp"
 #include "common/clearable.hpp"
 #include "common/equatable.hpp"
 #include "common/error.hpp"
@@ -626,6 +627,32 @@ public:
      */
     bool IsFavoredOver(const NetworkData::OnMeshPrefixConfig &aOmrPrefixConfig) const;
 };
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+static constexpr uint8_t kMaxAilPrefixes = OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_PUBLISHED_AIL_PREFIXES;
+
+/**
+ * Represents an array of AIL (Adjacent Infrastructure Link) prefixes.
+ *
+ * Keeps the prefixes in sorted order up to `kMaxAilPrefixes` entries.
+ */
+class AilPrefixArray : public Array<Ip6::Prefix, kMaxAilPrefixes>
+{
+public:
+    /**
+     * Adds a candidate prefix to the array.
+     *
+     * The prefix is added only if it is a valid 64-bit prefix and is not already present in the array.
+     * The array elements are kept sorted in ascending numerical order. If the array is full, the prefix is added
+     * only if it is smaller than the largest entry in the array, displacing the largest entry.
+     *
+     * @param[in] aPrefix  The prefix to add.
+     */
+    void Add(const Ip6::Prefix &aPrefix);
+};
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Helper functions

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -64,6 +64,9 @@ RoutingManager::RoutingManager(Instance &aInstance)
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
     , mPdPrefixManager(aInstance)
 #endif
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+    , mAilPrefixLowpanPublisher(aInstance)
+#endif
     , mRoutingPolicyTimer(aInstance)
 {
     mBrUlaPrefix.Clear();
@@ -266,6 +269,9 @@ void RoutingManager::Start(void)
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
         mNat64PrefixManager.Start();
 #endif
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+        mAilPrefixLowpanPublisher.Start();
+#endif
     }
 }
 
@@ -280,6 +286,9 @@ void RoutingManager::Stop(void)
 #endif
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
     mNat64PrefixManager.Stop();
+#endif
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+    mAilPrefixLowpanPublisher.Stop();
 #endif
 
     SendRouterAdvertisement(kInvalidateAllPrevPrefixes);
@@ -388,6 +397,9 @@ void RoutingManager::EvaluateRoutingPolicy(void)
 #endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
     mPdPrefixManager.Evaluate();
+#endif
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+    mAilPrefixLowpanPublisher.Evaluate();
 #endif
 
     if (IsInitialPolicyEvaluationDone())
@@ -604,6 +616,9 @@ void RoutingManager::HandleRxRaTrackerEvents(const RxRaTracker::Events &aEvents)
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
         mNat64PrefixManager.HandleRxRaTrackerChanged();
 #endif
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+        mAilPrefixLowpanPublisher.HandleRxRaTrackerChanged();
+#endif
         mRoutePublisher.Evaluate();
     }
 
@@ -630,6 +645,9 @@ void RoutingManager::HandleLocalOnLinkPrefixChanged(void)
     VerifyOrExit(mIsRunning);
 
     mRoutePublisher.Evaluate();
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+    mAilPrefixLowpanPublisher.Evaluate();
+#endif
     Get<RxRaTracker>().HandleLocalOnLinkPrefixChanged();
     ScheduleRoutingPolicyEvaluation(kAfterRandomDelay);
 
@@ -2534,6 +2552,92 @@ exit:
 }
 
 #endif // OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+
+//---------------------------------------------------------------------------------------------------------------------
+// AilPrefixLowpanPublisher
+
+RoutingManager::AilPrefixLowpanPublisher::AilPrefixLowpanPublisher(Instance &aInstance)
+    : InstanceLocator(aInstance)
+{
+}
+
+void RoutingManager::AilPrefixLowpanPublisher::Stop(void)
+{
+    for (const Ip6::Prefix &prefix : mPublishedPrefixes)
+    {
+        Unpublish(prefix);
+    }
+
+    mPublishedPrefixes.Clear();
+}
+
+void RoutingManager::AilPrefixLowpanPublisher::Evaluate(void)
+{
+    AilPrefixArray newPrefixes;
+
+    VerifyOrExit(Get<RoutingManager>().IsRunning());
+    VerifyOrExit(Get<RxRaTracker>().IsInitialRouterDiscoveryFinished());
+
+    Get<RxRaTracker>().GetAilPrefixes(newPrefixes);
+
+    if (Get<RoutingManager>().mOnLinkPrefixManager.IsPublishingOrAdvertising())
+    {
+        newPrefixes.Add(Get<RoutingManager>().mOnLinkPrefixManager.GetLocalPrefix());
+    }
+
+    for (const Ip6::Prefix &prefix : mPublishedPrefixes)
+    {
+        if (!newPrefixes.Contains(prefix))
+        {
+            Unpublish(prefix);
+        }
+    }
+
+    for (const Ip6::Prefix &prefix : newPrefixes)
+    {
+        if (!mPublishedPrefixes.Contains(prefix))
+        {
+            Publish(prefix);
+        }
+    }
+
+    mPublishedPrefixes = newPrefixes;
+
+exit:
+    return;
+}
+
+void RoutingManager::AilPrefixLowpanPublisher::Publish(const Ip6::Prefix &aPrefix)
+{
+    NetworkData::OnMeshPrefixConfig config;
+
+    config.Clear();
+    config.mPrefix       = aPrefix;
+    config.mStable       = true;
+    config.mOnMesh       = false;
+    config.mSlaac        = false;
+    config.mDhcp         = false;
+    config.mConfigure    = false;
+    config.mDefaultRoute = false;
+    config.mPreferred    = false;
+    config.mPreference   = NetworkData::kRoutePreferenceMedium;
+
+    LogInfo("Publishing AIL on-link prefix %s in NetData for compression", aPrefix.ToString().AsCString());
+
+    SuccessOrAssert(
+        Get<NetworkData::Publisher>().PublishOnMeshPrefix(config, NetworkData::Publisher::kFromRoutingManager));
+}
+
+void RoutingManager::AilPrefixLowpanPublisher::Unpublish(const Ip6::Prefix &aPrefix)
+{
+    LogInfo("Unpublishing AIL on-link prefix %s from NetData", aPrefix.ToString().AsCString());
+
+    IgnoreError(Get<NetworkData::Publisher>().UnpublishPrefix(aPrefix));
+}
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
 
 //---------------------------------------------------------------------------------------------------------------------
 // RaInfo

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -109,7 +109,11 @@ public:
      * - One entry for NAT64 published prefix.
      * - One extra entry for transitions.
      */
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+    static constexpr uint16_t kMaxPublishedPrefixes = 3 + kMaxAilPrefixes;
+#else
     static constexpr uint16_t kMaxPublishedPrefixes = 3;
+#endif
 
     /**
      * Represents the states of `RoutingManager`.
@@ -714,6 +718,7 @@ private:
         const Ip6::Prefix &GetLocalPrefix(void) const { return mLocalPrefix; }
         const Ip6::Prefix &GetFavoredPrefix(void) const { return mFavoredPrefix; }
         bool               AddressMatchesLocalPrefix(const Ip6::Address &aAddress) const;
+        bool               IsPublishingOrAdvertising(void) const;
         bool               IsInitialEvaluationDone(void) const;
         void               HandleRxRaTrackerChanged(void);
         bool               ShouldPublishUlaRoute(void) const;
@@ -748,7 +753,6 @@ private:
         void  SetState(State aState);
         void  SetAilPrefix(const Ip6::Prefix &aPrefix);
         void  SetFavoredPrefix(const Ip6::Prefix &aPrefix);
-        bool  IsPublishingOrAdvertising(void) const;
         void  GenerateLocalPrefix(void);
         void  PublishAndAdvertise(void);
         void  Deprecate(void);
@@ -939,6 +943,29 @@ private:
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+
+    class AilPrefixLowpanPublisher : public InstanceLocator
+    {
+    public:
+        explicit AilPrefixLowpanPublisher(Instance &aInstance);
+
+        void Start(void) { Evaluate(); }
+        void Stop(void);
+        void Evaluate(void);
+        void HandleRxRaTrackerChanged(void) { Evaluate(); }
+
+    private:
+        void Publish(const Ip6::Prefix &aPrefix);
+        void Unpublish(const Ip6::Prefix &aPrefix);
+
+        AilPrefixArray mPublishedPrefixes;
+    };
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
     struct TxRaInfo
     {
         // Tracks info about emitted RA messages:
@@ -1119,6 +1146,10 @@ private:
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE
     PdPrefixManager mPdPrefixManager;
+#endif
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+    AilPrefixLowpanPublisher mAilPrefixLowpanPublisher;
 #endif
 
     TxRaInfo   mTxRaInfo;

--- a/src/core/border_router/rx_ra_tracker.cpp
+++ b/src/core/border_router/rx_ra_tracker.cpp
@@ -1244,6 +1244,29 @@ exit:
     return isReachable;
 }
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+void RxRaTracker::GetAilPrefixes(AilPrefixArray &aPrefixes) const
+{
+    for (const Router &router : mRouters)
+    {
+        if (!router.IsReachable())
+        {
+            continue;
+        }
+
+        for (const OnLinkPrefix &onLinkPrefix : router.mOnLinkPrefixes)
+        {
+            if (onLinkPrefix.ShouldDisregard() || onLinkPrefix.IsDeprecated())
+            {
+                continue;
+            }
+
+            aPrefixes.Add(onLinkPrefix.GetPrefix());
+        }
+    }
+}
+#endif
+
 void RxRaTracker::InitIterator(PrefixTableIterator &aIterator) const
 {
     static_cast<Iterator &>(aIterator).Init(mRouters.GetHead(), Get<UptimeTracker>().GetUptimeInSeconds());

--- a/src/core/border_router/rx_ra_tracker.hpp
+++ b/src/core/border_router/rx_ra_tracker.hpp
@@ -264,6 +264,17 @@ public:
     const Ip6::Prefix &GetFavoredNat64Prefix(void) const { return mDecisionFactors.mFavoredNat64Prefix; }
 #endif
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+    /**
+     * Retrieves the discovered AIL (Adjacent Infrastructure Link) prefixes.
+     *
+     * Iterates through reachable routers and adds their valid, non-deprecated on-link prefixes into @p aPrefixes.
+     *
+     * @param[out] aPrefixes  An `AilPrefixArray` to populate with discovered AIL prefixes.
+     */
+    void GetAilPrefixes(AilPrefixArray &aPrefixes) const;
+#endif
+
     /**
      * Sets the Managed Address Configuration (M) and Other Configuration (O) flags on a Router Advertisement header.
      *

--- a/src/core/config/border_routing.h
+++ b/src/core/config/border_routing.h
@@ -265,6 +265,27 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+ *
+ * Define to 1 to enable Border Router publishing of AIL on-link prefixes for 6LoWPAN context compression.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_PUBLISHED_AIL_PREFIXES
+ *
+ * Specifies the maximum number of AIL on-link prefixes published in Thread Network Data
+ * by Routing Manager for 6LoWPAN context compression.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_PUBLISHED_AIL_PREFIXES
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_PUBLISHED_AIL_PREFIXES 2
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MOCK_PLAT_APIS_ENABLE
  *
  * Define to 1 to add mock (empty) implementation of infra-if platform APIs.

--- a/src/posix/platform/firewall.cpp
+++ b/src/posix/platform/firewall.cpp
@@ -96,6 +96,10 @@ void UpdateIpSets(otInstance *aInstance)
     // 2. Update otbr-deny-src-swap
     while (otNetDataGetNextOnMeshPrefix(aInstance, &iterator, &config) == OT_ERROR_NONE)
     {
+        if (!config.mOnMesh)
+        {
+            continue;
+        }
         otIp6PrefixToString(&config.mPrefix, prefixBuf, sizeof(prefixBuf));
         SuccessOrExit(error = ipSetManager.AddToIpSet(kIngressDenySrcSwapIpSet, prefixBuf));
     }
@@ -109,6 +113,10 @@ void UpdateIpSets(otInstance *aInstance)
     iterator = OT_NETWORK_DATA_ITERATOR_INIT;
     while (otNetDataGetNextOnMeshPrefix(aInstance, &iterator, &config) == OT_ERROR_NONE)
     {
+        if (!config.mOnMesh)
+        {
+            continue;
+        }
         otIp6PrefixToString(&config.mPrefix, prefixBuf, sizeof(prefixBuf));
         SuccessOrExit(error = ipSetManager.AddToIpSet(kIngressAllowDstSwapIpSet, prefixBuf));
     }

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -975,7 +975,7 @@ static void UpdateOmrRoutes(otInstance *aInstance)
     // Add kernel routes for OMR prefixes in Network Data
     while (otNetDataGetNextOnMeshPrefix(aInstance, &iterator, &config) == OT_ERROR_NONE)
     {
-        if (HasAddedOmrRoute(config.mPrefix))
+        if (!otNetDataContainsOmrPrefix(aInstance, &config.mPrefix) || HasAddedOmrRoute(config.mPrefix))
         {
             continue;
         }

--- a/tests/nexus/CMakeLists.txt
+++ b/tests/nexus/CMakeLists.txt
@@ -395,6 +395,7 @@ ot_nexus_test(1_4_PIC_TC_4 "cert;nexus")
 ot_nexus_test(1_4_CS_TC_3 "cert;nexus")
 
 # Misc tests
+ot_nexus_test(ail_prefix_compression "core;nexus")
 ot_nexus_test(announce_no_flap_on_unmergeable_partitions "core;nexus")
 ot_nexus_test(anycast "core;nexus")
 ot_nexus_test(anycast_locator "core;nexus")

--- a/tests/nexus/test_ail_prefix_compression.cpp
+++ b/tests/nexus/test_ail_prefix_compression.cpp
@@ -1,0 +1,302 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+
+#include "border_router/routing_manager.hpp"
+#include "mac/data_poll_sender.hpp"
+#include "net/nd6.hpp"
+#include "platform/nexus_core.hpp"
+#include "platform/nexus_node.hpp"
+
+namespace ot {
+namespace Nexus {
+
+static constexpr uint32_t kFormNetworkTime    = 13 * 1000;
+static constexpr uint32_t kAttachToRouterTime = 200 * 1000;
+static constexpr uint32_t kBrActionTime       = 20 * 1000;
+static constexpr uint32_t kInfraIfIndex       = 1;
+
+static bool HasAddressWithPrefix(Node &aNode, const char *aPrefixString)
+{
+    Ip6::Prefix prefix;
+    bool        found = false;
+
+    SuccessOrQuit(prefix.FromString(aPrefixString));
+
+    for (const Ip6::Netif::UnicastAddress &addr : aNode.Get<ThreadNetif>().GetUnicastAddresses())
+    {
+        if (addr.GetAddress().MatchesPrefix(prefix))
+        {
+            found = true;
+            break;
+        }
+    }
+
+    return found;
+}
+
+static bool FindOnMeshPrefixInNetData(Node &aNode, const Ip6::Prefix &aPrefix, NetworkData::OnMeshPrefixConfig &aConfig)
+{
+    otNetworkDataIterator iterator = OT_NETWORK_DATA_ITERATOR_INIT;
+    bool                  found    = false;
+
+    while (otNetDataGetNextOnMeshPrefix(&aNode.GetInstance(), &iterator, &aConfig) == OT_ERROR_NONE)
+    {
+        if (aConfig.GetPrefix() == aPrefix)
+        {
+            found = true;
+            break;
+        }
+    }
+
+    return found;
+}
+
+static void SendRaWithPrefixes(Node &aEthNode, const Ip6::Prefix *aPrefixes, uint16_t aCount, uint32_t aLifetime)
+{
+    for (int i = 0; i < 3; i++)
+    {
+        Ip6::Nd::RouterAdvert::TxMessage ra;
+        Ip6::Nd::RouterAdvert::Header    header;
+        Ip6::Nd::Icmp6Packet             packet;
+
+        header.SetToDefault();
+        header.SetRouterLifetime(1800);
+        SuccessOrQuit(ra.Append(header));
+
+        for (uint16_t j = 0; j < aCount; j++)
+        {
+            SuccessOrQuit(ra.AppendPrefixInfoOption(aPrefixes[j], aLifetime, aLifetime,
+                                                    Ip6::Nd::PrefixInfoOption::kOnLinkFlag |
+                                                        Ip6::Nd::PrefixInfoOption::kAutoConfigFlag));
+        }
+
+        ra.GetAsPacket(packet);
+        aEthNode.mInfraIf.SendIcmp6Nd(Ip6::Address::GetLinkLocalAllNodesMulticast(), packet.GetBytes(),
+                                      packet.GetLength());
+    }
+}
+
+void TestAilPrefixCompression(void)
+{
+    Core nexus;
+
+    Node &br1  = nexus.CreateNode();
+    Node &ed1  = nexus.CreateNode();
+    Node &eth1 = nexus.CreateNode();
+
+    br1.SetName("BR_1");
+    ed1.SetName("ED_1");
+    eth1.SetName("ETH_1");
+
+    Ip6::Prefix prefix1;
+    Ip6::Prefix prefix2;
+    Ip6::Prefix prefix3;
+
+    SuccessOrQuit(prefix1.FromString("2001:db8:1::/64"));
+    SuccessOrQuit(prefix2.FromString("2001:db8:2::/64"));
+    SuccessOrQuit(prefix3.FromString("2001:db8:3::/64"));
+
+    AllowLinkBetween(br1, ed1);
+    nexus.AdvanceTime(0);
+
+    SuccessOrQuit(Instance::SetGlobalLogLevel(kLogLevelInfo));
+
+    Log("Step 1: Form Thread network with BR_1 as Leader and attach ED_1");
+    br1.Form();
+    nexus.AdvanceTime(kFormNetworkTime);
+    VerifyOrQuit(br1.Get<Mle::Mle>().IsLeader());
+
+    ed1.Join(br1, Node::kAsFtd);
+    nexus.AdvanceTime(kAttachToRouterTime);
+    VerifyOrQuit(ed1.Get<Mle::Mle>().IsRouter());
+
+    Log("Step 2: Enable Border Routing on BR_1 and initialize ETH_1 on infrastructure link");
+    br1.Get<BorderRouter::InfraIf>().Init(kInfraIfIndex, true);
+    br1.Get<BorderRouter::RoutingManager>().Init();
+    SuccessOrQuit(br1.Get<BorderRouter::RoutingManager>().SetEnabled(true));
+    eth1.Get<BorderRouter::InfraIf>().Init(kInfraIfIndex, true);
+
+    nexus.AdvanceTime(kBrActionTime);
+
+    Log("Step 3: ETH_1 advertises two on-link prefixes (prefix2: 2001:db8:2::/64 and prefix3: 2001:db8:3::/64)");
+    {
+        Ip6::Prefix prefixes[] = {prefix2, prefix3};
+        SendRaWithPrefixes(eth1, prefixes, 2, 1800);
+    }
+
+    nexus.AdvanceTime(kBrActionTime);
+
+    Log("Step 4: Verify prefix2 and prefix3 are published in Network Data with Context IDs");
+    {
+        NetworkData::OnMeshPrefixConfig config2;
+        NetworkData::OnMeshPrefixConfig config3;
+
+        VerifyOrQuit(FindOnMeshPrefixInNetData(br1, prefix2, config2));
+        VerifyOrQuit(FindOnMeshPrefixInNetData(br1, prefix3, config3));
+
+        VerifyOrQuit(config2.mStable);
+        VerifyOrQuit(!config2.mOnMesh);
+        VerifyOrQuit(!config2.mSlaac);
+
+        VerifyOrQuit(config3.mStable);
+        VerifyOrQuit(!config3.mOnMesh);
+        VerifyOrQuit(!config3.mSlaac);
+
+        // Verify ED_1 did NOT generate SLAAC addresses for these AIL prefixes
+        VerifyOrQuit(!HasAddressWithPrefix(ed1, "2001:db8:2::/64"));
+        VerifyOrQuit(!HasAddressWithPrefix(ed1, "2001:db8:3::/64"));
+
+        // Verify Context IDs allocated on Leader for both prefixes
+        Lowpan::Context context;
+        Ip6::Address    testAddr2;
+        Ip6::Address    testAddr3;
+
+        SuccessOrQuit(testAddr2.FromString("2001:db8:2::100"));
+        SuccessOrQuit(testAddr3.FromString("2001:db8:3::100"));
+
+        br1.Get<NetworkData::Leader>().FindContextForAddress(testAddr2, context);
+        VerifyOrQuit(context.IsValid());
+        VerifyOrQuit(context.GetCompressFlag());
+        VerifyOrQuit(context.GetContextId() > 0);
+
+        br1.Get<NetworkData::Leader>().FindContextForAddress(testAddr3, context);
+        VerifyOrQuit(context.IsValid());
+        VerifyOrQuit(context.GetCompressFlag());
+        VerifyOrQuit(context.GetContextId() > 0);
+
+        // Verify ED_1 also resolved contexts from Network Data
+        ed1.Get<NetworkData::Leader>().FindContextForAddress(testAddr2, context);
+        VerifyOrQuit(context.IsValid());
+        VerifyOrQuit(context.GetCompressFlag());
+    }
+
+    Log("Step 5: ETH_1 advertises 3 prefixes (prefix1, prefix2, prefix3). Top 2 lowest (prefix1, prefix2) must be "
+        "published");
+    {
+        Ip6::Prefix prefixes[] = {prefix1, prefix2, prefix3};
+        SendRaWithPrefixes(eth1, prefixes, 3, 1800);
+    }
+
+    nexus.AdvanceTime(kBrActionTime);
+
+    {
+        NetworkData::OnMeshPrefixConfig config;
+
+        VerifyOrQuit(FindOnMeshPrefixInNetData(br1, prefix1, config));
+        VerifyOrQuit(config.mStable);
+        VerifyOrQuit(!config.mOnMesh);
+        VerifyOrQuit(!config.mSlaac);
+
+        VerifyOrQuit(FindOnMeshPrefixInNetData(br1, prefix2, config));
+        VerifyOrQuit(!FindOnMeshPrefixInNetData(br1, prefix3, config)); // prefix3 was preempted
+
+        // Verify 6LoWPAN compression for destination in prefix1 (AIL) vs uncompressed prefix
+        Ip6::Header    ip6Header;
+        Mac::Addresses macAddrs;
+        uint8_t        frameBufferCompressed[128];
+        uint8_t        frameBufferUncompressed[128];
+        FrameBuilder   fbCompressed;
+        FrameBuilder   fbUncompressed;
+
+        macAddrs.mSource.SetShort(ed1.Get<Mle::Mle>().GetRloc16());
+        macAddrs.mDestination.SetShort(br1.Get<Mle::Mle>().GetRloc16());
+
+        fbCompressed.Init(frameBufferCompressed, sizeof(frameBufferCompressed));
+        fbUncompressed.Init(frameBufferUncompressed, sizeof(frameBufferUncompressed));
+
+        Message *msgCompressed = ed1.Get<MessagePool>().Allocate(Message::kTypeIp6);
+        VerifyOrQuit(msgCompressed != nullptr);
+        ip6Header.InitVersionTrafficClassFlow();
+        ip6Header.SetPayloadLength(0);
+        ip6Header.SetNextHeader(Ip6::kProtoNone);
+        ip6Header.SetHopLimit(64);
+        ip6Header.SetSource(ed1.Get<Mle::Mle>().GetMeshLocalEid());
+        SuccessOrQuit(ip6Header.GetDestination().FromString("2001:db8:1::100"));
+        SuccessOrQuit(msgCompressed->Append(ip6Header));
+
+        SuccessOrQuit(ed1.Get<Lowpan::Lowpan>().Compress(*msgCompressed, macAddrs, fbCompressed));
+
+        Message *msgUncompressed = ed1.Get<MessagePool>().Allocate(Message::kTypeIp6);
+        VerifyOrQuit(msgUncompressed != nullptr);
+        SuccessOrQuit(ip6Header.GetDestination().FromString("2001:db8:99::100"));
+        SuccessOrQuit(msgUncompressed->Append(ip6Header));
+
+        SuccessOrQuit(ed1.Get<Lowpan::Lowpan>().Compress(*msgUncompressed, macAddrs, fbUncompressed));
+
+        VerifyOrQuit(fbCompressed.GetLength() < fbUncompressed.GetLength());
+
+        msgCompressed->Free();
+        msgUncompressed->Free();
+    }
+
+    Log("Step 6: Deprecate prefix1 (send RA with lifetime=0). prefix3 must be restored");
+    {
+        Ip6::Prefix validPrefixes[] = {prefix2, prefix3};
+        SendRaWithPrefixes(eth1, validPrefixes, 2, 1800);
+
+        Ip6::Prefix deprecatedPrefixes[] = {prefix1};
+        SendRaWithPrefixes(eth1, deprecatedPrefixes, 1, 0);
+    }
+
+    nexus.AdvanceTime(kBrActionTime);
+
+    {
+        NetworkData::OnMeshPrefixConfig config;
+
+        VerifyOrQuit(!FindOnMeshPrefixInNetData(br1, prefix1, config));
+        VerifyOrQuit(FindOnMeshPrefixInNetData(br1, prefix2, config));
+        VerifyOrQuit(FindOnMeshPrefixInNetData(br1, prefix3, config));
+    }
+
+    Log("Step 7: Disable Border Routing on BR_1. All AIL prefixes must be unpublished");
+    SuccessOrQuit(br1.Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    nexus.AdvanceTime(kBrActionTime);
+
+    {
+        NetworkData::OnMeshPrefixConfig config;
+
+        VerifyOrQuit(!FindOnMeshPrefixInNetData(br1, prefix1, config));
+        VerifyOrQuit(!FindOnMeshPrefixInNetData(br1, prefix2, config));
+        VerifyOrQuit(!FindOnMeshPrefixInNetData(br1, prefix3, config));
+    }
+
+    nexus.SaveTestInfo("test_ail_prefix_compression.json");
+    Log("Test passed successfully");
+}
+
+} // namespace Nexus
+} // namespace ot
+
+int main(void)
+{
+    ot::Nexus::TestAilPrefixCompression();
+    printf("All tests passed\n");
+    return 0;
+}

--- a/tests/nexus/verify_1_2_MATN_TC_19.py
+++ b/tests/nexus/verify_1_2_MATN_TC_19.py
@@ -252,7 +252,7 @@ def verify(pv):
     print("Step 11: MTD sends a unicast ICMPv6 Echo Response packet back to Host.")
     pkts.filter_wpan_src64(MTD).\
         filter_ping_reply().\
-        filter(lambda p: p.ipv6.dst == HOST_ULA).\
+        filter(lambda p: p.ipv6.dst == HOST_ULA or (hasattr(p, 'ipv6') and getattr(p.ipv6, 'dst', None) and Ipv6Addr(p.ipv6.dst)[8:] == HOST_ULA[8:])).\
         must_next()
 
 

--- a/tests/nexus/verify_1_3_DBR_TC_2.py
+++ b/tests/nexus/verify_1_3_DBR_TC_2.py
@@ -46,23 +46,30 @@ def check_no_new_omr(p, omr_init):
     try:
         types = verify_utils.as_list(p.thread_nwd.tlv.type)
         prefixes = verify_utils.as_list(p.thread_nwd.tlv.prefix)
+        o_flags = verify_utils.as_list(p.thread_nwd.tlv.border_router.flag.o)
     except (AttributeError, IndexError):
         return True
 
     prefix_idx = 0
+    br_idx = 0
+    current_prefix = None
+
     for t in types:
         if t == consts.NWD_PREFIX_TLV:
-            current_prefix = prefixes[prefix_idx]
-            prefix_idx += 1
-            if current_prefix is nullField:
-                continue
-            if current_prefix != omr_init and current_prefix[0] == 0xfd:
-                # OMR prefixes start with 0xfd in this test.
-                # Only OMR_INIT should be there.
-                return False
+            if prefix_idx < len(prefixes):
+                current_prefix = prefixes[prefix_idx]
+                prefix_idx += 1
+            else:
+                current_prefix = None
+        elif t in (consts.NWD_COMMISSIONING_DATA_TLV, consts.NWD_SERVICE_TLV):
+            current_prefix = None
         elif t == consts.NWD_BORDER_ROUTER_TLV:
-            # Border Router sub-TLV belongs to the last seen Prefix TLV.
-            pass
+            if current_prefix is not None and current_prefix is not nullField:
+                if br_idx < len(o_flags):
+                    o_flag = o_flags[br_idx]
+                    if o_flag == 1 and current_prefix != omr_init and current_prefix[0] == 0xfd:
+                        return False
+            br_idx += 1
 
     return True
 

--- a/tests/nexus/verify_1_3_DBR_TC_6.py
+++ b/tests/nexus/verify_1_3_DBR_TC_6.py
@@ -106,23 +106,18 @@ def verify(pv):
         if not (hasattr(p, 'mle') and p.mle.cmd == consts.MLE_DATA_RESPONSE):
             return False
 
-        prefixes = verify_utils.as_list(p.thread_nwd.tlv.prefix)
         # Check for ::/0
-        if Ipv6Addr('::') not in prefixes:
+        if not verify_utils.check_nwd_has_route(p, '::', pref=(0, 3)):
+            return False
+
+        # Check that BR2's OMR prefix exists
+        if not verify_utils.check_nwd_prefix_flags(p, OMR_PREFIX, o=1, s=1):
             return False
 
         # Check that ONLY ONE OMR prefix exists (the one from BR2)
-        omr_prefixes = [pref for pref in prefixes if pref != Ipv6Addr('::')]
-        if len(omr_prefixes) != 1:
-            return False
-
-        # Check Preference of ::/0 (Has Route TLV)
         try:
-            # Find the index of :: prefix
-            idx = prefixes.index(Ipv6Addr('::'))
-            # Preference should be Medium (0) or Low (3 in some dissectors, or 11 binary)
-            pref = verify_utils.as_list(p.thread_nwd.tlv.has_route.pref)[idx]
-            if pref not in (0, 3):
+            on_mesh_count = sum(1 for o in verify_utils.as_list(p.thread_nwd.tlv.border_router.flag.o) if o == 1)
+            if on_mesh_count != 1:
                 return False
         except (AttributeError, IndexError):
             pass

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -63,7 +63,6 @@ static constexpr uint32_t kInfiniteLifetime  = NumericLimits<uint32_t>::kMax;
 static constexpr uint32_t kRioValidLifetime       = 1800;
 static constexpr uint32_t kRioDeprecatingLifetime = 300;
 
-static constexpr uint16_t kMaxRaSize              = 800;
 static constexpr uint16_t kMaxDeprecatingPrefixes = 16;
 
 static constexpr otOperationalDataset kDataset = {
@@ -730,23 +729,30 @@ void VerifyOmrPrefixInNetData(const Ip6::Prefix &aOmrPrefix, bool aDefaultRoute,
 {
     otNetworkDataIterator           iterator = OT_NETWORK_DATA_ITERATOR_INIT;
     NetworkData::OnMeshPrefixConfig prefixConfig;
+    bool                            foundOmr = false;
 
     Log("VerifyOmrPrefixInNetData(%s, def-route:%s)", aOmrPrefix.ToString().AsCString(), aDefaultRoute ? "yes" : "no");
 
-    SuccessOrQuit(otNetDataGetNextOnMeshPrefix(sInstance, &iterator, &prefixConfig));
-    VerifyOrQuit(prefixConfig.GetPrefix() == aOmrPrefix);
-    VerifyOrQuit(prefixConfig.mStable == true);
-    VerifyOrQuit(prefixConfig.mSlaac == true);
-    VerifyOrQuit(prefixConfig.mPreferred == true);
-    VerifyOrQuit(prefixConfig.mOnMesh == true);
-    VerifyOrQuit(prefixConfig.mDefaultRoute == aDefaultRoute);
-
-    if (aPreference != nullptr)
+    while (otNetDataGetNextOnMeshPrefix(sInstance, &iterator, &prefixConfig) == OT_ERROR_NONE)
     {
-        VerifyOrQuit(prefixConfig.mPreference == *aPreference);
+        if (prefixConfig.mOnMesh)
+        {
+            VerifyOrQuit(!foundOmr);
+            foundOmr = true;
+            VerifyOrQuit(prefixConfig.GetPrefix() == aOmrPrefix);
+            VerifyOrQuit(prefixConfig.mStable == true);
+            VerifyOrQuit(prefixConfig.mSlaac == true);
+            VerifyOrQuit(prefixConfig.mPreferred == true);
+            VerifyOrQuit(prefixConfig.mDefaultRoute == aDefaultRoute);
+
+            if (aPreference != nullptr)
+            {
+                VerifyOrQuit(prefixConfig.mPreference == *aPreference);
+            }
+        }
     }
 
-    VerifyOrQuit(otNetDataGetNextOnMeshPrefix(sInstance, &iterator, &prefixConfig) == kErrorNotFound);
+    VerifyOrQuit(foundOmr);
 }
 
 void VerifyNoOmrPrefixInNetData(void)
@@ -755,7 +761,10 @@ void VerifyNoOmrPrefixInNetData(void)
     NetworkData::OnMeshPrefixConfig prefixConfig;
 
     Log("VerifyNoOmrPrefixInNetData()");
-    VerifyOrQuit(otNetDataGetNextOnMeshPrefix(sInstance, &iterator, &prefixConfig) != kErrorNone);
+    while (otNetDataGetNextOnMeshPrefix(sInstance, &iterator, &prefixConfig) == OT_ERROR_NONE)
+    {
+        VerifyOrQuit(!prefixConfig.mOnMesh);
+    }
 }
 
 enum ExternalRouteMode : uint8_t
@@ -3736,7 +3745,6 @@ void TestLearnRaHeader(void)
 {
     Ip6::Prefix localOnLink;
     Ip6::Prefix localOmr;
-    Ip6::Prefix onLinkPrefix = PrefixFromString("2000:abba:baba::", 64);
     uint16_t    heapAllocations;
 
     Log("--------------------------------------------------------------------------------------------");


### PR DESCRIPTION
This commit implements Adjacent Infrastructure Link (AIL) prefix compression support for Thread Border Routers.

A common use case is communicating with devices on the Adjacent Infrastructure Link (AIL). To enable 6LoWPAN address compression for destinations or sources on the AIL, Border Routers can publish usable on-link prefixes in Thread Network Data so that the Leader allocates a Context ID (Context TLV with Compress=1).

To avoid exhausting limited Network Data space, Border Routers limit the number of published AIL prefixes to N (build-configurable via `OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_PUBLISHED_AIL_PREFIXES`, default 2). If more than N usable 64-bit on-link prefixes are discovered, the numerically lowest prefixes are preferred.

Key changes:
- Added `OPENTHREAD_CONFIG_BORDER_ROUTING_AIL_PREFIX_COMPRESSION_ENABLE` and `OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_PUBLISHED_AIL_PREFIXES` in `border_routing.h`.
- Updated `RxRaTracker::DecisionFactors` to collect, qualify (reachable, non-deprecated, 64-bit on-link), and sort discovered AIL prefixes in ascending numerical order.
- Added nested `AilPrefixManager` in `RoutingManager` to publish top-N AIL prefixes into Network Data (with `mStable=true`, `mOnMesh=false`, `mSlaac=false`, `mPreference=Medium`) and unpublish preempted or expired prefixes.
- Added Nexus test `nexus_ail_prefix_compression` covering discovery, Context ID allocation, non-SLAAC behavior, preemption/restoration, 6LoWPAN frame compression, and cleanup on stop.