### PR TITLE
[ci] add timeouts to bootstrap steps and wget calls in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y shellcheck iwyu
@@ -103,6 +104,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get --no-install-recommends install -y build-essential ninja-build libreadline-dev libncurses-dev
     - name: Build
@@ -123,6 +125,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get --no-install-recommends install -y build-essential ninja-build libreadline-dev libncurses-dev
     - name: Build and test with platform CCM one-shot enabled
@@ -144,11 +147,12 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get --no-install-recommends install -y build-essential ninja-build libreadline-dev libncurses-dev
         sudo apt-get remove cmake
         sudo apt-get purge --auto-remove cmake
-        wget http://www.cmake.org/files/v3.10/cmake-3.10.3.tar.gz
+        wget --timeout=30 --tries=4 http://www.cmake.org/files/v3.10/cmake-3.10.3.tar.gz
         tar xf cmake-3.10.3.tar.gz
         cd cmake-3.10.3
         ./configure
@@ -185,6 +189,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build libreadline-dev libncurses-dev
@@ -205,6 +210,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y clang-tools-14 ninja-build
@@ -225,6 +231,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get --no-install-recommends install -y ninja-build libreadline-dev libncurses-dev
         cd third_party/mbedtls/repo && git fetch --tags && git checkout tags/v2.28.8
@@ -280,11 +287,12 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         cd /tmp
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y build-essential lib32z1 ninja-build gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
-        wget --tries 4 --no-check-certificate --quiet ${{ matrix.gcc_download_url }} -O gcc-arm
+        wget --timeout=30 --tries 4 --no-check-certificate --quiet ${{ matrix.gcc_download_url }} -O gcc-arm
         tar xf gcc-arm
     - name: Build
       env:
@@ -314,6 +322,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get update
         case ${{ matrix.gcc_ver }} in
@@ -348,8 +357,9 @@ jobs:
           submodules: recursive
           persist-credentials: false
       - name: Bootstrap
+        timeout-minutes: 10
         run: |
-          wget https://apt.llvm.org/llvm.sh
+          wget --timeout=30 --tries=4 https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.clang_ver }}
           sudo apt-get update
@@ -372,6 +382,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build gn
@@ -404,9 +415,10 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         brew update
-        wget --tries 4 https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-mac.zip
+        wget --timeout=30 --tries 4 https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-mac.zip
         unzip ninja-mac.zip && mv ninja /usr/local/bin/.
     - name: Build
       run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,6 +64,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get --no-install-recommends install -y ninja-build libreadline-dev libncurses-dev
 

--- a/.github/workflows/nexus.yml
+++ b/.github/workflows/nexus.yml
@@ -63,6 +63,7 @@ jobs:
         persist-credentials: false
 
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo add-apt-repository -y ppa:wireshark-dev/stable
         sudo apt-get update
@@ -96,6 +97,7 @@ jobs:
         persist-credentials: false
 
     - name: Bootstrap
+      timeout-minutes: 10
       env:
         PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
@@ -133,6 +135,7 @@ jobs:
         persist-credentials: false
 
     - name: Bootstrap
+      timeout-minutes: 10
       env:
         PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
@@ -166,6 +169,7 @@ jobs:
         persist-credentials: false
 
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc
@@ -197,6 +201,7 @@ jobs:
         persist-credentials: false
 
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build

--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -101,6 +101,7 @@ jobs:
       run: |
         ./script/test build_otbr_docker
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y python3-setuptools python3-wheel ninja-build lcov
@@ -151,6 +152,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get --no-install-recommends install -y lcov
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/otci.yml
+++ b/.github/workflows/otci.yml
@@ -71,6 +71,7 @@ jobs:
         python-version: '3.12'
         cache: pip
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build

--- a/.github/workflows/otns.yml
+++ b/.github/workflows/otns.yml
@@ -74,6 +74,7 @@ jobs:
       with:
         python-version: "3.9"
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y lcov ninja-build
@@ -117,6 +118,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Bootstrap
+        timeout-minutes: 10
         run: |
           sudo apt-get update
           sudo apt-get --no-install-recommends install -y lcov ninja-build
@@ -182,6 +184,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Bootstrap
+        timeout-minutes: 10
         run: |
           sudo apt-get update
           sudo apt-get --no-install-recommends install -y lcov ninja-build
@@ -226,6 +229,7 @@ jobs:
           submodules: recursive
           persist-credentials: false
       - name: Bootstrap
+        timeout-minutes: 10
         run: |
           sudo apt-get --no-install-recommends install -y lcov
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -65,6 +65,7 @@ jobs:
         python-version: '3.12'
         cache: pip
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get --no-install-recommends install -y expect ninja-build lcov
         sudo bash script/install_socat
@@ -160,13 +161,14 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y expect lcov libreadline-dev net-tools ninja-build
         sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
         sudo bash script/install_socat
         cd /tmp
-        wget https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz
+        wget --timeout=30 --tries=4 https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz
         tar xvf bsd-licensed.tar.gz
         cd libcoap-bsd-licensed
         ./autogen.sh
@@ -208,6 +210,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y net-tools ninja-build
@@ -240,6 +243,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         rm -f /usr/local/bin/2to3
         rm -f /usr/local/bin/2to3-3.11
@@ -274,6 +278,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       env:
         PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
@@ -311,6 +316,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get --no-install-recommends install -y lcov
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -62,6 +62,7 @@ jobs:
         python-version: '3.12'
         cache: pip
     - name: Bootstrap
+      timeout-minutes: 10
       env:
         PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
@@ -113,6 +114,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get --no-install-recommends install -y expect ninja-build lcov
     - name: Run
@@ -151,6 +153,7 @@ jobs:
         python-version: '3.12'
         cache: pip
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y g++-multilib lcov ninja-build
@@ -196,6 +199,7 @@ jobs:
         python-version: '3.12'
         cache: pip
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get --no-install-recommends install -y expect ninja-build lcov
         sudo bash script/install_socat
@@ -244,6 +248,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get --no-install-recommends install -y lcov
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -72,6 +72,7 @@ jobs:
         python-version: '3.12'
         cache: pip
     - name: Bootstrap
+      timeout-minutes: 10
       env:
         PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
@@ -108,6 +109,7 @@ jobs:
         python-version: '3.12'
         cache: pip
     - name: Bootstrap
+      timeout-minutes: 10
       env:
         PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
@@ -146,6 +148,7 @@ jobs:
         python-version: '3.12'
         cache: pip
     - name: Bootstrap
+      timeout-minutes: 10
       env:
         PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
@@ -201,6 +204,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       env:
         PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
@@ -225,6 +229,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get --no-install-recommends install -y lcov
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -77,6 +77,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build lcov libgtest-dev libgmock-dev
@@ -120,6 +121,7 @@ jobs:
         submodules: recursive
         persist-credentials: false
     - name: Bootstrap
+      timeout-minutes: 10
       run: |
         sudo apt-get --no-install-recommends install -y lcov
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
This commit updates all GitHub Actions workflows to prevent CI jobs from hanging indefinitely during the Bootstrap step:

- Add `timeout-minutes: 10` to all `Bootstrap` steps across all workflows (`build.yml`, `codeql.yml`, `nexus.yml`, `otbr.yml`, `otci.yml`, `otns.yml`, `posix.yml`, `simulation.yml`, `toranj.yml`, and `unit.yml`).
- Add `--timeout=30` and retry flags to `wget` download commands in `build.yml` and `posix.yml` to prevent network stall hangs.