### PR TITLE
[mac] use kPanIdBroadcast instead of kShortAddrBroadcast for PAN ID

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -719,7 +719,7 @@ TxFrame *Mac::PrepareBeaconRequest(TxFrames &aTxFrames)
 
     buildInfo.mAddrs.mSource.SetNone();
     buildInfo.mAddrs.mDestination.SetShort(kShortAddrBroadcast);
-    buildInfo.mPanIds.SetDestination(kShortAddrBroadcast);
+    buildInfo.mPanIds.SetDestination(kPanIdBroadcast);
 
     buildInfo.mType      = Frame::kTypeMacCmd;
     buildInfo.mCommandId = Frame::kMacCmdBeaconRequest;
@@ -1906,7 +1906,7 @@ void Mac::HandleReceivedFrame(RxFrame *aFrame, Error aError)
     // Verify destination PAN ID if present
     if (kErrorNone == aFrame->GetDstPanId(panId))
     {
-        VerifyOrExit(panId == kShortAddrBroadcast || panId == mPanId, error = kErrorDestinationAddressFiltered);
+        VerifyOrExit(panId == kPanIdBroadcast || panId == mPanId, error = kErrorDestinationAddressFiltered);
     }
 
     // Source Address Filtering


### PR DESCRIPTION
This commit replaces usages of `kShortAddrBroadcast` with `kPanIdBroadcast` in `src/core/mac/mac.cpp` where PAN IDs are handled:

- In `Mac::PrepareBeaconRequest()`, set destination PAN ID using `kPanIdBroadcast` instead of `kShortAddrBroadcast`.
- In `Mac::HandleReceivedFrame()`, check destination PAN ID against `kPanIdBroadcast` instead of `kShortAddrBroadcast`.