### PR TITLE
[coap] Add FETCH method (RFC 8132) and OSCORE option (RFC 8613)

### DIFF
--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -94,6 +94,7 @@ typedef enum otCoapCode
     OT_COAP_CODE_POST   = OT_COAP_CODE(0, 2), ///< Post
     OT_COAP_CODE_PUT    = OT_COAP_CODE(0, 3), ///< Put
     OT_COAP_CODE_DELETE = OT_COAP_CODE(0, 4), ///< Delete
+    OT_COAP_CODE_FETCH  = OT_COAP_CODE(0, 5), ///< Fetch (RFC 8132)
 
     OT_COAP_CODE_RESPONSE_MIN = OT_COAP_CODE(2, 0),  ///< 2.00
     OT_COAP_CODE_CREATED      = OT_COAP_CODE(2, 1),  ///< Created
@@ -135,6 +136,7 @@ typedef enum otCoapOptionType
     OT_COAP_OPTION_OBSERVE        = 6,  ///< Observe [RFC7641]
     OT_COAP_OPTION_URI_PORT       = 7,  ///< Uri-Port
     OT_COAP_OPTION_LOCATION_PATH  = 8,  ///< Location-Path
+    OT_COAP_OPTION_OSCORE         = 9,  ///< OSCORE (RFC 8613)
     OT_COAP_OPTION_URI_PATH       = 11, ///< Uri-Path
     OT_COAP_OPTION_CONTENT_FORMAT = 12, ///< Content-Format
     OT_COAP_OPTION_MAX_AGE        = 14, ///< Max-Age

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -721,6 +721,24 @@ void CoapBase::ProcessReceivedRequest(Msg &aRxMsg)
 
     SuccessOrExit(error = aRxMsg.mMessage.ReadUriPathOptions(uriPath));
 
+    if (aRxMsg.GetCode() == kCodeFetch)
+    {
+        bool hasOscoreOption     = false;
+        bool hasContentFmtOption = false;
+
+        SuccessOrExit(error = aRxMsg.mMessage.ReadFetchRequestOptions(hasOscoreOption, hasContentFmtOption));
+
+        if (!hasOscoreOption && !hasContentFmtOption)
+        {
+            if (aRxMsg.IsConfirmable())
+            {
+                IgnoreError(SendResponse(kCodeUnsupportedFormat, aRxMsg));
+            }
+
+            ExitNow(error = kErrorNone);
+        }
+    }
+
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
     {
         bool didHandle = false;
@@ -1383,10 +1401,10 @@ Error CoapBase::PendingRequests::ProcessObserveSend(const Msg &aTxMsg, Request &
     SuccessOrExit(error = iterator.Init(aTxMsg.mMessage, kOptionObserve));
     aRequest.mMetadata.mObserve = !iterator.IsDone();
 
-    // Special case, if we're sending a GET with Observe=1, that is a
+    // Special case, if we're sending a GET or FETCH with Observe=1, that is a
     // cancellation.
 
-    if (aRequest.mMetadata.mObserve && aTxMsg.IsGetRequest())
+    if (aRequest.mMetadata.mObserve && (aTxMsg.IsGetRequest() || aTxMsg.IsFetchRequest()))
     {
         uint64_t value = 0;
 

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -90,7 +90,7 @@ exit:
 //---------------------------------------------------------------------------------------------------------------------
 // `HeaderInfo`
 
-bool HeaderInfo::IsRequest(void) const { return IsValueInRange<uint8_t>(mCode, kCodeGet, kCodeDelete); }
+bool HeaderInfo::IsRequest(void) const { return IsValueInRange<uint8_t>(mCode, kCodeGet, kCodeFetch); }
 
 //---------------------------------------------------------------------------------------------------------------------
 // `Message`
@@ -423,6 +423,44 @@ exit:
     return error;
 }
 
+Error Message::ReadFetchRequestOptions(bool &aHasOscoreOption, bool &aHasContentFmtOption) const
+{
+    Error            error = kErrorNone;
+    Option::Iterator iterator;
+
+    aHasOscoreOption     = false;
+    aHasContentFmtOption = false;
+
+    SuccessOrExit(error = iterator.Init(*this));
+
+    while (!iterator.IsDone())
+    {
+        uint16_t optionNum = iterator.GetOption()->GetNumber();
+
+        if (optionNum > kOptionContentFormat)
+        {
+            break;
+        }
+
+        switch (iterator.GetOption()->GetNumber())
+        {
+        case kOptionOscore:
+            aHasOscoreOption = true;
+            break;
+        case kOptionContentFormat:
+            aHasContentFmtOption = true;
+            break;
+        default:
+            break;
+        }
+
+        SuccessOrExit(error = iterator.Advance());
+    }
+
+exit:
+    return error;
+}
+
 Error Message::AppendUriQueryOptions(const char *aUriQuery)
 {
     Error       error = kErrorNone;
@@ -720,6 +758,7 @@ const char *Message::CodeToString(void) const
         {kCodePost, "Post"},
         {kCodePut, "Put"},
         {kCodeDelete, "Delete"},
+        {kCodeFetch, "Fetch"},
         {kCodeCreated, "Created"},
         {kCodeDeleted, "Deleted"},
         {kCodeValid, "Valid"},

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -97,6 +97,7 @@ enum Code : uint8_t
     kCodePost   = OT_COAP_CODE_POST,   ///< Post
     kCodePut    = OT_COAP_CODE_PUT,    ///< Put
     kCodeDelete = OT_COAP_CODE_DELETE, ///< Delete
+    kCodeFetch  = OT_COAP_CODE_FETCH,  ///< Fetch (RFC 8132)
 
     // Response Codes:
 
@@ -144,6 +145,7 @@ enum OptionNumber : uint16_t
     kOptionObserve       = OT_COAP_OPTION_OBSERVE,        ///< Observe [RFC7641]
     kOptionUriPort       = OT_COAP_OPTION_URI_PORT,       ///< Uri-Port
     kOptionLocationPath  = OT_COAP_OPTION_LOCATION_PATH,  ///< Location-Path
+    kOptionOscore        = OT_COAP_OPTION_OSCORE,         ///< OSCORE (RFC 8613)
     kOptionUriPath       = OT_COAP_OPTION_URI_PATH,       ///< Uri-Path
     kOptionContentFormat = OT_COAP_OPTION_CONTENT_FORMAT, ///< Content-Format
     kOptionMaxAge        = OT_COAP_OPTION_MAX_AGE,        ///< Max-Age
@@ -349,6 +351,14 @@ public:
      * @retval FALSE  Message is not a Delete request.
      */
     bool IsDeleteRequest(void) const { return (mCode == kCodeDelete); }
+
+    /**
+     * Indicates whether or not the CoAP code in header is "Fetch" request.
+     *
+     * @retval TRUE   Message is a Fetch request.
+     * @retval FALSE  Message is not a Fetch request.
+     */
+    bool IsFetchRequest(void) const { return (mCode == kCodeFetch); }
 
     /**
      * Checks if a header is a response header.
@@ -697,6 +707,17 @@ public:
      * @retval  kErrorParse  CoAP Option header not well-formed.
      */
     Error ReadUriPathOptions(UriPathStringBuffer &aUriPath) const;
+
+    /**
+     * Reads FETCH request options to detect presence of OSCORE and Content-Format options.
+     *
+     * @param[out]  aHasOscoreOption     Set to `true` if OSCORE option is present.
+     * @param[out]  aHasContentFmtOption Set to `true` if Content-Format option is present.
+     *
+     * @retval  kErrorNone   Successfully read options.
+     * @retval  kErrorParse  CoAP Option header not well-formed.
+     */
+    Error ReadFetchRequestOptions(bool &aHasOscoreOption, bool &aHasContentFmtOption) const;
 
     /**
      * Appends a Uri-Query option.


### PR DESCRIPTION
## Summary

Adds support for the CoAP FETCH method (RFC 8132, code 0.05) and the OSCORE
option (RFC 8613, option number 9), required for OSCORE-protected CoAP communication.

## Problem

`HeaderInfo::IsRequest()` uses a range check `[kCodeGet, kCodeDelete]` (0.01–0.04),
so FETCH (0.05) is rejected as a non-request. OSCORE (RFC 8613) always uses FETCH
as the outer method, meaning all OSCORE-protected messages are silently dropped
before any resource handler is reached.

## Changes

| File | Change |
|------|--------|
| `include/openthread/coap.h` | Add `OT_COAP_CODE_FETCH` and `OT_COAP_OPTION_OSCORE` |
| `src/core/coap/coap_message.hpp` | Add `kCodeFetch`, `kOptionOscore`, declare `ReadFetchRequestOptions()` |
| `src/core/coap/coap_message.cpp` | Fix `IsRequest()` upper bound; implement `ReadFetchRequestOptions()` |
| `src/core/coap/coap.cpp` | Validate FETCH: reject with 4.15 if no OSCORE and no Content-Format option |

## RFC References

- [RFC 8132](https://www.rfc-editor.org/rfc/rfc8132) — PATCH and FETCH Methods for CoAP
- [RFC 8613](https://www.rfc-editor.org/rfc/rfc8613) — OSCORE

Closes 12838