### PR TITLE
[routing-manager] introduce `kToAdvertise` state in `OnLinkPrefixManager`

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1384,6 +1384,10 @@ void RoutingManager::OnLinkPrefixManager::Stop(void)
         break;
 
     case kPublishing:
+    case kToAdvertise:
+        SetState(kIdle);
+        break;
+
     case kAdvertising:
     case kDeprecating:
         SetState(kDeprecating);
@@ -1481,6 +1485,7 @@ void RoutingManager::OnLinkPrefixManager::PublishAndAdvertise(void)
         break;
 
     case kPublishing:
+    case kToAdvertise:
     case kAdvertising:
         ExitNow();
     }
@@ -1497,7 +1502,7 @@ void RoutingManager::OnLinkPrefixManager::PublishAndAdvertise(void)
 
     if (Get<RoutingManager>().NetworkDataContainsUlaRoute())
     {
-        SetState(kAdvertising);
+        SetState(kToAdvertise);
     }
 
 exit:
@@ -1506,16 +1511,28 @@ exit:
 
 void RoutingManager::OnLinkPrefixManager::Deprecate(void)
 {
-    // Deprecate the local on-link prefix if it was being advertised
-    // before. While depreciating the prefix, we wait for the lifetime
-    // timer to expire before unpublishing the prefix from the Network
-    // Data. We also continue to include it as a PIO in the RA message
-    // with zero preferred lifetime and the remaining valid lifetime
-    // until the timer expires.
+    // Deprecate the local on-link prefix only if it was being advertised
+    // before (`kAdvertising`).
+    //
+    // If the prefix is in `kPublishing` or `kToAdvertise` state, no
+    // outgoing RA containing the prefix as a PIO has been emitted yet.
+    // Since hosts on the infrastructure link have not seen or configured
+    // addresses from this prefix, there is no need to deprecate it, and
+    // it transitions directly to `kIdle`.
+    //
+    // While deprecating the prefix, we wait for the lifetime timer to
+    // expire before unpublishing the prefix from the Network Data. We
+    // also continue to include it as a PIO in the RA message with zero
+    // preferred lifetime and the remaining valid lifetime until the
+    // timer expires.
 
     switch (GetState())
     {
     case kPublishing:
+    case kToAdvertise:
+        SetState(kIdle);
+        break;
+
     case kAdvertising:
         SetState(kDeprecating);
         break;
@@ -1529,9 +1546,9 @@ void RoutingManager::OnLinkPrefixManager::Deprecate(void)
 bool RoutingManager::OnLinkPrefixManager::ShouldPublishUlaRoute(void) const
 {
     // Determine whether or not we should publish ULA prefix. We need
-    // to publish if we are in any of `kPublishing`, `kAdvertising`,
-    // or `kDeprecating` states, or if there is at least one old local
-    // prefix being deprecated.
+    // to publish if we are in any of `kPublishing`, `kToAdvertise`,
+    // `kAdvertising`, or `kDeprecating` states, or if there is at
+    // least one old local prefix being deprecated.
 
     return (GetState() != kIdle) || !mOldLocalPrefixes.IsEmpty();
 }
@@ -1540,12 +1557,31 @@ void RoutingManager::OnLinkPrefixManager::ResetExpireTime(TimeMilli aNow)
 {
     mExpireTime = aNow + TimeMilli::SecToMsec(kDefaultOnLinkPrefixLifetime);
     mTimer.FireAtIfEarlier(mExpireTime);
-    SavePrefix(mLocalPrefix, mExpireTime);
+
+    if (GetState() == kAdvertising)
+    {
+        SavePrefix(mLocalPrefix, mExpireTime);
+    }
 }
 
 bool RoutingManager::OnLinkPrefixManager::IsPublishingOrAdvertising(void) const
 {
-    return (GetState() == kPublishing) || (GetState() == kAdvertising);
+    bool matches = false;
+
+    switch (GetState())
+    {
+    case kIdle:
+    case kDeprecating:
+        break;
+
+    case kPublishing:
+    case kToAdvertise:
+    case kAdvertising:
+        matches = true;
+        break;
+    }
+
+    return matches;
 }
 
 Error RoutingManager::OnLinkPrefixManager::AppendAsPiosTo(RouterAdvert::TxMessage &aRaMessage)
@@ -1562,8 +1598,11 @@ exit:
 Error RoutingManager::OnLinkPrefixManager::AppendCurPrefix(RouterAdvert::TxMessage &aRaMessage)
 {
     // Append the local on-link prefix to the `aRaMessage` as a PIO
-    // only if it is being advertised or deprecated.
+    // only if it is ready to be advertised (`kToAdvertise`), is being
+    // advertised (`kAdvertising`), or is being deprecated (`kDeprecating`).
     //
+    // If in `kToAdvertise` state, we transition to `kAdvertising` as this
+    // is the first RA containing the prefix, and reset the expire time.
     // If in `kAdvertising` state, we reset the expire time.
     // If in `kDeprecating` state, we include it as PIO with zero
     // preferred lifetime and the remaining valid lifetime.
@@ -1576,6 +1615,10 @@ Error RoutingManager::OnLinkPrefixManager::AppendCurPrefix(RouterAdvert::TxMessa
 
     switch (GetState())
     {
+    case kToAdvertise:
+        SetState(kAdvertising);
+        OT_FALL_THROUGH;
+
     case kAdvertising:
         ResetExpireTime(now);
         break;
@@ -1634,7 +1677,7 @@ void RoutingManager::OnLinkPrefixManager::HandleNetDataChange(void)
 
     if (Get<RoutingManager>().NetworkDataContainsUlaRoute())
     {
-        SetState(kAdvertising);
+        SetState(kToAdvertise);
         Get<RoutingManager>().ScheduleRoutingPolicyEvaluation(kAfterRandomDelay);
     }
 
@@ -1651,7 +1694,7 @@ void RoutingManager::OnLinkPrefixManager::HandleExtPanIdChange(void)
     // so to allow Thread nodes to continue to communicate with `InfraIf`
     // device using addresses based on this prefix.
 
-    uint16_t    oldState  = GetState();
+    State       oldState  = GetState();
     Ip6::Prefix oldPrefix = mLocalPrefix;
 
     GenerateLocalPrefix();
@@ -1662,6 +1705,7 @@ void RoutingManager::OnLinkPrefixManager::HandleExtPanIdChange(void)
     {
     case kIdle:
     case kPublishing:
+    case kToAdvertise:
         break;
 
     case kAdvertising:
@@ -1741,6 +1785,7 @@ void RoutingManager::OnLinkPrefixManager::HandleTimer(void)
     case kIdle:
         break;
     case kPublishing:
+    case kToAdvertise:
     case kAdvertising:
     case kDeprecating:
         if (nextExpireTime.GetNow() >= mExpireTime)
@@ -1784,6 +1829,7 @@ const char *RoutingManager::OnLinkPrefixManager::StateToString(State aState)
 #define OnLinkPrefixManagerStateMapList(_) \
     _(kIdle, "Removed")                    \
     _(kPublishing, "Publishing")           \
+    _(kToAdvertise, "ToAdvertise")         \
     _(kAdvertising, "Advertising")         \
     _(kDeprecating, "Deprecating")
 

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -732,6 +732,7 @@ private:
         {
             kIdle,
             kPublishing,
+            kToAdvertise,
             kAdvertising,
             kDeprecating,
         };

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -831,6 +831,30 @@ void VerifyNat64PrefixInNetData(const Ip6::Prefix &aNat64Prefix)
     VerifyOrQuit(didFind);
 }
 
+void VerifyBrOnLinkPrefixInSettings(const Ip6::Prefix &aPrefix, bool aExpectedPresent)
+{
+    Settings::BrOnLinkPrefix savedPrefix;
+    bool                     found = false;
+
+    for (int index = 0; sInstance->Get<Settings>().ReadBrOnLinkPrefix(index, savedPrefix) == kErrorNone; index++)
+    {
+        if (savedPrefix.GetPrefix() == aPrefix)
+        {
+            found = true;
+            break;
+        }
+    }
+
+    VerifyOrQuit(found == aExpectedPresent);
+}
+
+void VerifyNoBrOnLinkPrefixInSettings(void)
+{
+    Settings::BrOnLinkPrefix savedPrefix;
+
+    VerifyOrQuit(sInstance->Get<Settings>().ReadBrOnLinkPrefix(0, savedPrefix) != kErrorNone);
+}
+
 struct Pio
 {
     using Flags = Ip6::Nd::PrefixInfoOption::Flags;
@@ -2751,6 +2775,155 @@ void TestLocalOnLinkPrefixDeprecation(void)
 
     Log("End of TestLocalOnLinkPrefixDeprecation");
 
+    FinalizeTest();
+}
+
+void TestUnadvertisedLocalOnLinkPrefix(void)
+{
+    static const otExtendedPanId kExtPanId1 = {{0x01, 0x02, 0x03, 0x04, 0x05, 0x6, 0x7, 0x08}};
+
+    Ip6::Prefix          localOnLink;
+    Ip6::Prefix          oldLocalOnLink;
+    Ip6::Prefix          localOmr;
+    Ip6::Prefix          onLinkPrefix   = PrefixFromString("2000:abba:baba::", 64);
+    Ip6::Address         routerAddressA = AddressFromString("fd00::aaaa");
+    otOperationalDataset dataset;
+
+    Log("--------------------------------------------------------------------------------------------");
+    Log("TestUnadvertisedLocalOnLinkPrefix");
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Scenario 1: A favored on-link prefix is discovered on AIL while local on-link
+    // prefix is in `kToAdvertise` state (before any RA is emitted).
+    // Ensure the unadvertised local on-link prefix transitions to `kIdle` and is NOT deprecated.
+
+    InitTest(/* aEnableBorderRouting */ false);
+
+    // Enable RxRaTracker before enabling RoutingManager.
+    // This allows initial RS router discovery to complete without
+    // timing dependencies or interference from RsSender start jitter.
+    sInstance->Get<BorderRouter::RxRaTracker>().SetEnabled(true, BorderRouter::RxRaTracker::kRequesterMultiAilDetector);
+    AdvanceTime(15000);
+    VerifyOrQuit(sInstance->Get<BorderRouter::RxRaTracker>().IsInitialRouterDiscoveryFinished());
+
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(true));
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().GetOnLinkPrefix(localOnLink));
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().GetOmrPrefix(localOmr));
+
+    Log("Local on-link prefix is %s", localOnLink.ToString().AsCString());
+
+    // Advance time slightly to allow the Leader to add the ULA route to Network Data
+    // and for OnLinkPrefixManager to transition to `kToAdvertise`.
+    // The first RA advertising the prefix is scheduled with `kAfterRandomDelay` (~2-4 seconds),
+    // so at 500 ms no RA advertising the prefix has been emitted.
+    AdvanceTime(500);
+
+    VerifyNoBrOnLinkPrefixInSettings();
+
+    // Send an RA from router A advertising an on-link prefix.
+    // This causes `OnLinkPrefixManager` to deprecate the local on-link prefix. Since it was
+    // in `kToAdvertise` (never advertised in an RA), it must transition directly to `kIdle`
+    // rather than `kDeprecating`.
+    SendRouterAdvert(routerAddressA, {Pio(onLinkPrefix, kValidLitime, kPreferredLifetime)});
+
+    sRaValidated = false;
+    sExpectedPio = kNoPio;
+    sExpectedRios.Clear();
+    sExpectedRios.Add(localOmr);
+
+    AdvanceTime(20000);
+
+    VerifyOrQuit(sRaValidated);
+    VerifyOrQuit(sDeprecatingPrefixes.IsEmpty());
+
+    VerifyExternalRouteInNetData(kDefaultRoute, kWithAdvPioCleared);
+
+    VerifyNoBrOnLinkPrefixInSettings();
+
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    sInstance->Get<BorderRouter::RxRaTracker>().SetEnabled(false,
+                                                           BorderRouter::RxRaTracker::kRequesterMultiAilDetector);
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Scenario 2: Extended PAN ID changes while local on-link prefix is in `kToAdvertise` state.
+    // Ensure the old prefix is NOT deprecated and not saved to Settings, while the new
+    // prefix is saved to Settings only after it is actually advertised in an RA.
+
+    sInstance->Get<BorderRouter::RxRaTracker>().SetEnabled(true, BorderRouter::RxRaTracker::kRequesterMultiAilDetector);
+    AdvanceTime(15000);
+    VerifyOrQuit(sInstance->Get<BorderRouter::RxRaTracker>().IsInitialRouterDiscoveryFinished());
+
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(true));
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().GetOnLinkPrefix(localOnLink));
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().GetOmrPrefix(localOmr));
+
+    oldLocalOnLink = localOnLink;
+
+    AdvanceTime(500);
+
+    VerifyNoBrOnLinkPrefixInSettings();
+
+    SuccessOrQuit(otDatasetGetActive(sInstance, &dataset));
+    VerifyOrQuit(dataset.mComponents.mIsExtendedPanIdPresent);
+    dataset.mExtendedPanId = kExtPanId1;
+    dataset.mActiveTimestamp.mSeconds++;
+    SuccessOrQuit(otDatasetSetActive(sInstance, &dataset));
+
+    AdvanceTime(500);
+
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().GetOnLinkPrefix(localOnLink));
+    VerifyOrQuit(localOnLink != oldLocalOnLink);
+    Log("Local on-link prefix changed to %s from %s", localOnLink.ToString().AsCString(),
+        oldLocalOnLink.ToString().AsCString());
+
+    VerifyNoBrOnLinkPrefixInSettings();
+
+    // Advance time for the RA to be emitted advertising the new local prefix.
+    // The old local on-link prefix should NOT be present in the RA as deprecating.
+    sRaValidated = false;
+    sExpectedPio = kPioAdvertisingLocalOnLink;
+    sExpectedRios.Clear();
+    sExpectedRios.Add(localOmr);
+
+    AdvanceTime(30000);
+
+    VerifyOrQuit(sRaValidated);
+    VerifyOrQuit(sDeprecatingPrefixes.IsEmpty());
+
+    VerifyBrOnLinkPrefixInSettings(oldLocalOnLink, false);
+    VerifyBrOnLinkPrefixInSettings(localOnLink, true);
+
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    sInstance->Get<BorderRouter::RxRaTracker>().SetEnabled(false,
+                                                           BorderRouter::RxRaTracker::kRequesterMultiAilDetector);
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Scenario 3: Routing Manager is stopped while local on-link prefix is in `kToAdvertise` state.
+    // Ensure no deprecating RA is emitted and prefix is never saved to Settings.
+
+    sInstance->Get<Settings>().DeleteAllBrOnLinkPrefixes();
+
+    sInstance->Get<BorderRouter::RxRaTracker>().SetEnabled(true, BorderRouter::RxRaTracker::kRequesterMultiAilDetector);
+    AdvanceTime(15000);
+    VerifyOrQuit(sInstance->Get<BorderRouter::RxRaTracker>().IsInitialRouterDiscoveryFinished());
+
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(true));
+    AdvanceTime(500);
+
+    VerifyNoBrOnLinkPrefixInSettings();
+
+    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(false));
+    sInstance->Get<BorderRouter::RxRaTracker>().SetEnabled(false,
+                                                           BorderRouter::RxRaTracker::kRequesterMultiAilDetector);
+
+    sRaValidated = false;
+    AdvanceTime(5000);
+    VerifyOrQuit(!sRaValidated);
+
+    VerifyNoBrOnLinkPrefixInSettings();
+    VerifyExternalRouteInNetData(kNoRoute);
+
+    Log("End of TestUnadvertisedLocalOnLinkPrefix");
     FinalizeTest();
 }
 
@@ -5436,6 +5609,7 @@ int main(void)
     ot::TestAdvNonUlaRoute();
     ot::TestFavoredOnLinkPrefix();
     ot::TestLocalOnLinkPrefixDeprecation();
+    ot::TestUnadvertisedLocalOnLinkPrefix();
     ot::TestExtPanIdChange();
     ot::TestConflictingPrefix();
     ot::TestPrefixStaleTime();


### PR DESCRIPTION
This commit introduces a new `kToAdvertise` state in `OnLinkPrefixManager` to represent a prefix that is ready to be advertised once an RA is emitted. The transition to `kAdvertising` (and persisting to `Settings`) only occurs when `AppendCurPrefix()` actually appends the prefix to an outgoing RA. If the prefix is stopped, deprecated, or replaced before the first RA is emitted, it transitions cleanly to `kIdle` without being deprecated or saved to non-volatile storage.

Previously, `OnLinkPrefixManager` transitioned directly to `kAdvertising` as soon as the ULA route was confirmed in Network Data. Because RA transmissions are scheduled asynchronously with random jitter and rate limits, if the routing manager was stopped, an external favored prefix was discovered on the infrastructure link, or the Extended PAN ID changed before any RA was transmitted, the manager assumed the prefix was already being used by infrastructure hosts. Consequently, it would deprecate the prefix for a full 30-minute cycle and persist it in `Settings`.

This commit also adds the `TestUnadvertisedLocalOnLinkPrefix()` unit test in `test_routing_manager` to validate these scenarios.