### PR TITLE
[mac] pass only data frames to MeshForwarder

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2079,11 +2079,7 @@ void Mac::HandleReceivedFrame(RxFrame *aFrame, Error aError)
     switch (aFrame->GetType())
     {
     case Frame::kTypeMacCmd:
-        if (HandleMacCommand(*aFrame)) // returns `true` when handled
-        {
-            ExitNow(error = kErrorNone);
-        }
-
+        HandleMacCommand(*aFrame);
         break;
 
     case Frame::kTypeBeacon:
@@ -2092,17 +2088,15 @@ void Mac::HandleReceivedFrame(RxFrame *aFrame, Error aError)
 
     case Frame::kTypeData:
         mCounters.mRxData++;
+        DumpDebg("RX", aFrame->GetPsdu(), aFrame->GetLength());
+        Get<MeshForwarder>().HandleReceivedFrame(*aFrame);
+        UpdateIdleMode();
         break;
 
     default:
         mCounters.mRxOther++;
-        ExitNow();
+        break;
     }
-
-    DumpDebg("RX", aFrame->GetPsdu(), aFrame->GetLength());
-    Get<MeshForwarder>().HandleReceivedFrame(*aFrame);
-
-    UpdateIdleMode();
 
 exit:
 
@@ -2202,9 +2196,8 @@ exit:
     return;
 }
 
-bool Mac::HandleMacCommand(RxFrame &aFrame)
+void Mac::HandleMacCommand(RxFrame &aFrame)
 {
-    bool    didHandle = false;
     uint8_t commandId;
 
     IgnoreError(aFrame.GetCommandId(commandId));
@@ -2223,14 +2216,12 @@ bool Mac::HandleMacCommand(RxFrame &aFrame)
             StartOperation(kOperationTransmitBeacon);
         }
 
-        didHandle = true;
         break;
 
     case Frame::kMacCmdDataRequest:
         mCounters.mRxDataPoll++;
 #if OPENTHREAD_FTD
         Get<DataPollHandler>().HandleDataPoll(aFrame);
-        didHandle = true;
 #endif
         break;
 
@@ -2238,8 +2229,6 @@ bool Mac::HandleMacCommand(RxFrame &aFrame)
         mCounters.mRxOther++;
         break;
     }
-
-    return didHandle;
 }
 
 void Mac::SetPromiscuous(bool aPromiscuous)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -790,7 +790,7 @@ private:
     void     BeginTransmit(void);
     Error    FilterDestShortAddress(ShortAddress aDestAddress) const;
     void     UpdateNeighborLinkInfo(Neighbor &aNeighbor, const RxFrame &aRxFrame);
-    bool     HandleMacCommand(RxFrame &aFrame);
+    void     HandleMacCommand(RxFrame &aFrame);
     void     HandleTimer(void);
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
     Error ProcessTxDone(TxFrame &aFrame, RxFrame *aAckFrame, Error &aError);

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1021,38 +1021,25 @@ void MeshForwarder::HandleReceivedFrame(Mac::RxFrame &aFrame)
 
     Get<SupervisionListener>().UpdateOnReceive(rxInfo.mMacAddrs.mSource, rxInfo.IsLinkSecurityEnabled());
 
-    switch (aFrame.GetType())
+    if (Lowpan::MeshHeader::IsMeshHeader(rxInfo.mFrameData))
     {
-    case Mac::Frame::kTypeData:
-        if (Lowpan::MeshHeader::IsMeshHeader(rxInfo.mFrameData))
-        {
 #if OPENTHREAD_FTD
-            HandleMesh(rxInfo);
+        HandleMesh(rxInfo);
 #endif
-        }
-        else if (Lowpan::FragmentHeader::IsFragmentHeader(rxInfo.mFrameData))
-        {
-            HandleFragment(rxInfo);
-        }
-        else if (Lowpan::Lowpan::IsLowpanHc(rxInfo.mFrameData))
-        {
-            HandleLowpanHc(rxInfo);
-        }
-        else
-        {
-            VerifyOrExit(rxInfo.mFrameData.GetLength() == 0, error = kErrorNotLowpanDataFrame);
+    }
+    else if (Lowpan::FragmentHeader::IsFragmentHeader(rxInfo.mFrameData))
+    {
+        HandleFragment(rxInfo);
+    }
+    else if (Lowpan::Lowpan::IsLowpanHc(rxInfo.mFrameData))
+    {
+        HandleLowpanHc(rxInfo);
+    }
+    else
+    {
+        VerifyOrExit(rxInfo.mFrameData.GetLength() == 0, error = kErrorNotLowpanDataFrame);
 
-            LogFrame("Received empty payload frame", aFrame, kErrorNone);
-        }
-
-        break;
-
-    case Mac::Frame::kTypeBeacon:
-        break;
-
-    default:
-        error = kErrorDrop;
-        break;
+        LogFrame("Received empty payload frame", aFrame, kErrorNone);
     }
 
 exit:


### PR DESCRIPTION
This commit simplifies frame dispatch in `Mac::HandleReceivedFrame()` so that only MAC Data frames (`kTypeData`) are forwarded to `MeshForwarder::HandleReceivedFrame()`:

- Consumes MAC command frames (`kTypeMacCmd`) and Beacon frames (`kTypeBeacon`) entirely within the MAC layer, avoiding unnecessary forwarding to `MeshForwarder`.
- Changes `Mac::HandleMacCommand()` return type to `void` since all MAC command frames are handled at the MAC layer.
- Scopes `DumpDebg("RX", ...)`, `MeshForwarder::HandleReceivedFrame()`, and `UpdateIdleMode()` directly to `case Frame::kTypeData`.
- Removes the outer `switch (aFrame.GetType())` in `MeshForwarder::HandleReceivedFrame()`, allowing it to directly parse 6LoWPAN headers and eliminating redundant address/payload parsing and supervision listener updates for non-data frames.