### PR TITLE
[icmp6] fix use-after-free when the echo reply is fragmented

### DIFF
--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -138,7 +138,7 @@ Error Icmp::HandleMessage(Message &aMessage, MessageInfo &aMessageInfo)
 
     if (icmp6Header.GetType() == Header::kTypeEchoRequest)
     {
-        SuccessOrExit(error = HandleEchoRequest(aMessage, aMessageInfo));
+        SuccessOrExit(error = HandleEchoRequest(aMessage, aMessageInfo, icmp6Header));
     }
 
     aMessage.MoveOffset(sizeof(icmp6Header));
@@ -178,10 +178,12 @@ bool Icmp::ShouldHandleEchoRequest(const Address &aAddress)
     return rval;
 }
 
-Error Icmp::HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMessageInfo)
+Error Icmp::HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMessageInfo, const Header &aRequestHeader)
 {
+    OT_UNUSED_VARIABLE(aRequestHeader);
+
     Error       error = kErrorNone;
-    Header      icmp6Header;
+    Header      replyHeader;
     Message    *replyMessage = nullptr;
     MessageInfo replyMessageInfo;
     uint16_t    dataOffset;
@@ -190,8 +192,8 @@ Error Icmp::HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMess
 
     LogInfo("Received Echo Request");
 
-    icmp6Header.Clear();
-    icmp6Header.SetType(Header::kTypeEchoReply);
+    replyHeader.Clear();
+    replyHeader.SetType(Header::kTypeEchoReply);
 
     if ((replyMessage = Get<Ip6>().NewMessage()) == nullptr)
     {
@@ -201,7 +203,7 @@ Error Icmp::HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMess
 
     dataOffset = aRequestMessage.GetOffset() + Header::kDataFieldOffset;
 
-    SuccessOrExit(error = replyMessage->AppendBytes(&icmp6Header, Header::kDataFieldOffset));
+    SuccessOrExit(error = replyMessage->AppendBytes(&replyHeader, Header::kDataFieldOffset));
     SuccessOrExit(error = replyMessage->AppendBytesFromMessage(aRequestMessage, dataOffset,
                                                                aRequestMessage.GetLength() - dataOffset));
 
@@ -214,8 +216,7 @@ Error Icmp::HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMess
 
     SuccessOrExit(error = Get<Ip6>().SendDatagram(*replyMessage, replyMessageInfo, kProtoIcmp6));
 
-    IgnoreError(replyMessage->Read(replyMessage->GetOffset(), icmp6Header));
-    LogInfo("Sent Echo Reply (seq = %d)", icmp6Header.GetSequence());
+    LogInfo("Sent Echo Reply (seq = %d)", aRequestHeader.GetSequence());
 
 exit:
     FreeMessageOnError(replyMessage, error);

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -216,7 +216,7 @@ public:
 private:
     typedef Icmp6Header Header;
 
-    Error HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMessageInfo);
+    Error HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMessageInfo, const Header &aRequestHeader);
 
     LinkedList<Handler> mHandlers;
 


### PR DESCRIPTION
`Icmp::HandleEchoRequest()` uses `replyMessage` after it has passed ownership of it to `Ip6::SendDatagram()`:

```c
SuccessOrExit(error = Get<Ip6>().SendDatagram(*replyMessage, replyMessageInfo, kProtoIcmp6));

IgnoreError(replyMessage->Read(replyMessage->GetOffset(), icmp6Header));
LogInfo("Sent Echo Reply (seq = %d)", icmp6Header.GetSequence());
```

`SendDatagram()` has two ownership outcomes (`src/core/net/ip6.cpp`):

```c
if (aMessage.GetLength() > kMaxDatagramLength)
{
    error = FragmentDatagram(aMessage, aIpProto);   // frees aMessage on success
}
else
{
    EnqueueDatagram(aMessage);                      // keeps aMessage queued
}
```

`FragmentDatagram()` enqueues the fragments and then calls `aMessage.Free()` on its success path, so for any reply larger than `kMaxDatagramLength` the subsequent `Read()` operates on a freed `Message`.

Because the reply size follows the request size, the remote peer selects which branch is taken. A single Echo Request with a payload large enough to push the reply past the MTU is sufficient.

### Reproducing

Requires `OPENTHREAD_CONFIG_IP6_FRAGMENTATION_ENABLE=1`, which is set in `tests/nexus/openthread-core-nexus-config.h` (and `script/cmake-build` enables `OT_IP6_FRAGM=ON`). No new test is needed — the existing `nexus_ipv6_fragmentation` already sends a 1952-byte Echo Request:

```sh
mkdir build-asan && cd build-asan
CC=clang CXX=clang++ cmake -GNinja \
  -DCMAKE_C_FLAGS="-g -O1 -fsanitize=address" \
  -DCMAKE_CXX_FLAGS="-g -O1 -fsanitize=address" \
  -DOT_COMPILE_WARNING_AS_ERROR=OFF \
  -DOT_PLATFORM=nexus -DOT_THREAD_VERSION=1.4 \
  -DOT_APP_CLI=OFF -DOT_APP_NCP=OFF -DOT_APP_RCP=OFF \
  -DOT_NEXUS_BUILD_TESTS=ON \
  -DOT_PROJECT_CONFIG=../tests/nexus/openthread-core-nexus-config.h ..
ninja nexus_ipv6_fragmentation
./tests/nexus/nexus_ipv6_fragmentation
```

Before this change:

```
==22303==ERROR: AddressSanitizer: heap-use-after-free
READ of size 2
    #0 ot::Message::GetOffset() const            src/core/common/message.hpp:538:59
    #1 ot::Ip6::Icmp::HandleEchoRequest(...)     src/core/net/icmp6.cpp:217:50
freed by:
    #4 ot::Ip6::Ip6::SendDatagram(...)           src/core/net/ip6.cpp:451:17
    #5 ot::Ip6::Icmp::HandleEchoRequest(...)     src/core/net/icmp6.cpp:215:5
```

After this change the test exits 0 with no sanitizer report.

### Notes

The dereference is a plain statement rather than part of the `LogInfo(...)` macro, so it happens regardless of the configured log level (observed with `OPENTHREAD_CONFIG_LOG_LEVEL_INIT = OT_LOG_LEVEL_CRIT`).

Since this is only surfaced by a sanitizer, it may be worth running the Nexus tests under `-fsanitize=address` in CI; that is how this was found.
