### PR TITLE
[mac] rename frame prepare and tx-done callbacks

### DIFF
--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -131,7 +131,7 @@ exit:
     return;
 }
 
-Mac::TxFrame *DataPollHandler::HandleFrameRequest(Mac::TxFrames &aTxFrames)
+Mac::TxFrame *DataPollHandler::PrepareFrame(Mac::TxFrames &aTxFrames)
 {
     Mac::TxFrame *frame = nullptr;
 
@@ -179,20 +179,20 @@ exit:
     return frame;
 }
 
-void DataPollHandler::HandleSentFrame(const Mac::TxFrame::ParseInfo &aFrameInfo, Error aError)
+void DataPollHandler::HandleFrameTxDone(const Mac::TxFrame::ParseInfo &aFrameInfo, Error aError)
 {
     Child *child = mIndirectTxChild;
 
     VerifyOrExit(child != nullptr);
 
     mIndirectTxChild = nullptr;
-    HandleSentFrame(aFrameInfo, aError, *child);
+    HandleFrameTxDone(aFrameInfo, aError, *child);
 
 exit:
     ProcessPendingPolls();
 }
 
-void DataPollHandler::HandleSentFrame(const Mac::TxFrame::ParseInfo &aFrameInfo, Error aError, Child &aChild)
+void DataPollHandler::HandleFrameTxDone(const Mac::TxFrame::ParseInfo &aFrameInfo, Error aError, Child &aChild)
 {
     if (aChild.IsFramePurgePending())
     {
@@ -254,7 +254,7 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame::ParseInfo &aFrameInfo,
         OT_ASSERT(false);
     }
 
-    Get<IndirectSender>().HandleSentFrameToChild(aFrameInfo, mFrameContext, aError, aChild);
+    Get<IndirectSender>().HandleFrameTxToChildDone(aFrameInfo, mFrameContext, aError, aChild);
 
 exit:
     return;

--- a/src/core/mac/data_poll_handler.hpp
+++ b/src/core/mac/data_poll_handler.hpp
@@ -167,7 +167,7 @@ public:
      *    callback `HandleFrameChangeDone()` is invoked.
      *
      * 2) In case of "replace" request, the ongoing indirect transmission is allowed to finish (current tx attempt).
-     *    2.a) If the tx attempt is successful, the `IndirectSender::HandleSentFrameToChild()` in invoked which
+     *    2.a) If the tx attempt is successful, the `IndirectSender::HandleFrameTxToChildDone()` is invoked which
      *         indicates the "replace" could not happen (in this case `HandleFrameChangeDone()` is no longer called).
      *    2.b) If the ongoing tx attempt is unsuccessful, then callback `HandleFrameChangeDone()` is invoked to allow
      *         the next layer to update the frame/message for the child.
@@ -186,10 +186,10 @@ private:
 
     // Callbacks from MAC
     void          HandleDataPoll(Mac::RxFrame::ParseInfo &aFrameInfo);
-    Mac::TxFrame *HandleFrameRequest(Mac::TxFrames &aTxFrames);
-    void          HandleSentFrame(const Mac::TxFrame::ParseInfo &aFrameInfo, Error aError);
+    Mac::TxFrame *PrepareFrame(Mac::TxFrames &aTxFrames);
+    void          HandleFrameTxDone(const Mac::TxFrame::ParseInfo &aFrameInfo, Error aError);
 
-    void HandleSentFrame(const Mac::TxFrame::ParseInfo &aFrameInfo, Error aError, Child &aChild);
+    void HandleFrameTxDone(const Mac::TxFrame::ParseInfo &aFrameInfo, Error aError, Child &aChild);
     void ProcessPendingPolls(void);
     void ResetTxAttempts(Child &aChild);
 

--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -190,7 +190,7 @@ uint32_t DataPollSender::GetKeepAlivePollPeriod(void) const
     return period;
 }
 
-void DataPollSender::HandlePollSent(Mac::TxFrame::ParseInfo &aFrameInfo, Error aError)
+void DataPollSender::HandlePollTxDone(Mac::TxFrame::ParseInfo &aFrameInfo, Error aError)
 {
     bool    shouldRecalculatePollPeriod = false;
     uint8_t maxRetxAttempts;
@@ -199,8 +199,8 @@ void DataPollSender::HandlePollSent(Mac::TxFrame::ParseInfo &aFrameInfo, Error a
 
     if (!aFrameInfo.GetTxFrame()->IsEmpty())
     {
-        Get<MeshForwarder>().UpdateNeighborOnSentFrame(aFrameInfo, aError, aFrameInfo.mAddrs.mDestination,
-                                                       /* aIsDataPoll */ true);
+        Get<MeshForwarder>().UpdateNeighborOnFrameTxDone(aFrameInfo, aError, aFrameInfo.mAddrs.mDestination,
+                                                         /* aIsDataPoll */ true);
     }
 
     if (GetParent().IsStateInvalid())
@@ -410,7 +410,7 @@ void DataPollSender::StopFastPolls(void)
     VerifyOrExit(mFastPollsUsers != 0);
 
     // If `mFastPollsUsers` hits the max, let it be cleared
-    // from `HandlePollSent()` (after all fast polls are sent).
+    // from `HandlePollTxDone()` (after all fast polls are sent).
     VerifyOrExit(mFastPollsUsers < kMaxFastPollsUsers);
 
     mFastPollsUsers--;

--- a/src/core/mac/data_poll_sender.hpp
+++ b/src/core/mac/data_poll_sender.hpp
@@ -122,16 +122,15 @@ public:
     uint32_t GetExternalPollPeriod(void) const { return mExternalPollPeriod; }
 
     /**
-     * Informs the data poll sender of success/error status of a previously requested poll frame
-     * transmission.
+     * Informs the data poll sender that a data poll frame transmission has completed.
      *
      * In case of transmit failure, the data poll sender may choose to send the next data poll more quickly (up to
      * some fixed number of attempts).
      *
      * @param[in] aFrameInfo  The data poll frame information.
-     * @param[in] aError      Error status of a data poll message transmission.
+     * @param[in] aError      Error status of a data poll frame transmission.
      */
-    void HandlePollSent(Mac::TxFrame::ParseInfo &aFrameInfo, Error aError);
+    void HandlePollTxDone(Mac::TxFrame::ParseInfo &aFrameInfo, Error aError);
 
     /**
      * Informs the data poll sender that a data poll timeout happened, i.e., when the ack in response to

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -959,7 +959,7 @@ void Mac::BeginTransmit(void)
         txFrames.SetChannel(mRadioChannel);
         txFrames.SetMaxCsmaBackoffs(kMaxCsmaBackoffsDirect);
         txFrames.SetMaxFrameRetries(mMaxFrameRetriesDirect);
-        frame = Get<MeshForwarder>().HandleFrameRequest(txFrames);
+        frame = Get<MeshForwarder>().PrepareFrame(txFrames);
         VerifyOrExit(frame != nullptr);
         seqNum = mDataSequence++;
         break;
@@ -969,7 +969,7 @@ void Mac::BeginTransmit(void)
         txFrames.SetChannel(mRadioChannel);
         txFrames.SetMaxCsmaBackoffs(kMaxCsmaBackoffsIndirect);
         txFrames.SetMaxFrameRetries(mMaxFrameRetriesIndirect);
-        frame = Get<DataPollHandler>().HandleFrameRequest(txFrames);
+        frame = Get<DataPollHandler>().PrepareFrame(txFrames);
         VerifyOrExit(frame != nullptr);
         // If the frame is marked as retransmission, then data sequence number is already set.
         shouldWriteSeqNum = !frame->IsARetransmission();
@@ -981,7 +981,7 @@ void Mac::BeginTransmit(void)
     case kOperationTransmitDataCsl:
         txFrames.SetMaxCsmaBackoffs(kMaxCsmaBackoffsCsl);
         txFrames.SetMaxFrameRetries(kMaxFrameRetriesCsl);
-        frame = Get<CslTxScheduler>().HandleFrameRequest(txFrames);
+        frame = Get<CslTxScheduler>().PrepareFrame(txFrames);
         VerifyOrExit(frame != nullptr);
         // If the frame is marked as retransmission, then data sequence number is already set.
         shouldWriteSeqNum = !frame->IsARetransmission();
@@ -1476,7 +1476,7 @@ void Mac::HandleTransmitDone(TxFrame::ParseInfo &aFrameInfo, RxFrame *aAckFrame,
 
         mCounters.mTxDataPoll++;
         FinishOperation();
-        Get<DataPollSender>().HandlePollSent(aFrameInfo, aError);
+        Get<DataPollSender>().HandlePollTxDone(aFrameInfo, aError);
         PerformNextOperation();
         break;
 
@@ -1496,7 +1496,7 @@ void Mac::HandleTransmitDone(TxFrame::ParseInfo &aFrameInfo, RxFrame *aAckFrame,
 
         DumpDebg("TX", aFrameInfo.GetTxFrame()->GetPsdu(), aFrameInfo.GetTxFrame()->GetLength());
         FinishOperation();
-        Get<MeshForwarder>().HandleSentFrame(aFrameInfo, aError);
+        Get<MeshForwarder>().HandleFrameTxDone(aFrameInfo, aError);
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
         Get<DataPollSender>().ProcessTxDone(aFrameInfo, ackFrameInfo, aError);
 #endif
@@ -1509,7 +1509,7 @@ void Mac::HandleTransmitDone(TxFrame::ParseInfo &aFrameInfo, RxFrame *aAckFrame,
 
         DumpDebg("TX", aFrameInfo.GetTxFrame()->GetPsdu(), aFrameInfo.GetTxFrame()->GetLength());
         FinishOperation();
-        Get<CslTxScheduler>().HandleSentFrame(aFrameInfo, aError);
+        Get<CslTxScheduler>().HandleFrameTxDone(aFrameInfo, aError);
         PerformNextOperation();
 
         break;
@@ -1532,7 +1532,7 @@ void Mac::HandleTransmitDone(TxFrame::ParseInfo &aFrameInfo, RxFrame *aAckFrame,
 
         DumpDebg("TX", aFrameInfo.GetTxFrame()->GetPsdu(), aFrameInfo.GetTxFrame()->GetLength());
         FinishOperation();
-        Get<DataPollHandler>().HandleSentFrame(aFrameInfo, aError);
+        Get<DataPollHandler>().HandleFrameTxDone(aFrameInfo, aError);
         PerformNextOperation();
         break;
 #endif // OPENTHREAD_FTD

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -234,7 +234,7 @@ Radio::Time64 CslTxScheduler::NeighborInfo::DetermineNextCslWindow(Radio::Time64
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 
-Mac::TxFrame *CslTxScheduler::HandleFrameRequest(Mac::TxFrames &aTxFrames)
+Mac::TxFrame *CslTxScheduler::PrepareFrame(Mac::TxFrames &aTxFrames)
 {
     Mac::TxFrame *frame = nullptr;
 
@@ -303,11 +303,11 @@ exit:
 
 #else // OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 
-Mac::TxFrame *CslTxScheduler::HandleFrameRequest(Mac::TxFrames &) { return nullptr; }
+Mac::TxFrame *CslTxScheduler::PrepareFrame(Mac::TxFrames &) { return nullptr; }
 
 #endif // OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 
-void CslTxScheduler::HandleSentFrame(const Mac::TxFrame::ParseInfo &aFrameInfo, Error aError)
+void CslTxScheduler::HandleFrameTxDone(const Mac::TxFrame::ParseInfo &aFrameInfo, Error aError)
 {
     VerifyOrExit(mCslTxNeighbor != nullptr);
 
@@ -359,7 +359,7 @@ void CslTxScheduler::HandleSentFrame(const Mac::TxFrame::ParseInfo &aFrameInfo, 
         OT_UNREACHABLE_CODE(break);
     }
 
-    Get<IndirectSender>().HandleSentFrameToCslNeighbor(aFrameInfo, mFrameContext, aError, *mCslTxNeighbor);
+    Get<IndirectSender>().HandleFrameTxToCslNeighborDone(aFrameInfo, mFrameContext, aError, *mCslTxNeighbor);
 
 exit:
     mCslTxMessage  = nullptr;

--- a/src/core/thread/csl_tx_scheduler.hpp
+++ b/src/core/thread/csl_tx_scheduler.hpp
@@ -242,8 +242,8 @@ private:
     void HandleTimer(void);
 
     // Callbacks from `Mac`
-    Mac::TxFrame *HandleFrameRequest(Mac::TxFrames &aTxFrames);
-    void          HandleSentFrame(const Mac::TxFrame::ParseInfo &aFrameInfo, Error aError);
+    Mac::TxFrame *PrepareFrame(Mac::TxFrames &aTxFrames);
+    void          HandleFrameTxDone(const Mac::TxFrame::ParseInfo &aFrameInfo, Error aError);
     void          HandleMacEnableStatusChanged(void);
 
     // Callback from `Radio`

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -239,7 +239,7 @@ void IndirectSender::RequestMessageUpdate(Child &aChild)
     if ((curMessage != nullptr) && !curMessage->GetIndirectTxChildMask().Has(Get<ChildTable>().GetChildIndex(aChild)))
     {
         // Set the indirect message for this child to `nullptr` to ensure
-        // it is not processed on `HandleSentFrameToChild()` callback.
+        // it is not processed on `HandleFrameTxToChildDone()` callback.
 
         aChild.SetIndirectMessage(nullptr);
 
@@ -381,10 +381,10 @@ exit:
     return error;
 }
 
-void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame::ParseInfo &aFrameInfo,
-                                            const FrameContext            &aContext,
-                                            Error                          aError,
-                                            Child                         &aChild)
+void IndirectSender::HandleFrameTxToChildDone(const Mac::TxFrame::ParseInfo &aFrameInfo,
+                                              const FrameContext            &aContext,
+                                              Error                          aError,
+                                              Child                         &aChild)
 {
     Message *message    = aChild.GetIndirectMessage();
     uint16_t nextOffset = aContext.mMessageNextOffset;
@@ -403,7 +403,7 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame::ParseInfo &aFram
     // support the "source address match" feature and always includes
     // "frame pending" flag in acks to data poll frames. In such a case,
     // `IndirectSender` prepares and sends an empty frame to the child
-    // after it sends a data poll. Here in `HandleSentFrameToChild()` we
+    // after it sends a data poll. Here in `HandleFrameTxToChildDone()` we
     // exit quickly if we detect the "send done" is for the empty frame
     // to ensure we do not update any newly added indirect message after
     // preparing the empty frame.
@@ -567,13 +567,13 @@ Error IndirectSender::PrepareFrameForCslNeighbor(Mac::TxFrame &aFrame,
     return error;
 }
 
-void IndirectSender::HandleSentFrameToCslNeighbor(const Mac::TxFrame::ParseInfo &aFrameInfo,
-                                                  const FrameContext            &aContext,
-                                                  Error                          aError,
-                                                  CslNeighbor                   &aCslNeighbor)
+void IndirectSender::HandleFrameTxToCslNeighborDone(const Mac::TxFrame::ParseInfo &aFrameInfo,
+                                                    const FrameContext            &aContext,
+                                                    Error                          aError,
+                                                    CslNeighbor                   &aCslNeighbor)
 {
 #if OPENTHREAD_FTD
-    HandleSentFrameToChild(aFrameInfo, aContext, aError, static_cast<Child &>(aCslNeighbor));
+    HandleFrameTxToChildDone(aFrameInfo, aContext, aError, static_cast<Child &>(aCslNeighbor));
 #else
     OT_UNUSED_VARIABLE(aFrameInfo);
     OT_UNUSED_VARIABLE(aContext);

--- a/src/core/thread/indirect_sender.hpp
+++ b/src/core/thread/indirect_sender.hpp
@@ -261,19 +261,19 @@ private:
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
     // Callbacks from `CslTxScheduler`
     Error PrepareFrameForCslNeighbor(Mac::TxFrame &aFrame, FrameContext &aContext, CslNeighbor &aCslNeighbor);
-    void  HandleSentFrameToCslNeighbor(const Mac::TxFrame::ParseInfo &aFrameInfo,
-                                       const FrameContext            &aContext,
-                                       Error                          aError,
-                                       CslNeighbor                   &aCslNeighbor);
+    void  HandleFrameTxToCslNeighborDone(const Mac::TxFrame::ParseInfo &aFrameInfo,
+                                         const FrameContext            &aContext,
+                                         Error                          aError,
+                                         CslNeighbor                   &aCslNeighbor);
 #endif
 
 #if OPENTHREAD_FTD
     // Callbacks from `DataPollHandler`
     Error PrepareFrameForChild(Mac::TxFrame &aFrame, FrameContext &aContext, Child &aChild);
-    void  HandleSentFrameToChild(const Mac::TxFrame::ParseInfo &aFrameInfo,
-                                 const FrameContext            &aContext,
-                                 Error                          aError,
-                                 Child                         &aChild);
+    void  HandleFrameTxToChildDone(const Mac::TxFrame::ParseInfo &aFrameInfo,
+                                   const FrameContext            &aContext,
+                                   Error                          aError,
+                                   Child                         &aChild);
     void  HandleFrameChangeDone(Child &aChild);
 
     void UpdateIndirectMessage(Child &aChild);

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -647,7 +647,7 @@ void MeshForwarder::SetRxOnWhenIdle(bool aRxOnWhenIdle)
     }
 }
 
-Mac::TxFrame *MeshForwarder::HandleFrameRequest(Mac::TxFrames &aTxFrames)
+Mac::TxFrame *MeshForwarder::PrepareFrame(Mac::TxFrames &aTxFrames)
 {
     Mac::TxFrame *frame         = nullptr;
     bool          addFragHeader = false;
@@ -736,10 +736,10 @@ exit:
     return frame;
 }
 
-Neighbor *MeshForwarder::UpdateNeighborOnSentFrame(Mac::TxFrame::ParseInfo &aFrameInfo,
-                                                   Error                    aError,
-                                                   const Mac::Address      &aMacDest,
-                                                   bool                     aIsDataPoll)
+Neighbor *MeshForwarder::UpdateNeighborOnFrameTxDone(Mac::TxFrame::ParseInfo &aFrameInfo,
+                                                     Error                    aError,
+                                                     const Mac::Address      &aMacDest,
+                                                     bool                     aIsDataPoll)
 {
     OT_UNUSED_VARIABLE(aIsDataPoll);
 
@@ -831,7 +831,7 @@ exit:
 }
 #endif // #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 
-void MeshForwarder::HandleSentFrame(Mac::TxFrame::ParseInfo &aFrameInfo, Error aError)
+void MeshForwarder::HandleFrameTxDone(Mac::TxFrame::ParseInfo &aFrameInfo, Error aError)
 {
     Neighbor *neighbor = nullptr;
 
@@ -857,7 +857,7 @@ void MeshForwarder::HandleSentFrame(Mac::TxFrame::ParseInfo &aFrameInfo, Error a
     if (!aFrameInfo.GetTxFrame()->IsEmpty())
     {
         neighbor =
-            UpdateNeighborOnSentFrame(aFrameInfo, aError, aFrameInfo.mAddrs.mDestination, /* aIsDataPoll */ false);
+            UpdateNeighborOnFrameTxDone(aFrameInfo, aError, aFrameInfo.mAddrs.mDestination, /* aIsDataPoll */ false);
     }
 
     UpdateSendMessage(aError, aFrameInfo.mAddrs.mDestination, neighbor);

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -256,8 +256,8 @@ public:
     /**
      * Handles a deferred ack.
      *
-     * Some radio links can use deferred ack logic, where a tx request always report `HandleSentFrame()` quickly. The
-     * link layer would wait for the ack and report it at a later time using this method.
+     * Some radio links can use deferred ack logic, where a tx request always reports `HandleFrameTxDone()` quickly.
+     * The link layer would wait for the ack and report it at a later time using this method.
      *
      * The link layer is expected to call `HandleDeferredAck()` (with success or failure status) for every tx request
      * on the radio link.
@@ -457,13 +457,13 @@ private:
     void  HandleDiscoverComplete(void);
 
     void          HandleReceivedFrame(Mac::RxFrame::ParseInfo &aFrameInfo);
-    Mac::TxFrame *HandleFrameRequest(Mac::TxFrames &aTxFrames);
-    Neighbor     *UpdateNeighborOnSentFrame(Mac::TxFrame::ParseInfo &aFrameInfo,
-                                            Error                    aError,
-                                            const Mac::Address      &aMacDest,
-                                            bool                     aIsDataPoll);
+    Mac::TxFrame *PrepareFrame(Mac::TxFrames &aTxFrames);
+    Neighbor     *UpdateNeighborOnFrameTxDone(Mac::TxFrame::ParseInfo &aFrameInfo,
+                                              Error                    aError,
+                                              const Mac::Address      &aMacDest,
+                                              bool                     aIsDataPoll);
     void UpdateNeighborLinkFailures(Neighbor &aNeighbor, Error aError, bool aAllowNeighborRemove, uint8_t aFailLimit);
-    void HandleSentFrame(Mac::TxFrame::ParseInfo &aFrameInfo, Error aError);
+    void HandleFrameTxDone(Mac::TxFrame::ParseInfo &aFrameInfo, Error aError);
     void UpdateSendMessage(Error aFrameTxError, Mac::Address &aMacDest, Neighbor *aNeighbor);
     void FinalizeMessageDirectTx(Message &aMessage, Error aError);
     void FinalizeAndRemoveMessage(Message &aMessage, Error aError, MessageAction aAction);


### PR DESCRIPTION
This commit renames MAC frame preparation and completion callbacks across `Mac`, frame providers (`MeshForwarder`, `DataPollHandler`, `CslTxScheduler`), and `IndirectSender`:

- `HandleFrameRequest` -> `PrepareFrame`
- `HandleSentFrame` -> `HandleFrameTxDone`
- `HandleSentFrameToChild` -> `HandleFrameTxToChildDone`
- `HandleSentFrameToCslNeighbor` -> `HandleFrameTxToCslNeighborDone`

This change:
- Replaces the passive `HandleFrameRequest` with `PrepareFrame` to accurately describe constructing and formatting the outgoing frame.
- Replaces `HandleSentFrame` with `HandleFrameTxDone` since it handles all TX outcomes (including errors/aborts), aligning with OpenThread's `Handle<Action>Done` convention.
- Establishes a symmetrical two-phase pipeline (`PrepareFrame*` and `HandleFrameTx*Done`).