### PR TITLE
ci: fix apt-get update failure by removing external lists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Bootstrap
       timeout-minutes: 10
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y shellcheck iwyu
         sudo bash script/install-llvm.sh
         python3 -m pip install yapf==0.43.0
@@ -191,7 +191,7 @@ jobs:
     - name: Bootstrap
       timeout-minutes: 10
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build libreadline-dev libncurses-dev
     - name: Package
       run: |
@@ -212,7 +212,7 @@ jobs:
     - name: Bootstrap
       timeout-minutes: 10
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y clang-tools-14 ninja-build
     - name: Run
       run: |
@@ -290,7 +290,7 @@ jobs:
       timeout-minutes: 10
       run: |
         cd /tmp
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y build-essential lib32z1 ninja-build gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
         wget --timeout=30 --tries 4 --no-check-certificate --quiet ${{ matrix.gcc_download_url }} -O gcc-arm
         tar xf gcc-arm
@@ -324,7 +324,7 @@ jobs:
     - name: Bootstrap
       timeout-minutes: 10
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         case ${{ matrix.gcc_ver }} in
           11)
             sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
@@ -362,7 +362,7 @@ jobs:
           wget --timeout=30 --tries=4 https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.clang_ver }}
-          sudo apt-get update
+          sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
           sudo apt-get --no-install-recommends install -y ninja-build libreadline-dev libncurses-dev
       - name: Build
         run: |
@@ -384,7 +384,7 @@ jobs:
     - name: Bootstrap
       timeout-minutes: 10
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build gn
     - name: Build
       run: |

--- a/.github/workflows/nexus.yml
+++ b/.github/workflows/nexus.yml
@@ -66,7 +66,7 @@ jobs:
       timeout-minutes: 10
       run: |
         sudo add-apt-repository -y ppa:wireshark-dev/stable
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y ninja-build tshark
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
 
@@ -101,7 +101,7 @@ jobs:
       env:
         PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build lcov
 
     - name: Build Nexus
@@ -139,7 +139,7 @@ jobs:
       env:
         PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build lcov
 
     - name: Build Nexus
@@ -171,7 +171,7 @@ jobs:
     - name: Bootstrap
       timeout-minutes: 10
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc
 
     - name: Build Nexus
@@ -203,7 +203,7 @@ jobs:
     - name: Bootstrap
       timeout-minutes: 10
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build
 
     - name: Set up Emscripten

--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Bootstrap
       timeout-minutes: 10
       run: |
-        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y python3-setuptools python3-wheel ninja-build lcov
         sudo bash script/install_socat
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt

--- a/.github/workflows/otci.yml
+++ b/.github/workflows/otci.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Bootstrap
       timeout-minutes: 10
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
         python3 -m pip install pytype adb-shell

--- a/.github/workflows/otns.yml
+++ b/.github/workflows/otns.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Bootstrap
       timeout-minutes: 10
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y lcov ninja-build
     - name: Run
       run: |
@@ -120,7 +120,7 @@ jobs:
       - name: Bootstrap
         timeout-minutes: 10
         run: |
-          sudo apt-get update
+          sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
           sudo apt-get --no-install-recommends install -y lcov ninja-build
       - name: Run
         run: |
@@ -186,7 +186,7 @@ jobs:
       - name: Bootstrap
         timeout-minutes: 10
         run: |
-          sudo apt-get update
+          sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
           sudo apt-get --no-install-recommends install -y lcov ninja-build
       - name: Run
         run: |

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -101,7 +101,7 @@ jobs:
         retention-days: 1
     - name: Run TUN Mode
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
         sudo apt-get install --no-install-recommends -y bind9-host ntp
         sudo bash script/install_socat
@@ -163,7 +163,7 @@ jobs:
     - name: Bootstrap
       timeout-minutes: 10
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y expect lcov libreadline-dev net-tools ninja-build
         sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
         sudo bash script/install_socat
@@ -212,7 +212,7 @@ jobs:
     - name: Bootstrap
       timeout-minutes: 10
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y net-tools ninja-build
         sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
     - name: Build

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -66,7 +66,7 @@ jobs:
       env:
         PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get install -y avahi-daemon avahi-utils lcov
         script/git-tool clone https://github.com/openthread/ot-commissioner.git /tmp/ot-commissioner --depth 1 --branch main
     - name: Build
@@ -155,7 +155,7 @@ jobs:
     - name: Bootstrap
       timeout-minutes: 10
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y g++-multilib lcov ninja-build
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build

--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -76,7 +76,7 @@ jobs:
       env:
         PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build lcov
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build & Run
@@ -113,7 +113,7 @@ jobs:
       env:
         PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build lcov
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build & Run
@@ -152,7 +152,7 @@ jobs:
       env:
         PR_BODY: "${{ github.event.pull_request.body }}"
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build
     - name: Build & Run
       run: |

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Bootstrap
       timeout-minutes: 10
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/*.list && sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build lcov libgtest-dev libgmock-dev
     - name: Build Simulation
       run: ./script/cmake-build simulation -DOT_BUILD_GTEST=ON -DOT_BORDER_ROUTING=ON -DOT_BORDER_ROUTING_DHCP6_PD=ON


### PR DESCRIPTION
As requested by @abtink in #13244, submitting the `apt-get update` CI fix as a separate, smaller PR.

This removes external apt sources lists before running `apt-get update` to prevent CI failures when third-party repositories go down or change their signing keys.