### PR TITLE
[meshcop-tlvs] fix `kRevMask` in `VendorStackVersionTlv`

### DIFF
--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -898,7 +898,7 @@ private:
     static constexpr uint8_t  kBuildOffset = 4;
     static constexpr uint16_t kBuildMask   = 0xfff << kBuildOffset;
     static constexpr uint8_t  kRevOffset   = 0;
-    static constexpr uint16_t kRevMask     = 0xf << kBuildOffset;
+    static constexpr uint16_t kRevMask     = 0xf << kRevOffset;
 
     // For `mMinorMajor`
     static constexpr uint8_t kMinorOffset = 4;


### PR DESCRIPTION
This commit fixes a bug in `VendorStackVersionTlv` where `kRevMask` was incorrectly defined using `kBuildOffset` instead of `kRevOffset`, causing the Revision field bitmask to be shifted incorrectly.