### PR TITLE
[style] replace all instances of constexpr static with static constexpr

### DIFF
--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -77,7 +77,7 @@ private:
     {
         int Compare(const char *aName) const { return strcmp(aName, mName); }
 
-        constexpr static bool AreInOrder(const ComponentMapper &aFirst, const ComponentMapper &aSecond)
+        static constexpr bool AreInOrder(const ComponentMapper &aFirst, const ComponentMapper &aSecond)
         {
             return AreStringsInOrder(aFirst.mName, aSecond.mName);
         }

--- a/src/cli/cli_utils.hpp
+++ b/src/cli/cli_utils.hpp
@@ -68,7 +68,7 @@ typedef uint64_t CommandId;
  *
  * @returns The associated `CommandId` with @p aString.
  */
-constexpr static CommandId Cmd(const char *aString)
+static constexpr CommandId Cmd(const char *aString)
 {
     return (aString[0] == '\0') ? 0 : (static_cast<uint8_t>(aString[0]) + Cmd(aString + 1) * 255u);
 }
@@ -143,7 +143,7 @@ public:
          * @retval TRUE  if @p aFirst and @p aSecond are in order, i.e. `aFirst < aSecond`.
          * @retval FALSE if @p aFirst and @p aSecond are not in order, i.e. `aFirst >= aSecond`.
          */
-        constexpr static bool AreInOrder(const CommandEntry &aFirst, const CommandEntry &aSecond)
+        static constexpr bool AreInOrder(const CommandEntry &aFirst, const CommandEntry &aSecond)
         {
             return AreStringsInOrder(aFirst.mName, aSecond.mName);
         }

--- a/src/core/common/binary_search.hpp
+++ b/src/core/common/binary_search.hpp
@@ -86,7 +86,7 @@ public:
      *
      * The `Entry` class MUST provide the following `static` and `constexpr` method to compare two entries.
      *
-     *    constexpr static bool Entry::AreInOrder(const Entry &aFirst, const Entry &aSecond);
+     *    static constexpr bool Entry::AreInOrder(const Entry &aFirst, const Entry &aSecond);
      *
      * The return value MUST be TRUE if the entries are in order, i.e. `aFirst < aSecond` and FALSE otherwise.
      *

--- a/src/core/common/crc.hpp
+++ b/src/core/common/crc.hpp
@@ -58,8 +58,8 @@ constexpr uint32_t kCrc32AnsiPolynomial = 0x04c11db7;
  */
 template <typename UintType> class CrcCalculator
 {
-    constexpr static bool kIsUint16 = TypeTraits::IsSame<UintType, uint16_t>::kValue;
-    constexpr static bool kIsUint32 = TypeTraits::IsSame<UintType, uint32_t>::kValue;
+    static constexpr bool kIsUint16 = TypeTraits::IsSame<UintType, uint16_t>::kValue;
+    static constexpr bool kIsUint32 = TypeTraits::IsSame<UintType, uint32_t>::kValue;
 
     static_assert(kIsUint16 || kIsUint32, "UintType MUST be either `uint16_t` or `uint32_t`");
 

--- a/src/core/common/string.hpp
+++ b/src/core/common/string.hpp
@@ -578,7 +578,7 @@ public:
     private:
         int Compare(uint16_t aKey) const { return ThreeWayCompare(aKey, mKey); }
 
-        constexpr static bool AreInOrder(const Entry &aFirst, const Entry &aSecond)
+        static constexpr bool AreInOrder(const Entry &aFirst, const Entry &aSecond)
         {
             return aFirst.mKey < aSecond.mKey;
         }

--- a/src/core/common/time_ticker.hpp
+++ b/src/core/common/time_ticker.hpp
@@ -106,7 +106,7 @@ private:
     static constexpr uint32_t kTickInterval  = Time::kOneSecondInMsec;
     static constexpr uint32_t kRestartJitter = 4; // in msec, jitter added when restarting the timer [-4,+4] ms.
 
-    constexpr static uint32_t Mask(Receiver aReceiver) { return static_cast<uint32_t>(1U) << aReceiver; }
+    static constexpr uint32_t Mask(Receiver aReceiver) { return static_cast<uint32_t>(1U) << aReceiver; }
 
     void HandleTimer(void);
 

--- a/src/core/common/type_traits.hpp
+++ b/src/core/common/type_traits.hpp
@@ -44,7 +44,7 @@ namespace TypeTraits {
  */
 struct TrueValue
 {
-    constexpr static bool kValue = true; ///< true value.
+    static constexpr bool kValue = true; ///< true value.
 };
 
 /**
@@ -52,7 +52,7 @@ struct TrueValue
  */
 struct FalseValue
 {
-    constexpr static bool kValue = false; ///< false value.
+    static constexpr bool kValue = false; ///< false value.
 };
 
 /**

--- a/src/core/mac/wakeup_tx_scheduler.hpp
+++ b/src/core/mac/wakeup_tx_scheduler.hpp
@@ -102,11 +102,11 @@ public:
     const Mac::WakeupRequest &GetWakeupRequest(void) const { return mWakeupRequest; }
 
 private:
-    constexpr static uint8_t  kConnectionRetryInterval = 1;
-    constexpr static uint8_t  kConnectionRetryCount    = 12;
-    constexpr static uint32_t kWakeupFrameLength       = 54; // Includes SHR
-    constexpr static bool     kWakeupFrameTxCca        = true;
-    constexpr static uint32_t kParentRequestLength     = 78; // Includes SHR
+    static constexpr uint8_t  kConnectionRetryInterval = 1;
+    static constexpr uint8_t  kConnectionRetryCount    = 12;
+    static constexpr uint32_t kWakeupFrameLength       = 54; // Includes SHR
+    static constexpr bool     kWakeupFrameTxCca        = true;
+    static constexpr uint32_t kParentRequestLength     = 78; // Includes SHR
 
     // Called by the MAC layer when a wake-up frame transmission is about to be started.
     Mac::TxFrame *PrepareWakeupFrame(Mac::TxFrames &aTxFrames);

--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -1764,7 +1764,7 @@ private:
     {
         int Compare(uint16_t aRecordType) const { return (aRecordType - mRecordType); }
 
-        constexpr static bool AreInOrder(const DataRecipe &aFirst, const DataRecipe &aSecond)
+        static constexpr bool AreInOrder(const DataRecipe &aFirst, const DataRecipe &aSecond)
         {
             return (aFirst.mRecordType < aSecond.mRecordType);
         }

--- a/src/core/thread/uri_paths.cpp
+++ b/src/core/thread/uri_paths.cpp
@@ -43,7 +43,7 @@ struct Entry
 {
     const char *mPath;
 
-    constexpr static bool AreInOrder(const Entry &aFirst, const Entry &aSecond)
+    static constexpr bool AreInOrder(const Entry &aFirst, const Entry &aSecond)
     {
         return AreStringsInOrder(aFirst.mPath, aSecond.mPath);
     }

--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -46,7 +46,7 @@ NcpBase::PropertyHandler NcpBase::FindGetPropertyHandler(spinel_prop_key_t aKey)
 {
 #define OT_NCP_GET_HANDLER_ENTRY(aPropertyName) {aPropertyName, &NcpBase::HandlePropertyGet<aPropertyName>}
 
-    constexpr static HandlerEntry sHandlerEntries[] = {
+    static constexpr HandlerEntry sHandlerEntries[] = {
         OT_NCP_GET_HANDLER_ENTRY(SPINEL_PROP_LAST_STATUS),
         OT_NCP_GET_HANDLER_ENTRY(SPINEL_PROP_PROTOCOL_VERSION),
         OT_NCP_GET_HANDLER_ENTRY(SPINEL_PROP_NCP_VERSION),
@@ -412,7 +412,7 @@ NcpBase::PropertyHandler NcpBase::FindSetPropertyHandler(spinel_prop_key_t aKey)
 {
 #define OT_NCP_SET_HANDLER_ENTRY(aPropertyName) {aPropertyName, &NcpBase::HandlePropertySet<aPropertyName>}
 
-    constexpr static HandlerEntry sHandlerEntries[] = {
+    static constexpr HandlerEntry sHandlerEntries[] = {
         OT_NCP_SET_HANDLER_ENTRY(SPINEL_PROP_POWER_STATE),
 #if OPENTHREAD_CONFIG_NCP_ENABLE_MCU_POWER_STATE_CONTROL
         OT_NCP_SET_HANDLER_ENTRY(SPINEL_PROP_MCU_POWER_STATE),
@@ -726,7 +726,7 @@ NcpBase::PropertyHandler NcpBase::FindInsertPropertyHandler(spinel_prop_key_t aK
 {
 #define OT_NCP_INSERT_HANDLER_ENTRY(aPropertyName) {aPropertyName, &NcpBase::HandlePropertyInsert<aPropertyName>}
 
-    constexpr static HandlerEntry sHandlerEntries[] = {
+    static constexpr HandlerEntry sHandlerEntries[] = {
 #if OPENTHREAD_CONFIG_PLATFORM_POWER_CALIBRATION_ENABLE
         OT_NCP_INSERT_HANDLER_ENTRY(SPINEL_PROP_PHY_CALIBRATED_POWER),
 #endif
@@ -779,7 +779,7 @@ NcpBase::PropertyHandler NcpBase::FindRemovePropertyHandler(spinel_prop_key_t aK
 {
 #define OT_NCP_REMOVE_HANDLER_ENTRY(aPropertyName) {aPropertyName, &NcpBase::HandlePropertyRemove<aPropertyName>}
 
-    constexpr static HandlerEntry sHandlerEntries[] = {
+    static constexpr HandlerEntry sHandlerEntries[] = {
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
         OT_NCP_REMOVE_HANDLER_ENTRY(SPINEL_PROP_THREAD_ON_MESH_NETS),

--- a/src/posix/platform/resolver.hpp
+++ b/src/posix/platform/resolver.hpp
@@ -48,10 +48,10 @@ class Resolver : public Logger<Resolver>
 public:
     static const char kLogModuleName[]; ///< Module name used for logging.
 
-    constexpr static ssize_t kMaxDnsMessageSize           = 512;
-    constexpr static ssize_t kMaxUpstreamTransactionCount = 16;
-    constexpr static ssize_t kMaxUpstreamServerCount      = 3;
-    constexpr static ssize_t kMaxRecursiveServerCount     = 3;
+    static constexpr ssize_t kMaxDnsMessageSize           = 512;
+    static constexpr ssize_t kMaxUpstreamTransactionCount = 16;
+    static constexpr ssize_t kMaxUpstreamServerCount      = 3;
+    static constexpr ssize_t kMaxRecursiveServerCount     = 3;
 
     /**
      * Initialize the upstream DNS resolver.

--- a/tests/unit/test_binary_search.cpp
+++ b/tests/unit/test_binary_search.cpp
@@ -46,7 +46,7 @@ void TestBinarySearch(void)
     {
         int Compare(const char *aName) const { return strcmp(aName, mName); }
 
-        constexpr static bool AreInOrder(const Entry &aFirst, const Entry &aSecond)
+        static constexpr bool AreInOrder(const Entry &aFirst, const Entry &aSecond)
         {
             return AreStringsInOrder(aFirst.mName, aSecond.mName);
         }


### PR DESCRIPTION
This commit updates all occurrences of `constexpr static` to follow the standard `static constexpr` order across the codebase for consistency.

In C++, the widely accepted convention places storage-class specifiers (`static`, `extern`) before declaration/evaluation specifiers (`constexpr`, `inline`), establishing storage duration and linkage before compile-time evaluation properties.

Updated occurrences include:
- `cli_dataset.hpp` and `cli_utils.hpp` command helpers/mappers
- `crc.hpp`, `string.hpp`, `time_ticker.hpp`, `type_traits.hpp`
- `wakeup_tx_scheduler.hpp` and `dns_types.hpp`
- `uri_paths.cpp` and `ncp_base_dispatcher.cpp`
- `resolver.hpp` in POSIX platform
- `binary_search.hpp` documentation and `test_binary_search.cpp`