### PR TITLE
[posix] do not bind upstream DNS sockets for resolv.conf nameservers

### DIFF
--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -431,7 +431,13 @@
 /**
  * @def OPENTHREAD_POSIX_CONFIG_UPSTREAM_DNS_BIND_TO_INFRA_NETIF
  *
- * Define as 1 to let the upstream DNS bind the socket to infra network interface.
+ * Define as 1 to bind the sockets used to query recursive DNS servers discovered through RDNSS
+ * to the infra network interface. Those servers are discovered on the infra link, so queries to
+ * them are always sent out that interface, regardless of the host routing table.
+ *
+ * Nameservers from the host's resolv.conf (or set via `otSysUpstreamDnsSetServerList()`) are
+ * host-wide configuration and are always reached following the host's routing table, independent
+ * of this setting.
  */
 #ifndef OPENTHREAD_POSIX_CONFIG_UPSTREAM_DNS_BIND_TO_INFRA_NETIF
 #define OPENTHREAD_POSIX_CONFIG_UPSTREAM_DNS_BIND_TO_INFRA_NETIF 1

--- a/src/posix/platform/resolver.cpp
+++ b/src/posix/platform/resolver.cpp
@@ -227,7 +227,8 @@ void Resolver::BorderRoutingRdnssCallback(void)
 otError Resolver::SendQueryToServer(Transaction        *aTxn,
                                     const otIp6Address &aServerAddress,
                                     const char         *aPacket,
-                                    uint16_t            aLength)
+                                    uint16_t            aLength,
+                                    bool                aViaInfraNetif)
 {
     otError      error = OT_ERROR_NONE;
     otIp4Address ip4Addr;
@@ -246,6 +247,8 @@ otError Resolver::SendQueryToServer(Transaction        *aTxn,
     }
     else
     {
+        int fd = (aViaInfraNetif && aTxn->mInfraUdpFd6 >= 0) ? aTxn->mInfraUdpFd6 : aTxn->mUdpFd6;
+
         memcpy(&serverAddr6.sin6_addr, &aServerAddress, sizeof(otIp6Address));
         serverAddr6.sin6_family = AF_INET6;
         serverAddr6.sin6_port   = htons(53);
@@ -255,7 +258,7 @@ otError Resolver::SendQueryToServer(Transaction        *aTxn,
             serverAddr6.sin6_scope_id = otSysGetInfraNetifIndex();
         }
 
-        VerifyOrExit(sendto(aTxn->mUdpFd6, aPacket, aLength, MSG_DONTWAIT, reinterpret_cast<sockaddr *>(&serverAddr6),
+        VerifyOrExit(sendto(fd, aPacket, aLength, MSG_DONTWAIT, reinterpret_cast<sockaddr *>(&serverAddr6),
                             sizeof(serverAddr6)) > 0,
                      error = OT_ERROR_NO_ROUTE);
     }
@@ -283,7 +286,8 @@ void Resolver::Query(otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery)
 
     for (uint32_t i = 0; i < mRecursiveDnsServerCount; i++)
     {
-        if (SendQueryToServer(txn, mRecursiveDnsServerList[i], packet, length) == OT_ERROR_NONE)
+        if (SendQueryToServer(txn, mRecursiveDnsServerList[i], packet, length, /* aViaInfraNetif */ true) ==
+            OT_ERROR_NONE)
         {
             serverCount++;
         }
@@ -291,7 +295,8 @@ void Resolver::Query(otPlatDnsUpstreamQuery *aTxn, const otMessage *aQuery)
 
     for (uint32_t i = 0; i < mUpstreamDnsServerCount; i++)
     {
-        if (SendQueryToServer(txn, mUpstreamDnsServerList[i], packet, length) == OT_ERROR_NONE)
+        if (SendQueryToServer(txn, mUpstreamDnsServerList[i], packet, length, /* aViaInfraNetif */ false) ==
+            OT_ERROR_NONE)
         {
             serverCount++;
         }
@@ -335,23 +340,35 @@ Resolver::Transaction *Resolver::AllocateTransaction(otPlatDnsUpstreamQuery *aTh
     {
         if (txn.mThreadTxn == nullptr)
         {
-            fd4OrError = CreateUdpSocket(AF_INET);
+            fd4OrError = CreateUdpSocket(AF_INET, /* aBindToInfraNetif */ false);
             if (fd4OrError < 0)
             {
                 LogInfo("Failed to create socket for upstream resolver: %d", fd4OrError);
                 break;
             }
 
-            fd6OrError = CreateUdpSocket(AF_INET6);
+            fd6OrError = CreateUdpSocket(AF_INET6, /* aBindToInfraNetif */ false);
             if (fd6OrError < 0)
             {
                 LogInfo("Failed to create socket for upstream resolver: %d", fd6OrError);
+                close(fd4OrError);
                 break;
             }
 
-            ret             = &txn;
-            ret->mUdpFd4    = fd4OrError;
-            ret->mUdpFd6    = fd6OrError;
+            ret               = &txn;
+            ret->mUdpFd4      = fd4OrError;
+            ret->mUdpFd6      = fd6OrError;
+            ret->mInfraUdpFd6 = -1;
+#if OPENTHREAD_POSIX_CONFIG_UPSTREAM_DNS_BIND_TO_INFRA_NETIF
+            if (mRecursiveDnsServerCount > 0)
+            {
+                ret->mInfraUdpFd6 = CreateUdpSocket(AF_INET6, /* aBindToInfraNetif */ true);
+                if (ret->mInfraUdpFd6 < 0)
+                {
+                    LogInfo("Failed to create infra-bound socket for upstream resolver, using unbound socket");
+                }
+            }
+#endif
             ret->mThreadTxn = aThreadTxn;
             break;
         }
@@ -419,6 +436,11 @@ void Resolver::CloseTransaction(Transaction *aTxn)
         close(aTxn->mUdpFd6);
         aTxn->mUdpFd6 = -1;
     }
+    if (aTxn->mInfraUdpFd6 >= 0)
+    {
+        close(aTxn->mInfraUdpFd6);
+        aTxn->mInfraUdpFd6 = -1;
+    }
     aTxn->mThreadTxn = nullptr;
 }
 
@@ -432,6 +454,11 @@ void Resolver::UpdateFdSet(Mainloop::Context &aContext)
             Mainloop::AddToErrorFdSet(txn.mUdpFd4, aContext);
             Mainloop::AddToReadFdSet(txn.mUdpFd6, aContext);
             Mainloop::AddToErrorFdSet(txn.mUdpFd6, aContext);
+            if (txn.mInfraUdpFd6 >= 0)
+            {
+                Mainloop::AddToReadFdSet(txn.mInfraUdpFd6, aContext);
+                Mainloop::AddToErrorFdSet(txn.mInfraUdpFd6, aContext);
+            }
         }
     }
 }
@@ -451,6 +478,12 @@ void Resolver::Process(const Mainloop::Context &aContext)
             else if (Mainloop::HasFdErrored(txn.mUdpFd6, aContext) || Mainloop::IsFdReadable(txn.mUdpFd6, aContext))
             {
                 ForwardResponse(txn.mThreadTxn, txn.mUdpFd6);
+                CloseTransaction(&txn);
+            }
+            else if (txn.mInfraUdpFd6 >= 0 && (Mainloop::HasFdErrored(txn.mInfraUdpFd6, aContext) ||
+                                               Mainloop::IsFdReadable(txn.mInfraUdpFd6, aContext)))
+            {
+                ForwardResponse(txn.mThreadTxn, txn.mInfraUdpFd6);
                 CloseTransaction(&txn);
             }
         }
@@ -473,21 +506,36 @@ void Resolver::SetRecursiveDnsServerList(const otIp6Address *aRecursiveDnsServer
     LogInfo("Set recursive DNS server list, count: %d", mRecursiveDnsServerCount);
 }
 
-int Resolver::CreateUdpSocket(sa_family_t aFamily)
+int Resolver::CreateUdpSocket(sa_family_t aFamily, bool aBindToInfraNetif)
 {
     int fd = -1;
 
-    VerifyOrExit(otSysGetInfraNetifName() != nullptr, LogDebg("No infra network interface available"));
     fd = socket(aFamily, SOCK_DGRAM, IPPROTO_UDP);
     VerifyOrExit(fd >= 0, LogDebg("Failed to create the UDP socket: %s", strerror(errno)));
+
 #if OPENTHREAD_POSIX_CONFIG_UPSTREAM_DNS_BIND_TO_INFRA_NETIF
-    if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, otSysGetInfraNetifName(), strlen(otSysGetInfraNetifName())) < 0)
+    if (aBindToInfraNetif)
     {
-        LogDebg("Failed to bind the UDP socket to infra interface %s: %s", otSysGetInfraNetifName(), strerror(errno));
-        close(fd);
-        fd = -1;
-        ExitNow();
+        const char *infraNetifName = otSysGetInfraNetifName();
+
+        if (infraNetifName == nullptr || infraNetifName[0] == '\0')
+        {
+            LogDebg("No infra network interface available");
+            close(fd);
+            fd = -1;
+            ExitNow();
+        }
+
+        if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, infraNetifName, strlen(infraNetifName)) < 0)
+        {
+            LogDebg("Failed to bind the UDP socket to infra interface %s: %s", infraNetifName, strerror(errno));
+            close(fd);
+            fd = -1;
+            ExitNow();
+        }
     }
+#else
+    OT_UNUSED_VARIABLE(aBindToInfraNetif);
 #endif
 
 exit:

--- a/src/posix/platform/resolver.hpp
+++ b/src/posix/platform/resolver.hpp
@@ -135,9 +135,12 @@ private:
         otPlatDnsUpstreamQuery *mThreadTxn;
         int                     mUdpFd4;
         int                     mUdpFd6;
+        // Socket bound to the infra netif, used for recursive DNS servers discovered
+        // on that link. -1 when unavailable (queries then use the unbound `mUdpFd6`).
+        int mInfraUdpFd6;
     };
 
-    static int CreateUdpSocket(sa_family_t aFamily);
+    static int CreateUdpSocket(sa_family_t aFamily, bool aBindToInfraNetif);
 
     Transaction *GetTransaction(otPlatDnsUpstreamQuery *aThreadTxn);
     Transaction *AllocateTransaction(otPlatDnsUpstreamQuery *aThreadTxn);
@@ -145,7 +148,8 @@ private:
     otError SendQueryToServer(Transaction        *aTxn,
                               const otIp6Address &aServerAddress,
                               const char         *aPacket,
-                              uint16_t            aLength);
+                              uint16_t            aLength,
+                              bool                aViaInfraNetif);
     void    ForwardResponse(otPlatDnsUpstreamQuery *aThreadTxn, int aFd);
     void    CloseTransaction(Transaction *aTxn);
     void    TryRefreshDnsServerList(void);


### PR DESCRIPTION
## Problem

Since #10864 the upstream DNS resolver binds its UDP sockets to the infra network interface via `SO_BINDTODEVICE`. This breaks any deployment where the nameservers in `/etc/resolv.conf` are not reachable through the infra interface: with the socket bound, the kernel either misroutes the query out the infra interface via its default route (the query goes unanswered and the upstream query times out), or fails the send entirely (`ENETUNREACH`).

Affected setups include:

- **Containers whose DNS is served on a bridge network.** The Home Assistant OS OpenThread Border Router add-on runs with host networking; its `/etc/resolv.conf` points at the Supervisor DNS (`172.30.32.3`), reachable only through an internal bridge, not through the infra interface. Upstream DNS (and with it DNS64/NAT64 name resolution for Thread devices) has been broken there since this change shipped — see home-assistant/addons#3947.
- **Hosts using a loopback stub resolver** (systemd-resolved's `127.0.0.53`, dnsmasq on `127.0.0.1`).

This failure mode was anticipated in the #10864 review ("On CPE devices, the interface used for DNS queries should be the upstream interface instead of the AIL"), which led to the compile-time option — but the default still breaks the deployments above, and a compile-time option is hard to reach for downstream users.

One wrinkle that long masked the regression during triage: since #11342 the resolver also queries RDNSS-discovered recursive DNS servers. Those are on-link on the infra interface and work fine despite the binding, so on networks whose router advertises RDNSS everything appears healthy, while IPv4-only networks (no RDNSS) are always broken. This made the issue look environment-dependent.

## Change

Treat the two server classes according to their scope:

- Nameservers from `/etc/resolv.conf` (or set via `otSysUpstreamDnsSetServerList()`) are **host-wide configuration**: reach them through the host's routing table using unbound sockets, as before #10864.
- Recursive DNS servers discovered through **RDNSS** are learned on the infra link: queries to them use a dedicated socket bound to the infra interface (created best-effort per transaction), still governed by `OPENTHREAD_POSIX_CONFIG_UPSTREAM_DNS_BIND_TO_INFRA_NETIF`.

This keeps the intent of #10864 for the server class that genuinely belongs to the infra link, while restoring correct behavior for host-scoped servers.

Also fixed in passing:
- Upstream DNS now works on hosts without an infra network interface (socket creation previously always failed via the unconditional `otSysGetInfraNetifName()` check, even for resolv.conf servers).
- A leak of the IPv4 socket when creating the IPv6 socket failed in `AllocateTransaction()`.

## Testing

- POSIX build with `-DOT_COMPILE_WARNING_AS_ERROR=ON` passes with the config flag at both `1` and `0`.
- Verified end-to-end on a Home Assistant Yellow border router (container deployment, host networking): with this change a Thread client resolves IPv4 names via DNS64/NAT64 through the resolv.conf nameserver on the bridge network again. Without it, upstream queries only succeed when the local router advertises RDNSS, matching the field reports in home-assistant/addons#3947.
- `test_upstream_dns.py` exercises the resolv.conf path (server on the backbone network) and continues to pass through normal routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)