### PR TITLE
[mac] centralize `CslPeriodToUsec()`

### DIFF
--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -439,7 +439,7 @@ exit:
 
 uint32_t otLinkGetCslPeriod(otInstance *aInstance)
 {
-    return Mac::Mac::CslPeriodToUsec(AsCoreType(aInstance).Get<Mac::Mac>().GetCslPeriod());
+    return Mac::CslPeriodToUsec(AsCoreType(aInstance).Get<Mac::Mac>().GetCslPeriod());
 }
 
 otError otLinkSetCslPeriod(otInstance *aInstance, uint32_t aPeriod)
@@ -453,8 +453,8 @@ otError otLinkSetCslPeriod(otInstance *aInstance, uint32_t aPeriod)
     }
     else
     {
-        VerifyOrExit((aPeriod % Radio::kUsPerTenSymbols) == 0, error = kErrorInvalidArgs);
-        periodInTenSymbolsUnit = ClampToUint16(aPeriod / Radio::kUsPerTenSymbols);
+        VerifyOrExit((aPeriod % Radio::kTenSymbolsDuration) == 0, error = kErrorInvalidArgs);
+        periodInTenSymbolsUnit = ClampToUint16(aPeriod / Radio::kTenSymbolsDuration);
         VerifyOrExit(periodInTenSymbolsUnit >= Radio::kMinCslPeriod, error = kErrorInvalidArgs);
     }
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2507,11 +2507,6 @@ uint32_t Mac::GetCslPeriodInMsec(void) const
 {
     return DivideAndRoundToClosest<uint32_t>(CslPeriodToUsec(GetCslPeriod()), 1000u);
 }
-
-uint32_t Mac::CslPeriodToUsec(uint16_t aPeriodInTenSymbols)
-{
-    return static_cast<uint32_t>(aPeriodInTenSymbols) * Radio::kUsPerTenSymbols;
-}
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -549,15 +549,6 @@ public:
     void SetCslPeriod(uint16_t aPeriod);
 
     /**
-     * This method converts a given CSL period in units of 10 symbols to microseconds.
-     *
-     * @param[in] aPeriodInTenSymbols   The CSL period in unit of 10 symbols.
-     *
-     * @returns The converted CSL period value in microseconds corresponding to @p aPeriodInTenSymbols.
-     */
-    static uint32_t CslPeriodToUsec(uint16_t aPeriodInTenSymbols);
-
-    /**
      * Indicates whether CSL is started at the moment.
      *
      * @retval TRUE   If CSL is enabled.

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -869,6 +869,15 @@ private:
 };
 
 /**
+ * Converts a given CSL period in units of 10 symbols to microseconds.
+ *
+ * @param[in] aCslPeriod  The CSL period in units of 10 symbols.
+ *
+ * @returns The CSL period in microseconds.
+ */
+inline uint32_t CslPeriodToUsec(uint16_t aCslPeriod) { return Radio::kTenSymbolsDuration * aCslPeriod; }
+
+/**
  * Represents CSL accuracy.
  */
 class CslAccuracy

--- a/src/core/mac/sub_mac_csl_receiver.cpp
+++ b/src/core/mac/sub_mac_csl_receiver.cpp
@@ -62,7 +62,7 @@ void SubMac::RestartCslTimerAfterSyncUpdate(void)
     // Only applies for the case where radio supports receive timing.
     if (RadioSupports(kCapReceiveTiming) && mCslTimer.IsRunning())
     {
-        uint32_t periodUs = mCslPeriod * Radio::kUsPerTenSymbols;
+        uint32_t periodUs = CslPeriodToUsec(mCslPeriod);
 
         mCslTimer.Stop();
 
@@ -176,7 +176,7 @@ void SubMac::HandleCslReceiveAt(uint32_t aTimeAhead, uint32_t aTimeAfter)
      *       x-|------------|-------------------------------------x-|------------|---------------------------------------|
      *            sample                   sleep                        sample                    sleep
      */
-    uint32_t      periodUs = mCslPeriod * Radio::kUsPerTenSymbols;
+    uint32_t      periodUs = CslPeriodToUsec(mCslPeriod);
     Radio::Time32 winStart;
     uint32_t      winDuration;
 
@@ -225,7 +225,7 @@ void SubMac::HandleCslReceiveOrSleep(uint32_t aTimeAhead, uint32_t aTimeAfter)
     }
     else
     {
-        uint32_t periodUs = mCslPeriod * Radio::kUsPerTenSymbols;
+        uint32_t periodUs = CslPeriodToUsec(mCslPeriod);
         uint32_t winStart;
         uint32_t winDuration;
 
@@ -255,7 +255,7 @@ void SubMac::GetCslWindowEdges(uint32_t &aAhead, uint32_t &aAfter)
      * ---|-----------|------------|-----------|-----------|------------|------------|----------//------------|---
      * -timeAhead                           CslPhase                             +timeAfter             -timeAhead
      */
-    uint32_t semiPeriod = mCslPeriod * Radio::kUsPerTenSymbols / 2;
+    uint32_t semiPeriod = CslPeriodToUsec(mCslPeriod) / 2;
     uint32_t elapsed    = 0;
     uint32_t semiWindow;
 
@@ -286,10 +286,7 @@ uint32_t SubMac::DetermineClockDrift(uint32_t aIntervalUs) const
     return Radio::DetermineClockDrift(clockAccuracy, aIntervalUs);
 }
 
-uint32_t SubMac::GetNextCycleDrift(void) const
-{
-    return DetermineClockDrift(static_cast<uint32_t>(mCslPeriod) * Radio::kUsPerTenSymbols);
-}
+uint32_t SubMac::GetNextCycleDrift(void) const { return DetermineClockDrift(CslPeriodToUsec(mCslPeriod)); }
 
 void SubMac::SetCslLastSyncToNow(void)
 {
@@ -332,7 +329,7 @@ void SubMac::LogReceived(RxFrame *aFrame)
     GetCslWindowEdges(ahead, after);
     ahead -= kMinReceiveOnAhead + kCslReceiveTimeAhead;
 
-    sampleTime = mCslSampleTime.GetAsTime32() - mCslPeriod * Radio::kUsPerTenSymbols;
+    sampleTime = mCslSampleTime.GetAsTime32() - CslPeriodToUsec(mCslPeriod);
     deviation  = Radio::ConvertTime64To32(aFrame->GetTimestamp()) + Radio::kHeaderPhrDuration - sampleTime;
 
     // This logs three values (all in microseconds):

--- a/src/core/mac/wakeup_tx_scheduler.cpp
+++ b/src/core/mac/wakeup_tx_scheduler.cpp
@@ -113,7 +113,8 @@ Mac::TxFrame *WakeupTxScheduler::PrepareWakeupFrame(Mac::TxFrames &aTxFrames)
     rendezvousTimeUs = mIntervalUs;
     rendezvousTimeUs += (mIntervalUs - (kWakeupFrameLength + kParentRequestLength) * Radio::kOctetDuration) / 2;
 
-    frame->Find<Mac::RendezvousTimeIe>()->SetRendezvousTime(ClampToUint16(rendezvousTimeUs / Radio::kUsPerTenSymbols));
+    frame->Find<Mac::RendezvousTimeIe>()->SetRendezvousTime(
+        ClampToUint16(rendezvousTimeUs / Radio::kTenSymbolsDuration));
 
     connectionIe = frame->Find<Mac::ConnectionIe>();
     connectionIe->SetRetryInterval(kConnectionRetryInterval);

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -67,16 +67,15 @@ constexpr uint8_t kSfdSize       = 1;                                   ///< SFD
 constexpr uint8_t kPhrSize       = 1;                                   ///< PHY Header (PHR) size in bytes.
 constexpr uint8_t kPhyHeaderSize = kPreambleSize + kSfdSize + kPhrSize; ///< Total PHY header size in bytes.
 
-constexpr uint32_t kUsPerTenSymbols   = OT_US_PER_TEN_SYMBOLS; ///< Time for 10 symbols in units of microseconds
-constexpr uint32_t kHeaderShrDuration = 160;                   ///< Duration of SHR in us
-constexpr uint32_t kHeaderPhrDuration = 32;                    ///< Duration of PHR in us
-constexpr uint32_t kOctetDuration     = 32;                    ///< Duration of one octet in us
+constexpr uint32_t kHeaderShrDuration = 160; ///< Duration of SHR in us
+constexpr uint32_t kHeaderPhrDuration = 32;  ///< Duration of PHR in us
+constexpr uint32_t kOctetDuration     = 32;  ///< Duration of one octet in us
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 /**
  * Minimum CSL period supported in units of 10 symbols.
  */
-constexpr uint64_t kMinCslPeriod  = OPENTHREAD_CONFIG_MAC_CSL_MIN_PERIOD * 1000 / kUsPerTenSymbols;
+constexpr uint64_t kMinCslPeriod  = OPENTHREAD_CONFIG_MAC_CSL_MIN_PERIOD * 1000 / kTenSymbolsDuration;
 constexpr uint64_t kMaxCslTimeout = OPENTHREAD_CONFIG_MAC_CSL_MAX_TIMEOUT;
 #endif
 

--- a/src/core/radio/radio_types.hpp
+++ b/src/core/radio/radio_types.hpp
@@ -57,6 +57,8 @@ namespace Radio {
 
 class Radio;
 
+constexpr uint32_t kTenSymbolsDuration = OT_US_PER_TEN_SYMBOLS; ///< 10 symbols duration in microseconds
+
 constexpr uint32_t kUncertaintyUnit = 10; ///< Clock uncertainty unit in microseconds.
 
 /**

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -220,8 +220,8 @@ Radio::Time64 CslTxScheduler::NeighborInfo::DetermineNextCslWindow(Radio::Time64
     //         = nextTmh - phrDuration
     //         = lastRxTimestamp + 160us * (n * cslPeriod + cslPhase)
 
-    uint32_t      periodInUs    = GetCslPeriod() * Radio::kUsPerTenSymbols;
-    Radio::Time64 firstTxWindow = GetLastRxTimestamp() + GetCslPhase() * Radio::kUsPerTenSymbols;
+    uint32_t      periodInUs    = Mac::CslPeriodToUsec(GetCslPeriod());
+    Radio::Time64 firstTxWindow = GetLastRxTimestamp() + GetCslPhase() * Radio::kTenSymbolsDuration;
     Radio::Time64 nextTxWindow  = aRadioNow - (aRadioNow % periodInUs) + (firstTxWindow % periodInUs);
 
     while (nextTxWindow < aRadioNow + aLeadTime)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3047,7 +3047,7 @@ uint64_t Mle::CalcParentCslMetric(const Mac::CslAccuracy &aCslAccuracy) const
 
     static constexpr uint64_t usInSecond = 1000000;
 
-    uint64_t cslPeriodUs  = Radio::kMinCslPeriod * Radio::kUsPerTenSymbols;
+    uint64_t cslPeriodUs  = Mac::CslPeriodToUsec(Radio::kMinCslPeriod);
     uint64_t cslTimeoutUs = GetCslTimeout() * usInSecond;
     uint64_t k            = cslTimeoutUs / cslPeriodUs;
 

--- a/tests/nexus/test_1_2_LP_5_3_2.cpp
+++ b/tests/nexus/test_1_2_LP_5_3_2.cpp
@@ -70,7 +70,7 @@ static constexpr uint32_t kCslPeriodMs = 500;
 /**
  * CSL period in units of 10 symbols.
  */
-static constexpr uint32_t kCslPeriodInTenSymbols = kCslPeriodMs * kUsPerMs / ot::Radio::kUsPerTenSymbols;
+static constexpr uint32_t kCslPeriodInTenSymbols = kCslPeriodMs * kUsPerMs / ot::Radio::kTenSymbolsDuration;
 
 /**
  * CSL timeout in seconds.


### PR DESCRIPTION
This commit improves consistency in radio symbol duration constants and centralizes the CSL period conversion helper:

- Renames `Radio::kUsPerTenSymbols` to `Radio::kTenSymbolsDuration` and moves it to `radio_types.hpp`, aligning with the naming convention of other duration constants (`kHeaderShrDuration`, `kOctetDuration`).
- Moves `CslPeriodToUsec()` from `Mac::Mac` (which was conditionally compiled under `OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE`) to `mac_types.hpp` as a free inline helper function.
- Replaces manual period-to-microseconds multiplications across the codebase (`SubMac`, `CslTxScheduler`, `Mle`, and `LinkApi`) with the `CslPeriodToUsec()` helper.