### PR TITLE
[thread] add otThreadSaveNetworkInfo for non-volatile store

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @note This number versions both OpenThread platform and user APIs.
  */
-#define OPENTHREAD_API_VERSION (615)
+#define OPENTHREAD_API_VERSION (616)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -354,6 +354,20 @@ uint32_t otThreadGetChildTimeout(otInstance *aInstance);
 void otThreadSetChildTimeout(otInstance *aInstance, uint32_t aTimeout);
 
 /**
+ * Saves the current network attachment state to non-volatile settings.
+ *
+ * This stores the current `NetworkInfo` and `ParentInfo` (if attached as a child) to the
+ * platform settings. It is intended to be called before a reset or any sleep mode that does
+ * not retain RAM.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ *
+ * @retval OT_ERROR_NONE           Successfully stored network info.
+ * @retval OT_ERROR_INVALID_STATE  The device is not attached to a Thread network.
+ */
+otError otThreadSaveNetworkInfo(otInstance *aInstance);
+
+/**
  * Gets the IEEE 802.15.4 Extended PAN ID.
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -6529,6 +6529,20 @@ template <> otError Interpreter::Process<Cmd("thread")>(Arg aArgs[])
     {
         OutputLine("%u", otThreadGetVersion());
     }
+    /**
+     * @cli thread save
+     * @code
+     * thread save
+     * Done
+     * @endcode
+     * @par
+     * Saves the current network attachment state to non-volatile settings.
+     * @sa otThreadSaveNetworkInfo
+     */
+    else if (aArgs[0] == "save")
+    {
+        error = otThreadSaveNetworkInfo(GetInstancePtr());
+    }
     else
     {
         error = OT_ERROR_INVALID_COMMAND;

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -46,6 +46,18 @@ void otThreadSetChildTimeout(otInstance *aInstance, uint32_t aTimeout)
     AsCoreType(aInstance).Get<Mle::Mle>().SetTimeout(aTimeout);
 }
 
+otError otThreadSaveNetworkInfo(otInstance *aInstance)
+{
+    Error     error    = kErrorNone;
+    Instance &instance = AsCoreType(aInstance);
+
+    VerifyOrExit(instance.Get<Mle::Mle>().IsAttached(), error = kErrorInvalidState);
+    instance.Get<Mle::Mle>().Store();
+
+exit:
+    return error;
+}
+
 const otExtendedPanId *otThreadGetExtendedPanId(otInstance *aInstance)
 {
     return &AsCoreType(aInstance).Get<MeshCoP::NetworkIdentity>().GetExtPanId();


### PR DESCRIPTION
This commit adds a public API to persist the current Thread attachment state to non-volatile settings when the ram is not retained.

Mle::Store() already writes NetworkInfo and (when attached as a child) ParentInfo. This change exposes that behavior through the public API and CLI so applications can request a save without reaching into core.

Changes:

Add otThreadSaveNetworkInfo() in include/openthread/thread.h and src/core/api/thread_api.cpp (requires the device to be attached).
Add thread save CLI command.
Bump OPENTHREAD_API_VERSION from 615 to 616