### PR TITLE
[posix] pass an interface index to IPV6_BOUND_IF

### DIFF
--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -41,6 +41,7 @@
 
 #include <errno.h>
 #include <ifaddrs.h>
+#include <net/if.h>
 #include <netdb.h>
 // clang-format off
 #include <netinet/in.h>
@@ -182,7 +183,13 @@ int InfraNetif::CreateIcmp6Socket(const char *aInfraIfName)
 #ifdef __linux__
     rval = setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, aInfraIfName, strlen(aInfraIfName));
 #else  // __NetBSD__ || __FreeBSD__ || __APPLE__
-    rval = setsockopt(sock, IPPROTO_IPV6, IPV6_BOUND_IF, aInfraIfName, strlen(aInfraIfName));
+    {
+        // IPV6_BOUND_IF takes an interface index, not a name.
+        unsigned int ifIndex = if_nametoindex(aInfraIfName);
+
+        VerifyOrDie(ifIndex != 0, OT_EXIT_INVALID_ARGUMENTS);
+        rval = setsockopt(sock, IPPROTO_IPV6, IPV6_BOUND_IF, &ifIndex, sizeof(ifIndex));
+    }
 #endif // __linux__
     VerifyOrDie(rval == 0, OT_EXIT_ERROR_ERRNO);
 


### PR DESCRIPTION
`IPV6_BOUND_IF` takes an interface index on every BSD (FreeBSD, NetBSD, macOS), but since #9887 the BSD branch of `InfraNetif::CreateIcmp6Socket()` has passed the interface name string instead. On macOS that makes the `setsockopt()` fail with `EINVAL`, so otbr-agent (with border routing enabled) dies at startup.

Resolve the name with `if_nametoindex()` and pass the index, exiting with `OT_EXIT_INVALID_ARGUMENTS` for an unknown name as `SetInfraNetif()` does.

Tested on an Apple Silicon Mac mini running otbr-agent in RCP mode (EFR32MG24 dongle) as a Matter-over-Thread border router with real devices, and independently confirmed by another user on an MG21 dongle in openthread/ot-br-posix#3469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
