### PR TITLE
[mac-frame] remove obsolete Frame friend declaration from ParseInfo

### DIFF
--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -182,8 +182,6 @@ public:
      */
     class ParseInfo : public Clearable<ParseInfo>
     {
-        friend class Frame; // TODO: At some point we should no longer need this, remove it.
-
     public:
         /**
          * Initializes the `ParseInfo` object.


### PR DESCRIPTION
Now that `Frame::ParseInfo` has been made public and its fields and methods are accessed directly, `Frame` no longer accesses any private members of `ParseInfo`. This commit removes the obsolete `friend class Frame;` declaration and its associated TODO.