### PR TITLE
[csl] simplify and enhance parent CSL metric calculation by `Mle`

### DIFF
--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -866,6 +866,15 @@ private:
 };
 
 /**
+ * Converts a given CSL period in units of 10 symbols to microseconds.
+ *
+ * @param[in] aCslPeriod  The CSL period in units of 10 symbols.
+ *
+ * @returns The CSL period in microseconds.
+ */
+inline constexpr uint32_t CslPeriodToUsec(uint16_t aCslPeriod) { return Radio::kTenSymbolsDuration * aCslPeriod; }
+
+/**
  * Minimum CSL period supported in units of 10 symbols.
  */
 constexpr uint16_t kMinCslPeriod =
@@ -877,13 +886,9 @@ static_assert((Time::MsecToUsec(OPENTHREAD_CONFIG_MAC_CSL_MIN_PERIOD) / Radio::k
               "kMinCslPeriod is too large to fit in uint16_t");
 
 /**
- * Converts a given CSL period in units of 10 symbols to microseconds.
- *
- * @param[in] aCslPeriod  The CSL period in units of 10 symbols.
- *
- * @returns The CSL period in microseconds.
+ * Minimum CSL period supported in microseconds.
  */
-inline uint32_t CslPeriodToUsec(uint16_t aCslPeriod) { return Radio::kTenSymbolsDuration * aCslPeriod; }
+constexpr uint32_t kMinCslPeriodInUsec = CslPeriodToUsec(kMinCslPeriod);
 
 /**
  * Represents CSL accuracy.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3007,17 +3007,35 @@ exit:
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 uint64_t Mle::CalcParentCslMetric(const Mac::CslAccuracy &aCslAccuracy) const
 {
-    // This function calculates the overall time that device will operate
-    // on battery by summing sequence of "ON quants" over a period of time.
+    // This method calculates a metric estimating the average CSL sample window
+    // expansion per CSL sample period over a CSL timeout interval with no
+    // synchronizations. Candidate-invariant terms (the receiver's own crystal
+    // accuracy and uncertainty, and fixed receive-on margins) are omitted.
+    //
+    // At sample period `i` (from 1 to `k`), the elapsed time since last sync is
+    // `i * P`, where `P` is the CSL period. The sample window expands on each
+    // side (ahead and after) by the clock drift `(i * P * accuracy / 10^6)`,
+    // totaling `2 * (i * P * accuracy / 10^6)` per sample period.
+    // Summing over all `k` periods yields:
+    //   Total Drift = 2 * (P * accuracy / 10^6) * sum(i from 1 to k)
+    //               = 2 * (P * accuracy / 10^6) * (k * (k + 1) / 2)
+    //               = k * (k + 1) * P * accuracy / 10^6
+    //
+    // Similarly, parent uncertainty (in microseconds) expands both sides at
+    // each of the `k` periods:
+    //   Total Uncertainty = 2 * uncertainty * k
+    //
+    // To simplify and avoid large numbers, the total metric is divided by `k`
+    // (which is constant across all parent candidates), representing the average
+    // window expansion per period (scaled by 10^6 to avoid integer division):
+    //   Metric = (k + 1) * P * accuracy + 2 * uncertainty * 10^6
 
-    static constexpr uint64_t usInSecond = 1000000;
+    static constexpr uint64_t kPpmScale = 1000000u;
 
-    uint64_t cslPeriodUs  = Mac::CslPeriodToUsec(Mac::kMinCslPeriod);
-    uint64_t cslTimeoutUs = GetCslTimeout() * usInSecond;
-    uint64_t k            = cslTimeoutUs / cslPeriodUs;
+    uint64_t k = static_cast<uint64_t>(GetCslTimeout()) * Time::kOneSecondInUsec / Mac::kMinCslPeriodInUsec;
 
-    return k * (k + 1) * cslPeriodUs / usInSecond * aCslAccuracy.GetClockAccuracy() +
-           Radio::ConvertUncertaintyToUsec(aCslAccuracy.GetUncertainty()) * k;
+    return (k + 1) * Mac::kMinCslPeriodInUsec * aCslAccuracy.GetClockAccuracy() +
+           2 * static_cast<uint64_t>(Radio::ConvertUncertaintyToUsec(aCslAccuracy.GetUncertainty())) * kPpmScale;
 }
 #endif
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -740,11 +740,11 @@ public:
     Error SetCslTimeout(uint32_t aTimeout);
 
     /**
-     * Calculates CSL metric of parent.
+     * Calculates the CSL metric of a parent candidate based on its CSL accuracy.
      *
-     * @param[in] aCslAccuracy The CSL accuracy.
+     * @param[in] aCslAccuracy  The CSL accuracy of the parent candidate.
      *
-     * @returns CSL metric.
+     * @returns The calculated CSL metric (smaller is better).
      */
     uint64_t CalcParentCslMetric(const Mac::CslAccuracy &aCslAccuracy) const;
 


### PR DESCRIPTION
This commit enhances and simplifies `Mle::CalcParentCslMetric()` used by CSL receiver SEDs during parent selection:

- Documents the arithmetic series derivation for cumulative CSL window drift over the timeout interval.
- Divides the total metric by `k` (the number of sample periods in the timeout interval). Since `k` is constant across all parent candidates, this preserves the exact comparison ordering while representing the average window expansion per period, working with much smaller numbers.
- Properly accounts for uncertainty on both sides of the window (`2 * uncertainty`).
- Scales the metric by 10^6 to avoid integer division on the clock drift term, preserving exact integer precision.
- Defines `kMinCslPeriodInUsec` as `constexpr` in `mac_types.hpp`.