### PR TITLE
[trel] fix unbounded retry loop on invalid peer address

### DIFF
--- a/src/core/radio/trel_peer.cpp
+++ b/src/core/radio/trel_peer.cpp
@@ -214,11 +214,7 @@ void Peer::SetPort(uint16_t aPort)
     VerifyOrExit(mPort != aPort);
 
     mPort = aPort;
-
-    if (mPort != 0)
-    {
-        AsCoreType(&mSockAddr).SetPort(mPort);
-    }
+    AsCoreType(&mSockAddr).SetPort(mPort);
 
 exit:
     return;

--- a/src/core/radio/trel_peer.hpp
+++ b/src/core/radio/trel_peer.hpp
@@ -134,7 +134,10 @@ public:
      * @retval TRUE   If the peer socket address is valid.
      * @retval FALSE  If the peer socket address is not valid.
      */
-    bool HasValidSockAddr(void) const { return !GetSockAddr().GetAddress().IsUnspecified(); }
+    bool HasValidSockAddr(void) const
+    {
+        return !GetSockAddr().GetAddress().IsUnspecified() && (GetSockAddr().GetPort() != 0);
+    }
 
     /**
      * Updates the IPv6 socket address of the discovered TREL peer based on a received message from peer.

--- a/src/core/radio/trel_peer_discoverer.cpp
+++ b/src/core/radio/trel_peer_discoverer.cpp
@@ -183,6 +183,11 @@ void PeerDiscoverer::HandleDiscoveredPeerInfo(const PeerInfo &aInfo)
     txtData.Init(aInfo.mTxtData, aInfo.mTxtLength);
     SuccessOrExit(txtData.Decode(txtInfo));
 
+    if (!aInfo.IsRemoved())
+    {
+        VerifyOrExit(!aInfo.GetSockAddr().GetAddress().IsUnspecified() && (aInfo.GetSockAddr().GetPort() != 0));
+    }
+
     VerifyOrExit(txtInfo.mExtAddress != Get<Mac::Mac>().GetExtAddress());
 
     if (aInfo.IsRemoved())

--- a/src/posix/platform/trel.cpp
+++ b/src/posix/platform/trel.cpp
@@ -248,14 +248,18 @@ static otError SendPacket(const uint8_t *aBuffer, uint16_t aLength, const otSock
 
         switch (errno)
         {
-        case ENETUNREACH:
-        case ENETDOWN:
-        case EHOSTUNREACH:
-            error = OT_ERROR_ABORT;
+        case EAGAIN:
+#if EWOULDBLOCK != EAGAIN
+        case EWOULDBLOCK:
+#endif
+        case ENOBUFS:
+        case EINTR:
+            error = OT_ERROR_INVALID_STATE;
             break;
 
         default:
-            error = OT_ERROR_INVALID_STATE;
+            error = OT_ERROR_ABORT;
+            break;
         }
     }
     else


### PR DESCRIPTION
When a TREL peer is discovered with UDP port 0 (or another invalid socket address), sendto() in the POSIX TREL implementation fails with EINVAL. SendPacket() previously mapped all errors other than ENETUNREACH, ENETDOWN, and EHOSTUNREACH to OT_ERROR_INVALID_STATE.

Because OT_ERROR_INVALID_STATE is used to signal transient buffer or would-block conditions, the packet remained at the head of the TX queue. Since the UDP socket remained writable, the POSIX main loop continuously woke up and retried SendPacket() in a tight busy loop, consuming 100% CPU and blocking all subsequent TREL transmissions.

This commit resolves the issue:
1. In POSIX TREL SendPacket(), map only transient would-block errors (EAGAIN, EWOULDBLOCK, ENOBUFS) to OT_ERROR_INVALID_STATE, and map all other errors to OT_ERROR_ABORT so the packet is dropped.
2. In Peer::HasValidSockAddr(), verify that the destination UDP port is non-zero in addition to checking for unspecified addresses.
3. In PeerDiscoverer::HandleDiscoveredPeerInfo(), validate that the discovered peer socket address has a non-zero port and is not unspecified before adding or updating the peer.

Resolves #13517.