### PR TITLE
[csl] calculate CSL window clock drift using sample time

### DIFF
--- a/src/core/mac/sub_mac_csl_receiver.cpp
+++ b/src/core/mac/sub_mac_csl_receiver.cpp
@@ -261,13 +261,19 @@ void SubMac::GetCslWindowEdges(uint32_t &aAhead, uint32_t &aAfter)
      * -timeAhead                           CslPhase                             +timeAfter             -timeAhead
      */
     uint32_t semiPeriod = mCslPeriod * Radio::kUsPerTenSymbols / 2;
-    uint32_t elapsed;
+    uint32_t elapsed    = 0;
     uint32_t semiWindow;
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_LOCAL_TIME_SYNC
-    elapsed = TimerMicro::GetNow() - mCslLastSync;
+    if (mCslSampleTime.GetAsLocalTimeMicro() > mCslLastSync)
+    {
+        elapsed = mCslSampleTime.GetAsLocalTimeMicro() - mCslLastSync;
+    }
 #else
-    elapsed = ClampToUint32(Get<Radio::Radio>().GetNow() - mCslLastSync);
+    if (mCslSampleTime.GetAsTime64() > mCslLastSync)
+    {
+        elapsed = ClampToUint32(mCslSampleTime.GetAsTime64() - mCslLastSync);
+    }
 #endif
 
     semiWindow = DetermineClockDrift(elapsed);


### PR DESCRIPTION
This commit updates `SubMac::GetCslWindowEdges()` to calculate the elapsed time for clock drift using the scheduled CSL sample time (`mCslSampleTime`) rather than the current time (`Now()`).

Specifically:
- Measures drift from `mCslLastSync` up to `mCslSampleTime`, matching the actual window target.
- Guards against underflow by verifying `mCslSampleTime > mCslLastSync` before subtraction, safely defaulting `elapsed` to zero otherwise.
- Handles both local-time sync and radio-time sync configurations consistently.