### PR TITLE
[posix] set OPENTHREAD_POSIX_CONFIG_INSTALL_EXTERNAL_ROUTES_ENABLE to 0

### DIFF
--- a/script/test
+++ b/script/test
@@ -351,6 +351,7 @@ do_build_otbr_docker()
         "-DOT_FULL_LOGS=ON"
         "-DOT_UPTIME=ON"
         "-DOTBR_DHCP6_PD=ON"
+        "-DOT_POSIX_INSTALL_EXTERNAL_ROUTES=ON"
     )
     local args=(
         "BORDER_ROUTING=${BORDER_ROUTING}"

--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -53,7 +53,7 @@ endif()
 
 ot_option(OT_POSIX_INFRA_NETIF_LOST_EXIT OPENTHREAD_POSIX_CONFIG_EXIT_ON_INFRA_NETIF_LOST_ENABLE "exit on infrastructure network interface lost")
 
-option(OT_POSIX_INSTALL_EXTERNAL_ROUTES "Install External Routes as IPv6 routes" ON)
+option(OT_POSIX_INSTALL_EXTERNAL_ROUTES "Install External Routes as IPv6 routes" OFF)
 if(OT_POSIX_INSTALL_EXTERNAL_ROUTES)
     target_compile_definitions(ot-posix-config
         INTERFACE "OPENTHREAD_POSIX_CONFIG_INSTALL_EXTERNAL_ROUTES_ENABLE=1"

--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -214,7 +214,7 @@
  * Define as 1 to add external routes to POSIX kernel when external routes are changed in netdata.
  */
 #ifndef OPENTHREAD_POSIX_CONFIG_INSTALL_EXTERNAL_ROUTES_ENABLE
-#define OPENTHREAD_POSIX_CONFIG_INSTALL_EXTERNAL_ROUTES_ENABLE 1
+#define OPENTHREAD_POSIX_CONFIG_INSTALL_EXTERNAL_ROUTES_ENABLE 0
 #endif
 
 /**


### PR DESCRIPTION
This commit updates the default value of the POSIX configuration option `OPENTHREAD_POSIX_CONFIG_INSTALL_EXTERNAL_ROUTES_ENABLE` and the CMake option `OT_POSIX_INSTALL_EXTERNAL_ROUTES` from 1 (ON) to 0 (OFF).

When enabled, the POSIX platform automatically installs external routes advertised in Thread Network Data (such as `fc00::/7` or `::/0` from peer Border Routers) directly into the host POSIX kernel routing table pointing to the `wpan0` interface.

On Border Routers connected to an Adjacent Infrastructure Link (AIL / Ethernet / Wi-Fi), this behavior can lead to serious routing issues:
- Routing loops and hairpinning: Traffic destined for external ULA or IPv6 destinations can match host kernel routes on `wpan0` and be forwarded across the low-bandwidth 802.15.4 Thread mesh to a peer BR, which forwards it right back onto the same Ethernet/Wi-Fi link.
- Sub-optimal egress and mesh congestion: Outbound host or LAN traffic unnecessarily traverses the Thread mesh instead of using native high-speed infrastructure links, congesting the mesh.

Thread devices on the mesh do not rely on POSIX host kernel routes, as they discover and route to external prefixes directly via Thread Network Data. Furthermore, reachability to on-mesh devices is handled separately via OMR route configuration (`INSTALL_OMR_ROUTES_ENABLE` / prefix route metrics).

Installing external routes into the host kernel is only beneficial for standalone non-Border Router POSIX nodes without an alternate network uplink. Disabling this option by default prevents routing loops and unintended route injection on Border Routers.