### PR TITLE
[posix] add a tx-power radio URL parameter

### DIFF
--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -152,6 +152,12 @@ void Radio::ProcessRadioUrl(const RadioUrl &aRadioUrl)
         SuccessOrDie(mRadioSpinel.SetCcaEnergyDetectThreshold(value));
     }
 
+    if (aRadioUrl.HasParam("tx-power"))
+    {
+        SuccessOrDie(aRadioUrl.ParseInt8("tx-power", value));
+        SuccessOrDie(mRadioSpinel.SetTransmitPower(value));
+    }
+
 #if OPENTHREAD_POSIX_CONFIG_CONFIGURATION_FILE_ENABLE
     // config files should be parsed before the region parameter
     if (aRadioUrl.HasParam("product-config-file"))

--- a/src/posix/platform/radio_url.cpp
+++ b/src/posix/platform/radio_url.cpp
@@ -108,8 +108,15 @@ const char *otSysGetRadioUrlHelpString(void)
     "                                  If the number of values is less than that of supported channels,\n" \
     "                                  the last value will be applied to all remaining channels.\n"        \
     "                                  Special value 0x7f disables a channel.\n"
+
+// Only meaningful while max-power-table is compiled in; without it the note
+// would point at a parameter the help does not list.
+#define OT_RADIO_URL_HELP_TX_POWER_CAP                                                                \
+    "                                  max-power-table only caps the power; the radio transmits at\n" \
+    "                                  min(tx-power, max-power-table).\n"
 #else
 #define OT_RADIO_URL_HELP_MAX_POWER_TABLE
+#define OT_RADIO_URL_HELP_TX_POWER_CAP
 #endif
 
     return "RadioURL:\n" OT_RADIO_URL_HELP_BUS OT_SPINEL_SPI_RADIO_URL_HELP_BUS OT_SPINEL_HDLC_RADIO_URL_HELP_BUS
@@ -117,6 +124,7 @@ const char *otSysGetRadioUrlHelpString(void)
            "    region[=region-code]          Set the radio's region code. The region code must be an\n"
            "                                  ISO 3166 alpha-2 code.\n"
            "    cca-threshold[=dbm]           Set the radio's CCA ED threshold in dBm measured at antenna connector.\n"
+           "    tx-power[=dbm]                Set the radio's transmit power in dBm.\n" OT_RADIO_URL_HELP_TX_POWER_CAP
            "    enable-coex[=1|0]             If not specified, RCP coex operates with its default configuration.\n"
            "                                  Disable coex with 0, and enable it with other values.\n"
            "    fem-lnagain[=dbm]             Set the Rx LNA gain in dBm of the external FEM.\n"

--- a/tests/scripts/expect/posix-tx-power.exp
+++ b/tests/scripts/expect/posix-tx-power.exp
@@ -1,0 +1,75 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+source "tests/scripts/expect/_common.exp"
+
+spawn $env(OT_POSIX_APPS)/ot-cli "spinel+hdlc+uart://$env(OT_SIMULATION_APPS)/ncp/ot-rcp?forkpty-arg=1&tx-power=11"
+expect_after {
+    timeout { exit 1 }
+}
+send "txpower\n"
+expect "11 dBm"
+expect_line "Done"
+send "\x04"
+expect eof
+
+spawn $env(OT_POSIX_APPS)/ot-cli "spinel+hdlc+uart://$env(OT_SIMULATION_APPS)/ncp/ot-rcp?forkpty-arg=1&tx-power=-20"
+expect_after {
+    timeout { exit 1 }
+}
+send "txpower\n"
+expect -- "-20 dBm"
+expect_line "Done"
+send "\x04"
+expect eof
+
+# Without the parameter the radio keeps its default, so the value above can
+# only have come from the radio URL.
+spawn $env(OT_POSIX_APPS)/ot-cli "spinel+hdlc+uart://$env(OT_SIMULATION_APPS)/ncp/ot-rcp?forkpty-arg=1"
+expect_after {
+    timeout { exit 1 }
+}
+send "txpower\n"
+expect "0 dBm"
+expect_line "Done"
+send "\x04"
+expect eof
+
+# Out of int8 range on either side: the value is rejected and the app exits.
+spawn $env(OT_POSIX_APPS)/ot-cli "spinel+hdlc+uart://$env(OT_SIMULATION_APPS)/ncp/ot-rcp?forkpty-arg=1&tx-power=128"
+expect_after {
+    timeout { exit 1 }
+}
+expect eof
+
+spawn $env(OT_POSIX_APPS)/ot-cli "spinel+hdlc+uart://$env(OT_SIMULATION_APPS)/ncp/ot-rcp?forkpty-arg=1&tx-power=-129"
+expect_after {
+    timeout { exit 1 }
+}
+expect eof


### PR DESCRIPTION
Closes #13573.

The radio URL configures the CCA threshold, the FEM LNA gain, the region and a per-channel power cap — but not the power the radio transmits at. This adds `tx-power[=dbm]`, applied during radio initialisation alongside `cca-threshold` and `fem-lnagain`:

```c
if (aRadioUrl.HasParam("tx-power"))
{
    SuccessOrDie(aRadioUrl.ParseInt8("tx-power", value));
    SuccessOrDie(mRadioSpinel.SetTransmitPower(value));
}
```

Going through `RadioSpinel::SetTransmitPower()` also puts it into the restoration bookkeeping, so unlike a `ot-ctl txpower` issued after start, it survives an RCP reset.

### Why `max-power-table` is not this

I originally assumed it was, in openthread/ot-br-posix#3520, and that was wrong. It caps: `min(txPower, channelMax)`. It can lower the power, never raise it. Nothing on the host sets the power during initialisation — `otPlatRadioSetTransmitPower()` is reached only from the CLI and the NCP property handler — and `OPENTHREAD_CONFIG_DEFAULT_TRANSMIT_POWER` is consumed by the platform layer (e.g. ot-efr32's `radio_power_manager.c`), not here. So an RCP deployment runs at whatever constant its RCP firmware carries, with no way to change it from configuration.

The help text says so explicitly, since that distinction cost me two weeks:

```
tx-power[=dbm]                Set the radio's transmit power in dBm. Unlike max-power-table,
                              which only caps it, this sets the power the radio transmits at.
```

### Verification

Simulated RCP, paired so the reading cannot come from anywhere else:

| radio URL | `ot-ctl txpower` |
|---|---|
| `?tx-power=11` | 11 dBm |
| no parameter | 0 dBm |

Real hardware, an SLZB-06M (EFR32, `SL-OPENTHREAD/2.4.2.0`). The radio was deliberately set to 5 dBm first, so that neither the default (0) nor a value retained from earlier (14) could be mistaken for success:

| step | `ot-ctl txpower` |
|---|---|
| set to 5 beforehand | 4 dBm |
| started with `tx-power=11` | **10 dBm** |

10 rather than 11 because the EFR32 selects the nearest step at or below the requested power — the same reason 5 reads back as 4, and 3 as 2. The value can only have come from the parameter.

`clang-format` 19.1.7 clean on both files.

### Context

This is the gap behind openthread/ot-br-posix#3520 and openthread#13524. On our border router a mains-powered plug 8.5 m away could not attach at 0 dBm — Child ID Requests arrived, the replies did not — and worked immediately at 14 dBm. Getting there needs `ot-ctl txpower 14` after every container start, through a Compose `post_start` hook, purely because there is nowhere in the configuration to say it. With this parameter that hook disappears.
