### PR TITLE
[mac] remove unused `Frame::AddAddrSizeTo()` declaration

### DIFF
--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -739,7 +739,6 @@ protected:
     static bool     IsDstPanIdPresent(uint16_t aFcf);
     static bool     IsSrcPanIdPresent(uint16_t aFcf);
     static AddrMode DetermineAddrMode(const Address &aAddress);
-    static Error    AddAddrSizeTo(uint8_t &aIndex, AddrMode aAddrMode);
     static uint8_t  CalculateSecurityHeaderSize(uint8_t aSecurityControl);
     static uint8_t  CalculateKeySourceSize(uint8_t aSecurityControl);
     static uint8_t  CalculateMicSize(uint8_t aSecurityControl);


### PR DESCRIPTION
This commit removes the now unused `Frame::AddAddrSizeTo()` method declaration from `mac_frame.hpp`.