### PR TITLE
[posix] fix unbounded retry loop in mDNS socket send

### DIFF
--- a/src/posix/platform/mdns_socket.cpp
+++ b/src/posix/platform/mdns_socket.cpp
@@ -302,6 +302,7 @@ void MdnsSocket::SendUnicast(otMessage *aMessage, const otPlatMdnsAddressInfo *a
 
     VerifyOrExit(mEnabled);
     VerifyOrExit(aAddress->mInfraIfIndex == mInfraIfIndex);
+    VerifyOrExit(aAddress->mPort != 0);
 
     length = otMessageGetLength(aMessage);
 
@@ -427,7 +428,17 @@ void MdnsSocket::SendQueuedMessages(MsgType aMsgType)
             }
 
             bytesSent = sendto(mFd6, buffer, length, 0, reinterpret_cast<struct sockaddr *>(&addr6), sizeof(addr6));
-            VerifyOrExit(bytesSent == length);
+
+            if (bytesSent < 0)
+            {
+                if ((errno == EAGAIN) || (errno == EWOULDBLOCK) || (errno == ENOBUFS) || (errno == EINTR))
+                {
+                    ExitNow();
+                }
+
+                LogWarn("sendto(IPv6) failed, errno:%s - dropping message", strerror(errno));
+            }
+
             metadata.mIp6Port = 0;
             mPendingIp6Tx--;
             break;
@@ -438,7 +449,17 @@ void MdnsSocket::SendQueuedMessages(MsgType aMsgType)
             addr.sin_port   = htons(metadata.mIp4Port);
             memcpy(&addr.sin_addr.s_addr, &metadata.mIp4Address, sizeof(otIp4Address));
             bytesSent = sendto(mFd4, buffer, length, 0, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr));
-            VerifyOrExit(bytesSent == length);
+
+            if (bytesSent < 0)
+            {
+                if ((errno == EAGAIN) || (errno == EWOULDBLOCK) || (errno == ENOBUFS) || (errno == EINTR))
+                {
+                    ExitNow();
+                }
+
+                LogWarn("sendto(IPv4) failed, errno:%s - dropping message", strerror(errno));
+            }
+
             metadata.mIp4Port = 0;
             mPendingIp4Tx--;
             break;


### PR DESCRIPTION
When sendto() for a queued IPv6 or IPv4 mDNS message fails with a non-transient error (e.g., ENETUNREACH, EHOSTUNREACH, EINVAL), MdnsSocket::SendQueuedMessages() previously used VerifyOrExit() to abort on failure.

Because VerifyOrExit() exited immediately before clearing the port in metadata or decrementing the pending transmission counter, the failing message remained in mTxQueue with pending state. Because the socket output buffer remained empty, select() continuously reported the socket as writable, causing Process() to retry sendto() on the same message in a tight busy loop consuming 100% CPU and blocking all subsequent queued messages (head-of-line blocking).

Additionally, if SendUnicast() received a destination with port 0, it would increment the pending transmission counter without setting the port in metadata, resulting in the message being skipped during transmission while permanently leaving the pending counter non-zero and causing an unbounded spin loop.

This commit resolves these issues:
1. In SendQueuedMessages(), differentiate transient buffer errors (EAGAIN, EWOULDBLOCK, ENOBUFS, EINTR) from non-transient errors. For transient errors, exit to wait for writability. For all other errors, log a warning and drop the failed transmission by clearing the port in metadata and decrementing the pending counter, allowing subsequent queued messages to be processed.
2. In SendUnicast(), validate that the destination port is non-zero before enqueueing the message.

Resolves #13601.