### PR TITLE
[meshcop] verify tlv header fits before length read in ValidateTlvs

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -109,7 +109,7 @@ Error Dataset::ValidateTlvs(void) const
 
     for (const Tlv *tlv = GetTlvsStart(); tlv < end; tlv = tlv->GetNext())
     {
-        VerifyOrExit(!tlv->IsExtended() && ((tlv + 1) <= end) && (tlv->GetNext() <= end));
+        VerifyOrExit(((tlv + 1) <= end) && !tlv->IsExtended() && (tlv->GetNext() <= end));
         VerifyOrExit(IsTlvValid(*tlv));
 
         // Ensure there are no duplicate TLVs.


### PR DESCRIPTION
ValidateTlvs() reads a TLV length byte before it has confirmed the 2-byte header is in bounds:

- `!tlv->IsExtended()` reads the length byte, but it runs ahead of the `(tlv + 1) <= end` guard in the same `VerifyOrExit`, so a trailing 1-byte partial TLV pulls one byte past the copied dataset data
- reachable from untrusted input: `Mle::RxMessage::ReadAndSaveDataset()` copies an Active/Pending Dataset TLV value into the buffer and then calls this, and the same gate covers MGMT_SET and TCAT
- `Tlv::FindTlv()` and `NetworkData::ValidateTlvs()` already put the header-fits check first, so this just brings the dataset path in line

Reordered the compound check so the bounds test precedes the length read.