### PR TITLE
[test] fix off-by-one bounds check in mock platform SettingsGet

### DIFF
--- a/tests/gtest/fake_platform.cpp
+++ b/tests/gtest/fake_platform.cpp
@@ -225,7 +225,7 @@ otError FakePlatform::SettingsGet(uint16_t aKey, uint16_t aIndex, uint8_t *aValu
         return OT_ERROR_NOT_FOUND;
     }
 
-    if (aIndex > setting->second.size())
+    if (aIndex >= setting->second.size())
     {
         return OT_ERROR_NOT_FOUND;
     }
@@ -280,7 +280,13 @@ otError FakePlatform::SettingsDelete(uint16_t aKey, int aIndex)
         return OT_ERROR_NOT_FOUND;
     }
 
-    if (static_cast<std::size_t>(aIndex) >= setting->second.size())
+    if (aIndex == -1)
+    {
+        mSettings.erase(setting);
+        return OT_ERROR_NONE;
+    }
+
+    if (aIndex < 0 || static_cast<std::size_t>(aIndex) >= setting->second.size())
     {
         return OT_ERROR_NOT_FOUND;
     }

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -319,7 +319,7 @@ OT_TOOL_WEAK otError otPlatSettingsGet(otInstance *, uint16_t aKey, int aIndex, 
         return OT_ERROR_NOT_FOUND;
     }
 
-    if (aIndex > setting->second.size())
+    if (aIndex < 0 || static_cast<size_t>(aIndex) >= setting->second.size())
     {
         return OT_ERROR_NOT_FOUND;
     }
@@ -373,7 +373,13 @@ OT_TOOL_WEAK otError otPlatSettingsDelete(otInstance *, uint16_t aKey, int aInde
         return OT_ERROR_NOT_FOUND;
     }
 
-    if (aIndex >= setting->second.size())
+    if (aIndex == -1)
+    {
+        settings.erase(setting);
+        return OT_ERROR_NONE;
+    }
+
+    if (aIndex < 0 || static_cast<size_t>(aIndex) >= setting->second.size())
     {
         return OT_ERROR_NOT_FOUND;
     }


### PR DESCRIPTION
In both tests/unit/test_platform.cpp and tests/gtest/fake_platform.cpp, the mock platform implementation of otPlatSettingsGet / SettingsGet checked if (aIndex > setting->second.size()) instead of >=.

When scanning stored settings with sequential indices (such as in Settings::AddOrUpdateBrOnLinkPrefix()), querying the first out-of-bounds index (aIndex == setting->second.size()) failed to return OT_ERROR_NOT_FOUND. Instead, it proceeded to index setting->second out-of-bounds (setting->second[aIndex]). When compiled with standard library assertions (e.g. _GLIBCXX_ASSERTIONS), this triggered an assertion failure and aborted the process in ot-test-routing_manager.

This commit updates the check to if (aIndex >= setting->second.size()) to correctly return OT_ERROR_NOT_FOUND when aIndex is out of range, matching the check used in otPlatSettingsDelete.