### PR TITLE
[dataset] fix bounds check order in Dataset::ValidateTlvs()

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -109,7 +109,7 @@ Error Dataset::ValidateTlvs(void) const
 
     for (const Tlv *tlv = GetTlvsStart(); tlv < end; tlv = tlv->GetNext())
     {
-        VerifyOrExit(!tlv->IsExtended() && ((tlv + 1) <= end) && (tlv->GetNext() <= end));
+        VerifyOrExit(((tlv + 1) <= end) && !tlv->IsExtended() && (tlv->GetNext() <= end));
         VerifyOrExit(IsTlvValid(*tlv));
 
         // Ensure there are no duplicate TLVs.

--- a/tests/unit/test_dataset.cpp
+++ b/tests/unit/test_dataset.cpp
@@ -158,7 +158,13 @@ void TestDataset(void)
 
     // Invalid datasets
 
+    SuccessOrQuit(dataset.SetFrom(kTlvBytes, 1));
+    VerifyOrQuit(dataset.ValidateTlvs() == kErrorParse);
+
     SuccessOrQuit(dataset.SetFrom(kTlvBytes, sizeof(kTlvBytes) - 1));
+    VerifyOrQuit(dataset.ValidateTlvs() == kErrorParse);
+
+    SuccessOrQuit(dataset.SetFrom(kDuplicateChannels, sizeof(kDuplicateChannels) / 2 + 1));
     VerifyOrQuit(dataset.ValidateTlvs() == kErrorParse);
 
     SuccessOrQuit(dataset.SetFrom(kDuplicateChannels, sizeof(kDuplicateChannels)));


### PR DESCRIPTION
In Dataset::ValidateTlvs(), the loop guard evaluated !tlv->IsExtended() before ((tlv + 1) <= end). Because IsExtended() reads the TLV length byte at offset 1, evaluating it before confirming that the 2-byte TLV header fits within bounds causes a 1-byte out-of-bounds read when processing a trailing 1-byte partial TLV or a 1-byte dataset buffer.

This path is reachable from untrusted inputs such as Mle::RxMessage::ReadAndSaveDataset(), MGMT_SET, and TCAT, which copy dataset values into a buffer and call ValidateTlvs().

This commit brings the Dataset validation path in line with Tlv::FindTlv() and NetworkData::ValidateTlvs() by checking that the header fits ((tlv + 1) <= end) before checking IsExtended(). It also adds unit tests covering 1-byte datasets and trailing 1-byte partial TLVs.