### PR TITLE
[dnssd] bound question count in `ShouldForwardToUpstream()`

### DIFF
--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -352,7 +352,7 @@ Server::ResponseCode Server::Request::ParseQuestions(uint8_t aTestMode, bool &aS
         VerifyOrExit(!(aTestMode & kTestModeRejectMultiQuestionQuery));
         VerifyOrExit(!(aTestMode & kTestModeIgnoreMultiQuestionQuery), aShouldRespond = false);
 
-        VerifyOrExit(questionCount == 2);
+        VerifyOrExit(questionCount == kMaxQuestionCount);
 
         // Allow SRV and TXT questions for the same service
         // instance name in the same query.
@@ -1107,15 +1107,19 @@ exit:
 bool Server::ShouldForwardToUpstream(const Request &aRequest) const
 {
     bool         shouldForward = false;
+    uint16_t     questionCount = aRequest.mHeader.GetQuestionCount();
     uint16_t     readOffset;
     Name::Buffer name;
 
     VerifyOrExit(mEnableUpstreamQuery);
 
     VerifyOrExit(aRequest.mHeader.IsRecursionDesiredFlagSet());
+
+    VerifyOrExit((questionCount > 0) && (questionCount <= kMaxQuestionCount));
+
     readOffset = sizeof(Header);
 
-    for (uint16_t i = 0; i < aRequest.mHeader.GetQuestionCount(); i++)
+    for (uint16_t i = 0; i < questionCount; i++)
     {
         SuccessOrExit(Name::ReadName(*aRequest.mMessage, readOffset, name));
         readOffset += sizeof(Question);

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -311,6 +311,7 @@ private:
     static constexpr bool     kBindUnspecifiedNetif         = OPENTHREAD_CONFIG_DNSSD_SERVER_BIND_UNSPECIFIED_NETIF;
     static constexpr uint32_t kQueryTimeout                 = OPENTHREAD_CONFIG_DNSSD_QUERY_TIMEOUT;
     static constexpr uint16_t kMaxConcurrentUpstreamQueries = 32;
+    static constexpr uint16_t kMaxQuestionCount             = 2;
 
     static constexpr uint16_t kRrTypeA     = ResourceRecord::kTypeA;
     static constexpr uint16_t kRrTypeNs    = ResourceRecord::kTypeNs;


### PR DESCRIPTION
## What this fixes

When DNS upstream forwarding is enabled, the DNS-SD server decides whether to forward a query by calling `ShouldForwardToUpstream()`. That check runs before the query is validated, and it trusts the `QDCOUNT` field in the DNS header (the number that says "how many questions are in this query").

The problem: `QDCOUNT` is attacker-controlled and can be set as high as 65535. The loop read one name per question straight from that number, before any of the normal validation (`ParseQuestions()`) had a chance to reject it. So a malformed query could make the server do more per-question parsing work than it should ever need to.

## The change

`ShouldForwardToUpstream()` now checks the question count up front and rejects any query claiming more than `kMaxQuestionCount` (2) questions; which is exactly the limit `ParseQuestions()` already enforces everywhere else. Anything larger is malformed and gets rejected later anyway, so nothing valid is affected.

The `2` was previously a bare number inside `ParseQuestions()`; it's now a named constant reused in both places, so the two code paths stay in sync.

## Files touched

- `src/core/net/dnssd_server.hpp`: add the `kMaxQuestionCount` constant.
- `src/core/net/dnssd_server.cpp`: add the up-front check in
  `ShouldForwardToUpstream()`, and use the constant in `ParseQuestions()`.
