### PR TITLE
[mac-frame] remove unused `PerformAesCcm()` declaration from `TxFrame`

### DIFF
--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -790,15 +790,6 @@ public:
      */
     Error GenerateWakeupFrame(PanId, const WakeupRequest &, const Address &) { return kErrorNotImplemented; }
 #endif
-
-private:
-    enum AesCcmOperation : uint8_t
-    {
-        kEncrypt,
-        kDecrypt,
-    };
-
-    Error PerformAesCcm(AesCcmOperation aOperation, const ExtAddress &aExtAddress);
 };
 
 /**


### PR DESCRIPTION
Following the refactoring of AES-CCM operations into `Frame::ParseInfo`, the private `PerformAesCcm()` method declaration and `AesCcmOperation` enum in `TxFrame` are no longer needed or used.