### PR TITLE
[mac] remove unused Multipurpose frame type and wake-up handling

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -872,17 +872,6 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame)
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     case Frame::kKeyIdMode2:
-#if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
-        if (aFrame.IsWakeupFrame())
-        {
-            uint8_t keySource[Frame::kKeySourceSizeMode2];
-
-            // Just set the key source here, further security processing will happen in SubMac
-            BigEndian::WriteUint32(keyManager.GetCurrentKeySequence(), keySource);
-            aFrame.SetKeySource(keySource);
-            ExitNow();
-        }
-#endif
         aFrame.SetAesKey(mMode2KeyMaterial);
 
         mKeyIdMode2FrameCounter++;
@@ -1710,29 +1699,8 @@ Error Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Neig
         break;
 
     case Frame::kKeyIdMode2:
-#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-        if (aFrame.IsWakeupFrame())
-        {
-            uint32_t  sequence;
-            uint8_t   keyIndex;
-            FrameData keySource;
-
-            // TODO: Avoid generating a new key if a wake-up frame was recently received already
-
-            IgnoreError(aFrame.GetKeyIndex(keyIndex));
-            aFrame.GetKeySource(keySource);
-            sequence = BigEndian::ReadUint32(keySource.GetBytes());
-            VerifyOrExit(DetermineKeyIndexFor(sequence) == keyIndex, error = kErrorSecurity);
-
-            macKey     = &keyManager.GetTemporaryMacKey(sequence);
-            extAddress = &aSrcAddr.GetExtended();
-        }
-        else
-#endif
-        {
-            macKey     = &mMode2KeyMaterial;
-            extAddress = &AsCoreType(&kMode2ExtAddress);
-        }
+        macKey     = &mMode2KeyMaterial;
+        extAddress = &AsCoreType(&kMode2ExtAddress);
         break;
 
     default:
@@ -2128,12 +2096,6 @@ void Mac::HandleReceivedFrame(RxFrame *aFrame, Error aError)
     case Frame::kTypeData:
         mCounters.mRxData++;
         break;
-
-#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-    case Frame::kTypeMultipurpose:
-        SuccessOrExit(error = HandleWakeupFrame(*aFrame));
-        OT_FALL_THROUGH;
-#endif
 
     default:
         mCounters.mRxOther++;
@@ -2726,60 +2688,6 @@ void Mac::UpdateWakeupListening(void)
     mLinks.UpdateWakeupListening(mWakeupListenEnabled, mWakeupListenInterval, mWakeupListenDuration, channel);
 }
 
-Error Mac::HandleWakeupFrame(const RxFrame &aFrame)
-{
-    Error               error = kErrorNone;
-    const ConnectionIe *connectionIe;
-    Address             srcAddress;
-    WakeupInfo          wakeupInfo;
-    Radio::Time32       rvTimeUs;
-    Radio::Time64       rvTimestampUs;
-    Radio::Time64       radioNowUs;
-
-    VerifyOrExit(mWakeupListenEnabled && aFrame.IsWakeupFrame());
-
-    SuccessOrExit(error = aFrame.GetSrcAddr(srcAddress));
-    VerifyOrExit(srcAddress.IsExtended(), error = kErrorDrop);
-
-    wakeupInfo.mExtAddress    = srcAddress.GetExtended();
-    connectionIe              = aFrame.Find<ConnectionIe>();
-    wakeupInfo.mRetryInterval = connectionIe->GetRetryInterval();
-    wakeupInfo.mRetryCount    = connectionIe->GetRetryCount();
-    VerifyOrExit(wakeupInfo.mRetryInterval > 0 && wakeupInfo.mRetryCount > 0, error = kErrorInvalidArgs);
-
-    radioNowUs = Get<Radio::Radio>().GetNow();
-    rvTimeUs   = aFrame.Find<RendezvousTimeIe>()->GetRendezvousTime() * Radio::kUsPerTenSymbols;
-    rvTimestampUs =
-        aFrame.GetTimestamp() + Radio::kHeaderPhrDuration + aFrame.GetLength() * Radio::kOctetDuration + rvTimeUs;
-
-    if (rvTimestampUs > radioNowUs + kCslRequestAhead)
-    {
-        wakeupInfo.mAttachDelayMs = Radio::ConvertTime64To32(rvTimestampUs - radioNowUs - kCslRequestAhead);
-        wakeupInfo.mAttachDelayMs = wakeupInfo.mAttachDelayMs / Time::kOneMsecInUsec;
-    }
-    else
-    {
-        wakeupInfo.mAttachDelayMs = 0;
-    }
-
-#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
-    {
-        uint32_t frameCounter;
-
-        IgnoreError(aFrame.GetFrameCounter(frameCounter));
-        LogInfo("Received wake-up frame, fc:%lu, rendezvous:%luus, retries:%u/%u", ToUlong(frameCounter),
-                ToUlong(rvTimeUs), wakeupInfo.mRetryCount, wakeupInfo.mRetryInterval);
-    }
-#endif
-
-    // Stop receiving more wake up frames
-    IgnoreError(SetWakeupListenEnabled(false));
-
-    Get<Mle::Mle>().HandleWakeupFrame(wakeupInfo);
-
-exit:
-    return error;
-}
 #endif // OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
 
 } // namespace Mac

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -826,8 +826,7 @@ private:
     void ProcessEnhAckProbing(const RxFrame &aFrame, const Neighbor &aNeighbor);
 #endif
 #if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-    Error HandleWakeupFrame(const RxFrame &aFrame);
-    void  UpdateWakeupListening(void);
+    void UpdateWakeupListening(void);
 #endif
 
     using OperationTask = TaskletIn<Mac, &Mac::PerformNextOperation>;

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1193,18 +1193,6 @@ exit:
 }
 #endif // OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
 
-#if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
-Error TxFrame::GenerateWakeupFrame(PanId aPanId, const WakeupRequest &aWakeupRequest, const Address &aSource)
-{
-    // Placeholder implementation following removal of legacy Multipurpose frame format.
-    OT_UNUSED_VARIABLE(aPanId);
-    OT_UNUSED_VARIABLE(aWakeupRequest);
-    OT_UNUSED_VARIABLE(aSource);
-
-    return kErrorFailed;
-}
-#endif
-
 bool RxFrame::IsSecuredWith(KeyIdModeFlags aFlags) const
 {
     bool      isSecure = false;

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -71,11 +71,10 @@ public:
      */
     enum Type : uint16_t
     {
-        kTypeBeacon       = 0, ///< Beacon Frame Type.
-        kTypeData         = 1, ///< Data Frame Type.
-        kTypeAck          = 2, ///< Ack Frame Type.
-        kTypeMacCmd       = 3, ///< MAC Command Frame Type.
-        kTypeMultipurpose = 5, ///< Multipurpose Frame Type.
+        kTypeBeacon = 0, ///< Beacon Frame Type.
+        kTypeData   = 1, ///< Data Frame Type.
+        kTypeAck    = 2, ///< Ack Frame Type.
+        kTypeMacCmd = 3, ///< MAC Command Frame Type.
     };
 
     /**
@@ -191,18 +190,6 @@ public:
      * @retval FALSE  If this is not a MAC Command Frame.
      */
     bool IsMacCommand(void) const { return GetType() == kTypeMacCmd; }
-
-#if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE || OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-    /**
-     * This method returns whether the frame is an IEEE 802.15.4 Wake-up frame.
-     *
-     * This is a placeholder implementation following removal of legacy Multipurpose frame format.
-     *
-     * @retval TRUE   If this is a Wake-up frame.
-     * @retval FALSE  If this is not a Wake-up frame.
-     */
-    bool IsWakeupFrame(void) const { return false; }
-#endif
 
     /**
      * Returns the IEEE 802.15.4 Frame Version.
@@ -986,7 +973,7 @@ public:
      * @retval  kErrorNone        Successfully generated Wake-up frame.
      * @retval  kErrorInvalidArgs @p aDest or @p aSource have incorrect type.
      */
-    Error GenerateWakeupFrame(PanId aPanId, const WakeupRequest &aWakeupRequest, const Address &aSource);
+    Error GenerateWakeupFrame(PanId, const WakeupRequest &, const Address &) { return kErrorNotImplemented; }
 #endif
 
 private:

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -360,16 +360,7 @@ void SubMac::ProcessTransmitSecurity(void)
 
     VerifyOrExit(ShouldHandleTransmitSecurity());
 
-#if OPENTHREAD_CONFIG_WAKEUP_COORDINATOR_ENABLE
-    if (mTransmitFrame.GetType() == Frame::kTypeMultipurpose)
-    {
-        VerifyOrExit(mTransmitFrame.HasKeyIdMode(Frame::kKeyIdMode2));
-    }
-    else
-#endif
-    {
-        VerifyOrExit(mTransmitFrame.HasKeyIdMode(Frame::kKeyIdMode1));
-    }
+    VerifyOrExit(mTransmitFrame.HasKeyIdMode(Frame::kKeyIdMode1));
 
     mTransmitFrame.SetAesKey(mKeyTrio.SelectKey(keyIndex));
 

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -424,18 +424,6 @@ const Mle::KeyMaterial &KeyManager::GetTemporaryMleKey(uint32_t aKeySequence)
     return mTemporaryMleKey;
 }
 
-#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-const Mle::KeyMaterial &KeyManager::GetTemporaryMacKey(uint32_t aKeySequence)
-{
-    HashKeys hashKeys;
-
-    ComputeKeys(aKeySequence, hashKeys);
-    mTemporaryMacKey.SetFrom(hashKeys.GetMacKey());
-
-    return mTemporaryMacKey;
-}
-#endif
-
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 const Mac::KeyMaterial &KeyManager::GetTemporaryTrelMacKey(uint32_t aKeySequence)
 {

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -367,15 +367,6 @@ public:
      */
     const Mle::KeyMaterial &GetTemporaryMleKey(uint32_t aKeySequence);
 
-    /**
-     * Returns a temporary MAC key Material computed from the given key sequence.
-     *
-     * @param[in]  aKeySequence  The key sequence value.
-     *
-     * @returns The temporary MAC key.
-     */
-    const Mle::KeyMaterial &GetTemporaryMacKey(uint32_t aKeySequence);
-
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
     /**
      * Returns the current MAC Frame Counter value for 15.4 radio link.
@@ -627,10 +618,6 @@ private:
     uint32_t         mKeySequence;
     Mle::KeyMaterial mMleKey;
     Mle::KeyMaterial mTemporaryMleKey;
-
-#if OPENTHREAD_CONFIG_WAKEUP_END_DEVICE_ENABLE
-    Mle::KeyMaterial mTemporaryMacKey;
-#endif
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
     Mac::KeyMaterial mTrelKey;


### PR DESCRIPTION
This commit removes the unused IEEE 802.15.4 Multipurpose frame format (`kTypeMultipurpose`) and its associated Wake-up frame handling across the `Mac` and `SubMac` layers.