### PR TITLE
[csl] cover `OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE` in CI

### DIFF
--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -189,6 +189,9 @@ jobs:
         #- - - - - - - - - - - - - - - - - - - - - - - - - - -
         git clean -dfx
         ./tests/toranj/build.sh --enable-plat-key-ref all
+        #- - - - - - - - - - - - - - - - - - - - - - - - - - -
+        git clean -dfx
+        ./tests/toranj/build.sh --enable-csl-debug --log-level DEBG all
 
   toranj-macos:
     name: toranj-macos

--- a/src/core/mac/sub_mac_csl_receiver.cpp
+++ b/src/core/mac/sub_mac_csl_receiver.cpp
@@ -246,12 +246,12 @@ void SubMac::LogReceived(RxFrame *aFrame)
 {
     static constexpr uint8_t kLogStringSize = 72;
 
-    String<kLogStringSize>  logString;
-    Mac::RxFrame::ParseInfo frameInfo;
-    int32_t                 deviation;
-    uint32_t                sampleTime, ahead, after;
+    String<kLogStringSize> logString;
+    RxFrame::ParseInfo     frameInfo;
+    int32_t                deviation;
+    uint32_t               sampleTime, ahead, after;
 
-    IgnoreError(frameInfo.ParseFrom(*aFrame, Mac::Frame::kParseAddrFields));
+    IgnoreError(frameInfo.ParseFrom(*aFrame, Frame::kParseAddrFields));
 
     VerifyOrExit(
         (frameInfo.mAddrs.mDestination.IsShort() && frameInfo.mAddrs.mDestination.GetShort() == GetShortAddress()) ||

--- a/tests/toranj/build.sh
+++ b/tests/toranj/build.sh
@@ -52,6 +52,7 @@ display_usage()
     echo "Options:"
     echo "        -c/--enable-coverage      Enable code coverage"
     echo "        -k/--enable-plat-key-ref  Enable OT_PLATFORM_KEY_REF"
+    echo "        -d/--enable-csl-debug     Enable OT_CSL_DEBUG"
     echo "        -l/--log-level            Set specific log level (NONE, CRIT, WARN, NOTE, INFO, DEBG)"
     echo ""
 }
@@ -67,6 +68,7 @@ cd ../.. || die "cd failed"
 
 ot_coverage=OFF
 ot_plat_key_ref=OFF
+ot_csl_debug=OFF
 ot_log_level=INFO
 
 while [ $# -ge 2 ]; do
@@ -80,6 +82,11 @@ while [ $# -ge 2 ]; do
             ;;
         -k | --enable-plat-key-ref)
             ot_plat_key_ref=ON
+            shift
+            ;;
+
+        -d | --enable-csl-debug)
+            ot_csl_debug=ON
             shift
             ;;
 
@@ -132,7 +139,8 @@ case ${build_config} in
         cd "${top_builddir}" || die "cd failed"
         cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=ON -DOT_COVERAGE=${ot_coverage} \
             -DOT_THREAD_VERSION=1.4 -DOT_APP_CLI=OFF -DOT_APP_NCP=ON -DOT_APP_RCP=OFF \
-            -DOT_OPERATIONAL_DATASET_AUTO_INIT=ON -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} \
+            -DOT_OPERATIONAL_DATASET_AUTO_INIT=ON \
+            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} -DOT_CSL_DEBUG=${ot_csl_debug} \
             -DOT_BORDER_ROUTING=OFF \
             -DOT_LOG_LEVEL="${ot_log_level}" \
             -DOT_PROJECT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
@@ -150,7 +158,7 @@ case ${build_config} in
             -DOT_15_4=ON -DOT_TREL=OFF -DOT_OPERATIONAL_DATASET_AUTO_INIT=ON \
             -DOT_BORDER_ROUTING=OFF \
             -DOT_LOG_LEVEL="${ot_log_level}" \
-            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} \
+            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} -DOT_CSL_DEBUG=${ot_csl_debug} \
             -DOT_PROJECT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
             "${top_srcdir}" || die
         ninja || die
@@ -167,7 +175,7 @@ case ${build_config} in
             -DOT_15_4=OFF -DOT_TREL=ON -DOT_OPERATIONAL_DATASET_AUTO_INIT=ON \
             -DOT_BORDER_ROUTING=OFF \
             -DOT_LOG_LEVEL="${ot_log_level}" \
-            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} \
+            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} -DOT_CSL_DEBUG=${ot_csl_debug} \
             -DOT_PROJECT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
             "${top_srcdir}" || die
         ninja || die
@@ -184,7 +192,7 @@ case ${build_config} in
             -DOT_15_4=ON -DOT_TREL=ON -DOT_OPERATIONAL_DATASET_AUTO_INIT=ON \
             -DOT_BORDER_ROUTING=OFF \
             -DOT_LOG_LEVEL="${ot_log_level}" \
-            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} \
+            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} -DOT_CSL_DEBUG=${ot_csl_debug} \
             -DOT_PROJECT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
             "${top_srcdir}" || die
         ninja || die
@@ -199,7 +207,7 @@ case ${build_config} in
         cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=ON -DOT_COVERAGE=${ot_coverage} \
             -DOT_THREAD_VERSION=1.4 -DOT_APP_CLI=ON -DOT_APP_NCP=OFF -DOT_APP_RCP=OFF \
             -DOT_LOG_LEVEL="${ot_log_level}" \
-            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} \
+            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} -DOT_CSL_DEBUG=${ot_csl_debug} \
             -DOT_PROJECT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
             "${top_srcdir}" || die
         ninja || die
@@ -214,7 +222,7 @@ case ${build_config} in
             -DOT_THREAD_VERSION=1.4 -DOT_APP_CLI=ON -DOT_APP_NCP=OFF -DOT_APP_RCP=OFF \
             -DOT_15_4=ON -DOT_TREL=OFF \
             -DOT_LOG_LEVEL="${ot_log_level}" \
-            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} \
+            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} -DOT_CSL_DEBUG=${ot_csl_debug} \
             -DOT_PROJECT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
             "${top_srcdir}" || die
         ninja || die
@@ -230,7 +238,7 @@ case ${build_config} in
             -DOT_THREAD_VERSION=1.4 -DOT_APP_CLI=ON -DOT_APP_NCP=OFF -DOT_APP_RCP=OFF \
             -DOT_15_4=OFF -DOT_TREL=ON \
             -DOT_LOG_LEVEL="${ot_log_level}" \
-            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} \
+            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} -DOT_CSL_DEBUG=${ot_csl_debug} \
             -DOT_PROJECT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
             "${top_srcdir}" || die
         ninja || die
@@ -246,7 +254,7 @@ case ${build_config} in
             -DOT_THREAD_VERSION=1.4 -DOT_APP_CLI=ON -DOT_APP_NCP=OFF -DOT_APP_RCP=OFF \
             -DOT_15_4=ON -DOT_TREL=ON \
             -DOT_LOG_LEVEL="${ot_log_level}" \
-            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} \
+            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} -DOT_CSL_DEBUG=${ot_csl_debug} \
             -DOT_PROJECT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
             "${top_srcdir}" || die
         ninja || die
@@ -261,7 +269,7 @@ case ${build_config} in
         cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=ON -DOT_COVERAGE=${ot_coverage} \
             -DOT_THREAD_VERSION=1.4 -DOT_APP_CLI=OFF -DOT_APP_NCP=OFF -DOT_APP_RCP=ON \
             -DOT_LOG_LEVEL="${ot_log_level}" \
-            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} \
+            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} -DOT_CSL_DEBUG=${ot_csl_debug} \
             -DOT_PROJECT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
             "${top_srcdir}" || die
         ninja || die
@@ -275,7 +283,7 @@ case ${build_config} in
         cmake -GNinja -DOT_PLATFORM=posix -DOT_COMPILE_WARNING_AS_ERROR=ON -DOT_COVERAGE=${ot_coverage} \
             -DOT_THREAD_VERSION=1.4 -DOT_APP_CLI=ON -DOT_APP_NCP=ON -DOT_APP_RCP=OFF \
             -DOT_LOG_LEVEL="${ot_log_level}" \
-            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} \
+            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} -DOT_CSL_DEBUG=${ot_csl_debug} \
             -DOT_PROJECT_CONFIG=../tests/toranj/openthread-core-toranj-config-posix.h \
             "${top_srcdir}" || die
         ninja || die
@@ -290,7 +298,7 @@ case ${build_config} in
             -DOT_THREAD_VERSION=1.4 -DOT_APP_CLI=ON -DOT_APP_NCP=ON -DOT_APP_RCP=OFF \
             -DOT_15_4=ON -DOT_TREL=OFF \
             -DOT_LOG_LEVEL="${ot_log_level}" \
-            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} \
+            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} -DOT_CSL_DEBUG=${ot_csl_debug} \
             -DOT_PROJECT_CONFIG=../tests/toranj/openthread-core-toranj-config-posix.h \
             "${top_srcdir}" || die
         ninja || die
@@ -305,7 +313,7 @@ case ${build_config} in
             -DOT_THREAD_VERSION=1.4 -DOT_APP_CLI=ON -DOT_APP_NCP=ON -DOT_APP_RCP=OFF \
             -DOT_15_4=OFF -DOT_TREL=ON \
             -DOT_LOG_LEVEL="${ot_log_level}" \
-            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} \
+            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} -DOT_CSL_DEBUG=${ot_csl_debug} \
             -DOT_PROJECT_CONFIG=../tests/toranj/openthread-core-toranj-config-posix.h \
             "${top_srcdir}" || die
         ninja || die
@@ -320,7 +328,7 @@ case ${build_config} in
             -DOT_THREAD_VERSION=1.4 -DOT_APP_CLI=ON -DOT_APP_NCP=ON -DOT_APP_RCP=OFF \
             -DOT_15_4=ON -DOT_TREL=ON \
             -DOT_LOG_LEVEL="${ot_log_level}" \
-            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} \
+            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} -DOT_CSL_DEBUG=${ot_csl_debug} \
             -DOT_PROJECT_CONFIG=../tests/toranj/openthread-core-toranj-config-posix.h \
             "${top_srcdir}" || die
         ninja || die
@@ -334,7 +342,7 @@ case ${build_config} in
         cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=ON -DOT_COVERAGE=${ot_coverage} \
             -DOT_THREAD_VERSION=1.4 -DOT_APP_CLI=ON -DOT_APP_NCP=ON -DOT_APP_RCP=ON \
             -DOT_LOG_LEVEL="${ot_log_level}" \
-            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} \
+            -DOT_PLATFORM_KEY_REF=${ot_plat_key_ref} -DOT_CSL_DEBUG=${ot_csl_debug} \
             -DOT_PROJECT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
             "${top_srcdir}" || die
         ninja || die


### PR DESCRIPTION
`OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE` was previously not covered in any CI builds.

This commit adds continuous CI coverage for the CSL debug configuration:
- Updates `tests/toranj/build.sh` to add `-d/--enable-csl-debug`, which passes `-DOT_CSL_DEBUG=ON` to CMake.
- Updates the `toranj-unittest` GitHub Actions workflow to run `./tests/toranj/build.sh --enable-csl-debug --log-level DEBG all`.

Additionally, this commit fixes the type qualification in `SubMac::LogReceived()` (`RxFrame::ParseInfo` and `Frame::kParseAddrFields`) so that it compiles cleanly when CSL debug is enabled.
