### PR TITLE
fix(ncp/link_raw): permit raw source matching on RCP builds and fix payload extraction

### DIFF
--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -117,11 +117,15 @@ otError otLinkRawSrcMatchEnable(otInstance *aInstance, bool aEnable)
     Error     error    = kErrorNone;
     Instance &instance = AsCoreType(aInstance);
 
+#if !OPENTHREAD_RADIO
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
+#endif
 
     instance.Get<Radio::Radio>().EnableSrcMatch(aEnable);
 
+#if !OPENTHREAD_RADIO
 exit:
+#endif
     return error;
 }
 
@@ -130,11 +134,15 @@ otError otLinkRawSrcMatchAddShortEntry(otInstance *aInstance, uint16_t aShortAdd
     Error     error    = kErrorNone;
     Instance &instance = AsCoreType(aInstance);
 
+#if !OPENTHREAD_RADIO
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
+#endif
 
     error = instance.Get<Radio::Radio>().AddSrcMatchShortEntry(aShortAddress);
 
+#if !OPENTHREAD_RADIO
 exit:
+#endif
     return error;
 }
 
@@ -143,11 +151,15 @@ otError otLinkRawSrcMatchAddExtEntry(otInstance *aInstance, const otExtAddress *
     Error     error    = kErrorNone;
     Instance &instance = AsCoreType(aInstance);
 
+#if !OPENTHREAD_RADIO
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
+#endif
 
     error = instance.Get<Radio::Radio>().AddSrcMatchExtEntry(AsCoreType(aExtAddress));
 
+#if !OPENTHREAD_RADIO
 exit:
+#endif
     return error;
 }
 
@@ -156,10 +168,15 @@ otError otLinkRawSrcMatchClearShortEntry(otInstance *aInstance, uint16_t aShortA
     Error     error    = kErrorNone;
     Instance &instance = AsCoreType(aInstance);
 
+#if !OPENTHREAD_RADIO
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
+#endif
+
     error = instance.Get<Radio::Radio>().ClearSrcMatchShortEntry(aShortAddress);
 
+#if !OPENTHREAD_RADIO
 exit:
+#endif
     return error;
 }
 
@@ -168,11 +185,15 @@ otError otLinkRawSrcMatchClearExtEntry(otInstance *aInstance, const otExtAddress
     Error     error    = kErrorNone;
     Instance &instance = AsCoreType(aInstance);
 
+#if !OPENTHREAD_RADIO
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
+#endif
 
     error = instance.Get<Radio::Radio>().ClearSrcMatchExtEntry(AsCoreType(aExtAddress));
 
+#if !OPENTHREAD_RADIO
 exit:
+#endif
     return error;
 }
 
@@ -181,11 +202,15 @@ otError otLinkRawSrcMatchClearShortEntries(otInstance *aInstance)
     Error     error    = kErrorNone;
     Instance &instance = AsCoreType(aInstance);
 
+#if !OPENTHREAD_RADIO
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
+#endif
 
     instance.Get<Radio::Radio>().ClearSrcMatchShortEntries();
 
+#if !OPENTHREAD_RADIO
 exit:
+#endif
     return error;
 }
 
@@ -194,11 +219,15 @@ otError otLinkRawSrcMatchClearExtEntries(otInstance *aInstance)
     Error     error    = kErrorNone;
     Instance &instance = AsCoreType(aInstance);
 
+#if !OPENTHREAD_RADIO
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
+#endif
 
     instance.Get<Radio::Radio>().ClearSrcMatchExtEntries();
 
+#if !OPENTHREAD_RADIO
 exit:
+#endif
     return error;
 }
 

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -114,121 +114,108 @@ otError otLinkRawEnergyScan(otInstance             *aInstance,
 
 otError otLinkRawSrcMatchEnable(otInstance *aInstance, bool aEnable)
 {
-    Error     error    = kErrorNone;
     Instance &instance = AsCoreType(aInstance);
 
-#if !OPENTHREAD_RADIO
-    VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
-#endif
+#if OPENTHREAD_RADIO
+    instance.Get<Radio::Radio>().EnableSrcMatch(aEnable);
+    return kErrorNone;
+#else
+    Error error = kErrorNone;
 
+    VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
     instance.Get<Radio::Radio>().EnableSrcMatch(aEnable);
 
-#if !OPENTHREAD_RADIO
 exit:
-#endif
     return error;
+#endif
 }
 
 otError otLinkRawSrcMatchAddShortEntry(otInstance *aInstance, uint16_t aShortAddress)
 {
-    Error     error    = kErrorNone;
     Instance &instance = AsCoreType(aInstance);
 
-#if !OPENTHREAD_RADIO
-    VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
+#if OPENTHREAD_RADIO
+    return instance.Get<Radio::Radio>().AddSrcMatchShortEntry(aShortAddress);
+#else
+    return instance.Get<Mac::LinkRaw>().IsEnabled()
+               ? instance.Get<Radio::Radio>().AddSrcMatchShortEntry(aShortAddress)
+               : kErrorInvalidState;
 #endif
-
-    error = instance.Get<Radio::Radio>().AddSrcMatchShortEntry(aShortAddress);
-
-#if !OPENTHREAD_RADIO
-exit:
-#endif
-    return error;
 }
 
 otError otLinkRawSrcMatchAddExtEntry(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
-    Error     error    = kErrorNone;
     Instance &instance = AsCoreType(aInstance);
 
-#if !OPENTHREAD_RADIO
-    VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
+#if OPENTHREAD_RADIO
+    return instance.Get<Radio::Radio>().AddSrcMatchExtEntry(AsCoreType(aExtAddress));
+#else
+    return instance.Get<Mac::LinkRaw>().IsEnabled()
+               ? instance.Get<Radio::Radio>().AddSrcMatchExtEntry(AsCoreType(aExtAddress))
+               : kErrorInvalidState;
 #endif
-
-    error = instance.Get<Radio::Radio>().AddSrcMatchExtEntry(AsCoreType(aExtAddress));
-
-#if !OPENTHREAD_RADIO
-exit:
-#endif
-    return error;
 }
 
 otError otLinkRawSrcMatchClearShortEntry(otInstance *aInstance, uint16_t aShortAddress)
 {
-    Error     error    = kErrorNone;
     Instance &instance = AsCoreType(aInstance);
 
-#if !OPENTHREAD_RADIO
-    VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
+#if OPENTHREAD_RADIO
+    return instance.Get<Radio::Radio>().ClearSrcMatchShortEntry(aShortAddress);
+#else
+    return instance.Get<Mac::LinkRaw>().IsEnabled()
+               ? instance.Get<Radio::Radio>().ClearSrcMatchShortEntry(aShortAddress)
+               : kErrorInvalidState;
 #endif
-
-    error = instance.Get<Radio::Radio>().ClearSrcMatchShortEntry(aShortAddress);
-
-#if !OPENTHREAD_RADIO
-exit:
-#endif
-    return error;
 }
 
 otError otLinkRawSrcMatchClearExtEntry(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
-    Error     error    = kErrorNone;
     Instance &instance = AsCoreType(aInstance);
 
-#if !OPENTHREAD_RADIO
-    VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
+#if OPENTHREAD_RADIO
+    return instance.Get<Radio::Radio>().ClearSrcMatchExtEntry(AsCoreType(aExtAddress));
+#else
+    return instance.Get<Mac::LinkRaw>().IsEnabled()
+               ? instance.Get<Radio::Radio>().ClearSrcMatchExtEntry(AsCoreType(aExtAddress))
+               : kErrorInvalidState;
 #endif
-
-    error = instance.Get<Radio::Radio>().ClearSrcMatchExtEntry(AsCoreType(aExtAddress));
-
-#if !OPENTHREAD_RADIO
-exit:
-#endif
-    return error;
 }
 
 otError otLinkRawSrcMatchClearShortEntries(otInstance *aInstance)
 {
-    Error     error    = kErrorNone;
     Instance &instance = AsCoreType(aInstance);
 
-#if !OPENTHREAD_RADIO
-    VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
-#endif
+#if OPENTHREAD_RADIO
+    instance.Get<Radio::Radio>().ClearSrcMatchShortEntries();
+    return kErrorNone;
+#else
+    Error error = kErrorNone;
 
+    VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
     instance.Get<Radio::Radio>().ClearSrcMatchShortEntries();
 
-#if !OPENTHREAD_RADIO
 exit:
-#endif
     return error;
+#endif
 }
 
 otError otLinkRawSrcMatchClearExtEntries(otInstance *aInstance)
 {
-    Error     error    = kErrorNone;
     Instance &instance = AsCoreType(aInstance);
 
-#if !OPENTHREAD_RADIO
-    VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
-#endif
+#if OPENTHREAD_RADIO
+    instance.Get<Radio::Radio>().ClearSrcMatchExtEntries();
+    return kErrorNone;
+#else
+    Error error = kErrorNone;
 
+    VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
     instance.Get<Radio::Radio>().ClearSrcMatchExtEntries();
 
-#if !OPENTHREAD_RADIO
 exit:
-#endif
     return error;
+#endif
 }
 
 otError otLinkRawSetMacKey(otInstance     *aInstance,

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1177,9 +1177,8 @@ otError NcpBase::HandleCommandPropertyInsertRemove(uint8_t aHeader, spinel_prop_
     // in case of success), then reset the read position back so
     // that the `PropertyHandler` method can parse the content.
 
-    mDecoder.SavePosition();
-    IgnoreError(mDecoder.ReadData(valuePtr, valueLen));
-    IgnoreError(mDecoder.ResetToSaved());
+    valuePtr = mDecoder.GetFrame() + mDecoder.GetReadLength();
+    valueLen = mDecoder.GetRemainingLength();
 
     mDisableStreamWrite = false;
 


### PR DESCRIPTION
### Problem

1. When running in pure Radio Co-Processor (`OPENTHREAD_RADIO=1`) mode, `Mac::LinkRaw` is disabled by design. However, calls to `otLinkRawSrcMatch*` check `instance.Get<Mac::LinkRaw>().IsEnabled()` and return `kErrorInvalidState`, which prevents NCP/RCP handlers from configuring radio source matching entries on RCP co-processors.
2. In `NcpBase::HandleCommandPropertyInsertRemove`, attempting to read raw variable length properties with `mDecoder.ReadData(...)` requires a length prefix. For properties that pass raw payloads (like `SPINEL_PROP_MAC_SRC_MATCH_EXTENDED_ADDRESSES`), `ReadData` returns `OT_ERROR_PARSE`.

### Solution

1. Guard `Mac::LinkRaw::IsEnabled()` checks with `#if !OPENTHREAD_RADIO` across `link_raw_api.cpp` so calls route directly to `Radio` on RCP builds.
2. Extract the unparsed payload directly using `mDecoder.GetFrame() + mDecoder.GetReadLength()` and `mDecoder.GetRemainingLength()`.
