### PR TITLE
[dhcp6-pd-client] use `OwnedPtr` in receive path

### DIFF
--- a/src/core/border_router/dhcp6_pd_client.cpp
+++ b/src/core/border_router/dhcp6_pd_client.cpp
@@ -374,7 +374,7 @@ Error Dhcp6PdClient::AppendIaPrefixOption(Message &aMessage, const Ip6::Prefix &
     return aMessage.Append(iaPrefixOption);
 }
 
-void Dhcp6PdClient::HandleReceived(Message &aMessage)
+void Dhcp6PdClient::HandleReceived(OwnedPtr<Message> aMessagePtr)
 {
     Header      header;
     OffsetRange serverDuidOffsetRange;
@@ -394,7 +394,7 @@ void Dhcp6PdClient::HandleReceived(Message &aMessage)
         ExitNow();
     }
 
-    SuccessOrExit(ParseHeaderAndValidateMessage(aMessage, header));
+    SuccessOrExit(ParseHeaderAndValidateMessage(*aMessagePtr, header));
 
     switch (header.GetMsgType())
     {
@@ -420,8 +420,8 @@ void Dhcp6PdClient::HandleReceived(Message &aMessage)
     // - The message does not include a Server ID option.
 
     VerifyOrExit(header.GetTransactionId() == mRetxTracker.GetTransactionId());
-    SuccessOrExit(ClientIdOption::MatchesEui64Duid(aMessage, Get<Mac::Mac>().GetExtAddress()));
-    SuccessOrExit(ServerIdOption::ReadDuid(aMessage, serverDuidOffsetRange));
+    SuccessOrExit(ClientIdOption::MatchesEui64Duid(*aMessagePtr, Get<Mac::Mac>().GetExtAddress()));
+    SuccessOrExit(ServerIdOption::ReadDuid(*aMessagePtr, serverDuidOffsetRange));
 
     // If we have selected a server, ensure the received server DUID
     // matches the one saved in `mServerDuid`. However, during the
@@ -433,28 +433,28 @@ void Dhcp6PdClient::HandleReceived(Message &aMessage)
     if (!mServerDuid.IsEmpty() && (mState != kStateSoliciting))
     {
         VerifyOrExit(serverDuidOffsetRange.GetLength() == mServerDuid.GetLength());
-        VerifyOrExit(aMessage.CompareBytes(serverDuidOffsetRange, mServerDuid.GetArrayBuffer()));
+        VerifyOrExit(aMessagePtr->CompareBytes(serverDuidOffsetRange, mServerDuid.GetArrayBuffer()));
     }
 
     // The client MUST process any SOL_MAX_RT option in an Advertise
     // or Reply message, even if the message contains a Status Code
     // option indicating a failure and will be discarded by the client
 
-    ProcessSolMaxRtOption(aMessage);
+    ProcessSolMaxRtOption(*aMessagePtr);
 
     switch (header.GetMsgType())
     {
     case kMsgTypeAdvertise:
-        HandleAdvertise(aMessage);
+        HandleAdvertise(*aMessagePtr);
         break;
 
     case kMsgTypeReply:
-        HandleReply(aMessage);
+        HandleReply(*aMessagePtr);
         break;
     }
 
 exit:
-    aMessage.Free();
+    return;
 }
 
 Error Dhcp6PdClient::ParseHeaderAndValidateMessage(Message &aMessage, Header &aHeader)

--- a/src/core/border_router/dhcp6_pd_client.hpp
+++ b/src/core/border_router/dhcp6_pd_client.hpp
@@ -230,7 +230,7 @@ private:
     void      UpdateStateAfterRetxExhausted(void);
     Error     AppendIaPdOption(Message &aMessage);
     Error     AppendIaPrefixOption(Message &aMessage, const Ip6::Prefix &aPrefix);
-    void      HandleReceived(Message &aMessage);
+    void      HandleReceived(OwnedPtr<Message> aMessagePtr);
     Error     ParseHeaderAndValidateMessage(Message &aMessage, Dhcp6::Header &aHeader);
     void      HandleAdvertise(const Message &aMessage);
     void      HandleReply(const Message &aMessage);

--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -213,21 +213,16 @@ void InfraIf::SendDhcp6(Message &aMessage, Ip6::Address &aDestAddress)
     otPlatInfraIfDhcp6PdClientSend(&GetInstance(), &aMessage, &aDestAddress, mIfIndex);
 }
 
-void InfraIf::HandleDhcp6Received(Message &aMessage, uint32_t aInfraIfIndex)
+void InfraIf::HandleDhcp6Received(OwnedPtr<Message> aMessagePtr, uint32_t aInfraIfIndex)
 {
     Error error = kErrorNone;
 
     VerifyOrExit(mInitialized && mIsRunning, error = kErrorInvalidState);
     VerifyOrExit(aInfraIfIndex == mIfIndex, error = kErrorDrop);
 
-    Get<Dhcp6PdClient>().HandleReceived(aMessage);
+    Get<Dhcp6PdClient>().HandleReceived(aMessagePtr.PassOwnership());
 
 exit:
-    if (error != kErrorNone)
-    {
-        aMessage.Free();
-    }
-
     LogDebgOnError(error, "process DHCPv6 msg");
 }
 
@@ -343,7 +338,7 @@ extern "C" void otPlatInfraIfDhcp6PdClientHandleReceived(otInstance *aInstance,
                                                          otMessage  *aMessage,
                                                          uint32_t    aInfraIfIndex)
 {
-    AsCoreType(aInstance).Get<InfraIf>().HandleDhcp6Received(AsCoreType(aMessage), aInfraIfIndex);
+    AsCoreType(aInstance).Get<InfraIf>().HandleDhcp6Received(OwnedPtr<Message>(AsCoreTypePtr(aMessage)), aInfraIfIndex);
 }
 #endif
 

--- a/src/core/border_router/infra_if.hpp
+++ b/src/core/border_router/infra_if.hpp
@@ -45,6 +45,7 @@
 #include "common/error.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
+#include "common/owned_ptr.hpp"
 #include "common/string.hpp"
 #include "net/ip6.hpp"
 
@@ -277,7 +278,7 @@ private:
     void DiscoverNat64PrefixDone(uint32_t aIfIndex, const Ip6::Prefix &aPrefix);
 #endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_ENABLE
-    void HandleDhcp6Received(Message &aMessage, uint32_t aInfraIfIndex);
+    void HandleDhcp6Received(OwnedPtr<Message> aMessagePtr, uint32_t aInfraIfIndex);
 #endif
 
     bool     mInitialized : 1;


### PR DESCRIPTION
This commit updates `InfraIf::HandleDhcp6Received()` and `Dhcp6PdClient::HandleReceived()` to use `OwnedPtr<Message>` for managing the received message lifetime, ensuring automatic freeing across all early-exit and normal code paths.