### PR TITLE
[srp-server] forward standard DNS queries to DNS-SD server

### DIFF
--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -139,8 +139,6 @@ void Server::Stop(void)
 
 void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    Request request;
-
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
     // We first let the `Srp::Server` process the received message.
     // It returns `kErrorNone` to indicate that it successfully
@@ -148,6 +146,19 @@ void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
 
     VerifyOrExit(Get<Srp::Server>().HandleDnssdServerUdpReceive(aMessage, aMessageInfo) != kErrorNone);
 #endif
+
+    IgnoreError(HandleQuery(aMessage, aMessageInfo));
+
+exit:
+    return;
+}
+
+Error Server::HandleQuery(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+{
+    Error   error = kErrorDrop;
+    Request request;
+
+    VerifyOrExit(IsRunning());
 
     request.mMessage     = &aMessage;
     request.mMessageInfo = &aMessageInfo;
@@ -158,9 +169,39 @@ void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
     LogInfo("Received query from %s", aMessageInfo.GetPeerAddr().ToString().AsCString());
 
     ProcessQuery(request);
+    error = kErrorNone;
 
 exit:
-    return;
+    return error;
+}
+
+#if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
+Error Server::HandleSrpServerUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+{
+    // This is called from `Srp::Server` when a UDP message is
+    // received on its socket. If `Dnssd::Server` is running, we
+    // process the received message as a DNS query. We return
+    // `kErrorNone` to indicate that message was processed by
+    // `Dnssd::Server`, otherwise `kErrorDrop` is returned.
+
+    return HandleQuery(aMessage, aMessageInfo);
+}
+#endif
+
+Ip6::Udp::Socket &Server::GetSocket(const Ip6::MessageInfo &aMessageInfo)
+{
+    Ip6::Udp::Socket *socket = &mSocket;
+
+#if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
+    Ip6::Udp::Socket &srpSocket = Get<Srp::Server>().GetSocket();
+
+    if (srpSocket.IsOpen() && (aMessageInfo.GetSockPort() == srpSocket.GetSockName().GetPort()))
+    {
+        socket = &srpSocket;
+    }
+#endif
+
+    return *socket;
 }
 
 void Server::ProcessQuery(Request &aRequest)
@@ -294,7 +335,7 @@ void Server::Response::Send(const Ip6::MessageInfo &aMessageInfo)
 
     mMessage->Write(0, mHeader);
 
-    SuccessOrExit(Get<Server>().mSocket.SendTo(*mMessage, aMessageInfo));
+    SuccessOrExit(Get<Server>().GetSocket(aMessageInfo).SendTo(*mMessage, aMessageInfo));
 
     // When `SendTo()` returns success it takes over ownership of
     // the given message, so we release ownership of `mMessage`.
@@ -1146,7 +1187,8 @@ void Server::OnUpstreamQueryDone(UpstreamQueryTransaction &aQueryTransaction, Me
 
     if (aResponseMessage != nullptr)
     {
-        error = mSocket.SendTo(*aResponseMessage, aQueryTransaction.GetMessageInfo());
+        error =
+            GetSocket(aQueryTransaction.GetMessageInfo()).SendTo(*aResponseMessage, aQueryTransaction.GetMessageInfo());
     }
     else
     {

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -580,8 +580,13 @@ private:
     };
 #endif
 
-    bool IsRunning(void) const { return mSocket.IsBound(); }
-    void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    bool              IsRunning(void) const { return mSocket.IsBound(); }
+    Ip6::Udp::Socket &GetSocket(const Ip6::MessageInfo &aMessageInfo);
+    void              HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    Error             HandleQuery(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+#if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
+    Error HandleSrpServerUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+#endif
     void ProcessQuery(Request &aRequest);
     void ResolveByProxy(Response &aResponse, const Ip6::MessageInfo &aMessageInfo);
     void RemoveQueryAndPrepareResponse(ProxyQuery &aQuery, ProxyQueryInfo &aInfo, Response &aResponse);

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -1713,6 +1713,25 @@ void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
 {
     Error error = ProcessMessage(aMessage, aMessageInfo);
 
+#if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
+    if (error != kErrorNone)
+    {
+        error = Get<Dns::ServiceDiscovery::Server>().HandleSrpServerUdpReceive(aMessage, aMessageInfo);
+    }
+#endif
+
+    if (error != kErrorNone)
+    {
+        Dns::UpdateHeader header;
+
+        if ((aMessage.Read(aMessage.GetOffset(), header) == kErrorNone) &&
+            (header.GetType() == Dns::UpdateHeader::kTypeQuery))
+        {
+            SendResponse(header, Dns::UpdateHeader::kResponseNotImplemented, aMessageInfo);
+            error = kErrorNone;
+        }
+    }
+
     LogWarnOnError(error, "handle DNS message");
     OT_UNUSED_VARIABLE(error);
 }

--- a/tests/nexus/test_srp_server_anycast_mode.cpp
+++ b/tests/nexus/test_srp_server_anycast_mode.cpp
@@ -77,36 +77,61 @@ static constexpr uint16_t kSrpServerAnycastPort   = 53;
  */
 struct BrowseContext
 {
-    Node *mClientNode;
-    bool  mDone;
+    Node   *mClientNode;
+    otError mError;
+    bool    mDone;
 };
 
 static void HandleBrowseResponse(otError aError, const otDnsBrowseResponse *aResponse, void *aContext)
 {
-    BrowseContext                     *context  = static_cast<BrowseContext *>(aContext);
-    const Dns::Client::BrowseResponse &response = *static_cast<const Dns::Client::BrowseResponse *>(aResponse);
-    char                               label[Dns::Name::kMaxLabelSize];
-    Dns::Client::ServiceInfo           serviceInfo;
-    char                               hostName[Dns::Name::kMaxNameSize];
+    BrowseContext *context = static_cast<BrowseContext *>(aContext);
 
-    SuccessOrQuit(aError);
+    context->mError = aError;
+    context->mDone  = true;
 
-    // Since there is only one match the server should include the service info in additional section.
-    SuccessOrQuit(response.GetServiceInstance(0, label, sizeof(label)));
-    VerifyOrQuit(StringMatch(label, kSrpInstanceName, kStringCaseInsensitiveMatch));
+    SuccessOrExit(aError);
+    {
+        const Dns::Client::BrowseResponse &response = *static_cast<const Dns::Client::BrowseResponse *>(aResponse);
+        char                               label[Dns::Name::kMaxLabelSize];
+        Dns::Client::ServiceInfo           serviceInfo;
+        char                               hostName[Dns::Name::kMaxNameSize];
 
-    serviceInfo.mHostNameBuffer     = hostName;
-    serviceInfo.mHostNameBufferSize = sizeof(hostName);
-    serviceInfo.mTxtData            = nullptr;
-    serviceInfo.mTxtDataSize        = 0;
+        // Since there is only one match the server should include the service info in additional section.
+        SuccessOrQuit(response.GetServiceInstance(0, label, sizeof(label)));
+        VerifyOrQuit(StringMatch(label, kSrpInstanceName, kStringCaseInsensitiveMatch));
 
-    SuccessOrQuit(response.GetServiceInfo(label, serviceInfo));
+        serviceInfo.mHostNameBuffer     = hostName;
+        serviceInfo.mHostNameBufferSize = sizeof(hostName);
+        serviceInfo.mTxtData            = nullptr;
+        serviceInfo.mTxtDataSize        = 0;
 
-    VerifyOrQuit(serviceInfo.mPort == kSrpServicePort);
-    VerifyOrQuit(StringStartsWith(serviceInfo.mHostNameBuffer, kSrpHostName, kStringCaseInsensitiveMatch));
-    VerifyOrQuit(AsCoreType(&serviceInfo.mHostAddress) == context->mClientNode->Get<Mle::Mle>().GetMeshLocalEid());
+        SuccessOrQuit(response.GetServiceInfo(label, serviceInfo));
 
-    context->mDone = true;
+        VerifyOrQuit(serviceInfo.mPort == kSrpServicePort);
+        VerifyOrQuit(StringStartsWith(serviceInfo.mHostNameBuffer, kSrpHostName, kStringCaseInsensitiveMatch));
+        VerifyOrQuit(AsCoreType(&serviceInfo.mHostAddress) == context->mClientNode->Get<Mle::Mle>().GetMeshLocalEid());
+    }
+
+exit:
+    return;
+}
+
+/**
+ * Test context for DNS record query.
+ */
+struct RecordContext
+{
+    otError mError;
+    bool    mDone;
+};
+
+static void HandleRecordResponse(otError aError, const otDnsRecordResponse *aResponse, void *aContext)
+{
+    RecordContext *context = static_cast<RecordContext *>(aContext);
+
+    context->mError = aError;
+    context->mDone  = true;
+    OT_UNUSED_VARIABLE(aResponse);
 }
 
 void TestSrpServerAnycastMode(const char *aJsonFileName)
@@ -226,11 +251,67 @@ void TestSrpServerAnycastMode(const char *aJsonFileName)
         // 5. Browse for the service from the browser node and verify result.
         BrowseContext context;
         context.mClientNode = &client;
+        context.mError      = OT_ERROR_NONE;
         context.mDone       = false;
 
         SuccessOrQuit(browser.Get<Dns::Client>().Browse(kSrpFullServiceType, HandleBrowseResponse, &context));
         nexus.AdvanceTime(kDnsQueryTime);
         VerifyOrQuit(context.mDone);
+        SuccessOrQuit(context.mError);
+
+        // 5b. Query targeting the SRP server's port explicitly.
+        // In unicast mode, this is the dynamic unicast SRP port, verifying that standard DNS
+        // queries sent to the SRP server socket are handled by DNS-SD server.
+        // In anycast mode, this is port 53.
+        {
+            Dns::Client::QueryConfig queryConfig;
+            queryConfig.Clear();
+            AsCoreType(&queryConfig.mServerSockAddr).SetAddress(server.Get<Mle::Mle>().GetMeshLocalEid());
+            queryConfig.mServerSockAddr.mPort = server.Get<Srp::Server>().GetPort();
+
+            context.mDone  = false;
+            context.mError = OT_ERROR_FAILED;
+            SuccessOrQuit(
+                browser.Get<Dns::Client>().Browse(kSrpFullServiceType, HandleBrowseResponse, &context, &queryConfig));
+            nexus.AdvanceTime(kDnsQueryTime);
+            VerifyOrQuit(context.mDone);
+            SuccessOrQuit(context.mError);
+
+            // Also query SOA record for default.service.arpa. targeting the SRP server's port.
+            RecordContext recordContext;
+            recordContext.mDone  = false;
+            recordContext.mError = OT_ERROR_FAILED;
+            SuccessOrQuit(browser.Get<Dns::Client>().QueryRecord(Dns::ResourceRecord::kTypeSoa, nullptr,
+                                                                 "default.service.arpa.", HandleRecordResponse,
+                                                                 &recordContext, &queryConfig));
+            nexus.AdvanceTime(kDnsQueryTime);
+            VerifyOrQuit(recordContext.mDone);
+            SuccessOrQuit(recordContext.mError);
+
+            // When DNS-SD server is stopped, querying the SRP server's port should receive NotImplemented response.
+            server.Get<Dns::ServiceDiscovery::Server>().Stop();
+
+            recordContext.mDone  = false;
+            recordContext.mError = OT_ERROR_NONE;
+            SuccessOrQuit(browser.Get<Dns::Client>().QueryRecord(Dns::ResourceRecord::kTypeSoa, nullptr,
+                                                                 "default.service.arpa.", HandleRecordResponse,
+                                                                 &recordContext, &queryConfig));
+            nexus.AdvanceTime(kDnsQueryTime);
+            VerifyOrQuit(recordContext.mDone);
+            VerifyOrQuit(recordContext.mError == OT_ERROR_NOT_IMPLEMENTED);
+
+            // Re-start DNS-SD server and verify queries work again.
+            SuccessOrQuit(server.Get<Dns::ServiceDiscovery::Server>().Start());
+
+            recordContext.mDone  = false;
+            recordContext.mError = OT_ERROR_FAILED;
+            SuccessOrQuit(browser.Get<Dns::Client>().QueryRecord(Dns::ResourceRecord::kTypeSoa, nullptr,
+                                                                 "default.service.arpa.", HandleRecordResponse,
+                                                                 &recordContext, &queryConfig));
+            nexus.AdvanceTime(kDnsQueryTime);
+            VerifyOrQuit(recordContext.mDone);
+            SuccessOrQuit(recordContext.mError);
+        }
 
         // 6. Clear host on client and stop both client and server.
         client.Get<Srp::Client>().ClearHostAndServices();


### PR DESCRIPTION
Thread Network Data publishes Service ID 0x5d as the combined "DNS/SRP Service", specifying an IPv6 address and UDP port (e.g., dynamic port 53539 in unicast mode). Per Thread specifications, a Border Router providing this service must support both SRP Server and DNS-SD Server. Clients implementing standard RFC 2136 dynamic DNS updates (such as Matter over Thread devices on Zephyr or Apple platforms) perform zone discovery by querying the SOA record for `default.service.arpa.` on the learned DNS/SRP server port before sending DNS Update messages.

Previously, in unicast mode when using a non-53 port, `Srp::Server` opened its own UDP socket and dropped any message whose query type was not `kQueryTypeUpdate`. As a result, standard DNS queries (such as SOA) sent to the published unicast DNS/SRP port were silently dropped, causing commissioning and registration timeouts for RFC 2136 clients.

This commit resolves the issue:
1. In `Srp::Server::HandleUdpReceive()`, if the incoming message is not an SRP Update, forward it to `Dnssd::Server::HandleSrpServerUdpReceive()`.
2. If `Dnssd::Server` is running, process the message as a standard DNS query.
3. Update `Dnssd::Server::Response::Send()` and `OnUpstreamQueryDone()` to transmit responses using the socket that received the request, ensuring the response UDP source port matches the destination port (e.g., 53539) and avoiding `kErrorInvalidArgs` from the UDP stack.
4. If `Dnssd::Server` is disabled or not running, `Srp::Server` replies with `kResponseNotImplemented` for DNS queries rather than silently dropping them.
5. Update Nexus test `srp_server_anycast_mode` to verify that standard DNS Browse and SOA queries sent to the published SRP server port succeed in both anycast and unicast modes, and verify that `kResponseNotImplemented` is returned when `Dnssd::Server` is stopped.